### PR TITLE
get rid of xrange again

### DIFF
--- a/src/sage/cpython/_py2_random.py
+++ b/src/sage/cpython/_py2_random.py
@@ -281,9 +281,9 @@ class Random(_random.Random):
         population contains repeats, then each occurrence is a possible
         selection in the sample.
 
-        To choose a sample in a range of integers, use xrange as an argument.
+        To choose a sample in a range of integers, use range as an argument.
         This is especially fast and space efficient for sampling from a
-        large population:   sample(xrange(10000000), 60)
+        large population:   sample(range(10000000), 60)
         """
 
         # Sampling without replacement entails tracking either potential

--- a/src/sage/geometry/integral_points.pxi
+++ b/src/sage/geometry/integral_points.pxi
@@ -545,13 +545,13 @@ cpdef rectangular_box_points(list box_min, list box_max,
     assert not (count_only and return_saturated)
     cdef int d = len(box_min)
     cdef int i, j
-    cdef list diameter = sorted([ (box_max[i]-box_min[i], i) for i in range(d) ],
+    cdef list diameter = sorted([(box_max[i]-box_min[i], i) for i in range(d)],
                                 reverse=True)
     cdef list diameter_value = [x[0] for x in diameter]
     cdef list diameter_index = [x[1] for x in diameter]
 
     # Construct the inverse permutation
-    cdef list orig_perm = list(xrange(len(diameter_index)))
+    cdef list orig_perm = list(range(len(diameter_index)))
     for i, j in enumerate(diameter_index):
         orig_perm[j] = i
 

--- a/src/sage/graphs/strongly_regular_db.pyx
+++ b/src/sage/graphs/strongly_regular_db.pyx
@@ -1070,25 +1070,25 @@ def is_polhill(int v, int k, int l, int mu):
     # We now define the P_{i,j}. see section 6.
 
     P = {}
-    P[0,1] = list(xrange((-1) + 1                  , 2**(s-2)+1))
-    P[1,1] = list(xrange((-1) + 2**(s-2)+2         , 2**(s-1)+1))
-    P[2,1] = list(xrange((-1) + 2**(s-1)+2         , 2**(s-1)+2**(s-2)+1))
-    P[3,1] = list(xrange((-1) + 2**(s-1)+2**(s-2)+2, 2**(s)+1))
+    P[0,1] = list(range((-1) + 1                  , 2**(s-2)+1))
+    P[1,1] = list(range((-1) + 2**(s-2)+2         , 2**(s-1)+1))
+    P[2,1] = list(range((-1) + 2**(s-1)+2         , 2**(s-1)+2**(s-2)+1))
+    P[3,1] = list(range((-1) + 2**(s-1)+2**(s-2)+2, 2**(s)+1))
 
-    P[0,2] = list(xrange((-1) + 2**(s-2)+2         , 2**(s-1)+2))
-    P[1,2] = list(xrange((-1) + 2**(s-1)+3         , 2**(s-1)+2**(s-2)+2))
-    P[2,2] = list(xrange((-1) + 2**(s-1)+2**(s-2)+3, 2**(s)+1)) + [0]
-    P[3,2] = list(xrange((-1) + 2                  , 2**(s-2)+1))
+    P[0,2] = list(range((-1) + 2**(s-2)+2         , 2**(s-1)+2))
+    P[1,2] = list(range((-1) + 2**(s-1)+3         , 2**(s-1)+2**(s-2)+2))
+    P[2,2] = list(range((-1) + 2**(s-1)+2**(s-2)+3, 2**(s)+1)) + [0]
+    P[3,2] = list(range((-1) + 2                  , 2**(s-2)+1))
 
-    P[0,3] = list(xrange((-1) + 2**(s-1)+3         , 2**(s-1)+2**(s-2)+3))
-    P[1,3] = list(xrange((-1) + 2**(s-1)+2**(s-2)+4, 2**(s)+1)) + [0,1]
-    P[2,3] = list(xrange((-1) + 3                  , 2**(s-2)+2))
-    P[3,3] = list(xrange((-1) + 2**(s-2)+3         , 2**(s-1)+2))
+    P[0,3] = list(range((-1) + 2**(s-1)+3         , 2**(s-1)+2**(s-2)+3))
+    P[1,3] = list(range((-1) + 2**(s-1)+2**(s-2)+4, 2**(s)+1)) + [0,1]
+    P[2,3] = list(range((-1) + 3                  , 2**(s-2)+2))
+    P[3,3] = list(range((-1) + 2**(s-2)+3         , 2**(s-1)+2))
 
-    P[0,4] = list(xrange((-1) + 2**(s-1)+2**(s-2)+4, 2**(s)+1))
-    P[1,4] = list(xrange((-1) + 3                  , 2**(s-2)+1)) + [2**(s-1)+1,2**(s-1)+2**(s-2)+2]
-    P[2,4] = list(xrange((-1) + 2**(s-2)+3         , 2**(s-1)+1)) + [2**(s-1)+2**(s-2)+1,1]
-    P[3,4] = list(xrange((-1) + 2**(s-1)+3         , 2**(s-1)+2**(s-2)+1)) + [2**(s-2)+1,0]
+    P[0,4] = list(range((-1) + 2**(s-1)+2**(s-2)+4, 2**(s)+1))
+    P[1,4] = list(range((-1) + 3                  , 2**(s-2)+1)) + [2**(s-1)+1,2**(s-1)+2**(s-2)+2]
+    P[2,4] = list(range((-1) + 2**(s-2)+3         , 2**(s-1)+1)) + [2**(s-1)+2**(s-2)+1,1]
+    P[3,4] = list(range((-1) + 2**(s-1)+3         , 2**(s-1)+2**(s-2)+1)) + [2**(s-2)+1,0]
 
     R = {x: copy(P[x]) for x in P}
 
@@ -1102,10 +1102,10 @@ def is_polhill(int v, int k, int l, int mu):
 
     # We now define the R_{i,j}. see *end* of section 6.
 
-    R[0,3] = list(xrange((-1) + 2**(s-1)+3         , 2**(s-1)+2**(s-2)+2))
-    R[1,3] = list(xrange((-1) + 2**(s-1)+2**(s-2)+4, 2**(s)+1)) + [0,1,2**(s-1)+2**(s-2)+2]
-    R[0,4] = list(xrange((-1) + 2**(s-1)+2**(s-2)+4, 2**(s)+1)) + [2**(s-1)+2**(s-2)+2]
-    R[1,4] = list(xrange((-1) + 3                  , 2**(s-2)+1)) + [2**(s-1)+1]
+    R[0,3] = list(range((-1) + 2**(s-1)+3         , 2**(s-1)+2**(s-2)+2))
+    R[1,3] = list(range((-1) + 2**(s-1)+2**(s-2)+4, 2**(s)+1)) + [0,1,2**(s-1)+2**(s-2)+2]
+    R[0,4] = list(range((-1) + 2**(s-1)+2**(s-2)+4, 2**(s)+1)) + [2**(s-1)+2**(s-2)+2]
+    R[1,4] = list(range((-1) + 3                  , 2**(s-2)+1)) + [2**(s-1)+1]
 
     for x in R:
         R[x] = [K[i] for i in R[x]]
@@ -2174,7 +2174,7 @@ def SRG_243_110_37_60():
     from sage.coding.golay_code import GolayCode
     M = GolayCode(GF(3), False).generator_matrix()
     V = list(M.right_kernel())
-    g = Graph([list(xrange(len(V))), lambda x, y: (V[x] - V[y]).hamming_weight() == 9])
+    g = Graph([list(range(len(V))), lambda x, y: (V[x] - V[y]).hamming_weight() == 9])
     g.name('Ternary Golay code')
     return g
 

--- a/src/sage/groups/perm_gps/partn_ref/automorphism_group_canonical_label.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/automorphism_group_canonical_label.pyx
@@ -282,8 +282,8 @@ def coset_rep(list perm=[0,1,2,3,4,5], list gens=[[1,2,3,4,5,0]]):
     output = get_aut_gp_and_can_lab(<void *> perm, part, n, &all_children_are_equivalent_trivial, &refine_and_return_invariant_trivial, &compare_perms, 1, group, NULL, NULL)
     SC_order(output.group, 0, I.value)
     assert I == 1
-    r_inv = list(xrange(n))
-    for i from 0 <= i < n:
+    r_inv = list(range(n))
+    for i in range(n):
         r_inv[output.relabeling[i]] = i
     label = [perm[r_inv[i]] for i in range(n)]
     PS_dealloc(part)

--- a/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
@@ -1575,7 +1575,7 @@ def SC_test_list_perms(list L, int n, int limit, bint gap, bint limit_complain, 
                         print('element {}'.format(permy))
                         print('GAP says it is an element, SC_contains(modify=1) does not')
                         raise AssertionError
-                    permy = list(xrange(1, n + 1))
+                    permy = list(range(1, n + 1))
                     shuffle(permy)
                     gap_says = (PermutationGroupElement(permy) in G)
                     for j from 0 <= j < n:

--- a/src/sage/groups/perm_gps/partn_ref/refinement_graphs.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/refinement_graphs.pyx
@@ -87,7 +87,7 @@ def isomorphic(G1, G2, partn, ordering2, dig, use_indicator_function, sparse=Fal
                 n = G_in.num_verts()
             elif n != G_in.num_verts():
                 return False
-            if G_in.vertices(sort=True) != list(xrange(n)):
+            if G_in.vertices(sort=True) != list(range(n)):
                 G_in = copy(G_in)
                 to = G_in.relabel(return_map=True)
                 frm = {}
@@ -98,7 +98,7 @@ def isomorphic(G1, G2, partn, ordering2, dig, use_indicator_function, sparse=Fal
             else:
                 if first:
                     partition = partn
-                to = list(xrange(n))
+                to = list(range(n))
                 frm = to
             if sparse:
                 G = SparseGraph(n)
@@ -389,7 +389,7 @@ def search_tree(G_in, partition, lab=True, dig=False, dict_rep=False, certificat
     if isinstance(G_in, GenericGraph):
         loops = G_in.has_loops()
         n = G_in.num_verts()
-        if G_in.vertices(sort=False) != list(xrange(n)):
+        if G_in.vertices(sort=False) != list(range(n)):
             G_in = copy(G_in)
             to = G_in.relabel(return_map=True)
             frm = {}
@@ -851,7 +851,7 @@ def random_tests(num=10, n_max=60, perms_per_graph=5):
                 print(H.graph6_string())
                 print(perm)
                 return
-            isom = isomorphic(G, H, [list(xrange(n))], list(xrange(n)), 0, 1)
+            isom = isomorphic(G, H, [list(range(n))], list(range(n)), 0, 1)
             if not isom or G.relabel(isom, inplace=False) != H:
                 print("isom FAILURE: graph6-")
                 print(H.graph6_string())
@@ -876,7 +876,7 @@ def random_tests(num=10, n_max=60, perms_per_graph=5):
                 print(E.dig6_string())
                 print(perm)
                 return
-            isom = isomorphic(D, E, [list(xrange(n))], list(xrange(n)), 1, 1)
+            isom = isomorphic(D, E, [list(range(n))], list(range(n)), 1, 1)
             if not isom or D.relabel(isom, inplace=False) != E:
                 print("isom FAILURE: dig6-")
                 print(E.dig6_string())
@@ -886,6 +886,7 @@ def random_tests(num=10, n_max=60, perms_per_graph=5):
         num_tests += 4*perms_per_graph
         num_graphs += 2
     print("All passed: %d random tests on %d graphs." % (num_tests, num_graphs))
+
 
 def orbit_partition(gamma, list_perm=False):
     r"""

