### PR TITLE
Introduce SAGE_OPTIONAL_PACKAGES_ASSUME_INSTALLED env variable

### DIFF
--- a/pkgs/sagemath-standard/setup.py
+++ b/pkgs/sagemath-standard/setup.py
@@ -79,9 +79,10 @@ t = time.time()
 from sage.misc.package import is_package_installed_and_updated
 distributions = ['']
 optional_packages_with_extensions = os.environ.get('SAGE_OPTIONAL_PACKAGES_WITH_EXTENSIONS', '').split(',')
+optional_packages_assume_installed = os.environ.get('SAGE_OPTIONAL_PACKAGES_ASSUME_INSTALLED', '').split(',')
 distributions += ['sagemath-{}'.format(pkg)
                   for pkg in optional_packages_with_extensions
-                  if is_package_installed_and_updated(pkg)]
+                  if is_package_installed_and_updated(pkg) or pkg in optional_packages_assume_installed]
 log.warn('distributions = {0}'.format(distributions))
 from sage_setup.find import find_python_sources
 python_packages, python_modules, cython_modules = find_python_sources(


### PR DESCRIPTION
Currently, the code in `pkgs/sagemath-standard/setup.py` that decides whether or not to build optional extensions relies on the `is_package_installed_and_updated` function, which is specific to sage-the-distro. Therefore, downstream distros need to patch this if they want to build optional extensions. 

This PR introduces a `SAGE_OPTIONAL_PACKAGES_ASSUME_INSTALLED` env variable that distros can use to specify which optional extensions to build, regardless of the `is_package_installed_and_updated` output.

Eventually this code should be ported away from `is_package_installed_and_updated` and use pkgconfig to detect optional libraries instead, but in the meantime this will save distros some patching.