### PR TITLE
simplify bool and make uninitialized streams nonzero unless they are trivially zero

### DIFF
--- a/src/sage/combinat/species/recursive_species.py
+++ b/src/sage/combinat/species/recursive_species.py
@@ -409,7 +409,7 @@ class CombinatorialSpecies(GenericCombinatorialSpecies):
             sage: B = species.CombinatorialSpecies(min=1)
             sage: B.define(X*E(B))
             sage: B.generating_series()
-
+            z + z^2 + 3/2*z^3 + 5/2*z^4 + 9/2*z^5 + 17/2*z^6 + 133/8*z^7 + O(z^8)
         """
         if not isinstance(x, GenericCombinatorialSpecies):
             raise TypeError("x must be a combinatorial species")

--- a/src/sage/combinat/species/recursive_species.py
+++ b/src/sage/combinat/species/recursive_species.py
@@ -401,6 +401,15 @@ class CombinatorialSpecies(GenericCombinatorialSpecies):
             [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
             sage: F.isotype_generating_series()[0:10]
             [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
+
+        Check that issues :trac:`35071` is fixed::
+
+            sage: X = species.SingletonSpecies()
+            sage: E = species.SetSpecies(max=3)
+            sage: B = species.CombinatorialSpecies(min=1)
+            sage: B.define(X*E(B))
+            sage: B.generating_series()
+
         """
         if not isinstance(x, GenericCombinatorialSpecies):
             raise TypeError("x must be a combinatorial species")

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -937,6 +937,23 @@ class Stream_uninitialized(Stream_inexact):
             yield self._target[n]
             n += 1
 
+    def is_nonzero(self):
+        r"""
+        Return ``True`` if and only if this stream is known
+        to be nonzero.
+
+        An assumption of this class is that it is nonzero.
+
+        EXAMPLES::
+
+            sage: from sage.data_structures.stream import Stream_uninitialized
+            sage: g = Stream_uninitialized(0)
+            sage: g.is_nonzero()
+            True
+        """
+        if self._target is None:
+            return True
+        return super().is_nonzero()
 
 class Stream_unary(Stream_inexact):
     r"""

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1039,6 +1039,21 @@ class Stream_uninitialized(Stream_inexact):
             yield self._target[n]
             n += 1
 
+    def is_nonzero(self):
+        r"""
+        Return ``True`` if and only if this stream is known
+        to be nonzero.
+
+        Uninitialized streams are considered to be non-zero.
+
+        EXAMPLES::
+
+            sage: from sage.data_structures.stream import Stream_uninitialized
+            sage: C = Stream_uninitialized(0)
+            sage: C.is_nonzero()
+            True
+        """
+        return True
 
 class Stream_unary(Stream_inexact):
     r"""

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -2959,7 +2959,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
             sage: g = L([2], valuation=-1, constant=1); g
             2*x^-1 + 1 + x + x^2 + O(x^3)
             sage: g * g^-1
-            1 + O(x^7)
+            1
 
             sage: L.<x> = LazyPowerSeriesRing(QQ)
             sage: ~(x + x^2)

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -4657,6 +4657,8 @@ class LazyPowerSeries(LazyCauchyProductSeries):
             sage: f = z^2
             sage: g = L.undefined(valuation=1)
             sage: g.define(z*f(f(g)))
