### PR TITLE
cylint: remove unused imports in pyx files in folders a*-geo*

### DIFF
--- a/src/sage/algebras/letterplace/free_algebra_element_letterplace.pyx
+++ b/src/sage/algebras/letterplace/free_algebra_element_letterplace.pyx
@@ -19,7 +19,6 @@ AUTHOR:
 
 from sage.groups.perm_gps.permgroup_named import CyclicPermutationGroup
 from sage.libs.singular.function import lib, singular_function
-from sage.misc.repr import repr_lincomb
 from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
 from cpython.object cimport PyObject_RichCompare
 

--- a/src/sage/algebras/letterplace/free_algebra_letterplace.pyx
+++ b/src/sage/algebras/letterplace/free_algebra_letterplace.pyx
@@ -115,8 +115,6 @@ TESTS::
     algebras with different term orderings, yet.
 
 """
-
-from sage.misc.misc_c import prod
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.libs.singular.function import lib, singular_function
 from sage.libs.singular.function cimport RingWrap

--- a/src/sage/algebras/quatalg/quaternion_algebra_cython.pyx
+++ b/src/sage/algebras/quatalg/quaternion_algebra_cython.pyx
@@ -25,7 +25,7 @@ AUTHORS:
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
 from sage.rings.integer_ring import ZZ
@@ -38,7 +38,6 @@ from sage.matrix.matrix_rational_dense cimport Matrix_rational_dense
 from .quaternion_algebra_element cimport QuaternionAlgebraElement_rational_field
 
 from sage.libs.gmp.mpz cimport mpz_t, mpz_lcm, mpz_init, mpz_set, mpz_clear, mpz_init_set, mpz_mul, mpz_fdiv_q, mpz_cmp_si
-from sage.libs.gmp.mpq cimport mpq_set_num, mpq_set_den, mpq_canonicalize
 
 from sage.libs.flint.fmpz cimport fmpz_set_mpz
 from sage.libs.flint.fmpq cimport fmpq_canonicalise

--- a/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
+++ b/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
@@ -32,12 +32,11 @@ Check that :trac:`20829` is fixed::
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.structure.element cimport AlgebraElement, RingElement, ModuleElement, Element
+from sage.structure.element cimport AlgebraElement, Element
 from sage.structure.richcmp cimport rich_to_bool, rich_to_bool_sgn, richcmp_item
 from sage.algebras.quatalg.quaternion_algebra_element cimport QuaternionAlgebraElement_abstract
 from sage.rings.rational cimport Rational
 from sage.rings.integer cimport Integer
-from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
 from sage.rings.number_field.number_field_element cimport NumberFieldElement
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.matrix.constructor import matrix

--- a/src/sage/calculus/ode.pyx
+++ b/src/sage/calculus/ode.pyx
@@ -401,9 +401,8 @@ class ode_solver():
             G.save(filename=filename)
 
     def ode_solve(self,t_span=False,y_0=False,num_points=False,params=[]):
-        import inspect
         cdef double h # step size
-        h=self.h
+        h = self.h
         cdef int i
         cdef int j
         cdef int type

--- a/src/sage/calculus/riemann.pyx
+++ b/src/sage/calculus/riemann.pyx
@@ -46,15 +46,12 @@ cimport numpy as np
 from math import pi
 from math import sin
 from math import cos
-from math import sqrt
 
 from math import log # used for complex plot lightness
 from math import atan
 
 from cmath import exp
 from cmath import phase
-
-from random import uniform # used for accuracy tests
 
 FLOAT = np.float64
 ctypedef np.float64_t FLOAT_T

--- a/src/sage/coding/binary_code.pyx
+++ b/src/sage/coding/binary_code.pyx
@@ -4103,7 +4103,6 @@ cdef class BinaryCodeClassifier:
                     m = BinaryCode(matrix(ZZ, rs))
 
                     m_aut_gp_gens, m_labeling, m_size, m_base = self._aut_gp_and_can_label(m)
-                    from sage.arith.misc import factorial
                     if True:  # size*factorial(n-B.ncols) == m_size:
 
                         if len(m_aut_gp_gens) == 0:

--- a/src/sage/coding/codecan/codecan.pyx
+++ b/src/sage/coding/codecan/codecan.pyx
@@ -96,8 +96,6 @@ from copy import copy
 from cysignals.memory cimport check_allocarray, sig_free
 
 from sage.rings.integer cimport Integer
-from sage.matrix.matrix cimport Matrix
-from sage.groups.perm_gps.permgroup import PermutationGroup
 cimport sage.groups.perm_gps.partn_ref2.refinement_generic
 from sage.modules.finite_submodule_iter cimport FiniteFieldsubspace_projPoint_iterator as FFSS_projPoint
 from sage.groups.perm_gps.partn_ref.data_structures cimport *
@@ -757,7 +755,6 @@ cdef class PartitionRefinementLinearCode(PartitionRefinement_generic):
 
         This graph will be later used in the refinement procedures.
         """
