### PR TITLE
Fix slow doctests or mark # long time

### DIFF
--- a/src/sage/calculus/tests.py
+++ b/src/sage/calculus/tests.py
@@ -143,7 +143,7 @@ No problems here::
 
 Other examples that now (:trac:`27958`) work::
 
-    sage: integrate(log(x)*exp(-x^2), x)
+    sage: integrate(log(x)*exp(-x^2), x)  # long time
     1/2*sqrt(pi)*erf(x)*log(x) - x*hypergeometric((1/2, 1/2), (3/2, 3/2), -x^2)
 
     sage: integrate(log(1+sqrt(1+4*x)/2)/x, x, 0, 1)
@@ -201,12 +201,12 @@ Maple documentation::
     1/3*sqrt(3)*arctan(1/3*sqrt(3)*(2*x + 1)) - 1/6*log(x^2 + x + 1) + 1/3*log(x - 1)
     sage: integrate(exp(-x^2), x)
     1/2*sqrt(pi)*erf(x)
-    sage: integrate(exp(-x^2)*log(x), x)
+    sage: integrate(exp(-x^2)*log(x), x)  # long time
     1/2*sqrt(pi)*erf(x)*log(x) - x*hypergeometric((1/2, 1/2), (3/2, 3/2), -x^2)
     sage: f = exp(-x^2)*log(x)
     sage: f.nintegral(x, 0, 999)
     (-0.87005772672831..., 7.5584...e-10, 567, 0)
-    sage: integral(1/sqrt(2*t^4 - 3*t^2 - 2), t, 2, 3)     # todo: maple can do this
+    sage: integral(1/sqrt(2*t^4 - 3*t^2 - 2), t, 2, 3)     # long time  # todo: maple can do this
     integrate(1/(sqrt(2*t^2 + 1)*sqrt(t^2 - 2)), t, 2, 3)
     sage: integral(integral(x*y^2, x, 0, y), y, -2, 2)
     32/5

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -1154,8 +1154,8 @@ class MultiPolynomialFunctor(ConstructionFunctor):
             Traceback (most recent call last):
             ...
             TypeError: unsupported operand parent(s) for +: 'Multivariate Polynomial Ring in x, y, z over Integer Ring' and 'Multivariate Polynomial Ring in y, s over Rational Field'
-            sage: R = PolynomialRing(ZZ, 'x', 500)
-            sage: S = PolynomialRing(GF(5), 'x', 200)
+            sage: R = PolynomialRing(ZZ, 'x', 50)
+            sage: S = PolynomialRing(GF(5), 'x', 20)
             sage: R.gen(0) + S.gen(0)
             2*x0
         """

--- a/src/sage/combinat/crystals/affine_factorization.py
+++ b/src/sage/combinat/crystals/affine_factorization.py
@@ -144,7 +144,7 @@ class AffineFactorizationCrystal(UniqueRepresentation, Parent):
             sage: W = WeylGroup(['A',3,1], prefix='s')
             sage: w = W.from_reduced_word([2,3,2,1])
             sage: B = crystals.AffineFactorization(w,3)
-            sage: TestSuite(B).run()
+            sage: TestSuite(B).run()  # long time
         """
         Parent.__init__(self, category = ClassicalCrystals())
         self.n = n
@@ -407,7 +407,7 @@ def affine_factorizations(w, l, weight=None):
        [[s1, s2, s1], [s2, s1, s2]]
        sage: W = WeylGroup(['A',3], prefix='s')
        sage: w0 = W.long_element()
-       sage: affine_factorizations(w0,6,(1,1,1,1,1,1))
+       sage: affine_factorizations(w0,6,(1,1,1,1,1,1))  # long time
        [[s1, s2, s1, s3, s2, s1],
        [s1, s2, s3, s1, s2, s1],
        [s1, s2, s3, s2, s1, s2],
@@ -498,12 +498,13 @@ class FactorizationToTableaux(CrystalMorphism):
 
             sage: W = WeylGroup(['A',4,1], prefix='s')
             sage: w = W.from_reduced_word([2,1,3,2,4,3,2,1])
-            sage: B = crystals.AffineFactorization(w, 4)
-            sage: phi = B._tableaux_isomorphism
-            sage: all(phi(b).e(i) == phi(b.e(i)) and phi(b).f(i) == phi(b.f(i))
+            sage: B = crystals.AffineFactorization(w, 4)         # long time
+            sage: phi = B._tableaux_isomorphism                  # long time
+            sage: all(phi(b).e(i) == phi(b.e(i)) and             # long time
+            ....:     phi(b).f(i) == phi(b.f(i))
             ....:     for b in B for i in B.index_set())
             True
-            sage: set(phi(b) for b in B) == set(phi.codomain())
+            sage: set(phi(b) for b in B) == set(phi.codomain())  # long time
             True
         """
         return True

--- a/src/sage/combinat/crystals/highest_weight_crystals.py
+++ b/src/sage/combinat/crystals/highest_weight_crystals.py
@@ -168,7 +168,7 @@ def HighestWeightCrystal(dominant_weight, model=None):
 
     Check that the correct crystal is constructed for the fundamental weights::
 
-        sage: for ct in CartanType.samples(finite=True, crystallographic=True):
+        sage: for ct in CartanType.samples(finite=True, crystallographic=True):  # long time
         ....:     L = ct.root_system().weight_lattice()
         ....:     La = L.fundamental_weights()
         ....:     for model in ['Tableaux', 'NakajimaMonomials', 'AlcovePaths', 'RiggedConfigurations']:

--- a/src/sage/combinat/designs/database.py
+++ b/src/sage/combinat/designs/database.py
@@ -1658,8 +1658,8 @@ def OA_10_469():
 
         sage: from sage.combinat.designs.designs_pyx import is_orthogonal_array
         sage: from sage.combinat.designs.database import OA_10_469
-        sage: OA = OA_10_469()
-        sage: is_orthogonal_array(OA,10,469,2)
+        sage: OA = OA_10_469()                  # long time
+        sage: is_orthogonal_array(OA,10,469,2)  # long time
         True
 
     The design is available from the general constructor::

--- a/src/sage/combinat/k_regular_sequence.py
+++ b/src/sage/combinat/k_regular_sequence.py
@@ -1112,7 +1112,7 @@ class kRegularSequenceSpace(RecognizableSeriesSpace):
 
         TESTS::
 
-            sage: Seq2.from_recurrence([
+            sage: Seq2.from_recurrence([  # long time
             ....:     f(4*n) == f(2*n),
             ....:     f(4*n + 1) == f(2*n),
             ....:     f(4*n + 2) == f(2*n),
@@ -1179,7 +1179,7 @@ class kRegularSequenceSpace(RecognizableSeriesSpace):
             ....:     g(22) == 22, g(23) == 23, g(24) == 24, g(25) == 25,
             ....:     g(26) == 26, g(27) == 27, g(28) == 28, g(29) == 29,
             ....:     g(30) == 30, g(31) == 31], g, m, offset=8)
-            sage: (S - T).is_trivial_zero()
+            sage: (S - T).is_trivial_zero()  # long time
             True
 
         Zero-sequence with non-zero initial values::

--- a/src/sage/combinat/rsk.py
+++ b/src/sage/combinat/rsk.py
@@ -2586,7 +2586,7 @@ class RuleStar(Rule):
         ....:                  for T in SemistandardTableaux(shape, max_entry=4)
         ....:                      if fc(row_reading(T.conjugate()))]
         sage: Checks = []
-        sage: for T in FC_tabs:
+        sage: for T in FC_tabs:  # long time
         ....:    shape = T.shape().conjugate()
         ....:    P = T.conjugate()
         ....:    Checks += [all((P,Q) == tuple(RSK(*RSK_inverse(P, Q,
@@ -2596,7 +2596,7 @@ class RuleStar(Rule):
         sage: all(Checks)
         True
         sage: Checks = []
-        sage: for T in FC_tabs:
+        sage: for T in FC_tabs:  # long time
         ....:    shape = T.shape().conjugate()
         ....:    P = T.conjugate()
         ....:    Checks += [all((P,Q) == tuple(RSK(RSK_inverse(P, Q,

--- a/src/sage/combinat/words/paths.py
+++ b/src/sage/combinat/words/paths.py
@@ -1614,30 +1614,34 @@ class FiniteWordPath_2d(FiniteWordPath_all):
 
             sage: P = WordPaths('abAB')
             sage: p = P('aaababbb')
-            sage: a = p.animate(); a    # optional -- ImageMagick
+            sage: a = p.animate(); print(a)
             Animation with 9 frames
-            sage: show(a)               # optional -- ImageMagick
-            sage: a.gif(delay=35, iterations=3)    # optional -- ImageMagick
+            sage: show(a)                           # optional -- ImageMagick  # long time
+            sage: show(a, delay=35, iterations=3)   # optional -- ImageMagick  # long time
 
         ::
 
             sage: P = WordPaths('abcdef',steps='triangle')
             sage: p =  P('abcdef')
-            sage: p.animate()           # optional -- ImageMagick
+            sage: a = p.animate(); print(a)
             Animation with 8 frames
+            sage: show(a)                           # optional -- ImageMagick  # long time
 
         If the path is closed, the plain polygon is added at the end of the
         animation::
 
             sage: P = WordPaths('abAB')
             sage: p = P('ababAbABABaB')
-            sage: a = p.animate(); a    # optional -- ImageMagick
+            sage: a = p.animate(); print(a)
             Animation with 14 frames
+            sage: show(a)                           # optional -- ImageMagick  # long time
 
         Another example illustrating a Fibonacci tile::
 
             sage: w = words.fibonacci_tile(2)
-            sage: show(w.animate())  # optional -- ImageMagick
+            sage: a = w.animate(); print(a)
+            Animation with 54 frames
+            sage: show(a)                           # optional -- ImageMagick  # long time
 
         The first 4 Fibonacci tiles in an animation::
 
@@ -1645,7 +1649,9 @@ class FiniteWordPath_2d(FiniteWordPath_all):
             sage: b = words.fibonacci_tile(1).animate()
             sage: c = words.fibonacci_tile(2).animate()
             sage: d = words.fibonacci_tile(3).animate()
-            sage: (a*b*c*d).show()  # optional -- ImageMagick   # long time
+            sage: print(a*b*c*d)
+            Animation with 296 frames
+            sage: show(a*b*c*d)                     # optional -- ImageMagick  # long time
 
         .. note::
 

--- a/src/sage/combinat/words/paths.py
+++ b/src/sage/combinat/words/paths.py
@@ -1616,8 +1616,8 @@ class FiniteWordPath_2d(FiniteWordPath_all):
             sage: p = P('aaababbb')
             sage: a = p.animate(); print(a)
             Animation with 9 frames
-            sage: show(a)                           # optional -- ImageMagick  # long time
-            sage: show(a, delay=35, iterations=3)   # optional -- ImageMagick  # long time
+            sage: show(a)                           # long time  # optional -- ImageMagick
+            sage: show(a, delay=35, iterations=3)   # long time  # optional -- ImageMagick
 
         ::
 
@@ -1625,7 +1625,7 @@ class FiniteWordPath_2d(FiniteWordPath_all):
             sage: p =  P('abcdef')
             sage: a = p.animate(); print(a)
             Animation with 8 frames
-            sage: show(a)                           # optional -- ImageMagick  # long time
+            sage: show(a)                           # long time  # optional -- ImageMagick
 
         If the path is closed, the plain polygon is added at the end of the
         animation::
@@ -1634,14 +1634,14 @@ class FiniteWordPath_2d(FiniteWordPath_all):
             sage: p = P('ababAbABABaB')
             sage: a = p.animate(); print(a)
             Animation with 14 frames
-            sage: show(a)                           # optional -- ImageMagick  # long time
+            sage: show(a)                           # long time  # optional -- ImageMagick
 
         Another example illustrating a Fibonacci tile::
 
             sage: w = words.fibonacci_tile(2)
             sage: a = w.animate(); print(a)
             Animation with 54 frames
-            sage: show(a)                           # optional -- ImageMagick  # long time
+            sage: show(a)                           # long time  # optional -- ImageMagick
 
         The first 4 Fibonacci tiles in an animation::
 
@@ -1651,7 +1651,7 @@ class FiniteWordPath_2d(FiniteWordPath_all):
             sage: d = words.fibonacci_tile(3).animate()
             sage: print(a*b*c*d)
             Animation with 296 frames
-            sage: show(a*b*c*d)                     # optional -- ImageMagick  # long time
+            sage: show(a*b*c*d)                     # long time  # optional -- ImageMagick
 
         .. note::
 

--- a/src/sage/crypto/lwe.py
+++ b/src/sage/crypto/lwe.py
@@ -283,7 +283,7 @@ class LWE(SageObject):
             sage: L = []
             sage: def add_samples():
             ....:     global L
-            ....:     L += [lwe() for _ in range(1000)]
+            ....:     L += [lwe() for _ in range(100)]
             sage: add_samples()
 
         To test the oracle, we use the internal secret to evaluate the samples
@@ -298,6 +298,7 @@ class LWE(SageObject):
 
             sage: from numpy import std
             sage: while abs(std([e if e <= 200 else e-401 for e in S()]) - 3.0) > 0.01:
+            ....:     L = []  # reset L to avoid quadratic behaviour
             ....:     add_samples()
 
         If ``m`` is not ``None`` the number of available samples is restricted::

--- a/src/sage/crypto/sbox.pyx
+++ b/src/sage/crypto/sbox.pyx
@@ -940,13 +940,11 @@ cdef class SBox(SageObject):
         Check that :trac:`22453` is fixed::
 
             sage: from sage.crypto.sboxes import AES
-            sage: aes_polys = AES.polynomials()
-            sage: p = aes_polys[0].parent("x3*y0 + x5*y0 + x7*y0 + x6*y1 + x2*y2"
-            ....:                         " + x3*y2 + x4*y2 + x2*y3 + x3*y3 +"
-            ....:                         " x5*y4 + x6*y4 + x3*y5 + x4*y5 + x4*y7"
-            ....:                         " + x2 + x3 + y2 + y3 + y4 + 1")
-            sage: p in aes_polys
-            True
+            sage: aes_polys = AES.polynomials()  # long time
+            sage: aes_polys[3]                   # long time
+            x3*y0 + x5*y0 + x7*y0 + x6*y1 + x2*y2 + x3*y2 + x4*y2
+                  + x2*y3 + x3*y3 + x5*y4 + x6*y4 + x3*y5 + x4*y5
+                  + x4*y7 + x2 + x3 + y2 + y3 + y4 + 1
         """
         cdef Py_ssize_t m = self.m
         cdef Py_ssize_t n = self.n

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -1083,7 +1083,7 @@ class DocTestController(SageObject):
             sage: from sage.doctest.control import DocTestDefaults, DocTestController
             sage: from sage.env import SAGE_SRC
             sage: import os
-            sage: dirname = os.path.join(SAGE_SRC, 'sage', 'rings', 'infinity.py')
+            sage: dirname = os.path.join(SAGE_SRC, 'sage', 'rings', 'all.py')
             sage: DD = DocTestDefaults()
 
             sage: DC = DocTestController(DD, [dirname])
@@ -1097,7 +1097,7 @@ class DocTestController(SageObject):
             sage: DC.run()
             Running doctests with ID ...
             Doctesting 1 file.
-            sage -t .../rings/infinity.py
+            sage -t .../rings/all.py
                 [... tests, ... s]
             ----------------------------------------------------------------------
             All tests passed!
@@ -1402,10 +1402,10 @@ def run_doctests(module, options=None):
 
     EXAMPLES::
 
-        sage: run_doctests(sage.rings.infinity)
+        sage: run_doctests(sage.rings.all)
         Running doctests with ID ...
         Doctesting 1 file.
-        sage -t .../sage/rings/infinity.py
+        sage -t .../sage/rings/all.py
             [... tests, ... s]
         ----------------------------------------------------------------------
         All tests passed!

--- a/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
+++ b/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
@@ -1232,11 +1232,13 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
             sage: a = 7/(b - 1)
             sage: f = DynamicalSystem_projective([a*y^2 - (a*y - x)^2, y^2])
             sage: g = DynamicalSystem_projective([x^2, y^2])
-            sage: # If all archimedean absolute values of a have modulus > 2,
-            sage: # then the pairing should be h(a).
-            sage: f.arakelov_zhang_pairing(g, n=6)
+
+        If all archimedean absolute values of a have modulus > 2,
+        then the pairing should be h(a).::
+
+            sage: f.arakelov_zhang_pairing(g, n=6)  # long time
             1.93846423207664
-            sage: _ - a.global_height()
+            sage: _ - a.global_height()             # long time
             -0.00744591697867292
         """
         n = kwds.pop('n', 5)
@@ -4794,8 +4796,8 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
 
             sage: P.<x,y,z> = ProjectiveSpace(ZZ, 2)
             sage: f = DynamicalSystem([x^2 - 2*y^2, y^2, z^2])
-            sage: X = f.periodic_points(2, minimal=False, formal=True, return_scheme=True)
-            sage: len(X.defining_polynomials())
+            sage: X = f.periodic_points(2, minimal=False, formal=True, return_scheme=True)  # long time
+            sage: len(X.defining_polynomials())                                             # long time
             19
 
         TESTS::
@@ -5132,7 +5134,7 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
             sage: P.<x,y,z> = ProjectiveSpace(QQ, 2)
             sage: f = DynamicalSystem_projective([x^2, z^2, y^2])
             sage: g = f.change_ring(QQbar)
-            sage: f.multiplier_spectra(1) == g.multiplier_spectra(1)
+            sage: f.multiplier_spectra(1) == g.multiplier_spectra(1)    # long time
             True
 
         ::
@@ -5140,7 +5142,7 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
             sage: K.<w> = QuadraticField(5)
             sage: P.<x,y,z> = ProjectiveSpace(K, 2)
             sage: f = DynamicalSystem_projective([x^2 + w*x*y + y^2, y^2, z^2])
-            sage: f.multiplier_spectra(1)
+            sage: f.multiplier_spectra(1)                               # long time
             [
             [1.000000000000000? - 1.572302755514847?*I                                         0]
             [1.000000000000000? - 1.572302755514847?*I 0.618033988749895? - 1.757887921270715?*I]
@@ -7480,8 +7482,8 @@ class DynamicalSystem_projective_field(DynamicalSystem_projective,
             sage: f = DynamicalSystem_projective([2*x + 12*y, 11*y+2*z, x+z])
             sage: m1 = matrix(L, 3, 3, [1,4,v^2,0,2,1,1,1,1])
             sage: g = f.conjugate(m1)
-            sage: m = f.conjugating_set(g)[0]
-            sage: f.conjugate(m) == g
+            sage: m = f.conjugating_set(g)[0]   # long time
+            sage: f.conjugate(m) == g           # long time
             True
 
         TESTS:
@@ -8191,7 +8193,7 @@ class DynamicalSystem_projective_field(DynamicalSystem_projective,
 
             sage: P.<x,y> = ProjectiveSpace(QQ, 1)
             sage: system = DynamicalSystem_projective([3^5*x^3 + x^2*y - 3^5*x*y^2, -3^5*x^2*y + x*y^2 + 3^5*y^3])
-            sage: system.potential_good_reduction(3, return_conjugation=True)
+            sage: system.potential_good_reduction(3, return_conjugation=True)  # long time
             (False, None, None)
 
         ::

--- a/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
+++ b/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
@@ -1219,9 +1219,9 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
             sage: f.arakelov_zhang_pairing(g)
             0.326954667248466
             sage: # Correct value should be = 0.323067...
-            sage: f.arakelov_zhang_pairing(g, n=9)
+            sage: f.arakelov_zhang_pairing(g, n=9)  # long time
             0.323091061918965
-            sage: _ - 0.323067
+            sage: _ - 0.323067                      # long time
             0.0000240619189654789
 
         Also from Prop. 18 of Petsche, Szpiro and Tucker, includes places of bad reduction::
@@ -5006,7 +5006,7 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
 
             sage: P.<x,y,z> = ProjectiveSpace(QQ, 2)
             sage: f = DynamicalSystem_projective([x^2, z^2, y^2])
-            sage: f.multiplier_spectra(2, formal=True)
+            sage: f.multiplier_spectra(2, formal=True)  # long time
             [
             [4 0]  [4 0]  [4 0]  [4 0]  [4 0]  [4 0]  [4 0]  [4 0]  [0 0]  [0 0]
             [0 4], [0 0], [0 0], [0 4], [0 4], [0 0], [0 0], [0 4], [0 0], [0 0],

--- a/src/sage/dynamics/complex_dynamics/mandel_julia.py
+++ b/src/sage/dynamics/complex_dynamics/mandel_julia.py
@@ -167,7 +167,7 @@ def mandelbrot_plot(f=None, **kwds):
         sage: B.<c> = CC[]
         sage: R.<z> = B[]
         sage: f = z^5 + c
-        sage: mandelbrot_plot(f)
+        sage: mandelbrot_plot(f)  # long time
         500x500px 24-bit RGB image
 
     When the polynomial is defined over a multivariate polynomial ring it is
@@ -175,7 +175,7 @@ def mandelbrot_plot(f=None, **kwds):
 
         sage: R.<a,b> = CC[]
         sage: f = a^2 + b^3
-        sage: mandelbrot_plot(f, parameter=b)
+        sage: mandelbrot_plot(f, parameter=b)  # long time
         500x500px 24-bit RGB image
 
     Interact functionality is not implemented for general polynomial maps::
@@ -593,7 +593,7 @@ def julia_plot(f=None, **kwds):
 
         sage: R.<z> = CC[]
         sage: f = z^3 - z + 1
-        sage: julia_plot(f)
+        sage: julia_plot(f)  # long time
         500x500px 24-bit RGB image
 
     To display an interactive plot of the Julia set in the Notebook,

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -1596,10 +1596,10 @@ class Polyhedron_base6(Polyhedron_base5):
 
             sage: D = polytopes.dodecahedron()                                  # optional - sage.rings.number_field
             sage: E3 = EuclideanSpace(3)                                        # optional - sage.rings.number_field    # optional - sage.symbolic
-            sage: submanifolds = [                                              # optional - sage.rings.number_field    # optional - sage.symbolic  # long time
+            sage: submanifolds = [                               # long time    # optional - sage.rings.number_field    # optional - sage.symbolic
             ....:     F.as_polyhedron().affine_hull_manifold(name=f'F{i}', orthogonal=True, ambient_space=E3)
             ....:     for i, F in enumerate(D.facets())]
-            sage: sum(FM.plot({}, srange(-2, 2, 0.1), srange(-2, 2, 0.1), opacity=0.2)  # not tested                    # optional - sage.symbolic  # optional - sage.plot  # optional - sage.rings.number_field  # long time
+            sage: sum(FM.plot({}, srange(-2, 2, 0.1), srange(-2, 2, 0.1), opacity=0.2)  # not tested    # long time     # optional - sage.symbolic  # optional - sage.plot  # optional - sage.rings.number_field
             ....:     for FM in submanifolds) + D.plot()
             Graphics3d Object
 

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -1596,10 +1596,10 @@ class Polyhedron_base6(Polyhedron_base5):
 
             sage: D = polytopes.dodecahedron()                                  # optional - sage.rings.number_field
             sage: E3 = EuclideanSpace(3)                                        # optional - sage.rings.number_field    # optional - sage.symbolic
-            sage: submanifolds = [                                              # optional - sage.rings.number_field    # optional - sage.symbolic
+            sage: submanifolds = [                                              # optional - sage.rings.number_field    # optional - sage.symbolic  # long time
             ....:     F.as_polyhedron().affine_hull_manifold(name=f'F{i}', orthogonal=True, ambient_space=E3)
             ....:     for i, F in enumerate(D.facets())]
-            sage: sum(FM.plot({}, srange(-2, 2, 0.1), srange(-2, 2, 0.1), opacity=0.2)  # not tested                    # optional - sage.symbolic  # optional - sage.plot  # optional - sage.rings.number_field
+            sage: sum(FM.plot({}, srange(-2, 2, 0.1), srange(-2, 2, 0.1), opacity=0.2)  # not tested                    # optional - sage.symbolic  # optional - sage.plot  # optional - sage.rings.number_field  # long time
             ....:     for FM in submanifolds) + D.plot()
             Graphics3d Object
 

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -2305,7 +2305,7 @@ def pseudo_partition_graph(int m, int a):
     EXAMPLES::
 
         sage: from sage.graphs.generators.distance_regular import *
-        sage: pseudo_partition_graph(6, 1)
+        sage: pseudo_partition_graph(6, 1)  # long time
         Folded Johnson graph with parameters 12,6: Graph on 462 vertices
 
     Not all graphs built with this function are pseudo partition graphs as

--- a/src/sage/groups/libgap_mixin.py
+++ b/src/sage/groups/libgap_mixin.py
@@ -545,7 +545,7 @@ class GroupMixinLibGAP():
             [ 1  1 -1]
             [ 2 -1  0]
             [ 1  1  1]
-            sage: MatrixGroup(SymmetricGroup(5)).character_table()
+            sage: MatrixGroup(SymmetricGroup(5)).character_table()  # long time
             [ 1 -1 -1  1 -1  1  1]
             [ 4  0  1 -1 -2  1  0]
             [ 5  1 -1  0 -1 -1  1]

--- a/src/sage/interacts/library.py
+++ b/src/sage/interacts/library.py
@@ -1548,7 +1548,7 @@ def function_tool(f, g, xrange, yrange, a, action, do_plot):
     it will simply return the underlying HTML and Sage code which
     creates the mathlet::
 
-        sage: interacts.calculus.function_tool()
+        sage: interacts.calculus.function_tool()  # long time
         ...Interactive function <function function_tool at ...> with 7 widgets
           f: EvalText(value='sin(x)', description='f')
           g: EvalText(value='cos(x)', description='g')
@@ -1678,7 +1678,7 @@ def julia(expo, c_real, c_imag, iterations, zoom_x, zoom_y, plot_points, dpi):
     it will simply return the underlying HTML and Sage code which
     creates the mathlet::
 
-        sage: interacts.fractals.julia()
+        sage: interacts.fractals.julia()  # long time
         ...Interactive function <function julia at ...> with 8 widgets
           expo: FloatSlider(value=2.0, description='expo', max=10.0, min=-10.0)
           c_real: FloatSlider(value=0.5, description='real part const.', max=2.0, min=-2.0, step=0.01)
@@ -1730,7 +1730,7 @@ def mandelbrot(expo, iterations, zoom_x, zoom_y, plot_points, dpi):
     it will simply return the underlying HTML and Sage code which
     creates the mathlet::
 
-        sage: interacts.fractals.mandelbrot()
+        sage: interacts.fractals.mandelbrot()  # long time
         ...Interactive function <function mandelbrot at ...> with 6 widgets
           expo: FloatSlider(value=2.0, description='expo', max=10.0, min=-10.0)
           iterations: IntSlider(value=20, description='# iterations', min=1)
@@ -1775,7 +1775,7 @@ def cellular_automaton(N, rule_number, size):
     it will simply return the underlying HTML and Sage code which
     creates the mathlet::
 
-        sage: interacts.fractals.cellular_automaton()
+        sage: interacts.fractals.cellular_automaton()  # long time
         ...Interactive function <function cellular_automaton at ...> with 3 widgets
           N: IntSlider(value=100, description='Number of iterations', max=500, min=1)
           rule_number: IntSlider(value=110, description='Rule number', max=255)
@@ -1834,7 +1834,7 @@ def polar_prime_spiral(interval, show_factors, highlight_primes, show_curves, n,
     it will simply return the underlying HTML and Sage code which
     creates the mathlet::
 
-        sage: sage.interacts.algebra.polar_prime_spiral()
+        sage: sage.interacts.algebra.polar_prime_spiral()  # long time
         ...Interactive function <function polar_prime_spiral at ...> with 6 widgets
           interval: IntRangeSlider(value=(1, 1000), description='range', max=4000, min=1, step=10)
           show_factors: Checkbox(value=True, description='show_factors')

--- a/src/sage/manifolds/differentiable/affine_connection.py
+++ b/src/sage/manifolds/differentiable/affine_connection.py
@@ -289,7 +289,7 @@ class AffineConnection(SageObject):
         True
         sage: nab.restrict(V)(a.restrict(U)) == da.restrict(W)
         True
-        sage: nab.restrict(U)(a.restrict(V)) == da.restrict(W)
+        sage: nab.restrict(U)(a.restrict(V)) == da.restrict(W)  # long time
         True
 
     Same examples with SymPy as the engine for symbolic calculus::
@@ -1918,17 +1918,17 @@ class AffineConnection(SageObject):
             ....:     for j in M.irange():
             ....:         for k in M.irange():
             ....:             nab.add_coef(eV)[i,j,k] = nab.coef(eVW)[i,j,k,c_uvW].expr()
-            sage: r = nab.riemann() ; r
+            sage: r = nab.riemann() ; r     # long time
             Tensor field of type (1,3) on the 2-dimensional differentiable
              manifold M
-            sage: r.parent()
+            sage: r.parent()                # long time
             Module T^(1,3)(M) of type-(1,3) tensors fields on the 2-dimensional
              differentiable manifold M
-            sage: r.display(eU)
+            sage: r.display(eU)             # long time
             (x^2*y - x*y^2) ∂/∂x⊗dx⊗dx⊗dy + (-x^2*y + x*y^2) ∂/∂x⊗dx⊗dy⊗dx + ∂/∂x⊗dy⊗dx⊗dy
              - ∂/∂x⊗dy⊗dy⊗dx - (x^2 - 1)*y ∂/∂y⊗dx⊗dx⊗dy + (x^2 - 1)*y ∂/∂y⊗dx⊗dy⊗dx
              + (-x^2*y + x*y^2) ∂/∂y⊗dy⊗dx⊗dy + (x^2*y - x*y^2) ∂/∂y⊗dy⊗dy⊗dx
-            sage: r.display(eV)
+            sage: r.display(eV)             # long time
             (1/32*u^3 - 1/32*u*v^2 - 1/32*v^3 + 1/32*(u^2 + 4)*v - 1/8*u - 1/4) ∂/∂u⊗du⊗du⊗dv
              + (-1/32*u^3 + 1/32*u*v^2 + 1/32*v^3 - 1/32*(u^2 + 4)*v + 1/8*u + 1/4) ∂/∂u⊗du⊗dv⊗du
              + (1/32*u^3 - 1/32*u*v^2 + 3/32*v^3 - 1/32*(3*u^2 - 4)*v - 1/8*u + 1/4) ∂/∂u⊗dv⊗du⊗dv
@@ -1941,20 +1941,20 @@ class AffineConnection(SageObject):
         The same computation parallelized on 2 cores::
 
             sage: Parallelism().set(nproc=2)
-            sage: r_backup = r
+            sage: r_backup = r              # long time
             sage: nab = M.affine_connection('nabla', r'\nabla')
             sage: nab[0,0,0], nab[0,1,0], nab[1,0,1] = x, x-y, x*y
             sage: for i in M.irange():
             ....:     for j in M.irange():
             ....:         for k in M.irange():
             ....:             nab.add_coef(eV)[i,j,k] = nab.coef(eVW)[i,j,k,c_uvW].expr()
-            sage: r = nab.riemann() ; r
+            sage: r = nab.riemann() ; r     # long time
             Tensor field of type (1,3) on the 2-dimensional differentiable
              manifold M
-            sage: r.parent()
+            sage: r.parent()                # long time
             Module T^(1,3)(M) of type-(1,3) tensors fields on the 2-dimensional
              differentiable manifold M
-            sage: r == r_backup
+            sage: r == r_backup             # long time
             True
             sage: Parallelism().set(nproc=1)  # switch off parallelization
 
@@ -2178,13 +2178,13 @@ class AffineConnection(SageObject):
             sage: v = M.vector_field()
             sage: v[:] = (x*y, z^2-3*x, z+2*y)
             sage: b = M.default_frame()
-            sage: for j in M.irange():  # check on M's default frame
+            sage: for j in M.irange():  # check on M's default frame  # long time
             ....:     nab(b[j]).contract(v) == \
             ....:      sum( nab.connection_form(i,j)(v)*b[i] for i in M.irange())
             True
             True
             True
-            sage: for j in M.irange():  # check on frame e
+            sage: for j in M.irange():  # check on frame e  # long time
             ....:     nab(e[j]).contract(v) == \
             ....:      sum( nab.connection_form(i,j,e)(v)*e[i] for i in M.irange())
             True
@@ -2271,10 +2271,10 @@ class AffineConnection(SageObject):
             sage: ef = e.coframe()
             sage: ef[1][:], ef[2][:], ef[3][:]
             ([1/y, 0, 0], [0, 1/z, 0], [0, 0, 1/x])
-            sage: nab.torsion_form(1, e)
+            sage: nab.torsion_form(1, e)  # long time
             2-form torsion (1) of connection nabla w.r.t. Vector frame
              (M, (e_1,e_2,e_3)) on the 3-dimensional differentiable manifold M
-            sage: nab.torsion_form(1, e).comp(e)[:]
+            sage: nab.torsion_form(1, e).comp(e)[:]  # long time
             [                       0                   -x^2*z          (x*y^2 + x*y)*z]
             [                   x^2*z                        0  (x^4 - x^3 + x*y^2)*z/y]
             [        -(x*y^2 + x*y)*z -(x^4 - x^3 + x*y^2)*z/y                        0]

--- a/src/sage/manifolds/differentiable/multivectorfield.py
+++ b/src/sage/manifolds/differentiable/multivectorfield.py
@@ -1393,25 +1393,29 @@ class MultivectorFieldParal(AlternatingContrTensor, TensorFieldParal):
 
         Let us check the graded Leibniz rule for `p=1` and `q=1`::
 
-            sage: a.bracket(b.wedge(c)) == a.bracket(b).wedge(c) + b.wedge(a.bracket(c))
+            sage: a.bracket(b.wedge(c)) == a.bracket(b).wedge(c) + b.wedge(a.bracket(c))  # long time
             True
 
         as well as for `p=2` and `q=1`::
 
-            sage: c.bracket(a.wedge(b)) == c.bracket(a).wedge(b) - a.wedge(c.bracket(b))
+            sage: c.bracket(a.wedge(b)) == c.bracket(a).wedge(b) - a.wedge(c.bracket(b))  # long time
             True
 
         Finally let us check the graded Jacobi identity for `p=1`, `q=1` and
         `r=2`::
 
-            sage: a.bracket(b.bracket(c)) + b.bracket(c.bracket(a)) \
-            ....: + c.bracket(a.bracket(b)) == 0
+            sage: a_bc = a.bracket(b.bracket(c))  # long time
+            sage: b_ca = b.bracket(c.bracket(a))  # long time
+            sage: c_ab = c.bracket(a.bracket(b))  # long time
+            sage: a_bc + b_ca + c_ab == 0         # long time
             True
 
         as well as for `p=1`, `q=2` and `r=2`::
 
-            sage: a.bracket(c.bracket(d)) + c.bracket(d.bracket(a)) \
-            ....: - d.bracket(a.bracket(c)) == 0
+            sage: a_cd = a.bracket(c.bracket(d))  # long time
+            sage: c_da = c.bracket(d.bracket(a))  # long time
+            sage: d_ac = d.bracket(a.bracket(c))  # long time
+            sage: a_cd + c_da - d_ac == 0         # long time
             True
 
         """

--- a/src/sage/manifolds/differentiable/symplectic_form.py
+++ b/src/sage/manifolds/differentiable/symplectic_form.py
@@ -290,9 +290,9 @@ class SymplecticForm(DiffForm):
 
             sage: from sage.manifolds.differentiable.symplectic_form import SymplecticForm
             sage: M = manifolds.Sphere(2, coordinates='stereographic')
-            sage: vol_form = M.induced_metric().volume_form()
-            sage: omega = SymplecticForm.wrap(vol_form, 'omega', r'\omega')
-            sage: omega.display()
+            sage: vol_form = M.induced_metric().volume_form()                   # long time
+            sage: omega = SymplecticForm.wrap(vol_form, 'omega', r'\omega')     # long time
+            sage: omega.display()                                               # long time
             omega = -4/(y1^4 + y2^4 + 2*(y1^2 + 1)*y2^2 + 2*y1^2 + 1) dy1∧dy2
         """
         if form.degree() != 2:

--- a/src/sage/modular/local_comp/type_space.py
+++ b/src/sage/modular/local_comp/type_space.py
@@ -373,15 +373,15 @@ class TypeSpace(SageObject):
         Test that :trac:`13158` is fixed::
 
             sage: f = Newforms(256,names='a')[0]
-            sage: T = TypeSpace(f,2)
-            sage: g = T.minimal_twist()
-            sage: g[0:3]
+            sage: T = TypeSpace(f,2)                            # long time
+            sage: g = T.minimal_twist()                         # long time
+            sage: g[0:3]                                        # long time
             [0, 1, 0]
-            sage: str(g[3]) in ('a', '-a', '-1/2*a', '1/2*a')
+            sage: str(g[3]) in ('a', '-a', '-1/2*a', '1/2*a')   # long time
             True
-            sage: g[4:]
+            sage: g[4:]                                         # long time
             []
-            sage: g.level()
+            sage: g.level()                                     # long time
             64
         """
         if self.is_minimal():

--- a/src/sage/modular/modform/ambient_R.py
+++ b/src/sage/modular/modform/ambient_R.py
@@ -91,12 +91,12 @@ class ModularFormsAmbient_R(ambient.ModularFormsAmbient):
 
         This checks that :trac:`13445` is fixed::
 
-            sage: M = ModularForms(Gamma1(29), base_ring=GF(29))
+            sage: M = ModularForms(Gamma0(11), base_ring=GF(11))
             sage: S = M.cuspidal_subspace()
             sage: 0 in [f.valuation() for f in S.basis()]
             False
             sage: from sage.modular.dims import dimension_cusp_forms
-            sage: len(S.basis()) == dimension_cusp_forms(Gamma1(29), 2)
+            sage: len(S.basis()) == dimension_cusp_forms(Gamma0(11), 2)
             True
         """
         if prec is None:

--- a/src/sage/modular/modform/cuspidal_submodule.py
+++ b/src/sage/modular/modform/cuspidal_submodule.py
@@ -379,7 +379,7 @@ class CuspidalSubmodule_wt1_gH(CuspidalSubmodule):
         A more elaborate example (two Galois-conjugate characters each giving a
         2-dimensional space)::
 
-            sage: CuspForms(GammaH(124, [85]), 1).q_expansion_basis()
+            sage: CuspForms(GammaH(124, [85]), 1).q_expansion_basis()  # long time
             [
             q - q^4 - q^6 + O(q^7),
             q^2 + O(q^7),

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -2304,13 +2304,22 @@ class Newform(ModularForm_abstract):
 
         EXAMPLES::
 
-            sage: f = Newforms(575, 2, names='a')[4]
-            sage: g, chi = f.minimal_twist(5)
+            sage: f = Newforms(121, 2)[3]
+            sage: g, chi = f.minimal_twist()
             sage: g
-            q + a*q^2 - a*q^3 - 2*q^4 + (1/2*a + 2)*q^5 + O(q^6)
+            q - 2*q^2 - q^3 + 2*q^4 + q^5 + O(q^6)
             sage: chi
+            Dirichlet character modulo 11 of conductor 11 mapping 2 |--> -1
+            sage: f.twist(chi, level=11) == g
+            True
+
+            sage: f = Newforms(575, 2, names='a')[4]    # long time
+            sage: g, chi = f.minimal_twist(5)           # long time
+            sage: g                                     # long time
+            q + a*q^2 - a*q^3 - 2*q^4 + (1/2*a + 2)*q^5 + O(q^6)
+            sage: chi                                   # long time
             Dirichlet character modulo 5 of conductor 5 mapping 2 |--> 1/2*a
-            sage: f.twist(chi, level=g.level()) == g
+            sage: f.twist(chi, level=g.level()) == g    # long time
             True
         """
         if p is None:

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -1074,7 +1074,7 @@ class ModularForm_abstract(ModuleElement):
 
             sage: F = Newforms(1,12)[0]
             sage: chi = DirichletGroup(7).0
-            sage: abs(F.symsquare_lseries(chi).check_functional_equation()) < 1e-5
+            sage: abs(F.symsquare_lseries(chi).check_functional_equation()) < 1e-5  # long time
             True
 
         AUTHORS:
@@ -2736,14 +2736,14 @@ class ModularFormElement_elliptic_curve(Newform):
 
         EXAMPLES::
 
-            sage: E = EllipticCurve('5077a')
+            sage: E = EllipticCurve('389a')
             sage: f = E.modular_form()
             sage: f
-            q - 2*q^2 - 3*q^3 + 2*q^4 - 4*q^5 + O(q^6)
+            q - 2*q^2 - 2*q^3 + 2*q^4 - 3*q^5 + O(q^6)
             sage: f.q_expansion(10)
-            q - 2*q^2 - 3*q^3 + 2*q^4 - 4*q^5 + 6*q^6 - 4*q^7 + 6*q^9 + O(q^10)
+            q - 2*q^2 - 2*q^3 + 2*q^4 - 3*q^5 + 4*q^6 - 5*q^7 + q^9 + O(q^10)
             sage: f.parent()
-            Modular Forms space of dimension 423 for Congruence Subgroup Gamma0(5077) of weight 2 over Rational Field
+            Modular Forms space of dimension 33 for Congruence Subgroup Gamma0(389) of weight 2 over Rational Field
 
             sage: E = EllipticCurve('37a')
             sage: f = E.modular_form() ; f

--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -808,14 +808,16 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
         Test that the memory leak in :trac:`31625` is fixed::
 
             sage: import gc
+            sage: gc.freeze()
             sage: L = IntegralLattice("A2")
-            sage: for k in range(1,500):
+            sage: for k in range(1,500):  # long time
             ....:     G = L.twist(k)
             ....:     D = G.discriminant_group()
             sage: tmp = gc.collect()
             sage: tmp = gc.collect()
             sage: len([a for a in gc.get_objects() if type(a)==type(L)])<=300
             True
+            sage: gc.unfreeze()
         """
         from sage.modules.torsion_quadratic_module import TorsionQuadraticModule
         D = TorsionQuadraticModule(self.dual_lattice(), self)

--- a/src/sage/parallel/decorate.py
+++ b/src/sage/parallel/decorate.py
@@ -517,10 +517,10 @@ def fork(f=None, timeout=0, verbose=False):
         sage: a
         5
 
-    We use ``fork`` to make sure that the function terminates after one
-    second, no matter what::
+    We use ``fork`` to make sure that the function terminates after 100 ms,
+    no matter what::
 
-        sage: @fork(timeout=1, verbose=True)
+        sage: @fork(timeout=0.1, verbose=True)
         ....: def g(n, m): return factorial(n).ndigits() + m
         sage: g(5, m=5)
         8
@@ -556,7 +556,9 @@ def fork(f=None, timeout=0, verbose=False):
 
         sage: cython('def f(): print(<char*>0)')                            # optional - sage.misc.cython
         sage: @fork
-        ....: def g(): f()
+        ....: def g():
+        ....:     os.environ["CYSIGNALS_CRASH_NDEBUG"]="yes" # skip enhanced backtrace (it is slow)
+        ....:     f()
         sage: print("this works"); g()                                      # optional - sage.misc.cython
         this works...
         <BLANKLINE>

--- a/src/sage/plot/animate.py
+++ b/src/sage/plot/animate.py
@@ -33,18 +33,18 @@ The sine function::
     sage: x = SR.var("x")
     sage: sines = [plot(c*sin(x), (-2*pi,2*pi), color=Color(c,0,0), ymin=-1, ymax=1) for c in sxrange(0,1,.2)]
     sage: a = animate(sines)
-    sage: a         # optional -- ImageMagick
+    sage: print(a)
     Animation with 5 frames
-    sage: a.show()  # optional -- ImageMagick
+    sage: a.show()                  # optional -- ImageMagick   # long time
 
 Animate using FFmpeg_ instead of ImageMagick::
 
-    sage: f = tmp_filename(ext='.gif')
-    sage: a.save(filename=f, use_ffmpeg=True) # optional -- ffmpeg
+    sage: a.show(use_ffmpeg=True)   # optional -- FFmpeg        # long time
 
 Animate as an APNG_::
 
-    sage: a.apng()  # long time
+    sage: a.apng(show_path=True)    # long time
+    Animation saved to ....png.
 
 An animated :class:`sage.plot.multigraphics.GraphicsArray` of rotating ellipses::
 
@@ -57,7 +57,7 @@ A simple animation of a circle shooting up to the right::
 
     sage: c = animate([circle((i,i), 1-1/(i+1), hue=i/10) for i in srange(0,2,0.2)],
     ....:               xmin=0,ymin=0,xmax=2,ymax=2,figsize=[2,2])
-    sage: c.show() # optional -- ImageMagick
+    sage: c.show()  # optional -- ImageMagick   # long time
 
 
 Animations of 3d objects::
@@ -70,7 +70,7 @@ Animations of 3d objects::
     Graphics3d Object
     sage: sp[-1]     # last frame
     Graphics3d Object
-    sage: sp.show()  # optional -- ImageMagick
+    sage: sp.show()  # optional -- ImageMagick   # long time
 
     sage: (x,y,z) = SR.var("x,y,z")
     sage: def frame(t):
@@ -87,7 +87,7 @@ illustrated by the following example::
 
     sage: t = SR.var("t")
     sage: a = animate((sin(c*pi*t) for c in sxrange(1,2,.2)))
-    sage: a.show()  # optional -- ImageMagick
+    sage: a.show()  # optional -- ImageMagick   # long time
 
 
 AUTHORS:
@@ -135,7 +135,7 @@ def animate(frames, **kwds):
 
         sage: t = SR.var("t")
         sage: a = animate((cos(c*pi*t) for c in sxrange(1,2,.2)))
-        sage: a.show()  # optional -- ImageMagick
+        sage: a.show()  # optional -- ImageMagick   # long time
 
     See also :mod:`sage.plot.animate` for more examples.
     """
@@ -164,12 +164,12 @@ class Animation(WithEqualityById, SageObject):
         sage: x = SR.var("x")
         sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.3)],
         ....:                xmin=0, xmax=2*pi, figsize=[2,1])
