### PR TITLE
`src/sage/libs/coxeter3/`: fix doctest warnings

### DIFF
--- a/src/sage/libs/coxeter3/coxeter.pyx
+++ b/src/sage/libs/coxeter3/coxeter.pyx
@@ -1,6 +1,7 @@
 # distutils: language = c++
 # distutils: libraries = coxeter3
 # sage_setup: distribution = sagemath-coxeter3
+# sage.doctest: optional - coxeter3
 
 """
 Low level part of the interface to Fokko Ducloux's Coxeter 3 library
@@ -35,10 +36,10 @@ cdef class String:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import String       # optional - coxeter3
-            sage: s = String("hello"); s                              # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import String
+            sage: s = String("hello"); s
             hello
-            sage: del s                                               # optional - coxeter3
+            sage: del s
         """
         self.x = c_String(str_to_bytes(s))
 
@@ -46,9 +47,9 @@ cdef class String:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import String       # optional - coxeter3
-            sage: s = String('Hi')                                    # optional - coxeter3
-            sage: s                                                   # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import String
+            sage: s = String('Hi')
+            sage: s
             Hi
         """
         return bytes_to_str(self.x.ptr())
@@ -62,9 +63,9 @@ cdef class String:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import String        # optional - coxeter3
-            sage: s = String('hello')                                  # optional - coxeter3
-            sage: hash(s) == hash('hello')                             # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import String
+            sage: s = String('hello')
+            sage: hash(s) == hash('hello')
             True
         """
         return hash(repr(self))
@@ -73,7 +74,6 @@ cdef class String:
         """
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import String
             sage: ta1 = String('A')
             sage: ta2 = String('A')
@@ -114,9 +114,9 @@ cdef class String:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import String       # optional - coxeter3
-            sage: s = String('Hi')                                    # optional - coxeter3
-            sage: len(s)                                              # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import String
+            sage: s = String('Hi')
+            sage: len(s)
             2
         """
         return self.x.length()
@@ -125,9 +125,9 @@ cdef class String:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import String       # optional - coxeter3
-            sage: s = String('Hi')                                    # optional - coxeter3
-            sage: TestSuite(s).run()                                  # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import String
+            sage: s = String('Hi')
+            sage: TestSuite(s).run()
         """
         return (String, (repr(self),) )
 
@@ -139,10 +139,10 @@ cdef class Type:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import Type         # optional - coxeter3
-            sage: t = Type('A'); t                                    # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import Type
+            sage: t = Type('A'); t
             A
-            sage: del t                                               # optional - coxeter3
+            sage: del t
         """
         self.x = c_Type(str_to_bytes(s))
 
@@ -150,8 +150,8 @@ cdef class Type:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import Type         # optional - coxeter3
-            sage: t = Type('A'); t                                    # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import Type
+            sage: t = Type('A'); t
             A
         """
         return bytes_to_str(self.x.name().ptr())
@@ -160,9 +160,9 @@ cdef class Type:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import Type         # optional - coxeter3
-            sage: t = Type('A')                                       # optional - coxeter3
-            sage: t.name()                                            # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import Type
+            sage: t = Type('A')
+            sage: t.name()
             A
         """
         return String(bytes_to_str(self.x.name().ptr()))
@@ -176,7 +176,6 @@ cdef class Type:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import Type
             sage: a = Type('A')
             sage: b = Type('B')
@@ -190,7 +189,6 @@ cdef class Type:
         """
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import Type
             sage: ta1 = Type('A')
             sage: ta2 = Type('A')
@@ -229,9 +227,9 @@ cdef class Type:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import Type           # optional - coxeter3
-            sage: t = Type('A')                                         # optional - coxeter3
-            sage: TestSuite(t).run()                                    # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import Type
+            sage: t = Type('A')
+            sage: TestSuite(t).run()
         """
         return (Type, (repr(self), ))
 
@@ -241,14 +239,14 @@ cdef class CoxGroup(SageObject):
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup   # optional - coxeter3
-            sage: W = CoxGroup(['A', 5]); W                                         # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5]); W
             Coxeter group of type A and rank 5
 
         Coxeter 3 segfault's on the trivial Coxeter group; so we catch
         this and raise a not implemented error::
 
-            sage: W = CoxGroup(['A', 0]); W                                         # optional - coxeter3
+            sage: W = CoxGroup(['A', 0]); W
             Traceback (most recent call last):
             ...
             NotImplementedError: Coxeter group of type ['A',0] using Coxeter 3 not yet implemented
@@ -256,8 +254,8 @@ cdef class CoxGroup(SageObject):
         Successfully initializes from a relabeled Cartan type::
 
             sage: ctype = CartanType(['B', 3]).relabel({1: 3, 2: 2, 3: 1})
-            sage: W = CoxGroup(ctype)                                               # optional - coxeter3
-            sage: CoxeterMatrix(W.coxeter_matrix(), ctype.index_set()) == CoxeterMatrix(ctype)  # optional - coxeter3
+            sage: W = CoxGroup(ctype)
+            sage: CoxeterMatrix(W.coxeter_matrix(), ctype.index_set()) == CoxeterMatrix(ctype)
             True
         """
         from sage.combinat.root_system.cartan_type import CartanType
@@ -307,9 +305,9 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                # optional - coxeter3
-            sage: W._ordering_from_cartan_type(CartanType(['A',5]))                     # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W._ordering_from_cartan_type(CartanType(['A',5]))
             [1, 2, 3, 4, 5]
         """
         from sage.arith.srange import srange
@@ -344,9 +342,9 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: A4 = CoxGroup(['A', 4])                                               # optional - coxeter3
-            sage: d = {A4: True}                                                        # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: A4 = CoxGroup(['A', 4])
+            sage: d = {A4: True}
         """
         return hash((self.__class__.__name__, self.type(), self.rank()))
 
@@ -354,7 +352,6 @@ cdef class CoxGroup(SageObject):
         """
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: A4 = CoxGroup(['A', 4])
             sage: A5 = CoxGroup(['A', 5])
@@ -399,9 +396,9 @@ cdef class CoxGroup(SageObject):
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup      # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                               # optional - coxeter3
-            sage: TestSuite((W)).run()                                                 # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: TestSuite((W)).run()
         """
         return (CoxGroup, (self.cartan_type,))
 
@@ -411,9 +408,9 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup      # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                               # optional - coxeter3
-            sage: del W                                                                # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: del W
         """
         del self.x
 
@@ -423,8 +420,8 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup      # optional - coxeter3
-            sage: W = CoxGroup(['A', 5]); W                                            # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5]); W
             Coxeter group of type A and rank 5
         """
         return "Coxeter group of type %s and rank %s"%(self.type(), self.rank())
@@ -433,9 +430,9 @@ cdef class CoxGroup(SageObject):
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup      # optional - coxeter3
-            sage: W = CoxGroup(['A', 2])                                               # optional - coxeter3
-            sage: list(iter(W))                                                        # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 2])
+            sage: list(iter(W))
             [[], [1], [2], [1, 2], [2, 1], [1, 2, 1]]
         """
         return CoxGroupIterator(self)
@@ -446,9 +443,9 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup      # optional - coxeter3
-            sage: W = CoxGroup(['A', 2])                                               # optional - coxeter3
-            sage: W.bruhat_interval([], [1,2])                                         # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 2])
+            sage: W.bruhat_interval([], [1,2])
             [[], [1], [2], [1, 2]]
         """
         cdef CoxGroupElement ww = CoxGroupElement(self, w)
@@ -474,9 +471,9 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                # optional - coxeter3
-            sage: W.orderings()                                                         # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W.orderings()
             ({1: 1, 2: 2, 3: 3, 4: 4, 5: 5}, {1: 1, 2: 2, 3: 3, 4: 4, 5: 5})
         """
         return self.in_ordering, self.out_ordering
@@ -489,9 +486,9 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                # optional - coxeter3
-            sage: W.type()                                                              # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W.type()
             A
         """
         return Type(bytes_to_str(self.x.type().name().ptr()))
@@ -502,9 +499,9 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                # optional - coxeter3
-            sage: W.rank()                                                              # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W.rank()
             5
         """
         return self.x.rank()
