### PR TITLE
clean E702 etc in integer.pyx

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -207,7 +207,8 @@ new_gen_from_integer = None
 cdef extern from *:
     int unlikely(int) nogil  # Defined by Cython
 
-cdef object numpy_long_interface = {'typestr': '=i4' if sizeof(long) == 4 else '=i8' }
+cdef object numpy_long_interface = {'typestr': '=i4' if sizeof(long) == 4
+                                    else '=i8'}
 cdef object numpy_int64_interface = {'typestr': '=i8'}
 cdef object numpy_object_interface = {'typestr': '|O'}
 
@@ -288,7 +289,6 @@ cdef _digits_internal(mpz_t v,l,int offset,int power_index,power_list,digits) no
     cdef mpz_t mpz_res
     cdef mpz_t mpz_quot
     cdef Integer temp
-    cdef int v_int
     if power_index < 5:
         # It turns out that simple repeated division is very fast for
         # relatively few digits.  I don't think this is a real algorithmic
@@ -318,6 +318,7 @@ cdef mpz_t PARI_PSEUDOPRIME_LIMIT
 mpz_init(PARI_PSEUDOPRIME_LIMIT)
 mpz_ui_pow_ui(PARI_PSEUDOPRIME_LIMIT, 2, 64)
 
+
 def is_Integer(x):
     """
     Return ``True`` if ``x`` is of the Sage :class:`Integer` type.
@@ -336,11 +337,13 @@ def is_Integer(x):
     """
     return isinstance(x, Integer)
 
+
 cdef inline Integer as_Integer(x) noexcept:
     if isinstance(x, Integer):
         return <Integer>x
     else:
         return Integer(x)
+
 
 cdef class IntegerWrapper(Integer):
     r"""
@@ -612,8 +615,6 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         #     mpz_init_set_sage(self.value, x)
 
         cdef Integer tmp
-        cdef char* xs
-        cdef int paritype
         cdef Py_ssize_t j
         cdef object otmp
 
@@ -675,8 +676,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
                 elif (isinstance(x, list) or isinstance(x, tuple)) and base > 1:
                     b = the_integer_ring(base)
-                    if b == 2: # we use a faster method
-                        for j from 0 <= j < len(x):
+                    if b == 2:  # we use a faster method
+                        for j in range(len(x)):
                             otmp = x[j]
                             if isinstance(otmp, int):
                                 if (<long> otmp) == 1:
@@ -968,7 +969,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: m.list()
             [5]
         """
-        return [ self ]
+        return [self]
 
     def __dealloc__(self):
         mpz_clear(self.value)
@@ -1037,7 +1038,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: (-45)._mathml_()
             '<mn>-45</mn>'
         """
-        return '<mn>%s</mn>'%self
+        return '<mn>%s</mn>' % self
 
     def __mpz__(self):
         """
@@ -1098,7 +1099,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             '1000000000'
         """
         if base < 2 or base > 36:
-            raise ValueError("base (=%s) must be between 2 and 36" % base)
+            raise ValueError(f"base (={base}) must be between 2 and 36")
         cdef size_t n
         cdef char *s
         n = mpz_sizeinbase(self.value, base) + 2
@@ -1157,16 +1158,15 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             '112th'
             sage: ZZ(111).ordinal_str()
             '111th'
-
         """
-        if self<0:
+        if self < 0:
             raise ValueError("Negative integers are not ordinals.")
         n = self.abs()
-        if ((n%100)!=11 and n%10==1):
+        if (n % 100) != 11 and n % 10 == 1:
             th = 'st'
-        elif ((n%100)!=12 and n%10==2):
+        elif (n % 100) != 12 and n % 10 == 2:
             th = 'nd'
-        elif ((n%100)!=13 and n%10==3):
+        elif (n % 100) != 13 and n % 10 == 3:
             th = 'rd'
         else:
             th = 'th'
@@ -1513,7 +1513,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                     o = -one
                 z = zero
             l = [z]*(s if s >= padto else padto)
-            for i from 0<= i < s:
+            for i in range(s):
                 # mpz_tstbit seems to return 0 for the high-order bit of
                 # negative numbers?!
                 if mpz_tstbit(self_abs.value,i):
@@ -1521,7 +1521,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         else:
             s = mpz_sizeinbase(self.value, 2)
             do_sig_on = (s > 256)
-            if do_sig_on: sig_on()
+            if do_sig_on:
+                sig_on()
 
             # We use a divide and conquer approach (suggested by the prior
             # author, malb?, of the digits method) here: for base b, compute
@@ -1577,7 +1578,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                 # assigning zero.
                 _digits_internal(self.value,l,0,i-1,power_list,digits)
 
-            if do_sig_on: sig_off()
+            if do_sig_on:
+                sig_off()
 
         # padding should be taken care of with-in the function
         # all we need to do is return
