### PR TITLE
Make doc preview message from github bot one liner

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -1,4 +1,4 @@
-# Triggers after the documentation build has finished, 
+# Triggers after the documentation build has finished,
 # taking the artifact and uploading it to netlify
 name: Publish documentation
 
@@ -47,7 +47,7 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/docs.zip', Buffer.from(download.data));
-      
+
       - name: Extract docs
         run: unzip docs.zip -d docs && unzip docs/docs.zip -d docs/docs
 
@@ -72,9 +72,8 @@ jobs:
           header: preview-comment
           recreate: true
           message: |
-            [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}) is ready! :tada:
-            Built with commit: ${{ steps.source-run-info.outputs.sourceHeadSha }}
-      
+            [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}) (built with commit ${{ steps.source-run-info.outputs.sourceHeadSha }}) is ready! :tada:
+
       - name: Update deployment status PR check
         uses: myrotvorets/set-commit-status-action@1.1.6
         if: ${{ always() }}


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

For each PR, github bot emits a comment with documentation preview message. Now it consists of two lines. This PR makes it one line, for quick eye scan from left to right once instead of twice.

![Screen Shot 2023-04-25 at 2 41 40 PM](https://user-images.githubusercontent.com/1456101/234184364-2e174edc-b895-470b-a675-cedbe1d263e8.png)

(I also tried to make the doc link open in a new tab, but it seems close to impossible.)

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
