### PR TITLE
Fix construction functor for p-adic relaxed types.

### DIFF
--- a/src/sage/rings/padics/generic_nodes.py
+++ b/src/sage/rings/padics/generic_nodes.py
@@ -1423,13 +1423,19 @@ class pAdicRingBaseGeneric(pAdicBaseGeneric, pAdicRingGeneric):
             sage: S = F(Z)
             sage: S._precision_cap()
             (31, 41)
+
+        The `secure` attribute for relaxed type is included in the functor::
+
+            sage: R = ZpER(5, secure=True)
+            sage: R.construction()
+            (Completion[5, prec=(20, 40, True)], Integer Ring)
         """
         from sage.categories.pushout import CompletionFunctor
         extras = {'print_mode':self._printer.dict(), 'type':self._prec_type(), 'names':self._names}
         if hasattr(self, '_label'):
             extras['label'] = self._label
         if self._prec_type() == "relaxed":
-            prec = (self._default_prec, self._halting_prec)
+            prec = (self._default_prec, self._halting_prec, self._secure)
         else:
             prec = self._precision_cap()
         return (CompletionFunctor(self.prime(), prec, extras), ZZ)
@@ -1595,6 +1601,12 @@ class pAdicFieldBaseGeneric(pAdicBaseGeneric, pAdicFieldGeneric):
             sage: S = F(Z)
             sage: S._precision_cap()
             (31, 41)
+
+        The `secure` attribute for relaxed type is included in the functor::
+
+            sage: K = QpER(5, secure=True)
+            sage: K.construction(forbid_frac_field=True)
+            (Completion[5, prec=(20, 40, True)], Rational Field)
         """
         from sage.categories.pushout import FractionField, CompletionFunctor
         if forbid_frac_field:
@@ -1602,7 +1614,7 @@ class pAdicFieldBaseGeneric(pAdicBaseGeneric, pAdicFieldGeneric):
             if hasattr(self, '_label'):
                 extras['label'] = self._label
             if self._prec_type() == "relaxed":
-                prec = (self._default_prec, self._halting_prec)
+                prec = (self._default_prec, self._halting_prec, self._secure)
             else:
                 prec = self._precision_cap()
             return (CompletionFunctor(self.prime(), prec, extras), QQ)

--- a/src/sage/rings/padics/local_generic.py
+++ b/src/sage/rings/padics/local_generic.py
@@ -375,6 +375,25 @@ class LocalGeneric(CommutativeRing):
             37-adic Ring with lattice-cap precision (label: change)
             sage: S.change(label = "new")
             37-adic Ring with lattice-cap precision (label: new)
+
+
+        TESTS:
+
+        The `secure` attribute for relaxed type is copied::
+
+            sage: R = ZpER(5, secure=True); R
+            5-adic Ring handled with relaxed arithmetics
+            sage: K = R.change(field=True); K
+            5-adic Field handled with relaxed arithmetics
+            sage: K.is_secure()
+            True
+
+        The `check=False` option works for relaxed type::
+
+            sage: R = ZpER(5) ; R
+            5-adic Ring handled with relaxed arithmetics
+            sage: K = R.change(field=True, check=False) ; K
+            5-adic Field handled with relaxed arithmetics
         """
         # We support both print_* and * for *=mode, pos, sep, alphabet
         for atr in ('print_mode', 'print_pos', 'print_sep', 'print_alphabet'):

--- a/src/sage/rings/padics/padic_base_leaves.py
+++ b/src/sage/rings/padics/padic_base_leaves.py
@@ -1128,6 +1128,8 @@ class pAdicRingRelaxed(pAdicRelaxedGeneric, pAdicRingBaseGeneric):
 
             sage: R = ZpER(7)
             sage: TestSuite(R).run(skip=['_test_log', '_test_matrix_smith'])
+            sage: R = ZpER(7, secure=True)
+            sage: TestSuite(R).run(skip=['_test_log', '_test_matrix_smith'])
         """
         from sage.rings.padics import padic_relaxed_element
         self._default_prec, self._halting_prec, self._secure = prec
@@ -1162,6 +1164,8 @@ class pAdicFieldRelaxed(pAdicRelaxedGeneric, pAdicFieldBaseGeneric):
         TESTS::
 
             sage: K = QpER(7)
+            sage: TestSuite(K).run(skip=['_test_log', '_test_matrix_smith'])
+            sage: K = QpER(7, secure=True)
             sage: TestSuite(K).run(skip=['_test_log', '_test_matrix_smith'])
         """
         from sage.rings.padics import padic_relaxed_element

--- a/src/sage/rings/padics/padic_generic.py
+++ b/src/sage/rings/padics/padic_generic.py
@@ -478,6 +478,12 @@ class pAdicGeneric(PrincipalIdealDomain, LocalGeneric):
             2-adic Ring with lattice-cap precision (label: test)
             sage: R.integer_ring({'mode':'series'}) is R
             True
+
+        The `secure` attribute for relaxed type is preserved::
+
+            sage: K = QpER(5, secure=True)
+            sage: K.integer_ring().is_secure()
+            True
         """
         # Currently does not support fields with non integral defining
         # polynomials.  This should change when the padic_general_extension


### PR DESCRIPTION
The precision for relaxed p-adics has 3 components:

    (default_prec, halting_prec, secure)

where the last one `secure` is a boolean defaulting to `False`.

However, the `construction()` method doesn't know about it:
```
sage: K = QpER(5, secure=True)
sage: K.construction(forbid_frac_field=True)
(Completion[5, prec=(20, 40)], Rational Field)
sage: R = ZpER(5, secure=True)
sage: R.construction()
(Completion[5, prec=(20, 40)], Integer Ring)
```

This has two undesired consequences for the `change()` method:

a. The `secure` attribute is not copied:
```
sage: K.is_secure()
True
sage: K.change().is_secure()
False
sage: R.is_secure()
True
sage: R.change().is_secure()
False
```

b. The `check=False` option is broken:
```
sage: K.change(check=False)
...
ValueError: not enough values to unpack (expected 3, got 2)
sage: R.change(check=False)
...
ValueError: not enough values to unpack (expected 3, got 2)
```

Fixing the `construction()` method solves both issues.

After this commit:
```
sage: K = QpER(5, secure=True)
sage: K.construction(forbid_frac_field=True)
(Completion[5, prec=(20, 40, True)], Rational Field)
sage: K.change().is_secure()
True
sage: K.change(check=False)
5-adic Field handled with relaxed arithmetics
sage: K.change(check=False).is_secure()
True

sage: R = ZpER(5, secure=True)
sage: R.construction()
(Completion[5, prec=(20, 40, True)], Integer Ring)
sage: R.change().is_secure()
True
sage: R.change(check=False)
5-adic Ring handled with relaxed arithmetics
sage: R.change(check=False).is_secure()
True
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.