### PR TITLE
Add missing backticks to correct formatting

### DIFF
--- a/src/sage/matrix/matrix_modn_dense_float.pyx
+++ b/src/sage/matrix/matrix_modn_dense_float.pyx
@@ -52,7 +52,7 @@ cdef class Matrix_modn_dense_float(Matrix_modn_dense_template):
     ``Matrix_modn_dense_double`` class is used for larger moduli.
 
     Routines here are for the most basic access, see the
-    `matrix_modn_dense_template.pxi` file for higher-level routines.
+    ``matrix_modn_dense_template.pxi`` file for higher-level routines.
     """
     def __cinit__(self):
         """


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->
`matrix_modn_dense_float.pyx` had single backticks in one of the docstrings which was causing it to render as LaTeX text, while it was intended to be monospace formatted. The missing backticks are added to fix this.

Fixes #35363 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
