### PR TITLE
Implementing the Casimir elements of a finite dimensional Lie algebra

### DIFF
--- a/src/sage/algebras/lie_algebras/poincare_birkhoff_witt.py
+++ b/src/sage/algebras/lie_algebras/poincare_birkhoff_witt.py
@@ -496,6 +496,46 @@ class PoincareBirkhoffWittBasis(CombinatorialFreeModule):
         """
         return m.length()
 
+    def casimir_element(self, order=2):
+        r"""
+        Return the Casimir element of ``self``.
+
+        .. SEEALSO::
+
+            :meth:`~sage.categories.finite_dimensional_lie_algebras_with_basis.FiniteDimensionalLieAlgebrasWithBasis.ParentMethods.casimir_element`
+
+        INPUT:
+
+        - ``order`` -- (default: ``2``) the order of the Casimir element
+
+        EXAMPLES::
+
+            sage: L = LieAlgebra(QQ, cartan_type=['G', 2])
+            sage: U = L.pbw_basis()
+            sage: C = U.casimir_element(); C
+            1/4*PBW[alpha[2]]*PBW[-alpha[2]] + 1/12*PBW[alpha[1]]*PBW[-alpha[1]]
+             + 1/12*PBW[alpha[1] + alpha[2]]*PBW[-alpha[1] - alpha[2]] + 1/12*PBW[2*alpha[1] + alpha[2]]*PBW[-2*alpha[1] - alpha[2]]
+             + 1/4*PBW[3*alpha[1] + alpha[2]]*PBW[-3*alpha[1] - alpha[2]]
+             + 1/4*PBW[3*alpha[1] + 2*alpha[2]]*PBW[-3*alpha[1] - 2*alpha[2]]
+             + 1/12*PBW[alphacheck[1]]^2 + 1/4*PBW[alphacheck[1]]*PBW[alphacheck[2]]
+             + 1/4*PBW[alphacheck[2]]^2 - 5/12*PBW[alphacheck[1]] - 3/4*PBW[alphacheck[2]]
+            sage: all(g * C == C * g for g in U.algebra_generators())
+            True
+
+        TESTS::
+
+            sage: H = lie_algebras.Heisenberg(QQ, oo)
+            sage: U = H.pbw_basis()
+            sage: U.casimir_element()
+            Traceback (most recent call last):
+            ...
+            ValueError: the Lie algebra must be finite dimensional
+        """
+        from sage.rings.infinity import Infinity
+        if self._g.dimension() == Infinity:
+            raise ValueError("the Lie algebra must be finite dimensional")
+        return self._g.casimir_element(order=order, UEA=self)
+
     class Element(CombinatorialFreeModule.Element):
         def _act_on_(self, x, self_on_left):
             """

