### PR TITLE
fix ZeroDivisionError in gcd of sparse polynomials

### DIFF
--- a/src/sage/rings/polynomial/polynomial_element_generic.py
+++ b/src/sage/rings/polynomial/polynomial_element_generic.py
@@ -953,6 +953,17 @@ class Polynomial_generic_sparse(Polynomial):
             1
             sage: (6*x).gcd(9)
             3
+
+        Check that :trac:`36427` is fixed::
+
+            sage: P = PolynomialRing(ZZ, "q", sparse=True)
+            sage: q = P.gen()
+            sage: 2*q^-100
+            2/q^100
+            sage: gcd(1, q^100)
+            1
+            sage: gcd(q^0, q^100)
+            1
         """
 
         from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
@@ -969,8 +980,8 @@ class Polynomial_generic_sparse(Polynomial):
             # <https://groups.google.com/d/msg/sage-devel/6qhW90dgd1k/Hoq3N7fWe4QJ>
             sd = self.degree()
             od = other.degree()
-            if max(sd,od) < 100 or \
-               min(len(self.__coeffs)/sd, len(other.__coeffs)/od) > .06:
+            if ((sd < 100 or len(self.__coeffs)/sd > .06)
+                    and (od < 100 or len(other.__coeffs)/od > .06)):
                 implementation = "FLINT"
             else:
                 implementation = "NTL"


### PR DESCRIPTION
Fixes #36427

As pointed out in #36427, attempting to calculate the gcd of two sparse polynomials raises a `ZeroDivisionError` if one of the polynomials is constant, and the other has large degree (at least 100). 

This is caused by an error in the code that tests whether converting either of the polynomials to FLINT will be very slow. To fix this, we check each polynomial individually, instead of trying to consider both polynomials at once.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
