### PR TITLE
Cohomology ring of a moment-angle complex

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -4140,6 +4140,9 @@ REFERENCES:
 .. [Lin1999] \J. van Lint, Introduction to coding theory, 3rd ed.,
              Springer-Verlag GTM, 86, 1999.
 
+.. [Lin2019] \A. Linton, "Massey Products in Moment-Angle Complexes", 2019.
+             https://eprints.soton.ac.uk/438662/1/ALinton_Thesis_FinalSubmission.pdf
+
 .. [Liv1993] Charles Livingston, *Knot Theory*, Carus Mathematical
              Monographs, number 24.
 

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -894,7 +894,6 @@ class MomentAngleComplex(UniqueRepresentation, SageObject):
             sage: a.get_simplicial_complex()
             Simplicial complex with vertex set (1, 3) and facets {(1,), (3,)}
         """
-
         return CohomologyRing(base_ring=base_ring, moment_angle_complex=self)
 
 
@@ -994,10 +993,10 @@ class CohomologyRing(CombinatorialFreeModule):
                 for x in combinations(vertices, i):
                     S = moment_angle_complex._simplicial_complex.generated_subcomplex(x, is_mutable=False)
                     # Because of the empty combination
-                    if len(S.vertices()) > 0 and isinstance(S.cohomology(deg-i-1, base_ring, generators=True), list):
+                    if S.vertices() and isinstance(S.cohomology(deg-i-1, base_ring, generators=True), list):
                         chmlgy = S.cohomology(deg-i-1, base_ring, generators=True)
                         for y in chmlgy:
-                            self._gens[deg].append((set(x), deg-i-1, y))
+                            self._gens[deg].append((frozenset(x), deg-i-1, y))
                         num_of_gens += len(chmlgy)
                     elif len(S.vertices()) == 0 and deg == 0:
                         num_of_gens = 1
@@ -1035,9 +1034,8 @@ class CohomologyRing(CombinatorialFreeModule):
         """
         if d is None:
             return Family(self._indices, self.monomial)
-        else:
-            indices = [(d, i) for i in self._graded_indices.get(d, [])]
-            return Family(indices, self.monomial)
+        indices = [(d, i) for i in self._graded_indices.get(d, [])]
+        return Family(indices, self.monomial)
 
     def degree_on_basis(self, i):
         """
@@ -1098,7 +1096,7 @@ class CohomologyRing(CombinatorialFreeModule):
         d = {(0, i): one for i in self._graded_indices[0]}
         return self._from_dict(d, remove_zeros=False)
 
-    def complex(self):
+    def moment_angle_complex(self):
         """
         Return the moment-angle complex associated with ``self``.
 
@@ -1113,7 +1111,7 @@ class CohomologyRing(CombinatorialFreeModule):
         return self._complex
 
     @cached_method
-    def _to_cycle_on_basis(self, i):
+    def _to_cocycle_on_basis(self, i):
         r"""
         Return the cocycle representative of the basis element
         indexed by ``i``.
@@ -1282,7 +1280,7 @@ class CohomologyRing(CombinatorialFreeModule):
         for base_element in elements:
             memo[base_element] = set()
             for x in elements:
-                if base_element * x == self.zero():
+                if not base_element * x:
                     memo[base_element].add(x)
 
         max_length = 1
@@ -1307,7 +1305,7 @@ class CohomologyRing(CombinatorialFreeModule):
         return max_length
 
     class Element(CombinatorialFreeModule.Element):
-        def to_cycle(self):
+        def to_cocycle(self):
             r"""
             Return the cocycle representative of ``self``.
 

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -1099,7 +1099,6 @@ class CohomologyRing(CombinatorialFreeModule):
             vertex_set = self.parent()._gens[self.leading_support()[0]][self.leading_support()[1]][0]
             print(self.parent()._complex.simplicial_complex().generated_subcomplex(vertex_set, is_mutable=is_mutable))
 