--- a/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
@@ -1619,7 +1619,7 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
 
             For the quadradic order (i.e., ``order=2``), then this uses
             K^{ij}`, the inverse of the Killing form matrix, to compute
-            `C_{(2)} = sum_{i,j} K^{ij} X_i \cdot X_j`, where `\{X_1, \ldots,
+            `C_{(2)} = \sum_{i,j} K^{ij} X_i \cdots X_j`, where `\{X_1, \ldots,
             X_n\}` is a basis for `\mathfrak{g}`. Otherwise this solves the
             system of equations
 
@@ -1628,8 +1628,10 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 f_{aj}^b \kappa^{jc\cdots d} + f_{aj}^c \kappa^{cj\cdots d}
                 \cdots + f_{aj}^d \kappa^{bc \cdots j}
 
-            for the symmetric tensor `\kappa^{i_1 \cdots i_m}`, where `m`
-            is the ``order``.
+            for the symmetric tensor `\kappa^{i_1 \cdots i_k}`, where `k`
+            is the ``order``. This system comes from `[X_i, C_{(k)}] = 0`
+            with `C_{(k)} = \sum_{i_1, \ldots, i_k\}^n
+            \kappa^{i_1 \cdots i_k} X_{i_1} \cdots X_{i_k}`.
 
             EXAMPLES::
 
@@ -1641,7 +1643,8 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 True
                 sage: U = L.pbw_basis()
                 sage: C = L.casimir_element(UEA=U); C
-                1/2*PBW[alpha[1]]*PBW[-alpha[1]] + 1/8*PBW[alphacheck[1]]^2 - 1/4*PBW[alphacheck[1]]
+                1/2*PBW[alpha[1]]*PBW[-alpha[1]] + 1/8*PBW[alphacheck[1]]^2
+                 - 1/4*PBW[alphacheck[1]]
                 sage: all(g * C == C * g for g in U.algebra_generators())
                 True
 
@@ -1736,7 +1739,6 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
             tens = ker.basis()[0]
             del eqns  # no need to hold onto the matrix
 
-            from sage.rings.integer_ring import ZZ
             def to_prod(index):
                 coeff = tens[index]
                 p = [0] * order

--- a/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
@@ -1628,10 +1628,13 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 f_{aj}^b \kappa^{jc\cdots d} + f_{aj}^c \kappa^{cj\cdots d}
                 \cdots + f_{aj}^d \kappa^{bc \cdots j}
 
-            for the symmetric tensor `\kappa^{i_1 \cdots i_k}`, where `k`
-            is the ``order``. This system comes from `[X_i, C_{(k)}] = 0`
-            with `C_{(k)} = \sum_{i_1, \ldots, i_k\}^n
-            \kappa^{i_1 \cdots i_k} X_{i_1} \cdots X_{i_k}`.
+            for the symmetric tensor `\kappa^{i_1 \cdots i_k}`, where `k` is
+            the ``order``. This system comes from `[X_i, C_{(k)}] = 0` with
+
+            .. MATH::
+
+                C_{(k)} = \sum_{i_1, \ldots, i_k}^n
+                \kappa^{i_1 \cdots i_k} X_{i_1} \cdots X_{i_k}.
 
             EXAMPLES::
 

--- a/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
@@ -1755,7 +1755,6 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
 
             return UEA.sum(to_prod(index) for index in tens.support())
 
-
     class ElementMethods:
         def adjoint_matrix(self, sparse=False): # In #11111 (more or less) by using matrix of a morphism
             """

--- a/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
@@ -1603,7 +1603,7 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
             for the center of `U(\mathfrak{g})` of homogeneous degree `k`
             (that is, it is an element of `U_k \setminus U_{k-1}`, where
             `\{U_i\}_{i=0}^{\infty}` is the natural filtration of
-            `U(\mathfrak{g})`. When `\mathfrak{g}` is a simple Lie algebra,
+            `U(\mathfrak{g})`). When `\mathfrak{g}` is a simple Lie algebra,
             then this spans `Z(U(\mathfrak{g}))_k`.
 
             INPUT:
@@ -1612,12 +1612,12 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
             - ``UEA`` -- (optional) the universal enveloping algebra to
               return the result in
             - ``force_generic`` -- (default: ``False``) if ``True`` for the
-              quadradic order, then this uses the default algorithm; otherwise
+              quadratic order, then this uses the default algorithm; otherwise
               this is ignored
 
             ALGORITHM:
 
-            For the quadradic order (i.e., ``order=2``), then this uses
+            For the quadratic order (i.e., ``order=2``), then this uses
             K^{ij}`, the inverse of the Killing form matrix, to compute
             `C_{(2)} = \sum_{i,j} K^{ij} X_i \cdots X_j`, where `\{X_1, \ldots,
             X_n\}` is a basis for `\mathfrak{g}`. Otherwise this solves the
@@ -1697,7 +1697,7 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
             B = self.basis()
 
             if order == 2 and not force_generic:
-                # Special case for the quadradic using the Killing form
+                # Special case for the quadratic using the Killing form
                 try:
                     K = self.killing_form_matrix().inverse()
                     return UEA.sum(K[i, j] * UEA(x) * UEA(y) for i, x in enumerate(B)

--- a/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
@@ -1618,7 +1618,7 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
             ALGORITHM:
 
             For the quadratic order (i.e., ``order=2``), then this uses
-            K^{ij}`, the inverse of the Killing form matrix, to compute
+            `K^{ij}`, the inverse of the Killing form matrix, to compute
             `C_{(2)} = \sum_{i,j} K^{ij} X_i \cdots X_j`, where `\{X_1, \ldots,
             X_n\}` is a basis for `\mathfrak{g}`. Otherwise this solves the
             system of equations


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

The Casimir element is an important element in the center of the universal enveloping algebra of a simple Lie algebra. We provide a generic implementation for all orders (> 1) for all finite dimensional Lie algebras.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
