### PR TITLE
Use NTL factoring functions for factor and squarefree_decomposition

### DIFF
--- a/src/sage/libs/ntl/GF2X.pxd
+++ b/src/sage/libs/ntl/GF2X.pxd
@@ -80,3 +80,8 @@ cdef extern from "ntlwrap.h":
 
     # xi = gi(h) mod f (i=1,2,3), deg(h) < n.
     void GF2X_CompMod3 "Comp2Mod"(GF2X_c x1, GF2X_c x2, GF2X_c x3, GF2X_c g1, GF2X_c g2, GF2X_c g3, GF2X_c h, GF2XModulus_c F)
+
+cdef extern from "ntlwrap_impl.h":
+    #### GF2XFactoring
+    void GF2X_factor_canzass(GF2X_c*** v, long** e, long* n, GF2X_c x, long verbose)
+    void GF2X_square_free_decomp(GF2X_c*** v, long** e, long* n, GF2X_c x)

--- a/src/sage/libs/ntl/ZZ_pEX.pxd
+++ b/src/sage/libs/ntl/ZZ_pEX.pxd
@@ -100,4 +100,8 @@ cdef extern from "ntlwrap.h":
 
 
 cdef extern from "ntlwrap_impl.h":
+    void ZZ_pEX_factor_canzass(ZZ_pEX_c*** v, long** e, long* n, ZZ_pEX_c x, long verbose)
+    void ZZ_pEX_square_free_decomp(ZZ_pEX_c*** v, long** e, long* n, ZZ_pEX_c x)
+
+    # The following are all used for padics.
     void ZZ_pEX_conv_modulus(ZZ_pEX_c fout, ZZ_pEX_c fin, ZZ_pContext_c c)

--- a/src/sage/libs/ntl/ZZ_pX.pxd
+++ b/src/sage/libs/ntl/ZZ_pX.pxd
@@ -108,7 +108,9 @@ cdef extern from "ntlwrap.h":
 
 cdef extern from "ntlwrap_impl.h":
     char* ZZ_pX_trace_list(ZZ_pX_c* x)
-    void ZZ_pX_factor(ZZ_pX_c*** v, long** e, long* n, ZZ_pX_c* x, long verbose)
+    void ZZ_pX_factor_berlekamp(ZZ_pX_c*** v, long** e, long* n, ZZ_pX_c* x, long verbose)
+    void ZZ_pX_factor_canzass(ZZ_pX_c*** v, long** e, long* n, ZZ_pX_c* x, long verbose)
+    void ZZ_pX_square_free_decomp(ZZ_pX_c*** v, long** e, long* n, ZZ_pX_c* x)
     void ZZ_pX_linear_roots(ZZ_p_c*** v, long* n, ZZ_pX_c* x)
 
     # The following are all used for padics.

--- a/src/sage/libs/ntl/ntl_ZZ_pX.pyx
+++ b/src/sage/libs/ntl/ntl_ZZ_pX.pyx
@@ -908,12 +908,25 @@ cdef class ntl_ZZ_pX():
         sig_off()
         return r
 
