### PR TITLE
add lazy_string in matrix2.pyx

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -79,6 +79,7 @@ AUTHORS:
 from cpython cimport *
 from cysignals.signals cimport sig_check
 
+from sage.misc.lazy_string import lazy_string
 from sage.misc.randstate cimport randstate, current_randstate
 from sage.structure.coerce cimport py_scalar_parent
 from sage.structure.sequence import Sequence
@@ -4856,7 +4857,7 @@ cdef class Matrix(Matrix1):
             return K
 
         R = self.base_ring()
-        tm = verbose("computing a right kernel for %sx%s matrix over %s" % (self.nrows(), self.ncols(), R),level=1)
+        tm = verbose(lazy_string("computing a right kernel for %sx%s matrix over %s", self.nrows(), self.ncols(), R), level=1)
 
         # Sanitize basis format
         #   'computed' is OK in right_kernel_matrix(), but not here

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -4879,7 +4879,7 @@ cdef class Matrix(Matrix1):
         else:
             K = ambient.submodule_with_basis(M.rows(), already_echelonized=False, check=False)
 
-        verbose("done computing a right kernel for %sx%s matrix over %s" % (self.nrows(), self.ncols(), R),level=1, t=tm)
+        verbose(lazy_string("done computing a right kernel for %sx%s matrix over %s", self.nrows(), self.ncols(), R), level=1, t=tm)
         self.cache('right_kernel', K)
         return K
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -4853,7 +4853,6 @@ cdef class Matrix(Matrix1):
         """
         K = self.fetch('right_kernel')
         if K is not None:
-            verbose("retrieving cached right kernel for %sx%s matrix" % (self.nrows(), self.ncols()),level=1)
             return K
 
         R = self.base_ring()
@@ -5029,7 +5028,6 @@ cdef class Matrix(Matrix1):
         """
         K = self.fetch('left_kernel')
         if K is not None:
-            verbose("retrieving cached left kernel for %sx%s matrix" % (self.nrows(), self.ncols()),level=1)
             return K
 
         tm = verbose("computing left kernel for %sx%s matrix" % (self.nrows(), self.ncols()),level=1)
@@ -7886,11 +7884,11 @@ cdef class Matrix(Matrix1):
             [ 1.00 0.000  10.0]
             [0.000  1.00  1.00]
         """
-        tm = verbose('generic in-place Gauss elimination on %s x %s matrix using %s algorithm'%(self._nrows, self._ncols, algorithm))
         cdef Py_ssize_t start_row, c, r, nr, nc, i, best_r
         if self.fetch('in_echelon_form'):
             return self.fetch('pivots')
 
+        tm = verbose('generic in-place Gauss elimination on %s x %s matrix using %s algorithm'%(self._nrows, self._ncols, algorithm))
         self.check_mutability()
         cdef Matrix A
 


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

Formatting verbose messages in the method right_kernel could be quite slow (even when the message is never printed). We use the functionality lazy_string in order to avoid the formatting.

Also, just calling `verbose()` is slow when just a cache lookup is needed.

#### Timings

Before:

```
sage: K.<a> = NumberField(x^2 - 2, embedding=1)
sage: A = MatrixSpace(K, 1, 1).one()
sage: %time _ = A.right_kernel()
CPU times: user 23 ms, sys: 3 ms, total: 26 ms
Wall time: 26.1 ms
sage: %timeit A.right_kernel()  # cache lookup
2.16 µs ± 70.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

After:

```
sage: K.<a> = NumberField(x^2 - 2, embedding=1)
sage: A = MatrixSpace(K, 1, 1).one()
sage: %time _ = A.right_kernel()
CPU times: user 11 ms, sys: 10 µs, total: 11 ms
Wall time: 11.2 ms
sage: %timeit A.right_kernel()  # cache lookup
103 ns ± 1.55 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

### 📝 Checklist

- [X] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion. **No**, this was discussed at SageDays 117, we have no linked issue on GitHub for this.
- [x] I have created tests covering the changes. **No**, there are already tests testing that verbose still works correctly.
- [x] I have updated the documentation accordingly. **No**, there are no user-facing changes.

