### PR TITLE
partial cython-lint cleanup in padics/

### DIFF
--- a/src/sage/rings/padics/CA_template.pxi
+++ b/src/sage/rings/padics/CA_template.pxi
@@ -89,7 +89,7 @@ cdef class CAElement(pAdicTemplateElement):
             self.absprec = aprec
         else:
             self.absprec = min(aprec, val + rprec)
-            if isinstance(x,CAElement) and x.parent() is self.parent():
+            if isinstance(x, CAElement) and x.parent() is self.parent():
                 cshift_notrunc(self.value, (<CAElement>x).value, 0, self.absprec, self.prime_pow, True)
             else:
                 cconv(self.value, x, self.absprec, 0, self.prime_pow)
@@ -395,9 +395,8 @@ cdef class CAElement(pAdicTemplateElement):
         creduce(q.value, q.value, q.absprec, q.prime_pow)
         return q, r
 
-
     def __pow__(CAElement self, _right, dummy):
-        """
+        r"""
         Exponentiation.
 
         When ``right`` is divisible by `p` then one can get more
@@ -474,8 +473,8 @@ cdef class CAElement(pAdicTemplateElement):
                 return base.__pow__(-_right, dummy)
             exact_exp = True
         elif self.parent() is _right.parent():
-            ## For extension elements, we need to switch to the
-            ## fraction field sometimes in highly ramified extensions.
+            # For extension elements, we need to switch to the
+            # fraction field sometimes in highly ramified extensions.
             exact_exp = (<CAElement>_right)._is_exact_zero()
             pright = _right
         else:
@@ -861,6 +860,7 @@ cdef class CAElement(pAdicTemplateElement):
         """
         def tuple_recursive(l):
             return tuple(tuple_recursive(x) for x in l) if isinstance(l, Iterable) else l
+
         return (self.parent(), tuple_recursive(trim_zeros(list(self.expansion()))), self.precision_absolute())
 
     def _teichmuller_set_unsafe(self):
@@ -1800,6 +1800,7 @@ cdef class pAdicConvert_CA_frac_field(Morphism):
         self._zero = _slots['_zero']
         Morphism._update_slots(self, _slots)
 
+
 def unpickle_cae_v2(cls, parent, value, absprec):
     r"""
     Unpickle capped absolute elements.
@@ -1834,4 +1835,3 @@ def unpickle_cae_v2(cls, parent, value, absprec):
     cunpickle(ans.value, value, ans.prime_pow)
     ans.absprec = absprec
     return ans
-

--- a/src/sage/rings/padics/CR_template.pxi
+++ b/src/sage/rings/padics/CR_template.pxi
@@ -145,7 +145,7 @@ cdef class CRElement(pAdicTemplateElement):
         else:
             self.relprec = min(rprec, aprec - val)
             self.ordp = val
-            if isinstance(x,CRElement) and x.parent() is self.parent():
+            if isinstance(x, CRElement) and x.parent() is self.parent():
                 cshift_notrunc(self.unit, (<CRElement>x).unit, 0, self.relprec, self.prime_pow, True)
             else:
                 cconv(self.unit, x, self.relprec, val, self.prime_pow)
@@ -678,8 +678,8 @@ cdef class CRElement(pAdicTemplateElement):
                 return base.__pow__(-_right, dummy)
             exact_exp = True
         elif self.parent() is _right.parent():
-            ## For extension elements, we need to switch to the
-            ## fraction field sometimes in highly ramified extensions.
+            # For extension elements, we need to switch to the
+            # fraction field sometimes in highly ramified extensions.
             exact_exp = (<CRElement>_right)._is_exact_zero()
             pright = _right
         else:
@@ -732,7 +732,7 @@ cdef class CRElement(pAdicTemplateElement):
         return ans
 
     cdef pAdicTemplateElement _lshift_c(self, long shift):
-        """
+        r"""
         Multiplies by `\pi^{\mbox{shift}}`.
 
         Negative shifts may truncate the result if the parent is not a
@@ -763,7 +763,7 @@ cdef class CRElement(pAdicTemplateElement):
         return ans
 
     cdef pAdicTemplateElement _rshift_c(self, long shift):
-        """
+        r"""
         Divides by ``\pi^{\mbox{shift}}``.
 
         Positive shifts may truncate the result if the parent is not a
@@ -878,7 +878,6 @@ cdef class CRElement(pAdicTemplateElement):
             cdivunit(q.unit, q.prime_pow.shift_rem, right.unit, q.relprec, q.prime_pow)
         q._normalize()
         return q, r
-
 
     def add_bigoh(self, absprec):
         """
@@ -1253,6 +1252,7 @@ cdef class CRElement(pAdicTemplateElement):
         """
         def tuple_recursive(l):
             return tuple(tuple_recursive(x) for x in l) if isinstance(l, list) else l
+
         return (self.parent(), tuple_recursive(trim_zeros(list(self.expansion()))), self.valuation(), self.precision_relative())
 
     def _teichmuller_set_unsafe(self):