@@ -1908,7 +1910,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             if mpz_fits_slong_p(self.value):
                 return s * mpz_get_si(self.value)
             else:
-                return s * int(self) # will raise the appropriate exception
+                return s * int(self)  # will raise the appropriate exception
 
     cdef _mul_long(self, long n) noexcept:
         """
@@ -2024,9 +2026,9 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             # left * den(right) / num(right)
             y = <Rational> Rational.__new__(Rational)
             mpq_div_zz(y.value, (<Integer>left).value,
-                                mpq_numref((<Rational>right).value))
+                       mpq_numref((<Rational>right).value))
             mpz_mul(mpq_numref(y.value), mpq_numref(y.value),
-                       mpq_denref((<Rational>right).value))
+                    mpq_denref((<Rational>right).value))
             return y
 
         return coercion_model.bin_op(left, right, operator.truediv)
@@ -2460,7 +2462,6 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         cdef size_t l_min
         cdef size_t l_max
         cdef size_t l
-        cdef Integer result
         cdef mpz_t accum
         cdef mpz_t temp_exp
 
@@ -2578,7 +2579,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             if (1 << (pow_2-1)) == upper-lower:
                 pow_2 -= 1
             pow_2_things = [rif_m]*pow_2
-            for i from 1<=i<pow_2:
+            for i in range(pow_2):
                 pow_2_things[i] = pow_2_things[i-1]**2
             for i from pow_2>i>=0:
                 middle = lower + int(2)**i
@@ -2683,13 +2684,12 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         cdef Integer result
         cdef size_t n_log2
         cdef size_t m_log2
-        cdef size_t guess # this will contain the final answer
+        cdef size_t guess  # this will contain the final answer
         cdef bint guess_filled = 0  # this variable is only used in one branch below
-        cdef mpz_t z
         if isinstance(m, Integer):
-            _m=<Integer>m
+            _m = <Integer>m
         else:
-            _m=<Integer>Integer(m)
+            _m = <Integer>Integer(m)
 
         self_sgn = mpz_sgn(self.value)
         if self_sgn == 0:
@@ -2717,7 +2717,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
             # we've already excluded the case when m is an exact power of 2
 
-            if n_log2/m_log2 > 8000:
+            if n_log2 / m_log2 > 8000:
                 # If we have a very large number of digits, it can be a nice
                 # shortcut to test the guess using interval arithmetic.
                 # (suggested by David Harvey and Carl Witty)
@@ -2729,7 +2729,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                     guess_filled = 1
                 elif self < approx_compare:
                     guess_filled = 1
-                    guess =  guess - 1
+                    guess = guess - 1
             if not guess_filled:
                 # At this point, either
                 #  1)  self is close enough to a perfect power of m that we
@@ -2864,15 +2864,14 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             if elog == -sage.rings.infinity.infinity or m**elog == self:
                 return elog
 
-        if (isinstance(m, Rational)
-                and m.numer() == 1):
+        if isinstance(m, Rational) and m.numer() == 1:
             elog = -self.exact_log(m.denom())
             if m**elog == self:
                 return elog
 
         from sage.functions.log import function_log
         return function_log(self,dont_call_method_on_arg=True)/\
-                function_log(m,dont_call_method_on_arg=True)
+            function_log(m,dont_call_method_on_arg=True)
 
     def exp(self, prec=None):
         r"""
@@ -3113,7 +3112,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
         cdef list all, prev, sorted
         cdef Py_ssize_t tip, top
-        cdef Py_ssize_t i, j, e, ee
+        cdef Py_ssize_t i, e, ee
         cdef Integer apn, p, pn, z, all_tip
 
         f = self.factor()
@@ -3124,7 +3123,6 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         cdef unsigned long p_c, pn_c, apn_c
         cdef Py_ssize_t all_len, sorted_len, prev_len
         cdef unsigned long* ptr
-        cdef unsigned long* empty_c
         cdef unsigned long* swap_tmp
         cdef unsigned long* all_c
         cdef unsigned long* sorted_c
@@ -3222,7 +3220,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                         sorted = []
                         tip = 0
                         top = len(all)
-                        mpz_mul(pn.value, pn.value, p.value) # pn *= p
+                        mpz_mul(pn.value, pn.value, p.value)  # pn *= p
                         for a in prev:
                             # apn = a*pn
                             apn = <Integer>PY_NEW(Integer)
