### PR TITLE
removed warning in sage.is_dead()

### DIFF
--- a/src/sage/databases/oeis.py
+++ b/src/sage/databases/oeis.py
@@ -732,7 +732,7 @@ class OEISSequence(SageObject, UniqueRepresentation):
         except AttributeError:
             pass
 
-    def _field(self, key):
+    def _field(self, key, warn=True):
         r"""
         Return the ``key`` field of the entry of ``self``.
 
@@ -751,7 +751,7 @@ class OEISSequence(SageObject, UniqueRepresentation):
             for line in self.raw_entry().splitlines():
                 fields[line[1]].append(line[11:])
             self._fields = fields
-            self.is_dead(warn_only=True)
+            self.is_dead(warn_only=warn)
             return self._fields[key]
 
     def id(self, format='A'):
@@ -995,7 +995,7 @@ class OEISSequence(SageObject, UniqueRepresentation):
             sage: s.keywords()
             ('nonn', 'hard')
         """
-        return tuple(self._field('K')[0].split(','))
+        return tuple(self._field('K', warn=False)[0].split(','))
 
     def natural_object(self):
         r"""


### PR DESCRIPTION
Fixes #36795
fixed warning in sage.is_dead() function in OEISSequence

added a parameter warn=True in _field function and changed self.is_dead(warn_only=True) to self.is_dead(warn_only=warn) inside the _field function, changed the self._field('K') to self._field('K', warn=False)
so the warning is not triggered


i am new to opensource / python and first time contributing please check the changes thoroughly and let me know if i have to make any new changes