### PR TITLE
Remove `tomli` from some build dependencies

### DIFF
--- a/build/pkgs/backcall/dependencies
+++ b/build/pkgs/backcall/dependencies
@@ -1,4 +1,4 @@
- | $(PYTHON_TOOLCHAIN) flit_core tomli $(PYTHON)
+ | $(PYTHON_TOOLCHAIN) flit_core $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/entrypoints/dependencies
+++ b/build/pkgs/entrypoints/dependencies
@@ -1,4 +1,4 @@
- | $(PYTHON_TOOLCHAIN) flit_core tomli $(PYTHON)
+ | $(PYTHON_TOOLCHAIN) flit_core $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pyparsing/dependencies
+++ b/build/pkgs/pyparsing/dependencies
@@ -1,4 +1,4 @@
- | pip wheel flit_core tomli $(PYTHON)
+ | pip wheel flit_core $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/tomli/spkg-install.in
+++ b/build/pkgs/tomli/spkg-install.in
@@ -1,7 +1,2 @@
 cd src
-# tomli's build system, flit_core, has a runtime dependency on tomli.
-# Hence we make the uninstalled tomli sources available during the installation
-# and disable build isolation -- which would require a tomli wheel to
-# be available for setting up the build environment.
-export PYTHONPATH="$(pwd)"
-sdh_pip_install --no-build-isolation .
+sdh_pip_install .


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

No longer needed because our current version of `flit_core` vendors it.

Also eliminates one use of `--no-build-isolation`.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