@@ -1506,7 +1506,7 @@ cdef class CRElement(pAdicTemplateElement):
         """
         # Since we keep this element normalized there's not much to do here.
         if p is not None and p != self.parent().prime():
-            raise ValueError('ring (%s) residue field of the wrong characteristic'%self.parent())
+            raise ValueError('ring (%s) residue field of the wrong characteristic' % self.parent())
         if exactzero((<CRElement>self).ordp):
             raise ValueError("unit part of 0 not defined")
         cdef Integer val = Integer.__new__(Integer)
@@ -1968,7 +1968,7 @@ cdef class pAdicConvert_CR_QQ(RingMap):
             1/5
         """
         cdef Rational ans = Rational.__new__(Rational)
-        cdef CRElement x =  _x
+        cdef CRElement x = _x
         if x.relprec == 0:
             mpq_set_ui(ans.value, 0, 1)
         else:
@@ -2521,6 +2521,7 @@ cdef class pAdicConvert_CR_frac_field(Morphism):
         """
         self._zero = _slots['_zero']
         Morphism._update_slots(self, _slots)
+
 
 def unpickle_cre_v2(cls, parent, unit, ordp, relprec):
     """

--- a/src/sage/rings/padics/FM_template.pxi
+++ b/src/sage/rings/padics/FM_template.pxi
@@ -84,7 +84,7 @@ cdef class FMElement(pAdicTemplateElement):
             polyt = type(self.prime_pow.modulus)
             self.value = <celement>polyt.__new__(polyt)
         cconstruct(self.value, self.prime_pow)
-        if isinstance(x,FMElement) and x.parent() is self.parent():
+        if isinstance(x, FMElement) and x.parent() is self.parent():
             cshift_notrunc(self.value, (<FMElement>x).value, 0, 0, self.prime_pow, False)
         else:
             cconv(self.value, x, self.prime_pow.ram_prec_cap, 0, self.prime_pow)
@@ -346,7 +346,6 @@ cdef class FMElement(pAdicTemplateElement):
         creduce(q.value, q.value, pcap, q.prime_pow)
         return q, r
 
-
     def __pow__(FMElement self, _right, dummy): # NOTE: dummy ignored, always use self.prime_pow.ram_prec_cap
         """
         Exponentiation by an integer
@@ -381,7 +380,7 @@ cdef class FMElement(pAdicTemplateElement):
         return ans
 
     cdef pAdicTemplateElement _lshift_c(self, long shift):
-        """
+        r"""
         Multiplies self by `\pi^{shift}`.
 
         If shift < -self.valuation(), digits will be truncated.  See
@@ -428,7 +427,7 @@ cdef class FMElement(pAdicTemplateElement):
         return ans
 
     cdef pAdicTemplateElement _rshift_c(self, long shift):
-        """
+        r"""
         Divides by `\pi^{shift}`, and truncates.
 
         Note that this operation will insert arbitrary digits (in
@@ -462,7 +461,7 @@ cdef class FMElement(pAdicTemplateElement):
         return ans
 
     def add_bigoh(self, absprec):
-        """
+        r"""
         Return a new element truncated modulo `\pi^{\mbox{absprec}}`.
 
         INPUT:
@@ -1541,6 +1540,7 @@ cdef class pAdicConvert_FM_frac_field(Morphism):
         """
         self._zero = _slots['_zero']
         Morphism._update_slots(self, _slots)
+
 
 def unpickle_fme_v2(cls, parent, value):
     """

--- a/src/sage/rings/padics/FP_template.pxi
+++ b/src/sage/rings/padics/FP_template.pxi
@@ -142,7 +142,7 @@ cdef class FPElement(pAdicTemplateElement):
             self._set_infinity()
         else:
             self.ordp = val
-            if isinstance(x,FPElement) and x.parent() is self.parent():
+            if isinstance(x, FPElement) and x.parent() is self.parent():
                 ccopy(self.unit, (<FPElement>x).unit, self.prime_pow)
             else:
                 cconv(self.unit, x, self.prime_pow.ram_prec_cap, val, self.prime_pow)
@@ -584,7 +584,6 @@ cdef class FPElement(pAdicTemplateElement):
         q._normalize()
         return q, r
 
-
     def __pow__(FPElement self, _right, dummy): # NOTE: dummy ignored, always use self.prime_pow.ram_prec_cap
         """
         Exponentiation by an integer
@@ -624,8 +623,8 @@ cdef class FPElement(pAdicTemplateElement):
                 _right = -_right
             exact_exp = True
         elif self.parent() is _right.parent():
-            ## For extension elements, we need to switch to the
-            ## fraction field sometimes in highly ramified extensions.
+            # For extension elements, we need to switch to the
+            # fraction field sometimes in highly ramified extensions.
             exact_exp = (<FPElement>_right)._is_exact_zero()
             pright = _right
         else:
@@ -665,7 +664,7 @@ cdef class FPElement(pAdicTemplateElement):
         return ans
 
     cdef pAdicTemplateElement _lshift_c(self, long shift):
-        """
+        r"""
         Multiplies self by `\pi^{shift}`.
 
         Negative shifts may truncate the result if the parent is not a
@@ -718,7 +717,7 @@ cdef class FPElement(pAdicTemplateElement):
         return ans
 
     cdef pAdicTemplateElement _rshift_c(self, long shift):
-        """
+        r"""
         Divides by `\pi^{shift}`.
 
         Positive shifts may truncate the result if the parent is not a
