### PR TITLE
Support linbox 1.7.0 and 1.6.3 at the same time

### DIFF
--- a/src/sage/libs/linbox/conversion.pxd
+++ b/src/sage/libs/linbox/conversion.pxd
@@ -177,9 +177,8 @@ cdef inline Vector_integer_dense new_sage_vector_integer_dense(P, DenseVector_in
     - v -- linbox vector
     """
     cdef Vector_integer_dense res = P()
-    cdef cppvector[Integer] * vec = &v.refRep()
     cdef size_t i
     for i in range(<size_t> res._degree):
-        mpz_set(res._entries[i], vec[0][i].get_mpz_const())
+        mpz_set(res._entries[i], v.getEntry(i).get_mpz_const())
 
     return res

--- a/src/sage/libs/linbox/linbox.pxd
+++ b/src/sage/libs/linbox/linbox.pxd
@@ -32,7 +32,7 @@ cdef extern from "linbox/matrix/dense-matrix.h":
         ctypedef Modular_double Field
         ctypedef double Element
         DenseMatrix_Modular_double(Field F, size_t m, size_t n)
-        DenseMatrix_Modular_double(Field F, Element*, size_t m, size_t n)
+        DenseMatrix_Modular_double(Field F, size_t m, size_t n, Element*)
         void setEntry(size_t i, size_t j, Element& a)
         Element &getEntry(size_t i, size_t j)
 
@@ -42,7 +42,7 @@ cdef extern from "linbox/matrix/dense-matrix.h":
         ctypedef Modular_float Field
         ctypedef float Element
         DenseMatrix_Modular_float(Field F, size_t m, size_t n)
-        DenseMatrix_Modular_float(Field F, Element*, size_t m, size_t n)
+        DenseMatrix_Modular_float(Field F, size_t m, size_t n, Element*)
         void setEntry(size_t i, size_t j, Element& a)
         Element &getEntry(size_t i, size_t j)
 
@@ -101,7 +101,6 @@ cdef extern from "linbox/vector/vector.h":
         DenseVector_integer (Field &F)
         DenseVector_integer (Field &F, long& m)
         DenseVector_integer (Field &F, cppvector[Integer]&)
-        cppvector[Element]& refRep()
         size_t size()
         void resize(size_t)
         void resize(size_t n, const Element&)

--- a/src/sage/libs/linbox/linbox.pxd
+++ b/src/sage/libs/linbox/linbox.pxd
@@ -32,7 +32,6 @@ cdef extern from "linbox/matrix/dense-matrix.h":
         ctypedef Modular_double Field
         ctypedef double Element
         DenseMatrix_Modular_double(Field F, size_t m, size_t n)
-        DenseMatrix_Modular_double(Field F, size_t m, size_t n, Element*)
         void setEntry(size_t i, size_t j, Element& a)
         Element &getEntry(size_t i, size_t j)
 
@@ -42,7 +41,6 @@ cdef extern from "linbox/matrix/dense-matrix.h":
         ctypedef Modular_float Field
         ctypedef float Element
         DenseMatrix_Modular_float(Field F, size_t m, size_t n)
-        DenseMatrix_Modular_float(Field F, size_t m, size_t n, Element*)
         void setEntry(size_t i, size_t j, Element& a)
         Element &getEntry(size_t i, size_t j)
 

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -221,9 +221,14 @@ cdef inline linbox_echelonize_efd(celement modulus, celement* entries, Py_ssize_
         return 0,[]
 
     cdef ModField *F = new ModField(<long>modulus)
-    cdef DenseMatrix *A = new DenseMatrix(F[0], <Py_ssize_t>nrows, <Py_ssize_t>ncols, <ModField.Element*>entries)
-    cdef Py_ssize_t r = reducedRowEchelonize(A[0])
+    cdef DenseMatrix *A = new DenseMatrix(F[0], nrows, ncols)
+
     cdef Py_ssize_t i,j
+    for i in range(nrows):
+        for j in range(ncols):
+            A.setEntry(i, j, entries[i*ncols+j])
+
+    cdef Py_ssize_t r = reducedRowEchelonize(A[0])
     for i in range(nrows):
         for j in range(ncols):
             entries[i*ncols+j] = <celement>A.getEntry(i,j)

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -221,7 +221,7 @@ cdef inline linbox_echelonize_efd(celement modulus, celement* entries, Py_ssize_
         return 0,[]
 
     cdef ModField *F = new ModField(<long>modulus)
-    cdef DenseMatrix *A = new DenseMatrix(F[0], <ModField.Element*>entries,<Py_ssize_t>nrows, <Py_ssize_t>ncols)
+    cdef DenseMatrix *A = new DenseMatrix(F[0], <Py_ssize_t>nrows, <Py_ssize_t>ncols, <ModField.Element*>entries)
     cdef Py_ssize_t r = reducedRowEchelonize(A[0])
     cdef Py_ssize_t i,j
     for i in range(nrows):


### PR DESCRIPTION
### :books: Description
    
The constructor `DenseMatrix(field, entries, m, n)` in 1.6.3 was changed to `DenseMatrix(field, m, n, entries)` in 1.7.0.
    
We replace use of this constructor by a different way to initialize a matrix from entries using part of the API that works both in 1.6.3 and in 1.7.0.
    
NOTE:  the two versions of the library are ABI-incompatible so changing linbox requires recompiling sagelib. To complicate matters, linbox doesn't change soname so the dynamic linker will let this go and sagemath will eventually crash.

See:  #35148 for the actual update of linbox -- this PR should make that one easier as well as system support of linbox, since both linbox 1.6.3 and 1.7.0 wil be supported.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.