### PR TITLE
Fix discrepancy in partitions between provided number and starting partition

### DIFF
--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -809,17 +809,12 @@ class EnumeratedSets(CategoryWithAxiom):
                 [0, 1, 2, 3, 4]
             """
             f = self.first()
-            yield f
-            while True:
+            while not (f is None or f is False):
+                yield f
                 try:
                     f = self.next(f)
-                except (TypeError, ValueError ):
-                    break
-
-                if f is None or f is False:
-                    break
-                else:
-                    yield f
+                except (TypeError, ValueError):
+                    f = None
 
         def _iterator_from_unrank(self):
             """

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -7505,24 +7505,6 @@ class Partitions_starting(Partitions):
         """
         return x in Partitions_n(self.n) and x <= self._starting
 
-    def __iter__(self):
-        """
-        Iterate over partitions less than `self._starting` in lex order.
-        
-        EXAMPLES::
-
-            sage: [p for p in Partitions(3, starting=[2,1])]
-            [[2, 1], [1, 1, 1]]
-            sage: [p for p in Partitions(3, starting=[2,2])]
-            [[2, 1], [1, 1, 1]]
-            sage: [p for p in Partitions(3, starting=[1,1])]
-            []
-        """
-        mu = self.first()
-        while mu:
-            yield mu
-            mu = self.next(mu)
-
     def first(self):
         """
         Return the first partition in ``self``.
@@ -7542,11 +7524,11 @@ class Partitions_starting(Partitions):
         """
         if self._starting in Partitions_n(self.n):
             return self._starting
-        
+
         if (k := self._starting.size()) < self.n:
             mu = list(self._starting) + [1] * (self.n - k)
             return next(Partition(mu))
-        
+
         #if self._starting.size() > self.n:
         return self.element_class(self, Partitions(self.n, outer=self._starting).first())
 
@@ -7595,6 +7577,8 @@ class Partitions_ending(Partitions):
             [[4], [3, 1], [2, 2]]
             sage: Partitions(4, ending=[4]).list()
             [[4]]
+            sage: Partitions(4, ending=[5]).list()
+            []
 
         TESTS::
 
@@ -7640,7 +7624,11 @@ class Partitions_ending(Partitions):
 
             sage: Partitions(4, ending=[1,1,1,1]).first()
             [4]
+            sage: Partitions(4, ending=[5]).first() is None
+            True
         """
+        if self._ending and self.n <= self._ending[0] and not (self.n == self._ending[0] and len(self._ending) == 1):
+            return None
         return self.element_class(self, [self.n])
 
     def next(self, part):
@@ -7653,8 +7641,10 @@ class Partitions_ending(Partitions):
             [3, 1]
             sage: Partitions(4, ending=[1,1,1,1]).next(Partition([1,1,1,1])) is None
             True
+            sage: Partitions(4, ending=[3]).next(Partition([3,1])) is None
+            True
         """
-        if part == self._ending:
+        if part <= self._ending:
             return None
         return next(part)
 

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -7522,7 +7522,7 @@ class Partitions_starting(Partitions):
             sage: Partitions(3, starting=[2,2]).first()
             [2, 1]
         """
-        if self._starting in Partitions_n(self.n):
+        if sum(self._starting) == self.n:
             return self._starting
 
         if (k := self._starting.size()) < self.n:
@@ -7588,6 +7588,7 @@ class Partitions_ending(Partitions):
         Partitions.__init__(self)
         self.n = n
         self._ending = ending_partition
