### PR TITLE
Fix the ascii art for the Heisenberg Lie algebras

### DIFF
--- a/src/sage/algebras/lie_algebras/heisenberg.py
+++ b/src/sage/algebras/lie_algebras/heisenberg.py
@@ -122,6 +122,21 @@ class HeisenbergAlgebra_abstract(IndexedGenerators):
         """
         return m
 
+    def _ascii_art_term(self, m):
+        r"""
+        Return a string representation of the term indexed by ``m``.
+
+        EXAMPLES::
+
+            sage: H = lie_algebras.Heisenberg(QQ, 3)
+            sage: H._ascii_art_term('p1')
+            p1
+            sage: H._ascii_art_term('z')
+            z
+        """
+        from sage.typeset.ascii_art import ascii_art
+        return ascii_art(m)
+
     def _latex_term(self, m):
         r"""
         Return a string representation of the term indexed by ``m``.

--- a/src/sage/algebras/lie_algebras/heisenberg.py
+++ b/src/sage/algebras/lie_algebras/heisenberg.py
@@ -133,6 +133,8 @@ class HeisenbergAlgebra_abstract(IndexedGenerators):
             p1
             sage: H._ascii_art_term('z')
             z
+            sage: ascii_art(sum(i * b for i, b in enumerate(H.basis())))
+            p2 + 2*p3 + 3*q1 + 4*q2 + 5*q3 + 6*z
         """
         from sage.typeset.ascii_art import ascii_art
         return ascii_art(m)


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

Applying `ascii_art(x)` to any element of the finite-dimensional Heisenberg algebra raises an error due to a missing method `_ascii_art_term`. We implement this.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