@@ -772,7 +771,7 @@ cdef class FPElement(pAdicTemplateElement):
 
     def _repr_(self, mode=None, do_latex=False):
         """
-        Returns a string representation of this element.
+        Return a string representation of this element.
 
         INPUT:
 
@@ -794,7 +793,7 @@ cdef class FPElement(pAdicTemplateElement):
         return self.parent()._printer.repr_gen(self, do_latex, mode=mode)
 
     def add_bigoh(self, absprec):
-        """
+        r"""
         Return a new element truncated modulo `\pi^{\mbox{absprec}}`.
 
         INPUT:
@@ -1221,7 +1220,7 @@ cdef class FPElement(pAdicTemplateElement):
             ValueError: unit part of 0 and infinity not defined
         """
         if p is not None and p != self.parent().prime():
-            raise ValueError('Ring (%s) residue field of the wrong characteristic.'%self.parent())
+            raise ValueError('Ring (%s) residue field of the wrong characteristic.' % self.parent())
         if huge_val(self.ordp):
             raise ValueError("unit part of 0 and infinity not defined")
         cdef Integer valuation = PY_NEW(Integer)
@@ -1659,7 +1658,7 @@ cdef class pAdicConvert_FP_QQ(RingMap):
             1/5
         """
         cdef Rational ans = Rational.__new__(Rational)
-        cdef FPElement x =  _x
+        cdef FPElement x = _x
         if very_pos_val(x.ordp):
             mpq_set_ui(ans.value, 0, 1)
         elif very_neg_val(x.ordp):
@@ -2139,6 +2138,7 @@ cdef class pAdicConvert_FP_frac_field(Morphism):
         """
         self._zero = _slots['_zero']
         Morphism._update_slots(self, _slots)
+
 
 def unpickle_fpe_v2(cls, parent, unit, ordp):
     """

--- a/src/sage/rings/padics/local_generic_element.pyx
+++ b/src/sage/rings/padics/local_generic_element.pyx
@@ -395,8 +395,8 @@ cdef class LocalGenericElement(CommutativeRingElement):
         for c in islice(self.expansion(lift_mode=lift_mode), int(start), int(stop), int(k)):
             genpow = 1
             if not isinstance(c, list):
-                c = [c] # relevant for the case of base-rings, or one-step
-                # eisenstein extensions
+                c = [c]  # relevant for the case of base-rings, or one-step
+                # Eisenstein extensions
             for d in c:
                 ans += d * genpow * ppow
                 genpow *= unramified_generator

--- a/src/sage/rings/padics/local_generic_element.pyx
+++ b/src/sage/rings/padics/local_generic_element.pyx
@@ -394,8 +394,9 @@ cdef class LocalGenericElement(CommutativeRingElement):
         unramified_generator = self.parent()(self.parent().residue_field().gen()).lift_to_precision()
         for c in islice(self.expansion(lift_mode=lift_mode), int(start), int(stop), int(k)):
             genpow = 1
-            if not isinstance(c, list): c = [c] # relevant for the case of base-rings, or one-step
-                                                # eisenstein extensions
+            if not isinstance(c, list):
+                c = [c] # relevant for the case of base-rings, or one-step
+                # eisenstein extensions
             for d in c:
                 ans += d * genpow * ppow
                 genpow *= unramified_generator

--- a/src/sage/rings/padics/morphism.pxd
+++ b/src/sage/rings/padics/morphism.pxd
@@ -7,4 +7,4 @@ cdef class FrobeniusEndomorphism_padics(RingHomomorphism):
     cdef long _power
     cdef long _order
 
-    cpdef Element _call_(self,x)
+    cpdef Element _call_(self, x)

--- a/src/sage/rings/padics/morphism.pyx
+++ b/src/sage/rings/padics/morphism.pyx
@@ -157,7 +157,6 @@ cdef class FrobeniusEndomorphism_padics(RingHomomorphism):
             sage: Frob._repr_short()
             'Frob'
         """
-        name = self.domain().variable_name()
         if self._power == 0:
             s = "Identity"
         elif self._power == 1:

--- a/src/sage/rings/padics/padic_ZZ_pX_CA_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_CA_element.pyx
@@ -1237,7 +1237,6 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
         cdef long self_ordp = self.valuation_c()
         cdef long self_relprec = self.absprec - self_ordp
         cdef long threshold # e / (p-1)
-        cdef long prime_long
         cdef mpz_t tmp, tmp2
         if mpz_fits_slong_p(self.prime_pow.prime.value) == 0:
             threshold = 0
@@ -1399,7 +1398,6 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
         """
         cdef pAdicZZpXCAElement right = <pAdicZZpXCAElement>_right
         cdef pAdicZZpXCAElement ans
-        cdef long tmpL
         cdef ZZ_pX_c tmpP
         if self.absprec == 0 or right.absprec == 0:
             return self._new_c(0)
@@ -1441,7 +1439,6 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
         """
         cdef pAdicZZpXCAElement right = <pAdicZZpXCAElement>_right
         cdef pAdicZZpXCAElement ans
-        cdef long tmpL
         cdef ZZ_pX_c tmpP
         if self.absprec == 0 or right.absprec == 0:
             return self._new_c(0)
