### PR TITLE
numpy-1.25 compatibility

### DIFF
--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -1631,6 +1631,17 @@ class SageOutputChecker(doctest.OutputChecker):
             got = ld_pie_warning_regex.sub('', got)
             did_fixup = True
 
+        if "Overriding pythran description" in got:
+            # Some signatures changed in numpy-1.25.x that may yet be
+            # reverted, but which pythran would otherwise warn about.
+            # Pythran has a special case for numpy.random that hides
+            # the warning -- I guess until we know if the changes will
+            # be reverted -- but only in v0.14.0 of pythran. Ignoring
+            # This warning allows us to support older pythran with e.g.
+            # numpy-1.25.2.
+            pythran_numpy_warning_regex = re.compile(r'WARNING: Overriding pythran description with argspec information for: numpy\.random\.[a-z_]+')
+            got = pythran_numpy_warning_regex.sub('', got)
+            did_fixup = True
         return did_fixup, want, got
 
     def output_difference(self, example, got, optionflags):

--- a/src/sage/tests/books/computational-mathematics-with-sagemath/graphique_doctest.py
+++ b/src/sage/tests/books/computational-mathematics-with-sagemath/graphique_doctest.py
@@ -134,11 +134,11 @@ Sage example in ./graphique.tex, line 1120::
   sage: t = srange(0, 5, 0.1); p = Graphics()
   sage: for k in srange(0, 10, 0.15):
   ....:       y = integrate.odeint(f, k, t)
-  ....:       p += line(zip(t, flatten(y)))
+  ....:       p += line(zip(t, flatten(y.tolist())))
   sage: t = srange(0, -5, -0.1); q = Graphics()
   sage: for k in srange(0, 10, 0.15):
   ....:       y = integrate.odeint(f, k, t)
-  ....:       q += line(zip(t, flatten(y)))
+  ....:       q += line(zip(t, flatten(y.tolist())))
   sage: y = var('y')
   sage: v = plot_vector_field((1, -cos(x*y)), (x,-5,5), (y,-2,11))
   sage: g = p + q + v; g.show()


### PR DESCRIPTION
Fixes two doctest failures with numpy-1.25.x. One is a warning from pythran that needs to be hidden (to avoid requiring a bleeding-edge version of pythran), and the other is a buggy doctest that now triggers a numpy warning.