### PR TITLE
fixing some pep8 E303 (folders before l* and after t*)

### DIFF
--- a/src/sage/categories/simplicial_sets.py
+++ b/src/sage/categories/simplicial_sets.py
@@ -1,12 +1,12 @@
 """
 Simplicial Sets
 """
-#*****************************************************************************
+# ****************************************************************************
 #  Copyright (C) 2015 John H. Palmieri <palmieri at math.washington.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
-#                  http://www.gnu.org/licenses/
-#******************************************************************************
+#                  https://www.gnu.org/licenses/
+# *****************************************************************************
 
 from sage.misc.cachefunc import cached_method
 from sage.categories.category_singleton import Category_singleton
@@ -15,6 +15,7 @@ from sage.categories.sets_cat import Sets
 from sage.categories.homsets import HomsetsCategory
 from sage.rings.infinity import Infinity
 from sage.rings.integer import Integer
+
 
 class SimplicialSets(Category_singleton):
     r"""
@@ -383,7 +384,6 @@ class SimplicialSets(Category_singleton):
                     if e not in gens:
                         char[e] = G.one()
                 return (G, char)
-
 
             def universal_cover_map(self):
                 r"""

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -615,7 +615,6 @@ class GenericGraph(GenericGraph_pyx):
 
         return self._backend.is_subgraph(other._backend, self, ignore_labels=not self.weighted())
 
-
     def _use_labels_for_hash(self):
         r"""
         Helper method for method ``__hash__``.
@@ -647,7 +646,6 @@ class GenericGraph(GenericGraph_pyx):
         if not hasattr(self, "_hash_labels") or self._hash_labels is None:
             self._hash_labels = self.weighted()
         return self._hash_labels
-
 
     @cached_method
     def __hash__(self):

--- a/src/sage/groups/braid.py
+++ b/src/sage/groups/braid.py
@@ -1467,7 +1467,6 @@ class Braid(FiniteTypeArtinGroupElement):
             return {qa: C[qa].homology() for qa in C}
         return self.annular_khovanov_complex(qagrad, ring).homology()
 
-
     @cached_method
     def left_normal_form(self, algorithm='libbraiding'):
         r"""
@@ -1866,7 +1865,6 @@ class Braid(FiniteTypeArtinGroupElement):
         b2 = B._element_from_libbraiding(L)
         n2 = len(b2.Tietze())
         return b2 if n2 <= n0 else b0
-
 
     def ultra_summit_set(self):
         """

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -239,7 +239,6 @@ Thanks to Chuck Livingston and Allison Moore for their support. For further ackn
 ##############################################################################
 
 
-
 from enum import Enum
 from sage.misc.cachefunc import cached_method
 from sage.misc.sage_eval import sage_eval
@@ -249,8 +248,6 @@ from sage.rings.integer_ring import ZZ
 from sage.groups.braid import BraidGroup
 from sage.knots.knot import Knots
 from sage.databases.knotinfo_db import KnotInfoColumns, db
-
-
 
 
 def eval_knotinfo(string, locals={}, to_tuple=True):
@@ -299,7 +296,6 @@ def knotinfo_bool(string):
     elif string == 'N':
         return False
     raise ValueError('%s is not a KnotInfo boolean')
-
 
 
 # ---------------------------------------------------------------------------------
@@ -446,7 +442,6 @@ class KnotInfoBase(Enum):
             return BraidGroup(2)
         else:
             return BraidGroup(n)
-
 
     @cached_method
     def _homfly_pol_ring(self, var1, var2):
@@ -1159,7 +1154,6 @@ class KnotInfoBase(Enum):
         """
         return not knotinfo_bool(self[self.items.unoriented])
 
-
     @cached_method
     def homfly_polynomial(self, var1='v', var2='z', original=False):
         r"""
@@ -1344,7 +1338,6 @@ class KnotInfoBase(Enum):
         a, z = R.gens()
         lc = {'a':  a, 'z': z}
         return R(eval_knotinfo(kauffman_polynomial, locals=lc))
-
 
     @cached_method
     def jones_polynomial(self, variab=None, skein_normalization=False, puiseux=False, original=False, use_sqrt=False):
@@ -1534,9 +1527,7 @@ class KnotInfoBase(Enum):
             else:
                 lc = {'x':  t}
 
-
         return R(eval_knotinfo(jones_polynomial, locals=lc))
-
 
     @cached_method
     def alexander_polynomial(self, var='t', original=False, laurent_poly=False):
@@ -1958,7 +1949,6 @@ class KnotInfoBase(Enum):
 
         raise ValueError('Link construction using %s not possible' %use_item)
 
-
     @cached_method
     def is_unique(self):
         r"""
