### PR TITLE
Fix typo in documentation

### DIFF
--- a/build/pkgs/gcc/spkg-configure.m4
+++ b/build/pkgs/gcc/spkg-configure.m4
@@ -232,7 +232,7 @@ SAGE_SPKG_CONFIGURE_BASE([gcc], [
     fi
     AC_SUBST(CFLAGS_MARCH)
 
-    # Determine wether compiler supports OpenMP.
+    # Determine whether compiler supports OpenMP.
     AC_LANG_PUSH([C])
     AX_OPENMP([
         AC_SUBST(OPENMP_CFLAGS)

--- a/m4/ax_gcc_option.m4
+++ b/m4/ax_gcc_option.m4
@@ -8,7 +8,7 @@
 #
 # DESCRIPTION
 #
-#   AX_GCC_OPTION checks wheter gcc accepts the passed OPTION. If it accepts
+#   AX_GCC_OPTION checks whether gcc accepts the passed OPTION. If it accepts
 #   the OPTION then ACTION-IF-SUCCESSFUL will be executed, otherwise
 #   ACTION-IF-UNSUCCESSFUL.
 #

--- a/m4/ax_gxx_option.m4
+++ b/m4/ax_gxx_option.m4
@@ -9,7 +9,7 @@
 #
 # DESCRIPTION
 #
-#   AX_GCC_OPTION checks wheter gcc accepts the passed OPTION. If it accepts
+#   AX_GCC_OPTION checks whether gcc accepts the passed OPTION. If it accepts
 #   the OPTION then ACTION-IF-SUCCESSFUL will be executed, otherwise
 #   ACTION-IF-UNSUCCESSFUL.
 #

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -550,7 +550,7 @@ cdef class GapElement(RingElement):
 
         INPUT:
 
-        - ``mut`` - (boolean) wheter to return an mutable copy
+        - ``mut`` - (boolean) whether to return an mutable copy
 
         EXAMPLES::
 

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1002,7 +1002,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
     @coerce_binop
     def divides(self, other):
         r"""
-        Test wheter ``self`` divides ``other``.
+        Test whether ``self`` divides ``other``.
 
         EXAMPLES::
 


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description
I noticed a typo while reading the documentation and thought this was the best way to fix it.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
