### PR TITLE
CI / tox: Update and speed up pyright

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,20 +103,9 @@ jobs:
           MAKE: make -j2 --output-sync=recurse
           SAGE_NUM_THREADS: 2
 
-      - name: Set up node to install pyright
-        if: always() && steps.worktree.outcome == 'success'
-        uses: actions/setup-node@v3
-        with:
-          node-version: '12'
-
-      - name: Install pyright
-        if: always() && steps.worktree.outcome == 'success'
-        # Fix to v232 due to bug https://github.com/microsoft/pyright/issues/3239
-        run: npm install -g pyright@1.1.232
-
       - name: Static code check with pyright
         if: always() && steps.worktree.outcome == 'success'
-        run: pyright
+        run: ./sage -tox -e pyright
         working-directory: ./worktree-image
 
       - name: Clean (fallback to non-incremental)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -22,6 +22,7 @@
     "reportUndefinedVariable": "warning",
     "reportOptionalOperand": "warning",
     "reportMissingImports": "warning",
+    "reportPrivateImportUsage": "warning",
     // Suppress because it flags our standard pattern @staticmethod __classcall__(cls, ...)
     "reportSelfClsParameterName": "none",
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -22,5 +22,6 @@
     "reportUndefinedVariable": "warning",
     "reportOptionalOperand": "warning",
     "reportMissingImports": "warning",
+    // Suppress because it flags our standard pattern @staticmethod __classcall__(cls, ...)
     "reportSelfClsParameterName": "none",
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -22,4 +22,5 @@
     "reportUndefinedVariable": "warning",
     "reportOptionalOperand": "warning",
     "reportMissingImports": "warning",
+    "reportSelfClsParameterName": "none",
 }

--- a/src/sage/misc/lazy_attribute.pyi
+++ b/src/sage/misc/lazy_attribute.pyi
@@ -1,3 +1,9 @@
 # This type-stub file helps pyright understand the decorator @lazy_attribute.
 
-lazy_attribute = property
+# Adapted from https://github.com/python/typeshed/blob/b9640005eb586afdbe0a57bac2b88a7a12465069/stdlib/builtins.pyi#L1237-L1254
+class lazy_attribute:
+    def __init__(
+        self,
+        f: Callable[[Any], Any] | None = ...
+    ) -> None: ...
+    def __get__(self, a: Any, cls: type) -> Any: ...

--- a/src/sage/misc/lazy_attribute.pyi
+++ b/src/sage/misc/lazy_attribute.pyi
@@ -1,0 +1,1 @@
+lazy_attribute = property

--- a/src/sage/misc/lazy_attribute.pyi
+++ b/src/sage/misc/lazy_attribute.pyi
@@ -1,1 +1,3 @@
+# This type-stub file helps pyright understand the decorator @lazy_attribute.
+
 lazy_attribute = property

