### PR TITLE
refresh the file plural.pyx

### DIFF
--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -37,8 +37,7 @@ The underlying libSINGULAR interface was implemented by
 
   - Martin Albrecht (2009-05): added `\ZZ/n\ZZ` support, refactoring
 
-  - Martin Albrecht (2009-06): refactored the code to allow better
-    re-use
+  - Martin Albrecht (2009-06): refactored the code to allow better re-use
 
 .. TODO::
 
@@ -100,7 +99,6 @@ TESTS::
     sage: TestSuite(P).run()
     sage: loads(dumps(P)) is P
     True
-
 """
 from cysignals.memory cimport sig_malloc, sig_free
 
@@ -128,12 +126,11 @@ from sage.rings.polynomial.multi_polynomial_libsingular cimport MPolynomialRing_
 from sage.rings.polynomial.multi_polynomial_ideal import NCPolynomialIdeal
 
 from sage.rings.polynomial.polydict import ETuple
-from sage.rings.ring import check_default_category
+from sage.rings.ring import check_default_category, Ring
 from sage.structure.element cimport CommutativeRingElement, Element, RingElement
 from sage.structure.factory import UniqueFactory
 from sage.structure.richcmp cimport rich_to_bool
 from sage.structure.parent cimport Parent
-from sage.structure.parent_gens cimport ParentWithGens
 from sage.rings.polynomial.term_order import TermOrder
 
 from sage.misc.functional import coerce
@@ -149,7 +146,6 @@ class G_AlgFactory(UniqueFactory):
         sage: H = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
         sage: H is A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y}) # indirect doctest
         True
-
     """
     def create_object(self, version, key, **extra_args):
         """
@@ -157,15 +153,15 @@ class G_AlgFactory(UniqueFactory):
 
         INPUT:
 
-        - ``key`` - a 6-tuple, formed by a base ring, a tuple of names, two
+        - ``key`` -- a 6-tuple, formed by a base ring, a tuple of names, two
           matrices over a polynomial ring over the base ring with the given
           variable names, a term order, and a category
-        - ``extra_args`` - a dictionary, whose only relevant key is 'check'.
+        - ``extra_args`` -- a dictionary, whose only relevant key is 'check'.
 
         TESTS::
 
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
-            sage: H=A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
+            sage: H = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
             sage: sorted(H.relations().items(), key=str)
             [(y*x, x*y - z), (z*x, x*z + 2*x), (z*y, y*z - 2*y)]
         """
@@ -183,12 +179,12 @@ class G_AlgFactory(UniqueFactory):
 
         INPUT:
 
-        - ``base_ring`` - a ring
-        - ``c,d`` - two matrices
-        - ``names`` - a tuple or list of names
-        - ``order`` - (optional) term order
-        - ``category`` - (optional) category
-        - ``check`` - optional bool
+        - ``base_ring`` -- a ring
+        - ``c,d`` -- two matrices
+        - ``names`` -- a tuple or list of names
+        - ``order`` -- (optional) term order
+        - ``category`` -- (optional) category
+        - ``check`` -- optional bool
 
         TESTS::
 
@@ -196,7 +192,6 @@ class G_AlgFactory(UniqueFactory):
             sage: H = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y})
             sage: H is A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y}) # indirect doctest
             True
