### PR TITLE
fix and activate pycodestyle E252

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,7 @@
     "python.linting.enabled": true,
     // The following pycodestyle arguments are the same as the pycodestyle-minimal
     // tox environnment, see the file SAGE_ROOT/src/tox.ini
-    "python.linting.pycodestyleArgs": ["--select= E111,E21,E222,E227,E251,E271,E303,E306,E401,E502,E701,E702,E703,E71,E72,W291,W293,W391,W605"],
+    "python.linting.pycodestyleArgs": ["--select= E111,E21,E222,E227,E25,E271,E303,E306,E401,E502,E701,E702,E703,E71,E72,W291,W293,W391,W605"],
     "cSpell.words": [
         "furo",
         "Conda",

--- a/src/sage/manifolds/scalarfield.py
+++ b/src/sage/manifolds/scalarfield.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from sage.tensor.modules.format_utilities import FormattedExpansion
     from sage.manifolds.chart import Chart
 
+
 class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
     r"""
     Scalar field on a topological manifold.
@@ -1133,15 +1134,19 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
         domain = parent._domain
         self._domain = domain
         self._manifold = domain.manifold()
-        self._is_zero = False # a priori, may be changed below or via
-                              # method __bool__()
+        self._is_zero = False
+        # a priori, may be changed below or via
+        # method __bool__()
+
         self._name = name
         if latex_name is None:
             self._latex_name = self._name
         else:
             self._latex_name = latex_name
-        self._express = {} # dict of coordinate expressions (ChartFunction
-                           # instances) with charts as keys
+        self._express = {}
+        # dict of coordinate expressions (ChartFunction
+        # instances) with charts as keys
+
         if coord_expression is not None:
             if isinstance(coord_expression, dict):
                 for chart, expression in coord_expression.items():
@@ -1163,7 +1168,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
                     self._express[chart] = chart.function(coord_expression)
         self._init_derived()   # initialization of derived quantities
 
-    ####### Required methods for an algebra element (beside arithmetic) #######
+    # ### Required methods for an algebra element (beside arithmetic) ###
 
     def __bool__(self):
         r"""
@@ -1425,11 +1430,10 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             sage: g = M.scalar_field({X: x+y})
             sage: f != g
             False
-
         """
         return not (self == other)
 
-    ####### End of required methods for an algebra element (beside arithmetic) #######
+    # ## End of required methods for an algebra element (beside arithmetic) ##
 
     def _init_derived(self):
         r"""
@@ -1441,10 +1445,10 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             sage: X.<x,y> = M.chart()
             sage: f = M.scalar_field({X: x+y})
             sage: f._init_derived()
-
         """
-        self._restrictions = {} # dict. of restrictions of self on subsets
-                                # of self._domain, with the subsets as keys
+        self._restrictions = {}
+        # dict. of restrictions of self on subsets
+        # of self._domain, with the subsets as keys
 
     def _del_derived(self):
         r"""
@@ -1466,7 +1470,6 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             sage: f._del_derived()
             sage: f._restrictions  # restrictions are derived quantities
             {}
-
         """
         self._restrictions.clear()
 
@@ -1486,7 +1489,6 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             'Scalar field f on the 2-dimensional topological manifold M'
             sage: f
             Scalar field f on the 2-dimensional topological manifold M
-
         """
         description = "Scalar field"
         if self._name is not None:
@@ -1513,12 +1515,10 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             '\\Phi'
             sage: latex(f)
             \Phi
-
         """
         if self._latex_name is None:
             return r'\text{' + str(self) + r'}'
-        else:
-            return self._latex_name
+        return self._latex_name
 
     def set_name(self, name=None, latex_name=None):
         r"""
@@ -1551,7 +1551,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
         """
         if self.is_immutable():
             raise ValueError("the name of an immutable element "
-                                 "cannot be changed")
+                             "cannot be changed")
         if name is not None:
             self._name = name
             if latex_name is None:
@@ -1787,7 +1787,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
                             found = True
                             if skchart not in self._express:
                                 self._express[skchart] = skchart.function(
-                                                  self._express[kchart].expr())
+                                    self._express[kchart].expr())
                             break
                     if found:
                         break
@@ -1796,8 +1796,8 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
                                      "compute the expression in the {}".format(chart))
             change = self._domain._coord_changes[(chart, from_chart)]
             # old coordinates expressed in terms of the new ones:
-            coords = [ change._transf._functions[i].expr()
-                       for i in range(self._manifold.dim()) ]
+            coords = [change._transf._functions[i].expr()
+                      for i in range(self._manifold.dim())]
             new_expr = self._express[from_chart](*coords)
             self._express[chart] = chart.function(new_expr)
             self._del_derived()
@@ -1921,7 +1921,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             chart = self._domain._def_chart
         self._express.clear()
         self._express[chart] = chart.function(coord_expression)
-        self._is_zero = False # a priori
+        self._is_zero = False  # a priori
         self._del_derived()
 
     def add_expr(self, coord_expression, chart=None):
@@ -2050,13 +2050,13 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
         """
         if self.is_immutable():
             raise ValueError("the expressions of an immutable element "
-                                 "cannot be changed")
+                             "cannot be changed")
         if not chart.domain().is_subset(self._domain):
             raise ValueError("the chart is not defined on a subset of " +
                              "the scalar field domain")
         schart = chart.restrict(subdomain)
         self._express[chart] = chart.function(self.expr(schart))
-        self._is_zero = False # a priori
+        self._is_zero = False  # a priori
         self._del_derived()
 
     def set_restriction(self, rst):
@@ -2101,7 +2101,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             self._express[chart.restrict(intersection)] = expr
         self._is_zero = False  # a priori
 
