### PR TITLE
`m4/sage_spkg_configure.m4`: Improve doc of `SAGE_DEPCHECK`, add macro for reverse depcheck

### DIFF
--- a/build/pkgs/backcall/spkg-configure.m4
+++ b/build/pkgs/backcall/spkg-configure.m4
@@ -3,5 +3,5 @@ SAGE_SPKG_CONFIGURE([backcall], [
 ],[
   # required-check phase; skip this package if ipython
   # from the system is used (it's the only reverse dep).
-  SAGE_SPKG_DEPCHECK([ipython], [sage_require_backcall=no])
+  SAGE_SPKG_DEPCHECK([ipython], [sage_require_backcall=no], [])
 ])

--- a/build/pkgs/backcall/spkg-configure.m4
+++ b/build/pkgs/backcall/spkg-configure.m4
@@ -1,1 +1,10 @@
-SAGE_SPKG_CONFIGURE([backcall], [SAGE_PYTHON_PACKAGE_CHECK([backcall])])
+SAGE_SPKG_CONFIGURE([backcall], [
+  SAGE_PYTHON_PACKAGE_CHECK([backcall])
+],[
+  # required-check phase; skip this package if ipython
+  # from the system is used (it's the only reverse dep).
+  AC_REQUIRE([SAGE_SPKG_CONFIGURE_IPYTHON])
+  AS_IF([test "${sage_spkg_install_ipython}" = "no"],[
+    sage_require_backcall=no
+  ])
+])

--- a/build/pkgs/backcall/spkg-configure.m4
+++ b/build/pkgs/backcall/spkg-configure.m4
@@ -3,8 +3,5 @@ SAGE_SPKG_CONFIGURE([backcall], [
 ],[
   # required-check phase; skip this package if ipython
   # from the system is used (it's the only reverse dep).
-  AC_REQUIRE([SAGE_SPKG_CONFIGURE_IPYTHON])
-  AS_IF([test "${sage_spkg_install_ipython}" = "no"],[
-    sage_require_backcall=no
-  ])
+  SAGE_SPKG_DEPCHECK([ipython], [sage_require_backcall=no])
 ])

--- a/build/pkgs/backcall/spkg-configure.m4
+++ b/build/pkgs/backcall/spkg-configure.m4
@@ -3,5 +3,5 @@ SAGE_SPKG_CONFIGURE([backcall], [
 ],[
   # required-check phase; skip this package if ipython
   # from the system is used (it's the only reverse dep).
-  SAGE_SPKG_DEPCHECK([ipython], [sage_require_backcall=no], [])
+  SAGE_SPKG_REVDEPCHECK([ipython])
 ])

--- a/m4/sage_spkg_configure.m4
+++ b/m4/sage_spkg_configure.m4
@@ -191,7 +191,7 @@ AC_DEFUN([SAGE_SPKG_CONFIGURE], [
 # DESCRIPTION
 #     *** to be called from SAGE_SPKG_CONFIGURE* ***
 #     check for space-separated list of package dependencies $1 of package SPKG_NAME
-#     do $2 if successful
+#     do $2 if none of $1 is (to be) installed by Sage, normally checks on suitability of the system SPKG_NAME
 #
 #     $3 is for off-label use - checking a reverse dependency, by REVDEPCHECK. Then the default action of
 #     setting sage_spkg_install_SPKG_NAME=yes whenever anything from $1 comes from Sage may be overwritten,

--- a/m4/sage_spkg_configure.m4
+++ b/m4/sage_spkg_configure.m4
@@ -208,3 +208,17 @@ AC_DEFUN([SAGE_SPKG_DEPCHECK], [
         $2
         ])
 ])
+
+
+# SYNOPSIS
+#
+#   SAGE_SPKG_REVDEPCHECK(PACKAGE-REVERSE-DEPENDENCIES)
+#                                 $1
+# DESCRIPTION
+#     *** to be called from SAGE_SPKG_CONFIGURE* ***
+#     check for space-separated list of package reverse dependencies $1 of package SPKG_NAME
+#     If they all come from the system, do not require SPKG_NAME
+#
+AC_DEFUN([SAGE_SPKG_REVDEPCHECK], [
+    SAGE_SPKG_DEPCHECK($1, [[sage_require_]SPKG_NAME=no], [])
+])

--- a/m4/sage_spkg_configure.m4
+++ b/m4/sage_spkg_configure.m4
@@ -185,7 +185,7 @@ AC_DEFUN([SAGE_SPKG_CONFIGURE], [
 
 # SYNOPSIS
 #
-#   SAGE_SPKG_DEPCHECK(PACKAGE-DEPENDENCIES, FURTHER-CHECK, [FAIL= [sage_spkg_install_]SPKG_NAME=yes])
+#   SAGE_SPKG_DEPCHECK(PACKAGE-DEPENDENCIES, FURTHER-CHECK, [DEPS_ARE_INSTALLED= [sage_spkg_install_]SPKG_NAME=yes])
 #                                 $1              $2                $3
 #
 # DESCRIPTION
@@ -193,8 +193,9 @@ AC_DEFUN([SAGE_SPKG_CONFIGURE], [
 #     check for space-separated list of package dependencies $1 of package SPKG_NAME
 #     do $2 if successful
 #
-#     $3 is for off-label use - checking a reverse dependency. Then the default action of
-#     setting sage_spkg_install_SPKG_NAME=yes may be overwritten, typically to [], i.e. nothing.
+#     $3 is for off-label use - checking a reverse dependency, by REVDEPCHECK. Then the default action of
+#     setting sage_spkg_install_SPKG_NAME=yes whenever anything from $1 comes from Sage may be overwritten,
+#     typically to [ ], i.e. a no-op (it can't be [], as m4_default checks non-emptiness)
 #
 AC_DEFUN([SAGE_SPKG_DEPCHECK], [
     m4_foreach_w([DEP], $1, [
@@ -202,7 +203,7 @@ AC_DEFUN([SAGE_SPKG_DEPCHECK], [
     AC_MSG_CHECKING([whether any of $1 is installed as or will be installed as SPKG])
     AS_IF([test x = y m4_foreach_w([DEP], $1, [ -o [x$sage_spkg_install_]DEP = xyes])], [
         AC_MSG_RESULT([yes; install SPKG_NAME as well])
-        m4_default($3, [sage_spkg_install_]SPKG_NAME=yes)
+        m4_default([$3], [sage_spkg_install_]SPKG_NAME=yes)
 	], [
         AC_MSG_RESULT([no])
         $2
@@ -215,10 +216,10 @@ AC_DEFUN([SAGE_SPKG_DEPCHECK], [
 #   SAGE_SPKG_REVDEPCHECK(PACKAGE-REVERSE-DEPENDENCIES)
 #                                 $1
 # DESCRIPTION
-#     *** to be called from SAGE_SPKG_CONFIGURE* ***
+#     *** to be called from REQUIRED-CHECK section of SAGE_SPKG_CONFIGURE* ***
 #     check for space-separated list of package reverse dependencies $1 of package SPKG_NAME
-#     If they all come from the system, do not require SPKG_NAME
+#     If they all come from the system, do not require SPKG_NAME (i.e. it's not needed)
 #
 AC_DEFUN([SAGE_SPKG_REVDEPCHECK], [
-    SAGE_SPKG_DEPCHECK($1, [[sage_require_]SPKG_NAME=no], [])
+    SAGE_SPKG_DEPCHECK($1, [[sage_require_]SPKG_NAME=no], [ ])
 ])

--- a/m4/sage_spkg_configure.m4
+++ b/m4/sage_spkg_configure.m4
@@ -185,13 +185,16 @@ AC_DEFUN([SAGE_SPKG_CONFIGURE], [
 
 # SYNOPSIS
 #
-#   SAGE_SPKG_DEPCHECK(PACKAGE-DEPENDENCIES, FURTHER-CHECK)
-#                                 $1              $2
+#   SAGE_SPKG_DEPCHECK(PACKAGE-DEPENDENCIES, FURTHER-CHECK, [FAIL= [sage_spkg_install_]SPKG_NAME=yes])
+#                                 $1              $2                $3
 #
 # DESCRIPTION
 #     *** to be called from SAGE_SPKG_CONFIGURE* ***
 #     check for space-separated list of package dependencies $1 of package SPKG_NAME
 #     do $2 if successful
+#
+#     $3 is for off-label use - checking a reverse dependency. Then the default action of
+#     setting sage_spkg_install_SPKG_NAME=yes may be overwritten, typically to [], i.e. nothing.
 #
 AC_DEFUN([SAGE_SPKG_DEPCHECK], [
     m4_foreach_w([DEP], $1, [
@@ -199,7 +202,8 @@ AC_DEFUN([SAGE_SPKG_DEPCHECK], [
     AC_MSG_CHECKING([whether any of $1 is installed as or will be installed as SPKG])
     AS_IF([test x = y m4_foreach_w([DEP], $1, [ -o [x$sage_spkg_install_]DEP = xyes])], [
         AC_MSG_RESULT([yes; install SPKG_NAME as well])
-        [sage_spkg_install_]SPKG_NAME=yes], [
+        m4_default($3, [sage_spkg_install_]SPKG_NAME=yes)
+	], [
         AC_MSG_RESULT([no])
         $2
         ])


### PR DESCRIPTION
ipython is the only package that depends on backcall, so backcall can be skipped if ipython comes from the system. This micro-optimization is not so micro now that ipython has dropped backcall upstream:

  https://github.com/ipython/ipython/commit/1c2687ea5

As a result, systems with newer ipythons may not have backcall installed. We don't want to install a pointless SPKG on those systems.
