### PR TITLE
Avoid redundant computations in finite field .conjugate() method

### DIFF
--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -1006,7 +1006,7 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             sage: G32(m1) == g1
             True
         """
-        [(p, k2)] = list(self.parent().cardinality().factor())
+        k2 = self.parent().degree()
         if k2 % 2:
             raise TypeError("cardinality of the field must be a square number")
         k = k2 / 2


### PR DESCRIPTION
### :books: Description

The previous implementation was factoring the order (characteristic^degree) to obtain the field degree.
The methods `cardinality()` and `order()` are really defined as `return self.characteristic()**self.degree()`.

Sage 10rc3
```
sage: p = next_prime(2**160)
sage: K = GF((p,2))
sage: x = K.random_element()
sage: %timeit x.conjugate()
13.2 ms ± 77.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

After patch:
```
sage: %timeit x.conjugate()
5.01 µs ± 15.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

None