### PR TITLE
`sage.sets.family`: Cythonize; change `MIPVariable` to a subclass of `FiniteFamily`

### DIFF
--- a/src/sage/combinat/root_system/type_relabel.py
+++ b/src/sage/combinat/root_system/type_relabel.py
@@ -10,7 +10,7 @@ Root system data for relabelled Cartan types
 
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_attribute import lazy_attribute
-from sage.sets.family import FiniteFamily
+from sage.sets.family import Family, FiniteFamily
 from sage.combinat.root_system import cartan_type
 from sage.combinat.root_system import ambient_space
 from sage.combinat.root_system.root_lattice_realizations import RootLatticeRealizations
@@ -173,10 +173,10 @@ class CartanType(cartan_type.CartanType_decorator):
             sage: rI5 = CartanType(['I',5]).relabel({1:0,2:1})
             sage: rI5.root_system().ambient_space()
         """
-        assert isinstance(relabelling, FiniteFamily)
         cartan_type.CartanType_decorator.__init__(self, type)
-        self._relabelling = relabelling._dictionary
-        self._relabelling_inverse = relabelling.inverse_family()._dictionary
+        relabelling = Family(relabelling)
+        self._relabelling = dict(relabelling.items())
+        self._relabelling_inverse = dict(relabelling.inverse_family().items())
         self._index_set = tuple(sorted(relabelling[i] for i in type.index_set()))
         # TODO: design an appropriate infrastructure to handle this
         # automatically? Maybe using categories and axioms?

--- a/src/sage/numerical/mip.pxd
+++ b/src/sage/numerical/mip.pxd
@@ -3,8 +3,11 @@ cdef extern from *:
     cdef int REAL = -1
     cdef int INTEGER = 0
 
+from sage.sets.family cimport FiniteFamily
 from sage.structure.sage_object cimport SageObject
 from sage.numerical.backends.generic_backend cimport GenericBackend
+
+
 cdef class MIPVariable
 
 
@@ -26,10 +29,8 @@ cdef class MixedIntegerLinearProgram(SageObject):
     cpdef sum(self, L) noexcept
 
 
-cdef class MIPVariable(SageObject):
+cdef class MIPVariable(FiniteFamily):
     cdef MixedIntegerLinearProgram _p
-    cdef dict _dict
-    cdef bint _dynamic_indices
     cdef int _vtype
     cdef str _name
     cdef object _lower_bound

--- a/src/sage/numerical/mip.pxd
+++ b/src/sage/numerical/mip.pxd
@@ -3,7 +3,7 @@ cdef extern from *:
     cdef int REAL = -1
     cdef int INTEGER = 0
 
-from sage.sets.family cimport FiniteFamily
+from sage.sets.family cimport FiniteFamily_base
 from sage.structure.sage_object cimport SageObject
 from sage.numerical.backends.generic_backend cimport GenericBackend
 
@@ -29,7 +29,7 @@ cdef class MixedIntegerLinearProgram(SageObject):
     cpdef sum(self, L) noexcept
 
 
-cdef class MIPVariable(FiniteFamily):
+cdef class MIPVariable(FiniteFamily_base):
     cdef MixedIntegerLinearProgram _p
     cdef int _vtype
     cdef str _name

--- a/src/sage/numerical/mip.pxd
+++ b/src/sage/numerical/mip.pxd
@@ -3,7 +3,7 @@ cdef extern from *:
     cdef int REAL = -1
     cdef int INTEGER = 0
 
-from sage.sets.family cimport FiniteFamily_base
+from sage.sets.family cimport FiniteFamily
 from sage.structure.sage_object cimport SageObject
 from sage.numerical.backends.generic_backend cimport GenericBackend
 
@@ -29,7 +29,7 @@ cdef class MixedIntegerLinearProgram(SageObject):
     cpdef sum(self, L) noexcept
 
 
-cdef class MIPVariable(FiniteFamily_base):
+cdef class MIPVariable(FiniteFamily):
     cdef MixedIntegerLinearProgram _p
     cdef int _vtype
     cdef str _name

--- a/src/sage/numerical/mip.pyx
+++ b/src/sage/numerical/mip.pyx
@@ -3237,7 +3237,7 @@ class MIPSolverException(RuntimeError):
     pass
 
 
-cdef class MIPVariable(FiniteFamily):
+cdef class MIPVariable(FiniteFamily_base):
     r"""
     ``MIPVariable`` is a variable used by the class
     ``MixedIntegerLinearProgram``.

