### PR TITLE
`src/sage/modular/arithgroup/farey.cpp`: Fix `#include` for `farey_symbol.h`

### DIFF
--- a/src/sage/modular/arithgroup/farey.cpp
+++ b/src/sage/modular/arithgroup/farey.cpp
@@ -29,7 +29,7 @@
 #include <Python.h>
 
 #include "farey.hpp"
-#include "farey_symbol.h"
+#include "sage/modular/arithgroup/farey_symbol.h"
 
 
 using namespace std;


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

This reverts one change of #36754, which broke building sagemath-standard as reported in https://github.com/sagemath/sage/pull/36754#issuecomment-1849460143

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
