### PR TITLE
Fix build of optional Cython modules broken in #29386

### DIFF
--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -228,7 +228,7 @@ fi
 # depending on SAGE_ROOT and SAGE_LOCAL which are already defined.
 if [ -n "$SAGE_LOCAL" ]; then
     export SAGE_SHARE="$SAGE_LOCAL/share"
-    export SAGE_SPKG_INST="$SAGE_LOCAL/var/lib/sage/installed"
+    export SAGE_SPKG_INST="$SAGE_LOCAL/var/lib/sage/installed"  # deprecated
 fi
 if [ -n "$SAGE_SHARE" ]; then
     export SAGE_DOC="$SAGE_SHARE/doc/sage"

--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -177,7 +177,8 @@ SAGE_VENV_SPKG_INST = var("SAGE_VENV_SPKG_INST", join(SAGE_VENV, "var", "lib", "
 SAGE_LOCAL = var("SAGE_LOCAL", SAGE_VENV)
 SAGE_SHARE = var("SAGE_SHARE", join(SAGE_LOCAL, "share"))
 SAGE_DOC = var("SAGE_DOC", join(SAGE_SHARE, "doc", "sage"))
-SAGE_SPKG_INST = var("SAGE_SPKG_INST", join(SAGE_LOCAL, "var", "lib", "sage", "installed"))
+SAGE_LOCAL_SPKG_INST = var("SAGE_LOCAL_SPKG_INST", join(SAGE_LOCAL, "var", "lib", "sage", "installed"))
+SAGE_SPKG_INST = var("SAGE_SPKG_INST", join(SAGE_LOCAL, "var", "lib", "sage", "installed"))  # deprecated
 
 # source tree of the Sage distribution
 SAGE_ROOT = var("SAGE_ROOT")  # no fallback for SAGE_ROOT

--- a/src/sage/misc/package.py
+++ b/src/sage/misc/package.py
@@ -390,7 +390,7 @@ def _spkg_inst_dirs():
     """
     Generator for the installation manifest directories as resolved paths.
 
-    It yields first ``SAGE_SPKG_INST``, then ``SAGE_VENV_SPKG_INST``,
+    It yields first ``SAGE_LOCAL_SPKG_INST``, then ``SAGE_VENV_SPKG_INST``,
     if defined; but it both resolve to the same directory, it only yields
     one element.
 
@@ -402,7 +402,7 @@ def _spkg_inst_dirs():
 
     """
     last_inst_dir = None
-    for inst_dir in (sage.env.SAGE_SPKG_INST, sage.env.SAGE_VENV_SPKG_INST):
+    for inst_dir in (sage.env.SAGE_LOCAL_SPKG_INST, sage.env.SAGE_VENV_SPKG_INST):
         if inst_dir:
             inst_dir = Path(inst_dir).resolve()
             if inst_dir.is_dir() and inst_dir != last_inst_dir:


### PR DESCRIPTION
The Cython modules depending on optional packages (such as sage.libs.coxeter3) were not being built after #29386. This showed up in the CI as numerous doctest failures; as reported in https://github.com/sagemath/sage/pull/36775#issuecomment-1858775972

Fixed here by avoiding a clash of environment variables that prevented the function `is_package_installed_and_updated` from functioning during the build of sagelib.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
