### PR TITLE
add .basis_matrix() wrapper to quaternion orders

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -1793,6 +1793,24 @@ class QuaternionOrder(Parent):
         else:
             raise NotImplementedError("ideal only implemented for quaternion algebras over QQ")
 
+    def basis_matrix(self):
+        r"""
+        Return the basis matrix of this quaternion order.
+
+        Convenience wrapper for ``O.unit_ideal().basis_matrix()``.
+
+        OUTPUT: matrix over `\QQ`
+
+        EXAMPLES::
+
+            sage: QuaternionAlgebra(-11,-1).maximal_order().basis_matrix()
+            [1/2 1/2   0   0]
+            [  0   1   0   0]
+            [  0   0 1/2 1/2]
+            [  0   0   0   1]
+        """
+        return self.unit_ideal().basis_matrix()
+
     def __mul__(self, other):
         """
         Every order equals its own unit ideal. Overload ideal multiplication

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -1795,21 +1795,39 @@ class QuaternionOrder(Parent):
 
     def basis_matrix(self):
         r"""
-        Return the basis matrix of this quaternion order.
-
-        Convenience wrapper for ``O.unit_ideal().basis_matrix()``.
+        Return the basis matrix of this quaternion order, for the
+        specific basis returned by :meth:`basis()`.
 
         OUTPUT: matrix over `\QQ`
 
         EXAMPLES::
 
-            sage: QuaternionAlgebra(-11,-1).maximal_order().basis_matrix()
-            [1/2 1/2   0   0]
-            [  0   1   0   0]
-            [  0   0 1/2 1/2]
-            [  0   0   0   1]
+            sage: O = QuaternionAlgebra(-11,-1).maximal_order()
+            sage: O.basis()
+            (1/2 + 1/2*i, 1/2*j - 1/2*k, i, -k)
+            sage: O.basis_matrix()
+            [ 1/2  1/2    0    0]
+            [   0    0  1/2 -1/2]
+            [   0    1    0    0]
+            [   0    0    0   -1]
+
+        Note that the returned matrix is *not* necessarily the same as
+        the basis matrix of the :meth:`unit_ideal()`::
+
+            sage: Q.<i,j,k> = QuaternionAlgebra(-1,-11)
+            sage: O = Q.quaternion_order([j,i,-1,k])
+            sage: O.basis_matrix()
+            [ 0  0  1  0]
+            [ 0  1  0  0]
+            [-1  0  0  0]
+            [ 0  0  0  1]
+            sage: O.unit_ideal().basis_matrix()
+            [1 0 0 0]
+            [0 1 0 0]
+            [0 0 1 0]
+            [0 0 0 1]
         """
-        return self.unit_ideal().basis_matrix()
+        return matrix(QQ, map(list, self.__basis))
 
     def __mul__(self, other):
         """


### PR DESCRIPTION
Computing the basis matrix of a quaternion order is a common operation, but it currently requires building it "by hand" from the `.basis()`. This straightforward patch adds a method `O.basis_matrix()` which computes `matrix(QQ, map(list, O.basis()))`.

Eventually, both orders and ideals should become children of a common "quaternion lattice" class; this patch is a quick hack to reduce the pain until that has happened.