### PR TITLE
cython-lint : removed many unused imports in rings/

### DIFF
--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -153,7 +153,6 @@ import sage.categories.fields
 cimport sage.rings.abc
 cimport sage.rings.rational
 
-from cpython.float cimport PyFloat_AS_DOUBLE
 from cpython.int cimport PyInt_AS_LONG
 from cpython.object cimport Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE
 from cpython.complex cimport PyComplex_FromDoubles
@@ -169,13 +168,13 @@ from sage.libs.arb.acb_hypgeom cimport *
 from sage.libs.arb.acb_elliptic cimport *
 from sage.libs.arb.acb_modular cimport *
 from sage.libs.arb.acb_poly cimport *
-from sage.libs.arb.arf cimport arf_init, arf_get_d, arf_get_mpfr, arf_set_mpfr, arf_clear, arf_set_mag, arf_set, arf_is_nan
-from sage.libs.arb.mag cimport (mag_init, mag_clear, mag_add, mag_set_d,
-        MAG_BITS, mag_is_inf, mag_is_finite, mag_zero, mag_set_ui_2exp_si,
+from sage.libs.arb.arf cimport arf_init, arf_get_d, arf_get_mpfr, arf_clear, arf_set, arf_is_nan
+from sage.libs.arb.mag cimport (mag_init, mag_clear, mag_set_d,
+        MAG_BITS, mag_zero, mag_set_ui_2exp_si,
         mag_mul_2exp_si)
-from sage.libs.flint.fmpz cimport fmpz_t, fmpz_init, fmpz_get_mpz, fmpz_set_mpz, fmpz_clear, fmpz_abs
+from sage.libs.flint.fmpz cimport fmpz_t, fmpz_init, fmpz_get_mpz, fmpz_set_mpz, fmpz_clear
 from sage.libs.flint.fmpq cimport fmpq_t, fmpq_init, fmpq_set_mpq, fmpq_clear
-from sage.libs.gmp.mpz cimport mpz_fits_ulong_p, mpz_fits_slong_p, mpz_get_ui, mpz_get_si, mpz_sgn
+from sage.libs.gmp.mpz cimport mpz_fits_slong_p, mpz_get_si
 from sage.libs.gsl.complex cimport gsl_complex_rect
 from sage.rings.real_double cimport RealDoubleElement
 from sage.rings.complex_double cimport ComplexDoubleElement
@@ -186,13 +185,12 @@ from sage.rings.real_arb import RealBallField
 from sage.rings.real_mpfi cimport RealIntervalField_class
 from sage.rings.real_mpfr cimport RealField_class, RealField, RealNumber
 from sage.rings.ring import Field
-from sage.structure.element cimport Element, ModuleElement
+from sage.structure.element cimport Element
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.arith.long cimport is_small_python_int
 
 from sage.misc.lazy_string import lazy_string
 from sage.misc.superseded import deprecated_function_alias
-from sage.rings.complex_mpfr import ComplexField
 from sage.rings.complex_interval_field import ComplexIntervalField, ComplexIntervalField_class
 from sage.rings.integer_ring import ZZ
 

--- a/src/sage/rings/complex_double.pyx
+++ b/src/sage/rings/complex_double.pyx
@@ -68,7 +68,6 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-import operator
 from cpython.object cimport Py_NE
 
 from sage.misc.randstate cimport randstate, current_randstate
@@ -83,7 +82,7 @@ import sage.rings.abc
 cimport sage.rings.ring
 cimport sage.rings.integer
 
-from sage.structure.element cimport RingElement, Element, ModuleElement, FieldElement
+from sage.structure.element cimport Element, FieldElement
 from sage.structure.parent  cimport Parent
 from sage.structure.parent_gens import ParentWithGens
 from sage.structure.richcmp cimport rich_to_bool

--- a/src/sage/rings/complex_interval.pyx
+++ b/src/sage/rings/complex_interval.pyx
@@ -64,13 +64,12 @@ from sage.libs.flint.fmpz cimport *
 from sage.libs.mpfr cimport MPFR_RNDU, MPFR_RNDD
 from sage.arith.constants cimport LOG_TEN_TWO_PLUS_EPSILON
 
-from sage.structure.element cimport FieldElement, RingElement, Element, ModuleElement
+from sage.structure.element cimport FieldElement
 from sage.structure.parent cimport Parent
 from .complex_mpfr cimport ComplexNumber
-from .complex_mpfr import ComplexField
 from sage.rings.integer cimport Integer
 cimport sage.rings.real_mpfi as real_mpfi
-from .real_mpfr cimport RealNumber, RealField
+from .real_mpfr cimport RealNumber
 from .convert.mpfi cimport mpfi_set_sage
 from .infinity import infinity
 
@@ -90,7 +89,7 @@ def is_ComplexIntervalFieldElement(x):
     return isinstance(x, ComplexIntervalFieldElement)
 
 
-cdef class ComplexIntervalFieldElement(sage.structure.element.FieldElement):
+cdef class ComplexIntervalFieldElement(FieldElement):
     """
     A complex interval.
 

--- a/src/sage/rings/complex_mpc.pyx
+++ b/src/sage/rings/complex_mpc.pyx
@@ -69,7 +69,7 @@ from sage.libs.mpfr cimport *
 from sage.libs.mpc cimport *
 from sage.structure.parent cimport Parent
 from sage.structure.parent_gens cimport ParentWithGens
-from sage.structure.element cimport RingElement, Element, ModuleElement
+from sage.structure.element cimport Element
 from sage.structure.richcmp cimport rich_to_bool
 from sage.categories.map cimport Map
 from sage.libs.pari.all import pari
@@ -2578,5 +2578,5 @@ cdef class CCtoMPC(Map):
 
 
 # Support Python's numbers abstract base class
-import numbers
+# import numbers
 from sage.rings.complex_mpc import MPComplexNumber

--- a/src/sage/rings/complex_mpfr.pyx
+++ b/src/sage/rings/complex_mpfr.pyx
@@ -30,15 +30,13 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-import math
-import operator
 import weakref
 
 import sage.misc.misc
 
 from sage.libs.mpfr cimport *
 
-from sage.structure.element cimport FieldElement, RingElement, Element, ModuleElement
+from sage.structure.element cimport RingElement, Element
 from sage.structure.richcmp cimport rich_to_bool
 from sage.categories.map cimport Map
 from sage.structure.parent import Parent
@@ -48,7 +46,7 @@ from sage.misc.sage_eval import sage_eval
 
 import sage.rings.abc
 from sage.arith.constants cimport LOG_TEN_TWO_PLUS_EPSILON
-from . import ring, infinity
+from . import infinity
 from .integer cimport Integer
 
 from .complex_double cimport ComplexDoubleElement

--- a/src/sage/rings/factorint.pyx
+++ b/src/sage/rings/factorint.pyx
@@ -8,7 +8,7 @@ AUTHORS:
 
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2010-2011 André Apitzsch <andre.apitzsch@st.ovgu.de>
 #                     2012      Nils Bruin
 #                     2014      David Roe
@@ -17,16 +17,14 @@ AUTHORS:
 #  Distributed under the terms of the GNU General Public License (GPL)
 #  as published by the Free Software Foundation; either version 2 of
 #  the License, or (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.ext.stdsage cimport PY_NEW
 from sage.libs.gmp.mpz cimport *
 
 from sage.rings.integer cimport Integer
-from sage.rings.fast_arith import prime_range
 from sage.structure.factorization_integer import IntegerFactorization
-from math import floor
 from sage.misc.misc_c import prod
 
 cdef extern from "limits.h":

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -505,7 +505,6 @@ cdef class FinitePolyExtElement(FiniteRingElement):
         """
         if var is None:
             var = self.parent().variable_name()
-        from sage.libs.pari.all import pari
         ffgen = self._parent.modulus()._pari_with_name(var).ffgen()
         polypari = self.polynomial()._pari_with_name()
         # Add ffgen - ffgen to ensure that we really get an FFELT

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -56,22 +56,15 @@ from cysignals.signals cimport sig_on, sig_off
 
 from cypari2.paridecl cimport *
 
-from sage.misc.randstate cimport randstate, current_randstate
-from sage.rings.finite_rings.finite_field_base cimport FiniteField
-from sage.rings.ring cimport Ring
+from sage.misc.randstate cimport current_randstate
 from .element_pari_ffelt cimport FiniteFieldElement_pari_ffelt
 from sage.structure.richcmp cimport richcmp
-from sage.structure.element cimport Element, ModuleElement, RingElement
-import operator
 import sage.arith.all
-import sage.rings.finite_rings.finite_field_constructor as finite_field
 
-from sage.libs.pari.all import pari
 from cypari2.gen cimport Gen
 from cypari2.stack cimport clear_stack
 
 from sage.structure.parent cimport Parent
-
 
 from sage.interfaces.abc import GapElement
 
@@ -1579,7 +1572,6 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
         """
         # TODO -- I'm sure this can be made vastly faster
         # using how elements are represented as a power of the generator ??
-        import sage.arith.all
 
         if self._multiplicative_order is not None:
             return self._multiplicative_order

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -34,11 +34,8 @@ from cypari2.paridecl cimport *
 
 from sage.structure.richcmp cimport (richcmp,
                                      richcmp_not_equal, rich_to_bool)
-from sage.structure.element cimport Element, ModuleElement, RingElement
 
 from sage.structure.parent cimport Parent
-
-from sage.rings.ring cimport Ring
 
 from sage.rings.finite_rings.finite_field_base cimport FiniteField
 
@@ -46,13 +43,8 @@ from sage.libs.pari.all import pari
 from cypari2.gen cimport Gen
 from cypari2.stack cimport clear_stack
 
-from sage.misc.randstate import current_randstate
-from sage.arith.long cimport pyobject_to_long
-
 from .element_pari_ffelt import FiniteFieldElement_pari_ffelt
 from .finite_field_ntl_gf2e import FiniteField_ntl_gf2e
-
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 
 from sage.interfaces.abc import GapElement
 

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -16,7 +16,6 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from cysignals.memory cimport sig_free
 from cysignals.signals cimport sig_on, sig_off
 
 from cypari2.paridecl cimport *
@@ -34,7 +33,6 @@ from sage.rings.integer cimport Integer
 from sage.rings.polynomial.polynomial_element import Polynomial
 from sage.rings.polynomial.multi_polynomial_element import MPolynomial
 from sage.rings.rational import Rational
-from sage.structure.element cimport Element, ModuleElement, RingElement
 from sage.structure.richcmp cimport rich_to_bool
 
 

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -1283,13 +1283,12 @@ cdef class FiniteField(Field):
         else:
             raise ValueError("{} is not a subfield".format(base))
 
-        if map is False: # shortcut
+        if map is False:  # shortcut
             return V
 
         if inclusion_map is None:
             inclusion_map = self.coerce_map_from(base)
 
-        from sage.modules.free_module_element import vector
         from sage.matrix.constructor import matrix
         from .maps_finite_field import (
             MorphismVectorSpaceToFiniteField, MorphismFiniteFieldToVectorSpace)

--- a/src/sage/rings/finite_rings/hom_finite_field_givaro.pyx
+++ b/src/sage/rings/finite_rings/hom_finite_field_givaro.pyx
@@ -22,13 +22,13 @@ AUTHOR:
 - Xavier Caruso (2012-06-29)
 """
 
-#############################################################################
+# ###########################################################################
 #    Copyright (C) 2012 Xavier Caruso <xavier.caruso@normalesup.org>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #
-#                  http://www.gnu.org/licenses/
-#****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ***************************************************************************
 
 
 from sage.rings.finite_rings.finite_field_constructor import FiniteField
@@ -41,7 +41,6 @@ from .hom_prime_finite_field cimport FiniteFieldHomomorphism_prime
 
 from sage.categories.homset import Hom
 from sage.structure.element cimport Element
-from sage.rings.morphism cimport RingHomomorphism_im_gens
 
 from sage.rings.finite_rings.finite_field_givaro import FiniteField_givaro
 from .element_givaro cimport FiniteField_givaroElement

--- a/src/sage/rings/finite_rings/hom_prime_finite_field.pyx
+++ b/src/sage/rings/finite_rings/hom_prime_finite_field.pyx
@@ -24,8 +24,6 @@ AUTHOR:
 #                  http://www.gnu.org/licenses/
 #****************************************************************************
 
-from sage.rings.integer cimport Integer
-
 from sage.categories.homset import Hom
 from sage.structure.element cimport Element
 
@@ -34,7 +32,6 @@ from .hom_finite_field cimport FiniteFieldHomomorphism_generic
 from .hom_finite_field cimport FrobeniusEndomorphism_finite_field
 
 from sage.rings.finite_rings.finite_field_base import FiniteField
-from sage.rings.morphism cimport RingHomomorphism_im_gens
 
 
 cdef class SectionFiniteFieldHomomorphism_prime(SectionFiniteFieldHomomorphism_generic):

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -78,13 +78,11 @@ from libc.math cimport log2, ceil
 
 from sage.libs.gmp.all cimport *
 
-import operator
-
 cdef bint use_32bit_type(int_fast64_t modulus):
     return modulus <= INTEGER_MOD_INT32_LIMIT
 
 from sage.arith.long cimport (
-    integer_check_long, integer_check_long_py, is_small_python_int, ERR_OVERFLOW)
+    integer_check_long, integer_check_long_py, is_small_python_int)
 
 import sage.rings.rational as rational
 from sage.libs.pari.all import pari, PariError
