### PR TITLE
fix pep8 E251 in categories, coding, crypto, logic

### DIFF
--- a/src/sage/categories/simplicial_sets.py
+++ b/src/sage/categories/simplicial_sets.py
@@ -500,7 +500,7 @@ class SimplicialSets(Category_singleton):
                                 faces_dict[cell] = grelems
                 cover = SimplicialSet(faces_dict, base_point=cells_dict[(self.base_point(), G.one())])
                 cover_map_data = {c : s[0] for (s,c) in cells_dict.items()}
-                return SimplicialSetMorphism(data = cover_map_data, domain = cover, codomain = self)
+                return SimplicialSetMorphism(data=cover_map_data, domain=cover, codomain=self)
 
             def cover(self, character):
                 r"""

--- a/src/sage/coding/code_constructions.py
+++ b/src/sage/coding/code_constructions.py
@@ -367,8 +367,8 @@ def DuadicCodeEvenPair(F,S1,S2):
     x = P2.gen()
     gg1 = P2([_lift2smallest_field(c)[0] for c in g1.coefficients(sparse=False)])
     gg2 = P2([_lift2smallest_field(c)[0] for c in g2.coefficients(sparse=False)])
-    C1 = CyclicCode(length = n, generator_pol = gg1)
-    C2 = CyclicCode(length = n, generator_pol = gg2)
+    C1 = CyclicCode(length=n, generator_pol=gg1)
+    C2 = CyclicCode(length=n, generator_pol=gg2)
     return C1,C2
 
 def DuadicCodeOddPair(F,S1,S2):
@@ -422,8 +422,8 @@ def DuadicCodeOddPair(F,S1,S2):
     gg2 = P2(coeffs2)
     gg1 = gcd(gg1, x**n - 1)
     gg2 = gcd(gg2, x**n - 1)
-    C1 = CyclicCode(length = n, generator_pol = gg1)
-    C2 = CyclicCode(length = n, generator_pol = gg2)
+    C1 = CyclicCode(length=n, generator_pol=gg1)
+    C2 = CyclicCode(length=n, generator_pol=gg2)
     return C1,C2
 
 def ExtendedQuadraticResidueCode(n,F):

--- a/src/sage/coding/decoder.py
+++ b/src/sage/coding/decoder.py
@@ -343,7 +343,7 @@ class Decoder(SageObject):
         else:
             raise NotImplementedError("Decoder does not have an _input_space parameter")
 
-    @abstract_method(optional = True)
+    @abstract_method(optional=True)
     def decoding_radius(self, **kwargs):
         r"""
         Return the maximal number of errors that ``self`` is able to correct.

--- a/src/sage/coding/encoder.py
+++ b/src/sage/coding/encoder.py
@@ -356,7 +356,7 @@ class Encoder(SageObject):
         """
         return self.code().base_field()**(self.code().dimension())
 
-    @abstract_method(optional = True)
+    @abstract_method(optional=True)
     def generator_matrix(self):
         r"""
         Returns a generator matrix of the associated code of ``self``.

--- a/src/sage/coding/extended_code.py
+++ b/src/sage/coding/extended_code.py
@@ -301,7 +301,7 @@ class ExtendedCodeOriginalCodeDecoder(Decoder):
         Decoder of Extension of [15, 7, 9] Reed-Solomon Code over GF(16) through Gao decoder for [15, 7, 9] Reed-Solomon Code over GF(16)
     """
 
-    def __init__(self, code, original_decoder = None, **kwargs):
+    def __init__(self, code, original_decoder=None, **kwargs):
         r"""
         TESTS:
 

--- a/src/sage/coding/guruswami_sudan/gs_decoder.py
+++ b/src/sage/coding/guruswami_sudan/gs_decoder.py
@@ -238,7 +238,7 @@ class GRSGuruswamiSudanDecoder(Decoder):
     ####################### static methods ###############################
 
     @staticmethod
-    def parameters_given_tau(tau, C = None, n_k = None):
+    def parameters_given_tau(tau, C=None, n_k=None):
         r"""
         Returns the smallest possible multiplicity and list size given the
         given parameters of the code and decoding radius.
@@ -307,7 +307,7 @@ class GRSGuruswamiSudanDecoder(Decoder):
         return (s, l)
 
     @staticmethod
-    def guruswami_sudan_decoding_radius(C = None, n_k = None, l = None, s = None):
+    def guruswami_sudan_decoding_radius(C=None, n_k=None, l=None, s=None):
         r"""
         Returns the maximal decoding radius of the Guruswami-Sudan decoder and
         the parameter choices needed for this.
