### PR TITLE
fixing most E222 warnings in py files

### DIFF
--- a/src/sage/algebras/cluster_algebra.py
+++ b/src/sage/algebras/cluster_algebra.py
@@ -613,7 +613,7 @@ class PrincipalClusterAlgebraElement(ClusterAlgebraElement):
                 y_exp = min(f_poly.dict())
                 coeff = f_poly.dict()[y_exp]
                 g_theta = tuple(g_vect + B*vector(y_exp))
-                out[g_theta] = out.get(g_theta, zero_A) +  A({zero_t + tuple(y_exp):coeff})
+                out[g_theta] = out.get(g_theta, zero_A) + A({zero_t + tuple(y_exp):coeff})
                 f_poly -= U({y_exp:coeff}) * A.theta_basis_F_polynomial(g_theta)
 
         return out

--- a/src/sage/algebras/lie_algebras/heisenberg.py
+++ b/src/sage/algebras/lie_algebras/heisenberg.py
@@ -261,7 +261,7 @@ class HeisenbergAlgebra_fd():
         """
         if self._n == 0:
             return Family(['z'], lambda i: self.z())
-        k =  ['p%s'%i for i in range(1, self._n+1)]
+        k = ['p%s'%i for i in range(1, self._n+1)]
         k += ['q%s'%i for i in range(1, self._n+1)]
         d = {}
         for i in range(1, self._n+1):

--- a/src/sage/algebras/splitting_algebra.py
+++ b/src/sage/algebras/splitting_algebra.py
@@ -343,14 +343,14 @@ class SplittingAlgebra(PolynomialQuotientRing_domain):
         # ------------------------------------------------------------------
         if cf0_inv is not None:
             deg_cf = len(cf)-1
-            pf =  P(cf)
+            pf = P(cf)
             for root in self._splitting_roots:
                 check = self(pf)
                 if not check.is_zero():
                     continue
                 root_inv = self.one()
                 for pos in range(deg_cf-1 ):
-                    root_inv =  (-1 )**(pos+1 ) * cf[deg_cf-pos-1 ] - root_inv * root
+                    root_inv = (-1 )**(pos+1 ) * cf[deg_cf-pos-1 ] - root_inv * root
                 verbose("inverse %s of root %s" % (root_inv, root))
                 root_inv = (-1 )**(deg_cf) * cf0_inv * root_inv
                 self._invertible_elements.update({root:root_inv})

--- a/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_lie_algebras_with_basis.py
@@ -1208,7 +1208,7 @@ class FiniteDimensionalLieAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                     zero = [zero] * len(indices)
                 for X in combinations(Ind, k):
                     if not sparse:
-                        ret =  list(zero)
+                        ret = list(zero)
                     for i in range(k):
                         Y = list(X)
                         Y.pop(i)

--- a/src/sage/coding/punctured_code.py
+++ b/src/sage/coding/punctured_code.py
@@ -652,7 +652,7 @@ class PuncturedCodeOriginalCodeDecoder(Decoder):
                 try:
                     shift = 0
                     for i in list_pts:
-                        yl[i + shift] =  values[shift]
+                        yl[i + shift] = values[shift]
                         shift += 1
                     y = A(yl)
                     values = next(I)

--- a/src/sage/combinat/designs/orthogonal_arrays_build_recursive.py
+++ b/src/sage/combinat/designs/orthogonal_arrays_build_recursive.py
@@ -1404,7 +1404,7 @@ def brouwer_separable_design(k,t,q,x,check=False,verbose=False,explain_construct
     assert x>=0
     assert is_prime_power(q)
     N2 = q**4+q**2+1
-    N1 = q**2+  q +1
+    N1 = q**2+ q +1
 
     # A projective plane on (q^2-q+1)*(q^2+q+1)=q^4+q^2+1 points
     B = difference_family(N2,q**2+1,1)[1][0]

--- a/src/sage/combinat/designs/steiner_quadruple_systems.py
+++ b/src/sage/combinat/designs/steiner_quadruple_systems.py
@@ -718,7 +718,7 @@ def steiner_quadruple_system(n, check=False):
     elif n == 38:
         sqs = IncidenceStructure(38, _SQS38(), copy=False, check=False)
     elif n%12 in [4, 8]:
-        nn =  n // 2
+        nn = n // 2
         sqs = two_n(steiner_quadruple_system(nn, check=False))
     elif n%18 in [4,10]:
         nn = (n+2) // 3

--- a/src/sage/combinat/root_system/root_lattice_realizations.py
+++ b/src/sage/combinat/root_system/root_lattice_realizations.py
@@ -594,7 +594,7 @@ class RootLatticeRealizations(Category_over_base_ring):
             if not self.cartan_type().is_finite():
                 from sage.sets.disjoint_union_enumerated_sets \
                                 import DisjointUnionEnumeratedSets
-                D =  DisjointUnionEnumeratedSets([self.positive_roots(),
+                D = DisjointUnionEnumeratedSets([self.positive_roots(),
                                                   self.negative_roots()])
                 D.rename("All roots of type {}".format(self.cartan_type()))
                 return D
@@ -1509,7 +1509,7 @@ class RootLatticeRealizations(Category_over_base_ring):
                 sage: s
                 simple reflections
             """
-            res =  self.alpha().zip(self.reflection, self.alphacheck())
+            res = self.alpha().zip(self.reflection, self.alphacheck())
             # Should we use rename to set a nice name for this family?
             res.rename("simple reflections")
             return res

--- a/src/sage/combinat/root_system/type_D.py
+++ b/src/sage/combinat/root_system/type_D.py
@@ -341,7 +341,7 @@ class CartanType(CartanType_standard_finite, CartanType_simply_laced):
         if n == 2:
             ret = "{}   {}\n".format(node(label(1)), node(label(2)))
             return ret + "{!s:4}{!s:4}".format(label(1), label(2))
-        ret =  (4*(n-3))*" "+"{} {}\n".format(node(label(n)), label(n))
+        ret = (4*(n-3))*" "+"{} {}\n".format(node(label(n)), label(n))
         ret += ((4*(n-3))*" " +"|\n")*2
         ret += "---".join(node(label(i)) for i in range(1, n)) +"\n"
         ret += "".join("{!s:4}".format(label(i)) for i in range(1,n))

