### PR TITLE
`sage.graphs`: fix doctest warnings due to modularization

### DIFF
--- a/src/sage/graphs/base/static_sparse_graph.pyx
+++ b/src/sage/graphs/base/static_sparse_graph.pyx
@@ -1032,15 +1032,16 @@ def spectral_radius(G, prec=1e-10):
 
     A larger example::
 
+        sage: # needs sage.modules
         sage: G = DiGraph()
         sage: G.add_edges((i,i+1) for i in range(200))
         sage: G.add_edge(200,0)
         sage: G.add_edge(1,0)
         sage: e_min, e_max = spectral_radius(G, 0.00001)
-        sage: p = G.adjacency_matrix(sparse=True).charpoly()                            # needs sage.modules
-        sage: p                                                                         # needs sage.modules
+        sage: p = G.adjacency_matrix(sparse=True).charpoly()
+        sage: p
         x^201 - x^199 - 1
-        sage: r = p.roots(AA, multiplicities=False)[0]                                  # needs sage.modules
+        sage: r = p.roots(AA, multiplicities=False)[0]
         sage: e_min < r < e_max
         True
 

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -1755,8 +1755,8 @@ def _line_graph_generalised_polygon(H):
     EXAMPLES::
 
         sage: # needs sage.libs.gap
-        sage: from sage.graphs.generators.distance_regular import \
-        ....: _line_graph_generalised_polygon
+        sage: from sage.graphs.generators.distance_regular import (
+        ....:     _line_graph_generalised_polygon)
         sage: G = graphs.GeneralisedHexagonGraph(1, 8)
         sage: H = _line_graph_generalised_polygon(G)
         sage: H.is_distance_regular(True)

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -3940,9 +3940,9 @@ def MathonPseudocyclicStronglyRegularGraph(t, G=None, L=None):
         sage: # needs sage.modules sage.rings.finite_rings
         sage: G.relabel(range(9))
         sage: G3x3 = graphs.MathonPseudocyclicStronglyRegularGraph(2, G=G, L=L)         # needs sage.groups sage.libs.gap
-        sage: G3x3.is_strongly_regular(parameters=True)
+        sage: G3x3.is_strongly_regular(parameters=True)                                 # needs sage.groups sage.libs.gap
         (441, 220, 109, 110)
-        sage: G3x3.automorphism_group(algorithm="bliss").order()        # optional - bliss
+        sage: G3x3.automorphism_group(algorithm="bliss").order()  # optional - bliss    # needs sage.groups sage.libs.gap
         27
         sage: G9 = graphs.MathonPseudocyclicStronglyRegularGraph(2)
         sage: G9.is_strongly_regular(parameters=True)

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -3937,12 +3937,12 @@ def MathonPseudocyclicStronglyRegularGraph(t, G=None, L=None):
         [-4 -3 -2  2  3  4 -1  0  1]
         [-2 -4 -3  4  2  3  1 -1  0]
 
-        sage: # needs sage.modules sage.rings.finite_rings
+        sage: # needs sage.modules sage.rings.finite_rings sage.groups sage.libs.gap
         sage: G.relabel(range(9))
-        sage: G3x3 = graphs.MathonPseudocyclicStronglyRegularGraph(2, G=G, L=L)         # needs sage.groups sage.libs.gap
-        sage: G3x3.is_strongly_regular(parameters=True)                                 # needs sage.groups sage.libs.gap
+        sage: G3x3 = graphs.MathonPseudocyclicStronglyRegularGraph(2, G=G, L=L)
+        sage: G3x3.is_strongly_regular(parameters=True)
         (441, 220, 109, 110)
-        sage: G3x3.automorphism_group(algorithm="bliss").order()  # optional - bliss    # needs sage.groups sage.libs.gap
+        sage: G3x3.automorphism_group(algorithm="bliss").order()  # optional - bliss
         27
         sage: G9 = graphs.MathonPseudocyclicStronglyRegularGraph(2)
         sage: G9.is_strongly_regular(parameters=True)

--- a/src/sage/graphs/graph_decompositions/tdlib.pyx
+++ b/src/sage/graphs/graph_decompositions/tdlib.pyx
@@ -125,10 +125,11 @@ def treedecomposition_exact(G, lb=-1):
 
     EXAMPLES::
 
