### PR TITLE
Compute dimensions of simple symmetric group modules over positive characteristic

### DIFF
--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -5538,8 +5538,8 @@ class Partition(CombinatorialElement):
         r"""
         Return the dimension of the simple module corresponding to ``self``.
 
-        This is equal to the dimension of the Specht module over a field
-        of characteristic `0`.
+        When the base ring is a field of characteristic `0`, this is equal
+        to the dimension of the Specht module.
 
         INPUT:
 

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -5518,7 +5518,7 @@ class Partition(CombinatorialElement):
 
         INPUT:
 
-        - ``BR`` -- (default: `\QQ`) the base ring
+        - ``base_ring`` -- (default: `\QQ`) the base ring
 
         EXAMPLES::
 
@@ -5533,6 +5533,43 @@ class Partition(CombinatorialElement):
             return StandardTableaux(self).cardinality()
         from sage.combinat.specht_module import specht_module_rank
         return specht_module_rank(self, base_ring)
+
+    def simple_module_dimension(self, base_ring=None):
+        r"""
+        Return the dimension of the simple module corresponding to ``self``.
+
+        This is equal to the dimension of the Specht module over a field
+        of characteristic `0`.
+
+        INPUT:
+
+        - ``base_ring`` -- (default: `\QQ`) the base ring
+
+        EXAMPLES::
+
+            sage: Partition([2,2,1]).simple_module_dimension()
+            5
+            sage: Partition([2,2,1]).specht_module_dimension(GF(3))                     # optional - sage.rings.finite_rings
+            5
+            sage: Partition([2,2,1]).simple_module_dimension(GF(3))                     # optional - sage.rings.finite_rings
+            4
+
+            sage: for la in Partitions(6, regular=3):
+            ....:     print(la, la.specht_module_dimension(), la.simple_module_dimension(GF(3)))
+            [6] 1 1
+            [5, 1] 5 4
+            [4, 2] 9 9
+            [4, 1, 1] 10 6
+            [3, 3] 5 1
+            [3, 2, 1] 16 4
+            [2, 2, 1, 1] 9 9
+        """
+        from sage.categories.fields import Fields
+        if base_ring is None or (base_ring in Fields() and base_ring.characteristic() == 0):
+            from sage.combinat.tableau import StandardTableaux
+            return StandardTableaux(self).cardinality()
+        from sage.combinat.specht_module import simple_module_rank
+        return simple_module_rank(self, base_ring)
 
 
 ##############

--- a/src/sage/combinat/specht_module.py
+++ b/src/sage/combinat/specht_module.py
@@ -457,3 +457,97 @@ def specht_module_rank(D, base_ring=None):
     if base_ring is None:
         base_ring = QQ
     return matrix(base_ring, [v.to_vector() for v in span_set]).rank()
+
+
+def polytabloid(T):
+    r"""
+    Compute the polytabloid element associated to a tableau ``T``.
+
+    For a tableau `T`, the polytabloid associated to `T` is
+
+    .. MATH::
+
+        e_T = \sum_{\sigma \in C_T} (-1)^{\sigma} \{\sigma T\},
+
+    where `\{\}` is the row-equivalence class, i.e. a tabloid,
+    and `C_T` is the column stabilizer of `T`. The sum takes place in
+    the module spanned by tabloids `\{T\}`.
+
+    OUTPUT:
+
+    A ``dict`` whose keys are taboids represented by tuples of frozensets
+    and whose values are the coefficient.
+
+    EXAMPLES::
+
+        sage: from sage.combinat.specht_module import polytabloid
+        sage: T = StandardTableau([[1,3,4],[2,5]])
+        sage: polytabloid(T)
+        {(frozenset({1, 3, 4}), frozenset({2, 5})): 1,
+         (frozenset({1, 4, 5}), frozenset({2, 3})): -1,
+         (frozenset({2, 3, 4}), frozenset({1, 5})): -1,
+         (frozenset({2, 4, 5}), frozenset({1, 3})): 1}
+    """
+    e_T = {}
+    C_T = T.column_stabilizer()
+    for perm in C_T:
+        TT = tuple([frozenset(perm(val) for val in row) for row in T])
+        if TT in e_T:
+            e_T[TT] += perm.sign()
+        else:
+            e_T[TT] = perm.sign()
+    return e_T
+
+
+def tabloid_gram_matrix(la, base_ring):
+    r"""
+    Compute the Gram matrix of the bilinear form of a Specht module
+    pulled back from the tabloid module.
+
+    For the module spanned by all tabloids, we define an bilinear form
+    by having the taboids be an orthonormal basis. We then pull this
+    bilinear form back across the natural injection of the Specht module
+    into the tabloid module.
+
+    EXAMPLES::
+
+        sage: from sage.combinat.specht_module import tabloid_gram_matrix
+        sage: tabloid_gram_matrix([3,2], GF(5))
+        [4 2 2 1 4]
+        [2 4 1 2 1]
+        [2 1 4 2 1]
+        [1 2 2 4 2]
+        [4 1 1 2 4]
+    """
+    from sage.combinat.tableau import StandardTableaux
+    ST = StandardTableaux(la)
+
+    def bilinear_form(p1, p2):
+        if len(p2) < len(p1):
+            p1, p2 = p2, p1
+        return sum(c1 * p2.get(T1, 0) for T1, c1 in p1.items() if c1)
+
+    gram_matrix = [[bilinear_form(polytabloid(T1), polytabloid(T2)) for T1 in ST] for T2 in ST]
+    return matrix(base_ring, gram_matrix)
+
+
+def simple_module_rank(la, base_ring):
+    r"""
+    Return the rank of the simple `S_n`-module corresponding to the
+    partition ``la`` of size `n` over ``base_ring``.
+
+    EXAMPLES::
+
+        sage: from sage.combinat.specht_module import simple_module_rank
+        sage: simple_module_rank([3,2,1,1], GF(3))
+        13
+    """
+    from sage.categories.fields import Fields
+    from sage.combinat.partition import Partition
+    if base_ring not in Fields():
+        raise NotImplementedError("the base must be a field")
+    p = base_ring.characteristic()
+    la = Partition(la)
+    if not la.is_regular(p):
+        raise ValueError(f"the partition {la} is not {p}-regular")
+    return tabloid_gram_matrix(la, base_ring).rank()

--- a/src/sage/combinat/specht_module.py
+++ b/src/sage/combinat/specht_module.py
@@ -475,7 +475,7 @@ def polytabloid(T):
 
     OUTPUT:
 
-    A ``dict`` whose keys are taboids represented by tuples of frozensets
+    A ``dict`` whose keys are tabloids represented by tuples of frozensets
     and whose values are the coefficient.
 
     EXAMPLES::
@@ -505,7 +505,7 @@ def tabloid_gram_matrix(la, base_ring):
     pulled back from the tabloid module.
 
     For the module spanned by all tabloids, we define an bilinear form
-    by having the taboids be an orthonormal basis. We then pull this
+    by having the tabloids be an orthonormal basis. We then pull this
     bilinear form back across the natural injection of the Specht module
     into the tabloid module.
 
@@ -541,6 +541,20 @@ def simple_module_rank(la, base_ring):
         sage: from sage.combinat.specht_module import simple_module_rank
         sage: simple_module_rank([3,2,1,1], GF(3))
         13
+
+    TESTS::
+
+        sage: from sage.combinat.specht_module import simple_module_rank
+        sage: simple_module_rank([1,1,1,1], GF(3))
+        Traceback (most recent call last):
+        ...
+        ValueError: the partition [1, 1, 1, 1] is not 3-regular
+
+        sage: from sage.combinat.specht_module import simple_module_rank
+        sage: simple_module_rank([2,1], GF(3)['x'])
+        Traceback (most recent call last):
+        ...
+        NotImplementedError: the base must be a field
     """
     from sage.categories.fields import Fields
     from sage.combinat.partition import Partition

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1587,6 +1587,26 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         span_set = specht_module_spanning_set(D, self)
         return matrix(self.base_ring(), [v.to_vector() for v in span_set]).rank()
 
