### PR TITLE
Partly fix conda ci and update python versions tested

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -41,6 +41,13 @@ jobs:
           bash ~/miniconda.sh -b -p $HOME/miniconda
           echo "CONDA=$HOME/miniconda" >> $GITHUB_ENV
 
+      # Workaround for https://github.com/actions/runner-images/issues/6910 / https://github.com/conda/conda/issues/12303
+      - name: Downgrade conda
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          conda config --set allow_conda_downgrades true
+          conda install conda=4.12.0 -y
+
       - name: Create conda environment files
         run: ./bootstrap-conda
 

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: [3.8, 3.9]
+        python: [3.9, 3.10, 3.11]
         conda-env: [environment, environment-optional]
 
     steps:

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: [3.9, 3.10, 3.11]
+        python: ['3.9', '3.10', '3.11']
         conda-env: [environment, environment-optional]
 
     steps:


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

Currently, the conda ci workflow fails on ubuntu (https://github.com/sagemath/sage/actions/runs/4158846126/jobs/7194339951) due to https://github.com/conda/conda/issues/12303 and/or https://github.com/actions/runner-images/issues/6910. We fix this for the time being by downgrading conda to 4.12 as recommended in https://github.com/actions/runner-images/issues/6910#issuecomment-1382071459.

Moreover, the python versions tested is updated to >= 3.9.

This doesn't completely fix the conda workflow though. There seem to be quite a few upstream issues as revealed in https://github.com/tobiasdiez/sage/actions/runs/4160653080:

- package pytz-deprecation-shim-0.1.0.post0-py310hff52083_1 requires python_abi 3.10.* *_cp310, but none of the providers can be installed (on python 3.9)
- package dot2tex-2.11.3-pyhd8ed1ab_0 requires python >=3.8, but none of the providers can be installed (this is strange as python version is actually >=3.9)
- package python-2.7.14-0 requires readline 6.2*, but none of the providers can be installed (not sure who pulls in python 2.7)
- package python-3.11.0-h582c2e5_0_cpython requires libzlib >=1.2.13,<1.3.0a0, but none of the providers can be installed
- package memory-allocator-0.1.1-py310h6acc77f_1 requires python_abi 3.10.* *_cp310, but none of the providers can be installed (on python 3.11)
- package rpy2-2.9.4-py37r341h941a26a_1 requires readline >=7.0,<8.0a0, but none of the providers can be installed
- package mathics3-1.1.0-py36h20b66c6_2 requires python_abi 3.6.* *_cp36m, but none of the providers can be installed
- package primecountpy-0.1.0-py310h2fea185_1 requires python_abi 3.10.* *_cp310, but none of the providers can be installed (on python 3.11)
- package pynormaliz-2.17-py311hc4645bb_1 requires python_abi 3.11.* *_cp311, but none of the providers can be installed (strangly this was on python 3.11)

Maybe some of these are related to https://github.com/sagemath/sage/issues/34776. CC: @isuruf

But at least now the standard build on python 3.9 and 3.10 starts, so I would propose to get this in and then work in follow-up PRs on fixing the remaining issues.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

