### PR TITLE
fix pep8 E303 in folders starting with m

### DIFF
--- a/src/sage/manifolds/chart.py
+++ b/src/sage/manifolds/chart.py
@@ -2317,7 +2317,6 @@ class RealChart(Chart):
         self._restrictions = new_restrictions
         self._fast_valid_coordinates = None
 
-
     def restrict(self, subset, restrictions=None):
         r"""
         Return the restriction of the chart to some open subset of its domain.

--- a/src/sage/manifolds/differentiable/automorphismfield_group.py
+++ b/src/sage/manifolds/differentiable/automorphismfield_group.py
@@ -175,7 +175,6 @@ class AutomorphismFieldGroup(UniqueRepresentation, Parent):
         Parent.__init__(self, category=Groups())
         self._vmodule = vector_field_module
 
-
     #### Parent methods ####
 
     def _element_constructor_(self, comp=[], frame=None, name=None,
@@ -265,7 +264,6 @@ class AutomorphismFieldGroup(UniqueRepresentation, Parent):
         return resu
 
     #### End of parent methods ####
-
 
     #### Monoid methods ####
 

--- a/src/sage/manifolds/differentiable/chart.py
+++ b/src/sage/manifolds/differentiable/chart.py
@@ -679,7 +679,6 @@ class DiffChart(Chart):
         return list(var(list_strings_velocities))
 
 
-
 #*****************************************************************************
 
 class RealDiffChart(DiffChart, RealChart):
@@ -1000,7 +999,6 @@ class RealDiffChart(DiffChart, RealChart):
         # Construction of the coordinate frame associated to the chart:
         self._frame = CoordFrame(self)
         self._coframe = self._frame._coframe
-
 
     def restrict(self, subset, restrictions=None):
         r"""

--- a/src/sage/manifolds/differentiable/degenerate.py
+++ b/src/sage/manifolds/differentiable/degenerate.py
@@ -368,7 +368,6 @@ class DegenerateManifold(DifferentiableManifold):
         return resu
 
 
-
 #*******************************************************************************************
 
 from sage.manifolds.differentiable.tensorfield_paral import TensorFieldParal

--- a/src/sage/manifolds/differentiable/degenerate_submanifold.py
+++ b/src/sage/manifolds/differentiable/degenerate_submanifold.py
@@ -1323,7 +1323,6 @@ class DegenerateSubmanifold(DegenerateManifold, DifferentiableSubmanifold):
         self._principal_directions[screen._name] = res
         return res
 
-
     def mean_curvature(self, screen=None):
         r"""
 

--- a/src/sage/manifolds/differentiable/diff_form.py
+++ b/src/sage/manifolds/differentiable/diff_form.py
@@ -1556,7 +1556,6 @@ class DiffFormParal(FreeModuleAltForm, TensorFieldParal, DiffForm):
         other_r = other.restrict(dom_resu)
         return FreeModuleAltForm.wedge(self_r, other_r)
 
-
     def interior_product(self, qvect):
         r"""
         Interior product with a multivector field.

--- a/src/sage/manifolds/differentiable/diff_map.py
+++ b/src/sage/manifolds/differentiable/diff_map.py
@@ -1144,7 +1144,6 @@ class DiffMap(ContinuousMap):
                             resu._components[frame] = comp
         return resu
 
