### PR TITLE
a few more links to errors in the doc

### DIFF
--- a/src/sage/categories/sets_with_partial_maps.py
+++ b/src/sage/categories/sets_with_partial_maps.py
@@ -13,10 +13,11 @@ SetsWithPartialMaps
 from sage.categories.category_singleton import Category_singleton
 from .objects import Objects
 
+
 class SetsWithPartialMaps(Category_singleton):
     """
     The category whose objects are sets and whose morphisms are
-    maps that are allowed to raise a ValueError on some inputs.
+    maps that are allowed to raise a :class:`ValueError` on some inputs.
 
     This category is equivalent to the category of pointed sets,
     via the equivalence sending an object X to X union {error},

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -23178,9 +23178,9 @@ class GenericGraph(GenericGraph_pyx):
 
         TESTS:
 
-        We get a KeyError when given an invalid partition (:trac:`6087`)::
+        We get a :class:`KeyError` when given an invalid partition (:trac:`6087`)::
 
-            sage: g=graphs.CubeGraph(3)
+            sage: g = graphs.CubeGraph(3)
             sage: g.relabel()
             sage: g.automorphism_group(partition=[[0,1,2],[3,4,5]],algorithm='sage')    # needs sage.groups
             Traceback (most recent call last):

--- a/src/sage/interfaces/axiom.py
+++ b/src/sage/interfaces/axiom.py
@@ -43,7 +43,7 @@ AUTHORS:
    clisp.
 
 If the string "error" (case insensitive) occurs in the output of
-anything from axiom, a RuntimeError exception is raised.
+anything from axiom, a :class:`RuntimeError` exception is raised.
 
 EXAMPLES: We evaluate a very simple expression in axiom.
 

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -430,7 +430,7 @@ class Gap_generic(ExtraTabCompletion, Expect):
         """
         Load the Gap package with the given name.
 
-        If loading fails, raise a RuntimeError exception.
+        If loading fails, raise a :class:`RuntimeError` exception.
 
         TESTS::
 

--- a/src/sage/interfaces/giac.py
+++ b/src/sage/interfaces/giac.py
@@ -48,7 +48,7 @@ EXAMPLES::
 
 
 If the string "error" (case insensitive) occurs in the output of
-anything from Giac, a RuntimeError exception is raised.
+anything from Giac, a :class:`RuntimeError` exception is raised.
 
 Tutorial
 --------

--- a/src/sage/interfaces/maple.py
+++ b/src/sage/interfaces/maple.py
@@ -36,7 +36,7 @@ EXAMPLES::
     (x-y)*(x^4+x^3*y+x^2*y^2+x*y^3+y^4)
 
 If the string "error" (case insensitive) occurs in the output of
-anything from Maple, a RuntimeError exception is raised.
+anything from Maple, a :class:`RuntimeError` exception is raised.
 
 Tutorial
 --------

--- a/src/sage/interfaces/maxima.py
+++ b/src/sage/interfaces/maxima.py
@@ -35,7 +35,7 @@ This is the interface used by the maxima object::
     <class 'sage.interfaces.maxima.Maxima'>
 
 If the string "error" (case insensitive) occurs in the output of
-anything from Maxima, a RuntimeError exception is raised.
+anything from Maxima, a :class:`RuntimeError` exception is raised.
 
 EXAMPLES: We evaluate a very simple expression in Maxima.
 

--- a/src/sage/interfaces/mwrank.py
+++ b/src/sage/interfaces/mwrank.py
@@ -294,7 +294,7 @@ class Mwrank_class(Expect):
 
         .. NOTE::
 
