### PR TITLE
fix pycodestyle E271 and E502 in pyx files

### DIFF
--- a/src/sage/numerical/backends/cvxpy_backend.pyx
+++ b/src/sage/numerical/backends/cvxpy_backend.pyx
@@ -235,7 +235,7 @@ cdef class CVXPYBackend:
             1.0
         """
         cdef int vtype = int(binary) + int(continuous) + int(integer)
-        if  vtype == 0:
+        if vtype == 0:
             continuous = True
         elif vtype != 1:
             raise ValueError("Exactly one parameter of 'binary', 'integer' and 'continuous' must be 'True'.")

--- a/src/sage/rings/function_field/element_rational.pyx
+++ b/src/sage/rings/function_field/element_rational.pyx
@@ -494,9 +494,8 @@ cdef class FunctionFieldElement_rational(FunctionFieldElement):
             -1/2*x + 1/2
             sage: (t*(x+1) - 1) in I
             True
-
         """
-        assert  len(I.gens()) == 1
+        assert len(I.gens()) == 1
         f = I.gens()[0]._x
         assert f.denominator() == 1
         assert self._x.denominator() == 1

--- a/src/sage/rings/polynomial/multi_polynomial.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial.pyx
@@ -238,9 +238,8 @@ cdef class MPolynomial(CommutativePolynomial):
 
         - Didier Deshommes
         """
-        degs = self.exponents()
         d = self.dict()
-        return  [ d[i] for i in degs ]
+        return [d[i] for i in self.exponents()]
 
     def truncate(self, var, n):
         """
@@ -1592,7 +1591,7 @@ cdef class MPolynomial(CommutativePolynomial):
             x = variable
         p = self.polynomial(x)
         q = other.polynomial(x)
-        return [R(f) for f in  p.subresultants(q)]
+        return [R(f) for f in p.subresultants(q)]
 
     def macaulay_resultant(self, *args):
         r"""

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -1234,8 +1234,8 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
             if self.base_ring().is_finite() \
                     or (isinstance(self.base_ring(), NumberField) and self.base_ring().is_absolute()):
                 R.set_ring() #sorry for that, but needed for minpoly
-                if  singular.eval('minpoly') != "(" + self.__minpoly + ")":
-                    singular.eval("minpoly=%s"%(self.__minpoly))
+                if singular.eval('minpoly') != "(" + self.__minpoly + ")":
+                    singular.eval("minpoly=%s" % (self.__minpoly))
                     self.__minpoly = singular.eval('minpoly')[1:-1] # store in correct format
             return R
         except (AttributeError, ValueError):
@@ -2526,7 +2526,9 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: print(f._repr_with_changed_varnames(['FOO', 'BAR', 'FOOBAR']))
             -FOO^2*BAR - 25/27*BAR^3 - FOOBAR^2
         """
-        return  singular_polynomial_str_with_changed_varnames(self._poly, self._parent_ring, varnames)
+        return singular_polynomial_str_with_changed_varnames(self._poly,
+                                                             self._parent_ring,
+                                                             varnames)
 
     def degree(self, MPolynomial_libsingular x=None, int std_grading=False):
         """
@@ -3581,7 +3583,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
                 else:
                     need_map = True
                     degree = (<unsigned long> p_GetExp(_p, i + 1, _ring)) * (<unsigned long> p_GetMaxExp(_f, _ring))
-                    if  degree > _ring.bitmask:
+                    if degree > _ring.bitmask:
                         id_Delete(&to_id, _ring)
                         p_Delete(&_p, _ring)
                         raise OverflowError("exponent overflow (%d)" % (degree,))
@@ -3783,7 +3785,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         coefficients = [zero] * (pTotDegMax + 1)
         while p:
             pTotDeg = p_Totaldegree(p, r)
-            if ( pTotDeg >= len(coefficients)  or  pTotDeg < 0 ):
+            if (pTotDeg >= len(coefficients) or pTotDeg < 0):
                 raise IndexError("list index("+str(pTotDeg)+" out of range(0-"+str(len(coefficients))+")")
             coefficients[pTotDeg] = si2sa(p_GetCoeff(p, r), r, k)
             p = pNext(p)
@@ -4512,7 +4514,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         _I = idInit(len(I),1)
 
         for f in I:
-            if not (isinstance(f,MPolynomial_libsingular) \
+            if not (isinstance(f,MPolynomial_libsingular)
                     and (<MPolynomial_libsingular>f)._parent is parent):
                 try:
                     f = parent.coerce(f)
@@ -4639,8 +4641,8 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
 
         _I = idInit(len(I),1)
         for f in I:
-            if not (isinstance(f,MPolynomial_libsingular) \
-                   and (<MPolynomial_libsingular>f)._parent is parent):
+            if not (isinstance(f,MPolynomial_libsingular)
+                    and (<MPolynomial_libsingular>f)._parent is parent):
                 try:
                     f = parent.coerce(f)
                 except TypeError as msg:
@@ -4688,8 +4690,8 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             rChangeCurrRing(r)
 
         _I = idInit(1, 1)
-        if not (isinstance(other,MPolynomial_libsingular) \
-               and (<MPolynomial_libsingular>other)._parent is parent):
+        if not (isinstance(other,MPolynomial_libsingular)
+                and (<MPolynomial_libsingular>other)._parent is parent):
             try:
                 other = parent.coerce(other)
             except TypeError as msg:
@@ -5725,17 +5727,18 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             True
         """
         if self.base_ring() is QQ:
