### PR TITLE
Fix Graph.add_clique() for one vertex

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -18371,6 +18371,9 @@ class GenericGraph(GenericGraph_pyx):
             True
             sage: G.vertices(sort=True)
             [0, 1, 2, 3]
+            sage: G.add_clique({4})
+            sage: G.vertices(sort=True)
+            [0, 1, 2, 3, 4]
             sage: D = DiGraph(4, loops=True)
             sage: D.add_clique(range(4), loops=True)
             sage: D.is_clique(directed_clique=True, loops=True)
@@ -18383,6 +18386,7 @@ class GenericGraph(GenericGraph_pyx):
             else:
                 self.add_edges(itertools.combinations_with_replacement(vertices, 2))
         else:
+            self.add_vertices(vertices)
             if self.is_directed():
                 self.add_edges(itertools.permutations(vertices, 2))
             else:


### PR DESCRIPTION
Before the change:

    sage: g = Graph()
    sage: g.add_clique([1,2])
    sage: g.add_clique([3])
    sage: g.vertices(sort=True)
    [1, 2]

After the change:

    sage: g = Graph()
    sage: g.add_clique([1,2])
    sage: g.add_clique([3])
    sage: g.vertices(sort=True)
    [1, 2, 3]

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.