--- a/src/sage/combinat/sf/llt.py
+++ b/src/sage/combinat/sf/llt.py
@@ -256,7 +256,7 @@ class LLT_class(UniqueRepresentation):
 
         elif isinstance(skp, list) and skp[0] in sage.combinat.skew_partition.SkewPartitions():
             #skp is a list of skew partitions
-            skp2 =  [Partition(core=[], quotient=[skp[i][0] for i in range(len(skp))])]
+            skp2 = [Partition(core=[], quotient=[skp[i][0] for i in range(len(skp))])]
             skp2 += [Partition(core=[], quotient=[skp[i][1] for i in range(len(skp))])]
             mu = Partitions(ZZ((skp2[0].size()-skp2[1].size()) / self.level()))
             skp = skp2

--- a/src/sage/combinat/t_sequences.py
+++ b/src/sage/combinat/t_sequences.py
@@ -520,7 +520,7 @@ def T_sequences_smallcases(t, existence=False, check=True):
     if t in db:
         if existence:
             return True
-        sequences =  list(map(Sequence, db[t]))
+        sequences = list(map(Sequence, db[t]))
         if check:
             assert is_T_sequences_set(sequences)
         return sequences

--- a/src/sage/combinat/words/morphic.py
+++ b/src/sage/combinat/words/morphic.py
@@ -207,7 +207,7 @@ class WordDatatype_morphic(WordDatatype_callable):
             sage: w.representation(5)
             [1, 0, 0, 0]
         """
-        letters_to_int =  {a:i for (i,a) in enumerate(self._alphabet)}
+        letters_to_int = {a:i for (i,a) in enumerate(self._alphabet)}
         position = letters_to_int[self._letter]
         M = self._morphism.incidence_matrix()
         vMk = vector([1]*len(self._alphabet))

--- a/src/sage/crypto/cryptosystem.py
+++ b/src/sage/crypto/cryptosystem.py
@@ -207,7 +207,7 @@ class Cryptosystem(parent_old.Parent, Set_generic):
         return (type(self) is type(right) and
             self._cipher_domain == right._cipher_domain and
             self._cipher_codomain == right._cipher_codomain and
-            self._key_space ==  right._key_space and
+            self._key_space == right._key_space and
             self._block_length == right._block_length and
             self._period == right._period)
 

--- a/src/sage/crypto/lwe.py
+++ b/src/sage/crypto/lwe.py
@@ -312,7 +312,7 @@ class LWE(SageObject):
             IndexError: Number of available samples exhausted.
         """
         self.n  = ZZ(n)
-        self.m =  m
+        self.m = m
         self.__i = 0
         self.K  = IntegerModRing(q)
         self.FM = FreeModule(self.K, n)
@@ -545,7 +545,7 @@ class RingLWE(SageObject):
         """
         self.N  = ZZ(N)
         self.n = euler_phi(N)
-        self.m =  m
+        self.m = m
         self.__i = 0
         self.K  = IntegerModRing(q)
 

--- a/src/sage/crypto/mq/rijndael_gf.py
+++ b/src/sage/crypto/mq/rijndael_gf.py
@@ -516,7 +516,7 @@ class RijndaelGF(SageObject):
         self._all_PR = PolynomialRing(self._F, len(state_names + subkey_names),
                                       state_names + subkey_names)
         self.state_vrs = matrix(4, self._Nb, self._state_PR.gens())
-        fNb =  4 * self._Nb
+        fNb = 4 * self._Nb
         self.subkey_vrs_list = list(self._all_PR.gens()[fNb:])
         self.subkey_vrs = [matrix(4, self._Nb,
                            self.subkey_vrs_list[fNb * i: fNb * (i + 1)])

--- a/src/sage/crypto/mq/sr.py
+++ b/src/sage/crypto/mq/sr.py
@@ -1804,7 +1804,7 @@ class SR_generic(MPolynomialSystemGenerator):
             names += self.varstrs("s", _n, r, e)
 
         if reverse_variables:
-            names +=  self.varstrs("k", 0, r*c, e)
+            names += self.varstrs("k", 0, r*c, e)
 
         #from sage.rings.polynomial.pbori.pbori import BooleanPolynomialRing
 
@@ -1970,7 +1970,7 @@ class SR_generic(MPolynomialSystemGenerator):
                     sbox += self.inversion_polynomials( kj[(4*c-3)*e  : (4*c-3)*e + e] , si[2*e : 3*e] , e )
                     sbox += self.inversion_polynomials( kj[(4*c-4)*e  : (4*c-4)*e + e] , si[3*e : 4*e] , e )
 
-            si =  L * si + d + rc
+            si = L * si + d + rc
             Sum = Matrix(R, r*e, 1)
             lin = []
             if c > 1:
@@ -3283,7 +3283,7 @@ class SR_gf2_2(SR_gf2):
             w = P.gens()[:e]
 
         S = self.sbox(inversion_only=True)
-        F =  S.polynomials(w, x, degree=e-2, groebner=groebner)
+        F = S.polynomials(w, x, degree=e-2, groebner=groebner)
         return F
 
 class AllowZeroInversionsContext:

--- a/src/sage/databases/cremona.py
+++ b/src/sage/databases/cremona.py
@@ -1377,7 +1377,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         if largest_conductor:
             print("largest conductor =", largest_conductor)
-            self.__largest_conductor__ =  largest_conductor
+            self.__largest_conductor__ = largest_conductor
 
         # Since July 2014 the data files have been arranged in
         # subdirectories (see trac #16903).

--- a/src/sage/databases/knotinfo_db.py
+++ b/src/sage/databases/knotinfo_db.py
@@ -45,8 +45,8 @@ class KnotInfoColumnTypes(Enum):
         <KnotInfoColumnTypes.OnlyLinks: 'L'>,
         <KnotInfoColumnTypes.KnotsAndLinks: 'B'>]
     """
