### PR TITLE
Drop Cygwin handling in spkg-install and spkg-install.in 

### DIFF
--- a/build/pkgs/ecl/spkg-install.in
+++ b/build/pkgs/ecl/spkg-install.in
@@ -1,12 +1,5 @@
 cd src
 
-if [ "$UNAME" = "CYGWIN" ]; then
-    # Some of ECL's sources rely on GNU-isms that are allowed by default on
-    # most glibcs, but not in newlib; https://github.com/sagemath/sage/issues/25057
-    CFLAGS="$CFLAGS -D_GNU_SOURCE"
-    CXXFLAGS="$CXXFLAGS -D_GNU_SOURCE"
-fi
-
 export CFLAGS
 export CXXFLAGS
 export LDFLAGS

--- a/build/pkgs/eclib/spkg-install.in
+++ b/build/pkgs/eclib/spkg-install.in
@@ -10,9 +10,6 @@ echo "would interfere with new builds..."
 rm -f "$SAGE_LOCAL"/lib/lib{curvesntl,g0nntl,jcntl,rankntl,mwrank}.*
 # Delete autotools libraries:
 rm -f "$SAGE_LOCAL"/lib/lib{e,j}c.*
-if [ "$UNAME" = "CYGWIN" ]; then
-    rm -f "$SAGE_LOCAL"/lib/cyg{e,j}c-*.dll
-fi
 echo "Deleting old include directory..."
 rm -rf "$SAGE_LOCAL"/include/eclib/
 

--- a/build/pkgs/ecm/spkg-install.in
+++ b/build/pkgs/ecm/spkg-install.in
@@ -73,11 +73,6 @@ else
     echo "to, or '--with-pic' was given in ECM_CONFIGURE."
 fi
 
-if [ "$UNAME" == "CYGWIN" ]; then
-    # Force shared library build only on Cygwin; it will not build otherwise
-    ECM_CONFIGURE="$ECM_CONFIGURE --enable-shared --disable-static"
-fi
-
 
 if [ "$SAGE_DEBUG" = yes ]; then
     # Add debug symbols and disable optimization:

--- a/build/pkgs/fplll/spkg-install.in
+++ b/build/pkgs/fplll/spkg-install.in
@@ -2,19 +2,9 @@ cd src || exit
 
 INCLUDES="-I$SAGE_LOCAL/include/"
 
-if [ "$UNAME" = "CYGWIN" ]; then
-    CXXFLAGS="$CXXFLAGS -std=gnu++11"
-fi
 CXXFLAGS="$CXXFLAGS -fPIC $INCLUDES -L$SAGE_LOCAL/lib"
 CPPFLAGS="$INCLUDES"
 CONFIGUREFLAGS="--prefix=$SAGE_LOCAL --libdir=$SAGE_LOCAL/lib"
-
-if [ "$UNAME" = "CYGWIN" ]; then
-    echo "Disable parallel building on Cygwin"
-    MAKE="$MAKE -j1"
-    export MAKE
-    CONFIGUREFLAGS="$CONFIGUREFLAGS --disable-recursive-enum"
-fi
 
 if [ "x$SAGE_DEBUG" = "xyes" ]; then
    CONFIGUREFLAGS="$CONFIGUREFLAGS --enable-debug"

--- a/build/pkgs/gc/spkg-install.in
+++ b/build/pkgs/gc/spkg-install.in
@@ -2,11 +2,6 @@ cd src
 
 GC_CONFIGURE="--enable-large-config"
 
-if [ "$UNAME" = "CYGWIN" ]; then
-    # See https://github.com/sagemath/sage/issues/22694
-    GC_CONFIGURE="$GC_CONFIGURE --enable-threads=posix --enable-handle-fork"
-fi
-
 sdh_configure $GC_CONFIGURE
 sdh_make
 sdh_make_install

--- a/build/pkgs/giac/spkg-install.in
+++ b/build/pkgs/giac/spkg-install.in
@@ -51,10 +51,6 @@ if [ "$UNAME" = "Darwin" ]; then
     echo "OS X Building without Native Language Support"
     DISABLENLS="--disable-nls"
 fi
-if [ "$UNAME" = "CYGWIN" ]; then
-    export ac_cv_lib_nauty_main=no
-    export ac_cv_header_nauty_naututil_h=no
-fi
 
 sdh_configure --disable-gui --disable-ao "$DISABLENLS" --enable-png=no --disable-samplerate --disable-static --disable-micropy --disable-quickjs
 

--- a/build/pkgs/gmp/spkg-install.in
+++ b/build/pkgs/gmp/spkg-install.in
@@ -122,15 +122,8 @@ export ABI CFLAGS CXXFLAGS LDFLAGS # Partially redundant, but safe(r).
 GMP_CONFIGURE="--enable-shared $GMP_CONFIGURE"
 
 # Also build the static library to be used by e.g. ECM
-# unless we are on Cygwin where we can only build a shared
-# or a static library but not both:
-if [ "$UNAME" = "CYGWIN" ]; then
-    echo "Building GMP with the C++ interface and (only) shared libraries."
-    GMP_CONFIGURE="--enable-cxx $GMP_CONFIGURE --disable-static"
-else
-    echo "Building GMP with the C++ interface and (also) static libraries."
-    GMP_CONFIGURE="--enable-cxx --enable-static $GMP_CONFIGURE"
-fi
+echo "Building GMP with the C++ interface and (also) static libraries."
+GMP_CONFIGURE="--enable-cxx --enable-static $GMP_CONFIGURE"
 
 # If SAGE_FAT_BINARY is enabled, then add --enable-fat to configure
 # options on Linux x86 systems.  On other systems, fat binaries are not

--- a/build/pkgs/iconv/spkg-install.in
+++ b/build/pkgs/iconv/spkg-install.in
@@ -1,21 +1,15 @@
-# Only build iconv on Solaris, HP-UX and Cygwin. See
+# Only build iconv on Solaris and HP-UX. See
 #     https://github.com/sagemath/sage/issues/8567 and
 #     https://github.com/sagemath/sage/issues/9603
 # for details.
 
 case "$UNAME" in
-CYGWIN|HP-UX|SunOS)
-    echo "iconv will be installed as the operating system is Cygwin, HP-UX or Solaris."
+HP-UX|SunOS)
+    echo "iconv will be installed as the operating system is HP-UX or Solaris."
     echo "These systems either lack iconv, or do not have a sufficiently capable"
     echo "version of iconv. See:"
     echo "    https://github.com/sagemath/sage/issues/8567"
     echo "    https://github.com/sagemath/sage/issues/9603"
-
-    # Disable NLS on Cygwin to be able to build libiconv without the Cygwin
-    # libiconv package.
-    if [ "$UNAME" = "CYGWIN" ]; then
-        ICONV_CONFIGURE="--disable-nls $ICONV_CONFIGURE"
-    fi
 
     cd src
 
@@ -24,9 +18,9 @@ CYGWIN|HP-UX|SunOS)
     sdh_make_install
     exit 0
     ;;
-*)  # Not CYGWIN, HP-UX or SunOS (Solaris)
+*)  # Not HP-UX or SunOS (Solaris)
     echo "iconv will not be installed, as we only need to build it on"
-    echo "Solaris, HP-UX and Cygwin, as the system's iconv will be used"
+    echo "Solaris and HP-UX as the system's iconv will be used"
     echo "on other platforms, rather than the one shipped with Sage."
     echo "See:"
     echo "    https://github.com/sagemath/sage/issues/8567"

--- a/build/pkgs/libatomic_ops/spkg-install.in
+++ b/build/pkgs/libatomic_ops/spkg-install.in
@@ -5,10 +5,6 @@ if [ "$SAGE64" = "yes" ]; then
     export CFLAGS="-m64 $CFLAGS"
 fi
 
-if [ "$UNAME" = "CYGWIN" ]; then
-    LIBATOMIC_OPS_CONFIGURE="$LIBATOMIC_OPS_CONFIGURE --enable-shared --disable-static"
-fi
-
 sdh_configure --enable-static $LIBATOMIC_OPS_CONFIGURE
 sdh_make
 sdh_make_install

