### PR TITLE
replace wrongly placed sig_on/off pair with sig_check

### DIFF
--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -744,7 +744,7 @@ cdef class Context:
         faster and produces more accurate results than the builtin
         Python function :func:`sum`.
 
-        With squared=True each term is squared, and with absolute=True
+        With ``squared=True`` each term is squared, and with ``absolute=True``
         the absolute value of each term is used.
 
         TESTS ::
@@ -856,7 +856,7 @@ cdef class Context:
                 MPF_clear(&sim)
                 return +unknown
         except KeyboardInterrupt:
-            raise KeyboardInterrupt('Ctlr-C has been pressed')
+            raise KeyboardInterrupt('Ctrl-C pressed while running fsum')
 
     def fdot(ctx, A, B=None, bint conjugate=False):
         r"""

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -19,7 +19,7 @@ from cpython.float cimport *
 from cpython.complex cimport *
 from cpython.number cimport *
 
-from cysignals.signals cimport sig_on, sig_off
+from cysignals.signals cimport sig_check
 
 from sage.ext.stdsage cimport PY_NEW
 
@@ -707,7 +707,6 @@ cdef class Context:
             False
             sage: isint(3+2j, gaussian=True)
             True
-
         """
         cdef MPF v
         cdef MPF w
@@ -745,6 +744,9 @@ cdef class Context:
         faster and produces more accurate results than the builtin
         Python function :func:`sum`.
 
+        With squared=True each term is squared, and with absolute=True
+        the absolute value of each term is used.
+
         TESTS ::
 
             sage: from mpmath import mp, fsum
@@ -752,8 +754,13 @@ cdef class Context:
             sage: fsum([1, 2, 0.5, 7])
             mpf('10.5')
 
-        With squared=True each term is squared, and with absolute=True
-        the absolute value of each term is used.
+        Check that the regression from `mpmath/issues/723 <https://github.com/mpmath/mpmath/issues/723>`__
+        has been fixed::
+
+            sage: from mpmath import *
+            sage: mp.dps=16
+            sage: zeta(-0.01 + 1000j)
+            mpc(real='-8.9714595...', imag='8.7321793...')
         """
         cdef MPF sre, sim, tre, tim, tmp
         cdef mpf rr
@@ -764,8 +771,8 @@ cdef class Context:
         workopts.prec = workopts.prec * 2 + 50
         workopts.rounding = ROUND_D
         unknown = global_context.zero
-        sig_on()
-        try:  # Way down, there is a ``finally`` with sig_off()
+        try:
+            sig_check()
             MPF_init(&sre)
             MPF_init(&sim)
             MPF_init(&tre)
@@ -848,8 +855,8 @@ cdef class Context:
                 MPF_clear(&sre)
                 MPF_clear(&sim)
                 return +unknown
-        finally:
-            sig_off()
+        except KeyboardInterrupt:
+            raise KeyboardInterrupt('Ctlr-C has been pressed')
 
     def fdot(ctx, A, B=None, bint conjugate=False):
         r"""


### PR DESCRIPTION
fixes the bug noted in https://github.com/mpmath/mpmath/issues/723
The problem comes from the `sig_on/off` pair guarding non-Cython statements; we replace it by `sig_check()`

```
sage: from mpmath import *
sage: mp.dps=16
sage: zeta(-0.01 + 1000j)
---------------------------------------------------------------------------
SystemError                               Traceback (most recent call last)
Cell In [3], line 1
----> 1 zeta(-RealNumber('0.01') + ComplexNumber(0, '1000'))

File /usr/lib/python3.11/site-packages/mpmath/functions/zeta.py:580, in zeta(ctx, s, a, derivative, method, **kwargs)
    578 if ctx.re(s) > 2*ctx.prec and a == 1 and not derivative:
    579     return ctx.one + ctx.power(2, -s)
--> 580 return +ctx._hurwitz(s, a, d, **kwargs)

File /usr/lib/python3.11/site-packages/mpmath/functions/zeta.py:595, in _hurwitz(ctx, s, a, d, **kwargs)
    593     print("zeta: Attempting reflection formula")
    594 try:
--> 595     return _hurwitz_reflection(ctx, s, a, d, atype)
    596 except NotImplementedError:
    597     pass

File /usr/lib/python3.11/site-packages/mpmath/functions/zeta.py:654, in _hurwitz_reflection(ctx, s, a, d, atype)
    652 p += shift*q
    653 assert 1 <= p <= q
--> 654 g = ctx.fsum(ctx.cospi(t/2-2*k*b)*ctx._hurwitz(t,(k,q)) \
    655     for k in range(1,q+1))
    656 g *= 2*ctx.gamma(t)/(2*ctx.pi*q)**t
    657 v += g

File /mnt/opt/Sage/sage-dev/src/sage/libs/mpmath/ext_main.pyx:767, in sage.libs.mpmath.ext_main.Context.fsum()
    765 workopts.rounding = ROUND_D
    766 unknown = global_context.zero
--> 767 sig_on()
    768 try:  # Way down, there is a ``finally`` with sig_off()
    769     MPF_init(&sre)

SystemError: calling remove_from_pari_stack() inside sig_on()
```