-        from sage.matrix.constructor import matrix
         cdef FFSS_projPoint iter = FFSS_projPoint(self._matrix)
         cdef mp_bitcnt_t i,j
 

--- a/src/sage/crypto/sbox.pyx
+++ b/src/sage/crypto/sbox.pyx
@@ -15,7 +15,6 @@ from sage.matrix.matrix0 cimport Matrix
 from sage.misc.cachefunc import cached_method
 from sage.misc.functional import is_even
 from sage.misc.misc_c import prod as mul
-from sage.misc.superseded import deprecated_function_alias
 from sage.modules.free_module_element import vector
 from sage.rings.finite_rings.finite_field_base import FiniteField
 from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF

--- a/src/sage/data_structures/bounded_integer_sequences.pyx
+++ b/src/sage/data_structures/bounded_integer_sequences.pyx
@@ -112,7 +112,6 @@ from sage.data_structures.bitset_base cimport *
 
 from cpython.int cimport PyInt_FromSize_t
 from cpython.slice cimport PySlice_GetIndicesEx
-from sage.libs.gmp.mpn cimport mpn_rshift, mpn_lshift, mpn_copyi, mpn_ior_n, mpn_zero, mpn_copyd, mpn_cmp
 from sage.libs.flint.flint cimport FLINT_BIT_COUNT as BIT_COUNT
 from sage.structure.richcmp cimport richcmp_not_equal, rich_to_bool
 

--- a/src/sage/finance/fractal.pyx
+++ b/src/sage/finance/fractal.pyx
@@ -20,11 +20,8 @@ AUTHOR:
 
 - William Stein (2008)
 """
-
-from sage.rings.real_double import RDF
 from sage.rings.complex_double import CDF
 from sage.rings.integer import Integer
-from sage.modules.free_module_element import vector
 I = CDF.gen()
 
 from sage.stats.time_series cimport TimeSeries

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/base.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/base.pyx
@@ -86,7 +86,6 @@ import numbers
 from memory_allocator cimport MemoryAllocator
 from cysignals.memory cimport check_calloc, sig_free
 
-from sage.rings.integer             import Integer
 from sage.graphs.graph              import Graph
 from sage.geometry.polyhedron.base  import Polyhedron_base
 from sage.geometry.lattice_polytope import LatticePolytopeClass

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/conversions.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/conversions.pyx
@@ -69,13 +69,10 @@ AUTHOR:
 
 from memory_allocator                 cimport MemoryAllocator
 
-from sage.structure.element import is_Matrix
 from sage.matrix.matrix_dense cimport Matrix_dense
 
 from .list_of_faces                   cimport ListOfFaces
 from .face_data_structure             cimport face_next_atom, face_add_atom_safe, facet_set_coatom, face_clear
-from .face_list_data_structure        cimport face_list_t
-
 
 cdef extern from "Python.h":
     int unlikely(int) nogil  # Defined by Cython

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/face_iterator.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/face_iterator.pyx
@@ -178,10 +178,8 @@ from cython.parallel cimport prange, threadid
 from cysignals.memory cimport check_allocarray, sig_free
 from memory_allocator cimport MemoryAllocator
 
-from sage.rings.integer     cimport smallInteger
 from cysignals.signals      cimport sig_check
-from .conversions           cimport bit_rep_to_Vrep_list, Vrep_list_to_bit_rep
-from .conversions            import facets_tuple_to_bit_rep_of_facets
+from .conversions           cimport bit_rep_to_Vrep_list
 from .base                  cimport CombinatorialPolyhedron
 
 from sage.geometry.polyhedron.face import combinatorial_face_to_polyhedral_face, PolyhedronFace

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/list_of_faces.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/list_of_faces.pyx
@@ -79,7 +79,6 @@ AUTHOR:
 
 - Jonathan Kliem (2019-04)
 """
-
 # ****************************************************************************
 #       Copyright (C) 2019 Jonathan Kliem <jonathan.kliem@gmail.com>
 #
@@ -90,13 +89,13 @@ AUTHOR:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.structure.element import is_Matrix
 from sage.matrix.matrix_dense  cimport Matrix_dense
 
 from .face_list_data_structure cimport *
 
 cdef extern from "Python.h":
     int unlikely(int) nogil  # Defined by Cython
+
 
 cdef class ListOfFaces:
     r"""

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/polyhedron_face_lattice.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/polyhedron_face_lattice.pyx
@@ -57,7 +57,7 @@ AUTHOR:
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 #*****************************************************************************
 
 from .conversions \
@@ -66,7 +66,6 @@ from .conversions \
 
 from .conversions cimport bit_rep_to_Vrep_list
 
-from sage.rings.integer        cimport smallInteger
 from .base                     cimport CombinatorialPolyhedron
 from .face_iterator            cimport FaceIterator
 from .face_list_data_structure cimport *


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Remove unused import in pyx files inside folders from `algebras` to `geometry` (excluding dynamics).

Found using `cython-lint | grep "imported but unused"`

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
