### PR TITLE
add default legend_color to eliminate KeyError when plotting arrow2d or disk

### DIFF
--- a/src/sage/combinat/root_system/plot.py
+++ b/src/sage/combinat/root_system/plot.py
@@ -1349,7 +1349,7 @@ class PlotOptions():
         - ``alpha`` -- a number in the interval `[0, 1]` (default: `1`)
           the desired transparency
 
-        - ``label`` -- an object to be used as for this cone.
+        - ``label`` -- an object to be used as the label for this cone.
           The label itself will be constructed by calling
           :func:`~sage.misc.latex.latex` or :func:`repr` on the
           object depending on the graphics backend.

--- a/src/sage/plot/arrow.py
+++ b/src/sage/plot/arrow.py
@@ -644,7 +644,7 @@ def arrow2d(tailpoint=None, headpoint=None, path=None, **options):
 
     TESTS:
 
-    Verify that :trac:`36153` is fixed::
+    Verify that :issue:`36153` is fixed::
 
         sage: A = arrow2d((-1,-1), (2,3), legend_label="test")
     """

--- a/src/sage/plot/arrow.py
+++ b/src/sage/plot/arrow.py
@@ -489,7 +489,8 @@ def arrow(tailpoint=None, headpoint=None, **kwds):
 
 
 @rename_keyword(color='rgbcolor')
-@options(width=2, rgbcolor=(0,0,1), zorder=2, head=1, linestyle='solid', legend_label=None)
+@options(width=2, rgbcolor=(0,0,1), zorder=2, head=1, linestyle='solid',
+         legend_label=None, legend_color=None)
 def arrow2d(tailpoint=None, headpoint=None, path=None, **options):
     """
     If ``tailpoint`` and ``headpoint`` are provided, returns an arrow from
@@ -640,6 +641,12 @@ def arrow2d(tailpoint=None, headpoint=None, path=None, **options):
     ::
 
         sage: arrow2d((-2,2), (7,1)).show(frame=True)
+
+    TESTS:
+
+    Verify that :trac:`36153` is fixed::
+
+        sage: A = arrow2d((-1,-1), (2,3), legend_label="test")
     """
     from sage.plot.all import Graphics
     g = Graphics()

--- a/src/sage/plot/circle.py
+++ b/src/sage/plot/circle.py
@@ -406,6 +406,10 @@ def circle(center, radius, **options):
         sage: P = circle((1,1), 1)
         sage: P.aspect_ratio()
         1.0
+
+    Verify that :trac:`36153` does not arise::
+
+        sage: C = circle((1,1), 1, legend_label="test")
     """
     from sage.plot.all import Graphics
 

--- a/src/sage/plot/circle.py
+++ b/src/sage/plot/circle.py
@@ -407,7 +407,7 @@ def circle(center, radius, **options):
         sage: P.aspect_ratio()
         1.0
 
-    Verify that :trac:`36153` does not arise::
+    Verify that :issue:`36153` does not arise::
 
         sage: C = circle((1,1), 1, legend_label="test")
     """

--- a/src/sage/plot/disk.py
+++ b/src/sage/plot/disk.py
@@ -247,7 +247,7 @@ class Disk(GraphicPrimitive):
 
 @rename_keyword(color='rgbcolor')
 @options(alpha=1, fill=True, rgbcolor=(0, 0, 1), thickness=0, legend_label=None,
-         aspect_ratio=1.0)
+         legend_color=None, aspect_ratio=1.0)
 def disk(point, radius, angle, **options):
     r"""
     A disk (that is, a sector or wedge of a circle) with center
@@ -346,6 +346,10 @@ def disk(point, radius, angle, **options):
         Traceback (most recent call last):
         ...
         ValueError: the center point of a plotted disk should have two or three coordinates
