### PR TITLE
Make FLINT polynomial factor() interruptible

### DIFF
--- a/src/sage/libs/flint/nmod_poly_linkage.pxi
+++ b/src/sage/libs/flint/nmod_poly_linkage.pxi
@@ -644,10 +644,12 @@ cdef factor_helper(Polynomial_zmod_flint poly, bint squarefree=False):
     cdef nmod_poly_factor_t factors_c
     nmod_poly_factor_init(factors_c)
 
+    sig_on()
     if squarefree:
         nmod_poly_factor_squarefree(factors_c, &poly.x)
     else:
         nmod_poly_factor(factors_c, &poly.x)
+    sig_off()
 
     factor_list = []
     cdef Polynomial_zmod_flint t

--- a/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
@@ -689,6 +689,16 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
             Traceback (most recent call last):
             ...
             NotImplementedError: factorization of polynomials over rings with composite characteristic is not implemented
+
+        Test that factorization can be interrupted::
+
+            sage: R.<x> = PolynomialRing(GF(65537), implementation="FLINT")
+            sage: f = R.random_element(9973) * R.random_element(10007)
+            sage: alarm(0.5); f.factor()
+            Traceback (most recent call last):
+            ...
+            AlarmInterrupt
+
         """
         R = self.base_ring()
 


### PR DESCRIPTION
### 📚 Description

This is useful for large degree polynomials.
Currently FLINT factorization of `Zmod(n)` polynomials for small `n` cannot be interrupted using Ctrl-C.

### 📝 Checklist

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies

None
