### PR TITLE
fix remaining W605 warnings in pxi files

### DIFF
--- a/src/sage/libs/linkages/padics/API.pxi
+++ b/src/sage/libs/linkages/padics/API.pxi
@@ -469,7 +469,7 @@ cdef inline long chash(celement a, long ordp, long prec, PowComputer_class prime
 
 # the expansion_mode enum is defined in padic_template_element_header.pxi
 cdef inline cexpansion_next(celement value, expansion_mode mode, long curpower, PowComputer_ prime_pow):
-    """
+    r"""
     Return the next digit in a `\pi`-adic expansion of ``value``.
 
     INPUT:
@@ -483,7 +483,7 @@ cdef inline cexpansion_next(celement value, expansion_mode mode, long curpower, 
     pass
 
 cdef inline cexpansion_getitem(celement value, long m, PowComputer_ prime_pow):
-    """
+    r"""
     Return the `m`th `\pi`-adic digit in the ``simple_mode`` expansion.
 
     INPUT:
@@ -512,7 +512,7 @@ cdef list ccoefficients(celement x, long valshift, PowComputer_class prime_pow):
     pass
 
 cdef int cteichmuller(celement out, celement value, long prec, PowComputer_class prime_pow) except -1:
-    """
+    r"""
     Teichmuller lifting.
 
     INPUT:

--- a/src/sage/libs/linkages/padics/fmpz_poly_unram.pxi
+++ b/src/sage/libs/linkages/padics/fmpz_poly_unram.pxi
@@ -668,7 +668,7 @@ cdef list ccoefficients(celement x, long valshift, long prec, PowComputer_ prime
     return ans
 
 cdef int cteichmuller(celement out, celement value, long prec, PowComputer_ prime_pow) except -1:
-    """
+    r"""
     Teichmuller lifting.
 
     INPUT:
@@ -848,7 +848,7 @@ cdef inline int cconv_mpz_t_out(mpz_t out, celement x, long valshift, long prec,
 ## Extra functions ##
 
 cdef cmatrix_mod_pn(celement a, long aprec, long valshift, PowComputer_ prime_pow):
-    """
+    r"""
     Returns the matrix of right multiplication by the element on
     the power basis `1, x, x^2, \ldots, x^{d-1}` for this
     extension field.  Thus the *rows* of this matrix give the

--- a/src/sage/libs/linkages/padics/mpz.pxi
+++ b/src/sage/libs/linkages/padics/mpz.pxi
@@ -568,7 +568,7 @@ cdef list ccoefficients(mpz_t x, long valshift, long prec, PowComputer_ prime_po
         return [ansq]
 
 cdef int cteichmuller(mpz_t out, mpz_t value, long prec, PowComputer_ prime_pow) except -1:
-    """
+    r"""
     Teichmuller lifting.
 
     INPUT:

--- a/src/sage/libs/linkages/padics/unram_shared.pxi
+++ b/src/sage/libs/linkages/padics/unram_shared.pxi
@@ -84,7 +84,7 @@ def frobenius_unram(self, arithmetic=True):
 
 @cython.binding(True)
 def norm_unram(self, base = None):
-    """
+    r"""
     Return the absolute or relative norm of this element.
 
     .. WARNING::
@@ -95,9 +95,9 @@ def norm_unram(self, base = None):
 
     INPUT:
 
-        ``base`` -- a subfield of the parent `L` of this element.
-                    The norm is the relative norm from ``L`` to ``base``.
-                    Defaults to the absolute norm down to `\QQ_p` or `\ZZ_p`.
+    ``base`` -- a subfield of the parent `L` of this element.
+                The norm is the relative norm from ``L`` to ``base``.
+                Defaults to the absolute norm down to `\QQ_p` or `\ZZ_p`.
 
     EXAMPLES::
 
@@ -171,7 +171,7 @@ def norm_unram(self, base = None):
 
 @cython.binding(True)
 def trace_unram(self, base = None):
-    """
+    r"""
     Return the absolute or relative trace of this element.
 
     If ``base`` is given then ``base`` must be a subfield of the

--- a/src/sage/libs/linkages/padics/unram_shared.pxi
+++ b/src/sage/libs/linkages/padics/unram_shared.pxi
@@ -3,7 +3,7 @@ cimport cython
 @cython.binding(True)
 def frobenius_unram(self, arithmetic=True):
     """
-    Returns the image of this element under the Frobenius automorphism
+    Return the image of this element under the Frobenius automorphism
     applied to its parent.
 
     INPUT:
@@ -48,9 +48,9 @@ def frobenius_unram(self, arithmetic=True):
         ...
         NotImplementedError: Frobenius automorphism only implemented for unramified extensions
 
-    TESTS::
+    TESTS:
 
-    We check that :trac:`23575` is resolved:
+    We check that :trac:`23575` is resolved::
 
         sage: x = R.random_element()
         sage: x.frobenius(arithmetic=false).frobenius() == x
@@ -95,9 +95,9 @@ def norm_unram(self, base = None):
 
     INPUT:
 
-    ``base`` -- a subfield of the parent `L` of this element.
-                The norm is the relative norm from ``L`` to ``base``.
-                Defaults to the absolute norm down to `\QQ_p` or `\ZZ_p`.
+    - ``base`` -- a subfield of the parent `L` of this element.
+                  The norm is the relative norm from ``L`` to ``base``.
+                  Defaults to the absolute norm down to `\QQ_p` or `\ZZ_p`.
 
     EXAMPLES::
 

--- a/src/sage/libs/symmetrica/sc.pxi
+++ b/src/sage/libs/symmetrica/sc.pxi
@@ -4,6 +4,7 @@ cdef extern from 'symmetrica/def.h':
     INT kranztafel(OP a, OP b, OP res, OP co, OP cl)
     INT c_ijk_sn(OP i, OP j, OP k, OP res)
 
+
 def chartafel_symmetrica(n):
     """
     you enter the degree of the symmetric group, as INTEGER
@@ -22,8 +23,7 @@ def chartafel_symmetrica(n):
         [ 0 -1  2  0  2]
         [ 1  0 -1 -1  3]
         [-1  1  1 -1  1]
-     """
-
+    """
     cdef OP cn, cres
 
     cn   = callocobject()
@@ -39,7 +39,6 @@ def chartafel_symmetrica(n):
     freeall(cres)
 
     return res
-
 
 
 def charvalue_symmetrica(irred, cls, table=None):
@@ -67,9 +66,7 @@ def charvalue_symmetrica(irred, cls, table=None):
         sage: m == symmetrica.chartafel(n)
         True
     """
-
     cdef OP cirred, cclass, ctable, cresult
-
 
     cirred = callocobject()
     cclass = callocobject()
@@ -80,8 +77,6 @@ def charvalue_symmetrica(irred, cls, table=None):
     else:
         ctable = callocobject()
         _op_matrix(table, ctable)
-
-
 
     #FIXME: assume that class is a partition
     _op_partition(cls, cclass)
@@ -101,41 +96,37 @@ def charvalue_symmetrica(irred, cls, table=None):
     return res
 
 
-
 def kranztafel_symmetrica(a, b):
-    """
-    you enter the INTEGER objects, say a and b, and res becomes a
-    MATRIX object, the charactertable of S_b \wr S_a, co becomes a
-    VECTOR object of classorders and cl becomes a VECTOR object of
+    r"""
+    you enter the INTEGER objects, say `a` and `b`, and ``res`` becomes a
+    MATRIX object, the charactertable of `S_b \wr S_a`, ``co`` becomes a
+    VECTOR object of classorders and ``cl`` becomes a VECTOR object of
     the classlabels.
 
     EXAMPLES::
 
-       sage: (a,b,c) = symmetrica.kranztafel(2,2)
-       sage: a
-       [ 1 -1  1 -1  1]
-       [ 1  1  1  1  1]
-       [-1  1  1 -1  1]
-       [ 0  0  2  0 -2]
-       [-1 -1  1  1  1]
-       sage: b
-       [2, 2, 1, 2, 1]
-       sage: for m in c: print(m)
-       [0 0]
-       [0 1]
-       [0 0]
-       [1 0]
-       [0 2]
-       [0 0]
-       [1 1]
-       [0 0]
-       [2 0]
-       [0 0]
-
+        sage: (a,b,c) = symmetrica.kranztafel(2,2)
+        sage: a
+        [ 1 -1  1 -1  1]
+        [ 1  1  1  1  1]
+        [-1  1  1 -1  1]
+        [ 0  0  2  0 -2]
+        [-1 -1  1  1  1]
+        sage: b
+        [2, 2, 1, 2, 1]
+        sage: for m in c: print(m)
+        [0 0]
+        [0 1]
+        [0 0]
+        [1 0]
+        [0 2]
+        [0 0]
+        [1 1]
+        [0 0]
+        [2 0]
+        [0 0]
     """
-
     cdef OP ca, cb, cres, cco, ccl
-
 
     ca = callocobject()
     cb = callocobject()
@@ -194,4 +185,3 @@ def kranztafel_symmetrica(a, b):
 ##     freeall(ck)
 
 ##     return res
-

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -1,4 +1,4 @@
-"""
+r"""
 Dense matrices over `\ZZ/n\ZZ` for `n` small using the LinBox library (FFLAS/FFPACK)
 
 FFLAS/FFPACK are libraries to provide BLAS/LAPACK-style routines for
@@ -857,7 +857,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
 
     cpdef _add_(self, right):
-        """
+        r"""
         Add two dense matrices over `\Z/n\Z`
 
         INPUT:
@@ -2284,7 +2284,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             return Matrix_dense.determinant(self)
 
     cdef xgcd_eliminate(self, celement * row1, celement* row2, Py_ssize_t start_col):
-        """
+        r"""
         Reduces ``row1`` and ``row2`` by a unimodular transformation
         using the xgcd relation between their first coefficients ``a`` and
         ``b``.
@@ -2297,7 +2297,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
         -``start_col`` - the column of the pivots in ``row1`` and
          ``row2``. It is assumed that all entries before ``start_col``
          in ``row1`` and ``row2`` are zero.
-
 
         OUTPUT:
 

--- a/src/sage/symbolic/series_impl.pxi
+++ b/src/sage/symbolic/series_impl.pxi
@@ -1,4 +1,4 @@
-"""
+r"""
 Symbolic Series
 
 Symbolic series are special kinds of symbolic expressions that are


### PR DESCRIPTION
This is fixing the few remaining W605 warnings issued by cython-lint, in some pxi files.

This is outside of rings/padics, handled in another place.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.