@@ -1824,7 +1821,7 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
             True
         """
         cdef pAdicZZpXCAElement ans
-        cdef long aprec, rprec
+        cdef long aprec
         if absprec is not None and not isinstance(absprec, Integer):
             absprec = Integer(absprec)
         if absprec is None:
@@ -1977,9 +1974,9 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
         cdef ZZ_pX_Modulus_c* m = self.prime_pow.get_modulus_capdiv(self.absprec)
         cdef ZZ_pX_c x
         ZZ_pX_SetX(x)
-        cdef Py_ssize_t i, j
+        cdef Py_ssize_t i
         zero = int(0)
-        for i from 0 <= i < n:
+        for i in range(n):
             curlist = cur.list()
             L.extend(curlist + [zero]*(n - len(curlist)))
             ZZ_pX_MulMod_pre(cur.x, cur.x, x, m[0])
@@ -2071,7 +2068,8 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
         cdef long ordp = self.valuation_c()
         cdef long rp = self.absprec - ordp
         cdef long goal
-        if n is not None: goal = self.absprec - n
+        if n is not None:
+            goal = self.absprec - n
         cdef pAdicZZpXCAElement v
         if n is None:
             L = []
@@ -2084,7 +2082,8 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
         else:
             v = self._new_c(rp)
         cdef pAdicZZpXCAElement u = self.unit_part()
-        if u is self: u = self.__copy__()
+        if u is self:
+            u = self.__copy__()
         while not ZZ_pX_IsZero(u.value):
             v = self._new_c(rp)
             self.prime_pow.teichmuller_set_c(&v.value, &u.value, rp)
@@ -2092,7 +2091,8 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
                 L.append(v)
             elif rp == goal:
                 return v
-            if rp == 1: break
+            if rp == 1:
+                break
             ZZ_pX_sub(u.value, u.value, v.value)
             rp -= 1
             if self.prime_pow.e == 1:
@@ -2318,6 +2318,7 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
             4*a*5 + (3*a^2 + a + 3)*5^2 + 4*a^2*5^3 + a^2*5^4 + O(5^5)
         """
         return self.ext_p_list_precs(pos, self.absprec)
+
 
 def make_ZZpXCAElement(parent, value, absprec, version):
     """

--- a/src/sage/rings/padics/padic_ZZ_pX_CR_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_CR_element.pyx
@@ -1415,13 +1415,9 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
             sage: z * 25
             3 + O(w^6)
         """
-        cdef ZZ_pX_c high_shifter, high_shifter2
+        cdef ZZ_pX_c high_shifter
         cdef ZZ_pX_Modulus_c *modulus
-        cdef ZZ_pX_Modulus_c modulus_up
         cdef ntl_ZZ_pContext_class c
-        cdef PowComputer_ZZ_pX_small_Eis sm
-        cdef PowComputer_ZZ_pX_big_Eis big
-        cdef ntl_ZZ_pX printer
         cdef ZZ_pX_c* high_array
         cdef long i, high_length
         if self.prime_pow.e == 1:
@@ -1922,7 +1918,6 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
         cdef long exp_val
         cdef long relprec
         cdef long threshold # e / (p-1)
-        cdef long prime_long
         cdef mpz_t tmp, tmp2
         if mpz_fits_slong_p(self.prime_pow.prime.value) == 0:
             threshold = 0
@@ -2212,7 +2207,6 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
         """
         cdef pAdicZZpXCRElement right = <pAdicZZpXCRElement>_right
         cdef ZZ_pX_c modulus_corrected
-        cdef ntl_ZZ_pContext_class ctx
         cdef pAdicZZpXCRElement ans
         if self._is_exact_zero():
             return self
@@ -2805,7 +2799,6 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
                 return zero
             elif n >= self.ordp + self.relprec:
                 raise PrecisionError
-        cdef Integer ordp
         if self.relprec == 0: # cannot have n = None
             return []
         if lift_mode == 'simple':
@@ -2881,11 +2874,11 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
         cdef ZZ_pX_Modulus_c* m = self.prime_pow.get_modulus_capdiv(self.ordp + self.relprec)
         cdef ZZ_pX_c x
         ZZ_pX_SetX(x)
-        cdef Py_ssize_t i, j
+        cdef Py_ssize_t i
         zero = int(0)
-        for i from 0 <= i < n:
+        for i in range(n):
             curlist = cur.list()
-            L.extend(curlist + [zero]*(n - len(curlist)))
+            L.extend(curlist + [zero] * (n - len(curlist)))
             ZZ_pX_MulMod_pre(cur.x, cur.x, x, m[0])
         return matrix(R, n, n,  L)
 

--- a/src/sage/rings/padics/padic_ZZ_pX_FM_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_FM_element.pyx
@@ -197,7 +197,6 @@ cdef class pAdicZZpXFMElement(pAdicZZpXElement):
         pAdicZZpXElement.__init__(self, parent)
         if empty:
             return
-        cdef mpz_t tmp
         cdef ZZ_c tmp_z
         cdef Integer tmp_Int
         cdef Py_ssize_t i
@@ -241,7 +240,7 @@ cdef class pAdicZZpXFMElement(pAdicZZpXElement):
             poly = x.polynomial().list()
             x = sum([poly[i].lift() * (z ** i) for i in range(len(poly))], parent.zero())
         elif isinstance(x, ntl_ZZ_p):
-            ctx_prec = ZZ_remove(tmp_z, (<ntl_ZZ>x.modulus()).x, self.prime_pow.pow_ZZ_tmp(1)[0])
+            ZZ_remove(tmp_z, (<ntl_ZZ>x.modulus()).x, self.prime_pow.pow_ZZ_tmp(1)[0])
             if ZZ_IsOne(tmp_z):
                 x = x.lift()
                 tmp_Int = Integer.__new__(Integer)
@@ -613,12 +612,9 @@ cdef class pAdicZZpXFMElement(pAdicZZpXElement):
         """
         if n < 0:
             return self._lshift_c(-n)
