### PR TITLE
Remove upstream urls from checksums.ini that point to trac

### DIFF
--- a/build/pkgs/giac/checksums.ini
+++ b/build/pkgs/giac/checksums.ini
@@ -2,4 +2,3 @@ tarball=giac-VERSION.tar.bz2
 sha1=78c15badd19b49b7d111ac204b611a4378ce3d15
 md5=8fbd43a5c60848b6813b7fc8698a0199
 cksum=1923149665
-upstream_url=https://trac.sagemath.org/raw-attachment/ticket/31563/giac-VERSION.tar.bz2

--- a/build/pkgs/iml/checksums.ini
+++ b/build/pkgs/iml/checksums.ini
@@ -2,4 +2,3 @@ tarball=iml-VERSION.tar.bz2
 sha1=8aba468a62e6fb0584be9b014350b734663c0670
 md5=a8083e70c0c4378f69eb772c1eeed6f0
 cksum=2793221462
-upstream_url=https://trac.sagemath.org/raw-attachment/ticket/33195/iml-1.0.4p2.tar.bz2

--- a/build/pkgs/mathjax/checksums.ini
+++ b/build/pkgs/mathjax/checksums.ini
@@ -2,4 +2,3 @@ tarball=mathjax-VERSION.tar.gz
 sha1=3f7abecf8cacd7f5d7f9ae6c3baca7739101c17d
 md5=ba1a65ab58aaad6c84f39735c619bc34
 cksum=1142131398
-upstream_url=https://trac.sagemath.org/raw-attachment/ticket/25833/mathjax-3.2.0.tar.gz

--- a/build/pkgs/msolve/checksums.ini
+++ b/build/pkgs/msolve/checksums.ini
@@ -2,4 +2,3 @@ tarball=msolve-VERSION.tar.gz
 sha1=5b227de8b222bfe8d143e1d7ea77ad71cd209dc8
 md5=2f34bd9ccb089688ae169201281108dc
 cksum=941373315
-upstream_url=https://trac.sagemath.org/raw-attachment/ticket/31664/msolve-VERSION.tar.gz


### PR DESCRIPTION
As part of the transition to github, this PR removes some references to the trac server from the Sage source.

### 📚 Description

I split off this PR from the main effort at #35015 since I wasn't sure what to do with some checksum links.  After some discussion, @dimpase and @mkoeppe noted that the links could just be deleted.  This PR will fix #35014.
