### PR TITLE
Fix tests with singular 4.3.2p4

### DIFF
--- a/src/sage/interfaces/singular.py
+++ b/src/sage/interfaces/singular.py
@@ -604,8 +604,7 @@ class Singular(ExtraTabCompletion, Expect):
             sage: i = singular.ideal(['x^2','y^2','z^2'])
             sage: s = i.std()
             sage: singular.eval('hilb(%s)'%(s.name()))
-            '// 1 t^0\n// -3 t^2\n// 3 t^4\n// -1 t^6\n\n// 1 t^0\n//
-            3 t^1\n// 3 t^2\n// 1 t^3\n// dimension (affine) = 0\n//
+            '...// dimension (affine) = 0\n//
             degree (affine) = 8'
 
         ::
@@ -613,15 +612,7 @@ class Singular(ExtraTabCompletion, Expect):
             sage: from sage.misc.verbose import set_verbose
             sage: set_verbose(1)
             sage: o = singular.eval('hilb(%s)'%(s.name()))
-            //         1 t^0
-            //        -3 t^2
-            //         3 t^4
-            //        -1 t^6
-            //         1 t^0
-            //         3 t^1
-            //         3 t^2
-            //         1 t^3
-            // dimension (affine) = 0
+            ...// dimension (affine) = 0
             // degree (affine)  = 8
 
         This is mainly useful if this method is called implicitly. Because
@@ -631,15 +622,7 @@ class Singular(ExtraTabCompletion, Expect):
         ::
 
             sage: o = s.hilb()
-            //         1 t^0
-            //        -3 t^2
-            //         3 t^4
-            //        -1 t^6
-            //         1 t^0
-            //         3 t^1
-            //         3 t^2
-            //         1 t^3
-            // dimension (affine) = 0
+            ...// dimension (affine) = 0
             // degree (affine)  = 8
             // ** right side is not a datum, assignment ignored
             ...

--- a/src/sage/libs/singular/function.pyx
+++ b/src/sage/libs/singular/function.pyx
@@ -1241,32 +1241,22 @@ cdef class SingularFunction(SageObject):
             sage: I = Ideal([x^3*y^2 + 3*x^2*y^2*z + y^3*z^2 + z^5])
             sage: I = Ideal(I.groebner_basis())
             sage: hilb = sage.libs.singular.function_factory.ff.hilb
-            sage: hilb(I) # Singular will print // ** _ is no standard basis
-            // ** _ is no standard basis
-            //         1 t^0
-            //        -1 t^5
-            <BLANKLINE>
-            //         1 t^0
-            //         1 t^1
-            //         1 t^2
-            //         1 t^3
-            //         1 t^4
-            // dimension (proj.)  = 1
-            // degree (proj.)   = 5
+            sage: from sage.misc.sage_ostools import redirection
+            sage: out = tmp_filename()
+            sage: with redirection(sys.stdout,  open(out, 'w')):
+            ....:     hilb(I) # Singular will print // ** _ is no standard basis
+            sage: with open(out) as f:
+            ....:     'is no standard basis' in f.read()
+            True
 
         So we tell Singular that ``I`` is indeed a Groebner basis::
 
-            sage: hilb(I,attributes={I:{'isSB':1}}) # no complaint from Singular
-            //         1 t^0
-            //        -1 t^5
-            <BLANKLINE>
-            //         1 t^0
-            //         1 t^1
-            //         1 t^2
-            //         1 t^3
-            //         1 t^4
-            // dimension (proj.)  = 1
-            // degree (proj.)   = 5
+            sage: out = tmp_filename()
+            sage: with redirection(sys.stdout,  open(out, 'w')):
+            ....:     hilb(I,attributes={I:{'isSB':1}}) # no complaint from Singular
+            sage: with open(out) as f:
+            ....:     'is no standard basis' in f.read()
+            False
 
 
         TESTS:

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -3123,13 +3123,16 @@ class MPolynomialIdeal_singular_repr(
             sage: I.hilbert_numerator()                                                 # needs sage.rings.number_field
             -t^5 + 1
 
-        This example returns a wrong answer due to an integer overflow in Singular::
+        This example returns a wrong answer in singular < 4.3.2p4 due to an integer overflow::
 
             sage: n=4; m=11; P = PolynomialRing(QQ, n*m, "x"); x = P.gens(); M = Matrix(n, x)
             sage: I = P.ideal(M.minors(2))
             sage: J = P * [m.lm() for m in I.groebner_basis()]
-            sage: J.hilbert_numerator(algorithm='singular')
-            ...120*t^33 - 3465*t^32 + 48180*t^31 - ...
+            sage: J.hilbert_numerator(algorithm='singular') # known bug
+            Traceback (most recent call last):
+            ....
+            RuntimeError: error in Singular function call 'hilb':
+            overflow at t^22
 
         Our two algorithms should always agree; not tested until
         :trac:`33178` is fixed::


### PR DESCRIPTION
Due to changes in the output of `hilb` in singular 4.3.2p4 (it now outputs a polynomial instead of a list of monomials and coefficients to debug), some tests are failing.

Additionally, the problematic `hilbert_numerator` example now correctly throws an overflow error instead of giving a wrong answer. We mark it as `known bug` so the test passes with older versions of singular, the label can be removed once we require 4.3.2p4.