### PR TITLE
SignedPermutation should allow iterables as input

### DIFF
--- a/src/sage/combinat/colored_permutations.py
+++ b/src/sage/combinat/colored_permutations.py
@@ -8,6 +8,7 @@ Colored Permutations
 """
 import itertools
 
+from collections.abc import Iterable
 from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.parent import Parent
 from sage.structure.unique_representation import UniqueRepresentation
@@ -1361,7 +1362,7 @@ class SignedPermutations(ColoredPermutations):
             True
 
         """
-        if isinstance(x, list) or isinstance(x, range):
+        if isinstance(x, Iterable):
             if x and isinstance(x[0], tuple):
                 c = []
                 p = []

--- a/src/sage/combinat/colored_permutations.py
+++ b/src/sage/combinat/colored_permutations.py
@@ -435,8 +435,8 @@ class ColoredPermutations(Parent, UniqueRepresentation):
         sage: s2*t*s2
         [[0, 1, 0], [1, 2, 3]]
 
-    We can also create a colored permutation by passing
-    either a list of tuples consisting of ``(color, element)``::
+    We can also create a colored permutation by passing either
+    an iterable consisting of tuples consisting of ``(color, element)``::
 
         sage: x = C([(2,1), (3,3), (3,2)]); x
         [[2, 3, 3], [1, 3, 2]]
@@ -445,12 +445,22 @@ class ColoredPermutations(Parent, UniqueRepresentation):
 
         sage: C([[3,3,1], [1,3,2]])
         [[3, 3, 1], [1, 3, 2]]
+        sage: C(([3,3,1], [1,3,2]))
+        [[3, 3, 1], [1, 3, 2]]
 
     There is also the natural lift from permutations::
 
         sage: P = Permutations(3)
         sage: C(P.an_element())
         [[0, 0, 0], [3, 1, 2]]
+
+
+    TESTS::
+
+        sage: T = ColoredPermutations(3,4); type(T[0])
+        <class 'sage.combinat.colored_permutations.ColoredPermutations_with_category.element_class'>
+        sage: C(T[0])
+        [[0, 0, 0], [1, 2, 3]]
 
     REFERENCES:
 

--- a/src/sage/combinat/colored_permutations.py
+++ b/src/sage/combinat/colored_permutations.py
@@ -8,7 +8,6 @@ Colored Permutations
 """
 import itertools
 
-from collections.abc import Iterable
 from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.parent import Parent
 from sage.structure.unique_representation import UniqueRepresentation
@@ -992,6 +991,18 @@ class SignedPermutation(ColoredPermutation,
             sage: SignedPermutation([2, 1, -3])
             [2, 1, -3]
 
+            sage: SignedPermutation((2,1,-3))
+            [2, 1, -3]
+
+            sage: SignedPermutation(range(1,4))
+            [1, 2, 3]
+
+        TESTS::
+
+            sage: T = SignedPermutation(range(1,4)); type(T)
+            <class 'sage.combinat.colored_permutations.SignedPermutations_with_category.element_class'>
+            sage: SignedPermutation(T)
+            [1, 2, 3]
         """
         return SignedPermutations(len(list(pi)))(pi)
 

--- a/src/sage/combinat/colored_permutations.py
+++ b/src/sage/combinat/colored_permutations.py
@@ -689,20 +689,22 @@ class ColoredPermutations(Parent, UniqueRepresentation):
             sage: x == C([[2,3,3], [1,3,2]])
             True
         """
-        if isinstance(x, list):
-            if isinstance(x[0], tuple):
-                c = []
-                p = []
-                for k in x:
-                    if len(k) != 2:
-                        raise ValueError("input must be pairs (color, element)")
-                    c.append(self._C(k[0]))
-                    p.append(k[1])
-                return self.element_class(self, c, self._P(p))
+        if isinstance(x, self.element_class) and x.parent() is self:
+            return self
+        x = list(x)
+        if isinstance(x[0], tuple):
+            c = []
+            p = []
+            for k in x:
+                if len(k) != 2:
+                    raise ValueError("input must be pairs (color, element)")
+                c.append(self._C(k[0]))
+                p.append(k[1])
+            return self.element_class(self, c, self._P(p))
 
-            if len(x) != 2:
-                raise ValueError("input must be a pair of a list of colors and a permutation")
-            return self.element_class(self, [self._C(v) for v in x[0]], self._P(x[1]))
+        if len(x) != 2:
+            raise ValueError("input must be a pair of a list of colors and a permutation")
+        return self.element_class(self, [self._C(v) for v in x[0]], self._P(x[1]))
 
     def _coerce_map_from_(self, C):
         """