-
         """
         if names is None:
             raise ValueError("The generator names must be provided")
@@ -255,9 +250,9 @@ cdef class NCPolynomialRing_plural(Ring):
 
         INPUT:
 
-        - ``base_ring`` - base ring (must be either `\GF{q}`, `\ZZ`, `\ZZ/n\ZZ`, `\QQ` or absolute number field)
+        - ``base_ring`` -- base ring (must be either `\GF{q}`, `\ZZ`, `\ZZ/n\ZZ`, `\QQ` or absolute number field)
         - ``names`` - a tuple of names of ring variables
-        - ``c``, ``d``- upper triangular matrices of coefficients,
+        - ``c``, ``d`` -- upper triangular matrices of coefficients,
           resp. commutative polynomials, satisfying the nondegeneracy
           conditions, which are to be tested if ``check`` is ``True``. These
           matrices describe the noncommutative relations:
@@ -266,8 +261,8 @@ cdef class NCPolynomialRing_plural(Ring):
 
           where ``0 <= i < j < self.ngens()``. Note that two variables
           commute if they are not part of one of these relations.
-        - ``order`` - term order
-        - ``check`` - check the noncommutative conditions (default: ``True``)
+        - ``order`` -- term order
+        - ``check`` -- check the noncommutative conditions (default: ``True``)
 
         TESTS:
 
@@ -339,16 +334,14 @@ cdef class NCPolynomialRing_plural(Ring):
         self._ngens = n
         self._term_order = order
 
-        Ring.__init__(self, base_ring, names, category=category)
+        Ring.__init__(self, base_ring, names, category=category,
+                      normalize=False)
         self._populate_coercion_lists_()
 
-        #MPolynomialRing_generic.__init__(self, base_ring, n, names, order)
-        #self._has_singular = True
-        assert(n == len(self._names))
+        assert n == len(self._names)
 
         self._one_element = new_NCP(self, p_ISet(1, self._ring))
         self._zero_element = new_NCP(self, NULL)
-
 
         if check:
             from sage.libs.singular.function_factory import ff
@@ -378,9 +371,9 @@ cdef class NCPolynomialRing_plural(Ring):
             True
         """
         return g_Algebra, (self.base_ring(), self._c, self._d,
-                            self.variable_names(),
-                            self.term_order(),
-                            self.category())
+                           self.variable_names(),
+                           self.term_order(),
+                           self.category())
 
     def __dealloc__(self):
         r"""
@@ -420,7 +413,7 @@ cdef class NCPolynomialRing_plural(Ring):
 
     def _element_constructor_(self, element):
         """
-        Make sure element is a valid member of self, and return the constructed element.
+        Make sure element is a valid member of ``self``, and return the constructed element.
 
         EXAMPLES::
 
@@ -441,7 +434,7 @@ cdef class NCPolynomialRing_plural(Ring):
 
         TESTS:
 
-        Check conversion from self::
+        Check conversion from ``self``::
 
             sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
             sage: P.<x,y,z> = A.g_algebra(relations={y*x:-x*y}, order = 'lex')
@@ -496,9 +489,7 @@ cdef class NCPolynomialRing_plural(Ring):
             sage: B = A.g_algebra({y*x:-x*y})
             sage: B(2)
             2
-
         """
-
         if element == 0:
             return self._zero_element
         if element == 1:
@@ -517,7 +508,8 @@ cdef class NCPolynomialRing_plural(Ring):
         except Exception:
             pass
 
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
 
         if isinstance(element, NCPolynomial_plural):
 
@@ -592,7 +584,7 @@ cdef class NCPolynomialRing_plural(Ring):
 
     def free_algebra(self):
         """
-        The free algebra of which this is the quotient.
+        Return the free algebra of which this is the quotient.
 
         EXAMPLES::
 
@@ -607,7 +599,9 @@ cdef class NCPolynomialRing_plural(Ring):
 
     def __hash__(self):
         """
-        Return a hash for this noncommutative ring, that is, a hash of the string
+        Return a hash for this noncommutative ring.
+
+        This is a hash of the string
         representation of this polynomial ring.
 
         NOTE:
@@ -624,7 +618,6 @@ cdef class NCPolynomialRing_plural(Ring):
             sage: P = A.g_algebra(relations={y*x:-x*y}, order = 'lex')
             sage: {P:2}[P]            # indirect doctest
             2
-
         """
         return <Py_hash_t> <void *> self
 
@@ -632,10 +625,10 @@ cdef class NCPolynomialRing_plural(Ring):
         """
         Return the free module of rank `n` over this ring.
 
-        NOTE:
+        .. NOTE::
 
-        This is not properly implemented yet. Thus, there is
-        a warning.
+            This is not properly implemented yet. Thus, there is
+            a warning.
 
         EXAMPLES::
 
@@ -653,7 +646,6 @@ cdef class NCPolynomialRing_plural(Ring):
             It's also not guaranteed that all multiplications are
             done from the right side.
             Ambient free module of rank 3 over Noncommutative Multivariate Polynomial Ring in x, y, z over Rational Field, nc-relations: {y*x: -x*y}
-
         """
         from sage.modules.free_module import FreeModule
         return FreeModule(self, n)