-    def display(self, chart: Optional[Chart]=None) -> FormattedExpansion:
+    def display(self, chart: Optional[Chart] = None) -> FormattedExpansion:
         r"""
         Display the expression of the scalar field in a given chart.
 
@@ -2155,11 +2155,12 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             on U: (x, y) ↦ y^2
             sage: latex(f.display())
             \begin{array}{llcl} f:& M & \longrightarrow & \mathbb{R} \\ \text{on}\ U : & \left(x, y\right) & \longmapsto & y^{2} \end{array}
-
         """
         from sage.misc.latex import latex
         from sage.typeset.unicode_characters import (unicode_to,
-                              unicode_mapsto, unicode_mathbbR, unicode_mathbbC)
+                                                     unicode_mapsto,
+                                                     unicode_mathbbR,
+                                                     unicode_mathbbC)
         from sage.tensor.modules.format_utilities import FormattedExpansion
 
         def _display_expression(self, chart, result):
@@ -2184,9 +2185,9 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
                 result._latex += r"\text{on}\ " + latex(chart.domain()) \
                                  + r": & "
             result._txt += repr(coords) + " " + unicode_mapsto + " " \
-                           + repr(expression) + "\n"
+                + repr(expression) + "\n"
             result._latex += latex(coords) + r"& \longmapsto & " \
-                             + latex(expression) + r"\\"
+                + latex(expression) + r"\\"
 
         # Name of the base field:
         field = self._domain.base_field()
@@ -2207,7 +2208,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
         else:
             symbol = self._name + ": "
         result._txt = symbol + self._domain._name + " " + unicode_to + " " \
-                      + field_name + "\n"
+            + field_name + "\n"
         if self._latex_name is None:
             symbol = ""
         else:
@@ -2311,7 +2312,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
                     self._restrictions[subdomain] = rst.restrict(subdomain)
                     break
             else:
-            # If this fails, the restriction must be created from scratch:
+                # If this fails, the restriction must be created from scratch:
                 sexpress = {}
                 for chart, funct in self._express.items():
                     for schart in subdomain.atlas():
@@ -2515,7 +2516,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             (-3, 7)
 
         """
-        #!# it should be "if p not in self_domain:" instead, but this test is
+        # ! # it should be "if p not in self_domain:" instead, but this test is
         # skipped for efficiency
         if p not in self._manifold:
             raise ValueError("the {} ".format(p) + "does not belong " +
@@ -2657,7 +2658,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             result._latex_name = '-' + self._latex_name
         return result
 
-    #########  CommutativeAlgebraElement arithmetic operators ########
+    # ###  CommutativeAlgebraElement arithmetic operators ###
 
     def _add_(self, other):
         r"""
@@ -2810,7 +2811,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             result._express[chart] = self._express[chart] * other._express[chart]
         result._name = format_mul_txt(self._name, '*', other._name)
         result._latex_name = format_mul_latex(self._latex_name, r' \cdot ',
-                                             other._latex_name)
+                                              other._latex_name)
         return result
 
     def _div_(self, other):
@@ -2843,10 +2844,9 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             Traceback (most recent call last):
             ...
             ZeroDivisionError: division of a scalar field by zero
-
         """
         from sage.tensor.modules.format_utilities import format_mul_txt, \
-                                                         format_mul_latex
+            format_mul_latex
         # Trivial cases:
         if other.is_trivial_zero():
             raise ZeroDivisionError("division of a scalar field by zero")
@@ -2862,7 +2862,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             result._express[chart] = self._express[chart] / other._express[chart]
         result._name = format_mul_txt(self._name, '/', other._name)
         result._latex_name = format_mul_latex(self._latex_name, '/',
-                                             other._latex_name)
+                                              other._latex_name)
         return result
 
     def _lmul_(self, number):
@@ -2966,7 +2966,7 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             result._express[chart] = number * expr
         return result
 
-    #########  End of CommutativeAlgebraElement arithmetic operators ########
+    # ###  End of CommutativeAlgebraElement arithmetic operators ###
 
     def _function_name(self, func, func_latex, parentheses=True):
         r"""
@@ -2985,7 +2985,6 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             sage: f = M.scalar_field({X: x+y})  # no name given to f
             sage: f._function_name("cos", r"\cos")
             (None, None)
-
         """
         if self._name is None:
             name = None
@@ -2993,12 +2992,10 @@ class ScalarField(CommutativeAlgebraElement, ModuleElementWithMutability):
             name = func + "(" + self._name + ")"
         if self._latex_name is None:
             latex_name = None
+        elif parentheses:
+            latex_name = func_latex + r"\left(" + self._latex_name + r"\right)"
         else:
-            if parentheses:
-                latex_name = func_latex + r"\left(" + self._latex_name + \
-                             r"\right)"
-            else:
-                latex_name = func_latex + r"{" + self._latex_name + r"}"
+            latex_name = func_latex + r"{" + self._latex_name + r"}"
         return name, latex_name
 
     def exp(self):

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -126,7 +126,7 @@ description =
     # W605: invalid escape sequence ‘x’
     # See https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 deps = pycodestyle
-commands = pycodestyle --select E111,E21,E222,E227,E251,E271,E303,E306,E401,E502,E701,E702,E703,E71,E72,W291,W293,W391,W605 {posargs:{toxinidir}/sage/}
+commands = pycodestyle --select E111,E21,E222,E227,E25,E271,E303,E306,E401,E502,E701,E702,E703,E71,E72,W291,W293,W391,W605 {posargs:{toxinidir}/sage/}
        pycodestyle --select E111,E271,E306,E401,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
 
 [pycodestyle]


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

This activates the check for pycodestyle E252 warning

`E252 missing whitespace around parameter equals`

Also add this to vscode settings. And fix all other pycodestyle warnings in the unique modified file.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