-    def factor(self, verbose=False):
+    def factor(self, algorithm=None, verbose=False):
         """
         Return the factorization of self. Assumes self is
         monic.
 
         NOTE: The roots are returned in a random order.
+
+        INPUT:
+
+        - ``algorithm`` -- string (optional). Possibles values are:
+
+          - ``"canzass"`` (defaut): Use NTL `CanZass` function implementing the
+            Cantor-Zassenhaus algorithm with improvements from von zur Gathen,
+            Kaltofen and Shoup.
+
+          - ``"berlekamp"``: use implementation of Berlekamp algorithm.
+
+          - ``"squarefree"``: use `SquareFreeDecomp` function returning a partial
+            factorization as a product of squarefree factors.
 
         EXAMPLES:
 
@@ -944,8 +957,17 @@ cdef class ntl_ZZ_pX():
         cdef long i, n
         if not self.is_monic():
             raise ValueError("self must be monic.")
+        if algorithm is None:
+            algorithm = "canzass"
+        if algorithm not in ("berlekamp", "canzass", "squarefree"):
+            raise ValueError("invalid algorithm name")
         sig_on()
-        ZZ_pX_factor(&v, &e, &n, &self.x, verbose)
+        if algorithm == "berlekamp":
+            ZZ_pX_factor_berlekamp(&v, &e, &n, &self.x, verbose)
+        elif algorithm == "canzass":
+            ZZ_pX_factor_canzass(&v, &e, &n, &self.x, verbose)
+        elif algorithm == "squarefree":
+            ZZ_pX_square_free_decomp(&v, &e, &n, &self.x)
         sig_off()
         F = []
         for i from 0 <= i < n:

--- a/src/sage/libs/ntl/ntlwrap_impl.h
+++ b/src/sage/libs/ntl/ntlwrap_impl.h
@@ -424,11 +424,39 @@ static char* ZZ_pX_trace_list(struct ZZ_pX* x)
     return buf;
 }
 
-static void ZZ_pX_factor(struct ZZ_pX*** v, long** e, long* n, struct ZZ_pX* x, long verbose)
+static void ZZ_pX_factor_berlekamp(struct ZZ_pX*** v, long** e, long* n, struct ZZ_pX* x, long verbose)
 {
     long i;
     vec_pair_ZZ_pX_long factors;
     berlekamp(factors, *x, verbose);
+    *n = factors.length();
+    *v = (ZZ_pX**) malloc(sizeof(ZZ_pX*) * (*n));
+    *e = (long*) malloc(sizeof(long)*(*n));
+    for (i=0; i<(*n); i++) {
+        (*v)[i] = new ZZ_pX(factors[i].a);
+        (*e)[i] = factors[i].b;
+    }
+}
+
+static void ZZ_pX_factor_canzass(struct ZZ_pX*** v, long** e, long* n, struct ZZ_pX* x, long verbose)
+{
+    long i;
+    vec_pair_ZZ_pX_long factors;
+    CanZass(factors, *x, verbose);
+    *n = factors.length();
+    *v = (ZZ_pX**) malloc(sizeof(ZZ_pX*) * (*n));
+    *e = (long*) malloc(sizeof(long)*(*n));
+    for (i=0; i<(*n); i++) {
+        (*v)[i] = new ZZ_pX(factors[i].a);
+        (*e)[i] = factors[i].b;
+    }
+}
+
+static void ZZ_pX_square_free_decomp(struct ZZ_pX*** v, long** e, long* n, const struct ZZ_pX* x)
+{
+    long i;
+    vec_pair_ZZ_pX_long factors;
+    SquareFreeDecomp(factors, *x);
     *n = factors.length();
     *v = (ZZ_pX**) malloc(sizeof(ZZ_pX*) * (*n));
     *e = (long*) malloc(sizeof(long)*(*n));
@@ -447,6 +475,66 @@ static void ZZ_pX_linear_roots(struct ZZ_p*** v, long* n, struct ZZ_pX* f)
     (*v) = (ZZ_p**) malloc(sizeof(ZZ_p*)*(*n));
     for (i=0; i<(*n); i++) {
         (*v)[i] = new ZZ_p(w[i]);
+    }
+}
+
+/////////// ZZ_pEX //////////////
+
+static void ZZ_pEX_factor_canzass(struct ZZ_pEX*** v, long** e, long* n, const struct ZZ_pEX &x, long verbose)
+{
+    long i;
+    vec_pair_ZZ_pEX_long factors;
+    CanZass(factors, x, verbose);
+    *n = factors.length();
+    *v = (ZZ_pEX**) malloc(sizeof(ZZ_pEX*) * (*n));
+    *e = (long*) malloc(sizeof(long)*(*n));
+    for (i=0; i<(*n); i++) {
+        (*v)[i] = new ZZ_pEX(factors[i].a);
+        (*e)[i] = factors[i].b;
+    }
+}
+
+static void ZZ_pEX_square_free_decomp(struct ZZ_pEX*** v, long** e, long* n, const struct ZZ_pEX &x)
+{
+    long i;
+    vec_pair_ZZ_pEX_long factors;
+    SquareFreeDecomp(factors, x);
+    *n = factors.length();
+    *v = (ZZ_pEX**) malloc(sizeof(ZZ_pEX*) * (*n));
+    *e = (long*) malloc(sizeof(long)*(*n));
+    for (i=0; i<(*n); i++) {
+        (*v)[i] = new ZZ_pEX(factors[i].a);
+        (*e)[i] = factors[i].b;
+    }
+}
+
+/////////// GF2X //////////////
+
+static void GF2X_factor_canzass(struct GF2X*** v, long** e, long* n, const struct GF2X &x, long verbose)
+{
+    long i;
+    vec_pair_GF2X_long factors;
+    CanZass(factors, x, verbose);
+    *n = factors.length();
+    *v = (GF2X**) malloc(sizeof(GF2X*) * (*n));
+    *e = (long*) malloc(sizeof(long)*(*n));
+    for (i=0; i<(*n); i++) {
+        (*v)[i] = new GF2X(factors[i].a);
+        (*e)[i] = factors[i].b;
+    }
+}
+
+static void GF2X_square_free_decomp(struct GF2X*** v, long** e, long* n, const struct GF2X &x)
+{
+    long i;
+    vec_pair_GF2X_long factors;
+    SquareFreeDecomp(factors, x);
+    *n = factors.length();
+    *v = (GF2X**) malloc(sizeof(GF2X*) * (*n));
+    *e = (long*) malloc(sizeof(long)*(*n));
+    for (i=0; i<(*n); i++) {
+        (*v)[i] = new GF2X(factors[i].a);
+        (*e)[i] = factors[i].b;
     }
 }
 

--- a/src/sage/rings/polynomial/polynomial_gf2x.pyx
+++ b/src/sage/rings/polynomial/polynomial_gf2x.pyx
@@ -11,6 +11,7 @@ AUTHOR:
 - Martin Albrecht (2008-10) initial implementation
 """
 