@@ -758,8 +750,7 @@ cdef class NCPolynomialRing_plural(Ring):
             rChangeCurrRing(_ring)
         from sage.libs.singular.function import singular_function
         ringlist = singular_function('ringlist')
-        result = ringlist(self, ring=self)
-        return result
+        return ringlist(self, ring=self)
 
     def relations(self, add_commutative=False):
         """
@@ -786,7 +777,6 @@ cdef class NCPolynomialRing_plural(Ring):
             {z*x: x*z + 2*x, z*y: y*z - 2*y}
             sage: H.relations(add_commutative=True)
             {y*x: x*y, z*x: x*z + 2*x, z*y: y*z - 2*y}
-
         """
         if add_commutative:
             if self._relations_commutative is not None:
@@ -799,7 +789,7 @@ cdef class NCPolynomialRing_plural(Ring):
             n = self.ngens()
             for r in range(0, n-1, 1):
                 for c in range(r+1, n, 1):
-                    res[ A.gen(c) * A.gen(r) ] = self.gen(c) * self.gen(r) # C[r, c] * P.gen(r) * P.gen(c) + D[r, c]
+                    res[A.gen(c) * A.gen(r)] = self.gen(c) * self.gen(r)  # C[r, c] * P.gen(r) * P.gen(c) + D[r, c]
             self._relations_commutative = res
             return res
 
@@ -814,14 +804,14 @@ cdef class NCPolynomialRing_plural(Ring):
         for r in range(0, n-1, 1):
             for c in range(r+1, n, 1):
                 if (self.gen(c) * self.gen(r) != self.gen(r) * self.gen(c)):
-                    res[ A.gen(c) * A.gen(r) ] = self.gen(c) * self.gen(r) # C[r, c] * P.gen(r) * P.gen(c) + D[r, c]
+                    res[A.gen(c) * A.gen(r)] = self.gen(c) * self.gen(r)  # C[r, c] * P.gen(r) * P.gen(c) + D[r, c]
 
         self._relations = res
         return self._relations
 
     def ngens(self):
         """
-        Returns the number of variables in this noncommutative polynomial ring.
+        Return the number of variables in this noncommutative polynomial ring.
 
         EXAMPLES::
 
@@ -834,7 +824,7 @@ cdef class NCPolynomialRing_plural(Ring):
 
     def gen(self, int n=0):
         """
-        Returns the ``n``-th generator of this noncommutative polynomial
+        Return the ``n``-th generator of this noncommutative polynomial
         ring.
 
         INPUT:
@@ -890,15 +880,14 @@ cdef class NCPolynomialRing_plural(Ring):
             Left Ideal (x + 2*y + 2*z - 1, 2*x*y + 2*y*z - y, x^2 - x + 2*y^2 + 2*z^2) of Noncommutative Multivariate Polynomial Ring in x, y, z over Rational Field, nc-relations: {y*x: -x*y}
             sage: P.ideal([x + 2*y + 2*z-1, 2*x*y + 2*y*z-y, x^2 + 2*y^2 + 2*z^2-x], side="twosided")
             Twosided Ideal (x + 2*y + 2*z - 1, 2*x*y + 2*y*z - y, x^2 - x + 2*y^2 + 2*z^2) of Noncommutative Multivariate Polynomial Ring in x, y, z over Rational Field, nc-relations: {y*x: -x*y}
-
         """
         coerce = kwds.get('coerce', True)
         if len(gens) == 1:
             gens = gens[0]
-        #if is_SingularElement(gens):
+        # if is_SingularElement(gens):
         #    gens = list(gens)
         #    coerce = True
-        #elif is_Macaulay2Element(gens):
+        # elif is_Macaulay2Element(gens):
         #    gens = list(gens)
         #    coerce = True
         if not isinstance(gens, (list, tuple)):
@@ -920,9 +909,9 @@ cdef class NCPolynomialRing_plural(Ring):
            sage: Q # indirect doctest
            <noncommutative RingWrap>
         """
-
         cdef ring* _ring = self._ring
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
 
         from sage.libs.singular.function import singular_function
         ring = singular_function('ring')
@@ -977,9 +966,9 @@ cdef class NCPolynomialRing_plural(Ring):
 
         INPUT:
 