-        # add reference to the docstring
         def cup_product(self, other):
             r"""
             Return the cup product of ``self`` and ``other``.
@@ -1171,8 +1170,14 @@ def eps(subcomplex, simplicial_complex):
             raise ValueError("{} is not a vertex of this simplicial complex".format(element))
         return (-1) ** simplicial_complex._vertex_to_index[element]
 
-    subcomplex = SimplicialComplex([subcomplex])
-    simplicial_complex = SimplicialComplex([simplicial_complex])
+    if not isinstance(subcomplex, SimplicialComplex):
+        # This may completely change the structure,
+        # but the ordering of the vertices will
+        # remain the same, and that's the only things
+        # that matters
+        subcomplex = SimplicialComplex([subcomplex])
+    if not isinstance(simplicial_complex, SimplicialComplex):
+        simplicial_complex = SimplicialComplex([simplicial_complex])
     res = 1
     for element in subcomplex.vertices():
         res *= _eps(element, simplicial_complex)

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -842,6 +842,15 @@ class CohomologyRing(CombinatorialFreeModule):
 
     .. NOTE::
 
+        The given isomorphism does not rely on the default
+        ring structure given by the direct sum of cohomologies,
+        but rather it is a vector space isomorphism, where the ring
+        structure (multiplication on the right-hand side) is defined in a certain way. See
+        :meth:`sage.topology.moment_angle_complex.CohomologyRing.Element.cup_product`
+        for more information.
+
+    .. NOTE::
+
         This is not intended to be created directly by the user, but instead via the
         :meth:`sage.topology.moment_angle_complex.MomentAngleComplex.cohomology_ring` method.
 
@@ -881,8 +890,8 @@ class CohomologyRing(CombinatorialFreeModule):
                 for x in combinations(vertices, i):
                     S = moment_angle_complex._simplicial_complex.generated_subcomplex(x, is_mutable=False)
                     # Because of the empty combination
-                    if len(S.vertices()) > 0 and isinstance(S.cohomology(deg-i-1, generators=True), list):
-                        chmlgy = S.cohomology(deg-i-1, generators=True)
+                    if len(S.vertices()) > 0 and isinstance(S.cohomology(deg-i-1, base_ring, generators=True), list):
+                        chmlgy = S.cohomology(deg-i-1, base_ring, generators=True)
                         for y in chmlgy:
                             self._gens[deg].append((set(x), deg-i-1, y))
                         num_of_gens += len(chmlgy)
@@ -1073,7 +1082,6 @@ class CohomologyRing(CombinatorialFreeModule):
 
             <lots_of_examples>
             """
-
             if not self.is_homogeneous():
                 raise ValueError("only defined for homogeneous elements")
             return sum(c * self.parent()._to_cycle_on_basis(i) for i, c in self)