@@ -100,7 +98,7 @@ from sage.structure.richcmp cimport rich_to_bool_sgn, rich_to_bool
 import sage.structure.element
 cimport sage.structure.element
 coerce_binop = sage.structure.element.coerce_binop
-from sage.structure.element cimport RingElement, ModuleElement, Element
+from sage.structure.element cimport Element
 from sage.categories.morphism cimport Morphism
 from sage.categories.map cimport Map
 

--- a/src/sage/rings/finite_rings/residue_field.pyx
+++ b/src/sage/rings/finite_rings/residue_field.pyx
@@ -160,7 +160,7 @@ And now over a large prime field::
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
 
@@ -168,9 +168,7 @@ from sage.rings.ring cimport Field
 from sage.rings.integer cimport Integer
 from sage.rings.rational cimport Rational
 from sage.categories.homset import Hom
-from sage.categories.basic import Fields, Rings
 from sage.categories.pushout import AlgebraicExtensionFunctor
-from sage.rings.finite_rings.integer_mod_ring import Integers
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from sage.rings.finite_rings.finite_field_constructor import zech_log_bound, FiniteField as GF

--- a/src/sage/rings/fraction_field_FpT.pyx
+++ b/src/sage/rings/fraction_field_FpT.pyx
@@ -6,23 +6,19 @@
 # distutils: language = c++
 "Univariate rational functions over prime fields"
 
