### PR TITLE
`sage --package create --pypi`: Create a wheel package by default if possible

### DIFF
--- a/build/make/Makefile.in
+++ b/build/make/Makefile.in
@@ -322,9 +322,8 @@ toolchain-deps:
 all-toolchain: base-toolchain
 	+$(MAKE_REC) toolchain-deps
 
-# All packages needed as a prerequisite to install other Python packages with
-# pip or which are otherwise used by the Python build tools; these should be
-# given as a prerequisite to any pip-installed packages
+# Shorthand for a list of packages sufficient for building and installing
+# typical Python packages from source. Wheel packages only need pip.
 PYTHON_TOOLCHAIN = setuptools pip setuptools_scm wheel setuptools_wheel
 
 # Trac #32056: Avoid installed setuptools leaking into the build of python3 by uninstalling it.

--- a/build/pkgs/six/checksums.ini
+++ b/build/pkgs/six/checksums.ini
@@ -1,5 +1,5 @@
-tarball=six-VERSION.tar.gz
-sha1=06fa0bb50f2a4e2917fd14c21e9d2d5508ce0163
-md5=a7c927740e4964dd29b72cebfc1429bb
-cksum=1693137720
-upstream_url=https://pypi.io/packages/source/s/six/six-VERSION.tar.gz
+tarball=six-VERSION-py2.py3-none-any.whl
+sha1=79e6f2e4f9e24898f1896df379871b9c9922f147
+md5=529d7fd7e14612ccde86417b4402d6f3
+cksum=2975792266
+upstream_url=https://pypi.io/packages/py2.py3/s/six/six-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/six/dependencies
+++ b/build/pkgs/six/dependencies
@@ -1,4 +1,4 @@
- | $(PYTHON_TOOLCHAIN) $(PYTHON)
+ | pip $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/six/spkg-install.in
+++ b/build/pkgs/six/spkg-install.in
@@ -1,3 +1,0 @@
-cd src
-
-sdh_pip_install .

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -290,8 +290,9 @@ class Application(object):
         if pypi:
             if source is None:
                 try:
-                    source = 'wheel'
-                    if not PyPiVersion(package_name, source='wheel').tarball.endswith('-none-any.whl'):
+                    if PyPiVersion(package_name, source='wheel').tarball.endswith('-none-any.whl'):
+                        source = 'wheel'
+                    else:
                         source = 'normal'
                 except PyPiError:
                     source = 'normal'

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -273,7 +273,7 @@ class Application(object):
             update.fix_checksum()
 
     def create(self, package_name, version=None, tarball=None, pkg_type=None, upstream_url=None,
-               description=None, license=None, upstream_contact=None, pypi=False, source='normal'):
+               description=None, license=None, upstream_contact=None, pypi=False, source=None):
         """
         Create a package
 
@@ -288,6 +288,13 @@ class Application(object):
         if '-' in package_name:
             raise ValueError('package names must not contain dashes, use underscore instead')
         if pypi:
+            if source is None:
+                try:
+                    source = 'wheel'
+                    if not PyPiVersion(package_name, source='wheel').tarball.endswith('-none-any.whl'):
+                        source = 'normal'
+                except PyPiError:
+                    source = 'normal'
             pypi_version = PyPiVersion(package_name, source=source)
             if source == 'normal':
                 if not tarball:
@@ -312,6 +319,10 @@ class Application(object):
                 license = pypi_version.license
             if not upstream_contact:
                 upstream_contact = pypi_version.package_url
+        if upstream_url and not tarball:
+            tarball = upstream_url.rpartition('/')[2]
+        if tarball and source is None:
+            source = 'normal'
         if tarball and not pkg_type:
             # If we set a tarball, also make sure to create a "type" file,
             # so that subsequent operations (downloading of tarballs) work.

--- a/build/sage_bootstrap/cmdline.py
+++ b/build/sage_bootstrap/cmdline.py
@@ -319,7 +319,7 @@ def make_parser():
         'package_name', default=None, type=str,
         help='Package name.')
     parser_create.add_argument(
-        '--source', type=str, default=None, help='Package source (one of normal, wheel, script, pip; default depends on provided arguments)')
+        '--source', type=str, default=None, help='Package source (one of normal, wheel, script, pip); default depends on provided arguments')
     parser_create.add_argument(
         '--version', type=str, default=None, help='Package version')
     parser_create.add_argument(

--- a/build/sage_bootstrap/cmdline.py
+++ b/build/sage_bootstrap/cmdline.py
@@ -319,7 +319,7 @@ def make_parser():
         'package_name', default=None, type=str,
         help='Package name.')
     parser_create.add_argument(
-        '--source', type=str, default='normal', help='Package source (one of normal, wheel, script, pip)')
+        '--source', type=str, default=None, help='Package source (one of normal, wheel, script, pip; default depends on provided arguments)')
     parser_create.add_argument(
         '--version', type=str, default=None, help='Package version')
     parser_create.add_argument(


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

We change the default of `sage --package create --pypi` to create a wheel package (if the package has a platform-independent wheel on PyPI) instead of a normal package (built from source).
This is simpler (no spkg-install.in script, no build dependencies) and a bit faster.

As an illustration, we change one SPKG, `six`, from normal to wheel.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
