### PR TITLE
Improve methods in `sage.misc.rest_index_of_methods` to fix the documentation of graphs.

### DIFF
--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -84,7 +84,6 @@ graphs. Here is what they can do
     :meth:`~DiGraph.strongly_connected_components_subgraphs` | Return the strongly connected components as a list of subgraphs.
     :meth:`~DiGraph.strongly_connected_component_containing_vertex` | Return the strongly connected component containing a given vertex
     :meth:`~DiGraph.strongly_connected_components` | Return the list of strongly connected components.
-    :meth:`~DiGraph.immediate_dominators` | Return the immediate dominators of all vertices reachable from `root`.
     :meth:`~DiGraph.strong_articulation_points` | Return the strong articulation points of this digraph.
 
 

--- a/src/sage/graphs/generators/chessboard.py
+++ b/src/sage/graphs/generators/chessboard.py
@@ -4,11 +4,11 @@ Chessboard graphs
 
 The methods defined here appear in :mod:`sage.graphs.graph_generators`.
 
-- :meth:`BishopGraph <GraphGenerators.BishopGraph>`
-- :meth:`KingGraph <GraphGenerators.KingGraph>`
-- :meth:`KnightGraph <GraphGenerators.KnightGraph>`
-- :meth:`QueenGraph <GraphGenerators.QueenGraph>`
-- :meth:`RookGraph <GraphGenerators.RookGraph>`
+- :meth:`BishopGraph <sage.graphs.graph_generators.GraphGenerators.BishopGraph>`
+- :meth:`KingGraph <sage.graphs.graph_generators.GraphGenerators.KingGraph>`
+- :meth:`KnightGraph <sage.graphs.graph_generators.GraphGenerators.KnightGraph>`
+- :meth:`QueenGraph <sage.graphs.graph_generators.GraphGenerators.QueenGraph>`
+- :meth:`RookGraph <sage.graphs.graph_generators.GraphGenerators.RookGraph>`
 
 AUTHORS:
 

--- a/src/sage/graphs/isgci.py
+++ b/src/sage/graphs/isgci.py
@@ -135,28 +135,28 @@ Predefined classes
 
    * - Apex
 
-     - :meth:`~Graph.is_apex()`,
-       :meth:`~Graph.apex_vertices()`
+     - :meth:`~sage.graphs.graph.Graph.is_apex()`,
+       :meth:`~sage.graphs.graph.Graph.apex_vertices()`
 
    * - AT_free
 
-     - :meth:`~Graph.is_asteroidal_triple_free`
+     - :meth:`~sage.graphs.graph.Graph.is_asteroidal_triple_free`
 
    * - Biconnected
 
-     - :meth:`~Graph.is_biconnected`,
-       :meth:`~GenericGraph.blocks_and_cut_vertices`,
-       :meth:`~GenericGraph.blocks_and_cuts_tree`
+     - :meth:`~sage.graphs.graph.Graph.is_biconnected`,
+       :meth:`~sage.graphs.generic_graph.GenericGraph.blocks_and_cut_vertices`,
+       :meth:`~sage.graphs.generic_graph.GenericGraph.blocks_and_cuts_tree`
 
    * - BinaryTrees
 
      - :meth:`~sage.graphs.graph_generators.GraphGenerators.BalancedTree`,
-       :meth:`~Graph.is_tree`
+       :meth:`~sage.graphs.graph.Graph.is_tree`
 
    * - Bipartite
 
      - :meth:`~sage.graphs.graph_generators.GraphGenerators.BalancedTree`,
-       :meth:`~sage.graphs.graph.Graph.is_bipartite`
+       :meth:`~sage.graphs.generic_graph.GenericGraph.is_bipartite`
 
    * - Block
 
@@ -212,7 +212,7 @@ Predefined classes
 
    * - Polyhedral
 
-     - :meth:`~sage.graphs.generic_graph.Graph.is_polyhedral`
+     - :meth:`~sage.graphs.graph.Graph.is_polyhedral`
 
    * - Split
 

--- a/src/sage/graphs/isgci.py
+++ b/src/sage/graphs/isgci.py
@@ -135,8 +135,8 @@ Predefined classes
 
    * - Apex
 
-     - :meth:`~sage.graphs.graph.Graph.is_apex()`,
-       :meth:`~sage.graphs.graph.Graph.apex_vertices()`
+     - :meth:`~sage.graphs.graph.Graph.is_apex`,
+       :meth:`~sage.graphs.graph.Graph.apex_vertices`
 
    * - AT_free
 

--- a/src/sage/misc/rest_index_of_methods.py
+++ b/src/sage/misc/rest_index_of_methods.py
@@ -47,7 +47,7 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
     - ``root`` -- module or class (default: ``None``); the module, or class,
       whose elements are to be listed. This is needed to recover the class when
       this method is called from :meth:`gen_thematic_rest_table_index` (see
-      :trac:`36178`).
+      :issue:`36178`).
 
     .. WARNING::
 
