### PR TITLE
Trac #34920: Fix description of inputs of primes.

### DIFF
--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -1010,7 +1010,7 @@ def eratosthenes(n):
     return [ZZ(2)] + [ZZ(x) for x in s if x and x <= n]
 
 
-def primes(start, stop=None, proof=None):
+def primes(start=2, stop=None, proof=None):
     r"""
     Return an iterator over all primes between start and stop-1,
     inclusive. This is much slower than ``prime_range``, but
@@ -1027,10 +1027,11 @@ def primes(start, stop=None, proof=None):
 
     INPUT:
 
-    - ``start`` - an integer - lower bound for the primes
+    - ``start`` - an integer (default: 2) optional argument -
+      giving lower bound for the primes
 
-    - ``stop`` - an integer (or infinity) optional argument -
-      giving upper (open) bound for the primes
+    - ``stop`` - an integer (or infinity) - giving upper (open) bound for the
+      primes
 
     - ``proof`` - bool or None (default: None)  If True, the function
       yields only proven primes.  If False, the function uses a


### PR DESCRIPTION
Fix docstring of the `primes` function.

### 📚 Description

The documentation of `primes` states that "stop" is optional and "start" is required, when in fact it is the opposite.

Closes #34920

### 📝 Checklist

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
