### PR TITLE
Implement __getitem__ and alias weight methods for quasimodular forms

### DIFF
--- a/src/sage/modular/quasimodform/element.py
+++ b/src/sage/modular/quasimodform/element.py
@@ -489,7 +489,8 @@ class QuasiModularFormsElement(ModuleElement):
         r"""
         Return the weight of the given quasimodular form.
 
-        Note that the given form must be homogeneous.
+        Note that the given form must be homogeneous. An alias of this method is
+        ``degree``.
 
         EXAMPLES::
 
@@ -500,6 +501,8 @@ class QuasiModularFormsElement(ModuleElement):
             6
             sage: QM(1/2).weight()
             0
+            sage: (QM.0).degree()
+            2
             sage: (QM.0 + QM.1).weight()
             Traceback (most recent call last):
             ...
@@ -509,6 +512,8 @@ class QuasiModularFormsElement(ModuleElement):
             return self.to_polynomial().degree()
         else:
             raise ValueError("the given graded quasiform is not an homogeneous element")
+
+    degree = weight  # alias
 
     def homogeneous_components(self):
         r"""

--- a/src/sage/modular/quasimodform/element.py
+++ b/src/sage/modular/quasimodform/element.py
@@ -24,6 +24,7 @@ from sage.modular.modform.element import GradedModularFormElement
 from sage.structure.element import ModuleElement
 from sage.structure.richcmp import richcmp, op_NE, op_EQ
 
+from sage.rings.integer import Integer
 from sage.rings.polynomial.polynomial_element import Polynomial
 
 class QuasiModularFormsElement(ModuleElement):
@@ -542,6 +543,49 @@ class QuasiModularFormsElement(ModuleElement):
         poly_self = self.to_polynomial()
         pol_hom_comp = poly_self.homogeneous_components()
         return {k: QM.from_polynomial(pol) for k, pol in pol_hom_comp.items()}
+
+    def __getitem__(self, weight):
+        r"""
+        Return the homogeneous component of the given quasimodular form ring
+        element.
+
+        An alias of this method is ``homogeneous_component``.
+
+        EXAMPLES::
+
+            sage: QM = QuasiModularForms(1)
+            sage: E2, E4, E6 = QM.gens()
+            sage: F = E2 + E4*E6 + E2^3*E6
+            sage: F[2]
+            1 - 24*q - 72*q^2 - 96*q^3 - 168*q^4 - 144*q^5 + O(q^6)
+            sage: F[10]
+            1 - 264*q - 135432*q^2 - 5196576*q^3 - 69341448*q^4 - 515625264*q^5 + O(q^6)
+            sage: F[12]
+            1 - 576*q + 21168*q^2 + 308736*q^3 - 15034608*q^4 - 39208320*q^5 + O(q^6)
+            sage: F[4]
+            0
+            sage: F.homogeneous_component(2)
+            1 - 24*q - 72*q^2 - 96*q^3 - 168*q^4 - 144*q^5 + O(q^6)
+
+        TESTS::
+
+            sage: F[x]
+            Traceback (most recent call last):
+            ...
+            KeyError: 'the weight must be an integer'
+            sage: F[-1]
+            Traceback (most recent call last):
+            ...
+            ValueError: the weight must be nonnegative
+        """
+        if not isinstance(weight, (int, Integer)):
+            raise KeyError("the weight must be an integer")
+        if weight < 0:
+            raise ValueError("the weight must be nonnegative")
+        return self.homogeneous_components().get(weight, self.parent().zero())
+
+    homogeneous_component = __getitem__  # alias
+
 
     def serre_derivative(self):
         r"""


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

This PR implements a `__getitem__` method for quasimodular forms ring elements to access their components of a fixed degree. Moreover, the PR defines the alias `degree = weight` (which is the right nomenclature for elements of a graded algebra, as discussed with @fchapoton).

@videlec 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

