### PR TITLE
Make SubgraphSearch robust to vertex labels

### DIFF
--- a/src/sage/graphs/generic_graph_pyx.pyx
+++ b/src/sage/graphs/generic_graph_pyx.pyx
@@ -726,7 +726,7 @@ cdef class SubgraphSearch:
             6
 
         Check that the method is working even when vertices or edges are of
-        incomparable types::
+        incomparable types (see :trac:`35904`)::
 
             sage: from sage.graphs.generic_graph_pyx import SubgraphSearch
             sage: G = Graph()


### PR DESCRIPTION
Part of #35902.

### :books: Description

We ensure that the method operates properly even when vertices and edges are of incomparable types.

On the way, we also avoid a call to `adjacency_matrix`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
