### PR TITLE
`sage.rings.polynomial.polynomial_ring[_constructor]`: Handle missing implementation modules

### DIFF
--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -1679,7 +1679,8 @@ class PolynomialRing_commutative(PolynomialRing_general, ring.CommutativeAlgebra
             else:
                 category = polynomial_default_category(base_ring.category(), 1)
         PolynomialRing_general.__init__(self, base_ring, name=name,
-                sparse=sparse, element_class=element_class, category=category)
+                                        sparse=sparse, implementation=implementation,
+                                        element_class=element_class, category=category)
 
     def quotient_by_principal_ideal(self, f, names=None, **kwds):
         """
@@ -1828,7 +1829,8 @@ class PolynomialRing_integral_domain(PolynomialRing_commutative, PolynomialRing_
                             continue
                 break
         PolynomialRing_commutative.__init__(self, base_ring, name=name,
-                                            sparse=sparse, element_class=element_class, category=category)
+                                            sparse=sparse, implementation=implementation,
+                                            element_class=element_class, category=category)
         self._has_singular = can_convert_to_singular(self)
 
     @cached_method(key=lambda self, d, q, sign, lead: (d, q, sign, tuple([x if isinstance(x, (tuple, list)) else (x, 0) for x in lead]) if isinstance(lead, (tuple, list)) else ((lead, 0))))
@@ -2063,7 +2065,8 @@ class PolynomialRing_field(PolynomialRing_integral_domain,
             from sage.rings.polynomial.polynomial_element_generic import Polynomial_generic_dense_field
             return Polynomial_generic_dense_field
 
-        PolynomialRing_integral_domain.__init__(self, base_ring, name=name, sparse=sparse,
+        PolynomialRing_integral_domain.__init__(self, base_ring, name=name,
+                                                sparse=sparse, implementation=implementation,
                                                 element_class=_element_class(), category=category)
 
     def _ideal_class_(self, n=0):
@@ -2469,7 +2472,7 @@ class PolynomialRing_dense_finite_field(PolynomialRing_field):
                     element_class = Polynomial_ZZ_pEX
                 break
         PolynomialRing_field.__init__(self, base_ring, sparse=False, name=name,
-                                      element_class=element_class)
+                                      implementation=implementation, element_class=element_class)
 
     @staticmethod
     def _implementation_names_impl(implementation, base_ring, sparse):
@@ -2871,7 +2874,9 @@ class PolynomialRing_cdvr(PolynomialRing_integral_domain):
             else:
                 from sage.rings.polynomial.polynomial_element_generic import Polynomial_generic_dense_cdvr
                 element_class = Polynomial_generic_dense_cdvr
-        PolynomialRing_integral_domain.__init__(self, base_ring, name, sparse, element_class=element_class, category=category)
+        PolynomialRing_integral_domain.__init__(self, base_ring, name, sparse,
+                                                implementation=implementation,
+                                                element_class=element_class, category=category)
 
 
 class PolynomialRing_cdvf(PolynomialRing_cdvr, PolynomialRing_field):
@@ -2900,7 +2905,9 @@ class PolynomialRing_cdvf(PolynomialRing_cdvr, PolynomialRing_field):
             else:
                 from sage.rings.polynomial.polynomial_element_generic import Polynomial_generic_dense_cdvf
                 element_class = Polynomial_generic_dense_cdvf
-        PolynomialRing_field.__init__(self, base_ring, name, sparse, element_class=element_class, category=category)
+        PolynomialRing_field.__init__(self, base_ring, name, sparse,
+                                      implementation=implementation, element_class=element_class,
+                                      category=category)
 
 
 class PolynomialRing_dense_padic_ring_generic(PolynomialRing_cdvr):
@@ -2908,7 +2915,9 @@ class PolynomialRing_dense_padic_ring_generic(PolynomialRing_cdvr):
     A class for dense polynomial ring over padic rings
     """
     def __init__(self, base_ring, name=None, implementation=None, element_class=None, category=None):
