### PR TITLE
Deprecate rename_vertices parameter in disjoint_union

### DIFF
--- a/src/sage/topology/simplicial_complex.py
+++ b/src/sage/topology/simplicial_complex.py
@@ -1991,22 +1991,11 @@ class SimplicialComplex(Parent, GenericCellComplex):
                                  rename_vertices=True)
         return self.suspension(1, is_mutable).suspension(int(n-1), is_mutable)
 
-    def disjoint_union(self, right, rename_vertices=True, is_mutable=True):
+    def disjoint_union(self, right, is_mutable=True):
         """
         The disjoint union of this simplicial complex with another one.
 
         :param right: the other simplicial complex (the right-hand factor)
-
-        :param rename_vertices: If this is True, the vertices in the
-           disjoint union will be renamed by the formula: vertex "v"
-           in the left-hand factor --> vertex "Lv" in the disjoint
-           union, vertex "w" in the right-hand factor --> vertex "Rw"
-           in the disjoint union.  If this is false, this tries to
-           construct the disjoint union without renaming the vertices;
-           this will cause problems if the two factors have any
-           vertices with names in common.
-
-        :type rename_vertices: boolean; optional, default True
 
         EXAMPLES::
 

--- a/src/sage/topology/simplicial_complex.py
+++ b/src/sage/topology/simplicial_complex.py
@@ -1991,11 +1991,22 @@ class SimplicialComplex(Parent, GenericCellComplex):
                                  rename_vertices=True)
         return self.suspension(1, is_mutable).suspension(int(n-1), is_mutable)
 
-    def disjoint_union(self, right, is_mutable=True):
+    def disjoint_union(self, right, rename_vertices=None, is_mutable=True):
         """
         The disjoint union of this simplicial complex with another one.
 
         :param right: the other simplicial complex (the right-hand factor)
+
+        :param rename_vertices: If this is True, the vertices in the
+           disjoint union will be renamed by the formula: vertex "v"
+           in the left-hand factor --> vertex "Lv" in the disjoint
+           union, vertex "w" in the right-hand factor --> vertex "Rw"
+           in the disjoint union.  If this is false, this tries to
+           construct the disjoint union without renaming the vertices;
+           this will cause problems if the two factors have any
+           vertices with names in common.
+
+        :type rename_vertices: boolean; optional, default True
 
         EXAMPLES::
 
@@ -2004,6 +2015,10 @@ class SimplicialComplex(Parent, GenericCellComplex):
             sage: S1.disjoint_union(S2).homology()                                      # optional - sage.modules
             {0: Z, 1: Z, 2: Z}
         """
+        if rename_vertices is not None:
+            from sage.misc.superseded import deprecation
+            deprecation(35907, 'the "rename_vertices" argument is deprecated')
+
         facets = []
         for f in self._facets:
             facets.append(tuple(["L" + str(v) for v in f]))


### PR DESCRIPTION
### :books: Description

The `rename_vertices` parameter is not mentioned anywhere within the body of the method `disjoint_union`. We remove the parameter.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.