### PR TITLE
Support for matplotlib-3.8.0

### DIFF
--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -36,6 +36,7 @@ AUTHORS:
 # ****************************************************************************
 
 import os
+from numbers import Integral
 from collections.abc import Iterable
 from math import isnan
 import sage.misc.verbose
@@ -2874,6 +2875,11 @@ class Graphics(WithEqualityById, SageObject):
                 weight=lopts.pop('font_weight', 'medium'),
                 variant=lopts.pop('font_variant', 'normal'))
             color = lopts.pop('back_color', 'white')
+            if 'loc' in lopts:
+                loc = lopts['loc']
+                if isinstance(loc, Integral):
+                    # matplotlib 3.8 doesn't support sage integers
+                    lopts['loc'] = int(loc)
             leg = subplot.legend(prop=prop, **lopts)
             if leg is None:
                 from warnings import warn


### PR DESCRIPTION
In matplotlib 3.8.0 there is a minor change that affects sagemath. The parameter to `loc` is supposed to be a string or an integer from 0 to 10 representing different positions. It used to work with sage integers, but now it doesn't.

This PR fixes it by coercing any `numbers.Integral` type into `int` before calling matplotlib.
 
- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.