### PR TITLE
fix the method monomials_of_degree

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -1380,9 +1380,15 @@ cdef class MPolynomialRing_base(sage.rings.ring.CommutativeRing):
             sage: mons = R.monomials_of_degree(2)
             sage: mons
             [z^2, y*z, x*z, y^2, x*y, x^2]
-            sage: P = PolynomialRing(QQ, 3, 'x,y,z', order=TermOrder('wdeglex', [1,2,1]))
+            sage: P = PolynomialRing(QQ, 3, 'x, y, z', order=TermOrder('wdeglex', [1, 2, 1]))
             sage: P.monomials_of_degree(2)
-            [y, z^2, x*z, x^2]
+            [z^2, y, x*z, x^2]
+            sage: P = PolynomialRing(QQ, 3, 'x, y, z', order='lex')
+            sage: P.monomials_of_degree(3)
+            [z^3, y*z^2, y^2*z, y^3, x*z^2, x*y*z, x*y^2, x^2*z, x^2*y, x^3]
+            sage: P = PolynomialRing(QQ, 3, 'x, y, z', order='invlex')
+            sage: P.monomials_of_degree(3)
+            [x^3, x^2*y, x*y^2, y^3, x^2*z, x*y*z, y^2*z, x*z^2, y*z^2, z^3]
 
         The number of such monomials equals `\binom{n+k-1}{k}`
         where `n` is the number of variables and `k` the degree::
@@ -1392,7 +1398,9 @@ cdef class MPolynomialRing_base(sage.rings.ring.CommutativeRing):
         """
         deg_of_gens = [x.degree() for x in self.gens()]
         from sage.combinat.integer_vector_weighted import WeightedIntegerVectors
-        return [self.monomial(*a) for a in WeightedIntegerVectors(degree, deg_of_gens)]
+        mons = [self.monomial(*a) for a in WeightedIntegerVectors(degree, deg_of_gens)]
+        mons.sort()  # This could be implemented in WeightedIntegerVectors instead
+        return mons
 
     def _macaulay_resultant_getS(self, mon_deg_tuple, dlist):
         r"""

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -444,7 +444,7 @@ cdef class MPolynomialRing_base(sage.rings.ring.CommutativeRing):
             1/2*x^3 + x*y + z^2 - 1/2*x + y + 25
 
         .. SEEALSO::
-        
+
             :meth:`lagrange_polynomial<sage.rings.polynomial.polynomial_ring.PolynomialRing_field.lagrange_polynomial>`
         """
         # get ring and number of variables
@@ -1387,8 +1387,9 @@ cdef class MPolynomialRing_base(sage.rings.ring.CommutativeRing):
             sage: len(mons) == binomial(3+2-1,2)
             True
         """
-        from sage.combinat.integer_vector import IntegerVectors
-        return [self.monomial(*a) for a in IntegerVectors(degree, self.ngens())]
+        deg_of_gens = [x.degree() for x in self.gens()]
+        from sage.combinat.integer_vector_weighted import WeightedIntegerVectors
+        return [self.monomial(*a) for a in WeightedIntegerVectors(degree, deg_of_gens)]
 
     def _macaulay_resultant_getS(self, mon_deg_tuple, dlist):
         r"""

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -1379,7 +1379,10 @@ cdef class MPolynomialRing_base(sage.rings.ring.CommutativeRing):
             sage: R.<x,y,z> = ZZ[]
             sage: mons = R.monomials_of_degree(2)
             sage: mons
-            [x^2, x*y, x*z, y^2, y*z, z^2]
+            [z^2, y*z, x*z, y^2, x*y, x^2]
+            sage: P = PolynomialRing(QQ, 3, 'x,y,z', order=TermOrder('wdeglex', [1,2,1]))
+            sage: P.monomials_of_degree(2)
+            [y, z^2, x*z, x^2]
 
         The number of such monomials equals `\binom{n+k-1}{k}`
         where `n` is the number of variables and `k` the degree::


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

Fixes #35042.

The goal of this PR is to fix two bugs of the method `monomials_of_degree`. First, the code does not take into account the case of weighted polynomial ring:
```
sage: P = PolynomialRing(QQ, 3, 'x,y,z', order=TermOrder('wdeglex', [4,5,6]))
sage: P.inject_variables()
Defining x, y, z
sage: x.degree()
4
sage: P.monomials_of_degree(1)
[x, y, z]
```
Next, as pointed out by @videlec, the current list of monomial that is returned is not sorted:
```
sage: R.<x,y,z> = ZZ[]
sage: mons = R.monomials_of_degree(2)
sage: mons
[x^2, x*y, x*z, y^2, y*z, z^2]
sage: sorted(mons)
[z^2, y*z, x*z, y^2, x*y, x^2]
sage: 
```

CC: @videlec, @yyyyx4 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