--- a/build/pkgs/libpng/spkg-install.in
+++ b/build/pkgs/libpng/spkg-install.in
@@ -6,11 +6,6 @@ export CFLAGS="$CFLAGS -fPIC -g"
 # Pick up Sage's zlib:
 export CPPFLAGS="-I$SAGE_LOCAL/include $CPPFLAGS"
 
-# Needed to generate a correct import library
-if [ "$UNAME" = "CYGWIN" ]; then
-    MAKE="$MAKE SYMBOL_PREFIX= "
-fi
-
 cd src
 
 sdh_configure --enable-shared=yes

--- a/build/pkgs/mcqd/spkg-install.in
+++ b/build/pkgs/mcqd/spkg-install.in
@@ -3,11 +3,6 @@ grep -v "std..cout.*current max" mcqd.h > mcqd2.h
 mv mcqd2.h mcqd.h
 
 case "$UNAME" in
-"CYGWIN")
-    SO_NAME="cygmcqd.dll"
-    IMPLIB_NAME="libmcqd.dll.a"
-    MCQD_LDFLAGS="-Wl,--out-implib,$IMPLIB_NAME"
-    ;;
 "Darwin")
     SO_NAME="libmcqd.dylib"
     ;;
@@ -19,12 +14,7 @@ esac
 $CXX -fPIC -O3 -c mcqd.cpp -o mcqd.o
 $CXX -shared mcqd.o -o "$SO_NAME" $MCQD_LDFLAGS
 
-if [ "$UNAME" = "CYGWIN" ]; then
-    sdh_install "$SO_NAME" "$SAGE_LOCAL/bin/"
-    sdh_install "$IMPLIB_NAME" "$SAGE_LOCAL/lib/"
-else
-    sdh_install "$SO_NAME" "$SAGE_LOCAL/lib/"
-fi
+sdh_install "$SO_NAME" "$SAGE_LOCAL/lib/"
 
 if [ "$UNAME" = "Darwin" ]; then
     install_name_tool -id ${SAGE_LOCAL}/lib/$SO_NAME \

--- a/build/pkgs/mpc/spkg-install.in
+++ b/build/pkgs/mpc/spkg-install.in
@@ -8,10 +8,6 @@ unset CFLAGS
 
 EXTRA=""
 
-if [ $UNAME = "CYGWIN" ]; then
-    EXTRA="--disable-static --enable-shared"
-fi
-
 # Building
 sdh_configure $SAGE_CONFIGURE_GMP $SAGE_CONFIGURE_MPFR $EXTRA
 sdh_make

--- a/build/pkgs/mpfr/spkg-install.in
+++ b/build/pkgs/mpfr/spkg-install.in
@@ -48,10 +48,6 @@ mpfr_configure()
     # currently causes problems on a few systems:
     SAGE_CONF_OPTS="--disable-thread-safe"
 
-    if [ "$UNAME" = CYGWIN ]; then
-        SAGE_CONF_OPTS="$SAGE_CONF_OPTS --disable-static --enable-shared"
-    fi
-
     ###########################################################################
     # Pre-configure MPFR with CC and CFLAGS unset:
     ###########################################################################

--- a/build/pkgs/ntl/spkg-install.in
+++ b/build/pkgs/ntl/spkg-install.in
@@ -31,9 +31,6 @@ ntl_configure()
         echo "Setting SHAREDFLAGS to '-fno-common'"
         SHAREDFLAGS="-fno-common"
         ;;
-      CYGWIN)
-        LIBTOOL_LINK_FLAGS="-no-undefined"
-        ;;
     esac
 
     # If SAGE_FAT_BINARY is enabled we don't want NTL to be built with CPU-

--- a/build/pkgs/numpy/spkg-install.in
+++ b/build/pkgs/numpy/spkg-install.in
@@ -7,11 +7,6 @@ set -e
 # -- this also affects numpy
 export CXX=$(echo "$CXX" | sed 's/-std=[a-z0-9+]*//g')
 
-if [ "$UNAME" = "CYGWIN" ]; then
-    # Trac #30643
-    export CPPFLAGS="${CPPFLAGS} -D_GNU_SOURCE"
-fi
-
 if [ "$SAGE_FAT_BINARY" = "yes" ]; then
     export NUMPY_FCONFIG="--cpu-baseline=NONE"
 else