@@ -1086,25 +1094,60 @@ class CohomologyRing(CombinatorialFreeModule):
 
             <lots_of_examples>
             """
+            if not self.is_homogeneous():
+                raise ValueError("only defined for homogeneous elements")
             vertex_set = self.parent()._gens[self.leading_support()[0]][self.leading_support()[1]][0]
             print(self.parent()._complex.simplicial_complex().generated_subcomplex(vertex_set, is_mutable=is_mutable))
 
         # add reference to the docstring
         def cup_product(self, other):
-            """
+            r"""
             Return the cup product of ``self`` and ``other``.
+
+            We define the cup product on cochains in cochain complexes
+            of full subcomplexes of the simplicial complex associated
+            with the moment-angle complex of ``self`` (this is
+            possible because of the main cohomology ring isomorphism).
+            Given two cochains, `\chi_L` and `\chi_M`, from cochain
+            complexes of full subcomplexes `\mathcal{K}_I` and `\mathcal{K}_J`,
+            respectively, we define
+
+            .. MATH::
+
+                \chi_L \otimes \chi_M =
+                \begin{cases}
+                    c_{L \cup M} \chi_{L \cup M}, &\text{if } I\cap J = \emptyset\\
+                    0, &\text{otherwise}
+                \end{cases}
+
+            where
+
+            .. MATH::
+
+                c_{L \cup M} = \epsilon(L, I) \epsilon(M, J) \zeta \epsilon(L\cup M, I\cup J)
+
+            and
+
+            .. MATH::
+
+                \zeta = \prod_{k \in I \setminus L} \epsilon(k, k \cup J \setminus M).
 
             ALGORITHM:
 
-            This algorithm is adopted from ...
+            This algorithm is adopted from [Lin2019]_, p. 16.
 
-            First we acquire the cocycle representatives of ``self`` and ``other``
-            (which are generators of cohomology groups of all full subcomplexes
-            of the simplicial complex associated with the moment-angle complex;
-            these are stored during initialization), as well as their corresponding
-            simplicial complexes. We then multiply them, as described in ... and
+            First we lift the cohomology classes to their cocycle representatives
+            (which are generators of cohomology groups of all full subcomplexes of
+            the simplicial complex associated with the moment-angle complex;
+            these are stored during initialization), as well as acquire their corresponding
+            simplicial complexes. We then multiply them, as described above and
             extract the cohomology class using chain contractions of the appropriate
             simplicial complex.
+
+            .. SEEALSO:
+
+                For more information on the `\epsilon` function,
+                see :meth:`sage.topology.moment_angle_complex.eps`
 
             EXAMPLES::
 

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -1253,6 +1253,59 @@ class CohomologyRing(CombinatorialFreeModule):
 
         return res
 
+    def cup_length(self):
+        """
+        Return the cup length of ``self``.
+
+        The cup length of a cohomology ring is defined as the maximal
+        number of elements whose product is non-trivial.
+
+        EXAMPLES::
+
+            sage: Z = MomentAngleComplex([[0], [1], [2]])
+            sage: H = Z.cohomology_ring(GF(2))
+            sage: H.cup_length()
+            1
+            sage: Z = MomentAngleComplex([[1,2], [2,3], [3,4], [4,5], [5,1]])
+            sage: H = Z.cohomology_ring()
+            sage: H.cup_length()
+            2
+        """
+        # It suffices to check this for base elements
+        elements = set(self.basis())
+        elements.remove(self.one())
+        # We create a dictionary, in which the keys are
+        # base elements, and values are lists, which
+        # represent the elements whose product with
+        # the key gives us zero
+        memo = {}
+        for base_element in elements:
+            memo[base_element] = set()
+            for x in elements:
+                if base_element * x == self.zero():
+                    memo[base_element].add(x)
+
+        max_length = 1
+        # The multiplication is commutative up to a sign,
+        # so we will not worry about the order in which
+        # we multiply the elements
+        for base_element in elements:
+            prod = base_element
+            length = 1
+            # We will avoid the elements which give us zero
+            avoid = memo[base_element]
+            for x in elements:
+                if x not in avoid and prod * x != self.zero():
+                    prod = prod * x
+                    length = length + 1
+                    # We further restrict the possible elements
+                    avoid = avoid.union(memo[x])
+
+            if length > max_length:
+                max_length = length
+
+        return max_length
+
     class Element(CombinatorialFreeModule.Element):
         def to_cycle(self):
             r"""

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -821,34 +821,8 @@ class MomentAngleComplex(UniqueRepresentation, SageObject):
         return not any(one_skeleton.subgraph_search(g) is not None for g in obstruction_graphs)
 
     def cohomology_ring(self, base_ring):
-         #return CohomologyRingFromProduct(base_ring=base_ring, moment_angle_complex=self)
          return CohomologyRing(base_ring=base_ring, moment_angle_complex=self)
 
-#################### ignore this one for now
-#class CohomologyRingFromProduct():
-    #def __init__(self, moment_angle_complex, base_ring):
-        #from sage.categories.cartesian_product import cartesian_product
-        #self._complex = moment_angle_complex
-        #self._base_ring = base_ring
-#
-        #vertices = moment_angle_complex.simplicial_complex().vertices()
-        #n = len(vertices)
-        #L = []
-#
-        #for x in moment_angle_complex.simplicial_complex().facets():
-            #subcomplex = moment_angle_complex.simplicial_complex().generated_subcomplex(x, is_mutable=False)
-            #L.append(subcomplex.cohomology_ring())
-#
-        #self._cohomology_ring = cartesian_product(L)
-#
-    #def cohomology_ring(self):
-        #return self._cohomology_ring
-#
-    #def _repr_(self):
-        #return "Cohomology module of {} over {}".format(self._complex, self.base_ring())
-#
-####
-# maybe just create a method instead of a classs?
 
 # _CartesianProduct
 class CohomologyRing(CombinatorialFreeModule):

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -16,6 +16,7 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
+from sage.combinat.free_module import CombinatorialFreeModule
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_attribute import lazy_attribute
 from sage.homology.homology_group import HomologyGroup
