### PR TITLE
Add missing commit when building large Cremona database

### DIFF
--- a/src/sage/databases/cremona.py
+++ b/src/sage/databases/cremona.py
@@ -1643,6 +1643,7 @@ class LargeCremonaDatabase(MiniCremonaDatabase):
             con.executemany("UPDATE t_curve SET gens=? WHERE curve=?",
                 curve_data)
             print("Committing...")
+            self.commit()
             if largest_conductor and int(v[0]) > largest_conductor:
                 break
 


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

Building the large Cremona database fails like this on an x86_64 Fedora Rawhide machine.  (I captured the output from an old sagemath 9.6 build, but the same error occurs with sagemath 9.7.)
```
Inserting allgens.90000-99999
Committing...
Traceback (most recent call last):
  File "/builddir/build/BUILD/sage-9.6/cremona.sage.py", line 10, in <module>
    c._init_from_ftpdata('ecdata-2019-10-29')
  File "/builddir/build/BUILDROOT/sagemath-9.6-4.fc38.x86_64/usr/lib64/python3.11/site-packages/sage/databases/cremona.py", line 1397, in _init_from_ftpdata
    self.vacuum()
  File "/builddir/build/BUILDROOT/sagemath-9.6-4.fc38.x86_64/usr/lib64/python3.11/site-packages/sage/databases/sql_db.py", line 2180, in vacuum
    self.__connection__.execute('VACUUM')
sqlite3.OperationalError: cannot VACUUM from within a transaction
```
The issue is a missing database commit, which this PR adds.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

