### PR TITLE
Replace shell bunzip2 with library code

### DIFF
--- a/src/sage/misc/persist.pyx
+++ b/src/sage/misc/persist.pyx
@@ -1102,9 +1102,9 @@ def unpickle_all(target, debug=False, run_test_suite=False):
       ``.sobj`` files.  The tar archive can be in any format that
       python's ``tarfile`` module understands; for example,
       ``.tar.gz`` or ``.tar.bz2``.
-    - ``debug`` -- a boolean (default: False)
+    - ``debug`` -- a boolean (default: ``False``)
       whether to report a stacktrace in case of failure
-    - ``run_test_suite`` -- a boolean (default: False)
+    - ``run_test_suite`` -- a boolean (default: ``False``)
       whether to run ``TestSuite(x).run()`` on the unpickled objects
 
     OUTPUT:
@@ -1120,7 +1120,7 @@ def unpickle_all(target, debug=False, run_test_suite=False):
        You must only pass trusted data to this function, including tar
        archives. We use the "data" filter from PEP 706 if possible
        while extracting the archive, but even that is not a perfect
-       solution, and it is only available since python-3.11.4.
+       solution, and it is only available since Python 3.11.4.
 
     EXAMPLES::
 

--- a/src/sage/misc/persist.pyx
+++ b/src/sage/misc/persist.pyx
@@ -1091,19 +1091,36 @@ def picklejar(obj, dir=None):
         fobj.write(stamp)
 
 
-def unpickle_all(dir, debug=False, run_test_suite=False):
+def unpickle_all(target, debug=False, run_test_suite=False):
     """
-    Unpickle all sobj's in the given directory, reporting failures as
-    they occur.  Also printed the number of successes and failure.
+    Unpickle all ``.sobj`` files in a directory or tar archive.
 
     INPUT:
 
-    - ``dir`` -- a string; the name of a directory (or of a .tar.bz2
-      file that decompresses to a directory) full of pickles.
+    - ``target`` -- a string; the name of a directory or of a (possibly
+      compressed) tar archive that contains a single directory of
+      ``.sobj`` files.  The tar archive can be in any format that
+      python's ``tarfile`` module understands; for example,
+      ``.tar.gz`` or ``.tar.bz2``.
     - ``debug`` -- a boolean (default: False)
       whether to report a stacktrace in case of failure
     - ``run_test_suite`` -- a boolean (default: False)
       whether to run ``TestSuite(x).run()`` on the unpickled objects
+
+    OUTPUT:
+
+    Typically, two lines are printed: the first reporting the number
+    of successfully unpickled files, and the second reporting the
+    number (zero) of failures. If there are failures, however, then a
+    list of failed files will be printed before either of those lines,
+    and the failure count will of course be non-zero.
+
+    .. WARNING::
+
+       You must only pass trusted data to this function, including tar
+       archives. We use the "data" filter from PEP 706 if possible
+       while extracting the archive, but even that is not a perfect
+       solution, and it is only available since python-3.11.4.
 
     EXAMPLES::
 
@@ -1113,33 +1130,61 @@ def unpickle_all(dir, debug=False, run_test_suite=False):
         Successfully unpickled 1 objects.
         Failed to unpickle 0 objects.
     """
-    i = 0
-    j = 0
+    import os.path, tarfile
+
+    ok_count = 0
+    fail_count = 0
     failed = []
     tracebacks = []
-    # This could use instead Python's tarfile module
-    if dir.endswith('.tar.bz2'):
-        # create a temporary directory
-        from sage.misc.temporary_file import tmp_dir
-        T = tmp_dir()
-        # extract tarball to it
-        os.system('cd "%s"; bunzip2 -c "%s" | tar fx - '%(T, os.path.abspath(dir)))
-        # Now use the directory in the tarball instead of dir
-        dir = T + "/" + os.listdir(T)[0]
 
-    for A in sorted(os.listdir(dir)):
-        if A.endswith('.sobj'):
+    if os.path.isfile(target) and tarfile.is_tarfile(target):
+        import tempfile
+        with tempfile.TemporaryDirectory() as T:
+            # Extract the tarball to a temporary directory. The "data"
+            # filter only became available in python-3.11.4. See PEP
+            # 706 for background.
+            with tarfile.open(target) as tf:
+                if hasattr(tarfile, "data_filter"):
+                    tf.extractall(T, filter="data")
+                else:
+                    tf.extractall(T)
+
+            # Ensure that the tarball contained exactly one thing, a
+            # directory.
+            bad_tarball_msg = "tar archive must contain only a single directory"
+            contents = os.listdir(T)
+            if len(contents) != 1:
+                raise ValueError(bad_tarball_msg)
+
+            dir = os.path.join(T, contents[0])
+            if not os.path.isdir(dir):
+                raise ValueError(bad_tarball_msg)
+
+            # If everything looks OK, start this function over again
+            # inside the extracted directory. Note: PEP 343 says the
+            # temporary directory will be cleaned up even when the
+            # "with" block is exited via a "return" statement. But
+            # also note that "return" doesn't happen until the
+            # recursive call to unpickle_all() has completed.
+            return unpickle_all(dir, debug, run_test_suite)
+
+    if not os.path.isdir(target):
+        raise ValueError("target is neither a directory nor a tar archive")
+
+    for A in sorted(os.listdir(target)):
+        f = os.path.join(target, A)
+        if os.path.isfile(f) and f.endswith('.sobj'):
             try:
-                obj = load(os.path.join(dir,A))
+                obj = load(f)
                 if run_test_suite:
                     TestSuite(obj).run(catch = False)
-                i += 1
+                ok_count += 1
             except Exception:
-                j += 1
+                fail_count += 1
                 if run_test_suite:
-                    print(" * unpickle failure: TestSuite(load('%s')).run()" % os.path.join(dir, A))
+                    print(" * unpickle failure: TestSuite(load('%s')).run()" % f)
                 else:
-                    print(" * unpickle failure: load('%s')" % os.path.join(dir, A))
+                    print(" * unpickle failure: load('%s')" % f)
                 from traceback import print_exc
                 print_exc()
                 failed.append(A)
@@ -1148,8 +1193,8 @@ def unpickle_all(dir, debug=False, run_test_suite=False):
 
     if failed:
         print("Failed:\n%s" % ('\n'.join(failed)))
-    print("Successfully unpickled %s objects." % i)
-    print("Failed to unpickle %s objects." % j)
+    print("Successfully unpickled %s objects." % ok_count)
+    print("Failed to unpickle %s objects." % fail_count)
     if debug:
         return tracebacks
 

--- a/src/sage/misc/persist.pyx
+++ b/src/sage/misc/persist.pyx
@@ -887,7 +887,7 @@ class SageUnpickler(_BaseUnpickler):
     @classmethod
     def loads(cls, data, **kwargs):
         """
-        Equivalent to :func:`pickle.dumps` but using the
+        Equivalent to :func:`pickle.loads` but using the
         :class:`sage.misc.persist.SagePickler`.
 
         INPUT:


### PR DESCRIPTION
Fix this,

```python
# This could use instead Python's tarfile module
if dir.endswith('.tar.bz2'):
    # create a temporary directory
    from sage.misc.temporary_file import tmp_dir
    T = tmp_dir()
    # extract tarball to it
    os.system('cd "%s"; bunzip2 -c "%s" | tar fx - '%(T, os.path.abspath(dir)))
```

by rewriting it using Python's `tarfile` and `tempfile` modules.