### PR TITLE
`sage.categories`: Modularization fixes for imports

### DIFF
--- a/src/sage/categories/finite_complex_reflection_groups.py
+++ b/src/sage/categories/finite_complex_reflection_groups.py
@@ -16,7 +16,6 @@ from sage.misc.misc_c import prod
 from sage.misc.cachefunc import cached_method
 from sage.categories.category_with_axiom import CategoryWithAxiom
 from sage.categories.coxeter_groups import CoxeterGroups
-from sage.sets.recursively_enumerated_set import RecursivelyEnumeratedSet
 
 
 class FiniteComplexReflectionGroups(CategoryWithAxiom):
@@ -758,6 +757,8 @@ class FiniteComplexReflectionGroups(CategoryWithAxiom):
                     [1] 1
                     [] 0
                 """
+                from sage.sets.recursively_enumerated_set import RecursivelyEnumeratedSet
+
                 if gens is None:
                     seeds = [(self.coxeter_element(), self.rank())]
                 else:

--- a/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
@@ -24,9 +24,7 @@ from sage.misc.lazy_import import LazyImport
 from sage.categories.category_with_axiom import CategoryWithAxiom_over_base_ring
 from sage.categories.lie_algebras import LieAlgebras
 from sage.categories.subobjects import SubobjectsCategory
-from sage.algebras.free_algebra import FreeAlgebra
 from sage.sets.family import Family
-from sage.matrix.constructor import matrix
 
 
 class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
@@ -97,6 +95,8 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                  The 6-Witt Lie algebra over Ring of integers modulo 6
                  in the Poincare-Birkhoff-Witt basis
             """
+            from sage.algebras.free_algebra import FreeAlgebra
+
             # Create the UEA relations
             # We need to get names for the basis elements, not just the generators
             I = self._basis_ordering
@@ -321,6 +321,8 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: parent(m)
                 Full MatrixSpace of 0 by 0 dense matrices over Rational Field
             """
+            from sage.matrix.constructor import matrix
+
             B = self.basis()
             m = matrix(self.base_ring(),
                        [[self.killing_form(x, y) for x in B] for y in B])
@@ -420,6 +422,8 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                  D{1} + D{1, 2} + D{2, 3} + D{3},
                  D{1, 2, 3} + D{1, 3} + D{2})
             """
+            from sage.matrix.constructor import matrix
+
             #from sage.algebras.lie_algebras.subalgebra import LieSubalgebra
             #if isinstance(S, LieSubalgebra) or S is self:
             if S is self:
@@ -541,6 +545,7 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
             :wikipedia:`Derivation_(differential_algebra)`
             """
             from sage.matrix.constructor import matrix
+
             R = self.base_ring()
             B = self.basis()
             keys = list(B.keys())
@@ -581,6 +586,8 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 [1 0 0], [0 1 0]
                 )
             """
+            from sage.matrix.constructor import matrix
+
             R = self.base_ring()
             IDer = matrix(R, [b.adjoint_matrix().list() for b in self.basis()])
             N = self.dimension()
@@ -691,6 +698,9 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
             if A not in LieAlgebras(self.base_ring()).FiniteDimensional().WithBasis():
                 raise NotImplementedError("A must be a finite dimensional"
                                           " Lie algebra with basis")
+
+            from sage.matrix.constructor import matrix
+
             B = self.basis()
             AB = A.basis()
             try:
@@ -798,6 +808,8 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 Subalgebra generated of Lie algebra on 2 generators (x, y) over Rational Field with basis:
                 ()
             """
+            from sage.matrix.constructor import matrix
+
             # Make sure we lift everything to the ambient space
             if self in LieAlgebras(self.base_ring()).Subobjects():
                 A = self.ambient()
@@ -1373,6 +1385,8 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: X * Y
                 Z
             """
+            from sage.matrix.constructor import matrix
+
             K = self._basis_ordering
             mats = []
             R = self.base_ring()
