### PR TITLE
some pep8 cleanup in rigged-configurations

### DIFF
--- a/src/sage/combinat/rigged_configurations/bij_abstract_class.py
+++ b/src/sage/combinat/rigged_configurations/bij_abstract_class.py
@@ -17,7 +17,7 @@ AUTHORS:
 - Travis Scrimshaw (2011-04-15): Initial version
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2011, 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -29,8 +29,8 @@ AUTHORS:
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from copy import deepcopy
 from sage.misc.abstract_method import abstract_method
@@ -120,19 +120,19 @@ class KRTToRCBijectionAbstract:
         """
         if verbose:
             from sage.combinat.rigged_configurations.tensor_product_kr_tableaux_element \
-              import TensorProductOfKirillovReshetikhinTableauxElement
+                import TensorProductOfKirillovReshetikhinTableauxElement
 
         for cur_crystal in reversed(self.tp_krt):
             target = cur_crystal.parent()._r
             # Iterate through the columns
             for col_number, cur_column in enumerate(reversed(cur_crystal.to_array(False))):
-                self.cur_path.insert(0, []) # Prepend an empty list
+                self.cur_path.insert(0, [])  # Prepend an empty list
 
                 self.cur_dims.insert(0, [0, 1])
 
                 for letter in reversed(cur_column):
                     self.cur_dims[0][0] = self._next_index(self.cur_dims[0][0], target)
-                    val = letter.value # Convert from a CrystalOfLetter to an Integer
+                    val = letter.value  # Convert from a CrystalOfLetter to an Integer
 
                     if verbose:
                         print("====================")
@@ -142,7 +142,7 @@ class KRTToRCBijectionAbstract:
                         print("--------------------\n")
 
                     # Build the next state
-                    self.cur_path[0].insert(0, [letter]) # Prepend the value
+                    self.cur_path[0].insert(0, [letter])  # Prepend the value
                     self.next_state(val)
 
                 # If we've split off a column, we need to merge the current column
@@ -166,7 +166,7 @@ class KRTToRCBijectionAbstract:
                     for a in range(self.n):
                         self._update_vacancy_nums(a)
 
-        self.ret_rig_con.set_immutable() # Return it to immutable
+        self.ret_rig_con.set_immutable()  # Return it to immutable
         return self.ret_rig_con
 
     @abstract_method
@@ -220,7 +220,7 @@ class KRTToRCBijectionAbstract:
         """
         # Check to make sure we have a valid index (currently removed)
         # If the current tableau is empty, there is nothing to do
-        if not self.ret_rig_con[a]: # Check to see if we have vacancy numbers
+        if not self.ret_rig_con[a]:  # Check to see if we have vacancy numbers
             return
 
         # Setup the first block
@@ -268,7 +268,7 @@ class KRTToRCBijectionAbstract:
                     pos = 0
                     width = rigged_partition[index]
                     val = rigged_partition.rigging[index]
-                    for i in reversed(range(index-1)):
+                    for i in reversed(range(index - 1)):
                         if rigged_partition[i] > width or rigged_partition.rigging[i] >= val:
                             pos = i + 1
                             break
@@ -333,7 +333,7 @@ class RCToKRTBijectionAbstract:
         # This is a dummy edge to start the process
         cp = RC_element.__copy__()
         cp.set_immutable()
-        self._graph = [ [[], (cp, 0)] ]
+        self._graph = [[[], (cp, 0)]]
 
     def __eq__(self, rhs):
         r"""
@@ -414,7 +414,7 @@ class RCToKRTBijectionAbstract:
                         y = self.rigged_con.parent()(*[x._clone() for x in self.cur_partitions], use_vacancy_numbers=True)
                         self._graph.append([self._graph[-1][1], (y, len(self._graph)), 'ls'])
 
-                while self.cur_dims[0][0]: # > 0:
+                while self.cur_dims[0][0]:  # > 0:
                     if verbose:
                         print("====================")
                         print(repr(self.rigged_con.parent()(*self.cur_partitions, use_vacancy_numbers=True)))
@@ -427,16 +427,16 @@ class RCToKRTBijectionAbstract:
                     b = self.next_state(ht)
 
                     # Make sure we have a crystal letter
-                    ret_crystal_path[-1].append(letters(b)) # Append the rank
+                    ret_crystal_path[-1].append(letters(b))  # Append the rank
 
                     if build_graph:
                         y = self.rigged_con.parent()(*[x._clone() for x in self.cur_partitions], use_vacancy_numbers=True)
                         self._graph.append([self._graph[-1][1], (y, len(self._graph)), letters(b)])
 
-                self.cur_dims.pop(0) # Pop off the leading column
+                self.cur_dims.pop(0)  # Pop off the leading column
 
         if build_graph:
-            self._graph.pop(0) # Remove the dummy at the start
+            self._graph.pop(0)  # Remove the dummy at the start
             from sage.graphs.digraph import DiGraph
             from sage.graphs.dot2tex_utils import have_dot2tex
             self._graph = DiGraph(self._graph, format="list_of_edges")

--- a/src/sage/combinat/rigged_configurations/bij_infinity.py
+++ b/src/sage/combinat/rigged_configurations/bij_infinity.py
@@ -175,13 +175,13 @@ class FromRCIsomorphism(Morphism):
         if ct.type() == 'D':
             lam[-2] = max(lam[-2], lam[-1])
             lam.pop()
-            l = sum([ [[r+1,1]]*v for r,v in enumerate(lam[:-1]) ], [])
+            l = sum([[[r+1, 1]]*v for r, v in enumerate(lam[:-1])], [])
             n = len(I)
-            l = l + sum([ [[n,1], [n-1,1]] for k in range(lam[-1])], [])
+            l = l + sum([[[n,1], [n-1,1]] for k in range(lam[-1])], [])
         else:
             if ct.type() == 'B':
                 lam[-1] *= 2
-            l = sum([ [[r,1]]*lam[i] for i,r in enumerate(I) ], [])
+            l = sum([[[r, 1]]*lam[i] for i, r in enumerate(I)], [])
 
         RC = RiggedConfigurations(ct.affine(), reversed(l))
         elt = RC(x)

--- a/src/sage/combinat/rigged_configurations/bij_type_A.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_A.py
@@ -21,7 +21,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2011, 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -33,8 +33,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_abstract_class import KRTToRCBijectionAbstract
 from sage.combinat.rigged_configurations.bij_abstract_class import RCToKRTBijectionAbstract
@@ -122,7 +122,7 @@ class RCToKRTBijectionTypeA(RCToKRTBijectionAbstract):
             sage: bijection.next_state(1)
             5
         """
