### PR TITLE
`sage.quadratic_forms`: Fix use of `staticmethod` for Python < 3.10

### DIFF
--- a/src/sage/quadratic_forms/genera/genus.py
+++ b/src/sage/quadratic_forms/genera/genus.py
@@ -121,7 +121,8 @@ def genera(sig_pair, determinant, max_scale=None, even=False):
     return genera
 
 
-genera = staticmethod(genera)
+# #35557: In Python < 3.10, a staticmethod cannot be called directly
+_genera_staticmethod = staticmethod(genera)
 
 
 def _local_genera(p, rank, det_val, max_scale, even):

--- a/src/sage/quadratic_forms/quadratic_form.py
+++ b/src/sage/quadratic_forms/quadratic_form.py
@@ -502,9 +502,8 @@ class QuadraticForm(SageObject):
         ])
 
     # Genus
-    lazy_import("sage.quadratic_forms.genera.genus", [
-            "genera"
-        ])
+    lazy_import("sage.quadratic_forms.genera.genus",
+                "_genera_staticmethod", as_="genera")
 
     def __init__(self, R, n=None, entries=None, unsafe_initialization=False, number_of_automorphisms=None, determinant=None):
         """


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Fixes #35557 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
