### PR TITLE
Replace imports from `sage.geometry...all`, update relint pattern

### DIFF
--- a/src/.relint.yml
+++ b/src/.relint.yml
@@ -49,7 +49,7 @@
     namespace package. Type import_statements("SOME_IDENTIFIER") to find a more specific import,
     or use 'sage --fiximports' to fix automatically in the source file.
   # Keep in sync with SAGE_ROOT/src/sage/misc/replace_dot_all.py
-  pattern: 'from\s+sage(|[.](arith|categories|combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|graphs|groups|interfaces|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|symbolic|tensor)[a-z0-9_.]*|[.]libs)[.]all\s+import'
+  pattern: 'from\s+sage(|[.](arith|categories|combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|geometry|graphs|groups|interfaces|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|symbolic|tensor)[a-z0-9_.]*|[.]libs)[.]all\s+import'
   # imports from .all are allowed in all.py; also allow in some modules that need sage.all
   filePattern: '(.*/|)(?!(all|benchmark|dev_tools|parsing|sage_eval))[^/.]*[.](py|pyx|pxi)$'
 

--- a/src/sage/combinat/root_system/plot.py
+++ b/src/sage/combinat/root_system/plot.py
@@ -916,7 +916,7 @@ class PlotOptions():
 
         # Bounding box
         from sage.rings.real_mpfr import RR
-        from sage.geometry.polyhedron.all import Polyhedron
+        from sage.geometry.polyhedron.constructor import Polyhedron
         from itertools import product
         if bounding_box in RR:
             bounding_box = [[-bounding_box,bounding_box]] * self.dimension
@@ -1383,7 +1383,7 @@ class PlotOptions():
         """
         if color is None:
             return self.empty()
-        from sage.geometry.polyhedron.all import Polyhedron
+        from sage.geometry.polyhedron.constructor import Polyhedron
         # TODO: we currently convert lines into rays, which simplify a
         # bit the calculation of the intersection. But it would be
         # nice to benefit from the new ``lines`` option of Polyhedra

--- a/src/sage/combinat/root_system/root_lattice_realizations.py
+++ b/src/sage/combinat/root_system/root_lattice_realizations.py
@@ -2539,7 +2539,7 @@ class RootLatticeRealizations(Category_over_base_ring):
                 Line defined by 2 points: [(1.5, -0.5), (1.5, 0.5)]
                 Point set defined by 8 point(s): [(-1.5, -0.5), (-1.5, 0.5), (-0.5, -1.5), (-0.5, 1.5), (0.5, -1.5), (0.5, 1.5), (1.5, -0.5), (1.5, 0.5)]
             """
-            from sage.geometry.polyhedron.all import Polyhedron
+            from sage.geometry.polyhedron.constructor import Polyhedron
             plot_options = self.plot_parse_options(**options)
             if not self.cartan_type().is_finite():
                 raise ValueError("the Cartan type must be finite")
@@ -3061,7 +3061,7 @@ class RootLatticeRealizations(Category_over_base_ring):
                 sage: L.plot_mv_polytope(p)
                 Graphics3d Object
             """
-            from sage.geometry.polyhedron.all import Polyhedron
+            from sage.geometry.polyhedron.constructor import Polyhedron
             plot_options = self.plot_parse_options(**options)
 
             # Setup the shift for plotting

--- a/src/sage/misc/replace_dot_all.py
+++ b/src/sage/misc/replace_dot_all.py
@@ -72,7 +72,7 @@ __import__("sage.all", globals(), locals(), ["*"])
 # Keep in sync with SAGE_ROOT/src/.relint.yml (namespace_pkg_all_import)
 
 default_package_regex = (r"sage("
-                         r"|[.](arith|categories|combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|graphs|groups|interfaces|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|tensor)[a-z0-9_.]*|[.]libs"
+                         r"|[.](arith|categories|combinat|crypto|databases|data_structures|dynamics|ext|game_theory|games|geometry|graphs|groups|interfaces|manifolds|matrix|matroids|misc|modules|monoids|numerical|probability|quadratic_forms|quivers|rings|sat|schemes|sets|stats|tensor)[a-z0-9_.]*|[.]libs"
                          r")[.]all")
 
 

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -64,7 +64,7 @@ you can run these commands with typeset mode on (``%display typeset``) and get
 
 Since it has only two variables, we can solve it graphically::
 
-    sage: P.plot()
+    sage: P.plot()                                                                      # optional - sage.plot
     Graphics object consisting of 19 graphics primitives
 
 
@@ -182,7 +182,7 @@ import re
 from copy import copy
 
 from sage.misc.abstract_method import abstract_method
-from sage.geometry.all import Polyhedron
+from sage.geometry.polyhedron.constructor import Polyhedron
 from sage.matrix.special import column_matrix
 from sage.matrix.special import identity_matrix
 from sage.matrix.constructor import Matrix as matrix
@@ -1534,19 +1534,19 @@ class InteractiveLPProblem(SageObject):
             sage: b = (1000, 1500)
             sage: c = (10, 5)
             sage: P = InteractiveLPProblem(A, b, c, ["C", "B"], variable_type=">=")
-            sage: p = P.plot()
-            sage: p.show()
+            sage: p = P.plot()                                                          # optional - sage.plot
+            sage: p.show()                                                              # optional - sage.plot
 
         In this case the plot works better with the following axes ranges::
 
-            sage: p = P.plot(0, 1000, 0, 1500)
-            sage: p.show()
+            sage: p = P.plot(0, 1000, 0, 1500)                                          # optional - sage.plot
+            sage: p.show()                                                              # optional - sage.plot
 
         TESTS:
 
         We check that zero objective can be dealt with::
 
-            sage: InteractiveLPProblem(A, b, (0, 0), ["C", "B"], variable_type=">=").plot()
+            sage: InteractiveLPProblem(A, b, (0, 0), ["C", "B"], variable_type=">=").plot()         # optional - sage.plot
             Graphics object consisting of 8 graphics primitives
         """
         FP = self.plot_feasible_set(*args, **kwds)
