### PR TITLE
Update python3 spkg-configure.m4 to allow system Python 3.12.x

### DIFF
--- a/build/pkgs/python3/spkg-configure.m4
+++ b/build/pkgs/python3/spkg-configure.m4
@@ -1,8 +1,8 @@
 SAGE_SPKG_CONFIGURE([python3], [
    m4_pushdef([MIN_VERSION],               [3.9.0])
    m4_pushdef([MIN_NONDEPRECATED_VERSION], [3.9.0])
-   m4_pushdef([LT_STABLE_VERSION],         [3.12.0])
-   m4_pushdef([LT_VERSION],                [3.12.0])
+   m4_pushdef([LT_STABLE_VERSION],         [3.13.0])
+   m4_pushdef([LT_VERSION],                [3.13.0])
    AC_ARG_WITH([python],
                [AS_HELP_STRING([--with-python=PYTHON3],
                                [Python 3 executable to use for the Sage venv; default: python3])])


### PR DESCRIPTION
When the necessary package upgrades (see #36181) are completed, we can allow system Python 3.12.x.