@@ -2170,7 +2160,6 @@ class KnotInfoBase(Enum):
         else:
             return webbrowser.open(filename.diagram_url(self[self.items.name]), new=new, autoraise=autoraise)
 
-
     def knot_atlas_webpage(self, new=0, autoraise=True):
         r"""
         Launch the Knot Atlas web-page for ``self``.
@@ -2210,7 +2199,6 @@ class KnotInfoBase(Enum):
         """
         import webbrowser
         return webbrowser.open(self[self.items.knotilus_page_anon], new=new, autoraise=autoraise)
-
 
 
 # --------------------------------------------------------------------------------------------
@@ -2255,7 +2243,6 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
         sage: L6a2(0) == L6a2('0')
         True
     """
-
 
     def __init__(self, crossing_number, is_knot, is_alternating, name_unoriented=None):
         r"""
@@ -2363,7 +2350,6 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
             res.append(KnotInfoSeries(cross_nr, is_knot, is_alt, curr_n_unori))
         return res
 
-
     @cached_method
     def lower_list(self, oriented=False, comp=None, det=None, homfly=None):
         r"""
@@ -2408,7 +2394,6 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
             l = LS.lower_list(oriented=oriented, comp=comp, det=det, homfly=homfly)
         return l + self.list(oriented=oriented, comp=comp, det=det, homfly=homfly)
 
-
     def __repr__(self):
         r"""
         Return the representation string of ``self``.
@@ -2425,7 +2410,6 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
             return 'Series of knots %s' %(self._name())
         else:
             return 'Series of links %s' %(self._name())
-
 
     def __getitem__(self, item):
         r"""
@@ -2585,7 +2569,6 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
             tester.assertTrue(self.is_recoverable(unique=False, max_samples=max_samples))
         else:
             tester.assertTrue(self.is_recoverable(unique=False))
-
 
     def inject(self, verbose=True):
         r"""

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -3612,7 +3612,6 @@ class Link(SageObject):
             ims += sum(line(a[0], **kwargs) for a in im)
         return image
 
-
     def _markov_move_cmp(self, braid):
         r"""
         Return whether ``self`` can be transformed to the closure of ``braid``
@@ -4083,7 +4082,6 @@ class Link(SageObject):
 
             raise NotImplementedError('this link cannot be uniquely determined%s' %non_unique_hint)
 
-
         self_m = self.mirror_image()
         ls, proved_s = self._knotinfo_matching_list()
         lm, proved_m = self_m._knotinfo_matching_list()
@@ -4129,7 +4127,6 @@ class Link(SageObject):
             return l
 
         return answer_list(l)
-
 
     def is_isotopic(self, other):
         r"""

--- a/src/sage/libs/eclib/interface.py
+++ b/src/sage/libs/eclib/interface.py
@@ -194,7 +194,6 @@ class mwrank_EllipticCurve(SageObject):
         """
         self.__verbose = verbose
 
-
     def _curve_data(self):
         r"""
         Returns the underlying :class:`_Curvedata` class for this mwrank elliptic curve.

--- a/src/sage/libs/gap/all_documented_functions.py
+++ b/src/sage/libs/gap/all_documented_functions.py
@@ -14,10 +14,8 @@ EXAMPLES::
     sage: List(_, Order)
     [ 2, 4, 2 ]
 """
-
 from sage.libs.gap.libgap import libgap
 from sage.libs.gap.assigned_names import FUNCTIONS as _FUNCTIONS
-
 
 
 for _f in _FUNCTIONS:

--- a/src/sage/libs/gap/gap_functions.py
+++ b/src/sage/libs/gap/gap_functions.py
@@ -7,9 +7,8 @@
 #   Distributed under the terms of the GNU General Public License (GPL)
 #   as published by the Free Software Foundation; either version 2 of
 #   the License, or (at your option) any later version.
-#                   http://www.gnu.org/licenses/
+#                   https://www.gnu.org/licenses/
 ###############################################################################
-
 
 
 # selected gap functions to use in tab completion

--- a/src/sage/logic/logic.py
+++ b/src/sage/logic/logic.py
@@ -326,10 +326,9 @@ class SymbolicLogic:
         var_order = statement1[2] + statement2[2]
         return [toks, variables, var_order]
 
-
-    #TODO: implement the simplify function which calls
-    #a c++ implementation of the ESPRESSO algorithm
-    #to simplify the truthtable: probably Minilog
+    # TODO: implement the simplify function which calls
+    # a c++ implementation of the ESPRESSO algorithm
+    # to simplify the truthtable: probably Minilog
     def simplify(self, table):
         """
         Call a C++ implementation of the ESPRESSO algorithm to simplify the

