### PR TITLE
Improve performance of __getitem__ of CFiniteSequence

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -1044,6 +1044,11 @@ REFERENCES:
             *Guide to using plantri*, version 5.0, 2016.
             http://cs.anu.edu.au/~bdm/plantri/plantri-guide.txt
 
+.. [BM2021] Alin Bostan and Ryuhei Mori,
+            *A simple and fast algorithm for computing the N-th term of a linearly recurrent sequence*,
+            Proceedings of Symposium on Simplicity in Algorithms (SOSA), pp. 118--132, 2021.
+            :doi:`10.1137/1.9781611976496.14`
+
 .. [BMBFLR2008] A. Blondin-Massé, S. Brlek, A. Frosini, S. Labbé,
                 S. Rinaldi, *Reconstructing words from a fixed
                 palindromic length sequence*, Proc. TCS 2008, 5th IFIP

--- a/src/sage/rings/cfinite_sequence.py
+++ b/src/sage/rings/cfinite_sequence.py
@@ -661,12 +661,15 @@ class CFiniteSequence(FieldElement,
             (quo, num) = num.quo_rem(den)
             P = self.parent().polynomial_ring()
             x = self.parent().gen()
-            m = n
-            while m:
-                num = P((num * den(-x)).list()[m % 2::2])
+            if quo.degree() < n:
+                wp = 0
+            else:
+                wp = quo[n]
+            while n:
+                num = P((num * den(-x)).list()[n % 2::2])
                 den = P((den * den(-x)).list()[::2])
-                m //= 2
-            return quo[n] + num[0] / den[0]
+                n //= 2
+            return wp + num[0] / den[0]
         else:
             raise TypeError("invalid argument type")
 

--- a/src/sage/rings/cfinite_sequence.py
+++ b/src/sage/rings/cfinite_sequence.py
@@ -644,6 +644,14 @@ class CFiniteSequence(FieldElement,
             [0, 0, 1, 2, 3, 4, 5, 6, 7, 8]
             sage: s = C(x^3 * (1 - x)^-2); s[0:10]
             [0, 0, 0, 1, 2, 3, 4, 5, 6, 7]
+            sage: s = C(1/(1-x^1000)); s[10^18]
+            1
+            sage: s = C(1/(1-x^1000)); s[10^20]
+            1
+
+        REFERENCES:
+
+        - [BM2021]_
         """
         if isinstance(key, slice):
             m = max(key.start, key.stop)

--- a/src/sage/rings/cfinite_sequence.py
+++ b/src/sage/rings/cfinite_sequence.py
@@ -649,25 +649,26 @@ class CFiniteSequence(FieldElement,
             m = max(key.start, key.stop)
             return [self[ii] for ii in range(*key.indices(m + 1))]
         elif isinstance(key, Integral):
+            n = key - self._off
+            if n < 0:
+                return 0
             den = self.denominator()
             num = self.numerator()
             if self._off >= 0:
                 num = num.shift(-self._off)
             else:
                 den = den.shift(self._off)
-            n = key - self._off
-            if n < 0:
-                return 0
             (quo, num) = num.quo_rem(den)
-            P = self.parent().polynomial_ring()
-            x = self.parent().gen()
             if quo.degree() < n:
                 wp = 0
             else:
                 wp = quo[n]
+            P = self.parent().polynomial_ring()
+            x = P.gen()
             while n:
-                num = P((num * den(-x)).list()[n % 2::2])
-                den = P((den * den(-x)).list()[::2])
+                nden = den(-x)
+                num = P((num * nden).list()[n % 2::2])
+                den = P((den * nden).list()[::2])
                 n //= 2
             return wp + num[0] / den[0]
         else:


### PR DESCRIPTION
Efficiency of `__getitem__` for CFiniteSequence is improved.

Fixes #36763

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
