### PR TITLE
add patch for PARI bug #2466

### DIFF
--- a/build/pkgs/pari/patches/bug2466.patch
+++ b/build/pkgs/pari/patches/bug2466.patch
@@ -1,0 +1,25 @@
+From 7ca0c2eae87def89fa7253c60e4791a8ef26629d Mon Sep 17 00:00:00 2001
+From: Bill Allombert <Bill.Allombert@math.u-bordeaux.fr>
+Date: Mon, 3 Apr 2023 15:30:26 +0200
+Subject: [PATCH] quadunitindex(8461,2)->1 instead of 3 [#2466]
+
+---
+ src/basemath/quad.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basemath/quad.c b/src/basemath/quad.c
+index 021a404b00..7ed554c2f3 100644
+--- a/src/basemath/quad.c
++++ b/src/basemath/quad.c
+@@ -359,7 +359,7 @@ quadunit_mod(GEN D, GEN N)
+     GEN M = shifti(mulii(q, N), 1);
+     quadunit_uvmod(D, d, M, &u, &v);
+     u = diviiexact(u, q);
+-    v = diviiexact(v, q); u = shifti(u,-1);
++    v = modii(diviiexact(v, q), N); u = shifti(u,-1);
+   }
+   return deg1pol_shallow(v, u, 0);
+ }
+-- 
+2.40.0
+

--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -1038,6 +1038,14 @@ class Order(IntegralDomain, sage.rings.abc.Order):
             ...
             NotImplementedError: computation of class numbers of non-maximal orders not in quadratic fields is not implemented
 
+        TESTS:
+
+        Test for PARI bug #2466::
+
+            sage: x = polygen(ZZ)
+            sage: R.<t> = EquationOrder(x^2 - 8461)
+            sage: R.class_number()
+            3
         """
         if not self.is_maximal():
             K = self.number_field()


### PR DESCRIPTION
PARI currently returns wrong results for `qfbclassno()` in some cases; see PARI bug [#2466](https://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=2466).

This pull request adds the upstream patch to Sage in order to fix the bug until a new PARI release becomes available.