### PR TITLE
`sage.misc.sageinspect`: fix doctest warnings due to modularisation

### DIFF
--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -1614,7 +1614,8 @@ def sage_getargspec(obj):
 
     The following was fixed in :trac:`16309`::
 
-        sage: cython(                                                                   # needs sage.misc.cython
+        sage: # needs sage.misc.cython
+        sage: cython(
         ....: '''
         ....: class Foo:
         ....:     @staticmethod


### PR DESCRIPTION
We fix the following doctest warnings:
```
sage -t --long --warn-long 30.7 --random-seed=263240816384135969928803999009622073573 src/sage/misc/sageinspect.py
**********************************************************************
File "src/sage/misc/sageinspect.py", line 1627, in sage.misc.sageinspect.sage_getargspec
Warning: Variable 'Foo' referenced here was set only in doctest marked '# needs sage.misc.cython'
    sage_getargspec(Foo.join)
**********************************************************************
File "src/sage/misc/sageinspect.py", line 1629, in sage.misc.sageinspect.sage_getargspec
Warning: Variable 'Bar' referenced here was set only in doctest marked '# needs sage.misc.cython'
    sage_getargspec(Bar.join)
**********************************************************************
File "src/sage/misc/sageinspect.py", line 1631, in sage.misc.sageinspect.sage_getargspec
Warning: Variable 'Bar' referenced here was set only in doctest marked '# needs sage.misc.cython'
    sage_getargspec(Bar.meet)
    [353 tests, 32.04 s]
```

These are (currently) the only warnings I see when running `./sage -t --long src/sage/misc/`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
