### PR TITLE
partial cython linting in algebras/

### DIFF
--- a/src/sage/algebras/clifford_algebra_element.pxd
+++ b/src/sage/algebras/clifford_algebra_element.pxd
@@ -1,7 +1,6 @@
 """
 Clifford algebra elements
 """
-
 from sage.modules.with_basis.indexed_element cimport IndexedFreeModuleElement
 from sage.data_structures.bitset cimport FrozenBitset
 
@@ -14,4 +13,3 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
 
 cdef class CohomologyRAAGElement(CliffordAlgebraElement):
     pass
-

--- a/src/sage/algebras/clifford_algebra_element.pyx
+++ b/src/sage/algebras/clifford_algebra_element.pyx
@@ -6,8 +6,7 @@ AUTHORS:
 - Travis Scrimshaw (2013-09-06): Initial version
 - Trevor Karn (2022-07-10): Rewrite multiplication using bitsets
 """
-
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2022 Trevor K. Karn <karnx018 at umn.edu>
 #                 (C) 2022 Travis Scrimshaw <tcscrims at gmail.com>
 #
@@ -16,8 +15,7 @@ AUTHORS:
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #                  http://www.gnu.org/licenses/
-#*****************************************************************************
-
+# ****************************************************************************
 from sage.structure.parent cimport Parent
 from sage.data_structures.bitset cimport Bitset
 from sage.algebras.weyl_algebra import repr_from_monomials
@@ -125,7 +123,7 @@ cdef class CliffordAlgebraElement(IndexedFreeModuleElement):
 
         for ml, cl in self:
             # Distribute the current term ``cl`` * ``ml`` over ``other``.
-            cur = copy(other._monomial_coefficients) # The current distribution of the term
+            cur = copy(other._monomial_coefficients)  # The current distribution of the term
             for i in reversed(ml):
                 # Distribute the current factor ``e[i]`` (the ``i``-th
                 # element of the standard basis).
@@ -142,10 +140,10 @@ cdef class CliffordAlgebraElement(IndexedFreeModuleElement):
                             break
                         # Add the additional term from the commutation
                         # get a non-frozen bitset to manipulate
-                        t = Bitset(mr) # a mutable copy
+                        t = Bitset(mr)  # a mutable copy
                         t.discard(j)
                         t = FrozenBitset(t)
-                        next_level[t] = next_level.get(t, zero) + cr * Q[i,j]
+                        next_level[t] = next_level.get(t, zero) + cr * Q[i, j]
                         # Note: ``Q[i,j] == Q(e[i]+e[j]) - Q(e[i]) - Q(e[j])`` for
                         # ``i != j``, where ``e[k]`` is the ``k``-th standard
                         # basis vector.
@@ -154,16 +152,16 @@ cdef class CliffordAlgebraElement(IndexedFreeModuleElement):
                             del next_level[t]
 
                     # Check to see if we have a squared term or not
-                    mr = Bitset(mr) # temporarily mutable
+                    mr = Bitset(mr)  # temporarily mutable
                     if i in mr:
                         mr.discard(i)
-                        cr *= Q[i,i]
+                        cr *= Q[i, i]
                         # Note: ``Q[i,i] == Q(e[i])`` where ``e[i]`` is the
                         # ``i``-th standard basis vector.
                     else:
                         # mr is implicitly sorted
                         mr.add(i)
-                    mr = FrozenBitset(mr) # refreeze it
+                    mr = FrozenBitset(mr)  # refreeze it
                     next_level[mr] = next_level.get(mr, zero) + cr
                     if next_level[mr] == zero:
                         del next_level[mr]
@@ -213,11 +211,6 @@ cdef class CliffordAlgebraElement(IndexedFreeModuleElement):
             sage: r * 2  # indirect doctest
             2*x*y*z + 2*x*y + 2*x*z + 2*y*z + 2*x + 2*y + 2*z + 2
         """
-        cdef dict d
-        cdef list to_remove
-        cdef Py_ssize_t num_cross, tot_cross, i, j
-        cdef FrozenBitset ml
-
         if supp.isempty():  # Multiplication by a base ring element
             if coeff == self._parent._base.one():
                 return self
@@ -315,7 +308,8 @@ cdef class CliffordAlgebraElement(IndexedFreeModuleElement):
             sage: all(x.reflection().reflection() == x for x in Cl.basis())
             True
         """
-        return self.__class__(self._parent, {m: (-1)**len(m) * c for m,c in self})
+        return self.__class__(self._parent,
+                              {m: (-1)**len(m) * c for m, c in self})
 
     degree_negation = reflection
 
@@ -361,7 +355,7 @@ cdef class CliffordAlgebraElement(IndexedFreeModuleElement):
         if not self._monomial_coefficients:
             return P.zero()
         g = P.gens()
-        return P.sum(c * P.prod(g[i] for i in reversed(m)) for m,c in self)
+        return P.sum(c * P.prod(g[i] for i in reversed(m)) for m, c in self)
 
     def conjugate(self):
         r"""
@@ -475,7 +469,7 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
         ml = FrozenBitset()
         if ml in self._monomial_coefficients:
             const_coeff = self._monomial_coefficients[ml]
-            d = dict(rhs._monomial_coefficients) # Make a shallow copy
+            d = dict(rhs._monomial_coefficients)  # Make a shallow copy
             to_remove = []
             if const_coeff != P._base.one():
                 for k in d:
@@ -488,10 +482,12 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
             d = {}
 
         n = P.ngens()
-        for ml, cl in self._monomial_coefficients.items(): # ml for "monomial on the left"
+        for ml, cl in self._monomial_coefficients.items():
+            # ml for "monomial on the left"
             if ml.isempty():  # We already handled the trivial element
                 continue
