### PR TITLE
Activate codecov reports even if other checks are failing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@
 comment: false
 # https://docs.codecov.com/docs/codecovyml-reference#codecov
 codecov:
-  require_ci_to_pass: true
+  require_ci_to_pass: false
 # https://docs.codecov.com/docs/commit-status
 coverage:
   status:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,8 @@
 # https://docs.codecov.com/docs/pull-request-comments#disable-comment
 comment: false
+# https://docs.codecov.com/docs/codecovyml-reference#codecov
+codecov:
+  require_ci_to_pass: true
 # https://docs.codecov.com/docs/commit-status
 coverage:
   status:


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Follow-up from https://github.com/sagemath/sage/pull/35056. Currently no codecov reports are displayed because the doc deployment workflow is failing and codecov by default only adds its checks if all other checks are passing. We change this setting so that codecov checks are always added, regardless of other failing tests.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
