### PR TITLE
improve the use of graphs in `sage/combinat/posets/*`

### DIFF
--- a/src/sage/combinat/posets/d_complete.py
+++ b/src/sage/combinat/posets/d_complete.py
@@ -89,18 +89,20 @@ class DCompletePoset(FiniteJoinSemilattice):
 
                 # Check if any of these make a longer double tailed diamond
                 found_diamond = False
-                for (mn, mx) in [(i, j) for i in potential_min for j in potential_max]:
-                    if len(H.neighbors_in(mx)) != 1:
+                for mx in potential_max:
+                    if H.in_degree(mx) != 1:
                         continue
-                    if len(H.all_paths(mn, mx)) == 2:
-                        # Success
-                        min_elmt = mn
-                        max_elmt = mx
-
-                        min_diamond[mx] = mn
-                        max_diamond[mn] = mx
-                        diamond_index[mx] = index
-                        found_diamond = True
+                    for mn in potential_min:
+                        if len(H.all_paths(mn, mx)) == 2:
+                            # Success
+                            min_elmt = mn
+                            max_elmt = mx
+                            min_diamond[mx] = mn
+                            max_diamond[mn] = mx
+                            diamond_index[mx] = index
+                            found_diamond = True
+                            break
+                    if found_diamond:
                         break
                 if not found_diamond:
                     break

--- a/src/sage/combinat/posets/hasse_diagram.py
+++ b/src/sage/combinat/posets/hasse_diagram.py
@@ -598,7 +598,7 @@ class HasseDiagram(DiGraph):
         """
         n = self.order()
         v_up = (frozenset(self.depth_first_search(v)) for v in range(n))
-        v_down = [frozenset(self.depth_first_search(v, neighbors=self.neighbors_in))
+        v_down = [frozenset(self.depth_first_search(v, neighbors=self.neighbor_in_iterator))
                   for v in range(n)]
         self._intervals = [[sorted(up.intersection(down)) for down in v_down]
                            for up in v_up]
@@ -1232,7 +1232,7 @@ class HasseDiagram(DiGraph):
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 10]
         """
         return sorted(self.depth_first_search(elements,
-                                              neighbors=self.neighbors_in))
+                                              neighbors=self.neighbor_in_iterator))
 
     def order_ideal_cardinality(self, elements):
         r"""
@@ -1256,7 +1256,7 @@ class HasseDiagram(DiGraph):
                 continue
             size += 1
             seen.add(v)
-            q.extend(self.neighbors_in(v))
+            q.extend(self.neighbor_in_iterator(v))
 
         return ZZ(size)
 
@@ -2545,9 +2545,9 @@ class HasseDiagram(DiGraph):
             sage: H.common_upper_covers([4, 5])                                         # optional - sage.combinat
             [6]
         """
-        covers = set(self.neighbors_out(vertices.pop()))
+        covers = set(self.neighbor_out_iterator(vertices.pop()))
         for v in vertices:
-            covers = covers.intersection(self.neighbors_out(v))
+            covers = covers.intersection(self.neighbor_out_iterator(v))
         return list(covers)
 
     def common_lower_covers(self, vertices):
