### PR TITLE
Remove self-`cimport`s

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
+++ b/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
@@ -34,7 +34,6 @@ Check that :trac:`20829` is fixed::
 
 from sage.structure.element cimport AlgebraElement, Element
 from sage.structure.richcmp cimport rich_to_bool, rich_to_bool_sgn, richcmp_item
-from sage.algebras.quatalg.quaternion_algebra_element cimport QuaternionAlgebraElement_abstract
 from sage.rings.rational cimport Rational
 from sage.rings.integer cimport Integer
 from sage.rings.number_field.number_field_element cimport NumberFieldElement

--- a/src/sage/graphs/base/boost_graph.pyx
+++ b/src/sage/graphs/base/boost_graph.pyx
@@ -561,7 +561,7 @@ cpdef bandwidth_heuristics(g, algorithm='cuthill_mckee'):
 
     Given a wrong algorithm::
 
-        from sage.graphs.base.boost_graph import bandwidth_heuristics
+        sage: from sage.graphs.base.boost_graph import bandwidth_heuristics
         sage: bandwidth_heuristics(graphs.PathGraph(3), algorithm='tip top')
         Traceback (most recent call last):
         ...
@@ -569,7 +569,7 @@ cpdef bandwidth_heuristics(g, algorithm='cuthill_mckee'):
 
     Given a graph with no edges::
 
-        from sage.graphs.base.boost_graph import bandwidth_heuristics
+        sage: from sage.graphs.base.boost_graph import bandwidth_heuristics
         sage: bandwidth_heuristics(Graph())
         (0, [])
         sage: bandwidth_heuristics(graphs.RandomGNM(10,0))                              # needs networkx