@@ -364,7 +364,7 @@ class GRSGuruswamiSudanDecoder(Decoder):
             return gilt(n - n/2*(s+1)/(l+1) - (k-1)/2*l/s)
         if l is None and s is None:
             tau = gilt(johnson_radius(n, n - k + 1))
-            return (tau, GRSGuruswamiSudanDecoder.parameters_given_tau(tau, n_k = (n, k)))
+            return (tau, GRSGuruswamiSudanDecoder.parameters_given_tau(tau, n_k=(n, k)))
         if l is not None and s is not None:
             return (get_tau(s,l), (s,l))
 
@@ -401,7 +401,7 @@ class GRSGuruswamiSudanDecoder(Decoder):
             return (tau, (s,l))
 
     @staticmethod
-    def _suitable_parameters_given_tau(tau, C = None, n_k = None):
+    def _suitable_parameters_given_tau(tau, C=None, n_k=None):
         r"""
         Return quite good multiplicity and list size parameters for the code
         parameters and the decoding radius.
@@ -473,7 +473,7 @@ class GRSGuruswamiSudanDecoder(Decoder):
         return (s, l)
 
     @staticmethod
-    def gs_satisfactory(tau, s, l, C = None, n_k = None):
+    def gs_satisfactory(tau, s, l, C=None, n_k=None):
         r"""
         Returns whether input parameters satisfy the governing equation of
         Guruswami-Sudan.
@@ -535,7 +535,7 @@ class GRSGuruswamiSudanDecoder(Decoder):
         return l > 0 and s > 0 and n * s * (s+1) < (l+1) * (2*s*(n-tau) - (k-1) * l)
 
     ####################### decoder itself ###############################
-    def __init__(self, code, tau = None, parameters = None, interpolation_alg = None, root_finder = None):
+    def __init__(self, code, tau=None, parameters=None, interpolation_alg=None, root_finder=None):
         r"""
         TESTS:
 
@@ -585,16 +585,16 @@ class GRSGuruswamiSudanDecoder(Decoder):
             raise ValueError("code has to be a generalized Reed-Solomon code")
         n, k = code.length(), code.dimension()
         if tau and parameters:
-            if not GRSGuruswamiSudanDecoder.gs_satisfactory(tau, parameters[0], parameters[1], C = code):
+            if not GRSGuruswamiSudanDecoder.gs_satisfactory(tau, parameters[0], parameters[1], C=code):
                 raise ValueError("Impossible parameters for the Guruswami-Sudan algorithm")
             self._tau, self._s, self._ell = tau, parameters[0], parameters[1]
         elif tau:
             self._tau = tau
-            self._s, self._ell = GRSGuruswamiSudanDecoder.parameters_given_tau(tau, n_k = (n, k))
+            self._s, self._ell = GRSGuruswamiSudanDecoder.parameters_given_tau(tau, n_k=(n, k))
         elif parameters:
             self._s = parameters[0]
             self._ell = parameters[1]
-            (self._tau,_) = GRSGuruswamiSudanDecoder.guruswami_sudan_decoding_radius(C = code, s=self._s, l=self._ell)
+            (self._tau,_) = GRSGuruswamiSudanDecoder.guruswami_sudan_decoding_radius(C=code, s=self._s, l=self._ell)
         else:
             raise ValueError("Specify either tau or parameters")
         if callable(interpolation_alg):
@@ -834,7 +834,7 @@ class GRSGuruswamiSudanDecoder(Decoder):
             raise ValueError("The provided interpolation algorithm has a wrong signature. See the documentation of `codes.decoders.GRSGuruswamiSudanDecoder.interpolation_algorithm()` for details")
         ## EXAMINE THE FACTORS AND CONVERT TO CODEWORDS
         try:
-            polynomials = self.rootfinding_algorithm()(Q, maxd = wy)
+            polynomials = self.rootfinding_algorithm()(Q, maxd=wy)
         except TypeError:
             raise ValueError("The provided root-finding algorithm has a wrong signature. See the documentation of `codes.decoders.GRSGuruswamiSudanDecoder.rootfinding_algorithm()` for details")
         if not polynomials:

--- a/src/sage/coding/information_set_decoder.py
+++ b/src/sage/coding/information_set_decoder.py
@@ -115,7 +115,7 @@ class InformationSetAlgorithm(SageObject):
         ISD Algorithm (MinimalISD) for [24, 12, 8] Extended Golay code over GF(2) decoding up to 4 errors
     """
 
