### PR TITLE
Emphasize h2 headings of the documentation

### DIFF
--- a/src/doc/ca/intro/index.rst
+++ b/src/doc/ca/intro/index.rst
@@ -304,7 +304,7 @@ Funcions
 
 La declaració general d'una funció
 de `n` arguments
-per la que s'hagi de fer 
+per la que s'hagi de fer
 una sèrie d'operacions és:
 
 .. skip
@@ -359,9 +359,9 @@ Com que en l'exemple donat la funció retorna dos valors, podem assignar-los a d
 
 Aquesta crida, però, ens donaria un error si la solució no existís o fos única.
 
-Observem que totes les variables utilitzades 
+Observem que totes les variables utilitzades
 són per defecte locals i que
-no ha calgut declarar-les. Una variable externa a la funció amb nom igual a una de 
+no ha calgut declarar-les. Una variable externa a la funció amb nom igual a una de
 les variables locals
 no es modificarà a causa de la funció. Per exemple, considerem la funció `f`:
 
@@ -620,7 +620,7 @@ Algebra lineal
 Construcció de vectors
 ----------------------
 
-Donat un cos `K`, creem l'espai vectorial 
+Donat un cos `K`, creem l'espai vectorial
 `K^n` mitjançant ``VectorSpace(K,n)``, o escrivint ``K^n``.
 Per crear vectors podem fer una coerció dins l'espai dels vectors corresponent o bé els podem definir directament::
 
@@ -701,7 +701,7 @@ la notació usual. Per trobar la matriu inversa d'una
 matriu invertible `m`
 escriurem ``m^-1``.
 
-Per trobar les solucions d'un sistema lineal `x m=v` on 
+Per trobar les solucions d'un sistema lineal `x m=v` on
 `m` és una matriu i `v` és un vector tenim  ``m.solve_left()``
 mentre que per resoldre el sistema `x m=v` tenim
 ``m.solve_right()``. ::
@@ -993,10 +993,10 @@ ordre visualitza una esfera utilitzant la fórmula clàssica:
     sage: implicit_plot3d(x^2 + y^2 + z^2 - 4, (x,-2, 2), (y,-2, 2), (z,-2, 2))
     Graphics3d Object
 
-Índexs i taules
-===============
-
 ..  [Jmol] Jmol: un visualitzador d'estructures químiques en 3D, de codi obert i escrit en Java i Javascript.  http://www.jmol.org/.
+
+Índex i cerca
+=============
 
 * :ref:`genindex`
 * :ref:`search`

--- a/src/doc/common/static/custom-furo.css
+++ b/src/doc/common/static/custom-furo.css
@@ -11,6 +11,14 @@ body[data-theme="dark"] div.highlight {
   background: #383838;
 }
 
