### PR TITLE
Fix g++ (13) warnings

### DIFF
--- a/src/sage/modular/arithgroup/farey.cpp
+++ b/src/sage/modular/arithgroup/farey.cpp
@@ -736,6 +736,7 @@ size_t FareySymbol::nu3() const {
 }
 
 size_t FareySymbol::rank_pi() const {
+  using namespace std::placeholders;
   if( index() == 2 ) return 1;
   return count_if(pairing.begin(), pairing.end(),
                   bind(greater<int>(), placeholders::_1, 0))/2;

--- a/src/sage/symbolic/ginac/archive.cpp
+++ b/src/sage/symbolic/ginac/archive.cpp
@@ -581,7 +581,7 @@ void archive::clear()
 /** Delete cached unarchived expressions in all archive_nodes (mainly for debugging). */
 void archive::forget()
 {
-	for_each(nodes.begin(), nodes.end(), std::mem_fun_ref(&archive_node::forget));
+	for_each(nodes.begin(), nodes.end(), std::mem_fn(&archive_node::forget));
 }
 
 /** Delete cached unarchived expressions from node (for debugging). */


### PR DESCRIPTION
This PR fix two gcc warnings for C++ standard methods deprecated since the C++11 standard.
* the first one fix is in ginac and the fix is copied from the upstream project
* the second fix is in farey.cpp

Fixes #34996

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [ ] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