@@ -515,7 +512,6 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: W = CoxGroup(['A', 5])
             sage: W.order()
@@ -536,7 +532,6 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: W = CoxGroup(['A', 5])
             sage: W.is_finite()
@@ -555,7 +550,6 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: W = CoxGroup(['A', 2])
             sage: W.full_context()
@@ -577,13 +571,13 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                # optional - coxeter3
-            sage: W.long_element()                                                      # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W.long_element()
             [1, 2, 1, 3, 2, 1, 4, 3, 2, 1, 5, 4, 3, 2, 1]
 
-            sage: W = CoxGroup(['A', 3, 1])                                             # optional - coxeter3
-            sage: W.long_element()                                                      # optional - coxeter3
+            sage: W = CoxGroup(['A', 3, 1])
+            sage: W.long_element()
             Traceback (most recent call last):
             ...
             TypeError: group needs to be finite
@@ -608,7 +602,6 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: W = CoxGroup(['A', 5])
             sage: w = [1,1,3,5,4,5,4]
@@ -623,9 +616,9 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup      # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                               # optional - coxeter3
-            sage: W.coxeter_matrix()                                                   # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W.coxeter_matrix()
             [1 3 2 2 2]
             [3 1 3 2 2]
             [2 3 1 3 2]
@@ -657,7 +650,6 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: W = CoxGroup(['A', 5])
             sage: W.coxeter_graph()
@@ -683,7 +675,6 @@ cdef class CoxGroupElement:
         """
         TESTS::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement
             sage: W = CoxGroup(['A', 5])
             sage: w = CoxGroupElement(W, [2,1,2,1,1], normal_form=False); w
@@ -714,7 +705,6 @@ cdef class CoxGroupElement:
 
         TESTS::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement
             sage: W = CoxGroup(['A', 4])
             sage: w = CoxGroupElement(W, [1,2,3,2,3])
@@ -727,7 +717,6 @@ cdef class CoxGroupElement:
         """
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,3])
@@ -741,8 +730,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,3])
@@ -759,7 +746,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,3])
@@ -775,7 +761,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,3])
@@ -810,9 +795,9 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *          # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                             # optional - coxeter3
-            sage: w = W([1,2,3]); w                                 # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3]); w
             [1, 2, 3]
 
         """
@@ -827,7 +812,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A', 5])
             sage: w = W([1,2,3])
@@ -841,7 +825,6 @@ cdef class CoxGroupElement:
         """
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A', 5])
             sage: V = CoxGroup(['A', 6])
@@ -890,7 +873,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,3])
@@ -905,7 +887,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,3])
@@ -920,7 +901,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,1])
@@ -935,7 +915,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,1])
@@ -950,7 +929,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,3,4,5,4])
@@ -971,7 +949,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',2])
             sage: x = W([1,2,1])
@@ -995,7 +972,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',2])
             sage: W([1,2,1]).coatoms()
@@ -1025,7 +1001,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement
             sage: W = CoxGroup(['A', 5])
             sage: w = CoxGroupElement(W, [2,1,2], normal_form=False); w
@@ -1044,7 +1019,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement
             sage: W = CoxGroup(['A', 5])
             sage: w = CoxGroupElement(W, [2,1,2,1,1], normal_form=False); w
@@ -1060,7 +1034,6 @@ cdef class CoxGroupElement:
         """
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: W = CoxGroup(['A', 5])
             sage: W([1]) * W([1])
@@ -1079,7 +1052,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: W = CoxGroup(['A', 5])
             sage: W([]).poincare_polynomial()
@@ -1108,7 +1080,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
             sage: W = CoxGroup(['A', 2])
             sage: W([]).kazhdan_lusztig_polynomial([1,2,1])
@@ -1141,7 +1112,6 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import *
             sage: W = CoxGroup(['A',5])
             sage: w = W([1,2,3,4,5,4])
@@ -1165,7 +1135,6 @@ cdef LFlags_to_list(CoxGroup parent, LFlags f) noexcept:
 
     EXAMPLES::
 
-            sage: # optional - coxeter3
         sage: from sage.libs.coxeter3.coxeter import *
         sage: W = CoxGroup(['A',5])
         sage: w = W([1,2,1])
@@ -1195,7 +1164,6 @@ class CoxGroupIterator():
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator
             sage: W = CoxGroup(['A', 2])
             sage: it = CoxGroupIterator(W)
@@ -1213,7 +1181,6 @@ class CoxGroupIterator():
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator
             sage: W = CoxGroup(['A', 2])
             sage: it = iter(W)
@@ -1228,7 +1195,6 @@ class CoxGroupIterator():
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator
             sage: W = CoxGroup(['A', 2])
             sage: it = CoxGroupIterator(W)
@@ -1251,8 +1217,8 @@ def get_CoxGroup(cartan_type):
     """
     TESTS::
 
-        sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator  # optional - coxeter3
-        sage: W = CoxGroup(['A', 2])                                                             # optional - coxeter3
+        sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator
+        sage: W = CoxGroup(['A', 2])
     """
     from sage.combinat.root_system.cartan_type import CartanType
     cartan_type = CartanType(cartan_type)

--- a/src/sage/libs/coxeter3/coxeter.pyx
+++ b/src/sage/libs/coxeter3/coxeter.pyx
@@ -73,17 +73,18 @@ cdef class String:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import String        # optional - coxeter3
-            sage: ta1 = String('A')                                    # optional - coxeter3
-            sage: ta2 = String('A')                                    # optional - coxeter3
-            sage: tb = String('b')                                     # optional - coxeter3
-            sage: ta1 == ta2                                           # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import String
+            sage: ta1 = String('A')
+            sage: ta2 = String('A')
+            sage: tb = String('b')
+            sage: ta1 == ta2
             True
-            sage: tb != ta1                                            # optional - coxeter3
+            sage: tb != ta1
             True
-            sage: all([ta1 < tb, ta1 <= tb, ta1 <= ta1])               # optional - coxeter3
+            sage: all([ta1 < tb, ta1 <= tb, ta1 <= ta1])
             True
-            sage: all([tb > ta1, tb >= ta1, tb >= tb])                 # optional - coxeter3
+            sage: all([tb > ta1, tb >= ta1, tb >= tb])
             True
         """
         if type(other) is not type(self):
@@ -175,12 +176,13 @@ cdef class Type:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import Type          # optional - coxeter3
-            sage: a = Type('A')                                        # optional - coxeter3
-            sage: b = Type('B')                                        # optional - coxeter3
-            sage: hash(a) == hash(b)                                   # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import Type
+            sage: a = Type('A')
+            sage: b = Type('B')
+            sage: hash(a) == hash(b)
             False
-            sage: d = {a: 1, b: 2}                                     # optional - coxeter3
+            sage: d = {a: 1, b: 2}
         """
         return hash(('Type', self.name()))
 
@@ -188,17 +190,18 @@ cdef class Type:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import Type          # optional - coxeter3
-            sage: ta1 = Type('A')                                      # optional - coxeter3
-            sage: ta2 = Type('A')                                      # optional - coxeter3
-            sage: tb = Type('b')                                       # optional - coxeter3
-            sage: ta1 == ta2                                           # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import Type
+            sage: ta1 = Type('A')
+            sage: ta2 = Type('A')
+            sage: tb = Type('b')
+            sage: ta1 == ta2
             True
-            sage: tb != ta1                                            # optional - coxeter3
+            sage: tb != ta1
             True
-            sage: all([ta1 < tb, ta1 <= tb, ta1 <= ta1])               # optional - coxeter3
+            sage: all([ta1 < tb, ta1 <= tb, ta1 <= ta1])
             True
-            sage: all([tb > ta1, tb >= ta1, tb >= tb])                 # optional - coxeter3
+            sage: all([tb > ta1, tb >= ta1, tb >= tb])
             True
         """
         if type(other) is not type(self):
@@ -232,6 +235,7 @@ cdef class Type:
         """
         return (Type, (repr(self), ))
 
+
 cdef class CoxGroup(SageObject):
     def __cinit__(self, cartan_type):
         """