-
     def pushforward(self, tensor):
         r"""
         Pushforward operator associated with ``self``.

--- a/src/sage/manifolds/differentiable/integrated_curve.py
+++ b/src/sage/manifolds/differentiable/integrated_curve.py
@@ -579,7 +579,6 @@ class IntegratedCurve(DifferentiableCurve):
                                for f in transf]
                 self._fast_changes_of_chart[CoC] = fast_transf
 
-
         self._velocities = list(velocities) # converts to list
         # since might not already be a list (which is later required)
         self._curve_parameter = curve_parameter
@@ -1376,12 +1375,10 @@ class IntegratedCurve(DifferentiableCurve):
         # 'tangent_vector_eval_at', and in 'plot' when plotting the
         # tangent vectors.)
 
-
         if isinstance(sol, list):
             coords_sol = [point[0:dim + 1] for point in sol]
         else:
             coords_sol = sol[:, 0:dim + 1].tolist() # far faster in numpy
-
 
         if verbose:
             print("Numerical integration completed.\n\n" +
@@ -1778,7 +1775,6 @@ class IntegratedCurve(DifferentiableCurve):
 
                             new_vel = self._fast_changes_of_frame[(new_chart.frame().restrict(inter),
                                chart.frame().restrict(inter))](last_pts, last_vel)
-
 
                             ics = new_pts + new_vel
                             chart = new_chart
@@ -2433,7 +2429,6 @@ class IntegratedCurve(DifferentiableCurve):
         #
         thickness = kwds.pop('thickness')
         aspect_ratio = kwds.pop('aspect_ratio')
-
 
         #
         # The mapping, if present, and the chart with respect to which the curve
@@ -3425,7 +3420,6 @@ class IntegratedAutoparallelCurve(IntegratedCurve):
 
         velocities = chart.symbolic_velocities()
 
-
         dim = parent.codomain().dim()
         i0 = parent.codomain().start_index()
 
@@ -3470,7 +3464,6 @@ class IntegratedAutoparallelCurve(IntegratedCurve):
                     equations_rhs_chart += [rhs.simplify_full()]
                 equations_rhs[chart] = equations_rhs_chart
 
-
         IntegratedCurve.__init__(self, parent, equations_rhs,
                                  velocities, curve_parameter,
                                  initial_tangent_vector, chart=chart,
@@ -3478,7 +3471,6 @@ class IntegratedAutoparallelCurve(IntegratedCurve):
                                  verbose=verbose, across_charts=across_charts)
 
         self._affine_connection = affine_connection
-
 
     def _repr_(self):
         r"""
@@ -3825,7 +3817,6 @@ class IntegratedGeodesic(IntegratedAutoparallelCurve):
     def __init__(self, parent, metric, curve_parameter,
                  initial_tangent_vector, chart=None, name=None,
                  latex_name=None, verbose=False, across_charts=False):
-
         r"""
         Construct a geodesic curve with respect to the given metric with the
         given initial tangent vector.

--- a/src/sage/manifolds/differentiable/levi_civita_connection.py
+++ b/src/sage/manifolds/differentiable/levi_civita_connection.py
@@ -387,7 +387,6 @@ class LeviCivitaConnection(AffineConnection):
                               start_index=self._domain._sindex,
                               output_formatter=DiffScalarField.coord_function)
 
-
     def coef(self, frame=None):
         r"""
         Return the connection coefficients relative to the given frame.

--- a/src/sage/manifolds/differentiable/manifold.py
+++ b/src/sage/manifolds/differentiable/manifold.py
@@ -2977,7 +2977,6 @@ class DifferentiableManifold(TopologicalManifold):
                              " has not been defined on the {}".format(self))
         return self._frame_changes[(frame1, frame2)]
 
-
     def set_change_of_frame(self, frame1, frame2, change_of_frame,
                          compute_inverse=True):
         r"""

--- a/src/sage/manifolds/differentiable/manifold_homset.py
+++ b/src/sage/manifolds/differentiable/manifold_homset.py
@@ -777,7 +777,6 @@ class IntegratedCurveSet(DifferentiableCurveSet):
         description += "which actually are integrated curves"
         return description
 
-
     def _element_constructor_(self, equations_rhs, velocities,
                  curve_parameter, initial_tangent_vector, chart=None,
                  name=None, latex_name=None, verbose=False, across_charts=False):
@@ -1220,7 +1219,6 @@ class IntegratedAutoparallelCurveSet(IntegratedCurveSet):
         description += "which actually are integrated autoparallel "
         description += "curves with respect to a certain affine connection"
         return description
-
 
     def _element_constructor_(self, affine_connection, curve_parameter,
                     initial_tangent_vector, chart=None, name=None,

--- a/src/sage/manifolds/differentiable/metric.py
+++ b/src/sage/manifolds/differentiable/metric.py
@@ -662,7 +662,6 @@ class PseudoRiemannianMetric(TensorField):
                 rst = self.restrict(dom)
                 rst.set(symbiform_rst)
 
-
     def inverse(self, expansion_symbol=None, order=1):
         r"""
         Return the inverse metric.
@@ -879,7 +878,6 @@ class PseudoRiemannianMetric(TensorField):
             frame = chart._frame
         return self.connection().coef(frame)
 
