### PR TITLE
Speedup of Poset characteristic polynomial

### DIFF
--- a/src/sage/combinat/posets/hasse_diagram.py
+++ b/src/sage/combinat/posets/hasse_diagram.py
@@ -419,6 +419,7 @@ class HasseDiagram(DiGraph):
         """
         return self.sinks()
 
+    @cached_method
     def bottom(self):
         """
         Return the bottom element of the poset, if it exists.
@@ -967,6 +968,61 @@ class HasseDiagram(DiGraph):
                 else:
                     self._moebius_function_values[(i, j)] = -sum(self.moebius_function(i, k) for k in ci[:-1])
         return self._moebius_function_values[(i, j)]
+
+    def bottom_moebius_function(self, j):
+        r"""
+        Return the value of the Möbius function of the poset
+        on the elements ``zero`` and ``j``, where ``zero`` is
+        ``self.bottom()``, the unique minimal element of the poset.
+
+        EXAMPLES::
+
+            sage: P = Poset({0: [1,2]})
+            sage: hasse = P._hasse_diagram
+            sage: hasse.bottom_moebius_function(1)
+            -1
+            sage: hasse.bottom_moebius_function(2)
+            -1
+            sage: P = Poset({0: [1,3], 1:[2], 2:[4], 3:[4]})
+            sage: hasse = P._hasse_diagram
+            sage: for i in range(5):
+            ....:   print(hasse.bottom_moebius_function(i))
+            1
+            -1
+            0
+            -1
+            1
+
+        TESTS::
+
+            sage: P = Poset({0:[2], 1:[2]})
+            sage: hasse = P._hasse_diagram
+            sage: hasse.bottom_moebius_function(1)
+            Traceback (most recent call last):
+            ...
+            ValueError: the poset has not a bottom element
+        """
+        zero = self.bottom()
+        if zero is None:
+            raise ValueError("the poset has not a bottom element")
+        # if the value has already been computed, either by self.moebius_function
+        # or by self.bottom_moebius_function, then just use the cached value.
+        try:
+            return self._moebius_function_values[(zero, j)]
+        # if the dict has not been initialized, do that and try again
+        except AttributeError:
+            self._moebius_function_values = {}
+            return self.bottom_moebius_function(j)
+        # if mu(zero, j) has not already been computed, we'll get a key error.
+        except KeyError:
+            if zero == j:
+                self._moebius_function_values[(zero, j)] = 1
+            # since zero is the minimal element, we can ignore the case that zero > j,
+            # and move on to computing the interval, which is exactly the order ideal.
+            else:
+                ci = self.order_ideal([j])
+                self._moebius_function_values[(zero, j)] = -sum(self.bottom_moebius_function(k) for k in ci[:-1])
+        return self._moebius_function_values[(zero, j)]
 
     def moebius_function_matrix(self, algorithm='cython'):
         r"""

--- a/src/sage/combinat/posets/hasse_diagram.py
+++ b/src/sage/combinat/posets/hasse_diagram.py
@@ -1023,7 +1023,8 @@ class HasseDiagram(DiGraph):
                 # do the depth_first_search over order_ideal, because we don't care
                 # about sorting the elements of the order ideal.
                 ci = self._backend.depth_first_search(j, reverse=True)
-                self._moebius_function_values[(zero, j)] = -sum(self.bottom_moebius_function(k) for k in ci if k != j)
+                next(ci)  # throw out the first element, which is j
+                self._moebius_function_values[(zero, j)] = -sum(self.bottom_moebius_function(k) for k in ci)
         return self._moebius_function_values[(zero, j)]
 
     def moebius_function_matrix(self, algorithm='cython'):

--- a/src/sage/combinat/posets/hasse_diagram.py
+++ b/src/sage/combinat/posets/hasse_diagram.py
@@ -1021,8 +1021,8 @@ class HasseDiagram(DiGraph):
             # and move on to computing the interval, which is exactly the order ideal.
             else:
                 # do the depth_first_search over order_ideal, because we don't care
-                # about sorting the elements of the order ideal
-                ci = self.depth_first_search([j], neighbors=self.neighbors_in)
+                # about sorting the elements of the order ideal.
+                ci = self._backend.depth_first_search(j, reverse=True)
                 self._moebius_function_values[(zero, j)] = -sum(self.bottom_moebius_function(k) for k in ci if k != j)
         return self._moebius_function_values[(zero, j)]
 

--- a/src/sage/combinat/posets/hasse_diagram.py
+++ b/src/sage/combinat/posets/hasse_diagram.py
@@ -1020,8 +1020,10 @@ class HasseDiagram(DiGraph):
             # since zero is the minimal element, we can ignore the case that zero > j,
             # and move on to computing the interval, which is exactly the order ideal.
             else:
-                ci = self.order_ideal([j])
-                self._moebius_function_values[(zero, j)] = -sum(self.bottom_moebius_function(k) for k in ci[:-1])
+                # do the depth_first_search over order_ideal, because we don't care
+                # about sorting the elements of the order
+                ci = self.depth_first_search([j], neighbors=self.neighbors_in)
+                self._moebius_function_values[(zero, j)] = -sum(self.bottom_moebius_function(k) for k in ci if k != j)
         return self._moebius_function_values[(zero, j)]
 
     def moebius_function_matrix(self, algorithm='cython'):

--- a/src/sage/combinat/posets/hasse_diagram.py
+++ b/src/sage/combinat/posets/hasse_diagram.py
@@ -1000,11 +1000,11 @@ class HasseDiagram(DiGraph):
             sage: hasse.bottom_moebius_function(1)
             Traceback (most recent call last):
             ...
-            ValueError: the poset has not a bottom element
+            ValueError: the poset does not have a bottom element
         """
         zero = self.bottom()
         if zero is None:
