### PR TITLE
Height function for projective subvarieties

### DIFF
--- a/src/sage/schemes/projective/projective_subscheme.py
+++ b/src/sage/schemes/projective/projective_subscheme.py
@@ -1410,10 +1410,12 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
         Return the (projective) global height of the subscheme.
 
         INPUT:
+
         - ``prec`` -- desired floating point precision (default:
           default RealField precision).
 
         OUTPUT:
+
         - a real number.
 
         EXAMPLES::
@@ -1439,11 +1441,14 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
         Return the (projective) local height of the subscheme.
 
         INPUT:
+
         - ``v`` -- a prime or prime ideal of the base ring.
+
         - ``prec`` -- desired floating point precision (default:
           default RealField precision).
 
         OUTPUT:
+
         - a real number.
 
         EXAMPLES::
@@ -1470,11 +1475,14 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
         Return the local height at the ``i``-th infinite place of the subscheme.
 
         INPUT:
+
         - ``i`` -- an integer.
+
         - ``prec`` -- desired floating point precision (default:
           default RealField precision).
 
         OUTPUT:
+
         - a real number.
 
         EXAMPLES::

--- a/src/sage/schemes/projective/projective_subscheme.py
+++ b/src/sage/schemes/projective/projective_subscheme.py
@@ -1404,3 +1404,81 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
         rel2 = rel + [CF]
         assert all(f in rel2 for f in CH.gens()), "did not find a principal generator"
         return alp(CF)
+
+    def global_height(self, prec=None):
+        """
+        Return the (projective) global height of the subscheme.
+        INPUT:
+        - ``prec`` -- desired floating point precision (default:
+          default RealField precision).
+        OUTPUT:
+        - a real number.
+        EXAMPLES::
+            sage: R.<x> = QQ[]
+            sage: NF.<a> = NumberField(x^2 - 5)
+            sage: P.<x,y,z> = ProjectiveSpace(NF, 2)
+            sage: X = P.subscheme([x^2 + y*z, 2*y*z, 3*x*y])
+            sage: X.global_height()
+            0.000000000000000
+
+        ::
+
+            sage: P.<x,y,z> = ProjectiveSpace(QQ, 2)
+            sage: X = P.subscheme([z^2 - 101*y^2 - 3*x*z])
+            sage: X.global_height() # long time
+            4.61512051684126
+        """
+        return self.Chow_form().global_height(prec)
+
+    def local_height(self, v, prec=None):
+        """
+        Return the (projective) local height of the subscheme.
+        INPUT:
+        - ``v`` -- a prime or prime ideal of the base ring.
+        - ``prec`` -- desired floating point precision (default:
+          default RealField precision).
+        OUTPUT:
+        - a real number.
+        EXAMPLES::
+            sage: R.<x> = QQ[]
+            sage: NF.<a> = NumberField(x^2 - 5)
+            sage: I = NF.ideal(3)
+            sage: P.<x,y,z> = ProjectiveSpace(NF, 2)
+            sage: X = P.subscheme([3*x*y - 5*x*z, y^2])
+            sage: X.local_height(I)
+            0.000000000000000
+
+        ::
+
+            sage: P.<x,y,z> = ProjectiveSpace(QQ, 2)
+            sage: X = P.subscheme([z^2 - 101*y^2 - 3*x*z])
+            sage: X.local_height(2)
+            0.000000000000000
+        """
+        return self.Chow_form().local_height(v, prec)
+
+    def local_height_arch(self, i, prec=None):
+        """
+        Return the local height at the ``i``-th infinite place of the subscheme.
+        INPUT:
+        - ``i`` -- an integer.
+        - ``prec`` -- desired floating point precision (default:
+          default RealField precision).
+        OUTPUT:
+        - a real number.
+        EXAMPLES::
+            sage: R.<x> = QQ[]
+            sage: NF.<a> = NumberField(x^2 - 5)
+            sage: P.<x,y,z> = ProjectiveSpace(NF, 2)
+            sage: X = P.subscheme([x^2 + y*z, 3*x*y])
+            sage: X.local_height_arch(1)
+            0.0000000000000000000000000000000
+
+        ::
+
+            sage: P.<x,y,z> = ProjectiveSpace(QQ, 2)
+            sage: X = P.subscheme([z^2 - 101*y^2 - 3*x*z])
+            sage: X.local_height_arch(1)
+            4.61512051684126
+        """
+        return self.Chow_form().local_height_arch(i, prec)

--- a/src/sage/schemes/projective/projective_subscheme.py
+++ b/src/sage/schemes/projective/projective_subscheme.py
@@ -1412,7 +1412,7 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
         INPUT:
 
         - ``prec`` -- desired floating point precision (default:
-          default RealField precision).
+          default ``RealField`` precision).
 
         OUTPUT:
 
@@ -1445,7 +1445,7 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
         - ``v`` -- a prime or prime ideal of the base ring.
 
         - ``prec`` -- desired floating point precision (default:
-          default RealField precision).
+          default ``RealField`` precision).
 
         OUTPUT:
 
@@ -1479,7 +1479,7 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
         - ``i`` -- an integer.
 
         - ``prec`` -- desired floating point precision (default:
-          default RealField precision).
+          default ``RealField`` precision).
 
         OUTPUT:
 

--- a/src/sage/schemes/projective/projective_subscheme.py
+++ b/src/sage/schemes/projective/projective_subscheme.py
@@ -1408,12 +1408,16 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
     def global_height(self, prec=None):
         """
         Return the (projective) global height of the subscheme.
+
         INPUT:
         - ``prec`` -- desired floating point precision (default:
           default RealField precision).
+
         OUTPUT:
         - a real number.
+
         EXAMPLES::
+
             sage: R.<x> = QQ[]
             sage: NF.<a> = NumberField(x^2 - 5)
             sage: P.<x,y,z> = ProjectiveSpace(NF, 2)
@@ -1433,13 +1437,17 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
     def local_height(self, v, prec=None):
         """
         Return the (projective) local height of the subscheme.
+
         INPUT:
         - ``v`` -- a prime or prime ideal of the base ring.
         - ``prec`` -- desired floating point precision (default:
           default RealField precision).
+
         OUTPUT:
         - a real number.
+
         EXAMPLES::
+
             sage: R.<x> = QQ[]
             sage: NF.<a> = NumberField(x^2 - 5)
             sage: I = NF.ideal(3)
@@ -1460,13 +1468,17 @@ class AlgebraicScheme_subscheme_projective_field(AlgebraicScheme_subscheme_proje
     def local_height_arch(self, i, prec=None):
         """
         Return the local height at the ``i``-th infinite place of the subscheme.
+
         INPUT:
         - ``i`` -- an integer.
         - ``prec`` -- desired floating point precision (default:
           default RealField precision).
+
         OUTPUT:
         - a real number.
+
         EXAMPLES::
+
             sage: R.<x> = QQ[]
             sage: NF.<a> = NumberField(x^2 - 5)
             sage: P.<x,y,z> = ProjectiveSpace(NF, 2)


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
--> Introduces three new methods related to height of projective subvarieties.
<!-- Describe your changes here in detail -->
Direct transfer from #34559. Methods implemented: local_height, local_height_arch, global_height.
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->Fixes #34559 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] Someone else has created tests covering the changes.
- [x] Someone else has updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
