### PR TITLE
fixing some E502 (unnecessary backslash) in pyx files

### DIFF
--- a/src/sage/groups/perm_gps/partn_ref/automorphism_group_canonical_label.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/automorphism_group_canonical_label.pyx
@@ -393,9 +393,10 @@ cdef void deallocate_agcl_work_space(agcl_work_space *work_space):
 cdef aut_gp_and_can_lab *get_aut_gp_and_can_lab(void *S,
     PartitionStack *partition, int n,
     bint (*all_children_are_equivalent)(PartitionStack *PS, void *S),
-    int (*refine_and_return_invariant)\
-         (PartitionStack *PS, void *S, int *cells_to_refine_by, int ctrb_len),
-    int (*compare_structures)(int *gamma_1, int *gamma_2, void *S1, void *S2, int degree),
+    int (*refine_and_return_invariant)(PartitionStack *PS, void *S,
+                                       int *cells_to_refine_by, int ctrb_len),
+    int (*compare_structures)(int *gamma_1, int *gamma_2, void *S1, void *S2,
+                              int degree),
     bint canonical_label, StabilizerChain *input_group,
     agcl_work_space *work_space_prealloc, aut_gp_and_can_lab *output_prealloc) except NULL:
     """

--- a/src/sage/groups/perm_gps/partn_ref/canonical_augmentation.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/canonical_augmentation.pyx
@@ -380,11 +380,13 @@ cdef void deallocate_cgd(canonical_generator_data *cgd):
     sig_free(cgd.parent_stack)
     sig_free(cgd)
 
+
 cdef iterator *setup_canonical_generator(int degree,
     bint (*all_children_are_equivalent)(PartitionStack *PS, void *S),
-    int (*refine_and_return_invariant)\
-         (PartitionStack *PS, void *S, int *cells_to_refine_by, int ctrb_len),
-    int (*compare_structures)(int *gamma_1, int *gamma_2, void *S1, void *S2, int degree),
+    int (*refine_and_return_invariant)(PartitionStack *PS, void *S,
+                                       int *cells_to_refine_by, int ctrb_len),
+    int (*compare_structures)(int *gamma_1, int *gamma_2, void *S1, void *S2,
+                              int degree),
     int (*generate_children)(void *, aut_gp_and_can_lab *, iterator *),
     void *(*apply_augmentation)(void *, void *, void *, int *, bint *),
     void (*free_object)(void *),

--- a/src/sage/groups/perm_gps/partn_ref/double_coset.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/double_coset.pyx
@@ -268,9 +268,10 @@ cdef void deallocate_dc_work_space(dc_work_space *work_space):
 
 cdef int double_coset(void *S1, void *S2, PartitionStack *partition1, int *ordering2,
     int n, bint (*all_children_are_equivalent)(PartitionStack *PS, void *S),
-    int (*refine_and_return_invariant)\
-         (PartitionStack *PS, void *S, int *cells_to_refine_by, int ctrb_len),
-    int (*compare_structures)(int *gamma_1, int *gamma_2, void *S1, void *S2, int degree),
+    int (*refine_and_return_invariant)(PartitionStack *PS, void *S,
+                                       int *cells_to_refine_by, int ctrb_len),
+    int (*compare_structures)(int *gamma_1, int *gamma_2, void *S1, void *S2,
+                              int degree),
     StabilizerChain *input_group,
     dc_work_space *work_space_prealloc, int *isom) except -1:
     """

