### PR TITLE
Document that GLPK/exact can be inexact

### DIFF
--- a/src/sage/numerical/backends/glpk_backend.pyx
+++ b/src/sage/numerical/backends/glpk_backend.pyx
@@ -1012,10 +1012,14 @@ cdef class GLPKBackend(GenericBackend):
         (`get_col_dual` etc.) or tableau data (`get_row_stat` etc.),
         one needs to switch to "simplex_only" before solving.
 
-        GLPK also has an exact rational simplex solver.  The only
-        access to data is via double-precision floats, however. It
-        reconstructs rationals from doubles and also provides results
-        as doubles.
+        GLPK also has an exact rational simplex solver.  The only access
+        to data is via double-precision floats, which means that
+        rationals in the input data may be rounded before the exact
+        solver sees them. Thus, it is unreasonable to expect that
+        arbitrary LPs with rational coefficients are solved exactly.
+        Once the LP has been read into the backend, it reconstructs
+        rationals from doubles and does solve exactly over the rationals,
+        but results are returned as as doubles.
 
         EXAMPLES::
 

--- a/src/sage/numerical/backends/glpk_exact_backend.pyx
+++ b/src/sage/numerical/backends/glpk_exact_backend.pyx
@@ -19,9 +19,13 @@ cdef class GLPKExactBackend(GLPKBackend):
     """
     MIP Backend that runs the GLPK solver in exact rational simplex mode.
 
-    The only access to data is via double-precision floats, however. It
-    reconstructs rationals from doubles and also provides results
-    as doubles.
+    The only access to data is via double-precision floats, which
+    means that rationals in the input data may be rounded before
+    the exact solver sees them. Thus, it is unreasonable to expect
+    that arbitrary LPs with rational coefficients are solved exactly.
+    Once the LP has been read into the backend, it reconstructs
+    rationals from doubles and does solve exactly over the rationals,
+    but results are returned as as doubles.
 
     There is no support for integer variables.
     """


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

The GLPK/exact linear programming (LP) backend isn't exact because rationals are converted to doubles to be passed to the backend. This means that, despite solving LPs exactly over the rationals, the solver can silently solve a rounded version of your LP. For example, coefficients of 1/3 are handled incorrectly as they are rounded to some 0.3333333ish number that fits in a double-precision float.

This PR simply expands the relevant documentation to explain more carefully that this can lead to problems. Fixes #35727.

The modified files lie in the ```src/``` subdirectory, are changes required to files with the same relative path under such as ```/build/pkgs/sagemath_environment/...```, ```build/pkgs/sagemath_repl/...```, and ```pkgs/sagemath-repl/...```?

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
