### PR TITLE
cylint: remove some unused variables in rings/

### DIFF
--- a/src/sage/rings/bernoulli_mod_p.pyx
+++ b/src/sage/rings/bernoulli_mod_p.pyx
@@ -311,8 +311,6 @@ def bernoulli_mod_p_single(long p, long k):
     if not sage.arith.all.is_prime(p):
         raise ValueError("p (=%s) must be a prime" % p)
 
-    R = Integers(p)
-
     cdef long x = bernmm_bern_modp(p, k)
     if x == -1:
         raise ArithmeticError("B_k is not integral at p")

--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -154,7 +154,7 @@ cimport sage.rings.abc
 cimport sage.rings.rational
 
 from cpython.int cimport PyInt_AS_LONG
-from cpython.object cimport Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE
+from cpython.object cimport Py_EQ, Py_NE
 from cpython.complex cimport PyComplex_FromDoubles
 
 from sage.ext.stdsage cimport PY_NEW
@@ -1402,7 +1402,6 @@ cdef class ComplexBall(RingElement):
         """
         cdef fmpz_t tmpz
         cdef fmpq_t tmpq
-        cdef long myprec
         cdef bint cplx = False
 
         Element.__init__(self, parent)
@@ -2426,17 +2425,15 @@ cdef class ComplexBall(RingElement):
             False
         """
         cdef ComplexBall lt, rt
-        cdef acb_t difference
 
         lt = left
         rt = right
 
         if op == Py_EQ:
             return acb_eq(lt.value, rt.value)
-        elif op == Py_NE:
+        if op == Py_NE:
             return acb_ne(lt.value, rt.value)
-        elif op == Py_GT or op == Py_GE or op == Py_LT or op == Py_LE:
-            raise TypeError("No order is defined for ComplexBalls.")
+        raise TypeError("No order is defined for ComplexBalls.")
 
     def identical(self, ComplexBall other):
         """

--- a/src/sage/rings/complex_mpc.pyx
+++ b/src/sage/rings/complex_mpc.pyx
@@ -816,7 +816,6 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
         """
         # This should not be called except when the number is being created.
         # Complex Numbers are supposed to be immutable.
-        cdef RealNumber x
         cdef mpc_rnd_t rnd
         rnd =(<MPComplexField_class>self._parent).__rnd
         if y is None:
@@ -2338,12 +2337,11 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
             sage: u.agm(v, algorithm="optimal")
             -0.410522769709397 + 4.60061063922097*I
         """
-        if algorithm=="pari":
+        if algorithm == "pari":
             t = self._parent(right).__pari__()
             return self._parent(self.__pari__().agm(t))
 
         cdef MPComplexNumber a, b, d, s, res
-        cdef mpfr_t sn,dn
         cdef mp_exp_t rel_prec
         cdef bint optimal = algorithm == "optimal"
 

--- a/src/sage/rings/fast_arith.pyx
+++ b/src/sage/rings/fast_arith.pyx
@@ -146,7 +146,6 @@ cpdef prime_range(start, stop=None, algorithm=None, bint py_ints=False):
     - Kevin Stueve (added primes iterator option) 2010-10-16
     - Robert Bradshaw (speedup using Pari prime table, py_ints option)
     """
-    cdef Integer z
     # input to pari.init_primes cannot be greater than 436273290 (hardcoded bound)
     DEF init_primes_max = 436273290
     DEF small_prime_max = 436273009  #  a prime < init_primes_max (preferably the largest)

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -81,7 +81,6 @@ cdef class FiniteRingElement(CommutativeRingElement):
             sage: r = a._nth_root_common(29*283*3539*12345, False, "Johnston", False)
             sage: r**(29*283*3539*12345) == a
             True
-
         """
         K = self.parent()
         q = K.order()
@@ -96,7 +95,7 @@ cdef class FiniteRingElement(CommutativeRingElement):
         if gcd == q-1:
             if all: return []
             else: raise ValueError("no nth root")
-        gcd, alpha, beta = n.xgcd(q-1) # gcd = alpha*n + beta*(q-1), so 1/n = alpha/gcd (mod q-1)
+        gcd, alpha, _ = n.xgcd(q-1)  # gcd = alpha*n + beta*(q-1), so 1/n = alpha/gcd (mod q-1)
         if gcd == 1:
             return [self**alpha] if all else self**alpha
 
@@ -406,12 +405,11 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             sage: e._vector_(reverse=True)
             (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1)
         """
