### PR TITLE
fix some pep8 in symbolic folder

### DIFF
--- a/src/sage/symbolic/assumptions.py
+++ b/src/sage/symbolic/assumptions.py
@@ -261,7 +261,7 @@ class GenericDeclaration(UniqueRepresentation):
             cur = maxima.get("context")
             # Redeclaring on the existing context does not seem to trigger
             # inconsistency checking.
-            ## maxima.set("context", self._context._maxima_init_())
+            # maxima.set("context", self._context._maxima_init_())
             # Instead, use a temporary context for this purpose
             context = maxima.newcontext('context' + maxima._next_var_name())
             must_declare = True
@@ -272,7 +272,7 @@ class GenericDeclaration(UniqueRepresentation):
             try:
                 maxima.eval("declare(%s, %s)" % (self._var._maxima_init_(), self._assumption))
             except RuntimeError as mess:
-                if 'inconsistent' in str(mess): # note Maxima doesn't tell you if declarations are redundant
+                if 'inconsistent' in str(mess):  # note Maxima doesn't tell you if declarations are redundant
                     # Inconsistency with one of the active contexts.
                     raise ValueError("Assumption is inconsistent")
                 else:
@@ -316,9 +316,9 @@ class GenericDeclaration(UniqueRepresentation):
             except KeyError:
                 return
             maxima.deactivate(self._context)
-        else: # trying to forget a declaration explicitly rather than implicitly
+        else:  # trying to forget a declaration explicitly rather than implicitly
             for x in _assumptions:
-                if repr(self) == repr(x): # so by implication x is also a GenericDeclaration
+                if repr(self) == repr(x):  # so by implication x is also a GenericDeclaration
                     x.forget()
                     break
             return
@@ -945,8 +945,8 @@ class assuming:
             sage: bool(x>-1)
             False
         """
-        self.replace=kwds.pop("replace",False)
-        self.Ass=args
+        self.replace = kwds.pop("replace", False)
+        self.Ass = args
 
     def __enter__(self):
         r"""
@@ -964,7 +964,7 @@ class assuming:
             False
         """
         if self.replace:
-            self.OldAss=assumptions()
+            self.OldAss = assumptions()
             forget(assumptions())
         assume(self.Ass)
 

--- a/src/sage/symbolic/expression_conversions.py
+++ b/src/sage/symbolic/expression_conversions.py
@@ -582,7 +582,7 @@ class InterfaceInit(Converter):
             raise NotImplementedError
         args = ex.operands()
         if (not all(isinstance(v, Expression) and v.is_symbol() for v in args) or
-            len(args) != len(set(args))):
+                len(args) != len(set(args))):
             # An evaluated derivative of the form f'(1) is not a
             # symbolic variable, yet we would like to treat it like
             # one. So, we replace the argument `1` with a temporary
@@ -1106,7 +1106,7 @@ class FriCASConverter(InterfaceInit):
         params_set = set(params)
         mult = ",".join(str(params.count(i)) for i in params_set)
         if (not all(isinstance(v, Expression) and v.is_symbol() for v in args) or
-            len(args) != len(set(args))):
+                len(args) != len(set(args))):
             # An evaluated derivative of the form f'(1) is not a
             # symbolic variable, yet we would like to treat it like
             # one. So, we replace the argument `1` with a temporary

--- a/src/sage/symbolic/integration/external.py
+++ b/src/sage/symbolic/integration/external.py
@@ -117,7 +117,8 @@ def mma_free_integrator(expression, v, a=None, b=None):
         input = "Integrate[{},{}]".format(math_expr, variable)
     elif a is not None and b is not None:
         input = "Integrate[{},{{{},{},{}}}]".format(math_expr, variable,
-                    a._mathematica_init_(), b._mathematica_init_())
+                                                    a._mathematica_init_(),
+                                                    b._mathematica_init_())
     else:
         raise ValueError('a(={}) and b(={}) should be both None'
                          ' or both defined'.format(a, b))
@@ -252,8 +253,8 @@ def giac_integrator(expression, v, a=None, b=None):
         result = ex.integrate(v._giac_(), a._giac_(), b._giac_())
     if 'integrate' in format(result) or 'integration' in format(result):
         return expression.integrate(v, a, b, hold=True)
-    else:
-        return result._sage_()
+    return result._sage_()
+
 
 def libgiac_integrator(expression, v, a=None, b=None):
     r"""

