### PR TITLE
less use of _an_element_impl

### DIFF
--- a/src/sage/combinat/free_module.py
+++ b/src/sage/combinat/free_module.py
@@ -777,20 +777,6 @@ class CombinatorialFreeModule(UniqueRepresentation, Module, IndexedGenerators):
                                lambda x: self.sum_of_terms((G(g), K(c))
                                                            for c, g in x))
 
-    def _an_element_impl(self):  # TODO: REMOVE?
-        """
-        Return an element of ``self``, namely the zero element.
-
-        EXAMPLES::
-
-            sage: F = CombinatorialFreeModule(QQ, ['a', 'b', 'c'])
-            sage: F._an_element_impl()
-            0
-            sage: _.parent() is F
-            True
-        """
-        return self.element_class(self, {})
-
     def _first_ngens(self, n):
         """
         Used by the preparser for ``F.<x> = ...``.

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -1428,6 +1428,15 @@ class Gap(Gap_generic):
         """
         return GapElement
 
+    def _an_element_(self):
+        """
+        EXAMPLES::
+
+            sage: gap._an_element_()
+            0
+        """
+        return self(0)
+
     def _function_element_class(self):
         """
         Returns the GapFunctionElement class.

--- a/src/sage/interfaces/lie.py
+++ b/src/sage/interfaces/lie.py
@@ -530,11 +530,11 @@ class LiE(ExtraTabCompletion, Expect):
         else:
             return self._tab_completion_list
 
-    def _an_element_impl(self):
+    def _an_element_(self):
         """
         EXAMPLES::
 
-            sage: lie._an_element_impl() # optional - lie
+            sage: lie._an_element_() # optional - lie
             0
         """
         return self(0)

--- a/src/sage/interfaces/lisp.py
+++ b/src/sage/interfaces/lisp.py
@@ -136,14 +136,14 @@ class Lisp(Expect):
                         x.append(M.strip())
                         self.__in_seq = s
                     except TypeError as s:
-                        return 'error evaluating "%s":\n%s' % (code,s)
+                        return 'error evaluating "%s":\n%s' % (code, s)
             return '\n'.join(x)
 
-    def _an_element_impl(self):
+    def _an_element_(self):
         """
         EXAMPLES::
 
-            sage: lisp._an_element_impl()
+            sage: lisp._an_element_()
             0
         """
         return self(0)

--- a/src/sage/interfaces/r.py
+++ b/src/sage/interfaces/r.py
@@ -1085,7 +1085,7 @@ class R(ExtraTabCompletion, Interface):
         """
         return self.function_call(function_name, args=args, kwds=kwds)
 
-    def _an_element_impl(self):
+    def _an_element_(self):
         """
         Returns an element belonging to the R interpreter.  This is used
         behind the scenes when doing things like comparisons, etc.
@@ -1094,7 +1094,7 @@ class R(ExtraTabCompletion, Interface):
 
         EXAMPLES::
 
-            sage: r._an_element_impl()  # optional - rpy2
+            sage: r._an_element_()  # optional - rpy2
             [1] 0
             sage: type(_)  # optional - rpy2
             <class 'sage.interfaces.r.RElement'>

--- a/src/sage/modular/hecke/algebra.py
+++ b/src/sage/modular/hecke/algebra.py
@@ -181,9 +181,11 @@ class HeckeAlgebra_base(CachedRepresentation, CommutativeAlgebra):
         self.__M = M
         CommutativeAlgebra.__init__(self, M.base_ring())
 
-    def _an_element_impl(self):
+    def _an_element_(self):
         r"""
-        Return an element of this algebra. Used by the coercion machinery.
+        Return an element of this algebra.
+
+        Used by the coercion machinery.
 
         EXAMPLES::
 


### PR DESCRIPTION
replace some methods `_an_element_impl` by `_an_element_`

one little step on the long way towards getting rid of `parent_old`

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.
