### PR TITLE
Workaround for an ecl race in maxima init 

### DIFF
--- a/src/sage/interfaces/maxima_lib.py
+++ b/src/sage/interfaces/maxima_lib.py
@@ -77,6 +77,26 @@ The output is parseable (i. e. :trac:`31796` is fixed)::
     sage: bar == foo
     True
 
+TESTS:
+
+Check our workaround for a race in ecl works, see :trac:`26968`.
+We use a temporary `MAXIMA_USERDIR` so it's empty; we place it
+in `DOT_SAGE` since we expect it to have more latency than `/tmp`.
+
+    sage: import tempfile, subprocess
+    sage: tmpdir = tempfile.TemporaryDirectory(dir=DOT_SAGE)
+    sage: _ = subprocess.run(['sage', '-c',  # long time
+    ....: f'''
+    ....: import os
+    ....: os.environ["MAXIMA_USERDIR"] = "{tmpdir.name}"
+    ....: if not os.fork():
+    ....:     import sage.interfaces.maxima_lib
+    ....: else:
+    ....:     import sage.interfaces.maxima_lib
+    ....:     os.wait()
+    ....: '''])
+    sage: tmpdir.cleanup()
+
 """
 
 # ****************************************************************************


### PR DESCRIPTION
### 📚 Description

When maxima is initialized a bug in ecl implementation of
`ensure-directories-exist` might result in a runtime error.

As a workaround, in case we get a runtime error we use python to create
the directory and continue with maxima initialization.

Note that for normal usage the directory will already exist within the
user's `DOT_SAGE` so this code will almost never run. However, when
running doctests on CI this occasionally triggers.

#### New doctest

The first commit introduces a doctest to try to catch this race.
We run a new instance of sage in a subprocess to ensure maxima is
not already initialized. We use a temporary `MAXIMA_USERDIR` so its empty,
and we try to initialize maxima twice in parallel to entice the race.

This temporary dir is placed within `DOT_SAGE` so it is easy
to try different filesystems.

The bug triggers more frequently if `DOT_SAGE` is in a high
latency filesystem (e.g. sshfs on a non-local host).

Closes #26968.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [x] I have created tests covering the changes.


