### PR TITLE
Improve PolynomialSequence.connection_graph() implementation

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -18371,6 +18371,9 @@ class GenericGraph(GenericGraph_pyx):
             True
             sage: G.vertices(sort=True)
             [0, 1, 2, 3]
+            sage: G.add_clique({4})
+            sage: G.vertices(sort=True)
+            [0, 1, 2, 3, 4]
             sage: D = DiGraph(4, loops=True)
             sage: D.add_clique(range(4), loops=True)
             sage: D.is_clique(directed_clique=True, loops=True)
@@ -18383,6 +18386,7 @@ class GenericGraph(GenericGraph_pyx):
             else:
                 self.add_edges(itertools.combinations_with_replacement(vertices, 2))
         else:
+            self.add_vertices(vertices)
             if self.is_directed():
                 self.add_edges(itertools.permutations(vertices, 2))
             else:

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -905,8 +905,28 @@ class PolynomialSequence_generic(Sequence_generic):
 
             sage: B.<x,y,z> = BooleanPolynomialRing()
             sage: F = Sequence([x*y + y + 1, z + 1])
-            sage: F.connection_graph()
+            sage: G = F.connection_graph(); G
             Graph on 3 vertices
+            sage: G.is_connected()
+            False
+            sage: F = Sequence([x])
+            sage: F.connection_graph()
+            Graph on 1 vertex
+
+        TESTS::
+
+            sage: F = Sequence([], B)
+            sage: F.connection_graph()
+            Graph on 0 vertices
+            sage: F = Sequence([1], B)
+            sage: F.connection_graph()
+            Graph on 0 vertices
+            sage: F = Sequence([x])
+            sage: F.connection_graph()
+            Graph on 1 vertex
+            sage: F = Sequence([x, y])
+            sage: F.connection_graph()
+            Graph on 2 vertices
             sage: F = Sequence([x*y*z])
             sage: F.connection_graph().is_clique()
             True

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -907,16 +907,17 @@ class PolynomialSequence_generic(Sequence_generic):
             sage: F = Sequence([x*y + y + 1, z + 1])
             sage: F.connection_graph()
             Graph on 3 vertices
+            sage: F = Sequence([x*y*z])
+            sage: F.connection_graph().is_clique()
+            True
+            sage: F = Sequence([x*y, y*z])
+            sage: F.connection_graph().is_clique()
+            False
         """
-        V = sorted(self.variables())
         from sage.graphs.graph import Graph
         g = Graph()
-        g.add_vertices(sorted(V))
         for f in self:
-            v = f.variables()
-            a,tail = v[0],v[1:]
-            for b in tail:
-                g.add_edge((a,b))
+            g.add_clique(f.variables())
         return g
 
     def connected_components(self):


### PR DESCRIPTION
Simplify the code; also, the previous code has to iterate over variables of the sequence twice (this is really bad before #35510).

This affects mainly the method `connected_components()`.

EDIT:
    
Moreover, now we add a clique between the variables of each polynomial, so it agrees with the description (the code before used to add just a spanning tree of the clique -- a star).
    
This makes this method a little bit slower for the purposes of `connected_components()` (for which adding a star is equivalent).
    
However, #35518 will rewrite `connected_components()` without using `connection_graph()` so this is not really a problem.


### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] New tests added to check that a clique is added for the variables in each polynomial.

### Dependencies
 - #35511