### PR TITLE
build/pkgs/networkx/dependencies: drop decorator

### DIFF
--- a/build/pkgs/networkx/dependencies
+++ b/build/pkgs/networkx/dependencies
@@ -1,4 +1,4 @@
- decorator | $(PYTHON_TOOLCHAIN) scipy $(PYTHON)
+ | $(PYTHON_TOOLCHAIN) scipy $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
NetworkX no longer needs decorator:

  https://github.com/networkx/networkx/commit/89a54703