-        sage: a                 # optional -- ImageMagick   # long time
+        sage: print(a)
         Animation with 21 frames
-        sage: a[:5]             # optional -- ImageMagick
+        sage: print(a[:5])
         Animation with 5 frames
         sage: a.show()          # optional -- ImageMagick   # long time
-        sage: a[:5].show()      # optional -- ImageMagick
+        sage: a[:5].show()      # optional -- ImageMagick   # long time
 
     The :meth:`show` method takes arguments to specify the
     delay between frames (measured in hundredths of a second, default
@@ -177,7 +177,7 @@ class Animation(WithEqualityById, SageObject):
     means to iterate forever). To iterate 4 times with half a second
     between each frame::
 
-        sage: a.show(delay=50, iterations=4) # optional -- ImageMagick # long time
+        sage: a.show(delay=50, iterations=4)  # optional -- ImageMagick   # long time
 
     An animation of drawing a parabola::
 
@@ -188,7 +188,7 @@ class Animation(WithEqualityById, SageObject):
         ....:       L += line([(i,i^2),(i+step,(i+step)^2)], rgbcolor=(1,0,0), thickness=2)
         ....:       v.append(L)
         sage: a = animate(v, xmin=0, ymin=0)
-        sage: a.show() # optional -- ImageMagick
+        sage: a.show()          # optional -- ImageMagick   # long time
         sage: show(L)
 
     TESTS:
@@ -204,7 +204,7 @@ class Animation(WithEqualityById, SageObject):
         sage: x = SR.var("x")
         sage: a = animate([plot(sin(x + float(k)), (0, 2*pi), ymin=-5, ymax=5)
         ....:              for k in srange(0,2*pi,0.3)])
-        sage: a.show() # optional -- ImageMagick   # long time
+        sage: a.show()  # optional -- ImageMagick   # long time
 
     Do not convert input iterator to a list, but ensure that
     the frame count is known after rendering the frames::
@@ -221,7 +221,7 @@ class Animation(WithEqualityById, SageObject):
         <generator object ...
 
         sage: from sage.plot.animate import Animation
-        sage: hash(Animation()) # random
+        sage: hash(Animation())  # random
         140658972348064
     """
     def __init__(self, v=None, **kwds):
@@ -235,8 +235,9 @@ class Animation(WithEqualityById, SageObject):
             sage: x = SR.var("x")
             sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.3)],  # indirect doctest
             ....:                xmin=0, xmax=2*pi, figsize=[2,1])
-            sage: a           # optional -- ImageMagick   # long time
+            sage: print(a)
             Animation with 21 frames
+            sage: a.show()      # optional -- ImageMagick   # long time
         """
         self._frames = v
         self._kwds = kwds
@@ -283,14 +284,14 @@ class Animation(WithEqualityById, SageObject):
 
             sage: a = animate([circle((i,-i), 1-1/(i+1), hue=i/10) for i in srange(0,2,0.2)],
             ....:               xmin=0,ymin=-2,xmax=2,ymax=0,figsize=[2,2])
-            sage: a           # optional -- ImageMagick
+            sage: print(a)
             Animation with 10 frames
-            sage: frame2 = a[2]  # indirect doctest
+            sage: a.show()          # optional -- ImageMagick   # long time
+            sage: frame2 = a[2]     # indirect doctest
             sage: frame2.show()
-            sage: a.show() # optional -- ImageMagick
-            sage: a[3:7]   # optional -- ImageMagick   # indirect doctest
+            sage: print(a[3:7])     # indirect doctest
             Animation with 4 frames
-            sage: a[3:7].show() # optional -- ImageMagick
+            sage: a[3:7].show()     # optional -- ImageMagick   # long time
         """
         if isinstance(i, slice):
             return Animation(self._frames[i], **self._kwds)
@@ -305,7 +306,7 @@ class Animation(WithEqualityById, SageObject):
 
             sage: a = animate([circle((i,-i), 1-1/(i+1), hue=i/10) for i in srange(0,2,0.2)],
             ....:               xmin=0,ymin=-2,xmax=2,ymax=0,figsize=[2,2])
-            sage: a           # optional -- ImageMagick
+            sage: print(a)
             Animation with 10 frames
             sage: a._repr_()
             'Animation with 10 frames'
@@ -323,19 +324,25 @@ class Animation(WithEqualityById, SageObject):
 
         EXAMPLES::
 
-            sage: a = animate([circle((i,0),1) for i in srange(0,2,0.4)],
-            ....:             xmin=0, ymin=-1, xmax=3, ymax=1,
-            ....:             figsize=[3,1], ticks=[1,1])
+            sage: a = animate([line([(0,0),(1,i)],hue=0/3) for i in range(2)],
+            ....:             xmin=0, ymin=0, xmax=1, ymax=1,
+            ....:             figsize=[1,1], axes=False)
+            sage: print(a)
+            Animation with 2 frames
             sage: a.show()        # optional -- ImageMagick
-            sage: b = animate([circle((0,i),1,hue=0) for i in srange(0,2,0.4)],
-            ....:             xmin=0, ymin=-1, xmax=2, ymax=3,
-            ....:             figsize=[1,2], ticks=[1,1])
+            sage: b = animate([line([(0,0),(i,1)],hue=2/3) for i in range(2)],
+            ....:             xmin=0, ymin=0, xmax=1, ymax=1,
+            ....:             figsize=[1,1], axes=False)
+            sage: print(b)
+            Animation with 2 frames
             sage: b.show()        # optional -- ImageMagick
             sage: s = a+b         # indirect doctest
+            sage: print(s)
+            Animation with 2 frames
             sage: len(a), len(b)
-            (5, 5)
+            (2, 2)
             sage: len(s)
-            5
+            2
             sage: s.show()        # optional -- ImageMagick
         """
         if not isinstance(other, Animation):
@@ -357,18 +364,26 @@ class Animation(WithEqualityById, SageObject):
 
         EXAMPLES::
 
-            sage: a = animate([circle((i,0),1,thickness=20*i) for i in srange(0,2,0.4)],
-            ....:                xmin=0, ymin=-1, xmax=3, ymax=1, figsize=[2,1], axes=False)
+            sage: a = animate([line([(0,0),(1,i)],hue=0/3) for i in range(2)],
+            ....:             xmin=0, ymin=0, xmax=1, ymax=1,
+            ....:             figsize=[1,1], axes=False)
+            sage: print(a)
+            Animation with 2 frames
             sage: a.show()             # optional -- ImageMagick
-            sage: b = animate([circle((0,i),1,hue=0,thickness=20*i) for i in srange(0,2,0.4)],
-            ....:                xmin=0, ymin=-1, xmax=1, ymax=3, figsize=[1,2], axes=False)
+            sage: b = animate([line([(0,0),(i,1)],hue=2/3) for i in range(2)],
+            ....:             xmin=0, ymin=0, xmax=1, ymax=1,
+            ....:             figsize=[1,1], axes=False)
+            sage: print(b)
+            Animation with 2 frames
             sage: b.show()             # optional -- ImageMagick
             sage: p = a*b              # indirect doctest
             sage: len(a), len(b)
-            (5, 5)
+            (2, 2)
             sage: len(p)
