### PR TITLE
Use CPU time for --warn-long

### DIFF
--- a/pkgs/sagemath-repl/MANIFEST.in
+++ b/pkgs/sagemath-repl/MANIFEST.in
@@ -7,6 +7,12 @@ include sage/misc/sagedoc.py
 include sage/misc/sage_input.py
 include sage/misc/sage_eval.py
 
+# expect_objects from sage.interfaces.quit is needed to compute the
+# CPU time used by each doctest. We include sage.interfaces.cleaner
+# because it is conditionally imported by sage.interfaces.quit.
+include sage/interfaces/quit.py
+include sage/interfaces/cleaner.py
+
 include VERSION.txt
 
 global-exclude all__*.py

--- a/pkgs/sagemath-repl/pyproject.toml.m4
+++ b/pkgs/sagemath-repl/pyproject.toml.m4
@@ -42,6 +42,7 @@ py-modules = [
 ]
 packages = [
     "sage.doctest",
+    "sage.interfaces",
     "sage.repl",
     "sage.repl.display",
     "sage.repl.ipython_kernel",

--- a/src/bin/sage
+++ b/src/bin/sage
@@ -428,7 +428,7 @@ usage_advanced() {
         echo "     --initial        -- only show the first failure per block"
         echo "     --debug          -- drop into PDB after an unexpected error"
         echo "     --failed         -- only test files that failed last test"
-        echo "     --warn-long [timeout] -- warning if doctest is slow"
+        echo "     --warn-long [timeout] -- warn if tests take too much CPU time"
         echo "     --only-errors    -- only output failures, not successes"
         echo "     --gc=GC          -- control garbarge collection (ALWAYS:"
         echo "                         collect garbage before every test; NEVER:"

--- a/src/doc/en/developer/doctesting.rst
+++ b/src/doc/en/developer/doctesting.rst
@@ -745,10 +745,10 @@ In order to run the long tests as well, do the following::
         cpu time: 25.2 seconds
         cumulative wall time: 34.7 seconds
 
-To find tests that take longer than the allowed time use the
-``--warn-long`` flag.  Without any options it will cause tests to
-print a warning if they take longer than 1.0 second. Note that this is
-a warning, not an error::
+To find tests that take longer than a specified amount of CPU time,
+use the ``--warn-long`` flag.  Without any options, it will cause a
+warning to be printed if any tests take longer than one
+cpu-second. Note that this is a warning, not an error::
 
     [roed@localhost sage]$ ./sage -t --warn-long src/sage/rings/factorint.pyx
     Running doctests with ID 2012-07-14-03-27-03-2c952ac1.
@@ -758,22 +758,22 @@ a warning, not an error::
     File "src/sage/rings/factorint.pyx", line 125, in sage.rings.factorint.base_exponent
     Failed example:
         base_exponent(-4)
-    Test ran for 4.09 s
+    Test ran for 4.09 cpu seconds
     **********************************************************************
     File "src/sage/rings/factorint.pyx", line 153, in sage.rings.factorint.factor_aurifeuillian
     Failed example:
         fa(2^6+1)
-    Test ran for 2.22 s
+    Test ran for 2.22 cpu seconds
     **********************************************************************
     File "src/sage/rings/factorint.pyx", line 155, in sage.rings.factorint.factor_aurifeuillian
     Failed example:
         fa(2^58+1)
-    Test ran for 2.22 s
+    Test ran for 2.22 cpu seconds
     **********************************************************************
     File "src/sage/rings/factorint.pyx", line 163, in sage.rings.factorint.factor_aurifeuillian
     Failed example:
         fa(2^4+1)
-    Test ran for 2.25 s
+    Test ran for 2.25 cpu seconds
     **********************************************************************
     ----------------------------------------------------------------------
     All tests passed!
@@ -792,12 +792,12 @@ You can also pass in an explicit amount of time::
     File "tests.py", line 240, in sage.rings.tests.test_random_elements
     Failed example:
         sage.rings.tests.test_random_elements(trials=1000)  # long time (5 seconds)
-    Test ran for 13.36 s
+    Test ran for 13.36 cpu seconds
     **********************************************************************
     File "tests.py", line 283, in sage.rings.tests.test_random_arith
     Failed example:
         sage.rings.tests.test_random_arith(trials=1000)   # long time (5 seconds?)
-    Test ran for 12.42 s
+    Test ran for 12.42 cpu seconds
     **********************************************************************
     ----------------------------------------------------------------------
     All tests passed!

--- a/src/sage/doctest/__main__.py
+++ b/src/sage/doctest/__main__.py
@@ -64,7 +64,7 @@ def _make_parser():
                         help="run as many doctests as possible in about 300 seconds (or the number of seconds given as an optional argument)")
     parser.add_argument("--warn-long", dest="warn_long", nargs='?',
                         type=float, default=-1.0, const=1.0, metavar="SECONDS",
-                        help="warn if tests take more time than SECONDS")
+                        help="warn if tests take more CPU time than SECONDS")
     # By default, include all tests marked 'sagemath_doc_html' -- see
     # https://github.com/sagemath/sage/issues/25345 and
     # https://github.com/sagemath/sage/issues/26110:

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -595,7 +595,8 @@ class DocTestController(SageObject):
         finish in less than about 5 seconds. Longer tests typically
         don't add coverage, they just make testing slow.
 
