### PR TITLE
cylint: no more xrange in matroids

### DIFF
--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -176,7 +176,7 @@ cdef class BasisExchangeMatroid(Matroid):
             self._E = groundset
         self._idx = {}
         cdef long i
-        for i in xrange(self._groundset_size):
+        for i in range(self._groundset_size):
             self._idx[self._E[i]] = i
 
         if basis is not None:
@@ -219,7 +219,7 @@ cdef class BasisExchangeMatroid(Matroid):
         self._groundset = frozenset(E)
 
         self._idx = {}
-        for i in xrange(self._groundset_size):
+        for i in range(self._groundset_size):
             self._idx[self._E[i]] = i
 
         if self._weak_partition_var:
@@ -1090,7 +1090,7 @@ cdef class BasisExchangeMatroid(Matroid):
         bitset_free(loops)
         bitset_free(loop)
         bitset_free(active_rows)
-        for i in xrange(self.full_rank()):
+        for i in range(self.full_rank()):
             bitset_free(comp[i])
         sig_free(comp)
         return res
@@ -1267,16 +1267,16 @@ cdef class BasisExchangeMatroid(Matroid):
         flats = <bitset_t*>sig_malloc((self.full_rank() + 1) * sizeof(bitset_t))
         todo = <bitset_t*>sig_malloc((self.full_rank() + 1) * sizeof(bitset_t))
 
-        for i in xrange(self.full_rank() + 1):
+        for i in range(self.full_rank() + 1):
             bitset_init(flats[i], self._bitset_size)
             bitset_init(todo[i], self._bitset_size)
-        f_vec = [0 for i in xrange(self.full_rank() + 1)]
+        f_vec = [0 for i in range(self.full_rank() + 1)]
         i = 0
         bitset_clear(todo[0])
         self.__closure(flats[0], todo[0])
         bitset_complement(todo[0], flats[0])
         self._f_vector_rec(f_vec, flats, todo, 0, 0)
-        for i in xrange(self.full_rank() + 1):
+        for i in range(self.full_rank() + 1):
             bitset_free(flats[i])
             bitset_free(todo[i])
         sig_free(flats)
@@ -1340,7 +1340,7 @@ cdef class BasisExchangeMatroid(Matroid):
         flats = <bitset_t*>sig_malloc((r + 1) * sizeof(bitset_t))
         todo = <bitset_t*>sig_malloc((r + 1) * sizeof(bitset_t))
 
-        for i in xrange(r + 1):
+        for i in range(r + 1):
             bitset_init(flats[i], self._bitset_size)
             bitset_init(todo[i], self._bitset_size)
         Rflats = SetSystem(self._E)
@@ -1349,7 +1349,7 @@ cdef class BasisExchangeMatroid(Matroid):
         self.__closure(flats[0], todo[0])
         bitset_complement(todo[0], flats[0])
         self._flats_rec(Rflats, r, flats, todo, 0, 0)
-        for i in xrange(r + 1):
+        for i in range(r + 1):
             bitset_free(flats[i])
             bitset_free(todo[i])
         sig_free(flats)
@@ -1415,7 +1415,7 @@ cdef class BasisExchangeMatroid(Matroid):
         coflats = <bitset_t*>sig_malloc((r + 1) * sizeof(bitset_t))
         todo = <bitset_t*>sig_malloc((r + 1) * sizeof(bitset_t))
 
-        for i in xrange(r + 1):
+        for i in range(r + 1):
             bitset_init(coflats[i], self._bitset_size)
             bitset_init(todo[i], self._bitset_size)
         Rcoflats = SetSystem(self._E)
@@ -1424,7 +1424,7 @@ cdef class BasisExchangeMatroid(Matroid):
         self.__coclosure(coflats[0], todo[0])
         bitset_complement(todo[0], coflats[0])
         self._coflats_rec(Rcoflats, r, coflats, todo, 0, 0)
-        for i in xrange(r + 1):
+        for i in range(r + 1):
             bitset_free(coflats[i])
             bitset_free(todo[i])
         sig_free(coflats)
@@ -1462,28 +1462,28 @@ cdef class BasisExchangeMatroid(Matroid):
         flats = <bitset_t*>sig_malloc((k + 1) * sizeof(bitset_t))
         todo = <bitset_t*>sig_malloc((k + 1) * sizeof(bitset_t))
 
-        for i in xrange(k + 1):
+        for i in range(k + 1):
             bitset_init(flats[i], self._bitset_size)
             bitset_init(todo[i], self._bitset_size)
-        f_inc = [[0 for e in range(self._groundset_size + 1)] for i in xrange(k + 1)]
+        f_inc = [[0 for e in range(self._groundset_size + 1)] for i in range(k + 1)]
         i = 0
         bitset_clear(todo[0])
         self.__closure(flats[0], todo[0])
         bitset_complement(todo[0], flats[0])
         self._flat_element_inv_rec(f_inc, k, flats, todo, 0, 0)
-        for i in xrange(k + 1):
+        for i in range(k + 1):
             bitset_free(flats[i])
             bitset_free(todo[i])
         sig_free(flats)
         sig_free(todo)
         fie = {}
         for e in range(self._groundset_size):
-            t = tuple([f_inc[i][e] for i in xrange(k + 1)])
+            t = tuple([f_inc[i][e] for i in range(k + 1)])
             if t in fie:
                 fie[t].add(self._E[e])
             else:
                 fie[t] = set([self._E[e]])
-        f_vec = tuple([f_inc[i][self._groundset_size] for i in xrange(k + 1)])
+        f_vec = tuple([f_inc[i][self._groundset_size] for i in range(k + 1)])
         return fie, f_vec
 
     cdef _flat_element_inv_rec(self, object f_inc, long R, bitset_t* flats, bitset_t* todo, long elt, long i):
@@ -1806,7 +1806,7 @@ cdef class BasisExchangeMatroid(Matroid):
             if self.__is_independent(self._input):
                 bitset_copy(self._input2, self._current_basis)
                 e = bitset_first(self._current_basis)
-                for e in xrange(self._groundset_size):
+                for e in range(self._groundset_size):
                     if not bitset_in(self._current_basis, e):
                         self.__fundamental_circuit(self._output, e)
                         if e > bitset_first(self._output):
@@ -1854,7 +1854,7 @@ cdef class BasisExchangeMatroid(Matroid):
             if self.__is_independent(self._input):
                 bitset_copy(self._input2, self._current_basis)
                 e = bitset_first(self._current_basis)
-                for e in xrange(self._groundset_size):
+                for e in range(self._groundset_size):
                     if not bitset_in(self._current_basis, e):
                         self.__fundamental_circuit(self._output, e)
                         if e > bitset_first(self._output):
