### PR TITLE
PR for #36198: fix return types in permutation.py so that methods return type `Integer` instead of type `int`.

### DIFF
--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -720,7 +720,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([3,4,1,2,5]).size()
             5
         """
-        return len(self)
+        return Integer(len(self))
 
     grade = size  # for the category SetsWithGrading()
 
@@ -1167,7 +1167,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([]).sign()
             1
         """
-        return (-1)**(len(self)-len(self.to_cycles()))
+        return Integer((-1)**(len(self)-len(self.to_cycles())))
 
     #one can also use sign as an alias for signature
     sign = signature
@@ -1476,21 +1476,23 @@ class Permutation(CombinatorialElement):
         l = len(p)
         # lightning fast if the length is less than 3
         # (is it really useful?)
+        zero = Integer(0)
+        one = Integer(1)
         if l < 4:
             if l == 0:
                 return []
             if l == 1:
-                return [0]
+                return [zero]
             if l == 2:
-                return [p[0] - 1, 0]
+                return [Integer(p[0] - 1), zero]
             if l == 3:
                 if p[0] == 1:
-                    return [0, p[1] - 2, 0]
+                    return [zero, Integer(p[1] - 2), zero]
                 if p[0] == 2:
                     if p[1] == 1:
-                        return [1, 0, 0]
-                    return [2, 0, 0]
-                return [p[1], 1, 0]
+                        return [one, zero, zero]
+                    return [Integer(2), zero, zero]
+                return [Integer(p[1]), one, zero]
         # choose the best one
         if l < 411:
             return self._to_inversion_vector_small()
@@ -1548,7 +1550,7 @@ class Permutation(CombinatorialElement):
         for pi in reversed(p):
             checked[pi] = 0
             iv[pi] = sum(checked[pi:])
-        return iv[1:]
+        return [Integer(a) for a in iv[1:]]
 
     def _to_inversion_vector_divide_and_conquer(self):
         r"""
@@ -1614,7 +1616,7 @@ class Permutation(CombinatorialElement):
             return merge_and_countv(sort_and_countv(L[:l]),
                                     sort_and_countv(L[l:]))
 
-        return sort_and_countv(self._list)[0]
+        return [Integer(a) for a in sort_and_countv(self._list)[0]]
 
     def inversions(self) -> list:
         r"""
@@ -1883,8 +1885,8 @@ class Permutation(CombinatorialElement):
         """
         if k > len(self):
             return 0
-        return sum(1 for pos in itertools.combinations(self, k)
-                   if all(pos[i] < pos[i + 1] for i in range(k - 1)))
+        return Integer(sum(1 for pos in itertools.combinations(self, k)
+                           if all(pos[i] < pos[i + 1] for i in range(k - 1))))
 
     def length(self) -> Integer:
         r"""
@@ -1934,7 +1936,7 @@ class Permutation(CombinatorialElement):
         """
         w = list(range(len(self)))
         for i, j in enumerate(self):
-            w[j - 1] = i + 1
+            w[j - 1] = Integer(i + 1)
         return Permutations()(w)
 
     __invert__ = inverse
@@ -2239,7 +2241,7 @@ class Permutation(CombinatorialElement):
             else:
                 # We replace y by x
                 r[idx] = x
-        return len(r)
+        return Integer(len(r))
 
     def longest_increasing_subsequences(self):
         r"""
@@ -3082,8 +3084,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([1,2,3,4]).number_of_fixed_points()
             4
         """
-
-        return len(self.fixed_points())
+        return Integer(len(self.fixed_points()))
 
     def is_derangement(self) -> bool:
         r"""
@@ -3209,7 +3210,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([1,4,3,2]).number_of_recoils()
             2
         """
-        return len(self.recoils())
+        return Integer(len(self.recoils()))
 
     def recoils_composition(self) -> Composition:
         r"""
@@ -3382,7 +3383,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([1,4,3,2]).number_of_descents(final_descent=True)
             3
         """
-        return len(self.descents(final_descent))
+        return Integer(len(self.descents(final_descent)))
 
     def number_of_idescents(self, final_descent=False) -> Integer:
         r"""
@@ -3400,7 +3401,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([1,4,3,2]).number_of_idescents(final_descent=True)
             3
         """
-        return len(self.idescents(final_descent))
+        return Integer(len(self.idescents(final_descent)))
 
     @combinatorial_map(name='descent composition')
     def descents_composition(self) -> Composition:
@@ -3497,7 +3498,7 @@ class Permutation(CombinatorialElement):
             6
         """
         descents = self.descents(final_descent)
-        return sum(descents)
+        return Integer(sum(descents))
 
     def multi_major_index(self, composition):
         r"""
@@ -3566,7 +3567,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([4,3,2,1]).imajor_index()
             6
         """
-        return sum(self.idescents(final_descent))
+        return Integer(sum(self.idescents(final_descent)))
 
     def to_major_code(self, final_descent=False):
         r"""
@@ -3655,7 +3656,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([4,1,3,2,6,5]).number_of_peaks()
             2
         """
-        return len(self.peaks())
+        return Integer(len(self.peaks()))
 
     #############
     # Saliances #
@@ -3701,7 +3702,7 @@ class Permutation(CombinatorialElement):
             sage: Permutation([5,4,3,2,1]).number_of_saliances()
             5
         """
-        return len(self.saliances())
+        return Integer(len(self.saliances()))
 
     ################
     # Bruhat Order #


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
For methods in combinat/permutation.py which have return type hint of `Integer`, actually return an `Integer` rather than an `int`.

<!-- Describe your changes here in detail -->

This should fix #36198.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [X] The title is concise, informative, and self-explanatory.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
