### PR TITLE
`sage.groups.perm_gps.partn_ref*`: Modularization fixes

### DIFF
--- a/src/sage/groups/perm_gps/partn_ref/data_structures.pxd
+++ b/src/sage/groups/perm_gps/partn_ref/data_structures.pxd
@@ -13,7 +13,6 @@ from sage.data_structures.bitset_base cimport *
 from libc.string cimport memcpy
 from libc.stdlib cimport rand
 from sage.libs.gmp.mpz cimport *
-from sage.groups.perm_gps.partn_ref2.refinement_generic cimport PartitionRefinement_generic
 
 
 cdef enum:
@@ -260,8 +259,7 @@ cdef PS_print(PartitionStack *PS)
 
 cdef void PS_unit_partition(PartitionStack *PS)
 
-cdef int PS_first_smallest(PartitionStack *PS, bitset_t b, int *second_pos=?,
-        PartitionRefinement_generic partn_ref_alg=?)
+cdef int PS_first_smallest(PartitionStack *PS, bitset_t b, int *second_pos=?)
 
 cdef PartitionStack *PS_from_list(list L)
 

--- a/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
@@ -292,7 +292,7 @@ cdef int PS_first_smallest(PartitionStack *PS, bitset_t b, int *second_pos=NULL)
     """
     cdef int i = 0, j = 0, location = 0, n = PS.degree
     bitset_zero(b)
-    while 1:
+    while True:
         if PS.levels[i] <= PS.depth:
             if i != j and n > i - j + 1:
                 n = i - j + 1
@@ -304,18 +304,17 @@ cdef int PS_first_smallest(PartitionStack *PS, bitset_t b, int *second_pos=NULL)
     # location now points to the beginning of the first, smallest,
     # nontrivial cell
     i = location
-    while 1:
+    while True:
         bitset_flip(b, PS.entries[i])
         if PS.levels[i] <= PS.depth:
             break
         i += 1
 
     if second_pos != NULL:
-        if n==2:
-            second_pos[0] = PS.entries[location+1]
+        if n == 2:
+            second_pos[0] = PS.entries[location + 1]
         else:
             second_pos[0] = -1
-
 
     return PS.entries[location]
 

--- a/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
@@ -284,8 +284,7 @@ cdef PS_print_partition(PartitionStack *PS, int k):
     s = s[:-1] + ')'
     print(s)
 
-cdef int PS_first_smallest(PartitionStack *PS, bitset_t b, int *second_pos=NULL,
-                           PartitionRefinement_generic partn_ref_alg=None):
+cdef int PS_first_smallest(PartitionStack *PS, bitset_t b, int *second_pos=NULL):
     """
     Find the first occurrence of the smallest cell of size greater than one,
     which is admissible (checked by the function ``test_allowance``).
@@ -295,8 +294,7 @@ cdef int PS_first_smallest(PartitionStack *PS, bitset_t b, int *second_pos=NULL,
     bitset_zero(b)
     while 1:
         if PS.levels[i] <= PS.depth:
-            if i != j and n > i - j + 1 and (partn_ref_alg is None or
-                                partn_ref_alg._minimization_allowed_on_col(PS.entries[j])):
+            if i != j and n > i - j + 1:
                 n = i - j + 1
                 location = j
             j = i + 1

--- a/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
@@ -33,7 +33,10 @@ from cysignals.memory cimport sig_malloc, sig_calloc, sig_realloc, sig_free
 
 from sage.data_structures.bitset_base cimport *
 from sage.rings.integer cimport Integer
-from sage.libs.flint.ulong_extras cimport n_is_prime
+# from sage.libs.flint.ulong_extras cimport n_is_prime
+# -- avoid modularization obstruction -- function is only used for a doctest helper
+from sage.arith.misc import is_prime as n_is_prime
+
 
 # OrbitPartition (OP)
 

--- a/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pxd
+++ b/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pxd
@@ -7,6 +7,7 @@
 #                  http://www.gnu.org/licenses/
 #*******************************************************************************
 
+from sage.data_structures.bitset_base cimport *
 from sage.groups.perm_gps.partn_ref.data_structures cimport OrbitPartition, PartitionStack
 from sage.libs.gap.element cimport GapElement, GapElement_Permutation
 from sage.structure.parent cimport Parent

--- a/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pxd
+++ b/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pxd
@@ -82,3 +82,7 @@ cdef class PartitionRefinement_generic:
                               bint* inner_group_changed, bint* changed_partition,
                               str refine_name)
     cdef int len(self)
