### PR TITLE
Fix deployment of docs to netlify

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -42,35 +42,18 @@ jobs:
           mkdir -p ./docs
           cp -r -L /sage/local/share/doc/sage/html/en/* ./docs
 
-      - name: Deploy to Netlify preview
-        id: preview-netlify
-        if: env.CAN_DEPLOY == 'true' && github.ref != 'refs/heads/develop'
-        uses: netlify/actions/cli@master
-        with:
-          args: deploy --dir=docs --alias="${NETLIFY_ALIAS}"
-        env:
-          # Set deployment url to commit hash to easily link from the trac.
-          # We could also set NETLIFY_ALIAS to the branch name.
-          # However, netlify currently doesn't support updates to a deployment with the same alias
-          # https://github.com/netlify/cli/issues/948
-          # https://github.com/netlify/cli/issues/1984
-          # Note that even if this feature is implemented, one would also need to first process the branch name
-          # to workaround the bug https://github.com/netlify/cli/issues/969.
-          NETLIFY_ALIAS: ${{ github.sha }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-
       - name: Deploy to Netlify production
         id: deploy-netlify
-        if: env.CAN_DEPLOY == 'true' && github.ref == 'refs/heads/develop'
+        if: env.CAN_DEPLOY == 'true'
         uses: netlify/actions/cli@master
         with:
-          args: deploy --dir=docs --prod
+          args: deploy --dir=docs --prod="${NETLIFY_PRODUCTION}"
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_PRODUCTION: ${{ github.ref == 'refs/heads/develop' }}
 
       - name: Report deployment url
         if: env.CAN_DEPLOY == 'true'
         run: |
-          echo "::notice::The documentation has being automatically deployed to Netlify. %0A ✅ Preview: ${{ steps.preview-netlify.outputs.NETLIFY_URL || steps.deploy-netlify.outputs.NETLIFY_URL }}"
+          echo "::notice::The documentation has being automatically deployed to Netlify. %0A ✅ Preview: ${{ steps.deploy-netlify.outputs.NETLIFY_URL }}"

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -38,9 +38,11 @@ jobs:
           # We also need to replace the symlinks because netlify is not following them
           mkdir -p ./docs
           cp -r -L /sage/local/share/doc/sage/html/en/* ./docs
+          # Zip everything for increased performance
+          zip -r docs.zip docs
 
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docs
-          path: docs/
+          path: docs.zip

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -15,8 +15,6 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     container: ghcr.io/sagemath/sage/sage-docker-ubuntu-focal-standard-with-targets:dev
-    env:
-      CAN_DEPLOY: ${{ secrets.NETLIFY_AUTH_TOKEN != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,7 +32,6 @@ jobs:
           SAGE_NUM_THREADS: 2
 
       - name: Copy docs
-        if: env.CAN_DEPLOY == 'true'
         run: |
           # For some reason the deploy step below cannot find /sage/...
           # So copy everything from there to local folder
@@ -42,18 +39,8 @@ jobs:
           mkdir -p ./docs
           cp -r -L /sage/local/share/doc/sage/html/en/* ./docs
 
-      - name: Deploy to Netlify production
-        id: deploy-netlify
-        if: env.CAN_DEPLOY == 'true'
-        uses: netlify/actions/cli@master
+      - name: Upload docs
+        uses: actions/upload-artifact@v2
         with:
-          args: deploy --dir=docs ${NETLIFY_PRODUCTION:+"--prod"}
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_PRODUCTION: ${{ github.ref == 'refs/heads/develop' }}
-
-      - name: Report deployment url
-        if: env.CAN_DEPLOY == 'true'
-        run: |
-          echo "::notice::The documentation has being automatically deployed to Netlify. %0A ✅ Preview: ${{ steps.deploy-netlify.outputs.NETLIFY_URL }}"
+          name: docs
+          path: docs/

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -47,7 +47,7 @@ jobs:
         if: env.CAN_DEPLOY == 'true'
         uses: netlify/actions/cli@master
         with:
-          args: deploy --dir=docs --prod="${NETLIFY_PRODUCTION}"
+          args: deploy --dir=docs ${NETLIFY_PRODUCTION:+"--prod"}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Prepare
         run: |
+          apt-get update && apt-get install -y zip
           # Reuse built SAGE_LOCAL contained in the Docker image
           ./bootstrap
           ./configure --enable-build-as-root --prefix=/sage/local --with-sage-venv --enable-download-from-upstream-url

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -37,13 +37,13 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/docs.zip', Buffer.from(download.data));
       - name: Extract docs
-        run: unzip docs.zip
+        run: unzip docs.zip && unzip docs/docs.zip
 
       - name: Deploy to Netlify production
         id: deploy-netlify
         uses: netlify/actions/cli@master
         with:
-          args: deploy --dir=docs ${NETLIFY_PRODUCTION:+"--prod"}
+          args: deploy --dir=docs/docs ${NETLIFY_PRODUCTION:+"--prod"}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -1,3 +1,5 @@
+# Triggers after the documentation build has finished, 
+# taking the artifact and uploading it to netlify
 name: Publish documentation
 
 on:
@@ -11,7 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      # Once https://github.com/actions/download-artifact/issues/172 is implemented, we can use the official download-artifact action
+      - name: Get information about workflow origin
+        uses: potiuk/get-workflow-origin@v1_5
+        id: source-run-info
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+
+      # Once https://github.com/actions/download-artifact/issues/172 and/or https://github.com/actions/download-artifact/issues/60 is implemented, we can use the official download-artifact action
       # For now use the solution from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
       - name: Download docs
         uses: actions/github-script@v3.1.0
@@ -33,18 +42,47 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/docs.zip', Buffer.from(download.data));
+      
       - name: Extract docs
         run: unzip docs.zip -d docs && unzip docs/docs.zip -d docs/docs
 
-      - name: Deploy to Netlify production
+      - name: Deploy to Netlify
         id: deploy-netlify
         uses: netlify/actions/cli@master
         with:
-          args: deploy --dir=docs/docs ${NETLIFY_PRODUCTION:+"--prod"}
+          args: deploy --dir=docs/docs/docs ${NETLIFY_PRODUCTION:+"--prod"} --message ${NETLIFY_MESSAGE} --alias ${NETLIFY_ALIAS}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_PRODUCTION: ${{ github.ref == 'refs/heads/develop' }}
+          NETLIFY_MESSAGE: ${{ source-run-info.outputs.pullRequestNumber }}
+          NETLIFY_ALIAS: deploy-preview-${{ source-run-info.outputs.pullRequestNumber }}
+
+      # Add deployment as status check, PR comment and annotation
+      # we could use the nwtgck/actions-netlify action for that, except for that it is not (yet) working in workflow_run context: https://github.com/nwtgck/actions-netlify/issues/545
+      - name: Add/Update deployment status PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ source-run-info.outputs.pullRequestNumber }}
+          header: preview-comment
+          recreate: true
+          message: |
+            [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}) is ready! :tada:
+            Built with commit: ${{ env.PR_HEADSHA }}
+      
+      - name: Update deployment status PR check
+        uses: myrotvorets/set-commit-status-action@1.1.6
+        if: ${{ always() }}
+        env:
+          DEPLOY_SUCCESS: Successfully deployed preview.
+          DEPLOY_FAILURE: Failed to deploy preview.
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+          context: Deploy Documentation
+          targetUrl: ${{ steps.deploy-netlify.outputs.NETLIFY_URL }}
+          description: ${{ job.status == 'success' && env.DEPLOY_SUCCESS || env.DEPLOY_FAILURE }}
 
       - name: Report deployment url
         run: |

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -73,7 +73,7 @@ jobs:
           recreate: true
           message: |
             [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}) is ready! :tada:
-            Built with commit: ${{ env.PR_HEADSHA }}
+            Built with commit: ${{ steps.source-run-info.outputs.sourceHeadSha }}
       
       - name: Update deployment status PR check
         uses: myrotvorets/set-commit-status-action@1.1.6

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -55,15 +55,15 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_PRODUCTION: ${{ github.ref == 'refs/heads/develop' }}
-          NETLIFY_MESSAGE: ${{ source-run-info.outputs.pullRequestNumber }}
-          NETLIFY_ALIAS: deploy-preview-${{ source-run-info.outputs.pullRequestNumber }}
+          NETLIFY_MESSAGE: ${{ steps.source-run-info.outputs.pullRequestNumber }}
+          NETLIFY_ALIAS: deploy-preview-${{ steps.source-run-info.outputs.pullRequestNumber }}
 
       # Add deployment as status check, PR comment and annotation
       # we could use the nwtgck/actions-netlify action for that, except for that it is not (yet) working in workflow_run context: https://github.com/nwtgck/actions-netlify/issues/545
       - name: Add/Update deployment status PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ source-run-info.outputs.pullRequestNumber }}
+          number: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           header: preview-comment
           recreate: true
           message: |

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Deploy to Netlify production
         id: deploy-netlify
-        if: env.CAN_DEPLOY == 'true'
         uses: netlify/actions/cli@master
         with:
           args: deploy --dir=docs ${NETLIFY_PRODUCTION:+"--prod"}
@@ -51,7 +50,6 @@ jobs:
           NETLIFY_PRODUCTION: ${{ github.ref == 'refs/heads/develop' }}
 
       - name: Report deployment url
-        if: env.CAN_DEPLOY == 'true'
         run: |
           echo "::notice::The documentation has being automatically deployed to Netlify. %0A ✅ Preview: ${{ steps.deploy-netlify.outputs.NETLIFY_URL }}"
 

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -12,7 +12,9 @@ jobs:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
-      secrets.NETLIFY_AUTH_TOKEN != ''
+      env.NETLIFY_AUTH_TOKEN_PRESENT
+    env:
+      NETLIFY_AUTH_TOKEN_PRESENT: ${{ secrets.NETLIFY_AUTH_TOKEN != '' }}
     steps:
       # Once https://github.com/actions/download-artifact/issues/172 is implemented, we can use the official download-artifact action
       # For now use the solution from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -1,0 +1,57 @@
+name: Publish documentation
+
+on:
+  workflow_run:
+    workflows: ["Build documentation"]
+    types:
+      - completed
+
+jobs:
+  upload-docs:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      secrets.NETLIFY_AUTH_TOKEN != ''
+    steps:
+      # Once https://github.com/actions/download-artifact/issues/172 is implemented, we can use the official download-artifact action
+      # For now use the solution from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+      - name: Download docs
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "docs"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/docs.zip', Buffer.from(download.data));
+      - name: Extract docs
+        run: unzip docs.zip
+
+      - name: Deploy to Netlify production
+        id: deploy-netlify
+        if: env.CAN_DEPLOY == 'true'
+        uses: netlify/actions/cli@master
+        with:
+          args: deploy --dir=docs ${NETLIFY_PRODUCTION:+"--prod"}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_PRODUCTION: ${{ github.ref == 'refs/heads/develop' }}
+
+      - name: Report deployment url
+        if: env.CAN_DEPLOY == 'true'
+        run: |
+          echo "::notice::The documentation has being automatically deployed to Netlify. %0A ✅ Preview: ${{ steps.deploy-netlify.outputs.NETLIFY_URL }}"
+

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -8,6 +8,11 @@ on:
     types:
       - completed
 
+permissions:
+  statuses: write
+  checks: write
+  pull-requests: write
+
 jobs:
   upload-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -9,9 +9,7 @@ on:
 jobs:
   upload-docs:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       # Once https://github.com/actions/download-artifact/issues/172 is implemented, we can use the official download-artifact action
       # For now use the solution from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -34,7 +34,7 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/docs.zip', Buffer.from(download.data));
       - name: Extract docs
-        run: unzip docs.zip && unzip docs/docs.zip
+        run: unzip docs.zip -d docs && unzip docs/docs.zip -d docs/docs
 
       - name: Deploy to Netlify production
         id: deploy-netlify

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -11,10 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      env.NETLIFY_AUTH_TOKEN_PRESENT
-    env:
-      NETLIFY_AUTH_TOKEN_PRESENT: ${{ secrets.NETLIFY_AUTH_TOKEN != '' }}
+      github.event.workflow_run.conclusion == 'success'
     steps:
       # Once https://github.com/actions/download-artifact/issues/172 is implemented, we can use the official download-artifact action
       # For now use the solution from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow


### PR DESCRIPTION
Normally, on github, netlify takes care of the build + deploy fully automatically. However, our build takes to long so that we would hit the free build mins relatively quickly. So we continue deploying the docs via github actions. But PR workflows don't have access to secrets, so we need to split the upload of the docs in a new workflow, see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/. 

Moreover, the netlify deploy cli doesn't take care of adding a PR comment and status check linking to the deployed website (netlify does this automatically if it would build + deploy the page). So we add this functionality manually.