@@ -814,6 +815,20 @@ class MomentAngleComplex(UniqueRepresentation, SageObject):
         ]
 
         return not any(one_skeleton.subgraph_search(g) is not None for g in obstruction_graphs)
+
+    def cohomology_ring(self):
+        from sage.categories.cartesian_product import cartesian_product
+
+        vertices = self._simplicial_complex.vertices()
+        n = len(vertices)
+        L = []
+
+        for i in range(n+1):
+            for x in combinations(vertices, i):
+                subcomplex = self._simplicial_complex.generated_subcomplex(x, is_mutable=False)
+                L.append(subcomplex.cohomology_ring())
+
+        return cartesian_product(L)
 
 # just create a method instead of a classs
 class CohomologyRing(CombinatorialFreeModule):

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -1086,6 +1086,7 @@ class CohomologyRing(CombinatorialFreeModule):
         Return the multiplicative identity element.
 
         EXAMPLES::
+
             sage: Z = MomentAngleComplex([[1,2], [3,4], [2,3,5], [1,5], [4,5]])
             sage: H = Z.cohomology_ring()
             sage: H.one()
@@ -1096,6 +1097,20 @@ class CohomologyRing(CombinatorialFreeModule):
         one = self._base_ring.one()
         d = {(0, i): one for i in self._graded_indices[0]}
         return self._from_dict(d, remove_zeros=False)
+
+    def complex(self):
+        """
+        Return the moment-angle complex associated with ``self``.
+
+        EXAMPLES::
+
+            sage: S2 = simplicial_complexes.Sphere(2)
+            sage: H = MomentAngleComplex(S2).cohomology_ring()
+            sage: H.complex()
+            Moment-angle complex of Simplicial complex with vertex set
+            (0, 1, 2, 3) and facets {(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)}
+        """
+        return self._complex
 
     @cached_method
     def _to_cycle_on_basis(self, i):

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -821,6 +821,80 @@ class MomentAngleComplex(UniqueRepresentation, SageObject):
         return not any(one_skeleton.subgraph_search(g) is not None for g in obstruction_graphs)
 
     def cohomology_ring(self, base_ring=QQ):
+        r"""
+        Return the unreduced cohomology of ``self`` with coefficients in
+        ``base_ring``.
+
+        This offers additional information about the cohomology,
+        and is intended to be used only when in need of specific
+        cohomology operations, such as the cup product, which
+        this does offer.
+
+        INPUT:
+
+        - ``base_ring`` -- commutative ring (default: ``QQ``); must be
+          ``ZZ`` or a field
+
+        The basis elements in dimension ``dim`` are named ``'h^{dim,i}'``
+        where `i` ranges between 0 and `r-1`, where `r` is the rank of
+        the cohomology group.
+
+        .. SEEALSO::
+
+            For more information on what this offers, see
+            :class:`.moment_angle_complex.CohomologyRing`.
+
+        EXAMPLES::
+
+            sage: Z = MomentAngleComplex([[1,2], [2,3], [3,4], [4,5], [5,1]])
+            sage: H = Z.cohomology_ring()
+            sage: sorted(H.basis())
+            [h^{0,0},
+             h^{3,0},
+             h^{3,1},
+             h^{3,2},
+             h^{3,3},
+             h^{3,4},
+             h^{4,0},
+             h^{4,1},
+             h^{4,2},
+             h^{4,3},
+             h^{4,4},
+             h^{7,0}]
+
+        Notice (by looking at the dimension) that this does
+        indeed coincide with the reduced cohomology::
+
+            sage: Z.cohomology(reduced=False, base_ring=QQ)
+            {0: Vector space of dimension 1 over Rational Field,
+             1: Vector space of dimension 0 over Rational Field,
+             2: Vector space of dimension 0 over Rational Field,
+             3: Vector space of dimension 5 over Rational Field,
+             4: Vector space of dimension 5 over Rational Field,
+             5: Vector space of dimension 0 over Rational Field,
+             6: Vector space of dimension 0 over Rational Field,
+             7: Vector space of dimension 1 over Rational Field}
+            sage: a = H.basis()[3, 0]; a
+            h^{3,0}
+            sage: b = H.basis()[4, 4]; b
+            h^{4,4}
+            sage: a.cup_product(b)
+            -h^{7,0}
+            sage: a * b  # alternative notation
+            -h^{7,0}
+            sage: a * a
+            0
+
+        We can lift cohomology classes to their cocycle
+        represetnatives and also acquire their originating
+        subcomplexes::
+
+            sage: a.to_cycle()
+            \chi_(1,)
+            sage: a.get_simplicial_complex()
+            Simplicial complex with vertex set (1, 3) and facets {(1,), (3,)}
+        """
+
         return CohomologyRing(base_ring=base_ring, moment_angle_complex=self)
 
 