--- a/build/pkgs/palp/spkg-install.in
+++ b/build/pkgs/palp/spkg-install.in
@@ -5,11 +5,6 @@ cd src
 mv Global.h Global.h-template
 
 CFLAGS="-O3 -W -Wall $CFLAGS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
-# On Cygwin the stack size is ridiculously low by default, so that the nef
-# executable which allocates everything on the stack for speed reason blows it
-if [ "$UNAME" = "CYGWIN" ] ; then
-  CFLAGS="$CFLAGS -Wl,--stack,8000000"
-fi
 
 # Undefine NDEBUG. Palp source has assert statements and preprocessing them
 # away changes the syntactical meaning of the program.

--- a/build/pkgs/patch/spkg-install.in
+++ b/build/pkgs/patch/spkg-install.in
@@ -10,7 +10,3 @@ cd src
 sdh_configure
 sdh_make
 sdh_make_install
-
-if [ "$UNAME" = "CYGWIN" ] ; then
-    cp ../patch.exe.manifest "$SAGE_DESTDIR$SAGE_LOCAL/bin/"
-fi

--- a/build/pkgs/ppl/spkg-install.in
+++ b/build/pkgs/ppl/spkg-install.in
@@ -17,12 +17,5 @@ if ! (sdh_configure --enable-interfaces=c,c++ $SAGE_CONFIGURE_GMP \
     sdh_configure --enable-interfaces=c++ $SAGE_CONFIGURE_GMP $PPL_CONFIGURE
 fi
 
-# Workaround to disable PPL's "watchdog timer", preventing it from clobbering
-# Cysignals' SIGALRM handler on Cygwin; see
-# https://github.com/sagemath/sage/issues/21190
-if [ "$UNAME" = "CYGWIN" ]; then
-    sed -i 's/#define HAVE_DECL_SETITIMER 1/#define HAVE_DECL_SETITIMER 0/' config.h
-fi
-
 sdh_make
 sdh_make_install

--- a/build/pkgs/python3/spkg-install.in
+++ b/build/pkgs/python3/spkg-install.in
@@ -59,8 +59,4 @@ fi
 if [ "$UNAME" = "Darwin" ] && \
     [ `uname -r | cut '-d.' -f1` -gt 9 ]; then
     rm -f "${SAGE_DESTDIR}${PYTHON_CONFIG_DIR}/libpython${PYTHON_LDVERSION}.a"
-elif [ "$UNAME" = "CYGWIN" ]; then
-    # See https://github.com/sagemath/sage/issues/20437
-    ln -sf "${PYTHON_CONFIG_DIR}/libpython${PYTHON_LDVERSION}.dll.a" \
-        "${SAGE_DESTDIR_LOCAL}/lib/libpython${PYTHON_LDVERSION}.dll.a"
 fi

--- a/build/pkgs/readline/spkg-install.in
+++ b/build/pkgs/readline/spkg-install.in
@@ -20,9 +20,6 @@ sdh_make_install
 case "$UNAME" in
     Darwin)
         DYLIB_NAME=libreadline.dylib;;
-    CYGWIN)
-        # It is of course very lame that readline names the file .dll.a, but that's what it does.
-        DYLIB_NAME=libreadline.dll.a;;
     OpenBSD)
         # Untested. (David Kirkby, 11th November 2010)
         # Extension changed from 6.1 to 6.2; still untested. (October 2011)

--- a/build/pkgs/singular/spkg-install.in
+++ b/build/pkgs/singular/spkg-install.in
@@ -40,16 +40,9 @@ remove_old_version()
         singular_resources  # 4.x and up
         gfan
     )
-    if [ "$UNAME" = "CYGWIN" ]; then
-        for name in ${libs[*]}; do
-            rm -f "$SAGE_LOCAL"/bin/cyg${name}*.dll
-            rm -f "$SAGE_LOCAL"/lib/lib${name}*.a
-        done
-    else
-        for name in ${libs[*]}; do
-            rm -f "$SAGE_LOCAL"/lib/lib${name}*
-        done
-    fi
+    for name in ${libs[*]}; do
+        rm -f "$SAGE_LOCAL"/lib/lib${name}*
+    done
 
     rm -f "$SAGE_LOCAL"/lib/p_Procs_Field* # 3.x only
     rm -rf "$SAGE_LOCAL/share/singular"
