### PR TITLE
`sage.matrix.operation_table`: Modularization and code style fixes

### DIFF
--- a/src/sage/matrix/operation_table.py
+++ b/src/sage/matrix/operation_table.py
@@ -948,44 +948,36 @@ class OperationTable(SageObject):
                    for i in range(self._n) for j in range(self._n)]
         return MS(entries)
 
-    # documentation hack
-    # makes the cmap default argument look nice in the docs
-    # by copying the gist_rainbow object and overriding __repr__
-    gist_rainbow_copy=copy(gist_rainbow)
-    class ReprOverrideLinearSegmentedColormap(gist_rainbow_copy.__class__):
-        def __repr__(self):
-            return "gist_rainbow"
-    gist_rainbow_copy.__class__=ReprOverrideLinearSegmentedColormap
-    
-
-    def color_table(self, element_names=True, cmap=gist_rainbow_copy, **options):
+    def color_table(self, element_names=True, cmap=None, **options):
         r"""
-        Returns a graphic image as a square grid where entries are color coded.
+        Return a graphic image as a square grid where entries are color coded.
 
         INPUT:
 
         - ``element_names`` - (default : ``True``) Whether to display text with element names on the image
 
-        - ``cmap`` - (default : ``gist_rainbow``) colour map for plot, see matplotlib.cm
+        - ``cmap`` - (default: :obj:`matplotlib.cm.gist_rainbow`) color map for plot, see :mod:`matplotlib.cm`
 
-        - ``**options`` - passed on to matrix_plot call
+        - ``**options`` - passed on to :func:`~sage.plot.matrix_plot.matrix_plot`
 
         EXAMPLES::
 
             sage: from sage.matrix.operation_table import OperationTable
-            sage: OTa = OperationTable(SymmetricGroup(3), operation=operator.mul)
-            sage: OTa.color_table()
+            sage: OTa = OperationTable(SymmetricGroup(3), operation=operator.mul)       # optional - sage.plot, sage.groups
+            sage: OTa.color_table()                                                     # optional - sage.plot, sage.groups
             Graphics object consisting of 37 graphics primitives
 
         .. PLOT::
 
             from sage.matrix.operation_table import OperationTable
             OTa = OperationTable(SymmetricGroup(3), operation=operator.mul)
-            sphinx_plot(OTa.color_table(), figsize=(3.0,3.0))
+            sphinx_plot(OTa.color_table(), figsize=(3.0, 3.0))
         """
-        from matplotlib.cm import gist_rainbow, Greys
         from sage.plot.matrix_plot import matrix_plot
         from sage.plot.text import text
+
+        if cmap is None:
+            from matplotlib.cm import gist_rainbow as cmap
 
         # Base matrix plot object, without text
         plot = matrix_plot(Matrix(self._table), cmap=cmap,
@@ -1019,6 +1011,29 @@ class OperationTable(SageObject):
         return plot
 
     def gray_table(self, **options):
+        r"""
+        Return a graphic image as a square grid where entries are displayed in grayscale.
+
+        INPUT:
+
+        - ``element_names`` - (default: ``True``) Whether to display text with element names on the image
+
+        - ``**options`` - passed on to :func:`~sage.plot.matrix_plot.matrix_plot`
+
+        EXAMPLES::
+
+            sage: from sage.matrix.operation_table import OperationTable
+            sage: OTa = OperationTable(SymmetricGroup(3), operation=operator.mul)       # optional - sage.plot, sage.groups
+            sage: OTa.gray_table()                                                      # optional - sage.plot, sage.groups
+            Graphics object consisting of 37 graphics primitives
+
+        .. PLOT::
+
+            from sage.matrix.operation_table import OperationTable
+            OTa = OperationTable(SymmetricGroup(3), operation=operator.mul)
+            sphinx_plot(OTa.gray_table(), figsize=(3.0, 3.0))
+        """
+        from matplotlib.cm import Greys
         return self.color_table(cmap=Greys, **options)
 
     def _ascii_table(self):

--- a/src/sage/matrix/operation_table.py
+++ b/src/sage/matrix/operation_table.py
@@ -14,12 +14,10 @@ This module implements general operation tables, which are very matrix-like.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.structure.sage_object import SageObject
-from matplotlib.cm import gist_rainbow, Greys
-from sage.plot.matrix_plot import matrix_plot
-from sage.matrix.constructor import Matrix
-from sage.plot.text import text
 from copy import copy
+
+from sage.structure.sage_object import SageObject
+from sage.matrix.constructor import Matrix
 
 
 class OperationTable(SageObject):
@@ -985,6 +983,9 @@ class OperationTable(SageObject):
             OTa = OperationTable(SymmetricGroup(3), operation=operator.mul)
             sphinx_plot(OTa.color_table(), figsize=(3.0,3.0))
         """
+        from matplotlib.cm import gist_rainbow, Greys
+        from sage.plot.matrix_plot import matrix_plot
+        from sage.plot.text import text
 
         # Base matrix plot object, without text
         plot = matrix_plot(Matrix(self._table), cmap=cmap,

--- a/src/sage/matrix/operation_table.py
+++ b/src/sage/matrix/operation_table.py
@@ -956,9 +956,9 @@ class OperationTable(SageObject):
 
         - ``element_names`` - (default : ``True``) Whether to display text with element names on the image
 
-        - ``cmap`` - (default: :obj:`matplotlib.cm.gist_rainbow`) color map for plot, see :mod:`matplotlib.cm`
+        - ``cmap`` -- (default: :obj:`matplotlib.cm.gist_rainbow`) color map for plot, see :mod:`matplotlib.cm`
 
-        - ``**options`` - passed on to :func:`~sage.plot.matrix_plot.matrix_plot`
+        - ``**options`` -- passed on to :func:`~sage.plot.matrix_plot.matrix_plot`
 
         EXAMPLES::
 
@@ -1016,9 +1016,9 @@ class OperationTable(SageObject):
 
         INPUT:
 
-        - ``element_names`` - (default: ``True``) Whether to display text with element names on the image
+        - ``element_names`` -- (default: ``True``) whether to display text with element names on the image
 
-        - ``**options`` - passed on to :func:`~sage.plot.matrix_plot.matrix_plot`
+        - ``**options`` -- passed on to :func:`~sage.plot.matrix_plot.matrix_plot`
 
         EXAMPLES::
 


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
We remove the module-level dependency of `sage.matrix.operation_table` on `matplotlib` and `sage.plot` and fix some code style issues.
<!-- Why is this change required? What problem does it solve? -->
It fixes a modularization regression introduced in #8598.
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