-        height -= 1 # indexing
+        height -= 1  # indexing
         n = self.n
         ell = [None] * n
         b = None
@@ -158,4 +158,4 @@ class RCToKRTBijectionTypeA(RCToKRTBijectionAbstract):
         if row_num is not None:
             self.cur_partitions[n - 1].rigging[row_num] = self.cur_partitions[n - 1].vacancy_numbers[row_num]
 
-        return(b)
+        return b

--- a/src/sage/combinat/rigged_configurations/bij_type_A2_dual.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_A2_dual.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_type_C import KRTToRCBijectionTypeC
 from sage.combinat.rigged_configurations.bij_type_C import RCToKRTBijectionTypeC
@@ -155,7 +155,7 @@ class KRTToRCBijectionTypeA2Dual(KRTToRCBijectionTypeC):
                     else:
                         j = i - 1
                         while j >= 0 and partition._list[j] <= max_width + 2:
-                            partition.rigging[j+1] = partition.rigging[j] # Shuffle it along
+                            partition.rigging[j+1] = partition.rigging[j]  # Shuffle it along
                             j -= 1
                         partition._list.pop(i)
                         partition._list.insert(j+1, max_width + 2)
@@ -219,7 +219,7 @@ class RCToKRTBijectionTypeA2Dual(RCToKRTBijectionTypeC):
             sage: bijection.next_state(2)
             -1
         """
-        height -= 1 # indexing
+        height -= 1  # indexing
         n = self.n
         ell = [None] * (2*n)
         case_S = [False] * n
@@ -333,4 +333,4 @@ class RCToKRTBijectionTypeA2Dual(RCToKRTBijectionTypeC):
             else:
                 self.cur_partitions[n-1].rigging[row_num_bar_next] = self.cur_partitions[n-1].vacancy_numbers[row_num_bar_next]
 
-        return(b)
+        return b

--- a/src/sage/combinat/rigged_configurations/bij_type_A2_even.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_A2_even.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_type_A import KRTToRCBijectionTypeA
 from sage.combinat.rigged_configurations.bij_type_C import KRTToRCBijectionTypeC
@@ -139,7 +139,7 @@ class RCToKRTBijectionTypeA2Even(RCToKRTBijectionTypeC):
             sage: bijection.next_state(2)
             -1
         """
-        height -= 1 # indexing
+        height -= 1  # indexing
         n = self.n
         ell = [None] * (2*n)
         case_S = [False] * n
@@ -213,4 +213,4 @@ class RCToKRTBijectionTypeA2Even(RCToKRTBijectionTypeC):
         if row_num_bar is not None:
             self.cur_partitions[n-1].rigging[row_num_bar] = self.cur_partitions[n-1].vacancy_numbers[row_num_bar]
 
-        return(b)
+        return b

--- a/src/sage/combinat/rigged_configurations/bij_type_A2_odd.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_A2_odd.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_type_A import KRTToRCBijectionTypeA
 from sage.combinat.rigged_configurations.bij_type_A import RCToKRTBijectionTypeA
@@ -126,7 +126,7 @@ class RCToKRTBijectionTypeA2Odd(RCToKRTBijectionTypeA):
             sage: bijection.next_state(1)
             -2
         """
-        height -= 1 # indexing
+        height -= 1  # indexing
         n = self.n
         ell = [None] * (2*n)
         b = None
@@ -194,4 +194,4 @@ class RCToKRTBijectionTypeA2Odd(RCToKRTBijectionTypeA):
         if ret_row_next is not None:
             self.cur_partitions[n-1].rigging[ret_row_next] = self.cur_partitions[n-1].vacancy_numbers[ret_row_next]
 
-        return(b)
+        return b

--- a/src/sage/combinat/rigged_configurations/bij_type_B.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_B.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_type_A import KRTToRCBijectionTypeA
 from sage.combinat.rigged_configurations.bij_type_C import KRTToRCBijectionTypeC
@@ -92,7 +92,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
         """
         if verbose:
             from sage.combinat.rigged_configurations.tensor_product_kr_tableaux_element \
-              import TensorProductOfKirillovReshetikhinTableauxElement
+                import TensorProductOfKirillovReshetikhinTableauxElement
 
         for cur_crystal in reversed(self.tp_krt):
             r = cur_crystal.parent().r()
@@ -108,7 +108,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                 if verbose:
                     print("====================")
                     if len(self.cur_path) == 0:
-                        print(repr([])) # Special case for displaying when the rightmost factor is a spinor
+                        print(repr([]))  # Special case for displaying when the rightmost factor is a spinor
                     else:
                         print(repr(TensorProductOfKirillovReshetikhinTableauxElement(self.tp_krt.parent(), self.cur_path)))
                     print("--------------------")
@@ -143,14 +143,14 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                 r = cur_crystal.parent().r()
                 # Iterate through the columns
                 for col_number, cur_column in enumerate(reversed(cur_crystal.to_array(False))):
-                    bij.cur_path.insert(0, []) # Prepend an empty list
+                    bij.cur_path.insert(0, [])  # Prepend an empty list
                     bij.cur_dims.insert(0, [0, 1])
 
                     # Note that we do not need to worry about iterating over columns
                     #   (see previous note about the data structure).
                     for letter in reversed(cur_column):
                         bij.cur_dims[0][0] += 1