@@ -253,7 +257,7 @@ cdef class CoxGroup(SageObject):
 
             sage: ctype = CartanType(['B', 3]).relabel({1: 3, 2: 2, 3: 1})
             sage: W = CoxGroup(ctype)                                               # optional - coxeter3
-            sage: CoxeterMatrix(W.coxeter_matrix(), ctype.index_set()) == CoxeterMatrix(ctype) # optional - coxeter3
+            sage: CoxeterMatrix(W.coxeter_matrix(), ctype.index_set()) == CoxeterMatrix(ctype)  # optional - coxeter3
             True
         """
         from sage.combinat.root_system.cartan_type import CartanType
@@ -350,21 +354,22 @@ cdef class CoxGroup(SageObject):
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: A4 = CoxGroup(['A', 4])                                               # optional - coxeter3
-            sage: A5 = CoxGroup(['A', 5])                                               # optional - coxeter3
-            sage: B4 = CoxGroup(['B', 4])                                               # optional - coxeter3
-            sage: A4 == A4                                                              # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: A4 = CoxGroup(['A', 4])
+            sage: A5 = CoxGroup(['A', 5])
+            sage: B4 = CoxGroup(['B', 4])
+            sage: A4 == A4
             True
-            sage: A4 != B4                                                              # optional - coxeter3
+            sage: A4 != B4
             True
-            sage: A4 < B4                                                               # optional - coxeter3
+            sage: A4 < B4
             True
-            sage: A5 > A4                                                               # optional - coxeter3
+            sage: A5 > A4
             True
-            sage: A4 >= A4                                                              # optional - coxeter3
+            sage: A4 >= A4
             True
-            sage: B4 >= A5                                                              # optional - coxeter3
+            sage: B4 >= A5
             True
         """
         if type(other) is not type(self):
@@ -510,12 +515,13 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                # optional - coxeter3
-            sage: W.order()                                                             # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W.order()
             720
-            sage: W = CoxGroup(['A', 3, 1])                                             # optional - coxeter3
-            sage: W.order()                                                             # optional - coxeter3
+            sage: W = CoxGroup(['A', 3, 1])
+            sage: W.order()
             +Infinity
         """
         if self.is_finite():
@@ -530,12 +536,13 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                # optional - coxeter3
-            sage: W.is_finite()                                                         # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W.is_finite()
             True
-            sage: W = CoxGroup(['A', 3, 1])                                             # optional - coxeter3
-            sage: W.is_finite()                                                         # optional - coxeter3
+            sage: W = CoxGroup(['A', 3, 1])
+            sage: W.is_finite()
             False
         """
         return isFiniteType(self.x)
@@ -548,11 +555,12 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup       # optional - coxeter3
-            sage: W = CoxGroup(['A', 2])                                                # optional - coxeter3
-            sage: W.full_context()                                                      # optional - coxeter3
-            sage: W = CoxGroup(['A', 2,1])                                              # optional - coxeter3
-            sage: W.full_context()                                                      # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 2])
+            sage: W.full_context()
+            sage: W = CoxGroup(['A', 2,1])
+            sage: W.full_context()
             Traceback (most recent call last):
             ...
             TypeError: group needs to be finite
@@ -562,7 +570,6 @@ cdef class CoxGroup(SageObject):
         cdef c_FiniteCoxGroup* fcoxgroup = <c_FiniteCoxGroup*>(self.x)
         if not fcoxgroup.isFullContext():
             fcoxgroup.fullContext()
-
 
     def long_element(self):
         """
@@ -601,10 +608,11 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup      # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                               # optional - coxeter3
-            sage: w = [1,1,3,5,4,5,4]                                                  # optional - coxeter3
-            sage: W.__call__(w)                                                        # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: w = [1,1,3,5,4,5,4]
+            sage: W.__call__(w)
             [3, 4, 5]
         """
         return CoxGroupElement(self, w).reduced()
@@ -649,11 +657,12 @@ cdef class CoxGroup(SageObject):
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup# optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                         # optional - coxeter3
-            sage: W.coxeter_graph()                                              # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W.coxeter_graph()
             Graph on 5 vertices
-            sage: W.coxeter_graph().edges(sort=True)                             # optional - coxeter3
+            sage: W.coxeter_graph().edges(sort=True)
             [(1, 2, None), (2, 3, None), (3, 4, None), (4, 5, None)]
         """
         from sage.graphs.graph import Graph
@@ -669,26 +678,26 @@ cdef class CoxGroup(SageObject):
         return g
 
 
-
 cdef class CoxGroupElement:
     def __init__(self, CoxGroup group, w, normal_form=True):
         """
         TESTS::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement  # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                            # optional - coxeter3
-            sage: w = CoxGroupElement(W, [2,1,2,1,1], normal_form=False); w                         # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement
+            sage: W = CoxGroup(['A', 5])
+            sage: w = CoxGroupElement(W, [2,1,2,1,1], normal_form=False); w
             [2, 1, 2, 1, 1]
-            sage: w = CoxGroupElement(W, [1,1,4,5,4], normal_form=False); w                         # optional - coxeter3
+            sage: w = CoxGroupElement(W, [1,1,4,5,4], normal_form=False); w
             [1, 1, 4, 5, 4]
-            sage: w = CoxGroupElement(W, [1,1,4,5,4]); w                                            # optional - coxeter3
+            sage: w = CoxGroupElement(W, [1,1,4,5,4]); w
             [4, 5, 4]
-            sage: W = CoxGroup(['A', 4])                                                            # optional - coxeter3
-            sage: CoxGroupElement(W, [1,2,3,2,3])                                                   # optional - coxeter3
+            sage: W = CoxGroup(['A', 4])
+            sage: CoxGroupElement(W, [1,2,3,2,3])
             [1, 3, 2]
-            sage: W = CoxGroup(['A', 4])                                                            # optional - coxeter3
-            sage: w = CoxGroupElement(W, [1,2,3,2,3])                                               # optional - coxeter3
-            sage: del w                                                                             # optional - coxeter3
+            sage: W = CoxGroup(['A', 4])
+            sage: w = CoxGroupElement(W, [1,2,3,2,3])
+            sage: del w
         """
         self.group = (<CoxGroup>group).x
         self._parent_group = group
@@ -705,10 +714,11 @@ cdef class CoxGroupElement:
 
         TESTS::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement  # optional - coxeter3
-            sage: W = CoxGroup(['A', 4])                                                            # optional - coxeter3
-            sage: w = CoxGroupElement(W, [1,2,3,2,3])                                               # optional - coxeter3
-            sage: w._coxnumber()                                                                    # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement
+            sage: W = CoxGroup(['A', 4])
+            sage: w = CoxGroupElement(W, [1,2,3,2,3])
+            sage: w._coxnumber()
             7
         """
         return int(self.group.extendContext(self.word))
@@ -717,10 +727,11 @@ cdef class CoxGroupElement:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *                                          # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                                                             # optional - coxeter3
-            sage: w = W([1,2,3])                                                                    # optional - coxeter3
-            sage: TestSuite(w).run()                                                                # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3])
+            sage: TestSuite(w).run()
         """
         return (CoxGroupElement, (self._parent_group, list(self)))
 
@@ -731,10 +742,11 @@ cdef class CoxGroupElement:
         EXAMPLES::
 
 
-            sage: from sage.libs.coxeter3.coxeter import *                                          # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                                                             # optional - coxeter3
-            sage: w = W([1,2,3])                                                                    # optional - coxeter3
-            sage: ~w                                                                                # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3])
+            sage: ~w
             [3, 2, 1]
         """
         return CoxGroupElement(self._parent_group, reversed(self))
