### PR TITLE
Typo: 'minumum' for 'minimum'

### DIFF
--- a/src/sage/libs/eclib/mwrank.pyx
+++ b/src/sage/libs/eclib/mwrank.pyx
@@ -840,7 +840,7 @@ cdef class _mw:
         - ``sat_bnd`` (int, default -1) -- upper bound on primes at
           which to saturate.  If -1 (default), compute a bound for the
           primes which may not be saturated, and use that.  Otherwise,
-          the bound used is the minumum of the value of ``sat_bnd``
+          the bound used is the minimum of the value of ``sat_bnd``
           and the computed bound.
 
         - ``sat_low_bd`` (int, default 2) -- only do saturation at


### PR DESCRIPTION
In sage/src/sage/libs/eclib/mwrank.pyx
Line 843 should read 'minumum' instead of 'minimum'.

<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
