### PR TITLE
Make "large multiplication" larger in coerce_actions.pyx

### DIFF
--- a/src/sage/structure/coerce_actions.pyx
+++ b/src/sage/structure/coerce_actions.pyx
@@ -781,6 +781,7 @@ cdef class IntegerMulAction(IntegerAction):
         Check that large multiplications can be interrupted::
 
             sage: # needs sage.schemes
+            sage: P = E([2,1,1])
             sage: alarm(0.001); 2^(10^8) * P
             Traceback (most recent call last):
             ...

--- a/src/sage/structure/coerce_actions.pyx
+++ b/src/sage/structure/coerce_actions.pyx
@@ -781,7 +781,7 @@ cdef class IntegerMulAction(IntegerAction):
         Check that large multiplications can be interrupted::
 
             sage: # needs sage.schemes
-            sage: alarm(0.001); 2^(10^7) * P
+            sage: alarm(0.001); 2^(10^8) * P
             Traceback (most recent call last):
             ...
             AlarmInterrupt


### PR DESCRIPTION
A doctest in coerce_actions.pyx tests whether "large multiplications can be interrupted". Depending on the random input and on the speed of the machine, that multiplication can happen too fast, and then the interrupt doesn't happen in time. So let's make the multiplication take longer.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->

This should fix #35973.

In some testing: this multiplication uses `P = E.random_element()` where `E` is some elliptic curve. If this happens to be `(0:1:0)`, then on at least one machine, the multiplication is completed too quickly. We could reject that particular point, or we can increase the multiplication by a factor of 10. This PR uses the second approach.

<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [X] The title is concise, informative, and self-explanatory.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
