### PR TITLE
some fixes for pycodestyle E275

### DIFF
--- a/src/sage/algebras/lie_conformal_algebras/weyl_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/weyl_lie_conformal_algebra.py
@@ -23,20 +23,21 @@ AUTHORS:
 - Reimundo Heluani (2019-08-09): Initial implementation.
 """
 
-#******************************************************************************
+# *****************************************************************************
 #       Copyright (C) 2019 Reimundo Heluani <heluani@potuz.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from .lie_conformal_algebra_with_structure_coefs import \
-                                LieConformalAlgebraWithStructureCoefficients
+    LieConformalAlgebraWithStructureCoefficients
 from sage.matrix.special import identity_matrix
 from sage.structure.indexed_generators import standardize_names_index_set
+
 
 class WeylLieConformalAlgebra(LieConformalAlgebraWithStructureCoefficients):
     r"""
@@ -132,7 +133,7 @@ class WeylLieConformalAlgebra(LieConformalAlgebraWithStructureCoefficients):
         from sage.matrix.matrix_space import MatrixSpace
         if ngens:
             from sage.rings.integer_ring import ZZ
-            if not(ngens in ZZ and not ngens % 2):
+            if not (ngens in ZZ and not ngens % 2):
                 raise ValueError("ngens needs to be an even positive Integer, "
                                  f"got {ngens}")
         if gram_matrix is not None:
@@ -163,8 +164,9 @@ class WeylLieConformalAlgebra(LieConformalAlgebraWithStructureCoefficients):
         names, index_set = standardize_names_index_set(names=names,
                                                       index_set=index_set,
                                                       ngens=ngens)
