### PR TITLE
Reject system `libnauty` if `cliquer` is built from SPKG

### DIFF
--- a/build/pkgs/libnauty/spkg-configure.m4
+++ b/build/pkgs/libnauty/spkg-configure.m4
@@ -1,4 +1,4 @@
-SAGE_SPKG_CONFIGURE([libnauty], [
+SAGE_SPKG_CONFIGURE([libnauty cliquer], [
   SAGE_SPKG_DEPCHECK([nauty], [
     dnl The library is actually installed by the nauty spkg.
     AC_CHECK_HEADER([nauty/nauty.h], [], [sage_spkg_install_libnauty=yes])


### PR DESCRIPTION
Fixes https://groups.google.com/g/sage-devel/c/YOBPUAflK_I @tscrim 

Previous discussion in #31403

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
