### PR TITLE
Deprecate `is_Algebra`, `is_CommutativeAlgebra`

### DIFF
--- a/src/sage/algebras/algebra.py
+++ b/src/sage/algebras/algebra.py
@@ -29,8 +29,13 @@ def is_Algebra(x):
         sage: from sage.algebras.algebra import is_Algebra
         sage: R.<x,y> = FreeAlgebra(QQ,2)
         sage: is_Algebra(R)
+        doctest:warning...
+        DeprecationWarning: the function is_Algebra is deprecated; use '... in Algebras(base_ring)' instead
+        See https://github.com/sagemath/sage/issues/99999 for details.
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(99999, "the function is_Algebra is deprecated; use '... in Algebras(base_ring)' instead")
     try:
         return isinstance(x, Algebra) or x in Algebras(x.base_ring())
     except Exception:

--- a/src/sage/algebras/algebra.py
+++ b/src/sage/algebras/algebra.py
@@ -31,7 +31,7 @@ def is_Algebra(x):
         sage: is_Algebra(R)
         doctest:warning...
         DeprecationWarning: the function is_Algebra is deprecated; use '... in Algebras(base_ring)' instead
-        See https://github.com/sagemath/sage/issues/99999 for details.
+        See https://github.com/sagemath/sage/issues/35253 for details.
         True
     """
     from sage.misc.superseded import deprecation

--- a/src/sage/algebras/algebra.py
+++ b/src/sage/algebras/algebra.py
@@ -35,7 +35,7 @@ def is_Algebra(x):
         True
     """
     from sage.misc.superseded import deprecation
-    deprecation(99999, "the function is_Algebra is deprecated; use '... in Algebras(base_ring)' instead")
+    deprecation(35253, "the function is_Algebra is deprecated; use '... in Algebras(base_ring)' instead")
     try:
         return isinstance(x, Algebra) or x in Algebras(x.base_ring())
     except Exception:

--- a/src/sage/categories/algebra_ideals.py
+++ b/src/sage/categories/algebra_ideals.py
@@ -12,6 +12,7 @@ Algebra ideals
 
 from .category_types import Category_ideal
 from .algebra_modules import AlgebraModules
+from .commutative_algebras import CommutativeAlgebras
 
 
 class AlgebraIdeals(Category_ideal):
@@ -48,7 +49,6 @@ class AlgebraIdeals(Category_ideal):
 
             sage: TestSuite(AlgebraIdeals(QQ['a'])).run()
         """
-        from sage.algebras.algebra import is_Algebra
         if not hasattr(A, "base_ring") or A not in CommutativeAlgebras(A.base_ring()):
             raise TypeError("A (=%s) must be a commutative algebra" % A)
         Category_ideal.__init__(self, A)

--- a/src/sage/categories/algebra_ideals.py
+++ b/src/sage/categories/algebra_ideals.py
@@ -55,7 +55,7 @@ class AlgebraIdeals(Category_ideal):
         except AttributeError:
             raise TypeError(f"A (={A}) must be an algebra")
         else:
-            if base_ring not in Rings() or A not in Algebras(base_ring):
+            if base_ring not in Rings() or A not in Algebras(base_ring.category()):
                 raise TypeError(f"A (={A}) must be an algebra")
 
         Category_ideal.__init__(self, A)

--- a/src/sage/categories/algebra_ideals.py
+++ b/src/sage/categories/algebra_ideals.py
@@ -10,9 +10,10 @@ Algebra ideals
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from .category_types import Category_ideal
 from .algebra_modules import AlgebraModules
-from .commutative_algebras import CommutativeAlgebras
+from .algebras import Algebras
+from .rings import Rings
+from .category_types import Category_ideal
 
 
 class AlgebraIdeals(Category_ideal):
@@ -49,8 +50,14 @@ class AlgebraIdeals(Category_ideal):
 
             sage: TestSuite(AlgebraIdeals(QQ['a'])).run()
         """
