### PR TITLE
CI macOS: Build following stages even when some job failed; adjust platforms

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -40,30 +40,35 @@ jobs:
     with:
       stage: "2"
     needs: [stage-1]
+    if: ${{ success() || failure() }}
 
   stage-2-optional-0-o:
     uses: ./.github/workflows/macos.yml
     with:
       stage: "2-optional-0-o"
     needs: [stage-2]
+    if: ${{ success() || failure() }}
 
   stage-2-optional-p-z:
     uses: ./.github/workflows/macos.yml
     with:
       stage: "2-optional-p-z"
     needs: [stage-2-optional-0-o]
+    if: ${{ success() || failure() }}
 
   stage-2-experimental-0-o:
     uses: ./.github/workflows/macos.yml
     with:
       stage: "2-optional-0-o"
     needs: [stage-2-optional-p-z]
+    if: ${{ success() || failure() }}
 
   stage-2-experimental-p-z:
     uses: ./.github/workflows/macos.yml
     with:
       stage: "2-experimental-p-z"
     needs: [stage-2-experimental-0-o]
+    if: ${{ success() || failure() }}
 
   dist:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,8 +29,7 @@ on:
            ["latest", "",             "homebrew-macos-usrlocal-maximal"],
            ["latest", "",             "homebrew-macos-usrlocal-python3_xcode-standard"],
            ["latest", "",             "conda-forge-macos-minimal"],
-           ["latest", "",             "conda-forge-macos-standard"],
-           ["latest", "",             "conda-forge-macos-maximal"]]
+           ["latest", "",             "conda-forge-macos-standard"]]
         type: string
       extra_sage_packages:
         description: 'Extra Sage packages to install as system packages'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ on:
         default: >-
           [["latest", "",             "homebrew-macos-usrlocal-minimal"],
            ["latest", "",             "homebrew-macos-usrlocal-standard"],
-           ["11",     "xcode_13.2.1", "homebrew-macos-usrlocal-standard"],
+           ["11",     "xcode_13.2.1", "homebrew-macos-usrlocal-minimal],
            ["12",     "",             "homebrew-macos-usrlocal-standard"],
            ["13",     "xcode_15.0",   "homebrew-macos-usrlocal-standard"],
            ["latest", "",             "homebrew-macos-usrlocal-maximal"],


### PR DESCRIPTION
To fix what can be seen in https://github.com/sagemath/sage/actions/runs/6827163283 - stage-2 was not attempted because some of the stage-1 jobs failed.

We also replace one of the failing platforms and remove another.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
