### PR TITLE
fix usage of verbose with positional argument

### DIFF
--- a/src/sage/schemes/elliptic_curves/gal_reps.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps.py
@@ -916,14 +916,14 @@ class GaloisRepresentation(SageObject):
                     a_ell = self._E.ap(ell)
                     u = k(a_ell)**2 * k(ell)**(-1)
                     if u == 3:
-                        verbose("found an element of order 6",2)
+                        verbose("found an element of order 6", level=2)
                         # found an element of order 6:
                         self.__image_type[p] = non_split_str
                         return self.__image_type[p]
 
                     if u == 2 and not has_an_el_order_4:
                         # found an element of order 4
-                        verbose("found an element of order 4",2)
+                        verbose("found an element of order 4", level=2)
                         has_an_el_order_4 = True
                         if has_an_el_order_3:
                             self.__image_type[p] = s4_str
@@ -931,13 +931,13 @@ class GaloisRepresentation(SageObject):
 
                     if u == 1 and not has_an_el_order_3:
                         # found an element of order 3
-                        verbose("found an element of order 3",2)
+                        verbose("found an element of order 3", level=2)
                         has_an_el_order_3 = True
                         if has_an_el_order_4:
                             self.__image_type[p] = s4_str
                             return self.__image_type[p]
 
-            verbose("p=5 and we could not determine the image, yet", 2)
+            verbose("p=5 and we could not determine the image, yet", level=2)
             # we have not yet determined the image, there are only the following possible subgroups of PGL_2
             # (unless we were unlucky and none of the elements of order 6 showed up above, for instance)
             # A_4       of order 12 with elements of order 2 and 3
@@ -995,15 +995,15 @@ class GaloisRepresentation(SageObject):
                     u = k(a_ell)**2 * k(ell)**(-1)
                     if (u not in ex_setp) and could_be_exc == 1:
                         # it can not be in the exceptional
-                        verbose("the image cannot be exceptional, found u=%s"%u,2)
+                        verbose("the image cannot be exceptional, found u=%s"%u, level=2)
                         could_be_exc = 0
                     if a_ell != 0 and arith.kronecker(a_ell**2 - 4*ell,p) == 1 and could_be_non_split == 1:
                         # it can not be in the normalizer of the non-split Cartan
-                        verbose("the image cannot be non-split, found u=%s"%u,2)
+                        verbose("the image cannot be non-split, found u=%s"%u, level=2)
                         could_be_non_split = 0
                     if a_ell != 0 and arith.kronecker(a_ell**2 - 4*ell,p) == -1 and could_be_split == 1:
                         # it can not be in the normalizer of the split Cartan
-                        verbose("the image cannot be split, found u=%s"%u,2)
+                        verbose("the image cannot be split, found u=%s"%u, level=2)
                         could_be_split = 0
 
             assert could_be_exc + could_be_split + could_be_non_split  > 0, "bug in image_type."
@@ -1064,7 +1064,7 @@ class GaloisRepresentation(SageObject):
             K = self._E.division_field(p, 'z')
             d = K.absolute_degree()
 
-            verbose("field of degree %s.  try to compute Galois group"%(d),2)
+            verbose("field of degree %s.  try to compute Galois group"%(d), level=2)
             # If the degree is too big, we have no chance at the Galois
             # group.  K.galois_group calls is_galois which used to rely on
             # pari's Galois group computations, so degree < 12


### PR DESCRIPTION
The second argument of verbose is a time, not the level, some calls were incorrectly using a positional argument in this case.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