+            sage: g
+            O(z^8)
 
         """
         fP = parent(self)

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -2805,7 +2805,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
                                         constant=c)
             return P.element_class(P, coeff_stream)
 
-        if self.base_ring().is_commutative():
+        if P.is_commutative():
             coeff_stream = Stream_cauchy_mul_commutative(left, right, P.is_sparse())
         else:
             coeff_stream = Stream_cauchy_mul(left, right, P.is_sparse())
@@ -3180,7 +3180,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
         # P._minimal_valuation is zero, because we allow division by
         # series of positive valuation
         right_inverse = Stream_cauchy_invert(right)
-        if self.base_ring().is_commutative():
+        if P.is_commutative():
             coeff_stream = Stream_cauchy_mul_commutative(left, right_inverse, P.is_sparse())
         else:
             coeff_stream = Stream_cauchy_mul(left, right_inverse, P.is_sparse())
@@ -3276,7 +3276,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
         d_self = Stream_function(lambda n: (n + 1) * coeff_stream[n + 1],
                                  False, 0)
         f = P.undefined(valuation=0)
-        if self.base_ring().is_commutative():
+        if P.is_commutative():
             d_self_f = Stream_cauchy_mul_commutative(d_self, f._coeff_stream, False)
         else:
             d_self_f = Stream_cauchy_mul(d_self, f._coeff_stream, False)
@@ -3329,7 +3329,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
         d_self = Stream_function(lambda n: (n + 1) * coeff_stream[n + 1],
                                  P.is_sparse(), 0)
         coeff_stream_inverse = Stream_cauchy_invert(coeff_stream)
-        if self.base_ring().is_commutative():
+        if P.is_commutative():
             d_self_quo_self = Stream_cauchy_mul_commutative(d_self,
                                                             coeff_stream_inverse,
                                                             P.is_sparse())

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -938,9 +938,13 @@ class LazyModuleElement(Element):
 
             sage: fz = L(lambda n: 0, valuation=0)
             sage: L.zero() == fz
-            False
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
             sage: fz == L.zero()
-            False
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
 
         TESTS::
 
@@ -952,13 +956,15 @@ class LazyModuleElement(Element):
 
         """
         if op is op_EQ:
-            prec = self.parent().options['halting_precision']
-            if prec is None:
-                return self._coeff_stream == other._coeff_stream
-
             # they may be trivially equal
             if self._coeff_stream == other._coeff_stream:
                 return True
+            # they may be trivially different
+            if self._coeff_stream != other._coeff_stream:
+                return False
+            prec = self.parent().options['halting_precision']
+            if prec is None:
+                raise ValueError("undecidable")
             # otherwise we check the first prec coefficients
             m = min(self._coeff_stream._approximate_order,
                     other._coeff_stream._approximate_order)
@@ -1003,7 +1009,9 @@ class LazyModuleElement(Element):
             sage: M = L(lambda n: 2*n if n < 10 else 1, valuation=0); M
             O(z^7)
             sage: bool(M)
-            True
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
             sage: M[15]
             1
             sage: bool(M)
@@ -1013,7 +1021,9 @@ class LazyModuleElement(Element):
             sage: M = L(lambda n: 2*n if n < 10 else 1, valuation=0); M
             O(z^7)
             sage: bool(M)
-            True
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
             sage: M[15]
             1
             sage: bool(M)
@@ -1040,9 +1050,11 @@ class LazyModuleElement(Element):
             True
             sage: g.define(1 + z*g)
             sage: bool(g)
-            True
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
         """
-        return bool(self._coeff_stream)
+        return not (self == self.parent().zero())
 
     def define(self, s):
         r"""
@@ -1716,7 +1728,9 @@ class LazyModuleElement(Element):
         Different scalars potentially give different series::
 
             sage: 2 * M == 3 * M
-            False
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
 
         Sparse series can be multiplied with a scalar::
 

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -219,6 +219,7 @@ from sage.arith.misc import divisors, moebius
 from sage.combinat.partition import Partition, Partitions
 from sage.misc.derivative import derivative_parse
 from sage.categories.integral_domains import IntegralDomains
+from sage.categories.rings import Rings
 from sage.rings.infinity import infinity
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
@@ -1802,7 +1803,7 @@ class LazyModuleElement(Element):
                                                    order=v,
                                                    constant=c,
                                                    degree=coeff_stream._degree))