+h2 {
+  background-color: rgba(68,138,255,.1);
+}
+
+h2[data-theme="dark"] {
+  background-color: rgba(101,31,255,.1);
+}
+
 /* Copied the style for a.pdf from website/templates/index_furo.html */
 
 a.pdf {

--- a/src/doc/common/static/custom-furo.css
+++ b/src/doc/common/static/custom-furo.css
@@ -16,7 +16,7 @@ h2 {
 }
 
 h2[data-theme="dark"] {
-  background-color: rgba(101,31,255,.1);
+  background-color: rgba(101,31,255,.2);
 }
 
 /* Copied the style for a.pdf from website/templates/index_furo.html */

--- a/src/doc/de/tutorial/index.rst
+++ b/src/doc/de/tutorial/index.rst
@@ -2,6 +2,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+==============================
 Willkommen beim Sage Tutorial!
 ==============================
 
@@ -40,8 +41,8 @@ __ http://creativecommons.org/licenses/by-sa/3.0/
    appendix
    bibliography
 
-Indizes und Tabellen
-====================
+Index und Suche
+===============
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/src/doc/en/constructions/index.rst
+++ b/src/doc/en/constructions/index.rst
@@ -48,8 +48,8 @@ interface http://sagecell.sagemath.org/ on the web.
    contributions
 
 
-Indices and tables
-==================
+Index and Search
+================
 
 * :ref:`genindex`
 * :ref:`search`

--- a/src/doc/en/developer/index.rst
+++ b/src/doc/en/developer/index.rst
@@ -185,8 +185,8 @@ Packaging
    packaging_sage_library
 
 
-Indices and tables
-==================
+Index and Search
+================
 
 * :ref:`genindex`
 * :ref:`search`

--- a/src/doc/en/faq/index.rst
+++ b/src/doc/en/faq/index.rst
@@ -22,8 +22,7 @@ __ http://creativecommons.org/licenses/by-sa/3.0/
    faq-usage
    faq-contribute
 
-Indices and tables
-==================
-
+Index and Search
+================
 * :ref:`genindex`
 * :ref:`search`

--- a/src/doc/en/reference/footer.txt
+++ b/src/doc/en/reference/footer.txt
@@ -1,12 +1,12 @@
-Indices and Tables
-==================
+Index and Search
+----------------
 
-* `Index <../genindex.html>`_
-* `Module Index <../py-modindex.html>`_
-* `Search Page <../search.html>`_
+* `Name index <../genindex.html>`_
+* `Module index <../py-modindex.html>`_
+* `Search page <../search.html>`_
 
 ..
-  comment: the following math environment forces Sphinx to load MathJax
+  comment: the following math directive forces Sphinx to load MathJax
   in the index.rst pages. Do not delete it!
 
 .. math::

--- a/src/doc/en/reference/index.rst
+++ b/src/doc/en/reference/index.rst
@@ -170,8 +170,8 @@ General Information
 * :doc:`Bibliographic References <references/index>`
 * :doc:`History and License <history_and_license/index>`
 
-Indices and Tables
-==================
+Index and Search
+================
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/src/doc/en/thematic_tutorials/index.rst
+++ b/src/doc/en/thematic_tutorials/index.rst
@@ -118,7 +118,7 @@ Advanced Programming
 .. --------
 
 Documentation
-=============
+-------------
 
 * :ref:`sws2rst`
 

--- a/src/doc/en/tutorial/index.rst
+++ b/src/doc/en/tutorial/index.rst
@@ -41,8 +41,8 @@ __ http://creativecommons.org/licenses/by-sa/3.0/
    appendix
    bibliography
 
-Indices and tables
-==================
+Index and Search
+================
 
 * :ref:`genindex`
 * :ref:`search`

--- a/src/doc/en/website/templates/index_furo.html
+++ b/src/doc/en/website/templates/index_furo.html
@@ -35,11 +35,7 @@ This is documentation for Sage {{ release }}.
 Documentations in other languages are available <a href="../../index.html">here</a>.
 </p>
 {% block tables %}
-<h2>
-  <strong>
-    Tutorials and FAQ
-  </strong>
-</h2>
+<h2>Tutorials and FAQ</h2>
 <table class="contentstable">
    <tr valign="top">
     <td width="50%">
@@ -147,11 +143,7 @@ Documentations in other languages are available <a href="../../index.html">here<
     </td>
   </tr>
 </table>
-<h2>
-  <strong>
-    Comprehensive Reference Manual
-  </strong>
-</h2>
+<h2>Comprehensive Reference Manual</h2>
 <table class="contentstable" align="center" cellspacing="20">
   <tr valign="top">
     <td width="50%">
@@ -178,11 +170,7 @@ Documentations in other languages are available <a href="../../index.html">here<
     </td>
   </tr>
 </table>
-<h2>
-  <strong>
-    Installation and Developer Guides
-  </strong>
-</h2>
+<h2>Installation and Developer Guides</h2>
 <table class="contentstable" align="center" cellspacing="20">
   <tr valign="top">
     <td width="50%">

--- a/src/doc/es/tutorial/index.rst
+++ b/src/doc/es/tutorial/index.rst
@@ -2,6 +2,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+=================================
 ¡Bienvenidos Al Tutorial De Sage!
 =================================
 
@@ -30,8 +31,8 @@ __ http://creativecommons.org/licenses/by-sa/3.0/
    introduction
    tour
 
-Indices and tables
-==================
+Índice y Buscar
+===============
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/src/doc/fr/tutorial/index.rst
+++ b/src/doc/fr/tutorial/index.rst
@@ -2,6 +2,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+=================================
 Bienvenue dans le tutoriel Sage !
 =================================
 
@@ -45,8 +46,8 @@ __ http://creativecommons.org/licenses/by-sa/3.0/
    appendix
    bibliography
 
-Index et tables
-===============
+Index et Recherche
+==================
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/src/doc/it/faq/index.rst
+++ b/src/doc/it/faq/index.rst
@@ -3,6 +3,7 @@
 .. your liking, but it should at least contain the root `toctree`
 .. directive.
 
+===========================
 Benvenuto alle FAQ di Sage!
 ===========================
 
@@ -20,7 +21,7 @@ __ http://creativecommons.org/licenses/by-sa/3.0/
    faq-usage
    faq-contribute
 
-Indice e tabelle
+Indice e Ricerca
 ================
 
 * :ref:`genindex`

--- a/src/doc/it/tutorial/index.rst
+++ b/src/doc/it/tutorial/index.rst
@@ -2,19 +2,21 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+==============================
 Benvenuti al tutorial di Sage!
-================================
+==============================
 
 Sage è un software di calcolo numerico e simbolico libero e open-source di supporto
+
 nell'insegnamento e della ricerca in algebra, geometria, teoria dei numeri, crittografia,
-calcolo numerico e aree correlate. Sia il modello di sviluppo di Sage, sia la tecnologia 
-utilizzata in Sage stesso, si distinguono per un'enfasi particolarmente forte 
-su apertura, community, cooperazione e collaborazione: vogliamo creare 
-l'automobile, non reinventare la ruota. L'obiettivo complessivo di Sage è creare 
-un'alternativa adeguata, libera e open-source a Maple, Mathematica, Magma e 
+calcolo numerico e aree correlate. Sia il modello di sviluppo di Sage, sia la tecnologia
+utilizzata in Sage stesso, si distinguono per un'enfasi particolarmente forte
+su apertura, community, cooperazione e collaborazione: vogliamo creare
+l'automobile, non reinventare la ruota. L'obiettivo complessivo di Sage è creare
+un'alternativa adeguata, libera e open-source a Maple, Mathematica, Magma e
 MATLAB.
 
-Questo tutorial è la via migliore per familiarizzare con Sage in poche ore e può 
+Questo tutorial è la via migliore per familiarizzare con Sage in poche ore e può
 essere letto in HTML o PDF.
 
 
@@ -24,8 +26,8 @@ essere letto in HTML o PDF.
    introduction
    tour_algebra
 
-Indici e tabelle
-==================
+Indice e Ricerca
+================
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/src/doc/ja/tutorial/index.rst
+++ b/src/doc/ja/tutorial/index.rst
@@ -1,6 +1,6 @@
-
+============================
 Sageチュートリアルへようこそ
-================================
+============================
 
 Sageは，代数学，幾何学，数論，暗号理論，数値解析，および関連諸分野の研究と教育を支援する，フリーなオープンソース数学ソフトウェアである．
 Sageの開発モデルとテクノロジーに共通する著しい特徴は，公開，共有，協調と協働の原則の徹底的な遵守である．
@@ -10,7 +10,7 @@ Sageの開発モデルとテクノロジーに共通する著しい特徴は，�
 Sageがどんなものか，短時間で知りたければ，まずこのチュートリアルを読んでみていただきたい．
 HTML版とPDF版のどちらを読んでもいいし，Sageノートブックを経由することもできる(チュートリアル内容を対話的に実行するには，ノートブックで ``Help`` ，  続けて ``Tutorial`` をクリックする)．
 
-この文章の著作権は `Creative Commons Attribution-Share Alike 3.0 License`__ 
+この文章の著作権は `Creative Commons Attribution-Share Alike 3.0 License`__
 に準ずる．
 
 __ http://creativecommons.org/licenses/by-sa/3.0/
@@ -29,8 +29,8 @@ __ http://creativecommons.org/licenses/by-sa/3.0/
    appendix
    bibliography
 
-Indices and tables
-==================
+索引と検索
+==========
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/src/doc/pt/tutorial/index.rst
+++ b/src/doc/pt/tutorial/index.rst
@@ -2,6 +2,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+===========================
 Bem-vindo ao Tutorial Sage!
 ===========================
 
@@ -38,8 +39,8 @@ __ http://creativecommons.org/licenses/by-sa/3.0/deed.pt
    appendix
    bibliography
 
-Índices e tabelas 
-=================
+Índice e Buscar
+===============
 
 * :ref:`genindex`
 * :ref:`modindex`


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

We add css styles to enphasize h2 headings, which is currently hardly distinguished  from h1 (the title) and h3 headings only by slight size differences. We make h2 headings more visible and function as section dividers.

For example, compare

https://deploy-preview-36861--sagemath-tobias.netlify.app/html/en/reference/structure/

with

https://deploy-preview-36784--sagemath-tobias.netlify.app/html/en/reference/structure/

We downgrade "Indices and Tables" to more appropriate h2 heading, and change it to "Index and Search" since actually there is no table in the section.

We do the same for non-English docs.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