@@ -2566,9 +2566,9 @@ class HasseDiagram(DiGraph):
             sage: H.common_lower_covers([4, 5])                                         # optional - sage.combinat
             [3]
         """
-        covers = set(self.neighbors_in(vertices.pop()))
+        covers = set(self.neighbor_in_iterator(vertices.pop()))
         for v in vertices:
-            covers = covers.intersection(self.neighbors_in(v))
+            covers = covers.intersection(self.neighbor_in_iterator(v))
         return list(covers)
 
     def _trivial_nonregular_congruence(self):
@@ -2764,7 +2764,7 @@ class HasseDiagram(DiGraph):
                     break
 
         # Special case to handle at last.
-        if len(self.neighbors_out(0)) == 1:
+        if self.out_degree(0) == 1:
             result.append(set(range(1, N)))
 
         return result
@@ -2830,8 +2830,8 @@ class HasseDiagram(DiGraph):
         uc = next(self.neighbor_out_iterator(a))
         if self.in_degree(uc) == 1:
             return uc
-        lt_a = set(self.depth_first_search(a, neighbors=self.neighbors_in))
-        tmp = list(self.depth_first_search(uc, neighbors=lambda v: [v_ for v_ in self.neighbor_in_iterator(v) if v_ not in lt_a]))
+        lt_a = set(self.depth_first_search(a, neighbors=self.neighbor_in_iterator))
+        tmp = set(self.depth_first_search(uc, neighbors=lambda v: [v_ for v_ in self.neighbor_in_iterator(v) if v_ not in lt_a]))
         result = None
         for e in tmp:
             if all(x not in tmp for x in self.neighbor_in_iterator(e)):
@@ -2990,7 +2990,7 @@ class HasseDiagram(DiGraph):
 
         def is_neutral(a):
             noncomp = all_elements.difference(self.depth_first_search(a))
-            noncomp.difference_update(self.depth_first_search(a, neighbors=self.neighbors_in))
+            noncomp.difference_update(self.depth_first_search(a, neighbors=self.neighbor_in_iterator))
 
             for x in noncomp.intersection(todo):
                 meet_ax = mt[a, x]
@@ -3071,7 +3071,7 @@ class HasseDiagram(DiGraph):
         if self.out_degree(lc) == 1:
             return lc
         gt_a = set(self.depth_first_search(a))
-        tmp = list(self.depth_first_search(lc, neighbors=lambda v: [v_ for v_ in self.neighbor_out_iterator(v) if v_ not in gt_a]))
+        tmp = set(self.depth_first_search(lc, neighbors=lambda v: [v_ for v_ in self.neighbor_out_iterator(v) if v_ not in gt_a]))
         result = None
         for e in tmp:
             if all(x not in tmp for x in self.neighbor_out_iterator(e)):
@@ -3346,9 +3346,9 @@ class HasseDiagram(DiGraph):
         join_irreducibles = [v for v in self if self.in_degree(v) == 1]
         meet_irreducibles = [v for v in self if self.out_degree(v) == 1]
         if len(join_irreducibles) < len(meet_irreducibles):
-            irr = [(v, self.neighbors_in(v)[0]) for v in join_irreducibles]
+            irr = [(v, next(self.neighbor_in_iterator(v))) for v in join_irreducibles]
         else:
-            irr = [(self.neighbors_out(v)[0], v) for v in meet_irreducibles]
+            irr = [(next(self.neighbor_out_iterator(v)), v) for v in meet_irreducibles]
         irr.sort(key=lambda x: x[0] - x[1])
         tried = []
         for pair in irr:

--- a/src/sage/combinat/posets/lattices.py
+++ b/src/sage/combinat/posets/lattices.py
@@ -1695,7 +1695,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         n = H.order()
         for e in range(n - 2, -1, -1):
             t = 0
-            for uc in H.neighbors_out(e):
+            for uc in H.neighbor_out_iterator(e):
                 t = jn[t, uc]
                 if t == n - 1:
                     break

--- a/src/sage/combinat/posets/lattices.py
+++ b/src/sage/combinat/posets/lattices.py
@@ -1805,13 +1805,13 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
                 return False
 
         for e1 in range(n - 1):
-            C = Counter(flatten([H.neighbors_out(e2) for e2 in H.neighbors_out(e1)]))
+            C = Counter(flatten([H.neighbors_out(e2) for e2 in H.neighbor_out_iterator(e1)]))
             for e3, c in C.items():
                 if c == 1 and len(H.closed_interval(e1, e3)) == 3:
                     if not certificate:
                         return False
-                    for e2 in H.neighbors_in(e3):
-                        if e2 in H.neighbors_out(e1):
+                    for e2 in H.neighbor_in_iterator(e3):
+                        if e2 in H.neighbor_out_iterator(e1):
                             break
                     return (False, (self._vertex_to_element(e1),
                                     self._vertex_to_element(e2),
@@ -1885,7 +1885,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         n = H.order() - 1
         for e in range(2, n + 1):
             t = n
-            for lc in H.neighbors_in(e):
+            for lc in H.neighbor_in_iterator(e):
                 t = mt[t, lc]
                 if t == 0:
                     break
@@ -1988,7 +1988,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
 
                 # Get elements more than B levels below it.
                 too_close = set(H.breadth_first_search(j,
-                                                       neighbors=H.neighbors_in,
+                                                       neighbors=H.neighbor_in_iterator,
                                                        distance=B - 2))
                 elems = [e for e in H.order_ideal([j]) if e not in too_close]
 
@@ -2378,7 +2378,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         if self.cardinality() < 3:
             return (True, None)
         H = self._hasse_diagram
-        atoms = set(H.neighbors_out(0))
+        atoms = set(H.neighbor_out_iterator(0))
         for v in H:
             if H.in_degree(v) == 1 and v not in atoms:
                 return (False, self._vertex_to_element(v))
@@ -2436,7 +2436,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         if self.cardinality() < 3:
             return (True, None)
         H = self._hasse_diagram
-        coatoms = set(H.neighbors_in(n - 1))
+        coatoms = set(H.neighbor_in_iterator(n - 1))
         for v in H:
             if H.out_degree(v) == 1 and v not in coatoms:
                 return (False, self._vertex_to_element(v))
@@ -3782,8 +3782,8 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
                     if certificate:
                         cert.append(e)
                     if i == 1 and o == 1:  # Remove inside the lattice
-                        lower = H.neighbors_in(e)[0]
-                        upper = H.neighbors_out(e)[0]
+                        lower = next(H.neighbor_in_iterator(e))
+                        upper = next(H.neighbor_out_iterator(e))
                         H.delete_vertex(e)
                         if upper not in H.depth_first_search(lower):
                             H.add_edge(lower, upper)
@@ -4125,11 +4125,11 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         H = self._hasse_diagram
         e = self._element_to_vertex(e)
         meetands = []
-        for a in H.neighbors_out(e):
-            above_a = list(H.depth_first_search(a))
+        for a in H.neighbor_out_iterator(e):
+            above_a = set(H.depth_first_search(a))
 
             def go_up(v):
-                return [v_ for v_ in H.neighbors_out(v) if v_ not in above_a]
+                return [v_ for v_ in H.neighbor_out_iterator(v) if v_ not in above_a]
 
             result = None
             for v in H.depth_first_search(e, neighbors=go_up):
@@ -4191,11 +4191,11 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         H = self._hasse_diagram
         e = self._element_to_vertex(e)
         joinands = []
-        for a in H.neighbors_in(e):
-            below_a = list(H.depth_first_search(a, neighbors=H.neighbors_in))
+        for a in H.neighbor_in_iterator(e):
+            below_a = set(H.depth_first_search(a, neighbors=H.neighbor_in_iterator))
 
             def go_down(v):
-                return [v_ for v_ in H.neighbors_in(v) if v_ not in below_a]
+                return [v_ for v_ in H.neighbor_in_iterator(v) if v_ not in below_a]
 
             result = None
             for v in H.depth_first_search(e, neighbors=go_down):

--- a/src/sage/combinat/posets/mobile.py
+++ b/src/sage/combinat/posets/mobile.py
@@ -112,13 +112,13 @@ class MobilePoset(FinitePoset):
         num_anchors = 0
 
         for r in ribbon:
-            anchor_neighbors = set(G.neighbors_out(r)).difference(set(R.neighbors_out(r)))
+            anchor_neighbors = set(G.neighbor_out_iterator(r)).difference(set(R.neighbor_out_iterator(r)))
             if len(anchor_neighbors) == 1:
                 num_anchors += 1
             elif len(anchor_neighbors) > 1:
                 return False
 
-            for lc in G.neighbors_in(r):
+            for lc in G.neighbor_in_iterator(r):
                 if lc in ribbon:
                     continue
 
@@ -151,7 +151,7 @@ class MobilePoset(FinitePoset):
 
         # Find the anchor vertex, if it exists, and return the edge
         for r in ribbon:
-            anchor_neighbors = set(H.neighbors_out(r)).difference(set(R.neighbors_out(r)))
+            anchor_neighbors = set(H.neighbor_out_iterator(r)).difference(set(R.neighbor_out_iterator(r)))
             if len(anchor_neighbors) == 1:
                 anchor = (r, anchor_neighbors.pop())
                 break


### PR DESCRIPTION
The main changes are:
- avoid sorting vertices or edges when not required
- avoid asking for edge labels when not needed
- use more iterators
- avoid computing all paths from `s` in `_ford_fulkerson_chronicle` (in `posets.py`)


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