-    def __init__(self, code, decoding_interval, algorithm_name, parameters = None):
+    def __init__(self, code, decoding_interval, algorithm_name, parameters=None):
         r"""
         TESTS::
 
@@ -394,7 +394,7 @@ class LeeBrickellISDAlgorithm(InformationSetAlgorithm):
         sage: A = LeeBrickellISDAlgorithm(C, (2,3)); A
         ISD Algorithm (Lee-Brickell) for [24, 12, 8] Extended Golay code over GF(2) decoding between 2 and 3 errors
     """
-    def __init__(self, code, decoding_interval, search_size = None):
+    def __init__(self, code, decoding_interval, search_size=None):
         r"""
         TESTS:
 

--- a/src/sage/coding/linear_code_no_metric.py
+++ b/src/sage/coding/linear_code_no_metric.py
@@ -406,7 +406,7 @@ class AbstractLinearCodeNoMetric(AbstractCode, Module):
         """
         gens = self.gens()
         from sage.structure.sequence import Sequence
-        return Sequence(gens, universe=self.ambient_space(), check = False, immutable=True, cr=True)
+        return Sequence(gens, universe=self.ambient_space(), check=False, immutable=True, cr=True)
 
     @cached_method
     def parity_check_matrix(self):

--- a/src/sage/coding/punctured_code.py
+++ b/src/sage/coding/punctured_code.py
@@ -57,7 +57,7 @@ def _puncture(v, points):
     new_v = [v[i] for i in range(len(v)) if i not in points]
     return S(new_v)
 
-def _insert_punctured_positions(l, punctured_points, value = None):
+def _insert_punctured_positions(l, punctured_points, value=None):
     r"""
     Returns ``l`` with ``value`` inserted in the corresponding
     position from ``punctured_points``.
@@ -485,7 +485,7 @@ class PuncturedCodeOriginalCodeDecoder(Decoder):
             True
     """
 
-    def __init__(self, code, strategy = None, original_decoder = None, **kwargs):
+    def __init__(self, code, strategy=None, original_decoder=None, **kwargs):
         r"""
         TESTS:
 
@@ -671,7 +671,7 @@ class PuncturedCodeOriginalCodeDecoder(Decoder):
         y = A(yl)
         return _puncture(D.decode_to_code(y), pts)
 
-    def decoding_radius(self, number_erasures = None):
+    def decoding_radius(self, number_erasures=None):
         r"""
         Returns maximal number of errors that ``self`` can decode.
 

--- a/src/sage/coding/subfield_subcode.py
+++ b/src/sage/coding/subfield_subcode.py
@@ -285,7 +285,7 @@ class SubfieldSubcodeOriginalCodeDecoder(Decoder):
         Decoder of Subfield subcode of [13, 5, 9] Reed-Solomon Code over GF(16) down to GF(4) through Gao decoder for [13, 5, 9] Reed-Solomon Code over GF(16)
     """
 
-    def __init__(self, code, original_decoder = None, **kwargs):
+    def __init__(self, code, original_decoder=None, **kwargs):
         r"""
         TESTS:
 

--- a/src/sage/crypto/cipher.py
+++ b/src/sage/crypto/cipher.py
@@ -73,7 +73,7 @@ class PublicKeyCipher(Cipher):
     """
     Public key cipher class
     """
-    def __init__(self, parent, key, public = True):
+    def __init__(self, parent, key, public=True):
         """
         Create a public key cipher
 

--- a/src/sage/crypto/classical_cipher.py
+++ b/src/sage/crypto/classical_cipher.py
@@ -503,7 +503,7 @@ class TranspositionCipher(SymmetricKeyCipher):
             raise ValueError("key (= %s) must have block length %s" % (key, n))
         SymmetricKeyCipher.__init__(self, parent, key)
 
-    def __call__(self, M, mode = "ECB"):
+    def __call__(self, M, mode="ECB"):
         S = self.domain() # = plaintext_space = ciphertext_space
         if not isinstance(M, StringMonoidElement) and M.parent() == S:
             raise TypeError("Argument M (= %s) must be a string in the plaintext space." % M)
@@ -555,7 +555,7 @@ class VigenereCipher(SymmetricKeyCipher):
         """
         SymmetricKeyCipher.__init__(self, parent, key)
 
-    def __call__(self, M, mode = "ECB"):
+    def __call__(self, M, mode="ECB"):
         S = self.domain() # = plaintext_space = ciphertext_space
         if not isinstance(M, StringMonoidElement) and M.parent() == S:
             raise TypeError("Argument M (= %s) must be a string in the plaintext space." % M)

