### PR TITLE
remove unused variables in pyx files in groups/

### DIFF
--- a/src/sage/groups/perm_gps/partn_ref/canonical_augmentation.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/canonical_augmentation.pyx
@@ -183,13 +183,9 @@ cdef void *canonical_generator_next(void *can_gen_data, int *degree, bint *mem_e
     cdef void *next_candidate
     cdef void *parent_cand
     cdef void *aug
-    cdef int i, next_cand_deg, parent_cand_deg
-    cdef int *isom
+    cdef int next_cand_deg, parent_cand_deg
     cdef PartitionStack *part
     cdef bint augmentation_is_canonical
-    cdef aut_gp_and_can_lab *output
-    cdef agcl_work_space *agcl_ws
-    cdef dc_work_space *dc_ws
 
     if cgd.level == 0:
         if cgd.mem_err:
@@ -344,6 +340,7 @@ cdef canonical_generator_data *allocate_cgd(int max_depth, int degree):
     cgd.degree_stack[0] = degree
     return cgd
 
+
 cdef void deallocate_cgd(canonical_generator_data *cgd):
     r"""
     Deallocate the data part of the canonical generation iterator struct.
@@ -351,8 +348,6 @@ cdef void deallocate_cgd(canonical_generator_data *cgd):
     if cgd is NULL:
         return
     cdef int i
-    cdef void *thingy
-    cdef void (*clearer)(void*)
     for i from 0 <= i < cgd.allocd_levels:
         if cgd.agcl_work_spaces[i] is not NULL:
             deallocate_agcl_work_space(cgd.agcl_work_spaces[i])

--- a/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/data_structures.pyx
@@ -45,7 +45,6 @@ cdef inline OrbitPartition *OP_new(int n):
     Allocate and return a pointer to a new OrbitPartition of degree n. Returns a
     null pointer in the case of an allocation failure.
     """
-    cdef int i
     cdef OrbitPartition *OP = <OrbitPartition *> \
                                 sig_malloc(sizeof(OrbitPartition))
     cdef int *int_array = <int *> sig_malloc( 4*n * sizeof(int) )
@@ -185,7 +184,6 @@ cdef inline PartitionStack *PS_new(int n, bint unit_partition):
     Allocate and return a pointer to a new PartitionStack of degree n. Returns a
     null pointer in the case of an allocation failure.
     """
-    cdef int i
     cdef PartitionStack *PS = <PartitionStack *> \
                                 sig_malloc(sizeof(PartitionStack))
     cdef int *int_array = <int *> sig_malloc( 2*n * sizeof(int) )
@@ -210,7 +208,7 @@ cdef void PS_unit_partition(PartitionStack *PS):
     for i in range(n - 1):
         PS.entries[i] = i
         PS.levels[i] = n
-    PS.entries[n-1] = n-1
+    PS.entries[n-1] = n - 1
     PS.levels[n-1] = -1
 
 cdef inline PartitionStack *PS_copy(PartitionStack *PS):
@@ -218,7 +216,7 @@ cdef inline PartitionStack *PS_copy(PartitionStack *PS):
     Allocate and return a pointer to a copy of PartitionStack PS. Returns a null
     pointer in the case of an allocation failure.
     """
-    cdef int i, n = PS.degree
+    cdef int n = PS.degree
 
     cdef PartitionStack *PS2 = <PartitionStack *> \
                                 sig_malloc(sizeof(PartitionStack))
@@ -327,7 +325,6 @@ cdef int PS_all_new_cells(PartitionStack *PS, bitset_t** nonsingletons_ptr):
     Return the number of rows of ``nonsingletons_ptr``.
     """
     cdef int beg=0, end, n = PS.degree, count=0, i, n_1 = n-1
-    cdef bint non_unit_partition = False
     cdef bitset_t scratch
     bitset_init(scratch, n)
     cdef bitset_t* nonsingletons = nonsingletons_ptr[0]
@@ -561,10 +558,6 @@ cdef StabilizerChain *SC_new(int n, bint init_gens=True):
     cdef int i
     cdef StabilizerChain *SC = <StabilizerChain *> \
                                 sig_calloc(1, sizeof(StabilizerChain))
-    cdef int *array1
-    cdef int *array2
-    cdef int *array3
-    cdef bint mem_err = 0
     if SC is NULL:
         return NULL
     SC.degree = n
@@ -762,7 +755,6 @@ cdef int SC_realloc_bitsets(StabilizerChain *SC, unsigned long size):
     cdef unsigned long new_size = size_old
     while new_size < size:
         new_size *= 2
-    cdef unsigned long limbs_old = SC.gen_used.limbs
     cdef long limbs = (new_size - 1)/(8*sizeof(unsigned long)) + 1
     cdef mp_limb_t *tmp = <mp_limb_t*> sig_realloc(SC.gen_used.bits, limbs * sizeof(mp_limb_t))
     if tmp is not NULL:
@@ -866,7 +858,7 @@ cdef StabilizerChain *SC_new_base(StabilizerChain *SC, int *base, int base_len):
     return NEW
 
 cdef int SC_new_base_nomalloc(StabilizerChain *SC_dest, StabilizerChain *SC, int *base, int base_len):
-    cdef int i, n = SC.degree
+    cdef int i
     SC_dest.base_size = 0
     for i in range(base_len):
         SC_add_base_point(SC_dest, base[i])
@@ -937,7 +929,7 @@ cdef StabilizerChain *SC_insert_base_point(StabilizerChain *SC, int level, int p
     return NEW
 
 cdef int SC_insert_base_point_nomalloc(StabilizerChain *SC_dest, StabilizerChain *SC, int level, int p):
-    cdef int i, b, n = SC.degree
+    cdef int i, b
     SC_copy_nomalloc(SC_dest, SC, level)
     SC_add_base_point(SC_dest, p)
     for i in range(level, SC.base_size):
@@ -956,7 +948,7 @@ cdef int SC_re_tree(StabilizerChain *SC, int level, int *perm, int x):
     """
     cdef int *gen
     cdef int *gen_inv
-    cdef int i, b, gen_index, error, n = SC.degree
+    cdef int i, b, gen_index, n = SC.degree
 
     # make sure we have room for the new generator:
     if SC.array_size[level] == SC.num_gens[level]:
@@ -1027,7 +1019,6 @@ cdef int SC_sift(StabilizerChain *SC, int level, int x, int *gens, int num_gens,
     cdef int y, b = SC.base_orbits[level][0]
     cdef int *perm
     cdef int *perm_rep_inv = temp
-    cdef int j
     for i from 0 <= i < num_gens:
         perm = new_gens + n*i # this is now rs
         y = perm[b]
@@ -1039,7 +1030,6 @@ cdef int SC_sift(StabilizerChain *SC, int level, int x, int *gens, int num_gens,
 cdef int SC_insert_and_sift(StabilizerChain *SC, int level, int *pi, int num_perms, bint sift):
     cdef int i, j, b, n = SC.degree
     cdef int perm_gen_index
-    cdef int max_orbit_size, max_orbit_place
     if sift:
         if SC_realloc_bitsets(SC, num_perms):
             return 1
@@ -1065,13 +1055,11 @@ cdef int SC_insert_and_sift(StabilizerChain *SC, int level, int *pi, int num_per
 
     # Record the old orbit elements and the old generators (see sifting phase)
     cdef int old_num_gens = SC.num_gens[level]
-    cdef int old_num_points = SC.orbit_sizes[level]
 
     # Add new points to the tree:
     cdef int x
     cdef int *perm
     cdef int start_over = 1
-    cdef int error
     cdef int re_treed = 0
     while start_over:
         start_over = 0

--- a/src/sage/groups/perm_gps/partn_ref/refinement_binary.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/refinement_binary.pyx
@@ -235,9 +235,8 @@ cdef class LinearBinaryCodeStruct(BinaryCodeStruct):
             sage: B = LinearBinaryCodeStruct(M)
             sage: B.automorphism_group()[1]
             17868913969917295853568000000
-
         """
-        cdef int i, n = self.degree
+        cdef int n = self.degree
         cdef PartitionStack *part
         if partition is None:
             part = PS_new(n, 1)
@@ -650,7 +649,7 @@ cdef int refine_by_bip_degree(PartitionStack *col_ps, void *S, int *cells_to_ref
     """
     cdef BinaryCodeStruct BCS = <BinaryCodeStruct> S
     cdef int current_cell_against = 0
-    cdef int current_cell, i, r, j
+    cdef int current_cell, i, r
     cdef int first_largest_subcell
     cdef int invariant = 0
     cdef PartitionStack *word_ps = BCS.word_ps
@@ -970,7 +969,7 @@ cdef inline int word_degree(PartitionStack *word_ps, BinaryCodeStruct BCS, int e
         of PS
     """
     cdef bitset_t cell, word
-    cdef int i, h
+    cdef int h
     bitset_init(cell, BCS.degree)
     bitset_zero(cell)
     bitset_init(word, BCS.degree)
@@ -1001,7 +1000,7 @@ cdef inline int col_degree(PartitionStack *col_ps, BinaryCodeStruct BCS, int ent
     """
     cdef bitset_t word
     bitset_init(word, BCS.degree)
-    cdef int degree = 0, word_basis, i, b
+    cdef int degree = 0
     entry = col_ps.entries[entry]
     while True:
         BCS.ith_word(BCS, word_ps.entries[cell_index], word)
@@ -1017,15 +1016,14 @@ cdef inline int sort_by_function_codes(PartitionStack *PS, int start, int *degre
     A simple counting sort, given the degrees of vertices to a certain cell.
 
     INPUT:
-    PS -- the partition stack to be checked
-    start -- beginning index of the cell to be sorted
-    degrees -- the values to be sorted by
-    count, count_max, output -- scratch space
 
+    - PS -- the partition stack to be checked
+    - start -- beginning index of the cell to be sorted
+    - degrees -- the values to be sorted by
+    - count, count_max, output -- scratch space
     """
-    cdef int n = PS.degree
     cdef int i, j, max, max_location
-    for j from 0 <= j < count_max:
+    for j in range(count_max):
         counts[j] = 0
     i = 0
     while PS.levels[i+start] > PS.depth:

--- a/src/sage/groups/perm_gps/partn_ref/refinement_graphs.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/refinement_graphs.pyx
@@ -65,7 +65,7 @@ def isomorphic(G1, G2, partn, ordering2, dig, use_indicator_function, sparse=Fal
     cdef GraphStruct GS1 = GraphStruct()
     cdef GraphStruct GS2 = GraphStruct()
     cdef GraphStruct GS
-    cdef int i, j, k, n = -1, cell_len
+    cdef int i, j, n = -1
     cdef list partition, cell
     cdef bint loops = 0
 
@@ -131,7 +131,6 @@ def isomorphic(G1, G2, partn, ordering2, dig, use_indicator_function, sparse=Fal
             raise TypeError("G must be a Sage graph")
         if first:
             frm1 = frm
-            to1 = to
         else:
             frm2 = frm
             to2 = to
@@ -464,7 +463,6 @@ def search_tree(G_in, partition, lab=True, dig=False, dict_rep=False, certificat
         sig_free(GS.scratch)
         raise MemoryError
 
-    lab_new = lab or certificate
     output = get_aut_gp_and_can_lab(<void *>GS, part, G.num_verts, &all_children_are_equivalent, &refine_by_degree, &compare_graphs, lab, NULL, NULL, NULL)
     sig_free( GS.scratch )
     # prepare output
@@ -693,7 +691,6 @@ cdef bint all_children_are_equivalent(PartitionStack *PS, void *S):
     cdef GraphStruct GS = <GraphStruct> S
     if GS.directed or GS.loops:
         return 0
-    cdef CGraph G = GS.G
     cdef int i, n = PS.degree
     cdef bint in_cell = 0
     cdef int nontrivial_cells = 0
@@ -1147,7 +1144,7 @@ cdef void *apply_dg_edge_aug(void *parent, void *aug, void *child, int *degree, 
     cdef GraphStruct GS_child = <GraphStruct> child, GS_par = <GraphStruct> parent
     cdef DenseGraph DG = <DenseGraph> GS_child.G, DG_par = <DenseGraph> GS_par.G
     cdef subset *edge = <subset *> aug
-    cdef int u, v, n = DG_par.num_verts
+    cdef int u, v
 
     # copy DG_par edges to DG
     copy_dense_graph(DG, DG_par)
@@ -1353,7 +1350,6 @@ def generate_dense_graphs_edge_addition(int n, bint loops, G=None, depth=None,
 
     cdef list out_list
     cdef void *thing
-    cdef GraphStruct thing_gs
     cdef Integer number
     cdef bint mem_err = 0
     if construct:
@@ -1476,7 +1472,7 @@ cdef void *canonical_dg_vert_parent(void *child, void *parent, int *permutation,
     """
     cdef GraphStruct GS_par = <GraphStruct> parent, GS = <GraphStruct> child
     cdef DenseGraph DG_par = <DenseGraph> GS_par.G, DG = <DenseGraph> GS.G
-    cdef int u, v, n = DG_par.num_verts
+    cdef int u, n = DG_par.num_verts
     cdef int *scratch = GS.scratch
 
     # copy DG edges to DG_par
@@ -1630,7 +1626,6 @@ def generate_dense_graphs_vert_addition(int n, base_G=None,
 
     cdef list out_list
     cdef void *thing
-    cdef GraphStruct thing_gs
     cdef Integer number
     cdef bint mem_err = 0
     if construct:


### PR DESCRIPTION
This removes unused variables in pyx files in the groups folder.

Found using cython-lint


### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.