### PR TITLE
Fix doctest in `src/sage/algebras/quantum_groups/quantum_group_gap.py`

### DIFF
--- a/src/sage/algebras/quantum_groups/quantum_group_gap.py
+++ b/src/sage/algebras/quantum_groups/quantum_group_gap.py
@@ -1579,7 +1579,7 @@ class QuantumGroupModule(Parent, UniqueRepresentation):
             sage: T = tensor([V,V])
             sage: S = T.highest_weight_decomposition()[0]
             sage: latex(S)
-            \begin{tikzpicture}
+            \begin{tikzpicture}...
             ...
             \end{tikzpicture}
         """


### PR DESCRIPTION
We fix the following doctest reported on [sage-release](https://groups.google.com/g/sage-release/c/achheVoUbrY/m/MZr7VNnpFgAJ)
```
sage -t --long --warn-long 216.1 --random-seed=336915508420415526544989948662812522502 src/sage/algebras/quantum_groups/quantum_group_gap.py
**********************************************************************
File "src/sage/algebras/quantum_groups/quantum_group_gap.py", line 1581, in sage.algebras.quantum_groups.quantum_group_gap.QuantumGroupModule._latex_
Failed example:
    latex(S)
Expected:
    \begin{tikzpicture}
    ...
    \end{tikzpicture}
Got:
    \begin{tikzpicture}[>=latex,line join=bevel,]
    %%
    \node (node_0) at (144.52bp,292.63bp) [draw,draw=none] {$\langle 1 {(1 v_0 \otimes 1 v_0)} \rangle$};
      \node (node_1) at (144.52bp,221.71bp) [draw,draw=none] {$\langle 1 {(1 v_0 \otimes F[a1] v_0)} + q^{-1} {(F[a1] v_0 \otimes 1 v_0)} \rangle$};
      \node (node_2) at (52.519bp,150.47bp) [draw,draw=none] {$\langle 1 {(F[a1] v_0 \otimes F[a1] v_0)} \rangle$};
      \node (node_3) at (236.52bp,150.47bp) [draw,draw=none] {$\langle 1 {(1 v_0 \otimes F[a1+a2] v_0)} + q^{-1} {(F[a1+a2] v_0 \otimes 1 v_0)} \rangle$};
      \node (node_4) at (144.52bp,79.224bp) [draw,draw=none] {$\langle 1 {(F[a1] v_0 \otimes F[a1+a2] v_0)} + q^{-1} {(F[a1+a2] v_0 \otimes F[a1] v_0)} \rangle$};
      \node (node_5) at (144.52bp,8.3018bp) [draw,draw=none] {$\langle 1 {(F[a1+a2] v_0 \otimes F[a1+a2] v_0)} \rangle$};
      \draw [blue,->] (node_0) ..controls (144.52bp,274.4bp) and (144.52bp,255.54bp)  .. (node_1);
      \definecolor{strokecol}{rgb}{0.0,0.0,0.0};
      \pgfsetstrokecolor{strokecol}
      \draw (153.02bp,257.33bp) node {$1$};
      \draw [blue,->] (node_1) ..controls (119.45bp,201.84bp) and (89.94bp,179.63bp)  .. (node_2);
      \draw (118.02bp,186.09bp) node {$1$};
      \draw [red,->] (node_1) ..controls (169.43bp,201.96bp) and (198.49bp,180.09bp)  .. (node_3);
      \draw (209.02bp,186.09bp) node {$2$};
      \draw [red,->] (node_2) ..controls (77.09bp,130.97bp) and (106.75bp,108.65bp)  .. (node_4);
      \draw (118.02bp,114.85bp) node {$2$};
      \draw [blue,->] (node_3) ..controls (211.6bp,130.71bp) and (182.55bp,108.85bp)  .. (node_4);
      \draw (209.02bp,114.85bp) node {$1$};
      \draw [red,->] (node_4) ..controls (144.52bp,60.535bp) and (144.52bp,41.477bp)  .. (node_5);
      \draw (153.02bp,43.604bp) node {$2$};
    %
    \end{tikzpicture}
**********************************************************************
1 item had failures:
   1 of   6 in sage.algebras.quantum_groups.quantum_group_gap.QuantumGroupModule._latex_
    [537 tests, 1 failure, 9.28 s]
----------------------------------------------------------------------
sage -t --long --warn-long 216.1 --random-seed=336915508420415526544989948662812522502 src/sage/algebras/quantum_groups/quantum_group_gap.py  # 1 doctest failed
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
