### PR TITLE
CI Linux incremental: Set max_parallel = 8, reduce standard-sitepackages platforms

### DIFF
--- a/.github/workflows/ci-linux-incremental.yml
+++ b/.github/workflows/ci-linux-incremental.yml
@@ -98,6 +98,7 @@ jobs:
           ["standard",
            "minimal"]
       docker_push_repository: ghcr.io/${{ github.repository }}/
+      max_parallel: 8
 
   site:
     needs: [changed_files]
@@ -120,16 +121,10 @@ jobs:
       docker_targets: "with-targets"
       targets: "${{needs.changed_files.outputs.uninstall_targets}} ${{needs.changed_files.outputs.build_targets}} build doc-html ptest"
       # Only test systems with a usable system python (>= 3.9)
+      # with only a small number of test failures as of 10.2.rc0
       tox_system_factors: >-
-        ["ubuntu-jammy",
-         "ubuntu-mantic",
-         "debian-bullseye",
-         "debian-bookworm",
-         "fedora-33",
-         "fedora-38",
-         "gentoo-python3.11",
-         "archlinux",
-         "debian-bullseye-i386"]
+        ["gentoo-python3.11",
+         "archlinux"]
       tox_packages_factors: >-
           ["standard-sitepackages"]
       docker_push_repository: ghcr.io/${{ github.repository }}/


### PR DESCRIPTION
To reduce the impact of the PRs that run CI Linux incremental on the GH Actions queue, in particular after a release (for example: https://github.com/sagemath/sage/actions/runs/6827962772)

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
