### PR TITLE
Support for tachyon >= 0.99.2

### DIFF
--- a/src/sage/interfaces/tachyon.py
+++ b/src/sage/interfaces/tachyon.py
@@ -683,12 +683,14 @@ properly.
 #*****************************************************************************
 
 import os
+import re
 
 from sage.cpython.string import bytes_to_str
 from sage.misc.pager import pager
 from sage.misc.superseded import deprecation
 from sage.misc.temporary_file import tmp_filename
 from sage.structure.sage_object import SageObject
+from sage.misc.cachefunc import cached_method
 
 
 class TachyonRT(SageObject):
@@ -799,6 +801,11 @@ class TachyonRT(SageObject):
             Parser failed due to an input file syntax error.
             Aborting render.
         """
+        if self.version() >= '0.99.2':
+            # this keyword was changed in 0.99.2
+            model = model.replace(
+                    "              focallength ",
+                    "              focaldist ")
         modelfile = tmp_filename(ext='.dat')
         with open(modelfile, 'w') as file:
             file.write(model)
@@ -850,6 +857,22 @@ class TachyonRT(SageObject):
             pager()(r)
         else:
             print(r)
+
+    @cached_method
+    def version(self):
+        """
+        Returns the version of the Tachyon raytracer being used.
+
+        TESTS::
+
+            sage: tachyon_rt.version()  # not tested
+            0.98.9
+            sage: tachyon_rt.version() >= '0.98.9'
+            True
+        """
+        with os.popen('tachyon') as f:
+            r = f.read()
+        return re.search(r"Version ([\d.]*)", r)[1]
 
     def help(self, use_pager=True):
         """

--- a/src/sage/interfaces/tachyon.py
+++ b/src/sage/interfaces/tachyon.py
@@ -865,14 +865,17 @@ class TachyonRT(SageObject):
 
         TESTS::
 
-            sage: tachyon_rt.version()  # not tested
+            sage: tachyon_rt.version()  # random
             0.98.9
             sage: tachyon_rt.version() >= '0.98.9'
             True
         """
         with os.popen('tachyon') as f:
-            r = f.read()
-        return re.search(r"Version ([\d.]*)", r)[1]
+            r = f.readline()
+        res = re.search(r"Version ([\d.]*)", r)
+        # debian patches tachyon so it won't report the version
+        # we hardcode '0.99' since that's indeed the version they ship
+        return res[1] if res else '0.99'
 
     def help(self, use_pager=True):
         """


### PR DESCRIPTION
Taken from #23712.

This is necessary to support tachyon >= 0.99.2, without losing support for older versions of tachyon.

In case #23712 gets delayed, it'd be nice to include this so nothing breaks if system tachyon is updated. This is the first commit from the branch there which already had positive review (the actual update of tachyon has an issue mentioned in https://github.com/sagemath/sage/issues/23712#issuecomment-1417941925.)

_From the commit log:_

In tachyon 0.99.2 the keyword `focallength` was changed to `focaldist`. To support it, when running on version >= 0.99.2 we "patch" the model as constructed by class `sage.plot.plot3d.tachyon.Tachyon`.

In the future (possibly when tachyon in sage gets upgraded), all the focallength occurences in sage.plot.plot3d.tachyon can be replaced by focaldist for consistency with new tachyon, and the logic here can be reversed (i.e. patch the model when self.version() < '0.99.2') or just drop support for old versions.