-        The default used here, for all tests, is 60 seconds.
+        The default used here is 10 seconds, unless `--long` was used,
+        in which case it is 60 seconds.
 
         TESTS:
 
@@ -613,7 +614,12 @@ class DocTestController(SageObject):
         if self.options.warn_long >= 0:     # Specified on the command line
             return
 
-        self.options.warn_long = 60.0
+        # The developer's guide says that even a "long time" test
+        # should ideally complete in under five seconds, so we're
+        # being rather generous here.
+        self.options.warn_long = 10.0
+        if self.options.long:
+            self.options.warn_long = 60.0
 
     def second_on_modern_computer(self):
         """

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -595,8 +595,8 @@ class DocTestController(SageObject):
         finish in less than about 5 seconds. Longer tests typically
         don't add coverage, they just make testing slow.
 
-        The default used here is 10 seconds, unless `--long` was used,
-        in which case it is 60 seconds.
+        The default used here is 5 seconds, unless `--long` was used,
+        in which case it is 30 seconds.
 
         TESTS:
 

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -1154,7 +1154,7 @@ class DocTestController(SageObject):
             sage: DC.run_doctests()
             Doctesting 1 file.
             sage -t .../sage/rings/homset.py
-                [... tests, ... s]
+                [... tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------
@@ -1231,7 +1231,7 @@ class DocTestController(SageObject):
             Running doctests with ID ...
             Doctesting 1 file.
             sage -t .../rings/all.py
-                [... tests, ... s]
+                [... tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------
@@ -1435,7 +1435,7 @@ class DocTestController(SageObject):
             Running doctests with ID ...
             Doctesting 1 file.
             sage -t .../sage/sets/non_negative_integers.py
-                [... tests, ... s]
+                [... tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------
@@ -1459,7 +1459,7 @@ class DocTestController(SageObject):
             Features to be detected: ...
             Doctesting 1 file.
             sage -t ....py
-                [0 tests, ... s]
+                [0 tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------
@@ -1485,7 +1485,7 @@ class DocTestController(SageObject):
             Features to be detected: ...
             Doctesting 1 file.
             sage -t ....py
-                [4 tests, ... s]
+                [4 tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------
@@ -1503,7 +1503,7 @@ class DocTestController(SageObject):
             Features to be detected: ...
             Doctesting 1 file.
             sage -t ....py
-                [4 tests, ... s]
+                [4 tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------
@@ -1629,7 +1629,7 @@ def run_doctests(module, options=None):
         Running doctests with ID ...
         Doctesting 1 file.
         sage -t .../sage/rings/all.py
-            [... tests, ... s]
+            [... tests, ...s wall]
         ----------------------------------------------------------------------
         All tests passed!
         ----------------------------------------------------------------------

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -617,9 +617,9 @@ class DocTestController(SageObject):
         # The developer's guide says that even a "long time" test
         # should ideally complete in under five seconds, so we're
         # being rather generous here.
-        self.options.warn_long = 10.0
+        self.options.warn_long = 5.0
         if self.options.long:
-            self.options.warn_long = 60.0
+            self.options.warn_long = 30.0
 
     def second_on_modern_computer(self):
         """

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -1521,7 +1521,7 @@ class DocTestController(SageObject):
             Features to be detected: ...
             Doctesting 1 file.
             sage -t ....py
