### PR TITLE
`sage.geometry.polyhedron`: fix doctest error due to modularization

### DIFF
--- a/src/sage/geometry/polyhedron/base_ZZ.py
+++ b/src/sage/geometry/polyhedron/base_ZZ.py
@@ -414,6 +414,7 @@ class Polyhedron_ZZ(Polyhedron_QQ):
             t^6 + 6*t^5 + 15*t^4 + 20*t^3 + 15*t^2 + 6*t + 1
 
             sage: # optional - pynormaliz
+            sage: from itertools import product
             sage: def hypercube(d):
             ....:     return Polyhedron(vertices=list(product([0,1],repeat=d)),backend='normaliz')
             sage: hypercube(3).ehrhart_polynomial(engine='normaliz')


### PR DESCRIPTION
On MacOS with sagemath 10.1.rc0, I have the following doctest error in `src/sage/geometry/polyhedron/base_ZZ.py`

```
sage -t --long --warn-long 18.5 --random-seed=240228246560107174999702016603267109757 src/sage/geometry/polyhedron/base_ZZ.py
**********************************************************************
File "src/sage/geometry/polyhedron/base_ZZ.py", line 419, in sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?
Failed example:
    hypercube(3).ehrhart_polynomial(engine='normaliz')
Exception raised:
    Traceback (most recent call last):
      File "/Users/dcoudert/sage/src/sage/doctest/forker.py", line 709, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/Users/dcoudert/sage/src/sage/doctest/forker.py", line 1144, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?[9]>", line 1, in <module>
        hypercube(Integer(3)).ehrhart_polynomial(engine='normaliz')
        ^^^^^^^^^^^^^^^^^^^^^
      File "<doctest sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?[8]>", line 2, in hypercube
        return Polyhedron(vertices=list(product([Integer(0),Integer(1)],repeat=d)),backend='normaliz')
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: 'sage.rings.integer.Integer' object is not iterable
**********************************************************************
File "src/sage/geometry/polyhedron/base_ZZ.py", line 421, in sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?
Failed example:
    hypercube(4).ehrhart_polynomial(engine='normaliz')
Exception raised:
    Traceback (most recent call last):
      File "/Users/dcoudert/sage/src/sage/doctest/forker.py", line 709, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/Users/dcoudert/sage/src/sage/doctest/forker.py", line 1144, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?[10]>", line 1, in <module>
        hypercube(Integer(4)).ehrhart_polynomial(engine='normaliz')
        ^^^^^^^^^^^^^^^^^^^^^
      File "<doctest sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?[8]>", line 2, in hypercube
        return Polyhedron(vertices=list(product([Integer(0),Integer(1)],repeat=d)),backend='normaliz')
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: 'sage.rings.integer.Integer' object is not iterable
**********************************************************************
File "src/sage/geometry/polyhedron/base_ZZ.py", line 423, in sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?
Failed example:
    hypercube(5).ehrhart_polynomial(engine='normaliz')
Exception raised:
    Traceback (most recent call last):
      File "/Users/dcoudert/sage/src/sage/doctest/forker.py", line 709, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/Users/dcoudert/sage/src/sage/doctest/forker.py", line 1144, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?[11]>", line 1, in <module>
        hypercube(Integer(5)).ehrhart_polynomial(engine='normaliz')
        ^^^^^^^^^^^^^^^^^^^^^
      File "<doctest sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?[8]>", line 2, in hypercube
        return Polyhedron(vertices=list(product([Integer(0),Integer(1)],repeat=d)),backend='normaliz')
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: 'sage.rings.integer.Integer' object is not iterable
**********************************************************************
File "src/sage/geometry/polyhedron/base_ZZ.py", line 425, in sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?
Failed example:
    hypercube(6).ehrhart_polynomial(engine='normaliz')
Exception raised:
    Traceback (most recent call last):
      File "/Users/dcoudert/sage/src/sage/doctest/forker.py", line 709, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/Users/dcoudert/sage/src/sage/doctest/forker.py", line 1144, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?[12]>", line 1, in <module>
        hypercube(Integer(6)).ehrhart_polynomial(engine='normaliz')
        ^^^^^^^^^^^^^^^^^^^^^
      File "<doctest sage.geometry.polyhedron.base_ZZ.Polyhedron_ZZ.?[8]>", line 2, in hypercube
        return Polyhedron(vertices=list(product([Integer(0),Integer(1)],repeat=d)),backend='normaliz')
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: 'sage.rings.integer.Integer' object is not iterable
```

This is caused by the `from itertools import product` in a block starting with `# optional - latte_int`. Apparently I don't have `latte_int` installed, and so this import is not done when starting the block with `pynormaliz` (I have it). So the fix is trivial.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
