### PR TITLE
some cython-lint fixes in matroids/

### DIFF
--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -41,9 +41,6 @@ Methods
 from .matroid cimport Matroid
 from .set_system cimport SetSystem
 
-from copy import copy
-from itertools import combinations, permutations
-
 from sage.data_structures.bitset_base cimport *
 
 cdef class BasisExchangeMatroid(Matroid):
@@ -1851,8 +1848,7 @@ cdef class BasisExchangeMatroid(Matroid):
             return NSC
         bitset_clear(self._input)
         bitset_set_first_n(self._input, self._matroid_rank)
-        cdef long e, f, corank
-        corank = self._groundset_size - self._matroid_rank
+        cdef long e, f
         repeat = True
         while repeat:
             if self.__is_independent(self._input):

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -79,9 +79,7 @@ from .basis_exchange_matroid cimport BasisExchangeMatroid
 from .set_system cimport SetSystem
 from cpython.object cimport Py_EQ, Py_NE
 
-from sage.arith.misc import binomial
-
-from itertools import permutations, combinations
+from itertools import combinations
 
 # class of general matroids, represented by their list of bases
 
@@ -684,7 +682,6 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         if self._bases_invariant_var is not None:
             return self._bases_invariant_var
         cdef long i, j
-        cdef bitset_t bb_comp
         cdef list bc
         cdef dict bi
         bc = [0 for i in xrange(len(self))]
@@ -1183,7 +1180,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         N.rename(getattr(self, '__custom_name'))
         return N
 
-    def __deepcopy__(self, memo={}):
+    def __deepcopy__(self, memo=None):
         """
         Create a deep copy.
 
@@ -1201,6 +1198,8 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             sage: M.groundset() is N.groundset()
             False
         """
+        if memo is None:
+            memo = {}
         N = BasisMatroid(M=self)
         N.rename(getattr(self, '__custom_name'))
         return N

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -517,7 +517,7 @@ cdef class CircuitClosuresMatroid(Matroid):
             N.rename(getattr(self, '__custom_name'))
         return N
 
-    def __deepcopy__(self, memo={}):
+    def __deepcopy__(self, memo=None):
         """
         Create a deep copy.
 
@@ -534,6 +534,8 @@ cdef class CircuitClosuresMatroid(Matroid):
             sage: M.groundset() is N.groundset()
             False
         """
+        if memo is None:
+            memo = {}
         from copy import deepcopy
         # Since matroids are immutable, N cannot reference itself in correct code, so no need to worry about the recursion.
         N = CircuitClosuresMatroid(groundset=deepcopy(self._groundset, memo), circuit_closures=deepcopy(self._circuit_closures, memo))

--- a/src/sage/matroids/extension.pyx
+++ b/src/sage/matroids/extension.pyx
@@ -31,7 +31,6 @@ Methods
 
 from sage.data_structures.bitset_base cimport *
 from .basis_matroid cimport BasisMatroid
-from sage.arith.misc import binomial
 
 
 cdef class CutNode:

--- a/src/sage/matroids/lean_matrix.pyx
+++ b/src/sage/matroids/lean_matrix.pyx
@@ -38,7 +38,6 @@ from cysignals.signals cimport sig_on, sig_off
 from sage.data_structures.bitset_base cimport *
 from sage.matrix.matrix2 cimport Matrix
 from sage.rings.integer_ring import ZZ
-from sage.rings.finite_rings.finite_field_constructor import FiniteField
 from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF
 from sage.rings.rational_field import QQ
 from sage.rings.integer cimport Integer
@@ -303,7 +302,7 @@ cdef class LeanMatrix:
             This is different from what matroid theorists tend to call a
             pivot, as it does not involve a column exchange!
         """
-        cdef long i, j
+        cdef long i
         self.rescale_row_c(x, self.get_unsafe(x, y) ** (-1), 0)
         for i from 0 <= i < self._nrows:
             s = self.get_unsafe(i, y)
@@ -491,7 +490,7 @@ cdef class LeanMatrix:
         """
         return self.copy()
 
