### PR TITLE
remove deprecated name parameter in category ; capital for Coxeter

### DIFF
--- a/src/sage/categories/bimodules.py
+++ b/src/sage/categories/bimodules.py
@@ -37,22 +37,24 @@ class Bimodules(CategoryWithParameters):
 
     def __init__(self, left_base, right_base, name=None):
         """
+        The ``name`` parameter is ignored.
+
         EXAMPLES::
 
             sage: C = Bimodules(QQ, ZZ)
             sage: TestSuite(C).run()
         """
-        if not ( left_base in Rings() or
-                 (isinstance(left_base, Category)
-                  and left_base.is_subcategory(Rings())) ):
+        if not (left_base in Rings() or
+                (isinstance(left_base, Category)
+                 and left_base.is_subcategory(Rings()))):
             raise ValueError("the left base must be a ring or a subcategory of Rings()")
-        if not ( right_base in Rings() or
-                 (isinstance(right_base, Category)
-                  and right_base.is_subcategory(Rings())) ):
+        if not (right_base in Rings() or
+                (isinstance(right_base, Category)
+                 and right_base.is_subcategory(Rings()))):
             raise ValueError("the right base must be a ring or a subcategory of Rings()")
         self._left_base_ring = left_base
         self._right_base_ring = right_base
-        Category.__init__(self, name)
+        Category.__init__(self)
 
     def _make_named_class_key(self, name):
         r"""

--- a/src/sage/categories/category.py
+++ b/src/sage/categories/category.py
@@ -118,6 +118,7 @@ from sage.categories.category_cy_helper import category_sort_key, _sort_uniq, _f
 
 _join_cache = WeakValueDictionary()
 
+
 class Category(UniqueRepresentation, SageObject):
     r"""
     The base class for modeling mathematical categories, like for example:
@@ -448,7 +449,7 @@ class Category(UniqueRepresentation, SageObject):
             cls = cls.__base__
         return super().__classcall__(cls, *args, **options)
 
-    def __init__(self, s=None):
+    def __init__(self):
         """
         Initialize this category.
 
@@ -468,12 +469,10 @@ class Category(UniqueRepresentation, SageObject):
 
         .. NOTE::
 
-            Specifying the name of this category by passing a string
-            is deprecated. If the default name (built from the name of
-            the class) is not adequate, please use
+            If the default name of the category (built from the name of
+            the class) is not adequate, please implement
             :meth:`_repr_object_names` to customize it.
         """
-        assert s is None
         self.__class__ = dynamic_class("{}_with_category".format(self.__class__.__name__),
                                        (self.__class__, self.subcategory_class, ),
                                        cache=False, reduction=None,
@@ -491,35 +490,8 @@ class Category(UniqueRepresentation, SageObject):
 
         """
         t = str(self.__class__.__base__)
-        t = t[t.rfind('.')+1:]
+        t = t[t.rfind('.') + 1:]
         return t[:t.rfind("'")]
-
-    # TODO: move this code into the method _repr_object_names once passing a string is not accepted anymore
-    @lazy_attribute
-    def __repr_object_names(self):
-        """
-        Determine the name of the objects of this category
-        from its type, if it has not been explicitly given
-        at initialisation.
-
-        EXAMPLES::
-
-            sage: Rings()._Category__repr_object_names
-            'rings'
-            sage: PrincipalIdealDomains()._Category__repr_object_names
-            'principal ideal domains'
-
-            sage: Rings()
-            Category of rings
-        """
-        i = -1
-        s = self._label
-        while i < len(s)-1:
-            for i in range(len(s)):
-                if s[i].isupper():
-                    s = s[:i] + " " + s[i].lower() + s[i+1:]
-                    break
-        return s.lstrip()
 
     def _repr_object_names(self):
         """
@@ -531,8 +503,24 @@ class Category(UniqueRepresentation, SageObject):
             'finite groups'
             sage: AlgebrasWithBasis(QQ)._repr_object_names()
             'algebras with basis over Rational Field'
+
+        TESTS::
+
+            sage: Rings()
+            Category of rings
+            sage: Rings()._repr_object_names()
+            'rings'
+            sage: PrincipalIdealDomains()._repr_object_names()
+            'principal ideal domains'
         """
-        return self.__repr_object_names
+        i = -1
+        s = self._label
+        while i < len(s) - 1:
+            for i in range(len(s)):
+                if s[i].isupper():
+                    s = s[:i] + " " + s[i].lower() + s[i + 1:]
+                    break
+        return s.lstrip()
 
     def _short_name(self):
         """
@@ -1256,7 +1244,7 @@ class Category(UniqueRepresentation, SageObject):
         recursively from the result of :meth:`additional_structure`
         on the super categories of ``self``.
         """
-        result = { D for C in self.super_categories() for D in C.structure() }
+        result = {D for C in self.super_categories() for D in C.structure()}
         if self.additional_structure() is not None:
             result.add(self)
         return frozenset(result)
@@ -1319,8 +1307,7 @@ class Category(UniqueRepresentation, SageObject):
                 False
         """
         return self.is_subcategory(other) and \
-           len(self.structure()) == \
-           len(other.structure())
+            len(self.structure()) == len(other.structure())
 
     @cached_method
     def full_super_categories(self):
@@ -1446,27 +1433,26 @@ class Category(UniqueRepresentation, SageObject):
             Traceback (most recent call last):
             ...
             AssertionError: Category of my objects is not a subcategory of Objects()
-
         """
-        from sage.categories.objects    import Objects
+        from sage.categories.objects import Objects
         from sage.categories.sets_cat import Sets
         tester = self._tester(**options)
         tester.assertTrue(isinstance(self.super_categories(), list),
-                       "%s.super_categories() should return a list" % self)
+                          "%s.super_categories() should return a list" % self)
         tester.assertTrue(self.is_subcategory(Objects()),
-                       "%s is not a subcategory of Objects()" % self)
+                          "%s is not a subcategory of Objects()" % self)
         tester.assertTrue(isinstance(self.parent_class, type))
         tester.assertTrue(all(not isinstance(cat, JoinCategory) for cat in self._super_categories))
         if not isinstance(self, JoinCategory):
-            tester.assertTrue(all(self._cmp_key > cat._cmp_key      for cat in self._super_categories))
-        tester.assertTrue(self.is_subcategory( Category.join(self.super_categories()) )) # Not an obviously passing test with axioms
+            tester.assertTrue(all(self._cmp_key > cat._cmp_key for cat in self._super_categories))
+        tester.assertTrue(self.is_subcategory(Category.join(self.super_categories())))  # Not an obviously passing test with axioms
 
         for category in self._all_super_categories_proper:
             if self.is_full_subcategory(category):
                 tester.assertTrue(any(cat.is_subcategory(category)
-                                   for cat in self.full_super_categories()),
-                               "Every full super category should be a super category"
-                               "of some immediate full super category")
+                                      for cat in self.full_super_categories()),
+                                  "Every full super category should be a super category"
+                                  "of some immediate full super category")
 
         if self.is_subcategory(Sets()):
             tester.assertTrue(isinstance(self.parent_class, type))
@@ -1588,7 +1574,7 @@ class Category(UniqueRepresentation, SageObject):
             doccls = cls
         else:
             # Otherwise, check XXXMethods
-            assert inspect.isclass(method_provider_cls),\
+            assert inspect.isclass(method_provider_cls), \
                 "%s.%s should be a class" % (cls.__name__, method_provider)
             mro = inspect.getmro(method_provider_cls)
             if len(mro) > 2 or (len(mro) == 2 and mro[1] is not object):
@@ -1941,7 +1927,7 @@ class Category(UniqueRepresentation, SageObject):
           appropriate convention for A<B. Using subcategory calls
           for A<B, but the current meet and join call for A>B.
         """
-        if self is other: # useful? fast pathway
+        if self is other:  # useful? fast pathway
             return self
         elif self.is_subcategory(other):
             return other
@@ -2050,14 +2036,13 @@ class Category(UniqueRepresentation, SageObject):
                 return (axiom_attribute(self),)
             warn(("Expecting {}.{} to be a subclass of CategoryWithAxiom to"
                   " implement a category with axiom; got {}; ignoring").format(
-                    self.__class__.__base__.__name__, axiom, axiom_attribute))
+                      self.__class__.__base__.__name__, axiom, axiom_attribute))
 
         # self does not implement this axiom
-        result = (self, ) + \
-                 tuple(cat
-                       for category in self._super_categories
-                       for cat in category._with_axiom_as_tuple(axiom))
-        hook = getattr(self, axiom+"_extra_super_categories", None)
+        result = (self, ) + tuple(cat
+                                  for category in self._super_categories
+                                  for cat in category._with_axiom_as_tuple(axiom))
+        hook = getattr(self, axiom + "_extra_super_categories", None)
         if hook is not None:
             assert inspect.ismethod(hook)
             result += tuple(hook())
@@ -2593,6 +2578,7 @@ def is_Category(x):
     """
     return isinstance(x, Category)
 
+
 @cached_function
 def category_sample():
     r"""
@@ -2606,7 +2592,8 @@ def category_sample():
 
         sage: from sage.categories.category import category_sample
         sage: sorted(category_sample(), key=str)                                        # needs sage.groups
-        [Category of G-sets for Symmetric group of order 8! as a permutation group,
+        [Category of Coxeter groups,
+         Category of G-sets for Symmetric group of order 8! as a permutation group,
          Category of Hecke modules over Rational Field,
          Category of Lie algebras over Rational Field,
          Category of additive magmas, ...,
@@ -2900,6 +2887,7 @@ class CategoryWithParameters(Category):
             return False
         return Unknown
 
+
 #############################################################
 # Join of several categories
 #############################################################
@@ -2948,11 +2936,11 @@ class JoinCategory(CategoryWithParameters):
 
         INPUT:
 
-        - super_categories -- Categories to join.  This category will
+        - ``super_categories`` -- Categories to join. This category will
           consist of objects and morphisms that lie in all of these
           categories.
 
-        - name -- An optional name for this category.
+        - ``name`` -- ignored
 
         TESTS::
 
@@ -2960,17 +2948,13 @@ class JoinCategory(CategoryWithParameters):
             sage: C = JoinCategory((Groups(), CommutativeAdditiveMonoids())); C
             Join of Category of groups and Category of commutative additive monoids
             sage: TestSuite(C).run()
-
         """
         assert len(super_categories) >= 2
         assert all(not isinstance(category, JoinCategory) for category in super_categories)
         # Use __super_categories to not overwrite the lazy attribute Category._super_categories
         # Maybe this would not be needed if the flattening/sorting is does consistently?
         self.__super_categories = list(super_categories)
-        if 'name' in kwds:
-            Category.__init__(self, kwds['name'])
-        else:
-            Category.__init__(self)
+        Category.__init__(self)
 
     def _make_named_class_key(self, name):
         r"""

--- a/src/sage/categories/category_types.py
+++ b/src/sage/categories/category_types.py
@@ -170,6 +170,8 @@ class Category_over_base(CategoryWithParameters):
         r"""
         Initialize ``self``.
 
+        The ``name`` parameter is ignored.
+
         EXAMPLES::
 
             sage: S = Spec(ZZ)
@@ -182,7 +184,7 @@ class Category_over_base(CategoryWithParameters):
             sage: TestSuite(C).run()
         """
         self.__base = base
-        Category.__init__(self, name)
+        Category.__init__(self)
 
     def _test_category_over_bases(self, **options):
         """
@@ -527,13 +529,15 @@ class Category_in_ambient(Category):
         """
         Initialize ``self``.
 
+        The parameter ``name`` is ignored.
+
         EXAMPLES::
 
             sage: C = Ideals(IntegerRing())
             sage: TestSuite(C).run()
         """
         self.__ambient = ambient
-        Category.__init__(self, name)
+        Category.__init__(self)
 
     def ambient(self):
         """

--- a/src/sage/categories/category_with_axiom.py
+++ b/src/sage/categories/category_with_axiom.py
@@ -269,7 +269,7 @@ from the name of the category with axiom (see
 covers the following examples::
 
     sage: FiniteCoxeterGroups()
-    Category of finite coxeter groups
+    Category of finite Coxeter groups
     sage: FiniteCoxeterGroups() is CoxeterGroups().Finite()
     True
     sage: FiniteCoxeterGroups._base_category_class_and_axiom_origin

--- a/src/sage/categories/complex_reflection_or_generalized_coxeter_groups.py
+++ b/src/sage/categories/complex_reflection_or_generalized_coxeter_groups.py
@@ -130,7 +130,7 @@ class ComplexReflectionOrGeneralizedCoxeterGroups(Category_singleton):
                 sage: ComplexReflectionGroups().Irreducible()
                 Category of irreducible complex reflection groups
                 sage: CoxeterGroups().Irreducible()
-                Category of irreducible coxeter groups
+                Category of irreducible Coxeter groups
 
             TESTS::
 

--- a/src/sage/categories/coxeter_groups.py
+++ b/src/sage/categories/coxeter_groups.py
@@ -41,7 +41,7 @@ class CoxeterGroups(Category_singleton):
     EXAMPLES::
 
         sage: C = CoxeterGroups(); C
-        Category of coxeter groups
+        Category of Coxeter groups
         sage: C.super_categories()
         [Category of generalized coxeter groups]
 
@@ -127,6 +127,17 @@ class CoxeterGroups(Category_singleton):
 
     Finite = LazyImport('sage.categories.finite_coxeter_groups', 'FiniteCoxeterGroups')
     Algebras = LazyImport('sage.categories.coxeter_group_algebras', 'CoxeterGroupAlgebras')
+
+    def _repr_object_names(self):
+        """
+        Return the name of the objects of this category.
+
+        EXAMPLES::
+
+            sage: CoxeterGroups().Finite()
+            Category of finite Coxeter groups
+        """
+        return "Coxeter groups"
 
     class ParentMethods:
         @abstract_method

--- a/src/sage/categories/finite_complex_reflection_groups.py
+++ b/src/sage/categories/finite_complex_reflection_groups.py
@@ -135,7 +135,7 @@ class FiniteComplexReflectionGroups(CategoryWithAxiom):
             desired output (well generated does not appear)::
 
                 sage: CoxeterGroups().Finite()
-                Category of finite coxeter groups
+                Category of finite Coxeter groups
             """
             return self._with_axiom('WellGenerated')
 

--- a/src/sage/categories/finite_coxeter_groups.py
+++ b/src/sage/categories/finite_coxeter_groups.py
@@ -25,10 +25,10 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
     EXAMPLES::
 
         sage: CoxeterGroups.Finite()
-        Category of finite coxeter groups
+        Category of finite Coxeter groups
         sage: FiniteCoxeterGroups().super_categories()
         [Category of finite generalized coxeter groups,
-         Category of coxeter groups]
+         Category of Coxeter groups]
 
         sage: G = CoxeterGroups().Finite().example()
         sage: G.cayley_graph(side = "right").plot()
@@ -55,7 +55,7 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
 
             sage: CoxeterGroups().Finite().super_categories()
             [Category of finite generalized coxeter groups,
-             Category of coxeter groups]
+             Category of Coxeter groups]
         """
         from sage.categories.complex_reflection_groups import ComplexReflectionGroups
         return [ComplexReflectionGroups().Finite().WellGenerated()]
@@ -214,7 +214,7 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
                   handle large / infinite Coxeter groups.
             """
             from sage.combinat.posets.posets import Poset
-            covers = tuple([u, v] for v in self for u in v.bruhat_lower_covers() )
+            covers = tuple([u, v] for v in self for u in v.bruhat_lower_covers())
             return Poset((self, covers), cover_relations=True, facade=facade)
 
         def shard_poset(self, side='right'):
@@ -590,7 +590,7 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
                 inv_woc = self.inversion_sequence(sorting_word)
                 S = self.simple_reflections()
                 T = self.reflections_from_w0()
-                Twords = {t : t.reduced_word() for t in T}
+                Twords = {t: t.reduced_word() for t in T}
 
             elements = set()
             covers = []
@@ -799,11 +799,12 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
                 sage: P.rank()
                 3
 
-                sage: W = CoxeterGroup(['H', 3], implementation="permutation")  # optional - gap3
-                sage: P = W.coxeter_poset()                                     # optional - gap3
-                sage: P                                                         # optional - gap3
+                sage: # optional - gap3
+                sage: W = CoxeterGroup(['H', 3], implementation="permutation")
+                sage: P = W.coxeter_poset()
+                sage: P
                 Finite meet-semilattice containing 363 elements
-                sage: P.rank()                                                  # optional - gap3
+                sage: P.rank()
                 3
             """
             I = self.index_set()
@@ -871,11 +872,12 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
                 sage: C.homology()
                 {0: 0, 1: 0, 2: Z}
 
-                sage: W = CoxeterGroup(['H', 3], implementation="permutation")  # optional - gap3
-                sage: C = W.coxeter_complex()                                   # optional - gap3
-                sage: C                                                         # optional - gap3
+                sage: # optional - gap3
+                sage: W = CoxeterGroup(['H', 3], implementation="permutation")
+                sage: C = W.coxeter_complex()
+                sage: C
                 Simplicial complex with 62 vertices and 120 facets
-                sage: C.homology()                                              # optional - gap3
+                sage: C.homology()
                 {0: 0, 1: 0, 2: Z}
             """
             I = self.index_set()
@@ -898,7 +900,7 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
             verts = set()
             for F in facets.values():
                 verts.update(F)
-            labels = {x: i for i,x in enumerate(verts)}
+            labels = {x: i for i, x in enumerate(verts)}
             result = [[labels[v] for v in F] for F in facets.values()]
             from sage.topology.simplicial_complex import SimplicialComplex
             return SimplicialComplex(result)
@@ -938,12 +940,13 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
             are those covers of `ws_i` that have a descent at `i`.
             """
 
-            i = self.first_descent(positive=True,side='right')
+            i = self.first_descent(positive=True, side='right')
             if i is not None:
-                wsi = self.apply_simple_reflection(i,side='right')
-                return [u.apply_simple_reflection(i,side='right') for u in wsi.bruhat_upper_covers() if u.has_descent(i,side='right')] + [wsi]
-            else:
-                return []
+                wsi = self.apply_simple_reflection(i, side='right')
+                return [u.apply_simple_reflection(i, side='right')
+                        for u in wsi.bruhat_upper_covers()
+                        if u.has_descent(i, side='right')] + [wsi]
+            return []
 
         def coxeter_knuth_neighbor(self, w):
             r"""
@@ -984,7 +987,7 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
             if not C[0] == 'A':
                 raise NotImplementedError("this has only been implemented in finite type A so far")
             d = []
-            for i in range(2,len(w)):
+            for i in range(2, len(w)):
                 v = [j for j in w]
                 if w[i-2] == w[i]:
                     if w[i] == w[i-1] - 1:
@@ -1046,7 +1049,7 @@ class FiniteCoxeterGroups(CategoryWithAxiom):
             R = [tuple(v) for v in self.reduced_words()]
             G = Graph()
             G.add_vertices(R)
-            G.add_edges([v,vp] for v in R for vp in self.coxeter_knuth_neighbor(v))
+            G.add_edges([v, vp] for v in R for vp in self.coxeter_knuth_neighbor(v))
             return G
 
         def is_coxeter_element(self):

--- a/src/sage/categories/finite_weyl_groups.py
+++ b/src/sage/categories/finite_weyl_groups.py
@@ -20,7 +20,7 @@ class FiniteWeylGroups(CategoryWithAxiom):
         sage: C
         Category of finite weyl groups
         sage: C.super_categories()
-        [Category of finite coxeter groups, Category of weyl groups]
+        [Category of finite Coxeter groups, Category of weyl groups]
         sage: C.example()
         The symmetric group on {0, ..., 3}
 

--- a/src/sage/categories/weyl_groups.py
+++ b/src/sage/categories/weyl_groups.py
@@ -26,7 +26,7 @@ class WeylGroups(Category_singleton):
         sage: WeylGroups()
         Category of weyl groups
         sage: WeylGroups().super_categories()
-        [Category of coxeter groups]
+        [Category of Coxeter groups]
 
     Here are some examples::
 
@@ -53,7 +53,7 @@ class WeylGroups(Category_singleton):
         EXAMPLES::
 
             sage: WeylGroups().super_categories()
-            [Category of coxeter groups]
+            [Category of Coxeter groups]
         """
         return [CoxeterGroups()]
 

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7268,7 +7268,7 @@ class StandardPermutations_n(StandardPermutations_n_abstract):
             Symmetric group algebra of order 4 over Rational Field
 
             sage: A.category()                                                          # optional - sage.combinat sage.modules
-            Join of Category of coxeter group algebras over Rational Field
+            Join of Category of Coxeter group algebras over Rational Field
                 and Category of finite group algebras over Rational Field
                 and Category of finite dimensional cellular algebras
                     with basis over Rational Field

--- a/src/sage/groups/matrix_gps/coxeter_group.py
+++ b/src/sage/groups/matrix_gps/coxeter_group.py
@@ -253,11 +253,11 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
         We check that :trac:`16630` is fixed::
 
             sage: CoxeterGroup(['D',4], base_ring=QQ).category()
-            Category of finite irreducible coxeter groups
+            Category of finite irreducible Coxeter groups
 
             sage: # needs sage.rings.number_field
             sage: CoxeterGroup(['H',4], base_ring=QQbar).category()
-            Category of finite irreducible coxeter groups
+            Category of finite irreducible Coxeter groups
             sage: F = CoxeterGroups().Finite()
             sage: all(CoxeterGroup([letter,i]) in F
             ....:     for i in range(2,5) for letter in ['A','B','D'])
@@ -265,9 +265,9 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
             sage: all(CoxeterGroup(['E',i]) in F for i in range(6,9))
             True
             sage: CoxeterGroup(['F',4]).category()
-            Category of finite irreducible coxeter groups
+            Category of finite irreducible Coxeter groups
             sage: CoxeterGroup(['G',2]).category()
-            Category of finite irreducible coxeter groups
+            Category of finite irreducible Coxeter groups
             sage: all(CoxeterGroup(['H',i]) in F for i in range(3,5))
             True
             sage: all(CoxeterGroup(['I',i]) in F for i in range(2,5))

--- a/src/sage/groups/perm_gps/permgroup_named.py
+++ b/src/sage/groups/perm_gps/permgroup_named.py
@@ -640,7 +640,7 @@ class SymmetricGroup(PermutationGroup_symalt):
         We illustrate the choice of the category::
 
             sage: A.category()                                                          # needs sage.combinat
-            Join of Category of coxeter group algebras over Rational Field
+            Join of Category of Coxeter group algebras over Rational Field
                 and Category of finite group algebras over Rational Field
                 and Category of finite dimensional cellular algebras with basis
                      over Rational Field


### PR DESCRIPTION
This is removing a deprecated parameter "name" in the init of "Category".

Also using the opportunity to add the capital to the name of  Coxeter.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
