### PR TITLE
GAP: fix definition of 'Int'

### DIFF
--- a/src/sage/libs/gap/element.pxd
+++ b/src/sage/libs/gap/element.pxd
@@ -15,7 +15,7 @@ from sage.structure.element cimport Element, ModuleElement, RingElement
 cdef Obj make_gap_list(sage_list) except NULL
 cdef Obj make_gap_matrix(sage_list, gap_ring) except NULL
 cdef Obj make_gap_record(sage_dict) except NULL
-cdef Obj make_gap_integer(sage_dict) except NULL
+cdef Obj make_gap_integer(sage_int) except NULL
 cdef Obj make_gap_string(sage_string) except NULL
 
 cdef GapElement make_any_gap_element(parent, Obj obj)

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -9,7 +9,7 @@
 #                   http://www.gnu.org/licenses/
 ###############################################################################
 
-from libc.stdint cimport uintptr_t, uint8_t, uint16_t, uint32_t, uint64_t
+from libc.stdint cimport intptr_t, uintptr_t, uint8_t, uint16_t, uint32_t, uint64_t
 
 cdef extern from "gap/system.h" nogil:
     ctypedef char Char

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -13,7 +13,7 @@ from libc.stdint cimport uintptr_t, uint8_t, uint16_t, uint32_t, uint64_t
 
 cdef extern from "gap/system.h" nogil:
     ctypedef char Char
-    ctypedef int Int
+    ctypedef intptr_t Int
     ctypedef uintptr_t UInt
     ctypedef uint8_t  UInt1
     ctypedef uint16_t UInt2


### PR DESCRIPTION
The GAP Int type, like UInt, has the size of a machine pointer (at least
on the usual desktop system architectures), not a machine int. I.e. on a
typical 64bit OS it is a 64bit integer, not a 32bit integer. This often
makes no difference on little endian systems but can have disastrous
consequences for large values or on big endian systems.

Also fix a copy&paste mistake in the `make_gap_integer` argument name.
