### PR TITLE
Mod 2 (co)homology as a module over the Steenrod algebra

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -1002,6 +1002,11 @@ REFERENCES:
             group actions}, (preprint March 2003, available on
             Mitter's MIT website).
 
+.. [Boa1982] J. M. Boardman, "The eightfold way to BP-operations",
+             in *Current trends in algebraic topology*, pp. 187–226,
+             Canadian Mathematical Society Proceedings, 2, Part 1.
+             Providence 1982. ISBN 978-0-8218-6003-8.
+
 .. [Bond2007] P. Bonderson, Nonabelian anyons and interferometry,
               Dissertation (2007). https://thesis.library.caltech.edu/2447/
 

--- a/src/sage/homology/homology_vector_space_with_basis.py
+++ b/src/sage/homology/homology_vector_space_with_basis.py
@@ -1008,7 +1008,6 @@ class CohomologyRing_mod2(CohomologyRing):
         sage: x * Sq(3)
         h^{4,0}
     """
-
     def __init__(self, base_ring, cell_complex):
         """
         Initialize ``self``.
@@ -1217,7 +1216,7 @@ class CohomologyRing_mod2(CohomologyRing):
 
             INPUT:
 
-            - ``a`` - an element of the mod 2 Steenrod algebra
+            - ``a`` -- an element of the mod 2 Steenrod algebra
             - ``self_on_left`` -- ``True`` if we are computing ``self * a``,
               otherwise ``a * self``
 
@@ -1284,7 +1283,7 @@ class CohomologyRing_mod2(CohomologyRing):
         - ``deg_codomain`` -- the degree of the codomain in the
           cohomology ring
 
-        - ``side`` default ``'left'``) -- whether we are computing
+        - ``side`` -- (default ``'left'``) whether we are computing
           the action as a left module action or a right module
 
         We will write this with respect to the left action;
@@ -1440,8 +1439,8 @@ def sum_indices(k, i_k_plus_one, S_k_plus_one):
             for l in sum_indices(k-1, i_k, S_k)]
 
 def is_GF2(R):
-    """
-    Return ``True`` iff ``R`` is isomorphic to the field GF(2).
+    r"""
+    Return ``True`` iff ``R`` is isomorphic to the field `\GF{2}`.
 
     EXAMPLES::
 

--- a/src/sage/homology/homology_vector_space_with_basis.py
+++ b/src/sage/homology/homology_vector_space_with_basis.py
@@ -36,7 +36,6 @@ from sage.categories.modules import Modules
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.matrix.constructor import matrix
 from sage.modules.free_module_element import vector
-from sage.rings.finite_rings.finite_field_constructor import GF
 from sage.sets.family import Family
 
 try:
@@ -679,10 +678,15 @@ class HomologyVectorSpaceWithBasis_mod2(HomologyVectorSpaceWithBasis):
                 True
                 sage: x4 * (Sq(2) * Sq(1)) == (x4 * Sq(2)) * Sq(1)
                 True
+                sage: 1 * x4
+                h_{4,0}
+                sage: x4 * 0
+                0
             """
             # Handle field elements first.
-            if a in self.base_ring():
-                return a * self
+            ret = CombinatorialFreeModule.Element._acted_upon_(self, a, self_on_left)
+            if ret is not None:  # did the scalar action
+                return ret
             m = self.degree()
             n = a.degree()
             if m <= n:
@@ -1245,10 +1249,15 @@ class CohomologyRing_mod2(CohomologyRing):
                 True
                 sage: x * (Sq(1) * Sq(2)) == (x * Sq(1)) * Sq(2)
                 True
+                sage: x * 1
+                h^{2,0}
+                sage: 0 * x
+                0
             """
             # Handle field elements first.
-            if a in self.base_ring():
-                return self.map_coefficients(lambda c: c*a)
+            ret = CombinatorialFreeModule.Element._acted_upon_(self, a, self_on_left)
+            if ret is not None:  # did the scalar action
+                return ret
             if self_on_left: # i.e., module element on left
                 a = a.antipode()
             b = a.change_basis('adem')

