### PR TITLE
CI Linux: Run `ubuntu-focal-standard` without waiting for other platforms

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -34,8 +34,7 @@ permissions:
 
 jobs:
 
-  # The default platform used by build.yml etc.
-
+  # standard-pre for the default platform (used by build.yml etc.)
   default-pre:
     uses: ./.github/workflows/docker.yml
     with:
@@ -49,6 +48,7 @@ jobs:
         ["standard"]
       docker_push_repository: ghcr.io/${{ github.repository }}/
 
+  # standard for the default platform (used by build.yml etc.)
   default:
     if: ${{ success() || failure() }}
     needs: [default-pre]

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -34,7 +34,46 @@ permissions:
 
 jobs:
 
+  # The default platform used by build.yml etc.
+
+  default-pre:
+    uses: ./.github/workflows/docker.yml
+    with:
+      # Build from scratch
+      docker_targets: "with-system-packages configured with-targets-pre"
+      # FIXME: duplicated from env.TARGETS
+      targets_pre: all-sage-local
+      tox_system_factors: >-
+        ["ubuntu-focal"]
+      tox_packages_factors: >-
+        ["standard"]
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+
+  default:
+    if: ${{ success() || failure() }}
+    needs: [default-pre]
+    uses: ./.github/workflows/docker.yml
+    with:
+      # Build incrementally from previous stage (pre)
+      incremental: true
+      free_disk_space: true
+      from_docker_repository: ghcr.io/${{ github.repository }}/
+      from_docker_target: "with-targets-pre"
+      docker_targets: "with-targets with-targets-optional"
+      # FIXME: duplicated from env.TARGETS
+      targets: build doc-html
+      targets_optional: ptest
+      tox_system_factors: >-
+        ["ubuntu-focal"]
+      tox_packages_factors: >-
+          ["standard"]
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+
+  # All platforms. This duplicates the default platform, but why not,
+  # it makes it more robust regarding random timeouts.
+
   standard-pre:
+    if: ${{ success() || failure() }}
     uses: ./.github/workflows/docker.yml
     with:
       # Build from scratch


### PR DESCRIPTION
This is so that the image for "build.yml" etc. is ready faster.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