+from sage.misc.randstate import current_randstate
 
 # We need to define this stuff before including the templating stuff
 # to make sure the function get_cparent is found since it is used in
@@ -26,12 +27,13 @@ include "sage/libs/ntl/ntl_GF2X_linkage.pxi"
 # and then the interface
 include "polynomial_template.pxi"
 
-from sage.libs.pari.all import pari
+from cysignals.memory cimport sig_free
 
+from sage.libs.pari.all import pari
 from sage.libs.m4ri cimport mzd_write_bit, mzd_read_bit
 from sage.matrix.matrix_mod2_dense cimport Matrix_mod2_dense
-
 from sage.misc.cachefunc import cached_method
+from sage.structure.factorization import Factorization
 
 cdef class Polynomial_GF2X(Polynomial_template):
     """
@@ -105,6 +107,100 @@ cdef class Polynomial_GF2X(Polynomial_template):
         if variable is None:
             variable = parent.variable_name()
         return pari(self.list()).Polrev(variable) * pari(1).Mod(2)
+
+    def factor(self, algorithm=None):
+        """
+        INPUT:
+
+        - ``algorithm`` (string or None) -- Either ``"NTL"`` for NTL
+          Cantor-Zassenhaus implementation (default if None is specified),
+          or ``"pari"`` to use PARI (which can be constrained by PARI stack size)
+
+        TESTS::
+
+            sage: R.<x> = PolynomialRing(GF(2), implementation="GF2X")
+            sage: f = R.random_element(5) * R.random_element(7)
+            sage: factors = f.factor()
+            sage: f == product(factors)
+            True
+            sage: factors == f.factor(algorithm="NTL")
+            True
+            sage: factors == f.factor(algorithm="pari")
+            True
+            sage: f = 5 * R.random_element(13) * R.random_element(17)
+            sage: factors = f.factor()
+            sage: f == product(factors)
+            True
+            sage: factors == f.factor(algorithm="NTL")
+            True
+            sage: factors == f.factor(algorithm="pari")
+            True
+
+        Test that factorization can be interrupted::
+
+            sage: R.<x> = PolynomialRing(GF(2), implementation="NTL")
+            sage: f = R.random_element(49999) * R.random_element(50021)
+            sage: alarm(0.5); f.factor()
+            Traceback (most recent call last):
+            ...
+            AlarmInterrupt
+        """
+
+        if algorithm == "pari":
+            return self._factor_pari_helper(self.__pari__().factor())
+
+        if algorithm is None:
+            algorithm = "NTL"
+        if algorithm != "NTL":
+            raise ValueError("invalid algorithm for factor()")
+
+        return self._factor_ntl_helper(squarefree=False)
+
+    def squarefree_decomposition(self):
+        r"""
+        TESTS::
+
+            sage: R.<x> = PolynomialRing(GF(2), implementation='GF2X')
+            sage: f = (x^8 + x^4 + 1)*(x^4 + x + 1)*(x^4 + x^3 + 1)
+            sage: f.squarefree_decomposition()
+            (x^2 + x + 1)^4 * (x^8 + x^7 + x^5 + x^4 + x^3 + x + 1)
+
+        """
+        return self._factor_ntl_helper(squarefree=True)
+
+    def _factor_ntl_helper(self, squarefree=True):
+        r"""
+        Compute factorization or squarefree decomposition and format
+        result as a Sage `Factorization` object.
+        """
+        lc = self.lc()
+        pol = self.monic()
+        current_randstate().set_seed_ntl(False)
+
+        cdef GF2X_c** v
+        cdef long* e
+        cdef long i, n
+        cdef Polynomial_GF2X r
+        sig_on()
+        if squarefree:
+            GF2X_square_free_decomp(&v, &e, &n, (<Polynomial_GF2X>pol).x)
+        else:
+            GF2X_factor_canzass(&v, &e, &n, (<Polynomial_GF2X>pol).x, 0)
+        sig_off()
+        F = []
+        for i from 0 <= i < n:
+            r = Polynomial_GF2X.__new__(Polynomial_GF2X)
+            celement_construct(&r.x, (<Polynomial_template>self)._cparent)
+            r._parent = (<Polynomial_template>self)._parent
+            r._cparent = (<Polynomial_template>self)._cparent
+            r.x = v[i][0]
+            F.append((r, e[i]))
+        for i from 0 <= i < n:
+            del v[i]
+        sig_free(v)
+        sig_free(e)
+
+        return Factorization(F, unit=lc)
 
     def modular_composition(Polynomial_GF2X self, Polynomial_GF2X g, Polynomial_GF2X h, algorithm=None):
         r"""

