### PR TITLE
Change `Rational`'s `round()` function default rounding from `away` to `even`

### DIFF
--- a/src/sage/rings/rational.pyx
+++ b/src/sage/rings/rational.pyx
@@ -3340,8 +3340,8 @@ cdef class Rational(sage.structure.element.FieldElement):
 
     def round(Rational self, mode="even"):
         """
-        Return the nearest integer to ``self``, rounding away from 0 by
-        default, for consistency with the builtin Python round.
+        Return the nearest integer to ``self``, rounding to even by
+        default for consistency with the builtin Python round.
 
         INPUT:
 

--- a/src/sage/rings/rational.pyx
+++ b/src/sage/rings/rational.pyx
@@ -3338,7 +3338,7 @@ cdef class Rational(sage.structure.element.FieldElement):
         mpz_tdiv_q(n.value, mpq_numref(self.value), mpq_denref(self.value))
         return n
 
-    def round(Rational self, mode="away"):
+    def round(Rational self, mode="even"):
         """
         Return the nearest integer to ``self``, rounding away from 0 by
         default, for consistency with the builtin Python round.
@@ -3362,13 +3362,13 @@ cdef class Rational(sage.structure.element.FieldElement):
         EXAMPLES::
 
             sage: (9/2).round()
-            5
+            4
             sage: n = 4/3; n.round()
             1
             sage: n = -17/4; n.round()
             -4
             sage: n = -5/2; n.round()
-            -3
+            -2
             sage: n.round("away")
             -3
             sage: n.round("up")


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->
Fixes #35473. Changes the default of the `RationalNumber`'s `round()` from `away` to `even`.  

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
