### PR TITLE
Avoid boilerplate computations in finite field arithmetic

### DIFF
--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -450,8 +450,10 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             sig_off()
             raise TypeError(f"unable to convert PARI {x.type()} to finite field element")
 
-        elif (isinstance(x, FreeModuleElement)
-              and x.parent() is self._parent.vector_space(map=False)):
+        elif ((isinstance(x, list) and len(x) == self._parent.degree()) or
+              (isinstance(x, FreeModuleElement)
+               and x.parent() is self._parent.vector_space(map=False))):
+            # Construction from a list/vector of d elements of Fp.
             g = (<pari_gen>self._parent._gen_pari).g
             t = g[1]  # codeword: t_FF_FpXQ, t_FF_Flxq, t_FF_F2xq
             n = len(x)
@@ -496,11 +498,8 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             self.construct_from(x.constant_coefficient())
 
         elif isinstance(x, list):
-            if len(x) == self._parent.degree():
-                self.construct_from(self._parent.vector_space(map=False)(x))
-            else:
-                Fp = self._parent.base_ring()
-                self.construct_from(self._parent.polynomial_ring()([Fp(y) for y in x]))
+            Fp = self._parent.base_ring()
+            self.construct_from(self._parent.polynomial_ring()([Fp(y) for y in x]))
 
         elif isinstance(x, str):
             self.construct_from(self._parent.polynomial_ring()(x))

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -1153,6 +1153,7 @@ cdef class FiniteField(Field):
             else:
                 return PolynomialRing(GF(self.characteristic()), variable_name)
 
+    @cached_method(key=lambda self, base, basis, map, subfield: (subfield or base, tuple(basis) if basis else None, map))
     def free_module(self, base=None, basis=None, map=None, subfield=None):
         """
         Return the vector space over the subfield isomorphic to this
@@ -1229,6 +1230,37 @@ cdef class FiniteField(Field):
             True
             sage: all(to_V(h(c) * e) == c * to_V(e) for e in E for c in F)
             True
+
+        TESTS::
+
+            The various calling conventions should not conflict with each other.
+
+            sage: K = GF(81)
+            sage: K.free_module(map=False)
+            Vector space of dimension 4 over Finite Field of size 3
+            sage: K.free_module(K.prime_subfield(), map=False)
+            Vector space of dimension 4 over Finite Field of size 3
+            sage: iota = Hom(K.prime_subfield(), K).an_element()
+            sage: K.free_module(iota, map=False)
+            Vector space of dimension 4 over Finite Field of size 3
+            sage: K.free_module(K.subfield(2, "g2"), map=False)
+            Vector space of dimension 2 over Finite Field in g2 of size 3^2
+
+            Same test, in reverse order with map=True
+
+            sage: K.free_module.clear_cache()
+            sage: V, _, _ = K.free_module(K.subfield(2, "g2"), map=True)
+            sage: V
+            Vector space of dimension 2 over Finite Field in g2 of size 3^2
+            sage: V, _, _ = K.free_module(iota, map=True)
+            sage: V
+            Vector space of dimension 4 over Finite Field of size 3
+            sage: V, _, _ = K.free_module(K.prime_subfield(), map=True)
+            sage: V
+            Vector space of dimension 4 over Finite Field of size 3
+            sage: V, _, _ = K.free_module(map=True)
+            sage: V
+            Vector space of dimension 4 over Finite Field of size 3
         """
         from sage.modules.all import VectorSpace
         from sage.categories.morphism import is_Morphism


### PR DESCRIPTION

### 📚 Description

It was observed for a long time that polynomial computations on finite field spend a lot of time in boilerplate constructors instead of doing actual computations. Commit 94af055c is an example contribution to reducing this boilerplate.
This pull request tries to remove the remaining extra computations by doing the following changes:
* make `free_module()` cached: this is consistent with the similar method on `sage.rings.number_field.number_field.NumberField_*`
* modify `FiniteFieldElement_pari_ffelt.construct_from` to handle both vectors and lists of size equal to the field degree. Currently Python lists are converted to vectors, which is expensive. Moreover, the similar number field method (`NumberField_generic._element_constructor_`) also considers lists and vectors in the same branch.

Since caching is dangerous, a few tests are added to cover a few possible combinations.

Benchmarks on code doing elliptic curve isogenies shows up to 2x speed improvement.

### 📝 Checklist

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies

