### PR TITLE
fix qepcad doctest

### DIFF
--- a/src/sage/interfaces/qepcad.py
+++ b/src/sage/interfaces/qepcad.py
@@ -833,7 +833,7 @@ class Qepcad:
                            x^2 + x*y + 3*x*z + 2*y*z + 2*z^2 - x - z < 0, \
                            -2*x + 1 < 0, -x*y - x*z - 2*y*z - 2*z^2 + z < 0, \
                            x + 3*y + 3*z - 1 < 0]
-            sage: qepcad(conds, memcells=2000000) # optional - qepcad
+            sage: qepcad(conds, memcells=3000000) # optional - qepcad
             2 x - 1 > 0 /\ z > 0 /\ z - y < 0 /\ 3 z + 3 y + x - 1 < 0
         """
         self._cell_cache = {}


### PR DESCRIPTION
This test started to fail on Sage 10.3.beta2 after the merged update of qepcad to 1.74 in https://github.com/sagemath/sage/pull/36837