-            10
-            sage: (a*b).show()         # optional -- ImageMagick
+            4
+            sage: print(p)
+            Animation with 4 frames
+            sage: p.show()             # optional -- ImageMagick
         """
         if not isinstance(other, Animation):
             other = Animation(other)
@@ -491,23 +506,24 @@ class Animation(WithEqualityById, SageObject):
         EXAMPLES::
 
             sage: E = EllipticCurve('37a')
-            sage: v = [E.change_ring(GF(p)).plot(pointsize=30) for p in [97, 101, 103, 107]]
+            sage: v = [E.change_ring(GF(p)).plot(pointsize=30) for p in [97, 101, 103]]
             sage: a = animate(v, xmin=0, ymin=0, axes=False)
-            sage: a        # optional -- ImageMagick
-            Animation with 4 frames
-            sage: a.show() # optional -- ImageMagick
+            sage: print(a)
+            Animation with 3 frames
+            sage: a.show()  # optional -- ImageMagick
 
         Modify the default arrangement of array::
 
             sage: g = a.graphics_array(); print(g)
-            Graphics Array of size 2 x 3
-            sage: g.show(figsize=[6,3])  # not tested
+            Graphics Array of size 1 x 3
+            sage: g.show(figsize=[6,3])
 
         Specify different arrangement of array and save it with a given file name::
 
             sage: g = a.graphics_array(ncols=2); print(g)
             Graphics Array of size 2 x 2
-            sage: f = tmp_filename(ext='.png')
+            sage: f = tmp_filename(ext='.png'); print(f)
+            ...png
             sage: g.save(f)
 
         Frames can be specified as a generator too; it is internally converted to a list::
@@ -515,7 +531,7 @@ class Animation(WithEqualityById, SageObject):
             sage: t = SR.var("t")
             sage: b = animate((plot(sin(c*pi*t)) for c in sxrange(1,2,.2)))
             sage: g = b.graphics_array()
-            sage: g
+            sage: print(g)
             Graphics Array of size 2 x 3
         """
         ncols = int(ncols)
@@ -567,12 +583,12 @@ class Animation(WithEqualityById, SageObject):
             ....:             xmin=0, xmax=2*pi, ymin=-1, ymax=1, figsize=[2,1])
             sage: td = tmp_dir()
             sage: a.gif()              # not tested
-            sage: a.gif(savefile=td + 'my_animation.gif', delay=35, iterations=3)  # optional -- ImageMagick
-            sage: with open(td + 'my_animation.gif', 'rb') as f: print(b'GIF8' in f.read())  # optional -- ImageMagick
+            sage: a.gif(savefile=td + 'my_animation.gif', delay=35, iterations=3)               # optional -- ImageMagick   # long time
+            sage: with open(td + 'my_animation.gif', 'rb') as f: print(b'GIF8' in f.read())     # optional -- ImageMagick   # long time
             True
-            sage: a.gif(savefile=td + 'my_animation.gif', show_path=True) # optional -- ImageMagick
+            sage: a.gif(savefile=td + 'my_animation.gif', show_path=True)                       # optional -- ImageMagick   # long time
             Animation saved to .../my_animation.gif.
-            sage: a.gif(savefile=td + 'my_animation_2.gif', show_path=True, use_ffmpeg=True) # optional -- ffmpeg
+            sage: a.gif(savefile=td + 'my_animation_2.gif', show_path=True, use_ffmpeg=True)    # optional -- ffmpeg        # long time
             Animation saved to .../my_animation_2.gif.
 
         .. NOTE::
@@ -643,7 +659,7 @@ class Animation(WithEqualityById, SageObject):
             sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.7)],
             ....:             xmin=0, xmax=2*pi, ymin=-1, ymax=1, figsize=[2,1])
             sage: td = tmp_dir()
-            sage: a._gif_from_imagemagick(savefile=td + 'new.gif') # optional -- imagemagick
+            sage: a._gif_from_imagemagick(savefile=td + 'new.gif')  # optional -- ImageMagick  # long time
 
         .. NOTE::
 
@@ -700,7 +716,7 @@ class Animation(WithEqualityById, SageObject):
         EXAMPLES::
 
             sage: x = SR.var("x")
-            sage: a = animate([plot(x^2 + n) for n in range(4)], ymin=0, ymax=4)
+            sage: a = animate([plot(x^2 + n) for n in range(2)], ymin=0, ymax=4)
             sage: from sage.repl.rich_output import get_display_manager
             sage: dm = get_display_manager()
             sage: a._rich_repr_(dm)       # optional -- ImageMagick
@@ -795,38 +811,38 @@ class Animation(WithEqualityById, SageObject):
             sage: x = SR.var("x")
             sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.7)],
             ....:                xmin=0, xmax=2*pi, figsize=[2,1])
-            sage: a.show()       # optional -- ImageMagick
+            sage: a.show()       # optional -- ImageMagick   # long time
 
         The preceding will loop the animation forever. If you want to show
         only three iterations instead::
 
-            sage: a.show(iterations=3)    # optional -- ImageMagick
+            sage: a.show(iterations=3)    # optional -- ImageMagick   # long time
 
         To put a half-second delay between frames::
 
-            sage: a.show(delay=50)        # optional -- ImageMagick
+            sage: a.show(delay=50)        # optional -- ImageMagick   # long time
 
         You can also make use of the HTML5 video element in the Sage Notebook::
 
-            sage: a.show(format="ogg")         # optional -- ffmpeg
-            sage: a.show(format="webm")        # optional -- ffmpeg
-            sage: a.show(format="mp4")         # optional -- ffmpeg
-            sage: a.show(format="webm", iterations=1)  # optional -- ffmpeg
+            sage: a.show(format="ogg")         # optional -- ffmpeg   # long time
+            sage: a.show(format="webm")        # optional -- ffmpeg   # long time
+            sage: a.show(format="mp4")         # optional -- ffmpeg   # long time
+            sage: a.show(format="webm", iterations=1)  # optional -- ffmpeg   # long time
 
         Other backends may support other file formats as well::
 
-            sage: a.show(format="flash")       # optional -- ffmpeg
-            sage: a.show(format="matroska")    # optional -- ffmpeg
-            sage: a.show(format="avi")         # optional -- ffmpeg
-            sage: a.show(format="wmv")         # optional -- ffmpeg
-            sage: a.show(format="quicktime")   # optional -- ffmpeg
+            sage: a.show(format="flash")       # optional -- ffmpeg   # long time
+            sage: a.show(format="matroska")    # optional -- ffmpeg   # long time
+            sage: a.show(format="avi")         # optional -- ffmpeg   # long time
+            sage: a.show(format="wmv")         # optional -- ffmpeg   # long time
+            sage: a.show(format="quicktime")   # optional -- ffmpeg   # long time
 
         TESTS:
 
         Use of positional parameters is discouraged, will likely get
         deprecated, but should still work for the time being::
 
-            sage: a.show(50, 3)           # optional -- ImageMagick
+            sage: a.show(50, 3)           # optional -- ImageMagick   # long time
 
         .. NOTE::
 
@@ -908,10 +924,10 @@ class Animation(WithEqualityById, SageObject):
             sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.7)],
             ....:             xmin=0, xmax=2*pi, ymin=-1, ymax=1, figsize=[2,1])
             sage: td = tmp_dir()
-            sage: a.ffmpeg(savefile=td + 'new.mpg')       # optional -- ffmpeg
-            sage: a.ffmpeg(savefile=td + 'new.avi')       # optional -- ffmpeg
-            sage: a.ffmpeg(savefile=td + 'new.gif')       # optional -- ffmpeg
-            sage: a.ffmpeg(savefile=td + 'new.mpg', show_path=True) # optional -- ffmpeg
+            sage: a.ffmpeg(savefile=td + 'new.mpg')       # optional -- ffmpeg   # long time
+            sage: a.ffmpeg(savefile=td + 'new.avi')       # optional -- ffmpeg   # long time
+            sage: a.ffmpeg(savefile=td + 'new.gif')       # optional -- ffmpeg   # long time
+            sage: a.ffmpeg(savefile=td + 'new.mpg', show_path=True) # optional -- ffmpeg   # long time
             Animation saved to .../new.mpg.
 
         .. NOTE::
@@ -925,7 +941,7 @@ class Animation(WithEqualityById, SageObject):
 
         TESTS::
 
-            sage: a.ffmpeg(output_format='gif',delay=30,iterations=5)     # optional -- ffmpeg
+            sage: a.ffmpeg(output_format='gif',delay=30,iterations=5)     # optional -- ffmpeg   # long time
         """
         from sage.features.ffmpeg import FFmpeg
         FFmpeg().require()
@@ -1044,7 +1060,7 @@ class Animation(WithEqualityById, SageObject):
         """
         pngdir = self.png()
         if savefile is None:
-            savefile = tmp_filename('.png')
+            savefile = tmp_filename(ext='.png')
         with open(savefile, "wb") as out:
             apng = APngAssembler(
                 out, len(self),
@@ -1090,10 +1106,10 @@ class Animation(WithEqualityById, SageObject):
             ....:             xmin=0, xmax=2*pi, ymin=-1, ymax=1, figsize=[2,1])
             sage: td = tmp_dir()
             sage: a.save()         # not tested
-            sage: a.save(td + 'wave.gif')   # optional -- ImageMagick
-            sage: a.save(td + 'wave.gif', show_path=True)   # optional -- ImageMagick
+            sage: a.save(td + 'wave.gif')                   # optional -- ImageMagick   # long time
+            sage: a.save(td + 'wave.gif', show_path=True)   # optional -- ImageMagick   # long time
             Animation saved to file .../wave.gif.
-            sage: a.save(td + 'wave.avi', show_path=True)   # optional -- ffmpeg
+            sage: a.save(td + 'wave.avi', show_path=True)   # optional -- ffmpeg        # long time
             Animation saved to file .../wave.avi.
             sage: a.save(td + 'wave0.sobj')
             sage: a.save(td + 'wave1.sobj', show_path=True)
@@ -1107,18 +1123,18 @@ class Animation(WithEqualityById, SageObject):
         Ensure that we can pass delay and iteration count to the saved
         GIF image (see :trac:`18176`)::
 
-            sage: a.save(td + 'wave.gif')   # optional -- ImageMagick
-            sage: with open(td + 'wave.gif', 'rb') as f: print(b'GIF8' in f.read())  # optional -- ImageMagick
+            sage: a.save(td + 'wave.gif')   # optional -- ImageMagick   # long time
+            sage: with open(td + 'wave.gif', 'rb') as f: print(b'GIF8' in f.read())  # optional -- ImageMagick   # long time
             True
-            sage: with open(td + 'wave.gif', 'rb') as f: print(b'!\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00' in f.read())  # optional -- ImageMagick
+            sage: with open(td + 'wave.gif', 'rb') as f: print(b'!\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00' in f.read())  # optional -- ImageMagick   # long time
             True
-            sage: a.save(td + 'wave.gif', delay=35)   # optional -- ImageMagick
-            sage: with open(td + 'wave.gif', 'rb') as f: print(b'GIF8' in f.read())  # optional -- ImageMagick
+            sage: a.save(td + 'wave.gif', delay=35)   # optional -- ImageMagick   # long time
+            sage: with open(td + 'wave.gif', 'rb') as f: print(b'GIF8' in f.read())  # optional -- ImageMagick   # long time
             True
-            sage: a.save(td + 'wave.gif', iterations=3)   # optional -- ImageMagick
-            sage: with open(td + 'wave.gif', 'rb') as f: print(b'!\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00' in f.read())  # optional -- ImageMagick
+            sage: a.save(td + 'wave.gif', iterations=3)   # optional -- ImageMagick   # long time
+            sage: with open(td + 'wave.gif', 'rb') as f: print(b'!\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00' in f.read())  # optional -- ImageMagick   # long time
             False
-            sage: with open(td + 'wave.gif', 'rb') as f:  # optional -- ImageMagick
+            sage: with open(td + 'wave.gif', 'rb') as f:  # optional -- ImageMagick   # long time
             ....:      check1 = b'!\xff\x0bNETSCAPE2.0\x03\x01\x02\x00\x00'
             ....:      check2 = b'!\xff\x0bNETSCAPE2.0\x03\x01\x03\x00\x00'
             ....:      data = f.read()

--- a/src/sage/plot/animate.py
+++ b/src/sage/plot/animate.py
@@ -1058,6 +1058,12 @@ class Animation(WithEqualityById, SageObject):
             ...
             ValueError: Chunk IHDR mismatch
 
+        TESTS::
+
+            sage: a = animate([])
+            sage: a.apng(show_path=True)
+            Animation saved to file ....png.
+
         """
         pngdir = self.png()
         if savefile is None:

--- a/src/sage/plot/animate.py
+++ b/src/sage/plot/animate.py
@@ -35,11 +35,11 @@ The sine function::
     sage: a = animate(sines)
     sage: print(a)
     Animation with 5 frames
-    sage: a.show()                  # optional -- ImageMagick   # long time
+    sage: a.show()                  # long time  # optional -- ImageMagick
 
 Animate using FFmpeg_ instead of ImageMagick::
 
-    sage: a.show(use_ffmpeg=True)   # optional -- FFmpeg        # long time
+    sage: a.show(use_ffmpeg=True)   # long time  # optional -- FFmpeg
 
 Animate as an APNG_::
 
@@ -51,13 +51,13 @@ An animated :class:`sage.plot.multigraphics.GraphicsArray` of rotating ellipses:
     sage: E = animate((graphics_array([[ellipse((0,0),a,b,angle=t,xmin=-3,xmax=3)+circle((0,0),3,color='blue') for a in range(1,3)] for b in range(2,4)]) for t in sxrange(0,pi/4,.15)))
     sage: str(E)    # animations produced from a generator do not have a known length
     'Animation with unknown number of frames'
-    sage: E.show()  # optional -- ImageMagick   # long time
+    sage: E.show()                  # long time  # optional -- ImageMagick
 
 A simple animation of a circle shooting up to the right::
 
     sage: c = animate([circle((i,i), 1-1/(i+1), hue=i/10) for i in srange(0,2,0.2)],
     ....:               xmin=0,ymin=0,xmax=2,ymax=2,figsize=[2,2])
-    sage: c.show()  # optional -- ImageMagick   # long time
+    sage: c.show()                  # long time  # optional -- ImageMagick
 
 
 Animations of 3d objects::
@@ -70,7 +70,7 @@ Animations of 3d objects::
     Graphics3d Object
     sage: sp[-1]     # last frame
     Graphics3d Object
-    sage: sp.show()  # optional -- ImageMagick   # long time
+    sage: sp.show()                 # long time  # optional -- ImageMagick
 
     sage: (x,y,z) = SR.var("x,y,z")
     sage: def frame(t):
@@ -78,7 +78,7 @@ Animations of 3d objects::
     sage: a = animate([frame(t) for t in srange(.01,1.5,.2)])
     sage: a[0]       # long time
     Graphics3d Object
-    sage: a.show()   # optional -- ImageMagick   # long time
+    sage: a.show()                  # long time  # optional -- ImageMagick
 
 If the input objects do not have a ``save_image`` method, then the
 animation object attempts to make an image by calling its internal
@@ -87,7 +87,7 @@ illustrated by the following example::
 
     sage: t = SR.var("t")
     sage: a = animate((sin(c*pi*t) for c in sxrange(1,2,.2)))
-    sage: a.show()  # optional -- ImageMagick   # long time
+    sage: a.show()                  # long time  # optional -- ImageMagick
 
 
 AUTHORS:
@@ -135,7 +135,7 @@ def animate(frames, **kwds):
 
         sage: t = SR.var("t")
         sage: a = animate((cos(c*pi*t) for c in sxrange(1,2,.2)))
-        sage: a.show()  # optional -- ImageMagick   # long time
+        sage: a.show()              # long time  # optional -- ImageMagick
 
     See also :mod:`sage.plot.animate` for more examples.
     """
@@ -168,8 +168,8 @@ class Animation(WithEqualityById, SageObject):
         Animation with 21 frames
         sage: print(a[:5])
         Animation with 5 frames
-        sage: a.show()          # optional -- ImageMagick   # long time
-        sage: a[:5].show()      # optional -- ImageMagick   # long time
+        sage: a.show()              # long time  # optional -- ImageMagick
+        sage: a[:5].show()          # long time  # optional -- ImageMagick
 
     The :meth:`show` method takes arguments to specify the
     delay between frames (measured in hundredths of a second, default
@@ -177,7 +177,7 @@ class Animation(WithEqualityById, SageObject):
     means to iterate forever). To iterate 4 times with half a second
     between each frame::
 
-        sage: a.show(delay=50, iterations=4)  # optional -- ImageMagick   # long time
+        sage: a.show(delay=50, iterations=4)  # long time  # optional -- ImageMagick
 
     An animation of drawing a parabola::
 
@@ -188,7 +188,7 @@ class Animation(WithEqualityById, SageObject):
         ....:       L += line([(i,i^2),(i+step,(i+step)^2)], rgbcolor=(1,0,0), thickness=2)
         ....:       v.append(L)
         sage: a = animate(v, xmin=0, ymin=0)
-        sage: a.show()          # optional -- ImageMagick   # long time
+        sage: a.show()              # long time  # optional -- ImageMagick
         sage: show(L)
 
     TESTS:
@@ -204,7 +204,7 @@ class Animation(WithEqualityById, SageObject):
         sage: x = SR.var("x")
         sage: a = animate([plot(sin(x + float(k)), (0, 2*pi), ymin=-5, ymax=5)
         ....:              for k in srange(0,2*pi,0.3)])
-        sage: a.show()  # optional -- ImageMagick   # long time
+        sage: a.show()              # long time  # optional -- ImageMagick
 
     Do not convert input iterator to a list, but ensure that
     the frame count is known after rendering the frames::
@@ -237,7 +237,7 @@ class Animation(WithEqualityById, SageObject):
             ....:                xmin=0, xmax=2*pi, figsize=[2,1])
             sage: print(a)
             Animation with 21 frames
