### PR TITLE
build/bin/sage-logger [V=0]: Show more lines of the log of failing builds

### DIFF
--- a/build/bin/sage-logger
+++ b/build/bin/sage-logger
@@ -79,7 +79,7 @@ if [ -n "$SAGE_SILENT_BUILD" -a ${use_prefix} = true ]; then
     status=$?
     if [[ $status != 0 ]]; then
         echo "  [$logname] error installing, exit status $status. End of log file:"
-        tail -n 72 "$logfile" | sed "/Please email sage-devel/,$ d;s;^;  [$logname]   ;" >&2
+        tail -n 120 "$logfile" | sed "/Please email sage-devel/,$ d;s;^;  [$logname]   ;" >&2
         echo "  [$logname] Full log file: $logfile"
     else
         echo "  [$logname] successfully installed."


### PR DESCRIPTION
When using `make V=0`, we build packages silently, and on errors we print out the tail of the log. For example, in 
https://github.com/sagemath/sage/actions/runs/6842945144/job/18611620859#step:11:7349
```
  [sphinxcontrib_serializinghtml-1.1.5] error installing, exit status 1. End of log file:
  [sphinxcontrib_serializinghtml-1.1.5]     │ exit code: 1
  [sphinxcontrib_serializinghtml-1.1.5]     ╰─> See above for output.
  [sphinxcontrib_serializinghtml-1.1.5]     
  [sphinxcontrib_serializinghtml-1.1.5]     note: This error originates from a subprocess, and is likely not a problem with pip.
  [sphinxcontrib_serializinghtml-1.1.5]     full command: /sage/local/var/lib/sage/venv-python3.9/bin/python3 -c '
  [sphinxcontrib_serializinghtml-1.1.5]     exec(compile('"'"''"'"''"'"'
```
But as this example shows, the current setting of showing 72 lines is no longer suitable for Python packages. It only shows lengthy output from a setuptools wrapper and boilerplate apologies from pip.

The real error message appears earlier, as can be seen in the full printout of the log: https://github.com/sagemath/sage/actions/runs/6842945144/job/18611620859#step:14:8095

Here we increase it from 72 lines to 120 lines, which should still be OK for output on the terminal.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
