### PR TITLE
Remove 'docker' from the names of the Docker images published on ghcr.io

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -647,7 +647,7 @@ commands =
     docker-{arm64,armhf}:  docker run --rm --privileged multiarch/qemu-user-static:register --reset
     docker:        bash -c 'if [ x"{env:DOCKER_CONFIG_FILE:}" != x ]; then mkdir -p {envdir}/.docker && ln -sf $(realpath "{env:DOCKER_CONFIG_FILE:}") {envdir}/.docker/; fi'
     docker:        bash -c 'for docker_target in {env:DOCKER_TARGETS:with-targets}; do \
-    docker:            BUILD_IMAGE_STEM=sage-$(echo {envname} | sed s/-incremental//); \
+    docker:            BUILD_IMAGE_STEM=sage-$(echo {envname} | sed "s/-docker//;s/-incremental//"); \
     docker:            BUILD_IMAGE=$DOCKER_PUSH_REPOSITORY$BUILD_IMAGE_STEM-$docker_target; \
     docker:            BUILD_TAG=$(git describe --dirty --always); \
     docker:            TAG_ARGS=$(for tag in $BUILD_TAG {env:EXTRA_DOCKER_TAGS:}; do echo --tag $BUILD_IMAGE:$tag; done); \

--- a/tox.ini
+++ b/tox.ini
@@ -647,7 +647,7 @@ commands =
     docker-{arm64,armhf}:  docker run --rm --privileged multiarch/qemu-user-static:register --reset
     docker:        bash -c 'if [ x"{env:DOCKER_CONFIG_FILE:}" != x ]; then mkdir -p {envdir}/.docker && ln -sf $(realpath "{env:DOCKER_CONFIG_FILE:}") {envdir}/.docker/; fi'
     docker:        bash -c 'for docker_target in {env:DOCKER_TARGETS:with-targets}; do \
-    docker:            BUILD_IMAGE_STEM=sage-$(echo {envname} | sed "s/-docker//;s/-incremental//"); \
+    docker:            BUILD_IMAGE_STEM=sage-$(echo {envname} | sed "s/docker-//;s/-incremental//"); \
     docker:            BUILD_IMAGE=$DOCKER_PUSH_REPOSITORY$BUILD_IMAGE_STEM-$docker_target; \
     docker:            BUILD_TAG=$(git describe --dirty --always); \
     docker:            TAG_ARGS=$(for tag in $BUILD_TAG {env:EXTRA_DOCKER_TAGS:}; do echo --tag $BUILD_IMAGE:$tag; done); \


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
We shorten the names of the Docker images generated by our portability tests slightly by removing the redundant word `docker` from it.
<!-- Why is this change required? What problem does it solve? -->
This is done because the previously used names still belong to the old repository (which is now renamed as sagemath/sage-archive-...), and the new repository does not have permissions to push new versions there.
This can be changed package by package in the web interface, but there is no API for doing so and we have over 1000 packages. So instead we change the naming pattern; the removal of the redundant word is a welcome side effect.
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

