### PR TITLE
add method is_simple to permutations

### DIFF
--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -998,8 +998,8 @@ class Permutation(CombinatorialElement):
         cycles = []
         toConsider = -1
 
-        #Create the list [1,2,...,len(p)]
-        l = [ i+1 for i in range(len(p))]
+        # Create the list [1,2,...,len(p)]
+        l = [i + 1 for i in range(len(p))]
         cycle = []
 
         #Go through until we've considered every number between
@@ -3101,11 +3101,25 @@ class Permutation(CombinatorialElement):
 
         See :oeis:`A111111`
 
+        For instance, ``[6,1,3,5,2,4]`` is not simple because it maps the
+        interval ``[3,4,5,6]`` to ``[2,3,4,5]``, whereas ``[2,6,3,5,1,4]`` is
+        simple.
+
         EXAMPLES::
 
             sage: g = Permutation([4,2,3,1])
             sage: g.is_simple()
             False
+
+            sage: g = Permutation([6,1,3,5,2,4])
+            sage: g.is_simple()
+            False
+
+            sage: g = Permutation([2,6,3,5,1,4])
+            sage: g.is_simple()
+            True
+
+        TESTS::
 
             sage: [len([pi for pi in Permutations(n) if pi.is_simple()])
             ....:  for n in range(5)]

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -3124,15 +3124,14 @@ class Permutation(CombinatorialElement):
         TESTS::
 
             sage: [len([pi for pi in Permutations(n) if pi.is_simple()])
-            ....:  for n in range(5)]
-            [1, 1, 2, 0, 2]
+            ....:  for n in range(6)]
+            [1, 1, 2, 0, 2, 6]
         """
         n = len(self)
         if n <= 2:
             return True
 
         # testing intervals starting at position 0
-        start = 0
         left = right = self._list[0]
         end = 1
         while end < n - 1:
@@ -3141,7 +3140,7 @@ class Permutation(CombinatorialElement):
                 left = elt
             elif elt > right:
                 right = elt
-            if right - left == end - start:
+            if right - left == end:
                 return False
             elif right - left == n - 1:
                 break

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -470,7 +470,7 @@ class Permutation(CombinatorialElement):
         elif isinstance(l, tuple) or \
              (isinstance(l, list) and l and
              all(isinstance(x, tuple) for x in l)):
-            if l and (isinstance(l[0], (int,Integer)) or len(l[0]) > 0):
+            if l and (isinstance(l[0], (int, Integer)) or len(l[0]) > 0):
                 if isinstance(l[0], tuple):
                     n = max(max(x) for x in l)
                     return from_cycles(n, [list(x) for x in l])
@@ -974,7 +974,7 @@ class Permutation(CombinatorialElement):
             cycle = [cycleFirst]
             l[i], next = False, l[i]
             while next != cycleFirst:
-                cycle.append( next )
+                cycle.append(next)
                 l[next - 1], next  = False, l[next - 1]
             # Add the cycle to the list of cycles
             if singletons or len(cycle) > 1:
@@ -1030,8 +1030,8 @@ class Permutation(CombinatorialElement):
             if next == cycleFirst:
                 toConsider = -1
             else:
-                cycle.append( next )
-                l.remove( next )
+                cycle.append(next)
+                l.remove(next)
                 toConsider = next
 
         # When we're finished, add the last cycle
@@ -1065,7 +1065,7 @@ class Permutation(CombinatorialElement):
 
         if not singletons:
             #remove the fixed points
-            L = set( i+1 for i,pi in enumerate(p) if pi != i+1 )
+            L = set(i+1 for i,pi in enumerate(p) if pi != i+1)
         else:
             L = set(range(1,len(p)+1))
 
@@ -1400,10 +1400,9 @@ class Permutation(CombinatorialElement):
             ...
             TypeError: i (= 10) must be between 1 and 7
         """
