### PR TITLE
some ruff details in modular (unicode)

### DIFF
--- a/src/sage/modular/cusps.py
+++ b/src/sage/modular/cusps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 The set `\mathbb{P}^1(\QQ)` of cusps
 

--- a/src/sage/modular/etaproducts.py
+++ b/src/sage/modular/etaproducts.py
@@ -633,7 +633,7 @@ def EtaProduct(level, dic) -> EtaGroupElement:
     -  ``dic`` -- (dictionary): a dictionary indexed by
        divisors of N such that the coefficient of `\eta(q^d)` is
        r[d]. Only nonzero coefficients need be specified. If Ligozat's
-       criteria are not satisfied, a ``ValueError`` will be raised.
+       criteria are not satisfied, a :class:`ValueError` will be raised.
 
     OUTPUT:
 

--- a/src/sage/modular/hypergeometric_motive.py
+++ b/src/sage/modular/hypergeometric_motive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Hypergeometric motives
 
@@ -261,7 +260,7 @@ def alpha_to_cyclotomic(alpha):
 
     The output represent a product of cyclotomic polynomials with exactly
     the given roots. Note that the multiplicity of `r/s` in the list
-    must be independent of `r`; otherwise, a ``ValueError`` will be raised.
+    must be independent of `r`; otherwise, a :class:`ValueError` will be raised.
 
     This is the inverse of :func:`cyclotomic_to_alpha`.
 

--- a/src/sage/modular/local_comp/smoothchar.py
+++ b/src/sage/modular/local_comp/smoothchar.py
@@ -1314,7 +1314,7 @@ class SmoothCharacterGroupQuadratic(SmoothCharacterGroupGeneric):
           ring coercible to it), specifying values on the quotients returned by
           :meth:`quotient_gens`.
 
-        A ``ValueError`` will be raised if `x^t \ne \chi(\alpha^t)`, where `t`
+        A :class:`ValueError` will be raised if `x^t \ne \chi(\alpha^t)`, where `t`
         is the smallest integer such that `\alpha^t` is congruent modulo
         `p^{\rm level}` to an element of `\QQ_p`.
 

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -658,7 +658,7 @@ class ModularForm_abstract(ModuleElement):
         specified, and in (a suitable extension of) the base field of
         ``self`` otherwise.
 
-        If ``self`` is not an eigenform for `W_d`, a ``ValueError`` is
+        If ``self`` is not an eigenform for `W_d`, a :class:`ValueError` is
         raised.
 
         .. SEEALSO::
@@ -2588,7 +2588,7 @@ class ModularFormElement(ModularForm_abstract, element.HeckeModuleElement):
         OUTPUT:
 
         The Atkin-Lehner eigenvalue of `W_d` on ``self``. If ``self`` is not an
-        eigenform for `W_d`, a ``ValueError`` is raised.
+        eigenform for `W_d`, a :class:`ValueError` is raised.
 
         .. SEEALSO::
 

