### PR TITLE
Don't force ecl lisp with `maxima -l ecl` on command line.

### DIFF
--- a/src/bin/sage
+++ b/src/bin/sage
@@ -672,7 +672,7 @@ if [ "$1" = '-maxima' -o "$1" = '--maxima' ]; then
     shift
     maxima_cmd=$(sage-config MAXIMA 2>/dev/null)
     if [ -z "${maxima_cmd}" ]; then
-        maxima_cmd="maxima -l ecl"
+        maxima_cmd="maxima"
     fi
     exec $maxima_cmd "$@"
 fi


### PR DESCRIPTION
Instead, use `maxima` which should run maxima under the default lisp. This is consistet with what happens with `sage.interfaces.maxima`.

Note that `maxima_lib` needs maxima built with ecl, but the pexpect interface to maxima works with any lisp and there are faster builds of maxima (e.g. the one compiled with sbcl).

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.