-        if isinstance(i,(int,Integer)) and 1 <= i <= len(self):
-            return self[i-1]
-        else:
-            raise TypeError("i (= %s) must be between %s and %s" % (i,1,len(self)))
+        if isinstance(i, (int, Integer)) and 1 <= i <= len(self):
+            return self[i - 1]
+        raise TypeError("i (= %s) must be between 1 and %s" % (i, len(self)))
 
     ########
     # Rank #
@@ -1471,26 +1470,25 @@ class Permutation(CombinatorialElement):
         l = len(p)
         # lightning fast if the length is less than 3
         # (is it really useful?)
-        if l<4:
-            if l==0:
+        if l < 4:
+            if l == 0:
                 return []
-            if l==1:
+            if l == 1:
                 return [0]
-            if l==2:
-                return [p[0]-1,0]
-            if l==3:
-                if p[0]==1:
-                    return [0,p[1]-2,0]
-                if p[0]==2:
-                    if p[1]==1:
-                        return [1,0,0]
-                    return [2,0,0]
-                return [p[1],1,0]
+            if l == 2:
+                return [p[0] - 1, 0]
+            if l == 3:
+                if p[0] == 1:
+                    return [0, p[1] - 2, 0]
+                if p[0] == 2:
+                    if p[1] == 1:
+                        return [1, 0, 0]
+                    return [2, 0, 0]
+                return [p[1], 1, 0]
         # choose the best one
-        if l<411:
+        if l < 411:
             return self._to_inversion_vector_small()
-        else:
-            return self._to_inversion_vector_divide_and_conquer()
+        return self._to_inversion_vector_divide_and_conquer()
 
     def _to_inversion_vector_orig(self):
         r"""
@@ -1594,21 +1592,21 @@ class Permutation(CombinatorialElement):
 
         def base_case(L):
             s = sorted(L)
-            d = dict((j,i) for (i,j) in enumerate(s))
+            d = dict((j, i) for i, j in enumerate(s))
             iv = [0]*len(L)
             checked = [1]*len(L)
             for pi in reversed(L):
                 dpi = d[pi]
                 checked[dpi] = 0
                 iv[dpi] = sum(checked[dpi:])
-            return iv,s
+            return iv, s
 
         def sort_and_countv(L):
-            if len(L)<250:
+            if len(L) < 250:
                 return base_case(L)
-            l = len(L)//2
-            return merge_and_countv( sort_and_countv(L[:l]),
-                                     sort_and_countv(L[l:]) )
+            l = len(L) // 2
+            return merge_and_countv(sort_and_countv(L[:l]),
+                                    sort_and_countv(L[l:]))
 
         return sort_and_countv(self._list)[0]
 
@@ -1754,10 +1752,10 @@ class Permutation(CombinatorialElement):
 
             p = self[:]
 
-            L = line([r(1,1)])
+            L = line([r(1, 1)])
             for i in range(len(p)):
-                L += line([r(i,1.0), r(p[i]-1,0)])
-                L += text(str(i), r(i,1.05)) + text(str(i), r(p[i]-1,-.05))
+                L += line([r(i, 1.0), r(p[i]-1, 0)])
+                L += text(str(i), r(i, 1.05)) + text(str(i), r(p[i]-1, -.05))
 
             return L.show(axes = False, **args)
 
@@ -1926,8 +1924,8 @@ class Permutation(CombinatorialElement):
             [3, 1, 5, 2, 4]
         """
         w = list(range(len(self)))
-        for i,j in enumerate(self):
-            w[j-1] = i+1
+        for i, j in enumerate(self):
+            w[j - 1] = i + 1
         return Permutations()(w)
 
     __invert__ = inverse
@@ -3006,7 +3004,7 @@ class Permutation(CombinatorialElement):
 
         rw = []
         for i in range(len(cocode)):
-            piece = [j+1 for j in range(i-cocode[i],i)]
+            piece = [j + 1 for j in range(i-cocode[i], i)]
             piece.reverse()
             rw += piece
 