--- a/src/sage/numerical/linear_tensor.py
+++ b/src/sage/numerical/linear_tensor.py
@@ -181,12 +181,11 @@ def LinearTensorParent(free_module_parent, linear_functions_parent):
     return LinearTensorParent_class(free_module_parent, linear_functions_parent)
 
 
-
-#*****************************************************************************
+# ****************************************************************************
 #
 # Parent of linear functions tensored with a free module
 #
-#*****************************************************************************
+# ****************************************************************************
 
 class LinearTensorParent_class(Parent):
     r"""

--- a/src/sage/tensor/modules/alternating_contr_tensor.py
+++ b/src/sage/tensor/modules/alternating_contr_tensor.py
@@ -311,7 +311,6 @@ class AlternatingContrTensor(FreeModuleTensor):
         """
         return self._tensor_rank
 
-
     def display(self, basis=None, format_spec=None):
         r"""
         Display the alternating contravariant tensor ``self`` in terms
@@ -469,7 +468,6 @@ class AlternatingContrTensor(FreeModuleTensor):
         return FormattedExpansion(resu_txt, resu_latex)
 
     disp = display
-
 
     def wedge(self, other):
         r"""

--- a/src/sage/tensor/modules/comp.py
+++ b/src/sage/tensor/modules/comp.py
@@ -1683,7 +1683,6 @@ class Components(SageObject):
         """
         return self + other
 
-
     def __sub__(self, other):
         r"""
         Component subtraction.
@@ -1757,7 +1756,6 @@ class Components(SageObject):
 
         """
         return (-self) + other
-
 
     def __mul__(self, other):
         r"""
@@ -1921,7 +1919,6 @@ class Components(SageObject):
                 for ind_o, val_o in other._comp.items():
                     result._comp[ind_s + ind_o] = val_s * val_o
         return result
-
 
     def __rmul__(self, other):
         r"""
@@ -2525,7 +2522,6 @@ class Components(SageObject):
         """
         for ind in self.index_generator():
             yield ind
-
 
     def symmetrize(self, *pos):
         r"""
@@ -3996,7 +3992,6 @@ class CompWithSym(Components):
                 result[[ind_res]] = res
             return result
 
-
     def non_redundant_index_generator(self):
         r"""
         Generator of indices, with only ordered indices in case of symmetries,
@@ -4438,7 +4433,6 @@ class CompWithSym(Components):
                 sum += self[[ind_perm]]
             result[[ind]] = sum / sym_group.order()
         return result
-
 
     def antisymmetrize(self, *pos):
         r"""
@@ -5339,7 +5333,6 @@ class CompFullyAntiSym(CompWithSym):
         """
         return CompFullyAntiSym(self._ring, self._frame, self._nid, self._sindex,
                                 self._output_formatter)
-
 
     def __add__(self, other):
         r"""

--- a/src/sage/tensor/modules/free_module_basis.py
+++ b/src/sage/tensor/modules/free_module_basis.py
@@ -905,7 +905,6 @@ class FreeModuleBasis(Basis_abstract):
             aut.add_comp(self)[:] = mat
             fmodule.set_change_of_basis(basis, self, aut)
 
-
     def module(self):
         r"""
         Return the free module on which the basis is defined.

--- a/src/sage/tensor/modules/free_module_element.py
+++ b/src/sage/tensor/modules/free_module_element.py
@@ -273,7 +273,6 @@ class FiniteRankFreeModuleElement(AlternatingContrTensor):
         return Components(fmodule._ring, basis, 1, start_index=fmodule._sindex,
                           output_formatter=fmodule._output_formatter)
 
-
     def _new_instance(self):
         r"""
         Create an instance of the same class as ``self``.

--- a/src/sage/tensor/modules/free_module_homset.py
+++ b/src/sage/tensor/modules/free_module_homset.py
@@ -466,7 +466,6 @@ class FreeModuleHomset(Homset):
 
     #### End of methods required for any Parent
 
-
     #### Monoid methods (case of an endomorphism set) ####
 
     def one(self):

--- a/src/sage/tensor/modules/free_module_linear_group.py
+++ b/src/sage/tensor/modules/free_module_linear_group.py
@@ -407,7 +407,6 @@ class FreeModuleLinearGroup(UniqueRepresentation, Parent):
             resu.set_comp(basis)[:] = comp
         return resu
 
-
     def _an_element_(self):
         r"""
         Construct some specific free module automorphism.