+
+
+cdef int PS_first_smallest_PR(PartitionStack *PS, bitset_t b, int *second_pos=?,
+        PartitionRefinement_generic partn_ref_alg=?)

--- a/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pyx
+++ b/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pyx
@@ -684,8 +684,7 @@ cdef class PartitionRefinement_generic:
         bitset_init(b, self._n)
         PS_move_all_mins_to_front(self._part)
         cdef int second_pos
-        cdef int smallest = PS_first_smallest(self._part, b, &second_pos,
-                                              self)
+        cdef int smallest = PS_first_smallest_PR(self._part, b, &second_pos, self)
         if second_pos != -1:
             self._fixed_not_minimized.append(second_pos)
         cdef int pos = smallest

--- a/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pyx
+++ b/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pyx
@@ -941,3 +941,40 @@ cdef class PartitionRefinement_generic:
         """
         if BACKTRACK_WITHLATEX_DEBUG:
             self._latex_debug_string += "]\n"
+
+
+cdef int PS_first_smallest_PR(PartitionStack *PS, bitset_t b, int *second_pos=NULL,
+                              PartitionRefinement_generic partn_ref_alg=None):
+    """
+    Find the first occurrence of the smallest cell of size greater than one,
+    which is admissible (checked by the function ``test_allowance``).
+    Its entries are stored to b and its minimum element is returned.
+
+    This generalizes :func:`sage.groups.perm_gps.partn_ref.data_structures.PS_first_smallest`.
+    """
+    cdef int i = 0, j = 0, location = 0, n = PS.degree
+    bitset_zero(b)
+    while 1:
+        if PS.levels[i] <= PS.depth:
+            if i != j and n > i - j + 1 and (partn_ref_alg is None or
+                                partn_ref_alg._minimization_allowed_on_col(PS.entries[j])):
+                n = i - j + 1
+                location = j
+            j = i + 1
+        if PS.levels[i] == -1: break
+        i += 1
+    # location now points to the beginning of the first, smallest,
+    # nontrivial cell
+    i = location
+    while 1:
+        bitset_flip(b, PS.entries[i])
+        if PS.levels[i] <= PS.depth: break
+        i += 1
+
+    if second_pos != NULL:
+        if n==2:
+            second_pos[0] = PS.entries[location+1]
+        else:
+            second_pos[0] = -1
+
+    return PS.entries[location]

--- a/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pyx
+++ b/src/sage/groups/perm_gps/partn_ref2/refinement_generic.pyx
@@ -953,26 +953,28 @@ cdef int PS_first_smallest_PR(PartitionStack *PS, bitset_t b, int *second_pos=NU
     """
     cdef int i = 0, j = 0, location = 0, n = PS.degree
     bitset_zero(b)
-    while 1:
+    while True:
         if PS.levels[i] <= PS.depth:
             if i != j and n > i - j + 1 and (partn_ref_alg is None or
                                 partn_ref_alg._minimization_allowed_on_col(PS.entries[j])):
                 n = i - j + 1
                 location = j
             j = i + 1
-        if PS.levels[i] == -1: break
+        if PS.levels[i] == -1:
+            break
         i += 1
     # location now points to the beginning of the first, smallest,
     # nontrivial cell
     i = location
-    while 1:
+    while True:
         bitset_flip(b, PS.entries[i])
-        if PS.levels[i] <= PS.depth: break
+        if PS.levels[i] <= PS.depth:
+            break
         i += 1
 
     if second_pos != NULL:
-        if n==2:
-            second_pos[0] = PS.entries[location+1]
+        if n == 2:
+            second_pos[0] = PS.entries[location + 1]
         else:
             second_pos[0] = -1
 


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. -->
`partn_ref2` depends on `sage.libs.gap`.

We restore the independence of `partn_ref` from `sage.libs.gap` by creating a separate function for the case of `PS_first_smallest` with non-`None` `partn_ref_alg` in `partn_ref2`.

We also remove the compile-time dependency on flint.
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
- Part of: #29705 
- Cherry-picked from: #35095 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