@@ -1606,6 +1620,8 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: E1 * E2 - E2 * E1 == e12.adjoint_matrix()
                 True
             """
+            from sage.matrix.constructor import matrix
+
             P = self.parent()
             basis = P.basis()
             return matrix(self.base_ring(),

--- a/src/sage/categories/loop_crystals.py
+++ b/src/sage/categories/loop_crystals.py
@@ -19,8 +19,7 @@ from sage.categories.crystals import Crystals
 from sage.categories.regular_crystals import RegularCrystals
 from sage.categories.tensor import TensorProductsCategory
 from sage.categories.map import Map
-from sage.graphs.dot2tex_utils import have_dot2tex
-from sage.functions.other import ceil
+
 
 class LoopCrystals(Category_singleton):
     r"""
@@ -117,6 +116,8 @@ class LoopCrystals(Category_singleton):
                 {...'edge_options': <function ... at ...>...}
                 sage: view(G, tightpage=True)  # optional - dot2tex graphviz, not tested (opens external window)
             """
+            from sage.graphs.dot2tex_utils import have_dot2tex
+
             G = Crystals().parent_class.digraph(self, subset, index_set)
             if have_dot2tex():
                 def eopt(u_v_label):
@@ -959,6 +960,8 @@ class KirillovReshetikhinCrystals(Category_singleton):
                     ....:     for b in hw)
                     True
                 """
+                from sage.functions.other import ceil
+
                 C = self.parent().crystals[0]
                 ell = ceil(C.s()/C.cartan_type().c()[C.r()])
                 is_perfect = all(ell == K.s()/K.cartan_type().c()[K.r()]
@@ -1090,6 +1093,8 @@ class KirillovReshetikhinCrystals(Category_singleton):
                     ....:     for elt in hw)
                     True
                 """
+                from sage.functions.other import ceil
+
                 ell = max(ceil(K.s()/K.cartan_type().c()[K.r()])
                           for K in self.parent().crystals)
                 if self.cartan_type().dual().type() == 'BC':

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -3462,8 +3462,8 @@ class AlgebraicExtensionFunctor(ConstructionFunctor):
             # nothing else helps, hence, we move to the pushout of the codomains of the embeddings
             try:
                 P = pushout(self.embeddings[0].parent(), other.embeddings[0].parent())
-                from sage.rings.number_field.number_field import is_NumberField
-                if is_NumberField(P):
+                from sage.rings.number_field.number_field_base import NumberField
+                if isinstance(p, NumberField):
                     return P.construction()[0]
             except CoercionException:
                 return None

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -3463,7 +3463,7 @@ class AlgebraicExtensionFunctor(ConstructionFunctor):
             try:
                 P = pushout(self.embeddings[0].parent(), other.embeddings[0].parent())
                 from sage.rings.number_field.number_field_base import NumberField
-                if isinstance(p, NumberField):
+                if isinstance(P, NumberField):
                     return P.construction()[0]
             except CoercionException:
                 return None

--- a/src/sage/categories/rings.py
+++ b/src/sage/categories/rings.py
@@ -1159,7 +1159,10 @@ class Rings(CategoryWithAxiom):
 
             if isinstance(arg, tuple):
                 from sage.categories.morphism import Morphism
-                from sage.rings.derivation import RingDerivation
+                try:
+                    from sage.rings.derivation import RingDerivation
+                except ImportError:
+                    RingDerivation = ()
                 if len(arg) == 2 and isinstance(arg[1], (Morphism, RingDerivation)):
                     from sage.rings.polynomial.ore_polynomial_ring import OrePolynomialRing
                     return OrePolynomialRing(self, arg[1], names=arg[0])


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
We should be able to import Python modules from `sage.categories` even if implementation modules are not installed; that's the premise of the distribution **sagemath-categories**.
Here we make changes to avoid module-level dependencies on some higher-level functionality, such as symbolic functions, linear algebra, etc.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

#35275 takes care of some other imports.

Part of 
- #29705 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