@@ -3510,7 +3508,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             ZeroDivisionError: cannot raise to a power modulo 0
         """
         cdef Integer x, _exp, _mod
-        _exp = Integer(exp); _mod = Integer(mod)
+        _exp = Integer(exp)
+        _mod = Integer(mod)
         if mpz_cmp_si(_mod.value,0) == 0:
             raise ZeroDivisionError("cannot raise to a power modulo 0")
 
@@ -3763,51 +3762,75 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             # We need to find i.
             m = start % 30
             if 0 <= m <= 1:
-                i = 0; m = start + (1-m)
+                i = 0
+                m = start + (1-m)
             elif 1 < m <= 7:
-                i = 1; m = start + (7-m)
+                i = 1
+                m = start + (7-m)
             elif 7 < m <= 11:
-                i = 2; m = start + (11-m)
+                i = 2
+                m = start + (11-m)
             elif 11 < m <= 13:
-                i = 3; m = start + (13-m)
+                i = 3
+                m = start + (13-m)
             elif 13 < m <= 17:
-                i = 4; m = start + (17-m)
+                i = 4
+                m = start + (17-m)
             elif 17 < m <= 19:
-                i = 5; m = start + (19-m)
+                i = 5
+                m = start + (19-m)
             elif 19 < m <= 23:
-                i = 6; m = start + (23-m)
+                i = 6
+                m = start + (23-m)
             elif 23 < m <= 29:
-                i = 7; m = start + (29-m)
-        dif[0]=6;dif[1]=4;dif[2]=2;dif[3]=4;dif[4]=2;dif[5]=4;dif[6]=6;dif[7]=2
+                i = 7
+                m = start + (29-m)
+        dif[0] = 6
+        dif[1] = 4
+        dif[2] = 2
+        dif[3] = 4
+        dif[4] = 2
+        dif[5] = 4
+        dif[6] = 6
+        dif[7] = 2
         cdef Integer x = PY_NEW(Integer)
         if mpz_fits_ulong_p(self.value):
             n = mpz_get_ui(self.value)   # ignores the sign automatically
-            if n == 1: return one
-            if start <= 2 and n%2==0:
-                mpz_set_ui(x.value,2); return x
-            if start <= 3 and n%3==0:
-                mpz_set_ui(x.value,3); return x
-            if start <= 5 and n%5==0:
-                mpz_set_ui(x.value,5); return x
+            if n == 1:
+                return one
+            if start <= 2 and n % 2 == 0:
+                mpz_set_ui(x.value,2)
+                return x
+            if start <= 3 and n % 3 == 0:
+                mpz_set_ui(x.value,3)
+                return x
+            if start <= 5 and n % 5 == 0:
+                mpz_set_ui(x.value,5)
+                return x
             limit = <unsigned long> sqrt_double(<double> n)
-            if bound < limit: limit = bound
+            if bound < limit:
+                limit = bound
             # Algorithm: only trial divide by numbers that
             # are congruent to 1,7,11,13,17,19,23,29 mod 30=2*3*5.
             while m <= limit:
-                if n%m == 0:
-                    mpz_set_ui(x.value, m); return x
-                m += dif[i%8]
+                if n % m == 0:
+                    mpz_set_ui(x.value, m)
+                    return x
+                m += dif[i % 8]
                 i += 1
             mpz_abs(x.value, self.value)
             return x
         else:
             # self is big -- it doesn't fit in unsigned long.
             if start <= 2 and mpz_even_p(self.value):
-                mpz_set_ui(x.value,2); return x
+                mpz_set_ui(x.value,2)
+                return x
             if start <= 3 and mpz_divisible_ui_p(self.value,3):
-                mpz_set_ui(x.value,3); return x
+                mpz_set_ui(x.value,3)
+                return x
             if start <= 5 and mpz_divisible_ui_p(self.value,5):
-                mpz_set_ui(x.value,5); return x
+                mpz_set_ui(x.value,5)
+                return x
 
             # x.value = floor(sqrt(self.value))
             sig_on()
@@ -3829,7 +3852,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             return x
 
     def factor(self, algorithm='pari', proof=None, limit=None, int_=False,
-                     verbose=0):
+               verbose=0):
         """
         Return the prime factorization of this integer as a
         formal Factorization object.
@@ -3949,23 +3972,22 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             raise ValueError("Algorithm is not known")
 
         cdef Integer n, p, unit
-        cdef int i
 
         if mpz_sgn(self.value) == 0:
             raise ArithmeticError("factorization of 0 is not defined")
 
         if mpz_sgn(self.value) > 0:
-            n    = self
+            n = self
             unit = one
         else:
-            n    = PY_NEW(Integer)
+            n = PY_NEW(Integer)
             unit = PY_NEW(Integer)
             mpz_neg(n.value, self.value)
             mpz_set_si(unit.value, -1)
 
         if mpz_cmpabs_ui(n.value, 1) == 0:
             return IntegerFactorization([], unit=unit, unsafe=True,
-                                            sort=False, simplify=False)
+                                        sort=False, simplify=False)
 
         if limit is not None:
             from sage.rings.factorint import factor_trial_division
