### PR TITLE
Implemented `remove_constraint` method.

### DIFF
--- a/src/sage/numerical/backends/cvxpy_backend.pyx
+++ b/src/sage/numerical/backends/cvxpy_backend.pyx
@@ -932,3 +932,5 @@ cdef class CVXPYBackend:
             self.col_lower_bound[index] = value
         else:
             return self.col_lower_bound[index]
+    def remove_constraint(self, i):
+        del self.constraints[i]


### PR DESCRIPTION
Implemented method `remove_constraint`.

### :books: Description
This pull request fixes issue #35369 by adding the missing `remove_constraint` method to the `CVXPYBackend` library. The implementation is based on the method described in the `ABC GenericBackend`. The method simply deletes the constraint at the given index using `del`. This allows the method to remove a constraint from the optimization problem.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.