### PR TITLE
src/sage/tests: fix another "Computational Math..." doctest

### DIFF
--- a/src/sage/tests/books/computational-mathematics-with-sagemath/graphique_doctest.py
+++ b/src/sage/tests/books/computational-mathematics-with-sagemath/graphique_doctest.py
@@ -215,11 +215,13 @@ Sage example in ./graphique.tex, line 1781::
   sage: plot3d(h, (u,-1,1), (v,-1,1), aspect_ratio=[1,1,1])
   Graphics3d Object
 
-Sage example in ./graphique.tex, line 1833::
+Sage example in ./graphique.tex, line 1833. Sometimes the result
+needs to be simplified to obtain a nice short expression::
 
   sage: f(x, y) = x^2 * y / (x^4 + y^2)
   sage: t, theta = var('t, theta')
-  sage: limit(f(t * cos(theta), t * sin(theta)) / t, t=0)
+  sage: result = limit(f(t * cos(theta), t * sin(theta)) / t, t=0)
+  sage: result.full_simplify()
   cos(theta)^2/sin(theta)
 
 Sage example in ./graphique.tex, line 1847::


### PR DESCRIPTION
One doctest for the Computational Math book fails for me,

```
  Failed example:
    limit(f(t * cos(theta), t * sin(theta)) / t, t=0)
  Expected:
    cos(theta)^2/sin(theta)
  Got:
    -1/2*(sin(3*theta) + sin(theta))/(cos(2*theta) - 1)
```

These results are equivalent, and the ugly one simplifies to the pretty one. We add a full_simplify() to the test to support both outputs. The discrepancy is most likely due to the version of Giac installed on the system.