-import sys
-
 from cysignals.signals cimport sig_on, sig_off
 
 from sage.rings.finite_rings.stdint cimport INTEGER_MOD_INT32_LIMIT
 
 from sage.libs.gmp.mpz cimport *
-from sage.rings.finite_rings.finite_field_constructor import GF
 from sage.libs.flint.nmod_poly cimport *
 from sage.libs.flint.ulong_extras cimport n_jacobi
-from sage.structure.element cimport Element, ModuleElement, FieldElement
+from sage.structure.element cimport Element, FieldElement
 from sage.rings.integer_ring import ZZ
-from sage.rings.fraction_field import FractionField_generic, FractionField_1poly_field
+from sage.rings.fraction_field import FractionField_1poly_field
 from sage.rings.finite_rings.integer_mod cimport IntegerMod_int
 from sage.rings.integer cimport Integer
 from sage.rings.polynomial.polynomial_zmod_flint cimport Polynomial_zmod_flint, get_cparent
-import sage.algebras.algebra
 
 from sage.structure.richcmp cimport rich_to_bool
 from sage.rings.finite_rings.integer_mod cimport mod_inverse_int

--- a/src/sage/rings/fraction_field_element.pyx
+++ b/src/sage/rings/fraction_field_element.pyx
@@ -9,22 +9,19 @@ AUTHORS:
   derivative to use Henrici's algorithms [Hor1972]_
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2005 William Stein <wstein@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.structure.element cimport FieldElement, parent
 from sage.structure.richcmp cimport richcmp
