### PR TITLE
Silence initialization of giac

### DIFF
--- a/src/sage/calculus/functional.py
+++ b/src/sage/calculus/functional.py
@@ -225,9 +225,7 @@ def integral(f, *args, **kwds):
 
     Sage is now (:trac:`27958`) able to compute the following integral::
 
-        sage: result = integral(exp(-x^2)*log(x), x)
-        ...
-        sage: result
+        sage: integral(exp(-x^2)*log(x), x)  # long time
         1/2*sqrt(pi)*erf(x)*log(x) - x*hypergeometric((1/2, 1/2), (3/2, 3/2), -x^2)
 
     and its value::

--- a/src/sage/calculus/tests.py
+++ b/src/sage/calculus/tests.py
@@ -121,9 +121,7 @@ No problems here::
     sage: integrate(sin(x^2),x)
     1/16*sqrt(pi)*((I + 1)*sqrt(2)*erf((1/2*I + 1/2)*sqrt(2)*x) + (I - 1)*sqrt(2)*erf((1/2*I - 1/2)*sqrt(2)*x) - (I - 1)*sqrt(2)*erf(sqrt(-I)*x) + (I + 1)*sqrt(2)*erf((-1)^(1/4)*x))
 
-    sage: result = integrate((1-x^2)^n,x)
-    ...
-    sage: result
+    sage: integrate((1-x^2)^n,x)  # long time
     x*hypergeometric((1/2, -n), (3/2,), x^2*exp_polar(2*I*pi))
     sage: integrate(x^x,x)
     integrate(x^x, x)

--- a/src/sage/libs/giac/giac.pyx
+++ b/src/sage/libs/giac/giac.pyx
@@ -27,8 +27,7 @@ in giac, but the mathematical computation  is not done. This class is mainly
 for cython users.  Here A is a Pygen element, and it is ready for any giac
 function.::
 
-    sage: from sage.libs.giac.giac import *     # random
-    //...
+    sage: from sage.libs.giac.giac import *
     sage: A = Pygen('2+2')
     sage: A
     2+2
@@ -2012,7 +2011,6 @@ class GiacFunctionNoEV(Pygen):
 # Some convenient settings
 ############################################################
 Pygen('printpow(1)').eval()  # default power is ^
-Pygen('add_language(1)').eval()  # Add the french keywords in the giac library language.
 # FIXME: print I for sqrt(-1) instead of i
 # GIAC_try_parse_i(False,context_ptr); (does not work??)
 

--- a/src/sage/symbolic/integration/integral.py
+++ b/src/sage/symbolic/integration/integral.py
@@ -663,9 +663,7 @@ def integrate(expression, v=None, a=None, b=None, algorithm=None, hold=False):
 
     where the default integrator obtains another answer::
 
-        sage: result = integrate(f(x), x)
-        ...
-        sage: result
+        sage: integrate(f(x), x)  # long time
         1/8*sqrt(x)*gamma(1/4)*gamma(-1/4)^2*hypergeometric((-1/4, -1/4, 1/4), (1/2, 3/4), -1/x^2)/(pi*gamma(3/4))
 
     The following definite integral is not found by maxima::

--- a/src/sage/symbolic/relation.py
+++ b/src/sage/symbolic/relation.py
@@ -930,8 +930,7 @@ def solve(f, *args, **kwds):
     A basic interface to Giac is provided::
 
         sage: solve([(2/3)^x-2], [x], algorithm='giac')
-        ...
-        [[-log(2)/(log(3) - log(2))]]
+        ...[[-log(2)/(log(3) - log(2))]]
 
         sage: f = (sin(x) - 8*cos(x)*sin(x))*(sin(x)^2 + cos(x)) - (2*cos(x)*sin(x) - sin(x))*(-2*sin(x)^2 + 2*cos(x)^2 - cos(x))
         sage: solve(f, x, algorithm='giac')


### PR DESCRIPTION
When sage.libs.giac.giac is imported for the first time, some noise is output to stderr. This is annoying and complicates doctesting as `...` has to be added to the _first_ time giac is used.

This output comes from the line

    Pygen('add_language(1)').eval()  # Add the french keywords in the giac library language.

which doesn't seem to be necessary.

This commit removes the line, and fixes a few doctests which where expecting some output when using libgiac for the first time.

Also label `# long time` a doctest in `src/sage/calculus/functional.py` which takes 6-7 seconds. Doing this in the first place motivates the current change as the initialization noise would happen in different tests depending on whether `--long` or not is used.

Same for a doctest in `src/sage/calculus/tests.py`, and one in `src/sage/symbolic/integration/integral.py`. A test in `src/sage/libs/giac/giac.pyx` was marked `# random` but after this fix it seems to work ok.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] There are existing tests covering the changes.