### PR TITLE
Remove deprecation warnings renaming parameter verbosity to verbose in graphs

### DIFF
--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -45,7 +45,6 @@ import itertools
 from .generic_graph import GenericGraph
 from .graph import Graph
 from sage.rings.integer import Integer
-from sage.misc.decorators import rename_keyword
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_import import lazy_import
 
@@ -2226,7 +2225,6 @@ class BipartiteGraph(Graph):
             raise ValueError('algorithm must be "Hopcroft-Karp", '
                              '"Eppstein", "Edmonds" or "LP"')
 
-    @rename_keyword(deprecation=32238, verbosity='verbose')
     def vertex_cover(self, algorithm="Konig", value_only=False,
                      reduction_rules=True, solver=None, verbose=0,
                      *, integrality_tolerance=1e-3):

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -432,8 +432,6 @@ from sage.features import PythonModule
 lazy_import('sage.graphs.mcqd', ['mcqd'],
             feature=PythonModule('sage.graphs.mcqd', spkg='mcqd'))
 
-from sage.misc.decorators import rename_keyword
-
 
 class Graph(GenericGraph):
     r"""
@@ -6904,7 +6902,6 @@ class Graph(GenericGraph):
         return BipartiteGraph(networkx.make_clique_bipartite(self.networkx_graph(), **kwds))
 
     @doc_index("Algorithmically hard stuff")
-    @rename_keyword(deprecation=32238, verbosity='verbose')
     def independent_set(self, algorithm="Cliquer", value_only=False, reduction_rules=True,
                         solver=None, verbose=0, *, integrality_tolerance=1e-3):
         r"""
@@ -6999,7 +6996,6 @@ class Graph(GenericGraph):
             return [u for u in self if u not in my_cover]
 
     @doc_index("Algorithmically hard stuff")
-    @rename_keyword(deprecation=32238, verbosity='verbose')
     def vertex_cover(self, algorithm="Cliquer", value_only=False,
                      reduction_rules=True, solver=None, verbose=0,
                      *, integrality_tolerance=1e-3):

--- a/src/sage/graphs/graph_decompositions/vertex_separation.pyx
+++ b/src/sage/graphs/graph_decompositions/vertex_separation.pyx
@@ -271,7 +271,6 @@ from sage.graphs.graph_decompositions.fast_digraph cimport FastDigraph, compute_
 from libc.stdint cimport uint8_t
 from sage.data_structures.binary_matrix cimport *
 from sage.graphs.base.static_dense_graph cimport dense_graph_init
-from sage.misc.decorators import rename_keyword
 
 
 ###############
@@ -1377,7 +1376,6 @@ def _vertex_separation_MILP_formulation(G, integrality=False, solver=None):
     return p, x, u, y, z
 
 
-@rename_keyword(deprecation=32222, verbosity='verbose')
 def vertex_separation_MILP(G, integrality=False, solver=None, verbose=0,
                            *, integrality_tolerance=1e-3):
     r"""


### PR DESCRIPTION
We remove the warnings introduced in #32222 and #32238 about the renaming of parameter `verbosity` to `verbose`.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
