### PR TITLE
Integer.{perfect_power,is_prime_power,is_irreducible}: Handle easy cases without PARI

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -5387,7 +5387,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             True
         """
         cdef Integer n = self if self >= 0 else -self
-        return n.__pari__().isprime()
+        return self.is_prime(proof=True)
 
     def is_pseudoprime(self):
         r"""

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -4812,15 +4812,15 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
             sage: 144.perfect_power()                                                   # optional - sage.libs.pari
             (12, 2)
-            sage: 1.perfect_power()                                                     # optional - sage.libs.pari
+            sage: 1.perfect_power()
             (1, 1)
-            sage: 0.perfect_power()                                                     # optional - sage.libs.pari
+            sage: 0.perfect_power()
             (0, 1)
-            sage: (-1).perfect_power()                                                  # optional - sage.libs.pari
+            sage: (-1).perfect_power()
             (-1, 1)
             sage: (-8).perfect_power()                                                  # optional - sage.libs.pari
             (-2, 3)
-            sage: (-4).perfect_power()                                                  # optional - sage.libs.pari
+            sage: (-4).perfect_power()
             (-4, 1)
             sage: (101^29).perfect_power()                                              # optional - sage.libs.pari
             (101, 29)
@@ -4838,7 +4838,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             if n >= 4:
                 if not (n & 1):
                     if mpz_popcount(self.value) == 1:
-                        return smallInteger(2), mpz_sizeinbase(self.value, 2) - 1
+                        return smallInteger(2), smallInteger(mpz_sizeinbase(self.value, 2) - 1)
                 if n < 1000:
                     if _small_primes_table[n >> 1]:
                         return self, one
@@ -5190,7 +5190,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             if not (n & 1):
                 if mpz_popcount(self.value) != 1:
                     return (self, zero) if get_data else False
-                return (smallInteger(2), mpz_sizeinbase(self.value, 2) - 1) if get_data else True
+                return (smallInteger(2), smallInteger(mpz_sizeinbase(self.value, 2) - 1)) if get_data else True
             if n < 1000:
                 if _small_primes_table[n >> 1]:
                     return (self, one) if get_data else True

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -5387,7 +5387,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             True
         """
         cdef Integer n = self if self >= 0 else -self
-        return self.is_prime(proof=True)
+        return n.is_prime(proof=True)
 
     def is_pseudoprime(self):
         r"""

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -4828,6 +4828,13 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             (-3, 5)
             sage: (-64).perfect_power()                                                 # optional - sage.libs.pari
             (-4, 3)
+
+        TESTS::
+
+            sage: 4.perfect_power()
+            (2, 2)
+            sage: 256.perfect_power()
+            (2, 8)
         """
         cdef long n
         # Fast PARI-free path
@@ -5178,6 +5185,15 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: n = 150607571^14
             sage: n.is_prime_power()                                                    # optional - sage.libs.pari
             True
+
+        TESTS::
+
+            sage: 2.is_prime_power(get_data=True)
+            (2, 1)
+            sage: 4.is_prime_power(get_data=True)
+            (2, 2)
+            sage: 512.is_prime_power(get_data=True)
+            (2, 9)
         """
         cdef long n
 


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
Taking care of small primes and powers of two.
<!-- Why is this change required? What problem does it solve? -->
In particular, this allows us to set up `GF(2)` without pulling in PARI, and avoids many `# optional` tags in `sage.combinat.designs` and `sage.combinat.posets`.

<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
- Part of: #29705 
- Cherry-picked from: #35095 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