-            sage: a.show()      # optional -- ImageMagick   # long time
+            sage: a.show()          # long time  # optional -- ImageMagick
         """
         self._frames = v
         self._kwds = kwds
@@ -286,12 +286,12 @@ class Animation(WithEqualityById, SageObject):
             ....:               xmin=0,ymin=-2,xmax=2,ymax=0,figsize=[2,2])
             sage: print(a)
             Animation with 10 frames
-            sage: a.show()          # optional -- ImageMagick   # long time
+            sage: a.show()          # long time  # optional -- ImageMagick
             sage: frame2 = a[2]     # indirect doctest
             sage: frame2.show()
             sage: print(a[3:7])     # indirect doctest
             Animation with 4 frames
-            sage: a[3:7].show()     # optional -- ImageMagick   # long time
+            sage: a[3:7].show()     # long time  # optional -- ImageMagick
         """
         if isinstance(i, slice):
             return Animation(self._frames[i], **self._kwds)
@@ -583,12 +583,12 @@ class Animation(WithEqualityById, SageObject):
             ....:             xmin=0, xmax=2*pi, ymin=-1, ymax=1, figsize=[2,1])
             sage: td = tmp_dir()
             sage: a.gif()              # not tested
-            sage: a.gif(savefile=td + 'my_animation.gif', delay=35, iterations=3)               # optional -- ImageMagick   # long time
-            sage: with open(td + 'my_animation.gif', 'rb') as f: print(b'GIF8' in f.read())     # optional -- ImageMagick   # long time
+            sage: a.gif(savefile=td + 'my_animation.gif', delay=35, iterations=3)             # long time  # optional -- ImageMagick
+            sage: with open(td + 'my_animation.gif', 'rb') as f: print(b'GIF8' in f.read())   # long time  # optional -- ImageMagick
             True
-            sage: a.gif(savefile=td + 'my_animation.gif', show_path=True)                       # optional -- ImageMagick   # long time
+            sage: a.gif(savefile=td + 'my_animation.gif', show_path=True)                     # long time  # optional -- ImageMagick
             Animation saved to .../my_animation.gif.
-            sage: a.gif(savefile=td + 'my_animation_2.gif', show_path=True, use_ffmpeg=True)    # optional -- ffmpeg        # long time
+            sage: a.gif(savefile=td + 'my_animation_2.gif', show_path=True, use_ffmpeg=True)  # long time  # optional -- ffmpeg
             Animation saved to .../my_animation_2.gif.
 
         .. NOTE::
@@ -659,7 +659,7 @@ class Animation(WithEqualityById, SageObject):
             sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.7)],
             ....:             xmin=0, xmax=2*pi, ymin=-1, ymax=1, figsize=[2,1])
             sage: td = tmp_dir()
-            sage: a._gif_from_imagemagick(savefile=td + 'new.gif')  # optional -- ImageMagick  # long time
+            sage: a._gif_from_imagemagick(savefile=td + 'new.gif')  # long time  # optional -- ImageMagick
 
         .. NOTE::
 
@@ -811,38 +811,38 @@ class Animation(WithEqualityById, SageObject):
             sage: x = SR.var("x")
             sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.7)],
             ....:                xmin=0, xmax=2*pi, figsize=[2,1])
-            sage: a.show()       # optional -- ImageMagick   # long time
+            sage: a.show()                              # long time  # optional -- ImageMagick
 
         The preceding will loop the animation forever. If you want to show
         only three iterations instead::
 
-            sage: a.show(iterations=3)    # optional -- ImageMagick   # long time
+            sage: a.show(iterations=3)                  # long time  # optional -- ImageMagick
 
         To put a half-second delay between frames::
 
-            sage: a.show(delay=50)        # optional -- ImageMagick   # long time
+            sage: a.show(delay=50)                      # long time  # optional -- ImageMagick
 
         You can also make use of the HTML5 video element in the Sage Notebook::
 
-            sage: a.show(format="ogg")         # optional -- ffmpeg   # long time
-            sage: a.show(format="webm")        # optional -- ffmpeg   # long time
-            sage: a.show(format="mp4")         # optional -- ffmpeg   # long time
-            sage: a.show(format="webm", iterations=1)  # optional -- ffmpeg   # long time
+            sage: a.show(format="ogg")                  # long time  # optional -- ffmpeg
+            sage: a.show(format="webm")                 # long time  # optional -- ffmpeg
+            sage: a.show(format="mp4")                  # long time  # optional -- ffmpeg
+            sage: a.show(format="webm", iterations=1)   # long time  # optional -- ffmpeg
 
         Other backends may support other file formats as well::
 
-            sage: a.show(format="flash")       # optional -- ffmpeg   # long time
-            sage: a.show(format="matroska")    # optional -- ffmpeg   # long time
-            sage: a.show(format="avi")         # optional -- ffmpeg   # long time
-            sage: a.show(format="wmv")         # optional -- ffmpeg   # long time
-            sage: a.show(format="quicktime")   # optional -- ffmpeg   # long time
+            sage: a.show(format="flash")                # long time  # optional -- ffmpeg
+            sage: a.show(format="matroska")             # long time  # optional -- ffmpeg
+            sage: a.show(format="avi")                  # long time  # optional -- ffmpeg
+            sage: a.show(format="wmv")                  # long time  # optional -- ffmpeg
+            sage: a.show(format="quicktime")            # long time  # optional -- ffmpeg
 
         TESTS:
 
         Use of positional parameters is discouraged, will likely get
         deprecated, but should still work for the time being::
 
-            sage: a.show(50, 3)           # optional -- ImageMagick   # long time
+            sage: a.show(50, 3)                         # long time  # optional -- ImageMagick
 
         .. NOTE::
 
@@ -924,10 +924,10 @@ class Animation(WithEqualityById, SageObject):
             sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.7)],
             ....:             xmin=0, xmax=2*pi, ymin=-1, ymax=1, figsize=[2,1])
             sage: td = tmp_dir()
-            sage: a.ffmpeg(savefile=td + 'new.mpg')       # optional -- ffmpeg   # long time
-            sage: a.ffmpeg(savefile=td + 'new.avi')       # optional -- ffmpeg   # long time
-            sage: a.ffmpeg(savefile=td + 'new.gif')       # optional -- ffmpeg   # long time
-            sage: a.ffmpeg(savefile=td + 'new.mpg', show_path=True) # optional -- ffmpeg   # long time
+            sage: a.ffmpeg(savefile=td + 'new.mpg')                  # long time  # optional -- ffmpeg
+            sage: a.ffmpeg(savefile=td + 'new.avi')                  # long time  # optional -- ffmpeg
+            sage: a.ffmpeg(savefile=td + 'new.gif')                  # long time  # optional -- ffmpeg
+            sage: a.ffmpeg(savefile=td + 'new.mpg', show_path=True)  # long time  # optional -- ffmpeg
             Animation saved to .../new.mpg.
 
         .. NOTE::
@@ -941,7 +941,7 @@ class Animation(WithEqualityById, SageObject):
 
         TESTS::
 
-            sage: a.ffmpeg(output_format='gif',delay=30,iterations=5)     # optional -- ffmpeg   # long time
+            sage: a.ffmpeg(output_format='gif',delay=30,iterations=5)  # long time  # optional -- ffmpeg
         """
         from sage.features.ffmpeg import FFmpeg
         FFmpeg().require()
@@ -1107,10 +1107,10 @@ class Animation(WithEqualityById, SageObject):
             ....:             xmin=0, xmax=2*pi, ymin=-1, ymax=1, figsize=[2,1])
             sage: td = tmp_dir()
             sage: a.save()         # not tested
-            sage: a.save(td + 'wave.gif')                   # optional -- ImageMagick   # long time
-            sage: a.save(td + 'wave.gif', show_path=True)   # optional -- ImageMagick   # long time
+            sage: a.save(td + 'wave.gif')                   # long time  # optional -- ImageMagick
+            sage: a.save(td + 'wave.gif', show_path=True)   # long time  # optional -- ImageMagick
             Animation saved to file .../wave.gif.
-            sage: a.save(td + 'wave.avi', show_path=True)   # optional -- ffmpeg        # long time
+            sage: a.save(td + 'wave.avi', show_path=True)   # long time  # optional -- ffmpeg
             Animation saved to file .../wave.avi.
             sage: a.save(td + 'wave0.sobj')
             sage: a.save(td + 'wave1.sobj', show_path=True)
@@ -1124,18 +1124,22 @@ class Animation(WithEqualityById, SageObject):
         Ensure that we can pass delay and iteration count to the saved
         GIF image (see :trac:`18176`)::
 
-            sage: a.save(td + 'wave.gif')   # optional -- ImageMagick   # long time
-            sage: with open(td + 'wave.gif', 'rb') as f: print(b'GIF8' in f.read())  # optional -- ImageMagick   # long time
+            sage: a.save(td + 'wave.gif')                   # long time  # optional -- ImageMagick
+            sage: with open(td + 'wave.gif', 'rb') as f:    # long time  # optional -- ImageMagick
+            ....:     print(b'GIF8' in f.read())
             True
-            sage: with open(td + 'wave.gif', 'rb') as f: print(b'!\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00' in f.read())  # optional -- ImageMagick   # long time
+            sage: with open(td + 'wave.gif', 'rb') as f:    # long time  # optional -- ImageMagick
+            ....:     print(b'!\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00' in f.read())
             True
-            sage: a.save(td + 'wave.gif', delay=35)   # optional -- ImageMagick   # long time
-            sage: with open(td + 'wave.gif', 'rb') as f: print(b'GIF8' in f.read())  # optional -- ImageMagick   # long time
+            sage: a.save(td + 'wave.gif', delay=35)         # long time  # optional -- ImageMagick
+            sage: with open(td + 'wave.gif', 'rb') as f:    # long time  # optional -- ImageMagick
+            ....:     print(b'GIF8' in f.read())
             True
-            sage: a.save(td + 'wave.gif', iterations=3)   # optional -- ImageMagick   # long time
-            sage: with open(td + 'wave.gif', 'rb') as f: print(b'!\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00' in f.read())  # optional -- ImageMagick   # long time
+            sage: a.save(td + 'wave.gif', iterations=3)     # long time  # optional -- ImageMagick
+            sage: with open(td + 'wave.gif', 'rb') as f:    # long time  # optional -- ImageMagick
+            ....:     print(b'!\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00' in f.read())
             False
-            sage: with open(td + 'wave.gif', 'rb') as f:  # optional -- ImageMagick   # long time
+            sage: with open(td + 'wave.gif', 'rb') as f:    # long time  # optional -- ImageMagick
             ....:      check1 = b'!\xff\x0bNETSCAPE2.0\x03\x01\x02\x00\x00'
             ....:      check2 = b'!\xff\x0bNETSCAPE2.0\x03\x01\x03\x00\x00'
             ....:      data = f.read()

--- a/src/sage/plot/animate.py
+++ b/src/sage/plot/animate.py
@@ -1043,7 +1043,8 @@ class Animation(WithEqualityById, SageObject):
             sage: a = animate([sin(x + float(k)) for k in srange(0,2*pi,0.7)],
             ....:                xmin=0, xmax=2*pi, figsize=[2,1])
             sage: dir = tmp_dir()
-            sage: a.apng()  # long time
+            sage: a.apng(show_path=True)  # long time
+            Animation saved to ....png.
             sage: a.apng(savefile=dir + 'my_animation.png', delay=35, iterations=3)  # long time
             sage: a.apng(savefile=dir + 'my_animation.png', show_path=True)  # long time
             Animation saved to .../my_animation.png.

--- a/src/sage/plot/plot3d/implicit_plot3d.py
+++ b/src/sage/plot/plot3d/implicit_plot3d.py
@@ -50,8 +50,10 @@ def implicit_plot3d(f, xrange, yrange, zrange, **kwds):
 
     A nested set of spheres with a hole cut out::
 
-        sage: implicit_plot3d((x^2 + y^2 + z^2), (x,-2,2), (y,-2,2), (z,-2,2), plot_points=60, contour=[1,3,5],
-        ....:                 region=lambda x,y,z: x<=0.2 or y>=0.2 or z<=0.2, color='aquamarine').show(viewer='tachyon')
+        sage: F = x^2 + y^2 + z^2
+        sage: P = implicit_plot3d(F, (x,-2,2), (y,-2,2), (z,-2,2), plot_points=60, contour=[1,3,5],
+        ....:                     region=lambda x,y,z: x<=0.2 or y>=0.2 or z<=0.2, color='aquamarine')
+        sage: P.show(viewer='tachyon')  # long time
 
     .. PLOT::
 
@@ -85,7 +87,8 @@ def implicit_plot3d(f, xrange, yrange, zrange, **kwds):
 
         sage: F = (x^2+9/4*y^2+z^2-1)^3 - x^2*z^3 - 9/(80)*y^2*z^3
         sage: r = 1.5
-        sage: implicit_plot3d(F, (x,-r,r), (y,-r,r), (z,-r,r), plot_points=80, color='red', smooth=False).show(viewer='tachyon')
+        sage: V = implicit_plot3d(F, (x,-r,r), (y,-r,r), (z,-r,r), plot_points=80, color='red', smooth=False)
+        sage: V.show(viewer='tachyon')  # long time
 
     .. PLOT::
 
@@ -154,7 +157,7 @@ def implicit_plot3d(f, xrange, yrange, zrange, **kwds):
         sage: cm = colormaps.gist_rainbow
         sage: G = implicit_plot3d(x^2 + y^2 + z^2, (x,-2,2), (y,-2,2), (z,-2, 2),
         ....:                     contour=4, color=(t,cm), plot_points=100)
-        sage: G.show(viewer='tachyon')
+        sage: G.show(viewer='tachyon')  # long time
 
     .. PLOT::
 

--- a/src/sage/rings/asymptotic/asymptotics_multivariate_generating_functions.py
+++ b/src/sage/rings/asymptotic/asymptotics_multivariate_generating_functions.py
@@ -1592,7 +1592,7 @@ class FractionWithFactoredDenominator(RingElement):
              432,
              3/5*sqrt(5)*sqrt(3)*sqrt(2)*sqrt(r)/sqrt(pi)
               + 463/6000*sqrt(5)*sqrt(3)*sqrt(2)/(sqrt(pi)*sqrt(r)))
-            sage: F.relative_error(asy[0], alpha, [1, 2, 4, 8, 16], asy[1])  # abs tol 1e-10
+            sage: F.relative_error(asy[0], alpha, [1, 2, 4, 8, 16], asy[1])  # abs tol 1e-10  # long time
             [((4, 3), 2.083333333, [2.092576110], [-0.004436533009]),
              ((8, 6), 2.787374614, [2.790732875], [-0.001204811281]),
              ((16, 12), 3.826259447, [3.827462310], [-0.0003143703383]),
@@ -2821,7 +2821,7 @@ class FractionWithFactoredDenominator(RingElement):
             sage: alpha = vector([3, 3, 2])
             sage: interval = [1, 2, 4]
             sage: S = [r*alpha for r in interval]
-            sage: F.maclaurin_coefficients(S, numerical=10)
+            sage: F.maclaurin_coefficients(S, numerical=10)  # long time
             {(3, 3, 2): 0.7849731445,
              (6, 6, 4): 0.7005249476,
              (12, 12, 8): 0.5847732654}
@@ -4028,10 +4028,10 @@ def diff_op(A, B, AB_derivs, V, M, r, N):
         sage: B = function('B')(*tuple(T))
         sage: AB_derivs = {}
         sage: M = matrix([[1, 2],[2, 1]])
-        sage: DD = diff_op(A, B, AB_derivs, T, M, 1, 2)
-        sage: sorted(DD)
+        sage: DD = diff_op(A, B, AB_derivs, T, M, 1, 2)  # long time (see :trac:`35207`)
+        sage: sorted(DD)                                 # long time
         [(0, 0, 0), (0, 1, 0), (0, 1, 1), (0, 1, 2)]
-        sage: DD[(0, 1, 2)].number_of_operands()
+        sage: DD[(0, 1, 2)].number_of_operands()         # long time
         246
     """
     from itertools import product

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -1382,7 +1382,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
     This example was suggested on sage-nt; see :trac:`18942`::
 
         sage: G = DirichletGroup(80)
-        sage: for chi in G:
+        sage: for chi in G:             # long time
         ....:     D = ModularSymbols(chi, 2, -1).cuspidal_subspace().new_subspace().decomposition()
         ....:     for f in D:
         ....:         elt = f.q_eigenform(10, 'alpha')[3]

