### PR TITLE
Fix bootstrapping on `centos-7`, `fedora-30`, `ubuntu-xenial`

### DIFF
--- a/build/sage_bootstrap/expand_class.py
+++ b/build/sage_bootstrap/expand_class.py
@@ -21,10 +21,11 @@ log = logging.getLogger()
 
 class PackageClass(object):
 
-    def __init__(self, *package_names_or_classes, exclude=(),
-                 include_dependencies=False, exclude_dependencies=False,
-                 **filters):
+    def __init__(self, *package_names_or_classes, **filters):
         self.__names = set()
+        exclude = filters.pop('exclude', ())
+        include_dependencies = filters.pop('include_dependencies', False)
+        exclude_dependencies = filters.pop('exclude_dependencies', False)
         filenames = filters.pop('has_files', [])
         no_filenames = filters.pop('no_files', [])
         excluded = []


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
On `centos-7`, still supported until June 2024, we have to use sage-bootstrap-python = python2. 
Support for Python 2 was broken accidentally in #36393, see https://github.com/sagemath/sage/actions/runs/6520548150/job/17767608828#step:10:1927

Fixed here, as tested with `tox -e docker-centos-7-devtoolset-gcc_11-standard -- config.status`.

Same issue also affects `fedora-30`, which is still tested by the CI as a proxy for old RHEL, and `ubuntu-xenial`. See #32074

<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
