### PR TITLE
CI: Make jobs more responsive to canceling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
           SAGE_NUM_THREADS: 2
 
       - name: Build modularized distributions
-        if: always() && steps.worktree.outcome == 'success'
+        if: (success() || failure()) && steps.worktree.outcome == 'success'
         run: make V=0 tox && make SAGE_CHECK=no pypi-wheels
         working-directory: ./worktree-image
         env:
@@ -104,7 +104,7 @@ jobs:
           SAGE_NUM_THREADS: 2
 
       - name: Static code check with pyright
-        if: always() && steps.worktree.outcome == 'success'
+        if: (success() || failure()) && steps.worktree.outcome == 'success'
         uses: jakebailey/pyright-action@v1
         with:
           version: 1.1.332
@@ -116,7 +116,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
       
       - name: Static code check with pyright (annotated)
-        if: always() && steps.worktree.outcome == 'success'
+        if: (success() || failure()) && steps.worktree.outcome == 'success'
         uses: jakebailey/pyright-action@v1
         with:
           version: 1.1.332
@@ -130,7 +130,7 @@ jobs:
 
       - name: Clean (fallback to non-incremental)
         id: clean
-        if: always() && steps.worktree.outcome == 'success' && steps.incremental.outcome != 'success'
+        if: (success() || failure()) && steps.worktree.outcome == 'success' && steps.incremental.outcome != 'success'
         run: |
           set -ex
           ./bootstrap && make doc-clean doc-uninstall sagelib-clean && git clean -fx src/sage && ./config.status
@@ -143,7 +143,7 @@ jobs:
         # This step is needed because building the modularized distributions installs some optional packages,
         # so the editable install of sagelib needs to build the corresponding optional extension modules.
         id: build
-        if: always() && (steps.incremental.outcome == 'success' || steps.clean.outcome == 'success')
+        if: (success() || failure()) && (steps.incremental.outcome == 'success' || steps.clean.outcome == 'success')
         run: |
           make build
         working-directory: ./worktree-image
@@ -154,7 +154,7 @@ jobs:
       # Testing
 
       - name: Test changed files (sage -t --new)
-        if: always() && steps.build.outcome == 'success'
+        if: (success() || failure()) && steps.build.outcome == 'success'
         run: |
           # We run tests with "sage -t --new"; this only tests the uncommitted changes.
           ./sage -t --new -p2
@@ -164,7 +164,7 @@ jobs:
           SAGE_NUM_THREADS: 2
 
       - name: Test modularized distributions
-        if: always() && steps.build.outcome == 'success'
+        if: (success() || failure()) && steps.build.outcome == 'success'
         run: make V=0 tox && make pypi-wheels-check
         working-directory: ./worktree-image
         env:
@@ -182,14 +182,14 @@ jobs:
           COLUMNS: 120
 
       - name: Test all files (sage -t --all --long)
-        if: always() && steps.build.outcome == 'success'
+        if: (success() || failure()) && steps.build.outcome == 'success'
         run: |
           ../sage -python -m pip install coverage
           ../sage -python -m coverage run ./bin/sage-runtests --all --long -p2 --random-seed=286735480429121101562228604801325644303
         working-directory: ./worktree-image/src
 
       - name: Prepare coverage results
-        if: always() && steps.build.outcome == 'success'
+        if: (success() || failure()) && steps.build.outcome == 'success'
         run: |
           ./venv/bin/python3 -m coverage combine src/.coverage/
           ./venv/bin/python3 -m coverage xml
@@ -197,7 +197,7 @@ jobs:
         working-directory: ./worktree-image
 
       - name: Upload coverage to codecov
-        if: always() && steps.build.outcome == 'success'
+        if: (success() || failure()) && steps.build.outcome == 'success'
         uses: codecov/codecov-action@v3
         with:
           files: ./worktree-image/coverage.xml

