### PR TITLE
Fix quadratic memory of berlekamp_massey

### DIFF
--- a/src/sage/matrix/berlekamp_massey.py
+++ b/src/sage/matrix/berlekamp_massey.py
@@ -87,12 +87,9 @@ def berlekamp_massey(a):
     R = K['x']
     x = R.gen()
 
-    f = {-1: R(a), 0: x**(2 * M)}
-    s = {-1: 1, 0: 0}
-    j = 0
-    while f[j].degree() >= M:
-        j += 1
-        qj, f[j] = f[j - 2].quo_rem(f[j - 1])
-        s[j] = s[j - 2] - qj * s[j - 1]
-    t = s[j].reverse()
-    return ~(t[t.degree()]) * t  # make monic  (~ is inverse in python)
+    f0, f1 = R(a), x**(2 * M)
+    s0, s1 = 1, 0
+    while f1.degree() >= M:
+        f0, (qj, f1) = f1, f0.quo_rem(f1)
+        s0, s1 = s1, s0 - qj * s1
+    return s1.reverse().monic()

--- a/src/sage/matrix/berlekamp_massey.py
+++ b/src/sage/matrix/berlekamp_massey.py
@@ -72,6 +72,12 @@ def berlekamp_massey(a):
         Traceback (most recent call last):
         ...
         ValueError: argument must have an even number of terms
+
+    Check that :issue:`36172` is fixed::
+
+        sage: p = next_prime(2**64)
+        sage: ls = [GF(p).random_element() for _ in range(2000)]
+        sage: _ = berlekamp_massey(ls)
     """
     if not isinstance(a, (list, tuple)):
         raise TypeError("argument must be a list or tuple")
@@ -84,9 +90,8 @@ def berlekamp_massey(a):
         K = a[0].parent().fraction_field()
     except AttributeError:
         K = sage.rings.rational_field.RationalField()
-    R = K['x']
-    x = R.gen()
 
+    R, x = K['x'].objgen()
     f0, f1 = R(a), x**(2 * M)
     s0, s1 = 1, 0
     while f1.degree() >= M:

--- a/src/sage/matrix/berlekamp_massey.py
+++ b/src/sage/matrix/berlekamp_massey.py
@@ -89,6 +89,6 @@ def berlekamp_massey(a):
     f0, f1 = R(a), x**(2 * M)
     s0, s1 = 1, 0
     while f1.degree() >= M:
-        f0, (qj, f1) = f1, f0.quo_rem(f1)
-        s0, s1 = s1, s0 - qj * s1
+        f0, (q, f1) = f1, f0.quo_rem(f1)
+        s0, s1 = s1, s0 - q * s1
     return s1.reverse().monic()

--- a/src/sage/matrix/berlekamp_massey.py
+++ b/src/sage/matrix/berlekamp_massey.py
@@ -72,12 +72,6 @@ def berlekamp_massey(a):
         Traceback (most recent call last):
         ...
         ValueError: argument must have an even number of terms
-
-    Check that :issue:`36172` is fixed::
-
-        sage: p = next_prime(2**64)
-        sage: ls = [GF(p).random_element() for _ in range(2000)]
-        sage: _ = berlekamp_massey(ls)
     """
     if not isinstance(a, (list, tuple)):
         raise TypeError("argument must be a list or tuple")


### PR DESCRIPTION
Fix #36172.

Reduced berlekamp_massey memory consumption by replacing a dictionary with temporary variables. The memory consumption of the line highlighted below reduced from 42MB to 4MB (probably inaccurate, but significant enough).

```python
from memory_profiler import profile
from sage.matrix.berlekamp_massey import berlekamp_massey
@profile
def gen_data():
    p = random_prime(2**64)
    ls = [GF(p).random_element() for _ in range(20000)]
    berlekamp_massey(ls); # <--- this line
gen_data()
```

I am not sure if I have to include extra doctests or not, or how to test memory consumptions, since the time complexity is also O(n^2).

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

