### PR TITLE
Add modules to modules/index.rst

### DIFF
--- a/src/doc/en/reference/modules/index.rst
+++ b/src/doc/en/reference/modules/index.rst
@@ -106,6 +106,8 @@ Vectors
    sage/modules/vector_callable_symbolic_dense
    sage/modules/vector_double_dense
    sage/modules/vector_real_double_dense
+   sage/modules/vector_numpy_dense
+   sage/modules/vector_numpy_integer_dense
    sage/modules/vector_complex_double_dense
    sage/modules/complex_double_vector
    sage/modules/real_double_vector


### PR DESCRIPTION
Add vector_numpy_integer_dense and vector_numpy_dense so that hyperlinks work again.

<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

This attempts to fix #35444 by adding the correct modules in `index.rst`. Currently `Vector_numpy_dense` can be accessed through the index page, but not through the Base class link of `Vector_double_dense`. Need help resolving this issue.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have updated the documentation accordingly.

@mkoeppe 