@@ -747,10 +759,11 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *                                          # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                                                             # optional - coxeter3
-            sage: w = W([1,2,3])                                                                    # optional - coxeter3
-            sage: w.parent_group()                                                                        # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3])
+            sage: w.parent_group()
             Coxeter group of type A and rank 5
 
         """
@@ -762,20 +775,21 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *                                          # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                                                             # optional - coxeter3
-            sage: w = W([1,2,3])                                                                    # optional - coxeter3
-            sage: w[0]                                                                              # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3])
+            sage: w[0]
             1
-            sage: w[2]                                                                              # optional - coxeter3
+            sage: w[2]
             3
-            sage: w[:-2]                                                                            # optional - coxeter3
+            sage: w[:-2]
             [1]
-            sage: w[-2:]                                                                            # optional - coxeter3
+            sage: w[-2:]
             [2, 3]
-            sage: w[3:0:-1]                                                                         # optional - coxeter3
+            sage: w[3:0:-1]
             [3, 2]
-            sage: w[4]                                                                              # optional - coxeter3
+            sage: w[4]
             Traceback (most recent call last):
             ...
             IndexError: The index (4) is out of range.
@@ -813,11 +827,12 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *         # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                           # optional - coxeter3
-            sage: w = W([1,2,3])                                   # optional - coxeter3
-            sage: v = W([2,3,4])                                   # optional - coxeter3
-            sage: hash(w) == hash(v)                               # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A', 5])
+            sage: w = W([1,2,3])
+            sage: v = W([2,3,4])
+            sage: hash(w) == hash(v)
             False
         """
         return hash((self.__class__.__name__, self.parent_group(), tuple(self)))
@@ -826,23 +841,24 @@ cdef class CoxGroupElement:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *        # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                          # optional - coxeter3
-            sage: V = CoxGroup(['A', 6])                          # optional - coxeter3
-            sage: w1 = W([1,2,3])                                 # optional - coxeter3
-            sage: w2 = W([2,3,4])                                 # optional - coxeter3
-            sage: v1 = V([1,2,3])                                 # optional - coxeter3
-            sage: w1 == w1                                        # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A', 5])
+            sage: V = CoxGroup(['A', 6])
+            sage: w1 = W([1,2,3])
+            sage: w2 = W([2,3,4])
+            sage: v1 = V([1,2,3])
+            sage: w1 == w1
             True
-            sage: w1 != w2                                        # optional - coxeter3
+            sage: w1 != w2
             True
-            sage: all([w1 < w2, w1 <= w2, w1 <= w1])              # optional - coxeter3
+            sage: all([w1 < w2, w1 <= w2, w1 <= w1])
             True
-            sage: all([w2 > w1, w2 >= w1, w2 >= w2])              # optional - coxeter3
+            sage: all([w2 > w1, w2 >= w1, w2 >= w2])
             True
-            sage: w1 == v1                                        # optional - coxeter3
+            sage: w1 == v1
             False
-            sage: w1 != v1                                        # optional - coxeter3
+            sage: w1 != v1
             True
         """
         if type(other) is not type(self):
@@ -874,10 +890,11 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *      # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                         # optional - coxeter3
-            sage: w = W([1,2,3])                                # optional - coxeter3
-            sage: [a for a in w]                                # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3])
+            sage: [a for a in w]
             [1, 2, 3]
         """
         return (self[i] for i in range(len(self)))
@@ -888,10 +905,11 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *       # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                          # optional - coxeter3
-            sage: w = W([1,2,3])                                 # optional - coxeter3
-            sage: len(w)                                         # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3])
+            sage: len(w)
             3
         """
         return self.word.length()
@@ -902,10 +920,11 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *      # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                         # optional - coxeter3
-            sage: w = W([1,2,1])                                # optional - coxeter3
-            sage: w.left_descents()                             # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,1])
+            sage: w.left_descents()
             [1, 2]
         """
         return LFlags_to_list(self._parent_group, self.group.ldescent(self.word))
@@ -916,10 +935,11 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *      # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                         # optional - coxeter3
-            sage: w = W([1,2,1])                                # optional - coxeter3
-            sage: w.right_descents()                            # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,1])
+            sage: w.right_descents()
             [1, 2]
         """
         return LFlags_to_list(self._parent_group, self.group.rdescent(self.word))
@@ -930,15 +950,16 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *       # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                          # optional - coxeter3
-            sage: w = W([1,2,3,4,5,4])                           # optional - coxeter3
-            sage: v = W([1,2,4,5,4])                             # optional - coxeter3
-            sage: v.bruhat_le(w)                                 # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3,4,5,4])
+            sage: v = W([1,2,4,5,4])
+            sage: v.bruhat_le(w)
             True
-            sage: w.bruhat_le(w)                                 # optional - coxeter3
+            sage: w.bruhat_le(w)
             True
-            sage: w.bruhat_le(v)                                 # optional - coxeter3
+            sage: w.bruhat_le(v)
             False
         """
         cdef CoxGroupElement ww = CoxGroupElement(self._parent_group, w)
@@ -950,10 +971,11 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *       # optional - coxeter3
-            sage: W = CoxGroup(['A',2])                          # optional - coxeter3
-            sage: x = W([1,2,1])                                 # optional - coxeter3
-            sage: x.is_two_sided_descent(1)                      # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',2])
+            sage: x = W([1,2,1])
+            sage: x.is_two_sided_descent(1)
             True
         """
         cdef Generator ss = self._parent_group.in_ordering[s]
@@ -973,11 +995,12 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *          # optional - coxeter3
-            sage: W = CoxGroup(['A',2])                             # optional - coxeter3
-            sage: W([1,2,1]).coatoms()                              # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',2])
+            sage: W([1,2,1]).coatoms()
             [[2, 1], [1, 2]]
-            sage: W([]).coatoms()                                   # optional - coxeter3
+            sage: W([]).coatoms()
             []
         """
         cdef c_List_CoxWord list = c_List_CoxWord(0)
@@ -1002,11 +1025,12 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement  # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                            # optional - coxeter3
-            sage: w = CoxGroupElement(W, [2,1,2], normal_form=False); w                             # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement
+            sage: W = CoxGroup(['A', 5])
+            sage: w = CoxGroupElement(W, [2,1,2], normal_form=False); w
             [2, 1, 2]
-            sage: w.normal_form()                                                                   # optional - coxeter3
+            sage: w.normal_form()
             [1, 2, 1]
 
         """
@@ -1020,11 +1044,12 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement  # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                            # optional - coxeter3
-            sage: w = CoxGroupElement(W, [2,1,2,1,1], normal_form=False); w                         # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupElement
+            sage: W = CoxGroup(['A', 5])
+            sage: w = CoxGroupElement(W, [2,1,2,1,1], normal_form=False); w
             [2, 1, 2, 1, 1]
-            sage: w.reduced()                                                                       # optional - coxeter3
+            sage: w.reduced()
             [1, 2, 1]
         """
         cdef CoxGroupElement res = self._new()
@@ -1035,11 +1060,12 @@ cdef class CoxGroupElement:
         """
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup                    # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                             # optional - coxeter3
-            sage: W([1]) * W([1])                                                                    # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W([1]) * W([1])
             []
-            sage: W([1,2]) * W([1])                                                                  # optional - coxeter3
+            sage: W([1,2]) * W([1])
             [1, 2, 1]
         """
         cdef CoxGroupElement res = self._new()
@@ -1053,11 +1079,12 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup                    # optional - coxeter3
-            sage: W = CoxGroup(['A', 5])                                                             # optional - coxeter3
-            sage: W([]).poincare_polynomial()                                                        # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 5])
+            sage: W([]).poincare_polynomial()
             1
-            sage: W([1,2,1]).poincare_polynomial()                                                   # optional - coxeter3
+            sage: W([1,2,1]).poincare_polynomial()
             t^3 + 2*t^2 + 2*t + 1
         """
         cdef CoxGroup W = self.parent_group()
@@ -1072,7 +1099,6 @@ cdef class CoxGroupElement:
             coefficients[result[j].length()] += 1
         return ZZ['t'](coefficients)
 
-
     def kazhdan_lusztig_polynomial(self, v):
         """
         Return the Kazhdan-Lusztig polynomial `P_{u,v}` where `u` is ``self``.
@@ -1082,11 +1108,12 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup                    # optional - coxeter3
-            sage: W = CoxGroup(['A', 2])                                                             # optional - coxeter3
-            sage: W([]).kazhdan_lusztig_polynomial([1,2,1])                                          # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 2])
+            sage: W([]).kazhdan_lusztig_polynomial([1,2,1])
             1