@@ -3986,7 +4008,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                 F = [(smallInteger(a), smallInteger(b)) for a, b in F]
                 F.sort()
                 return IntegerFactorization(F, unit=unit, unsafe=True,
-                                               sort=False, simplify=False)
+                                            sort=False, simplify=False)
 
         if mpz_sizeinbase(n.value, 2) < 40:
             from sage.rings.factorint import factor_trial_division
@@ -3997,20 +4019,20 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             F = factor_using_pari(n, int_=int_, debug_level=verbose, proof=proof)
             F.sort()
             return IntegerFactorization(F, unit=unit, unsafe=True,
-                                           sort=False, simplify=False)
+                                        sort=False, simplify=False)
         elif algorithm == 'flint':
             from sage.rings.factorint_flint import factor_using_flint
             F = factor_using_flint(n)
             F.sort()
             return IntegerFactorization(F, unit=unit, unsafe=True,
-                                           sort=False, simplify=False)
+                                        sort=False, simplify=False)
 
         elif algorithm in ['kash', 'magma']:
             if algorithm == 'kash':
                 from sage.interfaces.kash import kash as I
             else:
                 from sage.interfaces.magma import magma as I
-            str_res = I.eval('Factorization(%s)'%n)
+            str_res = I.eval('Factorization(%s)' % n)
             # The result looks like "[ <n1, p1>, <p2, e2>, ... ]
             str_res = str_res.replace(']', '').replace('[', '').replace('>', '').replace('<', '').split(',')
             res = [int(s.strip()) for s in str_res]
@@ -4025,7 +4047,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             F = qsieve(n)
             F.sort()
             return IntegerFactorization(F, unit=unit, unsafe=True,
-                                           sort=False, simplify=False)
+                                        sort=False, simplify=False)
         else:
             from sage.interfaces.ecm import ecm
             res = [(p, 1) for p in ecm.factor(n, proof=proof)]
@@ -4051,10 +4073,10 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: 0.support()
             Traceback (most recent call last):
             ...
