### PR TITLE
gap: switch to libgap API for GAP function calls

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2488,9 +2488,9 @@ cdef class GapElement_Function(GapElement):
         """
         cdef Obj result = NULL
         cdef Obj arg_list
-        cdef int i, n = len(args)
+        cdef int n = len(args)
 
-        if n > 0:
+        if n > 0 and n <= 3:
             libgap = self.parent()
             a = [x if isinstance(x, GapElement) else libgap(x) for x in args]
 
@@ -2498,43 +2498,22 @@ cdef class GapElement_Function(GapElement):
             sig_GAP_Enter()
             sig_on()
             if n == 0:
-                result = CALL_0ARGS(self.value)
+                result = GAP_CallFunc0Args(self.value)
             elif n == 1:
-                result = CALL_1ARGS(self.value,
+                result = GAP_CallFunc1Args(self.value,
                                            (<GapElement>a[0]).value)
             elif n == 2:
-                result = CALL_2ARGS(self.value,
+                result = GAP_CallFunc2Args(self.value,
                                            (<GapElement>a[0]).value,
                                            (<GapElement>a[1]).value)
             elif n == 3:
-                result = CALL_3ARGS(self.value,
+                result = GAP_CallFunc3Args(self.value,
                                            (<GapElement>a[0]).value,
                                            (<GapElement>a[1]).value,
                                            (<GapElement>a[2]).value)
-            elif n == 4:
-                result = CALL_4ARGS(self.value,
-                                           (<GapElement>a[0]).value,
-                                           (<GapElement>a[1]).value,
-                                           (<GapElement>a[2]).value,
-                                           (<GapElement>a[3]).value)
-            elif n == 5:
-                result = CALL_5ARGS(self.value,
-                                           (<GapElement>a[0]).value,
-                                           (<GapElement>a[1]).value,
-                                           (<GapElement>a[2]).value,
-                                           (<GapElement>a[3]).value,
-                                           (<GapElement>a[4]).value)
-            elif n == 6:
-                result = CALL_6ARGS(self.value,
-                                           (<GapElement>a[0]).value,
-                                           (<GapElement>a[1]).value,
-                                           (<GapElement>a[2]).value,
-                                           (<GapElement>a[3]).value,
-                                           (<GapElement>a[4]).value,
-                                           (<GapElement>a[5]).value)
-            elif n >= 7:
+            else:
                 arg_list = make_gap_list(args)
-                result = CALL_XARGS(self.value, arg_list)
+                result = GAP_CallFuncList(self.value, arg_list)
             sig_off()
         finally:
             GAP_Leave()

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -24,14 +24,6 @@ cdef extern from "gap/system.h" nogil:
 
 cdef extern from "gap/calls.h" nogil:
     bint IS_FUNC(Obj)
-    Obj CALL_0ARGS(Obj f)              # 0 arguments
-    Obj CALL_1ARGS(Obj f, Obj a1)      # 1 argument
-    Obj CALL_2ARGS(Obj f, Obj a1, Obj a2)
-    Obj CALL_3ARGS(Obj f, Obj a1, Obj a2, Obj a3)
-    Obj CALL_4ARGS(Obj f, Obj a1, Obj a2, Obj a3, Obj a4)
-    Obj CALL_5ARGS(Obj f, Obj a1, Obj a2, Obj a3, Obj a4, Obj a5)
-    Obj CALL_6ARGS(Obj f, Obj a1, Obj a2, Obj a3, Obj a4, Obj a5, Obj a6)
-    Obj CALL_XARGS(Obj f, Obj args)   # more than 6 arguments
 
 
 cdef extern from "gap/libgap-api.h" nogil:


### PR DESCRIPTION
### :books: Description

Switch to the official libgap API for making function calls. <s>This also simplifies the code quite a bit.</s> And it makes it possible to call non-standard GAP functions (i.e. functions which are not `T_FUNCTION` but just an arbitrary objects for which a function call method has been installed).

<s>As a caveat, I could *not* try this at all, as I currently cannot compile SageMath (it runs into weird errors, and I don't have time to debug this, sorry). In particular I just looked at the Cython documentation to find out how to get a raw pointer to the content of an array; but I am not even sure that I got the syntax right, let alone the semantics. But I figured it's worth a shot.</s>

UPDATE: I decided to not try to use `GAP_CallFuncArray` anymore; it just is impossible for me to figure out the right way to call it from Cython when I can only test my changes by pushing them here. Instead a more modest but hopefully less problematic approach is now used.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [ ] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