--- a/src/sage/numerical/mip.pyx
+++ b/src/sage/numerical/mip.pyx
@@ -3237,7 +3237,7 @@ class MIPSolverException(RuntimeError):
     pass
 
 
-cdef class MIPVariable(FiniteFamily_base):
+cdef class MIPVariable(FiniteFamily):
     r"""
     ``MIPVariable`` is a variable used by the class
     ``MixedIntegerLinearProgram``.

--- a/src/sage/sets/family.pxd
+++ b/src/sage/sets/family.pxd
@@ -5,6 +5,6 @@ cdef class AbstractFamily(Parent):
     cdef public __custom_name
 
 
-cdef class FiniteFamily_base(AbstractFamily):
+cdef class FiniteFamily(AbstractFamily):
     cdef public dict _dictionary
     cdef public object _keys

--- a/src/sage/sets/family.pxd
+++ b/src/sage/sets/family.pxd
@@ -6,5 +6,5 @@ cdef class AbstractFamily(Parent):
 
 
 cdef class FiniteFamily(AbstractFamily):
-    cdef dict _dictionary
-    cdef object _keys
+    cdef public dict _dictionary
+    cdef public object _keys

--- a/src/sage/sets/family.pxd
+++ b/src/sage/sets/family.pxd
@@ -5,6 +5,6 @@ cdef class AbstractFamily(Parent):
     cdef public __custom_name
 
 
-cdef class FiniteFamily(AbstractFamily):
+cdef class FiniteFamily_base(AbstractFamily):
     cdef public dict _dictionary
     cdef public object _keys

--- a/src/sage/sets/family.pxd
+++ b/src/sage/sets/family.pxd
@@ -1,0 +1,10 @@
+from sage.structure.parent cimport Parent
+
+
+cdef class AbstractFamily(Parent):
+    cdef public __custom_name
+
+
+cdef class FiniteFamily(AbstractFamily):
+    cdef dict _dictionary
+    cdef object _keys

--- a/src/sage/sets/family.pxd
+++ b/src/sage/sets/family.pxd
@@ -3,6 +3,7 @@ from sage.structure.parent cimport Parent
 
 cdef class AbstractFamily(Parent):
     cdef public __custom_name
+    cdef dict __dict__  # enables Python attributes as needed for EnumeratedSets()
 
 
 cdef class FiniteFamily(AbstractFamily):

--- a/src/sage/sets/family.pyx
+++ b/src/sage/sets/family.pyx
@@ -49,13 +49,13 @@ from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.categories.infinite_enumerated_sets import InfiniteEnumeratedSets
 from sage.misc.cachefunc import cached_method
 from sage.misc.call import AttrCallObject
-from sage.misc.lazy_import import lazy_import
+from sage.misc.lazy_import import LazyImport
 from sage.rings.infinity import Infinity
 from sage.rings.integer import Integer
 from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
 from sage.sets.non_negative_integers import NonNegativeIntegers
 
-lazy_import('sage.combinat.combinat', 'CombinatorialClass')
+CombinatorialClass = LazyImport('sage.combinat.combinat', 'CombinatorialClass')
 
 
 def Family(indices, function=None, hidden_keys=[], hidden_function=None, lazy=False, name=None):

--- a/src/sage/sets/family.pyx
+++ b/src/sage/sets/family.pyx
@@ -22,10 +22,16 @@ Check :trac:`12482` (shall be run in a fresh session)::
     Category of finite enumerated sets
 """
 