-    def __deepcopy__(self, memo={}):
+    def __deepcopy__(self, memo=None):
         """
         Return a deep copy of ``self``.
 
@@ -782,7 +781,6 @@ cdef class GenericMatrix(LeanMatrix):
         Warning: assumes ``M`` is a GenericMatrix instance!
         """
         cdef GenericMatrix A
-        cdef long i, j
         A = GenericMatrix(0, 0, ring=self._base_ring)
         A._entries = self._entries + ((<GenericMatrix>M)._entries)
         A._nrows = self._nrows + M.nrows()
@@ -1145,7 +1143,7 @@ cdef class BinaryMatrix(LeanMatrix):
         """
         Return the matrix obtained by prepending an identity matrix. Special case of ``augment``.
         """
-        cdef long i, j
+        cdef long i
         cdef BinaryMatrix A = BinaryMatrix(self._nrows, self._ncols + self._nrows)
         for i from 0 <= i < self._nrows:
             bitset_lshift(A._M[i], self._M[i], self._nrows)
@@ -1214,7 +1212,7 @@ cdef class BinaryMatrix(LeanMatrix):
             This is different from what matroid theorists tend to call a
             pivot, as it does not involve a column exchange!
         """
-        cdef long i, j
+        cdef long i
         for i from 0 <= i < self._nrows:
             if bitset_in(self._M[i], y) and i != x:
                 bitset_symmetric_difference(self._M[i], self._M[i], self._M[x])
@@ -1423,7 +1421,7 @@ cdef class BinaryMatrix(LeanMatrix):
         Helper method for isomorphism test.
         """
         cdef BinaryMatrix Q
-        cdef long i, r
+        cdef long i
         Q = BinaryMatrix(self._nrows + 1, self._ncols)
         for i from 0 <= i < self._nrows:
             bitset_copy(Q._M[i], self._M[i])
@@ -1795,7 +1793,7 @@ cdef class TernaryMatrix(LeanMatrix):
 
         Special case of ``augment``.
         """
-        cdef long i, j
+        cdef long i
         cdef TernaryMatrix A = TernaryMatrix(self._nrows, self._ncols + self._nrows)
         for i from 0 <= i < self._nrows:
             bitset_lshift(A._M0[i], self._M0[i], self._nrows)
@@ -1935,7 +1933,7 @@ cdef class TernaryMatrix(LeanMatrix):
             This is different from what matroid theorists tend to call a
             pivot, as it does not involve a column exchange!
         """
-        cdef long i, j
+        cdef long i
         if self._is_negative(x, y):
             self._row_negate(x)
         for i from 0 <= i < self._nrows:
@@ -2396,7 +2394,7 @@ cdef class QuaternaryMatrix(LeanMatrix):
         Return the matrix obtained by prepending an identity matrix. Special
         case of ``augment``.
         """
-        cdef long i, j
+        cdef long i
         cdef QuaternaryMatrix A = QuaternaryMatrix(self._nrows, self._ncols + self._nrows, ring=self._gf4)
         for i from 0 <= i < self._nrows:
             bitset_lshift(A._M0[i], self._M0[i], self._nrows)
@@ -2522,7 +2520,7 @@ cdef class QuaternaryMatrix(LeanMatrix):
             This is different from what matroid theorists tend to call a
             pivot, as it does not involve a column exchange!
         """
-        cdef long i, j
+        cdef long i
         self._row_div(x, self.get(x, y))
         for i from 0 <= i < self._nrows:
             if self.is_nonzero(i, y) and i != x:
@@ -3047,7 +3045,7 @@ cdef class PlusMinusOneMatrix(LeanMatrix):
             This is different from what matroid theorists tend to call a
             pivot, as it does not involve a column exchange!
         """
-        cdef long i, j
+        cdef long i
         cdef int a, s
         a = self.get(x, y)  # 1 or -1, so inverse is equal to itself
         self.rescale_row_c(x, a, 0)
@@ -3532,7 +3530,7 @@ cdef class RationalMatrix(LeanMatrix):
             This is different from what matroid theorists tend to call a
             pivot, as it does not involve a column exchange!
         """
