### PR TITLE
removing some unused imports in cython files

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -26,7 +26,6 @@ from .util import GAPError
 from sage.cpython.string cimport str_to_bytes, char_to_str
 from sage.misc.cachefunc import cached_method
 from sage.structure.sage_object cimport SageObject
-from sage.structure.parent import Parent
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from sage.rings.real_double import RDF

--- a/src/sage/libs/meataxe.pyx
+++ b/src/sage/libs/meataxe.pyx
@@ -1,15 +1,15 @@
 # distutils: libraries = mtx
 # sage_setup: distribution = sagemath-meataxe
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2017 Simon King <simon.king@uni-jena.de>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from cpython.exc cimport PyErr_SetObject
 from cysignals.signals cimport sig_block, sig_unblock
@@ -70,7 +70,6 @@ cdef Matrix_t *rawMatrix(int Field, list entries) except NULL:
 ## to make sure that MeatAxe is initialised.
 
 from sage.cpython.string cimport str_to_bytes, char_to_str
-import os
 
 cdef void sage_meataxe_error_handler(const MtxErrorRecord_t *err):
     sig_block()

--- a/src/sage/matrix/matrix_generic_dense.pyx
+++ b/src/sage/matrix/matrix_generic_dense.pyx
@@ -13,7 +13,6 @@ from .args cimport MatrixArgs_init
 
 cimport sage.matrix.matrix as matrix
 
-from sage.structure.element cimport parent as parent_c
 
 cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
     r"""

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -112,7 +112,7 @@ from sage.rings.integer_ring cimport IntegerRing_class
 from sage.rings.finite_rings.integer_mod_ring import IntegerModRing
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
-from sage.structure.element cimport ModuleElement, RingElement, Element, Vector
+from sage.structure.element cimport Element, Vector
 from sage.structure.element import is_Vector
 from sage.structure.sequence import Sequence
 
@@ -1542,7 +1542,6 @@ cdef class Matrix_integer_dense(Matrix_dense):
         cdef Matrix_integer_dense left = <Matrix_integer_dense>self
         cdef mod_int *moduli
         cdef int i, n, k
-        cdef object parent
 
         nr = left._nrows
         nc = right._ncols

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -111,8 +111,7 @@ from cysignals.signals cimport sig_check, sig_on, sig_str, sig_off
 cimport sage.matrix.matrix_dense as matrix_dense
 from .args cimport SparseEntry, MatrixArgs_init
 from libc.stdio cimport *
-from sage.structure.element cimport (Matrix, Vector,
-                                     ModuleElement, Element)
+from sage.structure.element cimport (Matrix, Vector)
 from sage.modules.free_module_element cimport FreeModuleElement
 from sage.libs.gmp.random cimport *
 from sage.misc.randstate cimport randstate, current_randstate

--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -186,7 +186,6 @@ from sage.rings.real_mpfi cimport RealIntervalField_class
 from sage.rings.real_mpfr cimport RealField_class, RealField, RealNumber
 from sage.rings.ring import Field
 from sage.structure.element cimport Element, ModuleElement
-from sage.structure.parent cimport Parent
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.arith.long cimport is_small_python_int
 

--- a/src/sage/rings/convert/mpfi.pyx
+++ b/src/sage/rings/convert/mpfi.pyx
@@ -20,7 +20,7 @@ from sage.libs.gsl.complex cimport *
 
 from sage.arith.long cimport integer_check_long
 from sage.cpython.string cimport bytes_to_str
-from sage.structure.element cimport Element, parent
+from sage.structure.element cimport Element
 
 import sage.rings.abc
 from ..integer cimport Integer

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -27,7 +27,7 @@ AUTHORS:
 #  Distributed under the terms of the GNU General Public License (GPL)
 #  as published by the Free Software Foundation; either version 2 of
 #  the License, or (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 #*****************************************************************************
 
 cimport cython
@@ -35,7 +35,6 @@ from cysignals.signals cimport sig_check
 from cpython.array cimport array
 
 from sage.categories.finite_fields import FiniteFields
-from sage.structure.parent cimport Parent
 from sage.misc.persist import register_unpickle_override
 from sage.misc.cachefunc import cached_method
 from sage.misc.prandom import randrange

--- a/src/sage/rings/function_field/element.pyx
+++ b/src/sage/rings/function_field/element.pyx
@@ -67,7 +67,7 @@ AUTHORS:
 
 from sage.structure.element cimport FieldElement, RingElement, ModuleElement, Element
 from sage.misc.cachefunc import cached_method
-from sage.structure.richcmp cimport richcmp, richcmp_not_equal
+
 
 def is_FunctionFieldElement(x):
     """

