### PR TITLE
Skip backport packages for newer python

### DIFF
--- a/build/pkgs/importlib_metadata/install-requires.txt
+++ b/build/pkgs/importlib_metadata/install-requires.txt
@@ -1,3 +1,3 @@
 # According to https://pypi.org/project/importlib-metadata/,
 # 4.13 provides the features of Python 3.11 importlib.metadata
-importlib_metadata >=4.13
+importlib_metadata >=4.13; python_version<'3.11'

--- a/build/pkgs/importlib_metadata/install-requires.txt
+++ b/build/pkgs/importlib_metadata/install-requires.txt
@@ -1,3 +1,3 @@
 # According to https://pypi.org/project/importlib-metadata/,
 # 4.13 provides the features of Python 3.11 importlib.metadata
-importlib_metadata >=4.13; python_version<'3.11'
+importlib_metadata >=4.13; python_version<"3.11"

--- a/build/pkgs/importlib_resources/install-requires.txt
+++ b/build/pkgs/importlib_resources/install-requires.txt
@@ -1,3 +1,3 @@
 # According to https://pypi.org/project/importlib-resources/,
 # version 5.7 provides the features of Python 3.11 importlib.resources
-importlib_resources >= 5.7
+importlib_resources >= 5.7; python_version<'3.11'

--- a/build/pkgs/importlib_resources/install-requires.txt
+++ b/build/pkgs/importlib_resources/install-requires.txt
@@ -1,3 +1,3 @@
 # According to https://pypi.org/project/importlib-resources/,
 # version 5.7 provides the features of Python 3.11 importlib.resources
-importlib_resources >= 5.7; python_version<'3.11'
+importlib_resources >= 5.7; python_version<"3.11"

--- a/build/pkgs/typing_extensions/install-requires.txt
+++ b/build/pkgs/typing_extensions/install-requires.txt
@@ -1,3 +1,3 @@
 # According to https://github.com/python/typing_extensions/blob/main/CHANGELOG.md,
 # version 4.4.0 adds another Python 3.11 typing backport
-typing_extensions >= 4.4.0; python_version<'3.11'
+typing_extensions >= 4.4.0; python_version<"3.11"

--- a/build/pkgs/typing_extensions/install-requires.txt
+++ b/build/pkgs/typing_extensions/install-requires.txt
@@ -1,3 +1,3 @@
 # According to https://github.com/python/typing_extensions/blob/main/CHANGELOG.md,
 # version 4.4.0 adds another Python 3.11 typing backport
-typing_extensions >= 4.4.0
+typing_extensions >= 4.4.0; python_version<'3.11'

--- a/m4/sage_python_package_check.m4
+++ b/m4/sage_python_package_check.m4
@@ -58,8 +58,17 @@ AC_DEFUN([SAGE_PYTHON_PACKAGE_CHECK], [
       AC_MSG_RESULT(yes)
       dnl strip all comments from install-requires.txt; this should leave
       dnl only a single line containing the version specification for this
-      dnl package.
-      SAGE_PKG_VERSPEC=$(sed '/^#/d' "./build/pkgs/$1/install-requires.txt")
+      dnl package. Afterwards, convert all double-quotes to single quotes.
+      dnl Both work, but only single quotes are documented. However, at the
+      dnl time of writing, double quotes are more compatible with our toml
+      dnl generation in ./bootstrap. Converting them from double- to single-
+      dnl quotes on-the-fly here lets us support both (in this macro, at
+      dnl least).
+      SAGE_PKG_VERSPEC=$(sed                   \
+        -e '/^#/d'                             \
+        -e "s/\"/'/g"                          \
+        "./build/pkgs/$1/install-requires.txt"
+      )
       AC_MSG_CHECKING([for python package $1 ("${SAGE_PKG_VERSPEC}")])
 
       dnl To prevent user-site (pip install --user) packages from being
@@ -77,10 +86,10 @@ AC_DEFUN([SAGE_PYTHON_PACKAGE_CHECK], [
 
       dnl double-quote SAGE_PKG_VERSPEC because platform-specific
       dnl dependencies like python_version<'3.11' will have single
-      dnl quotes in them.
+      dnl quotes in them. (We normalized the quotes earlier with sed.)
       AS_IF(
-        [PYTHONUSERBASE="${PYTHONUSERBASE}" config.venv/bin/python3 -c dnl
-           "import pkg_resources;                                      dnl
+        [PYTHONUSERBASE="${PYTHONUSERBASE}" config.venv/bin/python3 -c   dnl
+           "import pkg_resources;                                        dnl
             pkg_resources.require(\"${SAGE_PKG_VERSPEC}\".splitlines())" dnl
 	 2>&AS_MESSAGE_LOG_FD],
         [AC_MSG_RESULT(yes)],

--- a/m4/sage_python_package_check.m4
+++ b/m4/sage_python_package_check.m4
@@ -75,10 +75,13 @@ AC_DEFUN([SAGE_PYTHON_PACKAGE_CHECK], [
         PYTHONUSERBASE="${HOME}/.sage/local"
       ])
 
+      dnl double-quote SAGE_PKG_VERSPEC because platform-specific
+      dnl dependencies like python_version<'3.11' will have single
+      dnl quotes in them.
       AS_IF(
         [PYTHONUSERBASE="${PYTHONUSERBASE}" config.venv/bin/python3 -c dnl
            "import pkg_resources;                                      dnl
-            pkg_resources.require('${SAGE_PKG_VERSPEC}'.splitlines())" dnl
+            pkg_resources.require(\"${SAGE_PKG_VERSPEC}\".splitlines())" dnl
 	 2>&AS_MESSAGE_LOG_FD],
         [AC_MSG_RESULT(yes)],
         [AC_MSG_RESULT(no); sage_spkg_install_$1=yes]


### PR DESCRIPTION
Three of our SPKGs are backports that provide python-3.11 features:

* importlib_metadata
* importlib_resources
* typing_extensions

As a result, they are not needed when sage's python is v3.11 or newer. We un-require them in `spkg-configure.m4`