### PR TITLE
Use Singular maMapPoly to avoid quadratic complexity in polynomial evaluation

### DIFF
--- a/src/sage/libs/singular/decl.pxd
+++ b/src/sage/libs/singular/decl.pxd
@@ -978,10 +978,22 @@ cdef extern from "singular/Singular/libsingular.h":
     void setFlag(leftv *A, int F)
     void resetFlag(leftv *A, int F)
 
+    ctypedef number* (*nMapFunc)(number *c,const n_Procs_s* src,const n_Procs_s* dst)
+
+cdef extern from "singular/coeffs/coeffs.h":
+
+    number *ndCopyMap(number *, const n_Procs_s* src,const n_Procs_s* dst)
+
 cdef extern from "singular/coeffs/rmodulo2m.h":
 
     #init 2^m from a long
     number *nr2mMapZp(number *,const n_Procs_s* src,const n_Procs_s* dst)
+
+cdef extern from "singular/kernel/maps/gen_maps.h":
+
+    # mapping from p in r1 by i2 to r2
+
+    poly *maMapPoly(poly *p, ring *r1, ideal *i2, ring *r2, const nMapFunc nMap)
 
 cdef extern from "singular/kernel/maps/fast_maps.h":
 
@@ -992,8 +1004,6 @@ cdef extern from "singular/kernel/maps/fast_maps.h":
 cdef extern from "singular/polys/ext_fields/algext.h":
 
     naInitChar(n_Procs_s* cf, void * infoStruct)
-
-    ctypedef number* (*nMapFunc)(number *c,const n_Procs_s* src,const n_Procs_s* dst)
 
     nMapFunc naSetMap(const n_Procs_s* src, const n_Procs_s* dst)
 


### PR DESCRIPTION
### :books: Description

Currently evaluation of mutivariate polynomials using the Singular implementation is dominated by a quadratic algorithm for large polynomials, making it less efficient than the generic implementation.

Another Singular API does not have this problem and performs a more classical computation.

Fixes issue #35374 

Example:
```
sage: p = next_prime(2**24)
sage: x, y = polygens(GF(p), list("xy"))
sage: Rgeneric = PolynomialRing(GF(p), names=["x","y"], implementation="generic")
sage: pol = (x+y+1)^300
sage: polg = Rgeneric(pol)
# Generic
sage: %timeit polg(12,34)
86.5 ms ± 828 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# Before patch
sage: %time pol(12,34)
CPU times: user 6.76 s, sys: 30 ms, total: 6.79 s
# After patch
sage: %timeit pol(12,34)
12 ms ± 635 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.