-            for mr,cr in rhs._monomial_coefficients.items(): # mr for "monomial on the right"
+            for mr, cr in rhs._monomial_coefficients.items():
+                # mr for "monomial on the right"
                 if mr.isempty():
                     t = ml
                 else:
@@ -502,7 +498,7 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
                     it = iter(mr)
                     j = next(it)
 
-                    num_cross = 0 # keep track of the number of signs
+                    num_cross = 0  # keep track of the number of signs
                     tot_cross = 0
                     for i in ml:
                         while i > j:
@@ -576,7 +572,8 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
 
         n = self._parent.ngens()
         d = {}
-        for ml, cl in self._monomial_coefficients.items(): # ml for "monomial on the left"
+        for ml, cl in self._monomial_coefficients.items():
+            # ml for "monomial on the left"
             if not ml.isdisjoint(supp):
                 # if they intersect nontrivially, move along.
                 continue
@@ -584,7 +581,7 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
             it = iter(supp)
             j = next(it)
 
-            num_cross = 0 # keep track of the number of signs
+            num_cross = 0  # keep track of the number of signs
             tot_cross = 0
             for i in ml:
                 while i > j:
@@ -668,7 +665,8 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
             const_coeff = self._monomial_coefficients.pop(mr)
             d[supp] = const_coeff
 
-        for mr, cr in self._monomial_coefficients.items(): # mr for "monomial on the right"
+        for mr, cr in self._monomial_coefficients.items():
+            # mr for "monomial on the right"
             if not supp.isdisjoint(mr):
                 # if they intersect nontrivially, move along.
                 continue
@@ -676,7 +674,7 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
             it = iter(mr)
             j = next(it)  # We assume mr is non-empty here
 
-            num_cross = 0 # keep track of the number of signs
+            num_cross = 0  # keep track of the number of signs
             tot_cross = 0
             for i in supp:
                 while i > j:
@@ -839,7 +837,7 @@ cdef class ExteriorAlgebraElement(CliffordAlgebraElement):
         """
         P = self._parent
         return P.sum([c * cx * P.interior_product_on_basis(m, mx)
-                      for m,c in self for mx,cx in x])
+                      for m, c in self for mx, cx in x])
 
     antiderivation = interior_product
 
@@ -968,7 +966,8 @@ cdef class CohomologyRAAGElement(CliffordAlgebraElement):
                 tp = tuple(sorted(mr + ml))
                 if any(tp[i] == tp[i+1] for i in range(len(tp)-1)):  # e_i ^ e_i = 0
                     continue
-                if tp not in I: # not an independent set, so this term is also 0
+                if tp not in I:
+                    # not an independent set, so this term is also 0
                     continue
 
                 t = list(mr)

--- a/src/sage/algebras/exterior_algebra_groebner.pxd
+++ b/src/sage/algebras/exterior_algebra_groebner.pxd
@@ -1,7 +1,6 @@
 """
 Exterior algebras Gröbner bases
 """
-
 from sage.data_structures.bitset cimport FrozenBitset
 from sage.rings.integer cimport Integer
 from sage.algebras.clifford_algebra_element cimport CliffordAlgebraElement
@@ -53,4 +52,3 @@ cdef class GroebnerStrategyDegRevLex(GroebnerStrategy):
 
 cdef class GroebnerStrategyDegLex(GroebnerStrategy):
     pass
-

--- a/src/sage/algebras/exterior_algebra_groebner.pyx
+++ b/src/sage/algebras/exterior_algebra_groebner.pyx
@@ -21,8 +21,8 @@ AUTHORS:
 # ****************************************************************************
 
 from cysignals.signals cimport sig_check
-from sage.libs.gmp.mpz cimport mpz_sizeinbase, mpz_setbit, mpz_tstbit, mpz_cmp_si, mpz_sgn
-from sage.data_structures.bitset_base cimport (bitset_t, bitset_init, bitset_first,
+from sage.libs.gmp.mpz cimport mpz_sizeinbase, mpz_setbit, mpz_tstbit, mpz_sgn
+from sage.data_structures.bitset_base cimport (bitset_init, bitset_first,
                                                bitset_next, bitset_set_to, bitset_len)
 from sage.structure.parent cimport Parent
 from sage.structure.richcmp cimport richcmp, rich_to_bool
@@ -175,8 +175,8 @@ cdef class GroebnerStrategy:
         Convert ``f`` into a ``GBElement``.
         """
         cdef dict mc = <dict> f._monomial_coefficients
-        #if not mc:
-        #    return GBElement(f, FrozenBitset(), -1)
+        # if not mc:
+        #     return GBElement(f, FrozenBitset(), -1)
         cdef Integer r = <Integer> max(self.bitset_to_int(k) for k in mc)
         return GBElement(f, self.int_to_bitset(r), r)
 
@@ -232,7 +232,7 @@ cdef class GroebnerStrategy:
                 if self.build_S_poly(f0, f1):
                     L.add(self.partial_S_poly_right(f0, f1))
                     L.add(self.partial_S_poly_right(f1, f0))
-        else: # We compute a left Gröbner basis for two-sided ideals
+        else:  # We compute a left Gröbner basis for two-sided ideals
             for f0, f1 in P:
                 if self.build_S_poly(f0, f1):
                     L.add(self.partial_S_poly_left(f0, f1))
@@ -272,14 +272,14 @@ cdef class GroebnerStrategy:
         cdef set L = self.preprocessing(P, G)
         cdef Py_ssize_t i
         from sage.matrix.constructor import matrix
