### PR TITLE
Deprecate `is_NumberFieldOrder`

### DIFF
--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -335,6 +335,10 @@ def is_NumberFieldOrder(R):
         sage: is_NumberFieldOrder(45)
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(35288, 'In the future, IntegerRing_class will be'
+                'subclass of NumberFieldOrder_base. So no special'
+                'implementation is required for zz in is_NumberFieldOrder')
     return isinstance(R, Order) or R == ZZ
 
 


### PR DESCRIPTION
### 📚 Description

Resolves #35288 

### 📝 Checklist

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