-        cdef long i, j
+        cdef long i
         cdef mpq_t t
         mpq_init(t)
         mpq_inv(t, self._entries[self.index(x, y)])

--- a/src/sage/matroids/linear_matroid.pxd
+++ b/src/sage/matroids/linear_matroid.pxd
@@ -22,8 +22,8 @@ cdef class LinearMatroid(BasisExchangeMatroid):
     cpdef representation_vectors(self)
     cpdef LeanMatrix _basic_representation(self, B=*)
     cpdef LeanMatrix _reduced_representation(self, B=*)
-    
-    
+
+
     cpdef bint _is_field_isomorphism(self, LinearMatroid other, morphism)
     cpdef is_field_equivalent(self, other)
     cpdef is_field_isomorphism(self, other, morphism)

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -112,21 +112,18 @@ Methods
 # ****************************************************************************
 
 from copy import copy, deepcopy
-from itertools import combinations, product
+from itertools import product
 
 from cpython.object cimport Py_EQ, Py_NE
 
 from sage.data_structures.bitset_base cimport *
-from sage.graphs.graph import Graph
-from sage.graphs.spanning_tree import kruskal
 from sage.matrix.constructor import matrix
 from sage.matrix.matrix2 cimport Matrix
 from sage.matroids.basis_exchange_matroid cimport BasisExchangeMatroid
 from sage.matroids.lean_matrix cimport (LeanMatrix, GenericMatrix, BinaryMatrix,
                                         TernaryMatrix, QuaternaryMatrix, PlusMinusOneMatrix,
-                                        RationalMatrix, generic_identity)
+                                        RationalMatrix)
 from sage.matroids.matroid cimport Matroid
-from sage.matroids.set_system cimport SetSystem
 from sage.matroids.utilities import newlabel, spanning_stars, spanning_forest, lift_cross_ratios
 from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF
 from sage.rings.integer_ring import ZZ
@@ -168,7 +165,7 @@ cdef inline characteristic(LeanMatrix A):
 #     cdef long c, p, row
 #     for c in columns:
 #         is_pivot = False
-#         for row in xrange(r, A.nrows()):
+#         for row in range(r, A.nrows()):
 #             if A.get_unsafe(row, c) != 0:
 #                 is_pivot = True
 #                 p = row
@@ -176,7 +173,7 @@ cdef inline characteristic(LeanMatrix A):
 #         if is_pivot:
 #             A.swap_rows_c(p, r)
 #             A.rescale_row_c(r, A.get_unsafe(r, c) ** (-1), 0)
-#             for row in xrange(A.nrows()):
+#             for row in range(A.nrows()):
 #                 if row != r and A.get_unsafe(row, c) != 0:
 #                     A.add_multiple_of_row_c(row, r, -A.get_unsafe(row, c), 0)
 #             P.append(c)
@@ -276,7 +273,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
         """
         basis = self._setup_internal_representation(matrix, reduced_matrix, ring, keep_initial_representation)
         if groundset is None:
-            groundset = list(xrange(self._A.nrows() + self._A.ncols()))
+            groundset = list(range(self._A.nrows() + self._A.ncols()))
         else:
             groundset = list(groundset)
             if len(groundset) != self._A.nrows() + self._A.ncols():
@@ -2089,7 +2086,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             [0 1 1 0 0 1 1]
             [0 0 0 1 1 1 1]
         """
-        cdef long i, j
+        cdef long i
         cdef LeanMatrix M
         ext = []
         if self._representation is None:
@@ -2139,7 +2136,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             [0 0 0 1 1 1 0]
             [1 0 0 0 0 1 1]
         """
-        cdef long i, j
+        cdef long i
         cdef LeanMatrix M
         coext = []
         if self._representation is None:
@@ -3344,7 +3341,7 @@ cdef class BinaryMatroid(LinearMatroid):
         """
         if B is not None:
             self._move_current_basis(B, set())
