### PR TITLE
Fix conda install instructions after `setuptools` update

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           # Use --no-deps and pip check below to verify that all necessary dependencies are installed via conda.
           pip install --no-build-isolation --no-deps -v -v -e ./pkgs/sage-conf ./pkgs/sage-setup
-          pip install --no-build-isolation --no-deps -v -v -e ./src
+          pip install --no-build-isolation --no-deps --config-settings editable_mode=compat -v -v -e ./src
         env:
           SAGE_NUM_THREADS: 2
         

--- a/build/pkgs/setuptools/distros/conda.txt
+++ b/build/pkgs/setuptools/distros/conda.txt
@@ -1,4 +1,1 @@
-# Set this bound until https://github.com/sagemath/sage/issues/34209 adds support for PEP660 editable builds
-# By setting this version bound, we avoid having to include the following in our installation instructions.
-#   export SETUPTOOLS_ENABLE_FEATURES=legacy-editable
-"setuptools<64"
+setuptools

--- a/build/pkgs/setuptools_wheel/distros
+++ b/build/pkgs/setuptools_wheel/distros
@@ -1,0 +1,1 @@
+../setuptools/distros

--- a/build/pkgs/setuptools_wheel/distros/repology.txt
+++ b/build/pkgs/setuptools_wheel/distros/repology.txt
@@ -1,1 +1,0 @@
-python:setuptools

--- a/pkgs/sage-conf_conda/setup.py
+++ b/pkgs/sage-conf_conda/setup.py
@@ -30,22 +30,22 @@ class build_py(setuptools_build_py):
 
         if os.path.exists(os.path.join(SAGE_ROOT, 'config.status')):
             print(f'Reusing configured SAGE_ROOT={SAGE_ROOT}')
-        else:
-            cmd = f"cd {SAGE_ROOT} && ./configure --enable-build-as-root --with-system-python3=force --disable-notebook --disable-sagelib --disable-sage_conf --disable-doc"
-            cmd += ' --with-python=$CONDA_PREFIX/bin/python --prefix="$CONDA_PREFIX"'
-            cmd += ' $(for pkg in $(PATH="build/bin:$PATH" build/bin/sage-package list :standard: --exclude rpy2 --has-file spkg-configure.m4 --has-file distros/conda.txt); do echo --with-system-$pkg=force; done)'
-            print(f"Running {cmd}")
-            sys.stdout.flush()
-            if os.system(cmd) != 0:
-                if os.path.exists(os.path.join(SAGE_ROOT, 'config.status')):
-                    print("Warning: A configuration has been written, but the configure script has exited with an error. "
-                          "Carefully check any messages above before continuing.")
-                else:
-                    print(f"Error: The configure script has failed; this may be caused by missing build prerequisites.")
-                    sys.stdout.flush()
-                    PREREQ_SPKG = "_prereq bzip2 xz libffi"  # includes python3 SPKG_DEPCHECK packages
-                    os.system(f'cd {SAGE_ROOT} && export PACKAGES="$(build/bin/sage-get-system-packages conda {PREREQ_SPKG})" && [ -n "$PACKAGES" ] && echo "You can install the required build prerequisites using the following shell command" && echo "" && build/bin/sage-print-system-package-command conda --verbose --sudo install $PACKAGES && echo ""')
-                    raise SetupError("configure failed")
+
+        cmd = f"cd {SAGE_ROOT} && ./configure --enable-build-as-root --with-system-python3=force --disable-notebook --disable-sagelib --disable-sage_conf --disable-doc"
+        cmd += ' --with-python=$CONDA_PREFIX/bin/python --prefix="$CONDA_PREFIX"'
+        cmd += ' $(for pkg in $(PATH="build/bin:$PATH" build/bin/sage-package list :standard: --exclude rpy2 --has-file spkg-configure.m4 --has-file distros/conda.txt); do echo --with-system-$pkg=force; done)'
+        print(f"Running {cmd}")
+        sys.stdout.flush()
+        if os.system(cmd) != 0:
+            if os.path.exists(os.path.join(SAGE_ROOT, 'config.status')):
+                print("Warning: A configuration has been written, but the configure script has exited with an error. "
+                      "Carefully check any messages above before continuing.")
+            else:
+                print(f"Error: The configure script has failed; this may be caused by missing build prerequisites.")
+                sys.stdout.flush()
+                PREREQ_SPKG = "_prereq bzip2 xz libffi"  # includes python3 SPKG_DEPCHECK packages
+                os.system(f'cd {SAGE_ROOT} && export PACKAGES="$(build/bin/sage-get-system-packages conda {PREREQ_SPKG})" && [ -n "$PACKAGES" ] && echo "You can install the required build prerequisites using the following shell command" && echo "" && build/bin/sage-print-system-package-command conda --verbose --sudo install $PACKAGES && echo ""')
+                raise SetupError("configure failed")
 
         # In this mode, we never run "make".
 

--- a/pkgs/sage-conf_conda/setup.py
+++ b/pkgs/sage-conf_conda/setup.py
@@ -28,9 +28,6 @@ class build_py(setuptools_build_py):
             raise SetupError('No conda environment is active. '
                              'See https://doc.sagemath.org/html/en/installation/conda.html on how to get started.')
 
-        if os.path.exists(os.path.join(SAGE_ROOT, 'config.status')):
-            print(f'Reusing configured SAGE_ROOT={SAGE_ROOT}')
-
         cmd = f"cd {SAGE_ROOT} && ./configure --enable-build-as-root --with-system-python3=force --disable-notebook --disable-sagelib --disable-sage_conf --disable-doc"
         cmd += ' --with-python=$CONDA_PREFIX/bin/python --prefix="$CONDA_PREFIX"'
         cmd += ' $(for pkg in $(PATH="build/bin:$PATH" build/bin/sage-package list :standard: --exclude rpy2 --has-file spkg-configure.m4 --has-file distros/conda.txt); do echo --with-system-$pkg=force; done)'

--- a/src/doc/en/installation/conda.rst
+++ b/src/doc/en/installation/conda.rst
@@ -158,7 +158,7 @@ suffices to restart Sage.
 
 After editing any Cython files, rebuild the Sage library using::
 
-  $ pip install --no-build-isolation -v -v --editable src
+  $ pip install --no-build-isolation --config-settings editable_mode=compat -v -v --editable src
 
 In order to update the conda environment later, you can run::
 

--- a/src/doc/en/installation/conda.rst
+++ b/src/doc/en/installation/conda.rst
@@ -134,8 +134,9 @@ Here we assume that you are using a git checkout.
     installed. You can use the additional option ``python=3.9`` in the above
     ``env create`` command to select another Python version (here 3.9).
 
-  - Install the build prerequisites and the Sage library::
+  - Bootstrap the source tree and install the build prerequisites and the Sage library::
 
+      $ ./bootstrap
       $ pip install --no-build-isolation -v -v --editable ./pkgs/sage-conf_conda ./pkgs/sage-setup
       $ pip install --no-build-isolation --config-settings editable_mode=compat -v -v --editable ./src
 


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
- Updates install instructions for use with modern `setuptools` versions.
- Restore `bootstrap` step in instructions, lost in #36367 
- Unpin `setuptools`.
<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
