### PR TITLE
Support launching notebook 7

### DIFF
--- a/src/bin/sage-notebook
+++ b/src/bin/sage-notebook
@@ -29,7 +29,12 @@ class NotebookJupyter():
     def __init__(self, argv):
         self.print_banner()
         try:
-            from notebook.notebookapp import main
+            try:
+                # notebook 6
+                from notebook.notebookapp import main
+            except ImportError:
+                # notebook 7
+                from notebook.app import main
         except ImportError:
             import traceback
             traceback.print_exc()


### PR DESCRIPTION
As reported in #36414, running `sage -notebook` fails with jupyter notebook 7.

This seems to be just a matter of a changed import, which we fix.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.

Fixes: #36414 