### PR TITLE
fix doctest in `src/sage/combinat/posets/posets.py`

### DIFF
--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -1374,8 +1374,8 @@ class FinitePoset(UniqueRepresentation, Parent):
             sage: print(P._latex_())  # optional - dot2tex graphviz
             \begin{tikzpicture}[>=latex,line join=bevel,]
             %%
-            \node (node_...) at (5...bp,...bp) [draw,draw=none] {$...$};
-              \node (node_...) at (5...bp,...bp) [draw,draw=none] {$...$};
+            \node (node_...) at (...bp,...bp) [draw,draw=none] {$...$};
+              \node (node_...) at (...bp,...bp) [draw,draw=none] {$...$};
               \draw [black,->] (node_...) ..controls (...bp,...bp) and (...bp,...bp)  .. (node_...);
             %
             \end{tikzpicture}


### PR DESCRIPTION
The following doctest in `sage/combinat/posets/posets.py" is failing on some systems, e.g., here on fedora 35.

```py
sage -t --long --warn-long 14.4 --random-seed=28988349073943040517554297060681045316 src/sage/combinat/posets/posets.py
**********************************************************************
File "src/sage/combinat/posets/posets.py", line 1374, in sage.combinat.posets.posets.FinitePoset._latex_
Failed example:
    print(P._latex_())  # optional - dot2tex graphviz
Expected:
    \begin{tikzpicture}[>=latex,line join=bevel,]
    %%
    \node (node_...) at (5...bp,...bp) [draw,draw=none] {$...$};
      \node (node_...) at (5...bp,...bp) [draw,draw=none] {$...$};
      \draw [black,->] (node_...) ..controls (...bp,...bp) and (...bp,...bp)  .. (node_...);
    %
    \end{tikzpicture}
Got:
    \begin{tikzpicture}[>=latex,line join=bevel,]
    %%
    \node (node_0) at (6.0bp,6.5bp) [draw,draw=none] {$1$};
      \node (node_1) at (6.0bp,55.5bp) [draw,draw=none] {$2$};
      \draw [black,->] (node_0) ..controls (6.0bp,19.603bp) and (6.0bp,30.062bp)  .. (node_1);
    %
    \end{tikzpicture}
```
### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