-        if self_on_left or R.is_commutative():
+        if self_on_left or R in Rings().Commutative():
             return P.element_class(P, Stream_lmul(coeff_stream, scalar,
                                                   P.is_sparse()))
         return P.element_class(P, Stream_rmul(coeff_stream, scalar,
@@ -2805,7 +2806,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
                                         constant=c)
             return P.element_class(P, coeff_stream)
 
-        if P.is_commutative():
+        if P in Rings().Commutative():
             coeff_stream = Stream_cauchy_mul_commutative(left, right, P.is_sparse())
         else:
             coeff_stream = Stream_cauchy_mul(left, right, P.is_sparse())
@@ -3180,7 +3181,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
         # P._minimal_valuation is zero, because we allow division by
         # series of positive valuation
         right_inverse = Stream_cauchy_invert(right)
-        if P.is_commutative():
+        if P in Rings().Commutative():
             coeff_stream = Stream_cauchy_mul_commutative(left, right_inverse, P.is_sparse())
         else:
             coeff_stream = Stream_cauchy_mul(left, right_inverse, P.is_sparse())
@@ -3276,7 +3277,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
         d_self = Stream_function(lambda n: (n + 1) * coeff_stream[n + 1],
                                  False, 0)
         f = P.undefined(valuation=0)
-        if P.is_commutative():
+        if P in Rings().Commutative():
             d_self_f = Stream_cauchy_mul_commutative(d_self, f._coeff_stream, False)
         else:
             d_self_f = Stream_cauchy_mul(d_self, f._coeff_stream, False)
@@ -3329,7 +3330,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
         d_self = Stream_function(lambda n: (n + 1) * coeff_stream[n + 1],
                                  P.is_sparse(), 0)
         coeff_stream_inverse = Stream_cauchy_invert(coeff_stream)
-        if P.is_commutative():
+        if P in Rings().Commutative():
             d_self_quo_self = Stream_cauchy_mul_commutative(d_self,
                                                             coeff_stream_inverse,
                                                             P.is_sparse())

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -1064,23 +1064,11 @@ class LazyModuleElement(Element):
         """
         if isinstance(self._coeff_stream, Stream_zero):
             return False
-        if isinstance(self._coeff_stream, Stream_exact):
+        if self._coeff_stream.is_nonzero():
             return True
-        if isinstance(self._coeff_stream, Stream_uninitialized):
-            if self._coeff_stream._target is None:
-                return True
-            if isinstance(self._coeff_stream._target, Stream_zero):
-                return False
-            if isinstance(self._coeff_stream._target, Stream_exact):
-                return True
-        if self._coeff_stream._is_sparse:
-            cache = self._coeff_stream._cache
-            if any(cache[a] for a in cache):
-                return True
-        else:
-            if any(a for a in self._coeff_stream._cache):
-                return True
 
+        # TODO: the following might not be allowed, because it may
+        # step the iterator
         v = self._coeff_stream._approximate_order
         if self[v]:
             return True
@@ -1110,7 +1098,7 @@ class LazyModuleElement(Element):
             sage: binomial(2000, 1000) / C[1000]
             1001
 
-        The Catalan numbers but with a valuation 1::
+        The Catalan numbers but with a valuation `1`::
 
             sage: B = L.undefined(valuation=1)
             sage: B.define(z + B^2)
@@ -4662,6 +4650,14 @@ class LazyPowerSeries(LazyCauchyProductSeries):
             sage: g.define((z - (f - z)(g)))
             sage: g
             z - z^2 + 2*z^3 - 6*z^4 + 20*z^5 - 70*z^6 + 256*z^7 + O(z^8)
+
+        Check that issue :trac:`35071` is fixed::
+
+            sage: L.<z> = LazyPowerSeriesRing(QQ)
+            sage: f = z^2
+            sage: g = L.undefined(valuation=1)
+            sage: g.define(z*f(f(g)))
+
         """
         fP = parent(self)
         if len(g) != fP._arity:

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -195,6 +195,19 @@ components are in the correct ring::
     sage: s = SymmetricFunctions(GF(2)).s()
     sage: L = LazySymmetricFunctions(s)
     sage: check(L, lambda n: sum(k*s(la) for k, la in enumerate(Partitions(n))), valuation=0)
+
+Check that we can invert matrices::
+
+    sage: L.<z> = LazyLaurentSeriesRing(QQ)
+    sage: a11 = 1 + L(lambda n: 1 if not n else 0, valuation=0)
+    sage: a12 = 1 + L(lambda n: 1 if n == 1 else 0, valuation=0)
+    sage: a21 = 1 + L(lambda n: 1 if n == 2 else 0, valuation=0)
+    sage: a22 = 1 + L(lambda n: 1 if n == 3 else 0, valuation=0)
+    sage: m = matrix([[a11, a12], [a21, a22]])
+    sage: m.inverse()
+    [   1 + z + 2*z^2 + 3*z^3 + 4*z^4 + 5*z^5 + 6*z^6 + O(z^7) -1 - 2*z - 3*z^2 - 4*z^3 - 5*z^4 - 6*z^5 - 7*z^6 + O(z^7)]
+    [  -1 - z - 3*z^2 - 3*z^3 - 5*z^4 - 5*z^5 - 7*z^6 + O(z^7)  2 + 2*z + 4*z^2 + 4*z^3 + 6*z^4 + 6*z^5 + 8*z^6 + O(z^7)]
+
 """
 
 # ****************************************************************************
@@ -2761,6 +2774,9 @@ class LazyCauchyProductSeries(LazyModuleElement):
             and right.order() == 0
             and not right._constant):
             return self  # right == 1
+        if ((isinstance(left, Stream_cauchy_invert) and left._series == right)
+            or (isinstance(right, Stream_cauchy_invert) and right._series == left)):
+            return P.one()
         # The product is exact if and only if both factors are exact
         # and one of the factors has eventually 0 coefficients:
         # (p + a x^d/(1-x))(q + b x^e/(1-x))
@@ -3106,7 +3122,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
             return self
 
         # self is right
-        if left is right:
+        if left == right:
             return P.one()
 
         if (P._minimal_valuation is not None

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -1117,9 +1117,7 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         sage: f2 = f * 2  # currently no coefficients computed
         sage: f3 = f * 3  # currently no coefficients computed
         sage: f2 == f3
-        Traceback (most recent call last):
-        ...
-        ValueError: undecidable
+        False
         sage: f2  # computes some of the coefficients of f2
         2*z^-1 - 2 + 2*z - 2*z^2 + 2*z^3 - 2*z^4 + 2*z^5 + O(z^6)
         sage: f3  # computes some of the coefficients of f3

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -2260,10 +2260,10 @@ class LazyCompletionGradedAlgebra(LazySeriesRing):
             if basis not in GradedAlgebrasWithBasis:
                 raise ValueError("basis should be in GradedAlgebrasWithBasis")
             self._arity = 1
-        category = Algebras(base_ring.category())
-        if base_ring in IntegralDomains():
+        category = Algebras(basis.category())
+        if basis in IntegralDomains():
             category &= IntegralDomains()
-        elif base_ring in Rings().Commutative():
+        elif basis in Rings().Commutative():
             category = category.Commutative()
 
         if base_ring.is_zero():

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -664,8 +664,8 @@ class LazySeriesRing(UniqueRepresentation, Parent):
                                description='the number of coefficients to display for nonzero constant series',
                                checker=lambda x: x in ZZ and x > 0)
         halting_precision = dict(default=None,
-                               description='the number of coefficients, beginning with the approximate valuation, to check in equality tests',
-                               checker=lambda x: x is None or x in ZZ and x > 0)
+                                 description='the number of coefficients, beginning with the approximate valuation, to check in equality tests',
+                                 checker=lambda x: x is None or x in ZZ and x > 0)
 
     @cached_method
     def one(self):
@@ -1117,7 +1117,9 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         sage: f2 = f * 2  # currently no coefficients computed
         sage: f3 = f * 3  # currently no coefficients computed
         sage: f2 == f3
-        False
+        Traceback (most recent call last):
+        ...
+        ValueError: undecidable
         sage: f2  # computes some of the coefficients of f2
         2*z^-1 - 2 + 2*z - 2*z^2 + 2*z^3 - 2*z^4 + 2*z^5 + O(z^6)
         sage: f3  # computes some of the coefficients of f3


### PR DESCRIPTION
`bool` should return `True` if we know that the stream is non-zero, and `False` otherwise.  The behaviour of equality should be similar.  This simplifies things enormously.

### :books: Description

Fixes #35071

### :memo: Checklist

- [X] The title is concise, informative, and self-explanatory.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation accordingly.

### :hourglass: Dependencies