-        PolynomialRing_cdvr.__init__(self, base_ring, sparse=False, name=name, element_class=element_class, category=category)
+        PolynomialRing_cdvr.__init__(self, base_ring, sparse=False, name=name,
+                                     implementation=implementation, element_class=element_class,
+                                     category=category)
 
     @staticmethod
     def _implementation_names_impl(implementation, base_ring, sparse):
@@ -2935,7 +2944,9 @@ class PolynomialRing_dense_padic_field_generic(PolynomialRing_cdvf):
     A class for dense polynomial ring over padic fields
     """
     def __init__(self, base_ring, name=None, implementation=None, element_class=None, category=None):
-        PolynomialRing_cdvf.__init__(self, base_ring, sparse=False, name=name, element_class=element_class, category=category)
+        PolynomialRing_cdvf.__init__(self, base_ring, sparse=False, name=name,
+                                     implementation=implementation, element_class=element_class,
+                                     category=category)
 
     @staticmethod
     def _implementation_names_impl(implementation, base_ring, sparse):
@@ -2973,8 +2984,9 @@ class PolynomialRing_dense_padic_ring_capped_relative(PolynomialRing_dense_padic
                     polynomial_padic_capped_relative_dense import \
                     Polynomial_padic_capped_relative_dense
             element_class = Polynomial_padic_capped_relative_dense
-        PolynomialRing_dense_padic_ring_generic.__init__(self, base_ring,
-                name=name, element_class=element_class, category=category)
+        PolynomialRing_dense_padic_ring_generic.__init__(self, base_ring, name=name,
+                                                         implementation=implementation,
+                                                         element_class=element_class, category=category)
 
 
 class PolynomialRing_dense_padic_ring_capped_absolute(PolynomialRing_dense_padic_ring_generic):
@@ -2992,8 +3004,9 @@ class PolynomialRing_dense_padic_ring_capped_absolute(PolynomialRing_dense_padic
             from sage.rings.polynomial.padics.polynomial_padic_flat import \
                     Polynomial_padic_flat
             element_class = Polynomial_padic_flat
-        PolynomialRing_dense_padic_ring_generic.__init__(self, base_ring,
-                name=name, element_class=element_class, category=category)
+        PolynomialRing_dense_padic_ring_generic.__init__(self, base_ring, name=name,
+                                                         implementation=implementation,
+                                                         element_class=element_class, category=category)
 
 
 class PolynomialRing_dense_padic_ring_fixed_mod(PolynomialRing_dense_padic_ring_generic):
@@ -3012,8 +3025,9 @@ class PolynomialRing_dense_padic_ring_fixed_mod(PolynomialRing_dense_padic_ring_
             from sage.rings.polynomial.padics.polynomial_padic_flat import \
                     Polynomial_padic_flat
             element_class = Polynomial_padic_flat
-        PolynomialRing_dense_padic_ring_generic.__init__(self, base_ring,
-                name=name, element_class=element_class, category=category)
+        PolynomialRing_dense_padic_ring_generic.__init__(self, base_ring, name=name,
+                                                         implementation=implementation,
+                                                         element_class=element_class, category=category)
 
 
 class PolynomialRing_dense_padic_field_capped_relative(PolynomialRing_dense_padic_field_generic):
@@ -3032,8 +3046,9 @@ class PolynomialRing_dense_padic_field_capped_relative(PolynomialRing_dense_padi
                     polynomial_padic_capped_relative_dense import \
                     Polynomial_padic_capped_relative_dense
             element_class = Polynomial_padic_capped_relative_dense
-        PolynomialRing_dense_padic_field_generic.__init__(self, base_ring,
-                name=name, element_class=element_class, category=category)
+        PolynomialRing_dense_padic_field_generic.__init__(self, base_ring, name=name,
+                                                          implementation=implementation,
+                                                          element_class=element_class, category=category)
 
 
 class PolynomialRing_dense_mod_n(PolynomialRing_commutative):
@@ -3095,8 +3110,8 @@ class PolynomialRing_dense_mod_n(PolynomialRing_commutative):
                     self._implementation_repr = ' (using NTL)'
                 break
 
-        PolynomialRing_commutative.__init__(self, base_ring, name=name,
-                element_class=element_class, category=category)
+        PolynomialRing_commutative.__init__(self, base_ring, name=name, implementation=implementation,
+                                            element_class=element_class, category=category)
 
     @staticmethod
     def _implementation_names_impl(implementation, base_ring, sparse):
@@ -3272,8 +3287,8 @@ class PolynomialRing_dense_mod_p(PolynomialRing_dense_finite_field,
                     self._implementation_repr = ' (using GF2X)'
                 break
 
-        PolynomialRing_dense_mod_n.__init__(self, base_ring, name=name,
-                element_class=element_class, category=category)
+        PolynomialRing_dense_mod_n.__init__(self, base_ring, name=name, implementation=implementation,
+                                            element_class=element_class, category=category)
 
         self._has_singular = can_convert_to_singular(self)
 

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -1804,6 +1804,7 @@ class PolynomialRing_integral_domain(PolynomialRing_commutative, PolynomialRing_
         """
         self._implementation_repr = ''
         if element_class is None:
