### PR TITLE
Enable access to some methods in sage/graphs/graph_decompositions

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -9974,6 +9974,8 @@ class Graph(GenericGraph):
     from sage.graphs.graph_decompositions.vertex_separation import pathwidth
     from sage.graphs.graph_decompositions.tree_decomposition import treelength
     from sage.graphs.graph_decompositions.clique_separators import atoms_and_clique_separators
+    from sage.graphs.graph_decompositions.bandwidth import bandwidth
+    from sage.graphs.graph_decompositions.cutwidth import cutwidth
     from sage.graphs.matchpoly import matching_polynomial
     from sage.graphs.cliquer import all_max_clique as cliques_maximum
     from sage.graphs.cliquer import all_cliques

--- a/src/sage/graphs/graph_decompositions/bandwidth.pyx
+++ b/src/sage/graphs/graph_decompositions/bandwidth.pyx
@@ -1,3 +1,4 @@
+# cython: binding=True
 r"""
 Bandwidth of undirected graphs
 

--- a/src/sage/graphs/graph_decompositions/cutwidth.pyx
+++ b/src/sage/graphs/graph_decompositions/cutwidth.pyx
@@ -1,3 +1,4 @@
+# cython: binding=True
 r"""
 Cutwidth
 


### PR DESCRIPTION
### :books: Description

Files `src/sage/graphs/graph_decompositions/bandwidth.pyx` and `src/sage/graphs/graph_decompositions/cutwidth.pyx` were missing the statement `cython: binding=True`. So these methods were hardly accessible. We add the instruction and provide access in graphs.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies
