### PR TITLE
Corrected the typo in documentation - Permutation Groups

### DIFF
--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -29,7 +29,7 @@ Mathematical Folk Humor." Notices Amer. Math. Soc. 52, 24-34,
 Index of methods
 ----------------
 
-Here are the method of a :func:`PermutationGroup`
+Here are the methods of a :func:`PermutationGroup`
 
 {METHODS_OF_PermutationGroup_generic}
 


### PR DESCRIPTION
Fixes #36817

Updated documentation to correct grammatical error in the description of PermutationGroup, changing 'method' to 'methods'.