### PR TITLE
Remove mention of defunct magic command "%bg" from the tutorial

### DIFF
--- a/src/doc/en/tutorial/interactive_shell.rst
+++ b/src/doc/en/tutorial/interactive_shell.rst
@@ -383,33 +383,6 @@ IPython documentation <http://ipython.scipy.org/moin/Documentation>`_.
 Meanwhile, here are some fun tricks -- these are called "Magic
 commands" in IPython:
 
-- You can use ``%bg`` to run a command in the background, and then use
-  ``jobs`` to access the results, as follows.  (The comments ``not
-  tested`` are here because the ``%bg`` syntax doesn't work well with
-  Sage's automatic testing facility.  If you type this in yourself, it
-  should work as written.  This is of course most useful with commands
-  which take a while to complete.)
-
-  ::
-
-    sage: def quick(m): return 2*m
-    sage: %bg quick(20)  # not tested
-    Starting job # 0 in a separate thread.
-    sage: jobs.status()  # not tested
-    Completed jobs:
-    0 : quick(20)
-    sage: jobs[0].result  # the actual answer, not tested
-    40
-
-  Note that jobs run in the background don't use the Sage preparser --
-  see :ref:`section-mathannoy` for more information.  One
-  (perhaps awkward) way to get around this would be to run ::
-
-    sage: %bg eval(preparse('quick(20)')) # not tested
-
-  It is safer and easier, though, to just use ``%bg`` on commands
-  which don't require the preparser.
-
 - You can use ``%edit`` (or ``%ed`` or ``ed``) to open an editor, if
   you want to type in some complex code.  Before you start Sage, make
   sure that the :envvar:`EDITOR` environment variable is set to your

--- a/src/doc/fr/tutorial/interactive_shell.rst
+++ b/src/doc/fr/tutorial/interactive_shell.rst
@@ -387,34 +387,6 @@ celui-ci. Vous voudrez peut-être consulter la `documentation complète de IPyth
 astuces utiles -- qui reposent sur ce que IPython appelle des « commandes
 magiques » :
 
-- La commande magique ``%bg`` lance une commande en arrière-plan. Le résultat
-  sera ensuite accessible à travers l'objet ``jobs``, comme dans l'exemple
-  ci-dessous. (Les commentaires « not tested » sont là parce que ``%bg`` ne
-  fonctionne pas correctement dans l'infrastructure de test automatisé de Sage,
-  mais si vous reproduisez l'exemple, il devrait fonctionner comme indiqué.
-  Naturellement, ``%bg`` est surtout utile pour les commandes dont l'exécution
-  prend beaucoup de temps.)
-
-  ::
-
-    sage: def quick(m): return 2*m
-    sage: %bg quick(20)  # not tested
-    Starting job # 0 in a separate thread.
-    sage: jobs.status()  # not tested
-    Completed jobs:
-    0 : quick(20)
-    sage: jobs[0].result  # the actual answer, not tested
-    40
-
-  Attention, les tâches lancées en arrière-plan ignorent le préprocesseur Sage
-  (voir section :ref:`section-mathannoy`). Une manière (certes pas très
-  commode) de contourner le problème est la suivante ::
-
-    sage: %bg eval(preparse('quick(20)')) # not tested
-
-  Mais il est plus simple et plus sûr de réserver ``%bg`` aux commandes en pur
-  Python, qui ne font pas appel au préprocesseur.
-
 - Lorsque l'on souhaite saisir un morceau de code complexe, on peut utiliser
   ``%edit`` (ou ``%ed``, ou ``ed``) pour ouvrir un éditeur de texte.
   Assurez-vous que la variable d'environnement :envvar:`EDITOR` est réglée à

--- a/src/doc/ja/tutorial/interactive_shell.rst
+++ b/src/doc/ja/tutorial/interactive_shell.rst
@@ -353,33 +353,6 @@ IPythonトリック
 <http://ipython.scipy.org/moin/Documentation>`_ を読んみてほしい．
 そのかわり，ここではIPythonの「マジックコマンド」と呼ばれる，お便利なトリックをいくつか紹介させていただこう:
 