@@ -2162,7 +2162,7 @@ cdef class BasisExchangeMatroid(Matroid):
         Bitpacked version of ``is_isomorphism``.
         """
         cdef long i
-        morph = [other._idx[morphism[self._E[i]]] for i in xrange(len(self))]
+        morph = [other._idx[morphism[self._E[i]]] for i in range(len(self))]
         bitset_clear(self._input)
         bitset_set_first_n(self._input, self._matroid_rank)
         repeat = True
@@ -2226,7 +2226,7 @@ cdef class BasisExchangeMatroid(Matroid):
         if self.full_rank() != other.full_rank():
             return None
         if self.full_rank() == 0 or self.full_corank() == 0:
-            return {self.groundset_list()[i]: other.groundset_list()[i] for i in xrange(len(self))}
+            return {self.groundset_list()[i]: other.groundset_list()[i] for i in range(len(self))}
 
         if self._weak_invariant() != other._weak_invariant():
             return None
@@ -2234,7 +2234,7 @@ cdef class BasisExchangeMatroid(Matroid):
         PO = other._weak_partition()
         if len(PS) == len(self) and len(PO) == len(other):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             if self.__is_isomorphism(other, morphism):
                 return morphism
@@ -2247,7 +2247,7 @@ cdef class BasisExchangeMatroid(Matroid):
         PO = other._strong_partition()
         if len(PS) == len(self) and len(PO) == len(other):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             if self.__is_isomorphism(other, morphism):
                 return morphism
@@ -2258,7 +2258,7 @@ cdef class BasisExchangeMatroid(Matroid):
             PHS = self._heuristic_partition()
             PHO = other._heuristic_partition()
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PHS[i])] = min(PHO[i])
             if self.__is_isomorphism(other, morphism):
                 return morphism
@@ -2327,7 +2327,7 @@ cdef class BasisExchangeMatroid(Matroid):
         PO = other._weak_partition()
         if len(PS) == len(self) and len(PO) == len(other):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             return self.__is_isomorphism(other, morphism)
 
@@ -2337,7 +2337,7 @@ cdef class BasisExchangeMatroid(Matroid):
         PO = other._strong_partition()
         if len(PS) == len(self) and len(PO) == len(other):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             return self.__is_isomorphism(other, morphism)
 
@@ -2345,7 +2345,7 @@ cdef class BasisExchangeMatroid(Matroid):
             PHS = self._heuristic_partition()
             PHO = other._heuristic_partition()
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PHS[i])] = min(PHO[i])
             if self.__is_isomorphism(other, morphism):
                 return True

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -178,7 +178,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             bitset_init(self._bb, bc)
             bitset_set_first_n(self._bb, bc)
             NB = M.nonbases()
-            for i in xrange(len(NB)):
+            for i in range(len(NB)):
                 bitset_discard(self._bb, set_to_index(NB._subsets[i]))
 
             bitset_init(self._b, (<BasisExchangeMatroid>M)._bitset_size)
@@ -364,7 +364,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         cdef BasisMatroid D
         D = BasisMatroid(groundset=self._E, rank=self.full_corank())
         N = binom[self._groundset_size][self._matroid_rank]
-        for i in xrange(N):
+        for i in range(N):
             if not bitset_in(self._bb, i):
                 bitset_discard(D._bb, N - i - 1)
         D.reset_current_basis()
@@ -684,8 +684,8 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         cdef long i, j
         cdef list bc
         cdef dict bi
-        bc = [0 for i in xrange(len(self))]
-        for i in xrange(binom[self._groundset_size][self._matroid_rank]):
+        bc = [0 for i in range(len(self))]
+        for i in range(binom[self._groundset_size][self._matroid_rank]):
             if not bitset_in(self._bb, i):
                 index_to_set(self._b, i, self._matroid_rank, self._groundset_size)
                 j = bitset_first(self._b)
@@ -693,7 +693,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
                     bc[j] += 1
                     j = bitset_next(self._b, j + 1)
         bi = {}
-        for e in xrange(len(self)):
+        for e in range(len(self)):
             if bc[e] in bi:
                 bi[bc[e]].append(e)
             else:
@@ -902,7 +902,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         bitset_complement(bb_comp, self._bb)
 
         bitset_init(b2, max(len(self), 1))
-        morph = [(<BasisMatroid>other)._idx[morphism[self._E[i]]] for i in xrange(len(self))]
+        morph = [(<BasisMatroid>other)._idx[morphism[self._E[i]]] for i in range(len(self))]
         i = bitset_first(bb_comp)
         while i != -1:
             index_to_set(self._b, i, self._matroid_rank, self._groundset_size)
@@ -993,7 +993,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         if self.full_rank() != other.full_rank():
             return None
         if self.full_rank() == 0:
-            return {self.groundset_list()[i]: other.groundset_list()[i] for i in xrange(len(self))}
+            return {self.groundset_list()[i]: other.groundset_list()[i] for i in range(len(self))}
         if self.bases_count() != other.bases_count():
             return None
 
@@ -1003,7 +1003,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         PO = other._bases_partition()
         if len(PS) == len(self) and len(PO) == len(other):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             if self._is_relaxation(other, morphism):
                 return morphism
@@ -1016,7 +1016,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         PO = other._bases_partition2()
         if len(PS) == len(self) and len(PO) == len(other):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             if self._is_relaxation(other, morphism):
                 return morphism
@@ -1027,7 +1027,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             PHS = self._bases_partition3()
             PHO = other._bases_partition3()
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PHS[i])] = min(PHO[i])
             if self._is_relaxation(other, morphism):
                 return morphism
@@ -1085,7 +1085,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         PO = other._bases_partition()
         if len(PS) == len(self) and len(PO) == len(other):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             return self._is_relaxation(other, morphism)
 
@@ -1095,7 +1095,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         PO = other._bases_partition2()
         if len(PS) == len(self) and len(PO) == len(other):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             return self._is_relaxation(other, morphism)
 
@@ -1103,7 +1103,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             PHS = self._bases_partition3()
             PHO = other._bases_partition3()
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PHS[i])] = min(PHO[i])
             if self._is_relaxation(other, morphism):
                 return True
@@ -1246,7 +1246,7 @@ cdef  binom_init(long N, long K):
     if binom[0][0] != 1:
         binom[0][0] = 1
         binom[0][1] = 0
-        for n in xrange(1, 2955):
+        for n in range(1, 2955):
             bin = 1
             k = 0
             while bin < 2 ** 32 and k <= 32 and k <= n:

--- a/src/sage/matroids/extension.pyx
+++ b/src/sage/matroids/extension.pyx
@@ -340,8 +340,8 @@ cdef class LinearSubclasses:
 
         self._planes_on_line = [[] for l in range(self._hyperlines_count)]
         self._lines_on_plane = [[] for l in range(self._hyperplanes_count)]
-        for l in xrange(self._hyperlines_count):
-            for h in xrange(self._hyperplanes_count):
+        for l in range(self._hyperlines_count):
+            for h in range(self._hyperplanes_count):
                 if self._hyperplanes[h] >= self._hyperlines[l]:
                     self._lines_on_plane[h].append(l)
                     self._planes_on_line[l].append(h)
@@ -353,10 +353,10 @@ cdef class LinearSubclasses:
 
         if line_length is not None:
             self._line_length = line_length
-            self._mandatory_lines = [l for l in xrange(self._hyperlines_count) if len(self._planes_on_line[l]) >= line_length]
+            self._mandatory_lines = [l for l in range(self._hyperlines_count) if len(self._planes_on_line[l]) >= line_length]
 
         if subsets is not None:
-            for p in xrange(self._hyperplanes_count):
+            for p in range(self._hyperplanes_count):
                 H = self._hyperplanes[p]
                 for S in subsets:
                     if frozenset(S).issubset(H):
@@ -370,7 +370,7 @@ cdef class LinearSubclasses:
             if len(E) != len(E2) or len(F) != 1:
                 raise ValueError("LinearSubclasses: the ground set of the splice matroid is not of the form E + e-f")
 
-            for p in xrange(self._hyperplanes_count):
+            for p in range(self._hyperplanes_count):
                 X = self._hyperplanes[p] - F
                 if splice._rank(X) == splice.full_rank() - 1:
                     if splice._rank(X | F2) == splice.full_rank() - 1:
@@ -490,7 +490,7 @@ cdef class MatroidExtensions(LinearSubclasses):
             BM = BasisMatroid(M)
         LinearSubclasses.__init__(self, BM, line_length=line_length, subsets=subsets, splice=splice)
         self._BX = BM._extension(e, [])
-        self._BH = [BM._extension(e, [self._hyperplanes[i]]) for i in xrange(len(self._hyperplanes))]
+        self._BH = [BM._extension(e, [self._hyperplanes[i]]) for i in range(len(self._hyperplanes))]
         if orderly:
             self._orderly = True
 

--- a/src/sage/matroids/lean_matrix.pyx
+++ b/src/sage/matroids/lean_matrix.pyx
@@ -339,7 +339,7 @@ cdef class LeanMatrix:
         """
         Get coordinates of nonzero entries of row ``r``.
         """
-        return [i for i in xrange(self._ncols) if self.is_nonzero(r, i)]
+        return [i for i in range(self._ncols) if self.is_nonzero(r, i)]
 
     cdef LeanMatrix transpose(self):
         """
