### PR TITLE
Fix element labeling in `OperationTable.color_table`

### DIFF
--- a/src/sage/matrix/operation_table.py
+++ b/src/sage/matrix/operation_table.py
@@ -1011,9 +1011,8 @@ class OperationTable(SageObject):
             # iterate through each element
             for g in range(n):
                 for h in range(n):
-
                     # add text to the plot
-                    tPos = (g, h)
+                    tPos = (h, g)
                     tText = widenames[self._table[g][h]]
                     t = text(tText, tPos, rgbcolor=(0, 0, 0))
                     plot = plot + t


### PR DESCRIPTION
The labels were transposed.

Fixes https://ask.sagemath.org/question/73752/typo-in-operationtable/

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.
