### PR TITLE
configure.ac: disable tzlocal with --disable-r

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -487,7 +487,7 @@ AS_IF([test "$SAGE_ENABLE_notebook" = no -a "$SAGE_ENABLE_sagelib" = no], [
 AC_ARG_ENABLE([r],
   AS_HELP_STRING([--disable-r],
                  [disable build of the R package and related packages]), [
-    for pkg in r rpy2 r_jupyter; do
+    for pkg in r rpy2 r_jupyter tzlocal; do
       AS_VAR_SET([SAGE_ENABLE_$pkg], [$enableval])
     done
   ])


### PR DESCRIPTION
The tzlocal package is a dependency of rpy2 and is used nowhere else in sage. When the user disables R with `--disable-r`, we can safely disable tzlocal too.