--- a/src/sage/crypto/mq/sr.py
+++ b/src/sage/crypto/mq/sr.py
@@ -1091,7 +1091,7 @@ class SR_generic(MPolynomialSystemGenerator):
         """
         return self.vector(self.random_state_array(*args, **kwds))
 
-    def random_element(self, elem_type = "vector", *args, **kwds):
+    def random_element(self, elem_type="vector", *args, **kwds):
         """
         Return a random element for self.  Other arguments and keywords are
         passed to random_* methods.
@@ -1569,7 +1569,7 @@ class SR_generic(MPolynomialSystemGenerator):
         format_string = self.varformatstr(name, self.n, self.r*self.c, self.e)
         return format_string % (nr, rc, e)
 
-    def varstrs(self, name, nr, rc = None, e = None):
+    def varstrs(self, name, nr, rc=None, e=None):
         """
         Return a list of strings representing variables in ``self``.
 
@@ -2284,7 +2284,7 @@ class SR_gf2n(SR_generic):
 
         return shift_rows
 
-    def lin_matrix(self, length = None):
+    def lin_matrix(self, length=None):
         """
         Return the ``Lin`` matrix.
 
@@ -3051,7 +3051,7 @@ class SR_gf2(SR_generic):
 
         return l
 
-    def _inversion_polynomials_single_sbox(self, x= None, w=None, biaffine_only=None, correct_only=None):
+    def _inversion_polynomials_single_sbox(self, x=None, w=None, biaffine_only=None, correct_only=None):
         """
         Generate inversion polynomials of a single S-box.
 

--- a/src/sage/crypto/stream.py
+++ b/src/sage/crypto/stream.py
@@ -28,7 +28,7 @@ class LFSRCryptosystem(SymmetricKeyCryptosystem):
     """
     Linear feedback shift register cryptosystem class
     """
-    def __init__(self, field = None):
+    def __init__(self, field=None):
         """
         Create a linear feedback shift cryptosystem.
 

--- a/src/sage/crypto/stream_cipher.py
+++ b/src/sage/crypto/stream_cipher.py
@@ -61,9 +61,9 @@ class LFSRCipher(SymmetricKeyCipher):
             sage: E == loads(dumps(E))
             True
         """
-        SymmetricKeyCipher.__init__(self, parent, key = (poly, IS))
+        SymmetricKeyCipher.__init__(self, parent, key=(poly, IS))
 
-    def __call__(self, M, mode = "ECB"):
+    def __call__(self, M, mode="ECB"):
         r"""
         Generate key stream from the binary string ``M``.
 
@@ -179,7 +179,7 @@ class ShrinkingGeneratorCipher(SymmetricKeyCipher):
             raise TypeError("Argument e1 (= %s) must be a LFSR cipher." % e1)
         if not isinstance(e2, LFSRCipher):
             raise TypeError("Argument e2 (= %s) must be a LFSR cipher." % e2)
-        SymmetricKeyCipher.__init__(self, parent, key = (e1, e2))
+        SymmetricKeyCipher.__init__(self, parent, key=(e1, e2))
 
     def keystream_cipher(self):
         """
@@ -221,7 +221,7 @@ class ShrinkingGeneratorCipher(SymmetricKeyCipher):
         """
         return self.key()[1]
 
-    def __call__(self, M, mode = "ECB"):
+    def __call__(self, M, mode="ECB"):
         r"""
         INPUT:
 

--- a/src/sage/logic/logicparser.py
+++ b/src/sage/logic/logicparser.py
@@ -158,7 +158,7 @@ def polish_parse(s):
         raise SyntaxError("malformed statement")
 
     toks, vars_order = tokenize(s)
-    tree = tree_parse(toks, polish = True)
+    tree = tree_parse(toks, polish=True)
     # special case where the formula s is a single variable
     if isinstance(tree, str):
         return vars_order
@@ -568,7 +568,7 @@ def tree_parse(toks, polish=False):
             while tok != '(':
                 tok = stack.pop()
                 lrtoks.insert(0, tok)
-            branch = parse_ltor(lrtoks[1:-1], polish = polish)
+            branch = parse_ltor(lrtoks[1:-1], polish=polish)
             stack.append(branch)
     return stack[0]
 
@@ -643,7 +643,7 @@ def parse_ltor(toks, n=0, polish=False):
                         toks[j - 1] = args
                         del toks[j]
                         j -= 1
-                    return parse_ltor(toks, n = n, polish = polish)
+                    return parse_ltor(toks, n=n, polish=polish)
             else:
                 args = [toks[i - 1], toks[i], toks[i + 1]]
                 toks[i - 1] = [args[1], args[0], args[2]]


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

this fixes all warnings

`E251 unexpected spaces around keyword / parameter equals`

in `categories`, `crypto`, `coding` and `logic` folders:

purely done with autopep8

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
