### PR TITLE
Faster get_unsafe for NTL GF(p) polynomials

### DIFF
--- a/src/sage/libs/ntl/ntl_ZZ_pX.pyx
+++ b/src/sage/libs/ntl/ntl_ZZ_pX.pyx
@@ -264,9 +264,7 @@ cdef class ntl_ZZ_pX():
         if i < 0:
             r.set_from_int(0)
         else:
-            sig_on()
             r.x = ZZ_pX_coeff( self.x, i)
-            sig_off()
         return r
 
     cdef int getitem_as_int(ntl_ZZ_pX self, long i):

--- a/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
@@ -209,7 +209,7 @@ cdef class Polynomial_dense_mod_n(Polynomial):
             sage: f[:3]
             13*x^2 + 10*x + 5
         """
-        return self._parent._base(self.__poly[n]._sage_())
+        return self._parent._base((<ntl_ZZ_pX> self.__poly)[n]._integer_())
 
     def _unsafe_mutate(self, n, value):
         n = int(n)


### PR DESCRIPTION
### :books: Description

Unlike similar Zmod(n) polynomials, the GF(p) NTL polynomials would call the IntegerModRing constructor for each get_unsafe call resulting in very slow polynomial evaluation.


Benchmarks:
```
p = next_prime(2**80)
pol = GF(p)["x"].random_element(80000)
# Before
# evaluate pol at a random GF(p) element: 260.6ms
# evaluate pol at a random GF(p^2) element: 790.1ms
# evaluate pol at a random GF(p^5) element: 1155.8ms
# After
# evaluate pol at a random GF(p) element: 66.8ms
# evaluate pol at a random GF(p^2) element: 541.2ms
# evaluate pol at a random GF(p^5) element: 889.9ms
```

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.
