### PR TITLE
remove_constraint

### DIFF
--- a/src/sage/numerical/backends/cvxpy_backend.pyx
+++ b/src/sage/numerical/backends/cvxpy_backend.pyx
@@ -932,3 +932,30 @@ cdef class CVXPYBackend:
             self.col_lower_bound[index] = value
         else:
             return self.col_lower_bound[index]
+
+    cpdef remove_constraint(self, index):
+        """
+        Remove a linear constraint by index.
+
+        INPUT:
+
+        - ``index`` - index of the constraint to remove
+
+        EXAMPLES:
+
+            sage: from sage.numerical.backends.generic_backend import get_solver
+            sage: p = get_solver(solver = "CVXOPT")                 # optional - cvxopt
+            sage: p.add_variables(5)                                # optional - cvxopt
+            4
+            sage: p.add_linear_constraint(zip(range(5), range(5)), 2.0, 2.0)                # optional - cvxopt
+            sage: p.add_linear_constraint(zip(range(5), range(5)), 1.0, 1.0, name='foo')    # optional - cvxopt
+            sage: p.remove_constraint(1)                             # optional - cvxopt
+            sage: p.num_constraints()                                 # optional - cvxopt
+            1
+        """
+        self.G_matrix.pop(index)
+        self.row_lower_bound.pop(index)
+        self.row_upper_bound.pop(index)
+        self.row_name_var.pop(index)
+        for i in range(len(self.G_matrix)):
+            self.G_matrix[i].pop(-1)


### PR DESCRIPTION
# Implemented method `remove_constraint` as per `add_linear_constraint` method.

### :books: Description

This pull request fixes issue #35369 by adding the missing `remove_constraint` method to the `CVXPYBackend` library. The `remove_constraint` method takes an `index` of the constraint to remove. It removes the corresponding row from the `matrix`, as well as the `lower and upper bounds` and the constraint name. Then it rebuilds the list of constraints from the remaining rows of the `matrix`, using the same logic as in the `add_linear_constraint method`. Finally, it updates the problem attribute of the solver with the new list of constraints.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.