### PR TITLE
Implement infinite sums and products for lazy series

### DIFF
--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3358,7 +3358,7 @@ class Stream_infinite_operator(Stream):
         """
         if self._cur is None:
             temp = next(self._op_iter)
-            if not temp:
+            if isinstance(temp._coeff_stream, Stream_zero):
                 self._advance()
                 return
             self.initial(temp)
@@ -3370,7 +3370,7 @@ class Stream_infinite_operator(Stream):
             except StopIteration:
                 self._cur_order = infinity
                 return
-            if not next_factor:
+            if isinstance(next_factor._coeff_stream, Stream_zero):
                 continue
             coeff_stream = next_factor._coeff_stream
             while coeff_stream._approximate_order < order:

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3319,8 +3319,7 @@ class Stream_infinite_operator(Stream):
             self._advance()
         while self._cur_order <= 0:
             self._advance()
-        self._true_order = True
-        return self._cur._coeff_stream.order()
+        return self._cur._coeff_stream._approximate_order
 
     def _advance(self):
         r"""
@@ -3363,6 +3362,7 @@ class Stream_infinite_operator(Stream):
                 return
             self.initial(temp)
             self._cur_order = temp._coeff_stream._approximate_order
+
         order = self._cur_order
         while order == self._cur_order:
             try:
@@ -3379,8 +3379,9 @@ class Stream_infinite_operator(Stream):
                     order = coeff_stream._approximate_order
                     raise ValueError(f"invalid product computation with invalid order {order} < {self._cur_order}")
             self.apply_operator(next_factor)
-            # nonzero checks are safer than equality checks (i.e. in lazy series)
-            while not next_factor._coeff_stream[order]:
+            order = coeff_stream._approximate_order
+            # We check to see if we need to increment the order
+            if order == self._cur_order and not coeff_stream[order]:
                 order += 1
         self._cur_order = order
 

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -974,7 +974,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
         elif a in ZZ:
             if b != infinity:
                 if add_one:
-                    return super().prod(1 + f(i) for i in range(a, b+1))
+                    return super().prod(self.one() + f(i) for i in range(a, b+1))
                 return super().prod(f(i) for i in range(a, b+1))
             from sage.sets.non_negative_integers import NonNegativeIntegers
             it = (f(i+a) for i in NonNegativeIntegers())
@@ -983,7 +983,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
 
         # NOTE: We must have a new variable name for each new iterator
         if not add_one:
-            data = (g - 1 for g in it)
+            data = (g - self.one() for g in it)
         else:
             data = it
 

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -905,7 +905,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
         If ``a`` and ``b`` are both integers, then this returns the product
         `\prod_{i=a}^b f(i)`, where `f(i) = p_i` if ``add_one=False`` or
         `f(i) = 1 + p_i` otherwise. If ``b`` is not specified, then we consider
-        `b = \infty`. Note this corresponds to the Python `range(a, b+1)`.
+        `b = \infty`. Note this corresponds to the Python ``range(a, b+1)``.
 
         If `a` is any other iterable, then this returns the product
         `\prod_{i \in a} f(i)`, where `f(i) = p_i` if ``add_one=False`` or
@@ -1002,7 +1002,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
 
         If ``a`` and ``b`` are both integers, then this returns the sum
         `\sum_{i=a}^b f(i)`. If ``b`` is not specified, then we consider
-        `b = \infty`. Note this corresponds to the Python `range(a, b+1)`.
+        `b = \infty`. Note this corresponds to the Python ``range(a, b+1)``.
 
         If `a` is any other iterable, then this returns the sum
         `\sum{i \in a} f(i)`.

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -1683,9 +1683,7 @@ class LazyLaurentSeriesRing(LazySeriesRing):
             raise TypeError("the base ring is not a field")
         return R
 
-
     # === special functions ===
