### PR TITLE
fix and activate pycodestyle W2,W3,E714 in pyx files

### DIFF
--- a/src/sage/graphs/graph_coloring.pyx
+++ b/src/sage/graphs/graph_coloring.pyx
@@ -1512,7 +1512,7 @@ def _vizing_edge_coloring(g):
     ALGORITHM:
 
     This function's implementation is based on the algorithm described at [MG1992]_
-    
+
     EXAMPLES:
 
     Coloring the edges of the Petersen Graph::
@@ -1642,12 +1642,13 @@ def _vizing_edge_coloring(g):
         rotate_fan(fan_center, fan)
         e_colors[frozenset((fan_center, fan[-1]))] = d
 
-    matchings = dict()
-    for edge, c in e_colors.items(): 
+    matchings = {}
+    for edge, c in e_colors.items():
         matchings[c] = matchings.get(c, []) + [tuple(edge)]
     classes = list(matchings.values())
 
     return classes
+
 
 def round_robin(n):
     r"""

--- a/src/sage/misc/cachefunc.pyx
+++ b/src/sage/misc/cachefunc.pyx
@@ -107,9 +107,9 @@ By :trac:`11115`, even if a parent does not allow attribute
 assignment, it can inherit a cached method from the parent class of a
 category (previously, the cache would have been broken)::
 
-    sage: cython_code = ["from sage.misc.cachefunc import cached_method", 
+    sage: cython_code = ["from sage.misc.cachefunc import cached_method",
     ....: "from sage.misc.cachefunc import cached_in_parent_method",
-    ....: "from sage.categories.category import Category", 
+    ....: "from sage.categories.category import Category",
     ....: "from sage.categories.objects import Objects",
     ....: "class MyCategory(Category):",
     ....: "    @cached_method",

--- a/src/sage/modular/hypergeometric_misc.pyx
+++ b/src/sage/modular/hypergeometric_misc.pyx
@@ -24,14 +24,13 @@ cpdef hgm_coeffs(long long p, int f, int prec, gamma, m, int D,
         sage: D = 1
         sage: hgm_coeffs(7, 1, 2, gamma, [0]*6, D, gtable, prec, False)
         [7, 2*7, 6*7, 7, 6, 4*7]
-        
+
     Check issue from :trac:`28404`::
-    
+
         sage: H = Hyp(cyclotomic=[[10,2],[1,1,1,1,1]])
         sage: u = H.euler_factor(2,79) # indirect doctest
         sage: u.reverse().is_weil_polynomial()
-        True          
-
+        True
     """
     from sage.rings.padics.factory import Zp
 
@@ -116,8 +115,8 @@ cpdef hgm_coeffs(long long p, int f, int prec, gamma, m, int D,
                 if flip:
                     gv = -gv
                 if use_longs:
-                    w2 = gtab2[r1] # cast to long long to avoid overflow
-                    if gv > 0: 
+                    w2 = gtab2[r1]  # cast to long long to avoid overflow
+                    if gv > 0:
                         for j in range(gv):
                             w = w * w2 % q2
                     else:

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -115,7 +115,8 @@ description =
     # E703: statement ends with a semicolon
     # E711: comparison to None should be ‘if cond is None:’
     # E712: comparison to True should be ‘if cond is True:’ or ‘if cond:’
-    # E713 test for membership should be ’not in’
+    # E713: test for membership should be ’not in’
+    # E714: test for object identity should be ‘is not’
     # E721: do not compare types, use isinstance()
     # E722: do not use bare except, specify exception instead
     # W291: trailing whitespace
@@ -124,7 +125,7 @@ description =
     # See https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 deps = pycodestyle
 commands = pycodestyle --select E111,E211,E306,E401,E701,E702,E703,W291,W391,W605,E711,E712,E713,E721,E722 {posargs:{toxinidir}/sage/}
-       pycodestyle --select E111,E306,E401,E703,W391,W605,E712,E713,E721,E722 --filename *.pyx {posargs:{toxinidir}/sage/}
+       pycodestyle --select E111,E306,E401,E703,W2,W3,W605,E712,E713,E714,E721,E722 --filename *.pyx {posargs:{toxinidir}/sage/}
 
 [pycodestyle]
 max-line-length = 160


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

This fixes the pycodestyle warnings W2, W3 and E714 in all pyx files.

This also activate these checks in pycodestyle-minimal.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

