### PR TITLE
Implement persistent optional tag 

### DIFF
--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -109,7 +109,7 @@ def parse_optional_tags(string):
         ['bar', 'foo']
         sage: parse_optional_tags("sage: #optional -- foo.bar, baz")
         {'foo.bar'}
-        sage: parse_optional_tags("sage: #needs: foo.bar, baz")
+        sage: parse_optional_tags("sage: #needs foo.bar, baz")
         {'foo.bar'}
         sage: sorted(list(parse_optional_tags("    sage: factor(10^(10^10) + 1) # LoNg TiME, NoT TeSTED; OptioNAL -- P4cka9e")))
         ['long time', 'not tested', 'p4cka9e']
@@ -140,7 +140,7 @@ def parse_optional_tags(string):
     comment = "#" + (literals[comment]).lower()
 
     optional_regex = re.compile(r'arb216|arb218|py2|long time|not implemented|not tested|known bug'
-                                r'|[^ a-z]\s*(optional\s*[:-]*|needs:\s*)((?:\s|\w|[.])*)')
+                                r'|[^ a-z]\s*(optional|needs)\s*[:-]*((?:\s|\w|[.])*)')
 
     tags = []
     for m in optional_regex.finditer(comment):
@@ -593,13 +593,13 @@ class SageDocTestParser(doctest.DocTestParser):
         Optional tags at the start of an example block persist to the end of
         the block (delimited by a blank line)::
 
-            sage: # needs: sage.rings.number_field, long time
+            sage: # needs sage.rings.number_field, long time
             sage: QQbar(I)^10000
             1
             sage: QQbar(I)^10000  # not tested
             I
 
-            sage: # needs: sage.rings.finite_rings
+            sage: # needs sage.rings.finite_rings
             sage: GF(7)
             Finite Field of size 7
             sage: GF(10)

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -591,7 +591,7 @@ class SageDocTestParser(doctest.DocTestParser):
             87654321
 
         Optional tag at the start of an example block persists to the end of
-        the block::
+        the block (delimited by a blank line)::
 
             sage: # long time
             sage: QQbar(I)^10000

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -109,7 +109,7 @@ def parse_optional_tags(string):
         ['bar', 'foo']
         sage: parse_optional_tags("sage: #optional -- foo.bar, baz")
         {'foo.bar'}
-        sage: parse_optional_tags("sage: #needs foo.bar, baz")
+        sage: parse_optional_tags("sage: #needs: foo.bar, baz")
         {'foo.bar'}
         sage: sorted(list(parse_optional_tags("    sage: factor(10^(10^10) + 1) # LoNg TiME, NoT TeSTED; OptioNAL -- P4cka9e")))
         ['long time', 'not tested', 'p4cka9e']
@@ -140,7 +140,7 @@ def parse_optional_tags(string):
     comment = "#" + (literals[comment]).lower()
 
     optional_regex = re.compile(r'arb216|arb218|py2|long time|not implemented|not tested|known bug'
-                                r'|[^ a-z]\s*(optional|needs)\s*[:-]*((?:\s|\w|[.])*)')
+                                r'|[^ a-z]\s*(optional\s*[:-]*|needs:\s*)((?:\s|\w|[.])*)')
 
     tags = []
     for m in optional_regex.finditer(comment):
@@ -593,13 +593,13 @@ class SageDocTestParser(doctest.DocTestParser):
         Optional tags at the start of an example block persist to the end of
         the block (delimited by a blank line)::
 
-            sage: # needs sage.rings.number_field, long time
+            sage: # needs: sage.rings.number_field, long time
             sage: QQbar(I)^10000
             1
             sage: QQbar(I)^10000  # not tested
             I
 
-            sage: # needs sage.rings.finite_rings
+            sage: # needs: sage.rings.finite_rings
             sage: GF(7)
             Finite Field of size 7
             sage: GF(10)

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -139,7 +139,7 @@ def parse_optional_tags(string):
     # strip_string_literals replaces comments
     comment = "#" + (literals[comment]).lower()
 