--- a/src/sage/groups/perm_gps/partn_ref/refinement_sets.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/refinement_sets.pyx
@@ -383,7 +383,7 @@ def sets_isom_py(generators, set1, set2):
     set2 = set(set2)
     if not generators:
         if set1 == set2:
-            return list(xrange(max(set1) + 1))
+            return list(range(max(set1) + 1))
         else:
             return False
 
@@ -800,7 +800,6 @@ def sets_modulo_perm_group(list generators, int max_size,
         sage: X = sets_modulo_perm_group([[0,2,1,4,3,5,8,7,6],[8,7,6,3,5,4,2,1,0]], 9)
         sage: len(X)
         74
-
     """
     cdef list out_list = []
     cdef int i
@@ -809,7 +808,7 @@ def sets_modulo_perm_group(list generators, int max_size,
     if len(generators) == 0:
         ll = []
         for i in range(max_size,-1,-1):
-            ll.append(list(xrange(i)))
+            ll.append(list(range(i)))
         return ll
     cdef int n = len(generators[0]), n_gens = len(generators)
     cdef iterator *subset_iterator

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -965,7 +965,7 @@ cdef class Matrix(sage.structure.element.Matrix):
                     if ind < 0 or ind >= nrows:
                         raise IndexError("matrix index out of range")
             elif isinstance(row_index, slice):
-                row_list = list(xrange(*row_index.indices(nrows)))
+                row_list = list(range(*row_index.indices(nrows)))
             else:
                 if not PyIndex_Check(row_index):
                     raise TypeError("index must be an integer")
@@ -998,7 +998,7 @@ cdef class Matrix(sage.structure.element.Matrix):
                     if ind < 0 or ind >= ncols:
                         raise IndexError("matrix index out of range")
             elif isinstance(col_index, slice):
-                col_list =  list(xrange(*col_index.indices(ncols)))
+                col_list =  list(range(*col_index.indices(ncols)))
             else:
                 if not PyIndex_Check(col_index):
                     raise TypeError("index must be an integer")
@@ -1049,7 +1049,7 @@ cdef class Matrix(sage.structure.element.Matrix):
                     raise IndexError("matrix index out of range")
             r = self.matrix_from_rows(row_list)
         elif isinstance(row_index, slice):
-            row_list = list(xrange(*row_index.indices(nrows)))
+            row_list = list(range(*row_index.indices(nrows)))
             r = self.matrix_from_rows(row_list)
         else:
             if not PyIndex_Check(row_index):
@@ -3745,7 +3745,7 @@ cdef class Matrix(sage.structure.element.Matrix):
         - [FZ2001]_
         """
         cdef dict d = {}
-        cdef list queue = list(xrange(self._ncols))
+        cdef list queue = list(range(self._ncols))
         cdef int l, sign, i, j
 
         if skew:

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -6029,7 +6029,7 @@ cdef class Matrix(Matrix1):
         # sequence corresponding to the 0-th entries of the iterates,
         # then the 1-th entries, etc.
         if t == 0:
-            R = list(xrange(n))
+            R = list(range(n))
         else:
             R = [t]
         for i in R:
@@ -8584,7 +8584,7 @@ cdef class Matrix(Matrix1):
                 aM.append(aN)
         # We construct line l:
         for l in range(1, nrows - 1):
-            if not S == list(xrange(first_row[0] + ncols, first_row[0], -1)):
+            if not S == list(range(first_row[0] + ncols, first_row[0], -1)):
                 # Sort each row with respect to S for the first matrix in X = MS
                 X = copy(MS)
                 SM = [sorted([(S[j], X[0][k][j]) for j in range(ncols)], reverse=True)
@@ -13550,7 +13550,7 @@ cdef class Matrix(Matrix1):
                 M = self.change_ring(F)
             m, n = M._nrows, M._ncols
             d = min(m, n)
-            perm = list(xrange(m))
+            perm = list(range(m))
             zero = F(0)
             for k in range(d):
                 max_location = -1
@@ -18214,7 +18214,7 @@ def _choose(Py_ssize_t n, Py_ssize_t t):
     cdef Py_ssize_t j, temp
 
     x = []               # initialize T1
-    c = list(xrange(t))
+    c = list(range(t))
     if t == n:
         x.append(c)
         return x

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -4676,7 +4676,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         """
         if self._nrows == 0:
             pivots = []
-            nonpivots = list(xrange(self._ncols))
+            nonpivots = list(range(self._ncols))
             X = self.__copy__()
             d = Integer(1)
             return pivots, nonpivots, X, d
@@ -4945,7 +4945,6 @@ cdef class Matrix_integer_dense(Matrix_dense):
                 new_top = s*row_i  +  t*row_n
                 new_bot = bg*row_i - ag*row_n
 
-
                 # OK -- now we have to make sure the top part of the matrix
                 # but with row i replaced by
                 #     r = s*row_i[j]  +  t*row_n[j]
@@ -4953,7 +4952,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
                 # function with the top part of A (all but last row) and the
                 # row r.
 
-                zz = list(xrange(A.nrows() - 1))
+                zz = list(range(A.nrows() - 1))
                 del zz[i]
                 top_mat = A.matrix_from_rows(zz)
                 new_pivots = list(pivots)

--- a/src/sage/misc/misc_c.pyx
+++ b/src/sage/misc/misc_c.pyx
@@ -585,7 +585,7 @@ cpdef list normalize_index(object key, int size):
             raise IndexError("index out of range")
         return [index]
     elif isinstance(key, slice):
-        return list(xrange(*key.indices(size)))
+        return list(range(*key.indices(size)))
     elif type(key) is tuple:
         index_tuple = key
     elif type(key) is list:

--- a/src/sage/modular/modsym/relation_matrix_pyx.pyx
+++ b/src/sage/modular/modsym/relation_matrix_pyx.pyx
@@ -57,7 +57,7 @@ def sparse_2term_quotient_only_pm1(rels, n):
     tm = verbose("Starting optimized integer sparse 2-term quotient...")
 
     cdef int c0, c1, i, die
-    cdef list free = list(xrange(n))
+    cdef list free = list(range(n))
     cdef list coef = [1] * n
     cdef list related_to_me = [[] for i in range(n)]
 

--- a/src/sage/numerical/backends/generic_backend.pyx
+++ b/src/sage/numerical/backends/generic_backend.pyx
@@ -721,7 +721,7 @@ cdef class GenericBackend:
             tester = p._tester(**options)
         # From doctest of GenericBackend.solve:
         tester.assertIsNone(p.add_linear_constraints(5, 0, None))
-        tester.assertIsNone(p.add_col(list(xrange(5)), list(xrange(5))))
+        tester.assertIsNone(p.add_col(list(range(5)), list(range(5))))
         tester.assertEqual(p.solve(), 0)
         tester.assertIsNone(p.objective_coefficient(0,1))
         from sage.numerical.mip import MIPSolverException
@@ -1299,7 +1299,7 @@ cdef class GenericBackend:
         p.add_linear_constraints(5, 0, None)
         try:
             # p.add_col(range(5), range(5))     -- bad test because COIN sparsifies the 0s away on copy
-            p.add_col(list(xrange(5)), list(xrange(1, 6)))
+            p.add_col(list(range(5)), list(range(1, 6)))
         except NotImplementedError:
             # Gurobi does not implement add_col
             pass

--- a/src/sage/numerical/mip.pyx
+++ b/src/sage/numerical/mip.pyx
@@ -993,11 +993,11 @@ cdef class MixedIntegerLinearProgram(SageObject):
         cdef str s
         cdef GenericBackend b = self._backend
 
-        result = list()
+        result = []
 
         # If indices is None, we actually want to return all constraints
         if indices is None:
-            indices = list(xrange(b.nrows()))
+            indices = list(range(b.nrows()))
 
         # Only one constraint
         if isinstance(indices, (int, Integer)):

--- a/src/sage/plot/plot3d/index_face_set.pyx
+++ b/src/sage/plot/plot3d/index_face_set.pyx
@@ -1722,14 +1722,13 @@ cdef class IndexFaceSet(PrimitiveObject):
             sage: S = B.stickers(['red','yellow','blue'], 0.1, 0.05)
             sage: S.show()
             sage: (S+B).show()
-
         """
         all = []
         n = self.fcount
         ct = len(colors)
         for k in range(len(colors)):
             if colors[k]:
-                all.append(self.sticker(list(xrange(k, n, ct)), width, hover,
+                all.append(self.sticker(list(range(k, n, ct)), width, hover,
                                         texture=colors[k]))
         return Graphics3dGroup(all)
 

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -3214,7 +3214,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         cdef list pl, ml
 
         pl = list()
-        ml = list(xrange(r.N))
+        ml = list(range(r.N))
         if as_ETuples:
             while p:
                 for v from 1 <= v <= r.N:

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -2403,7 +2403,7 @@ cdef class NCPolynomial_plural(RingElement):
         p = self._poly
 
         pl = list()
-        ml = list(xrange(r.N))
+        ml = list(range(r.N))
         while p:
             for v from 1 <= v <= r.N:
                 ml[v - 1] = p_GetExp(p, v, r)

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -2711,7 +2711,7 @@ cdef class Polynomial(CommutativePolynomial):
         m = self.degree() + 1
         atomic_repr = self._parent.base_ring()._repr_option('element_is_atomic')
         coeffs = self.list(copy=False)
-        for n in reversed(xrange(m)):
+        for n in reversed(range(m)):
             x = coeffs[n]
             is_nonzero = False
             try:
@@ -2801,7 +2801,7 @@ cdef class Polynomial(CommutativePolynomial):
         if name is None:
             name = self._parent.latex_variable_names()[0]
         atomic_repr = self._parent.base_ring()._repr_option('element_is_atomic')
-        for n in reversed(xrange(m)):
+        for n in reversed(range(m)):
             x = coeffs[n]
             x = y = latex(x)
             if x != '0':


### PR DESCRIPTION
replace all `xrange` by `range`

apparently `xrange` tends to creep in

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.