### PR TITLE
fix and activate pep E271 in python files

### DIFF
--- a/src/sage/categories/simplicial_sets.py
+++ b/src/sage/categories/simplicial_sets.py
@@ -456,7 +456,7 @@ class SimplicialSets(Category_singleton):
                 """
                 from sage.topology.simplicial_set import AbstractSimplex, SimplicialSet
                 from sage.topology.simplicial_set_morphism import SimplicialSetMorphism
-                char = {a : b for (a,b) in character.items()}
+                char = {a: b for (a, b) in character.items()}
                 G = list(char.values())[0].parent()
                 if not G.is_finite():
                     raise NotImplementedError("can only compute universal covers of spaces with finite fundamental group")
@@ -465,14 +465,14 @@ class SimplicialSets(Category_singleton):
 
                 for s in self.n_cells(0):
                     for g in G:
-                        cell =  AbstractSimplex(0,name="({}, {})".format(s, g))
-                        cells_dict[(s,g)] = cell
+                        cell = AbstractSimplex(0, name="({}, {})".format(s, g))
+                        cells_dict[(s, g)] = cell
                         char[s] = G.one()
 
                 for d in range(1, self.dimension() + 1):
                     for s in self.n_cells(d):
                         if s not in char.keys():
-                            if d==1 and  s.is_degenerate():
+                            if d == 1 and s.is_degenerate():
                                 char[s] = G.one()
                             elif s.is_degenerate():
                                 if 0 in s.degeneracies():
@@ -483,8 +483,8 @@ class SimplicialSets(Category_singleton):
                                 char[s] = char[self.face(s, d)]
                         if s.is_nondegenerate():
                             for g in G:
-                                cell =  AbstractSimplex(d,name="({}, {})".format(s, g))
-                                cells_dict[(s,g)] = cell
+                                cell = AbstractSimplex(d, name="({}, {})".format(s, g))
+                                cells_dict[(s, g)] = cell
                                 fd = []
                                 faces = self.faces(s)
                                 f0 = faces[0]

--- a/src/sage/modular/modform_hecketriangle/abstract_ring.py
+++ b/src/sage/modular/modform_hecketriangle/abstract_ring.py
@@ -816,11 +816,11 @@ class FormsRing_abstract(Parent):
         (X,Y,Z,dX,dY,dZ) = self.diff_alg().gens()
 
         if (self.hecke_n() == infinity):
-            return   (X*Z-X*Y) * dX\
+            return (X*Z-X*Y) * dX\
                    + ZZ(1)/ZZ(2) * (Y*Z-X) * dY\
                    + ZZ(1)/ZZ(4) * (Z**2-X) * dZ
         else:
-            return   1/self._group.n() * (X*Z-Y) * dX\
+            return 1/self._group.n() * (X*Z-Y) * dX\
                    + ZZ(1)/ZZ(2) * (Y*Z-X**(self._group.n()-1)) * dY\
                    + (self._group.n()-2) / (4*self._group.n()) * (Z**2-X**(self._group.n()-2)) * dZ
 
@@ -1926,18 +1926,18 @@ class FormsRing_abstract(Parent):
         # The case n=infinity is special (there are 2 cusps)
         # Until we/I get confirmation what is what sort of Eisenstein series
         # this case is excluded...
-        if    n == infinity:
+        if n == infinity:
             # We set the weight zero Eisenstein series to 1
             pass
-        elif  k == 0:
+        elif k == 0:
             return self.one()
-        elif  k == 2:
+        elif k == 2:
             # This is a bit problematic, e.g. for n=infinity there is a
             # classical Eisenstein series of weight 2
             return self.E2()
-        elif  k == 4:
+        elif k == 4:
             return self.E4()
-        elif  k == 6:
+        elif k == 6:
             return self.E6()
 
         # Basic variables

--- a/src/sage/modular/modform_hecketriangle/constructor.py
+++ b/src/sage/modular/modform_hecketriangle/constructor.py
@@ -141,8 +141,8 @@ def rational_type(f, n=ZZ(3), base_ring=ZZ):
 
     num = R(f.numerator())
     denom = R(f.denominator())
-    ep_num = set([ZZ(1) - 2*(( sum([g.exponents()[0][m] for m in [1,2]]) )%2) for g in   dhom(num).monomials()])
-    ep_denom = set([ZZ(1) - 2*(( sum([g.exponents()[0][m] for m in [1,2]]) )%2) for g in dhom(denom).monomials()])
+    ep_num = set([ZZ.one() - 2*((sum([g.exponents()[0][m] for m in [1, 2]])) % 2) for g in dhom(num).monomials()])
+    ep_denom = set([ZZ.one() - 2*((sum([g.exponents()[0][m] for m in [1, 2]])) % 2) for g in dhom(denom).monomials()])
 
     if (n == infinity):
         hom_num = R(   num.subs(x=x**4, y=y**2, z=z**2) )

--- a/src/sage/modular/modsym/ambient.py
+++ b/src/sage/modular/modsym/ambient.py
@@ -1773,7 +1773,7 @@ class ModularSymbolsAmbient(ModularSymbolsSpace, AmbientHeckeModule):
         # We only run through spaces of level a multiple of the conductor of the character, which
         # we compute below, or set to 1 in case of Gamma_H or Gamma_1
         chi = self.character()
-        cond = 1 if chi is None   else   chi.conductor()
+        cond = 1 if chi is None   else chi.conductor()
         # Now actually run through the divisor levels, taking only the ones with that are
         # a multiple of the conductor.
         for d in reversed(divisors(self.level())):

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -108,6 +108,7 @@ description =
     # Check for the following issues:
     # E111: indentation is not a multiple of four
     # E211: whitespace before '('
+    # E271: multiple spaces after keyword
     # E306: expected 1 blank line before a nested definition, found 0
     # E401: multiple imports on one line
     # E701: multiple statements on one line (colon)
@@ -124,7 +125,7 @@ description =
     # W605: invalid escape sequence ‘x’
     # See https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 deps = pycodestyle
-commands = pycodestyle --select E111,E211,E306,E401,E701,E702,E703,W291,W391,W605,E711,E712,E713,E721,E722 {posargs:{toxinidir}/sage/}
+commands = pycodestyle --select E111,E211,E271,E306,E401,E701,E702,E703,W291,W391,W605,E711,E712,E713,E721,E722 {posargs:{toxinidir}/sage/}
        pycodestyle --select E111,E306,E401,E703,W293,W391,W605,E712,E713,E714,E721,E722 --filename *.pyx {posargs:{toxinidir}/sage/}
 
 [pycodestyle]


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

This fixes and activate the pycodestyle warning E271

E271: multiple spaces after keyword

in all python files inside src/sage

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
