### PR TITLE
Drinfeld modules: Make some imports lazy

### DIFF
--- a/src/sage/categories/drinfeld_modules.py
+++ b/src/sage/categories/drinfeld_modules.py
@@ -23,10 +23,12 @@ from sage.categories.category_types import Category_over_base_ring
 from sage.categories.homsets import Homsets
 from sage.misc.functional import log
 from sage.misc.latex import latex
+from sage.misc.lazy_import import lazy_import
 from sage.rings.integer import Integer
 from sage.rings.polynomial.ore_polynomial_ring import OrePolynomialRing
 from sage.rings.polynomial.polynomial_ring import PolynomialRing_general
-from sage.rings.ring_extension import RingExtension_generic
+
+lazy_import('sage.rings.ring_extension', 'RingExtension_generic')
 
 
 class DrinfeldModules(Category_over_base_ring):

--- a/src/sage/categories/drinfeld_modules.py
+++ b/src/sage/categories/drinfeld_modules.py
@@ -25,10 +25,10 @@ from sage.misc.functional import log
 from sage.misc.latex import latex
 from sage.misc.lazy_import import lazy_import
 from sage.rings.integer import Integer
-from sage.rings.polynomial.ore_polynomial_ring import OrePolynomialRing
-from sage.rings.polynomial.polynomial_ring import PolynomialRing_general
 
 lazy_import('sage.rings.ring_extension', 'RingExtension_generic')
+lazy_import('sage.rings.polynomial.ore_polynomial_ring', 'OrePolynomialRing')
+lazy_import('sage.rings.polynomial.polynomial_ring', 'PolynomialRing_general')
 
 
 class DrinfeldModules(Category_over_base_ring):

--- a/src/sage/categories/drinfeld_modules.py
+++ b/src/sage/categories/drinfeld_modules.py
@@ -26,9 +26,9 @@ from sage.misc.latex import latex
 from sage.misc.lazy_import import lazy_import
 from sage.rings.integer import Integer
 
-lazy_import('sage.rings.ring_extension', 'RingExtension_generic')
 lazy_import('sage.rings.polynomial.ore_polynomial_ring', 'OrePolynomialRing')
 lazy_import('sage.rings.polynomial.polynomial_ring', 'PolynomialRing_general')
+lazy_import('sage.rings.ring_extension', 'RingExtension_generic')
 
 
 class DrinfeldModules(Category_over_base_ring):

--- a/src/sage/rings/function_field/all.py
+++ b/src/sage/rings/function_field/all.py
@@ -1,2 +1,5 @@
 from .constructor import FunctionField
-from .drinfeld_modules.drinfeld_module import DrinfeldModule
+
+from sage.misc.lazy_import import lazy_import
+
+lazy_import("sage.rings.function_field.drinfeld_modules.drinfeld_module", "DrinfeldModule")

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -166,8 +166,6 @@ from sage.misc.lazy_attribute import lazy_attribute
 import sage.rings.abc
 from sage.rings.fraction_field_element import FractionFieldElement
 from sage.rings.finite_rings.element_base import FiniteRingElement
-
-from .polynomial_element import PolynomialBaseringInjection
 from .polynomial_real_mpfr_dense import PolynomialRealDense
 from .polynomial_integer_dense_flint import Polynomial_integer_dense_flint
 from sage.rings.polynomial.polynomial_singular_interface import PolynomialRing_singular_repr
@@ -679,6 +677,8 @@ class PolynomialRing_general(ring.Algebra):
                       To:   Univariate Polynomial Ring in x over Rational Field
             sage: R.coerce_map_from(GF(7))
         """
+        from .polynomial_element import PolynomialBaseringInjection
+
         return PolynomialBaseringInjection(self.base_ring(), self)
 
     def _coerce_map_from_(self, P):


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
We replace some `import`s by `lazy_imports` in `sage.categories.drinfeld_modules` and make the import of `DrinfeldModule` into the global namespace lazy. We also move the module-level import of `PolynomialBaseringInjection` in `sage.rings.polynomial.polynomial_ring` into a method. 
<!-- Why is this change required? What problem does it solve? -->

`git grep '^from sage.rings' src/sage/categories` reveals that the recently added `.drinfeld_modules` is the only module that imports nontrivial things from `sage.rings`. This is a new obstacle to modularization (it caused an error due to import cycles in #35095.) 

The purpose of reducing the module-level import to a method-level import is explained in https://doc.sagemath.org/html/en/developer/packaging_sage_library.html#module-level-runtime-dependencies

<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