-           If a RuntimeError exception is raised, then the mwrank
+           If a :class:`RuntimeError` exception is raised, then the mwrank
            interface is restarted and the command is retried once.
 
         EXAMPLES::

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -412,7 +412,7 @@ class Gap(Parent):
 
     def load_package(self, pkg):
         """
-        If loading fails, raise a RuntimeError exception.
+        If loading fails, raise a :class:`RuntimeError` exception.
 
         TESTS::
 

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -393,7 +393,7 @@ cdef class Matrix(sage.structure.element.Matrix):
         """
         This function gets called when you're about to change this matrix.
 
-        If self is immutable, a ValueError is raised, since you should
+        If self is immutable, a :class:`ValueError` is raised, since you should
         never change a mutable matrix.
 
         If self is mutable, the cache of results about self is deleted.
@@ -406,10 +406,10 @@ cdef class Matrix(sage.structure.element.Matrix):
     cdef check_bounds_and_mutability(self, Py_ssize_t i, Py_ssize_t j):
         """
         This function gets called when you're about to set the i,j entry of
-        this matrix. If i or j is out of range, an IndexError exception is
-        raised.
+        this matrix. If i or j is out of range, an :class:`IndexError`
+        exception is raised.
 
-        If self is immutable, a ValueError is raised, since you should
+        If self is immutable, a :class:`ValueError` is raised, since you should
         never change a mutable matrix.
 
         If self is mutable, the cache of results about self is deleted.

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1706,14 +1706,14 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
     def symplectic_form(self):
         r"""
-        Find a symplectic basis for self if self is an anti-symmetric,
+        Find a symplectic basis for ``self`` if ``self`` is an anti-symmetric,
         alternating matrix.
 
         Return a pair (F, C) such that the rows of C form a symplectic
-        basis for self and ``F = C * self * C.transpose()``.
+        basis for ``self`` and ``F = C * self * C.transpose()``.
 
-        Raise a :class:`ValueError` if self is not anti-symmetric,
-        or self is not alternating.
+        Raise a :class:`ValueError` if ``self`` is not anti-symmetric,
+        or ``self`` is not alternating.
 
         Anti-symmetric means that `M = -M^t`. Alternating means
         that the diagonal of `M` is identically zero.
@@ -1722,7 +1722,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         `e_1, \ldots, e_j, f_1, \ldots f_j, z_1, \dots, z_k`
         such that
 
-        -  `z_i M v^t` = 0 for all vectors `v`
+        -  `z_i M v^t = 0` for all vectors `v`
 
         -  `e_i M {e_j}^t = 0` for all `i, j`
 

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1712,8 +1712,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
         Return a pair (F, C) such that the rows of C form a symplectic
         basis for self and ``F = C * self * C.transpose()``.
 
-        Raise a ValueError if self is not anti-symmetric, or self is not
-        alternating.
+        Raise a :class:`ValueError` if self is not anti-symmetric,
+        or self is not alternating.
 
         Anti-symmetric means that `M = -M^t`. Alternating means
         that the diagonal of `M` is identically zero.

--- a/src/sage/modular/abvar/abvar.py
+++ b/src/sage/modular/abvar/abvar.py
@@ -580,9 +580,11 @@ class ModularAbelianVariety_abstract(Parent):
     def newform_label(self):
         """
         Return the label [level][isogeny class][group] of the newform
-        `f` such that this abelian variety is isogenous to the
-        newform abelian variety `A_f`. If this abelian variety is
-        not simple, raise a ValueError.
+        `f` such that this abelian variety is isogenous to the newform
+        abelian variety `A_f`.
+
+        If this abelian variety is not simple, this raises
+        a :class:`ValueError`.
 
         OUTPUT: string
 
@@ -687,8 +689,10 @@ class ModularAbelianVariety_abstract(Parent):
     def _isogeny_to_newform_abelian_variety(self):
         r"""
         Return an isogeny from self to an abelian variety `A_f`
-        attached to a newform. If self is not simple (so that no such
-        isogeny exists), raise a ValueError.
+        attached to a newform.
+
+        If self is not simple (so that no such
+        isogeny exists), this raises a :class:`ValueError`.
 
         EXAMPLES::
 
