### PR TITLE
remove deprecated slicing semantics of polynomials

### DIFF
--- a/src/sage/rings/laurent_series_ring_element.pyx
+++ b/src/sage/rings/laurent_series_ring_element.pyx
@@ -523,22 +523,32 @@ cdef class LaurentSeries(AlgebraElement):
             sage: f = -5/t^(10) + 1/3 + t + t^2 - 10/3*t^3 + O(t^5); f
             -5*t^-10 + 1/3 + t + t^2 - 10/3*t^3 + O(t^5)
 
-        Slicing is deprecated::
+        Slicing can be used to truncate, keeping the same precision::
 
-            sage: f[-10:2]
-            doctest:...: DeprecationWarning: polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead
-            See https://github.com/sagemath/sage/issues/18940 for details.
+            sage: f[:2]
             -5*t^-10 + 1/3 + t + O(t^5)
+
+        Any other kind of slicing is an error, see :trac:`18940`::
+
+            sage: f[-10:2:2]
+            Traceback (most recent call last):
+            ...
+            IndexError: polynomial slicing with a step is not defined
+
             sage: f[0:]
-            1/3 + t + t^2 - 10/3*t^3 + O(t^5)
+            Traceback (most recent call last):
+            ...
+            IndexError: polynomial slicing with a start is not defined
         """
         if isinstance(i, slice):
             start, stop, step = i.start, i.stop, i.step
-            if start is None:
-                start = 0
+            if step is not None:
+                raise IndexError("polynomial slicing with a step is not defined")
+            if start is not None:
+                raise IndexError("polynomial slicing with a start is not defined")
             if stop > self.__u.degree() or stop is None:
                 stop = self.__u.degree()
-            f = self.__u[start-self.__n:stop-self.__n:step]  # deprecation(18940)
+            f = self.__u[:stop - self.__n]
             return type(self)(self._parent, f, self.__n)
 
         return self.__u[i - self.__n]

--- a/src/sage/rings/polynomial/laurent_polynomial.pyx
+++ b/src/sage/rings/polynomial/laurent_polynomial.pyx
@@ -729,26 +729,30 @@ cdef class LaurentPolynomial_univariate(LaurentPolynomial):
             sage: f = -5/t^(10) + 1/3 + t + t^2 - 10/3*t^3; f
             -5*t^-10 + 1/3 + t + t^2 - 10/3*t^3
 
-        Slicing is deprecated::
+        Slicing can be used to truncate Laurent polynomials::
 
-            sage: f[-10:2]
-            doctest:...: DeprecationWarning: polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead
-            See https://github.com/sagemath/sage/issues/18940 for details.
-            -5*t^-10 + 1/3 + t
-            sage: f[0:]
-            1/3 + t + t^2 - 10/3*t^3
             sage: f[:3]
             -5*t^-10 + 1/3 + t + t^2
+
+        Any other kind of slicing is an error, see :trac:`18940`::
+
+            sage: f[-10:2]
+            Traceback (most recent call last):
+            ...
+            IndexError: polynomial slicing with a start is not defined
+
             sage: f[-14:5:2]
             Traceback (most recent call last):
             ...
-            NotImplementedError: polynomial slicing with a step is not defined
+            IndexError: polynomial slicing with a step is not defined
         """
         cdef LaurentPolynomial_univariate ret
         if isinstance(i, slice):
-            start = i.start - self.__n if i.start is not None else 0
-            stop = i.stop - self.__n if i.stop is not None else self.__u.degree() + 1
-            f = self.__u[start:stop:i.step]  # deprecation(18940)
+            start, stop, step = i.start, i.stop, i.step
+            if start is not None or step is not None:
+                self.__u[start:stop:step]  # error out, see issue #18940
+            stop = stop - self.__n if stop is not None else self.__u.degree() + 1
+            f = self.__u[:stop]
             ret = <LaurentPolynomial_univariate> self._new_c()
             ret.__u = f
             ret.__n = self.__n

