### PR TITLE
rename 'divided difference operator'

### DIFF
--- a/src/sage/algebras/quantum_groups/fock_space.py
+++ b/src/sage/algebras/quantum_groups/fock_space.py
@@ -754,8 +754,8 @@ class FockSpace(Parent, UniqueRepresentation):
 
             def e(self, *data):
                 r"""
-                Apply the action of the divided difference operator
-                `e_i^{(p)}` on ``self``.
+                Apply the action of the divided power operator
+                `e_i^{(p)} = e_i^{p} / [p]_q` on ``self``.
 
                 INPUT:
 
@@ -850,8 +850,8 @@ class FockSpace(Parent, UniqueRepresentation):
 
             def f(self, *data):
                 r"""
-                Apply the action of the divided difference operator
-                `f_i^{(p)}` on ``self``.
+                Apply the action of the divided power operator
+                `f_i^{(p)} = f_i^{p} / [p]_q` on ``self``.
 
                 INPUT:
 


### PR DESCRIPTION
The action of $e_i^{(p)}$ on Fock space corresponding to pair `(i,p)` is given by $e_i^{(p)} := e_i^{p} / [p]_q$.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
