### PR TITLE
Remove unused code from GAP interface

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -35,29 +35,6 @@ from sage.groups.perm_gps.permgroup_element cimport PermutationGroupElement
 from sage.combinat.permutation import Permutation
 from sage.structure.coerce cimport coercion_model as cm
 
-decode_type_number = {
-    0: 'T_INT (integer)',
-    T_INTPOS: 'T_INTPOS (positive integer)',
-    T_INTNEG: 'T_INTNEG (negative integer)',
-    T_RAT: 'T_RAT (rational number)',
-    T_CYC: 'T_CYC (universal cyclotomic)',
-    T_FFE: 'T_FFE (finite field element)',
-    T_PERM2: 'T_PERM2',
-    T_PERM4: 'T_PERM4',
-    T_BOOL: 'T_BOOL',
-    T_CHAR: 'T_CHAR',
-    T_FUNCTION: 'T_FUNCTION',
-    T_PLIST: 'T_PLIST',
-    T_PLIST_CYC: 'T_PLIST_CYC',
-    T_BLIST: 'T_BLIST',
-    T_STRING: 'T_STRING',
-    T_MACFLOAT: 'T_MACFLOAT (hardware floating point number)',
-    T_COMOBJ: 'T_COMOBJ (component object)',
-    T_POSOBJ: 'T_POSOBJ (positional object)',
-    T_DATOBJ: 'T_DATOBJ (data object)',
-    T_WPOBJ:  'T_WPOBJ (weak pointer object)',
-    }
-
 ############################################################################
 ### helper functions to construct lists and records ########################
 ############################################################################
@@ -681,11 +658,10 @@ cdef class GapElement(RingElement):
 
             sage: x = libgap(1)
             sage: x._type_number()
-            (0, 'T_INT (integer)')
+            (0, b'integer')
         """
         n = TNUM_OBJ(self.value)
-        global decode_type_number
-        name = decode_type_number.get(n, 'unknown')
+        name = TNAM_OBJ(self.value)
         return (n, name)
 
     def __dir__(self):

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -51,18 +51,8 @@ cdef extern from "gap/calls.h" nogil:
 
 
 cdef extern from "gap/gasman.h" nogil:
-    Obj NewBag "NewBag"(UInt type, UInt size)
     void MarkBag(Obj bag)
     UInt CollectBags(UInt size, UInt full)
-
-
-cdef extern from "gap/gasman_intern.h" nogil:
-    void CallbackForAllBags(void (*func)(Obj))
-
-
-cdef extern from "gap/gvars.h" nogil:
-    UInt GVarName "GVarName"(char* name)
-    void AssGVar "AssGVar"(UInt gvar, Obj val)
 
 
 cdef extern from "gap/integer.h" nogil:
@@ -122,35 +112,22 @@ cdef extern from "gap/objects.h" nogil:
     Obj SHALLOW_COPY_OBJ(Obj obj)
     Obj CopyObj(Obj obj, int mut)
 
-    UInt SIZE_OBJ(Obj obj)
     UInt TNUM_OBJ(Obj obj)
     char* TNAM_OBJ(Obj obj)
 
     cdef enum TNUM:
-        T_INT
-        T_INTPOS
-        T_INTNEG
         T_RAT
         T_CYC
         T_FFE
         T_MACFLOAT
         T_PERM2
         T_PERM4
-        T_TRANS2
-        T_TRANS4
-        T_PPERM2
-        T_PPERM4
         T_BOOL
         T_CHAR
         T_FUNCTION
         T_PLIST
-        T_PLIST_CYC
-        T_BLIST
-        T_STRING
         T_COMOBJ
         T_POSOBJ
-        T_DATOBJ
-        T_WPOBJ
 
 
 cdef extern from "gap/permutat.h" nogil:

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -274,10 +274,6 @@ cdef initialize():
     # receive error output
     GAP_EvalString(_reset_error_output_cmd)
 
-    # Prepare global GAP variable to hold temporary GAP objects
-    global reference_holder
-    reference_holder = GVarName("$SAGE_libgap_reference_holder")
-
     # Finished!
     _gap_is_initialized = True
 
@@ -396,29 +392,6 @@ cdef Obj gap_eval(str gap_string) except? NULL:
     finally:
         GAP_Leave()
         sig_off()
-
-
-###########################################################################
-### Helper to protect temporary objects from deletion ######################
-############################################################################
-
-# Hold a reference (inside the GAP kernel) to obj so that it doesn't
-# get deleted this works by assigning it to a global variable. This is
-# very simple, but you can't use it to keep two objects alive. Be
-# careful.
-cdef UInt reference_holder
-
-cdef void hold_reference(Obj obj):
-    """
-    Hold a reference (inside the GAP kernel) to obj
-
-    This ensures that the GAP garbage collector does not delete
-    ``obj``. This works by assigning it to a global variable. This is
-    very simple, but you can't use it to keep two objects alive. Be
-    careful.
-    """
-    global reference_holder
-    AssGVar(reference_holder, obj)
 
 
 ############################################################################


### PR DESCRIPTION
### :books: Description

This partially addresses my issue #35361, by removing some unused
code from the libgap based GAP interface. The `_type_number` now
returns slightly different values, but since it is just a debugging
tool for interactive use, that should be fine.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [ ] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
