### PR TITLE
missing #endif in singular's spkg-configure.m4

### DIFF
--- a/build/pkgs/singular/spkg-configure.m4
+++ b/build/pkgs/singular/spkg-configure.m4
@@ -12,6 +12,7 @@ SAGE_SPKG_CONFIGURE([singular], [
             #include <singular/singularconfig.h>
             #if !defined(HAVE_FLINT)
             #  error "Need Singular compiled with FLINT"
+            #endif
           ], [])
         ], [
           AC_MSG_RESULT([yes])


### PR DESCRIPTION
currently this test always fails, due to this syntax error, made in 8255c9475e8