### PR TITLE
remove duplicate args in @options() in region_plot

### DIFF
--- a/src/sage/plot/contour_plot.py
+++ b/src/sage/plot/contour_plot.py
@@ -1391,11 +1391,9 @@ def implicit_plot(f, xrange, yrange, **options):
         raise ValueError("fill=%s is not supported" % options['fill'])
 
 
-@options(plot_points=100, incol='blue', outcol=None, bordercol=None,
-         borderstyle=None, borderwidth=None, frame=False, axes=True,
-         legend_label=None, aspect_ratio=1, alpha=1)
-def region_plot(f, xrange, yrange, plot_points, incol, outcol, bordercol,
-                borderstyle, borderwidth, alpha, **options):
+@options(frame=False, axes=True, legend_label=None, aspect_ratio=1)
+def region_plot(f, xrange, yrange, plot_points=100, incol='blue', outcol=None, bordercol=None,
+                borderstyle=None, borderwidth=None, alpha=1, **options):
     r"""
     ``region_plot`` takes a boolean function of two variables, `f(x, y)`
     and plots the region where f is True over the specified

--- a/src/sage/plot/contour_plot.py
+++ b/src/sage/plot/contour_plot.py
@@ -1394,8 +1394,7 @@ def implicit_plot(f, xrange, yrange, **options):
 @options(plot_points=100, incol='blue', outcol=None, bordercol=None,
          borderstyle=None, borderwidth=None, frame=False, axes=True,
          legend_label=None, aspect_ratio=1, alpha=1)
-def region_plot(f, xrange, yrange, plot_points, incol, outcol, bordercol,
-                borderstyle, borderwidth, alpha, **options):
+def region_plot(f, xrange, yrange, **options):
     r"""
     ``region_plot`` takes a boolean function of two variables, `f(x, y)`
     and plots the region where f is True over the specified
@@ -1659,6 +1658,14 @@ def region_plot(f, xrange, yrange, plot_points, incol, outcol, bordercol,
     from warnings import warn
     import numpy
 
+    plot_points = options['plot_points']
+    incol = options.pop('incol')
+    outcol = options.pop('outcol')
+    bordercol = options.pop('bordercol')
+    borderstyle = options.pop('borderstyle')
+    borderwidth = options.pop('borderwidth')
+    alpha = options.pop('alpha')
+
     if not isinstance(f, (list, tuple)):
         f = [f]
 
@@ -1677,9 +1684,9 @@ def region_plot(f, xrange, yrange, plot_points, incol, outcol, bordercol,
     if neqs and not bordercol:
         bordercol = incol
     if not f:
-        return implicit_plot(feqs[0], xrange, yrange, plot_points=plot_points,
-                             fill=False, linewidth=borderwidth,
-                             linestyle=borderstyle, color=bordercol, **options)
+        return implicit_plot(feqs[0], xrange, yrange, fill=False,
+                             linewidth=borderwidth, linestyle=borderstyle,
+                             color=bordercol, **options)
     f_all, ranges = setup_for_eval_on_grid(feqs + f,
                                            [xrange, yrange],
                                            plot_points)


### PR DESCRIPTION
This is needed for Sphinx 7.1+, as outlined in #36295 and discovered in #36276 

This will resolve #36295

It also fixes a bug in `region_plot`, where in some cases `plot_points` were not passed to the backend.