### PR TITLE
Fixed two linter errors for dynamical semigroups

### DIFF
--- a/src/sage/dynamics/arithmetic_dynamics/dynamical_semigroup.py
+++ b/src/sage/dynamics/arithmetic_dynamics/dynamical_semigroup.py
@@ -961,7 +961,7 @@ class DynamicalSemigroup(Parent, metaclass=InheritComparisonClasscallMetaclass):
             ValueError: left dynamical semigroup's domain must equal right dynamical semigroup's codomain
 
         """
-        if type(self) != type(other_dynamical_semigroup):
+        if not isinstance(self, type(other_dynamical_semigroup)):
             raise TypeError("can only multiply dynamical semigroups with other dynamical semigroups of the same type")
         if self.domain() != other_dynamical_semigroup.codomain():
             raise ValueError("left dynamical semigroup's domain must equal right dynamical semigroup's codomain")

--- a/src/sage/dynamics/arithmetic_dynamics/dynamical_semigroup.py
+++ b/src/sage/dynamics/arithmetic_dynamics/dynamical_semigroup.py
@@ -982,7 +982,7 @@ class DynamicalSemigroup(Parent, metaclass=InheritComparisonClasscallMetaclass):
 
         OUTPUT: :class:`DynamicalSemigroup`
 
-        EXAMPLES:
+        EXAMPLES::
 
             sage: A.<x> = AffineSpace(QQ, 1)
             sage: f = DynamicalSystem(x^2, A)


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
--> Resolves two linter errors
<!-- Describe your changes here in detail -->
1. Fixes type comparison by using `isinstance()`
2. Fixes doc string formatting error
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". --> 
Fixes two linter issues originating from #35988 
This is part of issue #35954 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->
- #35988: origin of linter errors
- #35947: dependency of #35988 

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