@@ -545,7 +545,7 @@ cdef class LeanMatrix:
         - `True, E` -- if there exist a ``m``-separator ``E``.
 
         """
-        for z in xrange(self.ncols()):
+        for z in range(self.ncols()):
             if z in P_cols+Q_cols:
                 continue
             sol,cert = self.shifting(P_rows,P_cols,Q_rows,Q_cols,z,None,m)
@@ -610,22 +610,22 @@ cdef class LeanMatrix:
         if len(X_1) + len(Y_1) < m:
             return False, None
 
-        cdef set X=set(xrange(self.nrows()))
-        cdef set Y=set(xrange(self.ncols()))
+        cdef set X=set(range(self.nrows()))
+        cdef set Y=set(range(self.ncols()))
 
         cdef set X_3 = X-set(X_1+X_2)
         cdef set Y_3 = Y-set(Y_1+Y_2)
 
         cdef list lU_2 = sorted(list(U_2))
         cdef list lV_2 = sorted(list(V_2))
-        cdef dict rU = dict(zip(lU_2,xrange(len(U_2))))
-        cdef dict rV = dict(zip(lV_2,xrange(len(V_2))))
+        cdef dict rU = dict(zip(lU_2,range(len(U_2))))
+        cdef dict rV = dict(zip(lV_2,range(len(V_2))))
 
         # find a unique representation of every column in U_1xY_3 using columns in U_1xV_2
-        B = self.matrix_from_rows_and_columns(list(U_1), xrange(len(Y)))
+        B = self.matrix_from_rows_and_columns(list(U_1), range(len(Y)))
         B.gauss_jordan_reduce(lV_2)
         # find a unique representation of every rows in X_3xV_1 using rows in U_2xV_1
-        BT = self.matrix_from_rows_and_columns(xrange(len(X)),list(V_1)).transpose()
+        BT = self.matrix_from_rows_and_columns(range(len(X)),list(V_1)).transpose()
         BT.gauss_jordan_reduce(lU_2)
 
         cdef set X_p = set(X_1)
@@ -1349,17 +1349,17 @@ cdef class BinaryMatrix(LeanMatrix):
         bitset_complement(mask, mask)
         # copy relevant part of this matrix into A
         cdef bitset_t row, row2
-        for r in xrange(len(rows)):
+        for r in range(len(rows)):
             row = self._M[rows[r]]
             row2 = A._M[r]
             bitset_intersection(row2, row, mask) # yes, this is safe
-            for g in xrange(lg):
+            for g in range(lg):
                 if bitset_in(row, cols[g]):
                     bitset_add(row2, gaps[g])
         # record order of the columns in list `order`
-        cdef list order = list(xrange(lc))
+        cdef list order = list(range(lc))
         g = 0
-        for g in xrange(lg):
+        for g in range(lg):
             order[gaps[g]] = cols[g]
         # free up the two arrays and the bitset
         sig_free(gaps)
@@ -2026,14 +2026,14 @@ cdef class TernaryMatrix(LeanMatrix):
         # copy relevant part of this matrix into A
         cdef bitset_t row0, row1, row0_2, row1_2
         cdef mp_bitcnt_t p, q
-        for r in xrange(len(rows)):
+        for r in range(len(rows)):
             row0 = self._M0[rows[r]]
             row1 = self._M1[rows[r]]
             row0_2 = A._M0[r]
             row1_2 = A._M1[r]
             bitset_intersection(row0_2, row0, mask) # yes, this is safe
             bitset_intersection(row1_2, row1, mask) # yes, this is safe
-            for g in xrange(lg):
+            for g in range(lg):
                 p = cols[g]
                 if bitset_in(row0, p):
                     q = gaps[g]
@@ -2041,9 +2041,9 @@ cdef class TernaryMatrix(LeanMatrix):
                     if bitset_in(row1, p):
                         bitset_add(row1_2, q)
         # record order of the columns in list `order`
-        cdef list order = list(xrange(lc))
+        cdef list order = list(range(lc))
         g = 0
-        for g in xrange(lg):
+        for g in range(lg):
             order[gaps[g]] = cols[g]
         # free up the two arrays and the bitset
         sig_free(gaps)
@@ -2610,14 +2610,14 @@ cdef class QuaternaryMatrix(LeanMatrix):
         # copy relevant part of this matrix into A
         cdef bitset_t row0, row1, row0_2, row1_2
         cdef mp_bitcnt_t p, q
-        for r in xrange(len(rows)):
+        for r in range(len(rows)):
             row0 = self._M0[rows[r]]
             row1 = self._M1[rows[r]]
             row0_2 = A._M0[r]
             row1_2 = A._M1[r]
             bitset_intersection(row0_2, row0, mask) # yes, this is safe
             bitset_intersection(row1_2, row1, mask)
-            for g in xrange(lg):
+            for g in range(lg):
                 p = cols[g]
                 q = gaps[g]
                 if bitset_in(row0, p):
@@ -2625,9 +2625,9 @@ cdef class QuaternaryMatrix(LeanMatrix):
                 if bitset_in(row1, p):
                     bitset_add(row1_2, q)
         # record order of the columns in list `order`
-        cdef list order = list(xrange(lc))
+        cdef list order = list(range(lc))
         g = 0
-        for g in xrange(lg):
+        for g in range(lg):
             order[gaps[g]] = cols[g]
         # free up the two arrays and the bitset
         sig_free(gaps)

--- a/src/sage/matroids/linear_matroid.pxd
+++ b/src/sage/matroids/linear_matroid.pxd
@@ -23,7 +23,6 @@ cdef class LinearMatroid(BasisExchangeMatroid):
     cpdef LeanMatrix _basic_representation(self, B=*)
     cpdef LeanMatrix _reduced_representation(self, B=*)
 
-
     cpdef bint _is_field_isomorphism(self, LinearMatroid other, morphism)
     cpdef is_field_equivalent(self, other)
     cpdef is_field_isomorphism(self, other, morphism)

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -317,8 +317,8 @@ cdef class LinearMatroid(BasisExchangeMatroid):
                 A = (<LeanMatrix>matrix).copy()   # Deprecated Sage matrix operation
             if keep_initial_representation:
                 self._representation = A.copy()   # Deprecated Sage matrix operation
-            P = gauss_jordan_reduce(A, xrange(A.ncols()))
-            self._A = A.matrix_from_rows_and_columns(range(len(P)), [c for c in xrange(matrix.ncols()) if c not in P])
+            P = gauss_jordan_reduce(A, range(A.ncols()))
+            self._A = A.matrix_from_rows_and_columns(range(len(P)), [c for c in range(matrix.ncols()) if c not in P])
         else:
             reduced = True
             if not isinstance(reduced_matrix, LeanMatrix):
@@ -328,20 +328,20 @@ cdef class LinearMatroid(BasisExchangeMatroid):
                     self._A = GenericMatrix(reduced_matrix.nrows(), reduced_matrix.ncols(), M=reduced_matrix, ring=ring)
             else:
                 self._A = (<LeanMatrix>reduced_matrix).copy()   # Deprecated Sage matrix operation
-            P = list(xrange(self._A.nrows()))
+            P = list(range(self._A.nrows()))
         self._prow = <long* > sig_malloc((self._A.nrows() + self._A.ncols()) * sizeof(long))
         if matrix is not None:
-            for r in xrange(len(P)):
+            for r in range(len(P)):
                 self._prow[P[r]] = r
             r = 0
-            for c in xrange(A.ncols()):
+            for c in range(A.ncols()):
                 if c not in P:
                     self._prow[c] = r
                     r += 1
         else:
-            for r from 0 <= r < self._A.nrows():
+            for r in range(self._A.nrows()):
                 self._prow[r] = r
-            for r from 0 <= r < self._A.ncols():
+            for r in range(self._A.ncols()):
                 self._prow[self._A.nrows() + r] = r
         return P
 
@@ -413,7 +413,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
         pivi = piv ** (-1)
         self._A.rescale_row_c(px, pivi, 0)
         self._A.set_unsafe(px, py, pivi + self._one)       # pivoting without column scaling. Add extra so column does not need adjusting
-        for r in xrange(self._A.nrows()):            # if A and A' are the matrices before and after pivoting, then
+        for r in range(self._A.nrows()):            # if A and A' are the matrices before and after pivoting, then
             a = self._A.get_unsafe(r, py)       # ker[I A] equals ker[I A'] except for the labelling of the columns
             if a and r != px:
                 self._A.add_multiple_of_row_c(r, px, -a, 0)
@@ -1175,7 +1175,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             return False
         if len(PS) == len(self):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             return self._is_field_isomorphism(other, morphism)
 
@@ -1187,7 +1187,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             return False
         if len(PS) == len(self):
             morphism = {}
-            for i in xrange(len(self)):
+            for i in range(len(self)):
                 morphism[min(PS[i])] = min(PO[i])
             return self._is_field_isomorphism(other, morphism)
 
@@ -2094,11 +2094,9 @@ cdef class LinearMatroid(BasisExchangeMatroid):
         else:
             M = type(self._A)(self._representation.nrows(), self.size() + 1, self._representation)
         E = self._E + (element,)
-        D = {}
-        for i from 0 <= i < self.size():
-            D[E[i]] = i
+        D = {E[i]: i for i in range(self.size())}
         for chain in chains:
-            for i from 0 <= i < M.nrows():
+            for i in range(M.nrows()):
                 a = self._zero
                 for e in chain:
                     a += M.get_unsafe(i, D[e]) * chain[e]
@@ -2145,11 +2143,9 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             M = type(self._A)(self._representation.nrows() + 1, self.size() + 1, self._representation)
         M.set_unsafe(M.nrows() - 1, M.ncols() - 1, self._one)
         E = self._E + (element,)
-        D = {}
-        for i from 0 <= i < self.size():
-            D[E[i]] = i
+        D = {E[i]: i for i in range(self.size())}
         for cochain in cochains:
-            for i from 0 <= i < M.ncols() - 1:
+            for i in range(M.ncols() - 1):
                 M.set_unsafe(M.nrows() - 1, i, 0)
             for e in cochain:
                 M.set_unsafe(M.nrows() - 1, D[e], -cochain[e])
@@ -2782,9 +2778,9 @@ cdef class LinearMatroid(BasisExchangeMatroid):
                         B[x, y] = 0
 
             # remove row x1 and y1
-            Xp = list(xrange(n))
+            Xp = list(range(n))
             Xp.remove(x1)
-            Yp = list(xrange(m))
+            Yp = list(range(m))
             Yp.remove(y1)
 
             B = B.matrix_from_rows_and_columns(Xp,Yp)
@@ -2864,7 +2860,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             sage: OTG1 is OTG2
             True
 
-         """
+        """
         if R is None:
             R = self.base_ring()
 
@@ -2878,7 +2874,6 @@ cdef class LinearMatroid(BasisExchangeMatroid):
                     G, action = action, G
             else:
                 G, action = G_action, None # the None action is g.__call__
-
 
             from sage.algebras.orlik_terao import OrlikTeraoInvariantAlgebra
 
@@ -3088,17 +3083,17 @@ cdef class BinaryMatroid(LinearMatroid):
             if keep_initial_representation:
                 self._representation = A.copy()   # Deprecated Sage matrix operation
             if basis is None:
-                P = gauss_jordan_reduce(A, xrange(A.ncols()))
+                P = gauss_jordan_reduce(A, range(A.ncols()))
                 A.resize(len(P))   # Not a Sage matrix operation
             self._A = A
         else:
             A = BinaryMatrix(reduced_matrix.nrows(), reduced_matrix.ncols(), M=reduced_matrix)
-            P = list(xrange(A.nrows()))
+            P = list(range(A.nrows()))
             self._A = A.prepend_identity()   # Not a Sage matrix operation
 
         # Setup groundset, BasisExchangeMatroid data
         if groundset is None:
-            groundset = list(xrange(self._A.ncols()))
+            groundset = list(range(self._A.ncols()))
         else:
             if len(groundset) != self._A.ncols():
                 raise ValueError("size of groundset does not match size of matrix")
@@ -3110,17 +3105,17 @@ cdef class BinaryMatroid(LinearMatroid):
 
         # Setup index of displayed basis
         self._prow = <long* > sig_malloc((self._A.ncols()) * sizeof(long))
-        for c in xrange(self._A.ncols()):
+        for c in range(self._A.ncols()):
             self._prow[c] = -1
         if matrix is not None:
             if basis is None:
-                for r in xrange(len(P)):
+                for r in range(len(P)):
                     self._prow[P[r]] = r
             else:
-                for r in xrange(self._A.nrows()):
+                for r in range(self._A.nrows()):
                     self._prow[self._idx[basis[r]]] = r
         else:
-            for r from 0 <= r < self._A.nrows():
+            for r in range(self._A.nrows()):
                 self._prow[r] = r
 
         self._zero = GF2_zero
@@ -3449,12 +3444,12 @@ cdef class BinaryMatroid(LinearMatroid):
         i = 0
         U = set()
         while i + d < r:
-            for j in xrange(i, r - d):
+            for j in range(i, r - d):
                 if B.row_len(j) % 2 == 1:   # Not a Sage matrix operation
                     B.swap_rows_c(i, j)
                     break
             if B.row_len(i) % 2 == 1:   # Not a Sage matrix operation
-                for j in xrange(i + 1, r - d):
+                for j in range(i + 1, r - d):
                     if B.row_inner_product(i, j):   # Not a Sage matrix operation
                         B.add_multiple_of_row_c(j, i, 1, 0)
                 if B.row_len(i) % 4 == 1:   # Not a Sage matrix operation
@@ -3464,13 +3459,13 @@ cdef class BinaryMatroid(LinearMatroid):
                 U.add(i)
                 i += 1
             else:
-                for j in xrange(i + 1, r - d):
+                for j in range(i + 1, r - d):
                     if B.row_inner_product(i, j):   # Not a Sage matrix operation
                         B.swap_rows_c(i + 1, j)
                         break
                 if i + 1 < r - d:
                     if B.row_inner_product(i, i + 1):   # Not a Sage matrix operation
-                        for j in xrange(i + 2, r):
+                        for j in range(i + 2, r):
                             if B.row_inner_product(i, j):   # Not a Sage matrix operation
                                 B.add_multiple_of_row_c(j, i + 1, 1, 0)
                             if B.row_inner_product(i + 1, j):   # Not a Sage matrix operation
@@ -3485,7 +3480,7 @@ cdef class BinaryMatroid(LinearMatroid):
                     d += 1
 
         doubly_even = True
-        for i in xrange(r - d, r):
+        for i in range(r - d, r):
             if B.row_len(i) % 4 == 2:   # Not a Sage matrix operation
                 doubly_even = False
                 break
@@ -3502,8 +3497,8 @@ cdef class BinaryMatroid(LinearMatroid):
         self._b_projection = BT._matrix_times_matrix_((B._matrix_times_matrix_(BT))._matrix_times_matrix_(B))
         P = [F0, Fp]
         p = []
-        for a in xrange(2):
-            for b in xrange(a + 1):
+        for a in range(2):
+            for b in range(a + 1):
                 x = 0
                 for i in P[a]:
                     for j in P[b]:
@@ -3834,16 +3829,16 @@ cdef class BinaryMatroid(LinearMatroid):
 
         c = 1
         col = {}
-        for e in xrange(len(B)):
+        for e in range(len(B)):
             for f in range(len(B)):
                 if e is not f:
                     col[e, f] = c
                     c += 1
         M = []
         r = 0
-        for e in xrange(len(B)):
-            for f in xrange(e):
-                for g in xrange(f):
+        for e in range(len(B)):
+            for f in range(e):
+                for g in range(f):
                     if not C[e].issuperset(C[f] & C[g]):
                         M.append([col[e,f], col[e,g]])
                         r += 1
@@ -4154,17 +4149,17 @@ cdef class TernaryMatroid(LinearMatroid):
             if keep_initial_representation:
                 self._representation = A.copy()   # Deprecated Sage matrix operation
             if basis is None:
-                P = gauss_jordan_reduce(A, xrange(A.ncols()))
+                P = gauss_jordan_reduce(A, range(A.ncols()))
                 A.resize(len(P))   # Not a Sage matrix operation
             self._A = A
         else:
             A = TernaryMatrix(reduced_matrix.nrows(), reduced_matrix.ncols(), M=reduced_matrix)
-            P = list(xrange(A.nrows()))
+            P = list(range(A.nrows()))
             self._A = A.prepend_identity()   # Not a Sage matrix operation
 
         # Setup groundset, BasisExchangeMatroid data
         if groundset is None:
-            groundset = list(xrange(self._A.ncols()))
+            groundset = list(range(self._A.ncols()))
         else:
             if len(groundset) != self._A.ncols():
                 raise ValueError("size of groundset does not match size of matrix")
@@ -4176,17 +4171,17 @@ cdef class TernaryMatroid(LinearMatroid):
 
         # Setup index of displayed basis
         self._prow = <long* > sig_malloc((self._A.ncols()) * sizeof(long))
-        for c in xrange(self._A.ncols()):
+        for c in range(self._A.ncols()):
             self._prow[c] = -1
         if matrix is not None:
             if basis is None:
-                for r in xrange(len(P)):
+                for r in range(len(P)):
                     self._prow[P[r]] = r
             else:
-                for r in xrange(self._A.nrows()):
+                for r in range(self._A.nrows()):
                     self._prow[self._idx[basis[r]]] = r
         else:
-            for r from 0 <= r < self._A.nrows():
+            for r in range(self._A.nrows()):
                 self._prow[r] = r
 
         self._zero = GF3_zero
@@ -4482,7 +4477,7 @@ cdef class TernaryMatroid(LinearMatroid):
         c = self._one
         i = 0
         while i < r - d:
-            for j in xrange(i, r - d):
+            for j in range(i, r - d):
                 if T.row_inner_product(j, j) != 0:   # Not a Sage matrix operation
                     if j > i:
                         T.swap_rows_c(i, j)
@@ -4497,7 +4492,7 @@ cdef class TernaryMatroid(LinearMatroid):
                 T.swap_rows_c(i, r - d)
             else:
                 c = c * GF3(x)
-                for j in xrange(i + 1, r - d):
+                for j in range(i + 1, r - d):
                     y = T.row_inner_product(i, j)   # Not a Sage matrix operation
                     if y == 0:
                         continue
@@ -4510,16 +4505,16 @@ cdef class TernaryMatroid(LinearMatroid):
         TT = T.transpose()
         self._t_projection = TT._matrix_times_matrix_((T._matrix_times_matrix_(TT))._matrix_times_matrix_(T))
         F = frozenset()
-        for i in xrange(r - d, r):
+        for i in range(r - d, r):
             F = F | frozenset(T.nonzero_positions_in_row(i))
-        Fa = frozenset([j for j in xrange(len(self)) if self._t_projection.get(j, j) == 0]) - F   # Not a Sage matrix operation
-        Fb = frozenset([j for j in xrange(len(self)) if self._t_projection.get(j, j) == 1]) - F   # Not a Sage matrix operation
-        Fc = frozenset([j for j in xrange(len(self)) if self._t_projection.get(j, j) == -1]) - F   # Not a Sage matrix operation
+        Fa = frozenset([j for j in range(len(self)) if self._t_projection.get(j, j) == 0]) - F   # Not a Sage matrix operation
+        Fb = frozenset([j for j in range(len(self)) if self._t_projection.get(j, j) == 1]) - F   # Not a Sage matrix operation
+        Fc = frozenset([j for j in range(len(self)) if self._t_projection.get(j, j) == -1]) - F   # Not a Sage matrix operation
 
         P = [Fa, Fb, Fc]
         p = []
-        for a in xrange(3):
-            for b in xrange(a + 1):
+        for a in range(3):
+            for b in range(a + 1):
                 x = 0
                 for i in P[a]:
                     for j in P[b]:
@@ -5053,17 +5048,17 @@ cdef class QuaternaryMatroid(LinearMatroid):
             if keep_initial_representation:
                 self._representation = A.copy()   # Deprecated Sage matrix operation
             if basis is None:
-                P = gauss_jordan_reduce(A, xrange(A.ncols()))
+                P = gauss_jordan_reduce(A, range(A.ncols()))
                 A.resize(len(P))   # Not a Sage matrix operation
             self._A = A
         else:
             A = QuaternaryMatrix(reduced_matrix.nrows(), reduced_matrix.ncols(), M=reduced_matrix, ring=ring)
-            P = list(xrange(A.nrows()))
+            P = list(range(A.nrows()))
             self._A = A.prepend_identity()   # Not a Sage matrix operation
 
         # Setup groundset, BasisExchangeMatroid data
         if groundset is None:
-            groundset = list(xrange(self._A.ncols()))
+            groundset = list(range(self._A.ncols()))
         else:
             if len(groundset) != self._A.ncols():
                 raise ValueError("size of groundset does not match size of matrix")
@@ -5075,17 +5070,17 @@ cdef class QuaternaryMatroid(LinearMatroid):
 
         # Setup index of displayed basis
         self._prow = <long* > sig_malloc((self._A.ncols()) * sizeof(long))
-        for c in xrange(self._A.ncols()):
+        for c in range(self._A.ncols()):
             self._prow[c] = -1
         if matrix is not None:
             if basis is None:
-                for r in xrange(len(P)):
+                for r in range(len(P)):
                     self._prow[P[r]] = r
             else:
-                for r in xrange(self._A.nrows()):
+                for r in range(self._A.nrows()):
                     self._prow[self._idx[basis[r]]] = r
         else:
-            for r from 0 <= r < self._A.nrows():
+            for r in range(self._A.nrows()):
                 self._prow[r] = r
 
         self._zero = (<QuaternaryMatrix>self._A)._zero
@@ -5336,7 +5331,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
         d = 0
         i = 0
         while i < r - d:
-            for j in xrange(i, r - d):
+            for j in range(i, r - d):
                 if Q.row_inner_product(j, j) != 0:   # Not a Sage matrix operation
                     if j > i:
                         Q.swap_rows_c(i, j)
@@ -5351,7 +5346,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
                 d += 1
                 Q.swap_rows_c(i, r - d)
             else:
-                for j in xrange(i + 1, r - d):
+                for j in range(i + 1, r - d):
                     y = Q.row_inner_product(j, i)   # Not a Sage matrix operation
                     if y == 0:
                         continue
@@ -5362,15 +5357,15 @@ cdef class QuaternaryMatroid(LinearMatroid):
         QT.conjugate()   # Not a Sage matrix operation
         self._q_projection = QT._matrix_times_matrix_((Q._matrix_times_matrix_(QT))._matrix_times_matrix_(Q))
         F = frozenset()
-        for i in xrange(r - d, r):
+        for i in range(r - d, r):
             F = F | frozenset(Q.nonzero_positions_in_row(i))
-        Fa = frozenset([j for j in xrange(len(self)) if self._q_projection.get(j, j) == 0]) - F   # Not a Sage matrix operation
-        Fb = frozenset([j for j in xrange(len(self)) if self._q_projection.get(j, j) == 1]) - F   # Not a Sage matrix operation
+        Fa = frozenset([j for j in range(len(self)) if self._q_projection.get(j, j) == 0]) - F   # Not a Sage matrix operation
+        Fb = frozenset([j for j in range(len(self)) if self._q_projection.get(j, j) == 1]) - F   # Not a Sage matrix operation
 
         P = [Fa, Fb]
         p = []
-        for a in xrange(2):
-            for b in xrange(a + 1):
+        for a in range(2):
+            for b in range(a + 1):
                 x = 0
                 for i in P[a]:
                     for j in P[b]:
@@ -5782,28 +5777,28 @@ cdef class RegularMatroid(LinearMatroid):
                 A = (<PlusMinusOneMatrix>matrix).copy()   # Deprecated Sage matrix operation
             if keep_initial_representation:
                 self._representation = A.copy()   # Deprecated Sage matrix operation
-            P = gauss_jordan_reduce(A, xrange(A.ncols()))
-            self._A = A.matrix_from_rows_and_columns(range(len(P)), [c for c in xrange(matrix.ncols()) if c not in P])
+            P = gauss_jordan_reduce(A, range(A.ncols()))
+            self._A = A.matrix_from_rows_and_columns(range(len(P)), [c for c in range(matrix.ncols()) if c not in P])
         else:
             reduced = True
             if not isinstance(reduced_matrix, PlusMinusOneMatrix):
                 self._A = PlusMinusOneMatrix(reduced_matrix.nrows(), reduced_matrix.ncols(), M=reduced_matrix)
             else:
                 self._A = (<PlusMinusOneMatrix>reduced_matrix).copy()   # Deprecated Sage matrix operation
-            P = list(xrange(self._A.nrows()))
+            P = list(range(self._A.nrows()))
         self._prow = <long* > sig_malloc((self._A.nrows() + self._A.ncols()) * sizeof(long))
         if matrix is not None:
-            for r in xrange(len(P)):
+            for r in range(len(P)):
                 self._prow[P[r]] = r
             r = 0
-            for c in xrange(A.ncols()):
+            for c in range(A.ncols()):
                 if c not in P:
                     self._prow[c] = r
                     r += 1
         else:
-            for r from 0 <= r < self._A.nrows():
+            for r in range(self._A.nrows()):
                 self._prow[r] = r
-            for r from 0 <= r < self._A.ncols():
+            for r in range(self._A.ncols()):
                 self._prow[self._A.nrows() + r] = r
         return P
 
@@ -5855,7 +5850,7 @@ cdef class RegularMatroid(LinearMatroid):
         pivi = piv  # NOTE: 1 and -1 are their own inverses.
         (<PlusMinusOneMatrix>self._A).rescale_row_c(px, pivi, 0)
         (<PlusMinusOneMatrix>self._A).set(px, py, pivi + 1)       # pivoting without column scaling. Add extra so column does not need adjusting   # Not a Sage matrix operation
-        for r in xrange(self._A.nrows()):                 # if A and A' are the matrices before and after pivoting, then
+        for r in range(self._A.nrows()):                 # if A and A' are the matrices before and after pivoting, then
             a = (<PlusMinusOneMatrix>self._A).get(r, py)       # ker[I A] equals ker[I A'] except for the labelling of the columns   # Not a Sage matrix operation
             if a and r != px:
                 (<PlusMinusOneMatrix>self._A).add_multiple_of_row_c(r, px, -a, 0)
@@ -5981,14 +5976,14 @@ cdef class RegularMatroid(LinearMatroid):
         A = {}
         B = {}
         N = 0
-        for i in xrange(P.nrows()):
+        for i in range(P.nrows()):
             w = P.get_unsafe(i, i)
             if w != 0:
                 if w in A:
                     A[w] += 1
                 else:
                     A[w] = 1
-            for j in xrange(i):
+            for j in range(i):
                 w = abs(P.get_unsafe(i, j))
                 if w != 0:
                     if w in B:
@@ -6047,7 +6042,7 @@ cdef class RegularMatroid(LinearMatroid):
                 else:
                     A[w] = [e]
                 V.append(e)
-            for j in xrange(i):
+            for j in range(i):
                 f = self._E[j]
                 w = abs(P.get_unsafe(i, j))
                 if w != 0:

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -2357,7 +2357,7 @@ cdef class Matroid(SageObject):
                 rX = self._rank(XX)
                 if rX > i:
                     return False
-                for j in xrange(i, len(E) + 1):
+                for j in range(i, len(E) + 1):
                     for Y in combinations(E, j):
                         YY = frozenset(Y)
                         rY = self._rank(YY)
@@ -2510,10 +2510,10 @@ cdef class Matroid(SageObject):
             sage: [sorted(X) for X in CC[3]]
             [['a', 'b', 'c', 'd', 'e', 'f', 'g']]
         """