-    optional_regex = re.compile(r'arb216|arb218|py2|long time|not implemented|not tested|known bug' \
+    optional_regex = re.compile(r'arb216|arb218|py2|long time|not implemented|not tested|known bug'
                                 r'|[^ a-z]\s*(optional|needs)\s*[:-]*((?:\s|\w|[.])*)')
 
     tags = []

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -587,7 +587,8 @@ class SageDocTestParser(doctest.DocTestParser):
             sage: print(m)
             87654321
 
-        Optional tags at the start of an example block persists to the end of the block::
+        Optional tag at the start of an example block persists to the end of
+        the block::
 
             sage: # long time
             sage: QQbar(I)^10000

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -590,19 +590,19 @@ class SageDocTestParser(doctest.DocTestParser):
             sage: print(m)
             87654321
 
-        Optional tag at the start of an example block persists to the end of
+        Optional tags at the start of an example block persist to the end of
         the block (delimited by a blank line)::
 
-            sage: # long time
+            sage: # needs sage.rings.number_field, long time
             sage: QQbar(I)^10000
             1
             sage: QQbar(I)^10000  # not tested
             I
 
-            sage: # optional - sage.rings.finite_rings
+            sage: # needs sage.rings.finite_rings
             sage: GF(7)
             Finite Field of size 7
-            sage: GF(10)  # not tested
+            sage: GF(10)
             Traceback (most recent call last):
             ...
             ValueError: the order of a finite field must be a prime power

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -109,6 +109,8 @@ def parse_optional_tags(string):
         ['bar', 'foo']
         sage: parse_optional_tags("sage: #optional -- foo.bar, baz")
         {'foo.bar'}
+        sage: parse_optional_tags("sage: #needs foo.bar, baz")
+        {'foo.bar'}
         sage: sorted(list(parse_optional_tags("    sage: factor(10^(10^10) + 1) # LoNg TiME, NoT TeSTED; OptioNAL -- P4cka9e")))
         ['long time', 'not tested', 'p4cka9e']
         sage: parse_optional_tags("    sage: raise RuntimeError # known bug")
@@ -137,17 +139,18 @@ def parse_optional_tags(string):
     # strip_string_literals replaces comments
     comment = "#" + (literals[comment]).lower()
 
-    optional_regex = re.compile(r'(arb216|arb218|py2|long time|not implemented|not tested|known bug)|([^ a-z]\s*optional\s*[:-]*((\s|\w|[.])*))')
+    optional_regex = re.compile(r'arb216|arb218|py2|long time|not implemented|not tested|known bug' \
+                                r'|[^ a-z]\s*(optional|needs)\s*[:-]*((?:\s|\w|[.])*)')
 
     tags = []
     for m in optional_regex.finditer(comment):
-        cmd = m.group(1)
+        cmd = m.group(0)
         if cmd == 'known bug':
             tags.append('bug')  # so that such tests will be run by sage -t ... -only-optional=bug
+        elif m.group(1) is not None:
+            tags.extend(m.group(2).split() or [""])
         elif cmd:
             tags.append(cmd)
-        else:
-            tags.extend(m.group(3).split() or [""])
     return set(tags)
 
 

--- a/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
+++ b/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
@@ -5979,7 +5979,7 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
             sage: f = DynamicalSystem_projective([x^3 + x*y^2, y^3])
             sage: m = matrix(QQ, 2, 2, [-201221, -1, 1, 0])
             sage: f = f.conjugate(m)
-            sage: f.reduced_form(prec=50, smallest_coeffs=False) #needs 2 periodic
+            sage: f.reduced_form(prec=50, smallest_coeffs=False) # this needs 2 periodic
             Traceback (most recent call last):
             ...
             ValueError: accuracy of Newton's root not within tolerance(0.000066... > 1e-06), increase precision
@@ -5997,7 +5997,7 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
         ::
 
             sage: PS.<x,y> = ProjectiveSpace(ZZ, 1)
-            sage: f = DynamicalSystem_projective([x^2+ x*y, y^2]) #needs 3 periodic
+            sage: f = DynamicalSystem_projective([x^2+ x*y, y^2]) # this needs 3 periodic
             sage: m = matrix(QQ, 2, 2, [-221, -1, 1, 0])
             sage: f = f.conjugate(m)
             sage: f.reduced_form(prec=200, smallest_coeffs=False)


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

(1) Implement persistent optional tags for block-scoped optional tags
(2) Add "needs" as an alternative to "optional" 

Thus doctests can be written as
```python
            sage: # needs sage.rings.number_field, long time
            sage: QQbar(I)^10000
            1
            sage: QQbar(I)^10000  # not tested
            I
            sage: # needs sage.rings.finite_rings
            sage: GF(7)
            Finite Field of size 7
            sage: GF(10)
            Traceback (most recent call last):
            ...
            ValueError: the order of a finite field must be a prime power
```

Resolves #35750.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->

<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