+    def simple_module_dimension(self, la):
+        r"""
+        Return the dimension of the simple module of ``self`` indexed by the
+        partition ``la``.
+
+        EXAMPLES::
+
+            sage: SGA = SymmetricGroupAlgebra(GF(5), 6)
+            sage: SGA.simple_module_dimension(Partition([4,1,1]))
+            10
+            sage: SGA.simple_module_dimension(Partition([3,1,1]))
+            Traceback (most recent call last):
+            ...
+            ValueError: [3, 1, 1] is not a partition of 6
+        """
+        if sum(la) != self.n:
+            raise ValueError(f"{la} is not a partition of {self.n}")
+        from sage.combinat.specht_module import simple_module_rank
+        return simple_module_rank(la, self.base_ring())
+
     def jucys_murphy(self, k):
         r"""
         Return the Jucys-Murphy element `J_k` (also known as a

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1597,6 +1597,10 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             sage: SGA = SymmetricGroupAlgebra(GF(5), 6)
             sage: SGA.simple_module_dimension(Partition([4,1,1]))
             10
+
+        TESTS::
+
+            sage: SGA = SymmetricGroupAlgebra(GF(5), 6)
             sage: SGA.simple_module_dimension(Partition([3,1,1]))
             Traceback (most recent call last):
             ...

--- a/src/sage/combinat/tableau.py
+++ b/src/sage/combinat/tableau.py
@@ -2999,7 +2999,16 @@ class Tableau(ClonableList, metaclass=InheritComparisonClasscallMetaclass):
             sage: PermutationGroupElement([(1,4)]) in cs
             True
         """
-        return self.conjugate().row_stabilizer()
+        # Ensure that the permutations involve all elements of the
+        # tableau, by including the identity permutation on the set [1..k].
+        k = self.size()
+        gens = [list(range(1, k + 1))]
+        ell = len(self)
+        while ell > 1:
+            ell -= 1
+            for i, val in enumerate(self[ell]):
+                gens.append((val, self[ell-1][i]))
+        return PermutationGroup(gens)
 
     def height(self):
         """


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

We can compute Specht module dimensions, but an interesting open problem is to compute the dimensions of simple modules for `S_n` over fields of positive characteristic. We provide a way to compute dimensions by using the pullback of the polytabloid inner product and computing the rank of the Gram matrix.

This is based off of code provided by Jackson Walters.

We also implement a more efficient column stabilizer method for standard tableaux.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