-        CC = [set([]) for r in xrange(self.rank() + 1)]
+        CC = [set([]) for r in range(self.rank() + 1)]
         for C in self.circuits():
             CC[len(C) - 1].add(self.closure(C))
-        return {r: CC[r] for r in xrange(self.rank() + 1) if CC[r]}
+        return {r: CC[r] for r in range(self.rank() + 1) if CC[r]}
 
     cpdef nonspanning_circuit_closures(self):
         """
@@ -2543,10 +2543,10 @@ cdef class Matroid(SageObject):
             ...
             KeyError: 3
         """
-        CC = [set([]) for r in xrange(self.rank() + 1)]
+        CC = [set([]) for r in range(self.rank() + 1)]
         for C in self.nonspanning_circuits():
             CC[len(C) - 1].add(self.closure(C))
-        return {r: CC[r] for r in xrange(self.rank() + 1) if CC[r]}
+        return {r: CC[r] for r in range(self.rank() + 1) if CC[r]}
 
     cpdef nonbases(self):
         r"""
@@ -2791,7 +2791,7 @@ cdef class Matroid(SageObject):
             return []
         loops = self._closure(set())
         flags = [[loops, set(), self.groundset() - loops]]
-        for r in xrange(r):
+        for r in range(r):
             flags = self._extend_flags(flags)
         return flags
 
@@ -2912,7 +2912,7 @@ cdef class Matroid(SageObject):
         loops = self._closure(set())
         flags = [[loops, set(), self.groundset() - loops]]
         f_vec = [1]
-        for r in xrange(self.full_rank()):
+        for r in range(self.full_rank()):
             flags = self._extend_flags(flags)
             f_vec.append(len(flags))
         return f_vec
@@ -5571,9 +5571,9 @@ cdef class Matroid(SageObject):
                         B[x, y] = 0
 
             # remove row x1 and y1
-            Xp = list(xrange(n))
+            Xp = list(range(n))
             Xp.remove(x1)
-            Yp = list(xrange(m))
+            Yp = list(range(m))
             Yp.remove(y1)
             B = B.matrix_from_rows_and_columns(Xp,Yp)
 

--- a/src/sage/matroids/set_system.pyx
+++ b/src/sage/matroids/set_system.pyx
@@ -83,7 +83,7 @@ cdef class SetSystem:
         else:
             self._groundset = groundset
         self._idx = {}
-        for i in xrange(len(groundset)):
+        for i in range(len(groundset)):
             self._idx[groundset[i]] = i
 
         self._groundset_size = len(groundset)
@@ -125,7 +125,7 @@ cdef class SetSystem:
 
     def __dealloc__(self):
         cdef long i
-        for i in xrange(self._len):
+        for i in range(self._len):
             bitset_free(self._subsets[i])
         sig_free(self._subsets)
         bitset_free(self._temp)
@@ -205,7 +205,7 @@ cdef class SetSystem:
     cdef copy(self):
         cdef SetSystem S
         S = SetSystem(self._groundset, capacity=len(self))
-        for i in xrange(len(self)):
+        for i in range(len(self)):
             S._append(self._subsets[i])
         return S
 
@@ -232,7 +232,7 @@ cdef class SetSystem:
                 E.append(self._E[i])
         self._groundset = E
         self._idx = {}
-        for i in xrange(self._groundset_size):
+        for i in range(self._groundset_size):
             self._idx[self._groundset[i]] = i
 
     cpdef _complements(self):
@@ -255,7 +255,7 @@ cdef class SetSystem:
         if self._groundset_size == 0:
             return self
         S = SetSystem(self._groundset, capacity=len(self))
-        for i in xrange(len(self)):
+        for i in range(len(self)):
             bitset_complement(self._temp, self._subsets[i])
             S._append(self._temp)
         return S
@@ -266,7 +266,7 @@ cdef class SetSystem:
         """
         if k is None:
             k = self._len