-            #This part is for compatibility with the univariate case,
-            #where the numerator of a polynomial over RationalField
-            #is a polynomial over IntegerRing
+            # This part is for compatibility with the univariate case,
+            # where the numerator of a polynomial over RationalField
+            # is a polynomial over IntegerRing
             #
             # Github issue #11780: Create the polynomial ring over
             # the integers using the (cached) polynomial ring constructor:
             from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-            integer_polynomial_ring = PolynomialRing(ZZ,\
-            self.parent().ngens(), self.parent().gens(), order =\
-            self.parent().term_order())
-            return integer_polynomial_ring(self * self.denominator())
+            integer_poly_ring = PolynomialRing(ZZ,
+                                               self.parent().ngens(),
+                                               self.parent().gens(),
+                                               order=self.parent().term_order())
+            return integer_poly_ring(self * self.denominator())
         else:
             return self * self.denominator()
 

--- a/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
@@ -224,8 +224,8 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
         if isinstance(x, Polynomial):
             if x.parent() is self.parent():
                 sig_on()
-                fmpz_poly_set(self.__poly, \
-                        (<Polynomial_integer_dense_flint>x).__poly)
+                fmpz_poly_set(self.__poly,
+                              (<Polynomial_integer_dense_flint>x).__poly)
                 sig_off()
                 return
             else:
@@ -412,8 +412,8 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
             if isinstance(x, Polynomial_integer_dense_flint):
                 f = self._new()
                 sig_on()
-                fmpz_poly_compose(f.__poly, self.__poly, \
-                    (<Polynomial_integer_dense_flint> x0).__poly)
+                fmpz_poly_compose(f.__poly, self.__poly,
+                                  (<Polynomial_integer_dense_flint> x0).__poly)
                 sig_off()
                 return f
             if is_small_python_int(x0):

--- a/src/sage/rings/power_series_mpoly.pyx
+++ b/src/sage/rings/power_series_mpoly.pyx
@@ -131,8 +131,8 @@ cdef class PowerSeries_mpoly(PowerSeries):
         EXAMPLES:
         """
         cdef PowerSeries_mpoly right = <PowerSeries_mpoly>right_m
-        return PowerSeries_mpoly(self._parent, self.__f + right.__f, \
-                                         self.common_prec_c(right), check=True)
+        return PowerSeries_mpoly(self._parent, self.__f + right.__f,
+                                 self.common_prec_c(right), check=True)
 
     cpdef _sub_(self, right_m):
         """
@@ -141,14 +141,16 @@ cdef class PowerSeries_mpoly(PowerSeries):
         EXAMPLES:
         """
         cdef PowerSeries_mpoly right = <PowerSeries_mpoly>right_m
-        return PowerSeries_mpoly(self._parent, self.__f - right.__f, \
-                                         self.common_prec_c(right), check=True)
+        return PowerSeries_mpoly(self._parent, self.__f - right.__f,
+                                 self.common_prec_c(right), check=True)
 
     cpdef _rmul_(self, Element c):
-        return PowerSeries_mpoly(self._parent, self.__f._rmul_(c), self._prec, check=False)
+        return PowerSeries_mpoly(self._parent, self.__f._rmul_(c),
+                                 self._prec, check=False)
 
     cpdef _lmul_(self, Element c):
-        return PowerSeries_mpoly(self._parent, self.__f._lmul_(c), self._prec, check=False)
+        return PowerSeries_mpoly(self._parent, self.__f._lmul_(c),
+                                 self._prec, check=False)
 
 
 def make_powerseries_mpoly_v0(parent,  f, prec, is_gen):

--- a/src/sage/rings/power_series_poly.pyx
+++ b/src/sage/rings/power_series_poly.pyx
@@ -514,8 +514,8 @@ cdef class PowerSeries_poly(PowerSeries):
             1.00000000000000 + O(t^4)
         """
         cdef PowerSeries_poly right = <PowerSeries_poly>right_m
-        return PowerSeries_poly(self._parent, self.__f + right.__f, \
-                                         self.common_prec_c(right), check=True)
+        return PowerSeries_poly(self._parent, self.__f + right.__f,
+                                self.common_prec_c(right), check=True)
 
     cpdef _sub_(self, right_m):
         """
@@ -529,8 +529,8 @@ cdef class PowerSeries_poly(PowerSeries):
             13 - 2*w*t
         """
         cdef PowerSeries_poly right = <PowerSeries_poly>right_m
-        return PowerSeries_poly(self._parent, self.__f - right.__f, \
-                                         self.common_prec_c(right), check=True)
+        return PowerSeries_poly(self._parent, self.__f - right.__f,
+                                self.common_prec_c(right), check=True)
 
     cpdef _mul_(self, right_r):
         """


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Fix and activate the pycodestyle checks for E502 and E271 in pyx files.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
