### PR TITLE
Do not fail when `java` is available but `jmol` is not.

### DIFF
--- a/src/sage/interfaces/jmoldata.py
+++ b/src/sage/interfaces/jmoldata.py
@@ -71,6 +71,47 @@ class JmolData(SageObject):
         java_version_number = int(re.sub(r'.*version "(0\.|1\.)?(\d*)[\s\S]*', r'\2', version, flags=re.S))
         return java_version_number >= 7
 
+    def jmolpath(self):
+        """
+        Return the path to the jar file.
+
+        EXAMPLES::
+
+            sage: from sage.interfaces.jmoldata import JmolData
+            sage: JData = JmolData()
+            sage: JData.jmolpath()
+            '.../JmolData.jar'
+
+        """
+        jmolpath = os.path.join(JMOL_DIR, "JmolData.jar")
+
+        if sys.platform == 'cygwin':
+            import cygwin
+            jmolpath = cygwin.cygpath(jmolpath, 'w')
+
+        return jmolpath
+
+    def is_jmol_available(self):
+        """
+        Returns True if jmol is available and False if not.
+
+        EXAMPLES:
+
+        Check that it returns a boolean::
+
+            sage: from sage.interfaces.jmoldata import JmolData
+            sage: JData = JmolData()
+            sage: type(JData.is_jmol_available())
+            <... 'bool'>
+        """
+        if not os.path.isfile(self.jmolpath()):
+            return False
+
+        if not self.is_jvm_available():
+            return False
+
+        return True
+
     def export_image(self,
         targetfile,
         datafile, #name (path) of data file Jmol can read or script file telling it what to read or load
@@ -154,12 +195,11 @@ class JmolData(SageObject):
             sage: archive.close()
         """
         # Set up paths, file names and scripts
-        jmolpath = os.path.join(JMOL_DIR, "JmolData.jar")
+        jmolpath = self.jmolpath()
         target_native = targetfile
 
         if sys.platform == 'cygwin':
             import cygwin
-            jmolpath = cygwin.cygpath(jmolpath, 'w')
             target_native = cygwin.cygpath(target_native, 'w')
             if datafile_cmd != 'script':
                 datafile = cygwin.cygpath(datafile, 'w')

--- a/src/sage/plot/plot3d/base.pyx
+++ b/src/sage/plot/plot3d/base.pyx
@@ -278,7 +278,7 @@ cdef class Graphics3d(SageObject):
         T.export_jmol(scene_zip, **opts)
         from sage.interfaces.jmoldata import JmolData
         jdata = JmolData()
-        if not jdata.is_jvm_available():
+        if not jdata.is_jmol_available():
             # We can only use JMol to generate preview if a jvm is installed
             from sage.repl.rich_output.output_graphics import OutputImagePng
             tachyon = self._rich_repr_tachyon(OutputImagePng, **opts)

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -369,7 +369,7 @@ class BackendIPythonCommandline(BackendIPython):
         from sage.doctest import DOCTEST_MODE
         from sage.interfaces.jmoldata import JmolData
         jdata = JmolData()
-        if not jdata.is_jvm_available() and not DOCTEST_MODE:
+        if not jdata.is_jmol_available() and not DOCTEST_MODE:
             raise RuntimeError('jmol cannot run, no suitable java version found')
         launch_script = output_jmol.launch_script_filename()
         jmol_cmd = 'jmol'


### PR DESCRIPTION
If java is not available, sagemath will fallback to tachyon gracefully.

When java is available, sagemath will assume jmol is available and error if not. This commit fixes the issue by implementing a method `is_jmol_available()` to replace `is_jvm_available()`.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.