### PR TITLE
Stop sorting Graph vertices and edges by default

### DIFF
--- a/src/sage/geometry/polyhedron/base4.py
+++ b/src/sage/geometry/polyhedron/base4.py
@@ -95,7 +95,7 @@ class Polyhedron_base4(Polyhedron_base3):
             sage: P = polytopes.cube()
             sage: G = P.vertex_facet_graph(); G
             Digraph on 14 vertices
-            sage: G.vertices(key = lambda v: str(v))
+            sage: G.vertices(sort=True, key=lambda v: str(v))
             [A vertex at (-1, -1, -1),
              A vertex at (-1, -1, 1),
              A vertex at (-1, 1, -1),

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -3614,7 +3614,8 @@ class DiGraph(GenericGraph):
 
         Using a different order for the edges of the graph::
 
-            sage: fl = G.flow_polytope(edges=G.edges(key=lambda x: x[0] - x[1])); fl    # needs sage.geometry.polyhedron
+            sage: ordered_edges = G.edges(sort=True, key=lambda x: x[0] - x[1])
+            sage: fl = G.flow_polytope(edges=ordered_edges); fl                         # needs sage.geometry.polyhedron
             A 1-dimensional polyhedron in QQ^4 defined as the convex hull of 2 vertices
             sage: fl.vertices()                                                         # needs sage.geometry.polyhedron
             (A vertex at (0, 1, 1, 0), A vertex at (1, 0, 0, 1))

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -11332,19 +11332,15 @@ class GenericGraph(GenericGraph_pyx):
         for u in self._backend.iterator_nbrs(vertex):
             yield u
 
-    def vertices(self, sort=None, key=None, degree=None, vertex_property=None):
+    def vertices(self, sort=False, key=None, degree=None, vertex_property=None):
         r"""
         Return a list of the vertices.
 
         INPUT:
 
-        - ``sort`` -- boolean (default: ``None``); if ``True``, vertices are
-          sorted according to the default ordering
-
-          As of :trac:`22349`, this argument must be explicitly
-          specified (unless a ``key`` is given); otherwise a warning
-          is printed and ``sort=True`` is used. The default will
-          eventually be changed to ``False``.
+        - ``sort`` -- boolean (default: ``False``); whether to sort vertices
+          according the ordering specified with parameter ``key``. If ``False``
+          (default), vertices are not sorted.
 
         - ``key`` -- a function (default: ``None``); a function that takes a
           vertex as its one argument and returns a value that can be used for
@@ -11432,20 +11428,7 @@ class GenericGraph(GenericGraph_pyx):
             Traceback (most recent call last):
             ...
             ValueError: sort keyword is False, yet a key function is given
-
-        Deprecation warning for ``sort=None`` (:trac:`22349`)::
-
-            sage: G = graphs.HouseGraph()
-            sage: G.vertices()
-            doctest:...: DeprecationWarning: parameter 'sort' will be set to False by default in the future
-            See https://github.com/sagemath/sage/issues/22349 for details.
-            [0, 1, 2, 3, 4]
         """
-        if sort is None:
-            if key is None:
-                deprecation(22349, "parameter 'sort' will be set to False by default in the future")
-            sort = True
-
         if (not sort) and key:
             raise ValueError('sort keyword is False, yet a key function is given')
 

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -439,7 +439,6 @@ from .dot2tex_utils import assert_have_dot2tex
 from sage.misc.decorators import options
 from sage.misc.cachefunc import cached_method
 from sage.misc.prandom import random
-from sage.misc.superseded import deprecation
 from sage.misc.lazy_import import lazy_import, LazyImport
 
 from sage.rings.integer_ring import ZZ

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -12371,7 +12371,7 @@ class GenericGraph(GenericGraph_pyx):
                     label = None
         return self._backend.has_edge(u, v, label)
 
-    def edges(self, vertices=None, labels=True, sort=None, key=None,
+    def edges(self, vertices=None, labels=True, sort=False, key=None,
               ignore_direction=False, sort_vertices=True):
         r"""
         Return a :class:`~EdgesView` of edges.
@@ -12395,13 +12395,10 @@ class GenericGraph(GenericGraph_pyx):
         - ``labels`` -- boolean (default: ``True``); if ``False``, each edge is
           simply a pair ``(u, v)`` of vertices
 
-        - ``sort`` -- boolean (default: ``None``); if ``True``, edges are sorted
-          according to the default ordering
-
-          As of :trac:`22349`, this argument must be explicitly
-          specified (unless a ``key`` is given); otherwise a warning
-          is printed and ``sort=True`` is used. The default will
-          eventually be changed to ``False``.
+        - ``sort`` -- boolean (default: ``False``); whether to sort edges
+          according the ordering specified with parameter ``key``. If ``False``
+          (default), edges are not sorted. This is the fastest and less memory
+          consuming method for iterating over edges.
 
         - ``key`` -- a function (default: ``None``); a function that takes an
           edge (a pair or a triple, according to the ``labels`` keyword) as its
@@ -12497,7 +12494,7 @@ class GenericGraph(GenericGraph_pyx):
             ....:   G.set_edge_label(e[0], e[1], chr(ord('A') + e[0] + 5 * e[1]))
             sage: G.edges(sort=True)
             [(0, 1, 'F'), (0, 4, 'U'), (1, 2, 'L'), (2, 3, 'R'), (3, 4, 'X')]
-            sage: G.edges(key=lambda x: x[2])
+            sage: G.edges(sort=True, key=lambda x: x[2])
             [(0, 1, 'F'), (1, 2, 'L'), (2, 3, 'R'), (0, 4, 'U'), (3, 4, 'X')]
 
         We can restrict considered edges to those incident to a given set::
@@ -12548,20 +12545,7 @@ class GenericGraph(GenericGraph_pyx):
             sage: G.edge_label(0, 1)[0] += 1
             sage: G.edges(sort=True)
             [(0, 1, [8]), (0, 2, [7])]
-
-        Deprecation warning for ``sort=None`` (:trac:`27408`)::
-
-            sage: G = graphs.HouseGraph()
-            sage: G.edges(sort=None)
-            doctest:...: DeprecationWarning: parameter 'sort' will be set to False by default in the future
-            See https://github.com/sagemath/sage/issues/27408 for details.
-            [(0, 1, None), (0, 2, None), (1, 3, None), (2, 3, None), (2, 4, None), (3, 4, None)]
         """
-        if sort is None:
-            if key is None:
-                deprecation(27408, "parameter 'sort' will be set to False by default in the future")
-            sort = True
-
         if vertices is not None and vertices in self:
             vertices = [vertices]
 

--- a/src/sage/graphs/views.pyx
+++ b/src/sage/graphs/views.pyx
@@ -64,18 +64,10 @@ cdef class EdgesView:
     - ``ignore_direction`` -- boolean (default: ``False``); only applies to
       directed graphs. If ``True``, searches across edges in either direction.
 
-    - ``sort`` -- boolean (default: ``None``); whether to sort edges
-
-      - if ``None``, sort edges according to the default ordering and give a
-        deprecation warning as sorting will be set to ``False`` by default in
-        the future
-
-      - if ``True``, edges are sorted according the ordering specified with
-        parameter ``key``
-
-      - if ``False``, edges are not sorted. This is the fastest and less memory
-        consuming method for iterating over edges. This will become the default
-        behavior in the future.
+    - ``sort`` -- boolean (default: ``False``); whether to sort edges according
+      the ordering specified with parameter ``key``. If ``False`` (default),
+      edges are not sorted. This is the fastest and less memory consuming method
+      for iterating over edges.
 
     - ``key`` -- a function (default: ``None``); a function that takes an edge
       (a pair or a triple, according to the ``labels`` keyword) as its one
@@ -350,7 +342,7 @@ cdef class EdgesView:
 
     def __init__(self, G, vertices=None, vertices2=None, labels=True,
                  ignore_direction=False,
-                 sort=None, key=None, sort_vertices=True):
+                 sort=False, key=None, sort_vertices=True):
         """
         Construction of this :class:`EdgesView`.
 

--- a/src/sage/manifolds/subset.py
+++ b/src/sage/manifolds/subset.py
@@ -901,7 +901,7 @@ class ManifoldSubset(UniqueRepresentation, Parent):
             sage: U = M.open_subset('U'); V = M.open_subset('V'); W = M.open_subset('W')
             sage: D = M.subset_digraph(); D
             Digraph on 4 vertices
-            sage: D.edges(key=lambda e: (e[0]._name, e[1]._name))
+            sage: D.edges(sort=True, key=lambda e: (e[0]._name, e[1]._name))
             [(Set {U} of open subsets of the 3-dimensional differentiable manifold M,
               Set {M} of open subsets of the 3-dimensional differentiable manifold M,
               None),


### PR DESCRIPTION
Following #22349 and #27408, we finally set parameter `sort` to `False` by default for methods `vertices` and `edges`, and remove the corresponding deprecation warnings.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