-    OnlyKnots =     'K'       # column that is only used in the KnotInfo table
-    OnlyLinks =     'L'       # column that is only used in the LinkInfo table
+    OnlyKnots = 'K'       # column that is only used in the KnotInfo table
+    OnlyLinks = 'L'       # column that is only used in the LinkInfo table
     KnotsAndLinks = 'B'       # column that is only used in both tables
 
 
@@ -451,7 +451,7 @@ class KnotInfoDataBase(SageObject, UniqueRepresentation):
                 num_knots_file = os.path.join(self._sobj_path, self.filename.knots.num_knots(self.version()))
                 from builtins import FileNotFoundError
                 try:
-                    self._num_knots =  load(num_knots_file)
+                    self._num_knots = load(num_knots_file)
                 except FileNotFoundError:
                     self.create_filecache()
                 self._demo = False
@@ -582,7 +582,7 @@ class KnotInfoDataBase(SageObject, UniqueRepresentation):
         # ----------------------------------------------------------------
         # Columns that exist for knots and links
         # ----------------------------------------------------------------
-        column_dict =  load('%s/%s' %(sobj_path, self.filename.knots.sobj_column()))
+        column_dict = load('%s/%s' %(sobj_path, self.filename.knots.sobj_column()))
         cols = KnotInfoColumns('ColsTemp', column_dict)
         for col in cols:
             val_list = []

--- a/src/sage/functions/transcendental.py
+++ b/src/sage/functions/transcendental.py
@@ -444,7 +444,7 @@ def zeta_symmetric(s):
     if s == 1:  # deal with poles, hopefully
         return R(0.5)
 
-    return (s/2 + 1).gamma() *    (s-1) * (R.pi()**(-s/2)) *  s.zeta()
+    return (s/2 + 1).gamma() * (s-1) * (R.pi()**(-s/2)) * s.zeta()
 
 import math
 from sage.rings.polynomial.polynomial_real_mpfr_dense import PolynomialRealDense

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -3248,7 +3248,7 @@ class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.Lattic
                 # This row is smaller than 1st row, so nothing to do
                 del permutations[n_s]
                 continue
-            permutations[n_s][0] =  PGE(S_f, 1, k + 1) * permutations[n_s][0]
+            permutations[n_s][0] = PGE(S_f, 1, k + 1) * permutations[n_s][0]
             if d == 0:
                 # This row is the same, so we have a symmetry!
                 n_s += 1

--- a/src/sage/geometry/polyhedron/base5.py
+++ b/src/sage/geometry/polyhedron/base5.py
@@ -418,7 +418,7 @@ class Polyhedron_base5(Polyhedron_base4):
         from itertools import chain
         new_verts = chain(([0] + list(x) for x in self.vertex_generator()),
                           [[1] + list(c), [-1] + list(c)])
-        new_rays =  ([0] + r for r in self.rays())
+        new_rays = ([0] + r for r in self.rays())
         new_lines = ([0] + l for l in self.lines())
         new_ieqs = chain(([i.b()] + [ c*i.A() + i.b()] + list(i.A()) for i in self.inequalities()),
                          ([i.b()] + [-c*i.A() - i.b()] + list(i.A()) for i in self.inequalities()))
@@ -508,7 +508,7 @@ class Polyhedron_base5(Polyhedron_base4):
         from itertools import chain
         new_verts = chain(([0] + v for v in self.vertices()),
                           ([1] + v for v in self.vertices()))
