### PR TITLE
cython-lint : removing unused imports in polynomials

### DIFF
--- a/src/sage/rings/polynomial/cyclotomic.pyx
+++ b/src/sage/rings/polynomial/cyclotomic.pyx
@@ -36,8 +36,6 @@ from sage.arith.misc import factor
 from sage.rings.integer_ring import ZZ
 from sage.misc.misc_c import prod
 from sage.misc.misc import subsets
-from sage.rings.integer cimport Integer
-from sage.rings.rational cimport Rational
 from sage.libs.pari.all import pari
 
 

--- a/src/sage/rings/polynomial/laurent_polynomial.pyx
+++ b/src/sage/rings/polynomial/laurent_polynomial.pyx
@@ -12,7 +12,7 @@ Elements of Laurent polynomial rings
 
 from sage.rings.integer cimport Integer
 from sage.categories.map cimport Map
-from sage.structure.element import is_Element, coerce_binop, parent
+from sage.structure.element import coerce_binop, parent
 from sage.structure.factorization import Factorization
 from sage.misc.derivative import multi_derivative
 from sage.rings.polynomial.polydict cimport monomial_exponent

--- a/src/sage/rings/polynomial/multi_polynomial.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial.pyx
@@ -15,7 +15,7 @@ from sage.rings.integer_ring import ZZ
 from sage.structure.coerce cimport coercion_model
 from sage.misc.derivative import multi_derivative
 from sage.combinat.integer_lists.invlex import IntegerListsLex
-from itertools import chain, islice
+from itertools import chain
 
 from sage.misc.misc_c import prod
 
@@ -30,7 +30,7 @@ from sage.categories.map cimport Map
 from sage.modules.free_module_element import vector
 from sage.rings.rational_field import QQ
 from sage.rings.complex_interval_field import ComplexIntervalField
-from sage.rings.real_mpfr import RealField_class, RealField
+from sage.rings.real_mpfr import RealField
 
 from sage.rings.polynomial.polydict cimport ETuple
 from sage.rings.polynomial.polynomial_element cimport Polynomial

--- a/src/sage/rings/polynomial/multi_polynomial_ideal_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal_libsingular.pyx
@@ -56,12 +56,11 @@ from sage.libs.singular.decl cimport scKBase, poly, testHomog, idSkipZeroes, id_
 from sage.libs.singular.decl cimport OPT_REDTAIL, singular_options, kInterRed, t_rep_gb, p_GetCoeff
 from sage.libs.singular.decl cimport pp_Mult_nn, p_Delete, n_Delete
 from sage.libs.singular.decl cimport rIsPluralRing
-from sage.libs.singular.decl cimport n_unknown, n_Zp, n_Q, n_R, n_GF, n_long_R, n_algExt,n_transExt,n_long_C, n_Z, n_Zn, n_Znm, n_Z2m, n_CF
+from sage.libs.singular.decl cimport n_Z, n_Zn, n_Znm, n_Z2m
 
 from sage.rings.polynomial.multi_polynomial_libsingular cimport new_MP
 from sage.rings.polynomial.plural cimport new_NCP
 