@@ -1362,37 +1364,39 @@ class SignedPermutations(ColoredPermutations):
             True
 
         """
-        if isinstance(x, Iterable):
-            if x and isinstance(x[0], tuple):
-                c = []
-                p = []
-                for k in x:
-                    if len(k) != 2:
-                        raise ValueError("input must be pairs (sign, element)")
-                    if k[0] != 1 and k[0] != -1:
-                        raise ValueError("the sign must be +1 or -1")
-                    c.append(ZZ(k[0]))
-                    p.append(k[1])
-                return self.element_class(self, c, self._P(p))
+        if isinstance(x, self.element_class) and x.parent() is self:
+            return self
+        x = list(x)
+        if x and isinstance(x[0], tuple):
+            c = []
+            p = []
+            for k in x:
+                if len(k) != 2:
+                    raise ValueError("input must be pairs (sign, element)")
+                if k[0] != 1 and k[0] != -1:
+                    raise ValueError("the sign must be +1 or -1")
+                c.append(ZZ(k[0]))
+                p.append(k[1])
+            return self.element_class(self, c, self._P(p))
 
-            if len(x) == self._n:
-                c = []
-                p = []
-                one = ZZ.one()
-                for v in x:
-                    if v > 0:
-                        c.append(one)
-                        p.append(v)
-                    else:
-                        c.append(-one)
-                        p.append(-v)
-                return self.element_class(self, c, self._P(p))
+        if len(x) == self._n:
+            c = []
+            p = []
+            one = ZZ.one()
+            for v in x:
+                if v > 0:
+                    c.append(one)
+                    p.append(v)
+                else:
+                    c.append(-one)
+                    p.append(-v)
+            return self.element_class(self, c, self._P(p))
 
-            if len(x) != 2:
-                raise ValueError("input must be a pair of a list of signs and a permutation")
-            if any(s != 1 and s != -1 for s in x[0]):
-                raise ValueError("the sign must be +1 or -1")
-            return self.element_class(self, [ZZ(v) for v in x[0]], self._P(x[1]))
+        if len(x) != 2:
+            raise ValueError("input must be a pair of a list of signs and a permutation")
+        if any(s != 1 and s != -1 for s in x[0]):
+            raise ValueError("the sign must be +1 or -1")
+        return self.element_class(self, [ZZ(v) for v in x[0]], self._P(x[1]))
 
     def __iter__(self):
         """

--- a/src/sage/combinat/colored_permutations.py
+++ b/src/sage/combinat/colored_permutations.py
@@ -1361,7 +1361,7 @@ class SignedPermutations(ColoredPermutations):
             True
 
         """
-        if isinstance(x, list):
+        if isinstance(x, list) or isinstance(x, range):
             if x and isinstance(x[0], tuple):
                 c = []
                 p = []

--- a/src/sage/combinat/colored_permutations.py
+++ b/src/sage/combinat/colored_permutations.py
@@ -435,7 +435,7 @@ class ColoredPermutations(Parent, UniqueRepresentation):
         sage: s2*t*s2
         [[0, 1, 0], [1, 2, 3]]
 
-    We can also create a colored permutation by passing either
+    We can also create a colored permutation by passing
     an iterable consisting of tuples consisting of ``(color, element)``::
 
         sage: x = C([(2,1), (3,3), (3,2)]); x
@@ -455,12 +455,10 @@ class ColoredPermutations(Parent, UniqueRepresentation):
         [[0, 0, 0], [3, 1, 2]]
 
 
-    TESTS::
+    A colored permutation::
 
-        sage: T = ColoredPermutations(3,4); type(T[0])
-        <class 'sage.combinat.colored_permutations.ColoredPermutations_with_category.element_class'>
-        sage: C(T[0])
-        [[0, 0, 0], [1, 2, 3]]
+        sage: C(C.an_element()) == C.an_element()
+        True
 
     REFERENCES:
 
@@ -1006,13 +1004,6 @@ class SignedPermutation(ColoredPermutation,
 
             sage: SignedPermutation(range(1,4))
             [1, 2, 3]
-
-        TESTS::
-
-            sage: T = SignedPermutation(range(1,4)); type(T)
-            <class 'sage.combinat.colored_permutations.SignedPermutations_with_category.element_class'>
-            sage: SignedPermutation(T)
-            [1, 2, 3]
         """
         return SignedPermutations(len(list(pi)))(pi)
 
@@ -1384,6 +1375,9 @@ class SignedPermutations(ColoredPermutations):
             sage: S([]) == list(S)[0]
             True
 
+            sage: T = SignedPermutation(range(1,4))
+            sage: SignedPermutations(3)(T)
+            [1, 2, 3]
         """
         if isinstance(x, self.element_class) and x.parent() is self:
             return self


### PR DESCRIPTION
This is my pull request originally which addresses the issue #34923 
Fixes #34923 