### PR TITLE
Cross-link matrix methods image and column_space

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -5189,8 +5189,8 @@ cdef class Matrix(Matrix1):
 
     def image(self):
         """
-        Return the image of the homomorphism on rows defined by this
-        matrix.
+        Return the image of the homomorphism on rows defined by right
+        multiplication by this matrix: that is, the row-space.
 
         EXAMPLES::
 
@@ -5213,6 +5213,12 @@ cdef class Matrix(Matrix1):
 
             sage: image(B) == B.row_module()
             True
+            sage: image(B) == B.transpose().column_module()
+            True
+
+        .. SEEALSO::
+
+            :meth:`row_module`, :meth:`column_module`
         """
         return self.row_module()
 


### PR DESCRIPTION
This is my pull request originally created on trac, which I thought pushing on github.
Fixes #33548 