### PR TITLE
src/sage/doctest/control.py: double the default test timeout

### DIFF
--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -417,7 +417,7 @@ class DocTestController(SageObject):
             elif options.long:
                 options.timeout = int(os.getenv('SAGE_TIMEOUT_LONG', 30 * 60))
             else:
-                options.timeout = int(os.getenv('SAGE_TIMEOUT', 5 * 60))
+                options.timeout = int(os.getenv('SAGE_TIMEOUT', 10 * 60))
             # For non-default GC options, double the timeout
             if options.gc:
                 options.timeout *= 2


### PR DESCRIPTION
When running the test suite on an older machine, many files time out. For example,

```
$ sage -t src/sage/manifolds/differentiable/tensorfield.py
...
File "src/sage/manifolds/differentiable/tensorfield.py", line 248,
in sage.manifolds.differentiable.tensorfield.TensorField
Warning: Consider using a block-scoped tag by inserting the line
'sage: # long time' just before this line to avoid repeating the
tag 4 times
  s = t(a.restrict(U), b) ; s  # long time
  Timed out (and interrupt failed)
...
----------------------------------------------------------------------
Total time for all tests: 360.3 seconds
  cpu time: 0.0 seconds
  cumulative wall time: 0.0 seconds
```

This has run over the default (non-long) test timeout of 300s. This commit doubles that default, a change that should be unobjectionable for a few reasons:

  1. This timeout is a last line of defense intended to keep the test suite from looping forever when run unattended. For that purpose, ten minutes is as good as five.

  2. As more tests get added to each file, those files take longer to test on the same hardware. It should therefore be expected that we will sometimes need to increase the timeout. (Basically, if anyone is hitting it, it's too low.)

  3. We now use Github CI instead of patchbots for most automated testing, and Github has its own timeout.

  4. There is a separate mechanism, --warn-long, intended to catch tests that run for too long. The test timeout should not be thought of as a solution to that problem.

Closes: https://github.com/sagemath/sage/issues/32973
