### PR TITLE
Fix a bug for .ci/create-changes-html.sh

### DIFF
--- a/.ci/create-changes-html.sh
+++ b/.ci/create-changes-html.sh
@@ -69,12 +69,14 @@ for block in diff_blocks:
         count = 0
         for line in block.splitlines():
             if line.startswith('@@ -'):
-                line_number = int(re.search(r'@@ -(\d+)', line).group(1))
-                for i in range(line_number, -1, -1):
-                    if content[i].startswith('<'):
-                        count += 1
-                        content[i] = f'<span id="hunk{count}" style="visibility: hidden;"></span>' + content[i]
-                        break
+                search_result = re.search(r'@@ -(\d+),(\d+) \+(\d+),(\d+)', line)
+                if search_result:
+                    line_number = int(search_result.group(3))
+                    for i in range(line_number - 1, -1, -1):
+                        if content[i].startswith('<'):
+                            count += 1
+                            content[i] = f'<span id="hunk{count}" style="visibility: hidden;"></span>' + content[i]
+                            break
         with open(file_path, 'w') as file:
             file.writelines(content)
         hunks = '&nbsp;'.join(f'<a href="{path}#hunk{i+1}" class="hunk" target="_blank">#{i + 1}</a>' for i in range(count))


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

There is a bug in `.ci/create-changes-html.sh` which can result in failure of doc-build workflow, as seen in #36861. 

For instance, from a hunk in a diff
```diff
 <span class="go">(X0, X1)</span>
 </pre></div>
 </div>
@@ -428,8 +426,8 @@ Default to cyclotomic base ring.</p></li>
 <p>A tuple of integers.</p>
 <p>EXAMPLES:</p>
 <div class="highl
```
the script read `428` instead of reading `426`, which is the correct line number of modified part of a file. This caused failures.

Tested in #36861.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