-        #vector(foo) might pass in ZZ
+        # vector(foo) might pass in ZZ
         if isinstance(reverse, Parent):
             raise TypeError("Base field is fixed to prime subfield.")
 
         k = self.parent()
-        p = self.polynomial()
         ret = self.polynomial().padded_list(k.degree())
 
         if reverse:
@@ -422,7 +420,9 @@ cdef class FinitePolyExtElement(FiniteRingElement):
         r"""
         Return the matrix of left multiplication by the element on
         the power basis `1, x, x^2, \ldots, x^{d-1}` for the field
-        extension.  Thus the \emph{columns} of this matrix give the images
+        extension.
+
+        Thus the \emph{columns} of this matrix give the images
         of each of the `x^i`.
 
         INPUT:

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -147,7 +147,6 @@ def Mod(n, m, parent=None):
         return n
 
     # m is non-zero, so return n mod m
-    cdef IntegerMod_abstract x
     if parent is None:
         from .integer_mod_ring import IntegerModRing
         parent = IntegerModRing(m)
@@ -1524,7 +1523,6 @@ cdef class IntegerMod_abstract(FiniteRingElement):
                     return K(p**(pval // n) * mod(upart, p**(k-pval)).nth_root(n, algorithm=algorithm).lift())
             from sage.rings.padics.factory import ZpFM
             R = ZpFM(p,k)
-            self_orig = self
             if p == 2:
                 sign = [1]
                 if self % 4 == 3:
@@ -4033,9 +4031,6 @@ cpdef square_root_mod_prime(IntegerMod_abstract a, p=None):
     cdef int p_mod_16 = p % 16
     cdef double bits = log2(float(p))
     cdef long r, m
-
-    cdef Integer resZ
-
 
     if p_mod_16 % 2 == 0:  # p == 2
         return a

--- a/src/sage/rings/function_field/element.pyx
+++ b/src/sage/rings/function_field/element.pyx
@@ -655,15 +655,15 @@ cdef class FunctionFieldElement(FieldElement):
             sage: (y/x + 1).evaluate(p)                                                 # optional - sage.rings.finite_rings sage.rings.function_field
             1
         """
-        R, fr_R, to_R = place._residue_field()
+        R, _, to_R = place._residue_field()
 
         v = self.valuation(place)
         if v > 0:
             return R.zero()
-        elif v  == 0:
+        if v  == 0:
             return to_R(self)
-        else: # v < 0
-            raise ValueError('has a pole at the place')
+        # v < 0
+        raise ValueError('has a pole at the place')
 
     cpdef bint is_nth_power(self, n):
         r"""

--- a/src/sage/rings/function_field/element_polymod.pyx
+++ b/src/sage/rings/function_field/element_polymod.pyx
@@ -298,7 +298,7 @@ cdef class FunctionFieldElement_polymod(FunctionFieldElement):
         # reduce to the separable case
         poly = self._parent._polynomial
         if not poly.gcd(poly.derivative()).is_one():
-            L, from_L, to_L = self._parent.separable_model(('t', 'w'))
+            _, from_L, to_L = self._parent.separable_model(('t', 'w'))
             return from_L(to_L(self).nth_root(n))
 
         constant_base_field = self._parent.constant_base_field()
@@ -347,7 +347,7 @@ cdef class FunctionFieldElement_polymod(FunctionFieldElement):
         # reduce to the separable case
         poly = self._parent._polynomial
         if not poly.gcd(poly.derivative()).is_one():
-            L, from_L, to_L = self._parent.separable_model(('t', 'w'))
+            _, _, to_L = self._parent.separable_model(('t', 'w'))
             return to_L(self).is_nth_power(n)
 
         constant_base_field = self._parent.constant_base_field()

--- a/src/sage/rings/integer_ring.pyx
+++ b/src/sage/rings/integer_ring.pyx
@@ -413,7 +413,7 @@ cdef class IntegerRing_class(PrincipalIdealDomain):
             return self
 
         if isinstance(x, NumberFieldElement_base):
-            K, from_K = parent(x).subfield(x)
+            K, _ = parent(x).subfield(x)
             return K.order(K.gen())
 
         return PrincipalIdealDomain.__getitem__(self, x)
@@ -1651,7 +1651,7 @@ def crt_basis(X, xgcd=None):
     for i in range(len(X)):
         p = X[i]
         others = P // p
-        g, s, t = p.xgcd(others)
+        g, _, t = p.xgcd(others)
         if g != ONE:
             raise ArithmeticError("the elements of the list X must be coprime in pairs")
         Y.append(t * others)

--- a/src/sage/rings/laurent_series_ring_element.pyx
+++ b/src/sage/rings/laurent_series_ring_element.pyx
@@ -1255,7 +1255,6 @@ cdef class LaurentSeries(AlgebraElement):
             deg = prec - 1
 
         cdef long i
-        cdef int c
         for i in range(val, deg + 1):
             li = self[i]
             ri = right[i]

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -1514,8 +1514,8 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             ArithmeticError: vector is not in free module
         """
         K = self.number_field()