@@ -76,7 +76,7 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
         <BLANKLINE>
            :func:`~sage.misc.rest_index_of_methods.doc_index` @ Attribute an index name to a function.
            :func:`~sage.misc.rest_index_of_methods.gen_rest_table_index` @ Return a ReST table describing a list of functions.
-           :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted function (or methods) of a module (or class).
+           :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted functions (or methods) of a module (or class).
            :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Return the functions (resp. methods) of a given module (resp. class) with their names.
         <BLANKLINE>
         <BLANKLINE>
@@ -129,7 +129,7 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
         <BLANKLINE>
            :func:`~sage.misc.rest_index_of_methods.doc_index` @ Attribute an index name to a function.
            :func:`~sage.misc.rest_index_of_methods.gen_rest_table_index` @ Return a ReST table describing a list of functions.
-           :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted function (or methods) of a module (or class).
+           :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted functions (or methods) of a module (or class).
            :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Return the functions (resp. methods) of a given module (resp. class) with their names.
         <BLANKLINE>
         <BLANKLINE>
@@ -140,7 +140,7 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
            :delim: @
         <BLANKLINE>
            :func:`~sage.misc.rest_index_of_methods.doc_index` @ Attribute an index name to a function.
-           :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted function (or methods) of a module (or class).
+           :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted functions (or methods) of a module (or class).
            :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Return the functions (resp. methods) of a given module (resp. class) with their names.
         <BLANKLINE>
         <BLANKLINE>
@@ -153,7 +153,7 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
         sage: 'all_max_cliques`' in gen_rest_table_index(Graph)                         # needs sage.graphs
         False
 
-    Check that :trac:`36178` is fixed::
+    Check that :issue:`36178` is fixed::
 
         sage: print(gen_rest_table_index(Graph))                                        # needs sage.graphs
         ...
@@ -301,7 +301,7 @@ def list_of_subfunctions(root, only_local_functions=True):
 
 def gen_thematic_rest_table_index(root, additional_categories=None, only_local_functions=True):
     r"""
-    Return a ReST string of thematically sorted function (or methods) of a
+    Return a ReST string of thematically sorted functions (or methods) of a
     module (or class).
 
     INPUT:
@@ -374,4 +374,5 @@ def doc_index(name):
     return hey
 
 
-__doc__ = __doc__.format(INDEX_OF_FUNCTIONS=gen_rest_table_index([gen_rest_table_index]))
+__doc__ = __doc__.format(INDEX_OF_FUNCTIONS=gen_rest_table_index([gen_rest_table_index,
+                                                                  gen_thematic_rest_table_index]))

--- a/src/sage/misc/rest_index_of_methods.py
+++ b/src/sage/misc/rest_index_of_methods.py
@@ -35,17 +35,19 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
       precedence over the automatically computed name for the functions. Only
       used when ``list_of_entries`` is a list.
 
-    - ``sort`` (boolean; ``True``) -- whether to sort the list of methods
-      lexicographically.
+    - ``sort`` -- boolean (default: ``True``); whether to sort the list of
+      methods lexicographically.
 
-    - ``only_local_functions`` (boolean; ``True``) -- if ``list_of_entries`` is
-      a module, ``only_local_functions = True`` means that imported functions
-      will be filtered out. This can be useful to disable for making indexes of
-      e.g. catalog modules such as :mod:`sage.coding.codes_catalog`.
+    - ``only_local_functions`` -- boolean (default: ``True``); if
+      ``list_of_entries`` is a module, ``only_local_functions = True`` means
+      that imported functions will be filtered out. This can be useful to
+      disable for making indexes of e.g. catalog modules such as
+      :mod:`sage.coding.codes_catalog`.
 
-    - ``root`` -- (default: ``None``); the module, or class, whose elements are
-      to be listed. This is needed to recover the class when this method is
-      called from :meth:`gen_thematic_rest_table_index`.
+    - ``root`` -- module or class (default: ``None``); the module, or class,
+      whose elements are to be listed. This is needed to recover the class when
+      this method is called from :meth:`gen_thematic_rest_table_index` (see
+      :trac:`36178`).
 
     .. WARNING::
 
@@ -75,7 +77,7 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
            :func:`~sage.misc.rest_index_of_methods.doc_index` @ Attribute an index name to a function.
            :func:`~sage.misc.rest_index_of_methods.gen_rest_table_index` @ Return a ReST table describing a list of functions.
            :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted function (or methods) of a module (or class).
-           :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Returns the functions (resp. methods) of a given module (resp. class) with their names.
+           :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Return the functions (resp. methods) of a given module (resp. class) with their names.
         <BLANKLINE>
         <BLANKLINE>
 
@@ -128,7 +130,7 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
            :func:`~sage.misc.rest_index_of_methods.doc_index` @ Attribute an index name to a function.
            :func:`~sage.misc.rest_index_of_methods.gen_rest_table_index` @ Return a ReST table describing a list of functions.
            :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted function (or methods) of a module (or class).
-           :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Returns the functions (resp. methods) of a given module (resp. class) with their names.
+           :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Return the functions (resp. methods) of a given module (resp. class) with their names.
         <BLANKLINE>
         <BLANKLINE>
         sage: print(gen_rest_table_index(sage.misc.rest_index_of_methods, only_local_functions=False))
@@ -139,7 +141,7 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
         <BLANKLINE>
            :func:`~sage.misc.rest_index_of_methods.doc_index` @ Attribute an index name to a function.
            :func:`~sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` @ Return a ReST string of thematically sorted function (or methods) of a module (or class).
-           :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Returns the functions (resp. methods) of a given module (resp. class) with their names.
+           :func:`~sage.misc.rest_index_of_methods.list_of_subfunctions` @ Return the functions (resp. methods) of a given module (resp. class) with their names.
         <BLANKLINE>
         <BLANKLINE>
 
@@ -150,6 +152,13 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
         True
         sage: 'all_max_cliques`' in gen_rest_table_index(Graph)                         # needs sage.graphs
         False
+
+    Check that :trac:`36178` is fixed::
+
+        sage: print(gen_rest_table_index(Graph))                                        # needs sage.graphs
+        ...
+           :meth:`~sage.graphs.graph.Graph.independent_set` @ Return a maximum independent set.
+        ...
     """
     if names is None:
         names = {}
