### PR TITLE
avoid using `itertools.pairwise`

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -5211,7 +5211,6 @@ class GenericGraph(GenericGraph_pyx):
                            [])
 
             from sage.graphs.graph import Graph
-            from itertools import pairwise
             T = Graph(self.min_spanning_tree(), multiedges=True, format='list_of_edges')
             H = self.copy()
             H.delete_edges(T.edge_iterator())
@@ -5235,7 +5234,8 @@ class GenericGraph(GenericGraph_pyx):
 
                 cycle = Q + P[-2::-1]
                 if output == 'edge':
-                    cycle = [e] + [(x, y, T.edge_label(x, y)[0]) for x, y in pairwise(cycle)]
+                    cycle = [e] + [(x, y, T.edge_label(x, y)[0])
+                                   for x, y in zip(cycle[:-1], cycle[1:])]
                 L.append(cycle)
             return L
 


### PR DESCRIPTION
Method `pairwise` has been introduced in `itertools` version 3.10. As reported in #36493,  its use breaks the condo workflow with Python 3.9. So we modify the code to avoid using `pairwise`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies
See discussion https://github.com/sagemath/sage/pull/36493#issuecomment-1786350920,
