### PR TITLE
Fix SSL timeout in doctest / internet feature

### DIFF
--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -457,11 +457,15 @@ class DocTestController(SageObject):
                 options.hide.discard('all')
                 from sage.features.all import all_features
                 feature_names = {f.name for f in all_features() if not f.is_standard()}
+                from sage.doctest.external import external_software
+                feature_names.difference_update(external_software)
                 options.hide = options.hide.union(feature_names)
             if 'optional' in options.hide:
                 options.hide.discard('optional')
                 from sage.features.all import all_features
                 feature_names = {f.name for f in all_features() if f.is_optional()}
+                from sage.doctest.external import external_software
+                feature_names.difference_update(external_software)
                 options.hide = options.hide.union(feature_names)
 
         options.disabled_optional = set()

--- a/src/sage/features/internet.py
+++ b/src/sage/features/internet.py
@@ -56,7 +56,7 @@ class Internet(Feature):
         try:
             urlopen(req, timeout=1, context=default_context())
             return FeatureTestResult(self, True)
-        except urllib.error.URLError:
+        except (urllib.error.URLError, TimeoutError):
             return FeatureTestResult(self, False)
 
 


### PR DESCRIPTION
Recently I've been getting timeouts in a couple of doctests in `src/sage/doctest/control.py`, including earlier today when testing 10.2.rc1

This has two causes:
1. The test for the internet feature doesn't catch a `TimeoutError`.
2. These two doctests cause internet feature to be tested.

The first one is clearly a bug: sagemath only expects `urllib.error.URLError`, but in some cases urllib raises `TimeoutError`. Arguably a bug in urlib, but easier to fix (or workaround) on our side. Done in the first commit of this PR.

The second one is IMO a bug, since I didn't use `--optional=internet` no test should hit internet (in particular, should not test internet feature).

These two doctests are meant to test options `--hide=all` and `--hide=optional`. For some reason the semantics of these include testing for the internet feature. I believe the semantics of these options should be similar to `--optional=all`, that is, exclude "external" software  (internet feature is considered "external").

That's what I implemented in the second commit in this PR.

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.