--- a/src/sage/rings/polynomial/polynomial_zz_pex.pyx
+++ b/src/sage/rings/polynomial/polynomial_zz_pex.pyx
@@ -16,6 +16,8 @@ AUTHOR:
 from sage.rings.integer_ring import ZZ
 from sage.rings.integer_ring cimport IntegerRing_class
 
+from sage.structure.factorization import Factorization
+
 from sage.libs.ntl.ntl_ZZ_pEContext cimport ntl_ZZ_pEContext_class
 from sage.libs.ntl.ZZ_pE cimport ZZ_pE_to_ZZ_pX
 from sage.libs.ntl.ZZ_pX cimport ZZ_pX_deg, ZZ_pX_coeff
@@ -23,6 +25,8 @@ from sage.libs.ntl.ntl_ZZ_pX cimport ntl_ZZ_pX
 from sage.libs.ntl.ZZ_p cimport ZZ_p_rep
 from sage.libs.ntl.ntl_ZZ_pContext cimport ntl_ZZ_pContext_class
 from sage.libs.ntl.convert cimport ZZ_to_mpz
+
+from sage.misc.randstate import current_randstate
 
 # We need to define this stuff before including the templating stuff
 # to make sure the function get_cparent is found since it is used in
@@ -43,6 +47,8 @@ include "sage/libs/ntl/ntl_ZZ_pEX_linkage.pxi"
 
 # and then the interface
 include "polynomial_template.pxi"
