### PR TITLE
Fix for `sage -package create --pypi --source wheel`

### DIFF
--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -305,7 +305,7 @@ class Application(object):
                     raise ValueError('Only platform-independent wheels can be used for wheel packages, got {0}'.format(tarball))
                 if not version:
                     version = pypi_version.version
-                upstream_url = 'https://pypi.io/packages/py3/{0:1.1}/{0}/{1}'.format(package_name, tarball)
+                upstream_url = 'https://pypi.io/packages/{2}/{0:1.1}/{0}/{1}'.format(package_name, tarball, pypi_version.python_version)
             if not description:
                 description = pypi_version.summary
             if not license:

--- a/build/sage_bootstrap/pypi.py
+++ b/build/sage_bootstrap/pypi.py
@@ -69,7 +69,8 @@ class PyPiVersion(object):
         Return the source url
         """
         for download in self.json['urls']:
-            if download['python_version'] == self.python_version:
+            if self.python_version in download['python_version']:
+                self.python_version = download['python_version']
                 return download['url']
         raise PyPiError('No %s url for %s found', self.python_version, self.name)
 
@@ -79,7 +80,8 @@ class PyPiVersion(object):
         Return the source tarball name
         """
         for download in self.json['urls']:
-            if download['python_version'] == self.python_version:
+            if self.python_version in download['python_version']:
+                self.python_version = download['python_version']
                 return download['filename']
         raise PyPiError('No %s url for %s found', self.python_version, self.name)
 


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

This adds support for platform-independent wheels that are tagged `py2.py3` instead of `py3`.

Example: https://pypi.org/project/sphinxcontrib-jquery/#files

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
