### PR TITLE
fixing one bug in the use of valuation

### DIFF
--- a/src/sage/categories/discrete_valuation.py
+++ b/src/sage/categories/discrete_valuation.py
@@ -147,22 +147,31 @@ class DiscreteValuationRings(Category_singleton):
             Return the quotient and remainder for Euclidean division
             of ``self`` by ``other``.
 
-            TESTS::
+            EXAMPLES::
 
                 sage: R.<q> = GF(5)[[]]
                 sage: (q^2 + q).quo_rem(q)
                 (1 + q, 0)
                 sage: (q + 1).quo_rem(q^2)
                 (0, 1 + q)
+
+            TESTS::
+
                 sage: q.quo_rem(0)
                 Traceback (most recent call last):
                 ...
                 ZeroDivisionError: Euclidean division by the zero element not defined
 
+                sage: L = PowerSeriesRing(QQ, 't')
+                sage: t = L.gen()
+                sage: F = algebras.Free(L, ['A', 'B'])
+                sage: A, B = F.gens()
+                sage: f = t*A+t**2*B/2
             """
             if not other:
                 raise ZeroDivisionError("Euclidean division by the zero element not defined")
             P = self.parent()
+            other = P(other)
             if self.valuation() >= other.valuation():
                 return P(self / other), P.zero()
             else:

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -27,9 +27,7 @@ from sage.misc.superseded import deprecation
 from sage.typeset.ascii_art import AsciiArt, empty_ascii_art, ascii_art
 from sage.typeset.unicode_art import UnicodeArt, empty_unicode_art, unicode_art
 from sage.data_structures.blas_dict cimport add, negate, scal, axpy
-from sage.categories.fields import Fields
-
-_Fields = Fields()
+from sage.categories.modules import _Fields
 
 
 cdef class IndexedFreeModuleElement(ModuleElement):

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -27,6 +27,9 @@ from sage.misc.superseded import deprecation
 from sage.typeset.ascii_art import AsciiArt, empty_ascii_art, ascii_art
 from sage.typeset.unicode_art import UnicodeArt, empty_unicode_art, unicode_art
 from sage.data_structures.blas_dict cimport add, negate, scal, axpy
+from sage.categories.fields import Fields
+
+_Fields = Fields()
 
 
 cdef class IndexedFreeModuleElement(ModuleElement):
@@ -958,6 +961,12 @@ cdef class IndexedFreeModuleElement(ModuleElement):
             Traceback (most recent call last):
             ...
             TypeError: unsupported operand type(s) for /: 'str' and 'CombinatorialFreeModule_with_category.element_class'
+
+            sage: L = LazyPowerSeriesRing(QQ, 't')
+            sage: t = L.gen()
+            sage: F = algebras.Free(L, ['A', 'B'])
+            sage: A, B = F.gens()
+            sage: f = t*A + t**2*B/2
         """
         if not isinstance(left, IndexedFreeModuleElement):
             return NotImplemented
@@ -966,7 +975,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
         F = self._parent
         B = self.base_ring()
         D = self._monomial_coefficients
-        if not B.is_field():
+        if B not in _Fields:
             return type(self)(F, {k: c._divide_if_possible(x)
                                   for k, c in D.items()})
 


### PR DESCRIPTION
Trying to divide by an integer was failing here:

```
sage: L=PowerSeriesRing(QQ,'t')
sage: t=L.gen()
sage: F=algebras.Free(L,['A','B','C'])
sage: A,B,C=F.gens()
sage: f=t*A+t**2*B/2  # BUG HERE
```

and the same for Lazy power series.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.