-
     def christoffel_symbols_display(self, chart=None, symbol=None,
                 latex_symbol=None, index_labels=None, index_latex_labels=None,
                 coordinate_labels=True, only_nonzero=True,
@@ -1068,7 +1066,6 @@ class PseudoRiemannianMetric(TensorField):
 
         """
         return self.connection().riemann(name, latex_name)
-
 
     def ricci(self, name=None, latex_name=None):
         r"""
@@ -2270,7 +2267,6 @@ class PseudoRiemannianMetricParal(PseudoRiemannianMetric, TensorFieldParal):
             # The restriction is ready:
             self._restrictions[subdomain] = resu
         return self._restrictions[subdomain]
-
 
     def set(self, symbiform):
         r"""

--- a/src/sage/manifolds/differentiable/scalarfield.py
+++ b/src/sage/manifolds/differentiable/scalarfield.py
@@ -819,7 +819,6 @@ class DiffScalarField(ScalarField):
     derivative = differential  # allows one to use functional notation,
                                # e.g. diff(f) for f.differential()
 
-
     def lie_derivative(self, vector):
         r"""
         Compute the Lie derivative with respect to a vector field.

--- a/src/sage/manifolds/differentiable/tensorfield_paral.py
+++ b/src/sage/manifolds/differentiable/tensorfield_paral.py
@@ -657,7 +657,6 @@ class TensorFieldParal(FreeModuleTensor, TensorField):
         # Initialization of derived quantities:
         self._init_derived()
 
-
     def _repr_(self):
         r"""
         String representation of ``self``.
@@ -768,7 +767,6 @@ class TensorFieldParal(FreeModuleTensor, TensorField):
                 format_spec = basis
             basis = basis.frame()
         return (basis, format_spec)
-
 
     def _set_comp_unsafe(self, basis=None):
         r"""
@@ -1510,7 +1508,6 @@ class TensorFieldParal(FreeModuleTensor, TensorField):
                             rsum += tc[[indk]].coord_function(chart) * \
                                     vc[[i]].coord_function(chart).diff(ind[k])
                     resc[[ind]] = rsum.scalar_field()
-
 
             #
             # 3/ Final result (the tensor)

--- a/src/sage/manifolds/differentiable/vectorfield.py
+++ b/src/sage/manifolds/differentiable/vectorfield.py
@@ -359,7 +359,6 @@ class VectorField(MultivectorField):
             resu.set_name(name=name, latex_name=latex_name)
         return resu
 
-
     @options(max_range=8, scale=1, color='blue')
     def plot(self, chart=None, ambient_coords=None, mapping=None,
              chart_domain=None, fixed_coords=None, ranges=None,

--- a/src/sage/manifolds/differentiable/vectorfield_module.py
+++ b/src/sage/manifolds/differentiable/vectorfield_module.py
@@ -1206,7 +1206,6 @@ class VectorFieldModule(UniqueRepresentation, ReflexiveModule_base):
         return PseudoRiemannianMetric(self, name, signature=signature[0]-signature[1],
                                       latex_name=latex_name)
 
-
     def symplectic_form(
         self, name: Optional[str] = None, latex_name: Optional[str] = None
     ):

--- a/src/sage/manifolds/differentiable/vectorframe.py
+++ b/src/sage/manifolds/differentiable/vectorframe.py
@@ -764,7 +764,6 @@ class VectorFrame(FreeModuleBasis):
         # NB: set(self._restrictions.values()) is identical to
         #     self._subframes
 
-
     ###### Methods that must be redefined by derived classes of ######
     ###### FreeModuleBasis                                      ######
 
@@ -1776,7 +1775,6 @@ class CoordFrame(VectorFrame):
         # In the above:
         # - force_free=True ensures that a free module is constructed in case
         #   it is the first call to the vector field module on chart.domain()
-
 
     ###### Methods that must be redefined by derived classes of ######
     ###### FreeModuleBasis                                      ######

--- a/src/sage/manifolds/scalarfield.py
+++ b/src/sage/manifolds/scalarfield.py
@@ -2652,7 +2652,6 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             result._latex_name = '-' + self._latex_name
         return result
 
-
     #########  CommutativeAlgebraElement arithmetic operators ########
 
     def _add_(self, other):

--- a/src/sage/manifolds/trivialization.py
+++ b/src/sage/manifolds/trivialization.py
@@ -693,7 +693,6 @@ class TransitionMap(SageObject):
         """
         return self._automorphism.matrix(self._frame1)
 
-
     def __eq__(self, other):
         r"""
         Equality operator.

--- a/src/sage/matrix/benchmark.py
+++ b/src/sage/matrix/benchmark.py
@@ -562,7 +562,6 @@ s := Cputime(t);
         raise ValueError('unknown system "%s"'%system)
 
 
-
 #######################################################################
 # Dense Benchmarks over GF(p), for small p.
 #######################################################################
@@ -719,7 +718,6 @@ s := Cputime(t);
         return magma.eval('s')
     else:
         raise ValueError('unknown system "%s"'%system)
-
 
 
 # Matrix multiplication over GF(p)

--- a/src/sage/matrix/compute_J_ideal.py
+++ b/src/sage/matrix/compute_J_ideal.py
@@ -190,7 +190,6 @@ def lifting(p, t, A, G):
     """
     from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 
-
     DX = A.parent().base()
     (X,) = DX.variable_names()
     D = DX.base_ring()
@@ -202,7 +201,6 @@ def lifting(p, t, A, G):
 
     if not (A*G % p**(t-1)).is_zero():
         raise ValueError("A*G not zero mod %s^%s" % (p, t-1))
-
 
     R = A*G/p**(t-1)
     R.change_ring(DX)
@@ -351,7 +349,6 @@ class ComputeMinimalPolynomials(SageObject):
         self._DX = X.parent()
         self._cache = {}
 
-
     def find_monic_replacements(self, p, t, pt_generators, prev_nu):
         r"""
         Replace possibly non-monic generators of `N_{(p^t)}(B)` by monic
@@ -432,7 +429,6 @@ class ComputeMinimalPolynomials(SageObject):
 
         return replacements
 
-
     def current_nu(self, p, t, pt_generators, prev_nu):
         r"""
         Compute `(p^t)`-minimal polynomial of `B`.
@@ -482,7 +478,6 @@ class ComputeMinimalPolynomials(SageObject):
 
         from sage.misc.verbose import verbose
 
-
         if not all((g(self._B) % p**t).is_zero()
                    for g in pt_generators):
             raise ValueError("%s not in N_{(%s^%s)}(B)" %
@@ -518,7 +513,6 @@ class ComputeMinimalPolynomials(SageObject):
             verbose([g] + [h for (deg_h, h) in heap])
 
         return g
-
 
     def mccoy_column(self, p, t, nu):
         r"""
@@ -576,7 +570,6 @@ class ComputeMinimalPolynomials(SageObject):
                                  "McCoy column incorrect"
 
         return column
-
 
     def p_minimal_polynomials(self, p, s_max=None):
         r"""
@@ -768,7 +761,6 @@ class ComputeMinimalPolynomials(SageObject):
             d = self._A.ncols()
             G = matrix(self._DX, d, 0)
 
-
         while t < s_max:
             deg_prev_nu = nu.degree()
             t += 1
@@ -811,7 +803,6 @@ class ComputeMinimalPolynomials(SageObject):
             return result
 
         return p_min_polys
-
 
     def null_ideal(self, b=0):
         r"""
@@ -877,7 +868,6 @@ class ComputeMinimalPolynomials(SageObject):
 
         return self._DX.ideal(generators)
 
-
     def prime_candidates(self):
         r"""
         Determine those primes `p` where `\mu_B` might not be a
@@ -909,7 +899,6 @@ class ComputeMinimalPolynomials(SageObject):
         F, T = self._B.frobenius(2)
 
         return [p for (p, t) in factor(T.det())]
-
 
     def integer_valued_polynomials_generators(self):
         r"""

--- a/src/sage/media/wav.py
+++ b/src/sage/media/wav.py
@@ -102,7 +102,6 @@ class Wave(SageObject):
         else:
             raise ValueError("Must give a filename")
 
-
     def save(self, filename='sage.wav'):
         r"""
         Save this wave file to disk, either as a Sage sobj or as a .wav file.

--- a/src/sage/misc/gperftools.py
+++ b/src/sage/misc/gperftools.py
@@ -47,7 +47,6 @@ libc = None
 libprofiler = None
 
 
-
 class Profiler(SageObject):
 
     def __init__(self, filename=None):

--- a/src/sage/misc/sage_eval.py
+++ b/src/sage/misc/sage_eval.py
@@ -198,7 +198,6 @@ def sage_eval(source, locals=None, cmds='', preparse=True):
         return eval(source, sage.all.__dict__, locals)
 
 
-
 def sageobj(x, vars=None):
     """
     Return a native Sage object associated to ``x``, if possible and

--- a/src/sage/modular/quasimodform/element.py
+++ b/src/sage/modular/quasimodform/element.py
@@ -622,7 +622,6 @@ class QuasiModularFormsElement(ModuleElement):
 
     homogeneous_component = __getitem__  # alias
 
-
     def serre_derivative(self):
         r"""
         Return the Serre derivative of the given quasimodular form.

--- a/src/sage/modules/fg_pid/fgp_element.py
+++ b/src/sage/modules/fg_pid/fgp_element.py
@@ -120,7 +120,6 @@ class FGP_Element(ModuleElement):
         """
         return self._x
 
-
     def __neg__(self):
         """
         EXAMPLES::
@@ -134,7 +133,6 @@ class FGP_Element(ModuleElement):
         """
         P = self.parent()
         return P.element_class(P, -self._x)
-
 
     def _add_(self, other):
         """
@@ -170,7 +168,6 @@ class FGP_Element(ModuleElement):
         P = self.parent()
         return P.element_class(P, self._x + other._x)
 
-
     def _sub_(self, other):
         """
         EXAMPLES::
@@ -189,7 +186,6 @@ class FGP_Element(ModuleElement):
         """
         P = self.parent()
         return P.element_class(P, self._x - other._x)
-
 
     def _rmul_(self, c):
         """
@@ -292,7 +288,6 @@ class FGP_Element(ModuleElement):
             '(0, 11)'
         """
         return repr(self.vector())
-
 
     def __getitem__(self, *args):
         """

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -1830,7 +1830,6 @@ class Module_free_ambient(Module):
         raise NotImplementedError("the module must be a free module or "
                                   "have the base ring be a polynomial ring using Singular")
 
-
     def graded_free_resolution(self, *args, **kwds):
         r"""
         Return a graded free resolution of ``self``.

--- a/src/sage/modules/vector_space_morphism.py
+++ b/src/sage/modules/vector_space_morphism.py
@@ -866,7 +866,6 @@ class VectorSpaceMorphism(free_module_morphism.FreeModuleMorphism):
             if homspace.domain().dimension() != A.ncols():
                 raise TypeError('codomain dimension is incompatible with matrix size')
 
-
         A = homspace._matrix_space(side)(A)
         free_module_morphism.FreeModuleMorphism.__init__(self, homspace, A, side)
 

--- a/src/sage/modules/with_basis/morphism.py
+++ b/src/sage/modules/with_basis/morphism.py
@@ -690,7 +690,6 @@ class TriangularModuleMorphism(ModuleMorphism):
 
         self._inverse_on_support = inverse_on_support
 
-
         if invertible is None and (domain.basis().keys() == codomain.basis().keys()) and \
            (self._inverse_on_support==identity or domain in Modules.FiniteDimensional):
             invertible = True

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -494,7 +494,6 @@ class Representation(Representation_abstract):
         """
         return "left" if self._left_repr else "right"
 
-
     class Element(CombinatorialFreeModule.Element):
         def _acted_upon_(self, scalar, self_on_left=False):
             """

--- a/src/sage/monoids/free_abelian_monoid.py
+++ b/src/sage/monoids/free_abelian_monoid.py
@@ -220,7 +220,6 @@ class FreeAbelianMonoid_class(Parent):
             return x
         return self.element_class(self, x)
 
-
     def __contains__(self, x):
         """
         Return True if `x` is an element of this abelian monoid.


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

fix all pep8 E303 warning in the folders whose name starts with the letter m

purely done with autopep8:

```
$ autopep8 -i --select=E303 src/sage/m*/*.py
$ autopep8 -i --select=E303 src/sage/m*/*/*.py
```

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
