### PR TITLE
add meson_python to PYTHON_TOOLCHAIN

### DIFF
--- a/build/make/Makefile.in
+++ b/build/make/Makefile.in
@@ -325,7 +325,7 @@ all-toolchain: base-toolchain
 # All packages needed as a prerequisite to install other Python packages with
 # pip or which are otherwise used by the Python build tools; these should be
 # given as a prerequisite to any pip-installed packages
-PYTHON_TOOLCHAIN = setuptools pip setuptools_scm wheel setuptools_wheel
+PYTHON_TOOLCHAIN = setuptools pip setuptools_scm wheel setuptools_wheel meson_python
 
 # Trac #32056: Avoid installed setuptools leaking into the build of python3 by uninstalling it.
 # It will have to be reinstalled anyway because of its dependency on $(PYTHON).

--- a/build/pkgs/meson_python/dependencies
+++ b/build/pkgs/meson_python/dependencies
@@ -1,4 +1,4 @@
- meson pyproject_metadata tomli ninja_build patchelf | $(PYTHON_TOOLCHAIN) $(PYTHON)
+ meson pyproject_metadata tomli ninja_build patchelf | setuptools pip setuptools_scm wheel setuptools_wheel $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
fix race condition for building scipy, possibly other meson_python deps

cf e.g. sage-dev [report](https://groups.google.com/g/sage-support/c/9Yb2_51joU0/m/_MMFoBoFAQAJ)