### PR TITLE
Replace \mbox by \text in manifolds

### DIFF
--- a/src/sage/manifolds/chart.py
+++ b/src/sage/manifolds/chart.py
@@ -2165,7 +2165,7 @@ class RealChart(Chart):
                 rlatex += r"\right]"
                 if bounds[1][1] == 'periodic':
                     rtxt += " (periodic)"
-                    rlatex += r"\mbox{(periodic)}"
+                    rlatex += r"\text{(periodic)}"
             else:
                 rtxt += ")"
                 rlatex += r"\right)"

--- a/src/sage/manifolds/continuous_map.py
+++ b/src/sage/manifolds/continuous_map.py
@@ -505,7 +505,7 @@ class ContinuousMap(Morphism):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         else:
             return self._latex_name
 
@@ -1119,7 +1119,7 @@ class ContinuousMap(Morphism):
 
             sage: latex(Phi.display(c_xy, c_cart))
             \begin{array}{llcl} \Phi:& S^2 & \longrightarrow & \RR^3
-             \\ \mbox{on}\ U : & \left(x, y\right) & \longmapsto
+             \\ \text{on}\ U : & \left(x, y\right) & \longmapsto
              & \left(X, Y, Z\right) = \left(\frac{2 \, x}{x^{2} + y^{2} + 1},
                \frac{2 \, y}{x^{2} + y^{2} + 1},
                \frac{x^{2} + y^{2} - 1}{x^{2} + y^{2} + 1}\right)
@@ -1176,7 +1176,7 @@ class ContinuousMap(Morphism):
              2*y/(x**2 + y**2 + 1), (x**2 + y**2 - 1)/(x**2 + y**2 + 1))
             sage: latex(Phi.display(c_xy, c_cart))
             \begin{array}{llcl} \Phi:& S^2 & \longrightarrow & \RR^3
-             \\ \mbox{on}\ U : & \left(x, y\right) & \longmapsto
+             \\ \text{on}\ U : & \left(x, y\right) & \longmapsto
              & \left(X, Y, Z\right) = \left(\frac{2 x}{x^{2} + y^{2} + 1},
                \frac{2 y}{x^{2} + y^{2} + 1},
                \frac{x^{2} + y^{2} - 1}{x^{2} + y^{2} + 1}\right)
@@ -1212,7 +1212,7 @@ class ContinuousMap(Morphism):
                 result._latex += ' & '
             else:
                 result._txt += 'on ' + chart1._domain._name + ': '
-                result._latex += r'\mbox{on}\ ' + latex(chart1._domain) + \
+                result._latex += r'\text{on}\ ' + latex(chart1._domain) + \
                                 r': & '
             result._txt += repr(coords1) + ' ' + unicode_mapsto + ' '
             result._latex += latex(coords1) + r'& \longmapsto & '

--- a/src/sage/manifolds/differentiable/curve.py
+++ b/src/sage/manifolds/differentiable/curve.py
@@ -186,7 +186,7 @@ class DifferentiableCurve(DiffMap):
 
         sage: c = M.curve([sin(t), sin(2*t)/2], (t, 0, 2*pi))
         sage: latex(c)
-        \mbox{Curve in the 2-dimensional differentiable manifold M}
+        \text{Curve in the 2-dimensional differentiable manifold M}
         sage: c = M.curve([sin(t), sin(2*t)/2], (t, 0, 2*pi), name='c')
         sage: latex(c)
         c

--- a/src/sage/manifolds/differentiable/diff_form_module.py
+++ b/src/sage/manifolds/differentiable/diff_form_module.py
@@ -498,7 +498,7 @@ class DiffFormModule(UniqueRepresentation, Parent):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         else:
             return self._latex_name
 

--- a/src/sage/manifolds/differentiable/metric.py
+++ b/src/sage/manifolds/differentiable/metric.py
@@ -447,7 +447,7 @@ class PseudoRiemannianMetric(TensorField):
         """
         return type(self)(self._vmodule, 'unnamed metric',
                           signature=self._signature,
-                          latex_name=r'\mbox{unnamed metric}')
+                          latex_name=r'\text{unnamed metric}')
 
     def _init_derived(self):
         r"""
@@ -2706,7 +2706,7 @@ class DegenerateMetric(TensorField):
         """
         return type(self)(self._vmodule, 'unnamed metric',
                           signature=self._signature,
-                          latex_name=r'\mbox{unnamed metric}')
+                          latex_name=r'\text{unnamed metric}')
 
     def signature(self):
         r"""

