### PR TITLE
fix doctests to support numpy 1.24

### DIFF
--- a/src/sage/misc/persist.pyx
+++ b/src/sage/misc/persist.pyx
@@ -157,7 +157,7 @@ def load(*filename, compress=True, verbose=True, **kwargs):
         ....:     _ = f.write(code)
         sage: load(t)
         sage: hello
-        <fortran object>
+        <fortran ...>
     """
     import sage.repl.load
     if len(filename) != 1:

--- a/src/sage/plot/complex_plot.pyx
+++ b/src/sage/plot/complex_plot.pyx
@@ -461,6 +461,8 @@ def complex_to_rgb(z_values, contoured=False, tiled=False,
             rgb[i, j, 2] = b
 
     sig_off()
+    nan_indices = np.isnan(rgb).any(-1)     # Mask for undefined points
+    rgb[nan_indices] = 1                    # Make nan_indices white
     return rgb
 
 

--- a/src/sage/plot/histogram.py
+++ b/src/sage/plot/histogram.py
@@ -87,13 +87,8 @@ class Histogram(GraphicPrimitive):
 
         TESTS::
 
-            sage: h = histogram([10,3,5], normed=True)[0]
-            doctest:warning...:
-            DeprecationWarning: the 'normed' option is deprecated. Use 'density' instead.
-            See https://github.com/sagemath/sage/issues/25260 for details.
+            sage: h = histogram([10,3,5], density=True)[0]
             sage: h.get_minmax_data()
-            doctest:warning ...
-            ...VisibleDeprecationWarning: Passing `normed=True` on non-uniform bins has always been broken, and computes neither the probability density function nor the probability mass function. The result is only correct if the bins are uniform, when density=True will produce the same result anyway. The argument will be removed in a future version of numpy.
             {'xmax': 10.0, 'xmin': 3.0, 'ymax': 0.476190476190..., 'ymin': 0}
         """
         import numpy

--- a/src/sage/repl/ipython_extension.py
+++ b/src/sage/repl/ipython_extension.py
@@ -405,7 +405,7 @@ class SageMagics(Magics):
             ....: C END FILE FIB1.F
             ....: ''')
             sage: fib
-            <fortran object>
+            <fortran ...>
             sage: from numpy import array
             sage: a = array(range(10), dtype=float)
             sage: fib(a, 10)


### PR DESCRIPTION
Taken from #34816.

This is necessary when system numpy is 1.24, and a prerequiste to update numpy in sagemath.

It's probably safer at this time to merge this and leave the update for next release.

Testing: https://github.com/void-linux/void-packages/pull/42048

Depends on #35015