### PR TITLE
In doctesting, ignore two ld warnings from recent OS X:

### DIFF
--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -1653,7 +1653,9 @@ class SageOutputChecker(doctest.OutputChecker):
             did_fixup = True
 
         if "duplicate" in got:
-            # New warnings as of Sept '23, OS X 13.6, new command-line tools.
+            # New warnings as of Sept '23, OS X 13.6, new command-line
+            # tools. In particular, these seem to come from ld in
+            # Xcode 15.
             dup_rpath_regex = re.compile("ld: warning: duplicate -rpath .* ignored")
             dup_lib_regex = re.compile("ld: warning: ignoring duplicate libraries: .*")
             got = dup_rpath_regex.sub('', got)

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -1651,6 +1651,15 @@ class SageOutputChecker(doctest.OutputChecker):
             pythran_numpy_warning_regex = re.compile(r'WARNING: Overriding pythran description with argspec information for: numpy\.random\.[a-z_]+')
             got = pythran_numpy_warning_regex.sub('', got)
             did_fixup = True
+
+        if "duplicate" in got:
+            # New warnings as of Sept '23, OS X 13.6, new command-line tools.
+            dup_rpath_regex = re.compile("ld: warning: duplicate -rpath .* ignored")
+            dup_lib_regex = re.compile("ld: warning: ignoring duplicate libraries: .*")
+            got = dup_rpath_regex.sub('', got)
+            got = dup_lib_regex.sub('', got)
+            did_fixup = True
+
         return did_fixup, want, got
 
     def output_difference(self, example, got, optionflags):


### PR DESCRIPTION
in doctesting, ignore two warnings coming from ld in new OS X/command-line tools/Xcode 15

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

As of Xcode 15, I see warnings of this sort arising in doctesting:
```
ld: warning: duplicate -rpath '/path/to/SAGE_ROOT/local/lib' ignored
ld: warning: ignoring duplicate libraries: '-lflint', '-lgmp', '-lmpfr'
```
These all seem to arise from doctests involving `cython(...)`.

These warnings cause doctests to fail, so we ignore them, as we ignore similar warning messages in src/doctest/parsing.py.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [X] The title is concise, informative, and self-explanatory.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