-from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
 from sage.rings.polynomial.multi_polynomial_libsingular cimport MPolynomial_libsingular
 from sage.rings.polynomial.multi_polynomial_libsingular cimport MPolynomialRing_libsingular
 from sage.structure.sequence import Sequence

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -185,13 +185,13 @@ from sage.libs.singular.decl cimport (ring, poly, ideal, intvec, number,
 # singular functions
 from sage.libs.singular.decl cimport (
     errorreported,
-    n_IsUnit, n_Invers, n_GetChar,
+    n_Invers, n_GetChar,
     p_ISet, rChangeCurrRing, p_Copy, p_Init, p_SetCoeff, p_Setm, p_SetExp, p_Add_q,
     p_NSet, p_GetCoeff, p_Delete, p_GetExp, pNext, rRingVar, omAlloc0, omStrDup,
     omFree, p_Divide, p_SetCoeff0, n_Init, p_DivisibleBy, pLcm, p_LmDivisibleBy,
     pMDivide, p_MDivide, p_IsConstant, p_ExpVectorEqual, p_String, p_LmInit, n_Copy,
-    p_IsUnit, p_IsOne, p_Series, p_Head, idInit, fast_map_common_subexp, id_Delete,
-    p_IsHomogeneous, p_Homogen, p_Totaldegree,pLDeg1_Totaldegree, singclap_pdivide, singclap_factorize,
+    p_IsUnit, p_IsOne, p_Head, idInit, fast_map_common_subexp, id_Delete,
+    p_IsHomogeneous, p_Homogen, p_Totaldegree, singclap_pdivide, singclap_factorize,
     idLift, IDELEMS, On, Off, SW_USE_CHINREM_GCD, SW_USE_EZGCD,
     p_LmIsConstant, pTakeOutComp, singclap_gcd, pp_Mult_qq, p_GetMaxExp,
     pLength, kNF, p_Neg, p_Minus_mm_Mult_qq, p_Plus_mm_Mult_qq,
@@ -222,13 +222,11 @@ from sage.rings.polynomial.polynomial_ring import is_PolynomialRing
 
 # base ring imports
 import sage.rings.abc
-from sage.rings.finite_rings.finite_field_prime_modn import FiniteField_prime_modn
 from sage.rings.rational cimport Rational
 from sage.rings.rational_field import QQ
 import sage.rings.abc
 from sage.rings.integer_ring import is_IntegerRing, ZZ
 from sage.rings.integer cimport Integer
-from sage.rings.integer import GCD_list
 from sage.rings.number_field.number_field_base cimport NumberField
 
 from sage.rings.number_field.order import is_NumberFieldOrder
@@ -240,7 +238,7 @@ from sage.structure.parent cimport Parent
 from sage.structure.category_object cimport CategoryObject
 
 from sage.structure.coerce cimport coercion_model
-from sage.structure.element cimport Element, CommutativeRingElement
+from sage.structure.element cimport Element
 
 from sage.structure.richcmp cimport rich_to_bool, richcmp
 from sage.structure.factorization import Factorization
@@ -1373,12 +1371,10 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
             //        block   2 : ordering C
 
         """
-        from sage.functions.other import ceil
-
         if singular is None:
             from sage.interfaces.singular import singular
 
-        if self.ngens()==1:
+        if self.ngens() == 1:
             _vars = str(self.gen())
             if "*" in _vars: # 1.000...000*x
                 _vars = _vars.split("*")[1]

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -2,7 +2,6 @@ r"""
 Base class for multivariate polynomial rings
 """
 import itertools
-import warnings
 from collections.abc import Iterable
 from sage.matrix.constructor import matrix
 from sage.modules.free_module_element import vector
@@ -27,10 +26,8 @@ from sage.combinat.integer_vector import IntegerVectors
 
 from sage.rings.integer_ring import ZZ
 
-from .polydict import PolyDict
 from . import (multi_polynomial_ideal,
-               polynomial_ring,
-               multi_polynomial_element)
+               polynomial_ring)
 from .term_order import TermOrder
 from .polynomial_ring_constructor import (PolynomialRing,
                                           polynomial_default_category)

--- a/src/sage/rings/polynomial/ore_polynomial_element.pyx
+++ b/src/sage/rings/polynomial/ore_polynomial_element.pyx
@@ -33,20 +33,17 @@ AUTHORS:
 import re
 from cysignals.signals cimport sig_check
 from sage.structure.element import coerce_binop
-from sage.misc.superseded import experimental
 
 from sage.rings.infinity import infinity
-from sage.structure.factorization import Factorization
 from sage.structure.element cimport Element, RingElement, AlgebraElement
 from sage.structure.parent cimport Parent
 from sage.structure.parent_gens cimport ParentWithGens
-from sage.misc.abstract_method import abstract_method
 from sage.categories.homset import Hom
 from sage.rings.ring import _Fields
 from sage.rings.integer cimport Integer
 from cpython.object cimport PyObject_RichCompare
 from sage.categories.map cimport Map
-from sage.rings.morphism cimport Morphism, RingHomomorphism
+from sage.rings.morphism cimport Morphism
 from sage.rings.polynomial.polynomial_element cimport _dict_to_list
 
 

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -187,10 +187,7 @@ import operator
 
 from sage.cpython.string cimport str_to_bytes, char_to_str
 
-from sage.misc.cachefunc import cached_method
-
 from sage.misc.randstate import current_randstate
-from sage.arith.long cimport pyobject_to_long
 import sage.misc.weak_dict
 from sage.rings.integer import Integer
 from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF
@@ -202,7 +199,6 @@ from sage.rings.polynomial.polynomial_ring import PolynomialRing_general
 
 from sage.rings.ideal import FieldIdeal
 
-from sage.structure.coerce cimport coercion_model
 from sage.structure.element cimport Element
 
 from sage.structure.parent cimport Parent
@@ -4634,7 +4630,6 @@ cdef class BooleanPolynomial(MPolynomial):
             ...
             TypeError: argument must be a BooleanPolynomial
         """
-        from sage.rings.polynomial.pbori.pbori import red_tail
         if not I:
             return self
         if isinstance(I, BooleanPolynomialIdeal):
@@ -5128,7 +5123,6 @@ class BooleanPolynomialIdeal(MPolynomialIdeal):
             sage: I.reduce(gb[0]*B.gen(1))
             0
         """
-        from sage.rings.polynomial.pbori.pbori import red_tail
         try:
             g = self.__gb
         except AttributeError:

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -102,23 +102,21 @@ TESTS::
     True
 
 """
-
 from cysignals.memory cimport sig_malloc, sig_free
-from sage.cpython.string cimport bytes_to_str
 
 from sage.categories.algebras import Algebras
 from sage.cpython.string cimport char_to_str
 
 # singular rings
 
-from sage.libs.singular.ring cimport singular_ring_new, singular_ring_delete, wrap_ring, singular_ring_reference
+from sage.libs.singular.ring cimport singular_ring_delete, wrap_ring, singular_ring_reference
 
 from sage.libs.singular.singular cimport si2sa, sa2si, overflow_check
 
 
 from sage.libs.singular.function cimport RingWrap
 
-from sage.libs.singular.polynomial cimport (singular_polynomial_call, singular_polynomial_cmp, singular_polynomial_add, singular_polynomial_sub, singular_polynomial_neg, singular_polynomial_pow, singular_polynomial_mul, singular_polynomial_rmul, singular_polynomial_deg, singular_polynomial_str_with_changed_varnames, singular_polynomial_latex, singular_polynomial_str, singular_polynomial_div_coeff)
+from sage.libs.singular.polynomial cimport (singular_polynomial_cmp, singular_polynomial_add, singular_polynomial_sub, singular_polynomial_neg, singular_polynomial_pow, singular_polynomial_mul, singular_polynomial_rmul, singular_polynomial_deg, singular_polynomial_str_with_changed_varnames, singular_polynomial_latex, singular_polynomial_str, singular_polynomial_div_coeff)
 
 import sage.libs.singular.ring
 

--- a/src/sage/rings/polynomial/polydict.pyx
+++ b/src/sage/rings/polynomial/polydict.pyx
@@ -41,7 +41,6 @@ from sage.structure.richcmp cimport rich_to_bool
 from functools import reduce
 from pprint import pformat
 
-from sage.arith.power import generic_power
 from sage.misc.latex import latex
 
 

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -60,7 +60,7 @@ cdef is_FractionField
 cdef ZZ, QQ, RR, CC, RDF, CDF
 
 cimport cython
-from cpython.number cimport PyNumber_TrueDivide, PyNumber_Check
+from cpython.number cimport PyNumber_Check
 
 import operator
 import copy
@@ -70,14 +70,11 @@ from io import StringIO
 from sage.cpython.wrapperdescr cimport wrapperdescr_fastcall
 import sage.rings.rational
 import sage.rings.integer
-from . import polynomial_ring
 import sage.rings.integer_ring
 import sage.rings.rational_field
 import sage.rings.finite_rings.integer_mod_ring
 import sage.rings.fraction_field_element
 import sage.rings.infinity as infinity
-from sage.misc.sage_eval import sage_eval
-from sage.misc.abstract_method import abstract_method
 from sage.misc.latex import latex
 from sage.arith.power cimport generic_power
 from sage.arith.misc import crt
@@ -354,7 +351,7 @@ cdef class Polynomial(CommutativePolynomial):
             Graphics object consisting of 1 graphics primitive
         """
         R = self.base_ring()
-        from sage.plot.all import plot, point, line
+        from sage.plot.all import plot, point
         if R.characteristic() == 0:
             if xmin is None and xmax is None:
                 (xmin, xmax) = (-1,1)

--- a/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
@@ -47,7 +47,7 @@ from sage.libs.gmp.mpz cimport *
 from sage.arith.long cimport pyobject_to_long, is_small_python_int
 
 from sage.rings.polynomial.polynomial_element cimport Polynomial
-from sage.structure.element cimport ModuleElement, Element
+from sage.structure.element cimport Element
 from sage.structure.element import coerce_binop
 
 from sage.libs.ntl.ntl_ZZX cimport ntl_ZZX
@@ -70,7 +70,7 @@ from sage.libs.ntl.ZZX cimport *
 from sage.rings.complex_arb cimport ComplexBall
 from sage.rings.integer cimport Integer, smallInteger
 from sage.rings.real_arb cimport RealBall
-from sage.rings.real_mpfr cimport RealNumber, RealField_class
+from sage.rings.real_mpfr cimport RealNumber
 from sage.rings.real_mpfi cimport RealIntervalFieldElement
 
 from sage.rings.polynomial.evaluation_flint cimport fmpz_poly_evaluation_mpfr, fmpz_poly_evaluation_mpfi

--- a/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
@@ -27,7 +27,6 @@ do::
     sage: K
     Univariate Polynomial Ring in x over Integer Ring (using NTL)
 """
-
 #*****************************************************************************
 #       Copyright (C) 2007 William Stein <wstein@gmail.com>
 #
@@ -35,7 +34,7 @@ do::
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 #*****************************************************************************
 
 from cysignals.memory cimport sig_free
@@ -45,10 +44,9 @@ from sage.ext.cplusplus cimport ccrepr
 include "sage/libs/ntl/decl.pxi"
 
 from sage.rings.polynomial.polynomial_element cimport Polynomial
-from sage.structure.element cimport ModuleElement, Element
+from sage.structure.element cimport Element
 
 from sage.rings.integer_ring import IntegerRing
-from sage.rings.integer_ring cimport IntegerRing_class
 ZZ_sage = IntegerRing()
 
 from sage.libs.ntl.ntl_ZZX cimport ntl_ZZX
@@ -57,7 +55,7 @@ from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from sage.rings.integer import Integer
 from sage.rings.integer cimport Integer
-from sage.rings.real_mpfr cimport RealNumber, RealField_class
+from sage.rings.real_mpfr cimport RealNumber
 from sage.rings.real_mpfi cimport RealIntervalFieldElement
 
 from sage.libs.pari.all import pari, pari_gen
@@ -66,7 +64,6 @@ from sage.structure.element import coerce_binop
 
 from sage.rings.fraction_field_element import FractionFieldElement
 from sage.arith.functions import lcm
-import sage.rings.polynomial.polynomial_ring
 
 from sage.libs.ntl.ZZX cimport *
 

--- a/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
@@ -32,7 +32,6 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from cysignals.memory cimport sig_malloc, sig_free
 from cysignals.signals cimport sig_on, sig_off
 
 from sage.rings.polynomial.polynomial_element cimport Polynomial, _dict_to_list
@@ -41,17 +40,13 @@ from sage.libs.pari.all import pari, pari_gen
 
 from sage.rings.integer cimport smallInteger
 
-from sage.libs.ntl.all import ZZ as ntl_ZZ, ZZX, zero_ZZX, ZZ_p, ZZ_pX
-from sage.rings.rational_field import QQ
+from sage.libs.ntl.all import ZZX, ZZ_pX
 from sage.rings.integer_ring import ZZ
-from sage.rings.finite_rings.integer_mod import IntegerMod_abstract
 
 from sage.rings.fraction_field_element import FractionFieldElement
-import sage.rings.polynomial.polynomial_ring
 
 from sage.rings.infinity import infinity
 
-from . import polynomial_singular_interface
 from sage.interfaces.singular import singular as singular_default
 
 from sage.structure.element import coerce_binop
@@ -160,7 +155,6 @@ cdef class Polynomial_dense_mod_n(Polynomial):
             x = [ZZ(R(a)) for a in x]
 
         self.__poly = ZZ_pX(x, parent.modulus())
-
 
     def __reduce__(self):
         return make_element, (self.parent(), (self.list(), False, self.is_gen()))

--- a/src/sage/rings/polynomial/polynomial_rational_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_rational_flint.pyx
@@ -22,7 +22,7 @@ AUTHOR:
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from cysignals.memory cimport check_allocarray, check_malloc, sig_free
+from cysignals.memory cimport check_allocarray, sig_free
 from cysignals.signals cimport sig_on, sig_str, sig_off
 
 from cpython.int cimport PyInt_AS_LONG
@@ -53,7 +53,7 @@ from sage.rings.polynomial.polynomial_element cimport Polynomial
 from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
 
 from sage.structure.parent cimport Parent
-from sage.structure.element cimport Element, ModuleElement, RingElement
+from sage.structure.element cimport Element
 from sage.structure.element import coerce_binop
 
 from sage.misc.cachefunc import cached_method

--- a/src/sage/rings/polynomial/polynomial_real_mpfr_dense.pyx
+++ b/src/sage/rings/polynomial/polynomial_real_mpfr_dense.pyx
@@ -34,7 +34,7 @@ from sage.rings.real_mpfr cimport RealField_class, RealNumber
 from sage.rings.integer cimport Integer, smallInteger
 from sage.rings.rational cimport Rational
 
-from sage.structure.element cimport Element, ModuleElement, RingElement
+from sage.structure.element cimport Element
 from sage.structure.element cimport parent
 from sage.structure.element import coerce_binop
 from sage.libs.mpfr cimport *

--- a/src/sage/rings/polynomial/polynomial_zz_pex.pyx
+++ b/src/sage/rings/polynomial/polynomial_zz_pex.pyx
@@ -12,16 +12,10 @@ AUTHOR:
 - Yann Laigle-Chapuy (2010-01) initial implementation
 - Lorenz Panny (2023-01): :meth:`minpoly_mod`
 """
-
-from sage.rings.integer_ring import ZZ
-from sage.rings.integer_ring cimport IntegerRing_class
-
 from sage.libs.ntl.ntl_ZZ_pEContext cimport ntl_ZZ_pEContext_class
 from sage.libs.ntl.ZZ_pE cimport ZZ_pE_to_ZZ_pX
 from sage.libs.ntl.ZZ_pX cimport ZZ_pX_deg, ZZ_pX_coeff
-from sage.libs.ntl.ntl_ZZ_pX cimport ntl_ZZ_pX
 from sage.libs.ntl.ZZ_p cimport ZZ_p_rep
-from sage.libs.ntl.ntl_ZZ_pContext cimport ntl_ZZ_pContext_class
 from sage.libs.ntl.convert cimport ZZ_to_mpz
 
 # We need to define this stuff before including the templating stuff
@@ -44,7 +38,6 @@ include "sage/libs/ntl/ntl_ZZ_pEX_linkage.pxi"
 # and then the interface
 include "polynomial_template.pxi"
 
-from sage.libs.pari.all import pari
 from sage.libs.ntl.ntl_ZZ_pE cimport ntl_ZZ_pE
 
 cdef inline ZZ_pE_c_to_list(ZZ_pE_c x):

--- a/src/sage/rings/polynomial/real_roots.pyx
+++ b/src/sage/rings/polynomial/real_roots.pyx
@@ -147,7 +147,6 @@ from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.free_module import FreeModule
 from sage.matrix.matrix_space import MatrixSpace
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.polynomial.polynomial_ring import polygen
 from sage.misc.functional import numerator, denominator
 from sage.misc.misc_c import prod
 

--- a/src/sage/rings/polynomial/skew_polynomial_element.pyx
+++ b/src/sage/rings/polynomial/skew_polynomial_element.pyx
@@ -45,24 +45,13 @@ AUTHORS:
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 2 of the License, or
 #    (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 #****************************************************************************
-
-import re
 from cysignals.signals cimport sig_check
 
-from sage.rings.infinity import infinity
-from sage.structure.factorization import Factorization
-from sage.structure.element cimport Element, RingElement, AlgebraElement, ModuleElement
-from sage.misc.abstract_method import abstract_method
-from sage.categories.homset import Hom
-from sage.categories.fields import Fields
+from sage.structure.element cimport Element, RingElement, ModuleElement
 from sage.rings.integer cimport Integer
-from cpython.object cimport PyObject_RichCompare
-from sage.categories.map cimport Map
-from sage.rings.morphism cimport Morphism, RingHomomorphism
-from sage.rings.polynomial.polynomial_element cimport _dict_to_list
-from sage.structure.element import coerce_binop
+from sage.rings.morphism cimport RingHomomorphism
 from sage.misc.superseded import experimental
 
 from sage.rings.polynomial.ore_polynomial_element cimport OrePolynomial

--- a/src/sage/rings/polynomial/skew_polynomial_finite_field.pyx
+++ b/src/sage/rings/polynomial/skew_polynomial_finite_field.pyx
@@ -22,11 +22,10 @@ AUTHOR::
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 2 of the License, or
 #    (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 #****************************************************************************
 
 from sage.structure.element cimport parent
-from sage.rings.ring cimport Ring
 from sage.rings.integer_ring import ZZ
 from sage.rings.integer cimport Integer
 from sage.matrix.matrix_space import MatrixSpace
@@ -34,11 +33,8 @@ from sage.matrix.matrix2 import NotFullRankError
 
 from sage.rings.polynomial.polynomial_element cimport Polynomial
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.polynomial.ore_polynomial_element cimport OrePolynomial as SkewPolynomial
 from sage.rings.polynomial.skew_polynomial_finite_order cimport SkewPolynomial_finite_order_dense
 
-from sage.combinat.permutation import Permutation, Permutations
-from sage.combinat.partition import Partition
 from sage.structure.factorization import Factorization
 from sage.misc.mrange import xmrange_iter
 from sage.misc.prandom import sample

--- a/src/sage/rings/polynomial/skew_polynomial_finite_order.pyx
+++ b/src/sage/rings/polynomial/skew_polynomial_finite_order.pyx
@@ -18,12 +18,7 @@ AUTHOR::
 #    (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
-
-import copy
-import cysignals
 from sage.rings.ring cimport Ring
-from sage.rings.polynomial.polynomial_element cimport Polynomial
-from sage.rings.integer cimport Integer
 from sage.structure.element cimport RingElement
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.skew_polynomial_element cimport SkewPolynomial_generic_dense

--- a/src/sage/rings/polynomial/symmetric_reduction.pyx
+++ b/src/sage/rings/polynomial/symmetric_reduction.pyx
@@ -116,8 +116,6 @@ Symmetric Reduction Strategy is created::
 #
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
-import copy
-import operator
 import sys
 from sage.structure.richcmp cimport richcmp, Py_NE, Py_EQ
 


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

This is removing many unused imports in the pyx files inside `rings/polynomial`.

All were foudn using `cython-lint | grep "imported but unused"`

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
