### PR TITLE
adjust random tests for generators of elliptic curves

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -2319,6 +2319,22 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E1.gens(algorithm="pari")   #random
             [(-400 : 8000 : 1), (0 : -8000 : 1)]
 
+        TESTS::
+
+            sage: E = EllipticCurve('389a')
+            sage: len(E.gens())
+            2
+            sage: E.saturation(E.gens())[1]
+            1
+            sage: len(E.gens(algorithm="pari"))
+            2
+            sage: E.saturation(E.gens(algorithm="pari"))[1]
+            1
+            sage: E = EllipticCurve([-3/8,-2/3])
+            sage: P = E.lift_x(10/9)
+            sage: set(E.gens()) <= set([P,-P])
+            True
+
         """
         if proof is None:
             from sage.structure.proof.proof import get_flag
@@ -2370,23 +2386,29 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: proved
             True
 
+            sage: E = EllipticCurve([-127^2,0])
+            sage: E.gens(use_database=False, algorithm="pari",pari_effort=4)   # random
+            [(611429153205013185025/9492121848205441 : 15118836457596902442737698070880/924793900700594415341761 : 1)]
+
         TESTS::
 
-            sage: E = EllipticCurve([-127^2,0])
-            sage: E.gens(use_database=False, algorithm="pari")
-            Traceback (most recent call last):
-            ...
-            RuntimeError: generators could not be determined. So far we found []. Hint: increase pari_effort.
-            sage: E.gens(use_database=False, algorithm="pari",pari_effort=4)
-            [(611429153205013185025/9492121848205441 : 15118836457596902442737698070880/924793900700594415341761 : 1)]
+            sage: P = E.lift_x(611429153205013185025/9492121848205441)
+            sage: set(E.gens(use_database=False, algorithm="pari",pari_effort=4)) <= set([P+T for T
+            ....:  in E.torsion_points()] + [-P+T for T in E.torsion_points()])
+            True
 
             sage: E = EllipticCurve([-157^2,0])
             sage: E.gens(use_database=False, algorithm="pari")
             Traceback (most recent call last):
             ...
             RuntimeError: generators could not be determined. So far we found []. Hint: increase pari_effort.
-            sage: E.gens(use_database=False, algorithm="pari",pari_effort=10) # long time
+            sage: ge = E.gens(use_database=False, algorithm="pari",pari_effort=10)
+            sage: ge   #random
             [(-166136231668185267540804/2825630694251145858025 : 167661624456834335404812111469782006/150201095200135518108761470235125 : 1)]
+            sage: P = E.lift_x(-166136231668185267540804/2825630694251145858025)
+            sage: set(E.gens(use_database=False, algorithm="pari",pari_effort=4)) <= set([P+T for T
+            ....:  in E.torsion_points()] + [-P+T for T in E.torsion_points()])
+            True
 
         """
         # If the optional extended database is installed and an
@@ -2531,6 +2553,11 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             True
 
         TESTS::
+
+            sage: E = EllipticCurve('37a1')
+            sage: P = E([0,-1])
+            sage: set(E.gens()) <= set([P,-P])
+            True
 
             sage: E = EllipticCurve([2, 4, 6, 8, 10])
             sage: E.gens_certain()


### PR DESCRIPTION
#35626 introduced a test failure on some machines as some tests return random choices of generators of Mordell-Weil groups for elliptic curves.

This adds "random" to these tests and add some tests that do test if the returned answer is correct. This is only possible when the rank is 1 (and the returned point must be in a finite set). For larger ranks at best we can test if the number of generators is ok and if the points are saturated.

