### PR TITLE
Fix cardinality of special linear group

### DIFF
--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -101,12 +101,19 @@ class FiniteGroups(CategoryWithAxiom):
                 sage: G.cardinality()
                 384
             """
+
+            # Check whether the object has _deg attribute or not 
+            # Note for developers - It will have _deg attribute if it is derived from  MatrixGroup_generic class
+            # And if it has _deg attribute then return the value of that attribute
+            if hasattr(self, '_deg'):
+                return self._deg
+
+            # If object does not have _deg attribute then try to find its order with the help of order function.
             try:
                 o = self.order
+                return o()
             except AttributeError:
                 return self._cardinality_from_iterator()
-            else:
-                return o()
 
         def some_elements(self):
             """

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -102,7 +102,7 @@ class FiniteGroups(CategoryWithAxiom):
                 384
             """
 
-            # Check whether the object has _deg attribute or not 
+            # Check whether the object has _deg attribute or not
             # Note for developers - It will have _deg attribute if it is derived from  MatrixGroup_generic class
             # And if it has _deg attribute then return the value of that attribute
             if hasattr(self, '_deg'):

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -101,10 +101,6 @@ class FiniteGroups(CategoryWithAxiom):
                 sage: G.cardinality()
                 384
             """
-            # If the group is special group and finite then there is only one possibility that the degree
-            # and cardinality will be one.
-            if hasattr(self,'_special') and self._special==True:
-                return 1
             try:
                 o = self.order
                 return o()

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -102,13 +102,10 @@ class FiniteGroups(CategoryWithAxiom):
                 384
             """
 
-            # Check whether the object has _deg attribute or not
-            # Note for developers - It will have _deg attribute if it is derived from  MatrixGroup_generic class
-            # And if it has _deg attribute then return the value of that attribute
+            # Note for developers - self will have _deg attribute if it is derived from  MatrixGroup_generic class
             if hasattr(self, '_deg'):
                 return self._deg
 
-            # If object does not have _deg attribute then try to find its order with the help of order function.
             try:
                 o = self.order
                 return o()

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -101,11 +101,10 @@ class FiniteGroups(CategoryWithAxiom):
                 sage: G.cardinality()
                 384
             """
-
-            # Note for developers - self will have _deg attribute if it is derived from  MatrixGroup_generic class
-            if hasattr(self, '_deg'):
-                return self._deg
-
+            # If the group is special group and finite then there is only one possibility that the degree
+            # and cardinality will be one.
+            if hasattr(self,'_special') and self._special==True:
+                return 1
             try:
                 o = self.order
                 return o()

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -101,11 +101,9 @@ class FiniteGroups(CategoryWithAxiom):
                 sage: G.cardinality()
                 384
             """
-            try:
-                o = self.order
-                return o()
-            except AttributeError:
-                return self._cardinality_from_iterator()
+            if hasattr(self, 'order'):
+                return self.order()
+            return self._cardinality_from_iterator()
 
         def some_elements(self):
             """

--- a/src/sage/groups/libgap_wrapper.pyx
+++ b/src/sage/groups/libgap_wrapper.pyx
@@ -347,7 +347,7 @@ class ParentLibGAP(SageObject):
 
     def minimal_normal_subgroups(self):
         """
-        Return the nontrivial minimal normal subgroups ``self``.
+        Return the nontrivial minimal normal subgroups of ``self``.
 
         EXAMPLES::
 

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -277,6 +277,18 @@ def SL(n, R, var='a'):
         sage: S = SL(2,FqTN)
         sage: S.is_finite()
         True
+
+        Check if is_finite() function is giving correct answer for the special linear group which is not finite::
+
+        sage: SL(2, QQ).is_finite()
+        False
+
+        Check if the cardinality or order of infinite special linear group is +Infinity or not::
+
+        sage: SL(2, QQ).cardinality()
+        +Infinity
+        sage: SL(2, QQ).order()
+        +Infinity
     """
     degree, ring = normalize_args_vectorspace(n, R, var='a')
     try:

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -256,6 +256,27 @@ def SL(n, R, var='a'):
 
         sage: groups.matrix.SL(2, 3)
         Special Linear Group of degree 2 over Finite Field of size 3
