### PR TITLE
rectify docs around Tkinter

### DIFF
--- a/src/doc/en/faq/faq-usage.rst
+++ b/src/doc/en/faq/faq-usage.rst
@@ -93,8 +93,10 @@ How to get Sage's Python to recognize my system's Tcl/Tk install?
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 It may be that you have Tcl/Tk installed and that your system's Python
-recognizes it but Sage's Python does not. To fix that, install the
-tcl/tk development library. On Ubuntu, this is the command
+recognizes it but Sage's Python does not. Normally speaking, there is little
+need to build Sage's Python nowadays (anno 2023), but if you do, here it is.
+Make sure you installed the tcl/tk development library.  On Ubuntu, this is the
+command
 
 .. CODE-BLOCK:: shell-session
 
@@ -104,7 +106,7 @@ or something along that line. Next, reinstall Sage's Python:
 
 .. CODE-BLOCK:: shell-session
 
-    $ sage -f python3
+    $ make python3-clean python3-uninstall && make python3
 
 This will pick up the tcl/tk library automatically. After successfully
 reinstalling Sage's Python, from within the Sage command line interface,

--- a/src/doc/en/faq/faq-usage.rst
+++ b/src/doc/en/faq/faq-usage.rst
@@ -95,7 +95,7 @@ How to get Sage's Python to recognize my system's Tcl/Tk install?
 It may be that you have Tcl/Tk installed and that your system's Python
 recognizes it but Sage's Python does not. Normally speaking, there is little
 need to build Sage's Python nowadays (anno 2023), but if you do, here it is.
-Make sure you installed the tcl/tk development library.  On Ubuntu, this is the
+Make sure you installed the Tcl/Tk development library.  On Ubuntu, this is the
 command
 
 .. CODE-BLOCK:: shell-session
@@ -108,7 +108,7 @@ or something along that line. Next, reinstall Sage's Python:
 
     $ make python3-clean python3-uninstall && make python3
 
-This will pick up the tcl/tk library automatically. After successfully
+This will pick up the Tcl/Tk library automatically. After successfully
 reinstalling Sage's Python, from within the Sage command line interface,
 issue these commands:
 

--- a/src/doc/en/installation/source.rst
+++ b/src/doc/en/installation/source.rst
@@ -446,13 +446,25 @@ If you don't want conda to be used by sage, deactivate conda (for the current sh
   operating system, or its own compilers.
 
 
-Tcl/Tk
-^^^^^^
+Tcl/Tk (and system's Python)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you want to use `Tcl/Tk <https://www.tcl.tk/>`_ libraries in Sage, you need
-to install the Tcl/Tk and its development headers before building Sage.  Sage's
-Python will then automatically recognize your system's install of Tcl/Tk.
+If you want to use `Tcl/Tk <https://www.tcl.tk/>`_ libraries in Sage, and you
+are going to use your OS's Python3 as Sage's Python, you merely need to install
+its **Tkinter** module.  On Lunix systems, it is usually provided by the
+**python3-tk** or a similarly named (e.g. **python3-tkinter**) package,
+which can be installed using::
 
+    $ sudo apt-get install python3-tk
+
+or similar commands.
+
+Tcl/Tk (and Sage's own Python)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want to use `Tcl/Tk <https://www.tcl.tk/>`_ libraries in Sage,
+and you are going to build Sage's Python from source, you need to install
+these, and the corresponding headers.
 On Linux systems, these are usually provided by the **tk** and **tk-dev**
 (or **tk-devel**) packages which can be installed using::
 
@@ -460,6 +472,8 @@ On Linux systems, these are usually provided by the **tk** and **tk-dev**
 
 or similar commands.
 
+
+Sage's Python will then automatically recognize your system's install of Tcl/Tk.
 If you installed Sage first, all is not lost. You just need to rebuild
 Sage's Python and any part of Sage relying on it::
 

--- a/src/doc/en/installation/source.rst
+++ b/src/doc/en/installation/source.rst
@@ -451,7 +451,7 @@ Tcl/Tk (and system's Python)
 
 If you want to use `Tcl/Tk <https://www.tcl.tk/>`_ libraries in Sage, and you
 are going to use your OS's Python3 as Sage's Python, you merely need to install
-its **Tkinter** module.  On Lunix systems, it is usually provided by the
+its **Tkinter** module.  On Linux systems, it is usually provided by the
 **python3-tk** or a similarly named (e.g. **python3-tkinter**) package,
 which can be installed using::
 

--- a/src/doc/it/faq/faq-usage.rst
+++ b/src/doc/it/faq/faq-usage.rst
@@ -81,15 +81,16 @@ Come posso far riconoscere la mia attuale installazione di Tcl/Tk all'interprete
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Potresti avere la libreria Tcl/Tk installata e l'interprete Python del
-tuo sistema la riconosce ma l'interprete Python di Sage no.
-Per risolvere questo ti basta installare la libreria di sviluppo
-Tcl/Tk. Su Ubuntu lancia, da riga di comando::
+tuo sistema la riconosce ma l'interprete Python di Sage no. Ad oggi (2023)
+solitamente non c'è bisogno di compilare l'interprete Python di Sage, ma se ne
+hai bisogno, segui queste istruzioni. Controlla di aver installato la libreria
+di sviluppp Tcl/Tk. Su Ubuntu lancia, da riga di comando::
 
     sudo apt-get install tk8.5-dev
 
 o qualcosa di simile. Poi reinstalla l'interprete Python di Sage con::
 
-    sage -f python
+    make python3-clean python3-uninstall && make python3
 
 Questo aggancerà automaticamente la libreria Tcl/Tk.
 Dopo aver reinstallato correttamente l'interprete Python di Sage,


### PR DESCRIPTION
our instructions on Tkinter are outdated, as they don't take into account possible use of system Python in Sage.
This is a fix for this issue, which confuses users, see e.g. sage-develop [here](https://groups.google.com/g/sage-devel/c/IeGdueQOmEw/m/NNVAYqp4AQAJ)

The Italian FAQ has been done by Matteo, a native speaker.

Will fix #36710