--- a/src/sage/modular/modform_hecketriangle/abstract_space.py
+++ b/src/sage/modular/modform_hecketriangle/abstract_space.py
@@ -620,7 +620,7 @@ class FormsSpace_abstract(FormsRing_abstract):
     def homogeneous_part(self, k, ep):
         r"""
         Since ``self`` already is a homogeneous component return ``self``
-        unless the degree differs in which case a ``ValueError`` is raised.
+        unless the degree differs in which case a :class:`ValueError` is raised.
 
         EXAMPLES::
 

--- a/src/sage/modular/modform_hecketriangle/hecke_triangle_group_element.py
+++ b/src/sage/modular/modform_hecketriangle/hecke_triangle_group_element.py
@@ -183,7 +183,7 @@ class HeckeTriangleGroupElement(MatrixGroupElement_generic):
         of ``self`` as a product of the generators ``S`` and ``T``
         together with a sign correction ``sgn``.
 
-        If this decomposition is not possible a ``TypeError``
+        If this decomposition is not possible a :class:`TypeError`
         is raised. In particular this function can be used to
         check the membership in ``parent`` of an arbitrary matrix
         over the base ring.
@@ -257,7 +257,7 @@ class HeckeTriangleGroupElement(MatrixGroupElement_generic):
         of ``L`` are either the generator ``S`` or a non-trivial
         integer power of the generator ``T``. ``sgn`` is +- the identity.
 
-        If this decomposition is not possible a ``TypeError`` is raised.
+        If this decomposition is not possible a :class:`TypeError` is raised.
 
         EXAMPLES::
 

--- a/src/sage/modular/modform_hecketriangle/hecke_triangle_groups.py
+++ b/src/sage/modular/modform_hecketriangle/hecke_triangle_groups.py
@@ -757,7 +757,7 @@ class HeckeTriangleGroup(FinitelyGeneratedMatrixGroup_generic,
         OUTPUT:
 
         The corresponding embedding if it was found.
-        Otherwise a ``ValueError`` is raised.
+        Otherwise a :class:`ValueError` is raised.
 
         EXAMPLES::
 

--- a/src/sage/modular/modsym/manin_symbol_list.py
+++ b/src/sage/modular/modsym/manin_symbol_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Manin symbol lists
 

--- a/src/sage/modular/pollack_stevens/dist.pyx
+++ b/src/sage/modular/pollack_stevens/dist.pyx
@@ -67,7 +67,7 @@ def get_dist_classes(p, prec_cap, base, symk, implementation):
 
     - ``implementation`` - string - If not None, override the
       automatic choice of implementation. May be 'long' or 'vector',
-      otherwise raise a ``NotImplementedError``
+      otherwise raise a :class:`NotImplementedError`
 
     OUTPUT:
 
@@ -293,9 +293,9 @@ cdef class Dist(ModuleElement):
     def find_scalar(self, _other, p, M=None, check=True):
         r"""
         Return an ``alpha`` with ``other = self * alpha``, or raises
-        a ``ValueError``.
+        a :class:`ValueError`.
 
-        It will also raise a ``ValueError`` if this distribution is zero.
+        It will also raise a :class:`ValueError` if this distribution is zero.
 
         INPUT:
 
@@ -417,9 +417,9 @@ cdef class Dist(ModuleElement):
     def find_scalar_from_zeroth_moment(self, _other, p, M=None, check=True):
         r"""
         Return an ``alpha`` with ``other = self * alpha`` using only
-        the zeroth moment, or raises a ``ValueError``.
+        the zeroth moment, or raises a :class:`ValueError`.
 
-        It will also raise a ``ValueError`` if the zeroth moment of the
+        It will also raise a :class:`ValueError` if the zeroth moment of the
         distribution is zero.
 
         INPUT:

--- a/src/sage/modular/pollack_stevens/fund_domain.py
+++ b/src/sage/modular/pollack_stevens/fund_domain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Manin relations for overconvergent modular symbols
 

--- a/src/sage/modular/pollack_stevens/modsym.py
+++ b/src/sage/modular/pollack_stevens/modsym.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Element class for Pollack-Stevens' modular symbols
 
@@ -361,9 +360,9 @@ class PSModularSymbolElement(ModuleElement):
 
         OUTPUT:
 
-        - a prime or None.  If ``allow_none`` is False then a
-          ``ValueError`` will be raised rather than returning None if no
-          prime can be determined.
+        - a prime or ``None``.  If ``allow_none`` is ``False`` then a
+          :class:`ValueError` will be raised rather than returning ``None``
+          if no prime can be determined.
 
         EXAMPLES::
 

--- a/src/sage/modular/pollack_stevens/sigma0.py
+++ b/src/sage/modular/pollack_stevens/sigma0.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 The matrix monoid `\Sigma_0(N)`.
 


### PR DESCRIPTION
remove the utf8 encoding declarations

also wrap some errors codes in the doc

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.