-# ****************************************************************************
-#       Copyright (C) 2008 Nicolas Thiery <nthiery at users.sf.net>,
-#                          Mike Hansen <mhansen@gmail.com>,
-#                          Florent Hivert <Florent.Hivert@univ-rouen.fr>
+# *****************************************************************************
+#       Copyright (C) 2008-2017 Nicolas Thiery <nthiery at users.sf.net>
+#                     2008-2009 Mike Hansen <mhansen@gmail.com>
+#                     2008-2010 Florent Hivert <Florent.Hivert@univ-rouen.fr>
+#                     2013-2021 Travis Scrimshaw
+#                     2014      Nathann Cohen
+#                     2017      Erik M. Bray
+#                     2018      Frédéric Chapoton
+#                     2019      Markus Wageringel
+#                     2022      Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/sage/sets/family.pyx
+++ b/src/sage/sets/family.pyx
@@ -31,7 +31,7 @@ Check :trac:`12482` (shall be run in a fresh session)::
 #                     2017      Erik M. Bray
 #                     2018      Frédéric Chapoton
 #                     2019      Markus Wageringel
-#                     2022      Matthias Koeppe
+#                     2022-2023 Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -834,7 +834,6 @@ cdef class FiniteFamily(AbstractFamily):
         self.__init__(state['dictionary'], keys=state.get("keys"))
 
 
-
 class FiniteFamilyWithHiddenKeys(FiniteFamily):
     r"""
     A close variant of :class:`FiniteFamily` where the family contains some
@@ -876,7 +875,7 @@ class FiniteFamilyWithHiddenKeys(FiniteFamily):
             KeyError
         """
         try:
-            return super().__getitem__(i)
+            return FiniteFamily.__getitem__(self, i)
         except KeyError:
             try:
                 return self.hidden_dictionary[i]
@@ -930,7 +929,7 @@ class FiniteFamilyWithHiddenKeys(FiniteFamily):
             6
         """
         hidden_function = d['hidden_function']
-        if isinstance(hidden_function, str):
+        if isinstance(hidden_function, (str, bytes)):
             # Let's assume that hidden_function is an unpickled function.
             from sage.misc.fpickle import unpickle_function
             hidden_function = unpickle_function(hidden_function)

--- a/src/sage/sets/family.pyx
+++ b/src/sage/sets/family.pyx
@@ -540,48 +540,10 @@ cdef class AbstractFamily(Parent):
 
 
 
-cdef class FiniteFamily(AbstractFamily):
+cdef class FiniteFamily_base(AbstractFamily):
     r"""
-    A :class:`FiniteFamily` is an associative container which models a finite
-    family `(f_i)_{i \in I}`. Its elements `f_i` are therefore its
-    values. Instances should be created via the :func:`Family` factory. See its
-    documentation for examples and tests.
-
-    EXAMPLES:
-
-    We define the family `(f_i)_{i \in \{3,4,7\}}` with `f_3=a`,
-    `f_4=b`, and `f_7=d`::
-
-        sage: from sage.sets.family import FiniteFamily
-        sage: f = FiniteFamily({3: 'a', 4: 'b', 7: 'd'})
-
-    Individual elements are accessible as in a usual dictionary::
-
-        sage: f[7]
-        'd'
-
-    And the other usual dictionary operations are also available::
-
-        sage: len(f)
-        3
-        sage: f.keys()
-        [3, 4, 7]
-
-    However f behaves as a container for the `f_i`'s::
-
-        sage: list(f)
-        ['a', 'b', 'd']
-        sage: [ x for x in f ]
-        ['a', 'b', 'd']
-
-    The order of the elements can be specified using the ``keys`` optional argument::
-
-        sage: f = FiniteFamily({"a": "aa", "b": "bb", "c" : "cc" }, keys = ["c", "a", "b"])
-        sage: list(f)
-        ['cc', 'aa', 'bb']
-
+    Cython base class for :class:`FiniteFamily`.
     """
-
     def __init__(self, dictionary, keys=None):
         """
         TESTS::
