### PR TITLE
Fix tests with scipy 1.11

### DIFF
--- a/src/doc/en/faq/faq-usage.rst
+++ b/src/doc/en/faq/faq-usage.rst
@@ -322,7 +322,7 @@ ints. For example::
     sage: RealNumber = float; Integer = int
     sage: from scipy import stats
     sage: stats.ttest_ind([1,2,3,4,5], [2,3,4,5,.6])
-    Ttest_indResult(statistic=0.0767529..., pvalue=0.940704...)
+    Ttest...Result(statistic=0.0767529..., pvalue=0.940704...)
     sage: stats.uniform(0,15).ppf([0.5,0.7])
     array([  7.5,  10.5])
 

--- a/src/doc/it/faq/faq-usage.rst
+++ b/src/doc/it/faq/faq-usage.rst
@@ -304,7 +304,7 @@ anziché Integer di Sage. Ad esempio::
     sage: RealNumber = float; Integer = int
     sage: from scipy import stats
     sage: stats.ttest_ind([1,2,3,4,5], [2,3,4,5,.6])
-    Ttest_indResult(statistic=0.0767529..., pvalue=0.940704...)
+    Ttest...Result(statistic=0.0767529..., pvalue=0.940704...)
     sage: stats.uniform(0,15).ppf([0.5,0.7])
     array([  7.5,  10.5])
 

--- a/src/sage/numerical/optimize.py
+++ b/src/sage/numerical/optimize.py
@@ -155,7 +155,8 @@ def find_root(f, a, b, xtol=10e-13, rtol=2.0**-50, maxiter=100, full_output=Fals
         b = max(s_1, s_2)
 
     import scipy.optimize
-    brentqRes = scipy.optimize.brentq(f, a, b,
+    g = lambda x: float(f(x))
+    brentqRes = scipy.optimize.brentq(g, a, b,
                                  full_output=full_output, xtol=xtol, rtol=rtol, maxiter=maxiter)
     # A check following :trac:`4942`, to ensure we actually found a root
     # Maybe should use a different tolerance here?


### PR DESCRIPTION
Fix some test failures with `scipy 1.11`
- Cast to float before calling `scipy.optimize.brentq`, which now performs a NaN check that chokes on symbolic expressions.
- Some `Ttest_indResult` are now `TtestResult`

There are two more failures in `sage/matrix/matrix_double_dense.pyx` and `sage/matrix/matrix_space.py` caused by an upstream issue, reported at https://github.com/scipy/scipy/issues/18759