@@ -831,7 +905,7 @@ class CohomologyRing(CombinatorialFreeModule):
     Here we don't explicitly compute the cohomology ring
     of a moment-angle complex as a topological space, but
     we use the following result to compute its cohomology
-    ring (Theorem 4.5.8 of [BP2014]_)::
+    ring (Theorem 4.5.8 of [BP2014]_):
 
     .. MATH::
 
@@ -1287,7 +1361,7 @@ class CohomologyRing(CombinatorialFreeModule):
             cohomology class using chain contractions of the appropriate
             simplicial complex.
 
-            .. SEEALSO:
+            .. SEEALSO::
 
                 For more information on the `\epsilon` function,
                 see :meth:`sage.topology.moment_angle_complex.eps`.

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -22,6 +22,7 @@ from sage.misc.lazy_attribute import lazy_attribute
 from sage.homology.homology_group import HomologyGroup
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
+from sage.sets.family import Family
 from sage.structure.sage_object import SageObject
 from sage.structure.unique_representation import UniqueRepresentation
 from .cubical_complex import CubicalComplex, cubical_complexes
@@ -816,7 +817,7 @@ class MomentAngleComplex(UniqueRepresentation, SageObject):
 
         return not any(one_skeleton.subgraph_search(g) is not None for g in obstruction_graphs)
 
-    def cohomology_ring(self):
+    def cohomology_ring(self, base_ring):
         from sage.categories.cartesian_product import cartesian_product
 
         vertices = self._simplicial_complex.vertices()
@@ -829,10 +830,11 @@ class MomentAngleComplex(UniqueRepresentation, SageObject):
                 L.append(subcomplex.cohomology_ring())
 
         return cartesian_product(L)
+        #return CohomologyRing(base_ring=base_ring, moment_angle_complex=self)
 
-# just create a method instead of a classs
+# maybe just create a method instead of a classs?
 class CohomologyRing(CombinatorialFreeModule):
-    def __init__(self, base_ring, moment_angle_complex, category=None):
+    def __init__(self, base_ring, moment_angle_complex):
         self._complex = moment_angle_complex
 
         vertices = moment_angle_complex._simplicial_complex.vertices()
@@ -852,7 +854,7 @@ class CohomologyRing(CombinatorialFreeModule):
             indices.extend([(deg, k) for k in range(num_of_gens)])
             self._graded_indices[deg] = range(num_of_gens)
 
-        CombinatorialFreeModule.__init__(self, base_ring, indices, category=category)
+        CombinatorialFreeModule.__init__(self, base_ring, indices)
 
     def basis(self, d=None):
         if d is None:
@@ -872,3 +874,7 @@ class CohomologyRing(CombinatorialFreeModule):
         return 'h{}{{{},{}}}'.format(sym, i[0], i[1])
 
     _latex_term = _repr_term
+
+    class Element(CombinatorialFreeModule.Element):
+        def cup_product(self, other):
+            return super(self) * super(other)

--- a/src/sage/topology/moment_angle_complex.py
+++ b/src/sage/topology/moment_angle_complex.py
@@ -845,7 +845,8 @@ class CohomologyRing(CombinatorialFreeModule):
         The given isomorphism does not rely on the default
         ring structure given by the direct sum of cohomologies,
         but rather it is a vector space isomorphism, where the ring
-        structure (multiplication on the right-hand side) is defined in a certain way. See
+        structure (multiplication on the right-hand side) is defined
+        in a certain way. See
         :meth:`sage.topology.moment_angle_complex.CohomologyRing.Element.cup_product`
         for more information.
 
