### PR TITLE
remove deprecated in #32894 python module interfaces/primecount

### DIFF
--- a/src/sage/interfaces/primecount.py
+++ b/src/sage/interfaces/primecount.py
@@ -1,5 +1,0 @@
-from sage.misc.superseded import deprecation
-deprecation(32894, "the module sage.interfaces.primecount is deprecated - use primecountpy.primecount instead")
-from sage.misc.lazy_import import lazy_import
-lazy_import("primecountpy.primecount", ['phi', 'nth_prime', 'prime_pi', 'prime_pi_128'],
-    deprecation=(32894, "the module sage.interfaces.primecount is deprecated - use primecountpy.primecount instead"))


### PR DESCRIPTION
it has been deprecated for well over a year, time to complete the task started on #32894.