### PR TITLE
Use `pypa/build` instead of `pip wheel`

### DIFF
--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -69,11 +69,6 @@
 #
 #    Runs `pip uninstall` with the given arguments.  If unsuccessful, it displays a warning.
 #
-# - eval sdh_prefix_args PREFIX [...]
-#
-#    Helper function for transforming build options so that they can be passed
-#    through "pip".
-#
 # - sdh_cmake [...]
 #
 #    Runs `cmake` in the current directory with the given arguments, as well as
@@ -218,16 +213,6 @@ sdh_setup_bdist_wheel() {
     python3 setup.py --no-user-cfg \
          bdist_wheel --bdist-dir "$BDIST_DIR" \
          "$@" || sdh_die "Error building a wheel for $PKG_NAME"
-}
-
-sdh_prefix_args () {
-    prefix="$1"
-    shift
-    while [ $# -gt 0 ]; do
-        # Quoted quotes because the result is to be run through eval
-        echo "$prefix" \"$1\"
-        shift
-    done
 }
 
 sdh_pip_install() {

--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -237,7 +237,9 @@ sdh_pip_install() {
     install_options=""
     build_options=""
     # pip has --no-build-isolation but no flag that turns the default back on...
-    build_isolation_option="--find-links=$SAGE_SPKG_WHEELS"
+    build_isolation_option=""
+    export PIP_FIND_LINKS="$SAGE_SPKG_WHEELS"
+    unset PIP_NO_BINARY
     while [ $# -gt 0 ]; do
         case "$1" in
             --build-isolation)
@@ -245,11 +247,15 @@ sdh_pip_install() {
                 # its build environment using the stored wheels.
                 # We pass --find-links.
                 # The SPKG needs to declare "setuptools" as a dependency.
-                build_isolation_option="--find-links=$SAGE_SPKG_WHEELS"
+                build_isolation_option=""
+                export PIP_FIND_LINKS="$SAGE_SPKG_WHEELS"
+                unset PIP_NO_BINARY
                 ;;
             --no-build-isolation)
                 # Use --no-binary, so that no wheels from caches are used.
-                build_isolation_option="--no-build-isolation --no-binary :all:"
+                unset PIP_FIND_LINKS
+                export PIP_NO_BINARY=:all:
+                build_isolation_option="--no-build-isolation"
                 ;;
             --no-deps)
                 install_options="$install_options $1"
@@ -274,7 +280,9 @@ sdh_pip_install() {
                 ;;
             *)
                 echo >&2 "Warning: building with \"python3 -m pip wheel --wheel-dir=dist --verbose --no-deps --no-index --isolated --ignore-requires-python $build_isolation_option\" failed."
-                build_isolation_option="--no-build-isolation --no-binary :all:"
+                unset PIP_FIND_LINKS
+                export PIP_NO_BINARY=:all:
+                build_isolation_option="--no-build-isolation"
                 echo >&2 "Retrying with \"python3 -m pip wheel --wheel-dir=dist --verbose --no-deps --no-index --isolated --ignore-requires-python $build_isolation_option\"."
                 if python3 -m pip wheel --wheel-dir=dist --verbose --no-deps --no-index --isolated --ignore-requires-python $build_isolation_option $build_options "$@"; then
                     echo >&2 "Warning: Wheel building needed to use \"$build_isolation_option\" to succeed. This means that a dependencies file in build/pkgs/ needs to be updated. Please report this to sage-devel@googlegroups.com, including the build log of this package."
@@ -284,6 +292,8 @@ sdh_pip_install() {
                 ;;
         esac
     fi
+    unset PIP_FIND_LINKS
+    unset PIP_NO_BINARY
     sdh_store_and_pip_install_wheel $install_options .
 }
 

--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -256,7 +256,7 @@ sdh_pip_install() {
                 # Use --no-binary, so that no wheels from caches are used.
                 unset PIP_FIND_LINKS
                 export PIP_NO_BINARY=:all:
-                build_isolation_option="--no-isolation"
+                build_isolation_option="--no-isolation --skip-dependency-check"
                 ;;
             --no-deps)
                 install_options="$install_options $1"
@@ -283,7 +283,7 @@ sdh_pip_install() {
                 echo >&2 "Warning: building with \"python3 -m build --wheel --outdir=dist $build_isolation_option $build_options $@\" failed."
                 unset PIP_FIND_LINKS
                 export PIP_NO_BINARY=:all:
-                build_isolation_option="--no-isolation"
+                build_isolation_option="--no-isolation --skip-dependency-check"
                 echo >&2 "Retrying with \"python3 -m build --wheel --outdir=dist $build_isolation_option $build_options $@\"."
                 if python3 -m build --wheel --outdir=dist $build_isolation_option $build_options "$@"; then
                     echo >&2 "Warning: Wheel building needed to use \"$build_isolation_option\" to succeed. This means that a dependencies file in build/pkgs/ needs to be updated. Please report this to sage-devel@googlegroups.com, including the build log of this package."

--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -234,6 +234,7 @@ sdh_pip_install() {
     echo "Installing $PKG_NAME"
     mkdir -p dist
     rm -f dist/*.whl
+    export PIP_NO_INDEX=1
     install_options=""
     build_options=""
     # pip has --no-build-isolation but no flag that turns the default back on...
@@ -255,13 +256,13 @@ sdh_pip_install() {
                 # Use --no-binary, so that no wheels from caches are used.
                 unset PIP_FIND_LINKS
                 export PIP_NO_BINARY=:all:
-                build_isolation_option="--no-build-isolation"
+                build_isolation_option="--no-isolation"
                 ;;
             --no-deps)
                 install_options="$install_options $1"
                 ;;
             -C|--config-settings)
-                build_options="$build_options $1"
+                build_options="$build_options --config-setting"
                 shift
                 build_options="$build_options $1"
                 ;;
@@ -271,20 +272,20 @@ sdh_pip_install() {
         esac
         shift
     done
-    if python3 -m pip wheel --wheel-dir=dist --verbose --no-deps --no-index --isolated --ignore-requires-python $build_isolation_option $build_options "$@"; then
+    if python3 -m build --wheel --outdir=dist $build_isolation_option $build_options "$@"; then
         : # successful
     else
         case $build_isolation_option in
-            *--no-build-isolation*)
+            *--no-isolation*)
                 sdh_die "Error building a wheel for $PKG_NAME"
                 ;;
             *)
-                echo >&2 "Warning: building with \"python3 -m pip wheel --wheel-dir=dist --verbose --no-deps --no-index --isolated --ignore-requires-python $build_isolation_option\" failed."
+                echo >&2 "Warning: building with \"python3 -m build --wheel --outdir=dist $build_isolation_option $build_options $@\" failed."
                 unset PIP_FIND_LINKS
                 export PIP_NO_BINARY=:all:
-                build_isolation_option="--no-build-isolation"
-                echo >&2 "Retrying with \"python3 -m pip wheel --wheel-dir=dist --verbose --no-deps --no-index --isolated --ignore-requires-python $build_isolation_option\"."
-                if python3 -m pip wheel --wheel-dir=dist --verbose --no-deps --no-index --isolated --ignore-requires-python $build_isolation_option $build_options "$@"; then
+                build_isolation_option="--no-isolation"
+                echo >&2 "Retrying with \"python3 -m build --wheel --outdir=dist $build_isolation_option $build_options $@\"."
+                if python3 -m build --wheel --outdir=dist $build_isolation_option $build_options "$@"; then
                     echo >&2 "Warning: Wheel building needed to use \"$build_isolation_option\" to succeed. This means that a dependencies file in build/pkgs/ needs to be updated. Please report this to sage-devel@googlegroups.com, including the build log of this package."
                 else
                     sdh_die "Error building a wheel for $PKG_NAME"
@@ -294,6 +295,7 @@ sdh_pip_install() {
     fi
     unset PIP_FIND_LINKS
     unset PIP_NO_BINARY
+    unset PIP_NO_INDEX
     sdh_store_and_pip_install_wheel $install_options .
 }
 

--- a/build/make/Makefile.in
+++ b/build/make/Makefile.in
@@ -324,7 +324,7 @@ all-toolchain: base-toolchain
 
 # Shorthand for a list of packages sufficient for building and installing
 # typical Python packages from source. Wheel packages only need pip.
-PYTHON_TOOLCHAIN = setuptools pip setuptools_scm wheel flit_core hatchling
+PYTHON_TOOLCHAIN = setuptools pip setuptools_scm wheel flit_core hatchling python_build
 
 # Issue #32056: Avoid installed setuptools leaking into the build of python3 by uninstalling it.
 # It will have to be reinstalled anyway because of its dependency on $(PYTHON).

--- a/build/pkgs/editables/checksums.ini
+++ b/build/pkgs/editables/checksums.ini
@@ -1,5 +1,5 @@
-tarball=editables-VERSION.tar.gz
-sha1=90efed858e78bf6276d1a5959ec6692e11a6bce9
-md5=520de8c3a9dc5dfb2b365d104541c9de
-cksum=3074203672
-upstream_url=https://pypi.io/packages/source/e/editables/editables-VERSION.tar.gz
+tarball=editables-VERSION-py3-none-any.whl
+sha1=7aa90de86b05d6dc1a04c219b01ca7eab09de113
+md5=5de129d3a039b26b7f6798a4002acdf6
+cksum=24000838
+upstream_url=https://pypi.io/packages/py3/e/editables/editables-VERSION-py3-none-any.whl

--- a/build/pkgs/editables/dependencies
+++ b/build/pkgs/editables/dependencies
@@ -1,4 +1,4 @@
- | flit_core $(PYTHON)
+ | pip $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/editables/spkg-install.in
+++ b/build/pkgs/editables/spkg-install.in
@@ -1,2 +1,0 @@
-cd src
-sdh_pip_install .

--- a/build/pkgs/importlib_metadata/dependencies
+++ b/build/pkgs/importlib_metadata/dependencies
@@ -1,4 +1,4 @@
- zipp typing_extensions | $(PYTHON_TOOLCHAIN) tomli $(PYTHON)
+ zipp typing_extensions | pip tomli $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pyproject_hooks/dependencies
+++ b/build/pkgs/pyproject_hooks/dependencies
@@ -1,4 +1,4 @@
- | $(PYTHON_TOOLCHAIN) $(PYTHON)
+ | pip $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/python_build/dependencies
+++ b/build/pkgs/python_build/dependencies
@@ -1,4 +1,4 @@
-tomli packaging pyproject_hooks importlib_metadata | $(PYTHON_TOOLCHAIN) $(PYTHON)
+tomli packaging pyproject_hooks importlib_metadata | pip $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/uri_template/dependencies
+++ b/build/pkgs/uri_template/dependencies
@@ -1,4 +1,4 @@
- | $(PYTHON_TOOLCHAIN) $(PYTHON)
+ | pip $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

This is the next step of the long term effort to use the standard tools of modern Python packaging in the build system of the Sage distribution, enabled by making `python_build` a standard package. We add `python_build` to our `PYTHON_TOOLCHAIN` and replace the use of `pip wheel` by using `python -m build`.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
- Resolves #34590.
- Also, we remove the unused helper function `sdh_prefix_args`.

<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->
- Depends on #37300

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