-            sage: W([1,2,1]).kazhdan_lusztig_polynomial([])                                          # optional - coxeter3
+            sage: W([1,2,1]).kazhdan_lusztig_polynomial([])
             0
         """
         cdef CoxGroupElement vv
@@ -1114,15 +1141,16 @@ cdef class CoxGroupElement:
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import *          # optional - coxeter3
-            sage: W = CoxGroup(['A',5])                             # optional - coxeter3
-            sage: w = W([1,2,3,4,5,4])                              # optional - coxeter3
-            sage: v = W([1,2,4,5,4])                                # optional - coxeter3
-            sage: w.mu_coefficient(v)                               # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import *
+            sage: W = CoxGroup(['A',5])
+            sage: w = W([1,2,3,4,5,4])
+            sage: v = W([1,2,4,5,4])
+            sage: w.mu_coefficient(v)
             0
-            sage: w.mu_coefficient(w)                               # optional - coxeter3
+            sage: w.mu_coefficient(w)
             0
-            sage: v.mu_coefficient(w)                               # optional - coxeter3
+            sage: v.mu_coefficient(w)
             1
         """
         cdef CoxGroupElement vv = CoxGroupElement(self._parent_group, v)
@@ -1130,16 +1158,18 @@ cdef class CoxGroupElement:
         cdef CoxNbr y = self.group.extendContext(vv.word)
         return ZZ(self.group.mu(x,y))
 
+
 cdef LFlags_to_list(CoxGroup parent, LFlags f) noexcept:
     """
     Return the right descent set of this element.
 
     EXAMPLES::
 
-        sage: from sage.libs.coxeter3.coxeter import *         # optional - coxeter3
-        sage: W = CoxGroup(['A',5])                            # optional - coxeter3
-        sage: w = W([1,2,1])                                   # optional - coxeter3
-        sage: w.right_descents()                               # optional - coxeter3
+            sage: # optional - coxeter3
+        sage: from sage.libs.coxeter3.coxeter import *
+        sage: W = CoxGroup(['A',5])
+        sage: w = W([1,2,1])
+        sage: w.right_descents()
         [1, 2]
     """
     cdef Generator s
@@ -1150,6 +1180,7 @@ cdef LFlags_to_list(CoxGroup parent, LFlags f) noexcept:
         l.append(parent.out_ordering[s+1])
         f1 = f1 & (f1-1)
     return l
+
 
 class CoxGroupIterator():
     def __init__(self, group):
@@ -1164,10 +1195,11 @@ class CoxGroupIterator():
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator # optional - coxeter3
-            sage: W = CoxGroup(['A', 2])                                                            # optional - coxeter3
-            sage: it = CoxGroupIterator(W)                                                          # optional - coxeter3
-            sage: [next(it) for i in range(W.order())]                                              # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator
+            sage: W = CoxGroup(['A', 2])
+            sage: it = CoxGroupIterator(W)
+            sage: [next(it) for i in range(W.order())]
             [[], [1], [2], [1, 2], [2, 1], [1, 2, 1]]
         """
         self.group = group
@@ -1181,10 +1213,11 @@ class CoxGroupIterator():
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator # optional - coxeter3
-            sage: W = CoxGroup(['A', 2])                                                            # optional - coxeter3
-            sage: it = iter(W)                                                                      # optional - coxeter3
-            sage: it is iter(it)                                                                    # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator
+            sage: W = CoxGroup(['A', 2])
+            sage: it = iter(W)
+            sage: it is iter(it)
             True
         """
         return self
@@ -1195,10 +1228,11 @@ class CoxGroupIterator():
 
         EXAMPLES::
 
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator # optional - coxeter3
-            sage: W = CoxGroup(['A', 2])                                                            # optional - coxeter3
-            sage: it = CoxGroupIterator(W)                                                          # optional - coxeter3
-            sage: next(it)                                                                          # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator
+            sage: W = CoxGroup(['A', 2])
+            sage: it = CoxGroupIterator(W)
+            sage: next(it)
             []
         """
         if self.n >= self.order:

--- a/src/sage/libs/coxeter3/coxeter_group.py
+++ b/src/sage/libs/coxeter3/coxeter_group.py
@@ -3,12 +3,12 @@
 """
 Coxeter Groups implemented with Coxeter3
 """
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2009-2013 Mike Hansen <mhansen@gmail.com>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.libs.coxeter3.coxeter import get_CoxGroup, CoxGroupElement
 from sage.misc.cachefunc import cached_method
@@ -31,10 +31,10 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         """
         TESTS::
 
-            sage: from sage.libs.coxeter3.coxeter_group import CoxeterGroup # optional - coxeter3
-            sage: CoxeterGroup(['B',2])                                     # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter_group import CoxeterGroup       # optional - coxeter3
+            sage: CoxeterGroup(['B',2])                                           # optional - coxeter3
             Coxeter group of type ['B', 2] implemented by Coxeter3
-            sage: CoxeterGroup(CartanType(['B', 3]).relabel({1: 3, 2: 2, 3: 1})) # optional - coxeter3
+            sage: CoxeterGroup(CartanType(['B', 3]).relabel({1: 3, 2: 2, 3: 1}))  # optional - coxeter3
             Coxeter group of type ['B', 3] relabelled by {1: 3, 2: 2, 3: 1} implemented by Coxeter3
 
         """
@@ -46,15 +46,15 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         """
         TESTS::
 
-            sage: from sage.libs.coxeter3.coxeter_group import CoxeterGroup  # optional - coxeter3
-            sage: CoxeterGroup(['A',2])                                     # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter_group import CoxeterGroup       # optional - coxeter3
+            sage: CoxeterGroup(['A',2])                                           # optional - coxeter3
             Coxeter group of type ['A', 2] implemented by Coxeter3
 
         As degrees and codegrees are not implemented, they are skipped in the
         testsuite::
 
             sage: to_skip = ['_test_degrees', '_test_codegrees']
-            sage: TestSuite(CoxeterGroup(['A',2])).run(skip=to_skip)                    # optional - coxeter3
+            sage: TestSuite(CoxeterGroup(['A',2])).run(skip=to_skip)              # optional - coxeter3
         """
         category = CoxeterGroups()
         if cartan_type.is_finite():
@@ -277,8 +277,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         TESTS::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3') # optional - coxeter3
-            sage: W.m(1, 1)                                             # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')  # optional - coxeter3
+            sage: W.m(1, 1)                                              # optional - coxeter3
             doctest:warning...:
             DeprecationWarning: the .m(i, j) method has been deprecated; use .coxeter_matrix()[i,j] instead.
             See https://github.com/sagemath/sage/issues/30237 for details.
@@ -667,7 +667,7 @@ class CoxeterGroup(UniqueRepresentation, Parent):
                 sage: w.action(v)
                 -alpha[1] + alpha[2] + alpha[3]
             """
-            #TODO: Find a better way to do this
+            # TODO: Find a better way to do this
             W = self.parent().root_system().root_space().weyl_group()
             w = W.from_reduced_word(list(self))
             return w.action(v)
@@ -705,7 +705,9 @@ class CoxeterGroup(UniqueRepresentation, Parent):
             n = W.rank()
 
             if Q.ngens() != n:
-                raise ValueError("the number of generators for the polynomial ring must be the same as the rank of the root system")
+                raise ValueError("the number of generators for the polynomial "
+                                 "ring must be the same as the rank of the "
+                                 "root system")
 
             basis_elements = [alpha[i] for i in W.index_set()]
             basis_to_order = {s: i for i, s in enumerate(W.index_set())}
@@ -716,7 +718,7 @@ class CoxeterGroup(UniqueRepresentation, Parent):
                 exponents = poly.exponents()
 
                 for exponent in exponents:
-                    #Construct something in the root lattice from the exponent vector
+                    # Construct something in the root lattice from the exponent vector
                     exponent = sum(e*b for e, b in zip(exponent, basis_elements))
                     exponent = self.action(exponent)
 

--- a/src/sage/libs/coxeter3/coxeter_group.py
+++ b/src/sage/libs/coxeter3/coxeter_group.py
@@ -103,11 +103,12 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')  # optional - coxeter3
-            sage: W.index_set()                                          # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.index_set()
             (1, 2, 3)
