### PR TITLE
`sage -t`: Distinguish .pxd from .pyx in doctest basenames

### DIFF
--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -289,7 +289,7 @@ def skipfile(filename, tested_optional_tags=False, *,
         if log:
             log(f"Skipping '{filename}' because it is created by the jupyter-sphinx extension for internal use and should not be tested")
         return True
-    if if_installed and ext in ('.py', '.pyx', '.pxd'):
+    if if_installed:
         module_name = get_basename(filename)
         try:
             if not importlib.util.find_spec(module_name):  # tries to import the containing package

--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -84,8 +84,10 @@ def get_basename(path):
         sage: from sage.doctest.sources import get_basename
         sage: from sage.env import SAGE_SRC
         sage: import os
-        sage: get_basename(os.path.join(SAGE_SRC,'sage','doctest','sources.py'))
+        sage: get_basename(os.path.join(SAGE_SRC, 'sage', 'doctest', 'sources.py'))
         'sage.doctest.sources'
+        sage: get_basename(os.path.join(SAGE_SRC, 'sage', 'structure', 'element.pxd'))
+        'sage.structure.element.pxd'
     """
     if path is None:
         return None
@@ -111,10 +113,14 @@ def get_basename(path):
         # it goes.
         while is_package_or_sage_namespace_package_dir(root):
             root = os.path.dirname(root)
-    fully_qualified_path = os.path.splitext(path[len(root) + 1:])[0]
+    fully_qualified_path, ext = os.path.splitext(path[len(root) + 1:])
     if os.path.split(path)[1] == '__init__.py':
         fully_qualified_path = fully_qualified_path[:-9]
-    return fully_qualified_path.replace(os.path.sep, '.')
+    basename = fully_qualified_path.replace(os.path.sep, '.')
+    if ext in ['.pxd', '.pxi']:
+        # disambiguate from .pyx with the same basename
+        basename += ext
+    return basename
 
 
 class DocTestSource():


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
These basenames are used in the stats file, recording test failures and running times in `~/.sage/timings2.json`.
Currently, `element.pyx` and `element.pxd` have the same basename, and so they clobber each other in the stats file. It depends on the order of execution which of the two wins. This affects `sage -t --failed` and the sort order according to running times.

Here we disambiguate them by adding a suffix for .pxd and .pxi files.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Cherry-picked from #35095, where the stats are used for creating records of known test failures of the modularized distributions.
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
