### PR TITLE
Add a lift method to LieGenerator

### DIFF
--- a/src/sage/algebras/lie_algebras/lie_algebra_element.pxd
+++ b/src/sage/algebras/lie_algebras/lie_algebra_element.pxd
@@ -50,6 +50,7 @@ cdef class LieObject(SageObject):
 
 cdef class LieGenerator(LieObject):
     cdef public str _name
+    cpdef lift(self, dict UEA_gens_dict)
 
 cdef class LieBracket(LieObject):
     cdef public LieObject _left

--- a/src/sage/algebras/lie_algebras/lie_algebra_element.pyx
+++ b/src/sage/algebras/lie_algebras/lie_algebra_element.pyx
@@ -1661,6 +1661,25 @@ cdef class LieGenerator(LieObject):
         """
         return self._word
 
+    cpdef lift(self, dict UEA_gens_dict):
+        """
+        Lift ``self`` to the universal enveloping algebra.
+
+        ``UEA_gens_dict`` should be the dictionary for the
+        generators of the universal enveloping algebra.
+
+        EXAMPLES::
+
+            sage: L = LieAlgebra(QQ, 'x,y,z')
+            sage: Lyn = L.Lyndon()
+            sage: x,y,z = Lyn.gens()
+            sage: x.lift()
+            x
+            sage: x.lift().parent()
+            Free Algebra on 3 generators (x, y, z) over Rational Field
+        """
+        return UEA_gens_dict[self._name]
+
 cdef class LieBracket(LieObject):
     """
     An abstract Lie bracket (formally, just a binary tree).


### PR DESCRIPTION
The `FreeLieAlgebraElement.lift` method can try to call both `LieGenerator.lift` and `LieBracket.lift`, but the former is not defined. As a consequence coercion into the universal enveloping algebra fails for elements which are not brackets:

```
sage: L = LieAlgebra(QQ, ['X','Y']).Lyndon()
sage: X,Y = L.gens()
sage: U = L.universal_enveloping_algebra()
sage: U.one() + X.bracket(Y) # works fine
1 + X*Y - Y*X
sage: U.one() + X
Traceback (most recent call last)
...
AttributeError: 'sage.algebras.lie_algebras.lie_algebra_element.Lie' object has no attribute 'lift'
```

Copying the pre-existing code in `LieBracket.lift` to `LieGenerator.lift` with straight-forward modifications (since the generator case is even simpler) fixes this problem.

```
sage: U.one() + X
1 + X
```
