### PR TITLE
Add output documentation on monte_carlo_integral

### DIFF
--- a/src/sage/calculus/integration.pyx
+++ b/src/sage/calculus/integration.pyx
@@ -457,6 +457,11 @@ def monte_carlo_integral(func, xl, xu, size_t calls, algorithm='plain',
       * 'vegas' -- The VEGAS algorithm of Lepage is based on importance
         sampling.
 
+    OUTPUT:
+
+    A tuple whose first component is the approximated integral and whose second
+    component is an error estimate.
+
     EXAMPLES::
 
         sage: x, y = SR.var('x,y')


### PR DESCRIPTION
This small commit adds an OUTPUT description to the documentation of monte_carlo_integral. The wording of the output is essentially taken from numerical_integral.

This is a nearly trivial documentation change, made after having a conversation with someone using monte-carlo-integration and being confused at the output. Specifically, the output is the tuple `(approximate_integral, approximate_error_bound)`. The error bound wasn't documented.

I will also note that this is my first direct contribution in the github era - please let me know if there is something I should be doing here.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.