-        elif n == 0:
+        if n == 0:
             return self
         cdef pAdicZZpXFMElement ans = self._new_c()
-        cdef Py_ssize_t i
-        cdef long topcut, rem
-        cdef ntl_ZZ holder
         if n < self.prime_pow.ram_prec_cap:
             if self.prime_pow.e == 1:
                 ZZ_pX_right_pshift(ans.value, self.value, self.prime_pow.pow_ZZ_tmp(n)[0], self.prime_pow.get_top_context().x)
@@ -1034,9 +1030,9 @@ cdef class pAdicZZpXFMElement(pAdicZZpXElement):
         cdef ZZ_pX_Modulus_c* m = self.prime_pow.get_top_modulus()
         cdef ZZ_pX_c x
         ZZ_pX_SetX(x)
-        cdef Py_ssize_t i, j
+        cdef Py_ssize_t i
         zero = int(0)
-        for i from 0 <= i < n:
+        for i in range(n):
             curlist = cur.list()
             L.extend(curlist + [zero]*(n - len(curlist)))
             ZZ_pX_MulMod_pre(cur.x, cur.x, x, m[0])
@@ -1443,7 +1439,8 @@ cdef class pAdicZZpXFMElement(pAdicZZpXElement):
         cdef long ordp = self.valuation_c()
         cdef long rp = self.prime_pow.ram_prec_cap - ordp
         cdef long goal
-        if n is not None: goal = self.ram_prec_cap - n
+        if n is not None:
+            goal = self.ram_prec_cap - n
         cdef pAdicZZpXFMElement v
         if n is None:
             L = []
@@ -1454,15 +1451,18 @@ cdef class pAdicZZpXFMElement(pAdicZZpXElement):
         else:
             v = self._new_c()
         cdef pAdicZZpXFMElement u = self.unit_part()
-        if u is self: u = self.__copy__()
+        if u is self:
+            u = self.__copy__()
         while u.valuation_c() < rp:
-            if n is None: v = self._new_c()
+            if n is None:
+                v = self._new_c()
             self.prime_pow.teichmuller_set_c(&v.value, &u.value, self.prime_pow.ram_prec_cap)
             if n is None:
                 L.append(v)
             elif rp == goal:
                 return v
-            if rp == 1: break
+            if rp == 1:
+                break
             ZZ_pX_sub(u.value, u.value, v.value)
             rp -= 1
             if self.prime_pow.e == 1:

--- a/src/sage/rings/padics/padic_ZZ_pX_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_element.pyx
@@ -284,7 +284,6 @@ cdef class pAdicZZpXElement(pAdicExtElement):
         cdef Integer list_elt
         cdef ZZ_c halfp
         cdef Py_ssize_t i, j
-        cdef ZZ_p_c const_term_holder
         self.prime_pow.restore_top_context()
         ###ZZ_p_construct(&const_term_holder)
         cdef ntl_ZZ holder = ntl_ZZ()
@@ -621,6 +620,7 @@ def _test_preprocess_list(R, L):
     """
     return preprocess_list(R(0), L)
 
+
 cdef preprocess_list(pAdicZZpXElement elt, L):
     """
     See the documentation for :func:`_test_preprocess_list`.
@@ -630,7 +630,6 @@ cdef preprocess_list(pAdicZZpXElement elt, L):
     cdef ntl_ZZ_pContext_class ctx
     cdef ntl_ZZ pshift_z
     cdef Integer pshift_m
-    cdef long aprec
     cdef ntl_ZZ py_tmp
     if not isinstance(L, list):
         raise TypeError("L must be a list")

--- a/src/sage/rings/padics/padic_capped_relative_element.pyx
+++ b/src/sage/rings/padics/padic_capped_relative_element.pyx
@@ -576,6 +576,7 @@ def unpickle_pcre_v1(R, unit, ordp, relprec):
     """
     return unpickle_cre_v2(pAdicCappedRelativeElement, R, unit, ordp, relprec)
 
+
 def base_p_list(Integer n, bint pos, PowComputer_class prime_pow):
     r"""
     Return a base-`p` list of digits of ``n``.

--- a/src/sage/rings/padics/padic_printing.pyx
+++ b/src/sage/rings/padics/padic_printing.pyx
@@ -928,7 +928,6 @@ cdef class pAdicPrinter_class(SageObject):
             sage: repr(R(0,10))
             '...0000000000'
         """
-        cdef Py_ssize_t i
         s = ""
         if self.show_prec == "dots":
             unknown_digit = "?"
@@ -1063,10 +1062,8 @@ cdef class pAdicPrinter_class(SageObject):
         """
         cdef Integer lift_z, pprec
         cdef int ZZ_pEX
-        cdef Py_ssize_t i, j
+        cdef Py_ssize_t i
         cdef long val
-        #cdef bint ellipsis = 0
-        cdef ellipsis_unram
         cdef bint integral
         var_name = self.latex_var_name if do_latex else self.var_name
         if self.base:
@@ -1200,10 +1197,10 @@ cdef class pAdicPrinter_class(SageObject):
                                     s += " - "
                                     s += self._var(var_name, i, do_latex)
                                 else:
-                                    s += " - %s"%(arep)
+                                    s += " - %s" % (arep)
                                     s += self._dot_var(var_name, i, do_latex)
                             elif a == pk:
-                                if s != "":
+                                if s:
                                     s += " + "
                                 s += self._var(var_name, i, do_latex)
                             else:
@@ -1211,9 +1208,9 @@ cdef class pAdicPrinter_class(SageObject):
                                 v, u = a.val_unit(self.prime_pow.prime)
                                 arep = self._terse_frac(a, v, u, ram_name, do_latex)
                                 if s == "":
-                                    s = "%s"%arep
+                                    s = "%s" % arep
                                 else:
-                                    s += " + %s"%arep
+                                    s += " + %s" % arep
                                 s += self._dot_var(var_name, i, do_latex)
                     if ellipsis:
                         s += self._plus_ellipsis(do_latex)

--- a/src/sage/rings/padics/padic_relaxed_errors.pyx
+++ b/src/sage/rings/padics/padic_relaxed_errors.pyx
@@ -5,23 +5,23 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
 
 from sage.rings.padics.precision_error import PrecisionError
 
 
-cdef inline int ERROR_ABANDON      = 1
-cdef inline int ERROR_NOTDEFINED   = 1 << 1
-cdef inline int ERROR_PRECISION    = 1 << 2
-cdef inline int ERROR_OVERFLOW     = 1 << 3
-cdef inline int ERROR_NOTSQUARE    = 1 << 4  # maybe we should have something more generic here
-cdef inline int ERROR_INTEGRAL     = 1 << 5
-cdef inline int ERROR_DIVISION     = 1 << 6
-cdef inline int ERROR_CIRCULAR     = 1 << 7
+cdef inline int ERROR_ABANDON = 1
+cdef inline int ERROR_NOTDEFINED = 1 << 1
+cdef inline int ERROR_PRECISION = 1 << 2
+cdef inline int ERROR_OVERFLOW = 1 << 3
+cdef inline int ERROR_NOTSQUARE = 1 << 4  # maybe we should have something more generic here
+cdef inline int ERROR_INTEGRAL = 1 << 5
+cdef inline int ERROR_DIVISION = 1 << 6
+cdef inline int ERROR_CIRCULAR = 1 << 7
 
-cdef inline int ERROR_UNEXPECTED   = 1 << 30
+cdef inline int ERROR_UNEXPECTED = 1 << 30
 
 
 def raise_error(error, permissive=False):

--- a/src/sage/rings/padics/padic_template_element.pxi
+++ b/src/sage/rings/padics/padic_template_element.pxi
@@ -146,7 +146,7 @@ cdef class pAdicTemplateElement(pAdicGenericElement):
                         x = [x]
         elif sage.rings.finite_rings.integer_mod.is_IntegerMod(x):
             if not Integer(self.prime_pow.prime).divides(x.parent().order()):
-                raise TypeError("p does not divide modulus %s"%x.parent().order())
+                raise TypeError("p does not divide modulus %s" % x.parent().order())
         elif isinstance(x, Element) and isinstance(x.parent(), FiniteField):
             k = self.parent().residue_field()
             if not k.has_coerce_map_from(x.parent()):
@@ -624,7 +624,7 @@ cdef class pAdicTemplateElement(pAdicGenericElement):
             return trim_zeros(list(self.unit_part().expansion(lift_mode='smallest')))
 
     cpdef pAdicTemplateElement unit_part(self):
-        """
+        r"""
         Returns the unit part of this element.
 
         This is the `p`-adic element `u` in the same ring so that this
@@ -739,7 +739,7 @@ cdef class pAdicTemplateElement(pAdicGenericElement):
         if check_prec and (R.is_fixed_mod() or R.is_floating_point()):
             check_prec = False
         if check_prec and absprec > self.precision_absolute():
-            raise PrecisionError("insufficient precision to reduce modulo p^%s"%absprec)
+            raise PrecisionError("insufficient precision to reduce modulo p^%s" % absprec)
         if field and absprec != 1:
             raise ValueError("field keyword may only be set at precision 1")
         if absprec == 0:
@@ -834,15 +834,15 @@ cdef long padic_pow_helper(celement result, celement base, long base_val, long b
     """
     if base_val != 0:
         raise ValueError("in order to raise to a p-adic exponent, base must be a unit")
-    ####### NOTE:  this function needs to be updated for extension elements. #######
+    # TODO NOTE:  this function needs to be updated for extension elements.
     cdef long loga_val, loga_aprec, bloga_val, bloga_aprec
     cdef Integer expcheck, right
     cteichmuller(prime_pow.powhelper_oneunit, base, base_relprec, prime_pow)
     cdivunit(prime_pow.powhelper_oneunit, base, prime_pow.powhelper_oneunit, base_relprec, prime_pow)
     csetone(prime_pow.powhelper_teichdiff, prime_pow)
     csub(prime_pow.powhelper_teichdiff, prime_pow.powhelper_oneunit, prime_pow.powhelper_teichdiff, base_relprec, prime_pow)
-    ## For extension elements in ramified extensions, the computation of the
-    ## valuation and precision of log(a) is more complicated)
+    # For extension elements in ramified extensions, the computation of the
+    # valuation and precision of log(a) is more complicated)
     loga_val = cvaluation(prime_pow.powhelper_teichdiff, base_relprec, prime_pow)
     loga_aprec = base_relprec
     # valuation of b*log(a)
@@ -862,8 +862,8 @@ cdef long padic_pow_helper(celement result, celement base, long base_val, long b
         # Here we need to use the exp(b log(a)) definition,
         # since we can't convert the exponent to an integer
         raise NotImplementedError("exponents with negative valuation not yet supported")
-    ## For extension elements in ramified extensions
-    ## the following precision might need to be changed.
+    # For extension elements in ramified extensions
+    # the following precision might need to be changed.
     cpow(result, prime_pow.powhelper_oneunit, right.value, bloga_aprec, prime_pow)
     return bloga_aprec
 
@@ -1185,5 +1185,4 @@ cdef class ExpansionIterable():
         else:
             modestr = " (teichmuller)"
         p = self.elt.prime_pow.prime
-        return "%s-adic expansion of %s%s"%(p, self.elt, modestr)
-
+        return "%s-adic expansion of %s%s" % (p, self.elt, modestr)

--- a/src/sage/rings/padics/pow_computer.pyx
+++ b/src/sage/rings/padics/pow_computer.pyx
@@ -35,7 +35,7 @@ AUTHORS:
 #  as published by the Free Software Foundation; either version 2 of
 #  the License, or (at your option) any later version.
 #
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 #*****************************************************************************
 
 import weakref
@@ -186,7 +186,6 @@ cdef class PowComputer_class(SageObject):
             59049
         """
         cdef Integer _n = Integer(n)
-        cdef Integer ans
         if _n < 0:
             if mpz_fits_ulong_p((<Integer>-_n).value) == 0:
                 raise ValueError("result too big")
@@ -210,7 +209,7 @@ cdef class PowComputer_class(SageObject):
 
         See pow_mpz_t_tmp_demo for an example of this phenomenon.
         """
-        ## READ THE DOCSTRING
+        # READ THE DOCSTRING
         raise NotImplementedError
 
     def _pow_mpz_t_tmp_demo(self, m, n):
@@ -319,7 +318,7 @@ cdef class PowComputer_class(SageObject):
             sage: PC = PowComputer(3, 5, 10); PC
             PowComputer for 3
         """
-        return "PowComputer for %s"%(self.prime)
+        return "PowComputer for %s" % (self.prime)
 
     def _prime(self):
         """
@@ -411,8 +410,7 @@ cdef class PowComputer_class(SageObject):
             sage: P(-2)
             1/9
         """
-        cdef Integer z, _n
-        cdef mpz_t tmp
+        cdef Integer _n
         if n is infinity:
             return Integer(0)
         if not isinstance(n, Integer):
@@ -496,12 +494,10 @@ cdef class PowComputer_base(PowComputer_class):
             sage: PC = PowComputer(5, 7, 10)
             sage: PC(3)
             125
-
         """
         PowComputer_class.__init__(self, prime, cache_limit, prec_cap, ram_prec_cap, in_field, poly, shift_seed)
 
         cdef Py_ssize_t i
-        cdef Integer x
 
         mpz_set_ui(self.small_powers[0], 1)
         if cache_limit > 0:
@@ -633,6 +629,7 @@ cdef PowComputer_base PowComputer_c(Integer m, Integer cache_limit, Integer prec
     PC = PC_class(m, mpz_get_ui(cache_limit.value), mpz_get_ui(prec_cap.value), mpz_get_ui(prec_cap.value), in_field)
     pow_comp_cache[key] = weakref.ref(PC)
     return PC
+
 
 # To speed up the creation of PowComputers with the same m, we might eventually want to copy over data from an existing PowComputer.
 

--- a/src/sage/rings/padics/pow_computer_ext.pxd
+++ b/src/sage/rings/padics/pow_computer_ext.pxd
@@ -105,4 +105,3 @@ cdef class PowComputer_ZZ_pX_big_Eis(PowComputer_ZZ_pX_big):
 #    cdef context_dict #currently using a dict, optimize for speed later
 #    cdef modulus_dict #currently using a dict, optimize for speed later
 #
-

--- a/src/sage/rings/padics/pow_computer_ext.pyx
+++ b/src/sage/rings/padics/pow_computer_ext.pyx
@@ -191,8 +191,7 @@ cdef int ZZ_pX_Eis_init(PowComputer_ZZ_pX prime_pow, ntl_ZZ_pX shift_seed) excep
         raise TypeError("unrecognized Eisenstein type")
 
     cdef long i
-    cdef ZZ_pX_c tmp, modup, into_multiplier, shift_seed_inv
-    cdef ZZ_c a
+    cdef ZZ_pX_c into_multiplier, shift_seed_inv
     # We obtain successive p/x^(2^i) by squaring and then dividing by p.  So we need one extra digit of precision.
     prime_pow.restore_top_context()
     #cdef ntl_ZZ_pContext_class cup = prime_pow.get_context(prime_pow.prec_cap + low_length)
@@ -320,7 +319,6 @@ cdef int ZZ_pX_eis_shift_p(PowComputer_ZZ_pX self, ZZ_pX_c* x, ZZ_pX_c* a, long 
     cdef ZZ_pX_c low_part
     cdef ZZ_pX_c shifted_high_part
     cdef ZZ_pX_c powerx
-    cdef ZZ_pX_c shifter
     cdef ZZ_pX_c lowshift
     cdef ZZ_pX_c highshift
     cdef ZZ_pX_c working, working2
@@ -354,7 +352,6 @@ cdef int ZZ_pX_eis_shift_p(PowComputer_ZZ_pX self, ZZ_pX_c* x, ZZ_pX_c* a, long 
     else:
         raise TypeError("inconsistent type")
 
-    cdef ntl_ZZ_pX printer
     if n < 0:
         if fm:
             c = self.get_top_context()
@@ -478,7 +475,6 @@ cdef class PowComputer_ext(PowComputer_class):
             raise MemoryError("out of memory allocating power storing")
 
         cdef Py_ssize_t i
-        cdef Integer x
 
         ZZ_conv_from_int(self.small_powers[0], 1)
 
@@ -1574,7 +1570,6 @@ cdef class PowComputer_ZZ_pX_small(PowComputer_ZZ_pX):
             self.cleanup_ext()
             raise MemoryError("out of memory allocating moduli")
 
-        cdef ntl_ZZ_pX printer
         cdef Py_ssize_t i
         cdef ZZ_pX_c tmp, pol
         if isinstance(poly, ntl_ZZ_pX):

--- a/src/sage/rings/padics/pow_computer_relative.pyx
+++ b/src/sage/rings/padics/pow_computer_relative.pyx
@@ -150,14 +150,16 @@ cdef class PowComputer_relative(PowComputer_class):
             Relative PowComputer for modulus x^3 + 5*x + a*5
 
         """
-        return "Relative PowComputer for modulus %s"%(self.modulus,)
+        return "Relative PowComputer for modulus %s" % (self.modulus,)
 
     cdef unsigned long capdiv(self, unsigned long n):
         r"""
         Return `\lceil n/e \rceil`.
         """
-        if self.e == 1: return n
-        if n == 0: return 0
+        if self.e == 1:
+            return n
+        if n == 0:
+            return 0
         return (n - 1)/self.e + 1
 
     def polynomial(self, n=None, var='x'):

--- a/src/sage/rings/padics/qadic_flint_FP.pyx
+++ b/src/sage/rings/padics/qadic_flint_FP.pyx
@@ -108,7 +108,6 @@ cdef class qAdicFloatingPointElement(FPElement):
         cshift_notrunc(self.prime_pow.poly_flint_rep, self.unit, self.ordp, self.ordp + self.prime_pow.prec_cap, self.prime_pow, False)
         return self.prime_pow._new_fmpz_poly(self.prime_pow.poly_flint_rep, var), Integer(0)
 
-
     def _modp_rep(self, use_smallest_mode=False, return_list=True):
         r"""
         Return the element with the same reduction mod p that can be expressed

--- a/src/sage/rings/padics/relaxed_template.pxi
+++ b/src/sage/rings/padics/relaxed_template.pxi
@@ -948,11 +948,12 @@ cdef class RelaxedElement(pAdicGenericElement):
         return Integer(self._precrel + self._valuation)
 
     def precision_relative(self):
-        """
+        r"""
         Return the relative precision of this element.
 
         This is the power of `p` modulo which the unit part of this
         element is known.
+
         For unbounded nonzero elements, this methods return `+\infty`.
 
         EXAMPLES::
@@ -3056,7 +3057,6 @@ cdef class RelaxedElement_sub(RelaxedElementWithDigits):
         return 0
 
 
-
 # Multiplication
 
 cdef class RelaxedElement_mul(RelaxedElementWithDigits):
@@ -3684,7 +3684,7 @@ cdef class RelaxedElement_teichmuller(RelaxedElementWithDigits):
             p = self.prime_pow.prime
             size = mpz_sizeinbase(p.value, 2)
             i = size - 2
-            self._xns = [ ]
+            self._xns = []
             while i >= 0:
                 xn = element_class_mul(parent, xn, xn)
                 self._xns.append(xn)
@@ -3801,7 +3801,7 @@ cdef class RelaxedElement_unknown(RelaxedElementWithDigits):
         self._next = maxordp
         cdef cdigit digit
         if digits is not None:
-            digits = [ Integer(d) for d in digits ]
+            digits = [Integer(d) for d in digits]
             for d in digits:
                 digit_set_sage(digit, d)
                 element_iadd_digit(self._digits, digit, self._precrel)
@@ -3828,7 +3828,7 @@ cdef class RelaxedElement_unknown(RelaxedElementWithDigits):
             sage: x == loads(dumps(x))  # indirect doctest
             True
         """
-        digits = [ ]
+        digits = []
         for i in range(self._initialprecrel):
             digits.append(digit_get_sage(element_get_digit(self._digits, i)))
         definition = None
@@ -3932,6 +3932,7 @@ cdef class RelaxedElement_unknown(RelaxedElementWithDigits):
                 self._precrel += 1
         self._next = svenext
         return error
+
 
 def unpickle_unknown(uid, cls, parent, valuation, digits, definition):
     r"""
@@ -4084,7 +4085,7 @@ cdef class ExpansionIter():
                 self._next_smallest()
         elif self.mode == teichmuller_mode:
             self.tail = elt
-            self.coefficients = { }
+            self.coefficients = {}
             while self.current < self.start:
                 self._next_teichmuller()
 


### PR DESCRIPTION
Cleaning `pyx` and `pxi` files in `padics`, following suggestions of `cython-lint`

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.