### PR TITLE
Add monotile to polgyon examples

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -5565,6 +5565,10 @@ REFERENCES:
              Journal of Cryptology. 12. 193-196. 1999.
              :doi:`10.1007/s001459900052`.
 
+.. [Smi2023] \D. Smith, J. S. Myers, C. S. Kaplan and Chaim Goodman-Strauss, 
+             *An aperiodic monotile*,
+             :arxiv:`2303.10798`
+
 .. [SP2010] Fernando Solano and Michal Pioro, *Lightpath Reconfiguration in WDM
             networks*, IEEE/OSA Journal of Optical Communication and Networking
             2(12):1010-1021, 2010. :doi:`10.1364/JOCN.2.001010`.

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -5565,7 +5565,7 @@ REFERENCES:
              Journal of Cryptology. 12. 193-196. 1999.
              :doi:`10.1007/s001459900052`.
 
-.. [Smi2023] \D. Smith, J. S. Myers, C. S. Kaplan and Chaim Goodman-Strauss, 
+.. [Smi2023] \D. Smith, J. S. Myers, C. S. Kaplan and C. Goodman-Strauss, 
              *An aperiodic monotile*,
              :arxiv:`2303.10798`
 

--- a/src/sage/plot/polygon.py
+++ b/src/sage/plot/polygon.py
@@ -387,19 +387,19 @@ def polygon2d(points, **options):
         sphinx_plot(P)
 
     An aperiodic monotile::
-    
+
         sage: s = sqrt(3)
-        sage: polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s], 
+        sage: polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s],
                          [3/2, -1/2*s], [1, -s], [-1, -s], [-3/2, -1/2*s]], axes=False)
         Graphics object consisting of 1 graphics primitive
-        
+
     .. PLOT::
-    
+
         s = sqrt(3)
-        P = polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s], 
+        P = polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s],
                        [3/2, -1/2*s], [1, -s], [-1, -s], [-3/2, -1/2*s]], axes=False)
         sphinx_plot(P)
-    
+
     A purple hexagon::
 
         sage: L = [[cos(pi*i/3),sin(pi*i/3)] for i in range(6)]

--- a/src/sage/plot/polygon.py
+++ b/src/sage/plot/polygon.py
@@ -390,7 +390,7 @@ def polygon2d(points, **options):
 
         sage: s = sqrt(3)
         sage: polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0],
-        ....:            [9/2, -1/2*s], [3, -s], [3/2, -1/2*s], [1, -s], [-1, -s], 
+        ....:            [9/2, -1/2*s], [3, -s], [3/2, -1/2*s], [1, -s], [-1, -s],
         ....:            [-3/2, -1/2*s]], axes=False)
         Graphics object consisting of 1 graphics primitive
 

--- a/src/sage/plot/polygon.py
+++ b/src/sage/plot/polygon.py
@@ -386,6 +386,20 @@ def polygon2d(points, **options):
         P = polygon2d(v, legend_label='some form')
         sphinx_plot(P)
 
+    An aperiodic monotile::
+    
+        sage: s = sqrt(3)
+        sage: polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s], 
+                         [3/2, -1/2*s], [1, -s], [-1, -s], [-3/2, -1/2*s]], axes=False)
+        Graphics object consisting of 1 graphics primitive
+        
+    .. PLOT::
+    
+        s = sqrt(3)
+        P = polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s], 
+                       [3/2, -1/2*s], [1, -s], [-1, -s], [-3/2, -1/2*s]], axes=False)
+        sphinx_plot(P)
+    
     A purple hexagon::
 
         sage: L = [[cos(pi*i/3),sin(pi*i/3)] for i in range(6)]

--- a/src/sage/plot/polygon.py
+++ b/src/sage/plot/polygon.py
@@ -386,17 +386,17 @@ def polygon2d(points, **options):
         P = polygon2d(v, legend_label='some form')
         sphinx_plot(P)
 
-    An aperiodic monotile::
+    An aperiodic monotile, [Smi2023]_::
 
         sage: s = sqrt(3)
-        sage: polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s],
+        sage: polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s], \
                          [3/2, -1/2*s], [1, -s], [-1, -s], [-3/2, -1/2*s]], axes=False)
         Graphics object consisting of 1 graphics primitive
 
     .. PLOT::
 
         s = sqrt(3)
-        P = polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s],
+        P = polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s], \
                        [3/2, -1/2*s], [1, -s], [-1, -s], [-3/2, -1/2*s]], axes=False)
         sphinx_plot(P)
 

--- a/src/sage/plot/polygon.py
+++ b/src/sage/plot/polygon.py
@@ -389,8 +389,9 @@ def polygon2d(points, **options):
     An aperiodic monotile, [Smi2023]_::
 
         sage: s = sqrt(3)
-        sage: polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0], [9/2, -1/2*s], [3, -s], \
-                         [3/2, -1/2*s], [1, -s], [-1, -s], [-3/2, -1/2*s]], axes=False)
+        sage: polygon2d([[0, 0], [0, s], [1, s], [3/2, 3/2*s], [3, s], [3, 0], [4, 0],
+        ....:            [9/2, -1/2*s], [3, -s], [3/2, -1/2*s], [1, -s], [-1, -s], 
+        ....:            [-3/2, -1/2*s]], axes=False)
         Graphics object consisting of 1 graphics primitive
 
     .. PLOT::


### PR DESCRIPTION
This adds an aperiodic monotile to the many examples in the documentation of the `polygon2d` function.  https://arxiv.org/abs/2303.10798

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

