### PR TITLE
Fix doctests for nauty 2.8.6 output changes

### DIFF
--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -3660,7 +3660,7 @@ def nauty_gentreeg(options="", debug=False):
 
         sage: gen = graphs.nauty_gentreeg("4", debug=True)
         sage: print(next(gen))
-        >A ...gentreeg Z=2:3 D=3 n=4
+        >A ...gentreeg ...
         sage: gen = graphs.nauty_gentreeg("4 -q", debug=True)
         sage: next(gen)
         ''
@@ -3687,7 +3687,7 @@ def nauty_gentreeg(options="", debug=False):
         sage: list(graphs.nauty_gentreeg("3 -x", debug=True))
         ['>E Usage: ...gentreeg [-D#] [-Z#:#] [-ulps] [-q] n [res/mod] ...
         sage: list(graphs.nauty_gentreeg("3", debug=True))
-        ['>A ...gentreeg Z=2:2 D=2 n=3\n', Graph on 3 vertices]
+        ['>A ...gentreeg ...\n', Graph on 3 vertices]
     """
     import shlex
     from sage.features.nauty import NautyExecutable

--- a/src/sage/graphs/graph_generators.py
+++ b/src/sage/graphs/graph_generators.py
@@ -966,7 +966,7 @@ class GraphGenerators():
             ...
             ValueError: wrong format of parameter option
             sage: list(graphs.nauty_geng("-c3", debug=True))
-            ['>E Usage: ...geng [-cCmtfbd#D#] [-uygsnh] [-lvq] ...
+            ['>E Usage: ...geng ...\n']
             sage: list(graphs.nauty_geng("-c 3", debug=True))
             ['>A ...geng -cd1D2 n=3 e=2-3\n', Graph on 3 vertices, Graph on 3 vertices]
         """


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

See #35157 and #34133.

This changes doctests to accomodate to changes in nauty output (which are only used for debug purposes).

OTOH, there is a bug in the released nauty 2.8.6 which causes another doctest failure reported in #35157. On a system with patched nauty 2.8.6 the current PR is good enough.

Leave #35157 open. To fix it a good option might be running `gentreeg 2` at configure time and check the bug is not present so it's possible to use 2.8.6 from system if it's been patched. In case it's useful, the patch I'm using is https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-mathematics/nauty/files/nauty-2.8.6-gentreeg-gentourng.patch

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