@@ -733,13 +737,12 @@ class ModularAbelianVariety_abstract(Parent):
         """
         Given self and other, if both are simple, and correspond to the
         same newform with the same congruence subgroup, return an isogeny.
-        Otherwise, raise a ValueError.
+
+        Otherwise, this raises a :class:`ValueError`.
 
         INPUT:
 
-
-        -  ``self, other`` - modular abelian varieties
-
+        - ``self, other`` -- modular abelian varieties
 
         OUTPUT: an isogeny
 
@@ -3183,7 +3186,7 @@ class ModularAbelianVariety_abstract(Parent):
         `(t,N)`, where `N` is the ambient level and
         `t` is an integer that divides the quotient of `N`
         by the newform level. This function returns the tuple
-        `(t,N)`, or raises a ValueError if self isn't simple.
+        `(t,N)`, or raises a :class:`ValueError` if self is not simple.
 
         .. note::
 
@@ -3235,15 +3238,13 @@ class ModularAbelianVariety_abstract(Parent):
         """
         Return the number (starting at 0) of the isogeny class of new
         simple abelian varieties that self is in. If self is not simple,
-        raises a ValueError exception.
+        raises a :class:`ValueError` exception.
 
         INPUT:
 
-
-        -  ``none_if_not_known`` - bool (default: False); if
+        -  ``none_if_not_known`` -- bool (default: False); if
            True then this function may return None instead of True of False if
            we don't already know the isogeny number of self.
-
 
         EXAMPLES: We test the none_if_not_known flag first::
 

--- a/src/sage/modular/abvar/abvar.py
+++ b/src/sage/modular/abvar/abvar.py
@@ -525,15 +525,17 @@ class ModularAbelianVariety_abstract(Parent):
     def newform(self, names=None):
         """
         Return the newform `f` such that this abelian variety is isogenous to
-        the newform abelian variety `A_f`. If this abelian variety is not
-        simple, raise a ``ValueError``.
+        the newform abelian variety `A_f`.
+
+        If this abelian variety is not
+        simple, this raises a :class:`ValueError`.
 
         INPUT:
 
-        - ``names`` -- (default: None) If the newform has coefficients in a
-          number field, then a generator name must be specified.
+        - ``names`` -- (default: ``None``) If the newform has coefficients
+          in a number field, then a generator name must be specified.
 
-        OUTPUT: A newform `f` so that self is isogenous to `A_f`.
+        OUTPUT: A newform `f` so that ``self`` is isogenous to `A_f`.
 
         EXAMPLES::
 
@@ -3237,22 +3239,25 @@ class ModularAbelianVariety_abstract(Parent):
     def isogeny_number(self, none_if_not_known=False):
         """
         Return the number (starting at 0) of the isogeny class of new
-        simple abelian varieties that self is in. If self is not simple,
-        raises a :class:`ValueError` exception.
+        simple abelian varieties that ``self`` is in.
+
+        If ``self`` is not simple,
+        this raises a :class:`ValueError` exception.
 
         INPUT:
 
-        -  ``none_if_not_known`` -- bool (default: False); if
-           True then this function may return None instead of True of False if
-           we don't already know the isogeny number of self.
+        -  ``none_if_not_known`` -- bool (default: ``False``); if
+           ``True`` then this function may return ``None`` instead of ``True``
+           or ``False`` if
+           we do not already know the isogeny number of ``self``.
 
-        EXAMPLES: We test the none_if_not_known flag first::
+        EXAMPLES: We test the ``none_if_not_known`` flag first::
 
             sage: J0(33).isogeny_number(none_if_not_known=True) is None
             True
 
         Of course, `J_0(33)` is not simple, so this function
-        raises a ValueError::
+        raises a :class:`ValueError`::
 
             sage: J0(33).isogeny_number()
             Traceback (most recent call last):

