### PR TITLE
Fix a slow doctest in matrix_integer_dense_hnf.py

### DIFF
--- a/src/sage/matrix/matrix_integer_dense_hnf.py
+++ b/src/sage/matrix/matrix_integer_dense_hnf.py
@@ -1189,9 +1189,9 @@ def benchmark_hnf(nrange, bits=4):
     EXAMPLES::
 
         sage: import sage.matrix.matrix_integer_dense_hnf as hnf
-        sage: hnf.benchmark_hnf([50,100],32)
-        ('sage', 50, 32, ...),
-        ('sage', 100, 32, ...),
+        sage: hnf.benchmark_hnf([10,25],32)
+        ('sage', 10, 32, ...),
+        ('sage', 25, 32, ...),
     """
     b = 2**bits
     for n in nrange:


### PR DESCRIPTION
The hnf for integer dense matrices is quite slow, reported in #35161. While that issue is resolved, it doesn't make sense to keep this very slow test, so tune it down to an acceptable time.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

