### PR TITLE
src/doc/en/developer/portability_testing.rst: Update after migration

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,6 +29,9 @@ env:
   TARGETS: build doc-html
   TARGETS_OPTIONAL: ptest
 
+permissions:
+  packages: write
+
 jobs:
 
   standard-pre:

--- a/src/doc/en/developer/portability_testing.rst
+++ b/src/doc/en/developer/portability_testing.rst
@@ -987,8 +987,7 @@ errors or warnings issued during the build.
 
 In addition to these automatic runs in our main repository, all Sage
 developers can run the same tests on GitHub Actions in their personal
-forks of the Sage repository. To prepare this, `enable GitHub Actions
-  <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository>`_
+forks of the Sage repository. To prepare this, `enable GitHub Actions <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository>`_
 in your fork of the Sage repository.
 
 As usual we assume that ``origin`` is the name of the remote

--- a/src/doc/en/developer/portability_testing.rst
+++ b/src/doc/en/developer/portability_testing.rst
@@ -957,12 +957,15 @@ In particular, it automatically runs on our main repository sagemath/sage
 on every release tag.
 
 This is defined in the files
+
 - `$SAGE_ROOT/.github/workflows/ci-linux.yml
   <https://github.com/sagemath/sage/tree/develop/.github/workflows/ci-linux.yml>`_
   (which calls `$SAGE_ROOT/.github/workflows/docker.yml
   <https://github.com/sagemath/sage/tree/develop/.github/workflows/docker.yml>`_),
+
 - `$SAGE_ROOT/.github/workflows/ci-macos.yml
   <https://github.com/sagemath/sage/tree/develop/.github/workflows/ci-macos.yml>`_, and
+
 - `$SAGE_ROOT/.github/workflows/ci-cygwin-standard.yml
   <https://github.com/sagemath/sage/tree/develop/.github/workflows/ci-cygwin-standard.yml>`_
   (which calls `$SAGE_ROOT/.github/workflows/cygwin.yml

--- a/src/doc/en/developer/portability_testing.rst
+++ b/src/doc/en/developer/portability_testing.rst
@@ -984,15 +984,9 @@ errors or warnings issued during the build.
 
 In addition to these automatic runs in our main repository, all Sage
 developers can run the same tests on GitHub Actions in their personal
-forks of the Sage repository. To prepare this, use the following steps:
-
-- `Enable GitHub Actions
+forks of the Sage repository. To prepare this, `enable GitHub Actions
   <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository>`_
-  in your fork of the Sage repository.
-
-- Given read/write privileges for packages to GitHub Actions in your
-  fork of the Sage repository. See `Permissions for the GITHUB_TOKEN
-  <https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token>`_
+in your fork of the Sage repository.
 
 As usual we assume that ``origin`` is the name of the remote
 corresponding to your GitHub fork of the Sage repository::


### PR DESCRIPTION
…to GitHub (no more sagetrac-mirror)

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description
We update the documentation on portability testing. 
- Instead of referring to trac and sagetrac-mirror, we direct users to use their personal fork
- We remove the description of a method using pull requests because #34942 disabled it
- We update according to changed defaults on GH Actions.
<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

Test running at: https://github.com/mkoeppe/sage/actions/runs/4911075567/jobs/8768884045
(the "standard", "minimal" etc. jobs without "-pre" should now work).

