### PR TITLE
Add minimum version of conda gap package

### DIFF
--- a/build/pkgs/gap/distros/conda.txt
+++ b/build/pkgs/gap/distros/conda.txt
@@ -1,1 +1,1 @@
-gap-defaults
+gap-defaults>=4.12.2


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

Since https://github.com/sagemath/sage/pull/35093, sage no longer builds with gap 4.11. With this PR the new minimum version is correctly specified for the conda installation. This currently doesn't work as there is no suitable conda package yet, see https://github.com/conda-forge/gap-feedstock/pull/68. However, better fail with a good error message then some random warning during build.

It would be nice if in the future breaking package updates would only happen if conda provides a suitable package.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [x] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