-        if not hasattr(A, "base_ring") or A not in CommutativeAlgebras(A.base_ring()):
-            raise TypeError("A (=%s) must be a commutative algebra" % A)
+        try:
+            base_ring = A.base_ring()
+        except AttributeError:
+            raise TypeError(f"A (={A}) must be an algebra")
+        else:
+            if base_ring not in Rings() or A not in Algebras(base_ring):
+                raise TypeError(f"A (={A}) must be an algebra")
+
         Category_ideal.__init__(self, A)
 
     def algebra(self):

--- a/src/sage/categories/algebra_ideals.py
+++ b/src/sage/categories/algebra_ideals.py
@@ -49,8 +49,8 @@ class AlgebraIdeals(Category_ideal):
             sage: TestSuite(AlgebraIdeals(QQ['a'])).run()
         """
         from sage.algebras.algebra import is_Algebra
-        if not is_Algebra(A): # A not in Algebras() ?
-            raise TypeError("A (=%s) must be an algebra"%A)
+        if not hasattr(A, "base_ring") or A not in CommutativeAlgebras(A.base_ring()):
+            raise TypeError("A (=%s) must be a commutative algebra" % A)
         Category_ideal.__init__(self, A)
 
     def algebra(self):
@@ -82,6 +82,6 @@ class AlgebraIdeals(Category_ideal):
         try:
             if R.is_commutative():
                 return [AlgebraModules(R)]
-        except (AttributeError,NotImplementedError):
+        except (AttributeError, NotImplementedError):
             pass
         return []

--- a/src/sage/categories/algebra_modules.py
+++ b/src/sage/categories/algebra_modules.py
@@ -57,7 +57,7 @@ class AlgebraModules(Category_module):
         except AttributeError:
             raise TypeError(f"A (={A}) must be a commutative algebra")
         else:
-            if base_ring not in CommutativeRings() or A not in CommutativeAlgebras(base_ring):
+            if base_ring not in CommutativeRings() or A not in CommutativeAlgebras(base_ring.category()):
                 raise TypeError(f"A (={A}) must be a commutative algebra")
 
         Category_module.__init__(self, A)

--- a/src/sage/categories/algebra_modules.py
+++ b/src/sage/categories/algebra_modules.py
@@ -11,6 +11,8 @@ Algebra modules
 #******************************************************************************
 
 from .category_types import Category_module
+from .commutative_algebras import CommutativeAlgebras
+from .commutative_rings import CommutativeRings
 from .modules import Modules
 
 class AlgebraModules(Category_module):
@@ -50,9 +52,14 @@ class AlgebraModules(Category_module):
 
             sage: TestSuite(AlgebraModules(QQ['a'])).run()
         """
-        from sage.categories.commutative_algebras import CommutativeAlgebras
-        if not hasattr(A, "base_ring") or A not in CommutativeAlgebras(A.base_ring()):
-            raise TypeError("A (=%s) must be a commutative algebra" % A)
+        try:
+            base_ring = A.base_ring()
+        except AttributeError:
+            raise TypeError(f"A (={A}) must be a commutative algebra")
+        else:
+            if base_ring not in CommutativeRings() or A not in CommutativeAlgebras(base_ring):
+                raise TypeError(f"A (={A}) must be a commutative algebra")
+
         Category_module.__init__(self, A)
 
     @classmethod

--- a/src/sage/categories/commutative_algebra_ideals.py
+++ b/src/sage/categories/commutative_algebra_ideals.py
@@ -10,9 +10,10 @@ Commutative algebra ideals
 #                  http://www.gnu.org/licenses/
 #******************************************************************************
 
-from .category_types import Category_ideal, Category_in_ambient
 from .algebra_ideals import AlgebraIdeals
+from .category_types import Category_ideal, Category_in_ambient
 from .commutative_algebras import CommutativeAlgebras
+from .commutative_rings import CommutativeRings
 
 
 class CommutativeAlgebraIdeals(Category_ideal):
