### PR TITLE
add some class roles for linking Errors in doc

### DIFF
--- a/src/sage/databases/conway.py
+++ b/src/sage/databases/conway.py
@@ -179,7 +179,7 @@ class ConwayPolynomials(Mapping):
     def polynomial(self, p, n):
         """
         Return the Conway polynomial of degree ``n`` over ``GF(p)``,
-        or raise a RuntimeError if this polynomial is not in the
+        or raise a :class:`RuntimeError` if this polynomial is not in the
         database.
 
         .. NOTE::

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -1900,7 +1900,8 @@ class GenericGraph(GenericGraph_pyx):
           matrix. By default, the ordering given by
           :meth:`GenericGraph.vertices` with ``sort=True`` is used.
           If the vertices are not comparable, the keyword ``vertices`` must be
-          used to specify an ordering, or a TypeError exception will be raised.
+          used to specify an ordering, or a :class:`TypeError` exception will
+          be raised.
 
         - ``base_ring`` -- a ring (default: ``ZZ``); the base ring of the matrix
           space to use.

--- a/src/sage/interfaces/singular.py
+++ b/src/sage/interfaces/singular.py
@@ -584,7 +584,7 @@ class Singular(ExtraTabCompletion, Expect):
         -  ``x`` - string (of code)
 
         -  ``allow_semicolon`` - default: False; if False then
-           raise a TypeError if the input line contains a semicolon.
+           raise a :class:`TypeError` if the input line contains a semicolon.
 
         -  ``strip`` - ignored
 

--- a/src/sage/matrix/matrix_cyclo_dense.pyx
+++ b/src/sage/matrix/matrix_cyclo_dense.pyx
@@ -680,8 +680,9 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
 
     cdef long _hash_(self) except -1:
         """
-        Return hash of an immutable matrix. Raise a TypeError if input
-        matrix is mutable.
+        Return hash of an immutable matrix.
+
+        This raises a :class:`TypeError` if input matrix is mutable.
 
         EXAMPLES:
 

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -1343,8 +1343,8 @@ class MatrixSpace(UniqueRepresentation, Parent):
     def __len__(self):
         """
         Return number of elements of this matrix space if it fits in
-        an int; raise a TypeError if there are infinitely many
-        elements, and raise an OverflowError if there are finitely
+        an int; raise a :class:`TypeError` if there are infinitely many
+        elements, and raise an :class:`OverflowError` if there are finitely
         many but more than the size of an int.
 
         EXAMPLES::

--- a/src/sage/modular/abvar/abvar.py
+++ b/src/sage/modular/abvar/abvar.py
@@ -611,16 +611,19 @@ class ModularAbelianVariety_abstract(Parent):
 
     def elliptic_curve(self):
         """
-        Return an elliptic curve isogenous to self. If self is not dimension 1
-        with rational base ring, raise a ValueError.
+        Return an elliptic curve isogenous to ``self``.
 
-        The elliptic curve is found by looking it up in the CremonaDatabase.
-        The CremonaDatabase contains all curves up to some large conductor.  If
-        a curve is not found in the CremonaDatabase, a RuntimeError will be
-        raised. In practice, only the most committed users will see this
-        RuntimeError.
+        If ``self`` is not dimension 1
+        with rational base ring, this raises a :class:`ValueError`.
 
-        OUTPUT: an elliptic curve isogenous to self.
+        The elliptic curve is found by looking it up in the
+        CremonaDatabase.  The CremonaDatabase contains all curves up
+        to some large conductor.  If a curve is not found in the
+        CremonaDatabase, a :class:`RuntimeError` will be raised. In
+        practice, only the most committed users will see this
+        :class:`RuntimeError`.
+
+        OUTPUT: an elliptic curve isogenous to ``self``.
 
         EXAMPLES::
 
@@ -4183,7 +4186,8 @@ class ModularAbelianVariety_modsym_abstract(ModularAbelianVariety_abstract):
         """
         Return space of modular symbols (with given sign) associated to
         this modular abelian variety, if it can be found by cutting down
-        using Hecke operators. Otherwise raise a RuntimeError exception.
+        using Hecke operators. Otherwise raise a :class:`RuntimeError`
+        exception.
 
         EXAMPLES::
 

--- a/src/sage/modular/overconvergent/genus0.py
+++ b/src/sage/modular/overconvergent/genus0.py
@@ -422,9 +422,10 @@ class OverconvergentModularFormsSpace(Module):
 
     def base_extend(self, ring):
         r"""
