### PR TITLE
unify input of matrices and vectors

### DIFF
--- a/src/sage/combinat/k_regular_sequence.py
+++ b/src/sage/combinat/k_regular_sequence.py
@@ -150,6 +150,11 @@ class kRegularSequence(RecognizableSeries):
 
             :doc:`k-regular sequence <k_regular_sequence>`,
             :class:`kRegularSequenceSpace`.
+
+        TESTS::
+
+            sage: Seq2(([[1, 0], [0, 1]], [[1, 1], [0, 1]]), (1, 0), (0, 1))
+            2-regular sequence 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, ...
         """
         super().__init__(parent=parent, mu=mu, left=left, right=right)
 

--- a/src/sage/combinat/recognizable_series.py
+++ b/src/sage/combinat/recognizable_series.py
@@ -457,7 +457,7 @@ class RecognizableSeries(ModuleElement):
             return m
 
         if isinstance(mu, dict):
-            mu = dict((a, immutable(Matrix(M))) for a, M in mu.items())
+            mu = {a: Matrix(M, immutable=True) for a, M in mu.items()}
         mu = Family(mu)
 
         if not mu.is_finite():

--- a/src/sage/combinat/recognizable_series.py
+++ b/src/sage/combinat/recognizable_series.py
@@ -441,6 +441,7 @@ class RecognizableSeries(ModuleElement):
         super(RecognizableSeries, self).__init__(parent=parent)
 
         from copy import copy
+        from sage.matrix.constructor import Matrix
         from sage.modules.free_module_element import vector
         from sage.sets.family import Family
 
@@ -456,7 +457,7 @@ class RecognizableSeries(ModuleElement):
             return m
 
         if isinstance(mu, dict):
-            mu = dict((a, immutable(M)) for a, M in mu.items())
+            mu = dict((a, immutable(Matrix(M))) for a, M in mu.items())
         mu = Family(mu)
 
         if not mu.is_finite():


### PR DESCRIPTION
For recognizable series the input is handled differently for matrices and vectors. This easy patch unifies this.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