@@ -53,8 +54,14 @@ class CommutativeAlgebraIdeals(Category_ideal):
         """
         # TODO: replace by ``A in CommutativeAlgebras(*)`` once a
         # suitable mantra has been implemented for this.
-        if not hasattr(A, "base_ring") or A not in CommutativeAlgebras(A.base_ring()):
-            raise TypeError("A (=%s) must be a commutative algebra" % A)
+        try:
+            base_ring = A.base_ring()
+        except AttributeError:
+            raise TypeError(f"A (={A}) must be a commutative algebra")
+        else:
+            if base_ring not in CommutativeRings() or A not in CommutativeAlgebras(base_ring):
+                raise TypeError(f"A (={A}) must be a commutative algebra")
+
         Category_in_ambient.__init__(self, A)
 
     def algebra(self):

--- a/src/sage/categories/commutative_algebra_ideals.py
+++ b/src/sage/categories/commutative_algebra_ideals.py
@@ -53,8 +53,8 @@ class CommutativeAlgebraIdeals(Category_ideal):
         # suitable mantra has been implemented for this.
         from sage.algebras.algebra import is_Algebra
         from sage.rings.ring import CommutativeRing
-        if not (is_Algebra(A) and isinstance(A, CommutativeRing)):
-            raise TypeError("A (=%s) must be a commutative algebra"%A)
+        if not hasattr(A, "base_ring") or A not in CommutativeAlgebras(A.base_ring()):
+            raise TypeError("A (=%s) must be a commutative algebra" % A)
         Category_in_ambient.__init__(self, A)
 
     def algebra(self):

--- a/src/sage/categories/commutative_algebra_ideals.py
+++ b/src/sage/categories/commutative_algebra_ideals.py
@@ -12,6 +12,8 @@ Commutative algebra ideals
 
 from .category_types import Category_ideal, Category_in_ambient
 from .algebra_ideals import AlgebraIdeals
+from .commutative_algebras import CommutativeAlgebras
+
 
 class CommutativeAlgebraIdeals(Category_ideal):
     """
@@ -51,8 +53,6 @@ class CommutativeAlgebraIdeals(Category_ideal):
         """
         # TODO: replace by ``A in CommutativeAlgebras(*)`` once a
         # suitable mantra has been implemented for this.
-        from sage.algebras.algebra import is_Algebra
-        from sage.rings.ring import CommutativeRing
         if not hasattr(A, "base_ring") or A not in CommutativeAlgebras(A.base_ring()):
             raise TypeError("A (=%s) must be a commutative algebra" % A)
         Category_in_ambient.__init__(self, A)

--- a/src/sage/categories/commutative_algebra_ideals.py
+++ b/src/sage/categories/commutative_algebra_ideals.py
@@ -59,7 +59,7 @@ class CommutativeAlgebraIdeals(Category_ideal):
         except AttributeError:
             raise TypeError(f"A (={A}) must be a commutative algebra")
         else:
-            if base_ring not in CommutativeRings() or A not in CommutativeAlgebras(base_ring):
+            if base_ring not in CommutativeRings() or A not in CommutativeAlgebras(base_ring.category()):
                 raise TypeError(f"A (={A}) must be a commutative algebra")
 
         Category_in_ambient.__init__(self, A)

--- a/src/sage/rings/commutative_algebra.py
+++ b/src/sage/rings/commutative_algebra.py
@@ -28,6 +28,11 @@ def is_CommutativeAlgebra(x):
         sage: from sage.rings.commutative_algebra import is_CommutativeAlgebra
         sage: from sage.rings.ring import CommutativeAlgebra
         sage: is_CommutativeAlgebra(CommutativeAlgebra(ZZ))
+        doctest:warning...
+        DeprecationWarning: the function is_CommutativeAlgebra is deprecated; use '... in Algebras(base_ring).Commutative()' instead
+        See https://github.com/sagemath/sage/issues/35253 for details.
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(35253, "the function is_CommutativeAlgebra is deprecated; use '... in Algebras(base_ring).Commutative()' instead")
     return isinstance(x, CommutativeAlgebra)


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description
Part of 
- https://github.com/sagemath/sage/issues/32738
- #32414

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