-            ArithmeticError: Support of 0 not defined.
+            ArithmeticError: Support of 0 not defined
         """
         if self.is_zero():
-            raise ArithmeticError("Support of 0 not defined.")
+            raise ArithmeticError("Support of 0 not defined")
         return sage.arith.all.prime_factors(self)
 
     def coprime_integers(self, m):
@@ -4345,7 +4367,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         if mpz_cmpabs_ui(self.value, 1) <= 0:
             return self
 
-        odd  = PY_NEW(Integer)
+        odd = PY_NEW(Integer)
         bits = mpz_scan1(self.value, 0)
         mpz_tdiv_q_2exp(odd.value, self.value, bits)
         return odd
@@ -4918,100 +4940,100 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         cdef unsigned long b, c
         cdef mpz_t u, sabs, nabs
         a = mpz_cmp_ui(n.value, 2)
-        if a <= 0: # n <= 2
-            if a == 0: # n == 2
-                if mpz_popcount(self.value) == 1: #number of bits set in self == 1
+        if a <= 0:  # n <= 2
+            if a == 0:  # n == 2
+                if mpz_popcount(self.value) == 1:  # number of bits set in self == 1
                     return 1
                 else:
                     return 0
             a = mpz_cmp_si(n.value, -2)
-            if a >= 0: # -2 <= n < 2:
+            if a >= 0:  # -2 <= n < 2:
                 a = mpz_get_si(n.value)
-                if a == 1: # n == 1
-                    if mpz_cmp_ui(self.value, 1) == 0: # Only 1 is a power of 1
+                if a == 1:  # n == 1
+                    if mpz_cmp_ui(self.value, 1) == 0:  # Only 1 is a power of 1
                         return 1
                     else:
                         return 0
-                elif a == 0: # n == 0
-                    if mpz_cmp_ui(self.value, 0) == 0 or mpz_cmp_ui(self.value, 1) == 0: # 0^0 = 1, 0^x = 0
+                elif a == 0:  # n == 0
+                    if mpz_cmp_ui(self.value, 0) == 0 or mpz_cmp_ui(self.value, 1) == 0:  # 0^0 = 1, 0^x = 0
                         return 1
                     else:
                         return 0
-                elif a == -1: # n == -1
-                    if mpz_cmp_ui(self.value, 1) == 0 or mpz_cmp_si(self.value, -1) == 0: # 1 and -1 are powers of -1
+                elif a == -1:  # n == -1
+                    if mpz_cmp_ui(self.value, 1) == 0 or mpz_cmp_si(self.value, -1) == 0:  # 1 and -1 are powers of -1
                         return 1
                     else:
                         return 0
-                elif a == -2: # n == -2
+                elif a == -2:  # n == -2
                     mpz_init(sabs)
                     mpz_abs(sabs, self.value)
-                    if mpz_popcount(sabs) == 1: # number of bits set in |self| == 1
-                        b = mpz_scan1(sabs, 0) % 2 # b == 1 if |self| is an odd power of 2, 0 if |self| is an even power
+                    if mpz_popcount(sabs) == 1:  # number of bits set in |self| == 1
+                        b = mpz_scan1(sabs, 0) % 2  # b == 1 if |self| is an odd power of 2, 0 if |self| is an even power
                         mpz_clear(sabs)
                         if (b == 1 and mpz_cmp_ui(self.value, 0) < 0) or (b == 0 and mpz_cmp_ui(self.value, 0) > 0):
                             # An odd power of -2 is negative, an even power must be positive.
                             return 1
-                        else: # number of bits set in |self| is not 1, so self cannot be a power of -2
+                        else:  # number of bits set in |self| is not 1, so self cannot be a power of -2
                             return 0
-                    else: # |self| is not a power of 2, so self cannot be a power of -2
+                    else:  # |self| is not a power of 2, so self cannot be a power of -2
                         return 0
-            else: # n < -2
+            else:  # n < -2
                 mpz_init(nabs)
                 mpz_neg(nabs, n.value)
-                if mpz_popcount(nabs) == 1: # |n| = 2^k for k >= 2.  We special case this for speed
+                if mpz_popcount(nabs) == 1:  # |n| = 2^k for k >= 2.  We special case this for speed
                     mpz_init(sabs)
                     mpz_abs(sabs, self.value)
-                    if mpz_popcount(sabs) == 1: # |self| = 2^L for some L >= 0.
-                        b = mpz_scan1(sabs, 0) # the bit that self is set at
-                        c = mpz_scan1(nabs, 0) # the bit that n is set at
+                    if mpz_popcount(sabs) == 1:  # |self| = 2^L for some L >= 0.
+                        b = mpz_scan1(sabs, 0)  # the bit that self is set at
+                        c = mpz_scan1(nabs, 0)  # the bit that n is set at
                         # Having obtained b and c, we're done with nabs and sabs (on this branch anyway)
                         mpz_clear(nabs)
                         mpz_clear(sabs)
-                        if b % c == 0: # Now we know that |self| is a power of |n|
-                            b = (b // c) % 2 # Whether b // c is even or odd determines whether (-2^c)^(b // c) is positive or negative
+                        if b % c == 0:  # Now we know that |self| is a power of |n|
+                            b = (b // c) % 2  # Whether b // c is even or odd determines whether (-2^c)^(b // c) is positive or negative
                             a = mpz_cmp_ui(self.value, 0)
                             if b == 0 and a > 0 or b == 1 and a < 0:
                                 # These two cases are that b // c is even and self positive, or b // c is odd and self negative
                                 return 1
-                            else: # The sign of self is wrong
+                            else:  # The sign of self is wrong
                                 return 0
-                        else: # Since |self| is not a power of |n|, self cannot be a power of n
+                        else:  # Since |self| is not a power of |n|, self cannot be a power of n
                             return 0
-                    else: # self is not a power of 2, and thus cannot be a power of n, which is a power of 2.
+                    else:  # self is not a power of 2, and thus cannot be a power of n, which is a power of 2.
                         mpz_clear(nabs)
                         mpz_clear(sabs)
                         return 0
-                else: # |n| is not a power of 2, so we use mpz_remove
+                else:  # |n| is not a power of 2, so we use mpz_remove
                     mpz_init(u)
                     sig_on()
                     b = mpz_remove(u, self.value, nabs)
                     sig_off()
                     # Having obtained b and u, we're done with nabs
                     mpz_clear(nabs)
-                    if mpz_cmp_ui(u, 1) == 0: # self is a power of |n|
+                    if mpz_cmp_ui(u, 1) == 0:  # self is a power of |n|
                         mpz_clear(u)
-                        if b % 2 == 0: # an even power of |n|, and since self > 0, this means that self is a power of n
+                        if b % 2 == 0:  # an even power of |n|, and since self > 0, this means that self is a power of n
                             return 1
                         else:
                             return 0
-                    elif mpz_cmp_si(u, -1) == 0: # -self is a power of |n|
+                    elif mpz_cmp_si(u, -1) == 0:  # -self is a power of |n|
                         mpz_clear(u)
-                        if b % 2 == 1: # an odd power of |n|, and thus self is a power of n
+                        if b % 2 == 1:  # an odd power of |n|, and thus self is a power of n
                             return 1
                         else:
                             return 0
-                    else: # |self| is not a power of |n|, so self cannot be a power of n
+                    else:  # |self| is not a power of |n|, so self cannot be a power of n
                         mpz_clear(u)
                         return 0
-        elif mpz_popcount(n.value) == 1: # n > 2 and in fact n = 2^k for k >= 2
-            if mpz_popcount(self.value) == 1: # since n is a power of 2, so must self be.
-                if mpz_scan1(self.value, 0) % mpz_scan1(n.value, 0) == 0: # log_2(self) is divisible by log_2(n)
+        elif mpz_popcount(n.value) == 1:  # n > 2 and in fact n = 2^k for k >= 2
+            if mpz_popcount(self.value) == 1:  # since n is a power of 2, so must self be.
+                if mpz_scan1(self.value, 0) % mpz_scan1(n.value, 0) == 0:  # log_2(self) is divisible by log_2(n)
                     return 1
                 else:
                     return 0
-            else: # self is not a power of 2, and thus not a power of n
+            else:  # self is not a power of 2, and thus not a power of n
                 return 0
-        else: # n > 2, but not a power of 2, so we use mpz_remove
+        else:  # n > 2, but not a power of 2, so we use mpz_remove
             mpz_init(u)
             sig_on()
             mpz_remove(u, self.value, n.value)
@@ -5252,8 +5274,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             return (self, zero) if get_data else False
 
     _small_primes_table[:] = [
-        0,1,1,1,0,1,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,  #   1,  3,..., 49
-        0,1,0,0,1,1,0,0,1,0,1,1,0,0,1,0,1,0,0,1,0,0,0,1,0,  #  51, 53,..., 99
+        0,1,1,1,0,1,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,  # 001, 03,..., 49
+        0,1,0,0,1,1,0,0,1,0,1,1,0,0,1,0,1,0,0,1,0,0,0,1,0,  # 051, 53,..., 99
         1,1,0,1,1,0,1,0,0,0,0,0,0,1,0,1,0,0,1,1,0,0,0,0,1,  # 101,103,...,149
         1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,1,0,0,0,0,1,1,0,1,1,  # 151,153,...,199
         0,0,0,0,0,1,0,0,0,0,0,1,0,1,1,0,1,0,0,1,1,0,0,0,0,  # 201,203,...,249
@@ -5725,7 +5747,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         global objtogen
         if objtogen is None:
             from cypari2.gen import objtogen
-        flag =  self < 0 and proof
+        flag = self < 0 and proof
         return objtogen(self).qfbclassno(flag).sage()
 
     def squarefree_part(self, long bound=-1):
@@ -5829,7 +5851,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: 144168.next_probable_prime()
             144169
         """