-        - ``f`` - monomial
-        - ``g`` - monomial
-        - ``coeff`` - divide coefficients as well (default: ``False``)
+        - ``f`` -- monomial
+        - ``g`` -- monomial
+        - ``coeff`` -- divide coefficients as well (default: ``False``)
 
         EXAMPLES::
 
@@ -1050,7 +1039,8 @@ cdef class NCPolynomialRing_plural(Ring):
         if self is not g._parent:
             g = self.coerce(g)
 
-        if(r != currRing): rChangeCurrRing(r)
+        if r != currRing:
+            rChangeCurrRing(r)
 
         if not f._poly:
             return self._zero_element
@@ -1060,7 +1050,8 @@ cdef class NCPolynomialRing_plural(Ring):
         res = pMDivide(f._poly, g._poly)
         if coeff:
             if (r.cf.type == n_unknown) or r.cf.cfDivBy(p_GetCoeff(f._poly, r), p_GetCoeff(g._poly, r), r.cf):
-                n = r.cf.cfDiv( p_GetCoeff(f._poly, r) , p_GetCoeff(g._poly, r), r.cf)
+                n = r.cf.cfDiv(p_GetCoeff(f._poly, r),
+                               p_GetCoeff(g._poly, r), r.cf)
                 p_SetCoeff0(res, n, r)
             else:
                 raise ArithmeticError("Cannot divide these coefficients.")
@@ -1130,7 +1121,6 @@ cdef class NCPolynomialRing_plural(Ring):
         else:
             return True
 
-
     def monomial_lcm(self, NCPolynomial_plural f, NCPolynomial_plural g):
         """
         LCM for monomials. Coefficients are ignored.
@@ -1187,7 +1177,8 @@ cdef class NCPolynomialRing_plural(Ring):
         if g._poly == NULL:
             raise ArithmeticError("Cannot compute LCM of zero and nonzero element.")
 
-        if(self._ring != currRing): rChangeCurrRing(self._ring)
+        if self._ring != currRing:
+            rChangeCurrRing(self._ring)
 
         pLcm(f._poly, g._poly, m)
         p_Setm(m, self._ring)
@@ -1318,18 +1309,18 @@ cdef class NCPolynomialRing_plural(Ring):
 
         if p == NULL:
             if q == NULL:
-                return False #GCD(0,0) = 0
+                return False  # GCD(0,0) = 0
             else:
-                return True #GCD(x,0) = 1
+                return True  # GCD(x,0) = 1
 
         elif q == NULL:
-            return True # GCD(0,x) = 1
+            return True  # GCD(0,x) = 1
 
-        elif p_IsConstant(p,r) or p_IsConstant(q,r): # assuming a base field
+        elif p_IsConstant(p, r) or p_IsConstant(q, r):  # assuming a base field
             return False
 
         for i from 1 <= i <= r.N:
-            if p_GetExp(p,i,r) and p_GetExp(q,i,r):
+            if p_GetExp(p, i, r) and p_GetExp(q, i, r):
                 return False
         return True
 
@@ -1540,8 +1531,8 @@ cdef class NCPolynomial_plural(RingElement):
         """
         cdef poly *_p
         singular_polynomial_add(&_p, left._poly,
-                                 (<NCPolynomial_plural>right)._poly,
-                                 (<NCPolynomialRing_plural>left._parent)._ring)
+                                (<NCPolynomial_plural>right)._poly,
+                                (<NCPolynomialRing_plural>left._parent)._ring)
         return new_NCP((<NCPolynomialRing_plural>left._parent), _p)
 
     cpdef _sub_(left, right) noexcept:
@@ -1623,8 +1614,8 @@ cdef class NCPolynomial_plural(RingElement):
         # all currently implemented rings are commutative
         cdef poly *_p
         singular_polynomial_mul(&_p, left._poly,
-                                 (<NCPolynomial_plural>right)._poly,
-                                 (<NCPolynomialRing_plural>left._parent)._ring)
+                                (<NCPolynomial_plural>right)._poly,
+                                (<NCPolynomialRing_plural>left._parent)._ring)
         return new_NCP((<NCPolynomialRing_plural>left._parent),_p)
 
     cpdef _div_(left, right) noexcept:
@@ -1764,7 +1755,8 @@ cdef class NCPolynomial_plural(RingElement):
         cdef ring *r = parent._ring
         cdef poly *res
 
