### PR TITLE
cython-lint for graphs/

### DIFF
--- a/src/sage/graphs/base/static_sparse_graph.pxd
+++ b/src/sage/graphs/base/static_sparse_graph.pxd
@@ -14,7 +14,7 @@ cdef extern from "stdlib.h":
                   size_t size, int(*compar)(const_void *, const_void *)) nogil
 
 ctypedef struct short_digraph_s:
-    uint32_t *  edges
+    uint32_t * edges
     uint32_t ** neighbors
     PyObject * edge_labels
     int m

--- a/src/sage/graphs/base/static_sparse_graph.pyx
+++ b/src/sage/graphs/base/static_sparse_graph.pyx
@@ -784,10 +784,8 @@ cdef void strongly_connected_components_digraph_C(short_digraph g, int nscc, int
     cdef size_t s_nscc = <size_t>nscc
     cdef vector[vector[int]] scc_list = vector[vector[int]](nscc, vector[int]())
     cdef vector[vector[int]] sons = vector[vector[int]](nscc + 1, vector[int]())
-    cdef vector[int].iterator iter
     cdef short *neighbors = <short *> mem.calloc(nscc, sizeof(short))
     cdef long m = 0
-    cdef uint32_t degv
     cdef uint32_t *p_tmp
 
     for v in range(s_nscc):

--- a/src/sage/graphs/bliss.pyx
+++ b/src/sage/graphs/bliss.pyx
@@ -102,7 +102,6 @@ cdef void add_gen(void *user_param, unsigned int n, const unsigned int *aut) noe
     cdef int cur = 0
     cdef list perm = []
     cdef bint* done = <bint*> check_calloc(n, sizeof(bint))
-    cdef int i
 
     gens, int_to_vertex, N = <object>user_param
 
@@ -511,7 +510,6 @@ cpdef canonical_form(G, partition=None, return_graph=False, use_edge_labels=True
 
     cdef bint directed = G.is_directed()
 
-    cdef int labInd
     cdef list Vout = []
     cdef list Vin = []
     cdef list labels = []

--- a/src/sage/graphs/centrality.pyx
+++ b/src/sage/graphs/centrality.pyx
@@ -696,7 +696,7 @@ def centrality_closeness_top_k(G, int k=1, int verbose=0):
     cdef int* reachU
     cdef int* pred = <int*> mem.calloc(n, sizeof(int))
     cdef double *farness = <double*> mem.malloc(n * sizeof(double))
-    cdef int d, nd, x, v, w
+    cdef int d, nd, x, v
     cdef long f, gamma
     cdef int* queue = <int*> mem.malloc(n * sizeof(int))
     cdef double tildefL, tildefU

--- a/src/sage/graphs/connectivity.pxd
+++ b/src/sage/graphs/connectivity.pxd
@@ -36,7 +36,7 @@ cdef class TriconnectivitySPQR:
     cdef int* edge_extremity_first
     cdef int* edge_extremity_second
     cdef list int_to_original_edge_label
-    cdef int virtual_edge_num # number of created virtual edges
+    cdef int virtual_edge_num  # number of created virtual edges
 
     cdef int* edge_status
     cdef bint* reverse_edges
@@ -48,25 +48,25 @@ cdef class TriconnectivitySPQR:
 
     # Translates DFS number of a vertex to its new number
     cdef int* old_to_new
-    cdef int* newnum  # new number of vertex i
-    cdef int* node_at # node at dfs number of i
-    cdef int* lowpt1  # lowpt1 number of vertex i
-    cdef int* lowpt2  # lowpt2 number of vertex i
+    cdef int* newnum   # new number of vertex i
+    cdef int* node_at  # node at dfs number of i
+    cdef int* lowpt1   # lowpt1 number of vertex i
+    cdef int* lowpt2   # lowpt2 number of vertex i
 
     cdef _LinkedList ** adj
     cdef _LinkedListNode ** in_adj
     cdef int* nd        # Number of descendants of vertex i
     cdef int* parent    # Parent vertex of vertex i in the palm tree
-    cdef int* degree    # Degree of vertex i
-    cdef int* tree_arc  # Tree arc entering the vertex i
-    cdef int* vertex_at # vertex with DFS number of i
+    cdef int* degree     # Degree of vertex i
+    cdef int* tree_arc   # Tree arc entering the vertex i
+    cdef int* vertex_at  # vertex with DFS number of i
 
     cdef int dfs_counter
-    cdef list components_list # list of components of `graph_copy`
-    cdef list graph_copy_adjacency # Stores adjacency list
+    cdef list components_list  # list of components of `graph_copy`
+    cdef list graph_copy_adjacency  # Stores adjacency list
 
-    cdef bint* starts_path # Does edge e_index start a path
-    cdef int start_vertex # First vertex of exploration
+    cdef bint* starts_path   # Does edge e_index start a path
+    cdef int start_vertex    # First vertex of exploration
 
     # Stacks used in `path_search` function
     cdef list e_stack
@@ -75,10 +75,10 @@ cdef class TriconnectivitySPQR:
     cdef int* t_stack_b
     cdef int t_stack_top
 
-    cdef list comp_final_edge_list # entry i is list of edges in component i
-    cdef list comp_type            # entry i is type of component i
-    cdef dict final_edge_to_edge_index # associate final edge e to its index in int_to_edge
-    cdef GenericGraph_pyx spqr_tree # The final SPQR tree is stored
+    cdef list comp_final_edge_list  # entry i is list of edges in component i
+    cdef list comp_type             # entry i is type of component i
+    cdef dict final_edge_to_edge_index  # associate final edge e to its index in int_to_edge
+    cdef GenericGraph_pyx spqr_tree  # The final SPQR tree is stored
 
     # Arrays used in different methods. Allocated only once
     cdef int* tmp_array_n_int_1
@@ -86,7 +86,7 @@ cdef class TriconnectivitySPQR:
     cdef int* tmp_array_n_int_3
     cdef bint* tmp_array_n_bint_1
 
-    ### Methods ###
+    # === Methods ===
 
     cdef inline __tstack_push(self, int h, int a, int b) noexcept:
         """
@@ -142,7 +142,6 @@ cdef class TriconnectivitySPQR:
             return self.edge_extremity_second[e_index]
         return self.edge_extremity_first[e_index]
 
-
     cdef int __new_virtual_edge(self, int u, int v) noexcept
     cdef _LinkedListNode * __new_LinkedListNode(self, Py_ssize_t e_index) noexcept
     cdef Py_ssize_t __high(self, Py_ssize_t v) noexcept
@@ -155,4 +154,3 @@ cdef class TriconnectivitySPQR:
     cdef int __path_search(self, int start) except -1
     cdef __assemble_triconnected_components(self) noexcept
     cdef __build_spqr_tree(self) noexcept
-

--- a/src/sage/graphs/connectivity.pyx
+++ b/src/sage/graphs/connectivity.pyx
@@ -71,6 +71,7 @@ Methods
 
 from sage.misc.superseded import deprecation
 
+
 def is_connected(G):
     """
     Check whether the (di)graph is connected.
@@ -2041,7 +2042,7 @@ def bridges(G, labels=True):
     if G.order() < 2 or not is_connected(G):
         return
 
-    B, C = G.blocks_and_cut_vertices()
+    B, _ = G.blocks_and_cut_vertices()
 
     # A block of size 2 is a bridge, unless the vertices are connected with
     # multiple edges.
@@ -2209,8 +2210,9 @@ def cleave(G, cut_vertices=None, virtual_edges=True, solver=None, verbose=0,
     # If a vertex cut is given, we check that it is valid. Otherwise, we compute
     # a small vertex cut
     if cut_vertices is None:
-        cut_size, cut_vertices = G.vertex_connectivity(value_only=False, solver=solver, verbose=verbose,
-                                                       integrality_tolerance=integrality_tolerance)
+        _, cut_vertices = G.vertex_connectivity(value_only=False,
+                                                solver=solver, verbose=verbose,
+                                                integrality_tolerance=integrality_tolerance)
         if not cut_vertices:
             # Typical example is a clique
             raise ValueError("the input graph has no vertex cut")
@@ -2218,7 +2220,7 @@ def cleave(G, cut_vertices=None, virtual_edges=True, solver=None, verbose=0,
         cut_vertices = list(cut_vertices)
         for u in cut_vertices:
             if u not in G:
-                raise ValueError("vertex {} is not a vertex of the input graph".format(u))
+                raise ValueError(f"vertex {u} is not a vertex of the input graph")
 
     H = G.copy(immutable=False)
     H.delete_vertices(cut_vertices)

--- a/src/sage/graphs/distances_all_pairs.pyx
+++ b/src/sage/graphs/distances_all_pairs.pyx
@@ -192,8 +192,6 @@ cdef inline c_all_pairs_shortest_path_BFS(short_digraph sd,
     # This data structure is well documented in the module
     # sage.graphs.base.static_sparse_graph
     cdef uint32_t** p_vertices = sd.neighbors
-    cdef uint32_t* p_edges = sd.edges
-    cdef uint32_t* p_next = p_edges
 
     # We run n different BFS taking each vertex as a source
     for source in range(n):
@@ -549,7 +547,7 @@ def is_distance_regular(G, parameters=False):
         ([3, 2, 2, 2, 2, 2, None], [None, 1, 1, 1, 1, 1, 3])
 
     """
-    cdef int i, l, u, v, d, b, c, k
+    cdef int i, u, v, d, b, c, k
     cdef int n = G.order()
     cdef int infinity = <unsigned short> -1
 
@@ -776,7 +774,7 @@ cdef uint32_t * c_eccentricity_bounding(short_digraph sd) except NULL:
     cdef bitset_t seen
     bitset_init(seen, n)
 
-    cdef uint32_t v, w, next_v, tmp, cpt = 0
+    cdef uint32_t v, w, next_v, cpt = 0
 
     # The first vertex is the one with largest degree
     next_v = max((out_degree(sd, v), v) for v in range(n))[1]
@@ -1122,9 +1120,8 @@ cdef uint32_t diameter_lower_bound_2sweep(short_digraph g,
     - ``seen`` -- bitset of size ``n`` that must be initialized before calling
       this method (i.e., bitset_init(seen, n)). However, there is no need to
       clear it.
-
     """
-    cdef uint32_t LB, i, k, tmp
+    cdef uint32_t LB
 
     # We do a first BFS from source and get the eccentricity of source
     LB = simple_BFS(g, source, distances, NULL, waiting_list, seen)
@@ -1354,11 +1351,11 @@ cdef uint32_t diameter_iFUB(short_digraph g,
     - ``source`` -- starting node of the first BFS
 
     """
-    cdef uint32_t i, LB, s, m, d
+    cdef uint32_t i, LB, m
     cdef uint32_t n = g.n
 
     # We select a vertex m with low eccentricity using multi-sweep
-    LB, s, m, d = diameter_lower_bound_multi_sweep(g, source)
+    LB, _, m, _ = diameter_lower_bound_multi_sweep(g, source)
 
     # If the lower bound is a very large number, it means that the graph is not
     # connected and so the diameter is infinite.
@@ -1457,12 +1454,12 @@ cdef uint32_t diameter_DiFUB(short_digraph sd,
     cdef short_digraph rev_sd  # Copy of sd with edges reversed
     init_reverse(rev_sd, sd)
 
-    cdef uint32_t LB, s, m, d, LB_1, LB_2, UB
+    cdef uint32_t LB, m, LB_1, LB_2, UB
     cdef size_t i
     cdef bitset_t seen
 
     # We select a vertex with low eccentricity using 2Dsweep
-    LB, s, m, d = diameter_lower_bound_2Dsweep(sd, rev_sd, source)
+    LB, _, m, _ = diameter_lower_bound_2Dsweep(sd, rev_sd, source)
 
     # If the lower bound is a very large number, it means that the digraph is
     # not strongly connected and so the diameter is infinite.
@@ -2725,15 +2722,15 @@ def floyd_warshall(gg, paths=True, distances=False):
     cdef unsigned int n = max(gverts) + 1
 
     if n >= <unsigned short> -1:
-        raise ValueError("the graph backend contains more than "+str(<unsigned short> -1)+" nodes")
+        raise ValueError("the graph backend contains more than " + str(<unsigned short> -1) + " nodes")
 
     # All this just creates two tables prec[n][n] and dist[n][n]
     cdef MemoryAllocator mem = MemoryAllocator()
     cdef unsigned short* t_prec = NULL
-    cdef unsigned short**  prec = NULL
+    cdef unsigned short** prec = NULL
     # init dist
-    cdef unsigned short* t_dist = <unsigned short*>  mem.allocarray(n * n, sizeof(unsigned short))
-    cdef unsigned short**  dist = <unsigned short**> mem.allocarray(n, sizeof(unsigned short*))
+    cdef unsigned short* t_dist = <unsigned short*> mem.allocarray(n * n, sizeof(unsigned short))
+    cdef unsigned short** dist = <unsigned short**> mem.allocarray(n, sizeof(unsigned short*))
     dist[0] = t_dist
     cdef unsigned int i
     for i in range(1, n):

--- a/src/sage/graphs/edge_connectivity.pyx
+++ b/src/sage/graphs/edge_connectivity.pyx
@@ -984,9 +984,6 @@ cdef class GabowEdgeConnectivity:
             sage: GabowEdgeConnectivity(D).edge_connectivity()
             4
         """
-        # Target x and source y of joining edge e_id
-        cdef int x = self.my_to[e_id]
-        cdef int y = self.my_from[e_id]
         # Previous state (tree Ti or unused) of an edge
         cdef int previous_state = self.FIRSTEDGE
 

--- a/src/sage/graphs/generic_graph_pyx.pyx
+++ b/src/sage/graphs/generic_graph_pyx.pyx
@@ -612,6 +612,7 @@ def binary_string_from_dig6(s, n):
     m = "".join(l)
     return m[:n*n]
 
+
 # Exhaustive search in graphs
 
 cdef class SubgraphSearch:
@@ -831,16 +832,16 @@ cdef class SubgraphSearch:
         # whether both are of the same type)
         self.directed = G.is_directed()
 
-        cdef int i, j, k
+        cdef int i, j
 
         # A vertex is said to be busy if it is already part of the partial copy
         # of H in G.
-        self.busy       = <int *>  self.mem.allocarray(self.ng, sizeof(int))
-        self.tmp_array  = <int *>  self.mem.allocarray(self.ng, sizeof(int))
-        self.stack      = <int *>  self.mem.allocarray(self.nh, sizeof(int))
-        self.vertices   = <int *>  self.mem.allocarray(self.nh, sizeof(int))
+        self.busy = <int *> self.mem.allocarray(self.ng, sizeof(int))
+        self.tmp_array = <int *> self.mem.allocarray(self.ng, sizeof(int))
+        self.stack = <int *> self.mem.allocarray(self.nh, sizeof(int))
+        self.vertices = <int *> self.mem.allocarray(self.nh, sizeof(int))
         self.line_h_out = <int **> self.mem.allocarray(self.nh, sizeof(int *))
-        self.line_h_in  = <int **> self.mem.allocarray(self.nh, sizeof(int *)) if self.directed else NULL
+        self.line_h_in = <int **> self.mem.allocarray(self.nh, sizeof(int *)) if self.directed else NULL
 
         self.line_h_out[0] = <int *> self.mem.allocarray(self.nh*self.nh,
                                                          sizeof(int))
@@ -1029,6 +1030,7 @@ cdef inline bint vectors_inferior(int n, int *a, int *b) noexcept:
         if a[i] < b[i]:
             return False
     return True
+
 
 ##############################
 # Further tests. Unit tests for methods, functions, classes defined with cdef.

--- a/src/sage/graphs/genus.pyx
+++ b/src/sage/graphs/genus.pyx
@@ -143,7 +143,7 @@ cdef class simple_connected_genus_backtracker:
         cdef int *w = <int *> self.mem.malloc((self.num_verts + self.num_darts) * sizeof(int))
         cdef int *s = <int *> self.mem.malloc(2 * (self.num_darts - self.num_verts) * sizeof(int))
 
-        cdef int i, j, du, dv, u, v
+        cdef int i, j, dv, u, v
 
         for v in range(self.num_verts):
             if not G.has_vertex(v):
@@ -341,7 +341,6 @@ cdef class simple_connected_genus_backtracker:
         before the flip, the cycle breaks into three.  Otherwise, the number of
         cycles stays the same.
         """
-        cdef int cycles = 0
         cdef int *w = self.vertex_darts[v]
         cdef int *face_map = self.face_map
 
@@ -393,7 +392,7 @@ cdef class simple_connected_genus_backtracker:
         """
         Count all cycles.
         """
-        cdef int i, j, c, m
+        cdef int i
         self.num_cycles = 0
 
         for i in range(self.num_darts):
@@ -447,7 +446,7 @@ cdef class simple_connected_genus_backtracker:
             sage: gb.genus()
             0
         """
-        cdef int g, i
+        cdef int g
 
         # in the original genus implementation, this case resulted in infinite
         # recursion.  oops.  Let's skip that.

--- a/src/sage/graphs/graph_coloring.pyx
+++ b/src/sage/graphs/graph_coloring.pyx
@@ -1437,7 +1437,6 @@ def edge_coloring(g, value_only=False, vizing=False, hex_colors=False, solver=No
     cdef list L = [g] if g.is_connected() else g.connected_components_subgraphs()
     cdef int chi = 0
     cdef list classes = [], vertices
-    cdef list values
 
     if vizing:
         classes = _vizing_edge_coloring(g)
@@ -1684,12 +1683,13 @@ def _vizing_edge_coloring(g):
         rotate_fan(fan_center, fan)
         e_colors[frozenset((fan_center, fan[-1]))] = d
 
-    matchings = dict()
+    matchings = {}
     for edge, c in e_colors.items():
         matchings[c] = matchings.get(c, []) + [tuple(edge)]
     classes = list(matchings.values())
 
     return classes
+
 
 def round_robin(n):
     r"""

--- a/src/sage/graphs/graph_decompositions/vertex_separation.pyx
+++ b/src/sage/graphs/graph_decompositions/vertex_separation.pyx
@@ -332,7 +332,6 @@ def lower_bound(G):
         raise ValueError("the (di)graph can have at most 31 vertices")
 
     cdef FastDigraph FD = FastDigraph(G)
-    cdef int * g = FD.graph
     cdef unsigned int n = <unsigned int>FD.n
 
     # minimums[i] is means to store the value of c'_{i+1}

--- a/src/sage/graphs/graph_generators_pyx.pyx
+++ b/src/sage/graphs/graph_generators_pyx.pyx
@@ -6,16 +6,16 @@ AUTHORS:
 - David Coudert (2012)
 """
 
-
-################################################################################
+# #############################################################################
 #           Copyright (C) 2012 David Coudert <david.coudert@inria.fr>
 #
 # Distributed  under  the  terms  of  the  GNU  General  Public  License (GPL)
-#                         http://www.gnu.org/licenses/
-################################################################################
+#                         https://www.gnu.org/licenses/
+# #############################################################################
 
 from sage.misc.randstate cimport random
 from sage.misc.randstate import set_random_seed
+
 
 def RandomGNP(n, p, bint directed=False, bint loops=False, seed=None):
     r"""

--- a/src/sage/graphs/hyperbolicity.pyx
+++ b/src/sage/graphs/hyperbolicity.pyx
@@ -641,7 +641,7 @@ cdef tuple hyperbolicity_BCCM(int N,
     cdef int a, b, c, d, h_UB, n_val, n_acc, i, j
     cdef int hplusone
     cdef int condacc
-    cdef int x, y, S1, S2, S3
+    cdef int x, S1, S2, S3
     cdef list certificate = []
     cdef uint32_t nb_p  # The total number of pairs.
     cdef unsigned short *dist_a
@@ -1672,7 +1672,7 @@ def hyperbolicity_distribution(G, algorithm='sampling', sampling_size=10**6):
         return {0: sampling_size if algorithm=='sampling' else binomial(G.num_verts(), 4)}
 
     cdef int N = G.num_verts()
-    cdef int i, j
+    cdef int i
     cdef unsigned short** distances
     cdef unsigned short* _distances_
     cdef dict hdict

--- a/src/sage/graphs/independent_sets.pxd
+++ b/src/sage/graphs/independent_sets.pxd
@@ -10,4 +10,3 @@ cdef class IndependentSets:
     cdef int i
     cdef int count_only
     cdef int maximal
-

--- a/src/sage/graphs/independent_sets.pyx
+++ b/src/sage/graphs/independent_sets.pyx
@@ -223,7 +223,6 @@ cdef class IndependentSets:
         bitset_init(tmp, self.n)
 
         cdef uint64_t count = 0
-        cdef list ans
         cdef int j
 
         try:

--- a/src/sage/graphs/matchpoly.pyx
+++ b/src/sage/graphs/matchpoly.pyx
@@ -389,7 +389,7 @@ cdef void delete_and_add(int **edges, int nverts, int nedges, int totverts, int 
     cdef int edge1 = edges1[nedges]
     cdef int edge2 = edges2[nedges]
     cdef int new_nedges = 0
-    cdef int i, new_edge1, new_edge2
+    cdef int i
 
     # The new edges are all the edges that are not incident with (edge1, edge2)
 

--- a/src/sage/graphs/path_enumeration.pyx
+++ b/src/sage/graphs/path_enumeration.pyx
@@ -1790,9 +1790,7 @@ def all_paths_iterator(self, starting_vertices=None, ending_vertices=None,
         starting_vertices = self
     cdef dict data = {}
     cdef dict vertex_iterators
-    cdef list paths = []
     cdef list path
-    cdef list shortest_path
 
     if report_edges and labels:
         if use_multiedges:

--- a/src/sage/graphs/planarity.pyx
+++ b/src/sage/graphs/planarity.pyx
@@ -152,7 +152,6 @@ def is_planar(g, kuratowski=False, set_pos=False, set_embedding=False):
         if not kuratowski:
             return False
         g_dict = {}
-        from sage.graphs.graph import Graph
         for i in range(1, theGraph.N + 1):
             linked_list = []
             j = theGraph.V[i].link[1]

--- a/src/sage/graphs/strongly_regular_db.pyx
+++ b/src/sage/graphs/strongly_regular_db.pyx
@@ -1229,7 +1229,6 @@ def SRG_from_RSHCD(v, k, l, mu, existence=False, check=True):
     n = v
     a = (n-4*mu)//2
     e = 2*k - n + 1 + a
-    t = abs(a//2)
 
     if (e**2 == 1 and
             k == (n-1-a+e)/2 and
@@ -1510,7 +1509,7 @@ def is_twograph_descendant_of_srg(int v, int k0, int l, int mu):
         sage: graphs.strongly_regular_graph(279, 150, 85, 75).is_strongly_regular(parameters=True)  # optional - gap_package_design internet
         (279, 150, 85, 75)
     """
-    cdef int b, k, s
+    cdef int b, k
     if k0 != 2*mu or not v % 2:
         return
     b = v+1+4*mu
@@ -1570,9 +1569,8 @@ def is_taylor_twograph_srg(int v, int k, int l, int mu):
 
         sage: is_taylor_twograph_srg(730, 369, 168, 205)                                # needs sage.libs.pari
         (<function TaylorTwographSRG at ...>, 9)
-
     """
-    r, s = eigenvalues(v, k, l, mu)
+    r, _ = eigenvalues(v, k, l, mu)
     if r is None:
         return
     p, t = is_prime_power(v-1, get_data=True)
@@ -2391,8 +2389,8 @@ def strongly_regular_from_two_weight_code(L):
     if is_Matrix(L):
         L = LinearCode(L)
     V = [tuple(l) for l in L]
-    w1, w2 = sorted(set(sum(map(bool, x)) for x in V).difference([0]))
-    G = Graph([V, lambda u, v: sum(uu!=vv for uu, vv in zip(u, v)) == w1])
+    w1, _ = sorted(set(sum(map(bool, x)) for x in V).difference([0]))
+    G = Graph([V, lambda u, v: sum(uu != vv for uu, vv in zip(u, v)) == w1])
     G.relabel()
     G.name('two-weight code: '+str(L))
     return G

--- a/src/sage/graphs/weakly_chordal.pyx
+++ b/src/sage/graphs/weakly_chordal.pyx
@@ -204,14 +204,13 @@ def is_long_hole_free(g, certificate=False):
     if g.order() < 5:
         return (True, []) if certificate else True
 
-    cdef int a, b, c, d, i, u, v, w, vv, ww
+    cdef int u, v, w, vv, ww
 
     # Make a copy of the graph as a short_digraph. This data structure is well
     # documented in the module sage.graphs.base.static_sparse_graph.
     # Vertices are relabeled in 0..n-1
     cdef int n = g.order()
     cdef list id_label = list(g)
-    cdef dict label_id = {label: i for i, label in enumerate(id_label)}
     cdef short_digraph sd
     init_short_digraph(sd, g, edge_labelled=False, vertex_list=id_label)
 
@@ -228,7 +227,6 @@ def is_long_hole_free(g, certificate=False):
     # Allocate some data structures
     cdef MemoryAllocator mem = MemoryAllocator()
     cdef int* path = <int*> mem.allocarray(n, sizeof(int))
-    cdef int path_top
     cdef int* InPath = <int*> mem.allocarray(n, sizeof(int))
     for u in range(n):
         InPath[u] = -1
@@ -433,14 +431,13 @@ def is_long_antihole_free(g, certificate=False):
     if g.order() < 5:
         return (True, []) if certificate else True
 
-    cdef int a, b, c, d, i, u, v, w, vv, ww
+    cdef int u, v, w, vv, ww
 
     # Make a copy of the graph as a short_digraph. This data structure is well
     # documented in the module sage.graphs.base.static_sparse_graph.
     # Vertices are relabeled in 0..n-1
     cdef int n = g.order()
     cdef list id_label = list(g)
-    cdef dict label_id = {label: i for i, label in enumerate(id_label)}
     cdef short_digraph sd
     init_short_digraph(sd, g, edge_labelled=False, vertex_list=id_label)
 
@@ -457,7 +454,6 @@ def is_long_antihole_free(g, certificate=False):
     # Allocate some data structures
     cdef MemoryAllocator mem = MemoryAllocator()
     cdef int* path = <int*> mem.allocarray(n, sizeof(int))
-    cdef int path_top
     cdef int* InPath = <int*> mem.allocarray(n, sizeof(int))
     for u in range(n):
         InPath[u] = -1


### PR DESCRIPTION
fix many small details in pyx files in graphs, as found by

`cython-lint --ignore=E501,E741,E265,E221,E231,E201,E127,E129 src/sage/graphs/`

notably removing many unused def and variables.

There remains in particular a rather suspicious warning:

`src/sage/graphs/distances_all_pairs.pyx:1977:9: 'ecc_antipode' defined but unused (try prefixing with underscore?)`

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.