--- a/src/sage/rings/padics/padic_extension_leaves.py
+++ b/src/sage/rings/padics/padic_extension_leaves.py
@@ -89,7 +89,7 @@ class UnramifiedExtensionRingCappedRelative(UnramifiedExtensionGeneric, pAdicCap
     """
     TESTS::
 
-        sage: R.<a> = ZqCR(27,10000)
+        sage: R.<a> = ZqCR(27,1000)
         sage: TestSuite(R).run(skip='_test_log',max_runs=4)
     """
     def __init__(self, exact_modulus, poly, prec, print_mode, shift_seed, names, implementation='FLINT'):
@@ -147,7 +147,7 @@ class UnramifiedExtensionFieldCappedRelative(UnramifiedExtensionGeneric, pAdicCa
     """
     TESTS::
 
-        sage: R.<a> = QqCR(27,10000)
+        sage: R.<a> = QqCR(27,1000)
         sage: TestSuite(R).run(skip='_test_log',max_runs=4)
     """
     def __init__(self, exact_modulus, poly, prec, print_mode, shift_seed, names, implementation='FLINT'):
@@ -233,7 +233,7 @@ class UnramifiedExtensionRingCappedAbsolute(UnramifiedExtensionGeneric, pAdicCap
     """
     TESTS::
 
-        sage: R.<a> = ZqCA(27,10000)
+        sage: R.<a> = ZqCA(27,1000)
         sage: TestSuite(R).run(skip='_test_log',max_runs=4)
     """
     def __init__(self, exact_modulus, poly, prec, print_mode, shift_seed, names, implementation='FLINT'):
@@ -292,7 +292,7 @@ class UnramifiedExtensionRingFixedMod(UnramifiedExtensionGeneric, pAdicFixedModR
     """
     TESTS::
 
-        sage: R.<a> = ZqFM(27,10000)
+        sage: R.<a> = ZqFM(27,1000)
         sage: TestSuite(R).run(skip='_test_log',max_runs=4) # long time
     """
     def __init__(self, exact_modulus, poly, prec, print_mode, shift_seed, names, implementation='FLINT'):
@@ -479,7 +479,7 @@ class EisensteinExtensionRingCappedRelative(EisensteinExtensionGeneric, pAdicCap
     """
     TESTS::
 
-        sage: R = Zp(3, 10000, print_pos=False); S.<x> = ZZ[]; f = x^3 + 9*x - 3
+        sage: R = Zp(3, 1000, print_pos=False); S.<x> = ZZ[]; f = x^3 + 9*x - 3
         sage: W.<w> = R.ext(f)
         sage: TestSuite(R).run(skip='_test_log',max_runs=4)
     """
@@ -534,7 +534,7 @@ class EisensteinExtensionFieldCappedRelative(EisensteinExtensionGeneric, pAdicCa
     """
     TESTS::
 
-        sage: R = Qp(3, 10000, print_pos=False); S.<x> = ZZ[]; f = x^3 + 9*x - 3
+        sage: R = Qp(3, 1000, print_pos=False); S.<x> = ZZ[]; f = x^3 + 9*x - 3
         sage: W.<w> = R.ext(f)
         sage: TestSuite(R).run(skip='_test_log',max_runs=4)
     """
@@ -590,7 +590,7 @@ class EisensteinExtensionRingCappedAbsolute(EisensteinExtensionGeneric, pAdicCap
     """
     TESTS::
 
-        sage: R = ZpCA(3, 10000, print_pos=False); S.<x> = ZZ[]; f = x^3 + 9*x - 3
+        sage: R = ZpCA(3, 1000, print_pos=False); S.<x> = ZZ[]; f = x^3 + 9*x - 3
         sage: W.<w> = R.ext(f)
         sage: TestSuite(R).run(skip='_test_log',max_runs=4)
     """
@@ -645,7 +645,7 @@ class EisensteinExtensionRingFixedMod(EisensteinExtensionGeneric, pAdicFixedModR
     """
     TESTS::
 
-        sage: R = ZpFM(3, 10000, print_pos=False); S.<x> = ZZ[]; f = x^3 + 9*x - 3
+        sage: R = ZpFM(3, 1000, print_pos=False); S.<x> = ZZ[]; f = x^3 + 9*x - 3
         sage: W.<w> = R.ext(f)
         sage: TestSuite(R).run(skip='_test_log',max_runs=4)
     """

--- a/src/sage/rings/padics/padic_generic_element.pyx
+++ b/src/sage/rings/padics/padic_generic_element.pyx
@@ -1368,9 +1368,9 @@ cdef class pAdicGenericElement(LocalGenericElement):
 
             sage: p = next_prime(200)
             sage: F = Qp(p)
-            sage: l1 = [F(a/(p-1)).gamma(algorithm='pari') for a in range(p-1)]
-            sage: l2 = [F(a/(p-1)).gamma(algorithm='sage') for a in range(p-1)]
-            sage: all(l1[i] == l2[i] for i in range(p-1))
+            sage: l1 = [F(a/(p-1)).gamma(algorithm='pari') for a in range(p-1)]  # long time
+            sage: l2 = [F(a/(p-1)).gamma(algorithm='sage') for a in range(p-1)]  # long time
+            sage: all(l1[i] == l2[i] for i in range(p-1))  # long time
             True
 
         The `p`-adic Gamma function has anomalous behavior for the prime 2::

--- a/src/sage/rings/polynomial/ore_function_element.py
+++ b/src/sage/rings/polynomial/ore_function_element.py
@@ -165,7 +165,7 @@ class OreFunction(AlgebraElement):
             sage: P = K.random_element()
             sage: Q = K.random_element()
             sage: D = K.random_element()
-            sage: Q == 0 or D == 0 or (P*D) / (Q*D) == P/Q
+            sage: Q == 0 or D == 0 or (P*D) / (Q*D) == P/Q  # long time
             True
 
         """

--- a/src/sage/rings/tate_algebra_element.pyx
+++ b/src/sage/rings/tate_algebra_element.pyx
@@ -2750,7 +2750,7 @@ cdef class TateAlgebraElement(CommutativeAlgebraElement):
             sage: f(x0, y0).exp() == expf(x0, y0)
             True
 
-            sage: expf.log() == f
+            sage: expf.log() == f  # long time
             True
 
         """

--- a/src/sage/rings/tests.py
+++ b/src/sage/rings/tests.py
@@ -442,7 +442,7 @@ def test_karatsuba_multiplication(base_ring, maxdeg1, maxdeg2,
 
     Zero-tests over ``QQbar`` are currently very slow, so we test only very small examples::
 
-        test_karatsuba_multiplication(QQbar, 3, 3, numtests=2)
+        sage: test_karatsuba_multiplication(QQbar, 3, 3, numtests=2)        # long time
 
     Larger degrees (over ``ZZ``, using FLINT)::
 

--- a/src/sage/rings/tests.py
+++ b/src/sage/rings/tests.py
@@ -421,8 +421,8 @@ def test_karatsuba_multiplication(base_ring, maxdeg1, maxdeg2,
 
     First check that random tests are reproducible::
 
-        sage: import sage.rings.tests
-        sage: sage.rings.tests.test_karatsuba_multiplication(ZZ, 6, 5, verbose=True, seed=42)
+        sage: from sage.rings.tests import test_karatsuba_multiplication
+        sage: test_karatsuba_multiplication(ZZ, 6, 5, verbose=True, seed=42)
         test_karatsuba_multiplication: ring=Univariate Polynomial Ring in x over Integer Ring, threshold=2
         (2*x^6 - x^5 - x^4 - 3*x^3 + 4*x^2 + 4*x + 1)*(4*x^4 + x^3 - 2*x^2 - 20*x + 3)
           (16*x^2)*(-41*x + 1)
@@ -437,23 +437,27 @@ def test_karatsuba_multiplication(base_ring, maxdeg1, maxdeg2,
 
     Test Karatsuba multiplication of polynomials of small degree over some common rings::
 
-        sage: for C in [QQ, ZZ[I], ZZ[I, sqrt(2)], GF(49, 'a'), MatrixSpace(GF(17), 3)]:
-        ....:     sage.rings.tests.test_karatsuba_multiplication(C, 10, 10)
+        sage: for C in [QQ, ZZ[I], GF(49, 'a'), MatrixSpace(GF(17), 3)]:
+        ....:     test_karatsuba_multiplication(C, 10, 10)
 
     Zero-tests over ``QQbar`` are currently very slow, so we test only very small examples::
 
-        sage.rings.tests.test_karatsuba_multiplication(QQbar, 3, 3, numtests=2)
+        test_karatsuba_multiplication(QQbar, 3, 3, numtests=2)
 
     Larger degrees (over ``ZZ``, using FLINT)::
 
-        sage: sage.rings.tests.test_karatsuba_multiplication(ZZ, 1000, 1000, ref_mul=lambda f,g: f*g, base_ring_random_elt_args=[1000])
+        sage: test_karatsuba_multiplication(ZZ, 1000, 1000,
+        ....:                               ref_mul=lambda f,g: f*g,
+        ....:                               base_ring_random_elt_args=[1000])
 
     Some more aggressive tests::
 
-        sage: testrings = [QQ, ZZ[I], ZZ[I, sqrt(2)], GF(49, 'a'), MatrixSpace(GF(17), 3)]
+        sage: testrings = [ZZ[I, sqrt(2)], ZZ[I, sqrt(2), sqrt(3)]]         # long time
         sage: for C in testrings:                                           # long time
-        ....:     sage.rings.tests.test_karatsuba_multiplication(C, 10, 10)
-        sage: sage.rings.tests.test_karatsuba_multiplication(ZZ, 10000, 10000, ref_mul=lambda f,g: f*g, base_ring_random_elt_args=[100000])
+        ....:     test_karatsuba_multiplication(C, 100, 100)
+        sage: test_karatsuba_multiplication(ZZ, 10000, 10000,               # long time
+        ....:                               ref_mul=lambda f,g: f*g,
+        ....:                               base_ring_random_elt_args=[100000])
 
     """
     from sage.misc.prandom import randint

--- a/src/sage/schemes/curves/affine_curve.py
+++ b/src/sage/schemes/curves/affine_curve.py
@@ -37,20 +37,20 @@ EXAMPLES::
 
 Closed points of arbitrary degree can be computed::
 
-    sage: C.closed_points()                                                             # optional - sage.rings.finite_rings
+    sage: C.closed_points()                                                             # optional - sage.rings.finite_rings  # long time
     [Point (x, y, z), Point (x + 1, y, z)]
-    sage: C.closed_points(2)                                                            # optional - sage.rings.finite_rings
+    sage: C.closed_points(2)                                                            # optional - sage.rings.finite_rings  # long time
     [Point (x^2 + x + 1, y + 1, z),
      Point (y^2 + y + 1, x + y, z),
      Point (y^2 + y + 1, x + y + 1, z)]
-    sage: p = _[0]                                                                      # optional - sage.rings.finite_rings
-    sage: p.places()                                                                    # optional - sage.rings.finite_rings
+    sage: p = _[0]                                                                      # optional - sage.rings.finite_rings  # long time
+    sage: p.places()                                                                    # optional - sage.rings.finite_rings  # long time
     [Place (x^2 + x + 1, (1/(x^4 + x^2 + 1))*z^7 + (1/(x^4 + x^2 + 1))*z^6 + 1)]
 
 The places at infinity correspond to the extra closed points of the curve's
 projective closure::
 
-    sage: C.places_at_infinity()                                                        # optional - sage.rings.finite_rings
+    sage: C.places_at_infinity()                                                        # optional - sage.rings.finite_rings  # long time
     [Place (1/x, 1/x*z)]
 
 It is easy to transit to and from the function field of the curve::
@@ -2087,7 +2087,7 @@ class IntegralAffineCurve(AffineCurve_field):
             (x/(x^5 + 1))*y^4 + x^2/(x^5 + 1)
             sage: df = f.differential(); df                                             # optional - sage.rings.finite_rings
             ((1/(x^10 + 1))*y^4 + x^6/(x^10 + 1)) d(x)
-            sage: df.divisor()                                                          # optional - sage.rings.finite_rings
+            sage: df.divisor()                                                          # optional - sage.rings.finite_rings  # long time
             2*Place (1/x, 1/x^4*y^4 + 1/x^3*y^3 + 1/x^2*y^2 + 1/x*y + 1)
              + 2*Place (1/x, 1/x*y + 1)
              - 2*Place (x + 1, y)
@@ -2285,7 +2285,7 @@ class IntegralAffineCurve(AffineCurve_field):
 
             sage: A.<x,y> = AffineSpace(GF(7^2), 2)                                     # optional - sage.rings.finite_rings
             sage: C = Curve(x^2 - x^4 - y^4)                                            # optional - sage.rings.finite_rings
-            sage: C._singularities                                                      # optional - sage.rings.finite_rings
+            sage: C._singularities                                                      # optional - sage.rings.finite_rings  # long time
             [(Point (x, y),
               [Place (x, 1/x*y^3 + 1/x*y^2 + 1), Place (x, 1/x*y^3 + 1/x*y^2 + 6)])]
         """

--- a/src/sage/schemes/curves/affine_curve.py
+++ b/src/sage/schemes/curves/affine_curve.py
@@ -37,20 +37,20 @@ EXAMPLES::
 
 Closed points of arbitrary degree can be computed::
 
-    sage: C.closed_points()                                                             # optional - sage.rings.finite_rings  # long time
+    sage: C.closed_points()                     # long time                             # optional - sage.rings.finite_rings
     [Point (x, y, z), Point (x + 1, y, z)]
-    sage: C.closed_points(2)                                                            # optional - sage.rings.finite_rings  # long time
+    sage: C.closed_points(2)                    # long time                             # optional - sage.rings.finite_rings
     [Point (x^2 + x + 1, y + 1, z),
      Point (y^2 + y + 1, x + y, z),
      Point (y^2 + y + 1, x + y + 1, z)]
-    sage: p = _[0]                                                                      # optional - sage.rings.finite_rings  # long time
-    sage: p.places()                                                                    # optional - sage.rings.finite_rings  # long time
+    sage: p = _[0]                              # long time                             # optional - sage.rings.finite_rings
+    sage: p.places()                            # long time                             # optional - sage.rings.finite_rings
     [Place (x^2 + x + 1, (1/(x^4 + x^2 + 1))*z^7 + (1/(x^4 + x^2 + 1))*z^6 + 1)]
 
 The places at infinity correspond to the extra closed points of the curve's
 projective closure::
 
-    sage: C.places_at_infinity()                                                        # optional - sage.rings.finite_rings  # long time
+    sage: C.places_at_infinity()                # long time                             # optional - sage.rings.finite_rings
     [Place (1/x, 1/x*z)]
 
 It is easy to transit to and from the function field of the curve::
@@ -2087,7 +2087,7 @@ class IntegralAffineCurve(AffineCurve_field):
             (x/(x^5 + 1))*y^4 + x^2/(x^5 + 1)
             sage: df = f.differential(); df                                             # optional - sage.rings.finite_rings
             ((1/(x^10 + 1))*y^4 + x^6/(x^10 + 1)) d(x)
-            sage: df.divisor()                                                          # optional - sage.rings.finite_rings  # long time
+            sage: df.divisor()                  # long time                             # optional - sage.rings.finite_rings
             2*Place (1/x, 1/x^4*y^4 + 1/x^3*y^3 + 1/x^2*y^2 + 1/x*y + 1)
              + 2*Place (1/x, 1/x*y + 1)
              - 2*Place (x + 1, y)
@@ -2285,7 +2285,7 @@ class IntegralAffineCurve(AffineCurve_field):
 
             sage: A.<x,y> = AffineSpace(GF(7^2), 2)                                     # optional - sage.rings.finite_rings
             sage: C = Curve(x^2 - x^4 - y^4)                                            # optional - sage.rings.finite_rings
-            sage: C._singularities                                                      # optional - sage.rings.finite_rings  # long time
+            sage: C._singularities              # long time                             # optional - sage.rings.finite_rings
             [(Point (x, y),
               [Place (x, 1/x*y^3 + 1/x*y^2 + 1), Place (x, 1/x*y^3 + 1/x*y^2 + 6)])]
         """

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -889,15 +889,15 @@ class EllipticCurveIsogeny(EllipticCurveHom):
     Examples over relative number fields used not to work (see :trac:`16779`)::
 
         sage: pol26 = hilbert_class_polynomial(-4*26)
-        sage: pol = NumberField(pol26,'a').optimized_representation()[0].polynomial()   # optional - sage.rings.number_field, long time
-        sage: K.<a> = NumberField(pol)                                                  # optional - sage.rings.number_field, long time
-        sage: j = pol26.roots(K)[0][0]                                                  # optional - sage.rings.number_field, long time
-        sage: E = EllipticCurve(j=j)                                                    # optional - sage.rings.number_field, long time
-        sage: L.<b> = K.extension(x^2 + 26)                                             # optional - sage.rings.number_field, long time
-        sage: EL = E.change_ring(L)                                                     # optional - sage.rings.number_field, long time
-        sage: iso2 = EL.isogenies_prime_degree(2); len(iso2)                            # optional - sage.rings.number_field, long time
+        sage: pol = NumberField(pol26,'a').optimized_representation()[0].polynomial()   # long time  # optional - sage.rings.number_field
+        sage: K.<a> = NumberField(pol)                                                  # long time  # optional - sage.rings.number_field
+        sage: j = pol26.roots(K)[0][0]                                                  # long time  # optional - sage.rings.number_field
+        sage: E = EllipticCurve(j=j)                                                    # long time  # optional - sage.rings.number_field
+        sage: L.<b> = K.extension(x^2 + 26)                                             # long time  # optional - sage.rings.number_field
+        sage: EL = E.change_ring(L)                                                     # long time  # optional - sage.rings.number_field
+        sage: iso2 = EL.isogenies_prime_degree(2); len(iso2)                            # long time  # optional - sage.rings.number_field
         1
-        sage: iso3 = EL.isogenies_prime_degree(3); len(iso3)                            # optional - sage.rings.number_field, long time
+        sage: iso3 = EL.isogenies_prime_degree(3); len(iso3)                            # long time  # optional - sage.rings.number_field
         2
 
     Examples over function fields used not to work (see :trac:`11327`)::

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -889,15 +889,16 @@ class EllipticCurveIsogeny(EllipticCurveHom):
     Examples over relative number fields used not to work (see :trac:`16779`)::
 
         sage: pol26 = hilbert_class_polynomial(-4*26)
-        sage: pol = NumberField(pol26,'a').optimized_representation()[0].polynomial()   # long time  # optional - sage.rings.number_field
-        sage: K.<a> = NumberField(pol)                                                  # long time  # optional - sage.rings.number_field
-        sage: j = pol26.roots(K)[0][0]                                                  # long time  # optional - sage.rings.number_field
-        sage: E = EllipticCurve(j=j)                                                    # long time  # optional - sage.rings.number_field
-        sage: L.<b> = K.extension(x^2 + 26)                                             # long time  # optional - sage.rings.number_field
-        sage: EL = E.change_ring(L)                                                     # long time  # optional - sage.rings.number_field
-        sage: iso2 = EL.isogenies_prime_degree(2); len(iso2)                            # long time  # optional - sage.rings.number_field
+        sage: F = NumberField(pol26,'a')                            # long time         # optional - sage.rings.number_field
+        sage: pol = F.optimized_representation()[0].polynomial()    # long time         # optional - sage.rings.number_field
+        sage: K.<a> = NumberField(pol)                              # long time         # optional - sage.rings.number_field
+        sage: j = pol26.roots(K)[0][0]                              # long time         # optional - sage.rings.number_field
+        sage: E = EllipticCurve(j=j)                                # long time         # optional - sage.rings.number_field
+        sage: L.<b> = K.extension(x^2 + 26)                         # long time         # optional - sage.rings.number_field
+        sage: EL = E.change_ring(L)                                 # long time         # optional - sage.rings.number_field
+        sage: iso2 = EL.isogenies_prime_degree(2); len(iso2)        # long time         # optional - sage.rings.number_field
         1
-        sage: iso3 = EL.isogenies_prime_degree(3); len(iso3)                            # long time  # optional - sage.rings.number_field
+        sage: iso3 = EL.isogenies_prime_degree(3); len(iso3)        # long time         # optional - sage.rings.number_field
         2
 
     Examples over function fields used not to work (see :trac:`11327`)::

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -889,15 +889,15 @@ class EllipticCurveIsogeny(EllipticCurveHom):
     Examples over relative number fields used not to work (see :trac:`16779`)::
 
         sage: pol26 = hilbert_class_polynomial(-4*26)
-        sage: pol = NumberField(pol26,'a').optimized_representation()[0].polynomial()   # optional - sage.rings.number_field
-        sage: K.<a> = NumberField(pol)                                                  # optional - sage.rings.number_field
-        sage: j = pol26.roots(K)[0][0]                                                  # optional - sage.rings.number_field
-        sage: E = EllipticCurve(j=j)                                                    # optional - sage.rings.number_field
-        sage: L.<b> = K.extension(x^2 + 26)                                             # optional - sage.rings.number_field
-        sage: EL = E.change_ring(L)                                                     # optional - sage.rings.number_field
-        sage: iso2 = EL.isogenies_prime_degree(2); len(iso2)                            # optional - sage.rings.number_field
+        sage: pol = NumberField(pol26,'a').optimized_representation()[0].polynomial()   # optional - sage.rings.number_field, long time
+        sage: K.<a> = NumberField(pol)                                                  # optional - sage.rings.number_field, long time
+        sage: j = pol26.roots(K)[0][0]                                                  # optional - sage.rings.number_field, long time
+        sage: E = EllipticCurve(j=j)                                                    # optional - sage.rings.number_field, long time
+        sage: L.<b> = K.extension(x^2 + 26)                                             # optional - sage.rings.number_field, long time
+        sage: EL = E.change_ring(L)                                                     # optional - sage.rings.number_field, long time
+        sage: iso2 = EL.isogenies_prime_degree(2); len(iso2)                            # optional - sage.rings.number_field, long time
         1
-        sage: iso3 = EL.isogenies_prime_degree(3); len(iso3)                            # optional - sage.rings.number_field
+        sage: iso3 = EL.isogenies_prime_degree(3); len(iso3)                            # optional - sage.rings.number_field, long time
         2
 
     Examples over function fields used not to work (see :trac:`11327`)::

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -1279,8 +1279,8 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         See :trac:`31443`::
 
             sage: E = EllipticCurve('1590g1')
-            sage: m = E.modular_symbol(nap=300)
-            sage: [m(a/5) for a in [1..4]]
+            sage: m = E.modular_symbol(nap=300)     # long time
+            sage: [m(a/5) for a in [1..4]]          # long time
             [13/2, -13/2, -13/2, 13/2]
 
         These values are correct, as verified by the numerical
@@ -1519,7 +1519,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             Traceback (most recent call last):
             ...
             RuntimeError: unable to compute analytic rank using rubinstein algorithm (unable to convert ' 6.19283... and is too large' to an integer)
-            sage: EllipticCurve([1234567,89101112]).analytic_rank(algorithm='sympow')
+            sage: EllipticCurve([1234567,89101112]).analytic_rank(algorithm='sympow')  # long time
             Traceback (most recent call last):
             ...
             RuntimeError: failed to compute analytic rank
@@ -1867,10 +1867,10 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: r, s, G = E.simon_two_descent(); r,s
             (6, 6)
             sage: E = EllipticCurve([0, 0, 0, -10012, 346900])
-            sage: r, s, G = E.simon_two_descent(); r,s
+            sage: r, s, G = E.simon_two_descent(); r,s  # long time
             (7, 7)
             sage: E = EllipticCurve([0, 0, 1, -23737, 960366])
-            sage: r, s, G = E.simon_two_descent(); r,s
+            sage: r, s, G = E.simon_two_descent(); r,s  # long time
             (8, 8)
 
         Example from :trac:`10832`::
@@ -2810,13 +2810,13 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('389a1')
-            sage: E.point_search(5, verbose=False)
+            sage: E.point_search(1, verbose=False)
             [(-1 : 1 : 1), (0 : 0 : 1)]
 
         Increasing the height_limit takes longer, but finds no more
         points::
 
-            sage: E.point_search(10, verbose=False)
+            sage: E.point_search(10, verbose=False)  # long time
             [(-1 : 1 : 1), (0 : 0 : 1)]
 
         In fact this curve has rank 2 so no more than 2 points will ever be
@@ -5946,7 +5946,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         See :trac:`22063`::
 
-            sage: for n in [67,71,74,91]:
+            sage: for n in [67,71,74,91]:  # long time
             ....:     assert 4*n^6 + 4*n^2 in [P[0] for P in EllipticCurve([0,0,0,2,n^2]).integral_points()]
 
         ALGORITHM:

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -6983,7 +6983,7 @@ def integral_points_with_bounded_mw_coeffs(E, mw_base, N, x_bound):
         ....:     E = EllipticCurve([0,0,0,a,b])
         ....:     xs = [P[0] for P in E.integral_points()]
         ....:     return x in xs
-        sage: all(t(a,b,x) for a,b,x in [(-2,5, 1318), (4,-1, 4321),
+        sage: all(t(a,b,x) for a,b,x in [(-2,5, 1318), (4,-1, 4321),  # long time
         ....: (0,17, 5234), (11,4, 16833), (-13,37, 60721), (-12,-10, 80327),
         ....: (-7,22, 484961), (-9,28, 764396), (-13,4, 1056517), (-19,-51,
         ....: 2955980), (-24,124, 4435710), (-30,133, 5143326), (-37,60,

--- a/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
@@ -180,7 +180,7 @@ class GaloisRepresentation(SageObject):
             sage: K = NumberField(x**2 - 29, 'a'); a = K.gen()
             sage: E = EllipticCurve([1, 0, ((5 + a)/2)**2, 0, 0])
             sage: rho = E.galois_representation()
-            sage: rho.non_surjective() # See Section 5.10 of [Ser1972].
+            sage: rho.non_surjective() # See Section 5.10 of [Ser1972].  # long time
             [3, 5, 29]
             sage: K = NumberField(x**2 + 3, 'a'); a = K.gen()
             sage: E = EllipticCurve([0, -1, 1, -10, -20]).change_ring(K) # X_0(11)
@@ -295,15 +295,15 @@ class GaloisRepresentation(SageObject):
             sage: K = NumberField(x**2 - 29, 'a'); a = K.gen()
             sage: E = EllipticCurve([1, 0, ((5 + a)/2)**2, 0, 0])
             sage: rho = E.galois_representation()
-            sage: rho.isogeny_bound() # See Section 5.10 of [Ser1972].
+            sage: rho.isogeny_bound() # See Section 5.10 of [Ser1972].  # long time
             [3, 5]
             sage: K = NumberField(x**2 + 1, 'a')
             sage: EllipticCurve_from_j(K(1728)).galois_representation().isogeny_bound() # CM over K
             [0]
-            sage: EllipticCurve_from_j(K(0)).galois_representation().isogeny_bound() # CM NOT over K
+            sage: EllipticCurve_from_j(K(0)).galois_representation().isogeny_bound() # CM NOT over K  # long time
             [2, 3]
             sage: E = EllipticCurve_from_j(K(2268945/128)) # c.f. [Sut2012]
-            sage: E.galois_representation().isogeny_bound() # No 7-isogeny, but...
+            sage: E.galois_representation().isogeny_bound() # No 7-isogeny, but...  # long time
             [7]
 
         For curves with rational CM, there are infinitely many primes
@@ -371,21 +371,21 @@ class GaloisRepresentation(SageObject):
             sage: K = NumberField(x**2 - 29, 'a'); a = K.gen()
             sage: E = EllipticCurve([1, 0, ((5 + a)/2)**2, 0, 0])
             sage: rho = E.galois_representation()
-            sage: rho.isogeny_bound() # See Section 5.10 of [Ser1972].
+            sage: rho.isogeny_bound() # See Section 5.10 of [Ser1972].  # long time
             [3, 5]
-            sage: rho.reducible_primes()
+            sage: rho.reducible_primes()  # long time
             [3, 5]
 
             sage: K = NumberField(x**2 + 1, 'a')
             sage: EllipticCurve_from_j(K(1728)).galois_representation().isogeny_bound() # CM over K
             [0]
-            sage: EllipticCurve_from_j(K(0)).galois_representation().reducible_primes() # CM but NOT over K
+            sage: EllipticCurve_from_j(K(0)).galois_representation().reducible_primes() # CM but NOT over K  # long time
             [2, 3]
             sage: E = EllipticCurve_from_j(K(2268945/128)) # c.f. [Sut2012]
             sage: rho = E.galois_representation()
-            sage: rho.isogeny_bound() # ... but there is no 7-isogeny ...
+            sage: rho.isogeny_bound() # ... but there is no 7-isogeny ...  # long time
             [7]
-            sage: rho.reducible_primes()
+            sage: rho.reducible_primes()  # long time
             []
 
         For curves with rational CM, there are infinitely many primes
@@ -427,7 +427,7 @@ def _non_surjective(E, patience=100):
 
         sage: K = NumberField(x**2 - 29, 'a'); a = K.gen()
         sage: E = EllipticCurve([1, 0, ((5 + a)/2)**2, 0, 0])
-        sage: sage.schemes.elliptic_curves.gal_reps_number_field._non_surjective(E) # See Section 5.10 of [Ser1972].
+        sage: sage.schemes.elliptic_curves.gal_reps_number_field._non_surjective(E) # See Section 5.10 of [Ser1972].  # long time
         [3, 5, 29]
         sage: E = EllipticCurve_from_j(1728).change_ring(K) # CM
         sage: sage.schemes.elliptic_curves.gal_reps_number_field._non_surjective(E)
@@ -501,7 +501,7 @@ def Frobenius_filter(E, L, patience=100):
     EXAMPLES::
 
         sage: E = EllipticCurve('11a1') # has a 5-isogeny
-        sage: sage.schemes.elliptic_curves.gal_reps_number_field.Frobenius_filter(E,primes(40))
+        sage: sage.schemes.elliptic_curves.gal_reps_number_field.Frobenius_filter(E,primes(40))  # long time
         [5]
 
     Example to show that the output may contain primes where the
@@ -509,7 +509,7 @@ def Frobenius_filter(E, L, patience=100):
     essentially the unique such example by [Sut2012]_::
 
         sage: E = EllipticCurve_from_j(2268945/128)
-        sage: sage.schemes.elliptic_curves.gal_reps_number_field.Frobenius_filter(E, [7, 11])
+        sage: sage.schemes.elliptic_curves.gal_reps_number_field.Frobenius_filter(E, [7, 11])  # long time
         [7]
 
     This curve does possess a 7-isogeny modulo every prime of good
@@ -522,7 +522,7 @@ def Frobenius_filter(E, L, patience=100):
 
         sage: K.<i> = QuadraticField(-1)
         sage: E = EllipticCurve([1+i, -i, i, -399-240*i,  2627+2869*i])
-        sage: sage.schemes.elliptic_curves.gal_reps_number_field.Frobenius_filter(E, primes(20))
+        sage: sage.schemes.elliptic_curves.gal_reps_number_field.Frobenius_filter(E, primes(20))  # long time
         [2, 3]
 
     Here the curve really does possess isogenies of degrees 2 and 3::
@@ -1506,20 +1506,20 @@ def reducible_primes_Billerey(E, num_l=None, max_l=None, verbose=False):
         sage: from sage.schemes.elliptic_curves.gal_reps_number_field import reducible_primes_Billerey
         sage: K = NumberField(x**2 - 29, 'a'); a = K.gen()
         sage: E = EllipticCurve([1, 0, ((5 + a)/2)**2, 0, 0])
-        sage: reducible_primes_Billerey(E)
+        sage: reducible_primes_Billerey(E)  # long time
         [3, 5]
         sage: K = NumberField(x**2 + 1, 'a')
         sage: E = EllipticCurve_from_j(K(1728)) # CM over K
-        sage: reducible_primes_Billerey(E)
+        sage: reducible_primes_Billerey(E)  # long time
         [0]
         sage: E = EllipticCurve_from_j(K(0)) # CM but NOT over K
-        sage: reducible_primes_Billerey(E)
+        sage: reducible_primes_Billerey(E)  # long time
         [2, 3]
 
     An example where a prime is not reducible but passes the test::
 
         sage: E = EllipticCurve_from_j(K(2268945/128)).global_minimal_model() # c.f. [Sut2012]
-        sage: reducible_primes_Billerey(E)
+        sage: reducible_primes_Billerey(E)  # long time
         [7]
 
     TESTS:
@@ -1530,8 +1530,8 @@ def reducible_primes_Billerey(E, num_l=None, max_l=None, verbose=False):
         sage: j = 46969655/32768
         sage: E = EllipticCurve(j=K(j))
         sage: EK = E.change_ring(K)
-        sage: C = EK.isogeny_class(minimal_models=False)
-        sage: len(C)
+        sage: C = EK.isogeny_class(minimal_models=False)    # long time
+        sage: len(C)                                        # long time
         4
     """
     #verbose=True
@@ -1621,9 +1621,9 @@ def reducible_primes_naive(E, max_l=None, num_P=None, verbose=False):
         [2, 5, 197, 557, 653, 769]
         sage: reducible_primes_naive(E,num_P=20)
         [2, 5]
-        sage: reducible_primes_naive(E)
+        sage: reducible_primes_naive(E)  # long time
         [2, 5]
-        sage: [phi.degree() for phi in E.isogenies_prime_degree()]
+        sage: [phi.degree() for phi in E.isogenies_prime_degree()]  # long time
         [2, 2, 2, 5]
     """
     if max_l is None:

--- a/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
@@ -298,12 +298,15 @@ class GaloisRepresentation(SageObject):
             sage: rho.isogeny_bound() # See Section 5.10 of [Ser1972].  # long time
             [3, 5]
             sage: K = NumberField(x**2 + 1, 'a')
-            sage: EllipticCurve_from_j(K(1728)).galois_representation().isogeny_bound() # CM over K
+            sage: E = EllipticCurve_from_j(K(1728))             # CM over K
+            sage: E.galois_representation().isogeny_bound()
             [0]
-            sage: EllipticCurve_from_j(K(0)).galois_representation().isogeny_bound() # CM NOT over K  # long time
+            sage: E = EllipticCurve_from_j(K(0))                # CM NOT over K
+            sage: E.galois_representation().isogeny_bound()     # long time
             [2, 3]
-            sage: E = EllipticCurve_from_j(K(2268945/128)) # c.f. [Sut2012]
-            sage: E.galois_representation().isogeny_bound() # No 7-isogeny, but...  # long time
+            sage: E = EllipticCurve_from_j(K(2268945/128))      # c.f. [Sut2012]
+            sage: rho = E.galois_representation()
+            sage: rho.isogeny_bound()  # No 7-isogeny, but...   # long time
             [7]
 
         For curves with rational CM, there are infinitely many primes
@@ -371,21 +374,21 @@ class GaloisRepresentation(SageObject):
             sage: K = NumberField(x**2 - 29, 'a'); a = K.gen()
             sage: E = EllipticCurve([1, 0, ((5 + a)/2)**2, 0, 0])
             sage: rho = E.galois_representation()
-            sage: rho.isogeny_bound() # See Section 5.10 of [Ser1972].  # long time
-            [3, 5]
-            sage: rho.reducible_primes()  # long time
+            sage: rho.reducible_primes() # See Section 5.10 of [Ser1972].  # long time
             [3, 5]
 
             sage: K = NumberField(x**2 + 1, 'a')
-            sage: EllipticCurve_from_j(K(1728)).galois_representation().isogeny_bound() # CM over K
+            sage: E = EllipticCurve_from_j(K(1728))             # CM over K
+            sage: E.galois_representation().reducible_primes()
             [0]
-            sage: EllipticCurve_from_j(K(0)).galois_representation().reducible_primes() # CM but NOT over K  # long time
+            sage: E = EllipticCurve_from_j(K(0))                # CM but NOT over K
+            sage: E.galois_representation().reducible_primes()  # long time
             [2, 3]
-            sage: E = EllipticCurve_from_j(K(2268945/128)) # c.f. [Sut2012]
+            sage: E = EllipticCurve_from_j(K(2268945/128))      # c.f. [Sut2012]
             sage: rho = E.galois_representation()
-            sage: rho.isogeny_bound() # ... but there is no 7-isogeny ...  # long time
+            sage: rho.isogeny_bound()  # No 7-isogeny, but...   # long time
             [7]
-            sage: rho.reducible_primes()  # long time
+            sage: rho.reducible_primes()                        # long time
             []
 
         For curves with rational CM, there are infinitely many primes

--- a/src/sage/schemes/elliptic_curves/gp_simon.py
+++ b/src/sage/schemes/elliptic_curves/gp_simon.py
@@ -84,7 +84,7 @@ def simon_two_descent(E, verbose=0, lim1=None, lim3=None, limtriv=None,
 
         sage: K.<w> = NumberField(x^2-x-232)
         sage: E = EllipticCurve([2-w,18+3*w,209+9*w,2581+175*w,852-55*w])
-        sage: E.simon_two_descent()
+        sage: E.simon_two_descent()  # long time
         (0, 2, [])
     """
     init()

--- a/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
+++ b/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
@@ -258,12 +258,14 @@ def _isomorphisms(E, F):
 
         sage: p = random_prime(100)
         sage: F = GF(p).algebraic_closure()
-        sage: while True:
-        ....:     try:
-        ....:         E = EllipticCurve(list((F^5).random_element()))
-        ....:     except ArithmeticError:
-        ....:         continue
-        ....:     break
+        sage: j = F.random_element()
+        sage: while j in (0, 1728):     # skip the hard case
+        ....:     j = F.random_element()
+        sage: j = F(choice((0, 1728)))  # long time -- do the hard case
+        sage: E = EllipticCurve_from_j(j)
+        sage: u,r,s,t = (F^4).random_element()
+        sage: u = u or 1
+        sage: E = E.change_weierstrass_model(u,r,s,t)
         sage: Aut = E.automorphisms()
         sage: len(set(Aut)) == len(Aut)
         True

--- a/src/sage/structure/coerce_dict.pyx
+++ b/src/sage/structure/coerce_dict.pyx
@@ -36,7 +36,7 @@ references and resulted in a memory leak in the following example.
 However, this leak was fixed by :trac:`715`, using weak references::
 
     sage: K.<t> = GF(2^55)
-    sage: for i in range(50):
+    sage: for i in range(20):
     ....:     a = K.random_element()
     ....:     E = EllipticCurve(j=a)
     ....:     P = E.random_point()
@@ -404,17 +404,18 @@ cdef class MonoDict:
         sage: import gc
         sage: def count_type(T):
         ....:     return len([c for c in gc.get_objects() if isinstance(c,T)])
-        sage: _ = gc.collect()
+        sage: gc.freeze()  # so that gc.collect() only deals with our trash
         sage: N = count_type(MonoDict)
         sage: for i in range(100):
         ....:     V = [MonoDict({"id":j+100*i}) for j in range(100)]
-        ....:     n= len(V)
-        ....:     for i in range(n): V[i][V[(i+1)%n]]=(i+1)%n
+        ....:     n = len(V)
+        ....:     for i in range(n): V[i][V[(i+1)%n]] = (i+1)%n
         ....:     del V
         ....:     _ = gc.collect()
         ....:     assert count_type(MonoDict) == N
         sage: count_type(MonoDict) == N
         True
+        sage: gc.unfreeze()
 
     AUTHORS:
 

--- a/src/sage/tests/cmdline.py
+++ b/src/sage/tests/cmdline.py
@@ -530,11 +530,11 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: ret                                                   # long time
         0
 
-        sage: (out, err, ret) = test_executable([   # optional - gdb    # long time
+        sage: (out, err, ret) = test_executable([  # optional - gdb # long time
         ....:     "sage", "--gdb"], 'quit\n')
-        sage: out.find('(gdb) ') >= 0               # optional - gdb    # long time
+        sage: out.find('(gdb) ') >= 0              # optional - gdb # long time
         True
-        sage: ret                                   # optional - gdb    # long time
+        sage: ret                                  # optional - gdb # long time
         0
 
         sage: (out, err, ret) = test_executable(["sage", "--mwrank", "-v0", "-q"], "0 0 0 0 1\n")
@@ -732,8 +732,8 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: with open(input, 'w') as F:
         ....:     _ = F.write(s)
         sage: L = ["sage", "--ipynb2rst", input, output]
-        sage: _ = test_executable(L)                        # optional - pandoc  # long time
-        sage: print(open(output, 'r').read() == t)          # optional - pandoc  # long time # known bug #32697
+        sage: _ = test_executable(L)                # long time  # optional - pandoc
+        sage: print(open(output, 'r').read() == t)  # long time  # optional - pandoc  # known bug #32697
         True
     """
     pexpect_env = dict(os.environ)

--- a/src/sage/tests/cmdline.py
+++ b/src/sage/tests/cmdline.py
@@ -530,11 +530,11 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: ret                                                   # long time
         0
 
-        sage: (out, err, ret) = test_executable([  # optional - gdb # long time
+        sage: (out, err, ret) = test_executable([                   # long time  # optional - gdb
         ....:     "sage", "--gdb"], 'quit\n')
-        sage: out.find('(gdb) ') >= 0              # optional - gdb # long time
+        sage: out.find('(gdb) ') >= 0                               # long time  # optional - gdb
         True
-        sage: ret                                  # optional - gdb # long time
+        sage: ret                                                   # long time  # optional - gdb
         0
 
         sage: (out, err, ret) = test_executable(["sage", "--mwrank", "-v0", "-q"], "0 0 0 0 1\n")

--- a/src/sage/tests/cmdline.py
+++ b/src/sage/tests/cmdline.py
@@ -110,56 +110,62 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
 
     Run Sage itself with various options::
 
-        sage: (out, err, ret) = test_executable(["sage"], pydebug_ignore_warnings=True)
-        sage: out.find(version()) >= 0
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage"], pydebug_ignore_warnings=True)
+        sage: out.find(version()) >= 0                      # long time
         True
-        sage: err
+        sage: err                                           # long time
         ''
-        sage: ret
+        sage: ret                                           # long time
         0
 
-        sage: (out, err, ret) = test_executable(["sage"], "3^33\n", pydebug_ignore_warnings=True)
-        sage: out.find(version()) >= 0
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage"], "3^33\n", pydebug_ignore_warnings=True)
+        sage: out.find(version()) >= 0                      # long time
         True
-        sage: out.find("5559060566555523") >= 0
+        sage: out.find("5559060566555523") >= 0             # long time
         True
-        sage: err
+        sage: err                                           # long time
         ''
-        sage: ret
+        sage: ret                                           # long time
         0
 
-        sage: (out, err, ret) = test_executable(["sage", "-q"], "3^33\n", pydebug_ignore_warnings=True)
-        sage: out.find(version()) >= 0
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", "-q"], "3^33\n", pydebug_ignore_warnings=True)
+        sage: out.find(version()) >= 0                      # long time
         False
-        sage: out.find("5559060566555523") >= 0
+        sage: out.find("5559060566555523") >= 0             # long time
         True
-        sage: err
+        sage: err                                           # long time
         ''
-        sage: ret
+        sage: ret                                           # long time
         0
 
-        sage: (out, err, ret) = test_executable(["sage", "-c", "print(3^33)"])
-        sage: print(out)
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", "-c", "print(3^33)"])
+        sage: print(out)                                    # long time
         5559060566555523
-        sage: err
+        sage: err                                           # long time
         ''
-        sage: ret
+        sage: ret                                           # long time
         0
 
-        sage: (out, err, ret) = test_executable(["sage", "--min", "-c", "print(3^33)"])
-        sage: print(out)
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", "--min", "-c", "print(3^33)"])
+        sage: print(out)                                    # long time
         5559060566555523
-        sage: err
+        sage: err                                           # long time
         ''
-        sage: ret
+        sage: ret                                           # long time
         0
 
-        sage: (out, err, ret) = test_executable(["sage", "--startuptime"])
-        sage: out.find("Slowest module import") >= 0
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", "--startuptime"])
+        sage: out.find("Slowest module import") >= 0        # long time
         True
-        sage: err
+        sage: err                                           # long time
         ''
-        sage: ret
+        sage: ret                                           # long time
         0
 
     Test help::
@@ -253,19 +259,21 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: F = open(fullname, 'w')
         sage: _ = F.write("k.<a> = GF(5^3); print(a^124)\n")
         sage: F.close()
-        sage: (out, err, ret) = test_executable(["sage", fullname])
-        sage: print(out)
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", fullname])
+        sage: print(out)                                    # long time
         1
-        sage: err
+        sage: err                                           # long time
         ''
-        sage: ret
+        sage: ret                                           # long time
         0
-        sage: (out, err, ret) = test_executable(["sage", name], cwd=dir)
-        sage: print(out)
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", name], cwd=dir)
+        sage: print(out)                                    # long time
         1
-        sage: err
+        sage: err                                           # long time
         ''
-        sage: ret
+        sage: ret                                           # long time
         0
 
     Test running a ``.spyx`` file::
@@ -275,20 +283,22 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: F = open(fullname, 'w')
         sage: _ = F.write("from cysignals.signals cimport *\nfrom sage.rings.integer cimport Integer\ncdef long i, s = 0\nsig_on()\nfor i in range(1000): s += i\nsig_off()\nprint(Integer(s))")
         sage: F.close()
-        sage: (out, err, ret) = test_executable(["sage", fullname], pydebug_ignore_warnings=True)
-        sage: print(out)
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", fullname], pydebug_ignore_warnings=True)
+        sage: print(out)                                    # long time
         499500
-        sage: import re
-        sage: bool(re.match('Compiling.*spyx.*', err))
+        sage: import re                                     # long time
+        sage: bool(re.match('Compiling.*spyx.*', err))      # long time
         True
-        sage: ret
+        sage: ret                                           # long time
         0
-        sage: (out, err, ret) = test_executable(["sage", name], cwd=dir, pydebug_ignore_warnings=True)
-        sage: print(out)
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", name], cwd=dir, pydebug_ignore_warnings=True)
+        sage: print(out)                                    # long time
         499500
-        sage: bool(re.match('Compiling.*spyx.*', err))
+        sage: bool(re.match('Compiling.*spyx.*', err))      # long time
         True
-        sage: ret
+        sage: ret                                           # long time
         0
 
     Testing ``sage --preparse FILE`` and ``sage -t FILE``.  First create
@@ -308,15 +318,17 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
 
     Now test my_script.sage and the preparsed version my_script.sage.py::
 
-        sage: (out, err, ret) = test_executable(["sage", "-t", script])
-        sage: ret
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", "-t", "--optional=sage", script])
+        sage: ret                                           # long time
         0
-        sage: out.find("All tests passed!") >= 0
+        sage: out.find("All tests passed!") >= 0            # long time
         True
-        sage: (out, err, ret) = test_executable(["sage", "-t", script_py])
-        sage: ret
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", "-t", "--optional=sage", script_py])
+        sage: ret                                           # long time
         0
-        sage: out.find("All tests passed!") >= 0
+        sage: out.find("All tests passed!") >= 0            # long time
         True
 
     Test that the coding line and doctest are preserved::
@@ -335,10 +347,11 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: F = open(script, 'w')
         sage: _ = F.write(s)
         sage: F.close()
-        sage: (out, err, ret) = test_executable(["sage", "-t", script])
-        sage: ret
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", "-t", "--optional=sage", script])
+        sage: ret                                           # long time
         1
-        sage: out.find("1 item had failures:") >= 0
+        sage: out.find("1 item had failures:") >= 0         # long time
         True
 
     Test ``sage -t --debug -p 2`` on a ReST file, the ``-p 2`` should
@@ -349,9 +362,10 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: F = open(script, 'w')
         sage: _ = F.write(s)
         sage: F.close()
-        sage: (out, err, ret) = test_executable([
-        ....:     "sage", "-t", "--debug", "-p", "2", "--warn-long", "0", script], "help")
-        sage: print(out)
+        sage: (out, err, ret) = test_executable([           # long time
+        ....:     "sage", "-t", "--optional=sage", "--debug",
+        ....:     "-p", "2", "--warn-long", "0", script], "help")
+        sage: print(out)                                    # long time
         Debugging requires single-threaded operation, setting number of threads to 1.
         Running doctests with ID...
         Doctesting 1 file.
@@ -389,7 +403,7 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
            2 of   3 in ...
             [2 tests, 2 failures, ...]
         ...
-        sage: ret
+        sage: ret                                           # long time
         1
 
     Now run a test for the fixdoctests script and, in particular, check that the
@@ -401,11 +415,11 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: F = open(test_file, 'w')
         sage: _ = F.write(test)
         sage: F.close()
-        sage: (out, err, ret) = test_executable(["sage", "--fixdoctests", test_file])
-        sage: with open(test_file, 'r') as f:
+        sage: (out, err, ret) = test_executable(["sage", "--fixdoctests", test_file])       # long time
+        sage: with open(test_file, 'r') as f:                                               # long time
         ....:     fixed_test = f.read()
-        sage: import difflib
-        sage: list(difflib.unified_diff(test.splitlines(), fixed_test.splitlines()))[2:-1]
+        sage: import difflib                                                                # long time
+        sage: list(difflib.unified_diff(test.splitlines(), fixed_test.splitlines()))[2:-1]  # long time
         ['@@ -4,18 +4,23 @@\n',
          ' EXAMPLES::',
          ' ',
@@ -450,12 +464,13 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: ret
         42
 
-        sage: (out, err, ret) = test_executable(["sage", "--ipython"], "\n3**33\n", pydebug_ignore_warnings=True)
-        sage: out.find("5559060566555523") >= 0
+        sage: (out, err, ret) = test_executable([   # long time
+        ....:     "sage", "--ipython"], "\n3**33\n", pydebug_ignore_warnings=True)
+        sage: out.find("5559060566555523") >= 0     # long time
         True
-        sage: err
+        sage: err                                   # long time
         ''
-        sage: ret
+        sage: ret                                   # long time
         0
 
         sage: (out, err, ret) = test_executable(["sage", "--python"], "print(3^33)\n")
@@ -506,23 +521,25 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: ret
         0
 
-        sage: (out, err, ret) = test_executable(["sage", "--gap", "-q"], "Size(SymmetricGroup(5));\n")
-        sage: out
+        sage: (out, err, ret) = test_executable([                   # long time
+        ....:     "sage", "--gap", "-q"], "Size(SymmetricGroup(5));\n")
+        sage: out                                                   # long time
         '120\n'
-        sage: err.replace('gap: halving pool size.', '').strip()
+        sage: err.replace('gap: halving pool size.', '').strip()    # long time
         ''
-        sage: ret
+        sage: ret                                                   # long time
         0
 
-        sage: (out, err, ret) = test_executable(["sage", "--gdb"], 'quit\n')  # optional - gdb
-        sage: out.find('(gdb) ') >= 0  # optional - gdb
+        sage: (out, err, ret) = test_executable([   # optional - gdb    # long time
+        ....:     "sage", "--gdb"], 'quit\n')
+        sage: out.find('(gdb) ') >= 0               # optional - gdb    # long time
         True
-        sage: ret  # optional - gdb
+        sage: ret                                   # optional - gdb    # long time
         0
 
-        sage: (out, err, ret) = test_executable(["sage", "--mwrank", "-v0", "-q", "-o"], "0 0 1 -7 6 0 0 0 0 0\n")
+        sage: (out, err, ret) = test_executable(["sage", "--mwrank", "-v0", "-q"], "0 0 0 0 1\n")
         sage: out
-        'Curve [0,0,1,-7,6] :\tRank = 3\n[[3],[[1,-1],[-2,3],[-7/4,25/8]]]\n\n\n'
+        'Curve [0,0,0,0,1] :\tRank = 0\n\n'
         sage: err
         ''
         sage: ret
@@ -715,8 +732,8 @@ def test_executable(args, input="", timeout=100.0, pydebug_ignore_warnings=False
         sage: with open(input, 'w') as F:
         ....:     _ = F.write(s)
         sage: L = ["sage", "--ipynb2rst", input, output]
-        sage: _ = test_executable(L)                        # optional - pandoc
-        sage: print(open(output, 'r').read() == t)          # optional - pandoc  # known bug #32697
+        sage: _ = test_executable(L)                        # optional - pandoc  # long time
+        sage: print(open(output, 'r').read() == t)          # optional - pandoc  # long time # known bug #32697
         True
     """
     pexpect_env = dict(os.environ)

--- a/src/sage/tests/gosper-sum.py
+++ b/src/sage/tests/gosper-sum.py
@@ -118,7 +118,7 @@ doing random summations::
     sage: x = var('x')
     sage: (factorial(n-1)^2 / factorial(n-x) / factorial(n+x)).gosper_sum(n,1,m)
     (m^2*factorial(m - 1)^2*factorial(x + 1)*factorial(-x + 1) + x^2*factorial(m + x)*factorial(m - x) - factorial(m + x)*factorial(m - x))/(x^2*factorial(m + x)*factorial(m - x)*factorial(x + 1)*factorial(-x + 1))
-    sage: ((n*(n+a+b)*a^n*b^n)/factorial(n+a)/factorial(n+b)).gosper_sum(n,1,m).simplify_full()
+    sage: ((n*(n+a+b)*a^n*b^n)/factorial(n+a)/factorial(n+b)).gosper_sum(n,1,m).simplify_full()  # long time
     -(a^(m + 1)*b^(m + 1)*factorial(a - 1)*factorial(b - 1) - factorial(a + m)*factorial(b + m))/(factorial(a + m)*factorial(a - 1)*factorial(b + m)*factorial(b - 1))
 
     sage: check_unsolvable(1/n, n,1,m)
@@ -206,11 +206,11 @@ in the book fails the proof)::
     -1/2*(k - 2*n + 1)*k/((k - n)*(2*n + 1))
     sage: G(n,k) = c*F(n,k)
     sage: t = (F(n+1,k) - F(n,k) - G(n,k+1) + G(n,k))
-    sage: t.simplify_full().is_trivial_zero()
+    sage: t.simplify_full().is_trivial_zero()  # long time
     True
     sage: c = k/2/(-1+k-n)
     sage: GG(n,k) = c*F(n,k)
     sage: t = (F(n+1,k) - F(n,k) - GG(n,k+1) + GG(n,k))
-    sage: t.simplify_full().is_trivial_zero()
+    sage: t.simplify_full().is_trivial_zero()  # long time
     False
 """


### PR DESCRIPTION
### :books: Description

A test is supposed to take < 1s or else be marked # long time.

Here we consider slow tests taking >> 10s. When possible we fix or change the test to take less time, otherwise we just mark the test as long time. Occasionally we create a new smaller test and keep the original one as long.

After this and #35442 the slowest tests are a few taking ~ 10s.
The total time to doctest all goes down from 880 to 806 seconds (using `-tp 8 --all`).

~~NOTE: there's a minor merge conflict with #35314 which I will resolve once that PR is merged.~~

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.