### PR TITLE
Create index-pdf.html in html build

### DIFF
--- a/src/sage_docbuild/builders.py
+++ b/src/sage_docbuild/builders.py
@@ -654,11 +654,11 @@ class ReferenceTopBuilder(DocBuilder):
         os.makedirs(d, exist_ok=True)
         return d
 
-    def pdf(self):
+    def html(self):
         """
-        Build top-level document.
+        Build the top-level document.
         """
-        super().pdf()
+        super().html()
 
         # We want to build master index file which lists all of the PDF file.
         # We modify the file index.html from the "reference_top" target, if it
@@ -668,12 +668,8 @@ class ReferenceTopBuilder(DocBuilder):
         reference_dir = os.path.join(SAGE_DOC, 'html', 'en', 'reference')
         output_dir = self._output_dir('html')
 
-        # Check if the top reference index.html exists.
-        try:
-            with open(os.path.join(reference_dir, 'index.html')) as f:
-                html = f.read()
-        except FileNotFoundError:
-            return
+        with open(os.path.join(reference_dir, 'index.html')) as f:
+            html = f.read()
 
         # Install in output_dir a symlink to the directory containing static files.
         # Prefer relative path for symlinks.


### PR DESCRIPTION
When we `make doc-pdf`, `reference/index-pdf.html` is also built. With this PR, it  is built by default when we `make doc-html`.

Here it is: https://deploy-preview-36799--sagemath-tobias.netlify.app/html/en/reference/index-pdf

This is to fix the issue https://github.com/sagemath/sage/pull/36730#issuecomment-1837013688

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
