### PR TITLE
Fix bug in QF.find_primitive_p_divisible_vector__next

### DIFF
--- a/src/sage/quadratic_forms/quadratic_form__neighbors.py
+++ b/src/sage/quadratic_forms/quadratic_form__neighbors.py
@@ -74,6 +74,10 @@ def find_primitive_p_divisible_vector__next(self, p, v=None):
         sage: v = Q.find_primitive_p_divisible_vector__next(5, v); v
         (1, 0)
         sage: v = Q.find_primitive_p_divisible_vector__next(5, v); v
+        sage: v = Q.find_primitive_p_divisible_vector__next(2) ; v
+        (0, 1)
+        sage: v = Q.find_primitive_p_divisible_vector__next(2, v) ; v
+        (1, 0)
         sage: Q = QuadraticForm(QQ, matrix.diagonal([1,1,1,1]))
         sage: v = Q.find_primitive_p_divisible_vector__next(2)
         sage: Q(v)
@@ -83,6 +87,9 @@ def find_primitive_p_divisible_vector__next(self, p, v=None):
     n = self.dim()
     if v is None:
         w = vector(ZZ, [0] * (n - 1) + [1])
+        a = self(w)
+        if a in ZZ and (a % p == 0):
+            return w
     else:
         w = deepcopy(v)
 

--- a/src/sage/quadratic_forms/quadratic_form__neighbors.py
+++ b/src/sage/quadratic_forms/quadratic_form__neighbors.py
@@ -139,7 +139,7 @@ def find_primitive_p_divisible_vector__next(self, p, v=None):
             return w
 
 
-def find_p_neighbor_from_vec(self, p, y):
+def find_p_neighbor_from_vec(self, p, y, return_matrix=False):
     r"""
     Return the `p`-neighbor of ``self`` defined by ``y``.
 
@@ -154,25 +154,32 @@ def find_p_neighbor_from_vec(self, p, y):
     - ``p`` -- a prime number
     - ``y`` -- a vector with `q(y) \in p \ZZ`
     - ``odd`` -- (default: ``False``) if `p=2`, return also odd neighbors
+    - ``return_matrix`` -- (boolean, default ``False``) return
+      the transformation matrix instead of the quadratic form
 
     EXAMPLES::
 
+        sage: # needs sage.libs.pari
         sage: Q = DiagonalQuadraticForm(ZZ, [1,1,1,1])
         sage: v = vector([0,2,1,1])
-        sage: X = Q.find_p_neighbor_from_vec(3, v); X                                   # needs sage.libs.pari
+        sage: X = Q.find_p_neighbor_from_vec(3, v); X
         Quadratic form in 4 variables over Integer Ring with coefficients:
         [ 1 0 0 0 ]
         [ * 1 4 4 ]
         [ * * 5 12 ]
         [ * * * 9 ]
+        sage: B = Q.find_p_neighbor_from_vec(3, v, return_matrix=True)
+        sage: Q(B) == X
+        True
 
     Since the base ring and the domain are not yet separate,
     for rational, half integral forms we just pretend
     the base ring is `\ZZ`::
 
+        sage: # needs sage.libs.pari
         sage: Q = QuadraticForm(QQ, matrix.diagonal([1,1,1,1]))
         sage: v = vector([1,1,1,1])
-        sage: Q.find_p_neighbor_from_vec(2, v)                                          # needs sage.libs.pari
+        sage: Q.find_p_neighbor_from_vec(2, v)
         Quadratic form in 4 variables over Rational Field with coefficients:
         [ 1/2 1 1 1 ]
         [ * 1 1 2 ]
@@ -234,9 +241,12 @@ def find_p_neighbor_from_vec(self, p, y):
     # by definition this is the p-neighbor of L at y
     # assert B.det().abs() == 1
 
-    QF = self.parent()
-    Gnew = (B*G*B.T).change_ring(R)
-    return QF(Gnew)
+    if return_matrix:
+        return B.T
+    else:
+        QF = self.parent()
+        Gnew = (B*G*B.T).change_ring(R)
+        return QF(Gnew)
 
 
 def neighbor_iteration(seeds, p, mass=None, max_classes=ZZ(10)**3,

--- a/src/sage/quadratic_forms/ternary.pyx
+++ b/src/sage/quadratic_forms/ternary.pyx
@@ -955,7 +955,26 @@ def extend(v):
         [ 30   0  -7]
         sage: M.det()
         2
+
+    TESTS::
+
+        sage: M = matrix(3, extend( (0, 0, 1) ))
+        sage: M.det()
+        1
+        sage: M.column(0)
+        (0, 0, 1)
+        sage: M = matrix(3, extend( (0, 0, -2) ))
+        sage: M.det()
+        2
+        sage: M.column(0)
+        (0, 0, -2)
     """
+    if v[0] == v[1] == 0:
+        if v[2] < 0:
+            return v[0], 0, 1,  v[1], 1, 0,  v[2], 0, 0
+        else:
+            return v[0], 1, 0,  v[1], 0, 1,  v[2], 0, 0
+
     b1 = xgcd(v[0], v[1])
     b2 = xgcd(b1[1], b1[2])
     b3 = xgcd(b1[0], v[2])

--- a/src/sage/quadratic_forms/ternary_qf.py
+++ b/src/sage/quadratic_forms/ternary_qf.py
@@ -918,6 +918,13 @@ class TernaryQF(SageObject):
             [     0  -3/11  13/11]
             sage: Q(M) == Q11
             True
+
+        Test that it works with (0, 0, 1)::
+
+            sage: Q.find_p_neighbor_from_vec(3, (0,0,1))
+            Ternary quadratic form with integer coefficients:
+            [1 3 3]
+            [-2 0 -1]
         """
         if mat:
             q, M = _find_p_neighbor_from_vec(self._a, self._b, self._c, self._r, self._s, self._t, p, v, mat)


### PR DESCRIPTION
When the vector [0,...,0,1] is a zero mod p, it was missed from the iteration. Fix by check and return it if this is the case.
    
A doctest triggering the bug is included.

The second commit adds a return_matrix option for QF.find_p_neighbor_from_vec which is related and useful, similar to QF.is_globally_equivalent_to, etc.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.