### PR TITLE
New GitHub workflow to continue our images on Docker Hub

### DIFF
--- a/.github/workflows/push_to_docker_hub.yml
+++ b/.github/workflows/push_to_docker_hub.yml
@@ -1,0 +1,143 @@
+# This workflow replaces $SAGE_ROOT/.gitlab-ci.yml which has been
+# used formerly to make Docker images available on DockerHub.
+# The new workflow uses the same $SAGE_ROOT/docker/Dockerfile and
+# is based on docker/build-push-action@v4.
+#
+# A replacement has become neccessary because the GitLab runners
+# stopped to create new images since release 9.7.
+#
+# Concerning the images placed in the sagemath-dev repository you
+# should note the following difference to the releases build before
+# 9.8: They are no longer build on target sagemath-dev since this
+# causes a "No space left on device" error. Instead they are build
+# on target make-build, now. The main difference is the missing
+# documentation and that it enters in a bash shell.
+#
+# Sebastian Oehms, August 2023
+
+name: Build Docker images and push to DockerHub
+
+on:
+  workflow_dispatch:
+    # Allow to run manually
+    branches:
+      - 'develop'
+      - 'docker_hub_gha'
+  push:
+    tags:
+      # Just create image on pushing a tag
+      - '*'
+
+jobs:
+  sagemath-dev:
+    name: Build Docker image on target make-build and push to DockerHub sagemath-dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set tag
+        # docker/metadata-action@v4 is not used since we need to distinguish
+        # between latest and develop tags
+        id: set_tag
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          TAG_NAME=$(git tag --sort=v:refname | tail -1)
+          TAG="sagemath/sagemath-dev:$TAG_NAME"
+          TAG_LIST="$TAG, sagemath/sagemath-dev:develop"
+          TAG_LIST="$TAG" # don't tag develop until meaning of sagemath-dev is clear
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "TAG_LIST=$TAG_LIST" >> $GITHUB_ENV
+
+      - name: Update Tag List
+        id: upd_tag_list
+        run: |
+          TAG_LIST="${{ env.TAG_LIST }}, sagemath/sagemath-dev:latest"
+          TAG_LIST="${{ env.TAG_LIST }}"  # don't tag latest until meaning of sagemath-dev is clear
+          echo "TAG_LIST=$TAG_LIST" >> $GITHUB_ENV
+        if: "!contains(env.TAG_NAME, 'beta') && !contains(env.TAG_NAME, 'rc')"
+
+      - name: Check env
+        run: |
+          echo ${{ env.TAG_NAME }}
+          echo ${{ env.TAG }}
+          echo ${{ env.TAG_LIST }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push make-build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: make-build    # see the corresponding header-note
+          push: true
+          tags: ${{ env.TAG_LIST }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  sagemath:
+    needs: sagemath-dev
+    name: Build Docker image on target sagemath and push to DockerHub sagemath
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set tag
+        # docker/metadata-action@v4 is not used since we need to distinguish
+        # between latest and develop tags
+        id: set_tag
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          TAG_NAME=$(git tag --sort=v:refname | tail -1)
+          TAG="sagemath/sagemath:$TAG_NAME"
+          TAG_LIST="$TAG, sagemath/sagemath:develop"
+          BASE="sagemath/sagemath-dev:$TAG_NAME"
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "TAG_LIST=$TAG_LIST" >> $GITHUB_ENV
+          echo "BASE=$BASE" >> $GITHUB_ENV
+
+      - name: Update Tag List
+        id: upd_tag_list
+        run: |
+          TAG_LIST="${{ env.TAG_LIST }}, sagemath/sagemath:latest"
+          echo "TAG_LIST=$TAG_LIST" >> $GITHUB_ENV
+        if: "!contains(env.TAG_NAME, 'beta') && !contains(env.TAG_NAME, 'rc')"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push sagemath
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          build-args: |
+            MAKE_BUILD=${{ env.BASE }}
+          target: sagemath
+          push: true
+          tags: ${{ env.TAG_LIST }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/push_to_docker_hub.yml
+++ b/.github/workflows/push_to_docker_hub.yml
@@ -1,20 +1,3 @@
-# This workflow replaces $SAGE_ROOT/.gitlab-ci.yml which has been
-# used formerly to make Docker images available on DockerHub.
-# The new workflow uses the same $SAGE_ROOT/docker/Dockerfile and
-# is based on docker/build-push-action@v4.
-#
-# A replacement has become neccessary because the GitLab runners
-# stopped to create new images since release 9.7.
-#
-# Concerning the images placed in the sagemath-dev repository you
-# should note the following difference to the releases build before
-# 9.8: They are no longer build on target sagemath-dev since this
-# causes a "No space left on device" error. Instead they are build
-# on target make-build, now. The main difference is the missing
-# documentation and that it enters in a bash shell.
-#
-# Sebastian Oehms, August 2023
-
 name: Build Docker images and push to DockerHub
 
 on:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,11 +70,12 @@
 
 
 ARG ARTIFACT_BASE=source-clean
+ARG MAKE_BUILD=make-build
 
 ################################################################################
 # Image containing the run-time dependencies for Sage                          #
 ################################################################################
-FROM ubuntu:jammy as run-time-dependencies
+FROM ubuntu:latest as run-time-dependencies
 LABEL maintainer="Erik M. Bray <erik.bray@lri.fr>, Julian Rüth <julian.rueth@fsfe.org>"
 # Set sane defaults for common environment variables.
 ENV LC_ALL C.UTF-8
@@ -122,7 +123,7 @@ ARG SAGE_ROOT=/home/sage/sage
 RUN mkdir -p "$SAGE_ROOT"
 WORKDIR $SAGE_ROOT
 RUN git init
-RUN git remote add trac https://gitlab.com/sagemath/dev/tracmirror.git
+RUN git remote add upstream https://github.com/sagemath/sage.git
 
 ################################################################################
 # Image with the build context added, i.e., the directory from which `docker   #
@@ -155,10 +156,10 @@ WORKDIR $SAGE_ROOT
 # We create a list of all files present in the artifact-base (with a timestamp
 # of now) so we can find out later which files were added/changed/removed.
 RUN find . \( -type f -or -type l \) > $HOME/artifact-base.manifest
-RUN git fetch "$HOME/sage-context" HEAD \
+RUN git fetch --update-shallow "$HOME/sage-context" HEAD \
     && if [ -e docker/.commit ]; then \
           git reset `cat docker/.commit` \
-          || ( echo "Could not find commit `cat docker/.commit` in your local Git history. Please merge in the latest built develop branch to fix this: git fetch trac && git merge `cat docker/.commit`." && exit 1 ) \
+          || ( echo "Could not find commit `cat docker/.commit` in your local Git history. Please merge in the latest built develop branch to fix this: git fetch upstream && git merge `cat docker/.commit`." && exit 1 ) \
        else \
           echo "You are building from $ARTIFACT_BASE which has no docker/.commit file. That's a bug unless you are building from source-clean or something similar." \
           && git reset FETCH_HEAD \
@@ -203,7 +204,7 @@ RUN make build
 ################################################################################
 # Image with a full build of sage and its documentation.                       #
 ################################################################################
-FROM make-build as make-all
+FROM $MAKE_BUILD as make-all
 # The docbuild needs quite some RAM (as of May 2018). It sometimes calls
 # os.fork() to spawn an external program which then exceeds easily the
 # overcommit limit of the system (no RAM is actually used, but this limit is


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

This PR implements a GitHub workflow which sould establish a continuation of the Docker images in the Sage Docker Hub repositories. Therefore, it aims to replace `$SAGE_ROOT/.gitlab-ci.yml` which has been used formerly for this purpose but isn't working any more (see [sage-devel-thread fom April 5th](https://groups.google.com/g/sage-devel/c/eJ_OicQXM8Y)).

The new worklfow uses the same `$SAGE_ROOT/docker/Dockerfile` as `SAGE_ROOT/.gitlab-ci.yml` and is based on [docker/build-push-action@v4](https://github.com/docker/build-push-action).

Concerning the images placed in the [sagemath-dev repository](https://hub.docker.com/r/sagemath/sagemath-dev) you should note the following difference to the releases built before 9.8: They are no longer build on target `sagemath-dev` since this causes a "No space left on device" error (see the [log-file](https://github.com/soehms/sage/actions/runs/5694284990) of a correspondig test run). Instead they are build on target `make-build`, now. I think the main difference is the missing build of documentation.

But, I don't know if this fits with the idea of this repository. If we really need target `sagemath-dev` then maybe something like the `free disk space` step of job `linux` in `.github/workflows/docker.yml` would help to get it run through. What about to just pull `ghcr.io/sagemath/sage/sage-ubuntu-jammy-standard-with-targets` and push it to `sagemath-dev` on Docker Hub. Please post here what you think would be the preferred way. Until this is not clearified I ommit setting the tags `develop` and `latest` in `sagemath-dev` (note that these tags still have ongoing pulls).

The workflow does not use [docker/metadata-action@v4](https://github.com/docker/metadata-action#latest-tag) as we need to distinguish between `latest` and `develop` tags in the Docker Hub repositories. Furthermore, if the workflow is triggered manually, this should result in the same tags as when triggered by pushing a new release tag (`metadata` would take the branch name).

The reason why the worklflow is split into two jobs is because the time limit of 6 hours per job was exeeded in a former test with just one job.

I've tested the new workflow in my fork repository using the `workflow_dispatch` (see the corresponding [log-file](https://github.com/soehms/sage/actions/runs/5795823327)). The resulting tags on Docker Hub are:


* [sagemath/sagemath:10.1.beta9](https://hub.docker.com/layers/sagemath/sagemath/10.1.beta9/images/sha256-4c00148d6e6c2134728b0a74d0e778281d64a8f0ff9b49ade0b9af68de758f12?context=repo)
* [sagemath/sagemath:develop](https://hub.docker.com/layers/sagemath/sagemath/develop/images/sha256-4c00148d6e6c2134728b0a74d0e778281d64a8f0ff9b49ade0b9af68de758f12?context=repo)
* [sagemath/sagemath-dev:10.1.beta9](https://hub.docker.com/layers/sagemath/sagemath-dev/10.1.beta9/images/sha256-d5071d0cb683edf9f22d19c2c26d5d580dc4e05823c755bfce85c744b557fd14?context=repo)

In order that this worked I had to set the secrets `secrets.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_TOKEN` in my fork of the GitHub repository. Thus, after this PR is merged a maintainer has to set this secrets on the upstream repository.
                                   

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