--- a/src/sage/manifolds/differentiable/mixed_form.py
+++ b/src/sage/manifolds/differentiable/mixed_form.py
@@ -347,7 +347,7 @@ class MixedForm(AlgebraElement, ModuleElementWithMutability):
 
         """
         if self._name is None:
-            return r'\mbox{' + repr(self) + r'}'
+            return r'\text{' + repr(self) + r'}'
         else:
             return self._latex_name
 
@@ -549,7 +549,7 @@ class MixedForm(AlgebraElement, ModuleElementWithMutability):
         else:
             resu_txt += self[0]._name
         if self[0]._latex_name is None:
-            resu_latex += r"\mbox{(unnamed scalar field)}"
+            resu_latex += r"\text{(unnamed scalar field)}"
         else:
             resu_latex += latex(self[0])
         # Differential forms:
@@ -559,7 +559,7 @@ class MixedForm(AlgebraElement, ModuleElementWithMutability):
             else:
                 resu_txt += " + " + self[j]._name
             if self[j]._latex_name is None:
-                resu_latex += r"+\mbox{(unnamed " + str(j) + r"-form)}"
+                resu_latex += r"+\text{(unnamed " + str(j) + r"-form)}"
             else:
                 resu_latex += r"+" + latex(self[j])
         return FormattedExpansion(resu_txt, resu_latex)

--- a/src/sage/manifolds/differentiable/multivector_module.py
+++ b/src/sage/manifolds/differentiable/multivector_module.py
@@ -444,7 +444,7 @@ class MultivectorModule(UniqueRepresentation, Parent):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         else:
             return self._latex_name
 

--- a/src/sage/manifolds/differentiable/symplectic_form.py
+++ b/src/sage/manifolds/differentiable/symplectic_form.py
@@ -185,7 +185,7 @@ class SymplecticForm(DiffForm):
         return type(self)(
             self._vmodule,
             "unnamed symplectic form",
-            latex_name=r"\mbox{unnamed symplectic form}",
+            latex_name=r"\text{unnamed symplectic form}",
         )
 
     def _init_derived(self):

--- a/src/sage/manifolds/differentiable/tensorfield.py
+++ b/src/sage/manifolds/differentiable/tensorfield.py
@@ -108,8 +108,8 @@ class TensorField(ModuleElementWithMutability):
 
     .. MATH::
 
-        t(p):\ \underbrace{T_q^*M\times\cdots\times T_q^*M}_{k\ \; \mbox{times}}
-        \times \underbrace{T_q M\times\cdots\times T_q M}_{l\ \; \mbox{times}}
+        t(p):\ \underbrace{T_q^*M\times\cdots\times T_q^*M}_{k\ \; \text{times}}
+        \times \underbrace{T_q M\times\cdots\times T_q M}_{l\ \; \text{times}}
         \longrightarrow K,
 
     where `T_q^* M` is the dual vector space to `T_q M` and `K` is the
@@ -589,7 +589,7 @@ class TensorField(ModuleElementWithMutability):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         else:
             return self._latex_name
 

--- a/src/sage/manifolds/differentiable/tensorfield_module.py
+++ b/src/sage/manifolds/differentiable/tensorfield_module.py
@@ -520,7 +520,7 @@ class TensorFieldModule(UniqueRepresentation, ReflexiveModule_tensor):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         else:
             return self._latex_name
 

--- a/src/sage/manifolds/differentiable/tensorfield_paral.py
+++ b/src/sage/manifolds/differentiable/tensorfield_paral.py
@@ -355,8 +355,8 @@ class TensorFieldParal(FreeModuleTensor, TensorField):
 
     .. MATH::
 
-        t(p):\ \underbrace{T_q^*M\times\cdots\times T_q^*M}_{k\ \; \mbox{times}}
-        \times \underbrace{T_q M\times\cdots\times T_q M}_{l\ \; \mbox{times}}
+        t(p):\ \underbrace{T_q^*M\times\cdots\times T_q^*M}_{k\ \; \text{times}}
+        \times \underbrace{T_q M\times\cdots\times T_q M}_{l\ \; \text{times}}
         \longrightarrow K,
 
     where `T_q^* M` is the dual vector space to `T_q M` and `K` is the

--- a/src/sage/manifolds/differentiable/vector_bundle.py
+++ b/src/sage/manifolds/differentiable/vector_bundle.py
@@ -362,8 +362,8 @@ class TensorBundle(DifferentiableVectorBundle):
 
     .. MATH::
 
-        t:\ \underbrace{T_q^*N\times\cdots\times T_q^*N}_{k\ \; \mbox{times}}
-            \times \underbrace{T_q N\times\cdots\times T_q N}_{l\ \; \mbox{times}}
+        t:\ \underbrace{T_q^*N\times\cdots\times T_q^*N}_{k\ \; \text{times}}
+            \times \underbrace{T_q N\times\cdots\times T_q N}_{l\ \; \text{times}}
             \longrightarrow K
 
     (`k` is called the *contravariant* and `l` the *covariant* rank of the
@@ -464,7 +464,7 @@ class TensorBundle(DifferentiableVectorBundle):
             else:
                 name = self._dest_map._name + "^*"
             if self._dest_map._latex_name is None:
-                latex_name = r'\mbox{(unnamed map)}^* '
+                latex_name = r'\text{(unnamed map)}^* '
             else:
                 latex_name = self._dest_map._latex_name + r'^* '
         else:
@@ -1356,8 +1356,8 @@ class TensorBundle(DifferentiableVectorBundle):
 
         .. MATH::
 
-            p \mapsto \Big(\underbrace{e^*(p), \dots, e^*(p)}_{k\ \; \mbox{times}},
-            \underbrace{e(p), \dots, e(p)}_{l\ \; \mbox{times}}\Big) \in
+            p \mapsto \Big(\underbrace{e^*(p), \dots, e^*(p)}_{k\ \; \text{times}},
+            \underbrace{e(p), \dots, e(p)}_{l\ \; \text{times}}\Big) \in
             T^{(k,l)}_q N ,
 
         with `q=\Phi(p)`, defines a basis at each point `p \in U` and

--- a/src/sage/manifolds/differentiable/vectorfield_module.py
+++ b/src/sage/manifolds/differentiable/vectorfield_module.py
@@ -396,7 +396,7 @@ class VectorFieldModule(UniqueRepresentation, ReflexiveModule_base):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r"\text{" + str(self) + r"}"
         else:
             return self._latex_name
 

--- a/src/sage/manifolds/manifold_homset.py
+++ b/src/sage/manifolds/manifold_homset.py
@@ -207,7 +207,7 @@ class TopologicalManifoldHomset(UniqueRepresentation, Homset):
             \mathrm{Hom}\left(M,N\right)
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         else:
             return self._latex_name
 

--- a/src/sage/manifolds/point.py
+++ b/src/sage/manifolds/point.py
@@ -250,7 +250,7 @@ class ManifoldPoint(Element):
             sage: X.<x,y> = M.chart()
             sage: p = M((2,-3))
             sage: p._latex_()
-            '\\mbox{Point on the 2-dimensional topological manifold M}'
+            '\\text{Point on the 2-dimensional topological manifold M}'
             sage: p = M((2,-3), name='p')
             sage: p._latex_()
             'p'
@@ -262,7 +262,7 @@ class ManifoldPoint(Element):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         return self._latex_name
 
     def coordinates(self, chart=None, old_chart=None):

--- a/src/sage/manifolds/scalarfield.py
+++ b/src/sage/manifolds/scalarfield.py
@@ -40,12 +40,17 @@ REFERENCES:
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from typing import Optional
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
 from sage.structure.element import (CommutativeAlgebraElement,
                                     ModuleElementWithMutability)
 from sage.symbolic.expression import Expression
 from sage.manifolds.chart_func import ChartFunction
 from sage.misc.cachefunc import cached_method
+
+if TYPE_CHECKING:
+    from sage.tensor.modules.format_utilities import FormattedExpansion
+    from sage.manifolds.chart import Chart
 
 class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
     r"""
