### PR TITLE
add is_trivial method for groups

### DIFF
--- a/src/sage/groups/group.pyx
+++ b/src/sage/groups/group.pyx
@@ -186,6 +186,39 @@ cdef class Group(Parent):
         """
         return self.order() != infinity
 
+    def is_trivial(self):
+        r"""
+        Return ``True`` if this group is the trivial group.
+
+        A group is trivial, if it consists only of the identity
+        element.
+
+        .. WARNING::
+
+            It is in principle undecidable whether a group is
+            trivial, for example, if the group is given by a finite
+            presentation.  Thus, this method may not terminate.
+
+        EXAMPLES::
+
+            sage: groups.presentation.Cyclic(1).is_trivial()
+            True
+
+            sage: G.<a,b> = FreeGroup('a, b')
+            sage: H = G / (a^2, b^3, a*b*~a*~b)
+            sage: H.is_trivial()
+            False
+
+        A non-trivial presentation of the trivial group::
+
+            sage: F.<a,b> = FreeGroup()
+            sage: J = F / ((~a)*b*a*(~b)^2, (~b)*a*b*(~a)^2)
+            sage: J.is_trivial()
+            True
+        """
+        return self.order() == 1
+
+
     def is_multiplicative(self):
         r"""
         Returns True if the group operation is given by \* (rather than

--- a/src/sage/groups/matrix_gps/matrix_group.py
+++ b/src/sage/groups/matrix_gps/matrix_group.py
@@ -542,3 +542,34 @@ class MatrixGroup_generic(MatrixGroup_base):
             if lx != rx:
                 return richcmp_not_equal(lx, rx, op)
         return rich_to_bool(op, 0)
+
+    def is_trivial(self):
+        r"""
+        Return ``True`` if this group is the trivial group.
+
+        A group is trivial, if it consists only of the identity
+        element, that is, if all its generators are the identity.
+
+        EXAMPLES::
+
+            sage: MatrixGroup([identity_matrix(3)]).is_trivial()
+            True
+            sage: SL(2, ZZ).is_trivial()
+            False
+            sage: CoxeterGroup(['B',3], implementation="matrix").is_trivial()
+            False
+
+        TESTS::
+
+            sage: CoxeterGroup(['A',0], implementation="matrix").is_trivial()
+            True
+            sage: MatrixGroup([matrix(SR, [[1,x], [0,1]])]).is_trivial()
+            False
+            sage: G = MatrixGroup([identity_matrix(3), identity_matrix(3)])
+            sage: G.ngens()
+            2
+            sage: G.is_trivial()
+            True
+
+        """
+        return all(g.is_one() for g in self.gens())

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1365,6 +1365,29 @@ class PermutationGroup_generic(FiniteGroup):
         """
         return len(self.gens())
 
+    def is_trivial(self):
+        r"""
+        Return ``True`` if this group is the trivial group.
+
+        A permutation group is trivial, if it consists only of the
+        identity element, that is, if it has no generators.
+
+        EXAMPLES::
+
+            sage: G = PermutationGroup([], domain=["a", "b", "c"])
+            sage: G.is_trivial()
+            True
+            sage: SymmetricGroup(0).is_trivial()
+            True
+            sage: SymmetricGroup(1).is_trivial()
+            True
+            sage: SymmetricGroup(2).is_trivial()
+            False
+            sage: DihedralGroup(1).is_trivial()
+            False
+        """
+        return not self._gens or (len(self._gens) == 1 and self._gens[0].is_one())
+    
     @cached_method
     def one(self):
         """

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1371,7 +1371,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         A permutation group is trivial, if it consists only of the
         identity element, that is, if it has no generators or only
-        the trivial generator.
+        trivial generators.
 
         EXAMPLES::
 
@@ -1387,9 +1387,16 @@ class PermutationGroup_generic(FiniteGroup):
             sage: DihedralGroup(1).is_trivial()
             False
 
+        TESTS::
+
+            sage: G = PermutationGroup([[], []], canonicalize=False)
+            sage: G.ngens()
+            2
+            sage: G.is_trivial()
+            True
         """
-        return not self._gens or (len(self._gens) == 1 and self._gens[0].is_one())
-    
+        return all(g.is_one() for g in self._gens)
+
     @cached_method
     def one(self):
         """

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1370,7 +1370,8 @@ class PermutationGroup_generic(FiniteGroup):
         Return ``True`` if this group is the trivial group.
 
         A permutation group is trivial, if it consists only of the
-        identity element, that is, if it has no generators.
+        identity element, that is, if it has no generators or only
+        the trivial generator.
 
         EXAMPLES::
 
@@ -1385,6 +1386,7 @@ class PermutationGroup_generic(FiniteGroup):
             False
             sage: DihedralGroup(1).is_trivial()
             False
+
         """
         return not self._gens or (len(self._gens) == 1 and self._gens[0].is_one())
     


### PR DESCRIPTION
We add a method to check whether a permutation group is trivial, that is, consists only of the identity element.

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.