### PR TITLE
fix broken pyright in CI

### DIFF
--- a/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
+++ b/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
@@ -117,10 +117,7 @@ lazy_import('sage.rings.number_field.number_field_ideal', 'NumberFieldFractional
 lazy_import('sage.rings.padics.factory', 'Qp')
 lazy_import('sage.rings.qqbar', 'number_field_elements_from_algebraics')
 
-try:
-    from sage.libs.pari.all import PariError
-except ImportError:
-    PariError = ()
+from sage.libs.pari.all import PariError
 
 
 class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,


### PR DESCRIPTION
This is trying to fix our broken CI, where pyright complains about the type of `PariError`.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