+
+from cysignals.memory cimport sig_free
 
 from sage.libs.pari.all import pari
 from sage.libs.ntl.ntl_ZZ_pE cimport ntl_ZZ_pE
@@ -488,3 +494,104 @@ cdef class Polynomial_ZZ_pEX(Polynomial_template):
             x^4 + x^3 + x
         """
         return self.shift(-n)
+
+    def factor(self, algorithm=None):
+        """
+        INPUT:
+
+        - ``algorithm`` (string or None) -- Either ``"NTL"`` for NTL
+          Cantor-Zassenhaus implementation (default if None is specified),
+          or ``"pari"`` to use PARI (which can be constrained by PARI stack size)
+
+        TESTS::
+
+            sage: R.<x> = PolynomialRing(GF(37^4), implementation="NTL")
+            sage: f = R.random_element(5) * R.random_element(7)
+            sage: factors = f.factor()
+            sage: f == product(factors)
+            True
+            sage: factors == f.factor(algorithm="NTL")
+            True
+            sage: factors == f.factor(algorithm="pari")
+            True
+            sage: f = 5 * R.random_element(13) * R.random_element(17)
+            sage: factors = f.factor()
+            sage: f == product(factors)
+            True
+            sage: factors == f.factor(algorithm="NTL")
+            True
+            sage: factors == f.factor(algorithm="pari")
+            True
+
+        Test that factorization can be interrupted:
+
+            sage: R.<x> = PolynomialRing(GF(65537^4), implementation="NTL")
+            sage: f = R.random_element(997) * R.random_element(1007)
+            sage: alarm(0.5); f.factor(algorithm="NTL")
+            Traceback (most recent call last):
+            ...
+            AlarmInterrupt
+        """
+        if self.degree() < 0:
+            raise ArithmeticError("factorization of {!r} is not defined".format(self))
+
+        if algorithm is None:
+            algorithm = "pari"
+
+        if algorithm == "pari":
+            return self._factor_pari_helper(self.__pari__().factor())
+        elif algorithm == "NTL":
+            return self._factor_ntl_helper(squarefree=False)
+        else:
+            raise ValueError("invalid algorithm for factor()")
+
+    def squarefree_decomposition(self):
+        r"""
+        TESTS::
+
+            sage: R.<x> = PolynomialRing(GF(37^2), implementation='NTL')
+            sage: f = (x^37 + 1)*(x^4 + 2*x^3 + x + 1)
+            sage: f.squarefree_decomposition()
+            (x + 1)^37 * (x^4 + 2*x^3 + x + 1)
+
+        """
+        if self.degree() < 0:
+            raise ValueError("square-free decomposition not defined for zero polynomial")
+
+        return self._factor_ntl_helper(squarefree=True)
+
+    def _factor_ntl_helper(self, squarefree=True):
+        r"""
+        Compute factorization or squarefree decomposition and format
+        result as a Sage `Factorization` object.
+        """
+        lc = self.lc()
+        pol = self.monic()
+        current_randstate().set_seed_ntl(False)
+
+        self._parent._modulus.restore()
+
+        cdef ZZ_pEX_c** v
+        cdef long* e
+        cdef long i, n
+        cdef Polynomial_ZZ_pEX r
+        sig_on()
+        if squarefree:
+            ZZ_pEX_square_free_decomp(&v, &e, &n, (<Polynomial_ZZ_pEX>pol).x)
+        else:
+            ZZ_pEX_factor_canzass(&v, &e, &n, (<Polynomial_ZZ_pEX>pol).x, 0)
+        sig_off()
+        F = []
+        for i from 0 <= i < n:
+            r = Polynomial_ZZ_pEX.__new__(Polynomial_ZZ_pEX)
+            celement_construct(&r.x, (<Polynomial_template>self)._cparent)
+            r._parent = (<Polynomial_template>self)._parent
+            r._cparent = (<Polynomial_template>self)._cparent
+            r.x = v[i][0]
+            F.append((r, e[i]))
+        for i from 0 <= i < n:
+            del v[i]
+        sig_free(v)
+        sig_free(e)
+
+        return Factorization(F, unit=lc)


### PR DESCRIPTION
### 📚 Description

The patch extends the NTL Cython interface (some functions were already present) to expose factoring functions (mainly `CanZass` and `SquareFreeDecomp`) to make it available to the `.factor()` and `.squarefree_decomposition()` methods.

An `algorithm` keyword argument is added to use the PARI implementation or the NTL Berlekamp implementation.

The best choice depends on the type of field:
* for GF(2) (`GF2X` polynomials): the NTL implementation is several orders of magnitude faster than PARI, which for some reason uses the Berlekamp algorithm for large degrees.
* for GF(p) (`ZZ_pX` polynomials) : the NTL implementation seems to be quite faster (2x-5x) than PARI
* for GF(p^k) (`ZZ_pEX` polynomials) : the NTL implementation seems much slower than PARI and should not be the default

### 📝 Checklist

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies

ISSUES in this draft:
- the interface slots (factor_univariate_polynomial, etc.) on **base rings** are very strange, they should probably be on polynomial rings
- using NTL for field extensions hits issue #35339 (the issue is that calling `.monic()` fails)
- on Linux systems, the PARI stack pointer is a thread-local variable and suffers heavily from the cost of `__tls_get_addr()` possibly creating a large bias in benchmarks

Benchmark for GF(2): NTL is extremely faster
```
sage: R.<x> = PolynomialRing(Zmod(2))
PARI:
sage: pol = product(R.random_element(700) for _ in range(100))
sage: %time _ = pol.factor()
PariError: the PARI stack overflows (current size: 1073741824; maximum size: 1073741824)
sage: pol = product(R.random_element(500) for _ in range(100))
sage: %time _ = pol.factor()
CPU times: user 7min 23s, sys: 1.38 s, total: 7min 24s

NTL:
sage: pol = product(R.random_element(700) for _ in range(100))
sage: %time _ = pol.factor()
CPU times: user 2.03 s, sys: 8.01 ms, total: 2.04 s
Wall time: 2.03 s
sage: pol = product(R.random_element(500) for _ in range(100))
sage: %time _ = pol.factor()
CPU times: user 937 ms, sys: 0 ns, total: 937 ms
```

Benchmark for prime fields (NTL is faster):
Computing `isogenies_prime_degree` requires factoring a polynomial of degree `O(d^2)`
```
PARI:
sage: p = 73*666*2**400 - 1
sage: E = EllipticCurve(GF(p, 'a'), [1, 0])
sage: %time E.isogenies_prime_degree(73)
CPU times: user 5min 23s, sys: 20 ms, total: 5min 23s

sage: p = 89*30*2**500 - 1
sage: E = EllipticCurve(GF(p, 'a'), [1, 0])
sage: %time E.isogenies_prime_degree(89)
PariError: the PARI stack overflows (current size: 1073741824; maximum size: 1073741824)

NTL:
sage: p = 73*666*2**400 - 1
sage: E = EllipticCurve(GF(p, 'a'), [1, 0])
sage: %time E.isogenies_prime_degree(73)
CPU times: user 31.5 s, sys: 47.8 ms, total: 31.6 s

sage: p = 89*30*2**500 - 1
sage: E = EllipticCurve(GF(p, 'a'), [1, 0])
sage: %time E.isogenies_prime_degree(89)
CPU times: user 1min 8s, sys: 104 ms, total: 1min 9s
```

Benchmark for field extensions (PARI is faster):
```
sage: p = random_prime(2**90)
sage: R = PolynomialRing(GF(p**4), "x")
sage: pol = prod(R.random_element(5) for _ in range(5))

sage: %timeit pol.factor(algorithm="NTL")
619 ms ± 14 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
sage: %timeit pol.factor(algorithm="pari")
215 ms ± 9.84 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```