-        return Integer( self.__pari__().nextprime(True) )
+        return Integer(self.__pari__().nextprime(True))
 
     def next_prime(self, proof=None):
         r"""
@@ -6138,7 +6160,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: len([D for D in srange(-100,100) if D.is_discriminant()])
             100
         """
-        return self%4 in [0,1]
+        return self % 4 in [0, 1]
 
     def is_fundamental_discriminant(self):
         """
@@ -6166,17 +6188,16 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: len([D for D in srange(-100,100)                                      # needs sage.libs.pari
             ....:      if D.is_fundamental_discriminant()])
             61
-
         """
-        if self in [0,1]:
+        if self in [0, 1]:
             return False
-        Dmod4 = self%4
-        if Dmod4 in [2,3]:
+        Dmod4 = self % 4
+        if Dmod4 in [2, 3]:
             return False
         if Dmod4 == 1:
             return self.is_squarefree()
-        d = self//4
-        return d%4 in [2,3] and d.is_squarefree()
+        d = self // 4
+        return d % 4 in [2, 3] and d.is_squarefree()
 
     cpdef __pari__(self) noexcept:
         """
@@ -6274,9 +6295,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             True
         """
         if self.ndigits(2) > 10000:
-            return 'StringToInteger("%s",16)'%self.str(16)
-        else:
-            return str(self)
+            return 'StringToInteger("%s",16)' % self.str(16)
+        return str(self)
 
     def _sage_input_(self, sib, coerced):
         r"""
@@ -6339,13 +6359,13 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: Integer(-102).sqrtrem()
             Traceback (most recent call last):
             ...
-            ValueError: square root of negative integer not defined.
+            ValueError: square root of negative integer not defined
 
         """
         if mpz_sgn(self.value) < 0:
-            raise ValueError("square root of negative integer not defined.")
+            raise ValueError("square root of negative integer not defined")
         cdef Integer s = PY_NEW(Integer)
-        cdef Integer r  = PY_NEW(Integer)
+        cdef Integer r = PY_NEW(Integer)
         mpz_sqrtrem(s.value, r.value, self.value)
         return s, r
 
@@ -6365,10 +6385,10 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: Integer(-102).isqrt()
             Traceback (most recent call last):
             ...