--- a/src/sage/symbolic/maxima_wrapper.py
+++ b/src/sage/symbolic/maxima_wrapper.py
@@ -5,7 +5,7 @@
 #       Copyright (C) 2010 Burcin Erocal <burcin@erocal.org>
 #  Distributed under the terms of the GNU General Public License (GPL),
 #  version 2 or any later version.  The full text of the GPL is available at:
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 ###############################################################################
 
 from sage.structure.sage_object import SageObject
@@ -158,4 +158,4 @@ class MaximaWrapper(SageObject):
             sage: u._repr_()
             'MaximaWrapper(log(sqrt(2) + 1) + log(sqrt(2) - 1))'
         """
-        return "MaximaWrapper(%s)"%(self._exp)
+        return "MaximaWrapper(%s)" % (self._exp)

--- a/src/sage/symbolic/pynac_constant.py
+++ b/src/sage/symbolic/pynac_constant.py
@@ -2,7 +2,7 @@
 Wrapper around Pynac's constants
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2008 William Stein <wstein@gmail.com>
 #       Copyright (C) 2008 Burcin Erocal <burcin@erocal.org>
 #       Copyright (C) 2009 Mike Hansen <mhansen@gmail.com>
@@ -11,8 +11,8 @@ Wrapper around Pynac's constants
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.misc.lazy_import import lazy_import
 lazy_import('sage.symbolic.expression', 'PynacConstant', deprecation=32386)

--- a/src/sage/symbolic/relation.py
+++ b/src/sage/symbolic/relation.py
@@ -502,7 +502,7 @@ def test_relation_maxima(relation):
         except TypeError:
             raise ValueError("unable to evaluate the predicate '%s'" % repr(relation))
 
-    elif relation.operator() == operator.ne: # operator is not equal
+    elif relation.operator() == operator.ne:  # operator is not equal
         try:
             s = m.parent()._eval_line('is (notequal(%s,%s))' % (repr(m.lhs()),
                                                                 repr(m.rhs())))
@@ -518,7 +518,7 @@ def test_relation_maxima(relation):
     if s == 'true':
         return True
     elif s == 'false':
-        return False # if neither of these, s=='unknown' and we try a few other tricks
+        return False  # if neither of these, s=='unknown' and we try a few other tricks
 
     if relation.operator() != operator.eq:
         return False
@@ -1064,7 +1064,7 @@ def solve(f, *args, **kwds):
                             "symbolic expression or a list of symbolic "
                             "expressions.")
 
-    if isinstance(f, Expression): # f is a single expression
+    if isinstance(f, Expression):  # f is a single expression
         return _solve_expression(f, x, explicit_solutions, multiplicities, to_poly_solve, solution_dict, algorithm, domain)
 
     if not isinstance(f, (list, tuple)):
@@ -1094,7 +1094,7 @@ def solve(f, *args, **kwds):
     if algorithm == 'sympy':
         from sympy import solve as ssolve
         from sage.interfaces.sympy import sympy_set_to_list
-        if isinstance(f, Expression): # f is a single expression
+        if isinstance(f, Expression):  # f is a single expression
             sympy_f = f._sympy_()
         else:
             sympy_f = [s._sympy_() for s in f]
@@ -1145,27 +1145,27 @@ def solve(f, *args, **kwds):
             else:
                 raise
 
-    if len(s) == 0: # if Maxima's solve gave no solutions, try its to_poly_solve
+    if len(s) == 0:  # if Maxima's solve gave no solutions, try its to_poly_solve
         try:
             s = m.to_poly_solve(variables)
-        except Exception: # if that gives an error, stick with no solutions
+        except Exception:  # if that gives an error, stick with no solutions
             s = []
 
-    if len(s) == 0: # if to_poly_solve gave no solutions, try use_grobner
+    if len(s) == 0:  # if to_poly_solve gave no solutions, try use_grobner
         try:
             s = m.to_poly_solve(variables, 'use_grobner=true')
-        except Exception: # if that gives an error, stick with no solutions
+        except Exception:  # if that gives an error, stick with no solutions
             s = []
 
     sol_list = string_to_list_of_solutions(repr(s))
 
     # Relaxed form suggested by Mike Hansen (#8553):
     if kwds.get('solution_dict', None):
-        if not sol_list: # fixes IndexError on empty solution list (#8553)
+        if not sol_list:  # fixes IndexError on empty solution list (#8553)
             return []
         if isinstance(sol_list[0], list):
             sol_dict = [{eq.left(): eq.right() for eq in solution}
-                    for solution in sol_list]
+                        for solution in sol_list]
         else:
             sol_dict = [{eq.left(): eq.right()} for eq in sol_list]
 
@@ -1175,7 +1175,7 @@ def solve(f, *args, **kwds):
 
 
 def _solve_expression(f, x, explicit_solutions, multiplicities,
-                     to_poly_solve, solution_dict, algorithm, domain):
+                      to_poly_solve, solution_dict, algorithm, domain):
     """
     Solve an expression ``f``. For more information, see :func:`solve`.
 
