### PR TITLE
Documentation changes 

### DIFF
--- a/src/doc/en/developer/coding_basics.rst
+++ b/src/doc/en/developer/coding_basics.rst
@@ -1039,14 +1039,9 @@ written.
     The :ref:`doctest fixer <section-fixdoctests-optional-needs>` uses
     tab stops at columns 48, 56, 64, ... for these tags.
 
-- **Python3 print:** Python3 syntax for print must be used in Sage
-  code and doctests. If you use an old-style print in doctests, it
-  will raise a SyntaxError::
+- **Python3 print:** In SageMath code and doctests, adhere to Python 3 
+  syntax for the print function. Use parentheses as follows:::
 
-      sage: print "not like that"
-      Traceback (most recent call last):
-      ...
-      SyntaxError: ...
       sage: print("but like this")
       but like this
 

--- a/src/sage/databases/oeis.py
+++ b/src/sage/databases/oeis.py
@@ -732,7 +732,7 @@ class OEISSequence(SageObject, UniqueRepresentation):
         except AttributeError:
             pass
 
-    def _field(self, key):
+    def _field(self, key, warn=True):
         r"""
         Return the ``key`` field of the entry of ``self``.
 
@@ -751,7 +751,7 @@ class OEISSequence(SageObject, UniqueRepresentation):
             for line in self.raw_entry().splitlines():
                 fields[line[1]].append(line[11:])
             self._fields = fields
-            self.is_dead(warn_only=True)
+            self.is_dead(warn_only=warn)
             return self._fields[key]
 
     def id(self, format='A'):
@@ -995,7 +995,7 @@ class OEISSequence(SageObject, UniqueRepresentation):
             sage: s.keywords()
             ('nonn', 'hard')
         """
-        return tuple(self._field('K')[0].split(','))
+        return tuple(self._field('K', warn=False)[0].split(','))
 
     def natural_object(self):
         r"""


### PR DESCRIPTION
removed the old python2 print statment information from the developer documentation


removed the "Python3 print: Python3 syntax for print must be used in Sage code and doctests. If you use an old-style print in doctests, it will raise a SyntaxError:"
and changed it with
"In SageMath code and doctests, adhere to Python 3 
  syntax for the print function. Use parentheses as follows:"

