### PR TITLE
add missing #long time markers to ell_number_field

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -2301,9 +2301,9 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Check that the the point found has infinite order, and that it is on the curve::
 
-            sage: P=gg[0]; P.order()
+            sage: P=gg[0]; P.order()  # long time
             +Infinity
-            sage: E.defining_polynomial()(*P)
+            sage: E.defining_polynomial()(*P)  # long time
             0
 
         Here is a curve of rank 2::


### PR DESCRIPTION
Fixes #34959.

It would be nice if this could be merged quickly as this (I think) is making CI tests fail on all PRs.