### PR TITLE
configure.ac: disable mathjax with --disable-doc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -496,7 +496,7 @@ AC_ARG_ENABLE([doc],
   AS_HELP_STRING([--disable-doc],
                  [disable build of the Sage documentation and packages depending on it]), [
     dnl Disable packages needed for docbuilding
-    for pkg in sage_docbuild alabaster babel snowballstemmer imagesize sphinx sphinxcontrib_devhelp sphinxcontrib_jsmath sphinxcontrib_serializinghtml sphinxcontrib_applehelp sphinxcontrib_htmlhelp sphinxcontrib_qthelp sphinxcontrib_websupport jupyter_sphinx furo sphinx_copybutton; do
+    for pkg in sage_docbuild alabaster babel snowballstemmer imagesize sphinx sphinxcontrib_devhelp sphinxcontrib_jsmath sphinxcontrib_serializinghtml sphinxcontrib_applehelp sphinxcontrib_htmlhelp sphinxcontrib_qthelp sphinxcontrib_websupport jupyter_sphinx furo sphinx_copybutton mathjax; do
       AS_VAR_SET([SAGE_ENABLE_$pkg], [$enableval])
     done
     AS_VAR_IF([enableval], [no], [dnl Disable the docbuild by disabling the install tree for documentation


### PR DESCRIPTION
Our mathjax package is used only to build the sphinx documentation that can be disabled with `--disable-doc`. It therefore makes sense to disable the mathjax package along with the other dependencies pruned by `--disable-doc`.
