### PR TITLE
Fix one doctest for giac 1.9.0-73

### DIFF
--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -568,8 +568,8 @@ def symbolic_sum(expression, v, a, b, algorithm='maxima', hold=False):
 
     An example of this summation with Giac::
 
-        sage: symbolic_sum(1/(1+k^2), k, -oo, oo, algorithm='giac')
-        (pi*e^(2*pi) - pi*e^(-2*pi))/(e^(2*pi) + e^(-2*pi) - 2)
+        sage: symbolic_sum(1/(1+k^2), k, -oo, oo, algorithm='giac').factor()
+        pi*(e^(2*pi) + 1)/((e^pi + 1)*(e^pi - 1))
 
     The same summation is solved by SymPy::
 


### PR DESCRIPTION
With giac 1.9.0-73 the output of a `symbolic_sum()` test changes. Note that both answers are correct, and it's not clear that one is "better" than the other...

I managed to find a way to avoid trouble (by sending the output through `factor()`) so the output is the same with latest giac and earlier giac.

However, fixing doctests keeps getting harder (I mean: making sure the same doctest works for different releases of dependencies). I don't have a good idea on how to improve the situation.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.