-        cdef Integer r = Integer(2) ** self.rank - Integer(1) # r for "rank" or "reverso"
+        cdef Integer r = Integer(2) ** self.rank - Integer(1)  # r for "rank" or "reverso"
         M = matrix({(i, r - self.bitset_to_int(<FrozenBitset> m)): c
-                    for i,f in enumerate(L)
-                    for m,c in (<GBElement> f).elt._monomial_coefficients.items()},
+                    for i, f in enumerate(L)
+                    for m, c in (<GBElement> f).elt._monomial_coefficients.items()},
                    sparse=True)
         M.echelonize()  # Do this in place
         lead_supports = set((<GBElement> f).lsi for f in L)
-        return [GBElement(self.E.element_class(self.E, {self.int_to_bitset(r - Integer(j)): c for j,c in M[i].iteritems()}),
+        return [GBElement(self.E.element_class(self.E, {self.int_to_bitset(r - Integer(j)): c for j, c in M[i].iteritems()}),
                           self.int_to_bitset(Integer(r - p)),
                           Integer(r - p))
                 for i, p in enumerate(M.pivots())
@@ -309,8 +309,7 @@ cdef class GroebnerStrategy:
         """
         cdef FrozenBitset p0, p1
         cdef long deg
-        cdef Py_ssize_t i, j, k
-        cdef set additions
+        cdef Py_ssize_t i, j
         cdef GBElement f0, f1
         cdef list G = [], Gp
         cdef dict constructed = {}
@@ -321,7 +320,7 @@ cdef class GroebnerStrategy:
                 continue
             f0 = self.build_elt(f)
             if f0.lsi in constructed:
-                if f0 in constructed[f0.lsi]: # Already there
+                if f0 in constructed[f0.lsi]:  # Already there
                     continue
                 constructed[f0.lsi].add(f0)
             else:
@@ -338,7 +337,7 @@ cdef class GroebnerStrategy:
                         continue
                     f1 = self.build_elt(f)
                     if f1.lsi in constructed:
-                        if f1 in constructed[f1.lsi]: # Already there
+                        if f1 in constructed[f1.lsi]:  # Already there
                             continue
                         constructed[f1.lsi].add(f1)
                     else:
@@ -367,7 +366,7 @@ cdef class GroebnerStrategy:
             # Add the elements Gp to G when a new element is found
             for f0 in Gp:
                 if f0.lsi in constructed:
-                    if f0 in constructed[f0.lsi]: # Already there
+                    if f0 in constructed[f0.lsi]:  # Already there
                         continue
                     constructed[f0.lsi].add(f0)
                 else:
@@ -402,20 +401,16 @@ cdef class GroebnerStrategy:
         cdef GBElement f0, f1
 
         # Now that we have a Gröbner basis, we make this into a reduced Gröbner basis
-        cdef tuple supp
-        cdef bint did_reduction
-        cdef FrozenBitset lm, s
-        cdef Integer r
         cdef Py_ssize_t num_zeros = 0
         cdef Py_ssize_t n = len(G)
         cdef set pairs = set((i, j) for i in range(n) for j in range(n) if i != j)
 
         while pairs:
             sig_check()
-            i,j = pairs.pop()
+            i, j = pairs.pop()
             f0 = <GBElement> G[i]
             f1 = <GBElement> G[j]
-            assert f0.elt._monomial_coefficients is not f1.elt._monomial_coefficients, (i,j)
+            assert f0.elt._monomial_coefficients is not f1.elt._monomial_coefficients, (i, j)
             # We perform the classical reduction algorithm here on each pair
             # TODO: Make this faster by using the previous technique?
             if self.reduce_single(f0.elt, f1.elt):
@@ -500,7 +495,6 @@ cdef class GroebnerStrategy:
         """
         cdef FrozenBitset lm = self.leading_support(g), s, t
         cdef bint did_reduction = True, was_reduced=False
-        cdef tuple supp
         cdef CliffordAlgebraElement gp
 
         one = self.E._base.one()
@@ -520,7 +514,6 @@ cdef class GroebnerStrategy:
                 coeff = f[t] / gp._monomial_coefficients[t]
                 iaxpy(-coeff, gp._monomial_coefficients, f._monomial_coefficients)
         return was_reduced
-
 
     cdef Integer bitset_to_int(self, FrozenBitset X):
         raise NotImplementedError
@@ -658,8 +651,6 @@ cdef class GroebnerStrategyDegRevLex(GroebnerStrategy):
         """
         Convert a nonnegative integer ``n`` to a :class:`FrozenBitset`.
         """
-        cdef size_t i
-
         if mpz_sgn(n.value) == 0:
             return FrozenBitset()
 
@@ -701,8 +692,6 @@ cdef class GroebnerStrategyDegLex(GroebnerStrategy):
         """
         Convert a nonnegative integer ``n`` to a :class:`FrozenBitset`.
         """
-        cdef size_t i
-
         if mpz_sgn(n.value) == 0:
             return FrozenBitset()
 

--- a/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra_element.pyx
+++ b/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra_element.pyx
@@ -14,10 +14,8 @@ Elements of Finite Algebras
 # ****************************************************************************
 import re
 
-from sage.misc.lazy_attribute import lazy_attribute
 from sage.matrix.matrix_space import MatrixSpace
 from sage.structure.element import is_Matrix
-from sage.modules.free_module_element import vector
 from sage.rings.integer import Integer
 
 from cpython.object cimport PyObject_RichCompare as richcmp
@@ -36,7 +34,7 @@ cpdef FiniteDimensionalAlgebraElement unpickle_FiniteDimensionalAlgebraElement(A
     """
     cdef FiniteDimensionalAlgebraElement x = A.element_class.__new__(A.element_class)
     AlgebraElement.__init__(x, A)
-    x._vector  = vec
+    x._vector = vec
     x.__matrix = mat
     return x
 
@@ -90,13 +88,13 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
         k = A.base_ring()
         n = A.degree()
         if elt is None:
-            self._vector = MatrixSpace(k,1,n)()
+            self._vector = MatrixSpace(k, 1, n)()
             self.__matrix = MatrixSpace(k, n)()
         else:
             if isinstance(elt, int):
                 elt = Integer(elt)
             elif isinstance(elt, list):
-                elt = MatrixSpace(k,1,n)(elt)
+                elt = MatrixSpace(k, 1, n)(elt)
             if A == elt.parent():
                 mat = (<FiniteDimensionalAlgebraElement> elt).__matrix
                 if mat is None:
@@ -115,7 +113,7 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
                 else:
                     raise TypeError("algebra is not unitary")
             elif isinstance(elt, Vector):
-                self._vector = MatrixSpace(k,1,n)(list(elt))
+                self._vector = MatrixSpace(k, 1, n)(list(elt))
             elif is_Matrix(elt):
                 if elt.ncols() != n:
                     raise ValueError("matrix does not define an element of the algebra")
@@ -171,7 +169,7 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
         self._parent, D = state
         v = D.pop('_vector')
         if isinstance(v, Vector):
-            self._vector = MatrixSpace(self._parent.base_ring(), 1,len(v))(list(v))
+            self._vector = MatrixSpace(self._parent.base_ring(), 1, len(v))(list(v))
         else:
             self._vector = v
         self.__matrix = D.pop('_matrix', None)
@@ -197,7 +195,7 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
         if self.__matrix is None:
             A = self.parent()
             table = <tuple> A.table()
-            ret = sum(self._vector[0,i] * table[i] for i in xrange(A.degree()))
+            ret = sum(self._vector[0, i] * table[i] for i in range(A.degree()))
             self.__matrix = MatrixSpace(A.base_ring(), A.degree())(ret)
         return self.__matrix
 
@@ -211,9 +209,9 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
             sage: B(5).vector()
             (5, 0, 5)
         """
-        #By :trac:`23707`, ``self._vector`` now is a single row matrix,
-        #not a vector, which results in a speed-up. For backwards compatibility,
-        #this method still returns a vector.
+        # By :trac:`23707`, ``self._vector`` now is a single row matrix,
+        # not a vector, which results in a speed-up.
+        # For backwards compatibility, this method still returns a vector.
         return self._vector[0]
 
     def matrix(self):
@@ -248,7 +246,7 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
             {0: 1, 1: 1}
         """
         cdef Py_ssize_t i
-        return {i:self._vector[0,i] for i in range(self._vector.ncols())}
+        return {i: self._vector[0, i] for i in range(self._vector.ncols())}
 
     def left_matrix(self):
         """
@@ -261,12 +259,11 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
             [1 0 0]
             [0 1 0]
             [0 2 0]
-
         """
         A = self.parent()
         if A.is_commutative():
             return self._matrix
-        return sum([self._vector[0,i] * A.left_table()[i] for
+        return sum([self._vector[0, i] * A.left_table()[i] for
                     i in range(A.degree())])
 
     def _repr_(self):
@@ -299,8 +296,8 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
                 var = "*{}".format(A._names[n])
                 s += "{}{}".format(x, var)
         s = s.replace(" + -", " - ")
-        s = re.sub(r' 1(\.0+)?\*',' ', s)
-        s = re.sub(r' -1(\.0+)?\*',' -', s)
+        s = re.sub(r' 1(\.0+)?\*', ' ', s)
+        s = re.sub(r' -1(\.0+)?\*', ' -', s)
         if s == " ":
             return "0"
         return s[1:]
@@ -330,9 +327,8 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
             sage: A = FiniteDimensionalAlgebra(QQ, [Matrix([[1,0,0], [0,1,0], [0,0,0]]), Matrix([[0,1,0], [0,0,0], [0,0,0]]), Matrix([[0,0,0], [0,0,0], [0,0,1]])])
             sage: A([2,1/4,3])[2]
             3
-
         """
-        return self._vector[0,m]
+        return self._vector[0, m]
 
     def __len__(self):
         """
@@ -341,11 +337,10 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
             sage: A = FiniteDimensionalAlgebra(QQ, [Matrix([[1,0,0], [0,1,0], [0,0,0]]), Matrix([[0,1,0], [0,0,0], [0,0,0]]), Matrix([[0,0,0], [0,0,0], [0,0,1]])])
             sage: len(A([2,1/4,3]))
             3
-
         """
         return self._vector.ncols()
 
-    ## (Rich) comparison
+    # (Rich) comparison
     cpdef _richcmp_(self, right, int op):
         """
         EXAMPLES::
@@ -375,7 +370,6 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
             True
             sage: A(1) <= 0
             False
-
         """
         return richcmp(self._vector, <FiniteDimensionalAlgebraElement>right._vector, op)
 
@@ -435,7 +429,8 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
         if not self._parent.base_ring().has_coerce_map_from(other.parent()):
             raise TypeError("unsupported operand parent(s) for *: '{}' and '{}'"
                             .format(self.parent(), other.parent()))
-        return self._parent.element_class(self._parent, other * self._vector) # Note the different order
+        # Note the different order below
+        return self._parent.element_class(self._parent, other * self._vector)
 
     def __pow__(self, n, m):
         """

--- a/src/sage/algebras/fusion_rings/fast_parallel_fmats_methods.pxd
+++ b/src/sage/algebras/fusion_rings/fast_parallel_fmats_methods.pxd
@@ -2,4 +2,3 @@ cdef _fmat(fvars, Nk_ij, one, a, b, c, d, x, y)
 cpdef _backward_subs(factory, bint flatten=*)
 cpdef executor(tuple params)
 cpdef _solve_for_linear_terms(factory, list eqns=*)
-

--- a/src/sage/algebras/fusion_rings/fast_parallel_fmats_methods.pyx
+++ b/src/sage/algebras/fusion_rings/fast_parallel_fmats_methods.pyx
@@ -29,7 +29,7 @@ from sage.rings.ideal import Ideal
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 
 ##########################
-### Fast class methods ###
+#   Fast class methods   #
 ##########################
 
 cpdef _solve_for_linear_terms(factory, list eqns=None):
@@ -87,7 +87,8 @@ cpdef _solve_for_linear_terms(factory, list eqns=None):
                 # assert factory.test_fvars[s] == fvars[s], "OG value {}, Shared: {}".format(fvars[s], factory.test_fvars[s])
         if len(eq_tup) == 2:
             idx = has_appropriate_linear_term(eq_tup)
-            if idx < 0: continue
+            if idx < 0:
+                continue
             # The chosen term is guaranteed to be univariate in the largest variable
             exp = eq_tup[idx][0]
             max_var = exp._data[0]
@@ -161,7 +162,7 @@ cpdef _backward_subs(factory, bint flatten=True):
         sextuple = idx_to_sextuple[i]
         rhs = fvars[sextuple]
         d = {var_idx: fvars[idx_to_sextuple[var_idx]]
-              for var_idx in variables(rhs) if solved[var_idx]}
+             for var_idx in variables(rhs) if solved[var_idx]}
         if d:
             kp = compute_known_powers(get_variables_degrees([rhs], nvars), d, one)
             res = tuple(subs_squares(subs(rhs, kp, one), _ks).items())
@@ -210,7 +211,7 @@ cdef _fmat(fvars, _Nk_ij, id_anyon, a, b, c, d, x, y):
 # _Nk_ij = cached_function(_Nk_ij, name='_Nk_ij')
 
 ###############
-### Mappers ###
+#   Mappers   #
 ###############
 
 cdef req_cy(tuple basis, r_matrix, dict fvars, Nk_ij, id_anyon, tuple sextuple):
@@ -226,6 +227,7 @@ cdef req_cy(tuple basis, r_matrix, dict fvars, Nk_ij, id_anyon, tuple sextuple):
     for f in basis:
         rhs += _fmat(fvars, Nk_ij, id_anyon, c, a, b, d, e, f) * r_matrix(f, c, d, base_coercion=False) * _fmat(fvars, Nk_ij, id_anyon, a, b, c, d, f, g)
     return lhs-rhs
+
 
 @cython.wraparound(False)
 @cython.nonecheck(False)
@@ -287,12 +289,14 @@ cdef MPolynomial_libsingular feq_cy(tuple basis, fvars, Nk_ij, id_anyon, zero, t
     """
     a, b, c, d, e, f, g, k, l = nonuple
     lhs = _fmat(fvars, Nk_ij, id_anyon, f, c, d, e, g, l) * _fmat(fvars, Nk_ij, id_anyon, a, b, l, e, f, k)
-    if lhs == 0 and prune: # it is believed that if lhs=0, the equation carries no new information
+    if lhs == 0 and prune:
+        # it is believed that if lhs=0, the equation carries no new information
         return zero
     rhs = zero
     for h in basis:
         rhs += _fmat(fvars, Nk_ij, id_anyon, a, b, c, g, f, h)*_fmat(fvars, Nk_ij, id_anyon, a, h, d, e, g, k)*_fmat(fvars, Nk_ij, id_anyon, b, c, d, k, h, l)
     return lhs - rhs
+
 
 @cython.wraparound(False)
 @cython.nonecheck(False)
@@ -304,7 +308,7 @@ cdef get_reduced_pentagons(factory, tuple mp_params):
     # Set up multiprocessing parameters
     cdef list worker_results = list()
     cdef int child_id, n_proc
-    child_id, n_proc, output = mp_params
+    child_id, n_proc, _ = mp_params
     cdef unsigned long i
     cdef tuple nonuple, red
     cdef MPolynomial_libsingular pe
@@ -395,7 +399,7 @@ cdef list compute_gb(factory, tuple args):
     cdef MPolynomialRing_libsingular R = PolynomialRing(factory._FR.field(), len(sorted_vars), 'a', order=term_order)
 
     # Zip tuples into R and compute Groebner basis
-    cdef idx_map = { old : new for new, old in enumerate(sorted_vars) }
+    cdef idx_map = {old : new for new, old in enumerate(sorted_vars)}
     nvars = len(sorted_vars)
     F = factory.field()
     cdef list polys = list()
@@ -405,7 +409,7 @@ cdef list compute_gb(factory, tuple args):
     gb = Ideal(sorted(polys)).groebner_basis(algorithm="libsingular:slimgb")
 
     # Change back to fmats poly ring and append to temp_eqns
-    cdef dict inv_idx_map = { v : k for k, v in idx_map.items() }
+    cdef dict inv_idx_map = {v: k for k, v in idx_map.items()}
     cdef tuple t
     nvars = factory._poly_ring.ngens()
     for p in gb:
@@ -418,7 +422,7 @@ cdef list compute_gb(factory, tuple args):
     return collect_eqns(res)
 
 ################
-### Reducers ###
+#   Reducers   #
 ################
 
 cdef inline list collect_eqns(list eqns):
@@ -434,7 +438,7 @@ cdef inline list collect_eqns(list eqns):
     return list(reduced)
 
 ##############################
-### Parallel code executor ###
+#   Parallel code executor   #
 ##############################
 
 # Hard-coded module __dict__-style attribute with visible cdef methods
@@ -490,7 +494,7 @@ cpdef executor(tuple params):
     return mappers[fn_name](fmats_obj, args)
 
 ####################
-### Verification ###
+#   Verification   #
 ####################
 
 cdef feq_verif(factory, worker_results, fvars, Nk_ij, id_anyon, tuple nonuple, float tol=5e-8):
@@ -508,6 +512,7 @@ cdef feq_verif(factory, worker_results, fvars, Nk_ij, id_anyon, tuple nonuple, f
     if diff > tol or diff < -tol:
         worker_results.append(diff)
 
+
 @cython.wraparound(False)
 @cython.nonecheck(False)
 @cython.cdivision(True)
@@ -517,7 +522,6 @@ cdef pent_verify(factory, tuple mp_params):
     and reduce them.
     """
     child_id, n_proc, verbose = mp_params
-    cdef float t0
     cdef tuple nonuple
     cdef unsigned long long i
     cdef list worker_results = list()

--- a/src/sage/algebras/fusion_rings/fast_parallel_fusion_ring_braid_repn.pxd
+++ b/src/sage/algebras/fusion_rings/fast_parallel_fusion_ring_braid_repn.pxd
@@ -1,3 +1,2 @@
 cpdef _unflatten_entries(factory, list entries)
 cpdef executor(tuple params)
-

--- a/src/sage/algebras/fusion_rings/fast_parallel_fusion_ring_braid_repn.pyx
+++ b/src/sage/algebras/fusion_rings/fast_parallel_fusion_ring_braid_repn.pyx
@@ -15,7 +15,7 @@ from sage.algebras.fusion_rings.fast_parallel_fmats_methods cimport _fmat
 from sage.rings.qqbar import QQbar
 
 ###############
-### Mappers ###
+#   Mappers   #
 ###############
 
 cdef mid_sig_ij(fusion_ring, row, col, a, b):
@@ -96,6 +96,7 @@ cdef cached_odd_one_out_ij(fusion_ring, xi, xj, a, b):
     odd_one_out_ij_cache[xi, xj, a, b] = entry
     return entry
 
+
 @cython.nonecheck(False)
 @cython.cdivision(True)
 cdef sig_2k(fusion_ring, tuple args):
@@ -175,6 +176,7 @@ cdef sig_2k(fusion_ring, tuple args):
                         worker_results.append(((basis_dict[nnz_pos], i), entry))
     return worker_results
 
+
 @cython.nonecheck(False)
 @cython.cdivision(True)
 cdef odd_one_out(fusion_ring, tuple args):
@@ -252,7 +254,7 @@ cdef odd_one_out(fusion_ring, tuple args):
     return worker_results
 
 ##############################
-### Parallel code executor ###
+#   Parallel code executor   #
 ##############################
 
 # Hard-coded module __dict__-style attribute with visible cdef methods
@@ -300,7 +302,7 @@ cpdef executor(tuple params):
     return mappers[fn_name](fusion_ring_obj, args)
 
 ######################################
-### Pickling circumvention helpers ###
+#   Pickling circumvention helpers   #
 ######################################
 
 cpdef _unflatten_entries(fusion_ring, list entries):
@@ -323,7 +325,6 @@ cpdef _unflatten_entries(fusion_ring, list entries):
         True
     """
     F = fusion_ring.fvars_field()
-    fm = fusion_ring.get_fmatrix()
     if F != QQbar:
         for i, (coord, entry) in enumerate(entries):
             entries[i] = (coord, F(entry))

--- a/src/sage/algebras/fusion_rings/poly_tup_engine.pxd
+++ b/src/sage/algebras/fusion_rings/poly_tup_engine.pxd
@@ -21,4 +21,3 @@ cdef tuple reduce_poly_dict(dict eq_dict, ETuple nonz, KSHandler known_sq, Numbe
 cdef tuple _flatten_coeffs(tuple eq_tup)
 cpdef tuple _unflatten_coeffs(field, tuple eq_tup)
 cdef int has_appropriate_linear_term(tuple eq_tup)
-

--- a/src/sage/algebras/fusion_rings/poly_tup_engine.pyx
+++ b/src/sage/algebras/fusion_rings/poly_tup_engine.pyx
@@ -9,7 +9,7 @@ Arithmetic Engine for Polynomials as Tuples
 # ****************************************************************************
 
 ###########
-### API ###
+#   API   #
 ###########
 
 cpdef inline tuple poly_to_tup(MPolynomial_libsingular poly):
@@ -115,7 +115,7 @@ cpdef tuple _unflatten_coeffs(field, tuple eq_tup):
     return tuple(unflat)
 
 #################################
-### Useful private predicates ###
+#   Useful private predicates   #
 #################################
 
 cdef inline int has_appropriate_linear_term(tuple eq_tup):
@@ -146,7 +146,7 @@ cdef inline int has_appropriate_linear_term(tuple eq_tup):
     return -1
 
 ######################
-### "Change rings" ###
+#   "Change rings"   #
 ######################
 
 cpdef inline tup_to_univ_poly(tuple eq_tup, univ_poly_ring):
@@ -215,7 +215,7 @@ cpdef inline tuple resize(tuple eq_tup, dict idx_map, int nvars):
     return tuple(resized)
 
 ###########################
-### Convenience methods ###
+#   Convenience methods   #
 ###########################
 
 cdef inline ETuple degrees(tuple poly_tup):
@@ -225,7 +225,7 @@ cdef inline ETuple degrees(tuple poly_tup):
     # Deal with the empty tuple, representing the zero polynomial
     if not poly_tup:
         return ETuple()
-    cdef ETuple max_degs, exp
+    cdef ETuple max_degs
     cdef int i
     max_degs = <ETuple> (<tuple> poly_tup[0])[0]
     for i in range(1, len(poly_tup)):
@@ -251,7 +251,7 @@ cpdef list get_variables_degrees(list eqns, int nvars):
     cdef int i
     max_deg = degrees(eqns[0])
     for i in range(1, len(eqns)):
-        max_deg = max_deg.emax(degrees( <tuple>(eqns[i]) ))
+        max_deg = max_deg.emax(degrees(<tuple>(eqns[i])))
     cdef list dense = [0] * len(max_deg)
     for i in range(max_deg._nonzero):
         dense[max_deg._data[2*i]] = max_deg._data[2*i+1]
@@ -339,7 +339,7 @@ cdef inline bint tup_fixes_sq(tuple eq_tup):
     return True
 
 ######################
-### Simplification ###
+#   Simplification   #
 ######################
 
 cdef dict subs_squares(dict eq_dict, KSHandler known_sq):
@@ -358,7 +358,7 @@ cdef dict subs_squares(dict eq_dict, KSHandler known_sq):
     A dictionary of ``(ETuple, coeff)`` pairs.
     """
     cdef dict subbed, new_e
-    cdef ETuple exp, lm
+    cdef ETuple exp
     cdef int idx, power
     subbed = dict()
     for exp, coeff in eq_dict.items():
@@ -434,7 +434,7 @@ cdef tuple reduce_poly_dict(dict eq_dict, ETuple nonz, KSHandler known_sq, Numbe
     return to_monic(gcf_rmvd, one)
 
 ####################
-### Substitution ###
+#   Substitution   #
 ####################
 
 cpdef dict compute_known_powers(max_degs, dict val_dict, one):
@@ -521,7 +521,7 @@ cdef tuple tup_mul(tuple p1, tuple p2):
     return tuple(prod.items())
 
 ###############
-### Sorting ###
+#   Sorting   #
 ###############
 
 cdef tuple monom_sortkey(ETuple exp):
@@ -564,7 +564,7 @@ cpdef tuple poly_tup_sortkey(tuple eq_tup):
         (2, 0, 2, 2, 0, 1, -2, 1, 2, -2, 2, 1, 0, 1, 1, -1, 1)
     """
     cdef ETuple exp
-    cdef int i, l, nnz
+    cdef int i
     cdef list key = []
     for exp, c in eq_tup:
         # Compare by term degree

--- a/src/sage/algebras/fusion_rings/shm_managers.pxd
+++ b/src/sage/algebras/fusion_rings/shm_managers.pxd
@@ -21,4 +21,3 @@ cdef class FvarsHandler:
     cdef object fvars_t, pid_list
     cdef Py_ssize_t child_id
     cdef public object shm
-

--- a/src/sage/algebras/fusion_rings/shm_managers.pyx
+++ b/src/sage/algebras/fusion_rings/shm_managers.pyx
@@ -96,7 +96,7 @@ cdef class KSHandler:
         sage: ks.shm.unlink()
         sage: f.shutdown_worker_pool()
     """
-    def __init__(self, n_slots, field, use_mp=False, init_data={}, name=None):
+    def __init__(self, n_slots, field, use_mp=False, init_data=None, name=None):
         r"""
         Initialize ``self``.
 
@@ -115,6 +115,8 @@ cdef class KSHandler:
             sage: f.shutdown_worker_pool()
         """
         cdef int n, d
+        if init_data is None:
+            init_data = {}
         self.field = field
         n = n_slots
         d = self.field.degree()
@@ -342,6 +344,7 @@ cdef class KSHandler:
             if self.ks_dat['known'][i]:
                 yield i, self.get(i)
 
+
 def make_KSHandler(n_slots, field, init_data):
     r"""
     Provide pickling / unpickling support for :class:`KSHandler`.
@@ -357,6 +360,7 @@ def make_KSHandler(n_slots, field, init_data):
         True
     """
     return KSHandler(n_slots, field, init_data=init_data)
+
 
 cdef class FvarsHandler:
     r"""
@@ -451,7 +455,8 @@ cdef class FvarsHandler:
         sage: fvars.shm.unlink()
         sage: f.shutdown_worker_pool()
     """
-    def __init__(self, n_slots, field, idx_to_sextuple, init_data={}, use_mp=0,
+    def __init__(self, n_slots, field, idx_to_sextuple, init_data=None,
+                 use_mp=0,
                  pids_name=None, name=None, max_terms=20, n_bytes=32):
         r"""
         Initialize ``self``.
@@ -477,6 +482,8 @@ cdef class FvarsHandler:
         self.bytes = n_bytes
         cdef int slots = self.bytes // 8
         cdef int n_proc = use_mp + 1
+        if init_data is None:
+            init_data = {}
         self.fvars_t = np.dtype([
             ('modified', np.int8, (n_proc, )),
             ('ticks', 'u1', (max_terms, )),
@@ -575,7 +582,7 @@ cdef class FvarsHandler:
                 return self.obj_cache[idx]
         cdef ETuple e, exp
         cdef int count, nnz
-        cdef Integer d, num
+        cdef Integer num
         cdef list poly_tup, rats
         cdef NumberFieldElement_absolute cyc_coeff
         cdef Py_ssize_t cum, i, j, k
@@ -752,6 +759,7 @@ cdef class FvarsHandler:
         """
         for sextuple in self.sext_to_idx:
             yield sextuple, self[sextuple]
+
 
 def make_FvarsHandler(n, field, idx_map, init_data):
     r"""

--- a/src/sage/algebras/lie_algebras/lie_algebra_element.pxd
+++ b/src/sage/algebras/lie_algebras/lie_algebra_element.pxd
@@ -22,7 +22,7 @@ cdef class StructureCoefficientsElement(LieAlgebraMatrixWrapper):
     cpdef _bracket_(self, right)
     cpdef to_vector(self, bint sparse=*)
     cpdef dict monomial_coefficients(self, bint copy=*)
-    #cpdef lift(self)
+    # cpdef lift(self)
 
 cdef class UntwistedAffineLieAlgebraElement(Element):
     cdef dict _t_dict

--- a/src/sage/algebras/lie_algebras/lie_algebra_element.pyx
+++ b/src/sage/algebras/lie_algebras/lie_algebra_element.pyx
@@ -18,10 +18,9 @@ AUTHORS:
 # ****************************************************************************
 
 from copy import copy
-from cpython.object cimport Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE
+from cpython.object cimport Py_EQ, Py_NE, Py_GT, Py_GE
 
 from sage.misc.repr import repr_lincomb
-from sage.combinat.free_module import CombinatorialFreeModule
 from sage.structure.element cimport have_same_parent, parent
 from sage.structure.coerce cimport coercion_model
 from sage.cpython.wrapperdescr cimport wrapperdescr_fastcall
@@ -116,7 +115,7 @@ cdef class LieAlgebraElement(IndexedFreeModuleElement):
             -[a, [a, b]] + [a, b] - [[a, b], b]
         """
         s = codomain.zero()
-        if not self: # If we are 0
+        if not self:  # If we are 0
             return s
         names = self.parent().variable_names()
         if base_map is None:
@@ -408,7 +407,7 @@ cdef class LieAlgebraElementWrapper(ElementWrapper):
         if scalar_parent != self._parent.base_ring():
             # Temporary needed by coercion (see Polynomial/FractionField tests).
             if self._parent.base_ring().has_coerce_map_from(scalar_parent):
-                scalar = self._parent.base_ring()( scalar )
+                scalar = self._parent.base_ring()(scalar)
             else:
                 return None
         if self_on_left:
@@ -479,7 +478,7 @@ cdef class LieAlgebraMatrixWrapper(LieAlgebraElementWrapper):
             sage: z.value.is_immutable()
             True
         """
-        value.set_immutable() # Make the matrix immutable for hashing
+        value.set_immutable()  # Make the matrix immutable for hashing
         LieAlgebraElementWrapper.__init__(self, parent, value)
 
 
@@ -681,7 +680,7 @@ cdef class LieSubalgebraElementWrapper(LieAlgebraElementWrapper):
         if scalar_parent != self._parent.base_ring():
             # Temporary needed by coercion (see Polynomial/FractionField tests).
             if self._parent.base_ring().has_coerce_map_from(scalar_parent):
-                scalar = self._parent.base_ring()( scalar )
+                scalar = self._parent.base_ring()(scalar)
             else:
                 return None
         cdef LieSubalgebraElementWrapper ret
@@ -827,7 +826,7 @@ cdef class StructureCoefficientsElement(LieAlgebraMatrixWrapper):
         zero = self._parent.base_ring().zero()
         I = self._parent._indices
         cdef int i
-        for i,v in enumerate(self.value):
+        for i, v in enumerate(self.value):
             if v != zero:
                 yield (I[i], v)
 
@@ -879,7 +878,7 @@ cdef class StructureCoefficientsElement(LieAlgebraMatrixWrapper):
             {'x': 2, 'z': -3/2}
         """
         I = self._parent._indices
-        return {I[i]: v for i,v in self.value.iteritems()}
+        return {I[i]: v for i, v in self.value.iteritems()}
 
     def __getitem__(self, i):
         """
@@ -1262,7 +1261,7 @@ cdef class UntwistedAffineLieAlgebraElement(Element):
         cdef dict d = {}
         for t, g in self._t_dict.items():
             for k, c in g.monomial_coefficients(copy=False).iteritems():
-                d[k,t] = c
+                d[k, t] = c
         if self._c_coeff:
             d['c'] = self._c_coeff
         if self._d_coeff:
@@ -1322,7 +1321,6 @@ cdef class UntwistedAffineLieAlgebraElement(Element):
         if not self or not y:
             return self._parent.zero()
 
-        gd = self._parent._g.basis()
         cdef dict d = {}
         cdef UntwistedAffineLieAlgebraElement rt = <UntwistedAffineLieAlgebraElement>(y)
         c = self._parent.base_ring().zero()
@@ -1472,11 +1470,11 @@ class FreeLieAlgebraElement(LieAlgebraElement):
 
         cdef dict d = {}
         zero = self.base_ring().zero()
-        for ml, cl in self._monomial_coefficients.iteritems(): # The left monomials
-            for mr, cr in y._monomial_coefficients.iteritems(): # The right monomials
+        for ml, cl in self._monomial_coefficients.iteritems():  # The left monomials
+            for mr, cr in y._monomial_coefficients.iteritems():  # The right monomials
                 if ml == mr:
                     continue
-                if ml < mr: # Make sure ml < mr
+                if ml < mr:  # Make sure ml < mr
                     a, b = ml, mr
                 else:
                     a, b = mr, ml
@@ -1490,8 +1488,9 @@ class FreeLieAlgebraElement(LieAlgebraElement):
             return self.parent().zero()
         return type(self)(self.parent(), d)
 
+
 #####################################################################
-## Helper classes for free Lie algebras
+# Helper classes for free Lie algebras
 
 cdef class LieObject(SageObject):
     """


### PR DESCRIPTION
using --ignore=E501,E731,E741

<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Making use of the `cython-lint` command, and fixing manually the issues. Done here in `algebras` outside of `quatalg`

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
