### PR TITLE
src/sage/misc/sagedoc.py: Add latex to unicode mappings

### DIFF
--- a/src/sage/misc/sagedoc.py
+++ b/src/sage/misc/sagedoc.py
@@ -44,6 +44,7 @@ import re
 import shutil
 import sys
 import pydoc
+import sage.typeset.unicode_characters as uc
 from sage.misc.temporary_file import tmp_dir
 from sage.misc.viewer import browser
 from sage.misc import sageinspect
@@ -95,7 +96,24 @@ math_substitutes = [
     (r'\\rvert', '|'),
     (r'\\mid', '|'),
     (r' \\circ', ' o'),
-    (r'\\circ', ' o')
+    (r'\\circ', ' o'),
+    (r'\\{', '{'),
+    (r'\\}', '}'),
+    (r'\\!', ''),
+    (r'\\,', ''),
+    (r'\\;', '\u205F'),
+    (r'\\dim', 'dim'),
+    (r'\\in', '\u2208'),
+    (r'\\phi', '\u03C6'),
+    (r'\\Lambda', '\u039B'),
+    (r'\\NN', '\U0001D40D'),
+    (r'\\QQ', '\U0001D410'),
+    (r'\\RR', '\U0001D411'),
+    (r'\\ZZ', '\U0001D419'),
+    (r'\\otimes', uc.unicode_otimes),
+    (r'\\wedge', uc.unicode_wedge),
+    (r'\\bigwedge', uc.unicode_bigwedge),
+    (r'\\mathbf{k}', '\U0001D424'),
 ]
 nonmath_substitutes = [
     ('\\_', '_'),


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->

<!-- Why is this change required? What problem does it solve? -->
Docstrings formatted for the terminal, in uses like `CliffordAlgebra?`, are difficult to read when heavy LaTeX markup is used.
We add some mappings that replace LaTeX commands by Unicode characters.
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Resolves #35491
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
