### PR TITLE
add ruff to developer tools

### DIFF
--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -225,7 +225,7 @@ Ruff
 ====
 
 `Ruff <https://pypi.org/project/ruff/>`_ is a powerful and fast linter
-for Python code, written in C.
+for Python code, written in Rust.
 
 It comes with a large choice of possible checks, and has the capacity
 to fix some of the warnings it emits.

--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -219,6 +219,17 @@ Cython-lint
 `Cython-lint <https://pypi.org/project/cython-lint/>`_ checks Cython source files
 for coding style.
 
+.. _section-tools-ruff:
+
+Ruff
+====
+
+`Ruff <https://pypi.org/project/ruff/>`_ is a powerful and fast linter
+for Python code, written in C.
+
+It comes with a large choice of possible checks, and has the capacity
+to fix some of the warnings it emits.
+
 .. _section-tools-relint:
 
 Relint


### PR DESCRIPTION
This is just adding the fast linter `ruff` to the developer guide as yet another of our tools-of-the-trade.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
