### PR TITLE
getting rid of many uses of xrange in pyx files

### DIFF
--- a/src/sage/calculus/interpolators.pyx
+++ b/src/sage/calculus/interpolators.pyx
@@ -225,21 +225,21 @@ cdef class CCSpline:
         cdef int N, i, k
         N = len(pts)
         yvec = np.zeros(N, dtype=np.complex128)
-        for i in xrange(N):
+        for i in range(N):
             yvec[i] = 3 * (pts[(i - 1) % N] - 2*pts[i] + pts[(i + 1) % N])
         bmat = np.zeros([N, N], dtype=np.complex128)
-        for i in xrange(N):
+        for i in range(N):
             bmat[i, i] = 4
             bmat[(i - 1) % N, i] = 1
             bmat[(i + 1) % N, i] = 1
         bvec = (np.linalg.solve(bmat, yvec))
         cvec = np.zeros(N, dtype=np.complex128)
-        for i in xrange(N):
+        for i in range(N):
             cvec[i] = (pts[(i + 1) % N] - pts[i] - 1.0/3.0 *
                        bvec[(i + 1) % N] - 2./3. * bvec[i])
         dvec = np.array(pts, dtype=np.complex128)
         avec = np.zeros(N, dtype=np.complex128)
-        for i in xrange(N):
+        for i in range(N):
             avec[i] = 1.0/3.0 * (bvec[(i + 1) % N] - bvec[i])
         self.avec = avec
         self.bvec = bvec

--- a/src/sage/calculus/riemann.pyx
+++ b/src/sage/calculus/riemann.pyx
@@ -233,7 +233,7 @@ cdef class Riemann_Map:
         self.tk = np.array(np.arange(N) * TWOPI / N + 0.001 / N,
                            dtype=FLOAT)
         self.tk2 = np.zeros(N + 1, dtype=FLOAT)
-        for i in xrange(N):
+        for i in range(N):
             self.tk2[i] = self.tk[i]
         self.tk2[N] = TWOPI
         self.B = len(fs) # number of boundaries of the figure
@@ -246,14 +246,14 @@ cdef class Riemann_Map:
             dtype=COMPLEX)
         # Find the points on the boundaries and their derivatives.
         if self.exterior:
-            for k in xrange(self.B):
-                for i in xrange(N):
+            for k in range(self.B):
+                for i in range(N):
                     fk = fs[k](self.tk[N-i-1])
                     cps[k, i] = complex(1/fk)
                     dps[k, i] = complex(1/fk**2*fprimes[k](self.tk[N-i-1]))
         else:
-            for k in xrange(self.B):
-                for i in xrange(N):
+            for k in range(self.B):
+                for i in range(N):
                     cps[k, i] = complex(fs[k](self.tk[i]))
                     dps[k, i] = complex(fprimes[k](self.tk[i]))
         if self.exterior:
@@ -327,7 +327,7 @@ cdef class Riemann_Map:
              (normalized_dp[t]/(cp-cp[t])).conjugate())
               for t in np.arange(NB)], dtype=np.complex128)
         np.seterr(divide=errdivide,invalid=errinvalid) # resets the error handling
-        for i in xrange(NB):
+        for i in range(NB):
             K[i, i] = 1
         # Nystrom Method for solving 2nd kind integrals
         phi = np.linalg.solve(K, g) / NB * TWOPI
@@ -339,22 +339,22 @@ cdef class Riemann_Map:
         # regions.
         if B != 1:
             theta_array = np.zeros([1, NB])
-            for i in xrange(NB):
+            for i in range(NB):
                 theta_array[0, i] = phase(-I * np.power(phi[i], 2) * dp[i])
             self.theta_array = np.concatenate(
                 [theta_array.reshape([B, N]), np.zeros([B, 1])], axis=1)
-            for k in xrange(B):
+            for k in range(B):
                 self.theta_array[k, N] = self.theta_array[k, 0] + TWOPI
         # Finding the theta correspondence using abs. Well behaved, but
         # doesn't work on multiply connected domains.
         else:
             phi2 = phi.reshape([self.B, N])
             theta_array = np.zeros([B, N + 1], dtype=np.float64)
-            for k in xrange(B):
+            for k in range(B):
                 phik = phi2[k]
                 saa = (np.dot(abs(phi), abs(phi))) * TWOPI / NB
                 theta_array[k, 0] = 0