@@ -549,7 +548,6 @@ class FreeModuleLinearGroup(UniqueRepresentation, Parent):
         """
         from sage.misc.latex import latex
         return r"\mathrm{GL}\left("+ latex(self._fmodule)+ r"\right)"
-
 
     def base_module(self):
         r"""

--- a/src/sage/tensor/modules/free_module_morphism.py
+++ b/src/sage/tensor/modules/free_module_morphism.py
@@ -688,7 +688,6 @@ class FiniteRankFreeModuleMorphism(Morphism):
             resu._matrices[bases] = scalar * mat
         return resu
 
-
     #
     #  Other module methods
     #

--- a/src/sage/tensor/modules/free_module_tensor.py
+++ b/src/sage/tensor/modules/free_module_tensor.py
@@ -1149,7 +1149,6 @@ class FreeModuleTensor(ModuleElementWithMutability):
                     for jj in val:
                         new_comp[[jj[0]]] = jj[1]
 
-
             else:
                 # Sequential computation
                 for ind_new in new_comp.non_redundant_index_generator():
@@ -1560,7 +1559,6 @@ class FreeModuleTensor(ModuleElementWithMutability):
             else:
                 basis = self._fmodule._def_basis
         return self.comp(basis)[args]
-
 
     def __setitem__(self, args, value):
         r"""
@@ -3079,7 +3077,6 @@ class FreeModuleTensor(ModuleElementWithMutability):
             basis = self.pick_a_basis()
         res_comp = self._components[basis].symmetrize(*pos)
         return self._fmodule.tensor_from_comp(self._tensor_type, res_comp)
-
 
     def antisymmetrize(self, *pos, **kwargs):
         r"""

--- a/src/sage/tensor/modules/tensor_with_indices.py
+++ b/src/sage/tensor/modules/tensor_with_indices.py
@@ -385,7 +385,6 @@ class TensorWithIndices(SageObject):
                                  "with the tensor type")
         return con,cov
 
-
     def __init__(self, tensor, indices):
         r"""
         TESTS::
@@ -739,7 +738,6 @@ class TensorWithIndices(SageObject):
         result = self.__pos__()
         result._tensor = result._tensor + other.permute_indices(permutation)._tensor
         return result
-
 
     def __sub__(self, other):
         r"""

--- a/src/sage/tests/benchmark.py
+++ b/src/sage/tests/benchmark.py
@@ -382,7 +382,6 @@ class MPolynomialPower(Benchmark):
 ##         f = z**self.exp
 ##         return float(gp.eval('gettime/1000.0'))
 
-
     def magma(self):
         """
         Time the computation in Magma.
@@ -402,7 +401,6 @@ class MPolynomialPower(Benchmark):
         t = magma.cputime()
         w = z**magma(self.exp)
         return magma.cputime(t)
-
 
 
 class MPolynomialMult(Benchmark):
@@ -747,7 +745,6 @@ class MPolynomialMult2(Benchmark):
         return magma.cputime(t)
 
 
-
 class CharPolyTp(Benchmark):
     def __init__(self, N=37,k=2,p=2,sign=1):
         self.N = N
@@ -832,8 +829,6 @@ class CharPolyTp(Benchmark):
         return magma.cputime(t)
 
 
-
-
 class PolyFactor(Benchmark):
     def __init__(self, n, R):
         self.__n = n
@@ -901,7 +896,6 @@ class PolyFactor(Benchmark):
         gp.eval('gettime')
         f.factor()
         return float(gp.eval('gettime/1000.0'))
-
 
 
 class SquareInts(Benchmark):
@@ -1284,7 +1278,6 @@ class Fibonacci(Benchmark):
         gp.eval('gettime')
         n = gp('fibonacci(%s)'%self.__n)
         return float(gp.eval('gettime/1000.0'))
-
 
 
 class SEA(Benchmark):
@@ -1838,8 +1831,6 @@ class FiniteExtFieldAdd(Benchmark):
    * multivariate poly factor
 
 """
-
-
 
 
 def suite1():

--- a/src/sage/topology/simplicial_set_examples.py
+++ b/src/sage/topology/simplicial_set_examples.py
@@ -50,8 +50,7 @@ from sage.misc.lazy_import import lazy_import
 lazy_import('sage.categories.simplicial_sets', 'SimplicialSets')
 
 
-
-########################################################################
+# ######################################################################
 # The nerve of a finite monoid, used in sage.categories.finite_monoid.
 
 class Nerve(SimplicialSet_arbitrary):


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

fixing a few more pep8 E303 warning in folders with name starting with a letter either in [a-l] or [t-z]

E303 too many blank lines 

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