@@ -58,11 +51,6 @@ remove_old_version()
 
 config()
 {
-    if [ "$UNAME" = "CYGWIN" ]; then
-        # from Hans Schoenemann - https://github.com/Singular/Singular/issues/1017
-        SINGULAR_CONFIGURE="$SINGULAR_CONFIGURE --disable-p-procs-dynamic --enable-p-procs-static --with-builtinmodules=gfanlib,gitfan,interval,loctriv,partialgb,syzextra,customstd,cohomo,subsets,freealgebra,systhreads --disable-cf-inline --disable-Order-module --disable-bigintm-module --disable-pyobject-module"
-    fi
-
     # configure notes (dates from Singular 3.x, maybe outdated for 4.x):
     # 1) We really need to add --exec-prefix and --bindir as Singular
     #    uses some weird defaults.

--- a/build/pkgs/tachyon/spkg-install.in
+++ b/build/pkgs/tachyon/spkg-install.in
@@ -4,9 +4,6 @@ cd "$CUR/src/unix"
 
 TARGET=""
 case "$UNAME" in
-"CYGWIN")
-    TARGET=win32
-    ;;
 "Darwin")
     TARGET=macosx
     ;;
@@ -59,12 +56,7 @@ sdh_make "$TARGET"
 
 echo "Installing the Tachyon binary..."
 cd "$CUR"
-if [ "$UNAME" = CYGWIN ]; then
-    binary_name=tachyon.exe
-else
-    binary_name=tachyon
-fi
 
-# The '*' is a place-holder for the arch just built (e.g. 'win32' for
-# Cygwin, other directories won't exist):
-sdh_install src/compile/*/"${binary_name}" "$SAGE_LOCAL/bin"
+# The '*' is a place-holder for the arch just built (e.g. 'linux-ppc'
+# on PPC, other directories won't exist):
+sdh_install src/compile/*/tachyon "$SAGE_LOCAL/bin"

--- a/build/pkgs/zlib/spkg-install.in
+++ b/build/pkgs/zlib/spkg-install.in
@@ -1,22 +1,9 @@
 cd src/
-echo "patching win32/zlib.def with a binary patch"
-patch -p1 --posix --binary <"$SAGE_ROOT/build/pkgs/zlib/patches/cygwin-windef.diff_bin"
 
-if [ "$UNAME" = CYGWIN ]; then
-    export BINARY_PATH="$SAGE_LOCAL/bin"
-    export INCLUDE_PATH="$SAGE_LOCAL/include"
-    export LIBRARY_PATH="$SAGE_LOCAL/lib"
-    cp -f win32/Makefile.gcc Makefile || \
-        sdh_die "Error copying over zlib's Makefile for Cygwin."
-
-    # We want to install shared objects
-    sed -i 's/SHARED_MODE=0/SHARED_MODE=1/' Makefile
-else
-    # Trac #28890: zlib does not use a standard autoconf-generated configure
-    # script, so don't use the sdh_configure helper as it may have minor
-    # incompatibilities
-    ./configure --shared --prefix="$SAGE_LOCAL" --libdir="$SAGE_LOCAL/lib" || sdh_die "Error configuring $PKG_NAME"
-fi
+# Trac #28890: zlib does not use a standard autoconf-generated configure
+# script, so don't use the sdh_configure helper as it may have minor
+# incompatibilities
+./configure --shared --prefix="$SAGE_LOCAL" --libdir="$SAGE_LOCAL/lib" || sdh_die "Error configuring $PKG_NAME"
 
 sdh_make
 sdh_make_install


### PR DESCRIPTION
This mainly consists of

```
$ git grep -i cygwin build/pkgs/*/spkg-install*
```

and then deleting the resulting `[ "${UNAME}" = "CYGWIN" ]` cases. Two instances (under sagelib and pycygwin) have been omitted because they are being handled elsewhere.
