### PR TITLE
Use StringIO to format polynomials

### DIFF
--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -65,6 +65,7 @@ from cpython.number cimport PyNumber_TrueDivide, PyNumber_Check
 import operator
 import copy
 import re
+from io import StringIO
 
 from sage.cpython.wrapperdescr cimport wrapperdescr_fastcall
 import sage.rings.rational
@@ -2649,7 +2650,8 @@ cdef class Polynomial(CommutativePolynomial):
         # want their coefficient printed with its O() term
         if self._is_gen and not isinstance(self._parent._base, pAdicGeneric):
             return name
-        s = " "
+        sbuf = StringIO()
+        sbuf.write(" ")
         m = self.degree() + 1
         atomic_repr = self._parent.base_ring()._repr_option('element_is_atomic')
         coeffs = self.list(copy=False)
@@ -2665,7 +2667,7 @@ cdef class Polynomial(CommutativePolynomial):
                 is_nonzero = True
             if is_nonzero:
                 if n != m-1:
-                    s += " + "
+                    sbuf.write(" + ")
                 x = y = repr(x)
                 if y.find("-") == 0:
                     y = y[1:]
@@ -2677,7 +2679,9 @@ cdef class Polynomial(CommutativePolynomial):
                     var = "*%s"%name
                 else:
                     var = ""
-                s += "%s%s"%(x,var)
+                sbuf.write(x)
+                sbuf.write(var)
+        s = sbuf.getvalue()
         s = s.replace(" + -", " - ")
         s = re.sub(r' 1(\.0+)?\*',' ', s)
         s = re.sub(r' -1(\.0+)?\*',' -', s)


### PR DESCRIPTION
This patch modifies the repr()/str() method of polynomials to use a StringIO buffer instead of `s += ...` to build the result string. It is known that repeatedly calling `+=` has quadratic complexity for large Python strings.

Currently calling `str()`  on a high degree polynomial takes a very long amount of time and it may happen accidentally (a script was stuck during 2 hours trying to format a degree 300000 polynomial for an exception message).

```
sage: p = random_prime(2**96)
sage: K = GF(p**24, 'a')
sage: pol = K["x"].random_element(30000)
# Before patch
sage: %time _ = str(pol)
CPU times: user 2min 22s, sys: 1min 43s, total: 4min 5s
Wall time: 4min 5s
# After patch
sage: %time _ = str(pol)
CPU times: user 692 ms, sys: 21 ms, total: 713 ms
Wall time: 713 ms
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies

None.