@@ -218,15 +227,15 @@ def gen_rest_table_index(obj, names=None, sort=True, only_local_functions=True, 
 
 def list_of_subfunctions(root, only_local_functions=True):
     r"""
-    Returns the functions (resp. methods) of a given module (resp. class) with their names.
+    Return the functions (resp. methods) of a given module (resp. class) with their names.
 
     INPUT:
 
     - ``root`` -- the module, or class, whose elements are to be listed.
 
-    - ``only_local_functions`` (boolean; ``True``) -- if ``root`` is a module,
-      ``only_local_functions = True`` means that imported functions will be
-      filtered out. This can be useful to disable for making indexes of
+    - ``only_local_functions`` -- boolean (default: ``True``); if ``root`` is a
+      module, ``only_local_functions = True`` means that imported functions will
+      be filtered out. This can be useful to disable for making indexes of
       e.g. catalog modules such as :mod:`sage.coding.codes_catalog`.
 
     OUTPUT:
@@ -290,21 +299,22 @@ def list_of_subfunctions(root, only_local_functions=True):
     return list(functions.keys()), functions
 
 
-def gen_thematic_rest_table_index(root,additional_categories=None,only_local_functions=True):
+def gen_thematic_rest_table_index(root, additional_categories=None, only_local_functions=True):
     r"""
-    Return a ReST string of thematically sorted function (or methods) of a module (or class).
+    Return a ReST string of thematically sorted function (or methods) of a
+    module (or class).
 
     INPUT:
 
     - ``root`` -- the module, or class, whose elements are to be listed.
 
-    - ``additional_categories`` -- a dictionary associating a category (given as
-      a string) to a function's name. Can be used when the decorator
-      :func:`doc_index` does not work on a function.
+    - ``additional_categories`` -- dictionary (default: ``None``); a dictionary
+      associating a category (given as a string) to a function's name. Can be
+      used when the decorator :func:`doc_index` does not work on a function.
 
-    - ``only_local_functions`` (boolean; ``True``) -- if ``root`` is a module,
-      ``only_local_functions = True`` means that imported functions will be
-      filtered out. This can be useful to disable for making indexes of
+    - ``only_local_functions`` -- boolean (default: ``True``); if ``root`` is a
+      module, ``only_local_functions = True`` means that imported functions will
+      be filtered out. This can be useful to disable for making indexes of
       e.g. catalog modules such as :mod:`sage.coding.codes_catalog`.
 
     EXAMPLES::
@@ -359,7 +369,7 @@ def doc_index(name):
         'Wouhouuuuu'
     """
     def hey(f):
-        setattr(f,"doc_index",name)
+        setattr(f, "doc_index", name)
         return f
     return hey
 


### PR DESCRIPTION
Fixes #36178.

We ensure that method `sage.misc.rest_index_of_methods.gen_thematic_rest_table_index` adds the correct links to methods in the thematic tables of the documentation. For instance, some links were missing in the thematic tables of https://doc.sagemath.org/html/en/reference/graphs/sage/graphs/graph.html.

We also fix some links in the documentation.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