-- ``%bg`` を使えばコマンドをバックグラウンドで実行し， 結果には ``jobs`` でアクセスすることができる．(この機能は ``not tested`` とコメントされている．というのは ``%bg`` 書法がSageの自動テスト機能とは余り相性が良くないからだ．ユーザ各自が入力してやれば，その通り動作するはずである．もちろん，この機能が最も役立つのは実行に時間のかかるコマンドと組み合わせる場合である．)
-
-  使用例を以下に示す．
-
-  ::
-
-    sage: def quick(m): return 2*m
-    sage: %bg quick(20)  # not tested
-    Starting job # 0 in a separate thread.
-    sage: jobs.status()  # not tested
-    Completed jobs:
-    0 : quick(20)
-    sage: jobs[0].result  # the actual answer, not tested
-    40
-
-  バックグラウンドに送られるジョブはSageの前処理パーサを経由しないことに注意 -- 詳細は :ref:`section-mathannoy` 節を参照されたい．
-  パーサを通すための(不器用であるけれども)１つの方法は
-
-  ::
-
-    sage: %bg eval(preparse('quick(20)')) # not tested
-
-  とすることだろう．
-
-  ただし，より安全で簡単なのは前処理パーサを必要としないコマンドで ``%bg`` を使うことだろう．
-
-
 - ``%edit`` (``%ed`` や ``ed`` でもいい)を使ってエディタを起動すれば，複雑なコードの入力が楽になる．
   Sageの使用前に，環境変数 :envvar:`EDITOR` に好みのエディタ名を設定しておこう(``export EDITOR=/usr/bin/emacs`` または ``export EDITOR=/usr/bin/vim`` とするか， ``.profile`` ファイルなどで同様の設定をする)．
   するとSageプロンプトで ``%edit`` を実行すれば設定したエディタが起動する．そのエディタで関数

--- a/src/doc/pt/tutorial/interactive_shell.rst
+++ b/src/doc/pt/tutorial/interactive_shell.rst
@@ -372,34 +372,6 @@ pode usar quaisquer comandos e recursos do IPython. Você pode ler a
 `Documentação completa do IPython
 <http://ipython.scipy.org/moin/Documentation>`_ (em inglês).
 
-- Você pode usar ``%bg`` para executar um comando no background, e
-  então usar ``jobs`` para acessar os resultados, da seguinte forma.
-  (Os comentários ``not tested`` estão aqui porque a sintaxe ``%bg``
-  não funciona bem com o sistema de testes automáticos do Sage. Se
-  você digitar esses comandos, eles devem funcionar. Isso é obviamente
-  mais útil com comandos que demoram para serem completados.)
-
-  ::
-
-    sage: def quick(m): return 2*m
-    sage: %bg quick(20)  # not tested
-    Starting job # 0 in a separate thread.
-    sage: jobs.status()  # not tested
-    Completed jobs:
-    0 : quick(20)
-    sage: jobs[0].result  # the actual answer, not tested
-    40
-
-  Note que os comandos executados no background não usam o
-  pre-processador (preparser) do Sage -- veja :ref:`section-mathannoy`
-  para mais informações. Uma forma (estranha talvez) de contornar esse
-  problema seria executar ::
-
-    sage: %bg eval(preparse('quick(20)')) # not tested
-
-  É mais seguro e simples, todavia, usar ``%bg`` apenas em comandos
-  que não requerem o pre-processador (preparser).
-
 - Você pode usar ``%edit`` (ou ``%ed`` ou ``ed``) para abrir um
   editor, se você desejar digitar algum código mais complexo. Antes de
   iniciar o Sage, certifique-se de que a variável de ambiente


### PR DESCRIPTION
Remove the defunct magic command "%bg" from the tutorial

<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

The magic command "%bg" has not been part of IPython for some time, so we should remove it from the tutorial. (See https://stackoverflow.com/questions/10819479/missing-background-magic-command-bg-in-ipython and ipython/ipython#844.) This fixes #35836.

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