-                        val = letter.value # Convert from a CrystalOfLetter to an Integer
+                        val = letter.value  # Convert from a CrystalOfLetter to an Integer
 
                         if verbose:
                             print("====================")
@@ -160,7 +160,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                             print("--------------------\n")
 
                         # Build the next state
-                        bij.cur_path[0].insert(0, [letter]) # Prepend the value
+                        bij.cur_path[0].insert(0, [letter])  # Prepend the value
                         bij.next_state(val)
 
                     # If we've split off a column, we need to merge the current column
@@ -201,14 +201,14 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                 # Perform the regular type B_n^{(1)} bijection
                 # Iterate through the columns
                 for col_number, cur_column in enumerate(reversed(cur_crystal.to_array(False))):
-                    self.cur_path.insert(0, []) # Prepend an empty list
+                    self.cur_path.insert(0, [])  # Prepend an empty list
                     self.cur_dims.insert(0, [0, 1])
 
                     # Note that we do not need to worry about iterating over columns
                     #   (see previous note about the data structure).
                     for letter in reversed(cur_column):
                         self.cur_dims[0][0] += 1
-                        val = letter.value # Convert from a CrystalOfLetter to an Integer
+                        val = letter.value  # Convert from a CrystalOfLetter to an Integer
 
                         if verbose:
                             print("====================")
@@ -218,7 +218,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                             print("--------------------\n")
 
                         # Build the next state
-                        self.cur_path[0].insert(0, [letter]) # Prepend the value
+                        self.cur_path[0].insert(0, [letter])  # Prepend the value
                         self.next_state(val)
 
                     # If we've split off a column, we need to merge the current column
@@ -241,7 +241,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                         # And perform the inverse column splitting map on the RC
                         for a in range(self.n):
                             self._update_vacancy_nums(a)
-        self.ret_rig_con.set_immutable() # Return it to immutable
+        self.ret_rig_con.set_immutable()  # Return it to immutable
         return self.ret_rig_con
 
     def next_state(self, val):
@@ -371,7 +371,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                         # Add 2 boxes
                         j = i - 1
                         while j >= 0 and p._list[j] <= max_width + 2:
-                            p.rigging[j+1] = p.rigging[j] # Shuffle it along
+                            p.rigging[j+1] = p.rigging[j]  # Shuffle it along
                             j -= 1
                         p._list.pop(i)
                         p._list.insert(j+1, max_width + 2)
@@ -379,7 +379,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                     break
 
                 if p._list[i] == max_width and not singular_max_width:
-                    p._list[i] += 1 # We always at least add a box to the first singular value
+                    p._list[i] += 1  # We always at least add a box to the first singular value
                     p.rigging[i] = None
                     if case_QS:
                         width_n = p._list[i]
@@ -402,7 +402,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
             #   to attempt both
             # Make a *deep* copy of the element
             cp = self.ret_rig_con.__copy__()
-            for i,rp in enumerate(cp):
+            for i, rp in enumerate(cp):
                 cp[i] = rp._clone()
             # We attempt case (S) first
             self._insert_cell_case_S(p)
@@ -493,7 +493,7 @@ class KRTToRCBijectionTypeB(KRTToRCBijectionTypeC):
                 p.rigging[i] = None
                 case_QS = True
                 break
-        if not case_QS: # we have not added a box yet
+        if not case_QS:  # we have not added a box yet
             p._list.append(1)
             p.rigging.append(None)
             p.vacancy_numbers.append(None)
@@ -641,7 +641,7 @@ class RCToKRTBijectionTypeB(RCToKRTBijectionTypeC):
                             y = self.rigged_con.parent()(*[x._clone() for x in self.cur_partitions], use_vacancy_numbers=True)
                             self._graph.append([self._graph[-1][1], (y, len(self._graph)), 'ls'])
 
-                    while bij.cur_dims[0][0]: # > 0:
+                    while bij.cur_dims[0][0]:  # > 0:
                         if verbose:
                             print("====================")
                             print(repr(RC(*bij.cur_partitions, use_vacancy_numbers=True)))
@@ -653,15 +653,15 @@ class RCToKRTBijectionTypeB(RCToKRTBijectionTypeC):
                         bij.cur_dims[0][0] = bij._next_index(ht)
                         b = bij.next_state(ht)
                         # Make sure we have a crystal letter
-                        ret_crystal_path[-1].append(letters(b)) # Append the rank
+                        ret_crystal_path[-1].append(letters(b))  # Append the rank
 
                         if build_graph:
                             y = self.rigged_con.parent()(*[x._clone() for x in self.cur_partitions], use_vacancy_numbers=True)
                             self._graph.append([self._graph[-1][1], (y, len(self._graph)), letters(b)])
 
-                    bij.cur_dims.pop(0) # Pop off the leading column
+                    bij.cur_dims.pop(0)  # Pop off the leading column
 
-                self.cur_dims.pop(0) # Pop off the spin rectangle
+                self.cur_dims.pop(0)  # Pop off the spin rectangle
 
                 self.cur_partitions = bij.cur_partitions
                 # Convert the n-th partition back into the special type B one
@@ -712,7 +712,7 @@ class RCToKRTBijectionTypeB(RCToKRTBijectionTypeC):
                             y = self.rigged_con.parent()(*[x._clone() for x in self.cur_partitions], use_vacancy_numbers=True)
                             self._graph.append([self._graph[-1][1], (y, len(self._graph)), '2x'])
 
-                    while self.cur_dims[0][0]: #> 0:
+                    while self.cur_dims[0][0]:  # > 0:
                         if verbose:
                             print("====================")
                             print(repr(self.rigged_con.parent()(*self.cur_partitions, use_vacancy_numbers=True)))
@@ -720,20 +720,20 @@ class RCToKRTBijectionTypeB(RCToKRTBijectionTypeC):
                             print(ret_crystal_path)
                             print("--------------------\n")
 