+            given_implementation = implementation
             for implementation in self._implementation_names(implementation, base_ring, sparse):
                 if base_ring is ZZ:
                     if implementation == 'NTL':
@@ -1811,6 +1812,8 @@ class PolynomialRing_integral_domain(PolynomialRing_commutative, PolynomialRing_
                             from sage.rings.polynomial.polynomial_integer_dense_ntl \
                                 import Polynomial_integer_dense_ntl as element_class
                         except ImportError:
+                            if given_implementation:
+                                raise
                             continue
                         self._implementation_repr = ' (using NTL)'
                     elif implementation == 'FLINT':
@@ -1818,6 +1821,8 @@ class PolynomialRing_integral_domain(PolynomialRing_commutative, PolynomialRing_
                             from .polynomial_integer_dense_flint \
                                 import Polynomial_integer_dense_flint as element_class
                         except ImportError:
+                            if given_implementation:
+                                raise
                             continue
                 break
         PolynomialRing_commutative.__init__(self, base_ring, name=name,
@@ -2445,6 +2450,7 @@ class PolynomialRing_dense_finite_field(PolynomialRing_field):
             ValueError: unknown implementation 'superfast' for dense polynomial rings over Finite Field in z6 of size 2^6
         """
         if element_class is None:
+            given_implementation = implementation
             for implementation in self._implementation_names(implementation, base_ring):
                 if implementation == "NTL":
                     try:
@@ -2452,6 +2458,8 @@ class PolynomialRing_dense_finite_field(PolynomialRing_field):
                         from sage.libs.ntl.ntl_ZZ_pX import ntl_ZZ_pX
                         from sage.rings.polynomial.polynomial_zz_pex import Polynomial_ZZ_pEX
                     except ImportError:
+                        if given_implementation:
+                            raise
                         continue
                     p = base_ring.characteristic()
                     self._modulus = ntl_ZZ_pEContext(ntl_ZZ_pX(list(base_ring.modulus()), p))
@@ -3055,12 +3063,16 @@ class PolynomialRing_dense_mod_n(PolynomialRing_commutative):
             sage: type(R.gen())
             <class 'sage.rings.polynomial.polynomial_modn_dense_ntl.Polynomial_dense_modn_ntl_ZZ'>
         """
+        self._implementation_repr = ''
         if element_class is None:
+            given_implementation = implementation
             for implementation in self._implementation_names(implementation, base_ring):
                 if implementation == "FLINT":
                     try:
                         from .polynomial_zmod_flint import Polynomial_zmod_flint as element_class
                     except ImportError:
+                        if given_implementation:
+                            raise
                         continue
                     self._implementation_repr = ''
                 elif implementation == "NTL":
@@ -3068,6 +3080,8 @@ class PolynomialRing_dense_mod_n(PolynomialRing_commutative):
                     try:
                         from . import polynomial_modn_dense_ntl as modn_dense_ntl
                     except ImportError:
+                        if given_implementation:
+                            raise
                         continue
                     if modulus < ZZ(modn_dense_ntl.zz_p_max):
                         element_class = modn_dense_ntl.Polynomial_dense_modn_ntl_zz
@@ -3225,23 +3239,30 @@ class PolynomialRing_dense_mod_p(PolynomialRing_dense_finite_field,
             True
         """
         if element_class is None:
+            given_implementation = implementation
             for implementation in self._implementation_names(implementation, base_ring):
                 if implementation == "FLINT":
                     try:
                         from .polynomial_zmod_flint import Polynomial_zmod_flint as element_class
                     except ImportError:
+                        if given_implementation:
+                            raise
                         continue
                     self._implementation_repr = ''
                 elif implementation == "NTL":
                     try:
                         from .polynomial_modn_dense_ntl import Polynomial_dense_mod_p as element_class
                     except ImportError:
+                        if given_implementation:
+                            raise
                         continue
                     self._implementation_repr = ' (using NTL)'
                 elif implementation == "GF2X":
                     try:
                         from .polynomial_gf2x import Polynomial_GF2X as element_class
                     except ImportError:
+                        if given_implementation:
+                            raise
                         continue
                     self._implementation_repr = ' (using GF2X)'
                 break

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -3083,8 +3083,8 @@ class PolynomialRing_dense_mod_n(PolynomialRing_commutative):
             sage: type(R.gen())
             <class 'sage.rings.polynomial.polynomial_modn_dense_ntl.Polynomial_dense_modn_ntl_ZZ'>
         """
-        self._implementation_repr = ''
         if element_class is None:
+            self._implementation_repr = ''
             given_implementation = implementation
             for implementation in self._implementation_names(implementation, base_ring):
                 if implementation == "FLINT":

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -229,7 +229,8 @@ class PolynomialRing_general(ring.Algebra):
     Univariate polynomial ring over a ring.
     """
 
-    def __init__(self, base_ring, name=None, sparse=False, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, sparse=False, implementation=None,
+                 element_class=None, category=None):
         """
         EXAMPLES::
 
@@ -1667,7 +1668,8 @@ class PolynomialRing_commutative(PolynomialRing_general, ring.CommutativeAlgebra
     """
     Univariate polynomial ring over a commutative ring.
     """
-    def __init__(self, base_ring, name=None, sparse=False, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, sparse=False, implementation=None,
+                 element_class=None, category=None):
         if base_ring not in _CommutativeRings:
             raise TypeError("Base ring %s must be a commutative ring."%repr(base_ring))
         # We trust that, if a category is given, that it is useful.
@@ -2002,7 +2004,8 @@ class PolynomialRing_integral_domain(PolynomialRing_commutative, PolynomialRing_
 
 class PolynomialRing_field(PolynomialRing_integral_domain,
                            ring.PrincipalIdealDomain):
-    def __init__(self, base_ring, name="x", sparse=False, element_class=None, category=None):
+    def __init__(self, base_ring, name="x", sparse=False, implementation=None,
+                 element_class=None, category=None):
         """
         TESTS::
 
@@ -2846,7 +2849,8 @@ class PolynomialRing_cdvr(PolynomialRing_integral_domain):
     r"""
     A class for polynomial ring over complete discrete valuation rings
     """
-    def __init__(self, base_ring, name=None, sparse=False, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, sparse=False, implementation=None,
+                 element_class=None, category=None):
         r"""
         TESTS::
 
@@ -2874,7 +2878,8 @@ class PolynomialRing_cdvf(PolynomialRing_cdvr, PolynomialRing_field):
     """
     A class for polynomial ring over complete discrete valuation fields
     """
-    def __init__(self, base_ring, name=None, sparse=False, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, sparse=False, implementation=None,
+                 element_class=None, category=None):
         r"""
         TESTS::
 
@@ -2902,7 +2907,7 @@ class PolynomialRing_dense_padic_ring_generic(PolynomialRing_cdvr):
     r"""
     A class for dense polynomial ring over padic rings
     """
-    def __init__(self, base_ring, name=None, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, implementation=None, element_class=None, category=None):
         PolynomialRing_cdvr.__init__(self, base_ring, sparse=False, name=name, element_class=element_class, category=category)
 
     @staticmethod
@@ -2929,7 +2934,7 @@ class PolynomialRing_dense_padic_field_generic(PolynomialRing_cdvf):
     r"""
     A class for dense polynomial ring over padic fields
     """
-    def __init__(self, base_ring, name=None, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, implementation=None, element_class=None, category=None):
         PolynomialRing_cdvf.__init__(self, base_ring, sparse=False, name=name, element_class=element_class, category=category)
 
     @staticmethod
@@ -2953,7 +2958,7 @@ class PolynomialRing_dense_padic_field_generic(PolynomialRing_cdvf):
 
 
 class PolynomialRing_dense_padic_ring_capped_relative(PolynomialRing_dense_padic_ring_generic):
-    def __init__(self, base_ring, name=None, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, implementation=None, element_class=None, category=None):
         """
         TESTS::
 
@@ -2973,7 +2978,7 @@ class PolynomialRing_dense_padic_ring_capped_relative(PolynomialRing_dense_padic
 
 
 class PolynomialRing_dense_padic_ring_capped_absolute(PolynomialRing_dense_padic_ring_generic):
-    def __init__(self, base_ring, name=None, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, implementation=None, element_class=None, category=None):
         """
         TESTS::
 
@@ -2992,7 +2997,7 @@ class PolynomialRing_dense_padic_ring_capped_absolute(PolynomialRing_dense_padic
 
 
 class PolynomialRing_dense_padic_ring_fixed_mod(PolynomialRing_dense_padic_ring_generic):
-    def __init__(self, base_ring, name=None, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, implementation=None, element_class=None, category=None):
         """
         TESTS::
 
@@ -3012,7 +3017,7 @@ class PolynomialRing_dense_padic_ring_fixed_mod(PolynomialRing_dense_padic_ring_
 
 
 class PolynomialRing_dense_padic_field_capped_relative(PolynomialRing_dense_padic_field_generic):
-    def __init__(self, base_ring, name=None, element_class=None, category=None):
+    def __init__(self, base_ring, name=None, implementation=None, element_class=None, category=None):
         """
         TESTS::
 

--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -819,10 +819,10 @@ def _multi_variate(base_ring, names, sparse=None, order="degrevlex", implementat
     implementation_names = set([implementation])
 
     if implementation is None or implementation == "singular":
-        from sage.rings.polynomial.multi_polynomial_libsingular import MPolynomialRing_libsingular
         try:
+            from sage.rings.polynomial.multi_polynomial_libsingular import MPolynomialRing_libsingular
             R = MPolynomialRing_libsingular(base_ring, n, names, order)
-        except (TypeError, NotImplementedError):
+        except (ImportError, TypeError, NotImplementedError):
             if implementation is not None:
                 raise
         else:

--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -762,7 +762,6 @@ def _single_variate(base_ring, name, sparse=None, implementation=None, order=Non
     if specialized is not None:
         implementation_names = specialized._implementation_names_impl(implementation, base_ring, sparse)
         if implementation_names is not NotImplemented:
-            implementation = implementation_names[0]
             constructor = specialized
 
     # Generic implementations
@@ -780,7 +779,6 @@ def _single_variate(base_ring, name, sparse=None, implementation=None, order=Non
         else:
             constructor = polynomial_ring.PolynomialRing_commutative
         implementation_names = constructor._implementation_names(implementation, base_ring, sparse)
-        implementation = implementation_names[0]
 
         # Only use names which are not supported by the specialized class.
         if specialized is not None:


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
We modify the `__init__` methods of univariate polynomial implementation classes so that they all take an `implementation` keyword (and pass it on to their `super`).
We guard the imports of implementation classes in the `PolynomialRing` constructor with `try... except ImportError` and fall back to alternative implementations unless a specific implementation was requested.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->
This is part of:
- #29705 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