-# from sage.rings.polynomial.flatten import SpecializationMorphism
 
-from . import integer_ring
-from .integer_ring import ZZ
 from .rational_field import QQ
 
 import sage.misc.latex as latex

--- a/src/sage/rings/function_field/element.pyx
+++ b/src/sage/rings/function_field/element.pyx
@@ -65,7 +65,7 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.structure.element cimport FieldElement, RingElement, ModuleElement, Element
+from sage.structure.element cimport FieldElement
 from sage.misc.cachefunc import cached_method
 
 

--- a/src/sage/rings/function_field/element_polymod.pyx
+++ b/src/sage/rings/function_field/element_polymod.pyx
@@ -3,18 +3,17 @@ r"""
 Elements of function fields: extension
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2023 Kwankyu Lee <ekwankyu@gmail.com>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #  as published by the Free Software Foundation; either version 2 of
 #  the License, or (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
-from sage.misc.cachefunc import cached_method
 from sage.structure.richcmp cimport richcmp
-from sage.structure.element cimport FieldElement, RingElement, ModuleElement, Element
+from sage.structure.element cimport FieldElement
 
 from sage.rings.function_field.element cimport FunctionFieldElement
 

--- a/src/sage/rings/function_field/element_rational.pyx
+++ b/src/sage/rings/function_field/element_rational.pyx
@@ -2,18 +2,17 @@ r"""
 Elements of function fields: rational
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2023 Kwankyu Lee <ekwankyu@gmail.com>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #  as published by the Free Software Foundation; either version 2 of
 #  the License, or (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
-from sage.misc.cachefunc import cached_method
 from sage.structure.richcmp cimport richcmp, richcmp_not_equal
-from sage.structure.element cimport FieldElement, RingElement, ModuleElement, Element
+from sage.structure.element cimport FieldElement
 
 from sage.rings.function_field.element cimport FunctionFieldElement
 

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -143,8 +143,7 @@ AUTHORS:
 # creation and deletion are setup by the call to hook_fast_tp_functions
 
 cimport cython
-from libc.math cimport (ldexp, sqrt as sqrt_double, log as log_c,
-        ceil as ceil_c, isnan)
+from libc.math cimport (ldexp, sqrt as sqrt_double, isnan)
 from libc.string cimport memcpy
 from libc.limits cimport LONG_MAX
 
@@ -152,7 +151,6 @@ from cysignals.memory cimport check_allocarray, check_malloc, sig_free
 from cysignals.signals cimport sig_on, sig_off, sig_check, sig_occurred
 
 import operator
-import sys
 
 from sage.ext.stdsage cimport PY_NEW
 from sage.cpython.python_debug cimport if_Py_TRACE_REFS_then_PyObject_INIT
@@ -160,7 +158,7 @@ from sage.cpython.python_debug cimport if_Py_TRACE_REFS_then_PyObject_INIT
 from sage.libs.gmp.mpz cimport *
 from sage.libs.gmp.mpq cimport *
 from sage.cpython.string cimport char_to_str, str_to_bytes
