### PR TITLE
Fix doctests with ipython 8.12

### DIFF
--- a/src/sage/repl/inputhook.py
+++ b/src/sage/repl/inputhook.py
@@ -17,6 +17,8 @@ prompt. We use it to reload attached files if they have changed.
 
 import select
 import errno
+import contextlib
+import io
 
 from IPython import get_ipython
 from IPython.terminal.pt_inputhooks import register
@@ -65,7 +67,9 @@ def install():
     if not ip:
         return   # Not running in ipython, e.g. doctests
     if ip._inputhook != sage_inputhook:
-        ip.enable_gui('sage')
+        # silence `ip.enable_gui()` useless output
+        with contextlib.redirect_stdout(io.StringIO()):
+            ip.enable_gui('sage')
 
 
 def uninstall():
@@ -81,4 +85,6 @@ def uninstall():
     if not ip:
         return
     if ip._inputhook == sage_inputhook:
-        ip.enable_gui(None)
+        # silence `ip.enable_gui()` useless output
+        with contextlib.redirect_stdout(io.StringIO()):
+            ip.enable_gui(None)

--- a/src/sage/repl/inputhook.py
+++ b/src/sage/repl/inputhook.py
@@ -47,15 +47,25 @@ def install():
     """
     Install the Sage input hook
 
-    EXAMPLES::
+    EXAMPLES:
+
+    Make sure ipython is running so we really test this function::
+
+        sage: from sage.repl.interpreter import get_test_shell
+        sage: get_test_shell()
+        <sage.repl.interpreter.SageTestShell object at ...>
+
+    Run the function twice, to check it is idempotent (see :trac:`35235`)::
 
         sage: from sage.repl.inputhook import install
+        sage: install()
         sage: install()
     """
     ip = get_ipython()
     if not ip:
         return   # Not running in ipython, e.g. doctests
-    ip.enable_gui('sage')
+    if ip._inputhook != sage_inputhook:
+        ip.enable_gui('sage')
 
 
 def uninstall():


### PR DESCRIPTION
### :books: Description

As reported in https://github.com/sagemath/sage/pull/35337#issuecomment-1493113569, the update to ipython 8.12 introduces some  useless output when calling `get_ipython().enable_gui(...)` which causes a few doctest failures.

This PR silences this output by (temporarily) redirecting stdout to a string.

This is only one commit that sits right on top of https://github.com/sagemath/sage/commit/e9c3333d4145bf631f0eae91514219479e1000ef from #35337.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] Existing tests already cover the changes.

### :hourglass: Dependencies

- #35337 