### PR TITLE
compute traces of elliptic-curve endomorphisms

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -79,7 +79,7 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from copy import copy
+from copy import copy, deepcopy
 
 from sage.structure.sequence import Sequence
 
@@ -1442,7 +1442,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: negphi.rational_maps()                                                # optional - sage.rings.number_field
             ((x^2 + (-a)*x - 2)/(x + (-a)), (-x^2*y + (2*a)*x*y - y)/(x^2 + (-2*a)*x - 1))
         """
-        output = copy(self)
+        output = deepcopy(self)
         output._set_post_isomorphism(negation_morphism(output._codomain))
         return output
 
@@ -3312,13 +3312,13 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             NotImplemented
         """
         if isinstance(left, WeierstrassIsomorphism) and isinstance(right, EllipticCurveIsogeny):
-            result = copy(right)
+            result = deepcopy(right)
             result._set_post_isomorphism(left)
             return result
 
         if isinstance(left, EllipticCurveIsogeny) and isinstance(right, WeierstrassIsomorphism):
             assert isinstance(left, EllipticCurveIsogeny)
-            result = copy(left)
+            result = deepcopy(left)
             result._set_pre_isomorphism(right)
             return result
 

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2034,3 +2034,72 @@ def compute_model(E, name):
         return E.montgomery_model()
 
     raise NotImplementedError(f'cannot compute {name} model')
+
+def point_of_order(E, l):
+    r"""
+    Given an elliptic curve `E` over a finite field or a number field
+    and an integer `\ell \geq 1`, construct a point of order `\ell` on `E`,
+    possibly defined over an extension of the base field of `E`.
+
+    Currently only prime values of `\ell` are supported.
+
+    EXAMPLES::
+
+        sage: from sage.schemes.elliptic_curves.ell_field import point_of_order
+        sage: E = EllipticCurve(GF(101), [1,2,3,4,5])
+        sage: P = point_of_order(E, 5); P
+        (50*Y^5 + 48*Y^4 + 26*Y^3 + 37*Y^2 + 48*Y + 15 : 25*Y^5 + 31*Y^4 + 79*Y^3 + 39*Y^2 + 3*Y + 20 : 1)
+        sage: P.base_ring()
+        Finite Field in Y of size 101^6
+        sage: P.order()
+        5
+        sage: P.curve().a_invariants()
+        (1, 2, 3, 4, 5)
+
+    ::
+
+        sage: from sage.schemes.elliptic_curves.ell_field import point_of_order
+        sage: E = EllipticCurve(QQ, [7,7])
+        sage: P = point_of_order(E, 3); P
+        (x : -Y : 1)
+        sage: P.base_ring()
+        Number Field in Y with defining polynomial Y^2 - x^3 - 7*x - 7 over its base field
+        sage: P.order()
+        3
+        sage: P.curve().a_invariants()
+        (0, 0, 0, 7, 7)
+    """
+    # Construct the field extension defined by the given polynomial,
+    # in such a way that the result is recognized by Sage as a field.
+    def ffext(poly):
+        rng = poly.parent()
+        fld = rng.base_ring()
+        if fld in FiniteFields():
+            # Workaround: .extension() would return a PolynomialQuotientRing
+            # rather than another FiniteField.
+            return poly.splitting_field(rng.variable_name())
+        return fld.extension(poly, rng.variable_name())
+
+    l = ZZ(l)
+    if l == 1:
+        return E(0)
+
+    if not l.is_prime():
+        raise NotImplementedError('composite orders are currently unsupported')
+
+    xpoly = E.division_polynomial(l)
+    if xpoly.degree() < 1:  # supersingular and l == p
+        raise ValueError('curve does not have any points of the specified order')
+
+    mu = xpoly.factor()[0][0]
+    FF = ffext(mu)
+    xx = mu.any_root(ring=FF, assume_squarefree=True)
+
+    Y = polygen(FF, 'Y')
+    ypoly = E.defining_polynomial()(xx, Y, 1)
+    if ypoly.is_irreducible():
+        FF = ffext(ypoly)
+        xx = FF(xx)
+
+    EE = E.change_ring(FF)
+    return EE.lift_x(xx)

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2060,7 +2060,7 @@ def point_of_order(E, l):
 
         sage: from sage.schemes.elliptic_curves.ell_field import point_of_order
         sage: E = EllipticCurve(QQ, [7,7])
-        sage: P = point_of_order(E, 3); P
+        sage: P = point_of_order(E, 3); P  # random
         (x : -Y : 1)
         sage: P.base_ring()
         Number Field in Y with defining polynomial Y^2 - x^3 - 7*x - 7 over its base field

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -1123,9 +1123,9 @@ def compute_trace_generic(phi):
 
         sage: from sage.schemes.elliptic_curves.hom import compute_trace_generic
         sage: E = EllipticCurve(QQ, [1,2,3,4,5])
-        sage: m3 = E.scalar_multiplication(3)
-        sage: compute_trace_generic(m3)
-        6
+        sage: dbl = E.scalar_multiplication(2)
+        sage: compute_trace_generic(dbl)
+        4
 
     It works over number fields (for a CM curve)::
 

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -313,6 +313,13 @@ class EllipticCurveHom(Morphism):
 
         TESTS:
 
+        Make sure the cached value of the trace is not accidentally
+        copied on composition with automorphisms::
+
+            sage: aut = E.automorphisms()[1]  # [-1]
+            sage: (aut * tau).trace()
+            1
+
         It also works for more complicated :class:`EllipticCurveHom`
         children::
 
@@ -772,7 +779,7 @@ class EllipticCurveHom(Morphism):
             sage: EllipticCurveIsogeny(E,X^3-13*X^2-58*X+503,check=False)
             Isogeny of degree 7 from Elliptic Curve defined by y^2 + x*y = x^3 - x^2 - 107*x + 552 over Rational Field to Elliptic Curve defined by y^2 + x*y = x^3 - x^2 - 5252*x - 178837 over Rational Field
         """
-        return hash((self.domain(), self.codomain(), self.kernel_polynomial()))
+        return hash((self.domain(), self.codomain(), self.kernel_polynomial(), self.scaling_factor()))
 
     def as_morphism(self):
         r"""


### PR DESCRIPTION
In this patch, we add a generic method to compute the trace of an elliptic-curve endomorphism.

The computation uses a variant of Schoof's algorithm, which relies (only) on evaluating the endomorphism on small-order points, hence the method is totally independent of the internal representation of the `EllipticCurveHom`.

Adding this method is yet another step towards implementing endomorphism rings, especially for supporting the quaternionic (supersingular) case. I'm sure some speedups are possible, but they can come later.