--- a/src/sage/schemes/toric/variety.py
+++ b/src/sage/schemes/toric/variety.py
@@ -2250,20 +2250,21 @@ class ToricVariety_field(AmbientSpace):
             1
         """
         Td = QQ.one()
-        if self.dimension() >= 1:
+        dim = self.dimension()
+        if dim >= 1:
             c1 = self.Chern_class(1)
             Td += QQ.one() / 2 * c1
-        if self.dimension() >= 2:
-            c2 = self.Chern_class(2)
-            Td += QQ.one() / 12 * (c1**2 + c2)
-        if self.dimension() >= 3:
-            Td += QQ.one() / 24 * c1*c2
-        if self.dimension() >= 4:
-            c3 = self.Chern_class(3)
-            c4 = self.Chern_class(4)
-            Td += -QQ.one() / 720 * (c1**4 - 4*c1**2*c2 - 3*c2**2 - c1*c3 + c4)
-        if self.dimension() >= 5:
-            raise NotImplementedError('Todd class is currently only implemented up to degree 4')
+            if dim >= 2:
+                c2 = self.Chern_class(2)
+                Td += QQ.one() / 12 * (c1**2 + c2)
+                if dim >= 3:
+                    Td += QQ.one() / 24 * c1*c2
+                    if dim >= 4:
+                        c3 = self.Chern_class(3)
+                        c4 = self.Chern_class(4)
+                        Td += -QQ.one() / 720 * (c1**4 - 4*c1**2*c2 - 3*c2**2 - c1*c3 + c4)
+                        if dim >= 5:
+                            raise NotImplementedError('Todd class is currently only implemented up to degree 4')
         if deg is None:
             return Td
         else:

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -78,12 +78,13 @@ commands =
 [testenv:pyright]
 description =
     run the static typing checker pyright
-deps = pyright
+deps =
+    pyright
 setenv =
     {[sagedirect]setenv}
     HOME={envdir}
-    # Fix version, see .github/workflows/build.yml
-    PYRIGHT_PYTHON_FORCE_VERSION=1.1.232
+    PYRIGHT_PYTHON_FORCE_VERSION=latest
+    PYRIGHT_PYTHON_GLOBAL_NODE=false
 allowlist_externals = {[sagedirect]allowlist_externals}
 ## We run pyright from within the sage-env so that SAGE_LOCAL is available.
 ## pyright is already configured via SAGE_ROOT/pyrightconfig.json to use our venv.

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -85,6 +85,7 @@ setenv =
     HOME={envdir}
     PYRIGHT_PYTHON_FORCE_VERSION=1.1.332
     PYRIGHT_PYTHON_GLOBAL_NODE=false
+    NODE_OPTIONS=--max-old-space-size=8192
 allowlist_externals = {[sagedirect]allowlist_externals}
 ## We run pyright from within the sage-env so that SAGE_LOCAL is available.
 ## pyright is already configured via SAGE_ROOT/pyrightconfig.json to use our venv.

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -83,15 +83,14 @@ deps =
 setenv =
     {[sagedirect]setenv}
     HOME={envdir}
-    PYRIGHT_PYTHON_FORCE_VERSION=1.1.331
+    PYRIGHT_PYTHON_FORCE_VERSION=1.1.332
     PYRIGHT_PYTHON_GLOBAL_NODE=false
 allowlist_externals = {[sagedirect]allowlist_externals}
 ## We run pyright from within the sage-env so that SAGE_LOCAL is available.
 ## pyright is already configured via SAGE_ROOT/pyrightconfig.json to use our venv.
 ##
-## Running pyright on the whole Sage source tree takes very long
-## and may run out of memory. When no files/directories are given, just run it
-## on the packages that already have typing annotations.
+## Note that running pyright on the whole Sage source tree (= default) takes very long
+## and may run out of memory.
 commands =
     {env:SAGE} -sh -c 'pyright {posargs:}'
 

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -93,7 +93,7 @@ allowlist_externals = {[sagedirect]allowlist_externals}
 ## and may run out of memory. When no files/directories are given, just run it
 ## on the packages that already have typing annotations.
 commands =
-    {env:SAGE} -sh -c 'pyright {posargs:{toxinidir}/sage/combinat {toxinidir}/sage/manifolds}'
+    {env:SAGE} -sh -c 'pyright {posargs:}'
 
 [testenv:pycodestyle]
 description =

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -83,7 +83,7 @@ deps =
 setenv =
     {[sagedirect]setenv}
     HOME={envdir}
-    PYRIGHT_PYTHON_FORCE_VERSION=latest
+    PYRIGHT_PYTHON_FORCE_VERSION=1.1.331
     PYRIGHT_PYTHON_GLOBAL_NODE=false
 allowlist_externals = {[sagedirect]allowlist_externals}
 ## We run pyright from within the sage-env so that SAGE_LOCAL is available.


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

We bring `tox -e pyright` and the pyright invocation that is part of the CI "Build & Test" back in sync:
- They are now both pinned to today's latest pyright version
- node.js is provisioned via https://pypi.org/project/pyright/ and never accepts a preinstalled node version 
- node.js is configured to provide sufficient heap size. This reduces the runtime dramatically as pyright no longer has to fight with the garbage collector and eliminates spurious out of memory conditions.
- Both run on the entire source tree.

This is done so that even if the output of pyright may be incomprehensible to developers, at least there are no gratuitous differences between what's shown on CI and what is shown locally.

Also done as part of this ticket: A limited effort to get rid of some warnings, just enough to establish that it would be  premature to create problem matchers that annotate these warnings in the source code. Most of the warnings are meaningless and distracting noise because pyright is struggling with too many aspects of the Sage source code: lazy imports, methods in `ParentMethods`, `ElementMethods`, etc. 

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->
- #36515 (split out from here)
- #36516 (split out from here)
- #36517 (split out from here)

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
