### PR TITLE
Make BooleanPolynomial.variables() way faster

### DIFF
--- a/src/sage/rings/polynomial/pbori/pbori.pxd
+++ b/src/sage/rings/polynomial/pbori/pbori.pxd
@@ -41,8 +41,9 @@ cdef class BooleanMonomialVariableIterator:
     cdef object parent
     cdef BooleanPolynomialRing _ring
     cdef BooleanMonomial obj
-    cdef PBMonomVarIter _iter
-    cdef PBMonomVarIter _end
+    cdef PBMonomIter _iter
+    cdef PBMonomIter _end
+    cdef Py_ssize_t* pbind
 
 cdef class BooleanMonomialIterator:
     cdef BooleanMonomial obj

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -2857,11 +2857,14 @@ cdef class BooleanMonomialVariableIterator:
             sage: next(iter(m))
             x
         """
+        cdef int index
         cdef PBVar value
         if self._iter == self._end:
             raise StopIteration
-        value = self._iter.dereference()
+        index = self._iter.dereference()
         self._iter.increment()
+        value = PBBooleVariable(self.pbind[index],
+                                (<BooleanPolynomialRing>self._ring)._pbring)
         return new_BM_from_PBVar(self.parent, self._ring, value)
 
 cdef inline BooleanMonomialVariableIterator new_BMVI_from_BooleanMonomial(
@@ -2875,8 +2878,9 @@ cdef inline BooleanMonomialVariableIterator new_BMVI_from_BooleanMonomial(
     m.parent = monom._parent
     m._ring = monom._ring
     m.obj = monom
-    m._iter = m.obj._pbmonom.variableBegin()
-    m._end = m.obj._pbmonom.variableEnd()
+    m._iter = m.obj._pbmonom.begin()
+    m._end = m.obj._pbmonom.end()
+    m.pbind = (<BooleanPolynomialRing> monom.ring()).pbind
     return m
 
 


### PR DESCRIPTION
### :books: Description

The implementation of `BooleanMonomialVariableIterator` is a bit slow. It is based in polybori's `PBMonomVarIter` which implements an iterator over the variables of a boolean monomial which is slow.

However there is `PBMonomIter` which implements an iterator over the indices of the variables which seems to be faster; the variables can then be retrieved from the ring itself.

This is what we do in this commit. Performance is way better.

I don't know why this difference, maybe because the variables are strings and this suffers from allocation, while indices are just 32 bit ints.

Before this commit:
```
sage: R = BooleanPolynomialRing(512)
sage: f = sum(R.gen(randrange(512)) for _ in range(20))
sage: timeit('vs = f.variables()')
125 loops, best of 3: 6.1 ms per loop
```

After this commit:
```
sage: R = BooleanPolynomialRing(512)
sage: f = sum(R.gen(randrange(512)) for _ in range(20))
sage: timeit('vs = f.variables()')
625 loops, best of 3: 13.7 μs per loop
```

Another example taken from a doctest for the method `PolynomialSequence_generic.connected_components()` in `src/sage/rings/polynomial/multi_polynomial_sequence.py`:

Before this commit:
```
sage: sr = mq.SR(2,4,4,8,gf2=True,polybori=True)
sage: F, s = sr.polynomial_system()
sage: Fz = Sequence(F.part(2))
sage: %time vs = Fz.variables()
CPU times: user 603 ms, sys: 2.42 s, total: 3.03 s
Wall time: 3.03 s
sage: %time len(Fz.connected_components())
CPU times: user 2.59 s, sys: 10.9 s, total: 13.5 s
Wall time: 13.5 s
4
```

After this commit:
```
sage: sr = mq.SR(2,4,4,8,gf2=True,polybori=True)
sage: F, s = sr.polynomial_system()
sage: Fz = Sequence(F.part(2))
sage: %time vs = Fz.variables()
CPU times: user 9.77 ms, sys: 994 µs, total: 10.8 ms
Wall time: 13.7 ms
sage: %time len(Fz.connected_components())
CPU times: user 70.8 ms, sys: 8.27 ms, total: 79.1 ms
Wall time: 82.5 ms
4
```

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
