### PR TITLE
Allow to import `sage.cpython` module multiple times

### DIFF
--- a/src/sage/cpython/__init__.py
+++ b/src/sage/cpython/__init__.py
@@ -12,7 +12,8 @@ del _zlib
 # Monkey-patch ExtensionFileLoader to allow IPython to find the sources
 # of Cython files. See https://github.com/sagemath/sage/issues/24681
 from importlib.machinery import ExtensionFileLoader as _ExtensionFileLoader
-del _ExtensionFileLoader.get_source
+if hasattr(_ExtensionFileLoader, 'get_source'):
+    del _ExtensionFileLoader.get_source
 del _ExtensionFileLoader
 
 # Work around a Cygwin-specific bug caused by sqlite3; see


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

I don't really know why but pytest is sometimes importing the same module multiple times (I think once for the test collection and once for the execution). Importing cpython twice however fails since the second time `_ExtensionFileLoader.get_source` is already deleted.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