-                        self.cur_dims[0][0] -= 1 # This takes care of the indexing
+                        self.cur_dims[0][0] -= 1  # This takes care of the indexing
                         b = self.next_state(self.cur_dims[0][0])
 
                         # Make sure we have a crystal letter
-                        ret_crystal_path[-1].append(letters(b)) # Append the rank
+                        ret_crystal_path[-1].append(letters(b))  # Append the rank
 
                         if build_graph:
                             y = self.rigged_con.parent()(*[x._clone() for x in self.cur_partitions], use_vacancy_numbers=True)
                             self._graph.append([self._graph[-1][1], (y, len(self._graph)), letters(b)])
 
-                    self.cur_dims.pop(0) # Pop off the leading column
+                    self.cur_dims.pop(0)  # Pop off the leading column
 
         if build_graph:
-            self._graph.pop(0) # Remove the dummy at the start
+            self._graph.pop(0)  # Remove the dummy at the start
             from sage.graphs.digraph import DiGraph
             from sage.graphs.dot2tex_utils import have_dot2tex
             self._graph = DiGraph(self._graph)
@@ -796,7 +796,7 @@ class RCToKRTBijectionTypeB(RCToKRTBijectionTypeC):
                                 last_size = partition[j]
                                 case_S = True
                                 break
-                        if not case_Q: # We found a singular string above the quasi-singular one
+                        if not case_Q:  # We found a singular string above the quasi-singular one
                             break
                         ell[n-1] = i
                         last_size = partition[i]
@@ -882,7 +882,7 @@ class RCToKRTBijectionTypeB(RCToKRTBijectionTypeC):
         self._update_vacancy_numbers(n - 1)
         if row_num_next is not None:
             self.cur_partitions[n-1].rigging[row_num_next] = self.cur_partitions[n-1].vacancy_numbers[row_num_next]
-        if row_num_bar_next is not None: # If we enter here, it means case (Q, S) holds
+        if row_num_bar_next is not None:  # If we enter here, it means case (Q, S) holds
             vac_num = self.cur_partitions[n-1].vacancy_numbers[row_num_bar_next]
             self.cur_partitions[n-1].rigging[row_num_bar_next] = vac_num
             if make_quasisingular:
@@ -895,4 +895,4 @@ class RCToKRTBijectionTypeB(RCToKRTBijectionTypeC):
                     j += 1
                 self.cur_partitions[n-1].rigging[j-1] = vac_num - 1
 
-        return(b)
+        return b

--- a/src/sage/combinat/rigged_configurations/bij_type_C.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_C.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_type_A import KRTToRCBijectionTypeA
 from sage.combinat.rigged_configurations.bij_type_A import RCToKRTBijectionTypeA
@@ -151,7 +151,7 @@ class KRTToRCBijectionTypeC(KRTToRCBijectionTypeA):
             if partition.rigging[i] is None:
                 j = i - 1
                 while j >= 0 and partition._list[j] == partition._list[i]:
-                    partition.rigging[j+1] = partition.rigging[j] # Shuffle it along
+                    partition.rigging[j+1] = partition.rigging[j]  # Shuffle it along
                     j -= 1
                 partition._list[j+1] += 1
                 partition.rigging[j+1] = None
@@ -176,7 +176,7 @@ class RCToKRTBijectionTypeC(RCToKRTBijectionTypeA):
             sage: bijection.next_state(1)
             -1
         """
-        height -= 1 # indexing
+        height -= 1  # indexing
         n = self.n
         ell = [None] * (2*n)
         case_S = [False] * n
@@ -214,7 +214,7 @@ class RCToKRTBijectionTypeC(RCToKRTBijectionTypeA):
                 if a >= height and self.cur_partitions[a][ell[a]] == last_size:
                     ell[n+a] = ell[a]
                     case_S[a] = True
-                else: # note last_size > 1
+                else:  # note last_size > 1
                     ell[n+a] = self._find_singular_string(self.cur_partitions[a], last_size)
 
                     if ell[n + a] is None:
@@ -262,4 +262,4 @@ class RCToKRTBijectionTypeC(RCToKRTBijectionTypeA):
         if row_num_next is not None:
             self.cur_partitions[n-1].rigging[row_num_next] = self.cur_partitions[n-1].vacancy_numbers[row_num_next]
 
-        return(b)
+        return b

--- a/src/sage/combinat/rigged_configurations/bij_type_D.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_D.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2011, 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_type_A import KRTToRCBijectionTypeA
 from sage.combinat.rigged_configurations.bij_type_A import RCToKRTBijectionTypeA
@@ -83,7 +83,7 @@ class KRTToRCBijectionTypeD(KRTToRCBijectionTypeA):
             r = cur_crystal.parent().r()
             # Iterate through the columns
             for col_number, cur_column in enumerate(reversed(cur_crystal.to_array(False))):
-                self.cur_path.insert(0, []) # Prepend an empty list
+                self.cur_path.insert(0, [])  # Prepend an empty list
 
                 # Check to see if we are a spinor column
                 if r >= self.n-1:
@@ -102,7 +102,7 @@ class KRTToRCBijectionTypeD(KRTToRCBijectionTypeA):
                     # This check is needed for the n-1 spin column
                     if self.cur_dims[0][0] < r:
                         self.cur_dims[0][0] += 1
-                    val = letter.value # Convert from a CrystalOfLetter to an Integer
+                    val = letter.value  # Convert from a CrystalOfLetter to an Integer
 
                     if verbose:
                         print("====================")
@@ -112,7 +112,7 @@ class KRTToRCBijectionTypeD(KRTToRCBijectionTypeA):
                         print("--------------------\n")
 
                     # Build the next state
-                    self.cur_path[0].insert(0, [letter]) # Prepend the value
+                    self.cur_path[0].insert(0, [letter])  # Prepend the value
                     self.next_state(val)
 
                 # Check to see if we are a spinor column
@@ -139,7 +139,7 @@ class KRTToRCBijectionTypeD(KRTToRCBijectionTypeA):
                     for a in range(self.n):
                         self._update_vacancy_nums(a)
 
-        self.ret_rig_con.set_immutable() # Return it to immutable
+        self.ret_rig_con.set_immutable()  # Return it to immutable
         return self.ret_rig_con
 
     def next_state(self, val):
@@ -495,7 +495,7 @@ class RCToKRTBijectionTypeD(RCToKRTBijectionTypeA):
                         b = self.next_state(self.n)
                         if b == self.n:
                             b = -self.n
-                        ret_crystal_path[-1].append(letters(b)) # Append the rank
+                        ret_crystal_path[-1].append(letters(b))  # Append the rank
 
                         if build_graph:
                             y = self.rigged_con.parent()(*[x._clone() for x in self.cur_partitions], use_vacancy_numbers=True)
@@ -509,7 +509,7 @@ class RCToKRTBijectionTypeD(RCToKRTBijectionTypeA):
                         print(ret_crystal_path)
                         print("--------------------\n")
 
-                    self.cur_dims[0][0] -= 1 # This takes care of the indexing
+                    self.cur_dims[0][0] -= 1  # This takes care of the indexing
                     b = self.next_state(self.cur_dims[0][0])
 
                     # Corrections for spinor
@@ -518,13 +518,13 @@ class RCToKRTBijectionTypeD(RCToKRTBijectionTypeA):
                         b = -(self.n-1)
 
                     # Make sure we have a crystal letter
-                    ret_crystal_path[-1].append(letters(b)) # Append the rank
+                    ret_crystal_path[-1].append(letters(b))  # Append the rank
 
                     if build_graph:
                         y = self.rigged_con.parent()(*[x._clone() for x in self.cur_partitions], use_vacancy_numbers=True)
                         self._graph.append([self._graph[-1][1], (y, len(self._graph)), letters(b)])
 
-                self.cur_dims.pop(0) # Pop off the leading column
+                self.cur_dims.pop(0)  # Pop off the leading column
 
                 # Check to see if we were a spinor
                 if dim[0] >= self.n-1:
@@ -677,7 +677,7 @@ class RCToKRTBijectionTypeD(RCToKRTBijectionTypeA):
             self.cur_partitions[n - 1].rigging[ret_row_bar_next] = \
               self.cur_partitions[n - 1].vacancy_numbers[ret_row_bar_next]
 
-        return(b)
+        return b
 
     def doubling_map(self):
         r"""

