### PR TITLE
pplpy*:  update upstream info and deps

### DIFF
--- a/build/pkgs/pplpy/SPKG.rst
+++ b/build/pkgs/pplpy/SPKG.rst
@@ -20,4 +20,4 @@ GPL version 3
 Upstream Contact
 ----------------
 
--  https://github.com/videlec/pplpy
+-  https://github.com/sagemath/pplpy

--- a/build/pkgs/pplpy/dependencies
+++ b/build/pkgs/pplpy/dependencies
@@ -1,4 +1,4 @@
-$(PYTHON) $(MP_LIBRARY) gmpy2 cysignals mpfr mpc ppl | $(PYTHON_TOOLCHAIN)
+$(PYTHON) $(MP_LIBRARY) gmpy2 cysignals mpfr mpc ppl | $(PYTHON_TOOLCHAIN) sphinx
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pplpy_doc/SPKG.rst
+++ b/build/pkgs/pplpy_doc/SPKG.rst
@@ -15,4 +15,4 @@ GPL version 3
 Upstream Contact
 ----------------
 
--  https://github.com/videlec/pplpy
+-  https://github.com/sagemath/pplpy


### PR DESCRIPTION
### 📚 pplpy/pplpy_doc:  update upstream info and deps

these are now hosted on sagemath; 
also, build system of pplpy errors out if there is no sphinx.

### 📝 Checklist


- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.

