### PR TITLE
`src/sage/misc/cython.py`: Fix the workaround for setuptools_scm

### DIFF
--- a/src/sage/misc/cython.py
+++ b/src/sage/misc/cython.py
@@ -421,7 +421,7 @@ def cython(filename, verbose=0, compile_message=False,
                         os.curdir)
 
     # This emulates running "setup.py build" with the correct options
-    dist = Distribution()
+    #
     # setuptools plugins considered harmful:
     # If build isolation is not in use and setuptools_scm is installed,
     # then its file_finders entry point is invoked, which we don't need.
@@ -429,7 +429,12 @@ def cython(filename, verbose=0, compile_message=False,
     # LookupError: pyproject.toml does not contain a tool.setuptools_scm section
     # LookupError: setuptools-scm was unable to detect version ...
     # We just remove all handling of "setuptools.finalize_distribution_options" entry points.
-    dist._removed = staticmethod(lambda ep: True)
+    class Distribution_no_finalize_distribution_options(Distribution):
+        @staticmethod
+        def _removed(ep):
+            return True
+
+    dist = Distribution_no_finalize_distribution_options()
     dist.ext_modules = [ext]
     dist.include_dirs = includes
     buildcmd = dist.get_command_obj("build")


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
The part of #36400 that was intended to fix the runtime use of cython did not actually fix it because `finalize_distribution` is called already by `Distribution.__init__`.

This shows up when invoked from a directory with `pyproject.toml` or a similar config file. As the Build & Test workflow invokes the doctester from `SAGE_ROOT/src`, these errors show up in all tests. Marking it as a blocker so it is [applied automatically in CI workflows](https://github.com/sagemath/sage/wiki/Sage-10.2-Release-Tour#open-blocker-prs-are-applied-automatically-in-ci-workflows)

<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Fixes https://github.com/sagemath/sage/pull/36400#issuecomment-1781525600
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