--- a/src/sage/combinat/rigged_configurations/bij_type_D_tri.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_D_tri.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2014 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_type_A import KRTToRCBijectionTypeA
 from sage.combinat.rigged_configurations.bij_type_A import RCToKRTBijectionTypeA
@@ -169,7 +169,7 @@ class KRTToRCBijectionTypeDTri(KRTToRCBijectionTypeA):
                     else:
                         j = i - 1
                         while j >= 0 and P._list[j] <= max_width + 2:
-                            P.rigging[j+1] = P.rigging[j] # Shuffle it along
+                            P.rigging[j+1] = P.rigging[j]  # Shuffle it along
                             j -= 1
                         P._list.pop(i)
                         P._list.insert(j+1, max_width + 2)
@@ -193,7 +193,7 @@ class KRTToRCBijectionTypeDTri(KRTToRCBijectionTypeA):
                     if P.rigging[i] is None:
                         j = i - 1
                         while j >= 0 and P._list[j] == P._list[i]:
-                            P.rigging[j+1] = P.rigging[j] # Shuffle it along
+                            P.rigging[j+1] = P.rigging[j]  # Shuffle it along
                             j -= 1
                         P._list[j+1] += 1
                         P.rigging[j+1] = None
@@ -210,7 +210,7 @@ class KRTToRCBijectionTypeDTri(KRTToRCBijectionTypeA):
                     if P.rigging[i] is None:
                         j = i - 1
                         while j >= 0 and P._list[j] == P._list[i]:
-                            P.rigging[j+1] = P.rigging[j] # Shuffle it along
+                            P.rigging[j+1] = P.rigging[j]  # Shuffle it along
                             j -= 1
                         P._list[j+1] += 1
                         P.rigging[j+1] = None