@@ -1611,13 +1611,13 @@ class InteractiveLPProblem(SageObject):
             sage: b = (1000, 1500)
             sage: c = (10, 5)
             sage: P = InteractiveLPProblem(A, b, c, ["C", "B"], variable_type=">=")
-            sage: p = P.plot_feasible_set()
-            sage: p.show()
+            sage: p = P.plot_feasible_set()                                             # optional - sage.plot
+            sage: p.show()                                                              # optional - sage.plot
 
         In this case the plot works better with the following axes ranges::
 
-            sage: p = P.plot_feasible_set(0, 1000, 0, 1500)
-            sage: p.show()
+            sage: p = P.plot_feasible_set(0, 1000, 0, 1500)                             # optional - sage.plot
+            sage: p.show()                                                              # optional - sage.plot
         """
         if self.n() != 2:
             raise ValueError("only problems with 2 variables can be plotted")

--- a/src/sage/schemes/toric/fano_variety.py
+++ b/src/sage/schemes/toric/fano_variety.py
@@ -119,7 +119,10 @@ implementing them on your own as a patch for inclusion!
 
 import re
 
-from sage.geometry.all import Cone, FaceFan, Fan, LatticePolytope
+from sage.geometry.cone import Cone
+from sage.geometry.fan import FaceFan
+from sage.geometry.fan import Fan
+from sage.geometry.lattice_polytope import LatticePolytope
 from sage.misc.latex import latex
 from sage.misc.misc_c import prod
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/src/sage/schemes/toric/library.py
+++ b/src/sage/schemes/toric/library.py
@@ -42,7 +42,9 @@ from sage.structure.sage_object import SageObject
 
 from sage.matrix.constructor import Matrix as matrix
 from sage.matrix.special import identity_matrix
-from sage.geometry.all import Fan, LatticePolytope, ToricLattice
+from sage.geometry.fan import Fan
+from sage.geometry.lattice_polytope import LatticePolytope
+from sage.geometry.toric_lattice import ToricLattice
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from sage.arith.misc import GCD as gcd

--- a/src/sage/schemes/toric/morphism.py
+++ b/src/sage/schemes/toric/morphism.py
@@ -370,7 +370,8 @@ from sage.arith.misc import GCD as gcd
 from sage.misc.cachefunc import cached_method
 from sage.matrix.constructor import matrix, identity_matrix
 from sage.modules.free_module_element import vector
-from sage.geometry.all import Cone, Fan
+from sage.geometry.cone import Cone
+from sage.geometry.fan import Fan
 
 from sage.schemes.generic.scheme import is_Scheme
 from sage.schemes.generic.morphism import (


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

Per #35095, parts of `sage.geometry` will be shipped in sagemath-modules, sagemath-polyhedra, and sagemath-symbolics. Hence we replace imports from `sage.geometry...all`. 

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
- Continuation of #34201 
- Cherry-picked from #35095
- Part of #29705 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
