### PR TITLE
New comparison mode to lazy series and better undefined check

### DIFF
--- a/src/sage/combinat/species/recursive_species.py
+++ b/src/sage/combinat/species/recursive_species.py
@@ -401,6 +401,15 @@ class CombinatorialSpecies(GenericCombinatorialSpecies):
             [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
             sage: F.isotype_generating_series()[0:10]
             [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
+
+        Check that :issue:`35071` is fixed::
+
+            sage: X = species.SingletonSpecies()
+            sage: E = species.SetSpecies(max=3)
+            sage: B = species.CombinatorialSpecies(min=1)
+            sage: B.define(X*E(B))
+            sage: B.generating_series()
+            z + z^2 + 3/2*z^3 + 5/2*z^4 + 9/2*z^5 + 17/2*z^6 + 133/8*z^7 + O(z^8)
         """
         if not isinstance(x, GenericCombinatorialSpecies):
             raise TypeError("x must be a combinatorial species")

--- a/src/sage/combinat/species/recursive_species.py
+++ b/src/sage/combinat/species/recursive_species.py
@@ -230,7 +230,7 @@ class CombinatorialSpecies(GenericCombinatorialSpecies):
 
             sage: F = CombinatorialSpecies()
             sage: F.generating_series()
-            Uninitialized Lazy Laurent Series
+            Uninitialized Lazy Series
         """
         if base_ring not in self._generating_series:
             self._generating_series[base_ring] = series_ring.undefined(valuation=(0 if self._min is None else self._min))
@@ -247,7 +247,7 @@ class CombinatorialSpecies(GenericCombinatorialSpecies):
 
             sage: F = CombinatorialSpecies()
             sage: F.isotype_generating_series()
-            Uninitialized Lazy Laurent Series
+            Uninitialized Lazy Series
         """
         if base_ring not in self._isotype_generating_series:
             self._isotype_generating_series[base_ring] = series_ring.undefined(valuation=(0 if self._min is None else self._min))
@@ -264,7 +264,7 @@ class CombinatorialSpecies(GenericCombinatorialSpecies):
 
             sage: F = CombinatorialSpecies()
             sage: F.cycle_index_series()
-            Uninitialized Lazy Laurent Series
+            Uninitialized Lazy Series
         """
         if base_ring not in self._cycle_index_series:
             self._cycle_index_series[base_ring] = series_ring.undefined(valuation=(0 if self._min is None else self._min))

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1080,6 +1080,7 @@ class Stream_uninitialized(Stream_inexact):
             raise ValueError("the valuation must be specified for undefined series")
         super().__init__(False, true_order)
         self._approximate_order = approximate_order
+        self._initializing = False
 
     def iterate_coefficients(self):
         """
@@ -1113,7 +1114,15 @@ class Stream_uninitialized(Stream_inexact):
             sage: C.is_uninitialized()
             True
         """
-        return self._target is None
+        if self._target is None:
+            return True
+        if self._initializing:
+            return False
+        # We implement semaphore-like behavior for coupled (undefined) series
+        self._initializing = True
+        result = self._target.is_uninitialized()
+        self._initializing = False
+        return result
 
 
 class Stream_unary(Stream_inexact):

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -186,7 +186,7 @@ class Stream():
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
         The default implementation is ``False``.
 
@@ -243,7 +243,7 @@ class Stream_inexact(Stream):
 
     def is_nonzero(self):
         r"""
-        Return ``True`` if and only if the cache contains a nonzero element.
+        Return ``True`` if and only if the cache contains a non-zero element.
 
         EXAMPLES::
 
@@ -332,7 +332,7 @@ class Stream_inexact(Stream):
 
     def __getitem__(self, n):
         """
-        Return the `n`-th coefficient of ``self``.
+        Return the ``n``-th coefficient of ``self``.
 
         INPUT:
 
@@ -433,7 +433,7 @@ class Stream_inexact(Stream):
     def order(self):
         r"""
         Return the order of ``self``, which is the minimum index ``n`` such
-        that ``self[n]`` is nonzero.
+        that ``self[n]`` is non-zero.
 
         EXAMPLES::
 
@@ -659,7 +659,7 @@ class Stream_exact(Stream):
         # complicated otherwise
         for i, v in enumerate(initial_coefficients):
             if v:
-                # We have found the first nonzero coefficient
+                # We have found the first non-zero coefficient
                 order += i
                 initial_coefficients = initial_coefficients[i:]
                 if order + len(initial_coefficients) == self._degree:
@@ -738,7 +738,7 @@ class Stream_exact(Stream):
     def order(self):
         r"""
         Return the order of ``self``, which is the minimum index
-        ``n`` such that ``self[n]`` is nonzero.
+        ``n`` such that ``self[n]`` is non-zero.
 
         EXAMPLES::
 
@@ -869,9 +869,9 @@ class Stream_exact(Stream):
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
-        An assumption of this class is that it is nonzero.
+        An assumption of this class is that it is non-zero.
 
         EXAMPLES::
 
@@ -1578,7 +1578,7 @@ class Stream_cauchy_mul(Stream_binary):
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
         EXAMPLES::
 
@@ -1594,6 +1594,14 @@ class Stream_cauchy_mul(Stream_binary):
             True
         """
         return self._left.is_nonzero() and self._right.is_nonzero()
+
+
+class Stream_cauchy_mul_commutative(Stream_cauchy_mul, Stream_binaryCommutative):
+    """
+    Operator for multiplication of two coefficient streams using the
+    Cauchy product for commutative multiplication of coefficients.
+    """
+    pass
 
 
 class Stream_dirichlet_convolve(Stream_binary):
@@ -1644,7 +1652,7 @@ class Stream_dirichlet_convolve(Stream_binary):
             or self._right._approximate_order <= 0):
             raise ValueError("Dirichlet convolution is only defined for "
                              "coefficient streams with minimal index of "
-                             "nonzero coefficient at least 1")
+                             "non-zero coefficient at least 1")
         return self._left._approximate_order * self._right._approximate_order
 
     def get_coefficient(self, n):
@@ -2236,6 +2244,11 @@ class Stream_scalar(Stream_inexact):
     Base class for operators multiplying a coefficient stream by a
     scalar.
 
+    INPUT:
+
+    - ``series`` -- a :class:`Stream`
+    - ``scalar`` -- a non-zero, non-one scalar
+
     .. TODO::
 
         This does not inherit from :class:`Stream_unary`, because of
@@ -2322,7 +2335,7 @@ class Stream_scalar(Stream_inexact):
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
         EXAMPLES::
 
@@ -2355,7 +2368,7 @@ class Stream_rmul(Stream_scalar):
     INPUT:
 
     - ``series`` -- a :class:`Stream`
-    - ``scalar`` -- a non-zero scalar
+    - ``scalar`` -- a non-zero, non-one scalar
 
     EXAMPLES::
 
@@ -2397,7 +2410,7 @@ class Stream_lmul(Stream_scalar):
     INPUT:
 
     - ``series`` -- a :class:`Stream`
-    - ``scalar`` -- a non-zero scalar
+    - ``scalar`` -- a non-zero, non-one scalar
 
     EXAMPLES::
 
@@ -2504,7 +2517,7 @@ class Stream_neg(Stream_unary):
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
         EXAMPLES::
 
@@ -2643,9 +2656,9 @@ class Stream_cauchy_invert(Stream_unary):
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
-        An assumption of this class is that it is nonzero.
+        An assumption of this class is that it is non-zero.
 
         EXAMPLES::
 
@@ -2660,7 +2673,7 @@ class Stream_cauchy_invert(Stream_unary):
 
 class Stream_map_coefficients(Stream_inexact):
     r"""
-    The stream with ``function`` applied to each nonzero coefficient
+    The stream with ``function`` applied to each non-zero coefficient
     of ``series``.
 
     INPUT:
@@ -2787,7 +2800,7 @@ class Stream_map_coefficients(Stream_inexact):
 
 class Stream_shift(Stream):
     """
-    Operator for shifting a nonzero, nonexact stream.
+    Operator for shifting a non-zero, non-exact stream.
 
     Instances of this class share the cache with its input stream.
 
@@ -2833,7 +2846,7 @@ class Stream_shift(Stream):
     def order(self):
         r"""
         Return the order of ``self``, which is the minimum index
-        ``n`` such that ``self[n]`` is nonzero.
+        ``n`` such that ``self[n]`` is non-zero.
 
         EXAMPLES::
 
@@ -2903,9 +2916,9 @@ class Stream_shift(Stream):
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
-        An assumption of this class is that it is nonzero.
+        An assumption of this class is that it is non-zero.
 
         EXAMPLES::
 
@@ -2925,7 +2938,7 @@ class Stream_shift(Stream):
 
 class Stream_truncated(Stream_inexact):
     """
-    Operator for shifting a nonzero, nonexact stream that has
+    Operator for shifting a non-zero, non-exact stream that has
     been shifted below its minimal valuation.
 
     Instances of this class share the cache with its input stream.
@@ -3086,7 +3099,7 @@ class Stream_truncated(Stream_inexact):
     def order(self):
         """
         Return the order of ``self``, which is the minimum index ``n`` such
-        that ``self[n]`` is nonzero.
+        that ``self[n]`` is non-zero.
 
         EXAMPLES::
 
@@ -3132,7 +3145,7 @@ class Stream_truncated(Stream_inexact):
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
         EXAMPLES::
 
@@ -3180,7 +3193,7 @@ class Stream_truncated(Stream_inexact):
 
 class Stream_derivative(Stream_inexact):
     """
-    Operator for taking derivatives of a stream.
+    Operator for taking derivatives of a non-exact stream.
 
     INPUT:
 
@@ -3293,7 +3306,7 @@ class Stream_derivative(Stream_inexact):
     def is_nonzero(self):
         r"""
         Return ``True`` if and only if this stream is known
-        to be nonzero.
+        to be non-zero.
 
         EXAMPLES::
 

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1113,6 +1113,15 @@ class Stream_uninitialized(Stream_inexact):
             sage: C = Stream_uninitialized(0)
             sage: C.is_uninitialized()
             True
+
+        A more subtle uninitialized series::
+
+            sage: L.<z> = LazyPowerSeriesRing(QQ)
+            sage: T = L.undefined(1)
+            sage: D = L.undefined(0)
+            sage: T.define(z * exp(T) * D)
+            sage: T._coeff_stream.is_uninitialized()
+            True
         """
         if self._target is None:
             return True

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -199,6 +199,12 @@ class Stream():
         """
         return False
 
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return False
+
 
 class Stream_inexact(Stream):
     """
@@ -1042,6 +1048,12 @@ class Stream_uninitialized(Stream_inexact):
             yield self._target[n]
             n += 1
 
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return self._target is None
+
 
 class Stream_unary(Stream_inexact):
     r"""
@@ -1117,6 +1129,12 @@ class Stream_unary(Stream_inexact):
             True
         """
         return isinstance(other, type(self)) and self._series == other._series
+
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return self._series.is_undefined()
 
 
 class Stream_binary(Stream_inexact):
@@ -1205,6 +1223,12 @@ class Stream_binary(Stream_inexact):
         if not isinstance(other, type(self)):
             return False
         return self._left == other._left and self._right == other._right
+
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return self._left.is_undefined() or self._right.is_undefined()
 
 
 class Stream_binaryCommutative(Stream_binary):
@@ -2316,6 +2340,12 @@ class Stream_scalar(Stream_inexact):
         """
         return self._series.is_nonzero()
 
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return self._series.is_undefined()
+
 
 class Stream_rmul(Stream_scalar):
     """
@@ -2748,6 +2778,12 @@ class Stream_map_coefficients(Stream_inexact):
         return (isinstance(other, type(self)) and self._series == other._series
                 and self._function == other._function)
 
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return self._series.is_undefined()
+
 
 class Stream_shift(Stream):
     """
@@ -2881,6 +2917,11 @@ class Stream_shift(Stream):
         """
         return self._series.is_nonzero()
 
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return self._series.is_undefined()
 
 class Stream_truncated(Stream_inexact):
     """
@@ -3130,6 +3171,12 @@ class Stream_truncated(Stream_inexact):
         start = self._approximate_order - offset
         return any(self._cache[start:])
 
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return self._series.is_undefined()
+
 
 class Stream_derivative(Stream_inexact):
     """
@@ -3258,3 +3305,9 @@ class Stream_derivative(Stream_inexact):
             True
         """
         return self._series.is_nonzero()
+
+    def is_undefined(self):
+        """
+        Return ``True`` if ``self`` is an undefined stream.
+        """
+        return self._series.is_undefined()

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -665,7 +665,7 @@ class Stream_exact(Stream):
                 if order + len(initial_coefficients) == self._degree:
                     # Strip off the constant values at the end
                     for w in reversed(initial_coefficients):
-                        if w != self._constant:
+                        if not (w == self._constant):
                             break
                         initial_coefficients.pop()
                         self._degree -= 1

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1788,113 +1788,6 @@ class Stream_dirichlet_convolve(Stream_binary):
                        and (l := self._left[k])))
 
 
