### PR TITLE
CI Linux incremental: `make reconfigure` after uninstalling packages

### DIFF
--- a/.github/workflows/ci-linux-incremental.yml
+++ b/.github/workflows/ci-linux-incremental.yml
@@ -83,7 +83,7 @@ jobs:
       from_docker_target: "with-targets"
       from_docker_tag: "dev"
       docker_targets: "with-targets"
-      targets: "${{needs.changed_files.outputs.uninstall_targets}} ${{needs.changed_files.outputs.build_targets}} build doc-html ptest"
+      targets: "${{needs.changed_files.outputs.uninstall_targets}} reconfigure ${{needs.changed_files.outputs.build_targets}} build doc-html ptest"
       tox_system_factors: >-
         ["ubuntu-focal",
          "ubuntu-jammy",
@@ -119,7 +119,7 @@ jobs:
       from_docker_target: "with-targets"
       from_docker_tag: "dev"
       docker_targets: "with-targets"
-      targets: "${{needs.changed_files.outputs.uninstall_targets}} ${{needs.changed_files.outputs.build_targets}} build doc-html ptest"
+      targets: "${{needs.changed_files.outputs.uninstall_targets}} reconfigure ${{needs.changed_files.outputs.build_targets}} build doc-html ptest"
       # Only test systems with a usable system python (>= 3.9)
       # with only a small number of test failures as of 10.2.rc0
       tox_system_factors: >-

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ SPKG_COLLECT_FILES = build/pkgs/*/type build/pkgs/*/package-version.txt build/pk
 # If configure was run before, rerun it with the old arguments.
 # Otherwise, run configure with argument $PREREQ_OPTIONS.
 build/make/Makefile: configure $(SPKG_COLLECT_FILES) $(CONFIG_FILES:%=%.in)
+	$(MAKE) reconfigure
+
+reconfigure:
 	rm -f config.log
 	mkdir -p logs/pkgs
 	ln -s logs/pkgs/config.log config.log
@@ -62,6 +65,8 @@ build/make/Makefile: configure $(SPKG_COLLECT_FILES) $(CONFIG_FILES:%=%.in)
 		echo >&2 '****************************************************************************'; \
 	        exit 1; \
 	fi
+
+
 
 # This is used to monitor progress towards Python 3 and prevent
 # regressions. Should be removed after the full switch to python3.
@@ -339,7 +344,7 @@ list:
 	@$(MAKE) --silent build/make/Makefile >&2
 	@$(MAKE) --silent -f build/make/Makefile SAGE_PKGCONFIG=dummy $@
 
-.PHONY: default build dist install micro_release \
+.PHONY: default build dist install micro_release reconfigure \
 	misc-clean bdist-clean distclean bootstrap-clean maintainer-clean \
 	test check testoptional testall testlong testoptionallong testallong \
 	ptest ptestoptional ptestall ptestlong ptestoptionallong ptestallong \

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,6 @@ reconfigure:
 	        exit 1; \
 	fi
 
-
-
 # This is used to monitor progress towards Python 3 and prevent
 # regressions. Should be removed after the full switch to python3.
 #

--- a/m4/sage_spkg_collect.m4
+++ b/m4/sage_spkg_collect.m4
@@ -434,7 +434,7 @@ $COMMAND
 
     hint: After installation, re-run configure using:
 
-      \$ ./config.status --recheck && ./config.status
+      \$ make reconfigure
                 ])
             ], [
                 AC_MSG_NOTICE([No equivalent system packages for $SYSTEM are known to Sage])

--- a/src/doc/en/developer/portability_testing.rst
+++ b/src/doc/en/developer/portability_testing.rst
@@ -230,7 +230,7 @@ following::
   configure: hint: installing the following system packages is recommended and may avoid building some of the above SPKGs from source:
   configure:   $ sudo apt-get install libflint-arb-dev ... libzmq3-dev libz-dev
   configure: After installation, re-run configure using:
-  configure:   $ ./config.status --recheck && ./config.status
+  configure:   $ make reconfigure
 
 This information comes from Sage's database of equivalent distribution
 packages.  For example::


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
As observed in https://github.com/sagemath/sage/pull/36792#issuecomment-1841713301, the "CI Linux incremental" workflow, which is run when package scripts are updated, is not helpful when testing new or modified `spkg-configure.m4` scripts when the SPKG has been installed:

Although we uninstall packages with changed spkg-configure.m4 scripts already, a re-run of configure is not (always?) triggered.

So here we invoke it explicitly, using a new makefile target `make reconfigure`. 
(This new target also simplifies instructions issued by the system package advice facility.)

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