-        if(r != currRing): rChangeCurrRing(r)
+        if r != currRing:
+            rChangeCurrRing(r)
 
         if isinstance(I, NCPolynomialIdeal):
             try:
@@ -1777,7 +1769,7 @@ cdef class NCPolynomial_plural(RingElement):
         _I = idInit(len(I),1)
         for f in I:
             if not (isinstance(f, NCPolynomial_plural)
-                   and <NCPolynomialRing_plural>(<NCPolynomial_plural>f)._parent is parent):
+                    and <NCPolynomialRing_plural>(<NCPolynomial_plural>f)._parent is parent):
                 try:
                     f = parent.coerce(f)
                 except TypeError as msg:
@@ -1787,9 +1779,9 @@ cdef class NCPolynomial_plural(RingElement):
             _I.m[i] = p_Copy((<NCPolynomial_plural>f)._poly, r)
             i+=1
 
-        #the second parameter would be qring!
+        # the second parameter would be qring!
         res = kNF(_I, NULL, self._poly)
-        id_Delete(&_I,r)
+        id_Delete(&_I, r)
         return new_NCP(parent,res)
 
     def _repr_(self):
@@ -1971,8 +1963,10 @@ cdef class NCPolynomial_plural(RingElement):
 
     def degrees(self):
         """
-        Returns a tuple with the maximal degree of each variable in
-        this polynomial.  The list of degrees is ordered by the order
+        Return a tuple with the maximal degree of each variable in
+        this polynomial.
+
+        The list of degrees is ordered by the order
         of the generators.
 
         EXAMPLES::
@@ -1997,7 +1991,6 @@ cdef class NCPolynomial_plural(RingElement):
                 d[i] = max(d[i],p_GetExp(p, i+1, r))
             p = pNext(p)
         return tuple(d)
-
 
     def coefficient(self, degrees):
         """
@@ -2208,18 +2201,19 @@ cdef class NCPolynomial_plural(RingElement):
         cdef int n
         cdef int v
         r = (<NCPolynomialRing_plural>self._parent)._ring
-        if r!=currRing: rChangeCurrRing(r)
+        if r != currRing:
+            rChangeCurrRing(r)
         base = (<NCPolynomialRing_plural>self._parent)._base
         p = self._poly
         pd = dict()
         while p:
             d = dict()
             for v from 1 <= v <= r.N:
-                n = p_GetExp(p,v,r)
-                if n!=0:
+                n = p_GetExp(p, v, r)
+                if n != 0:
                     d[v-1] = n
 
-            pd[ETuple(d,r.N)] = si2sa(p_GetCoeff(p, r), r, base)
+            pd[ETuple(d, r.N)] = si2sa(p_GetCoeff(p, r), r, base)
 
             p = pNext(p)
         return pd
@@ -2273,7 +2267,6 @@ cdef class NCPolynomial_plural(RingElement):
             base_map = codomain
         return sum(prod(im_gens[i]**val for i, val in enumerate(t))*base_map(d[t]) for t in d)
 
-
     cdef long _hash_c(self) noexcept:
         """
         See :meth:`__hash__`
@@ -2283,16 +2276,17 @@ cdef class NCPolynomial_plural(RingElement):
         cdef int n
         cdef int v
         r = (<NCPolynomialRing_plural>self._parent)._ring
-        if r!=currRing: rChangeCurrRing(r)
+        if r != currRing:
+            rChangeCurrRing(r)
         base = (<NCPolynomialRing_plural>self._parent)._base
         p = self._poly
-        cdef long result = 0 # store it in a c-int and just let the overflowing additions wrap
+        cdef long result = 0  # store it in a c-int and just let the overflowing additions wrap
         cdef long result_mon
         var_name_hash = [hash(vn) for vn in self._parent.variable_names()]
         cdef long c_hash
         while p:
             c_hash = hash(si2sa(p_GetCoeff(p, r), r, base))
-            if c_hash != 0: # this is always going to be true, because we are sparse (correct?)
+            if c_hash != 0:  # this is always going to be true, because we are sparse (correct?)
                 # Hash (self[i], gen_a, exp_a, gen_b, exp_b, gen_c, exp_c, ...) as a tuple according to the algorithm.
                 # I omit gen,exp pairs where the exponent is zero.
                 result_mon = c_hash
@@ -2440,9 +2434,9 @@ cdef class NCPolynomial_plural(RingElement):
             True
         """
         cdef ring *_ring = (<NCPolynomialRing_plural>self._parent)._ring
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
         return bool(p_IsHomogeneous(self._poly,_ring))