-                for i in xrange(1, N):
+                for i in range(1, N):
                     theta_array[k, i] = (
                         theta_array[k, i - 1] +
                         ((TWOPI / NB * TWOPI *
@@ -368,7 +368,7 @@ cdef class Riemann_Map:
                     t0 = theta_array[k, tmax] + phase(phimax)
                 else:
                     t0 = theta_array[k, tmax] - phase(phimax)
-                for i in xrange(N):
+                for i in range(N):
                     theta_array[k, i] = theta_array[k, i] - t0
                 theta_array[k, N] = TWOPI + theta_array[k, 0]
             self.theta_array = theta_array
@@ -432,7 +432,7 @@ cdef class Riemann_Map:
         cdef int k, B
         if boundary < 0:
             temptk = self.tk
-            for i in xrange(self.B - 1):
+            for i in range(self.B - 1):
                 temptk = np.concatenate([temptk, self.tk])
             if absolute_value:
                 return np.column_stack(
@@ -504,7 +504,7 @@ cdef class Riemann_Map:
         """
         if boundary < 0:
             temptk = self.tk2
-            for i in xrange(self.B - 1):
+            for i in range(self.B - 1):
                 temptk = np.concatenate([temptk, self.tk2])
             return np.column_stack(
                 [temptk, self.theta_array.flatten()]).tolist()
@@ -532,8 +532,8 @@ cdef class Riemann_Map:
             [self.B, N + 1], dtype=np.complex128)
         cdef int k, i
         # Lots of setup for Simpson's method of integration.
-        for k in xrange(self.B):
-            for i in xrange(N // 3):
+        for k in range(self.B):
+            for i in range(N // 3):
                 p_vector[k, 3*i] = (2*coeff * dps[k, 3*i] *
                                     exp(I * theta_array[k, 3*i]))
                 p_vector[k, 3*i + 1] = (3*coeff * dps[k, 3*i + 1] *
@@ -636,8 +636,8 @@ cdef class Riemann_Map:
         self.p_vector_inverse = np.zeros([B, N], dtype=np.complex128)
         # Setup for trapezoid integration because integration points are
         # not equally spaced.
-        for k in xrange(B):
-            for i in xrange(N):
+        for k in range(B):
+            for i in range(N):
                 di = theta_array[k, (i + 1) % N] - theta_array[k, (i - 1) % N]
                 if di > PI:
                     di = di - TWOPI
@@ -645,12 +645,12 @@ cdef class Riemann_Map:
                     di = di + TWOPI
                 self.p_vector_inverse[k, i] = di / 2
         self.sinalpha = np.zeros([B, N], dtype=np.float64)
-        for k in xrange(B):
-            for i in xrange(N):
+        for k in range(B):
+            for i in range(N):
                 self.sinalpha[k, i] = sin(-theta_array[k, i])
         self.cosalpha = np.zeros([B, N], dtype=np.float64)
-        for k in xrange(B):
-            for i in xrange(N):
+        for k in range(B):
+            for i in range(N):
                 self.cosalpha[k, i] = cos(-theta_array[k, i])
 
     cpdef inverse_riemann_map(self, COMPLEX_T pt):
@@ -748,7 +748,7 @@ cdef class Riemann_Map:
         from sage.plot.all import list_plot
 
         plots = list(range(self.B))
-        for k in xrange(self.B):
+        for k in range(self.B):
             # This conditional should be eliminated when the thickness/pointsize
             # issue is resolved later. Same for the others in plot_spiderweb().
             if plotjoined:
@@ -814,13 +814,13 @@ cdef class Riemann_Map:
         cdef np.ndarray[COMPLEX_T, ndim=2] z_values = np.empty(
             [y_points, x_points], dtype=np.complex128)
         if self.exterior:
-            for i in xrange(x_points):
-                for j in xrange(y_points):
+            for i in range(x_points):
+                for j in range(y_points):
                     pt = 1/(xmin + 0.5*xstep + i*xstep + I*(ymin + 0.5*ystep + j*ystep))
                     z_values[j, i] = 1/(-np.dot(p_vector,1/(pre_q_vector - pt)))
         else:
-            for i in xrange(x_points):
-                for j in xrange(y_points):
+            for i in range(x_points):
+                for j in range(y_points):
                     pt = xmin + 0.5*xstep + i*xstep + I*(ymin + 0.5*ystep + j*ystep)
                     z_values[j, i] = -np.dot(p_vector,1/(pre_q_vector - pt))
         return z_values, xmin, xmax, ymin, ymax
@@ -949,9 +949,9 @@ cdef class Riemann_Map:
             s = spline(np.column_stack([self.theta_array[0], self.tk2]).tolist())
             tmax = self.theta_array[0, self.N]
             tmin = self.theta_array[0, 0]
-            for k in xrange(circles):
+            for k in range(circles):
                 temp = list(range(pts*2))
-                for i in xrange(2*pts):
+                for i in range(2*pts):
                     temp[i] = self.inverse_riemann_map(
                         (k + 1) / (circles + 1.0) * exp(I*i * TWOPI / (2*pts)))
                 if plotjoined:
@@ -961,14 +961,14 @@ cdef class Riemann_Map:
                     circle_list[k] = list_plot(comp_pt(temp, 1),
                         rgbcolor=rgbcolor, pointsize=thickness)
             line_list = list(range(spokes))
-            for k in xrange(spokes):
+            for k in range(spokes):
                 temp = list(range(pts))
                 angle = (k*1.0) / spokes * TWOPI
                 if angle >= tmax:
                     angle -= TWOPI
                 elif angle <= tmin:
                     angle += TWOPI
-                for i in xrange(pts - 1):
+                for i in range(pts - 1):
                     temp[i] = self.inverse_riemann_map(
                         (i * 1.0) / (pts * 1.0) * exp(I * angle) * linescale)
                 temp[pts - 1] = complex(
@@ -1238,8 +1238,8 @@ cpdef complex_to_spiderweb(np.ndarray[COMPLEX_T, ndim = 2] z_values,
         spoke_angles = srange(-PI,PI+TWOPI/spokes,TWOPI/spokes)
     else:
         spoke_angles = []
-    for i in xrange(imax-2): # the d arrays are 1 smaller on each side
-        for j in xrange(jmax-2):
+    for i in range(imax-2): # the d arrays are 1 smaller on each side
+        for j in range(jmax-2):
             z = z_values[i+1,j+1]
             mag = abs(z)
             arg = phase(z)
@@ -1309,9 +1309,9 @@ cpdef complex_to_rgb(np.ndarray[COMPLEX_T, ndim = 2] z_values):
         dtype=FLOAT, shape=(imax, jmax, 3))
 
     sig_on()
-    for i in xrange(imax):
+    for i in range(imax):
         row = z_values[i]
-        for j in xrange(jmax):
+        for j in range(jmax):
             z = row[j]
             mag = abs(z)
             arg = phase(z)

--- a/src/sage/coding/binary_code.pyx
+++ b/src/sage/coding/binary_code.pyx
@@ -202,10 +202,10 @@ def test_word_perms(t_limit=5.0):
         raise MemoryError("Error allocating memory.")
     from sage.misc.prandom import randint
     from sage.combinat.permutation import Permutations
-    S = Permutations(list(xrange(n)))
+    S = Permutations(list(range(n)))
     t = cputime()
     while cputime(t) < t_limit:
-        word = [randint(0, 1) for _ in xrange(n)]
+        word = [randint(0, 1) for _ in range(n)]
         cw1 = 0
         for j from 0 <= j < n:
             cw1 += (<codeword>word[j]) << (<codeword>j)
@@ -298,7 +298,7 @@ cdef WordPermutation *create_word_perm(object list_perm):
     word_perm.chunk_num = num_chunks
     words_per_chunk = 1 << chunk_size
     word_perm.gate = ( (<codeword>1) << chunk_size ) - 1
-    list_perm += list(xrange(len(list_perm), chunk_size*num_chunks))
+    list_perm += list(range(len(list_perm), chunk_size*num_chunks))
     word_perm.chunk_words = words_per_chunk
     for i from 0 <= i < num_chunks:
         images_i = <codeword *> sig_malloc(words_per_chunk * sizeof(codeword))
@@ -661,7 +661,7 @@ cdef codeword *expand_to_ortho_basis(BinaryCode B, int n):
     for j from i <= j < n:
         basis[j] = 0
     # now basis is length i
-    perm = list(xrange(B.nrows))
+    perm = list(range(B.nrows))
     perm_c = []
     for j from B.nrows <= j < B.ncols:
         if (<codeword>1 << j) & pivots:
@@ -669,7 +669,7 @@ cdef codeword *expand_to_ortho_basis(BinaryCode B, int n):
         else:
             perm_c.append(j)
     perm.extend(perm_c)
-    perm.extend(list(xrange(B.ncols, n)))
+    perm.extend(list(range(B.ncols, n)))
     perm_c = [0]*n
     for j from 0 <= j < n:
         perm_c[perm[j]] = j
@@ -4017,7 +4017,7 @@ cdef class BinaryCodeClassifier:
 
 
         for i from 0 <= i < len(aut_gp_gens):
-            parent_generators[i] = create_word_perm(aut_gp_gens[i] + list(xrange(B.ncols, n)))
+            parent_generators[i] = create_word_perm(aut_gp_gens[i] + list(range(B.ncols, n)))
 
         word = 0
         while ortho_basis[k] & (((<codeword>1) << B.ncols) - 1):
@@ -4116,7 +4116,7 @@ cdef class BinaryCodeClassifier:
                             aut_B_aug = libgap(PermutationGroup([PermutationGroupElement([a+1 for a in g]) for g in aug_aut_gp_gens]))
                         H = libgap(aut_m).Intersection2(aut_B_aug)
                         rt_transversal = [[int(a) - 1 for a in g.ListPerm(n)] for g in aut_B_aug.RightTransversal(H) if not g.IsOne()]
-                        rt_transversal.append(list(xrange(n)))
+                        rt_transversal.append(list(range(n)))
 
                         bingo2 = 0
                         for coset_rep in rt_transversal:

--- a/src/sage/coding/codecan/autgroup_can_label.pyx
+++ b/src/sage/coding/codecan/autgroup_can_label.pyx
@@ -124,8 +124,8 @@ def _cyclic_shift(n, p):
         sage: p.action(t)
         [0, 2, 7, 3, 1, 5, 6, 4, 8, 9]
     """
-    x = list(xrange(1, n + 1))
-    for i in xrange(1, len(p)):
+    x = list(range(1, n + 1))
+    for i in range(1, len(p)):
         x[p[i - 1]] = p[i] + 1
     x[p[len(p) - 1]] = p[0] + 1
     return Permutation(x)
@@ -229,17 +229,17 @@ class LinearCodeAutGroupCanLabel:
         S = SemimonomialTransformationGroup(F, mat.ncols())
 
         if P is None:
-            P = [list(xrange(mat.ncols()))]
+            P = [list(range(mat.ncols()))]
 
         pos2P = [-1] * mat.ncols()
-        for i in xrange(len(P)):
+        for i in range(len(P)):
             P[i].sort(reverse=True)
             for x in P[i]:
                 pos2P[x] = i
 
         col_list = mat.columns()
-        nz = [i for i in xrange(mat.ncols()) if not col_list[i].is_zero()]
-        z = [(pos2P[i], i) for i in xrange(mat.ncols()) if col_list[i].is_zero()]
+        nz = [i for i in range(mat.ncols()) if not col_list[i].is_zero()]
+        z = [(pos2P[i], i) for i in range(mat.ncols()) if col_list[i].is_zero()]
         z.sort()
         z = [i for (p, i) in z]
 
@@ -259,7 +259,7 @@ class LinearCodeAutGroupCanLabel:
         col2pos = []
         col2P = []
         for c in col_set:
-            X = [(pos2P[y], y) for y in xrange(mat.ncols()) if col_list[y] == c ]
+            X = [(pos2P[y], y) for y in range(mat.ncols()) if col_list[y] == c ]
             X.sort()
             col2pos.append([b for (a, b) in X ])
             col2P.append([a for (a, b) in X ])
@@ -272,7 +272,7 @@ class LinearCodeAutGroupCanLabel:
         P_refined = []
         p = [0]
         act_qty = col2P[0]
-        for i in xrange(1, len(col_set)):
+        for i in range(1, len(col_set)):
             if act_qty == col2P[i]:
                 p.append(i)
             else:
@@ -357,7 +357,7 @@ class LinearCodeAutGroupCanLabel:
         perm = [-1] * mat.ncols()
         mult = [F.one()] * mat.ncols()
 
-        for i in xrange(len(can_col_set)):
+        for i in range(len(can_col_set)):
             img = can_transp.get_perm()(i + 1)
             for j in col2pos[img - 1]:
                 pos = P[ pos2P[j] ].pop()
@@ -378,7 +378,7 @@ class LinearCodeAutGroupCanLabel:
         self._full_autom_order *= a
 
 
-        for i in xrange(len(col2P)):
+        for i in range(len(col2P)):
             if len(col2P[i]) > 1:
                 A, a = self._compute_trivial_automs(normalization,
                     normalization_inverse, col2pos[i], col2P[i])
@@ -508,11 +508,11 @@ class LinearCodeAutGroupCanLabel:
         n = S.degree()
         A = []
         for g in gens:
-            perm = list(xrange(1, n + 1))
+            perm = list(range(1, n + 1))
             mult = [S.base_ring().one()] * n
             short_perm = g.get_perm()
             short_mult = g.get_v()
-            for i in xrange(len(col2pos)):
+            for i in range(len(col2pos)):
                 c = col2pos[i]
                 img_iter = iter(col2pos[short_perm(i + 1) - 1])
                 for x in c:

--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -10,7 +10,7 @@ and also algebraic immunity.
 
 EXAMPLES::
 
-    sage: R.<x>=GF(2^8,'a')[]
+    sage: R.<x> = GF(2^8,'a')[]
     sage: from sage.crypto.boolean_function import BooleanFunction
     sage: B = BooleanFunction( x^254 ) # the Boolean function Tr(x^254)
     sage: B
@@ -900,7 +900,8 @@ cdef class BooleanFunction(SageObject):
                 temp[i] = W[i]*W[i]
 
             walsh_hadamard(temp, self._nvariables)
-            self._autocorrelation = tuple([temp[i] >> self._nvariables for i in xrange(n)])
+            self._autocorrelation = tuple([temp[i] >> self._nvariables
+                                           for i in range(n)])
             sig_free(temp)
 
         return self._autocorrelation

--- a/src/sage/data_structures/bitset.pyx
+++ b/src/sage/data_structures/bitset.pyx
@@ -2193,9 +2193,7 @@ def test_bitset(py_a, py_b, long n):
 
     print("a.hamming_weight() ", bitset_hamming_weight(a))
 
-    morphism = {}
-    for i in xrange(a.size):
-        morphism[i] = a.size - i - 1
+    morphism = {i: a.size - i - 1 for i in range(a.size)}
     bitset_map(r, a, morphism)
     print("a.map(m) ", bitset_string(r))
 

--- a/src/sage/dynamics/arithmetic_dynamics/projective_ds_helper.pyx
+++ b/src/sage/dynamics/arithmetic_dynamics/projective_ds_helper.pyx
@@ -89,7 +89,7 @@ cpdef _fast_possible_periods(self, return_points=False):
     p = PS.base_ring().order()
     N = int(PS.dimension_relative())
 
-    point_table = [[0,0] for i in xrange(p**(N + 1))]
+    point_table = [[0,0] for i in range(p**(N + 1))]
     index = 1
     periods = set()
     points_periods = []
@@ -173,7 +173,7 @@ def _enum_points(int prime, int dimension):
     highest_range = prime**dimension
 
     while current_range <= highest_range:
-        for value in xrange(current_range, 2*current_range):
+        for value in range(current_range, 2*current_range):
             yield _get_point_from_hash(value, prime, dimension)
         current_range = current_range * prime
 
@@ -211,7 +211,7 @@ cpdef list _get_point_from_hash(int value, int prime, int dimension):
     cdef list P = []
     cdef int i
 
-    for i in xrange(dimension + 1):
+    for i in range(dimension + 1):
         P.append(value % prime)
         value /= prime
 
@@ -258,7 +258,7 @@ cpdef _normalize_coordinates(list point, int prime, int len_points):
     """
     cdef int last_coefficient, coefficient, mod_inverse, val
 
-    for coefficient in xrange(len_points):
+    for coefficient in range(len_points):
         val = ((<int> point[coefficient]) + prime) % prime
         point[coefficient] = val
         if val != 0:
@@ -266,7 +266,7 @@ cpdef _normalize_coordinates(list point, int prime, int len_points):
 
     mod_inverse = _mod_inv(last_coefficient, prime)
 
-    for coefficient in xrange(len_points):
+    for coefficient in range(len_points):
         point[coefficient] = (point[coefficient] * mod_inverse) % prime
 
 cpdef _all_periodic_points(self):

--- a/src/sage/lfunctions/zero_sums.pyx
+++ b/src/sage/lfunctions/zero_sums.pyx
@@ -209,8 +209,8 @@ cdef class LFunctionZeroSum_abstract(SageObject):
             (11, -0.21799047934530644)
         """
         if not python_floats:
-            return [self.cn(i) for i in xrange(n + 1)]
-        return [float(self.cn(i)) for i in xrange(n + 1)]
+            return [self.cn(i) for i in range(n + 1)]
+        return [float(self.cn(i)) for i in range(n + 1)]
 
     def digamma(self, s, include_constant_term=True):
         r"""

--- a/src/sage/libs/coxeter3/coxeter.pyx
+++ b/src/sage/libs/coxeter3/coxeter.pyx
@@ -777,7 +777,7 @@ cdef class CoxGroupElement:
         """
         if isinstance(i, slice):
             #Get the start, stop, and step from the slice
-            return [self[ii] for ii in xrange(*i.indices(len(self)))]
+            return [self[ii] for ii in range(*i.indices(len(self)))]
         if i < 0:
             i += len(self)
         if i >= len(self):
@@ -873,7 +873,7 @@ cdef class CoxGroupElement:
             sage: [a for a in w]                                # optional - coxeter3
             [1, 2, 3]
         """
-        return (self[i] for i in xrange(len(self)))
+        return (self[i] for i in range(len(self)))
 
     def __len__(self):
         """

--- a/src/sage/libs/flint/fmpz_poly.pyx
+++ b/src/sage/libs/flint/fmpz_poly.pyx
@@ -152,7 +152,7 @@ cdef class Fmpz_poly(SageObject):
             sage: f.list()
             [2, 1, 0, -1]
         """
-        return [self[i] for i in xrange(self.degree() + 1)]
+        return [self[i] for i in range(self.degree() + 1)]
 
     def __add__(left, right):
         """

--- a/src/sage/libs/singular/function.pyx
+++ b/src/sage/libs/singular/function.pyx
@@ -686,8 +686,8 @@ cdef class Converter(SageObject):
         ncols = mat.ncols
         nrows = mat.nrows
         result = Matrix(self._sage_ring, nrows, ncols)
-        for i in xrange(nrows):
-            for j in xrange(ncols):
+        for i in range(nrows):
+            for j in range(ncols):
                 p = new_sage_polynomial(self._sage_ring, mat.m[i*ncols+j])
                 mat.m[i*ncols+j]=NULL
                 result[i,j] = p
@@ -767,8 +767,8 @@ cdef class Converter(SageObject):
         nrows = mat.rows()
 
         result = Matrix(ZZ, nrows, ncols)
-        for i in xrange(nrows):
-            for j in xrange(ncols):
+        for i in range(nrows):
+            for j in range(ncols):
                 result[i,j] = mat.get(i*ncols+j)
         return result
 
@@ -828,8 +828,8 @@ cdef class Converter(SageObject):
         ncols = mat.ncols()
         nrows = mat.nrows()
         cdef matrix* _m=mpNew(nrows,ncols)
-        for i in xrange(nrows):
-            for j in xrange(ncols):
+        for i in range(nrows):
+            for j in range(ncols):
                 #FIXME
                 p = copy_sage_polynomial_into_singular_poly(mat[i,j])
                 _m.m[ncols*i+j]=p
@@ -853,7 +853,7 @@ cdef class Converter(SageObject):
         cdef lists *singular_list=<lists*>omAlloc0Bin(slists_bin)
         singular_list.Init(n)
         cdef leftv* iv
-        for i in xrange(n):
+        for i in range(n):
             iv=c.pop_front()
             memcpy(&singular_list.m[i],iv,sizeof(leftv))
             omFreeBin(iv, sleftv_bin)
@@ -868,7 +868,7 @@ cdef class Converter(SageObject):
         cdef intvec *iv = new intvec()
         iv.resize(s)
 
-        for i in xrange(s):
+        for i in range(s):
             iv.ivGetVec()[i]=<int>a[i]
         return self._append(<void*>iv, INTVEC_CMD)
 
@@ -896,8 +896,8 @@ cdef class Converter(SageObject):
         cdef int ncols = <int> a.ncols()
         cdef intvec *iv = new intvec(nrows, ncols, 0)
 
-        for i in xrange(nrows):
-            for j in xrange(ncols):
+        for i in range(nrows):
+            for j in range(ncols):
                 iv.ivGetVec()[i*ncols+j]=<int>a[i,j]
         return self._append(<void*>iv, INTMAT_CMD)
 
@@ -971,7 +971,7 @@ cdef class Converter(SageObject):
         elif rtyp == LIST_CMD:
             singular_list = <lists*> to_convert.data
             ret = []
-            for i in xrange(singular_list.nr+1):
+            for i in range(singular_list.nr+1):
                 ret.append(self.to_python(&(singular_list.m[i])))
             return ret
         elif rtyp == MODUL_CMD:

--- a/src/sage/media/channels.pyx
+++ b/src/sage/media/channels.pyx
@@ -13,7 +13,7 @@ def _separate_channels(_data, _width, _nchannels):
 
     cdef int l = len(_data) / (width)
 
-    channel_data = [[] for i in xrange(nchannels)]
+    channel_data = [[] for i in range(nchannels)]
     if width == 1:
         # handle the one byte case
 

--- a/src/sage/misc/binary_tree.pyx
+++ b/src/sage/misc/binary_tree.pyx
@@ -506,9 +506,9 @@ class Test:
         """
         from sage.misc.prandom import randint
         t = BinaryTree()
-        for i in xrange(cycles):
-            r = randint(0,8)
-            s = randint(0,values)
+        for i in range(cycles):
+            r = randint(0, 8)
+            s = randint(0, values)
             if r==1:
                 t.insert(s)
             elif r == 2:

--- a/src/sage/misc/random_testing.py
+++ b/src/sage/misc/random_testing.py
@@ -54,9 +54,9 @@ def random_testing(fn):
     fails (raises an exception).
 
     If you want a very long-running test using this setup, you should do
-    something like (in Python 2)::
+    something like::
 
-        for _ in xrange(10^10): test_foo(100)
+        for _ in range(10^10): test_foo(100)
 
     instead of::
 

--- a/src/sage/modular/arithgroup/farey_symbol.pyx
+++ b/src/sage/modular/arithgroup/farey_symbol.pyx
@@ -609,7 +609,7 @@ cdef class Farey:
             s = r'\left( -\infty'
             a = [x._latex_() for x in self.fractions()] + [r'\infty']
             b = self.pairings()
-            for i in xrange(len(a)):
+            for i in range(len(a)):
                 u = b[i]
                 if u == -3:
                     u = r'\bullet'

--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -2116,9 +2116,9 @@ cdef class FreeModuleElement(Vector):   # abstract base class
             return "()"
         # compute column widths
         S = [repr(x) for x in self.list(copy=False)]
-        #width = max([len(x) for x in S])
+        # width = max([len(x) for x in S])
         s = "("
-        for i in xrange(d):
+        for i in range(d):
             if i == d-1:
                 sep = ""
             else:

--- a/src/sage/modules/vector_integer_dense.pyx
+++ b/src/sage/modules/vector_integer_dense.pyx
@@ -208,8 +208,8 @@ cdef class Vector_integer_dense(free_module_element.FreeModuleElement):
             (1, 2, 3, 4)
         """
         cdef int i
-        return [_Integer_from_mpz(self._entries[i]) for i in
-                                  xrange(self._degree)]
+        return [_Integer_from_mpz(self._entries[i])
+                for i in range(self._degree)]
 
     def __reduce__(self):
         return (unpickle_v1, (self._parent, self.list(), self._degree,

--- a/src/sage/numerical/gauss_legendre.pyx
+++ b/src/sage/numerical/gauss_legendre.pyx
@@ -132,11 +132,11 @@ def nodes_uncached(degree, prec):
     else:
         nodes = []
         n = degree
-        for j in xrange(1, n // 2 + 1):
+        for j in range(1, n // 2 + 1):
             r = R(math.cos(math.pi*(j-0.25)/(n+0.5)))
             while True:
                 t1,t2=ONE,ZERO
-                for j1 in xrange(1,n+1):
+                for j1 in range(1,n+1):
                     mpfr_mul(u,r.value,t1.value,rnd)
                     mpfr_mul_si(u,u,2*j1-1,rnd)
                     mpfr_mul_si(v,t2.value,j1-1,rnd)
@@ -250,10 +250,11 @@ def estimate_error(results, prec, epsilon):
         2.328235...e-10
     """
     if len(results)==2:
-        return max((results[0][i]-results[1][i]).abs() for i in xrange(len(results[0])))
+        return max((results[0][i]-results[1][i]).abs()
+                   for i in range(len(results[0])))
     e = []
-    ZERO = 0*epsilon
-    for i in xrange(len(results[0])):
+    ZERO = 0 * epsilon
+    for i in range(len(results[0])):
         try:
             if results[-1][i] == results[-2][i] == results[-3][i]:
                 e.append(0*epsilon)

--- a/src/sage/quadratic_forms/ternary.pyx
+++ b/src/sage/quadratic_forms/ternary.pyx
@@ -557,11 +557,11 @@ def _find_zeros_mod_p_odd(long long a, long long b, long long c, long long r, lo
     cdef long long x0
     cdef long long y0
 
-    zeros=[v]
-    x0=v[0]
-    y0=v[1]
-    more=False
-    for i in xrange(p):
+    zeros = [v]
+    x0 = v[0]
+    y0 = v[1]
+    more = False
+    for i in range(p):
         a_i=(a*x0**2+b*i**2-2*b*i*y0+b*y0**2-t*i*x0+t*x0*y0-2*a*x0+t*i-t*y0+s*x0-r*i+r*y0+a+c-s)%p
         #b_i=(-2*b*i**2+2*b*i*y0+t*i*x0+2*a*x0-2*t*i+t*y0+r*i-2*a+s)%p
         if a_i==0:

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -2561,7 +2561,7 @@ cdef class MonoidElement(Element):
             return []
         x = self._parent.one()
         l = [x]
-        for i in xrange(n - 1):
+        for i in range(n - 1):
             x = x * self
             l.append(x)
         return l
@@ -2727,7 +2727,7 @@ cdef class RingElement(ModuleElement):
             return []
         x = self._parent.one()
         l = [x]
-        for i in xrange(n - 1):
+        for i in range(n - 1):
             x = x * self
             l.append(x)
         return l

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -8322,7 +8322,7 @@ cdef class Expression(Expression_abc):
             else:
                 return new_Expression_from_pyobject(self._parent, y)
         zero = self._parent.zero()
-        return zero.add(*(pol[i]*self**i for i in xrange(pol.degree() + 1)))
+        return zero.add(*(pol[i]*self**i for i in range(pol.degree() + 1)))
 
     def collect_common_factors(self):
         """
@@ -12470,7 +12470,7 @@ cdef class Expression(Expression_abc):
             ex = self
         sympy_ex = ex._sympy_()
         solutions = diophantine(sympy_ex)
-        if isinstance(solutions, (set)):
+        if isinstance(solutions, set):
             solutions = list(solutions)
 
         if len(solutions) == 0:
@@ -12481,7 +12481,7 @@ cdef class Expression(Expression_abc):
             solutions = [tuple(SR(s) for s in sol) for sol in solutions]
         if x is None:
             wanted_vars = ex.variables()
-            var_idx = list(xrange(len(ex.variables())))
+            var_idx = list(range(len(ex.variables())))
         else:
             if isinstance(x, (list, tuple)):
                 wanted_vars = x

--- a/src/sage/symbolic/getitem_impl.pxi
+++ b/src/sage/symbolic/getitem_impl.pxi
@@ -138,8 +138,7 @@ cdef class OperandsWrapper(SageObject):
             else:
                 step = 1
             return [new_Expression_from_GEx(self._expr._parent,
-                self._expr._gobj.op(ind)) for ind in xrange(bind, eind, step)]
-
+                self._expr._gobj.op(ind)) for ind in range(bind, eind, step)]
 
         ind_err_msg = "index should either be a slice object, an integer or a list of integers"
         if isinstance(arg, (list, tuple)):

--- a/src/sage/symbolic/series_impl.pxi
+++ b/src/sage/symbolic/series_impl.pxi
@@ -240,21 +240,21 @@ cdef class SymbolicSeries(Expression):
         """
         if x is None:
             x = self.default_variable()
-        l = [[self.coefficient(x, d), d] for d in xrange(self.degree(x))]
+        l = [[self.coefficient(x, d), d] for d in range(self.degree(x))]
         if sparse:
             return l
-        else:
-            from sage.rings.integer_ring import ZZ
-            if any(not c[1] in ZZ for c in l):
-                raise ValueError("cannot return dense coefficient list with noninteger exponents")
-            val = l[0][1]
-            if val < 0:
-                raise ValueError("cannot return dense coefficient list with negative valuation")
-            deg = l[-1][1]
-            ret = [ZZ(0)] * int(deg+1)
-            for c in l:
-                ret[c[1]] = c[0]
-            return ret
+
+        from sage.rings.integer_ring import ZZ
+        if any(not c[1] in ZZ for c in l):
+            raise ValueError("cannot return dense coefficient list with noninteger exponents")
+        val = l[0][1]
+        if val < 0:
+            raise ValueError("cannot return dense coefficient list with negative valuation")
+        deg = l[-1][1]
+        ret = [ZZ(0)] * int(deg+1)
+        for c in l:
+            ret[c[1]] = c[0]
+        return ret
 
     def power_series(self, base_ring):
         """


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

this is replacing `xrange` by `range` in many `pyx` files, where it has the exact same meaning

(those are remnants of our py2 history)

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
