### PR TITLE
Support setuptools 68.0.0

### DIFF
--- a/src/sage/all__sagemath_repl.py
+++ b/src/sage/all__sagemath_repl.py
@@ -44,7 +44,7 @@ warnings.filterwarnings('ignore', category=DeprecationWarning,
 warnings.filterwarnings('ignore', category=DeprecationWarning,
     message='pkg_resources is deprecated as an API|'
             'Deprecated call to `pkg_resources.declare_namespace(.*)`',
-    module='pkg_resources')
+    module='pkg_resources|setuptools.sandbox')
 warnings.filterwarnings('ignore', category=DeprecationWarning,
     message='msvccompiler is deprecated and slated to be removed',
     module='distutils.msvccompiler')


### PR DESCRIPTION
In setuptools 68.0.0 deprecation warnings for pkg_resources are issued with `stacklevel=2` so they belong to the calling module instead of pkg_resources.

The deprecation warning we filter is reported on `setuptools.sandbox`.

We fix this, otherwise lots of doctests will fail.