-
 
     def q_pochhammer(self, q=None):
         r"""
@@ -1802,7 +1800,6 @@ class LazyLaurentSeriesRing(LazySeriesRing):
                 return ZZ.zero()
             return (-1) ** ((m + 1) // 6)
         return self(coefficients=coeff, valuation=0)
-
 
 ######################################################################
 

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -1023,6 +1023,17 @@ class LazySeriesRing(UniqueRepresentation, Parent):
             sage: L.sum(lambda n: t^n / (n+1), PositiveIntegers())
             1/2*t + 1/3*t^2 + 1/4*t^3 + 1/5*t^4 + 1/6*t^5 + 1/7*t^6 + 1/8*t^7 + O(t^8)
 
+            sage: L.<z> = LazyPowerSeriesRing(QQ)
+            sage: T = L.undefined(1)
+            sage: D = L.undefined(0)
+            sage: H = L.sum(lambda k: T(z^k)/k, 2)
+            sage: T.define(z*exp(T)*D)
+            sage: D.define(exp(H))
+            sage: T
+            z + z^2 + 2*z^3 + 4*z^4 + 9*z^5 + 20*z^6 + 48*z^7 + O(z^8)
+            sage: D
+            1 + 1/2*z^2 + 1/3*z^3 + 7/8*z^4 + 11/30*z^5 + 281/144*z^6 + O(z^7)
+
         We verify the Rogers-Ramanujan identities up to degree 100::
 
             sage: L.<q> = LazyPowerSeriesRing(QQ)

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -890,6 +890,45 @@ class LazySeriesRing(UniqueRepresentation, Parent):
         """
         return self.base_ring().is_exact()
 
+    def prod(self, args, index_set=None):
+        r"""
+        The product of elements of ``self``.
+
+        INPUT:
+
+        - ``args`` -- a list (or iterable) of elements of ``self``
+        - ``index_set`` -- (optional) an indexing set for the product or
+          or a boolean
+
+        If ``index_set`` is an iterable, then ``args`` should be a function
+        that takes in an index and returns an element `p_i` of ``self`` to
+        compute the product `\prod_{i \in I} (1 + p_i)`. The valuation of `p_i`
+        is weakly increasing as we iterate over `I` and there are only
+        finitely many terms with any fixed valuation. If ``index=True``,
+        then this will treat ``args`` as an infinite product indexed by
+        `0, 1, \ldots`. In particular, this assumes the product is nonzero.
+
+        EXAMPLES::
+
+            sage: L.<t> = LazyLaurentSeriesRing(QQ)
+            sage: euler = L.prod(lambda n: -t^n, PositiveIntegers())
+            sage: euler
+            1 - t - t^2 + t^5 + O(t^7)
+            sage: 1 / euler
+            1 + t + 2*t^2 + 3*t^3 + 5*t^4 + 7*t^5 + 11*t^6 + O(t^7)
+            sage: euler - L.euler()
+            O(t^7)
+        """
+        if index_set is None:
+            return super().prod(args)
+        if index_set is True:
+            it = args
+        else:
+            it = (args(i) for i in index_set)
+        from sage.data_structures.stream import Stream_infinite_product
+        coeff_stream = Stream_infinite_product(it, self)
+        return self.element_class(self, coeff_stream)
+
     def _test_invert(self, **options):
         """
         Test multiplicative inversion of elements of ``self``.
@@ -1506,7 +1545,9 @@ class LazyLaurentSeriesRing(LazySeriesRing):
             raise TypeError("the base ring is not a field")
         return R
 
+
     # === special functions ===
+
 
     def q_pochhammer(self, q=None):
         r"""
@@ -1623,6 +1664,7 @@ class LazyLaurentSeriesRing(LazySeriesRing):
                 return ZZ.zero()
             return (-1) ** ((m + 1) // 6)
         return self(coefficients=coeff, valuation=0)
+
 
 ######################################################################
 

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -926,7 +926,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
         else:
             it = (args(i) for i in index_set)
         from sage.data_structures.stream import Stream_infinite_product
-        coeff_stream = Stream_infinite_product(it, self)
+        coeff_stream = Stream_infinite_product(it, self.one())
         return self.element_class(self, coeff_stream)
 
     def _test_invert(self, **options):


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

We allow lazy series to compute infinite sums `\sum_{i \in I} p_i` and products `\prod_{i \in I} (1 + p_i)` over arbitrary (enumerated) index sets `I` subject to a somewhat mild technical constraint that the order of each input `p_i` is weakly increasing wrt the iteration order and the preimage of each order is finite.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

- #35265

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
