### PR TITLE
support for ecl 23.9.9

### DIFF
--- a/src/sage/libs/ecl.pyx
+++ b/src/sage/libs/ecl.pyx
@@ -563,15 +563,15 @@ cdef class EclObject:
     Floats in Python are IEEE double, which LISP has as well. However,
     the printing of floating point types in LISP depends on settings::
 
-        sage: a = EclObject(float(10^40))
+        sage: a = EclObject(float(1.234e40))
         sage: ecl_eval("(setf *read-default-float-format* 'single-float)")
         <ECL: SINGLE-FLOAT>
         sage: a
-        <ECL: 1.d40>
+        <ECL: 1.234d40>
         sage: ecl_eval("(setf *read-default-float-format* 'double-float)")
         <ECL: DOUBLE-FLOAT>
         sage: a
-        <ECL: 1.e40>
+        <ECL: 1.234e40>
 
     Tuples are translated to dotted lists::
 

--- a/src/sage/libs/eclsig.h
+++ b/src/sage/libs/eclsig.h
@@ -45,7 +45,11 @@ static inline void ecl_sig_off(void)
     sig_off();
 }
 
+#if ECL_VERSION_NUMBER < 230909
 #define ecl_mpz_from_bignum(obj) ((obj)->big.big_num)
+#else
+#define ecl_mpz_from_bignum(obj) ecl_bignum(obj)
+#endif
 
 cl_object ecl_bignum_from_mpz(mpz_t num)
 {


### PR DESCRIPTION
ecl 23.9.9 has two minor changes that affect sagemath:
- api for bignums changed, so the macro `ecl_mpz_from_bignum` has to be (conditionally) changed
- printing of floating point numbers changed `1.e40` to `1.0e40`, I changed the example to `1.234e40` which prints the same in 23.9.9 as in previous versions.

With this changes sagemath should work ok with either 21.2.1 or 23.9.9.