### PR TITLE
schemes/elliptic_curves: disable a test that takes too long

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -2306,7 +2306,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E.gens(algorithm="pari")    # random output
             [(5/4 : 5/8 : 1), (0 : 0 : 1)]
             sage: E = EllipticCurve([0,2429469980725060,0,275130703388172136833647756388,0])
-            sage: len(E.gens(algorithm="pari"))
+            sage: len(E.gens(algorithm="pari"))  # not tested (takes too long)
             14
 
         A non-integral example::


### PR DESCRIPTION
A doctest introduced in #35626 takes ~50s on current hardware (for comparision, doctesting the whole of `src/sage/schemes/elliptic_curves/ell_rational_field.py` takes ~22s for 889 tests).

This is too long even for `--long`, but the example is still interesting, so we just mark it `# not tested`.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.


CC: @chriswuthrich (should be a trivial review :pray:)