@@ -3093,6 +3091,35 @@ class Permutation(CombinatorialElement):
             True
         """
         return not self.fixed_points()
+
+    def is_simple(pi) -> bool:
+        """
+        Return if ``self`` is simple.
+
+        A permutation is simple if it does not send any proper sub-interval
+        to a sub-interval.
+
+        See :oeis:`A111111`
+
+        EXAMPLES::
+
+            sage: g = Permutation([4,2,3,1])
+            sage: g.is_simple()
+            False
+
+            sage: [len([pi for pi in Permutations(n) if pi.is_simple()])
+            ....:  for n in range(5)]
+            [1, 1, 2, 0, 2]
+        """
+        n = len(pi)
+        if n <= 2:
+            return True
+        for k in range(1, n - 1):
+            for start in range(n - k):
+                slic = pi[start:start + k + 1]
+                if max(slic) == min(slic) + k:
+                    return False
+        return True
 
     ############
     # Recoils  #
@@ -3753,16 +3780,16 @@ class Permutation(CombinatorialElement):
         p = self
         n = len(p)
 
-        for i in range(n-1):
-            for j in range(i+1,n):
+        for i in range(n - 1):
+            for j in range(i + 1, n):
                 if p[i] > p[j]:
                     ok = True
-                    for k in range(i+1, j):
+                    for k in range(i + 1, j):
                         if p[i] > p[k] and p[k] > p[j]:
                             ok = False
                             break
                     if ok:
-                        yield [i,j]
+                        yield [i, j]
 
     def bruhat_succ(self) -> list:
         r"""
@@ -7213,7 +7240,7 @@ class StandardPermutations_n(StandardPermutations_n_abstract):
             ['A', 0]
         """
         from sage.combinat.root_system.cartan_type import CartanType
-        return CartanType(['A', max(self.n - 1,0)])
+        return CartanType(['A', max(self.n - 1, 0)])
 
     def simple_reflection(self, i):
         r"""
@@ -7401,8 +7428,8 @@ class StandardPermutations_n(StandardPermutations_n_abstract):
                 [4, 2, 1, 3]
             """
             w = list(range(len(self)))
-            for i,j in enumerate(self):
-                w[j-1] = i+1
+            for i, j in enumerate(self):
+                w[j - 1] = i + 1
             return self.__class__(self.parent(), w)
 
         __invert__ = inverse
@@ -7546,8 +7573,8 @@ def from_inversion_vector(iv, parent=None):
     """
     p = iv[:]
     open_spots = list(range(len(iv)))
-    for i,ivi in enumerate(iv):
-        p[open_spots.pop(ivi)] = i+1
+    for i, ivi in enumerate(iv):
+        p[open_spots.pop(ivi)] = i + 1
 
     if parent is None:
         parent = Permutations()

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -76,6 +76,8 @@ Below are listed all methods and classes defined in this file.
     :meth:`~sage.combinat.permutation.Permutation.reduced_words_iterator` | An iterator for the reduced words of the permutation ``self``.
     :meth:`~sage.combinat.permutation.Permutation.reduced_word_lexmin` | Returns a lexicographically minimal reduced word of a permutation ``self``.
     :meth:`~sage.combinat.permutation.Permutation.fixed_points` | Returns a list of the fixed points of the permutation ``self``.
+    :meth:`~sage.combinat.permutation.Permutation.is_derangement` | Returns ``True`` if the permutation ``self`` is a derangement, and ``False`` otherwise.
+    :meth:`~sage.combinat.permutation.Permutation.is_simple` | Returns ``True`` if the permutation ``self`` is simple, and ``False`` otherwise.
     :meth:`~sage.combinat.permutation.Permutation.number_of_fixed_points` | Returns the number of fixed points of the permutation ``self``.
     :meth:`~sage.combinat.permutation.Permutation.recoils` | Returns the list of the positions of the recoils of the permutation ``self``.
     :meth:`~sage.combinat.permutation.Permutation.number_of_recoils` | Returns the number of recoils of the permutation ``self``.
