### PR TITLE
density plot: norm and colorbar

### DIFF
--- a/src/sage/plot/density_plot.py
+++ b/src/sage/plot/density_plot.py
@@ -20,7 +20,7 @@ Density plots
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 from sage.plot.primitive import GraphicPrimitive
-from sage.misc.decorators import options
+from sage.misc.decorators import options, suboptions
 from sage.plot.colors import get_cmap
 from sage.arith.srange import xsrange
 
@@ -114,7 +114,9 @@ class DensityPlot(GraphicPrimitive):
                        matplotlib Colormap. Type: import matplotlib.cm; matplotlib.cm.datad.keys()
                        for available colormap names.""",
                 'interpolation': 'What interpolation method to use',
-                'norm': "one of matplotlib.scale.get_scale_names() or matplotlib.colors.Normalize instance"}
+                'norm': "one of matplotlib.scale.get_scale_names() or matplotlib.colors.Normalize instance",
+                'colorbar': "Whether to show a colorbar or not",
+                'colorbar_options': "a dictionary of options for the colorbar"}
 
     def _repr_(self):
         """
@@ -145,13 +147,19 @@ class DensityPlot(GraphicPrimitive):
         x0, x1 = float(self.xrange[0]), float(self.xrange[1])
         y0, y1 = float(self.yrange[0]), float(self.yrange[1])
 
-        subplot.imshow(self.xy_data_array, origin='lower',
+        AI = subplot.imshow(self.xy_data_array, origin='lower',
                        cmap=cmap, extent=(x0,x1,y0,y1),
                        interpolation=options['interpolation'],
                        norm=options['norm'])
+        if options['colorbar']:
+            colorbar_options = options['colorbar_options']
+            from matplotlib import colorbar
+            cax, kwds = colorbar.make_axes_gridspec(subplot, **colorbar_options)
+            cb = colorbar.Colorbar(cax, AI, **kwds)
 
 
-@options(plot_points=25, cmap='gray', interpolation='catrom', norm=None)
+@suboptions('colorbar', orientation='vertical', format=None, spacing='uniform')
+@options(plot_points=25, cmap='gray', interpolation='catrom', norm=None, colorbar=False)
 def density_plot(f, xrange, yrange, **options):
     r"""
     ``density_plot`` takes a function of two variables, `f(x,y)`
@@ -188,6 +196,23 @@ def density_plot(f, xrange, yrange, **options):
 
     - ``norm`` -- string, one of ``matplotlib.scale.get_scale_names()``, or
       an instance of ``matplotlib.colors.Normalize`` (default: None)
+
+    - ``colorbar`` -- boolean (default: False) whether to show colorbar or not
+
+      The following options are to adjust the style and placement of
+      colorbars.  They have no effect if a colorbar is not shown.
+
+      - ``colorbar_orientation`` -- string (default: 'vertical'),
+        controls placement of the colorbar, can be either 'vertical'
+        or 'horizontal'
+
+      - ``colorbar_format`` -- a format string, this is used to format
+        the colorbar labels.
+
+      - ``colorbar_spacing`` -- string (default: 'proportional').  If
+        'proportional', make the contour divisions proportional to
+        values.  If 'uniform', space the colorbar divisions uniformly,
+        without regard for numeric values.
 
 
     EXAMPLES:
@@ -246,12 +271,12 @@ def density_plot(f, xrange, yrange, **options):
         sphinx_plot(g)
 
     Here we normalize colors only to the interval [-1, 1] and let other values be mapped to the closer one
-    of the two boundaries::
+    of the two boundaries. We also display a horizontal colorbar::
 
         x, y = var('x,y')
         from matplotlib.colors import Normalize
         norm = Normalize(-1, 1)
-        density_plot(x**2+y**2, (-1, 1), (-1, 1), norm=norm)
+        density_plot(x**2+y**2, (-1, 1), (-1, 1), norm=norm, colorbar=True, colorbar_orientation='horizontal')
 
     Some elliptic curves, but with symbolic endpoints.  In the first
     example, the plot is rotated 90 degrees because we switch the

--- a/src/sage/plot/density_plot.py
+++ b/src/sage/plot/density_plot.py
@@ -113,7 +113,8 @@ class DensityPlot(GraphicPrimitive):
                        a list of colors or an instance of a
                        matplotlib Colormap. Type: import matplotlib.cm; matplotlib.cm.datad.keys()
                        for available colormap names.""",
-                'interpolation': 'What interpolation method to use'}
+                'interpolation': 'What interpolation method to use',
+                'norm': "one of matplotlib.scale.get_scale_names() or matplotlib.colors.Normalize instance"}
 
     def _repr_(self):
         """
@@ -146,10 +147,11 @@ class DensityPlot(GraphicPrimitive):
 
         subplot.imshow(self.xy_data_array, origin='lower',
                        cmap=cmap, extent=(x0,x1,y0,y1),
-                       interpolation=options['interpolation'])
+                       interpolation=options['interpolation'],
+                       norm=options['norm'])
 
 
-@options(plot_points=25, cmap='gray', interpolation='catrom')
+@options(plot_points=25, cmap='gray', interpolation='catrom', norm=None)
 def density_plot(f, xrange, yrange, **options):
     r"""
     ``density_plot`` takes a function of two variables, `f(x,y)`
@@ -183,6 +185,9 @@ def density_plot(f, xrange, yrange, **options):
       ``'spline36'``, ``'quadric'``, ``'gaussian'``, ``'sinc'``,
       ``'bessel'``, ``'mitchell'``, ``'lanczos'``, ``'catrom'``,
       ``'hermite'``, ``'hanning'``, ``'hamming'``, ``'kaiser'``
+
+    - ``norm`` -- string, one of ``matplotlib.scale.get_scale_names()``, or
+      an instance of ``matplotlib.colors.Normalize`` (default: None)
 
 
     EXAMPLES:
@@ -239,6 +244,14 @@ def density_plot(f, xrange, yrange, **options):
         x,y = var('x,y')
         g = density_plot(1/(x**10 + y**10), (x,-10,10), (y,-10,10))
         sphinx_plot(g)
+
+    Here we normalize colors only to the interval [-1, 1] and let other values be mapped to the closer one
+    of the two boundaries::
+
+        x, y = var('x,y')
+        from matplotlib.colors import Normalize
+        norm = Normalize(-1, 1)
+        density_plot(x**2+y**2, (-1, 1), (-1, 1), norm=norm)
 
     Some elliptic curves, but with symbolic endpoints.  In the first
     example, the plot is rotated 90 degrees because we switch the


### PR DESCRIPTION
- add `norm` parameter to `density_plot`
- teach density plot to show colorbar

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

This pull request enables users to pass norm as an argument directly to the `density_plot` function. It also implements the colorbar for density plots, inspired by other plots. Closes #9150.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
