### PR TITLE
Support sympy 1.12

### DIFF
--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -1690,8 +1690,11 @@ def laplace(ex, t, s, algorithm='maxima'):
 
     Testing SymPy::
 
-        sage: laplace(t^n, t, s, algorithm='sympy')
-        (gamma(n + 1)/(s*s^n), 0, re(n) > -1)
+        sage: F, a, cond = laplace(t^n, t, s, algorithm='sympy')
+        sage: a, cond
+        (0, re(n) > -1)
+        sage: F.simplify()
+        s^(-n - 1)*gamma(n + 1)
 
     Testing Maxima::
 
@@ -1700,17 +1703,19 @@ def laplace(ex, t, s, algorithm='maxima'):
 
     Check that :trac:`24212` is fixed::
 
-        sage: laplace(cos(t^2), t, s, algorithm='sympy')
-        (-1/2*sqrt(pi)*(sqrt(2)*cos(1/4*s^2)*fresnel_sin(1/2*sqrt(2)*s/sqrt(pi)) -
-        sqrt(2)*fresnel_cos(1/2*sqrt(2)*s/sqrt(pi))*sin(1/4*s^2) - cos(1/4*pi + 1/4*s^2)),
-        0, True)
+        sage: F, a, cond = laplace(cos(t^2), t, s, algorithm='sympy')
+        sage: a, cond
+        (0, True)
+        sage: F._sympy_().simplify()
+        sqrt(pi)*(sqrt(2)*sin(s**2/4)*fresnelc(sqrt(2)*s/(2*sqrt(pi))) -
+        sqrt(2)*cos(s**2/4)*fresnels(sqrt(2)*s/(2*sqrt(pi))) + cos(s**2/4 + pi/4))/2
 
     Testing result from SymPy that Sage doesn't know how to handle::
 
         sage: laplace(cos(-1/t), t, s, algorithm='sympy')
         Traceback (most recent call last):
         ...
-        AttributeError: Unable to convert SymPy result (=meijerg(((), ()), ((-1/2, 0, 1/2), (0,)), s**2/16)/4) into Sage
+        AttributeError: Unable to convert SymPy result (=meijerg(((), ()), ((-1/2, 0, 1/2), (0,)), ...)/4) into Sage
     """
     if not isinstance(ex, (Expression, Function)):
         ex = SR(ex)
@@ -1817,8 +1822,8 @@ def inverse_laplace(ex, s, t, algorithm='maxima'):
 
     Transform an expression involving a time-shift, via SymPy::
 
-        sage: inverse_laplace(1/s^2*exp(-s), s, t, algorithm='sympy')
-        -(log(e^(-t)) + 1)*heaviside(t - 1)
+        sage: inverse_laplace(1/s^2*exp(-s), s, t, algorithm='sympy').simplify()
+        (t - 1)*heaviside(t - 1)
 
     The same instance with Giac::
 


### PR DESCRIPTION
### :books: Description

Sympy 1.12 has been released. This PR fixes 3 failing doctests in `sage.calculus.calculus`.

Tested with both 1.12 and 1.11.1.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.