### PR TITLE
some micro-details in Dyck words and Parking functions

### DIFF
--- a/src/sage/combinat/dyck_word.py
+++ b/src/sage/combinat/dyck_word.py
@@ -539,7 +539,7 @@ class DyckWord(CombinatorialElement):
                 final_fall = " "
             else:
                 final_fall = " _" + "__" * (length_of_final_fall - 1)
-            row = "  "*(n - alst[-1] - 1) + final_fall + "\n"
+            row = "  " * (n - alst[-1] - 1) + final_fall + "\n"
             for i in range(n - 1):
                 c = 0
                 row = row + "  "*(n-i-2-alst[-i-2])
@@ -1982,23 +1982,30 @@ class DyckWord_complete(DyckWord):
         from sage.arith.misc import multinomial
         return multinomial(self.rise_composition())
 
-    def list_parking_functions(self):
+    def list_parking_functions(self) -> list:
         r"""
         Return all parking functions whose supporting Dyck path is ``self``.
 
         EXAMPLES::
 
             sage: DyckWord([1,1,0,0,1,0]).list_parking_functions()
-            Permutations of the multi-set [1, 1, 3]
-            sage: DyckWord([1,1,1,0,0,0]).list_parking_functions()
-            Permutations of the multi-set [1, 1, 1]
-            sage: DyckWord([1,0,1,0,1,0]).list_parking_functions()
-            Standard permutations of 3
+            [[1, 1, 3], [1, 3, 1], [3, 1, 1]]
         """
+        return list(self.parking_functions())
+
+    def parking_functions(self):
+        r"""
+        Iterate over parking functions whose supporting Dyck path is ``self``.
+
+        EXAMPLES::
+
+            sage: list(DyckWord([1,1,0,1,0,0]).parking_functions())
+            [[1, 1, 2], [1, 2, 1], [2, 1, 1]]
+        """
+        from sage.combinat.parking_functions import ParkingFunction
         alist = self._area_sequence_iter()
-        return Permutations([i - ai + 1 for i, ai in enumerate(alist)])
-        # TODO: upon implementation of ParkingFunction class
-        # map(ParkingFunction, Permutations([i - alist[i]+1 for i in range(len(alist))]))
+        for pi in Permutations([i - ai + 1 for i, ai in enumerate(alist)]):
+            yield ParkingFunction(pi)
 
     def reading_permutation(self) -> Permutation:
         r"""

--- a/src/sage/combinat/parking_functions.py
+++ b/src/sage/combinat/parking_functions.py
@@ -222,11 +222,17 @@ class ParkingFunction(ClonableArray, metaclass=InheritComparisonClasscallMetacla
             <class 'sage.combinat.parking_functions.ParkingFunctions_n_with_category.element_class'>
             sage: type(b)
             <class 'sage.combinat.parking_functions.ParkingFunctions_n_with_category.element_class'>
+
+        Some checks for more general inputs::
+
+            sage: PF = ParkingFunction((1, 1, 2, 2, 5, 6))
+            sage: PF = ParkingFunction(Permutation([4,2,3,1]))
         """
-        if isinstance(lst, ParkingFunction):
-            lst = list(lst)
         if not isinstance(lst, list):
-            raise TypeError('input must be a list')
+            try:
+                lst = list(lst)
+            except TypeError:
+                raise TypeError('input must be convertible to a list')
         if parent is None:
             parent = ParkingFunctions_n(len(lst))
         ClonableArray.__init__(self, parent, lst)


### PR DESCRIPTION
This is 

- widening the input type of ParkingFunction to allow for tuples and list-like objects
- enhancing the method "list_parking_functions" of Dyck words to return Parking functions, and creating an iterator

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
