### PR TITLE
gap: use CALL_WITH_STREAM to redirect output to string

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -104,8 +104,7 @@ cdef char *capture_stdout(Obj func, Obj obj):
     print objects such as ``Print()`` and ``ViewObj()``.
     """
     cdef Obj s, stream, output_text_string
-    cdef UInt res
-    cdef TypOutputFile output
+    cdef Obj l
     # The only way to get a string representation of an object that is truly
     # consistent with how it would be represented at the GAP REPL is to call
     # ViewObj on it.  Unfortunately, ViewObj *prints* to the output stream,
@@ -121,12 +120,11 @@ cdef char *capture_stdout(Obj func, Obj obj):
         output_text_string = GAP_ValueGlobalVariable("OutputTextString")
         stream = CALL_2ARGS(output_text_string, s, GAP_True)
 
-        if not OpenOutputStream(&output, stream):
-            raise GAPError("failed to open output capture stream for "
-                           "representing GAP object")
+        l = GAP_NewPlist(1)
+        GAP_AssList(l, 1, obj)
 
-        CALL_1ARGS(func, obj)
-        CloseOutput(&output)
+        CALL_WITH_STREAM = GAP_ValueGlobalVariable("CALL_WITH_STREAM")
+        CALL_3ARGS(CALL_WITH_STREAM, stream, func, l)
         return CSTR_STRING(s)
     finally:
         GAP_Leave()

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -50,13 +50,6 @@ cdef extern from "gap/intobj.h" nogil:
     Int INT_INTOBJ(Obj)
 
 
-cdef extern from "gap/io.h" nogil:
-    ctypedef struct TypOutputFile:
-        pass
-    UInt OpenOutputStream(TypOutputFile* output, Obj stream)
-    UInt CloseOutput(TypOutputFile* output)
-
-
 cdef extern from "gap/libgap-api.h" nogil:
     """
     #define sig_GAP_Enter()  {int t = GAP_Enter(); if (!t) sig_error();}
@@ -89,6 +82,9 @@ cdef extern from "gap/libgap-api.h" nogil:
 
     bint GAP_IsList(Obj lst)
     UInt GAP_LenList(Obj lst)
+    void GAP_AssList(Obj lst, UInt pos, Obj val)
+    Obj GAP_ElmList(Obj lst, UInt pos)
+    Obj GAP_NewPlist(Int capacity)
 
     bint GAP_IsRecord(Obj obj)
     Obj GAP_NewPrecord(Int capacity)


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

This avoids use of deeply internal GAP APIs which may change at any time. In particular `TypOutputFile` is likely to change again and again.

In contrast, `CALL_WITH_STREAM` is on a much higher level (and even reachable from the GAP language itself). We have no plans to change it.

Together with PR #35702 this resolves #35361.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [ ] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