+        self._ending_size_is_not_same = (n != sum(self._ending))
 
     def _repr_(self):
         """
@@ -7653,7 +7654,7 @@ class Partitions_ending(Partitions):
 
         # if self._ending is a different size, we should make the comparison
         mu = next(part)
-        if mu < self._ending:
+        if self._ending_size_is_not_same and mu < self._ending:
             return None
         return mu
 

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -7451,6 +7451,22 @@ class Partitions_starting(Partitions):
             sage: Partitions(3, starting=[2,1]).list()
             [[2, 1], [1, 1, 1]]
 
+            sage: Partitions(7, starting=[2,2,1]).list()
+            [[2, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1]]
+
+            sage: Partitions(7, starting=[3,2]).list()
+            [[3, 1, 1, 1, 1],
+             [2, 2, 2, 1],
+             [2, 2, 1, 1, 1],
+             [2, 1, 1, 1, 1, 1],
+             [1, 1, 1, 1, 1, 1, 1]]
+
+            sage: Partitions(4, starting=[3,2]).list()
+            [[3, 1], [2, 2], [2, 1, 1], [1, 1, 1, 1]]
+
+            sage: Partitions(3, starting=[1,1]).list()
+            []
+
         TESTS::
 
             sage: p = Partitions(3, starting=[2,1])
@@ -7489,6 +7505,24 @@ class Partitions_starting(Partitions):
         """
         return x in Partitions_n(self.n) and x <= self._starting
 
+    def __iter__(self):
+        """
+        Iterate over partitions less than `self._starting` in lex order.
+        
+        EXAMPLES::
+
+            sage: [p for p in Partitions(3, starting=[2,1])]
+            [[2, 1], [1, 1, 1]]
+            sage: [p for p in Partitions(3, starting=[2,2])]
+            [[2, 1], [1, 1, 1]]
+            sage: [p for p in Partitions(3, starting=[1,1])]
+            []
+        """
+        mu = self.first()
+        while mu:
+            yield mu
+            mu = self.next(mu)
+
     def first(self):
         """
         Return the first partition in ``self``.
@@ -7497,8 +7531,24 @@ class Partitions_starting(Partitions):
 
             sage: Partitions(3, starting=[2,1]).first()
             [2, 1]
+            sage: Partitions(3, starting=[1,1,1]).first()
+            [1, 1, 1]
+            sage: Partitions(3, starting=[1,1]).first()
+            False
+            sage: Partitions(3, starting=[3,1]).first()
+            [3]
+            sage: Partitions(3, starting=[2,2]).first()
+            [2, 1]
         """
-        return self._starting
+        if self._starting in Partitions_n(self.n):
+            return self._starting
+        
+        if (k := self._starting.size()) < self.n:
+            mu = list(self._starting) + [1] * (self.n - k)
+            return next(Partition(mu))
+        
+        #if self._starting.size() > self.n:
+        return self.element_class(self, Partitions(self.n, outer=self._starting).first())
 
     def next(self, part):
         """

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -7636,7 +7636,10 @@ class Partitions_ending(Partitions):
         Return the next partition after ``part`` in ``self``.
 
         EXAMPLES::
-
+            sage: Partitions(4, ending=[1,1,1,1,1]).next(Partition([4]))
+            [3, 1]
+            sage: Partitions(4, ending=[3,2]).next(Partition([3,1])) is None
+            True
             sage: Partitions(4, ending=[1,1,1,1]).next(Partition([4]))
             [3, 1]
             sage: Partitions(4, ending=[1,1,1,1]).next(Partition([1,1,1,1])) is None
@@ -7644,9 +7647,15 @@ class Partitions_ending(Partitions):
             sage: Partitions(4, ending=[3]).next(Partition([3,1])) is None
             True
         """
-        if part <= self._ending:
+        # if we have passed the last Partition, there is no next partition
+        if part == self._ending:
             return None
-        return next(part)
+
+        # if self._ending is a different size, we should make the comparison
+        mu = next(part)
+        if mu < self._ending:
+            return None
+        return mu
 
 
 class PartitionsInBox(Partitions):


### PR DESCRIPTION
### :books: Description

The behavior of `Partitions(n, starting=mu)` is confusing. It iterates over partitions starting with `mu`, but it is not required that `mu` be a partition of `n`. For example:

```
sage: P = Partitions(5, starting=[3,1]); print(P); list(P)
Partitions of the integer 5 starting with [3, 1]
[[3, 1], [2, 2], [2, 1, 1], [1, 1, 1, 1]]
```
These are partitions of `4` not of `5`. The change is to add a `ValueError` in `Partitions_starting` to assert that `n`
must agree with the weight of `mu`. 

The example above was drawn from the tests, so a few tests are changed so that they now pass.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