-        for i in xrange(k, self._len):
+        for i in range(k, self._len):
             bitset_free(self._subsets[i])
         self._len = min(self._len, k)
         k2 = max(k, 1)
@@ -357,7 +357,7 @@ cdef class SetSystem:
         bitset_complement(active, active)
 
         # We compute the union of all sets containing 0, and deactivate them.
-        for i in xrange(self._len):
+        for i in range(self._len):
             if bitset_in(self._subsets[i], 0):
                 bitset_union(self._temp, self._subsets[i], self._temp)
                 bitset_discard(active, i)
@@ -388,7 +388,7 @@ cdef class SetSystem:
         """
         cdef long i, e
         cdef list cnt
-        cnt = [0 for v in xrange(self._groundset_size)]
+        cnt = [0 for v in range(self._groundset_size)]
         for e in E:
             i = bitset_first(self._subsets[e])
             while i >= 0:
@@ -405,7 +405,7 @@ cdef class SetSystem:
         cdef bint split
 
         C = {}
-        for i in xrange(len(P)):
+        for i in range(len(P)):
             v = bitset_first(P._subsets[i])
             if v < 0:
                 continue
@@ -443,7 +443,7 @@ cdef class SetSystem:
         """
         cdef long c
         c = 0
-        for p in xrange(len(P)):
+        for p in range(len(P)):
             c <<= bitset_len(P._subsets[p])
             bitset_intersection(self._temp, P._subsets[p], self._subsets[e])
             c += bitset_len(self._temp)
@@ -456,7 +456,7 @@ cdef class SetSystem:
         if P is None:
             P = self.groundset_partition()
         if E is None:
-            E = xrange(self._len)
+            E = range(self._len)
         if len(E) == 0:
             return [E]
 
@@ -486,7 +486,7 @@ cdef class SetSystem:
         S = SetSystem(self._groundset, capacity=len(self) + 1)
         bitset_clear(self._temp)
         bitset_add(self._temp, v)
-        for i in xrange(len(self)):
+        for i in range(len(self)):
             bitset_difference(S._temp, self._subsets[i], self._temp)
             S._append(S._temp)
         S._append(self._temp)
@@ -498,7 +498,7 @@ cdef class SetSystem:
         Helper method for partition methods below.
         """
         if E is None:
-            E = xrange(self._len)
+            E = range(self._len)
         if P is None:
             if self._groundset:
                 P = SetSystem(self._groundset, [self._groundset], capacity=self._groundset_size)
@@ -632,7 +632,7 @@ cdef class SetSystem:
             [3]
         """
         P, EP, h = self._equitable_partition(P, EP)
-        for i in xrange(len(P)):
+        for i in range(len(P)):
             if bitset_len(P._subsets[i]) > 1:
                 return self._heuristic_partition(P._distinguish(bitset_first(P._subsets[i])), EP)
         return P, EP, h
