### PR TITLE
Enable dependabot for github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enables automatic PRs from dependabot that update the versions of github actions that we use in our workflow. Thus, we no longer need to do this manually.

More details: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates