### PR TITLE
fix pycodestyle E303 in schemes

### DIFF
--- a/src/sage/schemes/curves/affine_curve.py
+++ b/src/sage/schemes/curves/affine_curve.py
@@ -1810,7 +1810,6 @@ class AffinePlaneCurve_field(AffinePlaneCurve, AffineCurve_field):
         f = self.defining_polynomial()
         return braid_monodromy(f)
 
-
     def riemann_surface(self, **kwargs):
         r"""
         Return the complex Riemann surface determined by this curve

--- a/src/sage/schemes/cyclic_covers/cycliccover_generic.py
+++ b/src/sage/schemes/cyclic_covers/cycliccover_generic.py
@@ -44,7 +44,6 @@ from sage.arith.misc import GCD
 from sage.schemes.curves.affine_curve import AffinePlaneCurve
 
 
-
 class CyclicCover_generic(AffinePlaneCurve):
     def __init__(self, AA, r, f, names=None):
         """

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -985,7 +985,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
     __inner_kernel_polynomial = None # the inner kernel polynomial (ignoring preisomorphism)
 
-
     #
     # member variables common to Velu's formula
     #
@@ -997,14 +996,12 @@ class EllipticCurveIsogeny(EllipticCurveHom):
     __v = None
     __w = None
 
-
     #
     # member variables specific to Kohel's algorithm.
     #
     __psi = None # psi polynomial
     __phi = None # phi polynomial
     __omega = None # omega polynomial, an element of k[x][y]
-
 
     #
     # Python Special Functions
@@ -1477,7 +1474,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         fx,fy = self.rational_maps()
         return fr'\left( {fx._latex_()} , {fy._latex_()} \right)'
 
-
     ###########################
     # Private Common Functions
     ###########################
@@ -1694,7 +1690,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             X_map = posti_X_map(X_map)
 
         self.__ratl_maps = self.__xfield(X_map), self.__xyfield(Y_map)
-
 
     def __init_kernel_polynomial(self):
         r"""
@@ -2250,7 +2245,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         else: # odd degree case
 
             phi, omega, v, w, _, d = self.__init_odd_kernel_polynomial(E, psi)
-
 
         #
         # Set up the necessary instance variables
@@ -2867,7 +2861,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             self.__init_kernel_polynomial()
         return self.__kernel_polynomial
 
-
     def is_separable(self):
         r"""
         Determine whether or not this isogeny is separable.
@@ -2890,7 +2883,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             True
         """
         return True
-
 
     def _set_pre_isomorphism(self, preWI):
         """
@@ -2980,7 +2972,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         self.__set_pre_isomorphism(domain, isom)
 
-
     def _set_post_isomorphism(self, postWI):
         """
         Modify this isogeny by post-composing with a
@@ -3043,7 +3034,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         self.__clear_cached_values()
 
         self.__set_post_isomorphism(codomain, isom)
-
 
     def dual(self):
         r"""
@@ -3268,7 +3258,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             phi_hat._set_post_isomorphism(post_iso)
             phi_hat.__perform_inheritance_housekeeping()
             return phi_hat
-
 
     @staticmethod
     def _composition_impl(left, right):

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -233,7 +233,6 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         n=len(f.roots())+1
         return rings.Integer(n).ord(rings.Integer(2))
 
-
     def quartic_twist(self, D):
         r"""
         Return the quartic twist of this curve by `D`.

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -2461,7 +2461,6 @@ class EllipticCurve_number_field(EllipticCurve_field):
         from sage.schemes.elliptic_curves.period_lattice import PeriodLattice_ell
         return PeriodLattice_ell(self,embedding)
 
-
     def real_components(self, embedding):
         """
         Return the number of real components with respect to a real embedding of the base field.

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -528,8 +528,6 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
         """
         return bool(self[2])
 
-
-
     def has_finite_order(self):
         """
         Return ``True`` if this point has finite additive order as an

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -403,7 +403,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             self.__is_integral = bool(misc.mul([x.denominator() == 1 for x in self.ainvs()]))
             return self.__is_integral
 
-
     def mwrank(self, options=''):
         r"""
         Run Cremona's mwrank program on this elliptic curve and return the
@@ -917,7 +916,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         if not python_ints:
             v = [Integer(x) for x in v]
         return v
-
 
         # There is some overhead associated with coercing the PARI
         # list back to Python, but it's not bad.  It's better to do it
@@ -2711,7 +2709,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             raise RuntimeError("curve must be minimal.")
         return self.mwrank_curve().CPS_height_bound()
 
-
     def silverman_height_bound(self, algorithm='default'):
         r"""
         Return the Silverman height bound.
@@ -3645,7 +3642,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         return L
 
-
     def modular_degree(self, algorithm='sympow', M=1):
         r"""
         Return the modular degree at level `MN` of this elliptic curve. The case
@@ -3778,7 +3774,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             except KeyError:
                 # self._generalized_congmod_numbers() also populates cache
                 return self._generalized_congmod_numbers(M)["moddeg"]
-
 
     def modular_parametrization(self):
         r"""
@@ -3914,7 +3909,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             except KeyError:
                 # self._generalized_congmod_numbers() also populates cache
                 return self._generalized_congmod_numbers(M)["congnum"]
-
 
     def cremona_label(self, space=False):
         """
@@ -4488,7 +4482,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         return Et, D
 
-
     ##########################################################
     # Isogeny class
     ##########################################################
@@ -4954,7 +4947,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 #         Return an isogeny from self to other if the two curves are in
 #         the same isogeny class.
 #         """
-
 
     def optimal_curve(self):
         """
@@ -6391,7 +6383,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         else:
             proof = bool(proof)
 
-
         if not self.is_integral():
             raise ValueError("S_integral_points() can only be called on an integral model")
         if not all(self.is_p_minimal(s) for s in S):
@@ -6710,7 +6701,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             disc_sh = R(E.short_weierstrass_model().discriminant()) #computes y^2=x^3 -27c4x -54c6
             k4 = R(20**4 * max(3**6 * c4**2, 16*(disc_sh.abs().sqrt())**3))
             k3 = R(32/3 * disc_sh.abs().sqrt() * (8 + 0.5*disc_sh.abs().log())**4)
-
 
         k2 = max(R(b2.abs()), R(b4.abs().sqrt()), R(b6.abs()**(1/3)), R(b8.abs()**(1/4))).log()
         k1 = R(7 * 10**(38*len_S+49)) * R(len_S**(20*len_S+15)) * max_S**24 * R(max(1,log(max_S, e))**(4*len_S - 2)) * k3 * k3.log()**2 * ((20*len_S - 19)*k3 + (e*k4).log()) + 2*R(2*b2.abs()+6).log()

--- a/src/sage/schemes/elliptic_curves/formal_group.py
+++ b/src/sage/schemes/elliptic_curves/formal_group.py
@@ -664,7 +664,6 @@ class EllipticCurveFormalGroup(SageObject):
             # express it in terms of the formal parameter
             return -Q[0] / Q[1]
 
-
         # Now the general case, not necessarily over a field.
 
         R = rings.PowerSeriesRing(self.curve().base_ring(), "t")

--- a/src/sage/schemes/elliptic_curves/gal_reps.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps.py
@@ -441,7 +441,6 @@ class GaloisRepresentation(SageObject):
         self.__is_surjective[key] = ans
         return ans
 
-
     def _is_surjective(self, p, A):
         r"""
         helper function for ``is_surjective``
@@ -1084,7 +1083,6 @@ class GaloisRepresentation(SageObject):
         self.__image_type[p] = "The image could not be determined. Sorry."
         return self.__image_type[p]
 
-
     def image_classes(self,p,bound=10000):
         r"""
         This function returns, given the representation `\rho`
@@ -1414,7 +1412,6 @@ class GaloisRepresentation(SageObject):
         if not arith.is_prime(p):
             raise ValueError('p (=%s) must be prime' % p)
         return self._E.j_invariant().valuation(p) >= 0
-
 
     def is_semistable(self,p):
         r"""

--- a/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
@@ -119,7 +119,6 @@ class GaloisRepresentation(SageObject):
         else:
             return "Compatible family of Galois representations associated to the " + repr(self.E)
 
-
     def __eq__(self,other):
         r"""
         Compares two Galois representations.
@@ -156,7 +155,6 @@ class GaloisRepresentation(SageObject):
             True
         """
         return self.E
