### PR TITLE
Ignore deprecation warnings triggered by pythran 0.12.1

### DIFF
--- a/src/sage/all__sagemath_repl.py
+++ b/src/sage/all__sagemath_repl.py
@@ -37,9 +37,17 @@ warnings.filterwarnings('ignore', category=DeprecationWarning,
 warnings.filterwarnings('ignore', category=DeprecationWarning,
     module='(.*[.]_vendor[.])?packaging')
 
-# Ignore numpy warnings triggered by pythran
+# Ignore a few warnings triggered by pythran 0.12.1
 warnings.filterwarnings('ignore', category=DeprecationWarning,
-                        module='pythran')
+    message='\n\n  `numpy.distutils` is deprecated since NumPy 1.23.0',
+    module='pythran.dist')
+warnings.filterwarnings('ignore', category=DeprecationWarning,
+    message='pkg_resources is deprecated as an API|'
+            'Deprecated call to `pkg_resources.declare_namespace(.*)`',
+    module='pkg_resources')
+warnings.filterwarnings('ignore', category=DeprecationWarning,
+    message='msvccompiler is deprecated and slated to be removed',
+    module='distutils.msvccompiler')
 
 warnings.filterwarnings('ignore', category=DeprecationWarning,
                         message='The distutils(.sysconfig module| package) is deprecated',


### PR DESCRIPTION
These happen with python 3.11, setuptools 67.6.1, numpy 1.24.2. When pythran 0.12.1 is installed, I get 24 doctest failures due to deprecation warnings; they are all gone with this commit.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] Current tests cover the changes.