+
+    Verify that :trac:`36153` is fixed::
+
+        sage: D = disk((0, 0), 5, (0, pi/2), legend_label="test")
     """
     from sage.plot.all import Graphics
     g = Graphics()

--- a/src/sage/plot/disk.py
+++ b/src/sage/plot/disk.py
@@ -347,7 +347,7 @@ def disk(point, radius, angle, **options):
         ...
         ValueError: the center point of a plotted disk should have two or three coordinates
 
-    Verify that :trac:`36153` is fixed::
+    Verify that :issue:`36153` is fixed::
 
         sage: D = disk((0, 0), 5, (0, pi/2), legend_label="test")
     """

--- a/src/sage/plot/ellipse.py
+++ b/src/sage/plot/ellipse.py
@@ -345,6 +345,11 @@ def ellipse(center, r1, r2, angle=0, **options):
         E=ellipse((0,0),2,1,legend_label="My ellipse", legend_color='green')
         sphinx_plot(E)
 
+    TESTS:
+
+    Verify that :trac:`36153` does not arise::
+
+        sage: E = ellipse((0,0), 2, 1, legend_label="test")
     """
     from sage.plot.all import Graphics
     g = Graphics()

--- a/src/sage/plot/ellipse.py
+++ b/src/sage/plot/ellipse.py
@@ -347,7 +347,7 @@ def ellipse(center, r1, r2, angle=0, **options):
 
     TESTS:
 
-    Verify that :trac:`36153` does not arise::
+    Verify that :issue:`36153` does not arise::
 
         sage: E = ellipse((0,0), 2, 1, legend_label="test")
     """

--- a/src/sage/plot/point.py
+++ b/src/sage/plot/point.py
@@ -580,7 +580,7 @@ def point2d(points, **options):
        sage: point2d(iter([]))
        Graphics object consisting of 0 graphics primitives
 
-    Verify that :trac:`36153` does not arise::
+    Verify that :issue:`36153` does not arise::
 
         sage: P = point((0.5, 0.5), legend_label="test")
     """

--- a/src/sage/plot/point.py
+++ b/src/sage/plot/point.py
@@ -579,6 +579,10 @@ def point2d(points, **options):
 
        sage: point2d(iter([]))
        Graphics object consisting of 0 graphics primitives
+
+    Verify that :trac:`36153` does not arise::
+
+        sage: P = point((0.5, 0.5), legend_label="test")
     """
     from sage.plot.plot import xydata_from_point_list
     from sage.plot.all import Graphics

--- a/src/sage/plot/polygon.py
+++ b/src/sage/plot/polygon.py
@@ -524,10 +524,15 @@ def polygon2d(points, **options):
         sage: polygon2d([[1,2], [5,6], [5,0]]).aspect_ratio()
         1.0
 
+    TESTS:
+
+    Verify that :trac:`36153` does not arise::
+
+        sage: P = polygon2d([[1,2], [5,6], [5,0]], legend_label="test")
+
     AUTHORS:
 
     - David Joyner (2006-04-14): the long list of examples above.
-
     """
     from sage.plot.plot import xydata_from_point_list
     from sage.plot.all import Graphics

--- a/src/sage/plot/polygon.py
+++ b/src/sage/plot/polygon.py
@@ -526,7 +526,7 @@ def polygon2d(points, **options):
 
     TESTS:
 
-    Verify that :trac:`36153` does not arise::
+    Verify that :issue:`36153` does not arise::
 
         sage: P = polygon2d([[1,2], [5,6], [5,0]], legend_label="test")
 


### PR DESCRIPTION
Fixes #36153.

The line `g._legend_colors = [options['legend_color']]` appears in the code for seven graphics objects. Five of them (`circle`, `ellipse`, `line2d`, `point2d`, and  `polygon2d`) set `None` as the default value for `legend_color`. The other two (`arrow2d` and `disk`) do not set a default, so a `KeyError` is raised if a `legend_label` is supplied, but no `legend_color` is specified. This bug was pointed out in #36153.

This PR adds `None` as the default value of `legend_color` in `arrow2d` and `disk`. 

It also adds the corresponding doctest to all seven of these graphics objects, except `line2d`, which already has the example `line([(0,0),(1,1)], legend_label='line')`.

The PR also corrects a typo in the docstring of the `cone` graphic object.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