--- a/src/sage/modular/modsym/p1list.pyx
+++ b/src/sage/modular/modsym/p1list.pyx
@@ -1371,8 +1371,8 @@ def lift_to_sl2z(c, d, N):
         sage: lift_to_sl2z(2,3,6000000)
         [1, 1, 2, 3]
 
-    You will get a ValueError exception if the input is invalid.  Note
-    that here gcd(15,6,24)=3::
+    You will get a :class:`ValueError` exception if the input is invalid.
+    Note that here gcd(15,6,24)=3::
 
         sage: lift_to_sl2z(15,6,24)
         Traceback (most recent call last):

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -646,11 +646,14 @@ cdef class IntegerMod_abstract(FiniteRingElement):
            ``R`` is the parent of ``self``.
 
 
-        OUTPUT: Integer `x` such that `b^x = a`, if this exists; a ValueError otherwise.
+        OUTPUT:
+
+        Integer `x` such that `b^x = a`, if this exists; a :class:`ValueError`
+        otherwise.
 
         .. NOTE::
 
-           The algorithm first factors the modulus, then invokes Pari's ``znlog``
+           The algorithm first factors the modulus, then invokes Pari's :pari:`znlog`
            function for each odd prime power in the factorization of the modulus.
            This method can be quite slow for large moduli.
 

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -2326,7 +2326,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         OUTPUT:
 
         If ``truncate_mode`` is 0 (default), then returns the exact n'th root
-        if ``self`` is an n'th power, or raises a ValueError if it is not.
+        if ``self`` is an n'th power, or raises a :class:`ValueError`
+        if it is not.
 
         If ``truncate_mode`` is 1, then if either ``n`` is odd or ``self`` is
         positive, returns a pair ``(root, exact_flag)`` where ``root`` is the

--- a/src/sage/rings/padics/padic_extension_generic.py
+++ b/src/sage/rings/padics/padic_extension_generic.py
@@ -375,7 +375,8 @@ class pAdicExtensionGeneric(pAdicGeneric):
         """
         Return the order with the same defining polynomial.
 
-        Will raise a ValueError if the coefficients of the defining polynomial are not integral.
+        Will raise a :class:`ValueError` if the coefficients of the defining
+        polynomial are not integral.
 
         EXAMPLES::
 

--- a/src/sage/rings/padics/padic_floating_point_element.pyx
+++ b/src/sage/rings/padics/padic_floating_point_element.pyx
@@ -144,7 +144,8 @@ cdef class pAdicFloatingPointElement(FPElement):
         precision.  If a rational is returned, its denominator will equal
         ``p^ordp(self)``.
 
-        This method will raise a ValueError when this element is infinity.
+        This method will raise a :class:`ValueError` when this element
+        is infinity.
 
         EXAMPLES::
 

--- a/src/sage/rings/power_series_ring_element.pyx
+++ b/src/sage/rings/power_series_ring_element.pyx
@@ -1510,21 +1510,21 @@ cdef class PowerSeries(AlgebraElement):
 
         INPUT:
 
-          - ``prec`` - integer (default: None): if not None and the series
-            has infinite precision, truncates series at precision
-            prec.
+          - ``prec`` - integer (default: ``None``): if not ``None``
+            and the series has infinite precision, truncates series at
+            precision prec.
 
-          - ``extend`` - bool (default: False); if True, return a square
+          - ``extend`` - bool (default: ``False``); if ``True``, return a square
             root in an extension ring, if necessary. Otherwise, raise
-            a ValueError if the square root is not in the base power series
-            ring. For example, if ``extend`` is True the square root of a
-            power series with odd degree leading coefficient is
-            defined as an element of a formal extension ring.
+            a :class:`ValueError` if the square root is not in the
+            base power series ring. For example, if ``extend`` is ``True``
+            the square root of a power series with odd degree leading
+            coefficient is defined as an element of a formal extension ring.
 
-          - ``name`` - string; if ``extend`` is True, you must also specify the print
+          - ``name`` - string; if ``extend`` is ``True``, you must also specify the print
             name of the formal square root.
 
-          - ``all`` - bool (default: False); if True, return all square
+          - ``all`` - bool (default: ``False``); if ``True``, return all square
             roots of self, instead of just one.
 
         ALGORITHM: Newton's method

--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -2009,7 +2009,7 @@ class ProjectivePlaneCurve_finite_field(ProjectivePlaneCurve_field):
         .. note::
 
             The Brill-Noether package does not always work (i.e., the
-            'bn' algorithm. When it fails a RuntimeError exception is
+            'bn' algorithm. When it fails a :class:`RuntimeError` exception is
             raised.
         """
         f = self.defining_polynomial()._singular_()