@@ -254,7 +254,7 @@ class RCToKRTBijectionTypeDTri(RCToKRTBijectionTypeA):
             sage: bijection.next_state(2)
             -3
         """
-        height -= 1 # indexing
+        height -= 1  # indexing
         ell = [None] * 6
         case_S = [False] * 3
         case_Q = False
@@ -305,7 +305,7 @@ class RCToKRTBijectionTypeDTri(RCToKRTBijectionTypeA):
                 else:
                     b = 0
 
-        if b is None: # Going back
+        if b is None:  # Going back
             if self.cur_partitions[1][ell[1]] == last_size:
                 ell[4] = ell[1]
                 case_S[1] = True
@@ -317,7 +317,7 @@ class RCToKRTBijectionTypeDTri(RCToKRTBijectionTypeA):
                 else:
                     last_size = self.cur_partitions[1][ell[4]]
 
-        if b is None: # Final partition
+        if b is None:  # Final partition
             P = self.cur_partitions[0]
             if ell[0] is not None and P[ell[0]] == last_size:
                 ell[5] = ell[0]
@@ -346,7 +346,7 @@ class RCToKRTBijectionTypeDTri(RCToKRTBijectionTypeA):
 
         if case_S[0]:
             row0 = [self.cur_partitions[0].remove_cell(ell[5], 2)]
-            row0.append( self.cur_partitions[0].remove_cell(ell[3], 2) )
+            row0.append(self.cur_partitions[0].remove_cell(ell[3], 2))
         else:
             if case_Q:
                 if ell[0] is None or ell[0] < ell[2]:
@@ -360,9 +360,9 @@ class RCToKRTBijectionTypeDTri(RCToKRTBijectionTypeA):
             else:
                 row0 = [self.cur_partitions[0].remove_cell(ell[0])]
                 if case_S[2]:
-                    row0.append( self.cur_partitions[0].remove_cell(ell[3], 2) )
+                    row0.append(self.cur_partitions[0].remove_cell(ell[3], 2))
 
-            row0.append( self.cur_partitions[0].remove_cell(ell[5]) )
+            row0.append(self.cur_partitions[0].remove_cell(ell[5]))
 
         self._update_vacancy_numbers(0)
         self._update_vacancy_numbers(1)
@@ -387,4 +387,4 @@ class RCToKRTBijectionTypeDTri(RCToKRTBijectionTypeA):
                 j += 1
             P.rigging[j-1] = vac_num - 1
 
-        return(b)
+        return b

--- a/src/sage/combinat/rigged_configurations/bij_type_D_twisted.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_D_twisted.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2011, 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_type_A import KRTToRCBijectionTypeA
 from sage.combinat.rigged_configurations.bij_type_A2_even import KRTToRCBijectionTypeA2Even
@@ -84,7 +84,7 @@ class KRTToRCBijectionTypeDTwisted(KRTToRCBijectionTypeD, KRTToRCBijectionTypeA2
             r = cur_crystal.parent().r()
             # Iterate through the columns
             for col_number, cur_column in enumerate(reversed(cur_crystal.to_array(False))):
-                self.cur_path.insert(0, []) # Prepend an empty list
+                self.cur_path.insert(0, [])  # Prepend an empty list
 
                 # Check to see if we are a spinor column
                 if r == self.n:
@@ -101,7 +101,7 @@ class KRTToRCBijectionTypeDTwisted(KRTToRCBijectionTypeD, KRTToRCBijectionTypeA2
 
                 for letter in reversed(cur_column):
                     self.cur_dims[0][0] += 1
-                    val = letter.value # Convert from a CrystalOfLetter to an Integer
+                    val = letter.value  # Convert from a CrystalOfLetter to an Integer
 
                     if verbose:
                         print("====================")
@@ -111,7 +111,7 @@ class KRTToRCBijectionTypeDTwisted(KRTToRCBijectionTypeD, KRTToRCBijectionTypeA2
                         print("--------------------\n")
 
                     # Build the next state
-                    self.cur_path[0].insert(0, [letter]) # Prepend the value
+                    self.cur_path[0].insert(0, [letter])  # Prepend the value
                     self.next_state(val)
 
                 # Check to see if we are a spinor column
@@ -138,7 +138,7 @@ class KRTToRCBijectionTypeDTwisted(KRTToRCBijectionTypeD, KRTToRCBijectionTypeA2
                     for a in range(self.n):
                         self._update_vacancy_nums(a)
 
-        self.ret_rig_con.set_immutable() # Return it to immutable
+        self.ret_rig_con.set_immutable()  # Return it to immutable
         return self.ret_rig_con
 
     def next_state(self, val):
@@ -571,4 +571,4 @@ class RCToKRTBijectionTypeDTwisted(RCToKRTBijectionTypeD, RCToKRTBijectionTypeA2
             else:
                 self.cur_partitions[n-1].rigging[row_num_bar_next] = self.cur_partitions[n-1].vacancy_numbers[row_num_bar_next]
 
-        return(b)
+        return b

--- a/src/sage/combinat/rigged_configurations/bij_type_E67.py
+++ b/src/sage/combinat/rigged_configurations/bij_type_E67.py
@@ -20,7 +20,7 @@ TESTS::
     sage: TestSuite(bijection).run()
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2011, 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -32,8 +32,8 @@ TESTS::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.rigged_configurations.bij_abstract_class import KRTToRCBijectionAbstract
 from sage.combinat.rigged_configurations.bij_abstract_class import RCToKRTBijectionAbstract
@@ -91,8 +91,8 @@ class KRTToRCBijectionTypeE67(KRTToRCBijectionAbstract):
             if not data:
                 break
 
-            max_val = max(l for a,l in data)
-            for a,l in data:
+            max_val = max(l for a, l in data)
+            for a, l in data:
                 if l == max_val:
                     self.ret_rig_con[a-1].insert_cell(max_width)
                     max_width = l
@@ -153,7 +153,7 @@ class KRTToRCBijectionTypeE67(KRTToRCBijectionAbstract):
                 return 2
             if r == 2:
                 return 5
-        else: # rank == 7
+        else:  # rank == 7
             #     1-2-3
             #    /
             # 0-7-6-5-4
@@ -240,12 +240,12 @@ class RCToKRTBijectionTypeE67(RCToKRTBijectionAbstract):
             data = [(a, self._find_singular_string(self.cur_partitions[a-1], last_size))
                     for a in b.value if a > 0]
             data = [(val, a, self.cur_partitions[a-1][val])
-                    for a,val in data if val is not None]
+                    for a, val in data if val is not None]
             if not data:
                 break
 
-            min_val = min(l for i,a,l in data)
-            for i,a,l in data:
+            min_val = min(l for i, a, l in data)
+            for i, a, l in data:
                 if l == min_val:
                     found = True
                     last_size = l
@@ -253,13 +253,13 @@ class RCToKRTBijectionTypeE67(RCToKRTBijectionAbstract):
                     b = b.f(a)
                     break
 
-        for a,p in enumerate(self.cur_partitions):
+        for a, p in enumerate(self.cur_partitions):
             self._update_vacancy_numbers(a)
             for i in range(len(p)):
                 if p.rigging[i] is None:
                     p.rigging[i] = p.vacancy_numbers[i]
 
-        return(b)
+        return b
 
     def _next_index(self, r):
         """
@@ -290,7 +290,7 @@ class RCToKRTBijectionTypeE67(RCToKRTBijectionAbstract):
                 return 2
             if r == 6:
                 return 1
-        else: # rank == 7
+        else:  # rank == 7
             #     1-2-3
             #    /
             # 0-7-6-5-4
