### PR TITLE
Various improvements to Weyl character rings

### DIFF
--- a/src/sage/algebras/fusion_rings/fusion_ring.py
+++ b/src/sage/algebras/fusion_rings/fusion_ring.py
@@ -401,7 +401,7 @@ class FusionRing(WeylCharacterRing):
             sage: A21 = FusionRing("A2", 1)
             sage: A21.test_braid_representation(max_strands=4)
             True
-            sage: F41 = FusionRing("F4", 1)             # long time
+            sage: F41 = FusionRing("F4", 1)            # long time
             sage: F41.test_braid_representation()      # long time
             True
         """

--- a/src/sage/combinat/root_system/weyl_characters.py
+++ b/src/sage/combinat/root_system/weyl_characters.py
@@ -154,9 +154,11 @@ class WeylCharacterRing(CombinatorialFreeModule):
         else:
             B = self._space
 
-        cat = AlgebrasWithBasis(base_ring).Subobjects()
+        cat = AlgebrasWithBasis(base_ring).Commutative()
         if k is None:
-            cat = cat.Graded()
+            cat = cat.Subobjects().Graded()
+        else:
+            cat = cat.FiniteDimensional()
         CombinatorialFreeModule.__init__(self, base_ring, B, category=cat)
 
         # Register the embedding of self into ambient as a coercion
@@ -537,7 +539,7 @@ class WeylCharacterRing(CombinatorialFreeModule):
                 d[g] = d.get(g,0) + d1[k]
             elif epsilon == -1:
                 d[g] = d.get(g,0) - d1[k]
-        return self._from_dict(d)
+        return self._from_dict(d, coerce=True)
 
     def dot_reduce(self, a):
         r"""
@@ -715,8 +717,15 @@ class WeylCharacterRing(CombinatorialFreeModule):
         alpha = self._space.simple_roots()
         r = self.rank()
         cm = {}
+        supp = []
         for i in index_set:
-            cm[i] = tuple(int(alpha[i].inner_product(alphacheck[j])) for j in index_set)
+            temp = []
+            cm[i] = [0] * r
+            for ind,j in enumerate(index_set):
+                cm[i][ind] = int(alpha[i].inner_product(alphacheck[j]))
+                if cm[i][ind]:
+                    temp.append(ind)
+            supp.append(temp)
             if debug:
                 print("cm[%s]=%s" % (i, cm[i]))
         accum = dd
@@ -733,15 +742,21 @@ class WeylCharacterRing(CombinatorialFreeModule):
                 if coroot >= 0:
                     mu = v
                     for j in range(coroot+1):
-                        next[mu] = next.get(mu,0)+accum[v]
+                        next[mu] = next.get(mu,0) + accum[v]
                         if debug:
                             print("     mu=%s, next[mu]=%s" % (mu, next[mu]))
-                        mu = tuple(mu[k] - cm[i][k] for k in range(r))
+                        mu = list(mu)
+                        for k in supp[i-1]:
+                            mu[k] -= cm[i][k]
+                        mu = tuple(mu)
                 else:
                     mu = v
                     for j in range(-1-coroot):
-                        mu = tuple(mu[k] + cm[i][k] for k in range(r))
-                        next[mu] = next.get(mu,0)-accum[v]
+                        mu = list(mu)
+                        for k in supp[i-1]:
+                            mu[k] += cm[i][k]
+                        mu = tuple(mu)
+                        next[mu] = next.get(mu,0) - accum[v]
                         if debug:
                             print("     mu=%s, next[mu]=%s" % (mu, next[mu]))
             accum = {}
@@ -1779,7 +1794,7 @@ class WeightRing(CombinatorialFreeModule):
                 # TODO: this only works for irreducible Cartan types!
                 prefix = (self._cartan_type[0].lower() + str(self._rank))
         self._prefix = prefix
-        category = AlgebrasWithBasis(self._base_ring)
+        category = AlgebrasWithBasis(self._base_ring).Commutative()
         CombinatorialFreeModule.__init__(self, self._base_ring, self._space, category=category)
 
     def _repr_(self):


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

We provide a number of improvements to the Weyl character ring:

1. We make it know that it is commutative (along with its ambient ring).
2. We speedup the `_demazure_helper` method by only doing operations based upon the support of the simple roots.
   ```
   sage: F = FusionRing(['B',10], 2, base_ring=QQ)
   sage: dd = {(1,0,0,1,0,0,0,0,0,0): 1}
   sage: %time X = F._demazure_helper(dd)
   CPU times: user 3.1 s, sys: 12 ms, total: 3.11 s
   Wall time: 3.11 s
   ```
   Previously took `~6s`.
3. We don't set the `FusionRing` as a subobject of the `WeightRing`.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