-        sage: import sage.graphs.graph_decompositions.tdlib as tdlib # optional - tdlib
-        sage: G = graphs.HouseGraph()                                # optional - tdlib
-        sage: T = tdlib.treedecomposition_exact(G)                   # optional - tdlib
-        sage: T.show(vertex_size=2000)                               # optional - tdlib
+        sage: # optional - tdlib
+        sage: import sage.graphs.graph_decompositions.tdlib as tdlib
+        sage: G = graphs.HouseGraph()
+        sage: T = tdlib.treedecomposition_exact(G)
+        sage: T.show(vertex_size=2000)
 
     TESTS::
 
@@ -176,10 +177,11 @@ def get_width(T):
 
     EXAMPLES::
 
-        sage: import sage.graphs.graph_decompositions.tdlib as tdlib # optional - tdlib
-        sage: G = graphs.PetersenGraph()                             # optional - tdlib
-        sage: T = tdlib.treedecomposition_exact(G)                   # optional - tdlib
-        sage: tdlib.get_width(T)                                     # optional - tdlib
+        sage: # optional - tdlib
+        sage: import sage.graphs.graph_decompositions.tdlib as tdlib
+        sage: G = graphs.PetersenGraph()
+        sage: T = tdlib.treedecomposition_exact(G)
+        sage: tdlib.get_width(T)
         4
     """
     return (max(len(x) for x in T) - 1) if T else -1


### PR DESCRIPTION
Part of : #29705

We fix the following doctest warnings due to the modularization.

```
sage -t --warn-long 17.6 --random-seed=165655739949225352692057073882229651510 src/sage/graphs/generators/distance_regular.pyx
**********************************************************************
File "src/sage/graphs/generators/distance_regular.pyx", line 1761, in sage.graphs.generators.distance_regular._line_graph_generalised_polygon
Warning: Variable '_line_graph_generalised_polygon' referenced here was set only in doctest marked '# needs sage.libs.gap'
    H = _line_graph_generalised_polygon(G)
    [181 tests, 7.59 s]
```

```
sage -t --warn-long 17.6 --random-seed=165655739949225352692057073882229651510 src/sage/graphs/generators/families.py
**********************************************************************
File "src/sage/graphs/generators/families.py", line 3943, in sage.graphs.generators.families.MathonPseudocyclicStronglyRegularGraph
Warning: Variable 'G3x3' referenced here was set only in doctest marked '# needs sage.groups sage.libs.gap sage.modules sage.rings.finite_rings'
    G3x3.is_strongly_regular(parameters=True)
**********************************************************************
File "src/sage/graphs/generators/families.py", line 3945, in sage.graphs.generators.families.MathonPseudocyclicStronglyRegularGraph
Warning: Variable 'G3x3' referenced here was set only in doctest marked '# needs sage.groups sage.libs.gap sage.modules sage.rings.finite_rings'
    G3x3.automorphism_group(algorithm="bliss").order()        # optional - bliss
    [449 tests, 4.75 s]
```

```
sage -t --warn-long 17.6 --random-seed=165655739949225352692057073882229651510 src/sage/graphs/graph_decompositions/tdlib.pyx
**********************************************************************
File "src/sage/graphs/graph_decompositions/tdlib.pyx", line 128, in sage.graphs.graph_decompositions.tdlib.treedecomposition_exact
Warning: Consider using a block-scoped tag by inserting the line 'sage: # optional - tdlib' just before this line to avoid repeating the tag 4 times
    import sage.graphs.graph_decompositions.tdlib as tdlib # optional - tdlib
**********************************************************************
File "src/sage/graphs/graph_decompositions/tdlib.pyx", line 179, in sage.graphs.graph_decompositions.tdlib.get_width
Warning: Consider using a block-scoped tag by inserting the line 'sage: # optional - tdlib' just before this line to avoid repeating the tag 4 times
    import sage.graphs.graph_decompositions.tdlib as tdlib # optional - tdlib
    [13 tests, 0.60 s]
```

```
sage -t --warn-long 17.6 --random-seed=165655739949225352692057073882229651510 src/sage/graphs/base/static_sparse_graph.pyx
**********************************************************************
File "src/sage/graphs/base/static_sparse_graph.pyx", line 1044, in sage.graphs.base.static_sparse_graph.spectral_radius
Warning: Variable 'r' referenced here was set only in doctest marked '# needs sage.modules'
    e_min < r < e_max
    [66 tests, 2.16 s]
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