@@ -346,7 +346,7 @@ def endpoint6(r):
         sage: endpoint6(6)
         (-1, 6)
     """
-    C = CrystalOfLetters(['E',6])
+    C = CrystalOfLetters(['E', 6])
     if r == 1:
         return C.module_generators[0]  # C((1,))
     elif r == 2:
@@ -383,7 +383,7 @@ def endpoint7(r):
         sage: endpoint7(7)
         (7,)
     """
-    C = CrystalOfLetters(['E',7])
+    C = CrystalOfLetters(['E', 7])
     if r == 1:
         return C((-7, 1))
     elif r == 2:

--- a/src/sage/combinat/rigged_configurations/kleber_tree.py
+++ b/src/sage/combinat/rigged_configurations/kleber_tree.py
@@ -170,7 +170,7 @@ def _draw_tree(tree_node, node_label=True, style_point=None, style_node='fill=wh
         else:
             lines_str += "\\draw%s (%s%s) -- (%s%s%s);\n"%(style_line_str, node_name, node_place_str, node_name, i, node_place_str)
 
-    #drawing root
+    # drawing root
     if style_node is None:
         style_node = ''
     else:
@@ -429,8 +429,8 @@ class KleberTreeNode(Element):
             sage: KT.root
             Kleber tree node with weight [0, 2, 0, 2, 0] and upwards edge root [0, 0, 0, 0, 0]
         """
-        return "Kleber tree node with weight %s and upwards edge root %s"%(
-            list(self.weight.to_vector()), list(self.up_root.to_vector()) )
+        return "Kleber tree node with weight %s and upwards edge root %s" % (
+            list(self.weight.to_vector()), list(self.up_root.to_vector()))
 
     def _latex_(self):
         r"""

--- a/src/sage/combinat/rigged_configurations/rc_crystal.py
+++ b/src/sage/combinat/rigged_configurations/rc_crystal.py
@@ -179,7 +179,7 @@ class CrystalOfRiggedConfigurations(UniqueRepresentation, Parent):
         else:
             category = (RegularCrystals(), HighestWeightCrystals(), InfiniteEnumeratedSets())
         Parent.__init__(self, category=category)
-        n = self._cartan_type.rank() #== len(self._cartan_type.index_set())
+        n = self._cartan_type.rank()  # == len(self._cartan_type.index_set())
         self.module_generators = (self.element_class(self, partition_list=[[] for _ in repeat(None, n)]),)
 
     options = RiggedConfigurations.options
@@ -444,7 +444,7 @@ class CrystalOfNonSimplyLacedRC(CrystalOfRiggedConfigurations):
             sage: elt == RC.from_virtual(RC.to_virtual(elt))
             True
         """
-        gamma = list(self._folded_ct.scaling_factors()) #map(int, self._folded_ct.scaling_factors())
+        gamma = list(self._folded_ct.scaling_factors())  # map(int, self._folded_ct.scaling_factors())
         sigma = self._folded_ct._orbit
         n = self._cartan_type.rank()
         partitions = [None] * n

--- a/src/sage/combinat/rigged_configurations/rigged_configuration_element.py
+++ b/src/sage/combinat/rigged_configurations/rigged_configuration_element.py
@@ -232,8 +232,8 @@ class RiggedConfigurationElement(ClonableArray):
             nu = []
             for i in range(n):
                 nu.append(RiggedPartition())
-            #raise ValueError("Invalid input")
-            #raise ValueError("Incorrect number of rigged partitions")
+            # raise ValueError("Invalid input")
+            # raise ValueError("Incorrect number of rigged partitions")
 
         # Set the vacancy numbers
         for a, partition in enumerate(nu):
@@ -330,7 +330,7 @@ class RiggedConfigurationElement(ClonableArray):
         ret_str = ""
         for tableau in self:
             ret_str += "\n" + repr(tableau)
-        return(ret_str)
+        return ret_str
 
     def _repr_horizontal(self):
         """
@@ -1039,7 +1039,7 @@ class RCNonSimplyLacedElement(RiggedConfigurationElement):
         return self.parent().from_virtual(virtual_rc)
 
 ##########################################################
-## Highest weight crystal rigged configuration elements ##
+#  Highest weight crystal rigged configuration elements  #
 ##########################################################
 
 
@@ -1229,7 +1229,7 @@ class RCHWNonSimplyLacedElement(RCNonSimplyLacedElement):
         return self.parent()._wt - sum(sum(x) * alpha[i] for i,x in enumerate(self))
 
 ##############################################
-## KR crystal rigged configuration elements ##
+#  KR crystal rigged configuration elements  #
 ##############################################
 
 
@@ -2278,7 +2278,7 @@ class KRRCNonSimplyLacedElement(KRRiggedConfigurationElement, RCNonSimplyLacedEl
             sage: RC(partition_list=[[1,1],[2,1],[1,1]]).cocharge()
             1
         """
-        #return self.to_virtual_configuration().cocharge() / self.parent()._folded_ct.gamma[0]
+        # return self.to_virtual_configuration().cocharge() / self.parent()._folded_ct.gamma[0]
         vct = self.parent()._folded_ct
         cc = ZZ.zero()
         rigging_sum = ZZ.zero()

--- a/src/sage/combinat/rigged_configurations/tensor_product_kr_tableaux.py
+++ b/src/sage/combinat/rigged_configurations/tensor_product_kr_tableaux.py
@@ -45,7 +45,7 @@ Type `D_n^{(1)}` examples::
     False
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2010-2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -57,8 +57,8 @@ Type `D_n^{(1)}` examples::
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.misc.cachefunc import cached_method
 from sage.structure.unique_representation import UniqueRepresentation
@@ -68,9 +68,9 @@ from sage.combinat.crystals.letters import CrystalOfLetters
 from sage.combinat.root_system.cartan_type import CartanType
 
 from sage.combinat.rigged_configurations.tensor_product_kr_tableaux_element \
-  import TensorProductOfKirillovReshetikhinTableauxElement
+    import TensorProductOfKirillovReshetikhinTableauxElement
 from sage.combinat.rigged_configurations.kr_tableaux import KirillovReshetikhinTableaux, \
-  KirillovReshetikhinTableauxElement
+    KirillovReshetikhinTableauxElement
 
 from sage.rings.integer import Integer
 
@@ -339,8 +339,8 @@ class TensorProductOfKirillovReshetikhinTableaux(FullTensorProductOfRegularCryst
         index_set = self._cartan_type.classical().index_set()
         from sage.sets.recursively_enumerated_set import RecursivelyEnumeratedSet
         return RecursivelyEnumeratedSet(self.module_generators,
-                    lambda x: [x.f(i) for i in index_set],
-                    structure=None).naive_search_iterator()
+                                        lambda x: [x.f(i) for i in index_set],
+                                        structure=None).naive_search_iterator()
 
     def _test_bijection(self, **options):
         r"""
@@ -360,7 +360,7 @@ class TensorProductOfKirillovReshetikhinTableaux(FullTensorProductOfRegularCryst
             if z != x:
                 rejects.append((x, z))
 
-        tester.assertEqual(len(rejects), 0, "Bijection is not correct: %s"%rejects)
+        tester.assertEqual(len(rejects), 0, "Bijection is not correct: %s" % rejects)
         if rejects:
             return rejects
 
@@ -415,7 +415,7 @@ class TensorProductOfKirillovReshetikhinTableaux(FullTensorProductOfRegularCryst
         """
         index_set = self.cartan_type().classical().index_set()
         return tuple(x for x in FullTensorProductOfRegularCrystals.__iter__(self)
-                                if x.is_highest_weight(index_set))
+                     if x.is_highest_weight(index_set))
 
     @cached_method
     def rigged_configurations(self):

--- a/src/sage/combinat/rigged_configurations/tensor_product_kr_tableaux_element.py
+++ b/src/sage/combinat/rigged_configurations/tensor_product_kr_tableaux_element.py
@@ -9,7 +9,7 @@ AUTHORS:
 - Travis Scrimshaw (2010-09-26): Initial version
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2010, 2011, 2012 Travis Scrimshaw <tscrim@ucdavis.edu>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
@@ -21,8 +21,8 @@ AUTHORS:
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.combinat.crystals.tensor_product import TensorProductOfRegularCrystalsElement
 
@@ -158,7 +158,7 @@ class TensorProductOfKirillovReshetikhinTableauxElement(TensorProductOfRegularCr
         ret_str = repr(self[0])
         for i in range(1, len(self)):
             ret_str += " (X) " + repr(self[i])
-        return(ret_str)
+        return ret_str
 
     def _repr_diagram(self):
         """
@@ -179,7 +179,7 @@ class TensorProductOfKirillovReshetikhinTableauxElement(TensorProductOfRegularCr
             sage: Partitions.options._reset()
         """
         comp = [crys._repr_diagram().splitlines() for crys in self]
-        num_comp = len(comp) # number of components
+        num_comp = len(comp)  # number of components
         col_len = [len(t) > 0 and len(t[0]) or 1 for t in comp]  # columns per component
         num_rows = max(len(t) for t in comp)                     # number of rows
 
@@ -190,11 +190,11 @@ class TensorProductOfKirillovReshetikhinTableauxElement(TensorProductOfRegularCr
             diag += '\n'
             for c in range(num_comp):
                 if c > 0:
-                    diag += '     ' # For the tensor symbol
+                    diag += '     '  # For the tensor symbol
                 if row < len(comp[c]):
                     diag += comp[c][row]
                 else:
-                    diag += ' '*col_len[c]
+                    diag += ' ' * col_len[c]
         return diag
 
     def pp(self):
@@ -244,7 +244,7 @@ class TensorProductOfKirillovReshetikhinTableauxElement(TensorProductOfRegularCr
             Tensor product of Kirillov-Reshetikhin tableaux of type ['A', 3, 1] and factor(s) ((1, 3), (2, 2))
         """
         from sage.combinat.rigged_configurations.tensor_product_kr_tableaux \
-                import TensorProductOfKirillovReshetikhinTableaux
+            import TensorProductOfKirillovReshetikhinTableaux
         P = self.parent()
         P = TensorProductOfKirillovReshetikhinTableaux(P._cartan_type, reversed(P.dims))
         return P(*[x.lusztig_involution() for x in reversed(self)])
@@ -266,11 +266,11 @@ class TensorProductOfKirillovReshetikhinTableauxElement(TensorProductOfRegularCr
         P = self.parent()
         if P.dims[0][1] == 1:
             raise ValueError("cannot split a single column")
-        r,s = P.dims[0]
-        B = [[r,1], [r,s-1]]
+        r, s = P.dims[0]
+        B = [[r, 1], [r, s - 1]]
         B.extend(P.dims[1:])
         from sage.combinat.rigged_configurations.tensor_product_kr_tableaux \
-                import TensorProductOfKirillovReshetikhinTableaux
+            import TensorProductOfKirillovReshetikhinTableaux
         TP = TensorProductOfKirillovReshetikhinTableaux(P._cartan_type, B)
         x = self[0].left_split()
         return TP(*(list(x) + self[1:]))
@@ -298,12 +298,12 @@ class TensorProductOfKirillovReshetikhinTableauxElement(TensorProductOfRegularCr
         P = self.parent()
         if P.dims[-1][1] == 1:
             raise ValueError("cannot split a single column")
-        r,s = P.dims[-1]
+        r, s = P.dims[-1]
         B = list(P.dims[:-1])
-        B.append([r, s-1])
+        B.append([r, s - 1])
         B.append([r, 1])
         from sage.combinat.rigged_configurations.tensor_product_kr_tableaux \
-                import TensorProductOfKirillovReshetikhinTableaux
+            import TensorProductOfKirillovReshetikhinTableaux
         TP = TensorProductOfKirillovReshetikhinTableaux(P._cartan_type, B)
         x = self[-1].right_split()
         return TP(*(self[:-1] + list(x)))


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

this fixes some pep8 warnings in `combinat/rigged_configurations`

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