--- a/src/sage/homology/homology_vector_space_with_basis.py
+++ b/src/sage/homology/homology_vector_space_with_basis.py
@@ -410,7 +410,7 @@ class HomologyVectorSpaceWithBasis(CombinatorialFreeModule):
             sage: coh.dual() is hom
             True
         """
-        if self.base_ring() == GF(2):
+        if is_GF2(self.base_ring()):
             if self._cohomology:
                 return HomologyVectorSpaceWithBasis_mod2(self.base_ring(),
                                                          self.complex())
@@ -590,7 +590,7 @@ class HomologyVectorSpaceWithBasis_mod2(HomologyVectorSpaceWithBasis):
             sage: H = simplicial_complexes.Sphere(3).homology_with_basis(GF(2))
             sage: TestSuite(H).run()
         """
-        if base_ring != GF(2):
+        if not is_GF2(base_ring):
             raise ValueError
         category = Modules(base_ring).WithBasis().Graded().FiniteDimensional().or_subcategory(category)
         category = Category.join((category,
@@ -641,7 +641,7 @@ class HomologyVectorSpaceWithBasis_mod2(HomologyVectorSpaceWithBasis):
 
             .. MATH::
 
-                (f \cdot a) (x) = f (a \cdot x)
+                (f \cdot a) (x) = f (a \cdot x).
 
             So given `f` (a.k.a. ``self``) and `a`, we compute `f (a
             \cdot x)` for all basis elements `x` in `H^{m-n}`,
@@ -1015,7 +1015,7 @@ class CohomologyRing_mod2(CohomologyRing):
             sage: H = RP2.cohomology_ring(GF(2))
             sage: TestSuite(H).run()
         """
-        if base_ring != GF(2):
+        if not is_GF2(base_ring):
             raise ValueError("the base ring must be GF(2)")
         category = Algebras(base_ring).WithBasis().Graded().FiniteDimensional()
         category = Category.join((category,
@@ -1105,11 +1105,12 @@ class CohomologyRing_mod2(CohomologyRing):
                 P = scomplex.cohomology_ring(self.base_ring())
                 self = P.sum_of_terms(self.monomial_coefficients().items())
             if not isinstance(scomplex, (SimplicialComplex, SimplicialSet_arbitrary)):
+                print(scomplex, isinstance(scomplex, SimplicialComplex))
                 raise NotImplementedError('Steenrod squares are not implemented for '
                                           'this type of cell complex')
             scomplex = P.complex()
             base_ring = P.base_ring()
-            if base_ring.characteristic() != 2:
+            if not is_GF2(base_ring):
                 # This should never happen: the class should only be
                 # instantiated in characteristic 2.
                 raise ValueError('Steenrod squares are only defined in characteristic 2')
@@ -1428,3 +1429,19 @@ def sum_indices(k, i_k_plus_one, S_k_plus_one):
         return [[S_k]]
     return [[i_k] + l for i_k in range(S_k, i_k_plus_one)
             for l in sum_indices(k-1, i_k, S_k)]
+
+def is_GF2(R):
+    """
+    Return ``True`` iff ``R`` is isomorphic to the field GF(2).
+
+    EXAMPLES::
+
+        sage: from sage.homology.homology_vector_space_with_basis import is_GF2
+        sage: is_GF2(GF(2))
+        True
+        sage: is_GF2(GF(2, impl='ntl'))
+        True
+        sage: is_GF2(GF(3))
+        False
+    """
+    return 2 == R.cardinality() == R.characteristic()

--- a/src/sage/homology/homology_vector_space_with_basis.py
+++ b/src/sage/homology/homology_vector_space_with_basis.py
@@ -1453,4 +1453,4 @@ def is_GF2(R):
         sage: is_GF2(GF(3))
         False
     """
-    return 2 == R.cardinality() == R.characteristic()
+    return 2 == R.characteristic() == R.cardinality()

--- a/src/sage/homology/homology_vector_space_with_basis.py
+++ b/src/sage/homology/homology_vector_space_with_basis.py
@@ -444,13 +444,13 @@ class HomologyVectorSpaceWithBasis(CombinatorialFreeModule):
 
             sage: simplicial_complexes.RandomComplex(12, 3, .5).homology_with_basis(GF(2))._test_duality() # long time
         """
-        tester = self._tester(**options))
+        tester = self._tester(**options)
         dual = self.dual()
         dims = [a[0] for a in self._indices]
         for dim in range(max(max(dims),  tester._max_runs) + 1):
             n = len(self.basis(dim))
             m = matrix(n, n, [a.eval(b) for a in self.basis(dim) for b in dual.basis(dim)])
-            tester.assertEqual(m, 1,f "error in dimension {dim}")
+            tester.assertEqual(m, 1, f"error in dimension {dim}")
 
     class Element(CombinatorialFreeModule.Element):
         def to_cycle(self):
@@ -596,7 +596,8 @@ class HomologyVectorSpaceWithBasis_mod2(HomologyVectorSpaceWithBasis):
         category = Category.join((category,
                                   LeftModules(SteenrodAlgebra(2)),
                                   RightModules(SteenrodAlgebra(2))))
-        HomologyVectorSpaceWithBasis.__init__(self, base_ring, cell_complex,
+        HomologyVectorSpaceWithBasis.__init__(self, base_ring,
+                                              cell_complex,
                                               cohomology=False,
                                               category=category)
 
@@ -681,18 +682,17 @@ class HomologyVectorSpaceWithBasis_mod2(HomologyVectorSpaceWithBasis):
             """
             # Handle field elements first.
             if a in self.base_ring():
-                return self.map_coefficients(lambda c: c*a)
-            if not self_on_left: # i.e., module element on left
-                a = a.antipode()
-
+                return a * self
             m = self.degree()
             n = a.degree()
             if m <= n:
                 return self.parent().zero()
 
+            if not self_on_left: # i.e., module element on left
+                a = a.antipode()
             P = self.parent()
             B = list(P.basis(m-n))
-            return P._from_dict({b.support()[0]: self.eval(a * x)
+            return P._from_dict({x.support()[0]: self.eval(a * x)
                                  for x in sorted(self.parent().dual().basis(m-n))})
 
 
@@ -960,7 +960,6 @@ class CohomologyRing_mod2(CohomologyRing):
     - ``base_ring`` -- must be the field ``GF(2)``
     - ``cell_complex`` -- the cell complex whose homology we are
       computing
-    - ``category`` -- (optional) a subcategory of modules with basis
 
     EXAMPLES:
 

--- a/src/sage/topology/cell_complex.py
+++ b/src/sage/topology/cell_complex.py
@@ -837,8 +837,7 @@ class GenericCellComplex(SageObject):
         .. SEEALSO::
 
             If ``cohomology`` is ``True``, this returns the cohomology
-            as a graded module. For the ring structure, use
-            :meth:`cohomology_ring`.
+            as a ring: it calls :meth:`cohomology_ring`.
 
         EXAMPLES::
 
@@ -866,7 +865,12 @@ class GenericCellComplex(SageObject):
             sage: list(H.basis(3))                                                      # needs sage.modules
             [h^{3,0}]
         """
-        from sage.homology.homology_vector_space_with_basis import HomologyVectorSpaceWithBasis
+        from sage.homology.homology_vector_space_with_basis import \
+            HomologyVectorSpaceWithBasis, HomologyVectorSpaceWithBasis_mod2
+        if base_ring == GF(2):
+            if cohomology:
+                return self.cohomology_ring(base_ring)
+            return HomologyVectorSpaceWithBasis_mod2(base_ring, self)
         return HomologyVectorSpaceWithBasis(base_ring, self, cohomology)
 
     def cohomology_ring(self, base_ring=QQ):

--- a/src/sage/topology/cell_complex.py
+++ b/src/sage/topology/cell_complex.py
@@ -867,9 +867,9 @@ class GenericCellComplex(SageObject):
         """
         from sage.homology.homology_vector_space_with_basis import \
             HomologyVectorSpaceWithBasis, HomologyVectorSpaceWithBasis_mod2
+        if cohomology:
+            return self.cohomology_ring(base_ring)
         if base_ring == GF(2):
-            if cohomology:
-                return self.cohomology_ring(base_ring)
             return HomologyVectorSpaceWithBasis_mod2(base_ring, self)
         return HomologyVectorSpaceWithBasis(base_ring, self, cohomology)
 

--- a/src/sage/topology/cell_complex.py
+++ b/src/sage/topology/cell_complex.py
@@ -47,7 +47,6 @@ by developers producing new classes, not casual users.
 from sage.structure.sage_object import SageObject
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
-from sage.rings.finite_rings.finite_field_constructor import GF
 from sage.misc.abstract_method import abstract_method
 
 
@@ -866,10 +865,12 @@ class GenericCellComplex(SageObject):
             [h^{3,0}]
         """
         from sage.homology.homology_vector_space_with_basis import \
-            HomologyVectorSpaceWithBasis, HomologyVectorSpaceWithBasis_mod2
+            HomologyVectorSpaceWithBasis, HomologyVectorSpaceWithBasis_mod2, \
+            is_GF2
+
         if cohomology:
             return self.cohomology_ring(base_ring)
-        if base_ring == GF(2):
+        if is_GF2(base_ring):
             return HomologyVectorSpaceWithBasis_mod2(base_ring, self)
         return HomologyVectorSpaceWithBasis(base_ring, self, cohomology)
 
@@ -977,8 +978,10 @@ class GenericCellComplex(SageObject):
             Cohomology ring of Simplicial complex with 9 vertices and
              18 facets over Rational Field
         """
-        from sage.homology.homology_vector_space_with_basis import CohomologyRing, CohomologyRing_mod2
-        if base_ring == GF(2):
+        from sage.homology.homology_vector_space_with_basis import CohomologyRing, \
+            CohomologyRing_mod2, is_GF2
+
+        if is_GF2(base_ring):
             return CohomologyRing_mod2(base_ring, self)
         return CohomologyRing(base_ring, self)
 

--- a/src/sage/topology/cell_complex.py
+++ b/src/sage/topology/cell_complex.py
@@ -47,6 +47,7 @@ by developers producing new classes, not casual users.
 from sage.structure.sage_object import SageObject
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
+from sage.rings.finite_rings.finite_field_constructor import GF
 from sage.misc.abstract_method import abstract_method
 
 
@@ -972,7 +973,9 @@ class GenericCellComplex(SageObject):
             Cohomology ring of Simplicial complex with 9 vertices and
              18 facets over Rational Field
         """
-        from sage.homology.homology_vector_space_with_basis import CohomologyRing
+        from sage.homology.homology_vector_space_with_basis import CohomologyRing, CohomologyRing_mod2
+        if base_ring == GF(2):
+            return CohomologyRing_mod2(base_ring, self)
         return CohomologyRing(base_ring, self)
 
     @abstract_method


### PR DESCRIPTION
Mod 2 (co)homology as a module over the Steenrod algebra

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

Implement:

- vector space duality for (co)homology of cell complexes with field coefficients, switching between homology and cohomology
- Steenrod operations on homology and cohomology, acting from the left and from the right

The Steenrod operation "Sq(i)" was already implemented for cohomology rings, raising an error if it was used with a base field other than GF(2). Now there is a new class, `CohomologyRing_mod2`, which should only be used with that base field, and the `Sq` method is attached to Elements of that new class.

Using Steenrod operations is more transparent: in addition to doing `x.Sq(i)`, users can do `Sq(i) * x` or `x * Sq(i)`, or indeed `a * x` or `x * a` for any element `a` of `SteenrodAlgebra(2)`. (The elements `Sq(i)` generate the Steenrod algebra, but they do not constitute a full list of the elements.)

This fixes #6103.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [X] The title is concise, informative, and self-explanatory.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
