### PR TITLE
build/pkgs/lrcalc_python: add standard python spkg-configure.m4

### DIFF
--- a/build/pkgs/lrcalc_python/spkg-configure.m4
+++ b/build/pkgs/lrcalc_python/spkg-configure.m4
@@ -1,0 +1,1 @@
+SAGE_SPKG_CONFIGURE([lrcalc_python], [SAGE_PYTHON_PACKAGE_CHECK([lrcalc_python])])


### PR DESCRIPTION
I'm adding this to Gentoo in about five minutes, and the system copy works fine.