-        Return the base extension of self to the given base ring. There must be
-        a canonical map to this ring from the current base ring, otherwise a
-        TypeError will be raised.
+        Return the base extension of ``self`` to the given base ring.
+
+        There must be a canonical map to this ring from the current
+        base ring, otherwise a :class:`TypeError` will be raised.
 
         EXAMPLES::
 

--- a/src/sage/modular/pollack_stevens/dist.pyx
+++ b/src/sage/modular/pollack_stevens/dist.pyx
@@ -853,7 +853,7 @@ cdef class Dist_vector(Dist):
             sage: QQ(d)
             4/3
 
-        We get a TypeError if there is more than 1 moment::
+        We get a :class:`TypeError` if there is more than 1 moment::
 
             sage: D = Symk(1); d = D([1,2]); d
             (1, 2)

--- a/src/sage/modules/vector_space_homspace.py
+++ b/src/sage/modules/vector_space_homspace.py
@@ -365,7 +365,7 @@ class VectorSpaceHomspace(sage.modules.free_module_homspace.FreeModuleHomspace):
             sage: H.zero().is_zero()
             True
 
-        Previously the above code resulted in a TypeError because the
+        Previously the above code resulted in a :class:`TypeError` because the
         dimensions of the matrix were incorrect.
         """
         from .vector_space_morphism import is_VectorSpaceMorphism, VectorSpaceMorphism

--- a/src/sage/numerical/gauss_legendre.pyx
+++ b/src/sage/numerical/gauss_legendre.pyx
@@ -304,7 +304,7 @@ def integrate_vector_N(f, prec, N=3):
         The nodes and weights are calculated in the real field with ``prec``
         bits of precision. If the vector space in which ``f`` takes values
         is over a field which is incompatible with this field (e.g. a finite
-        field) then a TypeError occurs.
+        field) then a :class:`TypeError` occurs.
     """
     # We use nodes_uncached, because caching takes up memory, and numerics in
     # Bruin-DisneyHogg-Gao suggest that caching provides little benefit in the

--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -2492,7 +2492,7 @@ cdef class RingHomomorphism_cover(RingHomomorphism):
 
         We verify that calling directly raises the expected error
         (just coercing into the codomain), but calling with __call__
-        (the second call below) gives a TypeError since 1/2 can't be
+        (the second call below) gives a :class:`TypeError` since 1/2 cannot be
         coerced into the domain. ::
 
             sage: f._call_(1/2)

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -388,7 +388,7 @@ class PolynomialRing_general(ring.Algebra):
             sage: S(x)
             x
 
-        Throw a TypeError if any of the coefficients cannot be coerced
+        Throw a :class:`TypeError` if any of the coefficients cannot be coerced
         into the base ring (:trac:`6777`)::
 
             sage: RealField(300)['x']( [ 1, ComplexField(300).gen(), 0 ])               # needs sage.rings.real_mpfr

--- a/src/sage/schemes/affine/affine_space.py
+++ b/src/sage/schemes/affine/affine_space.py
@@ -481,8 +481,8 @@ class AffineSpace_generic(AmbientSpace, AffineScheme):
 
     def _check_satisfies_equations(self, v):
         """
-        Return True if ``v`` defines a point on the scheme self; raise a
-        TypeError otherwise.
+        Return ``True`` if ``v`` defines a point on the scheme ``self``; raise a
+        :class:`TypeError` otherwise.
 
         EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -569,7 +569,7 @@ class RingClassField(SageObject):
     def is_subfield(self, M):
         """
         Return ``True`` if this ring class field is a subfield of the ring class field `M`.
-        If `M` is not a ring class field, then a TypeError is raised.
+        If `M` is not a ring class field, then a :class:`TypeError` is raised.
 
         EXAMPLES::
 
@@ -725,7 +725,7 @@ class GaloisGroup(SageObject):
             sage: G(alpha)
             Class field automorphism defined by 14*x^2 - 10*x*y + 25*y^2
 
-        A TypeError is raised when the coercion is not possible::
+        A :class:`TypeError` is raised when the coercion is not possible::
 
             sage: G(0)
             Traceback (most recent call last):
@@ -4341,7 +4341,7 @@ class KolyvaginPoint(HeegnerPoint):
         the case of conductor 1, computed using prec bits of
         precision, then approximated using some algorithm (e.g.,
         continued fractions).  If the precision is not enough to