-        new_rays =  ([0] + r for r in self.rays())
+        new_rays = ([0] + r for r in self.rays())
         new_lines = ([0] + l for l in self.lines())
         new_eqns = ([e.b()] + [0] + list(e[1:]) for e in self.equations())
         new_ieqs = chain(([i.b()] + [0] + list(i[1:]) for i in self.inequalities()),

--- a/src/sage/geometry/ribbon_graph.py
+++ b/src/sage/geometry/ribbon_graph.py
@@ -1221,7 +1221,7 @@ def bipartite_ribbon_graph(p, q):
         elif (i+1) % q != 0:
             k = (i+1) % q
         t = 0
-        if (i+1) %  q != 0:
+        if (i+1) % q != 0:
             t = 1
         aux_edge = [i+1, p*q + k*p - ((i+1 + t*q)/q).floor() +1]
         rho += [aux_edge]

--- a/src/sage/graphs/graph_database.py
+++ b/src/sage/graphs/graph_database.py
@@ -73,7 +73,7 @@ def degseq_to_data(degree_sequence):
         3221
     """
     degree_sequence.sort()
-    return sum(degree_sequence[i]*10**i for i in range(len(degree_sequence)))
+    return sum(di * 10**i for i, di in enumerate(degree_sequence))
 
 
 def data_to_degseq(data, graph6=None):
@@ -101,9 +101,8 @@ def data_to_degseq(data, graph6=None):
     if not degseq:
         # compute number of 0's in list from graph6 string
         from sage.graphs.generic_graph_pyx import length_and_string_from_graph6
-        return length_and_string_from_graph6(str(graph6))[0]*[0]
-    else:
-        return degseq
+        return length_and_string_from_graph6(str(graph6))[0] * [0]
+    return degseq
 
 
 def graph6_to_plot(graph6):
@@ -181,43 +180,43 @@ def subgraphs_to_query(subgraphs, db):
 # tables     columns                    input data type     sqlite data type
 # -----------------------------------------------------------------------------
 aut_grp = ['aut_grp_size',             # Integer           INTEGER
-            'num_orbits',               # Integer           INTEGER
-            'num_fixed_points',         # Integer           INTEGER
-            'vertex_transitive',        # bool              BOOLEAN
-            'edge_transitive']          # bool              BOOLEAN
+           'num_orbits',               # Integer           INTEGER
+           'num_fixed_points',         # Integer           INTEGER
+           'vertex_transitive',        # bool              BOOLEAN
+           'edge_transitive']          # bool              BOOLEAN
 degrees = ['degree_sequence',          # list              INTEGER (see degseq_to_data module function)
-            'min_degree',               # Integer           INTEGER
-            'max_degree',               # Integer           INTEGER
-            'average_degree',           # Real              REAL
-            'degrees_sd',               # Real              REAL
-            'regular']                  # bool              BOOLEAN
+           'min_degree',               # Integer           INTEGER
+           'max_degree',               # Integer           INTEGER
+           'average_degree',           # Real              REAL
+           'degrees_sd',               # Real              REAL
+           'regular']                  # bool              BOOLEAN
 misc = ['vertex_connectivity',      # Integer           INTEGER
-            'edge_connectivity',        # Integer           INTEGER
-            'num_components',           # Integer           INTEGER
-            'girth',                    # Integer           INTEGER
-            'radius',                   # Integer           INTEGER
-            'diameter',                 # Integer           INTEGER
-            'clique_number',            # Integer           INTEGER
-            'independence_number',      # Integer           INTEGER
-            'num_cut_vertices',         # Integer           INTEGER
-            'min_vertex_cover_size',    # Integer           INTEGER
-            'num_spanning_trees',       # Integer           INTEGER
-            'induced_subgraphs']        # String            STRING
+        'edge_connectivity',        # Integer           INTEGER
+        'num_components',           # Integer           INTEGER
+        'girth',                    # Integer           INTEGER
+        'radius',                   # Integer           INTEGER
+        'diameter',                 # Integer           INTEGER
+        'clique_number',            # Integer           INTEGER
+        'independence_number',      # Integer           INTEGER
+        'num_cut_vertices',         # Integer           INTEGER
+        'min_vertex_cover_size',    # Integer           INTEGER
+        'num_spanning_trees',       # Integer           INTEGER
+        'induced_subgraphs']        # String            STRING
 spectrum = ['spectrum',                 # String            STRING
             'min_eigenvalue',           # Real              REAL
             'max_eigenvalue',           # Real              REAL
             'eigenvalues_sd',           # Real              REAL
             'energy']                   # Real              REAL
-graph_data=['complement_graph6',        # String            STRING
-            'eulerian',                 # bool              BOOLEAN
-            'graph6',                   # String            STRING
-            'lovasz_number',            # Real              REAL
-            'num_cycles',               # Integer           INTEGER
-            'num_edges',                # Integer           INTEGER
-            'num_hamiltonian_cycles',   # Integer           INTEGER
-            'num_vertices',             # Integer           INTEGER
-            'perfect',                  # bool              BOOLEAN
-            'planar']                   # bool              BOOLEAN
+graph_data = ['complement_graph6',        # String            STRING
+              'eulerian',                 # bool              BOOLEAN
+              'graph6',                   # String            STRING
+              'lovasz_number',            # Real              REAL
+              'num_cycles',               # Integer           INTEGER
+              'num_edges',                # Integer           INTEGER
+              'num_hamiltonian_cycles',   # Integer           INTEGER
+              'num_vertices',             # Integer           INTEGER
+              'perfect',                  # bool              BOOLEAN
+              'planar']                   # bool              BOOLEAN
 
 valid_kwds = aut_grp + degrees + misc + spectrum + graph_data
 

--- a/src/sage/graphs/graph_database.py
+++ b/src/sage/graphs/graph_database.py
@@ -180,18 +180,18 @@ def subgraphs_to_query(subgraphs, db):
 
 # tables     columns                    input data type     sqlite data type
 # -----------------------------------------------------------------------------
-aut_grp =  ['aut_grp_size',             # Integer           INTEGER
+aut_grp = ['aut_grp_size',             # Integer           INTEGER
             'num_orbits',               # Integer           INTEGER
             'num_fixed_points',         # Integer           INTEGER
             'vertex_transitive',        # bool              BOOLEAN
             'edge_transitive']          # bool              BOOLEAN
-degrees =  ['degree_sequence',          # list              INTEGER (see degseq_to_data module function)
+degrees = ['degree_sequence',          # list              INTEGER (see degseq_to_data module function)
             'min_degree',               # Integer           INTEGER
             'max_degree',               # Integer           INTEGER
             'average_degree',           # Real              REAL
             'degrees_sd',               # Real              REAL
             'regular']                  # bool              BOOLEAN
-misc =     ['vertex_connectivity',      # Integer           INTEGER
+misc = ['vertex_connectivity',      # Integer           INTEGER
             'edge_connectivity',        # Integer           INTEGER
             'num_components',           # Integer           INTEGER
             'girth',                    # Integer           INTEGER

--- a/src/sage/groups/additive_abelian/additive_abelian_group.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_group.py
@@ -353,7 +353,7 @@ class AdditiveAbelianGroup_class(FGP_Module_class, AbelianGroup):
         if not self.invariants():
             return ZZ(1)
         else:
-            ann =  self.annihilator().gen()
+            ann = self.annihilator().gen()
             if ann:
                 return ann
             return ZZ(0)

--- a/src/sage/groups/finitely_presented_named.py
+++ b/src/sage/groups/finitely_presented_named.py
@@ -381,7 +381,7 @@ def DiCyclicPresentation(n):
         raise ValueError('input integer must be greater than 1')
 
     F = FreeGroup(['a','b'])
-    rls =  F([1])**(2*n), F([2,2])*F([-1])**n, F([-2,1,2,1])
+    rls = F([1])**(2*n), F([2,2])*F([-1])**n, F([-2,1,2,1])
     return FinitelyPresentedGroup(F, rls)
 
 def SymmetricPresentation(n):

--- a/src/sage/groups/perm_gps/cubegroup.py
+++ b/src/sage/groups/perm_gps/cubegroup.py
@@ -929,15 +929,15 @@ class CubeGroup(PermutationGroup_generic):
         """
         g = self.parse(mv)
         lst = self.facets(g)
-        line1 =  "             +--------------+\n"
-        line2 =  "             |%3d  %3d  %3d |\n"%(lst[0],lst[1],lst[2])
-        line3 =  "             |%3d   top %3d |\n"%(lst[3],lst[4])
-        line4 =  "             |%3d  %3d  %3d |\n"%(lst[5],lst[6],lst[7])
-        line5 =  "+------------+--------------+-------------+------------+\n"
-        line6 =  "|%3d %3d %3d |%3d  %3d  %3d |%3d  %3d %3d |%3d %3d %3d |\n"%(lst[8],lst[9],lst[10],lst[16],lst[17],lst[18],lst[24],lst[25],lst[26],lst[32],lst[33],lst[34])
-        line7 =  "|%3d left%3d |%3d  front%3d |%3d right%3d |%3d rear%3d |\n"%(lst[11],lst[12],lst[19],lst[20],lst[27],lst[28],lst[35],lst[36])
-        line8 =  "|%3d %3d %3d |%3d  %3d  %3d |%3d  %3d %3d |%3d %3d %3d |\n"%(lst[13],lst[14],lst[15],lst[21],lst[22],lst[23],lst[29],lst[30],lst[31],lst[37],lst[38],lst[39])
-        line9 =  "+------------+--------------+-------------+------------+\n"
+        line1 = "             +--------------+\n"
+        line2 = "             |%3d  %3d  %3d |\n"%(lst[0],lst[1],lst[2])
+        line3 = "             |%3d   top %3d |\n"%(lst[3],lst[4])
+        line4 = "             |%3d  %3d  %3d |\n"%(lst[5],lst[6],lst[7])
+        line5 = "+------------+--------------+-------------+------------+\n"
+        line6 = "|%3d %3d %3d |%3d  %3d  %3d |%3d  %3d %3d |%3d %3d %3d |\n"%(lst[8],lst[9],lst[10],lst[16],lst[17],lst[18],lst[24],lst[25],lst[26],lst[32],lst[33],lst[34])
+        line7 = "|%3d left%3d |%3d  front%3d |%3d right%3d |%3d rear%3d |\n"%(lst[11],lst[12],lst[19],lst[20],lst[27],lst[28],lst[35],lst[36])
+        line8 = "|%3d %3d %3d |%3d  %3d  %3d |%3d  %3d %3d |%3d %3d %3d |\n"%(lst[13],lst[14],lst[15],lst[21],lst[22],lst[23],lst[29],lst[30],lst[31],lst[37],lst[38],lst[39])
+        line9 = "+------------+--------------+-------------+------------+\n"
         line10 = "             |%3d  %3d  %3d |\n"%(lst[40],lst[41],lst[42])
         line11 = "             |%3d bottom%3d |\n"%(lst[43],lst[44])
         line12 = "             |%3d  %3d  %3d |\n"%(lst[45],lst[46],lst[47])
@@ -1002,9 +1002,9 @@ class CubeGroup(PermutationGroup_generic):
         cubeU = sum(cubiesU)
         cubiesF = [plot3d_cubie(cubie_centers(c),cubie_colors(c,state)) for c in [22,23,24,20,21]]
         cubeF = sum(cubiesF)
-        centerR =  polygon_plot3d([[1,3,1],[2,3,1],[2,3,2],[1,3,2],[1,3,1]],rgbcolor=green)
-        centerF =  polygon_plot3d([[3,1,1],[3,2,1],[3,2,2],[3,1,2],[3,1,1]],rgbcolor=red)
-        centerU =  polygon_plot3d([[1,1,3],[1,2,3],[2,2,3],[2,1,3],[1,1,3]],rgbcolor=lpurple)
+        centerR = polygon_plot3d([[1,3,1],[2,3,1],[2,3,2],[1,3,2],[1,3,1]],rgbcolor=green)
+        centerF = polygon_plot3d([[3,1,1],[3,2,1],[3,2,2],[3,1,2],[3,1,1]],rgbcolor=red)
+        centerU = polygon_plot3d([[1,1,3],[1,2,3],[2,2,3],[2,1,3],[1,1,3]],rgbcolor=lpurple)
         centers = centerF+centerR+centerU
         P = cubeR+cubeF+cubeU+centers
         P.axes(show=False)

--- a/src/sage/interfaces/singular.py
+++ b/src/sage/interfaces/singular.py
@@ -1906,7 +1906,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
                 exp = int(0)
 
                 if monomial not in ['1', '(1.000e+00)']:
-                    term =  monomial.split("^")
+                    term = monomial.split("^")
                     if len(term)==int(2):
                         exp = int(term[1])
                     else:
@@ -2060,7 +2060,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
         elif typ == 'intmat':
             from sage.matrix.constructor import matrix
             from sage.rings.integer_ring import ZZ
-            A =  matrix(ZZ, int(self.nrows()), int(self.ncols()))
+            A = matrix(ZZ, int(self.nrows()), int(self.ncols()))
             for i in range(A.nrows()):
                 for j in range(A.ncols()):
                     A[i,j] = sage.rings.integer.Integer(str(self[i+1,j+1]))
@@ -2496,7 +2496,7 @@ class SingularGBLogPrettyPrinter:
     cri_hilb = re.compile("h")          # used Hilbert series criterion
     hig_corn = re.compile(r"H\(\d+\)")   # found a 'highest corner' of degree d, no need to consider higher degrees
     num_crit = re.compile(r"\(\d+\)")    # n critical pairs are still to be reduced
-    red_num =  re.compile(r"\(S:\d+\)")  # doing complete reduction of n elements
+    red_num = re.compile(r"\(S:\d+\)")  # doing complete reduction of n elements
     deg_lead = re.compile(r"\d+")        # the degree of the leading terms is currently d
 
     # SlimGB

--- a/src/sage/interfaces/tides.py
+++ b/src/sage/interfaces/tides.py
@@ -851,7 +851,7 @@ def genfiles_mpfr(integrator, driver, f, ics, initial, final, delta,
 
     VAR = n-1
     PAR = len(parameters)
-    TT =  len(code)+1-VAR
+    TT = len(code)+1-VAR
 
     outfile = open(integrator, 'a')
 

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -2315,7 +2315,7 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
             if K.crossing_number() != cross_nr:
                 continue
             if not is_knot or cross_nr > 10:
-                if K.is_alternating() !=  is_alt:
+                if K.is_alternating() != is_alt:
                     continue
             if is_knot or oriented:
                 res.append(K)
@@ -2475,7 +2475,7 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
         """
         is_knot  = self._is_knot
         cross_nr = self._crossing_number
-        is_alt   =  self._is_alternating
+        is_alt   = self._is_alternating
         n_unori  = self._name_unoriented
 
         alt = 'a'

--- a/src/sage/manifolds/differentiable/tensorfield.py
+++ b/src/sage/manifolds/differentiable/tensorfield.py
@@ -4174,7 +4174,7 @@ class TensorField(ModuleElementWithMutability):
             metric = self._domain.metric()
         nabla = metric.connection()
         if n_cov == 0:
-            resu =  nabla(self).trace(n_con-1, n_con)
+            resu = nabla(self).trace(n_con-1, n_con)
         else:
             tup = self.up(metric, self._tensor_rank-1)
             resu = nabla(tup).trace(n_con, self._tensor_rank)

--- a/src/sage/manifolds/structure.py
+++ b/src/sage/manifolds/structure.py
@@ -93,7 +93,7 @@ class DifferentialStructure(Singleton):
     chart = DiffChart
     name = "differentiable"
     scalar_field_algebra = DiffScalarFieldAlgebra
-    homset =  DifferentiableManifoldHomset
+    homset = DifferentiableManifoldHomset
 
     def subcategory(self, cat):
         """
@@ -118,7 +118,7 @@ class RealDifferentialStructure(Singleton):
     chart = RealDiffChart
     name = "differentiable"
     scalar_field_algebra = DiffScalarFieldAlgebra
-    homset =  DifferentiableManifoldHomset
+    homset = DifferentiableManifoldHomset
 
     def subcategory(self, cat):
         """
@@ -142,7 +142,7 @@ class PseudoRiemannianStructure(Singleton):
     chart = RealDiffChart
     name = "pseudo-Riemannian"
     scalar_field_algebra = DiffScalarFieldAlgebra
-    homset =  DifferentiableManifoldHomset
+    homset = DifferentiableManifoldHomset
 
     def subcategory(self, cat):
         """
@@ -166,7 +166,7 @@ class RiemannianStructure(Singleton):
     chart = RealDiffChart
     name = "Riemannian"
     scalar_field_algebra = DiffScalarFieldAlgebra
-    homset =  DifferentiableManifoldHomset
+    homset = DifferentiableManifoldHomset
 
     def subcategory(self, cat):
         """
@@ -190,7 +190,7 @@ class LorentzianStructure(Singleton):
     chart = RealDiffChart
     name = "Lorentzian"
     scalar_field_algebra = DiffScalarFieldAlgebra
-    homset =  DifferentiableManifoldHomset
+    homset = DifferentiableManifoldHomset
 
     def subcategory(self, cat):
         """
@@ -214,7 +214,7 @@ class DegenerateStructure(Singleton):
     chart = RealDiffChart
     name = "degenerate_metric"
     scalar_field_algebra = DiffScalarFieldAlgebra
-    homset =  DifferentiableManifoldHomset
+    homset = DifferentiableManifoldHomset
 
     def subcategory(self, cat):
         """

--- a/src/sage/matrix/benchmark.py
+++ b/src/sage/matrix/benchmark.py
@@ -898,7 +898,7 @@ def hilbert_matrix(n):
     A = Matrix(QQ,n,n)
     for i in range(A.nrows()):
         for j in range(A.ncols()):
-            A[i,j] =  QQ(1)/((i+1)+(j+1)-1)
+            A[i,j] = QQ(1)/((i+1)+(j+1)-1)
     return A
 
 # Reduced row echelon form over QQ

--- a/src/sage/misc/rest_index_of_methods.py
+++ b/src/sage/misc/rest_index_of_methods.py
@@ -255,7 +255,7 @@ def list_of_subfunctions(root, only_local_functions=True):
         else:
             return inspect.isclass(root) or not (f is gen_rest_table_index)
 
-    functions =  {getattr(root,name):name for name,f in root.__dict__.items() if
+    functions = {getattr(root,name):name for name,f in root.__dict__.items() if
                   (not name.startswith('_')          and # private functions
                    not hasattr(f,'issue_number')      and # deprecated functions
                    not inspect.isclass(f)            and # classes

--- a/src/sage/modular/arithgroup/arithgroup_perm.py
+++ b/src/sage/modular/arithgroup/arithgroup_perm.py
@@ -395,7 +395,7 @@ def ArithmeticSubgroup_Permutation(
                 S3 = L * ~R
         elif S2 is not None: # initialize from L,S2
             if S3 is None:
-                S3 =  ~S2 * ~L
+                S3 = ~S2 * ~L
             if R is None:
                 R = ~S2 * ~L * S2
         elif S3 is not None: # initialize from L,S3

--- a/src/sage/modular/modform/ring.py
+++ b/src/sage/modular/modform/ring.py
@@ -1060,7 +1060,7 @@ class ModularFormsRing(Parent):
 
             # we may need to increase the precision of the cached cusp
             # generators
-            G =  []
+            G = []
             for j,f,F in self.__cached_cusp_gens:
                 if f.prec() >= working_prec:
                     f = F.qexp(working_prec).change_ring(self.base_ring())

--- a/src/sage/modular/overconvergent/hecke_series.py
+++ b/src/sage/modular/overconvergent/hecke_series.py
@@ -925,8 +925,8 @@ def katz_expansions(k0, p, ellp, mdash, n):
     S = Zmod(p ** mdash)
 
     Ep1 = eisenstein_series_qexp(p - 1, ellp, K=S, normalization="constant")
-    E4 =  eisenstein_series_qexp(4, ellp, K=S, normalization="constant")
-    E6 =  eisenstein_series_qexp(6, ellp, K=S, normalization="constant")
+    E4 = eisenstein_series_qexp(4, ellp, K=S, normalization="constant")
+    E6 = eisenstein_series_qexp(6, ellp, K=S, normalization="constant")
 
     delta = delta_qexp(ellp, K=S)
     h = delta / E6 ** 2

--- a/src/sage/modules/torsion_quadratic_module.py
+++ b/src/sage/modules/torsion_quadratic_module.py
@@ -885,7 +885,7 @@ class TorsionQuadraticModule(FGP_Module_class, CachedRepresentation):
                 pass
             # the ambient knows what to do with the generators
             gens = tuple(ambient(g) for g in gens)
-        Oq =  FqfOrthogonalGroup(ambient, gens, self, check=check)
+        Oq = FqfOrthogonalGroup(ambient, gens, self, check=check)
         return Oq
 
     def orthogonal_submodule_to(self, S):

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -4510,7 +4510,7 @@ class LPRevisedDictionary(LPAbstractDictionary):
                              "for auxiliary problems")
         super().__init__()
         self._problem = problem
-        R =  problem.coordinate_ring()
+        R = problem.coordinate_ring()
         self._x_B = vector(R, [variable(R, v) for v in basic_variables])
 
     def __eq__(self, other):
@@ -4611,7 +4611,7 @@ class LPRevisedDictionary(LPAbstractDictionary):
             headers.append("B^{-1} A_{%s}" % latex(entering))
         if show_ratios:
             headers.append(r"\hbox{Ratio}")
-        lines.append(" & ".join(headers) +  r" \\")
+        lines.append(" & ".join(headers) + r" \\")
         lines.append(r"\hline")
         Bi = self.B_inverse()
         c_B = self.c_B()

--- a/src/sage/quadratic_forms/quadratic_form.py
+++ b/src/sage/quadratic_forms/quadratic_form.py
@@ -780,7 +780,7 @@ class QuadraticForm(SageObject):
 
         """
         # Unpack the list of indices
-        i, j =  ij
+        i, j = ij
         i = int(i)
         j = int(j)
 
@@ -813,7 +813,7 @@ class QuadraticForm(SageObject):
 
         """
         # Unpack the list of indices
-        i, j =  ij
+        i, j = ij
         i = int(i)
         j = int(j)
 

--- a/src/sage/quadratic_forms/quadratic_form__siegel_product.py
+++ b/src/sage/quadratic_forms/quadratic_form__siegel_product.py
@@ -111,7 +111,7 @@ def siegel_product(self, u):
             factor1 *= i
 
         genericfactor = factor1 * ((u / f) ** m) \
-            * QQ(sqrt((2 ** n) *  f) / (u * d)) \
+            * QQ(sqrt((2 ** n) * f) / (u * d)) \
             * abs(QuadraticBernoulliNumber(m, d1) / bernoulli(2*m))
 
     # DIAGNOSTIC

--- a/src/sage/quadratic_forms/quadratic_form__split_local_covering.py
+++ b/src/sage/quadratic_forms/quadratic_form__split_local_covering.py
@@ -236,7 +236,7 @@ def vectors_by_length(self, bound):
         Q_val = Q_val_double.round()
 
         # SANITY CHECK: Roundoff Error is < 0.001
-        if abs(Q_val_double -  Q_val) > 0.001:
+        if abs(Q_val_double - Q_val) > 0.001:
             print(" x = ", x)
             print(" Float = ", Q_val_double, "   Long = ", Q_val)
             raise RuntimeError("The roundoff error is bigger than 0.001, so we should use more precision somewhere...")

--- a/src/sage/quadratic_forms/special_values.py
+++ b/src/sage/quadratic_forms/special_values.py
@@ -188,7 +188,7 @@ def QuadraticBernoulliNumber(k, d):
     f = abs(d1)
 
     # Make the (usual) k-th Bernoulli polynomial
-    x =  PolynomialRing(QQ, 'x').gen()
+    x = PolynomialRing(QQ, 'x').gen()
     bp = bernoulli_polynomial(x, k)
 
     # Make the k-th quadratic Bernoulli number

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1079,7 +1079,7 @@ def parse_ellipsis(code, preparse_step=True):
             if preparse_step:
                 arguments = arguments.replace(';', ', step=')
             range_or_iter = 'range' if code[start_list]=='[' else 'iter'
-            code = "%s(ellipsis_%s(%s))%s" %  (code[:start_list],
+            code = "%s(ellipsis_%s(%s))%s" % (code[:start_list],
                                                range_or_iter,
                                                arguments,
                                                code[end_list:])

--- a/src/sage/rings/function_field/differential.py
+++ b/src/sage/rings/function_field/differential.py
@@ -132,7 +132,7 @@ class FunctionFieldDifferential(ModuleElement):
         if self._f.is_zero(): # zero differential
             return '0'
 
-        r =  'd({})'.format(self.parent()._gen_base_differential)
+        r = 'd({})'.format(self.parent()._gen_base_differential)
 
         if self._f.is_one():
             return r
@@ -154,7 +154,7 @@ class FunctionFieldDifferential(ModuleElement):
         if self._f.is_zero(): # zero differential
             return '0'
 
-        r =  'd{}'.format(self.parent()._gen_base_differential)
+        r = 'd{}'.format(self.parent()._gen_base_differential)
 
         if self._f.is_one():
             return r

--- a/src/sage/rings/number_field/number_field_rel.py
+++ b/src/sage/rings/number_field/number_field_rel.py
@@ -323,7 +323,7 @@ class NumberField_relative(NumberField_generic):
                                      embedding=embedding, structure=structure)
 
         self._zero_element = self(0)
-        self._one_element =  self(1)
+        self._one_element = self(1)
 
     def change_names(self, names):
         r"""

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -817,10 +817,10 @@ class MPolynomialIdeal_singular_repr(
         from sage.libs.singular.function_factory import ff
 
         if algorithm == 'sy':
-            primdecSY =  ff.primdec__lib.primdecSY
+            primdecSY = ff.primdec__lib.primdecSY
             P = primdecSY(self)
         elif algorithm == 'gtz':
-            primdecGTZ =  ff.primdec__lib.primdecGTZ
+            primdecGTZ = ff.primdec__lib.primdecGTZ
             P = primdecGTZ(self)
 
         R = self.ring()
@@ -1117,7 +1117,7 @@ class MPolynomialIdeal_singular_repr(
         # the Singular routines are quite picky about their input.
         if is_groebner:
             if Q == P:
-                I =  MPolynomialIdeal(P, self.interreduced_basis()[::-1])
+                I = MPolynomialIdeal(P, self.interreduced_basis()[::-1])
             else:
                 I = self
                 I = MPolynomialIdeal(P, I.transformed_basis('fglm')[::-1]) # -> 'lex'
@@ -1463,7 +1463,7 @@ class MPolynomialIdeal_singular_repr(
 
         R = self.ring()
         S = self._groebner_basis_singular_raw(algorithm=algorithm, *args, **kwds)
-        S =  PolynomialSequence([R(S[i+1]) for i in range(len(S))], R, immutable=True)
+        S = PolynomialSequence([R(S[i+1]) for i in range(len(S))], R, immutable=True)
         return S
 
     @cached_method

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -2017,7 +2017,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
                 lambda f: f.lift().map_coefficients(base_to_isomorphic_base)(isomorphic_quotient.gen()))
 
             return (from_isomorphic_quotient * isomorphic_ring_to_isomorphic_quotient,
-                isomorphic_quotient_to_isomorphic_ring *  to_isomorphic_quotient,
+                isomorphic_quotient_to_isomorphic_ring * to_isomorphic_quotient,
                 isomorphic_ring)
 
         if self.modulus().degree() == 1:

--- a/src/sage/sat/converters/polybori.py
+++ b/src/sage/sat/converters/polybori.py
@@ -473,7 +473,7 @@ class CNFEncoder(ANF2CNFConverter):
 
         new_variables = []
         for j in range(0, nm, step):
-            m =  new_variables + monomial_list[j:j+step]
+            m = new_variables + monomial_list[j:j+step]
             if (j + step) < nm:
                 new_variables = [self.var(None)]
                 m += new_variables

--- a/src/sage/structure/factorization.py
+++ b/src/sage/structure/factorization.py
@@ -815,7 +815,7 @@ class Factorization(SageObject):
         if len(self) == 0:
             return repr(self.__unit)
         s = ''
-        mul =  ' * '
+        mul = ' * '
         if cr:
             mul += '\n'
         x = self.__x[0][0]
@@ -846,7 +846,7 @@ class Factorization(SageObject):
                 u = repr(self.__unit)
             else:
                 u = '(%s)'%self.__unit
-            s =  u + mul + s
+            s = u + mul + s
         return s
 
     def _latex_(self):
@@ -887,7 +887,7 @@ class Factorization(SageObject):
                 u = self.__unit._latex_()
             else:
                 u = '\\left(%s\\right)'%self.__unit._latex_()
-            s =  u + ' \\cdot ' + s
+            s = u + ' \\cdot ' + s
         return s
 
     @cached_method

--- a/src/sage/symbolic/callable.py
+++ b/src/sage/symbolic/callable.py
@@ -429,7 +429,7 @@ class CallableSymbolicExpressionRing_class(SymbolicRing, sage.rings.abc.Callable
         from sage.misc.latex import latex
         args = self.args()
         args = [latex(arg) for arg in args]
-        latex_x =  SymbolicRing._latex_element_(self, x)
+        latex_x = SymbolicRing._latex_element_(self, x)
         if len(args) == 1:
             return r"%s \ {\mapsto}\ %s" % (args[0], latex_x)
         else:

--- a/src/sage/symbolic/units.py
+++ b/src/sage/symbolic/units.py
@@ -99,7 +99,7 @@ from sage.misc.instancedoc import instancedoc
 # Unit conversions dictionary.
 ###############################################################################
 
-unitdict =  {
+unitdict = {
 'acceleration':
         {'gal':'1/100',
         'galileo':'1/100',

--- a/src/sage/tests/benchmark.py
+++ b/src/sage/tests/benchmark.py
@@ -410,7 +410,7 @@ class MPolynomialMult(Benchmark):
         self.nvars = nvars
         self.base = base
         self.allow_singular = allow_singular
-        s =  'Compute (x_0 + ... + x_%s) * (x_%s + ... + x_%s) over %s'%(
+        s = 'Compute (x_0 + ... + x_%s) * (x_%s + ... + x_%s) over %s'%(
             self.nvars/2 - 1, self.nvars/2, self.nvars, self.base)
         if self.allow_singular:
             s += ' (use singular for Sage mult.)'
@@ -563,7 +563,7 @@ class MPolynomialMult2(Benchmark):
         self.nvars = nvars
         self.base = base
         self.allow_singular = allow_singular
-        s =  'Compute (x_1 + 2*x_2 + 3*x_3 + ... + %s*x_%s) * (%s * x_%s + ... + %s*x_%s) over %s'%(
+        s = 'Compute (x_1 + 2*x_2 + 3*x_3 + ... + %s*x_%s) * (%s * x_%s + ... + %s*x_%s) over %s'%(
             self.nvars/2, self.nvars/2, self.nvars/2+1, self.nvars/2+1,
             self.nvars+1, self.nvars+1, self.base)
         if self.allow_singular:

--- a/src/sage/topology/delta_complex.py
+++ b/src/sage/topology/delta_complex.py
@@ -1384,9 +1384,9 @@ class DeltaComplex(GenericCellComplex):
             for cell in n_cells:
                 if n > 1:
                     faces = [tuple(simplex_cells[n-1][cell[j]]) for j in range(0,n+1)]
-                    one_cell =  dict(zip(faces, self_cells[n][n_cells[cell]]))
+                    one_cell = dict(zip(faces, self_cells[n][n_cells[cell]]))
                 else:
-                    temp =  dict(zip(cell, self_cells[n][n_cells[cell]]))
+                    temp = dict(zip(cell, self_cells[n][n_cells[cell]]))
                     one_cell = {}
                     for j in temp:
                         one_cell[(j,)] = temp[j]

--- a/src/sage/topology/simplicial_set_constructions.py
+++ b/src/sage/topology/simplicial_set_constructions.py
@@ -499,7 +499,7 @@ class PullbackOfSimplicialSets_finite(PullbackOfSimplicialSets, SimplicialSet_fi
         # the product.
         translate = {}
         for simplices in itertools.product(*nondegen):
-            dims =  [_.dimension() for _ in simplices]
+            dims = [_.dimension() for _ in simplices]
             dim_max = max(dims)
             sum_dims = sum(dims)
             for d in range(dim_max, sum_dims + 1):


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

fixing most E222 warnings issued by pycodestyle in `.py` files

E222 multiple spaces after operator

purely done with autopep8

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
