### PR TITLE
configure: Remove stray `stdin.info` file created in test

### DIFF
--- a/build/pkgs/info/spkg-configure.m4
+++ b/build/pkgs/info/spkg-configure.m4
@@ -9,6 +9,7 @@ SAGE_SPKG_CONFIGURE([info], [
         AS_IF([makeinfo -c foo 2>&1 | grep -q invalid], [
          dnl makeinfo found, but too old, and  does not support all options that ecl likes to use
          sage_spkg_install_info=yes])
+        rm -f stdin.info
        ])
     ])
 ])


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
Removes `stdin.info` generated by configure - https://groups.google.com/g/sage-release/c/4qxkufg2l6Y/m/24oPdOL-FQAJ
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
