### PR TITLE
tox.ini / GH Actions: Remove gentoo-python3.9

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,6 @@ on:
            "centos-7-devtoolset-gcc_11",
            "centos-stream-8-python3.9",
            "centos-stream-9-python3.9",
-           "gentoo-python3.9",
            "gentoo-python3.10",
            "gentoo-python3.11",
            "archlinux-latest",

--- a/tox.ini
+++ b/tox.ini
@@ -307,7 +307,6 @@ setenv =
     #
     gentoo:      SYSTEM=gentoo
     gentoo:      BASE_IMAGE=sheerluck/sage-on-gentoo-stage4
-    gentoo-python3.9: BASE_TAG=latest-py39
     gentoo-python3.10: BASE_TAG=latest-py10
     gentoo-python3.11: BASE_TAG=latest-py11
     gentoo:                                    IGNORE_MISSING_SYSTEM_PACKAGES=no


### PR DESCRIPTION
### :books: Description

We remove one line from `tox.ini` and one line from `docker.yml`
Since there will be no fresh docker images for python3.9 on gentoo, GH Actions will start to fail (sooner or later)

Resolves #35704

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
