### PR TITLE
Removed warning no longer relevant since #21212

### DIFF
--- a/src/sage/rings/power_series_poly.pyx
+++ b/src/sage/rings/power_series_poly.pyx
@@ -1122,11 +1122,6 @@ cdef class PowerSeries_poly(PowerSeries):
 
         a ratio of two polynomials
 
-        .. WARNING::
-
-            The current implementation uses a very slow algorithm and is not
-            suitable for high orders.
-
         ALGORITHM:
 
         This method uses the formula as a quotient of two determinants.


### PR DESCRIPTION
In PR https://github.com/sagemath/sage/issues/21212 the algorithm was improved to use the extended euclid's algorithm for gcd.

@fchapoton the warning was originally written by you, hopefully you agree with this change.