-            ValueError: square root of negative integer not defined.
+            ValueError: square root of negative integer not defined
         """
         if mpz_sgn(self.value) < 0:
-            raise ValueError("square root of negative integer not defined.")
+            raise ValueError("square root of negative integer not defined")
 
         cdef Integer x = PY_NEW(Integer)
 
@@ -6696,7 +6716,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                 try:
                     y = Integer(y)
                 except TypeError:
-                    raise TypeError("unsupported operands for %s: %s, %s"%(("<<" if sign == 1 else ">>"), self, y))
+                    raise TypeError("unsupported operands for %s: %s, %s" % (("<<" if sign == 1 else ">>"), self, y))
                 except ValueError:
                     return coercion_model.bin_op(self, y, operator.lshift if sign == 1 else operator.rshift)
 
@@ -6945,8 +6965,9 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
     def crt(self, y, m, n):
         """
         Return the unique integer between `0` and `mn` that is congruent to
-        the integer modulo `m` and to `y` modulo `n`. We assume that `m` and
-        `n` are coprime.
+        the integer modulo `m` and to `y` modulo `n`.
+
+        We assume that `m` and `n` are coprime.
 
         EXAMPLES::
 
@@ -6958,10 +6979,12 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: m%11
             5
         """
-        cdef object g, s, t
+        cdef object g, s
         cdef Integer _y, _m, _n
-        _y = Integer(y); _m = Integer(m); _n = Integer(n)
-        g, s, t = _m.xgcd(_n)
+        _y = Integer(y)
+        _m = Integer(m)
+        _n = Integer(n)
+        g, s, _ = _m.xgcd(_n)
         if not g.is_one():
             raise ArithmeticError("CRT requires that gcd of moduli is 1.")
         # Now s*m + t*n = 1, so the answer is x + (y-x)*s*m, where x=self.
@@ -7022,7 +7045,6 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         if mpz_sgn(self.value) < 0:
             return sage.rings.infinity.Infinity
         return smallInteger(mpz_popcount(self.value))
-
 
     def conjugate(self):
         """
@@ -7323,7 +7345,7 @@ def GCD_list(v):
     cdef int i, n = len(v)
     cdef Integer z = <Integer>PY_NEW(Integer)
 
-    for i from 0 <= i < n:
+    for i in range(n):
         if not isinstance(v[i], Integer):
             if not isinstance(v, list):
                 v = list(v)
@@ -7336,7 +7358,7 @@ def GCD_list(v):
 
     sig_on()
     mpz_gcd(z.value, (<Integer>v[0]).value, (<Integer>v[1]).value)
-    for i from 2 <= i < n:
+    for i in range(2, n):
         if mpz_cmp_ui(z.value, 1) == 0:
             break
         mpz_gcd(z.value, z.value, (<Integer>v[i]).value)
@@ -7480,7 +7502,7 @@ cdef class long_to_Z(Morphism):
     def _repr_type(self):
         return "Native"
 
-############### INTEGER CREATION CODE #####################
+# ############## INTEGER CREATION CODE #####################
 
 # This variable holds the size of any Integer object in bytes.
 cdef int sizeof_Integer
@@ -7491,6 +7513,7 @@ cdef Integer global_dummy_Integer
 global_dummy_Integer = Integer()
 # Reallocate to one limb to fix :trac:`31340` and :trac:`33081`
 _mpz_realloc(global_dummy_Integer.value, 1)
+
 
 def _check_global_dummy_Integer():
     """
@@ -7560,13 +7583,13 @@ cdef PyObject* fast_tp_new(type t, args, kwds) except NULL:
         # they do not possess references to other Python
         # objects (as indicated by the Py_TPFLAGS_HAVE_GC flag).
         # See below for a more detailed description.
-        new = <PyObject*>PyObject_Malloc( sizeof_Integer )
+        new = <PyObject*>PyObject_Malloc(sizeof_Integer)
         if unlikely(new == NULL):
             raise MemoryError
 
         # Now set every member as set in z, the global dummy Integer
         # created before this tp_new started to operate.
-        memcpy(new, (<void*>global_dummy_Integer), sizeof_Integer )
+        memcpy(new, (<void*>global_dummy_Integer), sizeof_Integer)
 
         # We allocate memory for the _mp_d element of the value of this
         # new Integer. We allocate one limb. Normally, one would use
@@ -7670,15 +7693,16 @@ cdef integer(x) noexcept:
         return x
     return Integer(x)
 
+
 def free_integer_pool():
     cdef int i
     cdef PyObject *o
 
     global integer_pool_count, integer_pool_size
 
-    for i from 0 <= i < integer_pool_count:
+    for i in range(integer_pool_count):
         o = integer_pool[i]
-        mpz_clear( (<Integer>o).value )
+        mpz_clear((<Integer>o).value)
         # Free the object. This assumes that Py_TPFLAGS_HAVE_GC is not
         # set. If it was set another free function would need to be
         # called.
@@ -7688,6 +7712,7 @@ def free_integer_pool():
     integer_pool_count = 0
     sig_free(integer_pool)
 
+
 # Replace default allocation and deletion with faster custom ones
 hook_fast_tp_functions()
 
@@ -7695,7 +7720,8 @@ hook_fast_tp_functions()
 initialized = False
 cdef set_zero_one_elements() noexcept:
     global the_integer_ring, initialized
-    if initialized: return
+    if initialized:
+        return
     the_integer_ring._zero_element = Integer(0)
     the_integer_ring._one_element = Integer(1)
     initialized = True

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -4073,7 +4073,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: 0.support()
             Traceback (most recent call last):
             ...
-            ArithmeticError: Support of 0 not defined
+            ArithmeticError: support of 0 not defined
         """
         if self.is_zero():
             raise ArithmeticError("Support of 0 not defined")

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -3825,7 +3825,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             if start <= 2 and mpz_even_p(self.value):
                 mpz_set_ui(x.value, 2)
                 return x