-        weyldict = { (i,j): {0: {('K',0): gram_matrix[index_set.rank(i),
-                    index_set.rank(j)]}} for i in index_set for j in index_set}
+        weyldict = {(i, j): {0: {('K', 0): gram_matrix[index_set.rank(i),
+                                                       index_set.rank(j)]}}
+                    for i in index_set for j in index_set}
 
         super().__init__(R, weyldict, names=names,
                          latex_names=latex_names,
@@ -182,7 +184,7 @@ class WeylLieConformalAlgebra(LieConformalAlgebraWithStructureCoefficients):
             The Weyl Lie conformal algebra with generators (alpha0, alpha1, K) over Integer Ring
         """
         return "The Weyl Lie conformal algebra with generators {} over {}"\
-                .format(self.gens(),self.base_ring())
+            .format(self.gens(), self.base_ring())
 
     def gram_matrix(self):
         r"""

--- a/src/sage/crypto/block_cipher/des.py
+++ b/src/sage/crypto/block_cipher/des.py
@@ -472,8 +472,8 @@ class DES(SageObject):
             DES block cipher with 16 rounds and the following key schedule:
             Original DES key schedule with 16 rounds
         """
-        return('DES block cipher with %s rounds and the following key '
-               'schedule:\n%s' % (self._rounds, self.keySchedule.__repr__()))
+        return ('DES block cipher with %s rounds and the following key '
+                'schedule:\n%s' % (self._rounds, self.keySchedule.__repr__()))
 
     def encrypt(self, plaintext, key):
         r"""

--- a/src/sage/crypto/mq/sr.py
+++ b/src/sage/crypto/mq/sr.py
@@ -665,7 +665,7 @@ class SR_generic(MPolynomialSystemGenerator):
             sage: sr1 != sr2
             True
         """
-        return not(self == other)
+        return not (self == other)
 
     def sub_bytes(self, d):
         r"""

--- a/src/sage/games/quantumino.py
+++ b/src/sage/games/quantumino.py
@@ -424,8 +424,8 @@ class QuantuminoSolver(SageObject):
             Quantumino solver for the box (5, 8, 2)
             Aside pentamino number: 9
         """
-        if not(0 <= aside < 17):
-            raise ValueError("aside (=%s) must be between 0 and 16" % aside)
+        if not (0 <= aside < 17):
+            raise ValueError(f"aside (={aside}) must be between 0 and 16")
         self._aside = aside
         self._box = box
 

--- a/src/sage/geometry/polyhedron/parent.py
+++ b/src/sage/geometry/polyhedron/parent.py
@@ -2,12 +2,12 @@ r"""
 Parents for Polyhedra
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2014 Volker Braun <vbraun.name@gmail.com>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
-#                  http://www.gnu.org/licenses/
-#******************************************************************************
+#                  https://www.gnu.org/licenses/
+# *****************************************************************************
 
 from sage.structure.parent import Parent
 from sage.structure.element import get_coercion_model
@@ -400,7 +400,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
         points = []
         R = self.base_ring()
         for i in range(self.ambient_dim() + 5):
-            points.append([R(i * j**2) for j in range(self.ambient_dim())])
+            points.append([R(i * j ^ 2) for j in range(self.ambient_dim())])
         return [
             self.element_class(self, [points[0:self.ambient_dim() + 1], [], []], None),
             self.element_class(self, [points[0:1], points[1:self.ambient_dim() + 1], []], None),
@@ -1212,8 +1212,10 @@ class Polyhedra_ZZ_ppl(Polyhedra_base):
         else:
             return Polyhedra_base._element_constructor_polyhedron(self, polyhedron, **kwds)
 
+
 class Polyhedra_ZZ_normaliz(Polyhedra_base):
     Element = Polyhedron_ZZ_normaliz
+
 
 class Polyhedra_QQ_ppl(Polyhedra_base):
     Element = Polyhedron_QQ_ppl
@@ -1244,26 +1246,34 @@ class Polyhedra_QQ_ppl(Polyhedra_base):
         else:
             return Polyhedra_base._element_constructor_polyhedron(self, polyhedron, **kwds)
 
+
 class Polyhedra_QQ_normaliz(Polyhedra_base):
     Element = Polyhedron_QQ_normaliz
+
 
 class Polyhedra_QQ_cdd(Polyhedra_base):
     Element = Polyhedron_QQ_cdd
 
+
 class Polyhedra_RDF_cdd(Polyhedra_base):
     Element = Polyhedron_RDF_cdd
+
 
 class Polyhedra_normaliz(Polyhedra_base):
     Element = Polyhedron_normaliz
 
+
 class Polyhedra_polymake(Polyhedra_base):
     Element = Polyhedron_polymake
+
 
 class Polyhedra_field(Polyhedra_base):
     Element = Polyhedron_field
 
+
 class Polyhedra_number_field(Polyhedra_base):
     Element = Polyhedron_number_field
+
 
 @cached_function
 def does_backend_handle_base_ring(base_ring, backend):

--- a/src/sage/geometry/polyhedron/parent.py
+++ b/src/sage/geometry/polyhedron/parent.py
@@ -193,7 +193,7 @@ def Polyhedra(ambient_space_or_base_ring=None, ambient_dim=None, backend=None, *
         return Polyhedra_field(base_ring.fraction_field(), ambient_dim, backend)
     else:
         raise ValueError('No such backend (=' + str(backend) +
-                         ') implemented for given basering (=' + str(base_ring)+').')
+                         ') implemented for given basering (=' + str(base_ring) + ').')
 
 
 class Polyhedra_base(UniqueRepresentation, Parent):
@@ -400,7 +400,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
         points = []
         R = self.base_ring()
         for i in range(self.ambient_dim() + 5):
-            points.append([R(i * j ^ 2) for j in range(self.ambient_dim())])
+            points.append([R(i*j ^ 2) for j in range(self.ambient_dim())])
         return [
             self.element_class(self, [points[0:self.ambient_dim() + 1], [], []], None),
             self.element_class(self, [points[0:1], points[1:self.ambient_dim() + 1], []], None),
@@ -421,7 +421,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             sage: p + p == p
             True
         """
-        Vrep = [[[self.base_ring().zero()]*self.ambient_dim()], [], []]
+        Vrep = [[[self.base_ring().zero()] * self.ambient_dim()], [], []]
         return self.element_class(self, Vrep, None)
 
     def empty(self):
@@ -454,7 +454,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             True
         """
         R = self.base_ring()
-        return self(None, [[[R.one()]+[R.zero()]*self.ambient_dim()], []], convert=True)
+        return self(None, [[[R.one()] + [R.zero()] * self.ambient_dim()], []], convert=True)
 
     @cached_method
     def Vrepresentation_space(self):
@@ -502,10 +502,9 @@ class Polyhedra_base(UniqueRepresentation, Parent):
         """
         if self.base_ring() in Fields():
             from sage.modules.free_module import VectorSpace
-            return VectorSpace(self.base_ring(), self.ambient_dim()+1)
-        else:
-            from sage.modules.free_module import FreeModule
-            return FreeModule(self.base_ring(), self.ambient_dim()+1)
+            return VectorSpace(self.base_ring(), self.ambient_dim() + 1)
+        from sage.modules.free_module import FreeModule
+        return FreeModule(self.base_ring(), self.ambient_dim() + 1)
 
     def _repr_base_ring(self):
         """
@@ -574,7 +573,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             sage: Polyhedra(QQ, 3)._repr_()
             'Polyhedra in QQ^3'
         """
-        return 'Polyhedra in '+self._repr_ambient_module()
+        return 'Polyhedra in ' + self._repr_ambient_module()
 
     def _element_constructor_(self, *args, **kwds):
         """
@@ -675,7 +674,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
                     if m == 0:
                         newlstlst.append(lst)
                     else:
-                        newlstlst.append([q/m for q in lst])
+                        newlstlst.append([q / m for q in lst])
                 else:
                     newlstlst.append(lst)
             return convert_base_ring(newlstlst)
@@ -900,14 +899,14 @@ class Polyhedra_base(UniqueRepresentation, Parent):
                         except TypeError:
                             pass
                     if other_ring is None:
-                        raise TypeError('Could not coerce '+str(other)+' into ZZ, QQ, or RDF.')
+                        raise TypeError(f'Could not coerce {other} into ZZ, QQ, or RDF.')
 
         if not other_ring.is_exact():
             other_ring = RDF  # the only supported floating-point numbers for now
 
         cm_map, cm_ring = get_coercion_model().analyse(self.base_ring(), other_ring)
         if cm_ring is None:
-            raise TypeError('Could not coerce type '+str(other)+' into ZZ, QQ, or RDF.')
+            raise TypeError(f'Could not coerce type {other} into ZZ, QQ, or RDF.')
         return cm_ring
 
     def _coerce_map_from_(self, X):

--- a/src/sage/geometry/polyhedron/parent.py
+++ b/src/sage/geometry/polyhedron/parent.py
@@ -400,10 +400,10 @@ class Polyhedra_base(UniqueRepresentation, Parent):
         points = []
         R = self.base_ring()
         for i in range(self.ambient_dim() + 5):
-            points.append([R(i*j^2) for j in range(self.ambient_dim())])
+            points.append([R(i * j**2) for j in range(self.ambient_dim())])
         return [
-            self.element_class(self, [points[0:self.ambient_dim()+1], [], []], None),
-            self.element_class(self, [points[0:1], points[1:self.ambient_dim()+1], []], None),
+            self.element_class(self, [points[0:self.ambient_dim() + 1], [], []], None),
+            self.element_class(self, [points[0:1], points[1:self.ambient_dim() + 1], []], None),
             self.element_class(self, [points[0:3], points[4:5], []], None),
             self.element_class(self, None, None)]
 

--- a/src/sage/interfaces/qepcad.py
+++ b/src/sage/interfaces/qepcad.py
@@ -2427,7 +2427,7 @@ class QepcadCell:
                         index = (index,)
                 self._index = index
 
-                self._dimension = sum([r&1 for r in index])
+                self._dimension = sum([r & 1 for r in index])
             if 'Level        ' in line:
                 self._level = int(line.split(':')[1].strip())
             if 'Number of children' in line:

--- a/src/sage/logic/boolformula.py
+++ b/src/sage/logic/boolformula.py
@@ -1167,7 +1167,7 @@ class BooleanFormula():
             lval = ('prop', tree[1])
         else:
             lval = tree[1]
-        if not isinstance(tree[2], tuple) and not(tree[2] is None):
+        if not isinstance(tree[2], tuple) and tree[2] is not None:
             rval = ('prop', tree[2])
         else:
             rval = tree[2]
@@ -1556,6 +1556,7 @@ class BooleanFormula():
     # For backward compatibility, we allow `self.length()` to be called as
     # `len(self)`, but this may be deprecated in the future (see :trac:`32148`):
     __len__ = length
+
 
 # allow is_consequence to be called as a function (not only as a method of BooleanFormula)
 is_consequence = BooleanFormula.is_consequence

--- a/src/sage/modular/arithgroup/congroup_gamma0.py
+++ b/src/sage/modular/arithgroup/congroup_gamma0.py
@@ -596,7 +596,7 @@ class Gamma0_class(GammaH_class):
         N = self.level()
         k = ZZ(k)
 
-        if not(p == 0 or N % p):
+        if not (p == 0 or N % p):
             return (self.dimension_cusp_forms(k) -
                     2 * self.restrict(N // p).dimension_new_cusp_forms(k))
 

--- a/src/sage/modular/btquotients/btquotient.py
+++ b/src/sage/modular/btquotients/btquotient.py
@@ -412,7 +412,7 @@ class BruhatTitsTree(SageObject, UniqueRepresentation):
         sage: T = BruhatTitsTree(4)
         Traceback (most recent call last):
         ...
-        ValueError: Input (4) must be prime
+        ValueError: input (4) must be prime
 
     AUTHORS:
 

--- a/src/sage/modular/btquotients/btquotient.py
+++ b/src/sage/modular/btquotients/btquotient.py
@@ -428,8 +428,8 @@ class BruhatTitsTree(SageObject, UniqueRepresentation):
             sage: T = BruhatTitsTree(17)
             sage: TestSuite(T).run()
         """
-        if not(ZZ(p).is_prime()):
-            raise ValueError('Input (%s) must be prime' % p)
+        if not ZZ(p).is_prime():
+            raise ValueError(f'input ({p}) must be prime')
         self._p = ZZ(p)
         self._Mat_22 = MatrixSpace(ZZ, 2, 2)
         self._mat_p001 = self._Mat_22([self._p, 0, 0, 1])
@@ -2283,7 +2283,7 @@ class BruhatTitsQuotient(SageObject, UniqueRepresentation):
             self._II = M([0, a, 1, 0])
             z = 0
             self._JJ = 0
-            while(self._JJ == 0):
+            while self._JJ == 0:
                 c = a * z * z + b
                 if c.is_square():
                     x = c.sqrt()

--- a/src/sage/modular/hypergeometric_motive.py
+++ b/src/sage/modular/hypergeometric_motive.py
@@ -688,11 +688,10 @@ class HypergeometricData():
         alpha = self._alpha
         beta = self._beta
         if flip_beta:
-            return(sum(1 for a in alpha if a <= x) -
-                   sum(1 for b in beta if 1 - b <= x))
-        else:
-            return(sum(1 for a in alpha if a <= x) -
-                   sum(1 for b in beta if b <= x))
+            return (sum(1 for a in alpha if a <= x) -
+                    sum(1 for b in beta if 1 - b <= x))
+        return (sum(1 for a in alpha if a <= x) -
+                sum(1 for b in beta if b <= x))
 
     def weight(self):
         """

--- a/src/sage/modular/modform/l_series_gross_zagier.py
+++ b/src/sage/modular/modform/l_series_gross_zagier.py
@@ -48,7 +48,7 @@ class GrossZagierLseries(SageObject):
         ideal = A.ideal()
         K = A.gens()[0].parent()
         D = K.disc()
-        if not(K.degree() == 2 and D < 0):
+        if not (K.degree() == 2 and D < 0):
             raise ValueError("A is not an ideal class in an"
                              " imaginary quadratic field")
         Q = ideal.quadratic_form().reduced_form()

--- a/src/sage/modular/modform_hecketriangle/abstract_space.py
+++ b/src/sage/modular/modform_hecketriangle/abstract_space.py
@@ -571,14 +571,13 @@ class FormsSpace_abstract(FormsRing_abstract):
             sage: el.parent() == subspace
             True
         """
-
         if not self.module():
-            raise ValueError("No free module defined for {}".format(self))
+            raise ValueError(f"no free module defined for {self}")
         basis = self.gens()
-        assert(len(basis) == len(vec))
+        assert len(basis) == len(vec)
         # vec = self.module()(self.module().linear_combination_of_basis(vec))
         # this also handles the trivial case (dimension 0)
-        return self(sum([vec[k]*basis[k] for k in range(0, len(vec))]))
+        return self(sum([vec[k] * basis[k] for k in range(len(vec))]))
 
     def element_from_ambient_coordinates(self, vec):
         r"""

--- a/src/sage/modular/modform_hecketriangle/hecke_triangle_group_element.py
+++ b/src/sage/modular/modform_hecketriangle/hecke_triangle_group_element.py
@@ -615,9 +615,9 @@ class HeckeTriangleGroupElement(MatrixGroupElement_generic):
         cf_index = ZZ.zero()
         one = ZZ.one()
 
-        while(p not in cf_dict):
+        while p not in cf_dict:
             cf_dict[p] = cf_index
-            if (p == infinity):
+            if p == infinity:
                 # TODO: The choice of r doesn't matter?
                 r = ZZ.zero()
             #elif self.is_elliptic():
@@ -819,7 +819,7 @@ class HeckeTriangleGroupElement(MatrixGroupElement_generic):
         number_of_ones.append(ones)
 
         initial_ones = number_of_ones.pop(0)
-        if len(list_larger) == 0:
+        if not list_larger:
             list_v1 = [-ZZ(1)]
             list_vlarger = [ initial_ones + 2 ]
         else:
@@ -835,7 +835,7 @@ class HeckeTriangleGroupElement(MatrixGroupElement_generic):
 
         L_len = len(L)
         k = 0
-        while(k < L_len - 1):
+        while k < L_len - 1:
             if L[k][0] == L[k+1][0]:
                 k_entry = L.pop(k+1)
                 L[k][1] += k_entry[1]

--- a/src/sage/modular/modsym/tests.py
+++ b/src/sage/modular/modsym/tests.py
@@ -67,9 +67,9 @@ class Test:
             weights = list(range(2, int(weights) + 1))
         self.levels = levels
         self.weights = weights
-        if not(levels):
+        if not levels:
             raise RuntimeError("levels must have positive length")
-        if not(weights):
+        if not weights:
             raise RuntimeError("weights must have positive length")
         self.current_space = None
         self.onlyg0 = onlyg0
@@ -78,7 +78,7 @@ class Test:
 
     def __repr__(self):
         """
-        Return the string representation of self.
+        Return the string representation of ``self``.
 
         EXAMPLES::
 

--- a/src/sage/modular/overconvergent/genus0.py
+++ b/src/sage/modular/overconvergent/genus0.py
@@ -943,8 +943,8 @@ class OverconvergentModularFormsSpace(Module):
         g = self._gsr.gen()
         answer = self._gsr(0)
         for i in range(n):
-            assert(x.valuation() >= i)
-            answer += (x[i] / self._basis_cache[i][i])*g**i
+            assert x.valuation() >= i
+            answer += (x[i] / self._basis_cache[i][i]) * g**i
             x = x - self._basis_cache[i] * answer[i]
         return answer + O(g**n)
 

--- a/src/sage/modular/pollack_stevens/modsym.py
+++ b/src/sage/modular/pollack_stevens/modsym.py
@@ -830,8 +830,8 @@ class PSModularSymbolElement(ModuleElement):
         # fundamental domain
         t = self.parent().coefficient_module().zero()
         for g in MR.gens()[1:]:
-            if not(g in MR.reps_with_two_torsion()
-                   or g in MR.reps_with_three_torsion()):
+            if not (g in MR.reps_with_two_torsion()
+                    or g in MR.reps_with_three_torsion()):
                 t += f[g] * MR.gammas[g] - f[g]
             else:
                 if g in MR.reps_with_two_torsion():
@@ -843,7 +843,7 @@ class PSModularSymbolElement(ModuleElement):
         if f[id] * MR.gammas[id] - f[id] != -t:
             print(t)
             print(f[id] * MR.gammas[id] - f[id])
-            raise ValueError("Does not add up correctly around loop")
+            raise ValueError("does not add up correctly around loop")
 
         print("This modular symbol satisfies the Manin relations")
 

--- a/src/sage/modular/quatalg/brandt.py
+++ b/src/sage/modular/quatalg/brandt.py
@@ -876,7 +876,7 @@ class BrandtModule_class(AmbientHeckeModule):
         """
         if not Integer(p).is_prime():
             raise ValueError("p must be a prime")
-        if not(self.level() % p):
+        if not self.level() % p:
             raise ValueError("p must be coprime to the level")
 
         R = self.order_of_level_N()
@@ -922,7 +922,7 @@ class BrandtModule_class(AmbientHeckeModule):
                     v = [A(1), alpha, beta, alpha * beta]
                     M = rational_matrix_from_rational_quaternions(v)
                     e = M.determinant()
-                    if e and not((d / e).valuation(p)):
+                    if e and not (d / e).valuation(p):
                         S = A.quaternion_order(v)
                         break
                 if S is not None:
@@ -1177,7 +1177,7 @@ class BrandtModule_class(AmbientHeckeModule):
         for r in range(len(C)):
             percent_done = 100 * r // len(C)
             if percent_done != last_percent:
-                if not(percent_done % 5):
+                if not percent_done % 5:
                     verbose("percent done: %s" % percent_done)
                 last_percent = percent_done
             if use_fast_alg:
@@ -1296,7 +1296,7 @@ class BrandtModule_class(AmbientHeckeModule):
         """
         level = self.level()
         p = ZZ(2)
-        while not(level % p):
+        while not level % p:
             p = next_prime(p)
         return p
 
@@ -1555,7 +1555,7 @@ class BrandtModule_class(AmbientHeckeModule):
         p = Integer(2)
         N = self.level()
         while V.dimension() >= 2:
-            while not(N % p):
+            while not N % p:
                 p = p.next_prime()
             A = V.T(p) - (p + 1)
             V = A.kernel()

--- a/src/sage/modular/ssmod/ssmod.py
+++ b/src/sage/modular/ssmod/ssmod.py
@@ -233,8 +233,8 @@ def dimension_supersingular_module(prime, level=1):
 
     - Iftikhar Burhanuddin - burhanud@usc.edu
     """
-    if not(Integer(prime).is_prime()):
-        raise ValueError("%s is not a prime" % prime)
+    if not Integer(prime).is_prime():
+        raise ValueError(f"{prime} is not a prime")
 
     if level == 1:
         return Gamma0(prime).dimension_modular_forms(2)
@@ -243,8 +243,7 @@ def dimension_supersingular_module(prime, level=1):
     # elif (level in [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 16, 18, 25]):
     # compute basis
 
-    else:
-        raise NotImplementedError
+    raise NotImplementedError
 
 
 def supersingular_D(prime):
@@ -331,12 +330,12 @@ def supersingular_j(FF):
 
     - Iftikhar Burhanuddin -- burhanud@usc.edu
     """
-    if not(FF.is_field()) or not(FF.is_finite()):
+    if not FF.is_field() or not FF.is_finite():
         raise ValueError("%s is not a finite field" % FF)
     prime = FF.characteristic()
-    if not(Integer(prime).is_prime()):
+    if not Integer(prime).is_prime():
         raise ValueError("%s is not a prime" % prime)
-    if not(Integer(FF.cardinality())) == Integer(prime**2):
+    if FF.cardinality() != Integer(prime**2):
         raise ValueError("%s is not a quadratic extension" % FF)
     if kronecker(-1, prime) != 1:
         j_invss = 1728                 # (2^2 * 3)^3

--- a/src/sage/modules/free_module_homspace.py
+++ b/src/sage/modules/free_module_homspace.py
@@ -215,7 +215,7 @@ class FreeModuleHomspace(sage.categories.homset.HomsetWithBase):
                 # Let us hope that FreeModuleMorphism knows to handle
                 # that case
                 pass
-        if not(self.codomain().base_ring().has_coerce_map_from(self.domain().base_ring())) and not(A.is_zero()):
+        if not self.codomain().base_ring().has_coerce_map_from(self.domain().base_ring()) and not A.is_zero():
             raise TypeError("nontrivial morphisms require a coercion map from the base ring of the domain to the base ring of the codomain")
         return free_module_morphism.FreeModuleMorphism(self, A, side)
 

--- a/src/sage/modules/free_module_integer.py
+++ b/src/sage/modules/free_module_integer.py
@@ -622,7 +622,7 @@ class FreeModule_submodule_with_basis_integer(FreeModule_submodule_with_basis_pi
         """
         w = matrix(ZZ, w)
         L = w.stack(self.reduced_basis).LLL()
-        assert(L[0] == 0)
+        assert L[0] == 0
         self._reduced_basis = L.matrix_from_rows(range(1, L.nrows()))
 
     @cached_method

--- a/src/sage/modules/with_basis/morphism.py
+++ b/src/sage/modules/with_basis/morphism.py
@@ -396,9 +396,9 @@ class ModuleMorphismByLinearity(ModuleMorphism):
             Add more tests for multi-parameter module morphisms.
         """
         before = args[0:self._position]
-        after = args[self._position+1:len(args)]
+        after = args[self._position + 1:len(args)]
         x = args[self._position]
-        assert(x.parent() is self.domain())
+        assert x.parent() is self.domain()
 
         mc = x.monomial_coefficients(copy=False)
         if self._is_module_with_basis_over_same_base_ring:

--- a/src/sage/monoids/automatic_semigroup.py
+++ b/src/sage/monoids/automatic_semigroup.py
@@ -557,7 +557,7 @@ class AutomaticSemigroup(UniqueRepresentation, Parent):
             sage: [m.lift() for m in M]
             [1, 3, 5, 9, 0, 10, 12, 6]
         """
-        assert(x in self)
+        assert x in self
         return x.lift()
 
     def semigroup_generators(self):
@@ -744,14 +744,14 @@ class AutomaticSemigroup(UniqueRepresentation, Parent):
             sage: a*b
             [1]
         """
-        assert(x in self)
-        assert(y in self)
+        assert x in self
+        assert y in self
         red = y._reduced_word
         if red is None:
             return self._retract(self._mul(x.lift(), y.lift()))
-        else:
-            for i in red:
-                x = x.transition(i)
+
+        for i in red:
+            x = x.transition(i)
         return x
 
     def from_reduced_word(self, l):
@@ -942,7 +942,7 @@ class AutomaticSemigroup(UniqueRepresentation, Parent):
                 [1, 2]
             """
             parent = self.parent()
-            assert(i in parent._generators.keys())
+            assert i in parent._generators.keys()
             return parent._retract(parent._mul(self.lift(), parent._generators_in_ambient[i]))
 
         def _repr_(self):

--- a/src/sage/plot/plot3d/shapes2.py
+++ b/src/sage/plot/plot3d/shapes2.py
@@ -1255,7 +1255,7 @@ class Line(PrimitiveObject):
 
         elif corner_cutoff <= -1:
             # no corners
-            if not(max_len is None):
+            if max_len is not None:
                 # forced by the maximal number of consecutive smooth points
                 return self.points[:-1][::max_len - 1]
             else:

--- a/src/sage/quadratic_forms/quadratic_form__mass__Conway_Sloane_masses.py
+++ b/src/sage/quadratic_forms/quadratic_form__mass__Conway_Sloane_masses.py
@@ -353,24 +353,24 @@ def conway_octane_of_this_unimodular_Jordan_block_at_2(self):
 
         # Diagonalize the 2x2 block
         else:
-            B = self[ind, ind+1]
-            if (B % 2 != 0):
+            B = self[ind, ind + 1]
+            if B % 2:
                 raise RuntimeError("we expected the mixed term to be even")
 
             a = self[ind, ind]
-            b = ZZ(B / ZZ(2))
-            c = self[ind+1, ind+1]
+            b = B // ZZ(2)
+            c = self[ind + 1, ind + 1]
             tmp_disc = b * b - a * c
 
             # Perform the diagonalization
-            if (tmp_disc % 8 == 1):                # 2xy
+            if tmp_disc % 8 == 1:                # 2xy
                 tmp_diag_vec[ind] = 1
-                tmp_diag_vec[ind+1] = -1
+                tmp_diag_vec[ind + 1] = -1
                 ind += 2
-            elif(tmp_disc % 8 == 5):               # 2x^2 + 2xy + 2y^2
-                tmp_diag_vec[0] = 3*u
+            elif tmp_disc % 8 == 5:               # 2x^2 + 2xy + 2y^2
+                tmp_diag_vec[0] = 3 * u
                 tmp_diag_vec[ind] = -u
-                tmp_diag_vec[ind+1] = -u
+                tmp_diag_vec[ind + 1] = -u
                 ind += 2
                 u = tmp_diag_vec[0]
             else:

--- a/src/sage/sat/boolean_polynomials.py
+++ b/src/sage/sat/boolean_polynomials.py
@@ -219,7 +219,7 @@ def solve(F, converter=None, solver=None, n=1, target_variables=None, **kwds):
        instead of classes is discouraged because these objects are
        stateful.
     """
-    assert(n>0)
+    assert n > 0
 
     try:
         len(F)
@@ -234,7 +234,7 @@ def solve(F, converter=None, solver=None, n=1, target_variables=None, **kwds):
         target_variables = PolynomialSequence(F).variables()
     else:
         target_variables = PolynomialSequence(target_variables).variables()
-        assert(set(target_variables).issubset(set(P.gens())))
+        assert set(target_variables).issubset(set(P.gens()))
 
     # instantiate the SAT solver
 

--- a/src/sage/sets/disjoint_union_enumerated_sets.py
+++ b/src/sage/sets/disjoint_union_enumerated_sets.py
@@ -258,8 +258,8 @@ class DisjointUnionEnumeratedSets(UniqueRepresentation, Parent):
         """
         # facade  = options.pop('facade', True);
         # keepkey = options.pop('keepkey', False);
-        assert(isinstance(facade, bool))
-        assert(isinstance(keepkey, bool))
+        assert isinstance(facade, bool)
+        assert isinstance(keepkey, bool)
         return super().__classcall__(
             cls, Family(fam),
             facade=facade, keepkey=keepkey, category=category)

--- a/src/sage/sets/family.py
+++ b/src/sage/sets/family.py
@@ -377,8 +377,8 @@ def Family(indices, function=None, hidden_keys=[], hidden_function=None, lazy=Fa
         sage: f[5]
         1
     """
-    assert(isinstance(hidden_keys, list))
-    assert(isinstance(lazy, bool))
+    assert isinstance(hidden_keys, list)
+    assert isinstance(lazy, bool)
 
     if not hidden_keys:
         if hidden_function is not None:
@@ -488,13 +488,14 @@ class AbstractFamily(Parent):
             sage: list(h)
             ['a1', 'b2', 'd3']
         """
-        assert(self.keys() == other.keys())
-        assert(self.hidden_keys() == other.hidden_keys())
-        return Family(self.keys(), lambda i: f(self[i],other[i]), hidden_keys=self.hidden_keys(), name=name)
+        assert self.keys() == other.keys()
+        assert self.hidden_keys() == other.hidden_keys()
+        return Family(self.keys(), lambda i: f(self[i], other[i]),
+                      hidden_keys=self.hidden_keys(), name=name)
 
     def map(self, f, name=None):
         r"""
-        Returns the family `( f(\mathtt{self}[i]) )_{i \in I}`, where
+        Return the family `( f(\mathtt{self}[i]) )_{i \in I}`, where
         `I` is the index set of self.
 
         .. TODO:: good name?

--- a/src/sage/stats/distributions/discrete_gaussian_lattice.py
+++ b/src/sage/stats/distributions/discrete_gaussian_lattice.py
@@ -95,7 +95,7 @@ def _iter_vectors(n, lower, upper, step=None):
             raise ValueError("Expected n>0 but got %d <= 0" % n)
         step = n
 
-    assert(step > 0)
+    assert step > 0
     if step == 1:
         for x in range(lower, upper):
             v = vector(ZZ, n)
@@ -470,7 +470,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             b_ = self._G[i]
             c_ = c.dot_product(b_) / b_.dot_product(b_)
             sigma_ = sigma / b_.norm()
-            assert(sigma_ > 0)
+            assert sigma_ > 0
             z = DiscreteGaussianDistributionIntegerSampler(sigma=sigma_, c=c_, algorithm="uniform+online")()
             c = c - z * B[i]
             v = v + z * B[i]

--- a/src/sage/structure/dynamic_class.py
+++ b/src/sage/structure/dynamic_class.py
@@ -322,7 +322,7 @@ def dynamic_class(name, bases, cls=None, reduction=None, doccls=None,
         name = str(name)
     except UnicodeEncodeError:
         pass
-    assert(isinstance(name, str))
+    assert isinstance(name, str)
     #    assert(cls is None or issubtype(type(cls), type) or type(cls) is classobj)
     if cache is True:
         return dynamic_class_internal(name, bases, cls, reduction, doccls, prepend_cls_bases)

--- a/src/sage/tests/benchmark.py
+++ b/src/sage/tests/benchmark.py
@@ -1848,7 +1848,7 @@ def suite1():
 
     Factorial(2*10**6).run(systems=['sage', 'magma'])
     Fibonacci(10**6).run()
-    Fibonacci(2*10^7).run(systems=["sage", "magma", "mathematica"])
+    Fibonacci(2*10**7).run(systems=["sage", "magma", "mathematica"])
 
     MatrixKernel(150,QQ).run()
 
@@ -1861,7 +1861,7 @@ def suite1():
     PolyFactor(700,GF(19))
 
     PolyFactor(500,GF(49,'a'))
-    PolyFactor(100,GF(10007^3,'a'))
+    PolyFactor(100,GF((10007,3),'a'))
 
     CharPolyTp(54,4).run()
     CharPolyTp(389,2).run()

--- a/src/sage/tests/finite_poset.py
+++ b/src/sage/tests/finite_poset.py
@@ -537,9 +537,9 @@ def test_finite_poset(P):
     P_dual = P.dual()
     selfdual_properties = ['chain', 'bounded', 'connected', 'graded', 'ranked', 'series_parallel', 'slender', 'lattice']
     for prop in selfdual_properties:
-        f = attrcall('is_'+prop)
+        f = attrcall('is_' + prop)
         if f(P) != f(P_dual):
-            raise ValueError("error in self-dual property %s" % prop)
+            raise ValueError(f"error in self-dual property {prop}")
     if P.is_graded():
         if P.is_bounded():
             if P.is_eulerian() != P_dual.is_eulerian():
@@ -547,7 +547,7 @@ def test_finite_poset(P):
             if P.is_eulerian():
                 P_ = P.star_product(P)
                 if not P_.is_eulerian():
-                    raise("error in star product / eulerian")
+                    raise ValueError("error in star product / eulerian")
         chain1 = P.random_maximal_chain()
         if len(chain1) != h1:
             raise ValueError("error in is_graded")

--- a/src/sage/topology/simplicial_set.py
+++ b/src/sage/topology/simplicial_set.py
@@ -1859,7 +1859,7 @@ class SimplicialSet_arbitrary(Parent):
                     keep.update([f.nondegenerate() for f in data[underlying]])
                 else:
                     # x is a vertex
-                    assert(underlying.dimension() == 0)
+                    assert underlying.dimension() == 0
                     vertices.add(underlying)
         missing = set(nondegenerate_simplices).difference(keep)
         for x in missing:
@@ -3319,7 +3319,7 @@ class SimplicialSet_finite(SimplicialSet_arbitrary, GenericCellComplex):
         for x in simplices:
             if x not in data:
                 # x had better be a vertex.
-                assert(x.dimension() == 0)
+                assert x.dimension() == 0
                 data[x] = None
 
         # Check the simplicial identity d_i d_j = d_{j-1} d_i.


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

This fixes some E275 warnings (E275 missing whitespace after keyword) plus a few other things

outside of `graphs`, `rings`, `misc`, `coding`  and `combinat` for now

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [ ] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
