### PR TITLE
Remove global sage.all import in pytest

### DIFF
--- a/src/bin/sage-runtests
+++ b/src/bin/sage-runtests
@@ -174,7 +174,8 @@ if __name__ == "__main__":
         filenames = [f for f in args.filenames
                      if f.endswith("_test.py") or not os.path.isfile(f)]
         if filenames or not args.filenames:
-            exit_code_pytest = pytest.main(pytest_options + filenames)
+            print(f"Running pytest on {filenames} with options {pytest_options}")
+            exit_code_pytest = pytest.main(filenames + pytest_options)
             if exit_code_pytest == 5:
                 # Exit code 5 means there were no test files, pass in this case
                 exit_code_pytest = 0

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -24,10 +24,6 @@ from _pytest.doctest import (
 )
 from _pytest.pathlib import import_path, ImportMode
 
-# Import sage.all is necessary to:
-# - avoid cyclic import errors, see Issue #33580
-# - inject it into globals namespace for doctests
-import sage.all
 from sage.doctest.parsing import SageDocTestParser, SageOutputChecker
 
 
@@ -138,7 +134,7 @@ def pytest_collect_file(
             return SageDoctestModule.from_parent(parent, path=file_path)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="session")
 def add_imports(doctest_namespace: dict[str, Any]):
     """
     Add global imports for doctests.
@@ -146,6 +142,7 @@ def add_imports(doctest_namespace: dict[str, Any]):
     See `pytest documentation <https://docs.pytest.org/en/stable/doctest.html#doctest-namespace-fixture>`.
     """
     # Inject sage.all into each doctest
+    import sage.all
     dict_all = sage.all.__dict__
 
     # Remove '__package__' item from the globals since it is not

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -113,8 +113,19 @@ class SageDoctestModule(DoctestModule):
                 )
 
 
+class IgnoreCollector(pytest.Collector):
+    """
+    Ignore a file.
+    """
+    def __init__(self, parent: pytest.Collector) -> None:
+        super().__init__('ignore', parent)
+
+    def collect(self) -> Iterable[pytest.Item | pytest.Collector]:
+        return []
+
+
 def pytest_collect_file(
-    file_path: Path, parent: pytest.File
+    file_path: Path, parent: pytest.Collector
 ) -> pytest.Collector | None:
     """
     This hook is called when collecting test files, and can be used to
@@ -128,7 +139,7 @@ def pytest_collect_file(
         # We don't allow pytests to be defined in Cython files.
         # Normally, Cython files are filtered out already by pytest and we only
         # hit this here if someone explicitly runs `pytest some_file.pyx`.
-        return pytest.skip("Skipping Cython file")
+        return IgnoreCollector.from_parent(parent)
     elif file_path.suffix == ".py":
         if parent.config.option.doctestmodules:
             return SageDoctestModule.from_parent(parent, path=file_path)

--- a/src/conftest_test.py
+++ b/src/conftest_test.py
@@ -2,9 +2,9 @@ from pathlib import Path
 import subprocess
 
 
-from sage.env import SAGE_ROOT
+from sage.env import SAGE_SRC
 
-input_file = Path(SAGE_ROOT) / "src" / "conftest_inputtest.py"
+input_file = Path(SAGE_SRC) / "conftest_inputtest.py"
 
 
 class TestOldDoctestSageScript:

--- a/src/conftest_test.py
+++ b/src/conftest_test.py
@@ -1,4 +1,10 @@
+from pathlib import Path
 import subprocess
+
+
+from sage.env import SAGE_ROOT
+
+input_file = Path(SAGE_ROOT) / "src" / "conftest_inputtest.py"
 
 
 class TestOldDoctestSageScript:
@@ -6,7 +12,7 @@ class TestOldDoctestSageScript:
 
     def test_invoke_on_inputtest_file(self):
         result = subprocess.run(
-            ["sage", "-t", "./src/conftest_inputtest.py"],
+            ["sage", "-t", input_file],
             capture_output=True,
             text=True,
         )
@@ -27,7 +33,7 @@ class TestPytestSageScript:
 
     def test_invoke_on_inputtest_file(self):
         result = subprocess.run(
-            ["sage", "--pytest", "./src/conftest_inputtest.py"],
+            ["sage", "--pytest", input_file],
             capture_output=True,
             text=True,
         )

--- a/src/sage/numerical/backends/cvxpy_backend_test.py
+++ b/src/sage/numerical/backends/cvxpy_backend_test.py
@@ -3,6 +3,7 @@ from sage.numerical.backends.generic_backend_test import GenericBackendTests
 from sage.numerical.backends.generic_backend import GenericBackend
 from sage.numerical.mip import MixedIntegerLinearProgram
 
+@pytest.importorskip("cvxpy")
 class TestCVXPYBackend(GenericBackendTests):
 
     @pytest.fixture

--- a/src/sage/numerical/backends/scip_backend_test.py
+++ b/src/sage/numerical/backends/scip_backend_test.py
@@ -3,6 +3,7 @@ from sage.numerical.backends.generic_backend_test import GenericBackendTests
 from sage.numerical.backends.generic_backend import GenericBackend
 from sage.numerical.mip import MixedIntegerLinearProgram
 
+@pytest.importorskip("pyscipopt")
 class TestSCIPBackend(GenericBackendTests):
 
     @pytest.fixture


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Thanks to the recent advantages around `sage.all` imports (thanks @mkoeppe), we can remove the global sage.all import for pytests. This means that all pytests run now without this global import, and also the collection of tests is way quicker.

Of course, for doctests invoked by pytest the `all` import is still needed, so it's moved into the corresponding fixture.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