-        rows, cols = self._current_rows_cols()
+        _, cols = self._current_rows_cols()
         return self._A.matrix_from_rows_and_columns(range(self.full_rank()), [self._idx[e] for e in cols])
 
     # isomorphism
@@ -4417,7 +4414,7 @@ cdef class TernaryMatroid(LinearMatroid):
         """
         if B is not None:
             self._move_current_basis(B, set())
-        rows, cols = self._current_rows_cols()
+        _, cols = self._current_rows_cols()
         return self._A.matrix_from_rows_and_columns(range(self.full_rank()), [self._idx[e] for e in cols])
 
     # isomorphism
@@ -5314,7 +5311,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
         """
         if B is not None:
             self._move_current_basis(B, set())
-        rows, cols = self._current_rows_cols()
+        _, cols = self._current_rows_cols()
         return self._A.matrix_from_rows_and_columns(range(self.full_rank()), [self._idx[e] for e in cols])
 
     cpdef _make_invariant(self):
@@ -6033,7 +6030,6 @@ cdef class RegularMatroid(LinearMatroid):
             Digraph on 55 vertices
         """
         # NEW VERSION, Uses Sage'S Graph Isomorphism
-        from sage.graphs.graph import Graph
         from sage.graphs.digraph import DiGraph
         if self._r_hypergraph is not None:
             return (self._hypergraph_vertex_partition, self._hypergraph_tuples, self._r_hypergraph)
@@ -6042,7 +6038,7 @@ cdef class RegularMatroid(LinearMatroid):
         B = {}
         V = []
         E = []
-        for i in xrange(P.nrows()):
+        for i in range(P.nrows()):
             e = self._E[i]
             w = P.get_unsafe(i, i)
             if w != 0:

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -335,9 +335,8 @@ from collections.abc import Iterable
 
 from sage.structure.richcmp cimport rich_to_bool, richcmp
 from sage.structure.sage_object cimport SageObject
-from itertools import combinations, permutations, product
+from itertools import combinations, product
 from .set_system cimport SetSystem
-from sage.graphs.spanning_tree import kruskal
 from sage.graphs.graph import Graph
 from sage.matrix.constructor import matrix
 
@@ -6305,7 +6304,7 @@ cdef class Matroid(SageObject):
         cdef frozenset Ax, Bx
 
         X = set(C)
-        e = X.pop()
+        _ = X.pop()
         # cl(X) = cl(C), and to be a chord x must be spanned by C
         for x in self._closure(X)-C:
             Ax = self._circuit(X.union([x]))
@@ -7585,7 +7584,7 @@ cdef class Matroid(SageObject):
         MIP.set_objective(sum([f[F] for F in FF]))
         for N in NB:
             MIP.add_constraint(sum([f[F] for F in FF if len(F.intersection(N)) > self.rank(F)]), min=1)
-        opt = MIP.solve(log=verbose)
+        _ = MIP.solve(log=verbose)
 
         fsol = MIP.get_values(f, convert=bool, tolerance=integrality_tolerance)
 

--- a/src/sage/matroids/set_system.pyx
+++ b/src/sage/matroids/set_system.pyx
@@ -401,7 +401,7 @@ cdef class SetSystem:
         Helper method for partition methods below.
         """
         cdef dict C
-        cdef long i, j, v, t0, t
+        cdef long i, v, t0, t
         cdef bint split
 
         C = {}
@@ -453,7 +453,6 @@ cdef class SetSystem:
         """
         Helper method for partition methods below.
         """
-        S = {}
         if P is None:
             P = self.groundset_partition()
         if E is None:
@@ -561,7 +560,7 @@ cdef class SetSystem:
             partition elements is an invariant of the isomorphism class of the
             hypergraph.
         """
-        cdef long h, l
+        cdef long h
         cdef list EP2, H
 
         if P is None:


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

This fixes some warnings of `cython-lint` in the `matroids` folder.

Command used:
```
cython-lint --ignore=E1,E2,E3,E5,E7 src/sage/matroids/
```

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