-from sage.arith.long cimport (pyobject_to_long, integer_check_long,
+from sage.arith.long cimport (integer_check_long,
                               integer_check_long_py, is_small_python_int)
 
 from cpython.list cimport *
@@ -170,13 +168,11 @@ from cpython.object cimport *
 from libc.stdint cimport uint64_t
 cimport sage.structure.element
 from sage.structure.coerce cimport coercion_model
-from sage.structure.element cimport (Element, EuclideanDomainElement,
-        parent)
+from sage.structure.element cimport (Element, parent)
 from sage.structure.parent cimport Parent
 from sage.rings.rational cimport Rational
 from sage.arith.rational_reconstruction cimport mpq_rational_reconstruction
 from sage.libs.gmp.pylong cimport *
-from sage.libs.gmp.mpq cimport mpq_neg
 from sage.libs.gmp.binop cimport mpq_add_z, mpq_mul_z, mpq_div_zz
 
 import sage.rings.infinity

--- a/src/sage/rings/integer_ring.pyx
+++ b/src/sage/rings/integer_ring.pyx
@@ -63,13 +63,11 @@ from sage.structure.coerce cimport is_numpy_type
 from sage.structure.element cimport parent
 from sage.structure.parent_gens import ParentWithGens
 from sage.structure.richcmp cimport rich_to_bool
-from sage.structure.sequence import Sequence
 
 from sage.misc.misc_c import prod
 from sage.misc.randstate cimport randstate, current_randstate, SAGE_RAND_MAX
 
 cimport sage.rings.integer as integer
-cimport sage.rings.rational as rational
 
 from . import ring
 

--- a/src/sage/rings/laurent_series_ring_element.pyx
+++ b/src/sage/rings/laurent_series_ring_element.pyx
@@ -51,7 +51,7 @@ AUTHORS:
 
 - Robert Bradshaw: Cython version
 """
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2005 William Stein <wstein@gmail.com>
 #                     2017 Vincent Delecroix <20100.delecroix@gmail.com>
 #
@@ -64,19 +64,16 @@ AUTHORS:
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from .infinity import infinity
 
-from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
-import sage.rings.polynomial.polynomial_element as polynomial
 import sage.misc.latex
-from sage.rings.integer import Integer
 from sage.rings.polynomial.laurent_polynomial import LaurentPolynomial_univariate
 from .power_series_ring_element cimport PowerSeries
-from sage.structure.element cimport Element, ModuleElement, RingElement, AlgebraElement
+from sage.structure.element cimport Element, AlgebraElement
 from sage.structure.richcmp cimport richcmp_not_equal, rich_to_bool
 from sage.misc.derivative import multi_derivative
 

--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -397,8 +397,6 @@ compare equal::
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from cpython.object cimport Py_EQ, Py_NE
-
 from . import ideal
 import sage.structure.all
 from sage.structure.richcmp cimport (richcmp, rich_to_bool)

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -45,7 +45,7 @@ include "sage/libs/ntl/decl.pxi"
 
 from sage.libs.gmp.mpz cimport *
 from sage.libs.gmp.mpq cimport *
-from sage.libs.mpfi cimport mpfi_t, mpfi_init, mpfi_set, mpfi_clear, mpfi_div_z, mpfi_init2, mpfi_get_prec, mpfi_set_prec
+from sage.libs.mpfi cimport mpfi_t, mpfi_clear, mpfi_div_z, mpfi_init2, mpfi_get_prec, mpfi_set_prec
 from sage.libs.mpfr cimport mpfr_equal_p, mpfr_less_p, mpfr_greater_p, mpfr_greaterequal_p, mpfr_floor, mpfr_get_z, MPFR_RNDN
 from sage.libs.ntl.error import NTLError
 from sage.libs.ntl.convert cimport mpz_to_ZZ
@@ -67,12 +67,10 @@ from sage.rings.real_mpfi cimport RealIntervalFieldElement
 
 cimport sage.rings.number_field.number_field_base as number_field_base
 
-from sage.rings.integer_ring cimport IntegerRing_class
 from sage.rings.rational cimport Rational
 from sage.rings.infinity import infinity
 from sage.categories.fields import Fields
 from sage.misc.superseded import deprecation
-from sage.modules.free_module_element import vector
 
 from sage.structure.element cimport Element, FieldElement
 from sage.structure.element cimport parent
@@ -2997,7 +2995,6 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             from sage.functions.log import exp
             from sage.rings.complex_mpfr import ComplexField
             from sage.rings.imaginary_unit import I
-            from sage.rings.real_mpfr import RR
             from sage.symbolic.constants import pi
             CC = ComplexField(53)
             two_pi_i = 2 * pi * I

--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -56,8 +56,6 @@ from sage.structure.richcmp cimport rich_to_bool_sgn
 from sage.rings.rational cimport Rational
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
-from sage.rings.real_double import RDF
-from sage.rings.complex_double import CDF
 from sage.categories.morphism cimport Morphism
 from sage.rings.number_field.number_field_element import _inverse_mod_generic
 from sage.rings.real_mpfi cimport RealIntervalField_class

--- a/src/sage/rings/number_field/number_field_morphisms.pyx
+++ b/src/sage/rings/number_field/number_field_morphisms.pyx
@@ -26,8 +26,6 @@ from sage.categories.morphism cimport Morphism
 from sage.categories.map cimport Map
 from sage.categories.pushout import pushout
 
-from sage.rings.real_mpfr import RealField, mpfr_prec_min
-from sage.rings.complex_mpfr import ComplexField
 from sage.rings.real_lazy import RLF, CLF, LazyField, LazyAlgebraic
 
 

--- a/src/sage/rings/number_field/totallyreal.pyx
+++ b/src/sage/rings/number_field/totallyreal.pyx
@@ -82,15 +82,15 @@ Authors
 ------
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2007 William Stein and John Voight
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from cysignals.memory cimport check_calloc, sig_free
 
@@ -105,10 +105,8 @@ from sage.libs.pari.misc cimport new_t_POL_from_int_star
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.integer import Integer
 from sage.rings.integer cimport Integer
-from sage.rings.integer_ring import IntegerRing
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
-from sage.misc.misc import cputime
 
 from sage.rings.number_field.totallyreal_data import tr_data, int_has_small_square_divisor
 from sage.rings.number_field.totallyreal_data cimport tr_data

--- a/src/sage/rings/number_field/totallyreal_data.pyx
+++ b/src/sage/rings/number_field/totallyreal_data.pyx
@@ -30,9 +30,7 @@ from cysignals.memory cimport sig_malloc, sig_free
 from sage.arith.misc import binomial
 from sage.arith.misc import GCD as gcd
 from sage.libs.gmp.mpz cimport *
-from sage.rings.rational_field import RationalField
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.real_mpfi import RealIntervalField
 from sage.rings.real_mpfr import RealField
 from sage.rings.integer_ring import ZZ
 from sage.rings.integer cimport Integer

--- a/src/sage/rings/power_series_mpoly.pyx
+++ b/src/sage/rings/power_series_mpoly.pyx
@@ -1,13 +1,11 @@
 # NOT ready to be used -- possibly should be deleted.
 
 from .power_series_ring_element cimport PowerSeries
-from sage.structure.element cimport Element, ModuleElement, RingElement
-from .infinity import infinity, is_Infinite
-from sage.libs.pari.all import PariError
-from .power_series_ring_element import is_PowerSeries
-from . import rational_field
+from sage.structure.element cimport Element
+from .infinity import infinity
 from .polynomial.multi_polynomial_ring_base import is_MPolynomialRing
 from . import power_series_poly
+
 
 cdef class PowerSeries_mpoly(PowerSeries):
 

--- a/src/sage/rings/power_series_poly.pyx
+++ b/src/sage/rings/power_series_poly.pyx
@@ -5,8 +5,8 @@ Power Series Methods
 The class ``PowerSeries_poly`` provides additional methods for univariate power series.
 """
 from .power_series_ring_element cimport PowerSeries
-from sage.structure.element cimport Element, ModuleElement, RingElement
-from .infinity import infinity, is_Infinite
+from sage.structure.element cimport Element
+from .infinity import infinity
 from sage.libs.pari.all import pari_gen, PariError
 
 
@@ -1221,9 +1221,7 @@ cdef class PowerSeries_poly(PowerSeries):
             Order(x^20)
         """
         from sage.symbolic.ring import SR
-        from sage.rings.infinity import PlusInfinity
-        poly = self.polynomial()
-        pex = SR(poly)
+        pex = SR(self.polynomial())
         var = SR.var(self.variable())
         return pex.series(var, self.prec())
 

--- a/src/sage/rings/power_series_ring_element.pyx
+++ b/src/sage/rings/power_series_ring_element.pyx
@@ -95,8 +95,6 @@ With power series the behavior is the same.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-import operator
-
 from cpython.object cimport Py_EQ, Py_NE
 from .infinity import infinity, is_Infinite
 
@@ -107,11 +105,8 @@ import sage.rings.polynomial.polynomial_element
 import sage.misc.misc
 import sage.arith.all as arith
 import sage.misc.latex
-from . import rational_field
-from . import integer_ring
 from .integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import IntegerModRing
-from warnings import warn
 
 from sage.categories.fields import Fields
 _Fields = Fields()
@@ -120,7 +115,7 @@ from sage.misc.derivative import multi_derivative
 
 Polynomial = sage.rings.polynomial.polynomial_element.Polynomial_generic_dense
 
-from sage.structure.element cimport AlgebraElement, RingElement, ModuleElement, Element
+from sage.structure.element cimport AlgebraElement, RingElement
 from sage.structure.richcmp cimport richcmp
 
 

--- a/src/sage/rings/puiseux_series_ring_element.pyx
+++ b/src/sage/rings/puiseux_series_ring_element.pyx
@@ -104,17 +104,12 @@ REFERENCES:
 
 from sage.arith.functions import lcm
 from sage.arith.misc import gcd
-from sage.ext.fast_callable import fast_callable
-from sage.rings.big_oh import O
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from sage.rings.complex_mpfr import ComplexField
 from sage.rings.infinity import infinity
 from sage.rings.laurent_series_ring_element cimport LaurentSeries
-from sage.rings.laurent_series_ring import LaurentSeriesRing
-from sage.rings.power_series_ring_element cimport PowerSeries
-from sage.structure.element cimport (Element, ModuleElement,
-                                     RingElement, AlgebraElement)
+from sage.structure.element cimport (Element, AlgebraElement)
 from sage.structure.richcmp cimport richcmp
 
 

--- a/src/sage/rings/rational.pyx
+++ b/src/sage/rings/rational.pyx
@@ -65,11 +65,9 @@ from cysignals.signals cimport sig_on, sig_off
 import operator
 import fractions
 
-from sage.arith.long cimport pyobject_to_long, integer_check_long_py
+from sage.arith.long cimport integer_check_long_py
 from sage.cpython.string cimport char_to_str, str_to_bytes
 
-import sage.misc.misc as misc
-from sage.structure.sage_object cimport SageObject
 from sage.structure.richcmp cimport rich_to_bool_sgn
 import sage.rings.rational_field
 
@@ -77,7 +75,6 @@ cimport sage.rings.integer as integer
 from .integer cimport Integer
 
 from .integer_ring import ZZ
-from sage.arith.rational_reconstruction cimport mpq_rational_reconstruction
 
 from sage.structure.coerce cimport is_numpy_type
 
@@ -85,11 +82,9 @@ from sage.libs.gmp.pylong cimport mpz_set_pylong
 
 from sage.structure.coerce cimport coercion_model
 from sage.structure.element cimport Element
-from sage.structure.element import coerce_binop
 from sage.structure.parent cimport Parent
 from sage.categories.morphism cimport Morphism
 from sage.categories.map cimport Map
-
 
 
 import sage.rings.real_mpfr

--- a/src/sage/rings/real_arb.pyx
+++ b/src/sage/rings/real_arb.pyx
@@ -217,12 +217,11 @@ from sage.libs.mpfi cimport *
 from sage.libs.mpfr cimport *
 from sage.libs.mpfr cimport MPFR_RNDN, MPFR_RNDU, MPFR_RNDD, MPFR_RNDZ
 
-from sage.structure.element cimport Element, ModuleElement, RingElement
+from sage.structure.element cimport Element, RingElement
 from sage.rings.ring cimport Field
 import sage.rings.abc
 from sage.rings.integer cimport Integer
 from sage.rings.rational cimport Rational
-from sage.rings.real_double cimport RealDoubleElement
 from sage.rings.real_mpfr cimport RealField_class, RealField, RealNumber
 from sage.arith.long cimport is_small_python_int
 

--- a/src/sage/rings/real_double.pyx
+++ b/src/sage/rings/real_double.pyx
@@ -45,13 +45,10 @@ from libc.string cimport memcpy
 from cpython.object cimport *
 from cpython.float cimport *
 
-from cysignals.signals cimport sig_on, sig_off
-
 from sage.ext.stdsage cimport PY_NEW
 from sage.cpython.python_debug cimport if_Py_TRACE_REFS_then_PyObject_INIT
 
 import math
-import operator
 
 import sage.rings.integer
 import sage.rings.rational

--- a/src/sage/rings/real_interval_absolute.pyx
+++ b/src/sage/rings/real_interval_absolute.pyx
@@ -7,7 +7,7 @@ from sage.ext.stdsage cimport PY_NEW
 from sage.libs.gmp.mpz cimport *
 
 from sage.structure.factory import UniqueFactory
-from sage.structure.element cimport RingElement, ModuleElement, Element, FieldElement
+from sage.structure.element cimport Element, FieldElement
 from sage.rings.ring cimport Field
 from sage.rings.integer cimport Integer
 import sage.rings.abc

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -264,7 +264,7 @@ from sage.libs.mpfi cimport *
 from sage.arith.constants cimport LOG_TEN_TWO_PLUS_EPSILON
 
 cimport sage.structure.element
-from sage.structure.element cimport RingElement, Element, ModuleElement
+from sage.structure.element cimport RingElement, Element
 from sage.structure.element cimport have_same_parent
 from sage.structure.parent cimport Parent
 from sage.structure.richcmp cimport richcmp
@@ -272,14 +272,10 @@ from sage.structure.richcmp cimport richcmp
 from .convert.mpfi cimport mpfi_set_sage
 from .real_mpfr cimport RealField_class, RealNumber, RealField
 from .integer cimport Integer
-from .real_double cimport RealDoubleElement
-from .real_double import RDF
 from .integer_ring import ZZ
 from .rational_field import QQ
-from sage.categories.morphism cimport Map
 
 cimport sage.rings.abc
-cimport sage.rings.real_mpfr as real_mpfr
 
 import math  # for log
 import sys
@@ -2935,8 +2931,9 @@ cdef class RealIntervalFieldElement(RingElement):
 
     def __rshift__(x, y):
         """
-        Returns `x / 2^y`, for `y` an integer. Much faster
-        than an ordinary division.
+        Return `x / 2^y`, for `y` an integer.
+
+        Much faster than an ordinary division.
 
         EXAMPLES::
 

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -132,9 +132,9 @@ from sage.misc.randstate cimport randstate, current_randstate
 from sage.cpython.string cimport char_to_str, str_to_bytes
 from sage.misc.superseded import deprecation_cython as deprecation
 
-from sage.structure.element cimport RingElement, Element, ModuleElement
+from sage.structure.element cimport Element
 from sage.structure.element cimport have_same_parent
-from sage.structure.richcmp cimport rich_to_bool_sgn, rich_to_bool
+from sage.structure.richcmp cimport rich_to_bool_sgn
 cdef bin_op
 from sage.structure.element import bin_op
 

--- a/src/sage/rings/ring_extension.pyx
+++ b/src/sage/rings/ring_extension.pyx
@@ -100,15 +100,15 @@ AUTHOR:
 - Xavier Caruso (2019)
 """
 
-#############################################################################
+# ###########################################################################
 #    Copyright (C) 2019 Xavier Caruso <xavier.caruso@normalesup.org>
 #
 #    This program is free softwGare: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 2 of the License, or
 #    (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ***************************************************************************
 
 
 from sage.misc.fast_methods cimport hash_by_id
@@ -122,7 +122,6 @@ from sage.structure.element cimport Element
 from sage.structure.category_object import normalize_names
 from sage.categories.map cimport Map
 from sage.categories.commutative_rings import CommutativeRings
-from sage.categories.commutative_algebras import CommutativeAlgebras
 from sage.categories.fields import Fields
 from sage.rings.ring cimport CommutativeRing, CommutativeAlgebra
 from sage.rings.integer_ring import ZZ

--- a/src/sage/rings/ring_extension_element.pyx
+++ b/src/sage/rings/ring_extension_element.pyx
@@ -6,26 +6,24 @@ AUTHOR:
 - Xavier Caruso (2019)
 """
 
-#############################################################################
+# ###########################################################################
 #    Copyright (C) 2019 Xavier Caruso <xavier.caruso@normalesup.org>
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 2 of the License, or
 #    (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ***************************************************************************
 
 
 from sage.ext.stdsage cimport PY_NEW
-from sage.misc.cachefunc import cached_method
 from sage.cpython.getattr cimport AttributeErrorMessage
 from sage.cpython.getattr import dir_with_other_class
 from sage.misc.latex import latex
 
 from sage.structure.category_object import normalize_names
 from sage.structure.element cimport CommutativeAlgebraElement
-from sage.structure.element cimport Element
 from sage.rings.integer_ring import ZZ
 from sage.categories.fields import Fields
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/src/sage/rings/semirings/tropical_semiring.pyx
+++ b/src/sage/rings/semirings/tropical_semiring.pyx
@@ -5,7 +5,7 @@ AUTHORS:
 
 - Travis Scrimshaw (2013-04-28) - Initial version
 """
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2013 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -17,8 +17,8 @@ AUTHORS:
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.misc.cachefunc import cached_method
 from sage.structure.parent import Parent
@@ -27,10 +27,8 @@ from sage.structure.element cimport Element, ModuleElement
 from sage.structure.richcmp cimport rich_to_bool
 from sage.categories.semirings import Semirings
 from sage.categories.map cimport Map
-from sage.sets.family import Family
 from sage.rings.integer_ring import ZZ
 
-import operator
 
 cdef class TropicalSemiringElement(Element):
     r"""

--- a/src/sage/rings/tate_algebra_element.pyx
+++ b/src/sage/rings/tate_algebra_element.pyx
@@ -20,14 +20,13 @@ AUTHOR:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from cpython.object cimport Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE
+from cpython.object cimport Py_EQ, Py_NE
 from sage.structure.richcmp cimport rich_to_bool_sgn
 from sage.structure.element import coerce_binop
 
 from sage.structure.element cimport Element
 from sage.structure.element cimport MonoidElement
 from sage.structure.element cimport CommutativeAlgebraElement
-from sage.structure.sequence import Sequence
 
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
@@ -258,9 +257,7 @@ cdef class TateAlgebraTerm(MonoidElement):
             ...00000000010*x*y
             sage: T(2*x*y)._latex_()
             '...00000000010xy'
-
         """
-        from sage.misc.latex import latex
         parent = self._parent
         s = ""
         if self._coeff._is_atomic() or (-self._coeff)._is_atomic():
@@ -1255,9 +1252,7 @@ cdef class TateAlgebraElement(CommutativeAlgebraElement):
             ...0000000001*x^3 + ...0000000001*x + ...00000000010*x^2
             sage: f._latex_()
             '...0000000001x^{3} + ...0000000001x + ...00000000010x^{2}'
-
         """
-        from sage.misc.latex import latex
         base = self._parent.base_ring()
         nvars = self._parent.ngens()
         vars = self._parent.variable_names()

--- a/src/sage/rings/tate_algebra_ideal.pyx
+++ b/src/sage/rings/tate_algebra_ideal.pyx
@@ -20,15 +20,13 @@ AUTHORS:
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 2 of the License, or
 #    (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
 from sage.rings.ideal import Ideal_generic
-from sage.misc.cachefunc import cached_method
 
 from sage.structure.richcmp import op_EQ, op_NE, op_LT, op_GT, op_LE, op_GE
 
-from sage.structure.element cimport Element
 from sage.rings.polynomial.polydict cimport PolyDict
 
 from sage.rings.tate_algebra_element cimport TateAlgebraTerm


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

using cython-lint, remove many unused imports in `rings`, outside of `polynomials` and `padics`

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