-        determine a point on the curve, then a RuntimeError is raised.
+        determine a point on the curve, then a :class:`RuntimeError` is raised.
         Even if the precision determines a point, there is no guarantee
         that it is correct.
 

--- a/src/sage/schemes/product_projective/space.py
+++ b/src/sage/schemes/product_projective/space.py
@@ -739,13 +739,13 @@ class ProductProjectiveSpaces_ring(AmbientSpace):
         except TypeError:
             raise TypeError("polynomials (=%s) must be elements of %s" % (polynomials,source_ring))
         for f in polynomials:
-            self._degree(f) #raises a ValueError if not multi-homogeneous
+            self._degree(f)  # raises a ValueError if not multi-homogeneous
         return polynomials
 
     def _check_satisfies_equations(self, v):
         """
-        Return True if ``v`` defines a point on the scheme this space; raise a
-        TypeError otherwise.
+        Return ``True`` if ``v`` defines a point on the scheme this space;
+        raise a :class:`TypeError` otherwise.
 
         EXAMPLES::
 

--- a/src/sage/schemes/projective/projective_space.py
+++ b/src/sage/schemes/projective/projective_space.py
@@ -359,8 +359,8 @@ class ProjectiveSpace_ring(UniqueRepresentation, AmbientSpace):
 
     def _check_satisfies_equations(self, v):
         """
-        Return True if ``v`` defines a point on the scheme; raise a
-        TypeError otherwise.
+        Return ``True`` if ``v`` defines a point on the scheme; raise a
+        :class:`TypeError` otherwise.
 
         EXAMPLES::
 

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -2706,7 +2706,7 @@ cdef class RingElement(ModuleElement):
             sage: 2r^(1/2)                                                              # needs sage.symbolic
             sqrt(2)
 
-        Exponent overflow should throw an OverflowError (:trac:`2956`)::
+        Exponent overflow should throw an :class:`OverflowError` (:trac:`2956`)::
 
             sage: K.<x,y> = AA[]                                                        # needs sage.rings.number_field
             sage: x^(2^64 + 12345)                                                      # needs sage.rings.number_field

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -1344,7 +1344,8 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
         r"""
         Return the unique homomorphism from self to codomain that
         sends ``self.gens()`` to the entries of ``im_gens``.
-        Raises a TypeError if there is no such homomorphism.
+
+        This raises a :class:`TypeError` if there is no such homomorphism.
 
         INPUT:
 

--- a/src/sage/structure/parent_gens.pyx
+++ b/src/sage/structure/parent_gens.pyx
@@ -199,10 +199,11 @@ cdef class ParentWithGens(ParentWithBase):
 
     def hom(self, im_gens, codomain=None, base_map=None, category=None, check=True):
         r"""
-        Return the unique homomorphism from self to codomain that
+        Return the unique homomorphism from ``self`` to codomain that
         sends ``self.gens()`` to the entries of ``im_gens``
         and induces the map ``base_map`` on the base ring.
-        Raises a TypeError if there is no such homomorphism.
+
+        This raises a :class:`TypeError` if there is no such homomorphism.
 
         INPUT:
 
@@ -272,7 +273,8 @@ cdef class ParentWithGens(ParentWithBase):
               From: Integer Ring
               To:   Finite Field of size 5
 
-        There might not be a natural morphism, in which case a TypeError exception is raised.
+        There might not be a natural morphism, in which case a
+        :class:`TypeError` exception is raised.
 
         ::
 

--- a/src/sage/structure/parent_old.pyx
+++ b/src/sage/structure/parent_old.pyx
@@ -221,11 +221,12 @@ cdef class Parent(parent.Parent):
         Given a list v of rings, try to coerce x canonically into each
         one in turn.  Return the __call__ coercion of the result into
         self of the first canonical coercion that succeeds.  Raise a
-        TypeError if none of them succeed.
+        :class:`TypeError` if none of them succeed.
 
         INPUT:
-             x -- Python object
-             v -- parent object or list (iterator) of parent objects
+
+        - x -- Python object
+        - v -- parent object or list (iterator) of parent objects
         """
         deprecation(33464, "usage of _coerce_try is deprecated")
         check_old_coerce(self)


### PR DESCRIPTION
this is adding a few `class` roles so that errors in the doc are linked to python documentation

Here done mostly for `TypeError`

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.