### PR TITLE
Fix GradedModularFormElement multiplication

### DIFF
--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -2783,7 +2783,7 @@ class ModularFormElement_elliptic_curve(Newform):
         """
         M = self.parent()
         S = M.cuspidal_subspace()
-#        return S.find_in_space( self.__E.q_expansion( S.q_expansion_basis()[0].prec() ) ) + [0] * ( M.dimension() - S.dimension() )
+        #        return S.find_in_space( self.__E.q_expansion( S.q_expansion_basis()[0].prec() ) ) + [0] * ( M.dimension() - S.dimension() )
         return vector(S.find_in_space(self.__E.q_expansion(S.sturm_bound())) + [0] * (M.dimension() - S.dimension()))
 
     def _compute_q_expansion(self, prec):
@@ -3553,16 +3553,17 @@ class GradedModularFormElement(ModuleElement):
             sage: (F4 + M(1))^2
             4 + 960*q + 66240*q^2 + 1063680*q^3 + 7961280*q^4 + 37560960*q^5 + O(q^6)
         """
+        from collections import defaultdict
+
         GM = self.__class__
         f_self = self._forms_dictionary
         f_other = other._forms_dictionary
-        f_mul = {}
+        f_mul = defaultdict(int)
+
         for k_self in f_self.keys():
             for k_other in f_other.keys():
-                try:
-                    f_mul[k_self + k_other] += f_self[k_self]*f_other[k_other]
-                except KeyError:
-                    f_mul[k_self + k_other] = f_self[k_self]*f_other[k_other]
+                f_mul[k_self + k_other] += f_self[k_self] * f_other[k_other]
+
         return GM(self.parent(), f_mul)
 
     def _lmul_(self, c):

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -3548,26 +3548,21 @@ class GradedModularFormElement(ModuleElement):
             sage: F4*F6 # indirect doctest
             1 - 264*q - 135432*q^2 - 5196576*q^3 - 69341448*q^4 - 515625264*q^5 + O(q^6)
 
-        This shows that the issue at :trac:`35932` is fixed::
+        This shows that the issue at :issue:`35932` is fixed::
 
             sage: (F4 + M(1))^2
             4 + 960*q + 66240*q^2 + 1063680*q^3 + 7961280*q^4 + 37560960*q^5 + O(q^6)
         """
         GM = self.__class__
-        parent = self.parent()
         f_self = self._forms_dictionary
         f_other = other._forms_dictionary
         f_mul = {}
         for k_self in f_self.keys():
             for k_other in f_other.keys():
-                if k_self + k_other not in f_mul:
-                    k_weight = k_self + k_other
-                    if k_weight == 0:
-                        M = parent.base_ring()
-                    else:
-                        M = parent.modular_forms_of_weight(k_weight).change_ring(parent.base_ring())
-                    f_mul[k_self + k_other] = M(0)
-                f_mul[k_self + k_other] += f_self[k_self]*f_other[k_other]
+                try:
+                     f_mul[k_self + k_other] += f_self[k_self]*f_other[k_other]
+                except KeyError:
+                     f_mul[k_self + k_other] = f_self[k_self]*f_other[k_other]
         return GM(self.parent(), f_mul)
 
     def _lmul_(self, c):

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -3560,9 +3560,9 @@ class GradedModularFormElement(ModuleElement):
         for k_self in f_self.keys():
             for k_other in f_other.keys():
                 try:
-                     f_mul[k_self + k_other] += f_self[k_self]*f_other[k_other]
+                    f_mul[k_self + k_other] += f_self[k_self]*f_other[k_other]
                 except KeyError:
-                     f_mul[k_self + k_other] = f_self[k_self]*f_other[k_other]
+                    f_mul[k_self + k_other] = f_self[k_self]*f_other[k_other]
         return GM(self.parent(), f_mul)
 
     def _lmul_(self, c):

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -3544,18 +3544,30 @@ class GradedModularFormElement(ModuleElement):
         TESTS::
 
             sage: M = ModularFormsRing(1)
-            sage: f4 = ModularForms(1, 4).0; f6 = ModularForms(1, 6).0;
-            sage: F4 = M(f4); F6 = M(f6);
+            sage: F4 = M.0; F6 = M.1;
             sage: F4*F6 # indirect doctest
             1 - 264*q - 135432*q^2 - 5196576*q^3 - 69341448*q^4 - 515625264*q^5 + O(q^6)
+
+        This shows that the issue at :trac:`35932` is fixed::
+
+            sage: (F4 + M(1))^2
+            4 + 960*q + 66240*q^2 + 1063680*q^3 + 7961280*q^4 + 37560960*q^5 + O(q^6)
         """
         GM = self.__class__
+        parent = self.parent()
         f_self = self._forms_dictionary
         f_other = other._forms_dictionary
         f_mul = {}
         for k_self in f_self.keys():
             for k_other in f_other.keys():
-                f_mul[k_self + k_other] = f_self[k_self]*f_other[k_other]
+                if k_self + k_other not in f_mul:
+                    k_weight = k_self + k_other
+                    if k_weight == 0:
+                        M = parent.base_ring()
+                    else:
+                        M = parent.modular_forms_of_weight(k_weight).change_ring(parent.base_ring())
+                    f_mul[k_self + k_other] = M(0)
+                f_mul[k_self + k_other] += f_self[k_self]*f_other[k_other]
         return GM(self.parent(), f_mul)
 
     def _lmul_(self, c):

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -2783,7 +2783,7 @@ class ModularFormElement_elliptic_curve(Newform):
         """
         M = self.parent()
         S = M.cuspidal_subspace()
-        #        return S.find_in_space( self.__E.q_expansion( S.q_expansion_basis()[0].prec() ) ) + [0] * ( M.dimension() - S.dimension() )
+#        return S.find_in_space( self.__E.q_expansion( S.q_expansion_basis()[0].prec() ) ) + [0] * ( M.dimension() - S.dimension() )
         return vector(S.find_in_space(self.__E.q_expansion(S.sturm_bound())) + [0] * (M.dimension() - S.dimension()))
 
     def _compute_q_expansion(self, prec):


### PR DESCRIPTION
Fix #35932 - incorrect multiplication for GradedModularFormElement.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