--- a/src/sage/rings/function_field/element_polymod.pyx
+++ b/src/sage/rings/function_field/element_polymod.pyx
@@ -13,7 +13,7 @@ Elements of function fields: extension
 #*****************************************************************************
 
 from sage.misc.cachefunc import cached_method
-from sage.structure.richcmp cimport richcmp, richcmp_not_equal
+from sage.structure.richcmp cimport richcmp
 from sage.structure.element cimport FieldElement, RingElement, ModuleElement, Element
 
 from sage.rings.function_field.element cimport FunctionFieldElement
@@ -76,7 +76,7 @@ cdef class FunctionFieldElement_polymod(FunctionFieldElement):
 
     def __bool__(self):
         """
-        Return True if the element is not zero.
+        Return ``True`` if the element is not zero.
 
         EXAMPLES::
 

--- a/src/sage/rings/integer_ring.pyx
+++ b/src/sage/rings/integer_ring.pyx
@@ -62,7 +62,6 @@ from sage.rings.number_field.number_field_element_base import NumberFieldElement
 from sage.structure.coerce cimport is_numpy_type
 from sage.structure.element cimport parent
 from sage.structure.parent_gens import ParentWithGens
-from sage.structure.parent cimport Parent
 from sage.structure.richcmp cimport rich_to_bool
 from sage.structure.sequence import Sequence
 

--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -375,21 +375,21 @@ compare equal::
     ....:             print("{} != {}".format(f, g))
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2006 William Stein <wstein@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from cpython.object cimport Py_EQ, Py_NE
 
 from . import ideal
 import sage.structure.all
-from sage.structure.richcmp cimport (richcmp, rich_to_bool, richcmp_not_equal)
+from sage.structure.richcmp cimport (richcmp, rich_to_bool)
 from sage.misc.cachefunc import cached_method
 
 

--- a/src/sage/rings/polynomial/ore_polynomial_element.pyx
+++ b/src/sage/rings/polynomial/ore_polynomial_element.pyx
@@ -27,7 +27,7 @@ AUTHORS:
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 2 of the License, or
 #    (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
 import re
@@ -37,7 +37,7 @@ from sage.misc.superseded import experimental
 
 from sage.rings.infinity import infinity
 from sage.structure.factorization import Factorization
-from sage.structure.element cimport Element, RingElement, AlgebraElement, ModuleElement
+from sage.structure.element cimport Element, RingElement, AlgebraElement
 from sage.structure.parent cimport Parent
 from sage.structure.parent_gens cimport ParentWithGens
 from sage.misc.abstract_method import abstract_method

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -131,7 +131,7 @@ from sage.rings.polynomial.multi_polynomial_ideal import NCPolynomialIdeal
 
 from sage.rings.polynomial.polydict import ETuple
 from sage.rings.ring import check_default_category
-from sage.structure.element cimport CommutativeRingElement, Element, ModuleElement, RingElement
+from sage.structure.element cimport CommutativeRingElement, Element, RingElement
 from sage.structure.factory import UniqueFactory
 from sage.structure.richcmp cimport rich_to_bool
 from sage.structure.parent cimport Parent

--- a/src/sage/rings/polynomial/skew_polynomial_element.pyx
+++ b/src/sage/rings/polynomial/skew_polynomial_element.pyx
@@ -54,8 +54,6 @@ from cysignals.signals cimport sig_check
 from sage.rings.infinity import infinity
 from sage.structure.factorization import Factorization
 from sage.structure.element cimport Element, RingElement, AlgebraElement, ModuleElement
-from sage.structure.parent cimport Parent
-from sage.structure.parent_gens cimport ParentWithGens
 from sage.misc.abstract_method import abstract_method
 from sage.categories.homset import Hom
 from sage.categories.fields import Fields

--- a/src/sage/rings/power_series_pari.pyx
+++ b/src/sage/rings/power_series_pari.pyx
@@ -76,7 +76,7 @@ from sage.libs.pari.all import pari
 
 from sage.rings.polynomial.polynomial_element cimport Polynomial
 from sage.rings.power_series_ring_element cimport PowerSeries
-from sage.structure.element cimport Element, RingElement
+from sage.structure.element cimport Element
 from sage.structure.parent cimport Parent
 from sage.rings.infinity import infinity
 

--- a/src/sage/rings/ring_extension.pyx
+++ b/src/sage/rings/ring_extension.pyx
@@ -118,7 +118,6 @@ from sage.cpython.getattr import dir_with_other_class
 from sage.misc.latex import latex, latex_variable_name
 
 from sage.structure.factory import UniqueFactory
-from sage.structure.parent cimport Parent
 from sage.structure.element cimport Element
 from sage.structure.category_object import normalize_names
 from sage.categories.map cimport Map

--- a/src/sage/structure/coerce_maps.pyx
+++ b/src/sage/structure/coerce_maps.pyx
@@ -1,8 +1,6 @@
 """
 Coerce maps
 """
-
-import re
 import types
 
 from sage.structure.parent cimport Parent

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -126,7 +126,7 @@ from .coerce cimport parent_is_integers
 from .coerce_exceptions import CoercionException
 from .coerce_maps cimport (NamedConvertMap, DefaultConvertMap,
                            DefaultConvertMap_unique, CallableConvertMap)
-from .element cimport parent, Element
+from .element cimport parent
 
 
 cdef _record_exception():

--- a/src/sage/structure/parent_gens.pyx
+++ b/src/sage/structure/parent_gens.pyx
@@ -68,9 +68,7 @@ This example illustrates generators for a free module over `\ZZ`.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from . import gens_py
 cimport sage.structure.parent as parent
-from sage.structure.coerce_dict cimport MonoDict
 cimport sage.structure.category_object as category_object
 
 
@@ -194,10 +192,9 @@ cdef class ParentWithGens(ParentWithBase):
         self._names = d['_names']
         self._latex_names = d['_latex_names']
 
-
-    #################################################################################
+    ######################################################################
     # Morphisms of objects with generators
-    #################################################################################
+    ######################################################################
 
     def hom(self, im_gens, codomain=None, base_map=None, category=None, check=True):
         r"""

--- a/src/sage/structure/parent_old.pyx
+++ b/src/sage/structure/parent_old.pyx
@@ -27,8 +27,6 @@ This came up in some subtle bug once::
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 from sage.misc.superseded import deprecation
-cimport sage.structure.sage_object as sage_object
-import operator
 from .coerce cimport py_scalar_parent
 from sage.ext.stdsage cimport HAS_DICTIONARY
 from sage.sets.pythonclass cimport Set_PythonType, Set_PythonType_class

--- a/src/sage/structure/richcmp.pyx
+++ b/src/sage/structure/richcmp.pyx
@@ -32,17 +32,17 @@ AUTHORS:
 - Jeroen Demeyer
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2017-2018 Jeroen Demeyer <J.Demeyer@UGent.be>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
-from cpython.object cimport Py_TYPE, PyTypeObject
+from cpython.object cimport PyTypeObject
 from sage.cpython.wrapperdescr cimport get_slotdef, wrapperbase, PyDescr_NewWrapper
 
 cdef extern from *:


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Removing some of the (many) unused import in cython files. Found using cython-lint

Here in libs, matrix, rings, structure folders

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
