### PR TITLE
Fix Max=Min warning in coin interacts

### DIFF
--- a/src/sage/interacts/library.py
+++ b/src/sage/interacts/library.py
@@ -848,7 +848,7 @@ def special_points(
 @library_interact(
     n=lambda: slider(2, 10000, 100, default=1000, label="Number of Tosses"),
     interval=lambda: range_slider(
-        0, 1, default=(0.45, 0.55), label="Plotting range (y)"
+        0.0, 1.0, default=(0.45, 0.55), label="Plotting range (y)"
     ),
 )
 def coin(n, interval):
@@ -877,7 +877,7 @@ def coin(n, interval):
         sage: interacts.statistics.coin()
         ...Interactive function <function coin at ...> with 2 widgets
           n: IntSlider(value=1000, description='Number of Tosses', max=10000, min=2, step=100)
-          interval: IntRangeSlider(value=(0, 0), description='Plotting range (y)', max=1)
+          interval: FloatRangeSlider(value=(0.45, 0.55), description='Plotting range (y)', max=1.0)
     """
     from random import random
     c = []

--- a/src/sage/interacts/test_jupyter.rst
+++ b/src/sage/interacts/test_jupyter.rst
@@ -281,7 +281,7 @@ Test all interacts from the Sage interact library::
     sage: test(interacts.statistics.coin)
     ...Interactive function <function coin at ...> with 2 widgets
       n: IntSlider(value=1000, description='Number of Tosses', max=10000, min=2, step=100)
-      interval: IntRangeSlider(value=(0, 0), description='Plotting range (y)', max=1)
+      interval: FloatRangeSlider(value=(0.45, 0.55), description='Plotting range (y)', max=1.0)
 
 Test matrix control (see :trac:`27735`)::
 


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

New versions of matplotlib complained about ymin = ymax (= 0). And I guess it makes more sense to have a float-slider in this case anyway.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