@@ -862,7 +863,29 @@ class CohomologyRing(CombinatorialFreeModule):
 
     EXAMPLES::
 
-    <lots_of_examples>
+        sage: Z = MomentAngleComplex([[1,2,3], [1,2,4], [3,5], [4,5]])
+        sage: H = Z.cohomology_ring(); H
+        Cohomology module of Moment-angle complex of Simplicial complex with
+        vertex set (1, 2, 3, 4, 5) and facets {(3, 5), (4, 5), (1, 2, 3),
+        (1, 2, 4)} over Rational Field
+        sage: a = H.an_element(); a
+        2*h^{0,0} + 2*h^{3,0} + 3*h^{3,1}
+        sage: b = H.basis()[3,2]
+
+    We can compute the cup product::
+
+        sage: a.cup_product(b)
+        2*h^{3,2} - 5*h^{6,0}
+        sage: a * a
+        4*h^{0,0} + 8*h^{3,0} + 12*h^{3,1}
+
+        sage: RP2 = simplicial_complexes.RealProjectivePlane()
+        sage: Z = MomentAngleComplex(RP2)
+        sage: H = Z.cohomology_ring(GF(2))
+        sage: x = H.basis(5)[5, 0]
+        sage: y = H.basis(5)[5, 1]
+        sage: x * y
+        0
     """
     def __init__(self, base_ring, moment_angle_complex):
         """
@@ -870,7 +893,12 @@ class CohomologyRing(CombinatorialFreeModule):
 
         TESTS::
 
-        <lots_of_examples>
+            sage: S2 = simplicial_complexes.Sphere(2)
+            sage: Z = MomentAngleComplex(S2)
+            sage: H = Z.cohomology_ring(GF(5))
+            sage: TestSuite(H).run()
+            sage: H = Z.cohomology_ring(ZZ)
+            sage: TestSuite(H).run()
         """
         self._complex = moment_angle_complex
         self._base_ring = base_ring
@@ -906,7 +934,8 @@ class CohomologyRing(CombinatorialFreeModule):
 
     def basis(self, d=None):
         """
-        Return (the degree ``d`` homogeneous component of) the basis of ``self``.
+        Return (the degree ``d`` homogeneous component of) the basis
+        of ``self``.
 
         INPUT:
 
@@ -914,7 +943,19 @@ class CohomologyRing(CombinatorialFreeModule):
 
         EXAMPLES::
 
-        <lots_of_examples>
+            sage: S2 = simplicial_complexes.Sphere(2)
+            sage: Z = MomentAngleComplex(S2)
+            sage: H = Z.cohomology_ring()
+            sage: H.basis()
+            Finite family {(0, 0): h^{0,0}, (7, 0): h^{7,0}}
+            sage: H.basis(5)
+            Finite family {}
+            sage: H.basis(7)
+            Finite family {(7, 0): h^{7,0}}
+            sage: H.basis()[7, 0]
+            h^{7,0}
+            sage: H.basis(8)
+            Finite family {}
         """
         if d is None:
             return Family(self._indices, self.monomial)
@@ -928,7 +969,10 @@ class CohomologyRing(CombinatorialFreeModule):
 
         EXAMPLES::
 
-        <lots_of_examples>
+            sage: Z = MomentAngleComplex([[1,2], [3,4,5], [1,5], [2,3]])
+            sage: H = Z.cohomology_ring(GF(5))
+            sage: H.degree_on_basis((4, 0))
+            4
         """
         return i[0]
 
@@ -938,7 +982,10 @@ class CohomologyRing(CombinatorialFreeModule):
 
         TESTS::
 
-        <lots_of_examples>
+            sage: MomentAngleComplex([[1,2,3], [3,4]]).cohomology_ring()
+            Cohomology module of Moment-angle complex of Simplicial complex
+            with vertex set (1, 2, 3, 4) and facets {(3, 4), (1, 2, 3)}
+            over Rational Field
         """
         return "Cohomology module of {} over {}".format(self._complex, self.base_ring())
 
@@ -948,7 +995,11 @@ class CohomologyRing(CombinatorialFreeModule):
 
         EXAMPLES::
 
-        <lots_of_examples>
+            sage: Z = MomentAngleComplex([[1,2], [3,4,5], [1,5], [2,3]])
+            sage: Z = MomentAngleComplex([[1,2], [3,4,5], [1,4], [2,3,5]])
+            sage: H = Z.cohomology_ring(GF(7))
+            sage: H.basis()[3, 2]
+            h^{3,2}
         """
         return 'h^{{{},{}}}'.format(i[0], i[1])
 
