### PR TITLE
configure.ac: disable webencodings,tinycss2 with --disable-notebook

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -473,7 +473,7 @@ AC_ARG_ENABLE([cvxopt],
 AC_ARG_ENABLE([notebook],
   AS_HELP_STRING([--disable-notebook],
                  [disable build of the Jupyter notebook and related packages]), [
-    for pkg in notebook nbconvert beautifulsoup4 sagenb_export nbformat nbclient terminado send2trash prometheus_client mistune pandocfilters bleach defusedxml jsonschema jupyter_jsmol argon2_cffi; do
+    for pkg in notebook nbconvert beautifulsoup4 sagenb_export nbformat nbclient terminado send2trash prometheus_client mistune pandocfilters bleach defusedxml jsonschema jupyter_jsmol argon2_cffi webencodings tinycss2; do
       AS_VAR_SET([SAGE_ENABLE_$pkg], [$enableval])
     done
   ])


### PR DESCRIPTION
The `--disable-notebook` flag disables the bleach and nbconvert packages, and the webencodings and tinycss2 packages are (solely) dependencies of those. We can therefore disable webencodings and tinycss2 whenever `--disable-notebook` is given.
