### PR TITLE
`sage --tox`, `sage --pytest`: Stop fallthrough when `tox`, `pytest` are not installed (yet)

### DIFF
--- a/src/bin/sage
+++ b/src/bin/sage
@@ -1001,6 +1001,7 @@ if [ "$1" = '-tox' -o "$1" = '--tox' ]; then
             exec tox -c "$SAGE_SRC" "$@"
         else
             echo "Run 'sage -i tox' to install"
+            exit 1
         fi
     else
         echo >&2 "error: Sage source directory or tox.ini not available"
@@ -1022,6 +1023,7 @@ if [ "$1" = '-pytest' -o "$1" = '--pytest' ]; then
             exec pytest --rootdir="$SAGE_SRC" --doctest-modules "$@" "$SAGE_SRC"
         else
             echo "Run 'sage -i pytest' to install"
+            exit 1
         fi
     else
         echo >&2 "error: Sage source directory or tox.ini not available"


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

When `pytest` is not installed, 
```
$ ./sage -pytest src/sage/tests/memcheck                                                     git:sage_tests_memcheck_optional
Run 'sage -i pytest' to install
/Users/mkoeppe/s/sage/sage-rebasing/worktree-clean/local/var/lib/sage/venv-python3.9/bin/python3: can't find '__main__' module in '/Users/mkoeppe/s/sage/sage-rebasing/worktree-clean/src/sage/tests/memcheck'
```

Here we add the missing error exit. Likewise for `sage --tox`.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