-            raise ValueError("the poset has not a bottom element")
+            raise ValueError("the poset does not have a bottom element")
         # if the value has already been computed, either by self.moebius_function
         # or by self.bottom_moebius_function, then just use the cached value.
         try:
@@ -1021,7 +1021,7 @@ class HasseDiagram(DiGraph):
             # and move on to computing the interval, which is exactly the order ideal.
             else:
                 # do the depth_first_search over order_ideal, because we don't care
-                # about sorting the elements of the order
+                # about sorting the elements of the order ideal
                 ci = self.depth_first_search([j], neighbors=self.neighbors_in)
                 self._moebius_function_values[(zero, j)] = -sum(self.bottom_moebius_function(k) for k in ci if k != j)
         return self._moebius_function_values[(zero, j)]

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -7614,9 +7614,8 @@ class FinitePoset(UniqueRepresentation, Parent):
         if not self.has_bottom():
             raise ValueError("the poset has not a bottom element")
         n = rk(hasse.maximal_elements()[0])
-        x0 = hasse.minimal_elements()[0]
         q = polygen(ZZ, 'q')
-        return sum(hasse.moebius_function(x0, x) * q**(n - rk(x)) for x in hasse)
+        return sum(hasse.bottom_moebius_function(x) * q**(n - rk(x)) for x in hasse)
 
     def chain_polynomial(self):
         """

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -7612,7 +7612,7 @@ class FinitePoset(UniqueRepresentation, Parent):
         if not self.is_graded():
             raise ValueError("the poset is not graded")
         if not self.has_bottom():
-            raise ValueError("the poset has not a bottom element")
+            raise ValueError("the poset does not have a bottom element")
         n = rk(hasse.maximal_elements()[0])
         q = polygen(ZZ, 'q')
         return sum(hasse.bottom_moebius_function(x) * q**(n - rk(x)) for x in hasse)


### PR DESCRIPTION
### 📚 Description
Add special method for Moebius function computation with minimal element, add cached_method to HasseDiagram.bottom, change to sum over bottom_moebius_function

This drastically reduces the time required to compute characteristic polynomials. On commit `fbb412787f`, we see

    sage: P = posets.SetPartitions(7)
    sage: %time P.characteristic_polynomial()
    CPU times: user 42.2 s, sys: 475 ms, total: 42.7 s
    Wall time: 45.2 s
    q^6 - 21*q^5 + 175*q^4 - 735*q^3 + 1624*q^2 - 1764*q + 720

With this commit we see: 
    
    sage: P = posets.SetPartitions(7)
    sage: %time P.characteristic_polynomial()
    CPU times: user 62.2 ms, sys: 1.83 ms, total: 64 ms
    Wall time: 63.1 ms
    q^6 - 21*q^5 + 175*q^4 - 735*q^3 + 1624*q^2 - 1764*q + 720

Fixes #34971 

### 📝 Checklist

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies

None

@tscrim is a suggested reviewer.
