### PR TITLE
fix pep8 E272 in all.py and similar files

### DIFF
--- a/src/sage/all.py
+++ b/src/sage/all.py
@@ -67,92 +67,92 @@ from .all__sagemath_repl import *  # includes .all__sagemath_objects, .all__sage
 from cysignals.signals import (AlarmInterrupt, SignalError,
         sig_on_reset as sig_on_count)
 
-from time                import sleep
+from time import sleep
 from functools import reduce  # in order to keep reduce in python3
 
 import sage.misc.lazy_import
 
-from sage.misc.all       import *         # takes a while
-from sage.typeset.all    import *
+from sage.misc.all import *         # takes a while
+from sage.typeset.all import *
 
 from sage.misc.sh import sh
 
-from sage.libs.all       import *
+from sage.libs.all import *
 from sage.data_structures.all import *
 
-from sage.structure.all  import *
-from sage.rings.all      import *
-from sage.arith.all      import *
-from sage.matrix.all     import *
+from sage.structure.all import *
+from sage.rings.all import *
+from sage.arith.all import *
+from sage.matrix.all import *
 
-from sage.symbolic.all   import *
-from sage.modules.all    import *
-from sage.monoids.all    import *
-from sage.algebras.all   import *
-from sage.modular.all    import *
-from sage.sat.all        import *
-from sage.schemes.all    import *
-from sage.graphs.all     import *
-from sage.groups.all     import *
-from sage.arith.power    import generic_power as power
-from sage.databases.all  import *
+from sage.symbolic.all import *
+from sage.modules.all import *
+from sage.monoids.all import *
+from sage.algebras.all import *
+from sage.modular.all import *
+from sage.sat.all import *
+from sage.schemes.all import *
+from sage.graphs.all import *
+from sage.groups.all import *
+from sage.arith.power import generic_power as power
+from sage.databases.all import *
 from sage.categories.all import *
-from sage.sets.all       import *
+from sage.sets.all import *
 from sage.probability.all import *
 from sage.interfaces.all import *
 
-from sage.functions.all  import *
-from sage.calculus.all   import *
+from sage.functions.all import *
+from sage.calculus.all import *
 
 lazy_import('sage.tests', 'all', as_='tests', deprecation=27337)
-from sage.cpython.all    import *
+from sage.cpython.all import *
 
-from sage.crypto.all     import *
+from sage.crypto.all import *
 import sage.crypto.mq as mq
 
-from sage.plot.all       import *
-from sage.plot.plot3d.all     import *
+from sage.plot.all import *
+from sage.plot.plot3d.all import *
 
-from sage.coding.all     import *
-from sage.combinat.all   import *
+from sage.coding.all import *
+from sage.combinat.all import *
 
 from sage.lfunctions.all import *
 
-from sage.geometry.all   import *
-from sage.geometry.triangulation.all   import *
-from sage.geometry.riemannian_manifolds.all   import *
+from sage.geometry.all import *
+from sage.geometry.triangulation.all import *
+from sage.geometry.riemannian_manifolds.all import *
 
-from sage.dynamics.all   import *
+from sage.dynamics.all import *
 
-from sage.homology.all   import *
+from sage.homology.all import *
 
-from sage.topology.all   import *
+from sage.topology.all import *
 
 from sage.quadratic_forms.all import *
 
-from sage.games.all      import *
+from sage.games.all import *
 
 lazy_import('sage.media.wav', 'Wave', as_='wave', deprecation=12673)
 
-from sage.logic.all      import *
+from sage.logic.all import *
 
-from sage.numerical.all  import *
+from sage.numerical.all import *
 
-from sage.stats.all      import *
+from sage.stats.all import *
 import sage.stats.all as stats
 
 lazy_import("sage.finance", "all", as_="finance", deprecation=32427)
 
-from sage.parallel.all   import *
+from sage.parallel.all import *
 
-from sage.ext.fast_callable  import fast_callable
-from sage.ext.fast_eval      import fast_float
+from sage.ext.fast_callable import fast_callable
+from sage.ext.fast_eval import fast_float
 
 from sage.sandpiles.all import *
 
-from sage.tensor.all     import *
+from sage.tensor.all import *
 
-from sage.matroids.all   import *
+from sage.matroids.all import *
 
 from sage.game_theory.all import *
 

--- a/src/sage/all__sagemath_objects.py
+++ b/src/sage/all__sagemath_objects.py
@@ -11,14 +11,14 @@ import warnings
 from cysignals.signals import (AlarmInterrupt, SignalError,
         sig_on_reset as sig_on_count)
 
-from time                import sleep
+from time import sleep
 
-from sage.misc.all__sagemath_objects       import *
-from sage.structure.all  import *
-from sage.arith.power    import generic_power as power
+from sage.misc.all__sagemath_objects import *
+from sage.structure.all import *
+from sage.arith.power import generic_power as power
 from sage.categories.all__sagemath_objects import *
 
-from sage.cpython.all    import *
+from sage.cpython.all import *
 
 from cysignals.alarm import alarm, cancel_alarm
 

