### PR TITLE
Use PARI implementation of Frobenius morphism

### DIFF
--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -850,6 +850,61 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         x.construct(FF_pow(self.val, (<pari_gen>exp).g))
         return x
 
+    def pth_power(FiniteFieldElement_pari_ffelt self, int k=1):
+        r"""
+        Return the `(p^k)^{th}` power of ``self``, where `p` is the
+        characteristic of the field.
+
+        INPUT:
+
+        - ``k`` -- integer (default: 1); must fit in a C ``int``
+
+        Note that if `k` is negative, then this computes the appropriate root.
+
+        TESTS::
+
+            sage: F.<a> = GF(13^64, impl='pari_ffelt'); F
+            Finite Field in a of size 13^64
+            sage: x = F.random_element()
+            sage: x.pth_power(0) == x
+            True
+            sage: x.pth_power(1) == x**13
+            True
+            sage: x.pth_power(2) == x**(13**2)
+            True
+            sage: x.pth_power(-1)**13 == x
+            True
+
+            sage: F.<a> = GF(127^16, impl='pari_ffelt'); F
+            Finite Field in a of size 127^16
+            sage: x = F.random_element()
+            sage: x.pth_power(0) == x
+            True
+            sage: x.pth_power(1) == x**127
+            True
+            sage: x.pth_power(2) == x**(127**2)
+            True
+            sage: x.pth_power(-1)**127 == x
+            True
+        """
+        cdef int n = int(self._parent.degree())
+        if k % n == 0:
+            return self
+        cdef Integer p = self._parent.characteristic()
+        if k == 1 and (p < 100 or p.bit_length()**2 < n):
+            # For extremely small primes or very large extension degrees,
+            # exponentiation is faster.
+            return self**p
+        # Otherwise use PARI field morphism (evaluation of a Fp polynomial
+        # at the image of the generator).
+        f = self._parent._pari_frobenius(k)
+        cdef FiniteFieldElement_pari_ffelt x = self._new()
+        sig_on()
+        x.construct(ffmap((<pari_gen>f).g, self.val))
+        return x
+
+    frobenius = pth_power
+
     def polynomial(self, name=None):
         """
         Return the unique representative of ``self`` as a polynomial

--- a/src/sage/rings/finite_rings/finite_field_pari_ffelt.py
+++ b/src/sage/rings/finite_rings/finite_field_pari_ffelt.py
@@ -124,6 +124,9 @@ class FiniteField_pari_ffelt(FiniteField):
         self._one_element = self.element_class(self, 1)
         self._gen = self.element_class(self, self._gen_pari)
 
+        # Cache for Frobenius endomorphisms (O(n) field elements)
+        self.__pari_frobenius_powers = []
+
     Element = FiniteFieldElement_pari_ffelt
 
     def __reduce__(self):
@@ -201,3 +204,28 @@ class FiniteField_pari_ffelt(FiniteField):
             20
         """
         return self._degree
+
+    def _pari_frobenius(self, k=1):
+        """
+        Return a cached PARI Frobenius endomorphism (internally defined
+        by the image of the generator).
+
+        TESTS::
+
+            sage: F = FiniteField(37^10, 'a', impl='pari_ffelt')
+            sage: x = F.random_element()
+            sage: all(x**(37**k) == F(F._pari_frobenius(k).ffmap(x)) for k in range(1, 30) if k % 10 != 0)
+            True
+            sage: F(F._pari_frobenius(-1).ffmap(x))**37 == x
+            True
+
+        """
+        k = k % self.degree()
+        if k == 0:
+            raise ValueError("_pari_frobenius requires a non-zero exponent")
+        g = self.gen()
+        i = len(self.__pari_frobenius_powers)
+        while i < k:
+            i += 1
+            self.__pari_frobenius_powers.append(g.__pari__().fffrobenius(i))
+        return self.__pari_frobenius_powers[k-1]

--- a/src/sage/rings/finite_rings/hom_finite_field.pyx
+++ b/src/sage/rings/finite_rings/hom_finite_field.pyx
@@ -619,7 +619,10 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
             sage: Frob(t) == t^5
             True
         """
-        return x ** self._q
+        if self.is_identity():
+            return x
+        else:
+            return x.pth_power(self._power)
 
 
     def order(self):


### PR DESCRIPTION
### 📚 Description

This pull request uses PARI `fffrobenius` and `ffmap` to implement the p-th power map for Finite fields using the PARI implementation (issue #4625).

It does not seem necessary to implement a similar thing for the Givaro implementation (where exponentiation is very fast) or the NTL implementation (only for characteristic 2).

### 📝 Checklist

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.


