### PR TITLE
docbuild: If `MATHJAX_DIR` does not contain mathjax, use CDN

### DIFF
--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -369,10 +369,10 @@ mathjax3_config = {
     },
 }
 
-if os.environ.get('SAGE_USE_CDNS', 'no') == 'yes':
+mathjax_path = 'mathjax/tex-chtml.js'
+if os.environ.get('SAGE_USE_CDNS', 'no') == 'yes' or not os.path.exists(os.path.join(MATHJAX_DIR, mathjax_path)):
     mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"
 else:
-    mathjax_path = 'mathjax/tex-chtml.js'
     html_common_static_path += [MATHJAX_DIR]
 
 # A list of glob-style patterns that should be excluded when looking for source


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
Short of a proper configuration mechanism for `MATHJAX_DIR` (#30296), we should at least not configure our docbuild to use it without checking first that something is there.
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Fixes https://github.com/sagemath/sage/issues/35528#issuecomment-1532246523
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