-            if start <= 3 and mpz_divisible_ui_p(self.value,3):
+            if start <= 3 and mpz_divisible_ui_p(self.value, 3):
                 mpz_set_ui(x.value,3)
                 return x
             if start <= 5 and mpz_divisible_ui_p(self.value,5):

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -3823,7 +3823,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         else:
             # self is big -- it doesn't fit in unsigned long.
             if start <= 2 and mpz_even_p(self.value):
-                mpz_set_ui(x.value,2)
+                mpz_set_ui(x.value, 2)
                 return x
             if start <= 3 and mpz_divisible_ui_p(self.value,3):
                 mpz_set_ui(x.value,3)

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -3829,7 +3829,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                 mpz_set_ui(x.value,3)
                 return x
             if start <= 5 and mpz_divisible_ui_p(self.value,5):
-                mpz_set_ui(x.value,5)
+                mpz_set_ui(x.value, 5)
                 return x
 
             # x.value = floor(sqrt(self.value))

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -2871,7 +2871,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
         from sage.functions.log import function_log
         return function_log(self,dont_call_method_on_arg=True)/\
-            function_log(m,dont_call_method_on_arg=True)
+            function_log(m, dont_call_method_on_arg=True)
 
     def exp(self, prec=None):
         r"""

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -3826,9 +3826,9 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                 mpz_set_ui(x.value, 2)
                 return x
             if start <= 3 and mpz_divisible_ui_p(self.value, 3):
-                mpz_set_ui(x.value,3)
+                mpz_set_ui(x.value, 3)
                 return x
-            if start <= 5 and mpz_divisible_ui_p(self.value,5):
+            if start <= 5 and mpz_divisible_ui_p(self.value, 5):
                 mpz_set_ui(x.value, 5)
                 return x
 

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -207,8 +207,7 @@ new_gen_from_integer = None
 cdef extern from *:
     int unlikely(int) nogil  # Defined by Cython
 
-cdef object numpy_long_interface = {'typestr': '=i4' if sizeof(long) == 4
-                                    else '=i8'}
+cdef object numpy_long_interface = {'typestr': '=i4' if sizeof(long) == 4 else '=i8'}
 cdef object numpy_int64_interface = {'typestr': '=i8'}
 cdef object numpy_object_interface = {'typestr': '|O'}
 
@@ -5274,8 +5273,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             return (self, zero) if get_data else False
 
     _small_primes_table[:] = [
-        0,1,1,1,0,1,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,  # 001, 03,..., 49
-        0,1,0,0,1,1,0,0,1,0,1,1,0,0,1,0,1,0,0,1,0,0,0,1,0,  # 051, 53,..., 99
+        0,1,1,1,0,1,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,  # 1,3,...,49
+        0,1,0,0,1,1,0,0,1,0,1,1,0,0,1,0,1,0,0,1,0,0,0,1,0,  # 51,53,...,99
         1,1,0,1,1,0,1,0,0,0,0,0,0,1,0,1,0,0,1,1,0,0,0,0,1,  # 101,103,...,149
         1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,1,0,0,0,0,1,1,0,1,1,  # 151,153,...,199
         0,0,0,0,0,1,0,0,0,0,0,1,0,1,1,0,1,0,0,1,1,0,0,0,0,  # 201,203,...,249

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -4076,7 +4076,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             ArithmeticError: support of 0 not defined
         """
         if self.is_zero():
-            raise ArithmeticError("Support of 0 not defined")
+            raise ArithmeticError("support of 0 not defined")
         return sage.arith.all.prime_factors(self)
 
     def coprime_integers(self, m):

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -2870,7 +2870,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                 return elog
 
         from sage.functions.log import function_log
-        return function_log(self,dont_call_method_on_arg=True)/\
+        return function_log(self, dont_call_method_on_arg=True)/\
             function_log(m, dont_call_method_on_arg=True)
 
     def exp(self, prec=None):


### PR DESCRIPTION
some cleanup in the file `integer.pyx`

mostly fixing E702 warnings, and other `cython-lint` warnings

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.