+
+        Check if :trac:`36876` is fixed: The cardinality or order of a special linear group with degree=1 over any field is 1::
+
+        sage: SL(1, QQ).cardinality()
+        1
+        sage: SL(1, RR).cardinality()
+        1
+        sage: SL(1, QQ).order()
+        1
+        sage: SL(1, CC).order()
+        1
+
+        Check if :trac:`35490` is fixed: The special linear group with degree=1 is finite::
+
+        sage: q = 7
+        sage: FqT.<T> = GF(q)[]
+        sage: N = T^2+1
+        sage: FqTN = QuotientRing(FqT, N*FqT)
+        sage: S = SL(2,FqTN)
+        sage: S.is_finite()
+        True
     """
     degree, ring = normalize_args_vectorspace(n, R, var='a')
     try:

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -323,36 +323,34 @@ class LinearMatrixGroup_generic(NamedMatrixGroup_generic):
         Check if :trac:`36876` is fixed::
             sage: SL(1, QQ).order()
             1
-            sage: SL(1, ZZ).cardinality()
-            1
+            sage: SL(2, ZZ).cardinality()
+            +Infinity
 
         Check if :trac:`35490` is fixed::
             sage: q = 7
             sage: FqT.<T> = GF(q)[]
             sage: N = T^2+1
             sage: FqTN = QuotientRing(FqT, N*FqT)
-            sage: S = SL(2,FqTN)
+            sage: S = SL(2, FqTN)
             sage: S.is_finite()
             True
             sage: S.order()
             117600
         """
-        from functools import reduce
-        import operator
         from sage.rings.infinity import Infinity
+        from sage.all import prod
 
         n = self.degree()
 
         if self.base_ring().is_finite():
             q = self.base_ring().order()
+            ord = prod(q**n - q**i for i in range(n)) / (q-1)
             if self._special:
-                return reduce(operator.mul, (q**n - q**i for i in range(0, n)), 1) / (q-1)
-            return reduce(operator.mul, (q**n - q**i for i in range(0, n)), 1)
+                return ord / (q-1)
+            return ord
 
-        if self._special:
-            if n == 1:
-                return 1
-            return Infinity
+        if self._special and n == 1:
+            return 1
 
         return Infinity
 

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -256,39 +256,6 @@ def SL(n, R, var='a'):
 
         sage: groups.matrix.SL(2, 3)
         Special Linear Group of degree 2 over Finite Field of size 3