@@ -717,8 +679,8 @@ cdef class FiniteFamily(AbstractFamily):
             False
         """
         return (isinstance(other, self.__class__) and
-                self._keys == (<FiniteFamily> other)._keys and
-                self._dictionary == (<FiniteFamily> other)._dictionary)
+                self._keys == (<FiniteFamily_base> other)._keys and
+                self._dictionary == (<FiniteFamily_base> other)._dictionary)
 
     def _repr_(self):
         """
@@ -833,6 +795,49 @@ cdef class FiniteFamily(AbstractFamily):
         """
         self.__init__(state['dictionary'], keys=state.get("keys"))
 
+
+class FiniteFamily(FiniteFamily_base):
+    r"""
+    A :class:`FiniteFamily` is an associative container which models a finite
+    family `(f_i)_{i \in I}`. Its elements `f_i` are therefore its
+    values. Instances should be created via the :func:`Family` factory. See its
+    documentation for examples and tests.
+
+    EXAMPLES:
+
+    We define the family `(f_i)_{i \in \{3,4,7\}}` with `f_3=a`,
+    `f_4=b`, and `f_7=d`::
+
+        sage: from sage.sets.family import FiniteFamily
+        sage: f = FiniteFamily({3: 'a', 4: 'b', 7: 'd'})
+
+    Individual elements are accessible as in a usual dictionary::
+
+        sage: f[7]
+        'd'
+
+    And the other usual dictionary operations are also available::
+
+        sage: len(f)
+        3
+        sage: f.keys()
+        [3, 4, 7]
+
+    However f behaves as a container for the `f_i`'s::
+
+        sage: list(f)
+        ['a', 'b', 'd']
+        sage: [ x for x in f ]
+        ['a', 'b', 'd']
+
+    The order of the elements can be specified using the ``keys`` optional argument::
+
+        sage: f = FiniteFamily({"a": "aa", "b": "bb", "c" : "cc" }, keys = ["c", "a", "b"])
+        sage: list(f)
+        ['cc', 'aa', 'bb']
+
+    """
+    pass
 
 class FiniteFamilyWithHiddenKeys(FiniteFamily):
     r"""

--- a/src/sage/sets/family.pyx
+++ b/src/sage/sets/family.pyx
@@ -38,18 +38,17 @@ from copy import copy
 from pprint import pformat, saferepr
 from collections.abc import Iterable
 
-from sage.misc.abstract_method import abstract_method
-from sage.misc.cachefunc import cached_method
-from sage.structure.parent import Parent
 from sage.categories.enumerated_sets import EnumeratedSets
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.categories.infinite_enumerated_sets import InfiniteEnumeratedSets
-from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
-from sage.misc.lazy_import import lazy_import
-from sage.rings.integer import Integer
+from sage.misc.cachefunc import cached_method
 from sage.misc.call import AttrCallObject
-from sage.sets.non_negative_integers import NonNegativeIntegers
+from sage.misc.lazy_import import lazy_import
 from sage.rings.infinity import Infinity
+from sage.rings.integer import Integer
+from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
+from sage.sets.non_negative_integers import NonNegativeIntegers
+
 lazy_import('sage.combinat.combinat', 'CombinatorialClass')
 
 