@@ -1499,7 +1504,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             sage: X.<x,y> = M.chart()
             sage: f = M.scalar_field({X: x+y})
             sage: f._latex_()
-            '\\mbox{Scalar field on the 2-dimensional topological manifold M}'
+            '\\text{Scalar field on the 2-dimensional topological manifold M}'
             sage: f = M.scalar_field({X: x+y}, name='f')
             sage: f._latex_()
             'f'
@@ -1511,7 +1516,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         else:
             return self._latex_name
 
@@ -2096,7 +2101,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             self._express[chart.restrict(intersection)] = expr
         self._is_zero = False  # a priori
 
-    def display(self, chart=None):
+    def display(self, chart: Optional[Chart]=None) -> FormattedExpansion:
         r"""
         Display the expression of the scalar field in a given chart.
 
@@ -2149,7 +2154,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             f: M → ℝ
             on U: (x, y) ↦ y^2
             sage: latex(f.display())
-            \begin{array}{llcl} f:& M & \longrightarrow & \mathbb{R} \\ \mbox{on}\ U : & \left(x, y\right) & \longmapsto & y^{2} \end{array}
+            \begin{array}{llcl} f:& M & \longrightarrow & \mathbb{R} \\ \text{on}\ U : & \left(x, y\right) & \longmapsto & y^{2} \end{array}
 
         """
         from sage.misc.latex import latex
@@ -2176,7 +2181,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
                 result._latex += " & "
             else:
                 result._txt += "on " + chart.domain()._name + ": "
-                result._latex += r"\mbox{on}\ " + latex(chart.domain()) \
+                result._latex += r"\text{on}\ " + latex(chart.domain()) \
                                  + r": & "
             result._txt += repr(coords) + " " + unicode_mapsto + " " \
                            + repr(expression) + "\n"

--- a/src/sage/manifolds/section.py
+++ b/src/sage/manifolds/section.py
@@ -345,7 +345,7 @@ class Section(ModuleElementWithMutability):
 
         """
         if self._latex_name is None:
-            return r'\mbox{' + str(self) + r'}'
+            return r'\text{' + str(self) + r'}'
         else:
             return self._latex_name
 


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
### 📚 Description

vscode uses katex to render the latex output of jupyter cells. However, katex doesn't support mbox (see https://github.com/KaTeX/KaTeX/issues/2050). Thus we replace `\mbox` with `\text`.

<!-- Describe your changes here in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Closes #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have linked an issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies
<!-- List all open pull requests that this PR logically depends on -->
<!--
- #xyz: short description why this is a dependency
- #abc: ...
-->

