### PR TITLE
Make Expression.simplify optionally use sympy

### DIFF
--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -10605,17 +10605,16 @@ cdef class Expression(Expression_abc):
 
         .. NOTE::
 
-           When using algorithm='maxima', this just sends the expression to Maxima
-           and converts it back to Sage. When algorith='sympy',
+           When using ``algorithm='maxima'``, this just sends the expression to Maxima
+           and converts it back to Sage. When ``algorithm='sympy'``,
            sympy's simplify method is used.
+
         INPUT:
 
-            - ``self`` -- an expression with held operations
-            - ``algorithm`` - (default: ``'maxima'``)  one of
-
-                    - ``'maxima'`` - use Maxima (the default)
-
-                    - ``'sympy'`` - use SymPy
+        - ``self`` -- an expression with held operations
+        - ``algorithm`` - (default: ``'maxima'``)  one of
+            - ``'maxima'`` - use Maxima (the default)
+            - ``'sympy'`` - use SymPy
 
         .. SEEALSO::
 
@@ -10648,7 +10647,7 @@ cdef class Expression(Expression_abc):
             sage: forget()
 
         Check that simplifying with sympy works correctly::
-        
+
             sage: expr = (-1/5*(2*sqrt(6)*(sqrt(5) - 5) + 11*sqrt(5) - 11)/(2*sqrt(6)*sqrt(5) - 11))
             sage: expr.simplify(algorithm='sympy')
             1/5*sqrt(5) - 1/5

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -10599,14 +10599,23 @@ cdef class Expression(Expression_abc):
         else:
             return self
 
-    def simplify(self):
+    def simplify(self, algorithm='maxima'):
         """
         Return a simplified version of this symbolic expression.
 
         .. NOTE::
 
-           Currently, this just sends the expression to Maxima
-           and converts it back to Sage.
+           When using algorithm='maxima', this just sends the expression to Maxima
+           and converts it back to Sage. When algorith='sympy',
+           sympy's simplify method is used.
+        INPUT:
+
+            - ``self`` -- an expression with held operations
+            - ``algorithm`` - (default: ``'maxima'``)  one of
+
+                    - ``'maxima'`` - use Maxima (the default)
+
+                    - ``'sympy'`` - use SymPy
 
         .. SEEALSO::
 
@@ -10623,6 +10632,12 @@ cdef class Expression(Expression_abc):
             sage: f.simplify()
             x^(-a + 1)*sin(2)
 
+        ::
+
+            sage: expr = (-1/5*(2*sqrt(6)*(sqrt(5) - 5) + 11*sqrt(5) - 11)/(2*sqrt(6)*sqrt(5) - 11))
+            sage: expr.simplify(algorithm='sympy')
+            1/5*sqrt(5) - 1/5
+
         TESTS:
 
         Check that :trac:`14637` is fixed::
@@ -10631,8 +10646,23 @@ cdef class Expression(Expression_abc):
             sage: acos(cos(x)).simplify()
             x
             sage: forget()
+
+        Check that simplifying with sympy works correctly::
+        
+            sage: expr = (-1/5*(2*sqrt(6)*(sqrt(5) - 5) + 11*sqrt(5) - 11)/(2*sqrt(6)*sqrt(5) - 11))
+            sage: expr.simplify(algorithm='sympy')
+            1/5*sqrt(5) - 1/5
+
+
         """
-        return self._parent(self._maxima_())
+        if algorithm == 'maxima':
+            return self._parent(self._maxima_())
+        elif algorithm == 'sympy':
+            return self._sympy_().simplify()._sage_()
+        else:
+            raise NotImplementedError(
+                    "unknown algorithm: '{}'".format(algorithm))
+
 
     def simplify_full(self):
         """


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

`Expression.simplify` currently uses maxima to simplify an expression. Sympy also has a method `simplify` that often works better. For this reason I propose to add an 'algorithm' parameter to the Expression.simplify method, to make it easy to use sympy's simplification method.

To illustrate why this is beneficial, consider the expression `x = (-1/5*(2*sqrt(6)*(sqrt(5) - 5) + 11*sqrt(5) - 11)/(2*sqrt(6)*sqrt(5) - 11))`. Both `x.simplify_full()` and `x.simplify()` are not able to simplify this expression. However, `x.simplify(algorithm='sympy')` would return `1/5*sqrt(5) - 1/5`.
<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

