### PR TITLE
Clarification on the MAX_MODULUS of float matrices modulo `n`

### DIFF
--- a/src/sage/matrix/matrix_modn_dense_double.pyx
+++ b/src/sage/matrix/matrix_modn_dense_double.pyx
@@ -51,8 +51,9 @@ cdef class Matrix_modn_dense_double(Matrix_modn_dense_template):
 
     These are matrices with integer entries mod ``n`` represented as
     floating-point numbers in a 64-bit word for use with LinBox routines.
-    This allows for ``n`` up to `2^{23}`.  The analogous
-    ``Matrix_modn_dense_float`` class is used for smaller moduli.
+    This allows for ``n`` up to `2^{23}`. By default, the analogous
+    ``Matrix_modn_dense_float`` class is used for smaller moduli, specifically
+    for ``n`` up to `2^{8}`.
 
     Routines here are for the most basic access, see the
     ``matrix_modn_dense_template.pxi`` file for higher-level routines.

--- a/src/sage/matrix/matrix_modn_dense_float.pyx
+++ b/src/sage/matrix/matrix_modn_dense_float.pyx
@@ -3,7 +3,7 @@
 # distutils: library_dirs = CBLAS_LIBDIR
 # distutils: include_dirs = CBLAS_INCDIR
 r"""
-Dense matrices over `\ZZ/n\ZZ` for `n < 2^{11}` using LinBox's ``Modular<float>``
+Dense matrices over `\ZZ/n\ZZ` for `n < 2^{8}` using LinBox's ``Modular<float>``
 
 AUTHORS:
 - Burcin Erocal
@@ -44,12 +44,13 @@ include "matrix_modn_dense_template.pxi"
 
 cdef class Matrix_modn_dense_float(Matrix_modn_dense_template):
     r"""
-    Dense matrices over `\ZZ/n\ZZ` for `n < 2^{11}` using LinBox's ``Modular<float>``
+    Dense matrices over `\ZZ/n\ZZ` for `n < 2^{8}` using LinBox's ``Modular<float>``
 
     These are matrices with integer entries mod ``n`` represented as
     floating-point numbers in a 32-bit word for use with LinBox routines.
-    This allows for ``n`` up to `2^{11}`.  The
-    ``Matrix_modn_dense_double`` class is used for larger moduli.
+    This could allow for ``n`` up to `2^{11}`, but for performance reasons
+    this is limited to ``n`` up to `2^{8}`, and for larger moduli the
+    ``Matrix_modn_dense_double`` class is used.
 
     Routines here are for the most basic access, see the
     ``matrix_modn_dense_template.pxi`` file for higher-level routines.


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. --> 
Improves the documentation to give more precisions on the upper limit MAX_MODULUS of `matrix_modn_dense_float.pyx` for performances sake.
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". --> Fixes #35365 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
