### PR TITLE
Remove some obsolete "six" dependencies

### DIFF
--- a/build/pkgs/cycler/dependencies
+++ b/build/pkgs/cycler/dependencies
@@ -1,4 +1,4 @@
- six | $(PYTHON_TOOLCHAIN) $(PYTHON)
+ | $(PYTHON_TOOLCHAIN) $(PYTHON)
 ----------
 All lines of this file are ignored except the first.
 

--- a/build/pkgs/matplotlib/dependencies
+++ b/build/pkgs/matplotlib/dependencies
@@ -1,4 +1,4 @@
- numpy freetype pillow dateutil pyparsing tornado six cycler qhull fonttools contourpy | $(PYTHON_TOOLCHAIN) kiwisolver certifi setuptools_scm_git_archive $(PYTHON)
+ numpy freetype pillow dateutil pyparsing tornado cycler qhull fonttools contourpy | $(PYTHON_TOOLCHAIN) kiwisolver certifi setuptools_scm_git_archive $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/traitlets/dependencies
+++ b/build/pkgs/traitlets/dependencies
@@ -1,4 +1,4 @@
- | $(PYTHON_TOOLCHAIN) ipython_genutils decorator six hatchling $(PYTHON)
+ | $(PYTHON_TOOLCHAIN) ipython_genutils decorator hatchling $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
Cycler, matplotlib, and traitlets no longer need the "six" package. Upstream removal commits are cited in the commit messages.