@@ -396,8 +395,7 @@ def Family(indices, function=None, hidden_keys=[], hidden_function=None, lazy=Fa
                 return TrivialFamily(indices)
             if isinstance(indices, (FiniteFamily, LazyFamily, TrivialFamily)):
                 return indices
-            if (indices in EnumeratedSets()
-                    or isinstance(indices, CombinatorialClass)):
+            if indices in EnumeratedSets():
                 return EnumeratedFamily(indices)
             if isinstance(indices, Iterable):
                 return TrivialFamily(indices)
@@ -418,7 +416,7 @@ def Family(indices, function=None, hidden_keys=[], hidden_function=None, lazy=Fa
                                       keys=indices)
 
 
-class AbstractFamily(Parent):
+cdef class AbstractFamily(Parent):
     """
     The abstract class for family
 
@@ -436,7 +434,6 @@ class AbstractFamily(Parent):
         """
         return []
 
-    @abstract_method
     def keys(self):
         """
         Return the keys of the family.
@@ -447,8 +444,8 @@ class AbstractFamily(Parent):
             sage: sorted(f.keys())
             [3, 4, 7]
         """
+        raise NotImplementedError
 
-    @abstract_method(optional=True)
     def values(self):
         """
         Return the elements (values) of this family.
@@ -459,6 +456,7 @@ class AbstractFamily(Parent):
             sage: sorted(f.values())
             ['aa', 'bb', 'cc']
         """
+        raise NotImplementedError
 
     def items(self):
         """
@@ -535,7 +533,8 @@ class AbstractFamily(Parent):
         return Family({self[k]: k for k in self.keys()})
 
 
-class FiniteFamily(AbstractFamily):
+
+cdef class FiniteFamily(AbstractFamily):
     r"""
     A :class:`FiniteFamily` is an associative container which models a finite
     family `(f_i)_{i \in I}`. Its elements `f_i` are therefore its
@@ -712,8 +711,8 @@ class FiniteFamily(AbstractFamily):
             False
         """
         return (isinstance(other, self.__class__) and
-                self._keys == other._keys and
-                self._dictionary == other._dictionary)
+                self._keys == (<FiniteFamily> other)._keys and
+                self._dictionary == (<FiniteFamily> other)._dictionary)
 
     def _repr_(self):
         """
@@ -829,6 +828,7 @@ class FiniteFamily(AbstractFamily):
         self.__init__(state['dictionary'], keys=state.get("keys"))
 
 
+
 class FiniteFamilyWithHiddenKeys(FiniteFamily):
     r"""
     A close variant of :class:`FiniteFamily` where the family contains some
@@ -869,15 +869,17 @@ class FiniteFamilyWithHiddenKeys(FiniteFamily):
             ...
             KeyError
         """
-        if i in self._dictionary:
-            return self._dictionary[i]
-
-        if i not in self.hidden_dictionary:
-            if i not in self._hidden_keys:
-                raise KeyError
-            self.hidden_dictionary[i] = self.hidden_function(i)
-
-        return self.hidden_dictionary[i]
+        try:
+            return super().__getitem__(i)
+        except KeyError:
+            try:
+                return self.hidden_dictionary[i]
+            except KeyError:
+                if i not in self._hidden_keys:
+                    raise KeyError
+                v = self.hidden_function(i)
+                self.hidden_dictionary[i] = v
+                return v
 
     def hidden_keys(self):
         """
@@ -902,11 +904,11 @@ class FiniteFamilyWithHiddenKeys(FiniteFamily):
         """
         from sage.misc.fpickle import pickle_function
         f = pickle_function(self.hidden_function)
-        return {'dictionary': self._dictionary,
-                'hidden_keys': self._hidden_keys,
-                'hidden_dictionary': self.hidden_dictionary,
-                'hidden_function': f,
-                'keys': self._keys}
+        state = super().__getstate__()
+        state.update({'hidden_keys': self._hidden_keys,
+                      'hidden_dictionary': self.hidden_dictionary,
+                      'hidden_function': f})
+        return state
 
     def __setstate__(self, d):
         """
@@ -1074,7 +1076,7 @@ class LazyFamily(AbstractFamily):
         """
         if self.function_name is not None:
             name = self.function_name + "(i)"
-        elif isinstance(self.function, type(lambda x: 1)):
+        elif isinstance(self.function, types.LambdaType):
             name = self.function.__name__
             name = name + "(i)"
         else:

--- a/src/sage/sets/family.pyx
+++ b/src/sage/sets/family.pyx
@@ -540,10 +540,48 @@ cdef class AbstractFamily(Parent):
 
 
 
-cdef class FiniteFamily_base(AbstractFamily):
+cdef class FiniteFamily(AbstractFamily):
     r"""
-    Cython base class for :class:`FiniteFamily`.
+    A :class:`FiniteFamily` is an associative container which models a finite
+    family `(f_i)_{i \in I}`. Its elements `f_i` are therefore its
+    values. Instances should be created via the :func:`Family` factory. See its
+    documentation for examples and tests.
+
+    EXAMPLES:
+
+    We define the family `(f_i)_{i \in \{3,4,7\}}` with `f_3=a`,
+    `f_4=b`, and `f_7=d`::
+
+        sage: from sage.sets.family import FiniteFamily
+        sage: f = FiniteFamily({3: 'a', 4: 'b', 7: 'd'})
+
+    Individual elements are accessible as in a usual dictionary::
+
+        sage: f[7]
+        'd'
+
+    And the other usual dictionary operations are also available::
+
+        sage: len(f)
+        3
+        sage: f.keys()
+        [3, 4, 7]
+
+    However f behaves as a container for the `f_i`'s::
+
+        sage: list(f)
+        ['a', 'b', 'd']
+        sage: [ x for x in f ]
+        ['a', 'b', 'd']
+
+    The order of the elements can be specified using the ``keys`` optional argument::
+
+        sage: f = FiniteFamily({"a": "aa", "b": "bb", "c" : "cc" }, keys = ["c", "a", "b"])
+        sage: list(f)
+        ['cc', 'aa', 'bb']
+
     """
+
     def __init__(self, dictionary, keys=None):
         """
         TESTS::
@@ -679,8 +717,8 @@ cdef class FiniteFamily_base(AbstractFamily):
             False
         """
         return (isinstance(other, self.__class__) and
-                self._keys == (<FiniteFamily_base> other)._keys and
-                self._dictionary == (<FiniteFamily_base> other)._dictionary)
+                self._keys == (<FiniteFamily> other)._keys and
+                self._dictionary == (<FiniteFamily> other)._dictionary)
 
     def _repr_(self):
         """
@@ -795,49 +833,6 @@ cdef class FiniteFamily_base(AbstractFamily):
         """
         self.__init__(state['dictionary'], keys=state.get("keys"))
 
