### PR TITLE
remark that WSL needs a lot of RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ mailing list](https://groups.google.com/group/sage-devel).
 --------------------------------
 
 The preferred way to run Sage on Windows is using the [Windows Subsystem for
-Linux](https://docs.microsoft.com/en-us/windows/wsl/faq), which allows
+Linux](https://docs.microsoft.com/en-us/windows/wsl/faq), a.k.a. WSL, which allows
 you to install a standard Linux distribution such as Ubuntu within
-your Windows.  Then all instructions for installation in Linux apply.
+your Windows. Make sure you allocate WSL sufficient RAM; 5GB is known to work, while
+2GB might be not enough for building Sage from source. 
+Then all instructions for installation in Linux apply.
 
 As an alternative, you can also run Linux on Windows using Docker (see
 above) or other virtualization solutions.

--- a/src/doc/en/installation/index.rst
+++ b/src/doc/en/installation/index.rst
@@ -62,6 +62,8 @@ Windows
     `official WSL setup guide
     <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_. Be
     sure to do the steps to install WSL2 and set it as default.
+    Make sure to allocate enough RAM to WSL: 5GB is known to be enough,
+    2GB might not allow you to build some packages.
     Then go to the Microsoft Store and install Ubuntu (or another
     Linux distribution). Start Ubuntu from the start menu.
 
@@ -73,6 +75,8 @@ Windows
       `official WSL setup guide
       <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_. Be
       sure to do the steps to install WSL2 and set it as default.
+      Make sure to allocate enough RAM to WSL: 5GB is known to be enough,
+      2GB might not allow you to build some packages.
       Then go to the Microsoft Store and install Ubuntu (or another
       Linux distribution). Start Ubuntu from the start menu.
 


### PR DESCRIPTION
We had reports to this end on sage-develop - typically people are not able to build scipy with only 2GB of RAM in WSL
(but 5 is enough).