-        V, from_V, to_V = K.absolute_vector_space()
-        h = K(1)
+        V, _, to_V = K.absolute_vector_space()
+        h = K.one()
         B = [to_V(h)]
         f = self.absolute_minpoly()
         for i in range(f.degree()-1):
@@ -2041,7 +2041,7 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         element_fac = [(P.gens_reduced()[0],e) for P,e in fac]
         # Compute the product of the p^e to figure out the unit
         from sage.misc.misc_c import prod
-        element_product = prod([p**e for p,e in element_fac], K(1))
+        element_product = prod([p**e for p,e in element_fac], K.one())
         from sage.structure.all import Factorization
         return Factorization(element_fac, unit=self/element_product)
 
@@ -3405,13 +3405,12 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             12
             sage: z^12==1 and z^6!=1 and z^4!=1
             True
-
         """
         if self.__multiplicative_order is None:
             from .number_field import NumberField_cyclotomic
             if self.is_rational():
                 if self.is_one():
-                    self.__multiplicative_order = ZZ(1)
+                    self.__multiplicative_order = ZZ.one()
                 elif (-self).is_one():
                     self.__multiplicative_order = ZZ(2)
                 else:
@@ -4379,7 +4378,7 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             ## the variable name is irrelevant below, because the
             ## matrix is over QQ
             F = K.absolute_field('alpha')
-            from_f, to_F = F.structure()
+            _, to_F = F.structure()
             return to_F(self).matrix()
 
         alpha = L.primitive_element()
@@ -4392,7 +4391,7 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         M = K.relativize(beta, (K.variable_name()+'0', L.variable_name()+'0') )
 
         # Carry self over to M.
-        from_M, to_M = M.structure()
+        _, to_M = M.structure()
         try:
             z = to_M(self)
         except Exception:

--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -1938,9 +1938,6 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
             sage: b._coefficients()
             [0, 1]
         """
-        # In terms of the generator...
-        cdef Rational const = <Rational>Rational.__new__(Rational)
-        cdef Rational lin = <Rational>Rational.__new__(Rational)
         if not self:
             return []
         ad, bd = self.parts()
@@ -2429,8 +2426,6 @@ cdef class NumberFieldElement_quadratic_sqrt(NumberFieldElement_quadratic):
             sage: (3/2*K.one())._coefficients()
             [3/2]
         """
-        # In terms of the generator... Rational const = <Rational>Rational.__new__(Rational)
-        cdef Rational lin = <Rational>Rational.__new__(Rational)
         if not self:
             return []
         cdef tuple parts = self.parts()
@@ -2852,9 +2847,6 @@ cdef class OrderElement_quadratic(NumberFieldElement_quadratic):
             sage: aa._coefficients()
             [0, 1/3]
         """
-        # In terms of the generator...
-        cdef Rational const = <Rational>Rational.__new__(Rational)
-        cdef Rational lin = <Rational>Rational.__new__(Rational)
         if not self:
             return []
         ad, bd = self.parts()