-                [4 tests, ... s]
+                [4 tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -639,6 +639,9 @@ class DocTestController(SageObject):
             sage: DC = DocTestController(DocTestDefaults(), [])
             sage: DC.second_on_modern_computer()   # not tested
         """
+        from sage.misc.superseded import deprecation
+        deprecation(32981, "this method is no longer used by the sage library and will eventually be removed")
+
         if len(self.stats) == 0:
             raise RuntimeError('no stored timings available')
         success = []

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -588,36 +588,32 @@ class DocTestController(SageObject):
 
     def _init_warn_long(self):
         """
-        Pick a suitable default for the ``--warn-long`` option if not specified.
+        Pick a suitable default for the ``--warn-long`` option if not
+        specified.
 
         It is desirable to have all tests (even ``# long`` ones)
         finish in less than about 5 seconds. Longer tests typically
         don't add coverage, they just make testing slow.
 
-        The default used here is 60 seconds on a modern computer. It
-        should eventually be lowered to 5 seconds, but its best to
-        boil the frog slowly.
+        The default used here, for all tests, is 60 seconds.
 
-        The stored timings are used to adjust this limit according to
-        the machine running the tests.
+        TESTS:
 
-        EXAMPLES::
+        Ensure that the user's command-line options are not changed::
 
-            sage: from sage.doctest.control import DocTestDefaults, DocTestController
+            sage: from sage.doctest.control import (DocTestDefaults,
+            ....:                                   DocTestController)
             sage: DC = DocTestController(DocTestDefaults(), [])
             sage: DC.options.warn_long = 5.0
             sage: DC._init_warn_long()
-            sage: DC.options.warn_long    # existing command-line options are not changed
+            sage: DC.options.warn_long
             5.00000000000000
         """
         # default is -1.0
         if self.options.warn_long >= 0:     # Specified on the command line
             return
-        try:
-            self.options.warn_long = 60.0 * self.second_on_modern_computer()
-        except RuntimeError as err:
-            if not sage.doctest.DOCTEST_MODE:
-                print(err)   # No usable timing information
+
+        self.options.warn_long = 60.0
 
     def second_on_modern_computer(self):
         """

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1367,12 +1367,12 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: check.walltime = 2.71
             sage: DTR.report_success(sys.stdout.write, doctests[0], ex, '1764',
             ....:                    check_timer=check)
-            ok [3.83 s]
+            ok [3.83s wall]
         """
         # We completely replace doctest.DocTestRunner.report_success
         # so that we can include time taken for the test
         if self._verbose:
-            out("ok [%.2f s]\n" %
+            out("ok [%.2fs wall]\n" %
                 (example.walltime + check_timer.walltime))
 
     def report_failure(self, out, test, example, got, globs):

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -729,7 +729,7 @@ class SageDocTestRunner(doctest.DocTestRunner):
             finally:
                 if self.debugger is not None:
                     self.debugger.set_continue()  # ==== Example Finished ====
-            check_starttime = walltime()
+            check_timer = Timer().start()
             got = self._fakeout.getvalue()
 
             outcome = FAILURE   # guilty until proved innocent or insane
@@ -803,22 +803,22 @@ class SageDocTestRunner(doctest.DocTestRunner):
                                 f"and it succeeded (raised an exception as expected).")
                         outcome = SUCCESS
 
-            check_duration = walltime(check_starttime)
-            self.total_walltime += example.walltime + check_duration
+            check_timer.stop()
+            self.total_walltime += example.walltime + check_timer.walltime
 
             # Report the outcome.
             if example.warnings:
                 for warning in example.warnings:
                     out(self._failure_header(test, example, f'Warning: {warning}'))
             if outcome is SUCCESS:
-                if self.options.warn_long > 0 and example.walltime + check_duration > self.options.warn_long:
+                if self.options.warn_long > 0 and example.cputime + check_timer.cputime > self.options.warn_long:
                     self.report_overtime(out, test, example, got,
-                                         check_duration=check_duration)
+                                         check_duration=check_timer.cputime)
                 elif example.warnings:
                     pass
                 elif not quiet:
                     self.report_success(out, test, example, got,
-                                        check_duration=check_duration)
+                                        check_duration=check_timer.cputime)
             elif probed_tags:
                 pass
             elif outcome is FAILURE:
@@ -1528,17 +1528,17 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
-            sage: ex.walltime = 1.23r
+            sage: ex.cputime = 1.23
             sage: DTR.report_overtime(sys.stdout.write, doctests[0], ex, 'BAD ANSWER\n', check_duration=2.34r)
             **********************************************************************
             File ".../sage/doctest/forker.py", line 12, in sage.doctest.forker
             Warning, slow doctest:
                 doctest_var = 42; doctest_var^2
-            Test ran for 1.23 s, check ran for 2.34 s
+            Test ran for 1.23 cpu seconds, check ran for 2.34 cpu seconds
         """
         out(self._failure_header(test, example, 'Warning, slow doctest:') +
-            ('Test ran for %.2f s, check ran for %.2f s\n'
-             % (example.walltime, check_duration)))
+            ('Test ran for %.2f cpu seconds, check ran for %.2f cpu seconds\n'
+             % (example.cputime, check_duration)))
 
     def report_unexpected_exception(self, out, test, example, exc_info):
         r"""

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -709,10 +709,12 @@ class SageDocTestRunner(doctest.DocTestRunner):
             elif self.options.gc < 0:
                 gc.disable()
 
+            from cysignals.signals import SignalError
             try:
                 # Don't blink!  This is where the user's code gets run.
                 self.compile_and_execute(example, compiler, test.globs)
-            except SystemExit:
+            except (SignalError, SystemExit):
+                # Tests can be killed by signals in unexpected places.
                 raise
             except BaseException:
                 exception = sys.exc_info()

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1359,13 +1359,13 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
-            sage: ex.walltime = 0.0r
+            sage: ex.cputime = 0.0r
             sage: DTR.report_success(sys.stdout.write, doctests[0], ex, '1764')
             ok [0.00 s]
         """
         # We completely replace doctest.DocTestRunner.report_success so that we can include time taken for the test
         if self._verbose:
-            out("ok [%.2f s]\n" % (example.walltime + check_duration))
+            out("ok [%.2f s]\n" % (example.cputime + check_duration))
 
     def report_failure(self, out, test, example, got, globs):
         r"""

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1537,12 +1537,12 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: DTR.report_overtime(sys.stdout.write, doctests[0], ex, 'BAD ANSWER\n', check_timer=check)
             **********************************************************************
             File ".../sage/doctest/forker.py", line 12, in sage.doctest.forker
-            Warning, slow doctest:
+            Warning: slow doctest:
                 doctest_var = 42; doctest_var^2
             Test ran for 1.23s cpu, 2.50s wall
             Check ran for 2.34s cpu, 3.12s wall
         """
-        out(self._failure_header(test, example, 'Warning, slow doctest:') +
+        out(self._failure_header(test, example, 'Warning: slow doctest:') +
             ('Test ran for %.2fs cpu, %.2fs wall\nCheck ran for %.2fs cpu, %.2fs wall\n'
              % (example.cputime,
                 example.walltime,

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -716,16 +716,6 @@ class SageDocTestRunner(doctest.DocTestRunner):
                 raise
             except BaseException:
                 exception = sys.exc_info()
-                # On Python 2, the exception lives in sys.exc_info() as
-                # long we are in the same stack frame. To ensure that
-                # sig_occurred() works correctly, we need to clear the
-                # exception. This is not an issue on Python 3, where the
-                # exception is cleared as soon as we are outside of the
-                # "except" clause.
-                try:
-                    sys.exc_clear()
-                except AttributeError:
-                    pass  # Python 3
             finally:
                 if self.debugger is not None:
                     self.debugger.set_continue()  # ==== Example Finished ====

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1758,9 +1758,9 @@ class DocTestDispatcher(SageObject):
             sage: DC.timer = Timer().start()
             sage: DD.serial_dispatch()
             sage -t .../rings/homset.py
-                [... tests, ... s]
+                [... tests, ...s wall]
             sage -t .../rings/ideal.py
-                [... tests, ... s]
+                [... tests, ...s wall]
         """
         for source in self.controller.sources:
             heading = self.controller.reporter.report_head(source)
@@ -1804,9 +1804,9 @@ class DocTestDispatcher(SageObject):
             sage: DC.timer = Timer().start()
             sage: DD.parallel_dispatch()
             sage -t .../databases/cremona.py
-                [... tests, ... s]
+                [... tests, ...s wall]
             sage -t .../rings/big_oh.py
-                [... tests, ... s]
+                [... tests, ...s wall]
 
         If the ``exitfirst=True`` option is given, the results for a failing
         module will be immediately printed and any other ongoing tests
@@ -1841,7 +1841,7 @@ class DocTestDispatcher(SageObject):
             **********************************************************************
             1 item had failures:
                1 of   1 in ...
-                [1 test, 1 failure, ... s]
+                [1 test, 1 failure, ...s wall]
             Killing test ...
         """
         opt = self.controller.options
@@ -2135,9 +2135,9 @@ class DocTestDispatcher(SageObject):
             sage: DC.timer = Timer().start()
             sage: DD.dispatch()
             sage -t .../sage/modules/free_module_homspace.py
-                [... tests, ... s]
+                [... tests, ...s wall]
             sage -t .../sage/rings/big_oh.py
-                [... tests, ... s]
+                [... tests, ...s wall]
         """
         if self.controller.options.serial:
             self.serial_dispatch()
@@ -2187,7 +2187,7 @@ class DocTestWorker(multiprocessing.Process):
         sage: W.join()  # Wait for worker to finish
         sage: result = W.result_queue.get()
         sage: reporter.report(FDS, False, W.exitcode, result, "")
-            [... tests, ... s]
+            [... tests, ...s wall]
     """
     def __init__(self, source, options, funclist=[], baseline=None):
         """
@@ -2199,7 +2199,7 @@ class DocTestWorker(multiprocessing.Process):
             Running doctests with ID ...
             Doctesting 1 file.
             sage -t .../sage/rings/big_oh.py
-                [... tests, ... s]
+                [... tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------
@@ -2246,7 +2246,7 @@ class DocTestWorker(multiprocessing.Process):
             Running doctests with ID ...
             Doctesting 1 file.
             sage -t .../sage/symbolic/units.py
-                [... tests, ... s]
+                [... tests, ...s wall]
             ----------------------------------------------------------------------
             All tests passed!
             ----------------------------------------------------------------------

--- a/src/sage/doctest/reporting.py
+++ b/src/sage/doctest/reporting.py
@@ -403,7 +403,7 @@ class DocTestReporter(SageObject):
             0
             sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
             ....:            "Good tests")
-                [... tests, ... s]
+                [... tests, ...s wall]
             sage: DTR.stats
             {'sage.doctest.reporting': {'ntests': ..., 'walltime': ...}}
 
@@ -414,7 +414,7 @@ class DocTestReporter(SageObject):
             1
             sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
             ....:            "Doctest output including the failure...")
-                [... tests, 1 failure, ... s]
+                [... tests, 1 failure, ...s wall]
 
         If the user has requested that we report on skipped doctests,
         we do so::
@@ -433,7 +433,7 @@ class DocTestReporter(SageObject):
                 5 magma tests not run
                 2 not tested tests not run
                 0 tests not run because we ran out of time
-                [... tests, ... s]
+                [... tests, ...s wall]
 
         Test an internal error in the reporter::
 
@@ -466,7 +466,7 @@ class DocTestReporter(SageObject):
             1
             sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
             ....:            "Failed test")
-                [... tests, 1 failure, ... s]
+                [... tests, 1 failure, ...s wall]
         """
         log = self.controller.log
         process_name = 'process (pid={0})'.format(pid) if pid else 'process'
@@ -625,7 +625,7 @@ class DocTestReporter(SageObject):
                     else:
                         total = count_noun(ntests, "test")
                     if not (self.controller.options.only_errors and not f):
-                        log("    [%s, %s%.2f s]" % (total, "%s, " % (count_noun(f, "failure")) if f else "", wall))
+                        log("    [%s, %s%.2fs wall]" % (total, "%s, "%(count_noun(f, "failure")) if f else "", wall))
 
             self.sources_completed += 1
 
@@ -680,13 +680,13 @@ class DocTestReporter(SageObject):
             0
             sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
             ....:            "Good tests")
-                [... tests, ... s]
+                [... tests, ...s wall]
             sage: runner.failures = 1
             sage: runner.update_results(D)
             1
             sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
             ....:            "Doctest output including the failure...")
-                [... tests, 1 failure, ... s]
+                [... tests, 1 failure, ...s wall]
 
         Now we can show the output of finalize::
 

--- a/src/sage/doctest/reporting.py
+++ b/src/sage/doctest/reporting.py
@@ -625,7 +625,7 @@ class DocTestReporter(SageObject):
                     else:
                         total = count_noun(ntests, "test")
                     if not (self.controller.options.only_errors and not f):
-                        log("    [%s, %s%.2fs wall]" % (total, "%s, "%(count_noun(f, "failure")) if f else "", wall))
+                        log("    [%s, %s%.2fs wall]" % (total, "%s, " % (count_noun(f, "failure")) if f else "", wall))
 
             self.sources_completed += 1
 

--- a/src/sage/doctest/test.py
+++ b/src/sage/doctest/test.py
@@ -29,7 +29,7 @@ Check that :issue:`2235` has been fixed::
     Running doctests...
     Doctesting 1 file.
     sage -t --warn-long 0.0 --random-seed=0 longtime.rst
-    [0 tests, ...s]
+    [0 tests, ...s wall]
     ----------------------------------------------------------------------
     All tests passed!
     ----------------------------------------------------------------------
@@ -40,7 +40,7 @@ Check that :issue:`2235` has been fixed::
     Running doctests...
     Doctesting 1 file.
     sage -t --long --warn-long 0.0 --random-seed=0 longtime.rst
-    [1 test, ...s]
+    [1 test, ...s wall]
     ----------------------------------------------------------------------
     All tests passed!
     ----------------------------------------------------------------------
@@ -442,7 +442,7 @@ Test running under gdb, without and with a timeout::
     Running doctests...
     Doctesting 1 file...
     sage -t... 1second.rst...
-        [2 tests, ... s]
+        [2 tests, ...s wall]
     ----------------------------------------------------------------------
     All tests passed!
     ----------------------------------------------------------------------
@@ -471,7 +471,7 @@ Test the ``--show-skipped`` option::
         1 long test not run
         1 not tested test not run
         0 tests not run because we ran out of time
-        [2 tests, ... s]
+        [2 tests, ...s wall]
     ----------------------------------------------------------------------
     All tests passed!
     ----------------------------------------------------------------------
@@ -488,7 +488,7 @@ Optional tests are run correctly::
         2 tests not run due to known bugs
         1 not tested test not run
         0 tests not run because we ran out of time
-        [4 tests, ... s]
+        [4 tests, ...s wall]
     ----------------------------------------------------------------------
     All tests passed!
     ----------------------------------------------------------------------
@@ -504,7 +504,7 @@ Optional tests are run correctly::
         1 not tested test not run
         2 sage tests not run
         0 tests not run because we ran out of time
-        [2 tests, ... s]
+        [2 tests, ...s wall]
     ----------------------------------------------------------------------
     All tests passed!
     ----------------------------------------------------------------------
@@ -533,7 +533,7 @@ Test ``atexit`` support in the doctesting framework::
     Running doctests...
     Doctesting 1 file.
     sage -t --warn-long 0.0 --random-seed=0 atexit.rst
-        [3 tests, ... s]
+        [3 tests, ...s wall]
     ----------------------------------------------------------------------
     All tests passed!
     ----------------------------------------------------------------------
@@ -564,7 +564,7 @@ Test that random tests are reproducible::
     **********************************************************************
     1 item had failures:
        1 of   2 in sage.doctest.tests.random_seed
-        [1 test, 1 failure, ...s]
+        [1 test, 1 failure, ...s wall]
     ----------------------------------------------------------------------
     sage -t --warn-long 0.0 --random-seed=0 random_seed.rst  # 1 doctest failed
     ----------------------------------------------------------------------
@@ -575,7 +575,7 @@ Test that random tests are reproducible::
     Running doctests...
     Doctesting 1 file.
     sage -t --warn-long 0.0 --random-seed=1 random_seed.rst
-        [1 test, ...s]
+        [1 test, ...s wall]
     ----------------------------------------------------------------------
     All tests passed!
     ----------------------------------------------------------------------

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -153,7 +153,7 @@ class Timer:
 
     def _quick_cputime(self):
         r"""
-        A fast and replacement for ``sage.misc.timing.cputime``.
+        A fast replacement for ``sage.misc.timing.cputime``.
 
         This is a "reliable" replacement (on Linux/BSD) that takes
         subprocesses (particularly pexpect interfaces) into

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -125,7 +125,7 @@ class Timer:
 
     def _quick_cputime(self):
         r"""
-        A fast and replacement for ``sage.misc.misc.cputime``.
+        A fast and replacement for ``sage.misc.timing.cputime``.
 
         This is a "reliable" replacement (on Linux/BSD) that takes
         subprocesses (particularly pexpect interfaces) into

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -162,7 +162,11 @@ class Timer:
             raise OSError(f"unable to access {path}") from e
 
         try:
-            # man 5 proc (linux)
+            # These fields used to be documented in the proc(5) man
+            # page, but are now most easily found in the Linux kernel
+            # documentation (Documentation/filesystems/proc.rst). The
+            # intent is to sum the user- and kernel-mode "jiffies" for
+            # both the given process and its children.
             cputicks = sum( float(s) for s in stats[13:17] )
         except (ArithmeticError, LookupError, TypeError) as e:
             # ArithmeticError: unexpected (non-numeric?) values in fields

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -170,6 +170,19 @@ class Timer:
 
         A float measuring the cputime in seconds of the sage process
         and all its subprocesses.
+
+        TESTS:
+
+        About all we can say for certain is that this will return a
+        nonnegative float::
+
+            sage: from sage.doctest.util import Timer
+            sage: cputime = Timer()._quick_cputime()
+            sage: cputime >= 0.0
+            True
+            sage: isinstance(cputime, float)
+            True
+
         """
         # Start by using os.times() to get the cputime for sage itself
         # and any subprocesses that have been wait()ed for and that

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -301,12 +301,13 @@ class Timer:
                     # installed as a transitive dependency (ipython
                     # needs it), but it isn't explicitly listed as
                     # a dependency of sagelib.
+                    from psutil import Process, ZombieProcess
                     try:
-                        from psutil import Process
                         cputime += sum(Process(S.pid()).cpu_times()[0:2])
-                    except (ImportError, ValueError):
+                    except (ImportError, ValueError, ZombieProcess):
                         # ImportError: no psutil
                         # ValueError: invalid (e.g. negative) PID
+                        # ZombieProcess: PID refers to a zombie
                         pass
 
         return cputime

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -133,7 +133,7 @@ class Timer:
         nonnegative float or raise an ``OSError``::
 
             sage: from sage.doctest.util import Timer
-            sage: cputime = 0.0
+            sage: cputime = float(0.0)
             sage: try:
             ....:     cputime = Timer()._pid_cpu_seconds(1)
             ....: except OSError:

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -23,7 +23,7 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.misc.timing import walltime
+from time import time as walltime
 from os import sysconf, times
 
 def count_noun(number, noun, plural=None, pad_number=False, pad_noun=False):
@@ -345,7 +345,7 @@ class Timer:
         """
         from sage.interfaces.quit import expect_objects
         self.cputime = self._quick_cputime(expect_objects) - self.cputime
-        self.walltime = walltime(self.walltime)
+        self.walltime = walltime() - self.walltime
         return self
 
     def annotate(self, object):

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -301,14 +301,18 @@ class Timer:
                     # installed as a transitive dependency (ipython
                     # needs it), but it isn't explicitly listed as
                     # a dependency of sagelib.
-                    from psutil import NoSuchProcess, Process, ZombieProcess
                     try:
-                        cputime += sum(Process(S.pid()).cpu_times()[0:2])
-                    except (ImportError, ValueError, NoSuchProcess, ZombieProcess):
-                        # ImportError: no psutil
-                        # ValueError: invalid (e.g. negative) PID
-                        # NoSuchProcess: it's gone
-                        # ZombieProcess: PID refers to a zombie
+                        from psutil import (NoSuchProcess,
+                                            Process,
+                                            ZombieProcess)
+                        try:
+                            cputime += sum(Process(S.pid()).cpu_times()[0:2])
+                        except (ValueError, NoSuchProcess, ZombieProcess):
+                            # ValueError: invalid (e.g. negative) PID
+                            # NoSuchProcess: it's gone
+                            # ZombieProcess: PID refers to a zombie
+                            pass
+                    except ImportError:
                         pass
 
         return cputime

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -110,11 +110,39 @@ class Timer:
         Parse the ``/proc`` filesystem to get the cputime of the given
         ``pid``.
 
-        This also includes the times for child processes **that have
-        been ``wait()``ed for and terminated**. Specifically, pexpect
-        processes DO NOT fall into that category.
+        This also includes the times for child processes, but only
+        those that have been ``wait()``ed for and that have already
+        terminated. It is important to note that pexpect processes DO
+        NOT fall into that category.
 
-        Raises an ``OSError`` if anything goes wrong.
+        INPUT:
+
+        - ``pid`` -- nonnegative integer; the process identifier (PID)
+          of the process whose cputime you want
+
+        OUTPUT:
+
+        A nonnegative float representing the number of cpu-seconds
+        used by the process associated with ``pid``. An ``OSError`` is
+        raised if anything goes wrong, which typically happens on
+        platforms that don't store this information under ``/proc``.
+
+        TESTS:
+
+        About all we can say for certain is that this will return a
+        nonnegative float or raise an ``OSError``::
+
+            sage: from sage.doctest.util import Timer
+            sage: cputime = 0.0
+            sage: try:
+            ....:     cputime = Timer()._pid_cpu_seconds(1)
+            ....: except OSError:
+            ....:     pass
+            sage: cputime >= 0.0
+            True
+            sage: isinstance(cputime, float)
+            True
+
         """
         try:
             with open(f"/proc/{pid}/stat", "r") as statfile:

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -301,12 +301,13 @@ class Timer:
                     # installed as a transitive dependency (ipython
                     # needs it), but it isn't explicitly listed as
                     # a dependency of sagelib.
-                    from psutil import Process, ZombieProcess
+                    from psutil import NoSuchProcess, Process, ZombieProcess
                     try:
                         cputime += sum(Process(S.pid()).cpu_times()[0:2])
-                    except (ImportError, ValueError, ZombieProcess):
+                    except (ImportError, ValueError, NoSuchProcess, ZombieProcess):
                         # ImportError: no psutil
                         # ValueError: invalid (e.g. negative) PID
+                        # NoSuchProcess: it's gone
                         # ZombieProcess: PID refers to a zombie
                         pass
 

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -111,8 +111,8 @@ class Timer:
         ``pid``.
 
         This also includes the times for child processes, but only
-        those that have been ``wait()``ed for and that have already
-        terminated. It is important to note that pexpect processes DO
+        those that have already terminated and for which ``wait()``
+        was called. It is important to note that pexpect processes DO
         NOT fall into that category.
 
         INPUT:
@@ -142,7 +142,6 @@ class Timer:
             True
             sage: isinstance(cputime, float)
             True
-
         """
         try:
             with open(f"/proc/{pid}/stat", "r") as statfile:

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -23,8 +23,8 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.misc.timing import walltime, cputime
-
+from sage.misc.timing import walltime
+from os import sysconf, times
 
 def count_noun(number, noun, plural=None, pad_number=False, pad_noun=False):
     """
@@ -104,6 +104,68 @@ class Timer:
         {}
         sage: TestSuite(Timer()).run()
     """
+
+    def _pid_cpu_seconds(self, pid):
+        r"""
+        Parse the ``/proc`` filesystem to get the cputime of the given
+        ``pid``.
+
+        This also includes the times for child processes **that have
+        been ``wait()``ed for and terminated**. Specifically, pexpect
+        processes DO NOT fall into that category.
+        """
+        with open(f"/proc/{pid}/stat", "r") as statfile:
+            stats = statfile.read().split()
+
+        # man 5 proc (linux)
+        cputicks = sum( float(s) for s in stats[13:17] )
+
+        hertz = sysconf("SC_CLK_TCK")
+        return (cputicks / hertz)
+
+    def _quick_cputime(self):
+        r"""
+        A fast and replacement for ``sage.misc.misc.cputime``.
+
+        This is a "reliable" replacement (on Linux/BSD) that takes
+        subprocesses (particularly pexpect interfaces) into
+        account. The ``cputime()`` function from the ``misc`` module
+        can be passed ``subprocesses=True``, but this has a few
+        faults; mainly that it relies on each pexpect interface to
+        implement its own ``cputime()`` function. And most of our
+        pexpect interfaces either don't implement one, or implement
+        one in a way that requires the subprocess (being pexpected) to
+        be in perfect working condition -- that will often not be the
+        case at the end of a doctest line.
+
+        OUTPUT:
+
+        A float measuring the cputime in seconds of the sage process
+        and all its subprocesses.
+        """
+        # Start by using os.times() to get the cputime for sage itself
+        # and any subprocesses that have been wait()ed for and that
+        # have terminated.
+        cputime = sum( times()[:4] )
+
+        # Now try to get the times for any pexpect interfaces, since
+        # they do not fall into the category above.
+        from sage.interfaces.quit import expect_objects
+        for s in expect_objects:
+            S = s()
+            if S and S.is_running():
+                try:
+                    cputime += self._pid_cpu_seconds(S.pid())
+                except (ArithmeticError, LookupError, OSError,
+                        TypeError, ValueError):
+                    # This will fail anywhere but linux/BSD, but
+                    # there's no good cross-platform way to get the
+                    # cputimes from pexpect interfaces without
+                    # totally mucking up the doctests.
+                    pass
+
+        return cputime
+
     def start(self):
         """
         Start the timer.
@@ -116,7 +178,7 @@ class Timer:
             sage: Timer().start()
             {'cputime': ..., 'walltime': ...}
         """
-        self.cputime = cputime()
+        self.cputime = self._quick_cputime()
         self.walltime = walltime()
         return self
 
@@ -134,7 +196,7 @@ class Timer:
             sage: timer.stop()
             {'cputime': ..., 'walltime': ...}
         """
-        self.cputime = cputime(self.cputime)
+        self.cputime = self._quick_cputime() - self.cputime
         self.walltime = walltime(self.walltime)
         return self
 

--- a/src/sage/interfaces/cleaner.py
+++ b/src/sage/interfaces/cleaner.py
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-repl
 """
 Interface to the Sage cleaner
 

--- a/src/sage/interfaces/quit.py
+++ b/src/sage/interfaces/quit.py
@@ -1,3 +1,4 @@
+# sage_setup: distribution = sagemath-repl
 """
 Quitting interfaces
 """


### PR DESCRIPTION
Finally address #32981.

Using wall time to measure which tests are "long" doesn't make much sense. Wall time is subject to every conflating factor:

1. Faster hardware runs tests in less wall time
2. Faster compiler flags makes code that runs in less wall time
3. A busy machine will run tests slower than an unburdened one
4. Operating system priority can increase or decrease the time taken by a process
5. etc.

Ideally, everyone would agree on how long is too long for a test to run. Attaining that ideal is not so easy, but the first step is to switch`--warn-long` away from using wall time and towards using CPU time. A second phase (https://github.com/sagemath/sage/issues/33022) will normalize the CPU time.


### Examples

#### --warn-long output

The user-facing portion of this can be tested with a low `--warn-long` value,

```
$ sage -t --warn-long=1 src/sage/rings/qqbar.py 
...
Doctesting 1 file.
sage -t --warn-long --random-seed=309742757431591512726158538133919135994 src/sage/rings/qqbar.py
**********************************************************************
File "src/sage/rings/qqbar.py", line 511, in sage.rings.qqbar
Warning, slow doctest:
    z, = [r for r in p4.roots(QQbar, False) if r in ival]
Test ran for 1.51s cpu, 1.51s wall
Check ran for 0.00s cpu, 0.00s wall
**********************************************************************
File "src/sage/rings/qqbar.py", line 524, in sage.rings.qqbar
Warning, slow doctest:
    z2 = QQbar.polynomial_root(p4, ival)
Test ran for 1.07s cpu, 1.07s wall
Check ran for 0.00s cpu, 0.00s wall
**********************************************************************
File "src/sage/rings/qqbar.py", line 808, in sage.rings.qqbar.AlgebraicField_common._factor_multivariate_polynomial
Warning, slow doctest:
    F = QQbar._factor_multivariate_polynomial(p)
Test ran for 2.38s cpu, 2.42s wall
Check ran for 0.00s cpu, 0.00s wall

...
```

#### pexpect accounting

Two different methods are used to account for the CPU time, one for linux, and one for everything else. This GAP command uses pexpect and should chew up a good bit of CPU time:

```
sage: from sage.doctest.util import Timer
sage: t = Timer()
sage: _ = t.start(); t.stop()    # no CPU time used between start/stop
{'cputime': 0.0, 'walltime': 7.605552673339844e-05}

sage: _ = t.start(); gap.eval('a:=List([0..10000],i->WordAlp("a",i));; IsSortedList(a);'); t.stop()    # lots of CPU time used
'true'
{'cputime': 30.089999999999996, 'walltime': 36.292088747024536}
```