@@ -675,13 +675,13 @@ cdef class SetSystem:
         if len(SP) != len(OP):
             return None
         p = SP._groundset_size + 1
-        for i in xrange(len(SP)):
+        for i in range(len(SP)):
             l = bitset_len(SP._subsets[i])
             if l != bitset_len(OP._subsets[i]):
                 return None
             if l != 1 and l < p:
                 p = l
-        for i in xrange(len(SP)):
+        for i in range(len(SP)):
             if bitset_len(SP._subsets[i]) == p:
                 SP2, SEP, sh = self._equitable_partition(SP._distinguish(bitset_first(SP._subsets[i])))
                 v = bitset_first(OP._subsets[i])
@@ -693,9 +693,9 @@ cdef class SetSystem:
                             return m
                     v = bitset_next(OP._subsets[i], v + 1)
                 return None
-        if sorted([self.subset_characteristic(SP, i) for i in xrange(len(self))]) != sorted([other.subset_characteristic(OP, i) for i in xrange(len(other))]):
+        if sorted([self.subset_characteristic(SP, i) for i in range(len(self))]) != sorted([other.subset_characteristic(OP, i) for i in range(len(other))]):
             return None
-        return dict([(self._groundset[bitset_first(SP._subsets[i])], other._groundset[bitset_first(OP._subsets[i])]) for i in xrange(len(SP))])
+        return dict([(self._groundset[bitset_first(SP._subsets[i])], other._groundset[bitset_first(OP._subsets[i])]) for i in range(len(SP))])
 
     cpdef _equivalence(self, is_equiv, SetSystem other, SetSystem SP=None, SetSystem OP=None):
         """
@@ -744,10 +744,10 @@ cdef class SetSystem:
                 return None
         if len(SP) != len(OP):
             return None
-        for i in xrange(len(SP)):
+        for i in range(len(SP)):
             if bitset_len(SP._subsets[i]) != bitset_len(OP._subsets[i]):
                 return None
-        for i in xrange(len(SP)):
+        for i in range(len(SP)):
             if bitset_len(SP._subsets[i]) > 1:
                 SP2, SEP, sh = self._equitable_partition(SP._distinguish(bitset_first(SP._subsets[i])))
                 v = bitset_first(OP._subsets[i])
@@ -759,7 +759,7 @@ cdef class SetSystem:
                             return m
                     v = bitset_next(OP._subsets[i], v + 1)
                 return None
-        morph = dict([(self._groundset[bitset_first(SP._subsets[i])], other._groundset[bitset_first(OP._subsets[i])]) for i in xrange(len(SP))])
+        morph = dict([(self._groundset[bitset_first(SP._subsets[i])], other._groundset[bitset_first(OP._subsets[i])]) for i in range(len(SP))])
         if is_equiv(self, other, morph):
             return morph
 

--- a/src/sage/matroids/unpickling.pyx
+++ b/src/sage/matroids/unpickling.pyx
@@ -39,6 +39,7 @@ from .graphic_matroid import GraphicMatroid
 from sage.rings.rational cimport Rational
 from sage.libs.gmp.mpq cimport mpq_set
 
+
 #############################################################################
 # BasisMatroid
 #############################################################################
@@ -224,7 +225,7 @@ def unpickle_binary_matrix(version, data):
         raise TypeError("object was created with newer version of Sage. Please upgrade.")
     nrows, ncols, versionB, size, limbs, longsize, M = data
     A = BinaryMatrix(nrows, ncols)
-    for i from 0 <= i < nrows:
+    for i in range(nrows):
         bitset_unpickle(A._M[i], (versionB, size, limbs, longsize, M[i]))
     return A
 
@@ -253,7 +254,7 @@ def unpickle_ternary_matrix(version, data):
         raise TypeError("object was created with newer version of Sage. Please upgrade.")
     nrows, ncols, versionB, size, limbs, longsize, M0, M1 = data
     A = TernaryMatrix(nrows, ncols)
-    for i from 0 <= i < nrows:
+    for i in range(nrows):
         bitset_unpickle(A._M0[i], (versionB, size, limbs, longsize, M0[i]))
         bitset_unpickle(A._M1[i], (versionB, size, limbs, longsize, M1[i]))
     return A
@@ -283,7 +284,7 @@ def unpickle_quaternary_matrix(version, data):
         raise TypeError("object was created with newer version of Sage. Please upgrade.")
     nrows, ncols, ring, versionB, size, limbs, longsize, M0, M1 = data
     A = QuaternaryMatrix(nrows, ncols, ring=ring)
-    for i from 0 <= i < nrows:
+    for i in range(nrows):
         bitset_unpickle(A._M0[i], (versionB, size, limbs, longsize, M0[i]))
         bitset_unpickle(A._M1[i], (versionB, size, limbs, longsize, M1[i]))
     return A
@@ -324,13 +325,14 @@ def unpickle_plus_minus_one_matrix(version, data):
         raise TypeError("object was created with newer version of Sage. Please upgrade.")
     cdef PlusMinusOneMatrix A = PlusMinusOneMatrix(data[0], data[1])
     cdef long i
-    for i from 0 <= i < A._nrows * A._ncols:
+    for i in range(A._nrows * A._ncols):
         A._entries[i] = data[2][i]
     return A
 
 
 from sage.misc.persist import register_unpickle_override
 register_unpickle_override("sage.matroids.unpickling", "unpickle_integer_matrix", unpickle_plus_minus_one_matrix)
+
 
 def unpickle_rational_matrix(version, data):
     """


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

getting rid of the uses of `xrange` in matroids

also changing a few C-style loops into python-style loops

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
