### PR TITLE
Adding a save method to class Standalone/TikzPicture for compatibility with sagetex

### DIFF
--- a/src/sage/doctest/external.py
+++ b/src/sage/doctest/external.py
@@ -380,6 +380,7 @@ class AvailableSoftware():
         sage: from sage.doctest.external import external_software, available_software
         sage: external_software
         ['cplex',
+         'dvips',
          'ffmpeg',
          'gurobi',
          'internet',

--- a/src/sage/features/latex.py
+++ b/src/sage/features/latex.py
@@ -206,6 +206,7 @@ class dvips(Executable):
         """
         Executable.__init__(self, "dvips", executable="dvips",
                             url="https://tug.org/texinfohtml/dvips.html")
+
 class TeXFile(StaticFile):
     r"""
     A :class:`sage.features.Feature` describing the presence of a TeX file

--- a/src/sage/features/latex.py
+++ b/src/sage/features/latex.py
@@ -186,6 +186,26 @@ class lualatex(LaTeX):
         super().__init__("lualatex")
 
 
+class dvips(Executable):
+    r"""
+    A :class:`~sage.features.Feature` describing the presence of ``dvips``
+
+    EXAMPLES::
+
+        sage: from sage.features.latex import dvips
+        sage: dvips().is_present()             # optional - dvips
+        FeatureTestResult('dvips', True)
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.latex import dvips
+            sage: isinstance(dvips(), dvips)
+            True
+        """
+        Executable.__init__(self, "dvips", executable="dvips",
+                            url="https://tug.org/texinfohtml/dvips.html")
 class TeXFile(StaticFile):
     r"""
     A :class:`sage.features.Feature` describing the presence of a TeX file
@@ -275,4 +295,5 @@ def all_features():
             pdflatex(),
             xelatex(),
             lualatex(),
+            dvips(),
             LaTeXPackage("tkz-graph")]

--- a/src/sage/features/latex.py
+++ b/src/sage/features/latex.py
@@ -50,6 +50,23 @@ class LaTeX(Executable):
             sage: from sage.features.latex import latex
             sage: latex().is_functional()             # optional - latex
             FeatureTestResult('latex', True)
+
+        When the feature is not functional, more information on the reason
+        can be obtained as follows::
+
+            sage: result = latex().is_functional()    # not tested
+            sage: print(result.reason)                # not tested
+            Running latex on a sample file
+            (with command='latex -interaction=nonstopmode tmp_wmpos8ak.tex')
+            returned non-zero exit status='1' with stderr=''
+            and stdout='This is pdfTeX,
+            ...
+            Runaway argument?
+            {document
+            ! File ended while scanning use of \end.
+            ...
+            No pages of output.
+            Transcript written on tmp_wmpos8ak.log.'
         """
         lines = []
         lines.append(r"\documentclass{article}")
@@ -77,8 +94,12 @@ class LaTeX(Executable):
             return FeatureTestResult(self, True)
         else:
             return FeatureTestResult(self, False, reason="Running latex on "
-                                     "a sample file returned non-zero "
-                                     "exit status {}".format(result.returncode))
+                                     "a sample file (with command='{}') returned non-zero "
+                                     "exit status='{}' with stderr='{}' "
+                                     "and stdout='{}'".format(result.args,
+                                                              result.returncode,
+                                                              result.stderr.strip(),
+                                                              result.stdout.strip()))
 
 
 class latex(LaTeX):

--- a/src/sage/misc/latex_standalone.py
+++ b/src/sage/misc/latex_standalone.py
@@ -622,7 +622,7 @@ class Standalone(SageObject):
 
     def pdf(self, filename=None, view=True, program=None):
         r"""
-        Compiles the latex code with pdflatex and create a pdf file.
+        Compile the latex code with pdflatex and create a pdf file.
 
         INPUT:
 
@@ -639,7 +639,7 @@ class Standalone(SageObject):
 
         OUTPUT:
 
-            string, path to pdf file
+        string, path to pdf file
 
         EXAMPLES::
 
@@ -748,7 +748,7 @@ class Standalone(SageObject):
 
     def dvi(self, filename=None, view=True, program='latex'):
         r"""
-        Compiles the latex code with latex and create a dvi file.
+        Compile the latex code with latex and create a dvi file.
 
         INPUT:
 
@@ -763,7 +763,7 @@ class Standalone(SageObject):
 
         OUTPUT:
 
-            string, path to dvi file
+        string, path to dvi file
 
         EXAMPLES::
 
@@ -867,7 +867,7 @@ class Standalone(SageObject):
 
     def png(self, filename=None, density=150, view=True):
         r"""
-        Compiles the latex code with pdflatex and converts to a png file.
+        Compile the latex code with pdflatex and converts to a png file.
 
         INPUT:
 
@@ -883,7 +883,7 @@ class Standalone(SageObject):
 
         OUTPUT:
 
-            string, path to png file
+        string, path to png file
 
         EXAMPLES::
 
@@ -956,7 +956,7 @@ class Standalone(SageObject):
 
     def svg(self, filename=None, view=True, program='pdftocairo'):
         r"""
-        Compiles the latex code with pdflatex and converts to a svg file.
+        Compile the latex code with pdflatex and converts to a svg file.
 
         INPUT:
 
@@ -972,7 +972,7 @@ class Standalone(SageObject):
 
         OUTPUT:
 
-            string, path to svg file
+        string, path to svg file
 
         EXAMPLES::
 
