### PR TITLE
Fix incorrect linear branch number for non-invertible SBox

### DIFF
--- a/src/sage/crypto/sbox.pyx
+++ b/src/sage/crypto/sbox.pyx
@@ -1410,6 +1410,12 @@ cdef class SBox(SageObject):
             sage: S = SBox([12,5,6,11,9,0,10,13,3,14,15,8,4,7,1,2])
             sage: S.linear_branch_number()
             2
+
+        TESTS::
+
+            sage: f = SBox([0, 2, 0, 6, 2, 2, 3, 7])
+            sage: f.linear_branch_number()
+            1
         """
         cdef Py_ssize_t m = self.m
         cdef Py_ssize_t n = self.n
@@ -1417,8 +1423,8 @@ cdef class SBox(SageObject):
         cdef Py_ssize_t ret = (1 << m) + (1 << n)
 
         cdef Py_ssize_t a, b, w
-        for a in range(1, 1 << m):
-            for b in range(1 << n):
+        for a in range(1 << m):
+            for b in range(1, 1 << n):
                 if lat.get_unsafe(a, b) != 0:
                     w = hamming_weight(a) + hamming_weight(b)
                     if w < ret:


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Fixes #29769
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
