### PR TITLE
Remove deprecated parameter circular from method `is_planar`

### DIFF
--- a/src/sage/graphs/planarity.pyx
+++ b/src/sage/graphs/planarity.pyx
@@ -30,7 +30,7 @@ cdef extern from "planarity/graph.h":
     cdef int gp_SortVertices(graphP theGraph)
 
 
-def is_planar(g, kuratowski=False, set_pos=False, set_embedding=False, circular=None):
+def is_planar(g, kuratowski=False, set_pos=False, set_embedding=False):
     r"""
     Check whether ``g`` is planar using Boyer's planarity algorithm.
 
@@ -54,8 +54,6 @@ def is_planar(g, kuratowski=False, set_pos=False, set_embedding=False, circular=
     - ``set_embedding`` -- boolean (default: ``False``); whether to record the
       combinatorial embedding returned (see
       :meth:`~sage.graphs.generic_graph.GenericGraph.get_embedding`)
-
-    - ``circular`` -- deprecated argument
 
     EXAMPLES::
 
@@ -98,10 +96,6 @@ def is_planar(g, kuratowski=False, set_pos=False, set_embedding=False, circular=
             ....:     assert (hasattr(G, '_pos') and G._pos is not None) == set_pos, (set_embedding, set_pos)
 
     """
-    if circular is not None:
-        from sage.misc.superseded import deprecation
-        deprecation(33759, 'the circular argument of is_planar is deprecated and has no effect')
-
     if set_pos and not g.is_connected():
         raise ValueError("is_planar() cannot set vertex positions for a disconnected graph")
 


### PR DESCRIPTION
Remove deprecated parameter `circular` from method `is_planar`. The deprecation was introduced in #33759.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