-            sage: C = CoxeterGroup(['A', 3,1], implementation='coxeter3') # optional - coxeter3
-            sage: C.index_set()                                           # optional - coxeter3
+            sage: C = CoxeterGroup(['A', 3,1], implementation='coxeter3')
+            sage: C.index_set()
             (0, 1, 2, 3)
         """
         return self.cartan_type().index_set()
@@ -157,7 +158,7 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         EXAMPLES::
 
             sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: s = W.simple_reflections()                                            # optional - coxeter3
+            sage: s = W.simple_reflections()                              # optional - coxeter3
             sage: s[2]*s[1]*s[2]                                          # optional - coxeter3
             [1, 2, 1]
         """
@@ -247,11 +248,12 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: R = W.root_system(); R                                  # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: R = W.root_system(); R
             Root system of type ['A', 3]
-            sage: alpha = R.root_space().basis()                          # optional - coxeter3
-            sage: alpha[2] + alpha[3]                                     # optional - coxeter3
+            sage: alpha = R.root_space().basis()
+            sage: alpha[2] + alpha[3]
             alpha[2] + alpha[3]
         """
         return self.cartan_type().root_system()
@@ -303,13 +305,14 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: W.kazhdan_lusztig_polynomial([], [1,2, 1])              # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.kazhdan_lusztig_polynomial([], [1,2, 1])
             1
-            sage: W.kazhdan_lusztig_polynomial([1],[3,2])                 # optional - coxeter3
+            sage: W.kazhdan_lusztig_polynomial([1],[3,2])
             0
-            sage: W = CoxeterGroup(['A',3],implementation='coxeter3')     # optional - coxeter3
-            sage: W.kazhdan_lusztig_polynomial([2],[2,1,3,2])             # optional - coxeter3
+            sage: W = CoxeterGroup(['A',3],implementation='coxeter3')
+            sage: W.kazhdan_lusztig_polynomial([2],[2,1,3,2])
             q + 1
 
         .. NOTE::
@@ -384,24 +387,26 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A',3], implementation='coxeter3')                      # optional - coxeter3
-            sage: W.parabolic_kazhdan_lusztig_polynomial([],[3,2],[1,3])                    # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: W = CoxeterGroup(['A',3], implementation='coxeter3')
+            sage: W.parabolic_kazhdan_lusztig_polynomial([],[3,2],[1,3])
             0
-            sage: W.parabolic_kazhdan_lusztig_polynomial([2],[2,1,3,2],[1,3])               # optional - coxeter3
+            sage: W.parabolic_kazhdan_lusztig_polynomial([2],[2,1,3,2],[1,3])
             q
 
-            sage: C = CoxeterGroup(['A',3,1], implementation='coxeter3')                    # optional - coxeter3
-            sage: C.parabolic_kazhdan_lusztig_polynomial([],[1],[0])                        # optional - coxeter3
+            sage: # optional - coxeter3
+            sage: C = CoxeterGroup(['A',3,1], implementation='coxeter3')
+            sage: C.parabolic_kazhdan_lusztig_polynomial([],[1],[0])
             1
-            sage: C.parabolic_kazhdan_lusztig_polynomial([],[1,2,1],[0])                    # optional - coxeter3
+            sage: C.parabolic_kazhdan_lusztig_polynomial([],[1,2,1],[0])
             1
-            sage: C.parabolic_kazhdan_lusztig_polynomial([],[0,1,0,1,2,1],[0])              # optional - coxeter3
+            sage: C.parabolic_kazhdan_lusztig_polynomial([],[0,1,0,1,2,1],[0])
             q
             sage: w=[1, 2, 1, 3, 0, 2, 1, 0, 3, 0, 2]
             sage: v=[1, 2, 1, 3, 0, 1, 2, 1, 0, 3, 0, 2, 1, 0, 3, 0, 2]
-            sage: C.parabolic_kazhdan_lusztig_polynomial(w,v,[1,3])                         # optional - coxeter3
+            sage: C.parabolic_kazhdan_lusztig_polynomial(w,v,[1,3])
             q^2 + q
-            sage: C.parabolic_kazhdan_lusztig_polynomial(w,v,[1,3],constant_term_one=False) # optional - coxeter3
+            sage: C.parabolic_kazhdan_lusztig_polynomial(w,v,[1,3],constant_term_one=False)
             q^4 + q^2
 
         TESTS::
@@ -437,13 +442,14 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             Check that :trac:`32266` is fixed::
 
-                sage: A3 = CoxeterGroup('A3', implementation='coxeter3')       # optional - coxeter3
-                sage: s1,s2,s3 = A3.simple_reflections()                       # optional - coxeter3
-                sage: s1*s3                                                    # optional - coxeter3
+                sage: # optional - coxeter3
+                sage: A3 = CoxeterGroup('A3', implementation='coxeter3')
+                sage: s1,s2,s3 = A3.simple_reflections()
+                sage: s1*s3
                 [1, 3]
-                sage: s3*s1                                                    # optional - coxeter3
+                sage: s3*s1
                 [1, 3]
-                sage: s3*s1 == s1*s3                                           # optional - coxeter3
+                sage: s3*s1 == s1*s3
                 True
             """
             if not isinstance(x, CoxGroupElement):
@@ -484,12 +490,13 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')   # optional - coxeter3
-                sage: w = W([1,2,3])                                          # optional - coxeter3
-                sage: v = W([3,1,2])                                          # optional - coxeter3
-                sage: v < w                                            # optional - coxeter3
+                sage: # optional - coxeter3
+                sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')
+                sage: w = W([1,2,3])
+                sage: v = W([3,1,2])
+                sage: v < w
                 False
-                sage: w < v                                            # optional - coxeter3
+                sage: w < v
                 True
 
             Some tests for equality::
@@ -534,11 +541,12 @@ class CoxeterGroup(UniqueRepresentation, Parent):
             """
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-                sage: w0 = W([1,2,1])                                         # optional - coxeter3
-                sage: w0[0]                                                   # optional - coxeter3
+                sage: # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: w0 = W([1,2,1])
+                sage: w0[0]
                 1
-                sage: w0[1]                                                   # optional - coxeter3
+                sage: w0[1]
                 2
 
             """
@@ -549,13 +557,14 @@ class CoxeterGroup(UniqueRepresentation, Parent):
             """
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-                sage: s = W.gens()                                            # optional - coxeter3
-                sage: s[1]._mul_(s[1])                                        # optional - coxeter3
+                sage: # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: s = W.gens()
+                sage: s[1]._mul_(s[1])
                 []
-                sage: s[1]*s[2]*s[1]                                          # optional - coxeter3
+                sage: s[1]*s[2]*s[1]
                 [1, 2, 1]
-                sage: s[2]*s[1]*s[2]                                          # optional - coxeter3
+                sage: s[2]*s[1]*s[2]
                 [1, 2, 1]
             """
             return self.__class__(self.parent(), self.value * y.value)
@@ -564,11 +573,12 @@ class CoxeterGroup(UniqueRepresentation, Parent):
             """
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')    # optional - coxeter3
-                sage: w = W([1,2,1])                                  # optional - coxeter3
-                sage: w.length()                                      # optional - coxeter3
+                sage: # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: w = W([1,2,1])
+                sage: w.length()
                 3
-                sage: len(w)                                          # optional - coxeter3
+                sage: len(w)
                 3
             """
             return len(self.value)
@@ -594,18 +604,18 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 2], implementation='coxeter3')      # optional - coxeter3
-                sage: W.long_element().poincare_polynomial()                     # optional - coxeter3
+                sage: # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 2], implementation='coxeter3')
+                sage: W.long_element().poincare_polynomial()
                 t^3 + 2*t^2 + 2*t + 1
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')      # optional - coxeter3
-                sage: W([2,1,3,2]).poincare_polynomial()                         # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: W([2,1,3,2]).poincare_polynomial()
                 t^4 + 4*t^3 + 5*t^2 + 3*t + 1
-                sage: W([1,2,3,2,1]).poincare_polynomial()                       # optional - coxeter3
+                sage: W([1,2,3,2,1]).poincare_polynomial()
                 t^5 + 4*t^4 + 6*t^3 + 5*t^2 + 3*t + 1
