### PR TITLE
Fix test output to pass with ipywidgets 8.0.5

### DIFF
--- a/src/sage/interacts/library.py
+++ b/src/sage/interacts/library.py
@@ -1436,7 +1436,7 @@ def riemann_sum(
         sage: interacts.calculus.riemann_sum()
         Manual interactive function <function riemann_sum at ...> with 9 widgets
           title: HTMLText(value='<h2>Riemann integral with random sampling</h2>')
-          f: EvalText(value='x^2+1', description='$f(x)=$', layout=Layout(max_width='41em'))
+          f: EvalText(value='x^2+1',... description='$f(x)=$', layout=Layout(max_width='41em'))
           n: IntSlider(value=5, description='# divisions', max=30, min=1)
           hr1: HTMLText(value='<hr>')
           interval_input: ToggleButtons(description='Integration interval', options=('from slider', 'from keyboard'), value='from slider')


### PR DESCRIPTION
With ipywidgets 8.0.5, the widget text output gets a new `continuous_update` parameter that makes a test fail.

There are some other test failures in `sage/combinat/cluster_algebra_quiver` due to an upstream bug, which is fixed in https://github.com/jupyter-widgets/ipywidgets/commit/812371531b977fdb214564d398d13fbbb3aad8ff 
