### PR TITLE
CI conda: On `pull_request`, only run 1 macOS job and 1 Linux job

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -22,11 +22,18 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu, macos]
+        os: >-
+          ${{ github.event_name == 'pull_request'
+                && fromJson('["ubuntu"]')
+                || fromJson('["ubuntu, "macos]') }}
         python: ['3.9', '3.10', '3.11']
         # Optional environment is disabled for now as its not yet working
         # environment: [environment, environment-optional]
         conda-env: [environment]
+        include: >-
+          ${{ github.event_name == 'pull_request'
+                && fromJson('[{"os": "macos, "python": "3.11", "conda-env": "environment"}]')
+                || fromJson('[]') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -22,17 +22,25 @@ jobs:
 
     strategy:
       matrix:
+        # On pushes to tags or branches, test the whole matrix.
         os: >-
           ${{ github.event_name == 'pull_request'
                 && fromJson('["ubuntu"]')
-                || fromJson('["ubuntu, "macos]') }}
-        python: ['3.9', '3.10', '3.11']
+                || fromJson('["ubuntu", "macos"]') }}
+        python: >-
+          ${{ github.event_name == 'pull_request'
+                && fromJson('["3.9"]')
+                || fromJson('["3.9", "3.10", "3.11"]') }}
         # Optional environment is disabled for now as its not yet working
         # environment: [environment, environment-optional]
         conda-env: [environment]
+        # On pull requests, only test two jobs:
+        # Ubuntu with Python 3.9, macOS with Python 3.10.
+        # Build & Test currently uses Python 3.11 (on ubuntu-focal).
+        # Together, they cover the supported minor Python versions.
         include: >-
           ${{ github.event_name == 'pull_request'
-                && fromJson('[{"os": "macos, "python": "3.11", "conda-env": "environment"}]')
+                && fromJson('[{"os": "macos", "python": "3.10", "conda-env": "environment"}]')
                 || fromJson('[]') }}
 
     steps:


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
as discussed in https://github.com/sagemath/sage/pull/36678#issuecomment-1806192342, https://github.com/sagemath/sage/pull/36616#issuecomment-1811508709

On pushes to a tag, all 3 Linux and 3 macOS jobs are still run, as demonstrated in https://github.com/mkoeppe/sage/actions/runs/6829619271

<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

After merging, the branch protection rule https://github.com/sagemath/sage/settings/branch_protection_rules/33965567 will need to be updated. It controls what workflows show as "Required" in the PR Checks.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
