### PR TITLE
Fix building the Singular docstring dict when Singular info is built with recent texinfo

### DIFF
--- a/src/sage/interfaces/singular.py
+++ b/src/sage/interfaces/singular.py
@@ -2405,7 +2405,7 @@ def generate_docstring_dictionary():
                     a, b = m.groups()
                     node_names[a] = b.strip()
 
-            if line == "6 Index\n":
+            if line in ("6 Index\n", "F Index\n"):
                 in_node = False
 
     nodes[curr_node] = "".join(L)  # last node


### PR DESCRIPTION
When building the Singular info with recent texinfo, sections are numbered using capital letters instead of numbers. This breaks the current matching logic.