--- a/src/sage/all__sagemath_repl.py
+++ b/src/sage/all__sagemath_repl.py
@@ -83,8 +83,8 @@ warnings.filterwarnings('ignore', category=DeprecationWarning,
 from .all__sagemath_objects import *
 from .all__sagemath_environment import *
 
-from sage.doctest.all    import *
-from sage.repl.all       import *
+from sage.doctest.all import *
+from sage.repl.all import *
 from sage.misc.all__sagemath_repl import *
 
 # For doctesting. These are overwritten later

--- a/src/sage/categories/all.py
+++ b/src/sage/categories/all.py
@@ -109,31 +109,31 @@ from .schemes import Schemes
 # * with basis
 from .modules_with_basis import ModulesWithBasis
 FreeModules = ModulesWithBasis
-from .hecke_modules            import HeckeModules
-from .algebras_with_basis      import AlgebrasWithBasis
-from .coalgebras_with_basis    import CoalgebrasWithBasis
-from .bialgebras_with_basis    import BialgebrasWithBasis
+from .hecke_modules import HeckeModules
+from .algebras_with_basis import AlgebrasWithBasis
+from .coalgebras_with_basis import CoalgebrasWithBasis
+from .bialgebras_with_basis import BialgebrasWithBasis
 from .hopf_algebras_with_basis import HopfAlgebrasWithBasis
 
 # finite dimensional * with basis
-from .finite_dimensional_modules_with_basis       import FiniteDimensionalModulesWithBasis
-from .finite_dimensional_algebras_with_basis      import FiniteDimensionalAlgebrasWithBasis
-from .finite_dimensional_coalgebras_with_basis    import FiniteDimensionalCoalgebrasWithBasis
-from .finite_dimensional_bialgebras_with_basis    import FiniteDimensionalBialgebrasWithBasis
+from .finite_dimensional_modules_with_basis import FiniteDimensionalModulesWithBasis
+from .finite_dimensional_algebras_with_basis import FiniteDimensionalAlgebrasWithBasis
+from .finite_dimensional_coalgebras_with_basis import FiniteDimensionalCoalgebrasWithBasis
+from .finite_dimensional_bialgebras_with_basis import FiniteDimensionalBialgebrasWithBasis
 from .finite_dimensional_hopf_algebras_with_basis import FiniteDimensionalHopfAlgebrasWithBasis
 
 # graded *
-from .graded_modules       import GradedModules
-from .graded_algebras      import GradedAlgebras
-from .graded_coalgebras    import GradedCoalgebras
-from .graded_bialgebras    import GradedBialgebras
+from .graded_modules import GradedModules
+from .graded_algebras import GradedAlgebras
+from .graded_coalgebras import GradedCoalgebras
+from .graded_bialgebras import GradedBialgebras
 from .graded_hopf_algebras import GradedHopfAlgebras
 
 # graded * with basis
-from .graded_modules_with_basis       import GradedModulesWithBasis
-from .graded_algebras_with_basis      import GradedAlgebrasWithBasis
-from .graded_coalgebras_with_basis    import GradedCoalgebrasWithBasis
-from .graded_bialgebras_with_basis    import GradedBialgebrasWithBasis
+from .graded_modules_with_basis import GradedModulesWithBasis
+from .graded_algebras_with_basis import GradedAlgebrasWithBasis
+from .graded_coalgebras_with_basis import GradedCoalgebrasWithBasis
+from .graded_bialgebras_with_basis import GradedBialgebrasWithBasis
 from .graded_hopf_algebras_with_basis import GradedHopfAlgebrasWithBasis
 
 # Coxeter groups

--- a/src/sage/categories/all__sagemath_objects.py
+++ b/src/sage/categories/all__sagemath_objects.py
@@ -10,19 +10,18 @@ import sage.structure.category_object    # imports sage.categories.category
 from .objects import Objects
 from .sets_cat import Sets, EmptySetError
 
-
 from .category import Category
 
 from .category_types import Elements
 
 from .cartesian_product import cartesian_product
 
-from .functor  import (ForgetfulFunctor,
+from .functor import (ForgetfulFunctor,
                       IdentityFunctor)
 
-from .homset   import (Hom, hom,
-                      End, end,
-                      Homset, HomsetWithBase)
+from .homset import (Hom, hom,
+                     End, end,
+                     Homset, HomsetWithBase)
 
 from .morphism import Morphism
 

--- a/src/sage/plot/plot3d/all.py
+++ b/src/sage/plot/plot3d/all.py
@@ -1,21 +1,21 @@
 
-from .plot3d            import plot3d, cylindrical_plot3d, spherical_plot3d, Spherical, SphericalElevation, Cylindrical
+from .plot3d import plot3d, cylindrical_plot3d, spherical_plot3d, Spherical, SphericalElevation, Cylindrical
 from .parametric_plot3d import parametric_plot3d
-from .plot_field3d      import plot_vector_field3d
+from .plot_field3d import plot_vector_field3d
 
 # We lazy_import the following modules since they import numpy which slows down sage startup
 from sage.misc.lazy_import import lazy_import
 lazy_import("sage.plot.plot3d.implicit_plot3d",["implicit_plot3d"])
 
-from .list_plot3d       import list_plot3d
+from .list_plot3d import list_plot3d
 from .revolution_plot3d import revolution_plot3d
 
-from .platonic          import tetrahedron, cube, octahedron, dodecahedron, icosahedron
+from .platonic import tetrahedron, cube, octahedron, dodecahedron, icosahedron
 
-from .shapes2           import sphere, line3d, polygon3d, polygons3d, point3d, text3d, bezier3d
+from .shapes2 import sphere, line3d, polygon3d, polygons3d, point3d, text3d, bezier3d
 
-from .shapes            import arrow3d
+from .shapes import arrow3d
 
-#from shapes import Box, ColorCube, Cone, Cylinder, LineSegment, Arrow, Sphere, Torus, Text as Text3D
-#from parametric_surface import ParametricSurface, MoebiusStrip
-#from plot3d import plot3d, axes as axes3d
+# from shapes import Box, ColorCube, Cone, Cylinder, LineSegment, Arrow, Sphere, Torus, Text as Text3D
+# from parametric_surface import ParametricSurface, MoebiusStrip
+# from plot3d import plot3d, axes as axes3d


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

fixing a bunch of E272 warnings in all.py and the like.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