-
 
     def is_monomial(self):
         """
@@ -2474,7 +2468,8 @@ cdef class NCPolynomial_plural(RingElement):
         if self._poly == NULL:
             return True
 
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
 
         _p = p_Head(self._poly, _ring)
         _n = p_GetCoeff(_p, _ring)
@@ -2538,7 +2533,8 @@ cdef class NCPolynomial_plural(RingElement):
         l = list()
         cdef NCPolynomialRing_plural parent = <NCPolynomialRing_plural>self._parent
         cdef ring *_ring = parent._ring
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
         cdef poly *p = p_Copy(self._poly, _ring)
         cdef poly *t
 
@@ -2550,7 +2546,7 @@ cdef class NCPolynomial_plural(RingElement):
             p.next = NULL
             p_SetCoeff(p, n_Init(1,_ring.cf), _ring)
             p_Setm(p, _ring)
-            l.append( new_NCP(parent,p) )
+            l.append(new_NCP(parent, p))
             p = t
 
         return l
@@ -2582,9 +2578,9 @@ cdef class NCPolynomial_plural(RingElement):
             p = pNext(p)
 
         if p_LmIsConstant(p, r):
-            return si2sa( p_GetCoeff(p, r), r, (<NCPolynomialRing_plural>self._parent)._base )
-        else:
-            return (<NCPolynomialRing_plural>self._parent)._base._zero_element
+            return si2sa(p_GetCoeff(p, r), r,
+                         (<NCPolynomialRing_plural>self._parent)._base)
+        return (<NCPolynomialRing_plural>self._parent)._base._zero_element
 
     cpdef is_constant(self) noexcept:
         """
@@ -2605,10 +2601,10 @@ cdef class NCPolynomial_plural(RingElement):
 
     def lm(NCPolynomial_plural self):
         """
-        Returns the lead monomial of ``self`` with respect to the term
+        Return the lead monomial of ``self`` with respect to the term
         order of ``self.parent()``.
 
-        In Sage a monomial is a product of variables in some power
+        In Sage, a monomial is a product of variables in some power
         without a coefficient.
 
         EXAMPLES::
@@ -2645,7 +2641,6 @@ cdef class NCPolynomial_plural(RingElement):
             sage: f = x^4*y^7*z^1 + x^4*y^2*z^3
             sage: f.lm()
             x^4*y^7*z
-
         """
         cdef poly *_p
         cdef ring *_ring
@@ -2677,7 +2672,6 @@ cdef class NCPolynomial_plural(RingElement):
             sage: f.lc()
             5
         """
-
         cdef poly *_p
         cdef ring *_ring
         cdef number *_n
@@ -2686,20 +2680,21 @@ cdef class NCPolynomial_plural(RingElement):
         if self._poly == NULL:
             return (<NCPolynomialRing_plural>self._parent)._base._zero_element
 
-        if(_ring != currRing): rChangeCurrRing(_ring)
+        if _ring != currRing:
+            rChangeCurrRing(_ring)
 
         _p = p_Head(self._poly, _ring)
         _n = p_GetCoeff(_p, _ring)
 
-        ret =  si2sa(_n, _ring, (<NCPolynomialRing_plural>self._parent)._base)
+        ret = si2sa(_n, _ring, (<NCPolynomialRing_plural>self._parent)._base)
         p_Delete(&_p, _ring)
         return ret
 
     def lt(NCPolynomial_plural self):
         """
-        Leading term of this polynomial.
+        Return the leading term of this polynomial.
 
-        In Sage a term is a product of variables in some power and a
+        In Sage, a term is a product of variables in some power and a
         coefficient.
 
         EXAMPLES::
@@ -2721,7 +2716,7 @@ cdef class NCPolynomial_plural(RingElement):
             return (<NCPolynomialRing_plural>self._parent)._zero_element
 
         return new_NCP((<NCPolynomialRing_plural>self._parent),
-                                           p_Head(self._poly,(<NCPolynomialRing_plural>self._parent)._ring))
+                       p_Head(self._poly,(<NCPolynomialRing_plural>self._parent)._ring))
 
     def is_zero(self):
         """
@@ -2739,10 +2734,7 @@ cdef class NCPolynomial_plural(RingElement):
             sage: (x-x).is_zero()
             True
         """
