### PR TITLE
fix pep8 E251 in rings/

### DIFF
--- a/src/sage/rings/complex_interval_field.py
+++ b/src/sage/rings/complex_interval_field.py
@@ -627,7 +627,7 @@ class ComplexIntervalField_class(sage.rings.abc.ComplexIntervalField):
         im = rand(*args, **kwds)
         return self.element_class(self, re, im)
 
-    def is_field(self, proof = True):
+    def is_field(self, proof=True):
         """
         Return ``True``, since the complex numbers are a field.
 

--- a/src/sage/rings/finite_rings/conway_polynomials.py
+++ b/src/sage/rings/finite_rings/conway_polynomials.py
@@ -273,7 +273,7 @@ class PseudoConwayLattice(WithEqualityById, SageObject):
             sage: PCL.check_consistency(60)  # long time
         """
         p = self.p
-        K = FiniteField(p**n, modulus = self.polynomial(n), names='a')
+        K = FiniteField(p**n, modulus=self.polynomial(n), names='a')
         a = K.gen()
         for m in n.divisors():
             assert (a**((p**n-1)//(p**m-1))).minimal_polynomial() == self.polynomial(m)

--- a/src/sage/rings/function_field/ideal.py
+++ b/src/sage/rings/function_field/ideal.py
@@ -1015,7 +1015,7 @@ class IdealMonoid(UniqueRepresentation, Parent):
             sage: TestSuite(M).run()                                                                                    # optional - sage.rings.finite_rings
         """
         self.Element = R._ideal_class
-        Parent.__init__(self, category = Monoids())
+        Parent.__init__(self, category=Monoids())
 
         self.__R = R
         self._populate_coercion_lists_()

--- a/src/sage/rings/function_field/place.py
+++ b/src/sage/rings/function_field/place.py
@@ -342,7 +342,7 @@ class PlaceSet(UniqueRepresentation, Parent):
             sage: TestSuite(places).run()                                               # optional - sage.rings.finite_rings sage.rings.function_field
         """
         self.Element = field._place_class
-        Parent.__init__(self, category = Sets().Infinite())
+        Parent.__init__(self, category=Sets().Infinite())
 
         self._field = field
 

--- a/src/sage/rings/homset.py
+++ b/src/sage/rings/homset.py
@@ -36,7 +36,7 @@ def is_RingHomset(H):
     return isinstance(H, RingHomset_generic)
 
 
-def RingHomset(R, S, category = None):
+def RingHomset(R, S, category=None):
     """
     Construct a space of homomorphisms between the rings ``R`` and ``S``.
 
@@ -51,8 +51,8 @@ def RingHomset(R, S, category = None):
     if quotient_ring.is_QuotientRing(R):
         from .polynomial.polynomial_quotient_ring import is_PolynomialQuotientRing
         if not is_PolynomialQuotientRing(R):  # backwards compatibility
-            return RingHomset_quo_ring(R, S, category = category)
-    return RingHomset_generic(R, S, category = category)
+            return RingHomset_quo_ring(R, S, category=category)
+    return RingHomset_generic(R, S, category=category)
 
 
 class RingHomset_generic(HomsetWithBase):
@@ -69,7 +69,7 @@ class RingHomset_generic(HomsetWithBase):
 
     Element = morphism.RingHomomorphism
 
-    def __init__(self, R, S, category = None):
+    def __init__(self, R, S, category=None):
         """
         Initialize ``self``.
 

--- a/src/sage/rings/ideal.py
+++ b/src/sage/rings/ideal.py
@@ -1689,7 +1689,7 @@ class Ideal_pid(Ideal_principal):
             raise ValueError("The ideal (%s) is not prime"%self)
         from sage.rings.integer_ring import ZZ
         if self.ring() is ZZ:
-            return ZZ.residue_field(self, check = False)
+            return ZZ.residue_field(self, check=False)
         raise NotImplementedError("residue_field() is only implemented for ZZ and rings of integers of number fields.")
 
 class Ideal_fractional(Ideal_generic):

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -5084,24 +5084,24 @@ class LazyPowerSeries(LazyCauchyProductSeries):
             poly = repr_lincomb([(1, m) for m in mons + bigO], is_latex=True, strip_one=True)
         elif formatter == ascii_art:
             if atomic_repr:
-                poly = ascii_art(*(mons + bigO), sep = " + ")
+                poly = ascii_art(*(mons + bigO), sep=" + ")
             else:
                 def parenthesize(m):
                     a = ascii_art(m)
                     h = a.height()
                     return ascii_art(ascii_left_parenthesis.character_art(h),
                                      a, ascii_right_parenthesis.character_art(h))
-                poly = ascii_art(*([parenthesize(m) for m in mons] + bigO), sep = " + ")
+                poly = ascii_art(*([parenthesize(m) for m in mons] + bigO), sep=" + ")
         elif formatter == unicode_art:
             if atomic_repr:
-                poly = unicode_art(*(mons + bigO), sep = " + ")
+                poly = unicode_art(*(mons + bigO), sep=" + ")
             else:
                 def parenthesize(m):
                     a = unicode_art(m)
                     h = a.height()
                     return unicode_art(unicode_left_parenthesis.character_art(h),
                                        a, unicode_right_parenthesis.character_art(h))
-                poly = unicode_art(*([parenthesize(m) for m in mons] + bigO), sep = " + ")
+                poly = unicode_art(*([parenthesize(m) for m in mons] + bigO), sep=" + ")
 
         return poly
 
@@ -5398,24 +5398,24 @@ class LazyCompletionGradedAlgebraElement(LazyCauchyProductSeries):
             poly = repr_lincomb([(1, m) for m in mons + bigO], is_latex=True, strip_one=True)
         elif formatter == ascii_art:
             if atomic_repr:
-                poly = ascii_art(*(mons + bigO), sep = " + ")
+                poly = ascii_art(*(mons + bigO), sep=" + ")
             else:
                 def parenthesize(m):
                     a = ascii_art(m)
                     h = a.height()
                     return ascii_art(ascii_left_parenthesis.character_art(h),
                                      a, ascii_right_parenthesis.character_art(h))
-                poly = ascii_art(*([parenthesize(m) for m in mons] + bigO), sep = " + ")
+                poly = ascii_art(*([parenthesize(m) for m in mons] + bigO), sep=" + ")
         elif formatter == unicode_art:
             if atomic_repr:
-                poly = unicode_art(*(mons + bigO), sep = " + ")
+                poly = unicode_art(*(mons + bigO), sep=" + ")
             else:
                 def parenthesize(m):
                     a = unicode_art(m)
                     h = a.height()
                     return unicode_art(unicode_left_parenthesis.character_art(h),
                                        a, unicode_right_parenthesis.character_art(h))
-                poly = unicode_art(*([parenthesize(m) for m in mons] + bigO), sep = " + ")
+                poly = unicode_art(*([parenthesize(m) for m in mons] + bigO), sep=" + ")
 
         return poly
 

--- a/src/sage/rings/multi_power_series_ring.py
+++ b/src/sage/rings/multi_power_series_ring.py
@@ -365,8 +365,7 @@ class MPowerSeriesRing_generic(PowerSeriesRing_generic, Nonexact):
         # Multivariate power series rings inherit from power series rings. But
         # apparently we can not call their initialisation. Instead, initialise
         # CommutativeRing and Nonexact:
-        CommutativeRing.__init__(self, base_ring, name_list, category =
-                                 _IntegralDomains if base_ring in
+        CommutativeRing.__init__(self, base_ring, name_list, category=_IntegralDomains if base_ring in
                                  _IntegralDomains else _CommutativeRings)
         Nonexact.__init__(self, default_prec)
 
@@ -561,7 +560,7 @@ class MPowerSeriesRing_generic(PowerSeriesRing_generic, Nonexact):
             sage: S.change_ring(GF(5))                                                  # optional - sage.rings.finite_rings
             Multivariate Power Series Ring in x, y over Finite Field of size 5
         """
-        return PowerSeriesRing(R, names = self.variable_names(), default_prec = self.default_prec())
+        return PowerSeriesRing(R, names=self.variable_names(), default_prec=self.default_prec())
 
     def remove_var(self, *var):
         """

--- a/src/sage/rings/number_field/number_field_ideal.py
+++ b/src/sage/rings/number_field/number_field_ideal.py
@@ -3196,7 +3196,7 @@ class NumberFieldFractionalIdeal(MultiplicativeGroupElement, NumberFieldIdeal, I
         """
         if not self.is_prime():
             raise ValueError("The ideal must be prime")
-        return self.number_field().residue_field(self, names = names)
+        return self.number_field().residue_field(self, names=names)
 
     def residue_class_degree(self):
         r"""

--- a/src/sage/rings/number_field/number_field_ideal_rel.py
+++ b/src/sage/rings/number_field/number_field_ideal_rel.py
@@ -129,7 +129,7 @@ class NumberFieldFractionalIdeal_rel(NumberFieldFractionalIdeal):
             self.__pari_rhnf = rnf.rnfidealabstorel(nfzk * L_hnf)
             return self.__pari_rhnf
 
-    def absolute_ideal(self, names = 'a'):
+    def absolute_ideal(self, names='a'):
         r"""
         If this is an ideal in the extension `L/K`, return the ideal with
         the same generators in the absolute field `L/\QQ`.

--- a/src/sage/rings/number_field/number_field_rel.py
+++ b/src/sage/rings/number_field/number_field_rel.py
@@ -2104,7 +2104,7 @@ class NumberField_relative(NumberField_generic):
         abs_base_gens = [self_into_L(_) for _ in self.base_field().gens()]
         v = sorted([ self.hom([ L_into_self(aa(a)) ]) for aa in aas if all(aa(g) == g for g in abs_base_gens) ])
         put_natural_embedding_first(v)
-        self.__automorphisms = Sequence(v, cr = (v != []), immutable=True,
+        self.__automorphisms = Sequence(v, cr=(v != []), immutable=True,
                                         check=False, universe=self.Hom(self))
         return self.__automorphisms
 
@@ -2611,7 +2611,7 @@ class NumberField_relative(NumberField_generic):
         L = K.relativize(beta, names)
         return K.relativize(beta, names, structure=structure.RelativeFromRelative(L))
 
-    def uniformizer(self, P, others = "positive"):
+    def uniformizer(self, P, others="positive"):
         """
         Returns an element of ``self`` with valuation 1 at the prime ideal `P`.
 

--- a/src/sage/rings/padics/factory.py
+++ b/src/sage/rings/padics/factory.py
@@ -723,10 +723,10 @@ class Qp_class(UniqueFactory):
         sage: K = Qp(15, check=False); a = K(999); a
         9 + 6*15 + 4*15^2 + O(15^20)
     """
-    def create_key(self, p, prec = None, type = 'capped-rel', print_mode = None,
-                   names = None, ram_name = None, print_pos = None,
-                   print_sep = None, print_alphabet = None, print_max_terms = None, show_prec = None, check = True,
-                   label = None):   # specific to Lattice precision
+    def create_key(self, p, prec=None, type='capped-rel', print_mode=None,
+                   names=None, ram_name=None, print_pos=None,
+                   print_sep=None, print_alphabet=None, print_max_terms=None, show_prec=None, check=True,
+                   label=None):   # specific to Lattice precision
         r"""
         Creates a key from input parameters for ``Qp``.
 
@@ -822,10 +822,10 @@ Qp = Qp_class("Qp")
 # Qq -- unramified extensions
 ######################################################
 
-def Qq(q, prec = None, type = 'capped-rel', modulus = None, names=None,
-          print_mode=None, ram_name = None, res_name = None, print_pos = None,
-       print_sep = None, print_max_ram_terms = None,
-       print_max_unram_terms = None, print_max_terse_terms = None, show_prec=None, check = True, implementation = 'FLINT'):
+def Qq(q, prec=None, type='capped-rel', modulus=None, names=None,
+          print_mode=None, ram_name=None, res_name=None, print_pos=None,
+       print_sep=None, print_max_ram_terms=None,
+       print_max_unram_terms=None, print_max_terse_terms=None, show_prec=None, check=True, implementation='FLINT'):
     r"""
     Given a prime power `q = p^n`, return the unique unramified
     extension of `\QQ_p` of degree `n`.
@@ -1380,7 +1380,7 @@ def Qq(q, prec = None, type = 'capped-rel', modulus = None, names=None,
 # Short constructor names for different types
 ######################################################
 
-def QpCR(p, prec = None, *args, **kwds):
+def QpCR(p, prec=None, *args, **kwds):
     r"""
     A shortcut function to create capped relative `p`-adic fields.
 
@@ -1394,7 +1394,7 @@ def QpCR(p, prec = None, *args, **kwds):
     """
     return Qp(p, prec, 'capped-rel', *args, **kwds)
 
-def QpFP(p, prec = None, *args, **kwds):
+def QpFP(p, prec=None, *args, **kwds):
     r"""
     A shortcut function to create floating point `p`-adic fields.
 
@@ -1408,7 +1408,7 @@ def QpFP(p, prec = None, *args, **kwds):
     """
     return Qp(p, prec, 'floating-point', *args, **kwds)
 
-def QqCR(q, prec = None, *args, **kwds):
+def QqCR(q, prec=None, *args, **kwds):
     r"""
     A shortcut function to create capped relative unramified `p`-adic
     fields.
@@ -1423,7 +1423,7 @@ def QqCR(q, prec = None, *args, **kwds):
     """
     return Qq(q, prec, 'capped-rel', *args, **kwds)
 
-def QqFP(q, prec = None, *args, **kwds):
+def QqFP(q, prec=None, *args, **kwds):
     r"""
     A shortcut function to create floating point unramified `p`-adic
     fields.
@@ -1439,7 +1439,7 @@ def QqFP(q, prec = None, *args, **kwds):
     return Qq(q, prec, 'floating-point', *args, **kwds)
 
 @experimental(23505)
-def QpLC(p, prec = None, *args, **kwds):
+def QpLC(p, prec=None, *args, **kwds):
     r"""
     A shortcut function to create `p`-adic fields with lattice precision.
 
@@ -1454,7 +1454,7 @@ def QpLC(p, prec = None, *args, **kwds):
     return Qp(p, prec, 'lattice-cap', *args, **kwds)
 
 @experimental(23505)
-def QpLF(p, prec = None, *args, **kwds):
+def QpLF(p, prec=None, *args, **kwds):
     r"""
     A shortcut function to create `p`-adic fields with lattice precision.
 
@@ -1930,10 +1930,10 @@ class Zp_class(UniqueFactory):
         sage: a + b
         1 + 5 + O(5^10)
     """
-    def create_key(self, p, prec = None, type = 'capped-rel', print_mode = None,
-                   names = None, ram_name = None, print_pos = None, print_sep = None, print_alphabet = None,
-                   print_max_terms = None, show_prec = None, check = True,
-                   label = None):
+    def create_key(self, p, prec=None, type='capped-rel', print_mode=None,
+                   names=None, ram_name=None, print_pos=None, print_sep=None, print_alphabet=None,
+                   print_max_terms=None, show_prec=None, check=True,
+                   label=None):
         r"""
         Creates a key from input parameters for ``Zp``.
 
@@ -2034,10 +2034,10 @@ Zp = Zp_class("Zp")
 # Zq -- unramified extensions
 ######################################################
 
-def Zq(q, prec = None, type = 'capped-rel', modulus = None, names=None,
-          print_mode=None, ram_name = None, res_name = None, print_pos = None,
-       print_sep = None, print_max_ram_terms = None,
-       print_max_unram_terms = None, print_max_terse_terms = None, show_prec = None, check = True, implementation = 'FLINT'):
+def Zq(q, prec=None, type='capped-rel', modulus=None, names=None,
+          print_mode=None, ram_name=None, res_name=None, print_pos=None,
+       print_sep=None, print_max_ram_terms=None,
+       print_max_unram_terms=None, print_max_terse_terms=None, show_prec=None, check=True, implementation='FLINT'):
     r"""
     Given a prime power `q = p^n`, return the unique unramified
     extension of `\ZZ_p` of degree `n`.
@@ -2599,7 +2599,7 @@ def Zq(q, prec = None, type = 'capped-rel', modulus = None, names=None,
 # Short constructor names for different types
 ######################################################
 
-def ZpCR(p, prec = None, *args, **kwds):
+def ZpCR(p, prec=None, *args, **kwds):
     r"""
     A shortcut function to create capped relative `p`-adic rings.
 
@@ -2613,7 +2613,7 @@ def ZpCR(p, prec = None, *args, **kwds):
     """
     return Zp(p, prec, 'capped-rel', *args, **kwds)
 
-def ZpCA(p, prec = None, *args, **kwds):
+def ZpCA(p, prec=None, *args, **kwds):
     r"""
     A shortcut function to create capped absolute `p`-adic rings.
 
@@ -2626,7 +2626,7 @@ def ZpCA(p, prec = None, *args, **kwds):
     """
     return Zp(p, prec, 'capped-abs', *args, **kwds)
 
-def ZpFM(p, prec = None, *args, **kwds):
+def ZpFM(p, prec=None, *args, **kwds):
     r"""
     A shortcut function to create fixed modulus `p`-adic rings.
 
@@ -2639,7 +2639,7 @@ def ZpFM(p, prec = None, *args, **kwds):
     """
     return Zp(p, prec, 'fixed-mod', *args, **kwds)
 
-def ZpFP(p, prec = None, *args, **kwds):
+def ZpFP(p, prec=None, *args, **kwds):
     r"""
     A shortcut function to create floating point `p`-adic rings.
 
@@ -2653,7 +2653,7 @@ def ZpFP(p, prec = None, *args, **kwds):
     """
     return Zp(p, prec, 'floating-point', *args, **kwds)
 
-def ZqCR(q, prec = None, *args, **kwds):
+def ZqCR(q, prec=None, *args, **kwds):
     r"""
     A shortcut function to create capped relative unramified `p`-adic rings.
 
@@ -2667,7 +2667,7 @@ def ZqCR(q, prec = None, *args, **kwds):
     """
     return Zq(q, prec, 'capped-rel', *args, **kwds)
 
-def ZqCA(q, prec = None, *args, **kwds):
+def ZqCA(q, prec=None, *args, **kwds):
     r"""
     A shortcut function to create capped absolute unramified `p`-adic rings.
 
@@ -2680,7 +2680,7 @@ def ZqCA(q, prec = None, *args, **kwds):
     """
     return Zq(q, prec, 'capped-abs', *args, **kwds)
 
-def ZqFM(q, prec = None, *args, **kwds):
+def ZqFM(q, prec=None, *args, **kwds):
     r"""
     A shortcut function to create fixed modulus unramified `p`-adic rings.
 
@@ -2693,7 +2693,7 @@ def ZqFM(q, prec = None, *args, **kwds):
     """
     return Zq(q, prec, 'fixed-mod', *args, **kwds)
 
-def ZqFP(q, prec = None, *args, **kwds):
+def ZqFP(q, prec=None, *args, **kwds):
     r"""
     A shortcut function to create floating point unramified `p`-adic rings.
 
@@ -3235,12 +3235,12 @@ class pAdicExtension_class(UniqueFactory):
         sage: W.precision_cap()
         12
     """
-    def create_key_and_extra_args(self, base, modulus, prec = None, print_mode = None,
-                                  names = None, var_name = None, res_name = None,
-                                  unram_name = None, ram_name = None, print_pos = None,
-                                  print_sep = None, print_alphabet = None, print_max_ram_terms = None,
-                                  print_max_unram_terms = None, print_max_terse_terms = None,
-                                  show_prec = None, check = True, unram = False, implementation='FLINT'):
+    def create_key_and_extra_args(self, base, modulus, prec=None, print_mode=None,
+                                  names=None, var_name=None, res_name=None,
+                                  unram_name=None, ram_name=None, print_pos=None,
+                                  print_sep=None, print_alphabet=None, print_max_ram_terms=None,
+                                  print_max_unram_terms=None, print_max_terse_terms=None,
+                                  show_prec=None, check=True, unram=False, implementation='FLINT'):
         r"""
         Creates a key from input parameters for :class:`pAdicExtension`.
 

--- a/src/sage/rings/padics/generic_nodes.py
+++ b/src/sage/rings/padics/generic_nodes.py
@@ -1201,7 +1201,7 @@ def is_pAdicRing(R):
 
 
 class pAdicRingGeneric(pAdicGeneric, sage.rings.abc.pAdicRing):
-    def is_field(self, proof = True):
+    def is_field(self, proof=True):
         """
         Return whether this ring is actually a field, ie ``False``.
 

--- a/src/sage/rings/padics/local_generic.py
+++ b/src/sage/rings/padics/local_generic.py
@@ -231,7 +231,7 @@ class LocalGeneric(CommutativeRing):
             sage: latex(Zq(27,names='a')) #indirect doctest
             \Bold{Z}_{3^{3}}
         """
-        return self._repr_(do_latex = True)
+        return self._repr_(do_latex=True)
 
     def change(self, **kwds):
         r"""

--- a/src/sage/rings/padics/padic_base_leaves.py
+++ b/src/sage/rings/padics/padic_base_leaves.py
@@ -729,7 +729,7 @@ class pAdicFieldCappedRelative(pAdicFieldBaseGeneric, pAdicCappedRelativeFieldGe
         if (algorithm == 'default'):
             k = ZZ.random_element()
             a = ZZ.random_element(self.prime()**self.precision_cap())
-            return self(self.prime()**k * a, absprec = k + self.precision_cap())
+            return self(self.prime()**k * a, absprec=k + self.precision_cap())
         else:
             raise NotImplementedError("Don't know %s algorithm"%algorithm)
 

--- a/src/sage/rings/padics/padic_generic.py
+++ b/src/sage/rings/padics/padic_generic.py
@@ -497,7 +497,7 @@ class pAdicGeneric(PrincipalIdealDomain, LocalGeneric):
             deprecation(23227, "Use the change method if you want to change print options in integer_ring()")
             return self.change(field=False, **print_mode)
 
-    def teichmuller(self, x, prec = None):
+    def teichmuller(self, x, prec=None):
         r"""
         Return the Teichmüller representative of ``x``.
 
@@ -614,7 +614,7 @@ class pAdicGeneric(PrincipalIdealDomain, LocalGeneric):
 #         """
 #         raise NotImplementedError
 
-    def extension(self, modulus, prec = None, names = None, print_mode = None, implementation='FLINT', **kwds):
+    def extension(self, modulus, prec=None, names=None, print_mode=None, implementation='FLINT', **kwds):
         r"""
         Create an extension of this p-adic ring.
 
@@ -665,7 +665,7 @@ class pAdicGeneric(PrincipalIdealDomain, LocalGeneric):
                         print_mode[option] = kwds[option]
                     else:
                         print_mode[option] = self._printer.dict()[option]
-        return ExtensionFactory(base=self, modulus=modulus, prec=prec, names=names, check = True, implementation=implementation, **print_mode)
+        return ExtensionFactory(base=self, modulus=modulus, prec=prec, names=names, check=True, implementation=implementation, **print_mode)
 
     def _is_valid_homomorphism_(self, codomain, im_gens, base_map=None):
         r"""

--- a/src/sage/rings/padics/relative_extension_leaves.py
+++ b/src/sage/rings/padics/relative_extension_leaves.py
@@ -210,7 +210,7 @@ class RelativeRamifiedExtensionRingFixedMod(EisensteinExtensionGeneric, pAdicFix
         """
         self._exact_modulus = exact_modulus
         unram_prec = (prec + approx_modulus.degree() - 1) // approx_modulus.degree()
-        KFP = approx_modulus.base_ring().change(prec = unram_prec+1)
+        KFP = approx_modulus.base_ring().change(prec=unram_prec+1)
         self.prime_pow = PowComputer_relative_maker(approx_modulus.base_ring().prime(), max(min(unram_prec - 1, 30), 1), unram_prec, prec, False, exact_modulus.change_ring(KFP), shift_seed.change_ring(KFP), 'fixed-mod')
         self._implementation = 'Polynomial'
         EisensteinExtensionGeneric.__init__(self, approx_modulus, prec, print_mode, names, RelativeRamifiedFixedModElement)

--- a/src/sage/rings/padics/unramified_extension_generic.py
+++ b/src/sage/rings/padics/unramified_extension_generic.py
@@ -52,7 +52,7 @@ class UnramifiedExtensionGeneric(pAdicExtensionGeneric):
         #else:
         #    self._PQR = pqr.PolynomialQuotientRing_domain(poly.parent(), poly, name = names)
         pAdicExtensionGeneric.__init__(self, poly, prec, print_mode, names, element_class)
-        self._res_field = GF(self.prime_pow.pow_Integer_Integer(poly.degree()), name = names[1], modulus = poly.change_ring(poly.base_ring().residue_field()))
+        self._res_field = GF(self.prime_pow.pow_Integer_Integer(poly.degree()), name=names[1], modulus=poly.change_ring(poly.base_ring().residue_field()))
 
     def _extension_type(self):
         """
@@ -209,7 +209,7 @@ class UnramifiedExtensionGeneric(pAdicExtensionGeneric):
         return self([0,1])
 
     @cached_method
-    def _frob_gen(self, arithmetic = True):
+    def _frob_gen(self, arithmetic=True):
         """
         Return frobenius of the generator for this unramified extension
 

--- a/src/sage/rings/polynomial/laurent_polynomial_ring_base.py
+++ b/src/sage/rings/polynomial/laurent_polynomial_ring_base.py
@@ -433,7 +433,7 @@ class LaurentPolynomialRing_generic(CommutativeRing, Parent):
         """
         return False
 
-    def is_field(self, proof = True):
+    def is_field(self, proof=True):
         """
         EXAMPLES::
 
@@ -480,7 +480,7 @@ class LaurentPolynomialRing_generic(CommutativeRing, Parent):
         """
         raise NotImplementedError
 
-    def random_element(self, low_degree = -2, high_degree = 2, terms = 5, choose_degree=False,*args, **kwds):
+    def random_element(self, low_degree=-2, high_degree=2, terms=5, choose_degree=False,*args, **kwds):
         """
         EXAMPLES::
 
@@ -530,11 +530,11 @@ class LaurentPolynomialRing_generic(CommutativeRing, Parent):
         if names is None:
             names = self.variable_names()
         if isinstance(self, LaurentPolynomialRing_univariate):
-            return LaurentPolynomialRing(base_ring, names[0], sparse = sparse)
+            return LaurentPolynomialRing(base_ring, names[0], sparse=sparse)
 
         if order is None:
             order = self.polynomial_ring().term_order()
-        return LaurentPolynomialRing(base_ring, self._n, names, order = order)
+        return LaurentPolynomialRing(base_ring, self._n, names, order=order)
 
     def fraction_field(self):
         """

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -3052,7 +3052,7 @@ class MPolynomialIdeal_singular_repr(
 
     @require_field
     @handle_AA_and_QQbar
-    def hilbert_numerator(self, grading = None, algorithm = 'sage'):
+    def hilbert_numerator(self, grading=None, algorithm='sage'):
         r"""
         Return the Hilbert numerator of this ideal.
 
@@ -3419,7 +3419,7 @@ class MPolynomialIdeal_macaulay2_repr:
         return R(k)
 
 class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
-    def __init__(self, ring, gens, coerce=True, side = "left"):
+    def __init__(self, ring, gens, coerce=True, side="left"):
         r"""
         Creates a non-commutative polynomial ideal.
 
@@ -3464,7 +3464,7 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
             raise ValueError("Only left and two-sided ideals are allowed.")
         Ideal_nc.__init__(self, ring, gens, coerce=coerce, side=side)
 
-    def __call_singular(self, cmd, arg = None):
+    def __call_singular(self, cmd, arg=None):
         """
         Internal function for calling a Singular function.
 

--- a/src/sage/rings/polynomial/polynomial_element_generic.py
+++ b/src/sage/rings/polynomial/polynomial_element_generic.py
@@ -1108,12 +1108,12 @@ class Polynomial_generic_sparse_field(Polynomial_generic_sparse, Polynomial_gene
         sage: loads(f.dumps()) == f
         True
     """
-    def __init__(self, parent, x=None, check=True, is_gen = False, construct=False):
+    def __init__(self, parent, x=None, check=True, is_gen=False, construct=False):
         Polynomial_generic_sparse.__init__(self, parent, x, check, is_gen)
 
 
 class Polynomial_generic_dense_field(Polynomial_generic_dense, Polynomial_generic_field):
-    def __init__(self, parent, x=None, check=True, is_gen = False, construct=False):
+    def __init__(self, parent, x=None, check=True, is_gen=False, construct=False):
         Polynomial_generic_dense.__init__(self, parent, x, check, is_gen)
 
 

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -1031,7 +1031,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             self.__gen = self(self.polynomial_ring().gen())
             return self.__gen
 
-    def is_field(self, proof = True):
+    def is_field(self, proof=True):
         """
         Return whether or not this quotient ring is a field.
 
@@ -1077,7 +1077,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             self._refine_category_(Fields())
         return ret
 
-    def is_integral_domain(self, proof = True):
+    def is_integral_domain(self, proof=True):
         """
         Return whether or not this quotient ring is an integral domain.
 

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -541,7 +541,7 @@ class PolynomialRing_general(ring.Algebra):
             return [None, "generic"]
         return NotImplemented
 
-    def is_integral_domain(self, proof = True):
+    def is_integral_domain(self, proof=True):
         """
         EXAMPLES::
 
@@ -552,7 +552,7 @@ class PolynomialRing_general(ring.Algebra):
         """
         return self.base_ring().is_integral_domain(proof)
 
-    def is_unique_factorization_domain(self, proof = True):
+    def is_unique_factorization_domain(self, proof=True):
         """
         EXAMPLES::
 
@@ -1065,9 +1065,9 @@ class PolynomialRing_general(ring.Algebra):
         """
         from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 
-        return PolynomialRing(self.base_ring(), names = var, sparse=self.is_sparse())
+        return PolynomialRing(self.base_ring(), names=var, sparse=self.is_sparse())
 
-    def extend_variables(self, added_names, order = 'degrevlex'):
+    def extend_variables(self, added_names, order='degrevlex'):
         r"""
         Return a multivariate polynomial ring with the same base ring but
         with ``added_names`` as additional variables.
@@ -1085,7 +1085,7 @@ class PolynomialRing_general(ring.Algebra):
 
         if isinstance(added_names, str):
             added_names = added_names.split(',')
-        return PolynomialRing(self.base_ring(), names = self.variable_names() + tuple(added_names), order = order)
+        return PolynomialRing(self.base_ring(), names=self.variable_names() + tuple(added_names), order=order)
 
     def variable_names_recursive(self, depth=sage.rings.infinity.infinity):
         r"""
@@ -1246,7 +1246,7 @@ class PolynomialRing_general(ring.Algebra):
     def is_exact(self):
         return self.base_ring().is_exact()
 
-    def is_field(self, proof = True):
+    def is_field(self, proof=True):
         """
         Return False, since polynomial rings are never fields.
 
@@ -1553,7 +1553,7 @@ class PolynomialRing_general(ring.Algebra):
         """
         self._Karatsuba_threshold = int(Karatsuba_threshold)
 
-    def polynomials( self, of_degree = None, max_degree = None ):
+    def polynomials( self, of_degree=None, max_degree=None ):
         """
         Return an iterator over the polynomials of specified degree.
 
@@ -1618,7 +1618,7 @@ class PolynomialRing_general(ring.Algebra):
             return self._polys_max( max_degree )
         raise ValueError("you should pass exactly one of of_degree and max_degree")
 
-    def monics( self, of_degree = None, max_degree = None ):
+    def monics( self, of_degree=None, max_degree=None ):
         """
         Return an iterator over the monic polynomials of specified degree.
 
@@ -1793,8 +1793,8 @@ class PolynomialRing_commutative(PolynomialRing_general, ring.CommutativeAlgebra
         if ring is not None and ring is not self:
             p = p.change_ring(ring)
             if degree_bound is None:
-                return p.roots(multiplicities = multiplicities, algorithm = algorithm)
-            return p.roots(multiplicities = multiplicities, algorithm = algorithm, degree_bound = degree_bound)
+                return p.roots(multiplicities=multiplicities, algorithm=algorithm)
+            return p.roots(multiplicities=multiplicities, algorithm=algorithm, degree_bound=degree_bound)
 
         roots = p._roots_from_factorization(p.factor(), multiplicities)
         if degree_bound is not None:

--- a/src/sage/rings/power_series_ring.py
+++ b/src/sage/rings/power_series_ring.py
@@ -1013,7 +1013,7 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
             Power Series Ring in T over Number Field in a
              with defining polynomial x^2 - 3 with a = 1.732050807568878?
         """
-        return PowerSeriesRing(R, name = self.variable_name(), default_prec = self.default_prec())
+        return PowerSeriesRing(R, name=self.variable_name(), default_prec=self.default_prec())
 
     def change_var(self, var):
         """
@@ -1026,7 +1026,7 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
             sage: R.change_var('D')
             Power Series Ring in D over Rational Field
         """
-        return PowerSeriesRing(self.base_ring(), names = var, sparse=self.is_sparse())
+        return PowerSeriesRing(self.base_ring(), names=var, sparse=self.is_sparse())
 
     def is_exact(self):
         """
@@ -1184,7 +1184,7 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
         """
         return self.has_coerce_map_from(parent(x))
 
-    def is_field(self, proof = True):
+    def is_field(self, proof=True):
         """
         Return ``False`` since the ring of power series over any ring is never
         a field.
@@ -1351,4 +1351,4 @@ def unpickle_power_series_ring_v0(base_ring, name, default_prec, sparse):
         sage: loads(dumps(P)) == P  # indirect doctest
         True
     """
-    return PowerSeriesRing(base_ring, name=name, default_prec = default_prec, sparse=sparse)
+    return PowerSeriesRing(base_ring, name=name, default_prec=default_prec, sparse=sparse)

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -1012,7 +1012,7 @@ class AlgebraicField_common(sage.rings.abc.AlgebraicField_common):
 
         trial = Factorization(factorization).value()
 
-        return Factorization(factorization, unit = f.lc() / trial.lc())
+        return Factorization(factorization, unit=f.lc() / trial.lc())
 
 
 class AlgebraicRealField(Singleton, AlgebraicField_common, sage.rings.abc.AlgebraicRealField):

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -832,7 +832,7 @@ class QuotientRing_nc(ring.Ring, sage.structure.parent_gens.ParentWithGens):
         return self.__I
 
     @cached_method
-    def is_field(self, proof = True):
+    def is_field(self, proof=True):
         r"""
         Returns ``True`` if the quotient ring is a field. Checks to see if the
         defining ideal is maximal.

--- a/src/sage/rings/rational_field.py
+++ b/src/sage/rings/rational_field.py
@@ -318,7 +318,7 @@ class RationalField(Singleton, number_field_base.NumberField):
         from . import integer_ring
         return FractionField(), integer_ring.ZZ
 
-    def completion(self, p, prec, extras = {}):
+    def completion(self, p, prec, extras={}):
         r"""
         Return the completion of `\QQ` at `p`.
 


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

fix all pycodestyle E251 warnings in `rings`

done with autopep8

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