--- a/.github/workflows/doc-build-pdf.yml
+++ b/.github/workflows/doc-build-pdf.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build (fallback to non-incremental)
         id: build
-        if: always() && steps.worktree.outcome == 'success' && steps.incremental.outcome != 'success'
+        if: (success() || failure()) && steps.worktree.outcome == 'success' && steps.incremental.outcome != 'success'
         run: |
           set -ex
           make sagelib-clean && git clean -fx src/sage && ./config.status && make build
@@ -105,7 +105,7 @@ jobs:
 
       - name: Build docs (PDF)
         id: docbuild
-        if: always() && (steps.incremental.outcome == 'success' || steps.build.outcome == 'success')
+        if: (success() || failure()) && (steps.incremental.outcome == 'success' || steps.build.outcome == 'success')
         run: |
           make doc-clean doc-uninstall; make doc-pdf
         working-directory: ./worktree-image
@@ -114,7 +114,7 @@ jobs:
           SAGE_NUM_THREADS: 2
 
       - name: Copy docs
-        if: always() && steps.docbuild.outcome == 'success'
+        if: (success() || failure()) && steps.docbuild.outcome == 'success'
         run: |
           # For some reason the deploy step below cannot find /sage/...
           # So copy everything from there to local folder
@@ -124,7 +124,7 @@ jobs:
           zip -r docs-pdf.zip docs
 
       - name: Upload docs
-        if: always() && steps.copy.outcome == 'success'
+        if: (success() || failure()) && steps.copy.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
           name: docs-pdf

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build (fallback to non-incremental)
         id: build
-        if: always() && steps.worktree.outcome == 'success' && steps.incremental.outcome != 'success'
+        if: (success() || failure()) && steps.worktree.outcome == 'success' && steps.incremental.outcome != 'success'
         run: |
           set -ex
           make sagelib-clean && git clean -fx src/sage && ./config.status && make sagemath_doc_html-build-deps
@@ -110,7 +110,7 @@ jobs:
 
       - name: Build docs
         id: docbuild
-        if: always() && (steps.incremental.outcome == 'success' || steps.build.outcome == 'success')
+        if: (success() || failure()) && (steps.incremental.outcome == 'success' || steps.build.outcome == 'success')
         # Always non-incremental because of the concern that
         # incremental docbuild may introduce broken links (inter-file references) though build succeeds
         run: |
@@ -127,7 +127,7 @@ jobs:
 
       - name: Copy docs
         id: copy
-        if: always() && steps.docbuild.outcome == 'success'
+        if: (success() || failure()) && steps.docbuild.outcome == 'success'
         run: |
           set -ex
           mkdir -p ./docs
@@ -191,7 +191,7 @@ jobs:
           zip -r docs.zip docs
 
       - name: Upload docs
-        if: always() && steps.copy.outcome == 'success'
+        if: (success() || failure()) && steps.copy.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
           name: docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,13 +37,13 @@ jobs:
       run: pip install tox
 
     - name: Code style check with pycodestyle
-      if: always() && steps.deps.outcome == 'success'
+      if: (success() || failure()) && steps.deps.outcome == 'success'
       run: tox -e pycodestyle-minimal
 
     - name: Code style check with relint
-      if: always() && steps.deps.outcome == 'success'
+      if: (success() || failure()) && steps.deps.outcome == 'success'
       run: tox -e relint -- src/sage/
 
     - name: Validate docstring markup as RST
-      if: always() && steps.deps.outcome == 'success'
+      if: (success() || failure()) && steps.deps.outcome == 'success'
       run: tox -e rst


### PR DESCRIPTION
... by replacing `always()` by `success() || failure()`, except for steps such as uploading / printing out logs or similar artifacts that have already been built.

Even upon canceling a workflow (manually or automatically when a new commit has been pushed to the same branch), a new step that uses `if: always() ....` will still be started, which can clog the GH Actions pipeline.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->
- Depends on #36614 (merged here to remove merge conflict)

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
