### PR TITLE
src/sage_docbuild/conf.py: Do not fail if pplpy doc is not installed

### DIFF
--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -234,6 +234,8 @@ def set_intersphinx_mappings(app, config):
     }
     if PPLPY_DOCS and os.path.exists(os.path.join(PPLPY_DOCS, 'objects.inv')):
         app.config.intersphinx_mapping['pplpy'] = (PPLPY_DOCS, None)
+    else:
+        app.config.intersphinx_mapping['pplpy'] = ('https://www.labri.fr/perso/vdelecro/pplpy/latest/', None)
 
     # Add master intersphinx mapping
     dst = os.path.join(invpath, 'objects.inv')

--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -929,6 +929,7 @@ def setup(app):
         app.add_config_value('intersphinx_mapping', {}, False)
         app.add_config_value('intersphinx_cache_limit', 5, False)
         app.add_config_value('intersphinx_disabled_reftypes', [], False)
+        app.add_config_value('intersphinx_timeout', None, False)
         app.connect('config-inited', set_intersphinx_mappings)
         app.connect('builder-inited', intersphinx.load_mappings)
         # We do *not* fully initialize intersphinx since we call it by hand

--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -231,7 +231,9 @@ def set_intersphinx_mappings(app, config):
     'python': ('https://docs.python.org/',
                 os.path.join(SAGE_DOC_SRC, "common",
                              "python{}.inv".format(python_version))),
-    'pplpy': (PPLPY_DOCS, None)}
+    }
+    if PPLPY_DOCS and os.path.exists(os.path.join(PPLPY_DOCS, 'objects.inv')):
+        app.config.intersphinx_mapping['pplpy'] = (PPLPY_DOCS, None)
 
     # Add master intersphinx mapping
     dst = os.path.join(invpath, 'objects.inv')


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
We change the sphinx configuration so that the object inventory of pplpy is only used when it is installed.

<!-- Why is this change required? What problem does it solve? -->
We currently have no way to install the pplpy documentation when using the all-conda installation method (#35528).

<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
