### PR TITLE
Extend `MAX_MODULUS` of `matrix_modn_dense_double.pyx`

### DIFF
--- a/src/sage/matrix/matrix_modn_dense_double.pyx
+++ b/src/sage/matrix/matrix_modn_dense_double.pyx
@@ -4,7 +4,7 @@
 # distutils: include_dirs = CBLAS_INCDIR
 # distutils: extra_compile_args = -D_XPG6
 r"""
-Dense matrices over `\ZZ/n\ZZ` for `n < 2^{23}` using LinBox's ``Modular<double>``
+Dense matrices over `\ZZ/n\ZZ` for `n < 94906266` using LinBox's ``Modular<double>``
 
 AUTHORS:
 
@@ -38,7 +38,7 @@ from sage.libs.linbox.fflas cimport \
 ctypedef Poly1Dom[ModField, Dense] ModDensePolyRing
 
 # Limit for LinBox Modular<double>
-MAX_MODULUS = 2**23
+MAX_MODULUS = 94906266
 
 from sage.rings.finite_rings.integer_mod cimport IntegerMod_int64
 
@@ -47,11 +47,11 @@ include "matrix_modn_dense_template.pxi"
 
 cdef class Matrix_modn_dense_double(Matrix_modn_dense_template):
     r"""
-    Dense matrices over `\ZZ/n\ZZ` for `n < 2^{23}` using LinBox's ``Modular<double>``
+    Dense matrices over `\ZZ/n\ZZ` for `n < 94906266` using LinBox's ``Modular<double>``
 
     These are matrices with integer entries mod ``n`` represented as
     floating-point numbers in a 64-bit word for use with LinBox routines.
-    This allows for ``n`` up to `2^{23}`. By default, the analogous
+    This allows for ``n`` up to `94906266`. By default, the analogous
     ``Matrix_modn_dense_float`` class is used for smaller moduli, specifically
     for ``n`` up to `2^{8}`.
 
@@ -70,7 +70,7 @@ cdef class Matrix_modn_dense_double(Matrix_modn_dense_template):
             <class 'sage.rings.finite_rings.integer_mod.IntegerMod_int64'>
         """
         self._get_template = self._base_ring.zero()
-        # note that INTEGER_MOD_INT32_LIMIT is ceil(sqrt(2^31-1)) < 2^23
+        # note that INTEGER_MOD_INT32_LIMIT is ceil(sqrt(2^31-1)) < 94906266
         self._fits_int32 = ((<Matrix_modn_dense_template>self).p <= INTEGER_MOD_INT32_LIMIT)
 
     cdef void set_unsafe_int(self, Py_ssize_t i, Py_ssize_t j, int value):

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -166,7 +166,7 @@ def get_matrix_class(R, nrows, ncols, sparse, implementation):
         sage: get_matrix_class(Zmod(2**30), 2, 2, False, 'linbox-double')
         Traceback (most recent call last):
         ...
-        ValueError: 'linbox-double' matrices can only deal with order < 8388608
+        ValueError: 'linbox-double' matrices can only deal with order < 94906266
 
         sage: type(matrix(SR, 2, 2, 0))
         <class 'sage.matrix.matrix_symbolic_dense.Matrix_symbolic_dense'>
@@ -617,7 +617,8 @@ class MatrixSpace(UniqueRepresentation, Parent):
 
            - ``linbox-float`` - for integer mod rings up to `2^8 = 256`
 
-           - ``linbox-double`` - for integer mod rings up to `2^23 = 8388608`
+           - ``linbox-double`` - for integer mod rings up to 
+           `floor(2^26*sqrt(2) + 1/2) = 94906266`
 
            - ``numpy`` - for real and complex floating point numbers
 

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -618,7 +618,7 @@ class MatrixSpace(UniqueRepresentation, Parent):
            - ``linbox-float`` - for integer mod rings up to `2^8 = 256`
 
            - ``linbox-double`` - for integer mod rings up to
-           `floor(2^26*sqrt(2) + 1/2) = 94906266`
+             `floor(2^26*sqrt(2) + 1/2) = 94906266`
 
            - ``numpy`` - for real and complex floating point numbers
 

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -617,7 +617,7 @@ class MatrixSpace(UniqueRepresentation, Parent):
 
            - ``linbox-float`` - for integer mod rings up to `2^8 = 256`
 
-           - ``linbox-double`` - for integer mod rings up to 
+           - ``linbox-double`` - for integer mod rings up to
            `floor(2^26*sqrt(2) + 1/2) = 94906266`
 
            - ``numpy`` - for real and complex floating point numbers


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
Assign to `MAX_MODULUS` of `matrix_modn_dense_double.pyx` the actual limit for LinBox `Modular<double>` (Givaro's `maxCardinality`)
<!-- Why is this change required? What problem does it solve? -->
It allows better speed performances for matrices over the integers mod N, for N having 24 to 27 bits.
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Fixes #35806 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
