### PR TITLE
`WordMorphism`: remove keyword deprecated in #26307

### DIFF
--- a/src/sage/combinat/words/morphism.py
+++ b/src/sage/combinat/words/morphism.py
@@ -568,7 +568,7 @@ class WordMorphism(SageObject):
         """
         return not self == other
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         r"""
         Return the string representation of the morphism.
 
@@ -587,7 +587,7 @@ class WordMorphism(SageObject):
         """
         return "WordMorphism: %s" % str(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         r"""
         Return the morphism in str.
 
@@ -625,7 +625,7 @@ class WordMorphism(SageObject):
              for lettre, image in self._morph.items()]
         return ', '.join(sorted(L))
 
-    def __call__(self, w, order=1, datatype=None):
+    def __call__(self, w, order=1):
         r"""
         Return the image of ``w`` under self to the given order.
 
@@ -634,8 +634,6 @@ class WordMorphism(SageObject):
         -  ``w`` - word or sequence in the domain of self
 
         -  ``order`` - integer or plus ``Infinity`` (default: 1)
-
-        - ``datatype`` - deprecated
 
         OUTPUT:
 
@@ -752,7 +750,7 @@ class WordMorphism(SageObject):
             sage: m('')
             word:
 
-        The default datatype when the input is a finite word is another
+        When the input is a finite word, the output is another
         finite word::
 
             sage: w = m('aabb')
@@ -764,49 +762,7 @@ class WordMorphism(SageObject):
             sage: import tempfile
             sage: with tempfile.NamedTemporaryFile(suffix=".sobj") as f:
             ....:     save(w, filename=f.name)
-
-        The ``datatype`` argument is deprecated::
-
-            sage: m = WordMorphism('a->ab,b->ba')
-            sage: w = m('aaab',datatype='list')
-            doctest:warning
-            ...
-            DeprecationWarning: the "datatype" argument is deprecated
-            See https://github.com/sagemath/sage/issues/26307 for details.
-
-            sage: type(w)
-            <class 'sage.combinat.words.word.FiniteWord_list'>
-            sage: w = m('aaab',datatype='str')
-            sage: type(w)
-            <class 'sage.combinat.words.word.FiniteWord_str'>
-            sage: w = m('aaab',datatype='tuple')
-            sage: type(w)
-            <class 'sage.combinat.words.word.FiniteWord_tuple'>
-
-        To use str datatype for the output word, the domain and codomain
-        alphabet must consist of str objects::
-
-            sage: m = WordMorphism({0:[0,1],1:[1,0]})
-            sage: w = m([0],4); type(w)
-            <class 'sage.combinat.words.word.FiniteWord_char'>
-            sage: w = m([0],4,datatype='list')
-            doctest:warning
-            ...
-            DeprecationWarning: the "datatype" argument is deprecated
-            See https://github.com/sagemath/sage/issues/26307 for details.
-            sage: type(w)
-            <class 'sage.combinat.words.word.FiniteWord_list'>
-            sage: w = m([0],4,datatype='str')
-            Traceback (most recent call last):
-            ...
-            ValueError: 0 not in alphabet
-            sage: w = m([0],4,datatype='tuple'); type(w)
-            <class 'sage.combinat.words.word.FiniteWord_tuple'>
         """
-        if datatype is not None:
-            from sage.misc.superseded import deprecation
-            deprecation(26307, 'the "datatype" argument is deprecated')
-
         if order == 1:
             D = self.domain()
             C = self.codomain()
@@ -817,10 +773,7 @@ class WordMorphism(SageObject):
                 im = C()
                 for a in w:
                     im += self._morph[a]
-                if datatype is not None:
-                    return C(im, datatype=datatype)
-                else:
-                    return im
+                return im
 
             if isinstance(w, Iterable):
                 pass
@@ -853,7 +806,7 @@ class WordMorphism(SageObject):
             return self.fixed_point(letter=letter)
 
         elif isinstance(order, (int, Integer)) and order > 1:
-            return self(self(w, order - 1), datatype=datatype)
+            return self(self(w, order - 1))
 
         elif order == 0:
             return self._domain(w)


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Remove the deprecated `datatype` argument in word morphisms introduced in #26307

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