-        if self._poly is NULL:
-            return True
-        else:
-            return False
+        return self._poly is NULL
 
     def __bool__(self):
         """
@@ -2758,10 +2750,7 @@ cdef class NCPolynomial_plural(RingElement):
             sage: bool(x-x)
             False
         """
-        if self._poly:
-            return True
-        else:
-            return False
+        return True if self._poly else False
 
     def __call__(self, *x, **kwds):
         """
@@ -2809,9 +2798,8 @@ cdef class NCPolynomial_plural(RingElement):
 
 #####################################################################
 
-
 cdef inline NCPolynomial_plural new_NCP(NCPolynomialRing_plural parent,
-        poly *juice) noexcept:
+                                        poly *juice) noexcept:
     """
     Construct NCPolynomial_plural from parent and SINGULAR poly.
 
@@ -2821,15 +2809,12 @@ cdef inline NCPolynomial_plural new_NCP(NCPolynomialRing_plural parent,
         sage: H = A.g_algebra({z*x:x*z+2*x, z*y:y*z-2*y})
         sage: H.gen(2)   # indirect doctest
         z
-
     """
     cdef NCPolynomial_plural p = NCPolynomial_plural.__new__(NCPolynomial_plural)
     p._parent = parent
     p._poly = juice
     p_Normalize(p._poly, parent._ring)
     return p
-
-
 
 
 cpdef MPolynomialRing_libsingular new_CRing(RingWrap rw, base_ring) noexcept:
@@ -2876,7 +2861,7 @@ cpdef MPolynomialRing_libsingular new_CRing(RingWrap rw, base_ring) noexcept:
         sage: C.one()
         1
     """
-    assert( rw.is_commutative() )
+    assert rw.is_commutative()
 
     cdef MPolynomialRing_libsingular self = <MPolynomialRing_libsingular>MPolynomialRing_libsingular.__new__(MPolynomialRing_libsingular)
 
@@ -2891,15 +2876,13 @@ cpdef MPolynomialRing_libsingular new_CRing(RingWrap rw, base_ring) noexcept:
     self._ring.ShortOut = 0
 
     self._ngens = rw.ngens()
-    self._term_order =  TermOrder(rw.ordering_string(), force=True)
+    self._term_order = TermOrder(rw.ordering_string(), force=True)
 
-    ParentWithGens.__init__(self, base_ring, tuple(rw.var_names()),
-                            normalize=False)
-#    self._populate_coercion_lists_()  # ???
+    names = tuple(rw.var_names())
+    Ring.__init__(self, base_ring, names, category=Algebras(base_ring),
+                  normalize=False)
 
-    #MPolynomialRing_generic.__init__(self, base_ring, n, names, order)
     self._has_singular = True
-#    self._relations = self.relations()
 
     return self
 
@@ -2951,8 +2934,7 @@ cpdef NCPolynomialRing_plural new_NRing(RingWrap rw, base_ring) noexcept:
         Noncommutative Multivariate Polynomial Ring in x, y, z over
         Rational Field, nc-relations: {y*x: x*y - 1}
     """
-
-    assert( not rw.is_commutative() )
+    assert not rw.is_commutative()
 
     cdef NCPolynomialRing_plural self = <NCPolynomialRing_plural>NCPolynomialRing_plural.__new__(NCPolynomialRing_plural)
     self._ring = rw._ring
@@ -2963,12 +2945,10 @@ cpdef NCPolynomialRing_plural new_NRing(RingWrap rw, base_ring) noexcept:
     self._ring.ShortOut = 0
 
     self._ngens = rw.ngens()
-    self._term_order =  TermOrder(rw.ordering_string(), force=True)
+    self._term_order = TermOrder(rw.ordering_string(), force=True)
 
-    ParentWithGens.__init__(self, base_ring, rw.var_names())
-#    self._populate_coercion_lists_()  # ???
+    Ring.__init__(self, base_ring, rw.var_names(), category=Algebras(base_ring))
 
-    #MPolynomialRing_generic.__init__(self, base_ring, n, names, order)
     self._has_singular = True
     self._relations = self.relations()
 
@@ -3029,6 +3009,7 @@ def new_Ring(RingWrap rw, base_ring):
         return new_CRing(rw, base_ring)
     return new_NRing(rw, base_ring)
 
+
 def SCA(base_ring, names, alt_vars, order='degrevlex'):
     """
     Return a free graded-commutative algebra
@@ -3067,24 +3048,25 @@ def SCA(base_ring, names, alt_vars, order='degrevlex'):
     n = len(names)
     alt_start = min(alt_vars)
     alt_end = max(alt_vars)
-    assert( alt_start >= 0 )
-    assert( (alt_end >= alt_start) and (alt_end < n) )
+    assert 0 <= alt_start <= alt_end < n
 
-    relations = {} # {y*x:-x*y}
+    relations = {}  # {y*x:-x*y}
     from sage.algebras.free_algebra import FreeAlgebra
     A = FreeAlgebra(base_ring, n, names)
     for r in range(0, n-1, 1):
         for c in range(r+1, n, 1):
-            if (r in alt_vars) and (c in alt_vars):
-                relations[ A.gen(c) * A.gen(r) ] = - A.gen(r) * A.gen(c)
+            if r in alt_vars and c in alt_vars:
+                relations[A.gen(c) * A.gen(r)] = - A.gen(r) * A.gen(c)
 
-    cdef NCPolynomialRing_plural H = A.g_algebra(relations=relations, order=order)
+    cdef NCPolynomialRing_plural H = A.g_algebra(relations=relations,
+                                                 order=order)
     I = H.ideal([H.gen(i) * H.gen(i) for i in alt_vars]).twostd()
     return H.quotient(I)
 
+
 def ExteriorAlgebra(base_ring, names,order='degrevlex'):
     """
-    Return the exterior algebra on some generators
+    Return the exterior algebra on some generators.
 
     This is also known as a Grassmann algebra. This is a finite
     dimensional algebra, where all generators anti-commute.
@@ -3116,16 +3098,18 @@ def ExteriorAlgebra(base_ring, names,order='degrevlex'):
         1
     """
     n = len(names)
-    relations = {} # {y*x:-x*y}
+    relations = {}  # {y*x:-x*y}
     from sage.algebras.free_algebra import FreeAlgebra
     A = FreeAlgebra(base_ring, n, names)
     for r in range(n-1):
         for c in range(r+1, n):
-            relations[ A.gen(c) * A.gen(r) ] = - A.gen(r) * A.gen(c)
+            relations[A.gen(c) * A.gen(r)] = - A.gen(r) * A.gen(c)
 
-    cdef NCPolynomialRing_plural H = A.g_algebra(relations=relations,order=order)
+    cdef NCPolynomialRing_plural H = A.g_algebra(relations=relations,
+                                                 order=order)
     I = H.ideal([H.gen(i) * H.gen(i) for i in range(n)]).twostd()
     return H.quotient(I)
+
 
 cdef poly *addwithcarry(poly *tempvector, poly *maxvector, int pos, ring *_ring) noexcept:
     if p_GetExp(tempvector, pos, _ring) < p_GetExp(maxvector, pos, _ring):

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -334,8 +334,7 @@ cdef class NCPolynomialRing_plural(Ring):
         self._ngens = n
         self._term_order = order
 
-        Ring.__init__(self, base_ring, names, category=category,
-                      normalize=False)
+        Ring.__init__(self, base_ring, names, category=category)
         self._populate_coercion_lists_()
 
         assert n == len(self._names)
@@ -2716,7 +2715,7 @@ cdef class NCPolynomial_plural(RingElement):
             return (<NCPolynomialRing_plural>self._parent)._zero_element
 
         return new_NCP((<NCPolynomialRing_plural>self._parent),
-                       p_Head(self._poly,(<NCPolynomialRing_plural>self._parent)._ring))
+                       p_Head(self._poly, (<NCPolynomialRing_plural>self._parent)._ring))
 
     def is_zero(self):
         """


### PR DESCRIPTION
The main goal is to get rid of `ParentWithGens` there, replaced by `Ring`.

I also took the opportunity to clean cython-lint warnings and other code and doc details.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.