### PR TITLE
Correct spelling in permgroup_named: Diyclic => Dicyclic

### DIFF
--- a/src/sage/algebras/fusion_rings/fusion_double.py
+++ b/src/sage/algebras/fusion_rings/fusion_double.py
@@ -711,7 +711,7 @@ class FusionDouble(CombinatorialFreeModule):
         EXAMPLES::
 
             sage: FusionDouble(DiCyclicGroup(4)).group()
-            Diyclic group of order 16 as a permutation group
+            DiCyclic group of order 16 as a permutation group
         """
         return self._G
 

--- a/src/sage/algebras/fusion_rings/fusion_double.py
+++ b/src/sage/algebras/fusion_rings/fusion_double.py
@@ -711,7 +711,7 @@ class FusionDouble(CombinatorialFreeModule):
         EXAMPLES::
 
             sage: FusionDouble(DiCyclicGroup(4)).group()
-            DiCyclic group of order 16 as a permutation group
+            Dicyclic group of order 16 as a permutation group
         """
         return self._G
 

--- a/src/sage/groups/perm_gps/permgroup_named.py
+++ b/src/sage/groups/perm_gps/permgroup_named.py
@@ -920,7 +920,7 @@ class DiCyclicGroup(PermutationGroup_unique):
     TESTS::
 
         sage: groups.permutation.DiCyclic(6)
-        Diyclic group of order 24 as a permutation group
+        DiCyclic group of order 24 as a permutation group
 
     AUTHOR:
 
@@ -976,9 +976,9 @@ class DiCyclicGroup(PermutationGroup_unique):
         EXAMPLES::
 
             sage: DiCyclicGroup(12)
-            Diyclic group of order 48 as a permutation group
+            DiCyclic group of order 48 as a permutation group
         """
-        return "Diyclic group of order %s as a permutation group"%self.order()
+        return "DiCyclic group of order %s as a permutation group"%self.order()
 
     def is_commutative(self):
         r"""

--- a/src/sage/groups/perm_gps/permgroup_named.py
+++ b/src/sage/groups/perm_gps/permgroup_named.py
@@ -920,7 +920,7 @@ class DiCyclicGroup(PermutationGroup_unique):
     TESTS::
 
         sage: groups.permutation.DiCyclic(6)
-        DiCyclic group of order 24 as a permutation group
+        Dicyclic group of order 24 as a permutation group
 
     AUTHOR:
 
@@ -976,9 +976,9 @@ class DiCyclicGroup(PermutationGroup_unique):
         EXAMPLES::
 
             sage: DiCyclicGroup(12)
-            DiCyclic group of order 48 as a permutation group
+            Dicyclic group of order 48 as a permutation group
         """
-        return "DiCyclic group of order %s as a permutation group"%self.order()
+        return "Dicyclic group of order %s as a permutation group"%self.order()
 
     def is_commutative(self):
         r"""


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

DiCyclic groups are defined in permgroups_named.py. In 3 places it is misspelled. This PR corrects the misspelling.

(I think the preferred spelling would be Dicyclic, not DiCyclic, but this PR does not change that.)

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x ] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
