### PR TITLE
GenericGraph.adjacency_matrix: using sort=True when getting vertices

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -1939,9 +1939,9 @@ class GenericGraph(GenericGraph_pyx):
             try:
                 vertices = self.vertices(sort=True)
             except TypeError:
-                raise TypeError ("Vertex labels are not comparable. You must "
-                                 "specify an ordering using parameter "
-                                 "``vertices``")
+                raise TypeError("Vertex labels are not comparable. You must "
+                                "specify an ordering using parameter "
+                                "``vertices``")
         elif (len(vertices) != n or
               set(vertices) != set(self.vertex_iterator())):
             raise ValueError("``vertices`` must be a permutation of the vertices")

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -1939,7 +1939,9 @@ class GenericGraph(GenericGraph_pyx):
             try:
                 vertices = self.vertices(sort=True)
             except TypeError:
-                raise TypeError ("Vertex labels are not comparable. You must specify an ordering using parameter ``vertices``")
+                raise TypeError ("Vertex labels are not comparable. You must "
+                                 "specify an ordering using parameter "
+                                 "``vertices``")
         elif (len(vertices) != n or
               set(vertices) != set(self.vertex_iterator())):
             raise ValueError("``vertices`` must be a permutation of the vertices")

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -1923,7 +1923,7 @@ class GenericGraph(GenericGraph_pyx):
             sage: Graph ([[0, 42, 'John'], [(42, 'John')]]).adjacency_matrix()
             Traceback (most recent call last):
             ...
-            TypeError: Vertices are not comparable, you must used the ``vertices`` parameter of the ``adjacency_matrix`` method to specify an ordering
+            TypeError: Vertex labels are not comparable. You must specify an ordering using parameter ``vertices``
             sage: Graph ([[0, 42, 'John'], [(42, 'John')]]).adjacency_matrix(vertices=['John', 42, 0])
             [0 1 0]
             [1 0 0]
@@ -1939,7 +1939,7 @@ class GenericGraph(GenericGraph_pyx):
             try:
                 vertices = self.vertices(sort=True)
             except TypeError:
-                raise TypeError ("Vertices are not comparable, you must used the ``vertices`` parameter of the ``adjacency_matrix`` method to specify an ordering")
+                raise TypeError ("Vertex labels are not comparable. You must specify an ordering using parameter ``vertices``")
         elif (len(vertices) != n or
               set(vertices) != set(self.vertex_iterator())):
             raise ValueError("``vertices`` must be a permutation of the vertices")

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -1799,6 +1799,8 @@ class GenericGraph(GenericGraph_pyx):
           the vertices defining how they should appear in the
           matrix. By default, the ordering given by
           :meth:`GenericGraph.vertices` with ``sort=True`` is used.
+          If the vertices are not comparable, the keyword ``vertices`` must be
+          used to specify an ordering, or a TypeError exception will be raised.
 
         - ``base_ring`` -- a ring (default: ``ZZ``); the base ring of the matrix
           space to use.
@@ -1918,6 +1920,14 @@ class GenericGraph(GenericGraph_pyx):
             Traceback (most recent call last):
             ...
             ValueError: ``vertices`` must be a permutation of the vertices
+            sage: Graph ([[0, 42, 'John'], [(42, 'John')]]).adjacency_matrix()
+            Traceback (most recent call last):
+            ...
+            TypeError: Vertices are not comparable, you must used the ``vertices`` parameter of the ``adjacency_matrix`` method to specify an ordering
+            sage: Graph ([[0, 42, 'John'], [(42, 'John')]]).adjacency_matrix(vertices=['John', 42, 0])
+            [0 1 0]
+            [1 0 0]
+            [0 0 0]
         """
         n = self.order()
         if sparse is None:
@@ -1926,7 +1936,10 @@ class GenericGraph(GenericGraph_pyx):
                 sparse = False
 
         if vertices is None:
-            vertices = self.vertices(sort=False)
+            try:
+                vertices = self.vertices(sort=True)
+            except TypeError:
+                raise TypeError ("Vertices are not comparable, you must used the ``vertices`` parameter of the ``adjacency_matrix`` method to specify an ordering")
         elif (len(vertices) != n or
               set(vertices) != set(self.vertex_iterator())):
             raise ValueError("``vertices`` must be a permutation of the vertices")

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -1926,7 +1926,7 @@ class GenericGraph(GenericGraph_pyx):
                 sparse = False
 
         if vertices is None:
-            vertices = self.vertices(sort=True)
+            vertices = self.vertices(sort=False)
         elif (len(vertices) != n or
               set(vertices) != set(self.vertex_iterator())):
             raise ValueError("``vertices`` must be a permutation of the vertices")


### PR DESCRIPTION
### 📚 Description

As illustrated by the following code, the method `adjacency_matrix` of the GenericGraph class failed when vertices where not sortable.

```python
G = Graph()
G.add_vertices ([14, 'test'])
G.adjacency_matrix()
```

I fixed the problem by using `sort=False` instead of `sort=True` in the line that get the list of vertices.

I did not open an issue for this bug, but it is similar to #35168 (fixed by PR #35170)


**NOTE**
I started to write a test to cover the changes but all others test are broken by this small commit. Indeed the adjacency matrix obtained with the new code can have a different row/column order. I am not sure what is the correct way to handle this situation 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies


