### PR TITLE
Limit wait for slow mirrors

### DIFF
--- a/build/sage_bootstrap/download/mirror_list.py
+++ b/build/sage_bootstrap/download/mirror_list.py
@@ -170,9 +170,7 @@ class MirrorList_from_url(object):
         timed_mirrors = []
         import time, socket
         log.info('Searching fastest mirror')
-        timeout = socket.getdefaulttimeout()
-        if timeout is None:
-            timeout = 1
+        timeout = 1
         for mirror in self.mirrors:
             if not mirror.startswith('http'):
                 log.debug('we currently can only handle http, got %s', mirror)
@@ -190,6 +188,11 @@ class MirrorList_from_url(object):
             result_ms = int(1000 * result)
             log.info(str(result_ms).rjust(5) + 'ms: ' + mirror)
             timed_mirrors.append((result, mirror))
+            timed_mirrors.sort()
+            if len(timed_mirrors) >= 5 and timed_mirrors[4][0] < 0.3:
+                # We don't need more than 5 decent mirrors
+                break
+
         if len(timed_mirrors) == 0:
             # We cannot reach any mirror directly, most likely firewall issue
             if 'http_proxy' not in os.environ:
@@ -197,7 +200,6 @@ class MirrorList_from_url(object):
                 raise MirrorListException('Failed to connect to any mirror, probably no internet connection')
             log.info('Cannot time mirrors via proxy, using default order')
         else:
-            timed_mirrors.sort()
             self._mirrors = [m[1] for m in timed_mirrors]
         log.info('Fastest mirror: ' + self.fastest)
 


### PR DESCRIPTION
Using a timeout of 1 second unconditionally, stopping when 5 good mirrors (300ms ping) are found

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
Fixes #34411
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
