### PR TITLE
Fix warning with ipython 8.11 (was #35235)

### DIFF
--- a/src/sage/repl/inputhook.py
+++ b/src/sage/repl/inputhook.py
@@ -47,15 +47,25 @@ def install():
     """
     Install the Sage input hook
 
-    EXAMPLES::
+    EXAMPLES:
+
+    Make sure ipython is running so we really test this function::
+
+        sage: from sage.repl.interpreter import get_test_shell
+        sage: get_test_shell()
+        <sage.repl.interpreter.SageTestShell object at ...>
+
+    Run the function twice, to check it is idempotent (see :trac:`35235`)::
 
         sage: from sage.repl.inputhook import install
+        sage: install()
         sage: install()
     """
     ip = get_ipython()
     if not ip:
         return   # Not running in ipython, e.g. doctests
-    ip.enable_gui('sage')
+    if ip._inputhook != sage_inputhook:
+        ip.enable_gui('sage')
 
 
 def uninstall():


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

ipython 8.11 throws new warnings "UserWarning: Shell was already running a gui event loop for sage; switching to sage." when running some tests.

This is because sage indeed tries to install the same gui event loop for ipython again and again. The fix is checking if the ipython input hook is already set to the sage input hook, in that case we don't install the gui event loop again.

In the test, we run `install()` twice so we can verify that running it multiple times won't cause a warning anymore.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [x] I have created tests covering the changes.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

### Replaces: #35235 
Since gh doesn't allow to change the branch on a PR.