-
 
     def non_surjective(self, A=100):
         r"""
@@ -708,7 +706,6 @@ def _exceptionals(E, L, patience=1000):
                 if u not in (1, 2, 4) and u**2 - 3 * u + 1 != 0:
                     D[l][2] = False
 
-
             if D[l] == [False, False, False]:
                 unexc.append(l)
 
@@ -902,7 +899,6 @@ def _semistable_reducible_primes(E, verbose=False):
         else:
             if verbose:
                 print("gx and gy both 0!")
-
 
         ## It is possible that our curve has CM. ##
 

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -1021,7 +1021,6 @@ class GaloisGroup(SageObject):
             d = self.__p1_to_automorphism
         return d[uv]
 
-
     def _alpha_to_p1_element(self, alpha):
         r"""
         Given an element of the ring of integers that is nonzero
@@ -1094,7 +1093,6 @@ class GaloisGroup(SageObject):
         """
         B = self.field().quadratic_field().maximal_order().basis()
         return uv[0]*B[0] + uv[1]*B[1]
-
 
     def _base_is_QQ(self):
         r"""
@@ -1179,7 +1177,6 @@ class GaloisGroup(SageObject):
         M = self.__base
         return isinstance(M, RingClassField) and M.conductor() == 1
 
-
     def __getitem__(self, i):
         """
         EXAMPLES::
@@ -1190,7 +1187,6 @@ class GaloisGroup(SageObject):
             Class field automorphism defined by x^2 + x*y + 44*y^2
         """
         return self._list()[i]
-
 
     def __len__(self):
         """
@@ -2204,7 +2200,6 @@ class HeegnerPoints_level_disc(HeegnerPoints):
         return "Set of all Heegner points on X_0(%s) associated to QQ[sqrt(%s)]"%(
             self.level(), self.discriminant())
 
-
     def discriminant(self):
         r"""
         Return the discriminant of the quadratic imaginary extension `K`.
@@ -2570,7 +2565,6 @@ class HeegnerPoints_level_disc_cond(HeegnerPoints_level, HeegnerPoints_level_dis
         m = 2*N
         return tuple(sorted( set([a%m for a in R(D).sqrt(all=True)]) ))
 
-
     @cached_method
     def points(self, beta=None):
         r"""
@@ -2756,7 +2750,6 @@ class HeegnerPointOnX0N(HeegnerPoint):
             C = ZZ((B*B - D*c*c)/(4*A))
             f = (A,B,C)
         self.__f = f
-
 
     def __hash__(self):
         """
@@ -3513,7 +3506,6 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         return all(self._check_poly_discriminant(g) for g,_ in f.factor())
 
-
     def point_exact(self, prec=53, algorithm='lll', var='a', optimize=False):
         """
         Return exact point on the elliptic curve over a number field
@@ -3943,7 +3935,6 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         g *= g.denominator()
         return (ZZ(g[2]), ZZ(g[1]), ZZ(g[0]))
 
-
     def _qf_atkin_lehner_act(self, Q, f):
         r"""
         Given a positive integer `Q` with `Q | N` and `\gcd(Q, N/Q) =
@@ -3986,7 +3977,6 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         tau = self._qf_to_tau(f)
         tau2 = ((u*Q*tau + v) / (N*tau + Q))
         return self._qf_from_tau(tau2)
-
 
     def _qf_reduce(self, f):
         """
@@ -4305,7 +4295,6 @@ class KolyvaginPoint(HeegnerPoint):
         else:
             raise NotImplementedError
 
-
     @cached_method
     def trace_to_real_numerical(self, prec=53):
         """
@@ -4485,7 +4474,6 @@ class KolyvaginPoint(HeegnerPoint):
 ##
 ##         """
 ##         raise NotImplementedError
-
 
     def kolyvagin_cohomology_class(self, n=None):
         """
@@ -4862,7 +4850,6 @@ class HeegnerQuatAlg(SageObject):
                 v.append(c)
             c += 1
         return v
-
 
     def optimal_embeddings(self, D, c, R):
         """

--- a/src/sage/schemes/elliptic_curves/hom_scalar.py
+++ b/src/sage/schemes/elliptic_curves/hom_scalar.py
@@ -207,7 +207,6 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
             raise ValueError(f'{P} not on {self._domain}')
         return self._m * P
 
-
     def _repr_(self):
         """
         Return basic facts about this scalar multiplication as a string.
@@ -219,7 +218,6 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
             Scalar-multiplication endomorphism [777] of Elliptic Curve defined by y^2 = x^3 + I*x + I over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
         """
         return f'Scalar-multiplication endomorphism [{self._m}] of {self._domain}'
-
 
     # EllipticCurveHom methods
 

--- a/src/sage/schemes/elliptic_curves/padic_lseries.py
+++ b/src/sage/schemes/elliptic_curves/padic_lseries.py
@@ -1520,7 +1520,6 @@ class pAdicLseriesSupersingular(pAdicLseries):
         frn = A * fr * A**(-1)
         return 1/p*frn
 
-
     def __phi_bpr(self, prec=0):
         r"""
         This returns a geometric Frobenius `\varphi` on the Dieudonné module `D_p(E)`

--- a/src/sage/schemes/elliptic_curves/padics.py
+++ b/src/sage/schemes/elliptic_curves/padics.py
@@ -786,10 +786,8 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
                    "answer with precision at least prec, but we didn't."
         return K(answer)
 
-
     # (man... I love python's local function definitions...)
     return height
-
 
 
 def padic_height_via_multiply(self, p, prec=20, E2=None, check_hypotheses=True):
@@ -933,7 +931,6 @@ def padic_height_via_multiply(self, p, prec=20, E2=None, check_hypotheses=True):
             assert answer.precision_absolute() >= prec, "we should have got an " \
                    "answer with precision at least prec, but we didn't."
         return K(answer)
-
 
     # (man... I love python's local function definitions...)
     return height

--- a/src/sage/schemes/elliptic_curves/period_lattice.py
+++ b/src/sage/schemes/elliptic_curves/period_lattice.py
@@ -1485,7 +1485,6 @@ class PeriodLattice_ell(PeriodLattice):
             z =  self.reduce(z)
         return z
 
-
     def elliptic_logarithm(self, P, prec=None, reduce=True):
         r"""
         Return the elliptic logarithm of a point.

--- a/src/sage/schemes/generic/divisor.py
+++ b/src/sage/schemes/generic/divisor.py
@@ -411,7 +411,6 @@ class Divisor_curve(Divisor_generic):
             self._support = [s[1] for s in pts]
             return self._support
 
-
     def coefficient(self, P):
         """
         Return the coefficient of a given point P in this divisor.

--- a/src/sage/schemes/generic/scheme.py
+++ b/src/sage/schemes/generic/scheme.py
@@ -715,7 +715,6 @@ class Scheme(Parent):
         """
         raise NotImplementedError
 
-
     def zeta_series(self, n, t):
         """
         Return the zeta series.

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
@@ -620,8 +620,6 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
         else:
             return self.local_coordinates_at_nonweierstrass(P, prec, name)
 
-
-
     def rational_points(self, **kwds):
         r"""
         Find rational points on the hyperelliptic curve, all arguments are passed

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_morphism.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_morphism.py
@@ -511,7 +511,6 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
         """
         return self.codomain()
 
-
     def __list__(self):
         r"""
         Return a list `(a(x), b(x))` of the polynomials giving the
@@ -668,8 +667,6 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
             True
         """
         return self.__polys[0] != 1
-
-
 
     def __neg__(self):
         r"""

--- a/src/sage/schemes/hyperelliptic_curves/monsky_washnitzer.py
+++ b/src/sage/schemes/hyperelliptic_curves/monsky_washnitzer.py
@@ -2794,7 +2794,6 @@ class SpecialHyperellipticQuotientRing(UniqueRepresentation, CommutativeAlgebra)
 SpecialHyperellipticQuotientRing_class = SpecialHyperellipticQuotientRing
 
 
-
 class MonskyWashnitzerDifferential(ModuleElement):
     r"""
     An element of the Monsky-Washnitzer ring of differentials, of

--- a/src/sage/schemes/projective/projective_rational_point.py
+++ b/src/sage/schemes/projective/projective_rational_point.py
@@ -307,7 +307,6 @@ def enum_projective_finite_field(X):
     return pts
 
 
-
 def sieve(X, bound):
     r"""
     Returns the list of all projective, rational points on scheme ``X`` of


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

This is fixing the last pycodestyle E303 warnings in schemes/
```
E303 too many blank lines 
```
These are also the last E303 warnings in all python files in `src/sage`.
Activating the check in the linter is left to another pull request.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
