### PR TITLE
Remove directories leftover from improper shutdown so sage-cleaner won't kill random processes

### DIFF
--- a/src/bin/sage-cleaner
+++ b/src/bin/sage-cleaner
@@ -99,6 +99,15 @@ def cleanup():
 
     return len(pid_list)
 
+def cleanup_cruft():
+    """ remove directories leftover from improper shutdown """
+    tmp_dirs = os.listdir(SAGE_TMP_ROOT)
+    for dir_entry in tmp_dirs:
+        baddir = os.path.join(SAGE_TMP_ROOT, dir_entry)
+        if os.path.isdir(baddir):
+            logger.warning('Removing old directory %s from SAGE_TMP_ROOT', baddir)
+            rm_rf(baddir)
+
 def kill_spawned_jobs(jobfile, parent_pid):
     logger.info("Killing %s's spawned jobs", parent_pid)
     killed_them_all = True
@@ -193,6 +202,7 @@ if __name__ == '__main__':
     setup_daemon()
     fix_old_mistakes()
     logger.info("Starting sage-cleaner with PID %s", os.getpid())
+    cleanup_cruft()
 
     if len(sys.argv) > 1:
         wait = int(sys.argv[1])


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

From #27769:

Under rare conditions, sage is killed at startup by sage-cleaner.

This requires:

    Files left over in ~/.sage/temp/HOSTNAME/PID
    A pid in ~/.sage/temp/HOSTNAME/PID/spawned_processes must exist, and be started at init time. Its process group id will be 0

When sage-cleaner tries to clean up, it will do a "kill 0", which will kill sage.

Files will only be left in ~/.sage/temp/HOSTNAME if sage is not shutdown properly. Most likely because of a reboot.

Even if the situation doesn't result on a "kill 0",  sage-cleaner would still go on a killing spree for random processes which is awful.

The current PR removes everything under ~/.sage/temp/HOSTNAME/ at sage-cleaner startup so this doesn't happen.

Since sage-cleaner won't run more than once at a time, this seems safe.

Fixes #27769 

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