--- a/src/sage/rings/polynomial/padics/polynomial_padic_capped_relative_dense.py
+++ b/src/sage/rings/polynomial/padics/polynomial_padic_capped_relative_dense.py
@@ -354,10 +354,11 @@ class Polynomial_padic_capped_relative_dense(Polynomial_generic_cdv, Polynomial_
 
     def __getitem__(self, n):
         """
-        Returns the coefficient of x^n if `n` is an integer,
-        returns the monomials of self of degree in slice `n` if `n` is a slice.
-
         Return the `n`-th coefficient of ``self``.
+
+        This returns the coefficient of `x^n` if `n` is an integer,
+        and returns the monomials of ``self`` of degree
+        in slice `n` if `n` is a slice ``[:k]``.
 
         EXAMPLES::
 
@@ -372,35 +373,28 @@ class Polynomial_padic_capped_relative_dense(Polynomial_generic_cdv, Polynomial_
             sage: a[:2]
             (13^2 + O(13^4))*t + 12*13^4 + 12*13^5 + 12*13^6 + 12*13^7 + 12*13^8 + 12*13^9 + 12*13^10 + O(13^11)
 
-        Any other kind of slicing is deprecated or an error, see
-        :trac:`18940`::
+        Any other kind of slicing is an error, see :trac:`18940`::
 
             sage: a[1:3]
-            doctest:warning...:
-            DeprecationWarning: polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead
-            See https://github.com/sagemath/sage/issues/18940 for details.
-            0*t^2 + (13^2 + O(13^4))*t
+            Traceback (most recent call last):
+            ...
+            IndexError: polynomial slicing with a start is not defined
+
             sage: a[1:3:2]
             Traceback (most recent call last):
             ...
-            NotImplementedError: polynomial slicing with a step is not defined
+            IndexError: polynomial slicing with a step is not defined
         """
         d = len(self._relprecs)  # = degree + 1
         if isinstance(n, slice):
             start, stop, step = n.start, n.stop, n.step
             if step is not None:
-                raise NotImplementedError("polynomial slicing with a step is not defined")
-            if start is None:
-                start = 0
-            else:
-                if start < 0:
-                    start = 0
-                from sage.misc.superseded import deprecation
-                deprecation(18940, "polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead")
+                raise IndexError("polynomial slicing with a step is not defined")
+            if start is not None:
+                raise IndexError("polynomial slicing with a start is not defined")
             if stop is None or stop > d:
                 stop = d
-            values = ([self.base_ring().zero()] * start
-                      + [self[i] for i in range(start, stop)])
+            values = [self[i] for i in range(stop)]
             return self.parent()(values)
 
         try:

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -1121,33 +1121,28 @@ cdef class Polynomial(CommutativeAlgebraElement):
             sage: pol[:6]
             5*x^5 + 4*x^4 + 3*x^3 + 2*x^2 + x
 
-        Any other kind of slicing is deprecated or an error, see
-        :trac:`18940`::
+        Any other kind of slicing is an error, see :trac:`18940`::
 
             sage: f[1:3]
-            doctest:...: DeprecationWarning: polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead
-            See https://github.com/sagemath/sage/issues/18940 for details.
-            x
+            Traceback (most recent call last):
+            ...
+            IndexError: polynomial slicing with a start is not defined
+
             sage: f[1:3:2]
             Traceback (most recent call last):
             ...
-            NotImplementedError: polynomial slicing with a step is not defined
+            IndexError: polynomial slicing with a step is not defined
         """
         cdef Py_ssize_t d = self.degree() + 1
         if isinstance(n, slice):
             start, stop, step = n.start, n.stop, n.step
             if step is not None:
-                raise NotImplementedError("polynomial slicing with a step is not defined")
-            if start is None:
-                start = 0
-            else:
-                if start < 0:
-                    start = 0
-                deprecation(18940, "polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead")
+                raise IndexError("polynomial slicing with a step is not defined")
+            if start is not None:
+                raise IndexError("polynomial slicing with a start is not defined")
             if stop is None or stop > d:
                 stop = d
-            values = ([self.base_ring().zero()] * start
-                      + [self.get_unsafe(i) for i in xrange(start, stop)])
+            values = [self.get_unsafe(i) for i in range(stop)]
             return self._new_generic(values)
 
         return self.get_coeff_c(pyobject_to_long(n))

--- a/src/sage/rings/polynomial/polynomial_element_generic.py
+++ b/src/sage/rings/polynomial/polynomial_element_generic.py
@@ -408,7 +408,7 @@ class Polynomial_generic_sparse(Polynomial):
         for n in D:
             del x[n]
 
-    def __getitem__(self,n):
+    def __getitem__(self, n):
         """
         Return the `n`-th coefficient of this polynomial.
 
@@ -436,37 +436,36 @@ class Polynomial_generic_sparse(Polynomial):
             sage: f[:2]
             -42.000*x + 8.0000
 
-        Any other kind of slicing is deprecated or an error::
+        Any other kind of slicing is an error, see :trac:`18940`::
 
             sage: f[1:3]
-            doctest:...: DeprecationWarning: polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead
-            See https://github.com/sagemath/sage/issues/18940 for details.
-            73.500*x^2 - 42.000*x
+            Traceback (most recent call last):
+            ...
+            IndexError: polynomial slicing with a start is not defined
+
             sage: f[1:3:2]
             Traceback (most recent call last):
             ...
-            NotImplementedError: polynomial slicing with a step is not defined
+            IndexError: polynomial slicing with a step is not defined
+
+        TESTS::
+
             sage: f["hello"]
             Traceback (most recent call last):
             ...
             TypeError: list indices must be integers, not str
         """
         if isinstance(n, slice):
-            d = self.degree() + 1
             start, stop, step = n.start, n.stop, n.step
             if step is not None:
-                raise NotImplementedError("polynomial slicing with a step is not defined")
-            if start is None:
-                start = 0
-            else:
-                if start < 0:
-                    start = 0
-                from sage.misc.superseded import deprecation
-                deprecation(18940, "polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead")
+                raise IndexError("polynomial slicing with a step is not defined")
+            if start is not None:
+                raise IndexError("polynomial slicing with a start is not defined")
+            d = self.degree() + 1
             if stop is None or stop > d:
                 stop = d
-            x = self.__coeffs
-            v = {k: x[k] for k in x.keys() if start <= k < stop}
+            v = {key: val for key, val in self.__coeffs.items()
+                 if key < stop}
             return self.parent()(v)
 
         try:

--- a/src/sage/rings/power_series_poly.pyx
+++ b/src/sage/rings/power_series_poly.pyx
@@ -405,12 +405,13 @@ cdef class PowerSeries_poly(PowerSeries):
         """
         Return the ``n``-th coefficient of ``self``.
 
-        If ``n`` is a slice object, this will return a power series of the
-        same precision, whose coefficients are the same as ``self`` for
-        those indices in the slice, and 0 otherwise.
-
         This returns 0 for negative coefficients and raises an
         ``IndexError`` if trying to access beyond known coefficients.
+
+        If ``n`` is a slice object ``[:k]``, this will return a power
+        series of the same precision, whose coefficients are the same
+        as ``self`` for those indices in the slice, and 0 otherwise.
+        Other kinds of slicing are not allowed.
 
         EXAMPLES::
 
@@ -426,10 +427,8 @@ cdef class PowerSeries_poly(PowerSeries):
             Traceback (most recent call last):
             ...
             IndexError: coefficient not known
-            sage: f[1:4]
-            doctest:...: DeprecationWarning: polynomial slicing with a start index is deprecated, use list() and slice the resulting list instead
-            See https://github.com/sagemath/sage/issues/18940 for details.
-            -17/5*t^3 + O(t^5)
+
+        Using slices::
 
             sage: R.<t> = ZZ[[]]
             sage: f = (2-t)^5; f
@@ -440,6 +439,13 @@ cdef class PowerSeries_poly(PowerSeries):
             1 + t^3 - 4*t^4 + O(t^7)
             sage: f[:4]
             1 + t^3 + O(t^7)
+
+        TESTS::
+
+            sage: f[1:4]
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: polynomial slicing with a start is not defined
         """
         if isinstance(n, slice):
             return PowerSeries_poly(self._parent, self.polynomial()[n],

--- a/src/sage/rings/power_series_poly.pyx
+++ b/src/sage/rings/power_series_poly.pyx
@@ -445,7 +445,7 @@ cdef class PowerSeries_poly(PowerSeries):
             sage: f[1:4]
             Traceback (most recent call last):
             ...
-            NotImplementedError: polynomial slicing with a start is not defined
+            IndexError: polynomial slicing with a start is not defined
         """
         if isinstance(n, slice):
             return PowerSeries_poly(self._parent, self.polynomial()[n],


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

This removes the deprecations introduced in #18940. So the only allowed slicing of polynomials is `p[:k]`.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

