### PR TITLE
Adapt to new Singular sat API

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -2446,7 +2446,7 @@ class MPolynomialIdeal_singular_repr(
             (Ideal (y, x^5) of Multivariate Polynomial Ring in x, y, z over Algebraic Field, 4)
         """
         from sage.libs.singular.function_factory import ff
-        # function renamed in singular > 4.3.2p4, see https://github.com/sagemath/sage/pull/35980
+        # function renamed in singular > 4.3.2p4, see issue #35980
         try:
             sat = ff.elim__lib.sat_with_exp
         except NameError:

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -2446,7 +2446,7 @@ class MPolynomialIdeal_singular_repr(
             (Ideal (y, x^5) of Multivariate Polynomial Ring in x, y, z over Algebraic Field, 4)
         """
         from sage.libs.singular.function_factory import ff
-        # function renamed in singular > 4.2.3p4
+        # function renamed in singular > 4.3.2p4, see https://github.com/sagemath/sage/pull/35980
         try:
             sat = ff.elim__lib.sat_with_exp
         except NameError:

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -2446,7 +2446,11 @@ class MPolynomialIdeal_singular_repr(
             (Ideal (y, x^5) of Multivariate Polynomial Ring in x, y, z over Algebraic Field, 4)
         """
         from sage.libs.singular.function_factory import ff
-        sat = ff.elim__lib.sat
+        # function renamed in singular > 4.2.3p4
+        try:
+            sat = ff.elim__lib.sat_with_exp
+        except NameError:
+            sat = ff.elim__lib.sat
         R = self.ring()
         ideal, expo = sat(self, other)
         return (R.ideal(ideal), ZZ(expo))


### PR DESCRIPTION
The `sat` function that returns the saturation exponent was renamed to `sat_with_exp` in [1] 

This patch makes Sage work with singular < 4.3.2p3 and > 4.3.2p4. With 4.3.2p3 and 4.3.2p4 it returns a wrong exponent [2], unless singular is patched with the above commit.

[1] https://github.com/Singular/Singular/commit/3f7e01a0f1f77073a3bc0dd325260ea88c216aff
[2] https://github.com/Singular/Singular/issues/1181