@@ -1056,7 +1056,7 @@ class Standalone(SageObject):
 
     def eps(self, filename=None, view=True, program='dvips'):
         r"""
-        Compiles the latex code with pdflatex and converts to a eps file.
+        Compile the latex code with pdflatex and converts to a eps file.
 
         INPUT:
 
@@ -1072,7 +1072,7 @@ class Standalone(SageObject):
 
         OUTPUT:
 
-            string, path to eps file
+        string, path to eps file
 
         EXAMPLES::
 
@@ -1173,7 +1173,7 @@ class Standalone(SageObject):
 
         OUTPUT:
 
-            string, path to tex file
+        string, path to tex file
 
         EXAMPLES::
 

--- a/src/sage/misc/latex_standalone.py
+++ b/src/sage/misc/latex_standalone.py
@@ -1223,6 +1223,64 @@ class Standalone(SageObject):
 
         return filename
 
+    def save(self, filename, **kwds):
+        r"""
+        Save the graphics to an image file.
+
+        INPUT:
+
+        - ``filename`` -- string. The filename and the image format
+          given by the extension, which can be one of the following:
+
+            * ``.pdf``,
+            * ``.png``,
+            * ``.svg``,
+            * ``.eps``,
+            * ``.dvi``,
+            * ``.sobj`` (for a Sage object you can load later),
+            * empty extension will be treated as ``.sobj``.
+
+        All other keyword arguments will be passed to the plotter.
+
+        OUTPUT:
+
+        - ``None``
+
+        .. NOTE::
+
+            This method follows the signature of the method
+            :meth:`sage.plot.Graphics.save` in order to be compatible with
+            with sagetex. In particular so that ``\sageplot{t}`` written
+            in a ``tex`` file works when ``t`` is an instance of
+            :class:`Standalone` or :class:`TikzPicture`.
+
+        EXAMPLES::
+
+            sage: from sage.misc.temporary_file import tmp_filename
+            sage: from sage.misc.latex_standalone import Standalone
+            sage: t = Standalone('Hello World')
+            sage: filename = tmp_filename('temp','.pdf')
+            sage: t.save(filename)                # long time (1s)   # optional latex
+            sage: filename = tmp_filename('temp','.eps')
+            sage: t.save(filename)                # long time (1s)   # optional latex dvips
+
+        """
+        ext = os.path.splitext(filename)[1].lower()
+        if ext == '' or ext == '.sobj':
+            raise NotImplementedError()
+        elif ext == '.pdf':
+            self.pdf(filename, **kwds)
+        elif ext == '.png':
+            self.png(filename, **kwds)
+        elif ext == '.svg':
+            self.svg(filename, **kwds)
+        elif ext == '.eps':
+            self.eps(filename, **kwds)
+        elif ext == '.dvi':
+            self.dvi(filename, **kwds)
+        else:
+            raise ValueError("allowed file extensions for images are "
+                             ".pdf, .png, .svg, .eps, .dvi!")
 
 class TikzPicture(Standalone):
     r"""

--- a/src/sage/misc/latex_standalone.py
+++ b/src/sage/misc/latex_standalone.py
@@ -805,6 +805,14 @@ class Standalone(SageObject):
             CalledProcessError: Command '['latex', '-interaction=nonstopmode',
             'tikz_...tex']' returned non-zero exit status 1.
 
+        We test the behavior when a wrong value is provided::
+
+            sage: t = Standalone('Hello World')
+            sage: _ = t.dvi(program='lates')
+            Traceback (most recent call last):
+            ...
+            ValueError: program(=lates) should be latex
+
         """
         from sage.features.latex import latex
 
@@ -1097,6 +1105,16 @@ class Standalone(SageObject):
             sage: path_to_file = t.eps(filename, program='pdftocairo') # long time (1s)   # optional latex pdftocairo
             sage: path_to_file[-4:]                                    # long time (fast) # optional latex pdftocairo
             '.eps'
+
+        TESTS:
+
+        We test the behavior when a wrong value is provided::
+
+            sage: t = Standalone('Hello World')
+            sage: _ = t.eps(program='convert')
+            Traceback (most recent call last):
+            ...
+            ValueError: program(=convert) should be 'pdftocairo' or 'dvips'
 
         """
 


### PR DESCRIPTION
We add a save method to class Standalone/TikzPicture for compatibility with sagetex. In particular, so that `\sageplot{t}` works when `t` is an instance of Standalone/TikzPicture classes.

For example the following `file.tex`:

```
\documentclass{article}
\usepackage[margin=2cm]{geometry}
\usepackage{sagetex}
\begin{document}
\begin{sagecommandline}
sage: from sage.misc.latex_standalone import TikzPicture
sage: V = [[1,0,1],[1,0,0],[1,1,0],[0,0,-1],[0,1,0],
....:      [-1,0,0],[0,1,1],[0,0,1],[0,-1,0]]
sage: P = Polyhedron(vertices=V).polar()
sage: s = P.projection().tikz([674,108,-731],112, output_type='LatexExpr')
sage: t = TikzPicture(s)
\end{sagecommandline}
\begin{center}
    \sageplot{t}
\end{center}
\end{document}
```

will compile fine with the commands:
```
pdflatex file.tex
sage file.sagetex.sage
pdflatex file.tex
```
provided the `sagetex.sty` file is in the same repository.

Since sagetex creates by defaults `eps` and `pdf` images, we added methods `dvi` and `eps` to the class Standalone following what was done in the other methods. Also, we added a feature `dvips` to tag the doctests with this new external feature. Finally, we made a small improvement to the latex feature by providing more information in the reason why a latex feature does not work.

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.