### PR TITLE
fix doctest for nauty 2.8.8

### DIFF
--- a/src/sage/graphs/graph_generators.py
+++ b/src/sage/graphs/graph_generators.py
@@ -1130,7 +1130,7 @@ class GraphGenerators():
             sage: list(graphs.nauty_genbg("-c1 2", debug=True))
             ['>E Usage: ...genbg [-c -ugs -vq -lzF] [-Z#] [-D#] [-A] [-d#|-d#:#] [-D#|-D#:#] n1 n2...
             sage: list(graphs.nauty_genbg("-c 1 2", debug=True))
-            ['>A ...genbg n=1+2 e=2:2 d=1:1 D=2:1 c\n', Bipartite graph on 3 vertices]
+            ['>A ...genbg n=1+2 e=2:2 d=1:1 D=2:1 c...\n', Bipartite graph on 3 vertices]
 
         We must have n1=1..24, n2=0..32 and n1+n2=1..32 (:trac:`34179`)::
 


### PR DESCRIPTION
Updating to nauty 2.8.8 has one test failing. Fix it in a backwards compatible way.

Note that nauty output is only debug, and the fact that sagemath tests this output is dubious (see #35250).

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.