--- a/src/sage/graphs/comparability.pyx
+++ b/src/sage/graphs/comparability.pyx
@@ -677,7 +677,6 @@ def is_permutation(g, algorithm="greedy", certificate=False, check=True,
        ....:        break
 
     """
-    from sage.graphs.comparability import is_comparability
     if certificate:
 
         # First poset, we stop if it fails

--- a/src/sage/graphs/strongly_regular_db.pyx
+++ b/src/sage/graphs/strongly_regular_db.pyx
@@ -2649,7 +2649,6 @@ def SRG_126_50_13_24():
         sage: G.is_strongly_regular(parameters=True)
         (126, 50, 13, 24)
     """
-    from sage.graphs.strongly_regular_db import SRG_175_72_20_36
     from sage.graphs.generators.smallgraphs import HoffmanSingletonGraph
     hs = HoffmanSingletonGraph()
     s = set(hs.vertices(sort=False)).difference(hs.neighbors(0) + [0])

--- a/src/sage/libs/flint/fmpz_poly.pyx
+++ b/src/sage/libs/flint/fmpz_poly.pyx
@@ -27,7 +27,7 @@ from sage.arith.long cimport pyobject_to_long
 from sage.cpython.string cimport char_to_str, str_to_bytes
 from sage.structure.sage_object cimport SageObject
 from sage.rings.integer cimport Integer
-from sage.libs.flint.fmpz_poly cimport *
+
 
 cdef class Fmpz_poly(SageObject):
 

--- a/src/sage/libs/flint/qsieve.pyx
+++ b/src/sage/libs/flint/qsieve.pyx
@@ -7,7 +7,6 @@ been absorbed into flint.
 from cysignals.signals cimport sig_on, sig_off
 from sage.libs.flint.fmpz cimport fmpz_t, fmpz_init, fmpz_set_mpz
 from sage.libs.flint.fmpz_factor cimport *
-from sage.libs.flint.qsieve cimport *
 from sage.rings.integer cimport Integer
 
 

--- a/src/sage/matrix/matrix_modn_sparse.pxd
+++ b/src/sage/matrix/matrix_modn_sparse.pxd
@@ -1,4 +1,4 @@
-from .matrix_sparse cimport Matrix_sparse
+from sage.matrix.matrix_sparse cimport Matrix_sparse
 from sage.modules.vector_modn_sparse cimport *
 
 cdef class Matrix_modn_sparse(Matrix_sparse):

--- a/src/sage/matrix/matrix_modn_sparse.pyx
+++ b/src/sage/matrix/matrix_modn_sparse.pyx
@@ -86,17 +86,15 @@ from libc.limits cimport UINT_MAX
 from cysignals.memory cimport check_calloc, sig_free
 from cysignals.signals cimport sig_on, sig_off
 
-from sage.ext.stdsage cimport PY_NEW
-
-from sage.libs.flint.fmpz cimport fmpz_get_mpz, fmpz_set_mpz
-from sage.libs.flint.fmpz_mat cimport fmpz_mat_entry
-from sage.libs.gmp.mpz cimport mpz_set
-
-from sage.modules.vector_modn_sparse cimport *
-
 cimport sage.libs.linbox.givaro as givaro
 cimport sage.libs.linbox.linbox as linbox
 
+from sage.arith.misc import is_prime
+from sage.data_structures.binary_search cimport *
+from sage.ext.stdsage cimport PY_NEW
+from sage.libs.flint.fmpz cimport fmpz_get_mpz, fmpz_set_mpz
+from sage.libs.flint.fmpz_mat cimport fmpz_mat_entry
+from sage.libs.gmp.mpz cimport mpz_set
 from sage.libs.linbox.conversion cimport (get_method,
                                           METHOD_DEFAULT,
                                           METHOD_DENSE_ELIMINATION,
@@ -107,31 +105,23 @@ from sage.libs.linbox.conversion cimport (get_method,
                                           new_linbox_matrix_integer_sparse,
                                           new_linbox_vector_integer_dense,
                                           new_sage_vector_integer_dense)
-
-from sage.matrix.matrix_sparse cimport Matrix_sparse
+from sage.matrix.args cimport SparseEntry, MatrixArgs_init
+from sage.matrix.matrix2 import Matrix as Matrix2
 from sage.matrix.matrix_dense cimport Matrix_dense
+from sage.matrix.matrix_integer_dense cimport Matrix_integer_dense
+from sage.misc.verbose import verbose, get_verbose
+from sage.modules.vector_integer_dense cimport Vector_integer_dense
+from sage.modules.vector_integer_sparse cimport *
+from sage.modules.vector_modn_sparse cimport *
+from sage.rings.fast_arith cimport arith_int
 from sage.rings.finite_rings.integer_mod cimport IntegerMod_int, IntegerMod_abstract
 from sage.rings.integer cimport Integer
-from sage.rings.rational_field import QQ
 from sage.rings.integer_ring import ZZ
-
-from sage.misc.verbose import verbose, get_verbose
-
-from sage.matrix.matrix2 import Matrix as Matrix2
-from .args cimport SparseEntry, MatrixArgs_init
-from sage.arith.misc import is_prime
-
-from sage.data_structures.binary_search cimport *
-from sage.modules.vector_integer_sparse cimport *
-
-from .matrix_integer_dense cimport Matrix_integer_dense
-from sage.modules.vector_integer_dense cimport Vector_integer_dense
-
+from sage.rings.rational_field import QQ
 from sage.structure.element cimport Matrix
 
 ################
 # TODO: change this to use extern cdef's methods.
-from sage.rings.fast_arith cimport arith_int
 cdef arith_int ai
 ai = arith_int()
 ################

--- a/src/sage/matrix/matrix_modn_sparse.pyx
+++ b/src/sage/matrix/matrix_modn_sparse.pyx
@@ -90,18 +90,26 @@ from sage.ext.stdsage cimport PY_NEW
 
 from sage.libs.flint.fmpz cimport fmpz_get_mpz, fmpz_set_mpz
 from sage.libs.flint.fmpz_mat cimport fmpz_mat_entry
+from sage.libs.gmp.mpz cimport mpz_set
 
 from sage.modules.vector_modn_sparse cimport *
 
 cimport sage.libs.linbox.givaro as givaro
 cimport sage.libs.linbox.linbox as linbox
 
-from sage.libs.linbox.conversion cimport *
+from sage.libs.linbox.conversion cimport (get_method,
+                                          METHOD_DEFAULT,
+                                          METHOD_DENSE_ELIMINATION,
+                                          METHOD_SPARSE_ELIMINATION,
+                                          METHOD_BLACKBOX,
+                                          METHOD_WIEDEMANN,
+                                          new_linbox_matrix_modn_sparse,
+                                          new_linbox_matrix_integer_sparse,
+                                          new_linbox_vector_integer_dense,
+                                          new_sage_vector_integer_dense)
 
-from .matrix2 cimport Matrix
-cimport sage.matrix.matrix as matrix
-cimport sage.matrix.matrix_sparse as matrix_sparse
-cimport sage.matrix.matrix_dense as matrix_dense
+from sage.matrix.matrix_sparse cimport Matrix_sparse
+from sage.matrix.matrix_dense cimport Matrix_dense
 from sage.rings.finite_rings.integer_mod cimport IntegerMod_int, IntegerMod_abstract
 from sage.rings.integer cimport Integer
 from sage.rings.rational_field import QQ
@@ -113,13 +121,13 @@ from sage.matrix.matrix2 import Matrix as Matrix2
 from .args cimport SparseEntry, MatrixArgs_init
 from sage.arith.misc import is_prime
 
-cimport sage.structure.element
-
 from sage.data_structures.binary_search cimport *
 from sage.modules.vector_integer_sparse cimport *
 
 from .matrix_integer_dense cimport Matrix_integer_dense
 from sage.modules.vector_integer_dense cimport Vector_integer_dense
+
+from sage.structure.element cimport Matrix
 
 ################
 # TODO: change this to use extern cdef's methods.
@@ -133,7 +141,7 @@ ai = arith_int()
 # Github Issue #12679.
 MAX_MODULUS = 46341
 
-cdef class Matrix_modn_sparse(matrix_sparse.Matrix_sparse):
+cdef class Matrix_modn_sparse(Matrix_sparse):
     def __cinit__(self):
         nr = self._nrows
         nc = self._ncols
@@ -257,7 +265,7 @@ cdef class Matrix_modn_sparse(matrix_sparse.Matrix_sparse):
         else:
             raise ValueError("unknown matrix format")
 
-    cdef sage.structure.element.Matrix _matrix_times_matrix_(self, sage.structure.element.Matrix _right):
+    cdef Matrix _matrix_times_matrix_(self, Matrix _right):
         """
         This code is implicitly called for multiplying self by another
         sparse matrix.
@@ -336,7 +344,7 @@ cdef class Matrix_modn_sparse(matrix_sparse.Matrix_sparse):
                 set_entry(&ans.rows[i], j, s)
         return ans
 
-    def _matrix_times_matrix_dense(self, sage.structure.element.Matrix _right):
+    def _matrix_times_matrix_dense(self, Matrix _right):
         """
         Multiply self by the sparse matrix _right, and return the
         result as a dense matrix.
@@ -361,7 +369,7 @@ cdef class Matrix_modn_sparse(matrix_sparse.Matrix_sparse):
             <class 'sage.matrix.matrix_mod2_dense.Matrix_mod2_dense'>
         """
         cdef Matrix_modn_sparse right
-        cdef matrix_dense.Matrix_dense ans
+        cdef Matrix_dense ans
         right = _right
 
         cdef c_vector_modint* v
@@ -871,7 +879,7 @@ cdef class Matrix_modn_sparse(matrix_sparse.Matrix_sparse):
             self.cache('det', d)
             return d
         elif algorithm == 'generic':
-            d = matrix_sparse.Matrix_sparse.determinant(self)
+            d = Matrix_sparse.determinant(self)
             self.cache('det', d)
             return d
         else:
@@ -949,7 +957,7 @@ cdef class Matrix_modn_sparse(matrix_sparse.Matrix_sparse):
         if algorithm == "generic":
             return Matrix_sparse.solve_right(self, B)
         else:
-            if isinstance(B, sage.structure.element.Matrix):
+            if isinstance(B, Matrix):
                 from sage.matrix.special import diagonal_matrix
                 m, d = self._solve_matrix_linbox(B, algorithm)
                 return m  * diagonal_matrix([QQ((1,x)) for x in d])
@@ -1121,7 +1129,7 @@ cdef class Matrix_modn_sparse(matrix_sparse.Matrix_sparse):
         from sage.modules.free_module_element import vector
 
         cdef Matrix_integer_dense B
-        if not isinstance(mat, Matrix):
+        if not isinstance(mat, Matrix2):
             B = <Matrix_integer_dense?> matrix(ZZ, mat, sparse=False)
         else:
             B = <Matrix_integer_dense?> mat.change_ring(ZZ).dense_matrix()

--- a/src/sage/modules/vector_modn_sparse.pyx
+++ b/src/sage/modules/vector_modn_sparse.pyx
@@ -7,8 +7,6 @@
 
 from cysignals.memory cimport sig_malloc, sig_free
 
-from sage.modules.vector_modn_sparse cimport c_vector_modint
-
 
 cdef int allocate_c_vector_modint(c_vector_modint* v, Py_ssize_t num_nonzero) except -1:
     """

--- a/src/sage/rings/complex_mpc.pyx
+++ b/src/sage/rings/complex_mpc.pyx
@@ -2557,4 +2557,3 @@ cdef class CCtoMPC(Map):
 
 # Support Python's numbers abstract base class
 # import numbers
-from sage.rings.complex_mpc import MPComplexNumber

--- a/src/sage/rings/ring_extension.pxd
+++ b/src/sage/rings/ring_extension.pxd
@@ -1,6 +1,5 @@
 from sage.categories.map cimport Map
 from sage.rings.ring cimport CommutativeRing, CommutativeAlgebra
-from sage.rings.ring_extension cimport RingExtension_generic
 
 
 cdef class RingExtension_generic(CommutativeAlgebra):

--- a/src/sage/symbolic/constants_c_impl.pxi
+++ b/src/sage/symbolic/constants_c_impl.pxi
@@ -16,9 +16,6 @@ The constant `e`
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.symbolic.expression cimport Expression
-
-
 # keep exp(1) for fast access
 # this is initialized in the constructor of the class E below to prevent
 # circular imports while loading the library

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -6396,7 +6396,6 @@ cdef class Expression(Expression_abc):
             sage: type(u._unpack_operands()[0])
             <... 'tuple'>
         """
-        from sage.symbolic.expression import unpack_operands
         return unpack_operands(self)
 
     def operands(self):


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

Some Cython modules contain redundant `cimport` statements that cimport from themselves - directly or indirectly. 

We remove them and make some related cleanups of `import`s/`cimport`s.

This helps with Cython 3.0.2, in which the self-`cimport`s trigger surprising behavior in the presence of implicit namespace packages.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
- Cherry-picked from #35095 
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
