### PR TITLE
`givaro`, `zeromq`: Add patches for GCC 13 support

### DIFF
--- a/build/pkgs/gcc/spkg-configure.m4
+++ b/build/pkgs/gcc/spkg-configure.m4
@@ -165,8 +165,8 @@ SAGE_SPKG_CONFIGURE_BASE([gcc], [
                     # Install our own GCC if the system-provided one is older than gcc 8
                     SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_VERSION, which is quite old])
                 ],
-                [1[[3-9]].*], [
-                    # Install our own GCC if the system-provided one is newer than 12.x.
+                [1[[4-9]].*], [
+                    # Install our own GCC if the system-provided one is newer than 13.x.
                     # See https://github.com/sagemath/sage/issues/29456
                     SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_VERSION, which is too recent for this version of Sage])
                 ])

--- a/build/pkgs/gfortran/spkg-configure.m4
+++ b/build/pkgs/gfortran/spkg-configure.m4
@@ -86,8 +86,8 @@ SAGE_SPKG_CONFIGURE([gfortran], [
                         # Install our own gfortran if the system-provided one is older than gcc-4.8.
                         SAGE_SHOULD_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is quite old])
                     ],
-                    [1[[3-9]].*], [
-                        # Install our own gfortran if the system-provided one is newer than 12.x.
+                    [1[[4-9]].*], [
+                        # Install our own gfortran if the system-provided one is newer than 13.x.
                         # See https://github.com/sagemath/sage/issues/29456, https://github.com/sagemath/sage/issues/31838
                         SAGE_MUST_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is too recent for this version of Sage])
                     ])

--- a/build/pkgs/givaro/patches/218.patch
+++ b/build/pkgs/givaro/patches/218.patch
@@ -1,0 +1,23 @@
+From c7744bb133496cd7ac04688f345646d505e1bf52 Mon Sep 17 00:00:00 2001
+From: "Benjamin A. Beasley" <code@musicinmybrain.net>
+Date: Thu, 19 Jan 2023 09:12:22 -0500
+Subject: [PATCH] Add missing #include <cstdint> for (u)int64_t
+
+Fixes failure to compile on GCC 13.
+---
+ src/library/poly1/givdegree.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/library/poly1/givdegree.h b/src/library/poly1/givdegree.h
+index 3753a425..eb85a0dd 100644
+--- a/src/library/poly1/givdegree.h
++++ b/src/library/poly1/givdegree.h
+@@ -19,6 +19,8 @@
+ #ifndef __GIVARO_poly1degree_H
+ #define __GIVARO_poly1degree_H
+ 
++#include <cstdint>
++
+ #include <iostream>
+ 
+ namespace Givaro {

--- a/build/pkgs/zeromq/patches/438d5d88392baffa6c2c5e0737d9de19d6686f0d.patch
+++ b/build/pkgs/zeromq/patches/438d5d88392baffa6c2c5e0737d9de19d6686f0d.patch
@@ -1,0 +1,58 @@
+From 438d5d88392baffa6c2c5e0737d9de19d6686f0d Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Tue, 20 Dec 2022 21:45:16 +0000
+Subject: [PATCH] src/secure_allocator.hpp: define missing 'rebind' type
+
+`gcc-13` added an assert to standard headers to make sure custom
+allocators have intended implementation of rebind type instead
+of inherited rebind. gcc change:
+    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=64c986b49558a7
+
+Without the fix build fails on this week's `gcc-13` as:
+
+    [ 92%] Building CXX object tests/CMakeFiles/test_security_curve.dir/test_security_curve.cpp.o
+    In file included from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/ext/alloc_traits.h:34,
+                     from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_uninitialized.h:64,
+                     from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/memory:69,
+                     from tests/../src/secure_allocator.hpp:42,
+                     from tests/../src/curve_client_tools.hpp:49,
+                     from tests/test_security_curve.cpp:53:
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h: In instantiation of 'struct std::__allocator_traits_base::__rebind<zmq::secure_allocator_t<unsigned char>, unsigned char, void>':
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:94:11:   required by substitution of 'template<class _Alloc, class _Up> using std::__alloc_rebind = typename std::__allocator_traits_base::__rebind<_Alloc, _Up>::type [with _Alloc = zmq::secure_allocator_t<unsigned char>; _Up = unsigned char]'
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:228:8:   required by substitution of 'template<class _Alloc> template<class _Tp> using std::allocator_traits< <template-parameter-1-1> >::rebind_alloc = std::__alloc_rebind<_Alloc, _Tp> [with _Tp = unsigned char; _Alloc = zmq::secure_allocator_t<unsigned char>]'
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/ext/alloc_traits.h:126:65:   required from 'struct __gnu_cxx::__alloc_traits<zmq::secure_allocator_t<unsigned char>, unsigned char>::rebind<unsigned char>'
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_vector.h:88:21:   required from 'struct std::_Vector_base<unsigned char, zmq::secure_allocator_t<unsigned char> >'
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_vector.h:423:11:   required from 'class std::vector<unsigned char, zmq::secure_allocator_t<unsigned char> >'
+    tests/../src/curve_client_tools.hpp:64:76:   required from here
+    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:70:31: error: static assertion failed: allocator_traits<A>::rebind_alloc<A::value_type> must be A
+       70 |                         _Tp>::value,
+          |                               ^~~~~
+
+The change adds trivial `rebind` definition with expected return type
+and satisfies conversion requirements.
+---
+ src/secure_allocator.hpp | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/secure_allocator.hpp b/src/secure_allocator.hpp
+index e0871dcc99..5e97368911 100644
+--- a/src/secure_allocator.hpp
++++ b/src/secure_allocator.hpp
+@@ -99,6 +99,17 @@ bool operator!= (const secure_allocator_t<T> &, const secure_allocator_t<U> &)
+ #else
+ template <typename T> struct secure_allocator_t : std::allocator<T>
+ {
++    secure_allocator_t () ZMQ_DEFAULT;
++
++    template <class U>
++    secure_allocator_t (const secure_allocator_t<U> &) ZMQ_NOEXCEPT
++    {
++    }
++
++    template <class U> struct rebind
++    {
++        typedef secure_allocator_t<U> other;
++    };
+ };
+ #endif
+ }


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Part of the fix for #35092. 
Tested using `tox -e docker-fedora-38-minimal -- givaro zeromq`.
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
