### PR TITLE
Cleanup conditional assert

### DIFF
--- a/src/sage/cpython/dict_del_by_value.pyx
+++ b/src/sage/cpython/dict_del_by_value.pyx
@@ -46,31 +46,6 @@ cdef extern from "dict_internal.h":
         PyObject * me_key
         PyObject * me_value
 
-
-# dk_lookup was removed in python 3.11
-DEF HAS_DK_LOOKUP = PY_VERSION_HEX < 0x30b0000
-
-IF HAS_DK_LOOKUP:
-
-    cdef extern from *:
-        """
-        #define DK_LOOKUP(dk) ((dk)->dk_lookup)
-        """
-        ctypedef void * dict_lookup_func  # Precise definition not needed
-        dict_lookup_func DK_LOOKUP(PyDictKeysObject *mp)
-
-    cdef dict_lookup_func lookdict
-
-    def init_lookdict():
-        global lookdict
-        # A dict which a non-string key uses the generic "lookdict"
-        # as lookup function
-        cdef object D = {}
-        D[0] = 0
-        lookdict = DK_LOOKUP((<PyDictObject *>D).ma_keys)
-
-    init_lookdict()
-
 cdef int del_dictitem_by_exact_value(PyDictObject *mp, PyObject *value, Py_hash_t hash) except -1:
     """
     This is used in callbacks for the weak values of :class:`WeakValueDictionary`.
@@ -146,12 +121,6 @@ cdef int del_dictitem_by_exact_value(PyDictObject *mp, PyObject *value, Py_hash_
             # key not found
             return 0
         ep = &(entries[ix])
-
-    # We need the lookup function to be the generic lookdict, otherwise
-    # deletions may not work correctly
-    IF HAS_DK_LOOKUP:
-        # Can this fail? In any case dk_lookup was removed in python 3.11
-        assert DK_LOOKUP(keys) is lookdict
 
     T = PyList_New(2)
     PyList_SetItem(T, 0, ep.me_key)


### PR DESCRIPTION
The code we remove here is a legacy assert which has no equivalent in python 3.12. The way it's implemented uses compile time `IF` which is deprecated in cython 3 so it's desirable to remove.

See also: https://github.com/sagemath/sage/pull/36524#discussion_r1369530294

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