-
-class FiniteFamily(FiniteFamily_base):
-    r"""
-    A :class:`FiniteFamily` is an associative container which models a finite
-    family `(f_i)_{i \in I}`. Its elements `f_i` are therefore its
-    values. Instances should be created via the :func:`Family` factory. See its
-    documentation for examples and tests.
-
-    EXAMPLES:
-
-    We define the family `(f_i)_{i \in \{3,4,7\}}` with `f_3=a`,
-    `f_4=b`, and `f_7=d`::
-
-        sage: from sage.sets.family import FiniteFamily
-        sage: f = FiniteFamily({3: 'a', 4: 'b', 7: 'd'})
-
-    Individual elements are accessible as in a usual dictionary::
-
-        sage: f[7]
-        'd'
-
-    And the other usual dictionary operations are also available::
-
-        sage: len(f)
-        3
-        sage: f.keys()
-        [3, 4, 7]
-
-    However f behaves as a container for the `f_i`'s::
-
-        sage: list(f)
-        ['a', 'b', 'd']
-        sage: [ x for x in f ]
-        ['a', 'b', 'd']
-
-    The order of the elements can be specified using the ``keys`` optional argument::
-
-        sage: f = FiniteFamily({"a": "aa", "b": "bb", "c" : "cc" }, keys = ["c", "a", "b"])
-        sage: list(f)
-        ['cc', 'aa', 'bb']
-
-    """
-    pass
 
 class FiniteFamilyWithHiddenKeys(FiniteFamily):
     r"""


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description
Fixes #31750

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

