### PR TITLE
register magic modes for lazy imported interfaces

### DIFF
--- a/src/sage/repl/interface_magic.py
+++ b/src/sage/repl/interface_magic.py
@@ -97,7 +97,7 @@ class InterfaceMagic():
         except ImportError:
             return
         for name, obj in sage.interfaces.all.__dict__.items():
-            if isinstance(obj, sage.interfaces.interface.Interface):
+            if isinstance(obj, (sage.interfaces.interface.Interface, sage.misc.lazy_import.LazyImport)):
                 yield cls(name, obj)
 
     @classmethod


### PR DESCRIPTION
### :books: Description

Addresses  #35246

The lazy imported interfaces are not registered as magic modes. This patch registers them too.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [] I have created tests covering the changes.
- [] I have updated the documentation accordingly.
