### PR TITLE
fix typo in documentation

### DIFF
--- a/src/sage/categories/map.pyx
+++ b/src/sage/categories/map.pyx
@@ -1092,7 +1092,7 @@ cdef class Map(Element):
         - ``self`` -- a Map in some ``Hom(X, Y, category_right)``
         - ``left`` -- a Map in some ``Hom(Y, Z, category_left)``
 
-        Returns the composition of ``self`` followed by ``right`` as a
+        Returns the composition of ``self`` followed by ``left`` as a
         morphism in ``Hom(X, Z, category)`` where ``category`` is the
         meet of ``category_left`` and ``category_right``.
 


### PR DESCRIPTION
We fix a typo in the documentation of the method `post_compose` in `sage.categories.map`

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion (not relevant).
- [ ] I have created tests covering the changes (not relevant).
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies