### PR TITLE
regular sequences: use "positive" partial sums algorithm

### DIFF
--- a/src/sage/combinat/k_regular_sequence.py
+++ b/src/sage/combinat/k_regular_sequence.py
@@ -728,20 +728,36 @@ class kRegularSequence(RecognizableSeries):
                             1: [0 0]
                                [0 1]},
              (1, 1))
+
             sage: P = E.partial_sums(minimize=False)
             sage: P.linear_representation()
-            ((1, 0, -1, 0),
-             Finite family {0: [ 0  1| 0  0]
-                               [ 0  2| 0 -1]
-                               [-----+-----]
-                               [ 0  0| 0  1]
-                               [ 0  0| 0  1],
-                            1: [0 1|0 0]
+            ((1, 0, 0, 0),
+             Finite family {0: [0 1|0 0]
                                [0 2|0 0]
+                               [---+---]
+                               [0 0|0 1]
+                               [0 0|0 1],
+                            1: [0 1|0 1]
+                               [0 2|0 1]
                                [---+---]
                                [0 0|0 0]
                                [0 0|0 1]},
-             (1, 1, 1, 1))
+             (0, 0, 1, 1))
+
+            sage: P = E.partial_sums(include_n=True, minimize=False)
+            sage: P.linear_representation()
+            ((1, 0, 1, 0),
+             Finite family {0: [0 1|0 0]
+                               [0 2|0 0]
+                               [---+---]
+                               [0 0|0 1]
+                               [0 0|0 1],
+                            1: [0 1|0 1]
+                               [0 2|0 1]
+                               [---+---]
+                               [0 0|0 0]
+                               [0 0|0 1]},
+             (0, 0, 1, 1))
         """
         from itertools import chain
         from sage.matrix.constructor import Matrix
@@ -752,17 +768,21 @@ class kRegularSequence(RecognizableSeries):
         A = P.alphabet()
         k = P.k
         dim = self.dimension()
-
-        B = {r: sum(self.mu[a] for a in A[r:]) for r in A}
         Z = zero_matrix(dim)
-        B[k] = Z
+
+        z = A[0]
+        assert z == 0
+        B = {z: Z}
+        for r in A:
+            B[r+1] = B[r] + self.mu[r]
+        C = B[k]
 
         result = P.element_class(
             P,
-            {r: Matrix.block([[B[0], -B[r + 1]], [Z, self.mu[r]]]) for r in A},
+            {r: Matrix.block([[C, B[r]], [Z, self.mu[r]]]) for r in A},
             vector(chain(self.left,
-                         (dim * (0,) if include_n else -self.left))),
-            vector(chain(self.right, self.right)))
+                         (dim * (0,) if not include_n else self.left))),
+            vector(chain(dim * (0,), self.right)))
 
         return result
 


### PR DESCRIPTION
Implement a different algorithm to be used by method `.partial_sums` of a `kRegularSequence`.

The new algorithm for partial summation has the advantage that only positive signs are used, which is somehow more "naturally" (compared to the existing algorithm that is kind of subtractive).

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

None.