-
-                sage: rw = sage.combinat.permutation.from_reduced_word           # optional - coxeter3
-                sage: p = [w.poincare_polynomial() for w in W]                   # optional - coxeter3
-                sage: [rw(w.reduced_word()) for i,w in enumerate(W) if p[i] != p[i].reverse()] # optional - coxeter3
+                sage: rw = sage.combinat.permutation.from_reduced_word
+                sage: p = [w.poincare_polynomial() for w in W]
+                sage: [rw(w.reduced_word()) for i,w in enumerate(W) if p[i] != p[i].reverse()]
                 [[3, 4, 1, 2], [4, 2, 3, 1]]
             """
             return self.value.poincare_polynomial()
@@ -648,12 +658,13 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')   # optional - coxeter3
-                sage: R = W.root_system().root_space()                        # optional - coxeter3
-                sage: v = R.an_element(); v                                   # optional - coxeter3
+                sage: # optional - coxeter3
+                sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')
+                sage: R = W.root_system().root_space()
+                sage: v = R.an_element(); v
                 2*alpha[1] + 2*alpha[2] + 3*alpha[3]
-                sage: w = W([1,2,3])                                          # optional - coxeter3
-                sage: w.action(v)                                             # optional - coxeter3
+                sage: w = W([1,2,3])
+                sage: w.action(v)
                 -alpha[1] + alpha[2] + alpha[3]
             """
             #TODO: Find a better way to do this
@@ -675,14 +686,15 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-                sage: S = PolynomialRing(QQ, 'x,y,z').fraction_field()        # optional - coxeter3
-                sage: x,y,z = S.gens()                                        # optional - coxeter3
-                sage: W([1]).action_on_rational_function(x+y+z)               # optional - coxeter3
+                sage: # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: S = PolynomialRing(QQ, 'x,y,z').fraction_field()
+                sage: x,y,z = S.gens()
+                sage: W([1]).action_on_rational_function(x+y+z)
                 (x^2*y + x*z + 1)/x
-                sage: W([2]).action_on_rational_function(x+y+z)               # optional - coxeter3
+                sage: W([2]).action_on_rational_function(x+y+z)
                 (x*y^2 + y^2*z + 1)/y
-                sage: W([3]).action_on_rational_function(x+y+z)               # optional - coxeter3
+                sage: W([3]).action_on_rational_function(x+y+z)
                 (y*z^2 + x*z + 1)/z
             """
             Q = f.parent()

--- a/src/sage/libs/coxeter3/coxeter_group.py
+++ b/src/sage/libs/coxeter3/coxeter_group.py
@@ -1,4 +1,5 @@
 # sage_setup: distribution = sagemath-coxeter3
+# sage.doctest: optional - coxeter3
 
 """
 Coxeter Groups implemented with Coxeter3
@@ -31,10 +32,10 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         """
         TESTS::
 
-            sage: from sage.libs.coxeter3.coxeter_group import CoxeterGroup       # optional - coxeter3
-            sage: CoxeterGroup(['B',2])                                           # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter_group import CoxeterGroup
+            sage: CoxeterGroup(['B',2])
             Coxeter group of type ['B', 2] implemented by Coxeter3
-            sage: CoxeterGroup(CartanType(['B', 3]).relabel({1: 3, 2: 2, 3: 1}))  # optional - coxeter3
+            sage: CoxeterGroup(CartanType(['B', 3]).relabel({1: 3, 2: 2, 3: 1}))
             Coxeter group of type ['B', 3] relabelled by {1: 3, 2: 2, 3: 1} implemented by Coxeter3
 
         """
@@ -46,15 +47,15 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         """
         TESTS::
 
-            sage: from sage.libs.coxeter3.coxeter_group import CoxeterGroup       # optional - coxeter3
-            sage: CoxeterGroup(['A',2])                                           # optional - coxeter3
+            sage: from sage.libs.coxeter3.coxeter_group import CoxeterGroup
+            sage: CoxeterGroup(['A',2])
             Coxeter group of type ['A', 2] implemented by Coxeter3
 
         As degrees and codegrees are not implemented, they are skipped in the
         testsuite::
 
             sage: to_skip = ['_test_degrees', '_test_codegrees']
-            sage: TestSuite(CoxeterGroup(['A',2])).run(skip=to_skip)              # optional - coxeter3
+            sage: TestSuite(CoxeterGroup(['A',2])).run(skip=to_skip)
         """
         category = CoxeterGroups()
         if cartan_type.is_finite():
@@ -67,9 +68,9 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         """
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3'); W      # optional - coxeter3 # indirect doctest
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3'); W      # indirect doctest
             Coxeter group of type ['A', 3] implemented by Coxeter3
-            sage: W = CoxeterGroup(['A', 3, 1], implementation='coxeter3'); W   # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3, 1], implementation='coxeter3'); W
             Coxeter group of type ['A', 3, 1] implemented by Coxeter3
         """
         return "Coxeter group of type %s implemented by Coxeter3" % (self.cartan_type())
@@ -78,8 +79,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         """
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 2], implementation='coxeter3')    # optional - coxeter3
-            sage: list(W)                                                  # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 2], implementation='coxeter3')
+            sage: list(W)
             [[], [1], [2], [1, 2], [2, 1], [1, 2, 1]]
         """
         for x in self._coxgroup:
@@ -91,8 +92,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: W.cartan_type()                                         # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.cartan_type()
             ['A', 3]
         """
         return self._cartan_type
@@ -103,7 +104,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
             sage: W.index_set()
             (1, 2, 3)
@@ -119,8 +119,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')    # optional - coxeter3
-            sage: W.bruhat_interval([1],[3,1,2,3])                         # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.bruhat_interval([1],[3,1,2,3])
             [[1], [1, 2], [1, 3], [1, 2, 3], [1, 3, 2], [1, 2, 3, 2]]
         """
         u, v = self(u), self(v)
@@ -132,8 +132,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')    # optional - coxeter3
-            sage: W.cardinality()                                          # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.cardinality()
             24
         """
         return self._coxgroup.order()
@@ -144,8 +144,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: W.one()                                                 # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.one()
             []
 
         """
@@ -157,9 +157,9 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: s = W.simple_reflections()                              # optional - coxeter3
-            sage: s[2]*s[1]*s[2]                                          # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: s = W.simple_reflections()
+            sage: s[2]*s[1]*s[2]
             [1, 2, 1]
         """
         from sage.sets.family import Family
@@ -173,10 +173,10 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')  # optional - coxeter3
-            sage: W.from_reduced_word([1, 3])                            # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.from_reduced_word([1, 3])
             [1, 3]
-            sage: W.from_reduced_word([3, 1])                            # optional - coxeter3
+            sage: W.from_reduced_word([3, 1])
             [1, 3]
         """
         return self.element_class(self, w)
@@ -187,8 +187,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: W.rank()                                                # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.rank()
             3
         """
         return self._coxgroup.rank()
@@ -199,8 +199,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: W.is_finite()                                           # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.is_finite()
             True
         """
         return self._coxgroup.is_finite()
@@ -212,10 +212,10 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: W.length(W([1,2]))                                      # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.length(W([1,2]))
             2
-            sage: W.length(W([1,1]))                                      # optional - coxeter3
+            sage: W.length(W([1,1]))
             0
 
         """
@@ -231,12 +231,12 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')    # optional - coxeter3
-            sage: m = W.coxeter_matrix(); m                                # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: m = W.coxeter_matrix(); m
             [1 3 2]
             [3 1 3]
             [2 3 1]
-            sage: m.index_set() == W.index_set()                           # optional - coxeter3
+            sage: m.index_set() == W.index_set()
             True
 
         """
@@ -248,7 +248,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
             sage: R = W.root_system(); R
             Root system of type ['A', 3]
