### PR TITLE
Adjust the sync label bot to reflect recent GitHub CLI changes

### DIFF
--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -258,7 +258,7 @@ class GhLabelSynchronizer:
         self._bot_login = read_login([errtxt, outtxt], ['account', 'as'])
         if not self._bot_login:
             self._bot_login = default_bot
-            info('Bot is unknown')
+            warning('Bot is unknown')
             return self._bot_login
         if self._bot_login.endswith('[bot]'):
             self._bot_login = self._bot_login.split('[bot]')[0]

--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -141,6 +141,7 @@ class GhLabelSynchronizer:
         self._commits = None
         self._commit_date = None
         self._bot_login = None
+        self._gh_version = None
 
         s = url.split('/')
         self._owner = s[3]
@@ -235,13 +236,30 @@ class GhLabelSynchronizer:
         """
         if self._bot_login:
             return self._bot_login
-        cmd = 'gh auth status'
         from subprocess import run
+        cmd = 'gh version'
         capt = run(cmd, shell=True, capture_output=True)
-        l = str(capt.stderr).split()
-        if not 'as' in l:
-            l = str(capt.stdout).split()
-        self._bot_login = l[l.index('as')+1]
+        self._gh_version = str(capt.stdout).split('\\n')[0]
+        info('version: %s' % self._gh_version)
+        cmd = 'gh auth status'
+        capt = run(cmd, shell=True, capture_output=True)
+        errtxt = str(capt.stderr)
+        outtxt = str(capt.stdout)
+        debug('auth status err: %s' % errtxt)
+        debug('auth status out: %s' % outtxt)
+        def read_login(txt, position_mark):
+            for t in txt:
+                for p in position_mark:
+                    # the output text has changed from as to account
+                    # around version 2.40.0
+                    l = t.split()
+                    if p in l:
+                        return l[l.index(p)+1]
+        self._bot_login = read_login([errtxt, outtxt], ['account', 'as'])
+        if not self._bot_login:
+            self._bot_login = default_bot
+            info('Bot is unknown')
+            return self._bot_login
         if self._bot_login.endswith('[bot]'):
             self._bot_login = self._bot_login.split('[bot]')[0]
         info('Bot is %s' % self._bot_login)


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

At least since version 2.40.0 of `gh` the output of `gh auth status` has changed. This broke the method `bot_login` where the bot's login name is obtained. The first failure appeared on 13.12 in [this scheduled run](https://github.com/sagemath/sage/actions/runs/7199213174/job/19610401946). More specifically, the word before the login name used for positioning has changed from `as` to `account`.


In a logfile it looks like this:

```
Run chmod a+x .github/sync_labels.py
INFO:root:cmdline_args (1) ['https://github.com/sagemath/sage']
INFO:root:url: https://github.com/sagemath/sage
INFO:root:Create label handler for pull request #sage and actor sagetrac-github-bot
Traceback (most recent call last):
  File "/home/runner/work/sage/sage/.github/sync_labels.py", line 1081, in <module>
    gh = GhLabelSynchronizer(url, default_actor)
  File "/home/runner/work/sage/sage/.github/sync_labels.py", line 157, in __init__
    self.bot_login()
  File "/home/runner/work/sage/sage/.github/sync_labels.py", line 244, in bot_login
    self._bot_login = l[l.index('as')+1]
ValueError: 'as' is not in list
Error: Process completed with exit code 1.
```

This PR does the following:

* implements an adjustment to this change
* avoids raising an error if the bot name cannot be discovered (to better behave with similar changes in the future)
* adds more log messages to make it easier to identify similar issues



<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
