### PR TITLE
Drop support for GCC < 8.4, drop testing of `debian-buster` and `fedora-29`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,11 +24,9 @@ on:
            "ubuntu-kinetic",
            "ubuntu-lunar",
            "ubuntu-mantic",
-           "debian-buster",
            "debian-bullseye",
            "debian-bookworm",
            "debian-sid",
-           "linuxmint-19-gcc_8-python3.8",
            "linuxmint-19.3-gcc_8-python3.8",
            "linuxmint-20.1",
            "linuxmint-20.2",
@@ -36,7 +34,6 @@ on:
            "linuxmint-21",
            "linuxmint-21.1",
            "linuxmint-21.2",
-           "fedora-29-python3.8",
            "fedora-30-python3.8",
            "fedora-31",
            "fedora-32",
@@ -59,7 +56,6 @@ on:
            "opensuse-tumbleweed-python3.10",
            "conda-forge",
            "ubuntu-bionic-gcc_8-i386",
-           "debian-buster-i386",
            "debian-bullseye-i386",
            ]
       tox_packages_factors:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ on:
            "debian-buster-gcc_spkg",
            "debian-bullseye",
            "debian-bookworm",
+           "debian-trixie",
            "debian-sid",
            "linuxmint-20.1",
            "linuxmint-20.2",

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,6 @@ on:
            "debian-bullseye",
            "debian-bookworm",
            "debian-sid",
-           "linuxmint-19.3-gcc_8-python3.8",
            "linuxmint-20.1",
            "linuxmint-20.2",
            "linuxmint-20.3",

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,7 @@ on:
            "ubuntu-kinetic",
            "ubuntu-lunar",
            "ubuntu-mantic",
+           "debian-buster-gcc_spkg",
            "debian-bullseye",
            "debian-bookworm",
            "debian-sid",

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ on:
            "linuxmint-21",
            "linuxmint-21.1",
            "linuxmint-21.2",
-           "fedora-30-python3.8",
+           "fedora-30",
            "fedora-31",
            "fedora-32",
            "fedora-33",

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ in the Installation Guide.
 
 3.  [Linux, WSL] Install the required minimal build prerequisites.
 
-    - Compilers: `gcc`, `gfortran`, `g++` (GCC 8.x to 12.x and recent
-      versions of Clang (LLVM) are supported).
+    - Compilers: `gcc`, `gfortran`, `g++` (GCC versions from 8.4.0 to 13.x
+      and recent versions of Clang (LLVM) are supported).
       See [build/pkgs/gcc/SPKG.rst](build/pkgs/gcc/SPKG.rst) and
       [build/pkgs/gfortran/SPKG.rst](build/pkgs/gfortran/SPKG.rst)
       for a discussion of suitable compilers.

--- a/build/pkgs/gcc/SPKG.rst
+++ b/build/pkgs/gcc/SPKG.rst
@@ -6,7 +6,7 @@ Description
 
 This package represents the required C and C++ compilers.
 
-- GCC (GNU Compiler Collection) versions 8.x to 12.x are supported.
+- GCC (GNU Compiler Collection) versions 8.x (>= 8.4.0) to 13.x are supported.
 
 - Clang (LLVM) is also supported.
 
@@ -25,7 +25,7 @@ need to run::
 Vendor and versions of the C and C++ compilers should match.
 
 Users of older Linux distributions (in particular, ``ubuntu-xenial``
-or older, ``debian-stretch`` or older, ``linuxmint-18`` or older)
+or older, ``debian-buster`` or older, ``linuxmint-18`` or older)
 should upgrade their systems before attempting to install Sage from
 source.  Users of ``ubuntu-bionic``, ``linuxmint-19.x``, and
 ``opensuse-15.x`` can install a versioned ``gcc`` system package

--- a/build/pkgs/gcc/spkg-configure.m4
+++ b/build/pkgs/gcc/spkg-configure.m4
@@ -161,8 +161,8 @@ SAGE_SPKG_CONFIGURE_BASE([gcc], [
             # Add the .0 because Debian/Ubuntu gives version numbers like
             # 4.6 instead of 4.6.4 (Trac #18885)
             AS_CASE(["$GXX_VERSION.0"],
-                [[[0-7]].*], [
-                    # Install our own GCC if the system-provided one is older than gcc 8
+                [[[0-7]].*|8.[[0-3]].*], [
+                    # Install our own GCC if the system-provided one is older than gcc 8.4
                     SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_VERSION, which is quite old])
                 ],
                 [1[[4-9]].*], [

--- a/tox.ini
+++ b/tox.ini
@@ -238,6 +238,7 @@ setenv =
     debian-bullseye:  BASE_TAG=bullseye
     debian-bullseye:                           IGNORE_MISSING_SYSTEM_PACKAGES=yes
     debian-bookworm:  BASE_TAG=bookworm
+    debian-trixie:    BASE_TAG=trixie
     debian-sid:       BASE_TAG=sid
     #
     # https://hub.docker.com/u/linuxmintd


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
Prerequisite of:
- #34816
- #35703
- #35801 

See also:
- #32074

Instead of fully dropping `debian-buster` (LTS until 2024-06) in the CI, we replace it by `debian-buster-gcc_spkg` to verify that users on this platform have the recourse of installing a newer GCC. 

We also remove `linuxmint-19.3-gcc_8-python3.8` and change `fedora-30-python3.8` to `fedora-30` (which builds python from spkg), to prevent a merge conflict with https://github.com/sagemath/sage/pull/35404

We also add `debian-trixie` (= current testing).

<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