@@ -1305,7 +1305,7 @@ def _solve_expression(f, x, explicit_solutions, multiplicities,
         alist = assumptions()
         return any(isinstance(a, GenericDeclaration) and a.has(v) and
                    a._assumption in ['even', 'odd', 'integer', 'integervalued']
-            for a in alist)
+                   for a in alist)
     if len(ex.variables()) and all(has_integer_assumption(var) for var in ex.variables()):
         return f.solve_diophantine(x, solution_dict=solution_dict)
 
@@ -1332,13 +1332,13 @@ def _solve_expression(f, x, explicit_solutions, multiplicities,
     m = ex._maxima_()
     P = m.parent()
     if explicit_solutions:
-        P.eval('solveexplicit: true') # switches Maxima to looking for only explicit solutions
+        P.eval('solveexplicit: true')  # switches Maxima to looking for only explicit solutions
     try:
         if to_poly_solve != 'force':
             s = m.solve(x).str()
-        else: # omit Maxima's solve command
+        else:  # omit Maxima's solve command
             s = str([])
-    except TypeError as mess: # if Maxima's solve has an error, we catch it
+    except TypeError as mess:  # if Maxima's solve has an error, we catch it
         if "Error executing code in Maxima" in str(mess):
             s = str([])
         else:
@@ -1356,9 +1356,9 @@ def _solve_expression(f, x, explicit_solutions, multiplicities,
         else:
             return ans
 
-    X = string_to_list_of_solutions(s) # our initial list of solutions
+    X = string_to_list_of_solutions(s)  # our initial list of solutions
 
-    if multiplicities: # to_poly_solve does not return multiplicities, so in this case we end here
+    if multiplicities:  # to_poly_solve does not return multiplicities, so in this case we end here
         if len(X) == 0:
             return X, []
         else:
@@ -1397,7 +1397,7 @@ def _solve_expression(f, x, explicit_solutions, multiplicities,
                      "unable to make sense of Maxima expression" in \
                      str(mess):
                     if not explicit_solutions:
-                        X.append(eq) # we keep this implicit solution
+                        X.append(eq)  # we keep this implicit solution
                 else:
                     raise
 
@@ -1565,8 +1565,6 @@ def solve_mod(eqns, modulus, solution_dict=False):
         [(0,)]
         sage: solve_mod([2*x^2+x*y, -x*y+2*y^2+x-2*y, -2*x^2+2*x*y-y^2-x-y], 1)
         [(0, 0)]
-
-
     """
     from sage.rings.finite_rings.integer_mod_ring import Integers
     from sage.rings.integer import Integer
@@ -1585,7 +1583,7 @@ def solve_mod(eqns, modulus, solution_dict=False):
     vars = list(set(sum([list(e.variables()) for e in eqns], [])))
     vars.sort(key=repr)
 
-    if modulus == 1: # degenerate case
+    if modulus == 1:  # degenerate case
         ans = [tuple(Integers(1)(0) for v in vars)]
         return ans
 
@@ -1611,10 +1609,8 @@ def solve_mod(eqns, modulus, solution_dict=False):
     # if solution_dict == True:
     # Relaxed form suggested by Mike Hansen (#8553):
     if solution_dict:
-        sol_dict = [dict(zip(vars, solution)) for solution in ans]
-        return sol_dict
-    else:
-        return ans
+        return [dict(zip(vars, solution)) for solution in ans]
+    return ans
 
 
 def _solve_mod_prime_power(eqns, p, m, vars):

--- a/src/sage/symbolic/subring.py
+++ b/src/sage/symbolic/subring.py
@@ -403,10 +403,6 @@ class GenericSymbolicSubring(SymbolicRing):
             sage: C.has_coerce_map_from(SR)  # indirect doctest
             False
         """
-        if P == SR:
-            # Workaround; can be deleted once #19231 is fixed
-            return False
-
         from sage.rings.infinity import InfinityRing
         from sage.rings.qqbar import AA, QQbar
         from sage.rings.real_lazy import RLF, CLF
@@ -414,18 +410,18 @@ class GenericSymbolicSubring(SymbolicRing):
         if isinstance(P, type):
             return SR._coerce_map_from_(P)
 
-        elif RLF.has_coerce_map_from(P) or \
-             CLF.has_coerce_map_from(P) or \
-             AA.has_coerce_map_from(P) or \
-             QQbar.has_coerce_map_from(P):
+        if RLF.has_coerce_map_from(P) or \
+           CLF.has_coerce_map_from(P) or \
+           AA.has_coerce_map_from(P) or \
+           QQbar.has_coerce_map_from(P):
             return True
 
-        elif (P is InfinityRing or
-              isinstance(P, (sage.rings.abc.RealIntervalField,
-                             sage.rings.abc.ComplexIntervalField))):
+        if (P is InfinityRing or
+            isinstance(P, (sage.rings.abc.RealIntervalField,
+                           sage.rings.abc.ComplexIntervalField))):
             return True
 
-        elif P._is_numerical():
+        if P._is_numerical():
             return P not in (RLF, CLF, AA, QQbar)
 
     def __eq__(self, other):

--- a/src/sage/symbolic/substitution_map.py
+++ b/src/sage/symbolic/substitution_map.py
@@ -7,15 +7,15 @@ Pynac's ``subs()`` methods and pass a wrapper for the substitution map
 back to Python.
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2013 Volker Braun <vbraun.name@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.misc.lazy_import import lazy_import
 lazy_import('sage.symbolic.expression', ('SubstitutionMap', 'make_map'), deprecation=32386)

--- a/src/sage/symbolic/tests.py
+++ b/src/sage/symbolic/tests.py
@@ -2,15 +2,15 @@
 Tests for the Sage/Pynac interaction
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2013 Volker Braun <vbraun.name@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 
 def rational_powers_memleak():
@@ -34,7 +34,7 @@ def rational_powers_memleak():
     gc.collect()
     c0 = sum(1 for obj in gc.get_objects())
     for i in range(1000):
-        a = ZZ(2).sqrt()
+        _ = ZZ(2).sqrt()
     gc.collect()
     c1 = sum(1 for obj in gc.get_objects())
     # Test that we do not leak an object at each iteration


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

fixes some pycodestyle warnings in the symbolic folder.

also a few details in the code ;

in particular removing a workaround in the subrings of symbolic ring (#19231 )

<!-- Describe your changes here in detail. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
