### PR TITLE
Faster computation of cached Frobenius powers

### DIFF
--- a/src/sage/rings/finite_rings/finite_field_pari_ffelt.py
+++ b/src/sage/rings/finite_rings/finite_field_pari_ffelt.py
@@ -225,7 +225,12 @@ class FiniteField_pari_ffelt(FiniteField):
             raise ValueError("_pari_frobenius requires a non-zero exponent")
         g = self.gen()
         i = len(self.__pari_frobenius_powers)
+        if i == 0:
+            self.__pari_frobenius_powers.append(g.__pari__().fffrobenius(1))
+            i = 1
+        f1 = self.__pari_frobenius_powers[0]
         while i < k:
             i += 1
-            self.__pari_frobenius_powers.append(g.__pari__().fffrobenius(i))
+            fi = self.__pari_frobenius_powers[-1].ffcompomap(f1)
+            self.__pari_frobenius_powers.append(fi)
         return self.__pari_frobenius_powers[k-1]


### PR DESCRIPTION
### :books: Description

Calling repeatedly PARI fffrobenius function involves redundant computations that can be avoided by reusing already computed powers.

This is a follow-up to #35316 improving the performance of Frobenius on first call:
```
sage: p = next_prime(2**120)
....: K = GF(p**120, 'a')
....: x = K.random_element()
sage: %time _ = [x.frobenius(i) for i in (0, 20, 40, 60, 80, 100)]
Sage 9.8
CPU times: user 9.73 s, sys: 8 ms, total: 9.73 s
Sage 10 beta 8
CPU times: user 6.84 s, sys: 194 µs, total: 6.84 s
After patch
CPU times: user 681 ms, sys: 0 ns, total: 681 ms
When cached (10.0beta8)
30.9 ms ± 155 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

sage: K = GF(5**240, 'a')
....: x = K.random_element()
sage: %time _ = [x.frobenius(i) for i in range(240)]
Sage 9.8
CPU times: user 1.72 s, sys: 1.12 ms, total: 1.73 s
Sage 10.0beta8
CPU times: user 1.02 s, sys: 1.02 ms, total: 1.02 s
After patch
CPU times: user 219 ms, sys: 12 µs, total: 219 ms
When cached (10.0beta8)
168 ms ± 391 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.