-
-        Check if :trac:`36876` is fixed: The cardinality or order of a special linear group with degree=1 over any field is 1::
-
-        sage: SL(1, QQ).cardinality()
-        1
-        sage: SL(1, RR).cardinality()
-        1
-        sage: SL(1, QQ).order()
-        1
-        sage: SL(1, CC).order()
-        1
-
-        Check if :trac:`35490` is fixed: The special linear group with degree=1 is finite::
-
-        sage: q = 7
-        sage: FqT.<T> = GF(q)[]
-        sage: N = T^2+1
-        sage: FqTN = QuotientRing(FqT, N*FqT)
-        sage: S = SL(2,FqTN)
-        sage: S.is_finite()
-        True
-
-        Check if is_finite() function is giving correct answer for the special linear group which is not finite::
-
-        sage: SL(2, QQ).is_finite()
-        False
-
-        Check if the cardinality or order of infinite special linear group is +Infinity or not::
-
-        sage: SL(2, QQ).cardinality()
-        +Infinity
-        sage: SL(2, QQ).order()
-        +Infinity
     """
     degree, ring = normalize_args_vectorspace(n, R, var='a')
     try:
@@ -340,3 +307,53 @@ class LinearMatrixGroup_generic(NamedMatrixGroup_generic):
         else:
             if x.determinant() == 0:
                 raise TypeError('matrix must non-zero determinant')
+
+    def order(self):
+        """
+        Return the order of ``self``.
+
+        EXAMPLES::
+
+            sage: G = SL(3, GF(5))
+            sage: G.order()
+            372000
+
+        TESTS:
+
+        Check if trac:`36876` is fixed::
+            sage: SL(1, QQ).order()
+            1
+            sage: SL(1, ZZ).cardinality()
+            1
+
+        Check if trac:`35490` is fixed::
+            sage: q = 7
+            ....: FqT.<T> = GF(q)[]
+            ....: N = T^2+1
+            ....: FqTN = QuotientRing(FqT, N*FqT)
+            ....: S = SL(2,FqTN)
+            ....: S.is_finite()
+            True
+            ....: S.order()
+            117600
+        """
+        from functools import reduce
+        import operator
+        from sage.rings.infinity import Infinity
+
+        n = self.degree()
+
+        if self.base_ring().is_finite():
+            q = self.base_ring().order()
+            if self._special:
+                return reduce(operator.mul, (q**n - q**i for i in range(0, n)), 1) / (q-1)
+            return reduce(operator.mul, (q**n - q**i for i in range(0, n)), 1)
+
+        if self._special:
+            if n == 1:
+                return 1
+            return Infinity
+
+        return Infinity
+
+    cardinality = order

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -344,14 +344,13 @@ class LinearMatrixGroup_generic(NamedMatrixGroup_generic):
 
         if self.base_ring().is_finite():
             q = self.base_ring().order()
-            ord = prod(q**n - q**i for i in range(n)) / (q-1)
+            ord = prod(q**n - q**i for i in range(n))
             if self._special:
                 return ord / (q-1)
             return ord
 
         if self._special and n == 1:
             return 1
-
         return Infinity
 
     cardinality = order

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -328,13 +328,13 @@ class LinearMatrixGroup_generic(NamedMatrixGroup_generic):
 
         Check if :trac:`35490` is fixed::
             sage: q = 7
-            ....: FqT.<T> = GF(q)[]
-            ....: N = T^2+1
-            ....: FqTN = QuotientRing(FqT, N*FqT)
-            ....: S = SL(2,FqTN)
-            ....: S.is_finite()
+            sage: FqT.<T> = GF(q)[]
+            sage: N = T^2+1
+            sage: FqTN = QuotientRing(FqT, N*FqT)
+            sage: S = SL(2,FqTN)
+            sage: S.is_finite()
             True
-            ....: S.order()
+            sage: S.order()
             117600
         """
         from functools import reduce

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -66,6 +66,8 @@ from sage.categories.groups import Groups
 from sage.groups.matrix_gps.named_group import (
     normalize_args_vectorspace, NamedMatrixGroup_generic)
 from sage.misc.latex import latex
+from sage.misc.misc_c import prod
+from sage.rings.infinity import Infinity
 
 
 ###############################################################################
@@ -321,12 +323,14 @@ class LinearMatrixGroup_generic(NamedMatrixGroup_generic):
         TESTS:
 
         Check if :trac:`36876` is fixed::
+
             sage: SL(1, QQ).order()
             1
             sage: SL(2, ZZ).cardinality()
             +Infinity
 
         Check if :trac:`35490` is fixed::
+
             sage: q = 7
             sage: FqT.<T> = GF(q)[]
             sage: N = T^2+1
@@ -337,9 +341,6 @@ class LinearMatrixGroup_generic(NamedMatrixGroup_generic):
             sage: S.order()
             117600
         """
-        from sage.rings.infinity import Infinity
-        from sage.all import prod
-
         n = self.degree()
 
         if self.base_ring().is_finite():

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -320,13 +320,13 @@ class LinearMatrixGroup_generic(NamedMatrixGroup_generic):
 
         TESTS:
 
-        Check if trac:`36876` is fixed::
+        Check if :trac:`36876` is fixed::
             sage: SL(1, QQ).order()
             1
             sage: SL(1, ZZ).cardinality()
             1
 
-        Check if trac:`35490` is fixed::
+        Check if :trac:`35490` is fixed::
             sage: q = 7
             ....: FqT.<T> = GF(q)[]
             ....: N = T^2+1


### PR DESCRIPTION
- Fixed infinite recursion of the cardinality and order functions
- Improved pycodestyle
- Add more doctests to cover all cases

This patch fixes #36876 and fixes #35490. In this PR, I have implemented a method to fix the
answer given by cardinality function for finite special linear groups
(before it was going into infinite recursion). This also fixes the answer given by is_finite()
function for finite special linear groups.
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
None
