### PR TITLE
Add `round()` functionality for modules with `Real` and `Rational` fields

### DIFF
--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -1058,8 +1058,78 @@ cdef class FreeModuleElement(Vector):   # abstract base class
         return '%s![%s]' % (R.name(), v)
 
     def round(self, round_type='nearest'):
-        """
-        Returns a list 
+        r"""
+        Returns a vector (or module element) with rounded entries.
+
+        INPUT:
+
+        - ``round_type` -- default: ``nearest`` - rounds to nearest integer, ``up`` - rounds upwards, ``down`` - rounds downwards.
+
+        OUTPUT:
+
+        A vector, or free module element, with all elements
+        rounded according to ``round_type``
+
+        .. NOTE::
+
+            Only works if the underlying field is ``RealField``, ``RealDoubleField``, or ``RationalField``.
+
+        EXAMPLES:
+
+        If the underlying field is ``RationalField``. ::
+
+            sage: v = vector(QQ, [1.2, 2.4])
+            sage: v.round()
+            (1, 2)
+            sage: v.round(round_type="up")
+            (2, 3)
+            sage: v.round(round_type="down")
+            (1, 2)
+
+        If the underlying field is ``RealField`` (arbitrary precision). ::
+
+            sage: v = vector(RealField(), [1.2, 2.4])
+            sage: v.round()
+            (1, 2)
+            sage: v.round(round_type="up")
+            (2, 3)
+            sage: v.round(round_type="down")
+            (1, 2)
+            sage: v = vector(RealField(23), [1.2, 2.4])
+            sage: v.round()
+            (1, 2)
+            sage: v.round(round_type="up")
+            (2, 3)
+            sage: v.round(round_type="down")
+            (1, 2)
+
+        If the underlying field is ``RealDoubleField``. ::
+
+            sage: v = vector(RDF, [1.2, 2.4])
+            sage: v.round()
+            (1, 2)
+            sage: v.round(round_type="up")
+            (2, 3)
+            sage: v.round(round_type="down")
+            (1, 2)
+
+        If the underlying field is none of the above. ::
+
+            sage: v = vector(ZZ, [1, 2])
+            sage: v.round()
+            Traceback (most recent call last):
+            ...
+            TypeError: the underlying ring/field must be RealField, RealDoubleField, RationalField
+            sage: v = vector(CC, [1, 2.3])
+            sage: v.round()
+            Traceback (most recent call last):
+            ...
+            TypeError: the underlying ring/field must be RealField, RealDoubleField, RationalField
+        
+        .. NOTE::
+
+            Look at ``round()``, ``ceil()`` and ``floor()`` methods of ``RealField``, ``RealDoubleField``, and ``RationalField``.
+        
         """
 
         from sage.rings.rational_field import RationalField

--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -1057,6 +1057,22 @@ cdef class FreeModuleElement(Vector):   # abstract base class
         v = ','.join(a._magma_init_(magma) for a in self.list())
         return '%s![%s]' % (R.name(), v)
 
+    def round(self, round_type='nearest'):
+        """
+        Description of the function (TO DO)
+        """
+
+        # Should there be a check for whether the input type is rational, float or double?
+
+        if (round_type == 'nearest'):
+            return self.apply_map(lambda x : x.round())
+        elif (round_type == 'up'):
+            return self.apply_map(lambda x : x.ceil())
+        elif (round_type == 'down'):
+            return self.apply_map(lambda x : x.floor())
+        else:
+            raise AttributeError("round_type needs to be \'up\', \'down\' or \'nearest\'")
+
     def numpy(self, dtype=object):
         """
         Convert self to a numpy array.

--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -1059,7 +1059,7 @@ cdef class FreeModuleElement(Vector):   # abstract base class
 
     def round(self, round_type='nearest'):
         """
-        Description of the function (TO DO)
+        Returns a list 
         """
 
         from sage.rings.rational_field import RationalField
@@ -1067,7 +1067,7 @@ cdef class FreeModuleElement(Vector):   # abstract base class
         type_flag = True
         try:
             field_name = self.base_ring().name()
-            if (len(field_name) > 9 and field_name[0:8] != 'RealField' and field_name != 'RealDoubleField'):
+            if (len(field_name) >= 9 and field_name[0:9] != 'RealField' and field_name != 'RealDoubleField'):
                 # assert field is neither RealField or RealDoubleField
                 type_flag = False
         except:

--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -1062,7 +1062,24 @@ cdef class FreeModuleElement(Vector):   # abstract base class
         Description of the function (TO DO)
         """
 
-        # Should there be a check for whether the input type is rational, float or double?
+        from sage.rings.rational_field import RationalField
+
+        type_flag = True
+        try:
+            field_name = self.base_ring().name()
+            if (len(field_name) > 9 and field_name[0:8] != 'RealField' and field_name != 'RealDoubleField'):
+                # assert field is neither RealField or RealDoubleField
+                type_flag = False
+        except:
+            # assert flag == True
+            # assert not RealField_class and not RealDoubleField_class
+            if (self.base_ring() != RationalField()):
+                type_flag = False
+
+        if (not type_flag):
+            raise TypeError("the underlying ring/field must be RealField, RealDoubleField, RationalField")
+
+        # assert self.base_ring() is either RealField, RealDoubleField or RationalField
 
         if (round_type == 'nearest'):
             return self.apply_map(lambda x : x.round())


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

Add `round()` function for `FreeModuleElement` class which uses the `round()`, `ceil()` and `floor()` functions of `RealField`, `RealDoubleField` and `RationalField`. This partially solves #33921 . 

Doing the same for matrices is trivial, but since this is my first technical PR, I would like to get some feedback on this first and once the changes for modules are accepted, I'll make the changes for matrices as well?

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