--- a/src/sage/libs/mpmath/ext_impl.pyx
+++ b/src/sage/libs/mpmath/ext_impl.pyx
@@ -1847,8 +1847,8 @@ cdef MPF_complex_pow_int(MPF *zre, MPF *zim, MPF *xre, MPF *xim, mpz_t n, MPopts
     xret = MPF_to_tuple(xre)
     ximt = MPF_to_tuple(xim)
     from mpmath.libmp import mpc_pow_int
-    vr, vi = mpc_pow_int((xret, ximt), mpzi(n), \
-        opts.prec, rndmode_to_python(opts.rounding))
+    vr, vi = mpc_pow_int((xret, ximt), mpzi(n),
+                         opts.prec, rndmode_to_python(opts.rounding))
     MPF_set_tuple(zre, vr)
     MPF_set_tuple(zim, vi)
 
@@ -1892,8 +1892,8 @@ cdef MPF_complex_pow_re(MPF *zre, MPF *zim, MPF *xre, MPF *xim, MPF *y, MPopts o
     ximt = MPF_to_tuple(xim)
     yret = MPF_to_tuple(y)
     from mpmath.libmp import mpc_pow_mpf, fzero
-    vr, vi = mpc_pow_mpf((xret, ximt), yret, \
-        opts.prec, rndmode_to_python(opts.rounding))
+    vr, vi = mpc_pow_mpf((xret, ximt), yret,
+                         opts.prec, rndmode_to_python(opts.rounding))
     MPF_set_tuple(zre, vr)
     MPF_set_tuple(zim, vi)
 
@@ -1910,8 +1910,8 @@ cdef MPF_complex_pow(MPF *zre, MPF *zim, MPF *xre, MPF *xim, MPF *yre, MPF *yim,
     yret = MPF_to_tuple(yre)
     yimt = MPF_to_tuple(yim)
     from mpmath.libmp import mpc_pow
-    vr, vi = mpc_pow((xret,ximt), (yret,yimt), \
-        opts.prec, rndmode_to_python(opts.rounding))
+    vr, vi = mpc_pow((xret, ximt), (yret, yimt),
+                     opts.prec, rndmode_to_python(opts.rounding))
     MPF_set_tuple(zre, vr)
     MPF_set_tuple(zim, vi)
 

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -2602,13 +2602,15 @@ def hypsum_internal(int p, int q, param_types, str ztype, coeffs, z,
         sage: print(mp.hyp1f1(1,2,3))
         6.36184564106256
 
-    TODO: convert mpf/mpc parameters to fixed-point numbers here
-    instead of converting to tuples within MPF_hypsum.
+    .. TODO::
+
+        convert mpf/mpc parameters to fixed-point numbers here
+        instead of converting to tuples within MPF_hypsum.
     """
     cdef mpf f
     cdef mpc c
     c = mpc.__new__(mpc)
-    have_complex, magn = MPF_hypsum(&c.re, &c.im, p, q, param_types, \
+    have_complex, magn = MPF_hypsum(&c.re, &c.im, p, q, param_types,
         ztype, coeffs, z, prec, wp, epsshift, magnitude_check, kwargs)
     if have_complex:
         v = c

--- a/src/sage/libs/mpmath/utils.pyx
+++ b/src/sage/libs/mpmath/utils.pyx
@@ -128,7 +128,7 @@ cpdef normalize(long sign, Integer man, exp, long bc, long prec, str rnd):
     res = PY_NEW(Integer)
     if shift > 0:
         if rnd == 'n':
-            if mpz_tstbit(man.value, shift-1) and (mpz_tstbit(man.value, shift)\
+            if mpz_tstbit(man.value, shift-1) and (mpz_tstbit(man.value, shift)
                 or (mpz_scan1(man.value, 0) < (shift-1))):
                 mpz_cdiv_q_2exp(res.value, man.value, shift)
             else:

--- a/src/sage/libs/ntl/ntl_ZZ.pyx
+++ b/src/sage/libs/ntl/ntl_ZZ.pyx
@@ -93,8 +93,8 @@ cdef class ntl_ZZ():
             v = str(v)
             if not v:
                 v = '0'
-            if not ((v[0].isdigit() or v[0] == '-') and \
-                    (v[1:-1].isdigit() or (len(v) <= 2)) and \
+            if not ((v[0].isdigit() or v[0] == '-') and
+                    (v[1:-1].isdigit() or (len(v) <= 2)) and
                     (v[-1].isdigit() or (v[-1].lower() in ['l','r']))):
                 raise ValueError("invalid integer: %s" % v)
             ccreadstr(self.x, v)

--- a/src/sage/rings/complex_mpc.pyx
+++ b/src/sage/rings/complex_mpc.pyx
@@ -313,8 +313,8 @@ cdef class MPComplexField_class(sage.rings.ring.Field):
         try:
             n = _mpc_rounding_modes.index(rnd)
         except ValueError:
-            raise ValueError("rnd (=%s) must be of the form RNDxy"\
-                "where x and y are one of N, Z, U, D" % rnd)
+            raise ValueError("rnd (=%s) must be of the form RNDxy"
+                             "where x and y are one of N, Z, U, D" % rnd)
         self.__rnd = n
         self.__rnd_str = rnd
 
@@ -1158,8 +1158,8 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
             TypeError: can...t convert complex to float; use abs(z)
         """
         if mpfr_zero_p(self.value.im):
-            return mpfr_get_d(self.value.re,\
-                                   rnd_re((<MPComplexField_class>self._parent).__rnd))
+            return mpfr_get_d(self.value.re,
+                              rnd_re((<MPComplexField_class>self._parent).__rnd))
         else:
             raise TypeError("can't convert complex to float; use abs(z)")
 

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -779,14 +779,14 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             na = a_red.multiplicative_order()
             nb = b_red.multiplicative_order()
             if not na.divides(nb):  # cannot be a power
-                raise ValueError(f"no logarithm of {self} found to base {b} modulo {self.modulus()}" \
+                raise ValueError(f"no logarithm of {self} found to base {b} modulo {self.modulus()}"
                               + (f" (no solution modulo {q})" if q != self.modulus() else ""))
 
             if p == 2 and e >= 3:   # (ZZ/2^e)* is not cyclic; must not give unsolvable DLPs to Pari
                 try:
                     v = discrete_log(a_red, b_red, nb)
                 except ValueError:
-                    raise ValueError(f"no logarithm of {self} found to base {b} modulo {self.modulus()}" \
+                    raise ValueError(f"no logarithm of {self} found to base {b} modulo {self.modulus()}"
                                   + (f" (no solution modulo {q})" if q != self.modulus() else ""))
             else:
                 try:

--- a/src/sage/rings/finite_rings/residue_field.pyx
+++ b/src/sage/rings/finite_rings/residue_field.pyx
@@ -1579,8 +1579,8 @@ class ResidueFiniteField_prime_modn(ResidueField_generic, FiniteField_prime_modn
             self._populate_coercion_lists_(coerce_list=coerce_list, convert_list=[ReductionMap(K, self, None, None, None, None)]) # could be special-cased a bit more.
         else:
             PBinv = PB**(-1)
-            self._populate_coercion_lists_(coerce_list=[IntegerMod_to_IntegerMod(GF(intp), self), Integer_to_IntegerMod(self), Int_to_IntegerMod(self), ResidueFieldHomomorphism_global(OK, self, to_vs, to_order, PB, PBinv)], \
-                                                 convert_list=[ReductionMap(K, self, to_vs, to_order, PB, PBinv)])
+            self._populate_coercion_lists_(coerce_list=[IntegerMod_to_IntegerMod(GF(intp), self), Integer_to_IntegerMod(self), Int_to_IntegerMod(self), ResidueFieldHomomorphism_global(OK, self, to_vs, to_order, PB, PBinv)],
+                                           convert_list=[ReductionMap(K, self, to_vs, to_order, PB, PBinv)])
 
     def _element_constructor_(self, x):
         """

--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -2035,8 +2035,8 @@ cdef class RingHomomorphism_im_gens(RingHomomorphism):
         """
         D = self.domain()
         ig = self._im_gens
-        s = '\n'.join(['%s |--> %s'%(D.gen(i), ig[i]) for\
-                       i in range(D.ngens())])
+        s = '\n'.join('{} |--> {}'.format(D.gen(i), ig[i])
+                       for i in range(D.ngens()))
         if s and self._base_map is not None:
             s += '\nwith map of base ring'
         return s
@@ -2866,21 +2866,22 @@ cdef class RingHomomorphism_from_quotient(RingHomomorphism):
         """
         return hash(self.phi)
 
-    def _repr_defn(self):
+    def _repr_defn(self) -> str:
         """
         Used internally for printing this function.
 
         EXAMPLES::
 
-            sage: R.<x,y> = QQ[]; S.<xx,yy> = R.quo([x^2,y^2]); f = S.hom([yy,xx])
+            sage: R.<x,y> = QQ[]; S.<xx,yy> = R.quo([x^2,y^2])
+            sage: f = S.hom([yy,xx])
             sage: print(f._repr_defn())
             xx |--> yy
             yy |--> xx
         """
         D = self.domain()
         ig = self.phi.im_gens()
-        return '\n'.join(['%s |--> %s'%(D.gen(i), ig[i]) for\
-                          i in range(D.ngens())])
+        return '\n'.join('{} |--> {}'.format(D.gen(i), ig[i])
+                         for i in range(D.ngens()))
 
     cpdef Element _call_(self, x):
         """

--- a/src/sage/rings/padics/padic_printing.pyx
+++ b/src/sage/rings/padics/padic_printing.pyx
@@ -483,18 +483,17 @@ cdef class pAdicPrinter_class(SageObject):
             sage: P._sep()
             '&'
         """
-
-        return pAdicPrinter, (self.ring, \
-                              {'mode': self._print_mode(), \
-                               'pos': self.pos, \
-                               'ram_name': self.ram_name, \
-                               'unram_name': self.unram_name, \
-                               'var_name': self.var_name, \
-                               'max_ram_terms': self.max_ram_terms, \
-                               'max_unram_terms': self.max_unram_terms, \
-                               'max_terse_terms': self.max_terse_terms, \
-                               'sep':self.sep, \
-                               'alphabet': self.alphabet, \
+        return pAdicPrinter, (self.ring,
+                              {'mode': self._print_mode(),
+                               'pos': self.pos,
+                               'ram_name': self.ram_name,
+                               'unram_name': self.unram_name,
+                               'var_name': self.var_name,
+                               'max_ram_terms': self.max_ram_terms,
+                               'max_unram_terms': self.max_unram_terms,
+                               'max_terse_terms': self.max_terse_terms,
+                               'sep':self.sep,
+                               'alphabet': self.alphabet,
                                'show_prec': self.show_prec})
 
     def __richcmp__(self, other, op):

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -178,7 +178,6 @@ native PolyBoRi counterparts. For instance, sets of points can be
 represented as tuples of tuples (Sage) or as ``BooleSet`` (PolyBoRi)
 and naturally the second option is faster.
 """
-
 from cpython.object cimport Py_EQ, Py_NE
 from cython.operator cimport dereference as deref
 from cysignals.memory cimport sig_malloc, sig_free
@@ -1098,12 +1097,10 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
 
         INPUT:
 
-
         -  ``gens`` - list or tuple of generators
 
         -  ``coerce`` - bool (default: True) automatically
            coerce the given polynomials to this ring to form the ideal
-
 
         EXAMPLES::
 
@@ -1219,7 +1216,6 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
             sage: B = BooleanPolynomialRing(n, 'x')
             sage: r = B.random_element(terms=(n/2)**2)
         """
-        from sage.rings.integer import Integer
         from sage.arith.misc import binomial
 
         if not vars_set:
@@ -1270,7 +1266,6 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
 
         INPUT:
 
-
         -  ``degree`` - maximum degree
 
         -  ``monom_counts`` - a list containing total number
@@ -1284,7 +1279,6 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
 
         -  ``l`` - number of monomials to generate
 
-
         EXAMPLES::
 
             sage: P.<x,y,z> = BooleanPolynomialRing(3)
@@ -1292,8 +1286,6 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
             sage: all(t in [x, y, x*y, P(1)] for t in f.terms())
             True
         """
-        from sage.rings.integer import Integer
-        from sage.rings.integer_ring import ZZ
         if l == 0:
             return self._zero_element
         if l == 1:
@@ -1302,10 +1294,10 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
             else:
                 return self._random_monomial_uniform(monom_counts, vars_set)
 
-        return self._random_uniform_rec(degree, monom_counts,
-                    vars_set, dfirst, l//2) + \
-               self._random_uniform_rec(degree, monom_counts,
-                    vars_set, dfirst, l - l//2)
+        return (self._random_uniform_rec(degree, monom_counts,
+                                         vars_set, dfirst, l // 2) +
+                self._random_uniform_rec(degree, monom_counts,
+                                         vars_set, dfirst, l - l // 2))
 
     def _random_monomial_uniform(self, monom_counts, vars_set):
         r"""
@@ -1314,13 +1306,11 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
 
         INPUT:
 
-
         -  ``monom_counts`` - list of number of monomials up
            to given degree
 
         -  ``vars_set`` - list of variable indices to use in
            the generated monomial
-
 
         EXAMPLES::
 
@@ -1360,11 +1350,9 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
 
         INPUT:
 
-
         -  ``degree`` - maximum degree
 
         -  ``vars_set`` - list of variable indices of self
-
 
         EXAMPLES::
 
@@ -1490,13 +1478,11 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
 
         INPUT:
 
-
         -  ``zeros`` - the set of interpolation points mapped
            to zero
 
         -  ``ones`` - the set of interpolation points mapped to
            one
-
 
         EXAMPLES:
 
@@ -1877,7 +1863,6 @@ class BooleanMonomialMonoid(UniqueRepresentation, Monoid_class):
     INPUT:
 
     - ``polring`` - the polynomial ring our monomials lie in
-
 
     EXAMPLES::
 
@@ -2809,7 +2794,6 @@ cdef class BooleanMonomial(MonoidElement):
 
         - ``rhs`` - a boolean monomial
 
-
         EXAMPLES::
 
             sage: B.<a,b,c,d> = BooleanPolynomialRing()
@@ -2952,7 +2936,6 @@ cdef class BooleanPolynomial(MPolynomial):
     INPUT:
 
     - ``parent`` - a boolean polynomial ring
-
 
     TESTS::
 
@@ -3822,9 +3805,7 @@ cdef class BooleanPolynomial(MPolynomial):
 
         INPUT:
 
-
         -  ``mon`` - a monomial
-
 
         EXAMPLES::
 
@@ -3984,12 +3965,10 @@ cdef class BooleanPolynomial(MPolynomial):
 
         INPUT:
 
-
         -  ``in_dict`` - (optional) dict with variable:value
            pairs
 
         -  ``**kwds`` - names parameters
-
 
         EXAMPLES::
 
@@ -4387,9 +4366,7 @@ cdef class BooleanPolynomial(MPolynomial):
 
         INPUT:
 
-
         -  ``rhs`` - a boolean polynomial
-
 
         EXAMPLES::
 
@@ -4452,9 +4429,7 @@ cdef class BooleanPolynomial(MPolynomial):
 
         INPUT:
 
-
         -  ``deg`` - a degree
-
 
         EXAMPLES::
 
@@ -4508,9 +4483,7 @@ cdef class BooleanPolynomial(MPolynomial):
 
         INPUT:
 
-
         -  ``s`` - candidate points for evaluation to zero
-
 
         EXAMPLES::
 
@@ -4619,10 +4592,8 @@ cdef class BooleanPolynomial(MPolynomial):
 
         INPUT:
 
-
         -  ``I`` - a list/set of polynomials in self.parent().
            If I is an ideal, the generators are used.
-
 
         EXAMPLES::
 

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -841,8 +841,7 @@ cdef class BooleanPolynomialRing(MPolynomialRing_base):
                 raise TypeError("cannot coerce monomial %s to %s" % (other, self))
 
         elif isinstance(other, BooleanPolynomial) and \
-            ((<BooleanPolynomialRing>(<BooleanPolynomial>other)\
-            ._parent)._pbring.nVariables() <= self._pbring.nVariables()):
+            ((<BooleanPolynomialRing>(<BooleanPolynomial>other)._parent)._pbring.nVariables() <= self._pbring.nVariables()):
             # try PolyBoRi's built-in coercions
             if self._pbring.hash() == \
                     (<BooleanPolynomialRing>(<BooleanPolynomial>other)._parent)._pbring.hash():
@@ -2080,7 +2079,7 @@ class BooleanMonomialMonoid(UniqueRepresentation, Monoid_class):
             ValueError: cannot convert monomial t*x*y to MonomialMonoid of Boolean PolynomialRing in x, y, z: name t not defined
         """
         if isinstance(other, BooleanMonomial) and \
-            ((<BooleanMonomial>other)._parent.ngens() <= \
+            ((<BooleanMonomial>other)._parent.ngens() <=
             (<BooleanPolynomialRing>self._ring)._pbring.nVariables()):
             try:
                 var_mapping = get_var_mapping(self, other.parent())
@@ -2182,7 +2181,7 @@ class BooleanMonomialMonoid(UniqueRepresentation, Monoid_class):
                     return new_BM_from_PBMonom(self,
                             (<BooleanPolynomialRing>self._ring),
                             (<BooleanPolynomial>other)._pbpoly.lead())
-                elif ((<BooleanPolynomial>other)._pbpoly.nUsedVariables() <= \
+                elif ((<BooleanPolynomial>other)._pbpoly.nUsedVariables() <=
                     (<BooleanPolynomialRing>self._ring)._pbring.nVariables()):
                         try:
                             var_mapping = get_var_mapping(self, other)

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -1780,7 +1780,7 @@ cdef class NCPolynomial_plural(RingElement):
 
         _I = idInit(len(I),1)
         for f in I:
-            if not (isinstance(f, NCPolynomial_plural) \
+            if not (isinstance(f, NCPolynomial_plural)
                    and <NCPolynomialRing_plural>(<NCPolynomial_plural>f)._parent is parent):
                 try:
                     f = parent.coerce(f)

--- a/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
@@ -727,7 +727,7 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
             ...
             ValueError: leading coefficient must be invertible
         """
-        if self.base_ring().characteristic().gcd(\
+        if self.base_ring().characteristic().gcd(
                 self.leading_coefficient().lift()) != 1:
             raise ValueError("leading coefficient must be invertible")
         cdef Polynomial_zmod_flint res = self._new()


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

This removes most instances of pycodestyle warning

E502 the backslash is redundant between brackets

inside pyx files. There remains only a few in rings/, that could be easily fixed when activiting the check in the linter.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

