### PR TITLE
avoid importing `DiGraph` from `sage.graphs.graph`

### DIFF
--- a/src/sage/categories/coxeter_groups.py
+++ b/src/sage/categories/coxeter_groups.py
@@ -1088,7 +1088,7 @@ class CoxeterGroups(Category_singleton):
                             nextlayer.add(t)
                 curlayer = nextlayer
 
-            from sage.graphs.graph import DiGraph
+            from sage.graphs.digraph import DiGraph
             return Poset(DiGraph(d, format='dict_of_lists',
                                  data_structure='static_sparse'),
                          cover_relations=True,
@@ -1174,7 +1174,7 @@ class CoxeterGroups(Category_singleton):
                             else:
                                 d.append((u, v))
 
-            from sage.graphs.graph import DiGraph
+            from sage.graphs.digraph import DiGraph
             return DiGraph(d)
 
         def canonical_representation(self):

--- a/src/sage/combinat/binary_tree.py
+++ b/src/sage/combinat/binary_tree.py
@@ -748,7 +748,7 @@ class BinaryTree(AbstractClonableTree, ClonableArray,
             sage: t1.graph(with_leaves=False).edges(sort=True)
             [(0, 1, None), (0, 2, None), (2, 3, None), (2, 4, None)]
         """
-        from sage.graphs.graph import DiGraph
+        from sage.graphs.digraph import DiGraph
 
         if with_leaves:   # We want leaves and nodes.
 

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -112,7 +112,6 @@ from sage.geometry.point_collection import (PointCollection,
                                             is_PointCollection,
                                             read_palp_point_collection)
 from sage.geometry.toric_lattice import ToricLattice, is_ToricLattice
-from sage.graphs.graph import DiGraph, Graph
 from sage.groups.perm_gps.permgroup_named import SymmetricGroup
 
 from sage.misc.lazy_import import lazy_import
@@ -2039,6 +2038,7 @@ class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.Lattic
         else:
             # Get face lattice as a sublattice of the ambient one
             allowed_indices = frozenset(self._ambient_vertex_indices)
+            from sage.graphs.digraph import DiGraph
             L = DiGraph()
             empty = self._ambient.face_lattice().bottom()
             L.add_vertex(0) # In case it is the only one
@@ -3974,6 +3974,7 @@ class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.Lattic
             sage: g.edges(sort=True)                                                    # needs palp sage.graphs
             [(0, 1, None), (0, 3, None), (1, 2, None), (2, 3, None)]
         """
+        from sage.graphs.graph import Graph
         skeleton = Graph()
         skeleton.add_vertices(self.skeleton_points(1))
         for edge in self.edges():

--- a/src/sage/graphs/bliss.pyx
+++ b/src/sage/graphs/bliss.pyx
@@ -581,7 +581,7 @@ cpdef canonical_form(G, partition=None, return_graph=False, use_edge_labels=True
 
     if return_graph:
         if directed:
-            from sage.graphs.graph import DiGraph
+            from sage.graphs.digraph import DiGraph
             H = DiGraph(new_edges, loops=G.allows_loops(), multiedges=G.allows_multiple_edges())
         else:
             from sage.graphs.graph import Graph

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -421,7 +421,6 @@ from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 import sage.graphs.generic_graph_pyx as generic_graph_pyx
 from sage.graphs.generic_graph import GenericGraph
-from sage.graphs.digraph import DiGraph
 from sage.graphs.independent_sets import IndependentSets
 from sage.misc.rest_index_of_methods import doc_index, gen_thematic_rest_table_index
 from sage.graphs.views import EdgesView
@@ -3514,6 +3513,7 @@ class Graph(GenericGraph):
         if name:
             name = 'An orientation of ' + name
 
+        from sage.graphs.digraph import DiGraph
         if not self.size():
             D = DiGraph(data=[self.vertices(sort=False), []],
                         format='vertices_and_edges',

--- a/src/sage/graphs/graph_generators_pyx.pyx
+++ b/src/sage/graphs/graph_generators_pyx.pyx
@@ -63,8 +63,6 @@ def RandomGNP(n, p, bint directed=False, bint loops=False, seed=None):
         ...
         ValueError: parameter 'loops' can be set to True only when 'directed' is True
     """
-    from sage.graphs.graph import Graph, DiGraph
-
     if seed is not None:
         set_random_seed(seed)
 
@@ -74,8 +72,10 @@ def RandomGNP(n, p, bint directed=False, bint loops=False, seed=None):
     cdef int pp = int(round(float(p * RAND_MAX_f)))
 
     if directed:
+        from sage.graphs.digraph import DiGraph
         G = DiGraph(loops=loops)
     else:
+        from sage.graphs.graph import Graph
         G = Graph()
         if loops:
             raise ValueError("parameter 'loops' can be set to True only when 'directed' is True")

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1931,7 +1931,6 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         """
 
         from warnings import warn
-        from sage.graphs.graph import DiGraph, Graph
         from sage.matrix.constructor import Matrix
 
         # warn users if things are getting big
@@ -1983,8 +1982,13 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                 labels.append(E._equation_string())
 
         A = Matrix([r + [0] * (len(A) - len(r)) for r in A])
-        G = (DiGraph if directed else Graph)(A, format="adjacency_matrix",
-                data_structure="static_sparse")
+        if directed:
+            from sage.graphs.digraph import DiGraph as GraphType
+        else:
+            from sage.graphs.graph import Graph as GraphType
+
+        G = GraphType(A, format="adjacency_matrix",
+                      data_structure="static_sparse")
         # inplace relabelling is necessary for static_sparse graphs
         GL = G.relabel(labels, inplace=False)
         return GL

--- a/src/sage/sets/disjoint_set.pyx
+++ b/src/sage/sets/disjoint_set.pyx
@@ -600,7 +600,7 @@ cdef class DisjointSet_of_integers(DisjointSet_class):
             [(0, 0, None), (1, 1, None), (2, 1, None), (3, 1, None), (4, 1, None)]
         """
         d = {i: [self._nodes.parent[i]] for i in range(self.cardinality())}
-        from sage.graphs.graph import DiGraph
+        from sage.graphs.digraph import DiGraph
         return DiGraph(d)
 
 cdef class DisjointSet_of_hashables(DisjointSet_class):
@@ -891,5 +891,5 @@ cdef class DisjointSet_of_hashables(DisjointSet_class):
             e = self._int_to_el[i]
             p = self._int_to_el[self._nodes.parent[i]]
             d[e] = [p]
-        from sage.graphs.graph import DiGraph
+        from sage.graphs.digraph import DiGraph
         return DiGraph(d)

--- a/src/sage/sets/set.py
+++ b/src/sage/sets/set.py
@@ -813,7 +813,7 @@ class Set_object(Set_generic, Set_base, Set_boolean_operators, Set_add_sub_opera
             raise NotImplementedError(
                 "this method is only implemented for finite sets")
         from sage.combinat.posets.lattices import FiniteLatticePoset
-        from sage.graphs.graph import DiGraph
+        from sage.graphs.digraph import DiGraph
         from sage.rings.integer import Integer
         n = self.cardinality()
         # list, contains at position 0 <= i < 2^n


### PR DESCRIPTION
We remove the top level import of `DiGraph` from `src/sage/graphs/graph.py` to prevent using `from sage.graphs.graph import DiGraph`.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