@@ -3092,7 +3094,7 @@ class Permutation(CombinatorialElement):
         """
         return not self.fixed_points()
 
-    def is_simple(pi) -> bool:
+    def is_simple(self) -> bool:
         """
         Return if ``self`` is simple.
 
@@ -3125,12 +3127,12 @@ class Permutation(CombinatorialElement):
             ....:  for n in range(5)]
             [1, 1, 2, 0, 2]
         """
-        n = len(pi)
+        n = len(self)
         if n <= 2:
             return True
         for k in range(1, n - 1):
             for start in range(n - k):
-                slic = pi[start:start + k + 1]
+                slic = self[start:start + k + 1]
                 if max(slic) == min(slic) + k:
                     return False
         return True

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -3130,11 +3130,39 @@ class Permutation(CombinatorialElement):
         n = len(self)
         if n <= 2:
             return True
-        for k in range(1, n - 1):
-            for start in range(n - k):
-                slic = self[start:start + k + 1]
-                if max(slic) == min(slic) + k:
+
+        # testing intervals starting at position 0
+        start = 0
+        left = right = self._list[0]
+        end = 1
+        while end < n - 1:
+            elt = self._list[end]
+            if elt < left:
+                left = elt
+            elif elt > right:
+                right = elt
+            if right - left == end - start:
+                return False
+            elif right - left == n - 1:
+                break
+            end += 1
+
+        # testing intervals starting at later positions
+        for start in range(1, n - 1):
+            left = right = self._list[start]
+            end = start + 1
+            while end < n:
+                elt = self._list[end]
+                if elt < left:
+                    left = elt
+                elif elt > right:
+                    right = elt
+                if right - left == end - start:
                     return False
+                elif right - left > n - 1 - start:
+                    break
+                end += 1
+
         return True
 
     ############

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -877,7 +877,7 @@ class Permutation(CombinatorialElement):
         t = []
         w = list(self)
         for i in reversed(shape):
-            t = [ w[:i] ] + t
+            t = [w[:i]] + t
             w = w[i:]
         return tableau.Tableau(t)
 
@@ -1020,7 +1020,7 @@ class Permutation(CombinatorialElement):
                 #Start with the first element in the list
                 toConsider = l[0]
                 l.remove(toConsider)
-                cycle = [ toConsider ]
+                cycle = [toConsider]
                 cycleFirst = toConsider
 
             #Figure out where the element under consideration
@@ -3078,7 +3078,7 @@ class Permutation(CombinatorialElement):
 
     def is_derangement(self) -> bool:
         r"""
-        Return if ``self`` is a derangement.
+        Return whether ``self`` is a derangement.
 
         A permutation `\sigma` is a derangement if `\sigma` has no
         fixed points.
@@ -3096,16 +3096,16 @@ class Permutation(CombinatorialElement):
 
     def is_simple(self) -> bool:
         """
-        Return if ``self`` is simple.
+        Return whether ``self`` is simple.
 
         A permutation is simple if it does not send any proper sub-interval
         to a sub-interval.
 
-        See :oeis:`A111111`
-
         For instance, ``[6,1,3,5,2,4]`` is not simple because it maps the
         interval ``[3,4,5,6]`` to ``[2,3,4,5]``, whereas ``[2,6,3,5,1,4]`` is
         simple.
+
+        See :oeis:`A111111`
 
         EXAMPLES::
 

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -3121,8 +3121,6 @@ class Permutation(CombinatorialElement):
             sage: g.is_simple()
             True
 
-        TESTS::
-
             sage: [len([pi for pi in Permutations(n) if pi.is_simple()])
             ....:  for n in range(6)]
             [1, 1, 2, 0, 2, 6]


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Add one method to permutations, checking if it is simple (not sending any proper sub-interval to a sub-interval)

Also fixing a few pep8 warnings in the modified file on the way.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