@@ -264,8 +263,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-            sage: W._an_element_()                                        # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W._an_element_()
             []
 
         """
@@ -277,8 +276,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         TESTS::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')  # optional - coxeter3
-            sage: W.m(1, 1)                                              # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.m(1, 1)
             doctest:warning...:
             DeprecationWarning: the .m(i, j) method has been deprecated; use .coxeter_matrix()[i,j] instead.
             See https://github.com/sagemath/sage/issues/30237 for details.
@@ -305,7 +304,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
             sage: W.kazhdan_lusztig_polynomial([], [1,2, 1])
             1
@@ -328,7 +326,7 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             In particular, `P_{u,u}=1`::
 
-                sage: all(W.kazhdan_lusztig_polynomial(u,u) == 1 for u in W) # optional - coxeter3
+                sage: all(W.kazhdan_lusztig_polynomial(u,u) == 1 for u in W)
                 True
 
             This convention differs from Theorem 2.7 in [LT1998]_ by:
@@ -339,20 +337,20 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             To access the Leclerc-Thibon convention use::
 
-                sage: W = CoxeterGroup(['A',3],implementation='coxeter3')                         # optional - coxeter3
-                sage: W.kazhdan_lusztig_polynomial([2],[2,1,3,2],constant_term_one=False)         # optional - coxeter3
+                sage: W = CoxeterGroup(['A',3],implementation='coxeter3')
+                sage: W.kazhdan_lusztig_polynomial([2],[2,1,3,2],constant_term_one=False)
                 q^3 + q
 
         TESTS:
 
         We check that Coxeter3 and Sage's implementation give the same results::
 
-            sage: C = CoxeterGroup(['B', 3], implementation='coxeter3')                           # optional - coxeter3
+            sage: C = CoxeterGroup(['B', 3], implementation='coxeter3')
             sage: W = WeylGroup("B3",prefix="s")
             sage: [s1,s2,s3] = W.simple_reflections()
             sage: R.<q> = LaurentPolynomialRing(QQ)
             sage: KL = KazhdanLusztigPolynomial(W,q)
-            sage: all(KL.P(1,w) == C.kazhdan_lusztig_polynomial([],w.reduced_word()) for w in W)  # optional - coxeter3  # long (15s)
+            sage: all(KL.P(1,w) == C.kazhdan_lusztig_polynomial([],w.reduced_word()) for w in W)  # long (15s)
             True
         """
         u, v = self(u), self(v)
@@ -387,14 +385,12 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         EXAMPLES::
 
-            sage: # optional - coxeter3
             sage: W = CoxeterGroup(['A',3], implementation='coxeter3')
             sage: W.parabolic_kazhdan_lusztig_polynomial([],[3,2],[1,3])
             0
             sage: W.parabolic_kazhdan_lusztig_polynomial([2],[2,1,3,2],[1,3])
             q
 
-            sage: # optional - coxeter3
             sage: C = CoxeterGroup(['A',3,1], implementation='coxeter3')
             sage: C.parabolic_kazhdan_lusztig_polynomial([],[1],[0])
             1
@@ -411,8 +407,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
         TESTS::
 
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')                     # optional - coxeter3
-            sage: type(W.parabolic_kazhdan_lusztig_polynomial([2],[],[1]))                  # optional - coxeter3
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: type(W.parabolic_kazhdan_lusztig_polynomial([2],[],[1]))
             <class 'sage.rings.polynomial.polynomial_integer_dense_flint.Polynomial_integer_dense_flint'>
         """
         u = self(u)
@@ -436,13 +432,12 @@ class CoxeterGroup(UniqueRepresentation, Parent):
             """
             TESTS::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')    # optional - coxeter3
-                sage: W([2,1,2])                                               # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: W([2,1,2])
                 [1, 2, 1]
 
             Check that :trac:`32266` is fixed::
 
-                sage: # optional - coxeter3
                 sage: A3 = CoxeterGroup('A3', implementation='coxeter3')
                 sage: s1,s2,s3 = A3.simple_reflections()
                 sage: s1*s3
@@ -463,9 +458,9 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-                sage: w = W([1,2,1])                                          # optional - coxeter3
-                sage: list(iter(w))                                           # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: w = W([1,2,1])
+                sage: list(iter(w))
                 [1, 2, 1]
             """
             return iter(self.value)
@@ -476,9 +471,9 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')  # optional - coxeter3
-                sage: w = W([1,2,3])                                         # optional - coxeter3
-                sage: w.coatoms()                                            # optional - coxeter3
+                sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')
+                sage: w = W([1,2,3])
+                sage: w.coatoms()
                 [[2, 3], [3, 1], [1, 2]]
             """
             W = self.parent()
@@ -490,7 +485,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: # optional - coxeter3
                 sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')
                 sage: w = W([1,2,3])
                 sage: v = W([3,1,2])
@@ -501,10 +495,10 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             Some tests for equality::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')    # optional - coxeter3
-                sage: W([1,2,1]) == W([2,1,2])                                 # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: W([1,2,1]) == W([2,1,2])
                 True
-                sage: W([1,2,1]) == W([2,1])                                   # optional - coxeter3
+                sage: W([1,2,1]) == W([2,1])
                 False
             """
             return richcmp(list(self), list(other), op)
@@ -515,9 +509,9 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')  # optional - coxeter3
-                sage: w = W([1,2,3])                                         # optional - coxeter3
-                sage: w.reduced_word()                                       # optional - coxeter3
+                sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')
+                sage: w = W([1,2,3])
+                sage: w.reduced_word()
                 [1, 2, 3]
             """
             return list(self)
@@ -528,9 +522,9 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-                sage: w = W([1,2,3])                                          # optional - coxeter3
-                sage: ~w                                                      # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: w = W([1,2,3])
+                sage: ~w
                 [3, 2, 1]
             """
             return self.__class__(self.parent(), ~self.value)
@@ -541,7 +535,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
             """
             EXAMPLES::
 
-                sage: # optional - coxeter3
                 sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
                 sage: w0 = W([1,2,1])
                 sage: w0[0]
@@ -557,7 +550,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
             """
             EXAMPLES::
 
-                sage: # optional - coxeter3
                 sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
                 sage: s = W.gens()
                 sage: s[1]._mul_(s[1])
@@ -573,7 +565,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
             """
             EXAMPLES::
 
-                sage: # optional - coxeter3
                 sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
                 sage: w = W([1,2,1])
                 sage: w.length()
@@ -591,8 +582,8 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')   # optional - coxeter3
-                sage: W([]).bruhat_le([1,2,1])                                # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: W([]).bruhat_le([1,2,1])
                 True
             """
             v = self.parent()(v)
@@ -604,7 +595,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: # optional - coxeter3
                 sage: W = CoxeterGroup(['A', 2], implementation='coxeter3')
                 sage: W.long_element().poincare_polynomial()
                 t^3 + 2*t^2 + 2*t + 1
@@ -626,10 +616,10 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 4], implementation='coxeter3')   # optional - coxeter3
-                sage: W([1,2]).has_right_descent(1)                           # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 4], implementation='coxeter3')
+                sage: W([1,2]).has_right_descent(1)
                 False
-                sage: W([1,2]).has_right_descent(2)                           # optional - coxeter3
+                sage: W([1,2]).has_right_descent(2)
                 True
             """
             return i in self.value.right_descents()
@@ -640,10 +630,10 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: W = CoxeterGroup(['A', 4], implementation='coxeter3')   # optional - coxeter3
-                sage: W([1,2]).has_left_descent(1)                            # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 4], implementation='coxeter3')
+                sage: W([1,2]).has_left_descent(1)
                 True
-                sage: W([1,2]).has_left_descent(2)                            # optional - coxeter3
+                sage: W([1,2]).has_left_descent(2)
                 False
             """
             return i in self.value.left_descents()
@@ -658,7 +648,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: # optional - coxeter3
                 sage: W = CoxeterGroup(['B', 3], implementation='coxeter3')
                 sage: R = W.root_system().root_space()
                 sage: v = R.an_element(); v
@@ -686,7 +675,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
             EXAMPLES::
 
-                sage: # optional - coxeter3
                 sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
                 sage: S = PolynomialRing(QQ, 'x,y,z').fraction_field()
                 sage: x,y,z = S.gens()


### PR DESCRIPTION
Use more block-scope tags to avoid doctest warnings like
```
File "src/sage/libs/coxeter3/coxeter.pyx", line 1198, in sage.libs.coxeter3.coxeter.CoxGroupIterator.__next__
Warning: Consider using a block-scoped tag by inserting the line 'sage: # optional - coxeter3' just before this line to avoid repeating the tag 4 times
    from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup, CoxGroupIterator # optional - coxeter3
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