--- a/src/sage/rings/number_field/totallyreal.pyx
+++ b/src/sage/rings/number_field/totallyreal.pyx
@@ -256,7 +256,6 @@ def enumerate_totallyreal_fields_prim(n, B, a = [], verbose=0, return_seqs=False
     cdef Py_ssize_t k0, lenS
     cdef tr_data T
     cdef Integer dB
-    cdef double db_odlyzko
 
     if not isinstance(n, Integer):
         try:
@@ -280,7 +279,6 @@ def enumerate_totallyreal_fields_prim(n, B, a = [], verbose=0, return_seqs=False
     t2val = B_pari
     ngt2 = B_pari
     ng = B_pari
-    pari_tmp1 = B_pari
 
     dB = Integer.__new__(Integer)
     dB_odlyzko = odlyzko_bound_totallyreal(n_int)

--- a/src/sage/rings/number_field/totallyreal_data.pyx
+++ b/src/sage/rings/number_field/totallyreal_data.pyx
@@ -120,13 +120,13 @@ cdef double eval_seq_as_poly(int *f, int n, double x):
 
         f[n]*x^n + f[n-1]*x^(n-1) + ... + f[0].
     """
-    cdef double s, xp
+    cdef double s
 
     # Horner's method: With polynomials of small degree, we shouldn't
     # expect asymptotic methods to be any faster.
     s = f[n]
     for i from n > i >= 0:
-        s = s*x+f[i]
+        s = s * x + f[i]
     return s
 
 cdef double newton(int *f, int *df, int n, double x0, double eps):
@@ -220,13 +220,10 @@ cpdef lagrange_degree_3(int n, int an1, int an2, int an3):
         sage: sage.rings.number_field.totallyreal_data.lagrange_degree_3(4,12,19,42)
         [0.0, -1.0]
     """
-    cdef double zmin, zmax, val
-    cdef double *roots_data
     cdef long coeffs[7]
     cdef int r, rsq, rcu
     cdef int nr, nrsq, nrcu
     cdef int s1, s1sq, s1cu, s1fo, s2, s2sq, s2cu, s3, s3sq
-    cdef int found_minmax = 0
 
     RRx = PolynomialRing(RealField(20),'x')
 
@@ -357,11 +354,11 @@ cdef int eval_seq_as_poly_int(int *f, int n, int x):
 
         f[n]*x^n + f[n-1]*x^(n-1) + ... + f[0].
     """
-    cdef int s, xp
+    cdef int s
 
     s = f[n]
     for i from n > i >= 0:
-        s = s*x+f[i]
+        s = s * x + f[i]
     return s
 
 cdef double eps_abs, phi, sqrt2
@@ -374,7 +371,7 @@ cdef int easy_is_irreducible(int *a, int n):
     Very often, polynomials have roots in {+/-1, +/-2, +/-phi, sqrt2}, so we rule
     these out quickly.  Returns 0 if reducible, 1 if inconclusive.
     """
-    cdef int s, t, st, sgn, i
+    cdef int s, t, st, i
 
     # Check if a has a root in {1,-1,2,-2}.
     if eval_seq_as_poly_int(a,n,1) == 0 or eval_seq_as_poly_int(a,n,-1) == 0 or eval_seq_as_poly_int(a,n,2) == 0 or eval_seq_as_poly_int(a,n,-2) == 0:
@@ -666,8 +663,7 @@ cdef class tr_data:
 
             None. The return value is stored in the variable f_out.
         """
-
-        cdef int n, np1, k, i, j, nk, kz
+        cdef int n, np1, k, i, nk, kz
         cdef int *gnkm
         cdef int *gnkm1
         cdef double *betak

--- a/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
+++ b/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
@@ -1705,7 +1705,7 @@ cdef class LaurentPolynomial_mpair(LaurentPolynomial):
         cdef dict d, dr
         cdef ETuple v
         cdef LaurentPolynomial_mpair ans
-        cdef list L, mon, exp
+        cdef list mon, exp
         cdef Matrix mat = M
 
         n = self._parent.ngens()

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -1601,7 +1601,6 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
         cdef poly *res
         cdef ring *r = self._ring
         cdef number *n
-        cdef number *denom
 
         if self is not f._parent:
             f = self.coerce(f)
@@ -1720,7 +1719,8 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
         if g._poly == NULL:
             raise ArithmeticError("Cannot compute LCM of zero and nonzero element.")
 
-        if(self._ring != currRing): rChangeCurrRing(self._ring)
+        if self._ring != currRing:
+            rChangeCurrRing(self._ring)
 
         pLcm(f._poly, g._poly, m)
         p_Setm(m, self._ring)
@@ -3240,7 +3240,8 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             2
         """
         cdef ring *_ring = self._parent_ring
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
 
         if not (p_IsUnit(self._poly,_ring)):
             raise ArithmeticError("Element is not a unit.")
@@ -3271,7 +3272,8 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             True
         """
         cdef ring *_ring = self._parent_ring
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
         return bool(p_IsHomogeneous(self._poly,_ring))
 
     cpdef _homogenize(self, int var):
@@ -3303,17 +3305,16 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         """
         cdef ring *_ring = self._parent_ring
         cdef MPolynomialRing_libsingular parent = self._parent
-        cdef MPolynomial_libsingular f
 
         if self.is_homogeneous():
             return self
 
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
 
         if var < parent._ring.N:
-            return new_MP(parent, p_Homogen(self._poly, var+1, _ring))
-        else:
-            raise TypeError("var must be < self.parent().ngens()")
+            return new_MP(parent, p_Homogen(self._poly, var + 1, _ring))
+        raise TypeError("var must be < self.parent().ngens()")
 
     def is_monomial(self):
         """
@@ -3344,12 +3345,13 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         if self._poly == NULL:
             return False
 
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
 
         _p = p_Head(self._poly, _ring)
         _n = p_GetCoeff(_p, _ring)
 
-        ret = bool((not self._poly.next) and _ring.cf.cfIsOne(_n,_ring.cf))
+        ret = bool((not self._poly.next) and _ring.cf.cfIsOne(_n, _ring.cf))
 
         p_Delete(&_p, _ring)
         return ret
@@ -3672,7 +3674,8 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         cdef list l = []
         cdef MPolynomialRing_libsingular parent = self._parent
         cdef ring *_ring = parent._ring
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
         cdef poly *p = p_Copy(self._poly, _ring)
         cdef poly *t
 
@@ -3771,7 +3774,8 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
 
         zero = k(0)
 
-        if(r != currRing): rChangeCurrRing(r)
+        if r != currRing:
+            rChangeCurrRing(r)
 
         pTotDegMax = -1
         while p2:
@@ -3855,7 +3859,8 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         cdef poly *p
         cdef poly *v
         cdef ring *r = self._parent_ring
-        if(r != currRing): rChangeCurrRing(r)
+        if r != currRing:
+            rChangeCurrRing(r)
         cdef int i
         l = list()
         si = set()
@@ -3984,7 +3989,8 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         if self._poly == NULL:
             return self._parent._base._zero_element
 
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
 
         _p = p_Head(self._poly, _ring)
         _n = p_GetCoeff(_p, _ring)

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -1318,9 +1318,7 @@ cdef class MPolynomialRing_base(sage.rings.ring.CommutativeRing):
             sage: R.<x,y> = QQ[]
             sage: R.some_elements()
             [x, y, x + y, x^2 + x*y, 0, 1]
-
         """
-        R = self.base_ring()
         L = list(self.gens())
         if L:
             L.append(L[0] + L[-1])
@@ -1701,7 +1699,6 @@ cdef class MPolynomialRing_base(sage.rings.ring.CommutativeRing):
         mons_idx = {str(mon): idx for idx, mon in enumerate(mons)}
         mons_num = len(mons)
         mons_to_keep = []
-        newflist = []
         # strip coefficients of the input polynomials:
         flist = [[f.exponents(), f.coefficients()] for f in flist]
         numer_matrix = zero_matrix(self.base_ring(), mons_num, sparse=sparse)

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -2168,8 +2168,6 @@ class BooleanMonomialMonoid(UniqueRepresentation, Monoid_class):
                             var_mapping = get_var_mapping(self, other)
                         except NameError as msg:
                             raise ValueError("cannot convert polynomial %s to %s: %s" % (other, self, msg))
-                        t = (<BooleanPolynomial>other)._pbpoly.lead()
-
                         m = self._one_element
                         for i in new_BMI_from_BooleanMonomial(other.lm()):
                             m*= var_mapping[i]
@@ -2353,7 +2351,6 @@ cdef class BooleanMonomial(MonoidElement):
             sage: m(x=B(1))
             y
         """
-        P = self.parent()
         if args and kwds:
             raise ValueError("using keywords and regular arguments not supported")
         if args:
@@ -6440,7 +6437,6 @@ cdef class ReductionStrategy:
         return deref(self._strat).size()
 
     def __getitem__(self, Py_ssize_t i):
-        cdef PBPoly t
         if i < 0 or <size_t>i >= deref(self._strat).size():
             raise IndexError
         return BooleanPolynomialEntry(new_BP_from_PBPoly(self._parent,
@@ -6941,7 +6937,6 @@ cdef class GroebnerStrategy:
         return deref(self._strat).generators.size()
 
     def __getitem__(self, Py_ssize_t i):
-        cdef PBPoly t
         if i < 0 or <size_t>i >= deref(self._strat).generators.size():
             raise IndexError
         return new_BP_from_PBPoly(self._parent, deref(self._strat).generators[i].p)
@@ -7510,10 +7505,9 @@ def if_then_else(root, a, b):
         if not isinstance(root, int):
             raise TypeError("only variables are acceptable as root")
 
-    cdef Py_ssize_t* pbind = ring.pbind
     root = ring.pbind[root]
 
-    if (root >= a_set.navigation().value()) or (root >= b_set.navigation().value()):
+    if root >= a_set.navigation().value() or root >= b_set.navigation().value():
         raise IndexError("index of root must be less than "
                          "the values of roots of the branches")
 
@@ -7592,7 +7586,7 @@ cdef BooleanPolynomialRing BooleanPolynomialRing_from_PBRing(PBRing _ring):
     """
     Get BooleanPolynomialRing from C++-implementation
     """
-    cdef int i, j
+    cdef int i
     cdef BooleanPolynomialRing self = BooleanPolynomialRing.__new__(BooleanPolynomialRing)
 
     cdef int n = _ring.nVariables()

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -1038,14 +1038,13 @@ cdef class NCPolynomialRing_plural(Ring):
 
         .. WARNING::
 
-           Assumes that the head term of f is a multiple of the head
-           term of g and return the multiplicant m. If this rule is
-           violated, funny things may happen.
+            Assumes that the head term of f is a multiple of the head
+            term of g and return the multiplicant m. If this rule is
+            violated, funny things may happen.
         """
         cdef poly *res
         cdef ring *r = self._ring
         cdef number *n
-        cdef number *denom
 
         if self is not f._parent:
             f = self.coerce(f)

--- a/src/sage/rings/polynomial/polydict.pyx
+++ b/src/sage/rings/polynomial/polydict.pyx
@@ -787,7 +787,6 @@ cdef class PolyDict:
         if not self:
             return "0"
 
-        n = len(vars)
         poly = ""
 
         sort_kwargs = {'reverse': True}
@@ -886,7 +885,6 @@ cdef class PolyDict:
             sage: -x - y
             x + y
         """
-        n = len(vars)
         poly = ""
         sort_kwargs = {'reverse': True}
         if sortkey:
@@ -2353,7 +2351,7 @@ cdef class ETuple:
         """
         if not n:
             raise ZeroDivisionError
-        cdef size_t i, j
+        cdef size_t i
         cdef ETuple result = self._new()
         result._data = <int*> sig_malloc(sizeof(int) * 2 * self._nonzero)
         result._nonzero = 0

--- a/src/sage/rings/polynomial/polynomial_compiled.pyx
+++ b/src/sage/rings/polynomial/polynomial_compiled.pyx
@@ -12,7 +12,7 @@ AUTHORS:
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 ################################################################################
 
 from sage.misc.binary_tree cimport BinaryTree
@@ -140,9 +140,8 @@ cdef class CompiledPolynomialFunction:
         Return the resultant head DAG node, and a binary tree
         containing the dummy nodes.
         """
-
         cdef BinaryTree gaps
-        cdef int d, i
+        cdef int d
         cdef generic_pd s
 
         s = univar_pd()
@@ -154,7 +153,7 @@ cdef class CompiledPolynomialFunction:
         s = coeff_pd(d)
         gap_width = 0
 
-        d-= 1
+        d -= 1
         while d > 0:
             gap_width += 1
             if self._coeffs[d]:

--- a/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
@@ -996,15 +996,14 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
             sage: f = -30*x; f.factor()
             (-1) * 2 * 3 * 5 * x
         """
-        cdef int i
         cdef int deg = ZZX_deg(self.__poly)
-        # it appears that pari has a window from about degrees 30 and 300 in which it beats NTL.
+        # it appears that pari has a window from about degrees 30 and 300
+        # in which it beats NTL.
         c = self.content()
-        g = self//c
+        g = self // c
         if deg < 30 or deg > 300:
-            return c.factor()*g._factor_ntl()
-        else:
-            return c.factor()*g._factor_pari()
+            return c.factor() * g._factor_ntl()
+        return c.factor() * g._factor_pari()
 
     def factor_mod(self, p):
         """

--- a/src/sage/rings/polynomial/polynomial_rational_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_rational_flint.pyx
@@ -491,7 +491,6 @@ cdef class Polynomial_rational_flint(Polynomial):
         """
         cdef Polynomial_rational_flint f
         cdef Rational r
-        cdef mpz_t tmpz
         cdef fmpz_t tmpfz
         cdef fmpq_t tmpfq
         cdef RealBall arb_a, arb_z

--- a/src/sage/rings/polynomial/symmetric_reduction.pyx
+++ b/src/sage/rings/polynomial/symmetric_reduction.pyx
@@ -583,8 +583,8 @@ cdef class SymmetricReductionStrategy:
         while True:
             REDUCTOR = []
             for q in lml:
-                c, P, w = q.symmetric_cancellation_order(p)
-                if (c is not None) and (c <= 0):
+                c, P, _ = q.symmetric_cancellation_order(p)
+                if c is not None and c <= 0:
                     REDUCTOR = [self(q ** P)]
                     break
             if not REDUCTOR:

--- a/src/sage/rings/real_arb.pyx
+++ b/src/sage/rings/real_arb.pyx
@@ -1656,7 +1656,6 @@ cdef class RealBall(RingElement):
             0.250000000000000
         """
         cdef RealNumber left, mid, right
-        cdef long prec = field.precision()
         cdef int sl, sr
         if (field.rnd == MPFR_RNDN or
                 field.rnd == MPFR_RNDZ and arb_contains_zero(self.value)):
@@ -2428,22 +2427,21 @@ cdef class RealBall(RingElement):
             False
         """
         cdef RealBall lt, rt
-        cdef arb_t difference
 
         lt = left
         rt = right
 
         if op == Py_EQ:
             return arb_eq(lt.value, rt.value)
-        elif op == Py_NE:
+        if op == Py_NE:
             return arb_ne(lt.value, rt.value)
-        elif op == Py_GT:
+        if op == Py_GT:
             return arb_gt(lt.value, rt.value)
-        elif op == Py_LT:
+        if op == Py_LT:
             return arb_lt(lt.value, rt.value)
-        elif op == Py_GE:
+        if op == Py_GE:
             return arb_ge(lt.value, rt.value)
-        elif op == Py_LE:
+        if op == Py_LE:
             return arb_le(lt.value, rt.value)
 
     def min(self, *others):

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -5860,21 +5860,20 @@ def create_RealNumber(s, int base=10, int pad=0, rnd="RNDN", int min_prec=53):
 
     # Check for a valid base
     if base < 2 or base > 62:
-        raise ValueError("base (=%s) must be an integer between 2 and 62"%base)
+        raise ValueError(f"base (={base}) must be an integer between 2 and 62")
 
     if base == 10 and min_prec == 53 and len(s) <= 15 and rnd == "RNDN":
         R = RR
     else:
         # For bases 15 and up, treat 'e' as digit
         if base <= 14 and ('e' in s or 'E' in s):
-            #Figure out the exponent
-            index = max( s.find('e'), s.find('E') )
-            exponent = int(s[index+1:])
+            # Figure out the exponent
+            index = max(s.find('e'), s.find('E'))
             mantissa = s[:index]
         else:
             mantissa = s
 
-        #Find the first nonzero entry in rest
+        # Find the first nonzero entry in rest
         sigfig_mantissa = mantissa.lstrip('-0.')
         sigfigs = len(sigfig_mantissa) - ('.' in sigfig_mantissa)
 

--- a/src/sage/rings/sum_of_squares.pyx
+++ b/src/sage/rings/sum_of_squares.pyx
@@ -307,7 +307,7 @@ def four_squares_pyx(uint32_t n):
         sage: all(s(four_squares_pyx(n)) == n for n in range(5000,10000))
         True
     """
-    cdef uint_fast32_t fac, j, nn
+    cdef uint_fast32_t fac, j
     cdef uint_fast32_t i[3]
 
     if n == 0:
@@ -315,7 +315,7 @@ def four_squares_pyx(uint32_t n):
 
     # division by power of 4
     fac = 0
-    while n%4 == 0:
+    while n % 4 == 0:
         n >>= 2
         fac += 1
 


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

remove some of the many unused variables in pyx files in the `rings` folder, found using `cython-lint`

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