-class Stream_dirichlet_invert(Stream_unary):
-    r"""
-    Operator for inverse with respect to Dirichlet convolution of the stream.
-
-    INPUT:
-
-    - ``series`` -- a :class:`Stream`
-
-    EXAMPLES::
-
-        sage: from sage.data_structures.stream import (Stream_dirichlet_invert, Stream_function)
-        sage: f = Stream_function(lambda n: 1, True, 1)
-        sage: g = Stream_dirichlet_invert(f, True)
-        sage: [g[i] for i in range(10)]
-        [0, 1, -1, -1, 0, -1, 1, -1, 0, 0]
-        sage: [moebius(i) for i in range(10)]                                           # needs sage.libs.pari
-        [0, 1, -1, -1, 0, -1, 1, -1, 0, 0]
-    """
-    def __init__(self, series, is_sparse):
-        """
-        Initialize.
-
-        TESTS::
-
-            sage: from sage.data_structures.stream import (Stream_exact, Stream_dirichlet_invert)
-            sage: f = Stream_exact([0, 0], constant=1)
-            sage: g = Stream_dirichlet_invert(f, True)
-            sage: g[1]
-            Traceback (most recent call last):
-            ...
-            ZeroDivisionError: the Dirichlet inverse only exists if the coefficient with index 1 is non-zero
-        """
-        super().__init__(series, is_sparse)
-        self._zero = ZZ.zero()
-
-    @lazy_attribute
-    def _approximate_order(self):
-        """
-        Compute and return the approximate order of ``self``.
-
-        EXAMPLES::
-
-            sage: from sage.data_structures.stream import Stream_function, Stream_dirichlet_invert
-            sage: f = Stream_function(lambda n: n, True, 1)
-            sage: h = Stream_dirichlet_invert(f, True)
-            sage: h._approximate_order
-            1
-            sage: [h[i] for i in range(5)]
-            [0, -2, -8, -12, -48]
-        """
-        # this is the true order, but we want to check first
-        if self._series._approximate_order > 1:
-            raise ZeroDivisionError("the Dirichlet inverse only exists if the "
-                                    "coefficient with index 1 is non-zero")
-        self._true_order = True
-        return 1
-
-    @lazy_attribute
-    def _ainv(self):
-        """
-        The inverse of the leading coefficient.
-
-        EXAMPLES::
-
-            sage: from sage.data_structures.stream import (Stream_exact, Stream_dirichlet_invert)
-            sage: f = Stream_exact([0, 3], constant=2)
-            sage: g = Stream_dirichlet_invert(f, True)
-            sage: g._ainv
-            1/3
-
-            sage: f = Stream_exact([Zmod(6)(5)], constant=2, order=1)
-            sage: g = Stream_dirichlet_invert(f, True)
-            sage: g._ainv
-            5
-        """
-        try:
-            return ~self._series[1]
-        except TypeError:
-            return self._series[1].inverse_of_unit()
-
-    def get_coefficient(self, n):
-        """
-        Return the ``n``-th coefficient of ``self``.
-
-        INPUT:
-
-        - ``n`` -- integer; the degree for the coefficient
-
-        EXAMPLES::
-
-            sage: from sage.data_structures.stream import (Stream_exact, Stream_dirichlet_invert)
-            sage: f = Stream_exact([0, 3], constant=2)
-            sage: g = Stream_dirichlet_invert(f, True)
-            sage: g.get_coefficient(6)
-            2/27
-            sage: [g[i] for i in range(8)]
-            [0, 1/3, -2/9, -2/9, -2/27, -2/9, 2/27, -2/9]
-        """
-        if n == 1:
-            return self._ainv
-        # TODO: isn't self[k] * l and l * self[k] the same here?
-        c = sum(self[k] * l for k in divisors(n)
-                if (k < n
-                    and (l := self._series[n // k])))
-        return -c * self._ainv
-
-
 class Stream_cauchy_compose(Stream_binary):
     r"""
     Return ``f`` composed by ``g``.
@@ -2765,6 +2658,113 @@ class Stream_cauchy_invert(Stream_unary):
             True
         """
         return True
+
+
+class Stream_dirichlet_invert(Stream_unary):
+    r"""
+    Operator for inverse with respect to Dirichlet convolution of the stream.
+
+    INPUT:
+
+    - ``series`` -- a :class:`Stream`
+
+    EXAMPLES::
+
+        sage: from sage.data_structures.stream import (Stream_dirichlet_invert, Stream_function)
+        sage: f = Stream_function(lambda n: 1, True, 1)
+        sage: g = Stream_dirichlet_invert(f, True)
+        sage: [g[i] for i in range(10)]
+        [0, 1, -1, -1, 0, -1, 1, -1, 0, 0]
+        sage: [moebius(i) for i in range(10)]                                           # needs sage.libs.pari
+        [0, 1, -1, -1, 0, -1, 1, -1, 0, 0]
+    """
+    def __init__(self, series, is_sparse):
+        """
+        Initialize.
+
+        TESTS::
+
+            sage: from sage.data_structures.stream import (Stream_exact, Stream_dirichlet_invert)
+            sage: f = Stream_exact([0, 0], constant=1)
+            sage: g = Stream_dirichlet_invert(f, True)
+            sage: g[1]
+            Traceback (most recent call last):
+            ...
+            ZeroDivisionError: the Dirichlet inverse only exists if the coefficient with index 1 is non-zero
+        """
+        super().__init__(series, is_sparse)
+        self._zero = ZZ.zero()
+
+    @lazy_attribute
+    def _approximate_order(self):
+        """
+        Compute and return the approximate order of ``self``.
+
+        EXAMPLES::
+
+            sage: from sage.data_structures.stream import Stream_function, Stream_dirichlet_invert
+            sage: f = Stream_function(lambda n: n, True, 1)
+            sage: h = Stream_dirichlet_invert(f, True)
+            sage: h._approximate_order
+            1
+            sage: [h[i] for i in range(5)]
+            [0, -2, -8, -12, -48]
+        """
+        # this is the true order, but we want to check first
+        if self._series._approximate_order > 1:
+            raise ZeroDivisionError("the Dirichlet inverse only exists if the "
+                                    "coefficient with index 1 is non-zero")
+        self._true_order = True
+        return 1
+
+    @lazy_attribute
+    def _ainv(self):
+        """
+        The inverse of the leading coefficient.
+
+        EXAMPLES::
+
+            sage: from sage.data_structures.stream import (Stream_exact, Stream_dirichlet_invert)
+            sage: f = Stream_exact([0, 3], constant=2)
+            sage: g = Stream_dirichlet_invert(f, True)
+            sage: g._ainv
+            1/3
+
+            sage: f = Stream_exact([Zmod(6)(5)], constant=2, order=1)
+            sage: g = Stream_dirichlet_invert(f, True)
+            sage: g._ainv
+            5
+        """
+        try:
+            return ~self._series[1]
+        except TypeError:
+            return self._series[1].inverse_of_unit()
+
+    def get_coefficient(self, n):
+        """
+        Return the ``n``-th coefficient of ``self``.
+
+        INPUT:
+
+        - ``n`` -- integer; the degree for the coefficient
+
+        EXAMPLES::
+
+            sage: from sage.data_structures.stream import (Stream_exact, Stream_dirichlet_invert)
+            sage: f = Stream_exact([0, 3], constant=2)
+            sage: g = Stream_dirichlet_invert(f, True)
+            sage: g.get_coefficient(6)
+            2/27
+            sage: [g[i] for i in range(8)]
+            [0, 1/3, -2/9, -2/9, -2/27, -2/9, 2/27, -2/9]
+        """
+        if n == 1:
+            return self._ainv
+        # TODO: isn't self[k] * l and l * self[k] the same here?
+        c = sum(self[k] * l for k in divisors(n)
+                if (k < n
+                    and (l := self._series[n // k])))
+        return -c * self._ainv
 
 
 class Stream_map_coefficients(Stream_unary):

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -261,7 +261,6 @@ from sage.data_structures.stream import (
     Stream_dirichlet_invert,
     Stream_plethysm
 )
-from sage.misc.unknown import Unknown, UnknownError
 
 
 class LazyModuleElement(Element):
@@ -954,23 +953,30 @@ class LazyModuleElement(Element):
             False
 
             sage: fz = L(lambda n: 0, valuation=0)
-            sage: (L.zero() == fz) is None
-            True
-            sage: (fz == L.zero()) is None
-            True
+            sage: L.zero() == fz
+            False
+            sage: fz == L.zero()
+            False
 
-        With using :class:`Unknown`::
+        With using secure computations::
 
-            sage: L.options.use_unknown = True
+            sage: L.options.secure = True
             sage: fz = L(lambda n: 0, valuation=0)
-            sage: (L.zero() == fz) is None
-            True
-            sage: (fz == L.zero()) is None
-            True
-            sage: (fz != L.zero()) is None
-            True
+            sage: L.zero() == fz
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
+            sage: fz == L.zero()
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
+            sage: fz != L.zero()
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
 
-        With using finite halting precision::
+        With using finite halting precision (which ignores
+        the ``secure`` option)::
 
             sage: L.options.halting_precision = 40
             sage: fz = L(lambda n: 0, valuation=0)
@@ -990,43 +996,20 @@ class LazyModuleElement(Element):
             True
         """
         if op is op_EQ:
-            if (not self.parent().options['use_unknown']
-                and self.parent().options['halting_precision'] is None):
-                return self._coeff_stream == other._coeff_stream
+            if self._coeff_stream == other._coeff_stream:
+                return True
 
-            if isinstance(self._coeff_stream, Stream_zero):
-                if isinstance(other._coeff_stream, Stream_zero):
-                    return True
-                if other._coeff_stream.is_undefined() or other._coeff_stream.is_nonzero():
-                    return False
-            elif isinstance(other._coeff_stream, Stream_zero):
-                if self._coeff_stream.is_undefined() or self._coeff_stream.is_nonzero():
-                    return False
-            elif isinstance(self._coeff_stream, Stream_exact):
-                if isinstance(other._coeff_stream, Stream_exact):
-                    return self._coeff_stream == other._coeff_stream
-                if self._coeff_stream != other._coeff_stream or other._coeff_stream.is_undefined():
-                    return False
-            elif isinstance(other._coeff_stream, Stream_exact):
-                if other._coeff_stream != self._coeff_stream or self._coeff_stream.is_undefined():
-                    return False
-            else:
-                # both streams are inexact, perhaps they are equal by
-                # construction
-                if self._coeff_stream == other._coeff_stream:
-                    return True
-                # perhaps their caches are different
-                if self._coeff_stream != other._coeff_stream:
-                    return False
-                if self._coeff_stream.is_undefined() or other._coeff_stream.is_undefined():
-                    return False
+            if (not self.parent().options['secure']
+                and self.parent().options['halting_precision'] is None):
+                return False
+
+            if self._coeff_stream != other._coeff_stream:
+                return False
 
             # undecidable otherwise
             prec = self.parent().options['halting_precision']
             if prec is None:
-                return None
-                #return Unknown
-                # raise UnknownError("undecidable")
+                raise ValueError("undecidable")
             # at least one of the approximate orders is not infinity
             m = min(self._coeff_stream._approximate_order,
                     other._coeff_stream._approximate_order)
@@ -1137,7 +1120,6 @@ class LazyModuleElement(Element):
             sage: M.is_zero()
             True
 
-
         With finite halting precision, it can be considered to
         be indistinguishable from zero until possibly enough
         coefficients are computed::
@@ -1161,30 +1143,24 @@ class LazyModuleElement(Element):
             return False
 
         prec = self.parent().options['halting_precision']
-        if prec is None and not self.parent().options['use_unknown']:
+        if prec is None and not self.parent().options['secure']:
             return True
 
         if isinstance(self._coeff_stream, Stream_exact):
             return True
-        if self._coeff_stream.is_undefined():
+        if self._coeff_stream.is_uninitialized():
             return True
-        if self._coeff_stream._is_sparse:
-            cache = self._coeff_stream._cache
-            if any(cache[a] for a in cache):
-                return True
-        else:
-            if any(self._coeff_stream._cache):
-                return True
+        if self._coeff_stream.is_nonzero():
+            return True
 
         if prec is None:
-            return True
-            #raise UnknownError("undecidable")
+            raise ValueError("undecidable")
         v = self._coeff_stream._approximate_order
         return any(self[i] for i in range(v, v + prec))
 
     def is_nonzero(self):
-        """
-        Return ``True`` if ``self`` is known to be nonzero.
+        r"""
+        Return ``True`` if ``self`` is *known* to be nonzero.
 
         EXAMPLES:
 
@@ -1227,6 +1203,52 @@ class LazyModuleElement(Element):
         if self.parent().options['halting_precision'] is not None:
             return bool(self)
         return False
+
+    def prove_nonzero(self):
+        r"""
+        Generate coefficients until the result is shown to be nonzero
+        and returns the degree with the first nonzero coefficient.
+
+        .. WARNING::
+
+            If the stream is exactly zero, this will run forever.
+
+        EXAMPLES::
+
+            sage: L.<z> = LazyLaurentSeriesRing(GF(5))
+            sage: g = L(lambda n: 0 if n < 50 else 1, valuation=2)
+            sage: g.prove_nonzero()
+            50
+
+            sage: L.zero().prove_nonzero()
+            Traceback (most recent call last):
+            ...
+            ValueError: trivially zero
+        """
+        if isinstance(self._coeff_stream, Stream_zero):
+            raise ValueError("trivially zero")
+
+        i = self._coeff_stream._approximate_order
+        while True:
+            if self[i]:
+                return i
+            i += 1
+
+    def is_trivial_zero(self):
+        r"""
+        Return whether ``self`` is known to be trivially zero.
+
+        EXAMPLES::
+
+            sage: L.<z> = LazyLaurentSeriesRing(ZZ)
+            sage: f = L(lambda n: 0, valuation=2)
+            sage: f.is_trivial_zero()
+            False
+
+            sage: L.zero().is_trivial_zero()
+            True
+        """
+        return isinstance(self._coeff_stream, Stream_zero)
 
     def define(self, s):
         r"""
@@ -1540,9 +1562,9 @@ class LazyModuleElement(Element):
             O(z^-3)
 
             sage: s = L.undefined(valuation=0); s
-            Uninitialized Lazy Laurent Series
+            Uninitialized Lazy Series
             sage: (s + s^2).map_coefficients(lambda f: f % 3)
-            Uninitialized Lazy Laurent Series
+            Uninitialized Lazy Series
             sage: L(0)
             0
 
@@ -1555,8 +1577,8 @@ class LazyModuleElement(Element):
         """
         if isinstance(self._coeff_stream, Stream_zero):
             return '0'
-        if self._coeff_stream.is_undefined():
-            return 'Uninitialized Lazy Laurent Series'
+        if self._coeff_stream.is_uninitialized():
+            return 'Uninitialized Lazy Series'
         return self._format_series(repr)
 
     def _latex_(self):
@@ -1608,7 +1630,7 @@ class LazyModuleElement(Element):
         from sage.misc.latex import latex
         if isinstance(self._coeff_stream, Stream_zero):
             return latex('0')
-        if self._coeff_stream.is_undefined():
+        if self._coeff_stream.is_uninitialized():
             return latex("Undef")
         return self._format_series(latex)
 
@@ -1623,14 +1645,17 @@ class LazyModuleElement(Element):
             sage: L.<z> = LazyLaurentSeriesRing(e)
             sage: L.options.display_length = 3
             sage: ascii_art(1 / (1 - e[1]*z))
-            e[] + e[1]*z + e[1, 1]*z^2 + O(e[]*z^3)
+            e[] + e[1]*z + e[1, 1]*z^2 + O(e[]*z^3
+            sage: x = L.undefined(valuation=0)                                          # optional - sage.combinat
+            sage: ascii_art(x + x^2 - 5)                                                # optional - sage.combinat
+            Uninitialized Lazy Series
             sage: L.options._reset()
         """
         from sage.typeset.ascii_art import ascii_art, AsciiArt
         if isinstance(self._coeff_stream, Stream_zero):
             return AsciiArt('0')
-        if isinstance(self._coeff_stream, Stream_uninitialized) and self._coeff_stream._target is None:
-            return AsciiArt('Uninitialized Lazy Laurent Series')
+        if self._coeff_stream.is_uninitialized():
+            return AsciiArt('Uninitialized Lazy Series')
         return self._format_series(ascii_art, True)
 
     def _unicode_art_(self):
@@ -1645,13 +1670,16 @@ class LazyModuleElement(Element):
             sage: L.options.display_length = 3
             sage: unicode_art(1 / (1 - e[1]*z))
             e[] + e[1]*z + e[1, 1]*z^2 + O(e[]*z^3)
+            sage: x = L.undefined(valuation=0)                                          # optional - sage.combinat
+            sage: ascii_art(x + x^2 - 5)                                                # optional - sage.combinat
+            Uninitialized Lazy Series
             sage: L.options._reset()
         """
         from sage.typeset.unicode_art import unicode_art, UnicodeArt
         if isinstance(self._coeff_stream, Stream_zero):
             return UnicodeArt('0')
-        if isinstance(self._coeff_stream, Stream_uninitialized) and self._coeff_stream._target is None:
-            return UnicodeArt('Uninitialized Lazy Laurent Series')
+        if self._coeff_stream.is_uninitialized():
+            return UnicodeArt('Uninitialized Lazy Series')
         return self._format_series(unicode_art, True)
 
     def change_ring(self, ring):
@@ -1931,12 +1959,14 @@ class LazyModuleElement(Element):
 
         Different scalars potentially give different series::
 
-            sage: (2 * M == 3 * M) is None
-            True
+            sage: 2 * M == 3 * M
+            False
 
-            sage: L.options.use_unknown = True
-            sage: (2 * M == 3 * M) is None
-            True
+            sage: L.options.secure = True
+            sage: 2 * M == 3 * M
+            Traceback (most recent call last):
+            ...
+            ValueError: undecidable
 
             sage: L.options.halting_precision = 30
             sage: 2 * M == 3 * M

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -1158,9 +1158,18 @@ class LazyModuleElement(Element):
         v = self._coeff_stream._approximate_order
         return any(self[i] for i in range(v, v + prec))
 
-    def is_nonzero(self):
+    def is_nonzero(self, proof=False):
         r"""
         Return ``True`` if ``self`` is *known* to be nonzero.
+
+        INPUT:
+
+        - ``proof`` -- (default: ``False``) if ``True``, this will also return
+          an index such that ``self`` has a nonzero coefficient
+
+        .. WARNING::
+
+            If the stream is exactly zero, this will run forever.
 
         EXAMPLES:
 
@@ -1197,42 +1206,32 @@ class LazyModuleElement(Element):
             sage: g.is_nonzero()  # checks up to degree 62 = 42 + 20
             True
             sage: L.options._reset()
+
+        With a proof::
+
+            sage: L.<z> = LazyLaurentSeriesRing(GF(5))
+            sage: g = L(lambda n: 5 if n < 50 else 1, valuation=2)
+            sage: g.is_nonzero(proof=True)
+            (True, 50)
+
+            sage: L.zero().is_nonzero(proof=True)
+            (False, None)
         """
+        if proof:
+            if isinstance(self._coeff_stream, Stream_zero):
+                return (False, None)
+
+            i = self._coeff_stream._approximate_order
+            while True:
+                if self[i]:
+                    return (True, i)
+                i += 1
+
         if self._coeff_stream.is_nonzero():
             return True
         if self.parent().options['halting_precision'] is not None:
             return bool(self)
         return False
-
-    def prove_nonzero(self):
-        r"""
-        Generate coefficients until the result is shown to be nonzero
-        and returns the degree with the first nonzero coefficient.
-
-        .. WARNING::
-
-            If the stream is exactly zero, this will run forever.
-
-        EXAMPLES::
-
-            sage: L.<z> = LazyLaurentSeriesRing(GF(5))
-            sage: g = L(lambda n: 0 if n < 50 else 1, valuation=2)
-            sage: g.prove_nonzero()
-            50
-
-            sage: L.zero().prove_nonzero()
-            Traceback (most recent call last):
-            ...
-            ValueError: trivially zero
-        """
-        if isinstance(self._coeff_stream, Stream_zero):
-            raise ValueError("trivially zero")
-
-        i = self._coeff_stream._approximate_order
-        while True:
-            if self[i]:
-                return i
-            i += 1
 
     def is_trivial_zero(self):
         r"""
@@ -1645,7 +1644,7 @@ class LazyModuleElement(Element):
             sage: L.<z> = LazyLaurentSeriesRing(e)
             sage: L.options.display_length = 3
             sage: ascii_art(1 / (1 - e[1]*z))
-            e[] + e[1]*z + e[1, 1]*z^2 + O(e[]*z^3
+            e[] + e[1]*z + e[1, 1]*z^2 + O(e[]*z^3)
             sage: x = L.undefined(valuation=0)                                          # optional - sage.combinat
             sage: ascii_art(x + x^2 - 5)                                                # optional - sage.combinat
             Uninitialized Lazy Series
@@ -1655,7 +1654,7 @@ class LazyModuleElement(Element):
         if isinstance(self._coeff_stream, Stream_zero):
             return AsciiArt('0')
         if self._coeff_stream.is_uninitialized():
-            return AsciiArt('Uninitialized Lazy Series')
+            return AsciiArt(['Uninitialized Lazy Series'])
         return self._format_series(ascii_art, True)
 
     def _unicode_art_(self):
@@ -1671,7 +1670,7 @@ class LazyModuleElement(Element):
             sage: unicode_art(1 / (1 - e[1]*z))
             e[] + e[1]*z + e[1, 1]*z^2 + O(e[]*z^3)
             sage: x = L.undefined(valuation=0)                                          # optional - sage.combinat
-            sage: ascii_art(x + x^2 - 5)                                                # optional - sage.combinat
+            sage: unicode_art(x + x^2 - 5)                                              # optional - sage.combinat
             Uninitialized Lazy Series
             sage: L.options._reset()
         """
@@ -1679,7 +1678,7 @@ class LazyModuleElement(Element):
         if isinstance(self._coeff_stream, Stream_zero):
             return UnicodeArt('0')
         if self._coeff_stream.is_uninitialized():
-            return UnicodeArt('Uninitialized Lazy Series')
+            return UnicodeArt(['Uninitialized Lazy Series'])
         return self._format_series(unicode_art, True)
 
     def change_ring(self, ring):

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -939,21 +939,21 @@ class LazyModuleElement(Element):
             False
 
             sage: fz = L(lambda n: 0, valuation=0)
-            sage: L.zero() == fz
-            False
-            sage: fz == L.zero()
-            False
+            sage: (L.zero() == fz) is None
+            True
+            sage: (fz == L.zero()) is None
+            True
 
         With using :class:`Unknown`::
 
             sage: L.options.use_unknown = True
             sage: fz = L(lambda n: 0, valuation=0)
-            sage: L.zero() == fz
-            Unknown
-            sage: fz == L.zero()
-            Unknown
-            sage: fz != L.zero()
-            Unknown
+            sage: (L.zero() == fz) is None
+            True
+            sage: (fz == L.zero()) is None
+            True
+            sage: (fz != L.zero()) is None
+            True
 
         With using finite halting precision::
 
@@ -1009,7 +1009,8 @@ class LazyModuleElement(Element):
             # undecidable otherwise
             prec = self.parent().options['halting_precision']
             if prec is None:
-                return Unknown
+                return None
+                #return Unknown
                 # raise UnknownError("undecidable")
             # at least one of the approximate orders is not infinity
             m = min(self._coeff_stream._approximate_order,
@@ -1018,7 +1019,7 @@ class LazyModuleElement(Element):
 
         if op is op_NE:
             ret = (self == other)
-            if ret is Unknown:
+            if ret is None:
                 return ret
             return not ret
 
@@ -1165,7 +1166,8 @@ class LazyModuleElement(Element):
                 return True
 
         if prec is None:
-            raise UnknownError("undecidable")
+            return True
+            #raise UnknownError("undecidable")
         v = self._coeff_stream._approximate_order
         return any(self[i] for i in range(v, v + prec))
 
@@ -1918,12 +1920,12 @@ class LazyModuleElement(Element):
 
         Different scalars potentially give different series::
 
-            sage: 2 * M == 3 * M
-            False
+            sage: (2 * M == 3 * M) is None
+            True
 
             sage: L.options.use_unknown = True
-            sage: 2 * M == 3 * M
-            Unknown
+            sage: (2 * M == 3 * M) is None
+            True
 
             sage: L.options.halting_precision = 30
             sage: 2 * M == 3 * M

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -196,6 +196,19 @@ components are in the correct ring::
     sage: L = LazySymmetricFunctions(s)                                                 # needs sage.combinat
     sage: check(L, lambda n: sum(k*s(la) for k, la in enumerate(Partitions(n))),        # needs sage.combinat
     ....:       valuation=0)
+
+Check that we can invert matrices::
+
+    sage: L.<z> = LazyLaurentSeriesRing(QQ)
+    sage: a11 = 1 + L(lambda n: 1 if not n else 0, valuation=0)
+    sage: a12 = 1 + L(lambda n: 1 if n == 1 else 0, valuation=0)
+    sage: a21 = 1 + L(lambda n: 1 if n == 2 else 0, valuation=0)
+    sage: a22 = 1 + L(lambda n: 1 if n == 3 else 0, valuation=0)
+    sage: m = matrix([[a11, a12], [a21, a22]])
+    sage: m.inverse()
+    [   1 + z + 2*z^2 + 3*z^3 + 4*z^4 + 5*z^5 + 6*z^6 + O(z^7) -1 - 2*z - 3*z^2 - 4*z^3 - 5*z^4 - 6*z^5 - 7*z^6 + O(z^7)]
+    [  -1 - z - 3*z^2 - 3*z^3 - 5*z^4 - 5*z^5 - 7*z^6 + O(z^7)  2 + 2*z + 4*z^2 + 4*z^3 + 6*z^4 + 6*z^5 + 8*z^6 + O(z^7)]
+
 """
 
 # ****************************************************************************
@@ -219,6 +232,7 @@ from sage.arith.misc import divisors, factorial, moebius
 from sage.combinat.partition import Partition, Partitions
 from sage.misc.derivative import derivative_parse
 from sage.categories.integral_domains import IntegralDomains
+from sage.categories.rings import Rings
 from sage.rings.infinity import infinity
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
@@ -228,6 +242,7 @@ from sage.categories.tensor import tensor
 from sage.data_structures.stream import (
     Stream_add,
     Stream_cauchy_mul,
+    Stream_cauchy_mul_commutative,
     Stream_sub,
     Stream_cauchy_compose,
     Stream_lmul,
@@ -1064,11 +1079,9 @@ class LazyModuleElement(Element):
             False
             sage: M = L(lambda n: 2*n if n < 10 else 1, valuation=0); M
             O(z^7)
-            sage: bool(M)
-            Traceback (most recent call last):
-            ...
-            ValueError: undecidable as lazy Laurent series
-            sage: M[15]
+            sage: bool(M)                                                               # optional - sage.rings.finite_rings
+            True
+            sage: M[15]                                                                 # optional - sage.rings.finite_rings
             1
             sage: bool(M)
             True
@@ -1077,11 +1090,9 @@ class LazyModuleElement(Element):
             sage: L.<z> = LazyLaurentSeriesRing(GF(2), sparse=True)
             sage: M = L(lambda n: 2*n if n < 10 else 1, valuation=0); M
             O(z^7)
-            sage: bool(M)
-            Traceback (most recent call last):
-            ...
-            ValueError: undecidable as lazy Laurent series
-            sage: M[15]
+            sage: bool(M)                                                               # optional - sage.rings.finite_rings
+            True
+            sage: M[15]                                                                 # optional - sage.rings.finite_rings
             1
             sage: bool(M)
             True
@@ -1237,7 +1248,7 @@ class LazyModuleElement(Element):
             sage: binomial(2000, 1000) / C[1000]                                        # needs sage.symbolic
             1001
 
-        The Catalan numbers but with a valuation 1::
+        The Catalan numbers but with a valuation `1`::
 
             sage: B = L.undefined(valuation=1)
             sage: B.define(z + B^2)
@@ -2002,6 +2013,19 @@ class LazyModuleElement(Element):
             sage: f = L(constant=2)
             sage: 2*f
             0
+
+        Check that non-commutativity is taken into account::
+
+            sage: M = MatrixSpace(ZZ, 2)
+            sage: L.<z> = LazyPowerSeriesRing(M)
+            sage: f = L(lambda n: matrix([[1,n],[0,1]]))
+            sage: m = matrix([[1,0],[1,1]])
+            sage: (m * f - f * m)[1]
+            [-1  0]
+            [ 0  1]
+            sage: m * f[1] - f[1] * m
+            [-1  0]
+            [ 0  1]
         """
         # With the current design, the coercion model does not have
         # enough information to detect a priori that this method only
@@ -2042,7 +2066,7 @@ class LazyModuleElement(Element):
                                                    order=v,
                                                    constant=c,
                                                    degree=coeff_stream._degree))
-        if self_on_left or R.is_commutative():
+        if self_on_left or R in Rings().Commutative():
             return P.element_class(P, Stream_lmul(coeff_stream, scalar,
                                                   P.is_sparse()))
         return P.element_class(P, Stream_rmul(coeff_stream, scalar,
@@ -3010,6 +3034,9 @@ class LazyCauchyProductSeries(LazyModuleElement):
             and right.order() == 0
             and not right._constant):
             return self  # right == 1
+        if ((isinstance(left, Stream_cauchy_invert) and left._series == right)
+            or (isinstance(right, Stream_cauchy_invert) and right._series == left)):
+            return P.one()
         # The product is exact if and only if both factors are exact
         # and one of the factors has eventually 0 coefficients:
         # (p + a x^d/(1-x))(q + b x^e/(1-x))
@@ -3057,7 +3084,11 @@ class LazyCauchyProductSeries(LazyModuleElement):
                                         constant=c)
             return P.element_class(P, coeff_stream)
 
-        return P.element_class(P, Stream_cauchy_mul(left, right, P.is_sparse()))
+        if P in Rings().Commutative():
+            coeff_stream = Stream_cauchy_mul_commutative(left, right, P.is_sparse())
+        else:
+            coeff_stream = Stream_cauchy_mul(left, right, P.is_sparse())
+        return P.element_class(P, coeff_stream)
 
     def __pow__(self, n):
         r"""
@@ -3200,7 +3231,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
             sage: g = L([2], valuation=-1, constant=1); g
             2*x^-1 + 1 + x + x^2 + O(x^3)
             sage: g * g^-1
-            1 + O(x^7)
+            1
 
             sage: L.<x> = LazyPowerSeriesRing(QQ)
             sage: ~(x + x^2)
@@ -3383,7 +3414,7 @@ class LazyCauchyProductSeries(LazyModuleElement):
             return self
 
         # self is right
-        if left is right:
+        if left == right:
             return P.one()
 
         if (P._minimal_valuation is not None
@@ -3458,7 +3489,11 @@ class LazyCauchyProductSeries(LazyModuleElement):
         # P._minimal_valuation is zero, because we allow division by
         # series of positive valuation
         right_inverse = Stream_cauchy_invert(right)
-        return P.element_class(P, Stream_cauchy_mul(left, right_inverse, P.is_sparse()))
+        if P in Rings().Commutative():
+            coeff_stream = Stream_cauchy_mul_commutative(left, right_inverse, P.is_sparse())
+        else:
+            coeff_stream = Stream_cauchy_mul(left, right_inverse, P.is_sparse())
+        return P.element_class(P, coeff_stream)
 
     def _floordiv_(self, other):
         r"""
@@ -3549,7 +3584,9 @@ class LazyCauchyProductSeries(LazyModuleElement):
         d_self = Stream_function(lambda n: (n + 1) * coeff_stream[n + 1],
                                  False, 0)
         f = P.undefined(valuation=0)
-        d_self_f = Stream_cauchy_mul(d_self, f._coeff_stream, False)
+        # d_self and f._coeff_stream always commute, the coefficients
+        # of the product are of the form sum_{k=1}^n a_k a_{n+1-k}.
+        d_self_f = Stream_cauchy_mul_commutative(d_self, f._coeff_stream, False)
         int_d_self_f = Stream_function(lambda n: d_self_f[n-1] / R(n) if n else R.one(),
                                        False, 0)
         f._coeff_stream._target = int_d_self_f
@@ -3598,9 +3635,11 @@ class LazyCauchyProductSeries(LazyModuleElement):
         # multivariate power series
         d_self = Stream_function(lambda n: (n + 1) * coeff_stream[n + 1],
                                  P.is_sparse(), 0)
-        d_self_quo_self = Stream_cauchy_mul(d_self,
-                                            Stream_cauchy_invert(coeff_stream),
-                                            P.is_sparse())
+        coeff_stream_inverse = Stream_cauchy_invert(coeff_stream)
+        # d_self and coeff_stream_inverse always commute
+        d_self_quo_self = Stream_cauchy_mul_commutative(d_self,
+                                                        coeff_stream_inverse,
+                                                        P.is_sparse())
         int_d_self_quo_self = Stream_function(lambda n: d_self_quo_self[n-1] / R(n),
                                               P.is_sparse(), 1)
         return P.element_class(P, int_d_self_quo_self)

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -3605,7 +3605,8 @@ class LazyCauchyProductSeries(LazyModuleElement):
         coeff_stream = self._coeff_stream
         # TODO: coefficients should not be checked here, it prevents
         # us from using self.define in some cases!
-        if any(coeff_stream[i] for i in range(coeff_stream._approximate_order, 1)):
+        if ((not coeff_stream.is_uninitialized())
+            and any(coeff_stream[i] for i in range(coeff_stream._approximate_order, 1))):
             raise ValueError("can only compose with a positive valuation series")
         # WARNING: d_self need not be a proper element of P, e.g. for
         # multivariate power series
@@ -3657,8 +3658,9 @@ class LazyCauchyProductSeries(LazyModuleElement):
         coeff_stream = self._coeff_stream
         # TODO: coefficients should not be checked here, it prevents
         # us from using self.define in some cases!
-        if (any(coeff_stream[i] for i in range(coeff_stream._approximate_order, 0))
-            or coeff_stream[0] != R.one()):
+        if ((not coeff_stream.is_uninitialized())
+            and (any(coeff_stream[i] for i in range(coeff_stream._approximate_order, 0))
+                 or coeff_stream[0] != R.one())):
             raise ValueError("can only compose with a positive valuation series")
         # WARNING: d_self need not be a proper element of P, e.g. for
         # multivariate power series

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -246,6 +246,7 @@ from sage.data_structures.stream import (
     Stream_dirichlet_invert,
     Stream_plethysm
 )
+from sage.misc.unknown import Unknown, UnknownError
 
 
 class LazyModuleElement(Element):
@@ -939,13 +940,31 @@ class LazyModuleElement(Element):
 
             sage: fz = L(lambda n: 0, valuation=0)
             sage: L.zero() == fz
-            Traceback (most recent call last):
-            ...
-            ValueError: undecidable
+            False
             sage: fz == L.zero()
-            Traceback (most recent call last):
-            ...
-            ValueError: undecidable
+            False
+
+        With using :class:`Unknown`::
+
+            sage: L.options.use_unknown = True
+            sage: fz = L(lambda n: 0, valuation=0)
+            sage: L.zero() == fz
+            Unknown
+            sage: fz == L.zero()
+            Unknown
+            sage: fz != L.zero()
+            Unknown
+
+        With using finite halting precision::
+
+            sage: L.options.halting_precision = 40
+            sage: fz = L(lambda n: 0, valuation=0)
+            sage: L.zero() == fz
+            True
+            sage: fz == L.zero()
+            True
+
+            sage: L.options._reset()
 
         TESTS::
 
@@ -954,24 +973,27 @@ class LazyModuleElement(Element):
             sage: g = L([0,0,1,0,1,0,0], degree=7, constant=1)
             sage: f == g
             True
-
         """
         if op is op_EQ:
+            if (not self.parent().options['use_unknown']
+                and self.parent().options['halting_precision'] is None):
+                return self._coeff_stream == other._coeff_stream
+
             if isinstance(self._coeff_stream, Stream_zero):
                 if isinstance(other._coeff_stream, Stream_zero):
                     return True
-                if other._coeff_stream.is_nonzero():
+                if other._coeff_stream.is_undefined() or other._coeff_stream.is_nonzero():
                     return False
             elif isinstance(other._coeff_stream, Stream_zero):
-                if self._coeff_stream.is_nonzero():
+                if self._coeff_stream.is_undefined() or self._coeff_stream.is_nonzero():
                     return False
             elif isinstance(self._coeff_stream, Stream_exact):
                 if isinstance(other._coeff_stream, Stream_exact):
                     return self._coeff_stream == other._coeff_stream
-                if self._coeff_stream != other._coeff_stream:
+                if self._coeff_stream != other._coeff_stream or other._coeff_stream.is_undefined():
                     return False
             elif isinstance(other._coeff_stream, Stream_exact):
-                if other._coeff_stream != self._coeff_stream:
+                if other._coeff_stream != self._coeff_stream or self._coeff_stream.is_undefined():
                     return False
             else:
                 # both streams are inexact, perhaps they are equal by
@@ -981,19 +1003,26 @@ class LazyModuleElement(Element):
                 # perhaps their caches are different
                 if self._coeff_stream != other._coeff_stream:
                     return False
+                if self._coeff_stream.is_undefined() or other._coeff_stream.is_undefined():
+                    return False
 
             # undecidable otherwise
             prec = self.parent().options['halting_precision']
             if prec is None:
-                raise ValueError("undecidable")
+                return Unknown
+                # raise UnknownError("undecidable")
             # at least one of the approximate orders is not infinity
             m = min(self._coeff_stream._approximate_order,
                     other._coeff_stream._approximate_order)
             return all(self[i] == other[i] for i in range(m, m + prec))
 
         if op is op_NE:
-            return not (self == other)
+            ret = (self == other)
+            if ret is Unknown:
+                return ret
+            return not ret
 
+        # FIXME: This should check for equality in <= and >= and other return NotImplemented
         return False
 
     def __hash__(self):
@@ -1016,9 +1045,8 @@ class LazyModuleElement(Element):
         """
         Test whether ``self`` is not zero.
 
-        An uninitialized series returns ``True`` as it is considered
-        as a formal variable, such as a generator of a polynomial
-        ring.
+        When the halting precision is infinite, then any series that is
+        not known to be zero will be ``True``.
 
         TESTS::
 
@@ -1082,18 +1110,52 @@ class LazyModuleElement(Element):
             sage: g.define(1 + z*g)
             sage: bool(g)
             True
+
+        Comparison with finite halting precision::
+
+            sage: M = L(lambda n: 2*n if n < 10 else 0, valuation=0)
+            sage: bool(M)
+            True
+            sage: M.is_zero()
+            False
+
+            sage: L.options.halting_precision = 20
+            sage: bool(M)
+            False
+            sage: M.is_zero()
+            True
+
+
+        With finite halting precision, it can be considered to
+        be indistinguishable from zero until possibly enough
+        coefficients are computed::
+
+            sage: L.<z> = LazyLaurentSeriesRing(GF(2))
+            sage: L.options.halting_precision = 20
+            sage: f = L(lambda n: 0, valuation=0)
+            sage: f.is_zero()
+            True
+
+            sage: g = L(lambda n: 0 if n < 50 else 1, valuation=2)
+            sage: bool(g)  # checks up to degree 22 = 2 + 20
+            False
+            sage: bool(g)  # checks up to degree 42 = 22 + 20
+            False
+            sage: bool(g)  # checks up to degree 62 = 42 + 20
+            True
+            sage: L.options._reset()
         """
         if isinstance(self._coeff_stream, Stream_zero):
             return False
+
+        prec = self.parent().options['halting_precision']
+        if prec is None and not self.parent().options['use_unknown']:
+            return True
+
         if isinstance(self._coeff_stream, Stream_exact):
             return True
-        if isinstance(self._coeff_stream, Stream_uninitialized):
-            if self._coeff_stream._target is None:
-                return True
-            if isinstance(self._coeff_stream._target, Stream_zero):
-                return False
-            if isinstance(self._coeff_stream._target, Stream_exact):
-                return True
+        if self._coeff_stream.is_undefined():
+            return True
         if self._coeff_stream._is_sparse:
             cache = self._coeff_stream._cache
             if any(cache[a] for a in cache):
@@ -1102,14 +1164,56 @@ class LazyModuleElement(Element):
             if any(self._coeff_stream._cache):
                 return True
 
-        v = self._coeff_stream._approximate_order
-        if self[v]:
-            return True
-
-        prec = self.parent().options['halting_precision']
         if prec is None:
-            raise ValueError("undecidable as lazy Laurent series")
+            raise UnknownError("undecidable")
+        v = self._coeff_stream._approximate_order
         return any(self[i] for i in range(v, v + prec))
+
+    def is_nonzero(self):
+        """
+        Return ``True`` if ``self`` is known to be nonzero.
+
+        EXAMPLES:
+
+        A series that it not known to be nonzero with no halting precision::
+
+            sage: L.<z> = LazyLaurentSeriesRing(GF(2))
+            sage: f = L(lambda n: 0, valuation=0)
+            sage: f.is_nonzero()
+            False
+            sage: bool(f)
+            True
+            sage: g = L(lambda n: 0 if n < 50 else 1, valuation=2)
+            sage: g.is_nonzero()
+            False
+            sage: g[60]
+            1
+            sage: g.is_nonzero()
+            True
+
+        With finite halting precision, it can be considered to
+        be indistinguishable from zero until possibly enough
+        coefficients are computed::
+
+            sage: L.options.halting_precision = 20
+            sage: f = L(lambda n: 0, valuation=0)
+            sage: f.is_zero()
+            True
+
+            sage: g = L(lambda n: 0 if n < 50 else 1, valuation=2)
+            sage: g.is_nonzero()  # checks up to degree 22 = 2 + 20
+            False
+            sage: g.is_nonzero()  # checks up to degree 42 = 22 + 20
+            False
+            sage: g.is_nonzero()  # checks up to degree 62 = 42 + 20
+            True
+            sage: L.options._reset()
+        """
+        if self._coeff_stream.is_nonzero():
+            return True
+        if self.parent().options['halting_precision'] is not None:
+            return bool(self)
+        return False
 
     def define(self, s):
         r"""
@@ -1358,6 +1462,24 @@ class LazyModuleElement(Element):
             sage: (f*s[1]).revert() + 1 - f                                             # needs lrcalc_python sage.combinat
             O^7
 
+        Undefined series inside of another series (see :issue:`35071`)::
+
+            sage: L.<z> = LazyPowerSeriesRing(QQ)
+            sage: f = z^2
+            sage: b = L.undefined(valuation=1)
+            sage: b.define(z*f(f(b)))
+            sage: b
+            O(z^8)
+
+            sage: L.<x> = LazyPowerSeriesRing(ZZ)
+            sage: f = L.undefined()
+            sage: f.define(L(lambda n: 0 if not n else sigma(f[n-1]+1)))
+            sage: f
+            x + 3*x^2 + 7*x^3 + 15*x^4 + 31*x^5 + 63*x^6 + O(x^7)
+            sage: f = L.undefined()
+            sage: f.define((1/(1-L(lambda n: 0 if not n else sigma(f[n-1]+1)))))
+            sage: f
+            1 + 3*x + 16*x^2 + 87*x^3 + 607*x^4 + 4518*x^5 + 30549*x^6 + O(x^7)
         """
         if not isinstance(self._coeff_stream, Stream_uninitialized) or self._coeff_stream._target is not None:
             raise ValueError("series already defined")
@@ -1404,7 +1526,9 @@ class LazyModuleElement(Element):
             sage: L(lambda x: x if x > 0 else 0, valuation=-10)
             O(z^-3)
 
-            sage: L.undefined(valuation=0)
+            sage: s = L.undefined(valuation=0); s
+            Uninitialized Lazy Laurent Series
+            sage: (s + s^2).map_coefficients(lambda f: f % 3)
             Uninitialized Lazy Laurent Series
             sage: L(0)
             0
@@ -1418,7 +1542,7 @@ class LazyModuleElement(Element):
         """
         if isinstance(self._coeff_stream, Stream_zero):
             return '0'
-        if isinstance(self._coeff_stream, Stream_uninitialized) and self._coeff_stream._target is None:
+        if self._coeff_stream.is_undefined():
             return 'Uninitialized Lazy Laurent Series'
         return self._format_series(repr)
 
@@ -1451,7 +1575,10 @@ class LazyModuleElement(Element):
             sage: latex(L(lambda x: x if x > 0 else 0, valuation=-10))
             O(\frac{1}{z^{3}})
 
-            sage: latex(L.undefined(valuation=0))
+            sage: s = L.undefined(valuation=0)
+            sage: latex(s)
+            \text{\texttt{Undef}}
+            sage: latex((s + s^2).map_coefficients(lambda f: f % 3))
             \text{\texttt{Undef}}
             sage: latex(L(0))
             0
@@ -1468,7 +1595,7 @@ class LazyModuleElement(Element):
         from sage.misc.latex import latex
         if isinstance(self._coeff_stream, Stream_zero):
             return latex('0')
-        if isinstance(self._coeff_stream, Stream_uninitialized) and self._coeff_stream._target is None:
+        if self._coeff_stream.is_undefined():
             return latex("Undef")
         return self._format_series(latex)
 
@@ -1792,9 +1919,17 @@ class LazyModuleElement(Element):
         Different scalars potentially give different series::
 
             sage: 2 * M == 3 * M
-            Traceback (most recent call last):
-            ...
-            ValueError: undecidable
+            False
+
+            sage: L.options.use_unknown = True
+            sage: 2 * M == 3 * M
+            Unknown
+
+            sage: L.options.halting_precision = 30
+            sage: 2 * M == 3 * M
+            False
+
+            sage: L.options._reset()
 
         Sparse series can be multiplied with a scalar::
 
@@ -3207,8 +3342,28 @@ class LazyCauchyProductSeries(LazyModuleElement):
             sage: f / f
             s[]
 
+        Dividing when the coefficient ring is a lazy Dirichlet ring::
+
+            sage: D = LazyDirichletSeriesRing(QQ, "s")
+            sage: zeta = D(constant=1)
+            sage: L.<t> = LazyLaurentSeriesRing(D)
+            sage: 1 / (1 - t*zeta)
+            (1 + O(1/(8^s)))
+             + (1 + 1/(2^s) + 1/(3^s) + 1/(4^s) + 1/(5^s) + 1/(6^s) + 1/(7^s) + O(1/(8^s)))*t
+             + ... + O(t^7)
+
+        Check for dividing by other type of `0` series::
+
+            sage: L.<t> = LazyPowerSeriesRing(QQ)
+            sage: f = L(lambda n: 0, valuation=0)
+            sage: L.options.halting_precision = 20
+            sage: 1 / f
+            Traceback (most recent call last):
+            ...
+            ZeroDivisionError: cannot divide by 0
+            sage: L.options._reset()
         """
-        if isinstance(other._coeff_stream, Stream_zero):
+        if not other:
             raise ZeroDivisionError("cannot divide by 0")
 
         P = self.parent()

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -2400,10 +2400,10 @@ class LazyCompletionGradedAlgebra(LazySeriesRing):
             if basis not in GradedAlgebrasWithBasis:
                 raise ValueError("basis should be in GradedAlgebrasWithBasis")
             self._arity = 1
-        category = Algebras(base_ring.category())
-        if base_ring in IntegralDomains():
+        category = Algebras(basis.category())
+        if basis in IntegralDomains():
             category &= IntegralDomains()
-        elif base_ring in Rings().Commutative():
+        elif basis in Rings().Commutative():
             category = category.Commutative()
 
         if base_ring.is_zero():

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -19,6 +19,21 @@ We provide lazy implementations for various `\NN`-graded rings.
     :class:`sage.rings.padics.generic_nodes.pAdicRelaxedGeneric`,
     :func:`sage.rings.padics.factory.ZpER`
 
+.. WARNING::
+
+    When the halting precision is infinite, the default for ``bool(f)``
+    is ``True`` for any lazy series ``f`` that is not known to be zero.
+    This could end up resulting in infinite loops::
+
+        sage: L.<x> = LazyPowerSeriesRing(ZZ)
+        sage: f = L(lambda n: 0, valuation=0)
+        sage: 1 / f  # not tested - infinite loop
+
+.. SEEALSO::
+
+    The examples of :class:`LazyLaurentSeriesRing` contain a discussion
+    about the different methods of comparisons the lazy series can use.
+
 AUTHORS:
 
 - Kwankyu Lee (2019-02-24): initial version
@@ -489,7 +504,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
                     if valuation is None:
                         raise ValueError("you must specify the degree for the polynomial 0")
                     degree = valuation
-                if x == R.zero():
+                if not x:
                     coeff_stream = Stream_exact([], order=degree, constant=constant)
                     return self.element_class(self, coeff_stream)
                 initial_coefficients = [x[i] for i in range(x.valuation(), x.degree() + 1)]
@@ -662,6 +677,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
               - constant_length:   3
               - display_length:    7
               - halting_precision: None
+              - use_unknown:     False
 
             sage: LLS.options.display_length
             7
@@ -695,8 +711,11 @@ class LazySeriesRing(UniqueRepresentation, Parent):
                                description='the number of coefficients to display for nonzero constant series',
                                checker=lambda x: x in ZZ and x > 0)
         halting_precision = dict(default=None,
-                               description='the number of coefficients, beginning with the approximate valuation, to check in equality tests',
-                               checker=lambda x: x is None or x in ZZ and x > 0)
+                                 description='the number of coefficients, beginning with the approximate valuation, to check in equality tests',
+                                 checker=lambda x: x is None or x in ZZ and x > 0)
+        use_unknown = dict(default=False,
+                             description='whether to raise an error when a comparison is unknown',
+                             checker=lambda x: x is True or x is False)
 
     @cached_method
     def one(self):
@@ -1142,26 +1161,28 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         sage: s
         1 + z + 2*z^2 + 5*z^3 + 14*z^4 + 42*z^5 + 132*z^6 + O(z^7)
 
-    If the series is not specified by a finite number of initial
-    coefficients and a constant for the remaining coefficients, then
-    equality checking will depend on the coefficients which have
-    already been computed.  If this information is not enough to
-    check that two series are different we raise an error::
+    By default, any two series ``f`` and ``g`` that are not known to
+    be equal are considered to be different::
 
-        sage: f = 1 / (z + z^2); f
-        z^-1 - 1 + z - z^2 + z^3 - z^4 + z^5 + O(z^6)
-        sage: f2 = f * 2  # currently no coefficients computed
-        sage: f3 = f * 3  # currently no coefficients computed
-        sage: f2 == f3
-        Traceback (most recent call last):
-        ...
-        ValueError: undecidable
-        sage: f2  # computes some of the coefficients of f2
-        2*z^-1 - 2 + 2*z - 2*z^2 + 2*z^3 - 2*z^4 + 2*z^5 + O(z^6)
-        sage: f3  # computes some of the coefficients of f3
-        3*z^-1 - 3 + 3*z - 3*z^2 + 3*z^3 - 3*z^4 + 3*z^5 + O(z^6)
-        sage: f2 == f3
+        sage: f = L(lambda n: 0, valuation=0)
+        sage: f == 0
         False
+
+    .. WARNING::
+
+        We have imposed that ``(f == g) == not (f != g)``, and so
+        ``f != g`` returning ``True`` might not mean that the two
+        series are actually different::
+
+            sage: g = L.zero()
+            sage: f != g
+            True
+
+        This can be verified by :meth:`~sage.rings.lazy_series.is_nonzero()`,
+        which only returns ``True`` if the series is known to be nonzero::
+
+            sage: (f - g).is_nonzero()
+            False
 
     The implementation of the ring can be either be a sparse or a dense one.
     The default is a sparse implementation::
@@ -1172,6 +1193,66 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         sage: L.<z> = LazyLaurentSeriesRing(ZZ, sparse=False)
         sage: L.is_sparse()
         False
+
+    We additionally provide two other methods of performing comparisons.
+    The first is returning an :class:`Unknown` and the second uses a check
+    up to a (user set) finite precision. These behaviors are set using the
+    options ``use_unknown`` and ``halting_precision``. In particular,
+    this applies to series that are not specified by a finite number
+    of initial coefficients and a constant for the remaining coefficients.
+    Equality checking will depend on the coefficients which have
+    already been computed. If this information is not enough to
+    check that two series are different, then if ``L.options.use_unknown``
+    is set to ``True``, then we return an :class:`Unknown`::
+
+        sage: L.options.use_unknown = True
+        sage: f = 1 / (z + z^2); f
+        z^-1 - 1 + z - z^2 + z^3 - z^4 + z^5 + O(z^6)
+        sage: f2 = f * 2  # currently no coefficients computed
+        sage: f3 = f * 3  # currently no coefficients computed
+        sage: f2 == f3
+        Unknown
+        sage: f2  # computes some of the coefficients of f2
+        2*z^-1 - 2 + 2*z - 2*z^2 + 2*z^3 - 2*z^4 + 2*z^5 + O(z^6)
+        sage: f3  # computes some of the coefficients of f3
+        3*z^-1 - 3 + 3*z - 3*z^2 + 3*z^3 - 3*z^4 + 3*z^5 + O(z^6)
+        sage: f2 == f3
+        False
+        sage: f2a = f + f
+        sage: f2 == f2a
+        Unknown
+        sage: zf = L(lambda n: 0, valuation=0)
+        sage: zf == 0
+        Unknown
+
+    For boolean checks, an error is raised when it is not known to be nonzero::
+
+        sage: bool(zf)
+        Traceback (most recent call last):
+        ...
+        UnknownError: undecidable
+
+    If the halting precision is set to a finite number `p` (for unlimited
+    precision, it is set to ``None``), then it will check up to `p` values
+    from the current position::
+
+        sage: L.options.halting_precision = 20
+        sage: f2 = f * 2  # currently no coefficients computed
+        sage: f3 = f * 3  # currently no coefficients computed
+        sage: f2 == f3
+        False
+        sage: f2a = f + f
+        sage: f2 == f2a
+        True
+        sage: zf = L(lambda n: 0, valuation=0)
+        sage: zf == 0
+        True
+
+    TESTS:
+
+    We reset the options::
+
+        sage: L.options._reset()
     """
     Element = LazyLaurentSeries
 

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -677,7 +677,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
               - constant_length:   3
               - display_length:    7
               - halting_precision: None
-              - use_unknown:     True
+              - secure:            False
 
             sage: LLS.options.display_length
             7
@@ -713,9 +713,9 @@ class LazySeriesRing(UniqueRepresentation, Parent):
         halting_precision = dict(default=None,
                                  description='the number of coefficients, beginning with the approximate valuation, to check in equality tests',
                                  checker=lambda x: x is None or x in ZZ and x > 0)
-        use_unknown = dict(default=True,
-                             description='whether to raise an error when a comparison is unknown',
-                             checker=lambda x: x is True or x is False)
+        secure = dict(default=False,
+                      description='whether to raise an error when a comparison is unknown',
+                      checker=lambda x: x is True or x is False)
 
     @cached_method
     def one(self):
@@ -1165,8 +1165,15 @@ class LazyLaurentSeriesRing(LazySeriesRing):
     be equal are considered to be different::
 
         sage: f = L(lambda n: 0, valuation=0)
-        sage: (f == 0) is None
-        True
+        sage: f == 0
+        False
+
+        sage: f = L(constant=1, valuation=0).derivative(); f
+        1 + 2*z + 3*z^2 + 4*z^3 + 5*z^4 + 6*z^5 + 7*z^6 + O(z^7)
+        sage: g = L(lambda n: (n+1), valuation=0); g
+        1 + 2*z + 3*z^2 + 4*z^3 + 5*z^4 + 6*z^5 + 7*z^6 + O(z^7)
+        sage: f == g
+        False
 
     .. WARNING::
 
@@ -1174,8 +1181,9 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         ``f != g`` returning ``True`` might not mean that the two
         series are actually different::
 
+            sage: f = L(lambda n: 0, valuation=0)
             sage: g = L.zero()
-            sage: (f != g) is None
+            sage: f != g
             True
 
         This can be verified by :meth:`~sage.rings.lazy_series.is_nonzero()`,
@@ -1195,23 +1203,25 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         False
 
     We additionally provide two other methods of performing comparisons.
-    The first is returning an :class:`Unknown` and the second uses a check
+    The first is raising a ``ValueError`` and the second uses a check
     up to a (user set) finite precision. These behaviors are set using the
-    options ``use_unknown`` and ``halting_precision``. In particular,
+    options ``secure`` and ``halting_precision``. In particular,
     this applies to series that are not specified by a finite number
     of initial coefficients and a constant for the remaining coefficients.
     Equality checking will depend on the coefficients which have
     already been computed. If this information is not enough to
-    check that two series are different, then if ``L.options.use_unknown``
-    is set to ``True``, then we return an :class:`Unknown`::
+    check that two series are different, then if ``L.options.secure``
+    is set to ``True``, then we raise a ``ValueError``::
 
-        sage: L.options.use_unknown = True
+        sage: L.options.secure = True
         sage: f = 1 / (z + z^2); f
         z^-1 - 1 + z - z^2 + z^3 - z^4 + z^5 + O(z^6)
         sage: f2 = f * 2  # currently no coefficients computed
         sage: f3 = f * 3  # currently no coefficients computed
-        sage: (f2 == f3) is None
-        True
+        sage: f2 == f3
+        Traceback (most recent call last):
+        ...
+        ValueError: undecidable
         sage: f2  # computes some of the coefficients of f2
         2*z^-1 - 2 + 2*z - 2*z^2 + 2*z^3 - 2*z^4 + 2*z^5 + O(z^6)
         sage: f3  # computes some of the coefficients of f3
@@ -1219,16 +1229,22 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         sage: f2 == f3
         False
         sage: f2a = f + f
-        sage: (f2 == f2a) is None
-        True
+        sage: f2 == f2a
+        Traceback (most recent call last):
+        ...
+        ValueError: undecidable
         sage: zf = L(lambda n: 0, valuation=0)
-        sage: (zf == 0) is None
-        True
+        sage: zf == 0
+        Traceback (most recent call last):
+        ...
+        ValueError: undecidable
 
     For boolean checks, an error is raised when it is not known to be nonzero::
 
         sage: bool(zf)
-        True
+        Traceback (most recent call last):
+        ...
+        ValueError: undecidable
 
     If the halting precision is set to a finite number `p` (for unlimited
     precision, it is set to ``None``), then it will check up to `p` values

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -677,7 +677,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
               - constant_length:   3
               - display_length:    7
               - halting_precision: None
-              - use_unknown:     False
+              - use_unknown:     True
 
             sage: LLS.options.display_length
             7
@@ -713,7 +713,7 @@ class LazySeriesRing(UniqueRepresentation, Parent):
         halting_precision = dict(default=None,
                                  description='the number of coefficients, beginning with the approximate valuation, to check in equality tests',
                                  checker=lambda x: x is None or x in ZZ and x > 0)
-        use_unknown = dict(default=False,
+        use_unknown = dict(default=True,
                              description='whether to raise an error when a comparison is unknown',
                              checker=lambda x: x is True or x is False)
 
@@ -1165,8 +1165,8 @@ class LazyLaurentSeriesRing(LazySeriesRing):
     be equal are considered to be different::
 
         sage: f = L(lambda n: 0, valuation=0)
-        sage: f == 0
-        False
+        sage: (f == 0) is None
+        True
 
     .. WARNING::
 
@@ -1175,7 +1175,7 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         series are actually different::
 
             sage: g = L.zero()
-            sage: f != g
+            sage: (f != g) is None
             True
 
         This can be verified by :meth:`~sage.rings.lazy_series.is_nonzero()`,
@@ -1210,8 +1210,8 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         z^-1 - 1 + z - z^2 + z^3 - z^4 + z^5 + O(z^6)
         sage: f2 = f * 2  # currently no coefficients computed
         sage: f3 = f * 3  # currently no coefficients computed
-        sage: f2 == f3
-        Unknown
+        sage: (f2 == f3) is None
+        True
         sage: f2  # computes some of the coefficients of f2
         2*z^-1 - 2 + 2*z - 2*z^2 + 2*z^3 - 2*z^4 + 2*z^5 + O(z^6)
         sage: f3  # computes some of the coefficients of f3
@@ -1219,18 +1219,16 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         sage: f2 == f3
         False
         sage: f2a = f + f
-        sage: f2 == f2a
-        Unknown
+        sage: (f2 == f2a) is None
+        True
         sage: zf = L(lambda n: 0, valuation=0)
-        sage: zf == 0
-        Unknown
+        sage: (zf == 0) is None
+        True
 
     For boolean checks, an error is raised when it is not known to be nonzero::
 
         sage: bool(zf)
-        Traceback (most recent call last):
-        ...
-        UnknownError: undecidable
+        True
 
     If the halting precision is set to a finite number `p` (for unlimited
     precision, it is set to ``None``), then it will check up to `p` values


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

This fixes #35071 by:

1. providing a method to streams to see if they are unitinalized
2. includes a new mode for comparisons in the lazy series ring based on the proposal in #35429.

The new comparison mode `secure` simply returns `False` when it cannot verify that `f == g` and makes sure that `(f == g) == not (f != g)`, and this will become the new default. In particular, it will return `True` for `f != g` both when it cannot show that `f == g` and when they are genuinely different. In order to verify when the comparison is unknown, we expose the `is_nonzero()` that only returns `True` when the series is _known_ to be nonzero. Thus, we verify by `(f - g).is_nonzero()`.

When a finite halting precision is given, then that takes priority.

For the infinite halting precision in the "old" version (`secure = True`), it will raise a `ValueError` when it cannot verify the result.

**NOTE:** `f.is_zero()` is still the default `not f` for speed and the assumption these are in agreement elsewhere in Sage.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