@@ -2150,7 +2150,7 @@ class ProjectivePlaneCurve_finite_field(ProjectivePlaneCurve_field):
         .. NOTE::
 
            The Brill-Noether package does not always work (i.e., the 'bn'
-           algorithm. When it fails a RuntimeError exception is raised.
+           algorithm. When it fails a :class:`RuntimeError` exception is raised.
 
         EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -729,7 +729,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         - ``all`` (bool, default False) -- if True, return a (possibly
           empty) list of all points; if False, return just one point,
-          or raise a ValueError if there are none.
+          or raise a :class:`ValueError` if there are none.
 
         - ``extend`` (bool, default False) --
 

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -2256,7 +2256,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         If the upper and lower bounds given by Simon two-descent are
         the same, then the rank has been uniquely identified and we
-        return this. Otherwise, we raise a ValueError with an error
+        return this. Otherwise, we raise a :class:`ValueError` with an error
         message specifying the upper and lower bounds.
 
         .. NOTE::

--- a/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
@@ -432,7 +432,7 @@ def _non_surjective(E, patience=100):
 
     - ``list`` -- A list of primes where mod-`p` representation is very likely
       not surjective. At any prime not in this list, the representation is
-      definitely surjective. If E has CM, a ValueError is raised.
+      definitely surjective. If E has CM, a :class:`ValueError` is raised.
 
     EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/period_lattice.py
+++ b/src/sage/schemes/elliptic_curves/period_lattice.py
@@ -813,14 +813,14 @@ class PeriodLattice_ell(PeriodLattice):
         """
         return self.real_flag != 0
 
-    def is_rectangular(self):
+    def is_rectangular(self) -> bool:
         r"""
-        Return True if this period lattice is rectangular.
+        Return ``True`` if this period lattice is rectangular.
 
         .. NOTE::
 
-            Only defined for real lattices; a RuntimeError is raised for
-            non-real lattices.
+            Only defined for real lattices; a :class:`RuntimeError`
+            is raised for non-real lattices.
 
         EXAMPLES::
 
@@ -864,8 +864,8 @@ class PeriodLattice_ell(PeriodLattice):
 
         .. NOTE::
 
-            Only defined for real lattices; a RuntimeError is raised for
-            non-real lattices.
+            Only defined for real lattices; a :class:`RuntimeError`
+            is raised for non-real lattices.
 
         EXAMPLES::
 

--- a/src/sage/tensor/modules/tensor_with_indices.py
+++ b/src/sage/tensor/modules/tensor_with_indices.py
@@ -258,8 +258,8 @@ class TensorWithIndices(SageObject):
         indices.
 
         Parse ``indices`` checking usual conventions on repeating indices,
-        wildcard, balanced parentheses/brackets and raises a ValueError if not.
-        Return a couple contravariant/covariant indices.
+        wildcard, balanced parentheses/brackets and raises a :class:`ValueError`
+        if not. Return a couple contravariant/covariant indices.
 
         INPUT:
 


### PR DESCRIPTION
This adds a few more links from Errors to standard python documentation.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about. We're here to help! -->
