### PR TITLE
build/pkgs/pari: require pari-2.5.14, drop tests for patched v2.5.13

### DIFF
--- a/build/pkgs/pari/spkg-configure.m4
+++ b/build/pkgs/pari/spkg-configure.m4
@@ -1,6 +1,6 @@
 SAGE_SPKG_CONFIGURE([pari], [
   dnl See gp_version below on how the version is computed from MAJV.MINV.PATCHV
-  m4_pushdef([SAGE_PARI_MINVER],["134912"])dnl this version and higher allowed
+  m4_pushdef([SAGE_PARI_MINVER],["134916"])dnl this version and higher allowed
   m4_pushdef([SAGE_PARI_MAXVER],["999999"])dnl this version and higher not allowed
   SAGE_SPKG_DEPCHECK([gmp readline], [
     AC_PATH_PROG([GP], [gp])
@@ -66,24 +66,6 @@ SAGE_SPKG_CONFIGURE([pari], [
             AC_MSG_NOTICE([Install seadata package and reconfigure.])
             AC_MSG_NOTICE([Otherwise Sage will build its own pari/GP.])
             sage_spkg_install_pari=yes
-        fi
-
-        AC_MSG_CHECKING([whether factor() bug 2469 of pari 2.15.3 is fixed])
-        result=`echo "f=factor(2^2203-1); print(\"ok\")" | timeout 1 $GP -qf`
-        if test x"$result" = xok; then
-          AC_MSG_RESULT([yes])
-        else
-           AC_MSG_RESULT([no; cannot use system pari/GP with known bug])
-           sage_spkg_install_pari=yes
-        fi
-
-        AC_MSG_CHECKING([whether qfbclassno() bug 2466 of pari 2.15.3 is fixed])
-        result=`echo "qfbclassno(33844)" | $GP -qf`
-        if test x"$result" = x3; then
-          AC_MSG_RESULT([yes])
-        else
-           AC_MSG_RESULT([no; cannot use system pari/GP with known bug])
-           sage_spkg_install_pari=yes
         fi
 
     fi dnl end GP test


### PR DESCRIPTION
We currently check for either pari-2.5.14, or an unofficial (patched) version of pari-2.5.13 that is missing two bugs present in the upstream release. However, one of those bug-checks fails on macOS, making it impossible to use the system pari there.

pari-2.5.14 has been out for a few months. Any distro fast enough to have backported patches to pari-2.5.13 will likely have pari-2.5.14 by now. On that assumption, we simply require pari-2.5.14 to fix the macOS issue, and hope it does not affect anyone still using a patched pari-2.5.13.

- Also fixes #36729 