### PR TITLE
.github/workflows/docker.yml: Interrupt the build before the 6 hour cancellation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,10 @@ on:
       free_disk_space:
         default: false
         type: boolean
+      timeout:
+        description: 'Elapsed time (seconds) at which to kill the build'
+        default: 20000
+        type: number
       #
       # Publishing to GitHub Packages
       #
@@ -224,6 +228,7 @@ jobs:
         if: inputs.free_disk_space
       - name: Configure and build Sage distribution within a Docker container
         run: |
+          (sleep ${{ inputs.timeout }}; for id in $(docker ps -q); do docker exec $id pkill make; done) &
           set -o pipefail; EXTRA_DOCKER_BUILD_ARGS="--build-arg NUMPROC=4 --build-arg USE_MAKEFLAGS=\"-k V=0 SAGE_NUM_THREADS=3\"" tox -e $TOX_ENV -- $TARGETS 2>&1 | sed "/^configure: notice:/s|^|::warning file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;/^configure: warning:/s|^|::warning file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;/^configure: error:/s|^|::error file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;"
       - name: Copy logs from the Docker image or build container
         run: |


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
When a CI Linux workflow is canceled, because we are using `docker build`, no image is written out.

Here we add an input parameter `timeout`, defaulting to 5.5 hours, after which we kill the  `make` process inside of the build container.
Then our script (in tox) writes out and pushes an image (marked as "-failed") to ghcr.io, enabling better diagnostics.

See https://github.com/mkoeppe/sage/actions/runs/6831246509/job/18580446041 for a test run where for demonstration purposes I set the timeout to 6 minutes.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
