### PR TITLE
pkg-config should be `_bootstrap`, not `_prereq`, on all distros

### DIFF
--- a/build/pkgs/_bootstrap/distros/conda.txt
+++ b/build/pkgs/_bootstrap/distros/conda.txt
@@ -1,2 +1,5 @@
 # Packages needed for ./bootstrap
-autoconf automake libtool
+autoconf
+automake
+libtool
+pkg-config

--- a/build/pkgs/_bootstrap/distros/slackware.txt
+++ b/build/pkgs/_bootstrap/distros/slackware.txt
@@ -2,3 +2,4 @@
 autoconf
 automake
 libtool
+pkg-config

--- a/build/pkgs/_bootstrap/distros/void.txt
+++ b/build/pkgs/_bootstrap/distros/void.txt
@@ -1,3 +1,4 @@
 # Packages needed for ./bootstrap
 autoconf automake libtool
 xtools mk-configure
+pkg-config

--- a/build/pkgs/_prereq/distros/conda.txt
+++ b/build/pkgs/_prereq/distros/conda.txt
@@ -5,4 +5,3 @@ perl
 python
 tar
 bc
-pkg-config

--- a/build/pkgs/_prereq/distros/slackware.txt
+++ b/build/pkgs/_prereq/distros/slackware.txt
@@ -14,6 +14,5 @@ python3          # on slackware-current
 flex
 # for https upstream_url downloads
 ca-certificates
-pkg-config
 libxml2
 cyrus-sasl

--- a/build/pkgs/_prereq/distros/void.txt
+++ b/build/pkgs/_prereq/distros/void.txt
@@ -5,7 +5,6 @@ libgomp-devel
 m4
 make
 perl
-pkg-config
 python3
 tar
 which


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Fixes #35088
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