@@ -959,8 +1010,12 @@ class CohomologyRing(CombinatorialFreeModule):
         Return the multiplicative identity element.
 
         EXAMPLES::
-
-        <lots_of_examples>
+            sage: Z = MomentAngleComplex([[1,2], [3,4], [2,3,5], [1,5], [4,5]])
+            sage: H = Z.cohomology_ring()
+            sage: H.one()
+            h^{0,0}
+            sage: all(H.one() * x == x == x * H.one() for x in H.basis())
+            True
         """
         one = self._base_ring.one()
         d = {(0, i): one for i in self._graded_indices[0]}
@@ -968,13 +1023,22 @@ class CohomologyRing(CombinatorialFreeModule):
 
     @cached_method
     def _to_cycle_on_basis(self, i):
-        """
+        r"""
         Return the cocycle representative of the basis element
         indexed by ``i``.
 
+        .. SEEALSO::
+
+            :meth:`Element.to_cycle`, :meth:`Element.get_simplicial_complex`.
+
         EXAMPLES::
 
-        <lots_of_examples>
+            sage: Z = MomentAngleComplex([[1,2], [3,4,5], [1,5], [2,3]])
+            sage: H = Z.cohomology_ring()
+            sage: H._to_cycle_on_basis((3, 2))
+            \chi_(2,)
+            sage: H._to_cycle_on_basis((4, 2))
+            \chi_(2,) + \chi_(4,)
         """
         subcomplex = self._complex.simplicial_complex().generated_subcomplex(self._gens[i[0]][i[1]][0], is_mutable=False)
         cochains = subcomplex.n_chains(self._gens[i[0]][i[1]][1], base_ring=self._base_ring, cochains=True)
@@ -1078,6 +1142,15 @@ class CohomologyRing(CombinatorialFreeModule):
             """
             Return the cocycle representative of ``self``.
 
+            The cohomology class gets lifted to its cococyle
+            representative in the cochain complex of the
+            corresponding simplicial complex given in the main
+            isomorphism.
+
+            .. SEEALSO::
+
+                :meth:`get_simplicial_complex`.
+
             EXAMPLES::
 
             <lots_of_examples>
@@ -1135,13 +1208,13 @@ class CohomologyRing(CombinatorialFreeModule):
 
             This algorithm is adopted from [Lin2019]_, p. 16.
 
-            First we lift the cohomology classes to their cocycle representatives
-            (which are generators of cohomology groups of all full subcomplexes of
-            the simplicial complex associated with the moment-angle complex;
-            these are stored during initialization), as well as acquire their corresponding
-            simplicial complexes. We then multiply them, as described above and
-            extract the cohomology class using chain contractions of the appropriate
-            simplicial complex.
+            First we lift the cohomology classes to their cocycle
+            representatives (which are generators of cohomology groups of all
+            full subcomplexes of the simplicial complex associated with the
+            moment-angle complex; these are stored during initialization),
+            as well as acquire their corresponding simplicial complexes. We then
+            multiply them, as described above and extract the cohomology class
+            using chain contractions of the appropriate simplicial complex.
 
             .. SEEALSO:
 


### PR DESCRIPTION
This PR provides the ``MomentAngleComplex`` class with its own cohomology ring (similar to the one which is available for simplicial, cubical and delta complexes). It requires its own separate class because we do not wish to compute this space explicitly (for efficiency reasons), but rather use a certain isomorphism which allows us to compute the cohomology ring more efficiently. The added class (``CohomologyRing``) is designed to mimic the already implemented class for cohomology rings by adding as many analogue methods as possible (most significant of which allows us to compute the cup product), but its structure differs fundamentally, and therefore must be a separate class.

This is a part of #35640 (GSoC 2023).

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

- #35875 
