### PR TITLE
ruff UP details and links to errors in doc in geometry folder

### DIFF
--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Convex rational polyhedral cones
 
@@ -554,7 +553,7 @@ def _ambient_space_point(body, data):
 
     An integral, rational, real algebraic, or numeric point of the
     ambient space of ``body`` is returned if ``data`` were
-    successfully interpreted in such a way. A ``TypeError`` is raised
+    successfully interpreted in such a way. A :class:`TypeError` is raised
     otherwise.
 
     TESTS::
@@ -1664,7 +1663,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         otherwise, in particular when ``point`` is incompatible with
         the ambient space.
 
-        A ``ValueError`` is raised if ``region`` is not one of the
+        A :class:`ValueError` is raised if ``region`` is not one of the
         three allowed values.
 
         TESTS::
@@ -2340,8 +2339,8 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         or
         :meth:`~sage.geometry.cone.ConvexRationalPolyhedralCone.facet_of`. The
         cone returned by this method will have ``self`` as ambient. If ``cone``
-        does not represent a valid cone of ``self``, ``ValueError`` exception
-        is raised.
+        does not represent a valid cone of ``self``, :class:`ValueError`
+        exception is raised.
 
         .. NOTE::
 
@@ -3017,8 +3016,8 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         - :class:`cone <ConvexRationalPolyhedralCone>`.
 
-        Raises ``ValueError`` if the ambient space dimensions are not
-        compatible.
+        This raises :class:`ValueError` if the ambient space dimensions
+        are not compatible.
 
         EXAMPLES::
 
@@ -5349,7 +5348,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         Either a lattice element or vector contained in both this cone
         and its ambient vector space. If ``ring`` is ``ZZ``, a lattice
         element is returned; otherwise a vector is returned. If ``ring``
-        is neither ``ZZ`` nor ``QQ``, then a ``NotImplementedError`` is
+        is neither ``ZZ`` nor ``QQ``, then a :class:`NotImplementedError` is
         raised.
 
         EXAMPLES:
@@ -6267,7 +6266,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
 
     A new, randomly generated cone.
 
-    A ``ValueError`` will be thrown under the following conditions:
+    A :class:`ValueError` will be thrown under the following conditions:
 
     * Any of ``min_ambient_dim``, ``max_ambient_dim``, ``min_rays``, or
       ``max_rays`` are negative.
@@ -6425,7 +6424,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
         provided.
 
     If the user requests too many rays in zero, one, or two dimensions,
-    a ``ValueError`` is thrown::
+    a :class:`ValueError` is thrown::
 
         sage: random_cone(max_ambient_dim=0, min_rays=1)
         Traceback (most recent call last):
@@ -6513,7 +6512,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
         sage: random_cone(lattice=L, strictly_convex=True)
         0-d cone in 0-d lattice L
 
-    A ``ValueError`` is thrown if a non-solid cone is requested in a
+    A :class:`ValueError` is thrown if a non-solid cone is requested in a
     zero-dimensional lattice::
 
         sage: L = ToricLattice(0)
@@ -6527,7 +6526,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
         ...
         ValueError: all cones are solid when max_ambient_dim is zero.
 
-    A ``ValueError`` is thrown if a solid cone is requested but the
+    A :class:`ValueError` is thrown if a solid cone is requested but the
     maximum number of rays is too few::
 
         sage: random_cone(min_ambient_dim=4, max_rays=3, solid=True)
@@ -6542,7 +6541,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
         ValueError: max_rays must be at least 5 for a solid cone in this
         lattice.
 
-    A ``ValueError`` is thrown if a non-solid cone is requested but
+    A :class:`ValueError` is thrown if a non-solid cone is requested but
     ``min_rays`` guarantees a solid cone::
 
         sage: random_cone(max_ambient_dim=4, min_rays=10, solid=False)

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -1956,7 +1956,7 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
 
             We think of the origin as of the smallest cone containing no rays
             at all. If there is no ray in ``self`` that contains all ``rays``,
-            a ``ValueError`` exception will be raised.
+            a :class:`ValueError` exception will be raised.
 
         EXAMPLES::
 
@@ -2352,8 +2352,8 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         or
         :meth:`~sage.geometry.cone.ConvexRationalPolyhedralCone.facet_of`. The
         cone returned by this method will have ``self`` as ambient. If ``cone``
-        does not represent a valid cone of ``self``, ``ValueError`` exception
-        is raised.
+        does not represent a valid cone of ``self``, :class:`ValueError`
+        exception is raised.
 
         .. NOTE::
 
@@ -3504,8 +3504,8 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         OUTPUT:
 
         The complex associated to the fan as a :class:`ChainComplex
-        <sage.homology.chain_complex.ChainComplex>`. Raises a
-        ``ValueError`` if the extended complex is requested for a
+        <sage.homology.chain_complex.ChainComplex>`. This raises a
+        :class:`ValueError` if the extended complex is requested for a
         non-complete fan.
 
         EXAMPLES::

--- a/src/sage/geometry/fan_morphism.py
+++ b/src/sage/geometry/fan_morphism.py
@@ -520,8 +520,8 @@ class FanMorphism(FreeModuleMorphism):
           domain fan is mapped to the origin. If it is `j`, then the `i`-th ray
           of the domain fan is mapped onto the `j`-th ray of the codomain fan.
           If there is a ray in the domain fan which is mapped into the relative
-          interior of a higher dimensional cone, a ``ValueError`` exception is
-          raised.
+          interior of a higher dimensional cone, a :class:`ValueError`
+          exception is raised.
 
         .. NOTE::
 
@@ -601,8 +601,8 @@ class FanMorphism(FreeModuleMorphism):
         OUTPUT:
 
         - none, but the domain fan of self is replaced with its minimal
-          refinement, if possible. Otherwise a ``ValueError`` exception is
-          raised.
+          refinement, if possible. Otherwise a :class:`ValueError`
+          exception is raised.
 
         TESTS::
 
@@ -763,11 +763,11 @@ class FanMorphism(FreeModuleMorphism):
 
     def _support_error(self):
         r"""
-        Raise a ``ValueError`` exception due to support incompatibility.
+        Raise a :class:`ValueError` exception due to support incompatibility.
 
         OUTPUT:
 
-        - none, a ``ValueError`` exception is raised.
+        - none, a :class:`ValueError` exception is raised.
 
         TESTS:
 
@@ -806,10 +806,10 @@ class FanMorphism(FreeModuleMorphism):
 
         OUTPUT:
 
-        - none, but a ``ValueError`` exception is raised if there is a cone of
-          the domain fan of ``self`` which is not completely contained in a
-          single cone of the codomain fan of ``self``, or if one of these fans
-          does not sit in the appropriate lattice.
+        - none, but a :class:`ValueError` exception is raised if there is
+          a cone of the domain fan of ``self`` which is not completely
+          contained in a single cone of the codomain fan of ``self``,
+          or if one of these fans does not sit in the appropriate lattice.
 
         EXAMPLES::
 

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_coercion.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_coercion.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Coercion Maps Between Hyperbolic Plane Models
 
@@ -82,7 +81,7 @@ class HyperbolicModelCoercion(Morphism):
         """
         C = self.codomain()
         if not C.is_bounded() and self.domain().is_bounded() and x.is_boundary():
-            msg = u"boundary points are not implemented for the {}"
+            msg = "boundary points are not implemented for the {}"
             raise NotImplementedError(msg.format(C.name()))
 
         y = self.image_coordinates(x.coordinates())

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_geodesic.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_geodesic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Hyperbolic Geodesics
 
@@ -622,7 +621,7 @@ class HyperbolicGeodesic(SageObject):
     def ideal_endpoints(self):
         r"""
         Return the ideal endpoints in bounded models.  Raise a
-        ``NotImplementedError`` in models that are not bounded.
+        :class:`NotImplementedError` in models that are not bounded.
 
         EXAMPLES::
 
@@ -660,7 +659,7 @@ class HyperbolicGeodesic(SageObject):
     def complete(self):
         r"""
         Return the geodesic with ideal endpoints in bounded models.  Raise a
-        ``NotImplementedError`` in models that are not bounded.
+        :class:`NotImplementedError` in models that are not bounded.
         In the following examples we represent complete geodesics by a dashed
         line.
 
@@ -817,7 +816,7 @@ class HyperbolicGeodesic(SageObject):
         r"""
         Return the unique hyperbolic geodesic perpendicular to two given
         geodesics, if such a geodesic exists.  If none exists, raise a
-        ``ValueError``.
+        :class:`ValueError`.
 
         INPUT:
 
@@ -1278,7 +1277,7 @@ class HyperbolicGeodesicUHP(HyperbolicGeodesic):
         r"""
         Return the unique hyperbolic geodesic perpendicular to ``self``
         and ``other``, if such a geodesic exists; otherwise raise a
-        ``ValueError``.
+        :class:`ValueError`.
 
         INPUT:
 

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_interface.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_interface.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Interface to Hyperbolic Models
 

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_isometry.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_isometry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Hyperbolic Isometries
 
@@ -489,7 +488,7 @@ class HyperbolicIsometry(Morphism):
     def translation_length(self):
         r"""
         For hyperbolic elements, return the translation length;
-        otherwise, raise a ``ValueError``.
+        otherwise, raise a :class:`ValueError`.
 
         EXAMPLES::
 
@@ -512,7 +511,7 @@ class HyperbolicIsometry(Morphism):
     def axis(self):
         r"""
         For a hyperbolic isometry, return the axis of the
-        transformation; otherwise raise a ``ValueError``.
+        transformation; otherwise raise a :class:`ValueError`.
 
         EXAMPLES::
 
@@ -593,7 +592,7 @@ class HyperbolicIsometry(Morphism):
     def repelling_fixed_point(self):
         r"""
         For a hyperbolic isometry, return the attracting fixed point;
-        otherwise raise a ``ValueError``.
+        otherwise raise a :class:`ValueError`.
 
         OUTPUT:
 
@@ -612,7 +611,7 @@ class HyperbolicIsometry(Morphism):
     def attracting_fixed_point(self):
         r"""
         For a hyperbolic isometry, return the attracting fixed point;
-        otherwise raise a `ValueError``.
+        otherwise raise a :class:`ValueError`.
 
         OUTPUT:
 
@@ -735,7 +734,7 @@ class HyperbolicIsometryUHP(HyperbolicIsometry):
     def translation_length(self): #UHP
         r"""
         For hyperbolic elements, return the translation length;
-        otherwise, raise a ``ValueError``.
+        otherwise, raise a :class:`ValueError`.
 
         EXAMPLES::
 
@@ -843,9 +842,11 @@ class HyperbolicIsometryUHP(HyperbolicIsometry):
             return self.domain().get_geodesic(*pts)
         return pts
 
-    def repelling_fixed_point(self): #UHP
+    def repelling_fixed_point(self):  # UHP
         r"""
-        Return the repelling fixed point; otherwise raise a ``ValueError``.
+        Return the repelling fixed point.
+
+        Otherwise, this raises a :class:`ValueError`.
 
         OUTPUT:
 
@@ -867,9 +868,11 @@ class HyperbolicIsometryUHP(HyperbolicIsometry):
             return self.domain().get_point(infinity)
         return self.domain().get_point(v[0] / v[1])
 
-    def attracting_fixed_point(self): #UHP
+    def attracting_fixed_point(self):  # UHP
         r"""
-        Return the attracting fixed point; otherwise raise a ``ValueError``.
+        Return the attracting fixed point.
+
+        Otherwise, this raises a :class:`ValueError`.
 
         OUTPUT:
 

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_model.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Hyperbolic Models
 
@@ -156,7 +155,7 @@ class HyperbolicModel(Parent, UniqueRepresentation, BindableClass):
             sage: HyperbolicPlane().UHP()
             Hyperbolic plane in the Upper Half Plane Model
         """
-        return u'Hyperbolic plane in the {}'.format(self._name)
+        return 'Hyperbolic plane in the {}'.format(self._name)
 
     def _element_constructor_(self, x, is_boundary=None, **graphics_options):  # Abstract
         """
@@ -260,7 +259,7 @@ class HyperbolicModel(Parent, UniqueRepresentation, BindableClass):
     def point_test(self, p):  # Abstract
         r"""
         Test whether a point is in the model.  If the point is in the
-        model, do nothing.  Otherwise, raise a ``ValueError``.
+        model, do nothing.  Otherwise, raise a :class:`ValueError`.
 
         EXAMPLES::
 
@@ -298,7 +297,7 @@ class HyperbolicModel(Parent, UniqueRepresentation, BindableClass):
     def bdry_point_test(self, p):  # Abstract
         r"""
         Test whether a point is in the model.  If the point is in the
-        model, do nothing; otherwise raise a ``ValueError``.
+        model, do nothing; otherwise raise a :class:`ValueError`.
 
         EXAMPLES::
 
@@ -340,7 +339,7 @@ class HyperbolicModel(Parent, UniqueRepresentation, BindableClass):
         Test whether an isometry ``A`` is in the model.
 
         If the isometry is in the model, do nothing. Otherwise, raise
-        a ``ValueError``.
+        a :class:`ValueError`.
 
         EXAMPLES::
 
@@ -1173,7 +1172,7 @@ class HyperbolicModelPD(HyperbolicModel):
         # name should really be 'Poincaré Disk Model', but utf8 is not
         # accepted by repr
         HyperbolicModel.__init__(self, space,
-                                 name=u'Poincare Disk Model', short_name="PD",
+                                 name='Poincare Disk Model', short_name="PD",
                                  bounded=True, conformal=True, dimension=2,
                                  isometry_group="PU(1, 1)",
                                  isometry_group_is_projective=True)

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_point.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_point.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Hyperbolic Points
 

--- a/src/sage/geometry/hyperplane_arrangement/arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/arrangement.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Hyperplane Arrangements
 
@@ -2723,7 +2722,7 @@ class HyperplaneArrangementElement(Element):
 
         OUTPUT:
 
-        A polyhedron. A ``ValueError`` is raised if the point is not
+        A polyhedron. A :class:`ValueError` is raised if the point is not
         interior to a region, that is, sits on a hyperplane.
 
         EXAMPLES::

--- a/src/sage/geometry/hyperplane_arrangement/hyperplane.py
+++ b/src/sage/geometry/hyperplane_arrangement/hyperplane.py
@@ -484,7 +484,7 @@ class Hyperplane(LinearExpression):
         A vector in the ambient vector space that lies on the
         hyperplane.
 
-        In finite characteristic, a ``ValueError`` is raised if the
+        In finite characteristic, a :class:`ValueError` is raised if the
         the norm of the hyperplane normal is zero.
 
         EXAMPLES::

--- a/src/sage/geometry/hyperplane_arrangement/library.py
+++ b/src/sage/geometry/hyperplane_arrangement/library.py
@@ -65,7 +65,7 @@ def make_parent(base_ring, dimension, names=None):
     return HyperplaneArrangements(base_ring, names=names)
 
 
-class HyperplaneArrangementLibrary():
+class HyperplaneArrangementLibrary:
     """
     The library of hyperplane arrangements.
     """

--- a/src/sage/geometry/integral_points.pxi
+++ b/src/sage/geometry/integral_points.pxi
@@ -119,7 +119,7 @@ cpdef tuple parallelotope_points(spanning_points, lattice) noexcept:
         sage: parallelotope_points(c.rays(), c.lattice())
         (N(0, 0), N(1, 1))
 
-    A ``ValueError`` is raised if the ``spanning_points`` are not
+    A :class:`ValueError` is raised if the ``spanning_points`` are not
     linearly independent::
 
         sage: rays = list(map(ToricLattice(2), [(1,1)]*2))
@@ -853,9 +853,9 @@ cdef class Inequality_int:
 
     OUTPUT:
 
-    Inequality `A x + b \geq 0`. A ``OverflowError`` is raised if a
+    Inequality `A x + b \geq 0`. A :class:`OverflowError` is raised if a
     machine integer is not long enough to hold the results. A
-    ``ValueError`` is raised if some of the input is not integral.
+    :class:`ValueError` is raised if some of the input is not integral.
 
     EXAMPLES::
 

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Lattice and reflexive polytopes
 
@@ -5017,8 +5016,8 @@ class NefPartition(SageObject, Hashable):
             Since a nef-partition induces a partition on the set of boundary
             lattice points of `\Delta^\circ`, the value of `j` is well-defined
             for all `i` but the one that corresponds to the origin, in which
-            case this method will raise a ``ValueError`` exception. (The origin
-            always belongs to all `\nabla_j`.)
+            case this method will raise a :class:`ValueError` exception.
+            (The origin always belongs to all `\nabla_j`.)
 
         See :class:`nef-partition <NefPartition>` class documentation for
         definitions and notation.

--- a/src/sage/geometry/point_collection.pyx
+++ b/src/sage/geometry/point_collection.pyx
@@ -756,7 +756,7 @@ cdef class PointCollection(SageObject):
         OUTPUT:
 
         - an integer if ``point`` is in ``self[start:stop]``, otherwise a
-          ``ValueError`` exception is raised.
+          :class:`ValueError` exception is raised.
 
         EXAMPLES::
 

--- a/src/sage/geometry/polyhedral_complex.py
+++ b/src/sage/geometry/polyhedral_complex.py
@@ -163,7 +163,7 @@ class PolyhedralComplex(GenericCellComplex):
 
     - ``face_to_face_check`` -- boolean (default: ``False``);
       if ``True``, then the constructor checks whether the cells
-      are face-to-face, and it raises a ``ValueError`` if they are not
+      are face-to-face, and it raises a :class:`ValueError` if they are not
 
     - ``is_mutable`` and ``is_immutable`` -- boolean (default: ``True`` and
       ``False`` respectively); set ``is_mutable=False`` or ``is_immutable=True``
@@ -967,7 +967,7 @@ class PolyhedralComplex(GenericCellComplex):
     def __call__(self, x):
         """
         If ``x`` is a polyhedron in this complex, return it.
-        Otherwise, raise a ``ValueError``.
+        Otherwise, raise a :class:`ValueError`.
 
         EXAMPLES::
 
@@ -1072,10 +1072,10 @@ class PolyhedralComplex(GenericCellComplex):
 
     def graph(self):
         """
-        The 1-skeleton of this polyhedral complex, as a graph.
+        Return the 1-skeleton of this polyhedral complex, as a graph.
 
-        The vertices of the graph are of type ``vector``. Raises
-        a ``NotImplementedError`` if the polyhedral complex is unbounded.
+        The vertices of the graph are of type ``vector``. This raises
+        a :class:`NotImplementedError` if the polyhedral complex is unbounded.
 
         .. WARNING::
 

--- a/src/sage/geometry/polyhedron/backend_cdd.py
+++ b/src/sage/geometry/polyhedron/backend_cdd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 The cdd backend for polyhedral computations
 """

--- a/src/sage/geometry/polyhedron/backend_polymake.py
+++ b/src/sage/geometry/polyhedron/backend_polymake.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 The polymake backend for polyhedral computations
 

--- a/src/sage/geometry/polyhedron/base7.py
+++ b/src/sage/geometry/polyhedron/base7.py
@@ -133,7 +133,7 @@ class Polyhedron_base7(Polyhedron_base6):
         else:
             from sage.geometry.triangulation.point_configuration import PointConfiguration
             A, b = self.affine_hull_projection(as_affine_map=True, orthogonal=True, orthonormal=True, extend=True)
-            pc = PointConfiguration((A(v.vector()) for v in self.Vrep_generator()))
+            pc = PointConfiguration(A(v.vector()) for v in self.Vrep_generator())
 
         barycenters = [sum(self.Vrepresentation(i).vector() for i in simplex)/(self.dim() + 1) for simplex in triangulation]
         volumes = [pc.volume(simplex) for simplex in triangulation]

--- a/src/sage/geometry/polyhedron/library.py
+++ b/src/sage/geometry/polyhedron/library.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Library of commonly used, famous, or interesting polytopes
 
@@ -489,7 +488,7 @@ def gale_transform_to_primal(vectors, base_ring=None, backend=None):
     return m.right_kernel_matrix(basis='computed').columns()
 
 
-class Polytopes():
+class Polytopes:
     """
     A class of constructors for commonly used, famous, or interesting
     polytopes.
@@ -1003,7 +1002,7 @@ class Polytopes():
             sage: TestSuite(rd_norm).run()                                      # optional - pynormaliz
         """
         v = [[2,0,0],[-2,0,0],[0,2,0],[0,-2,0],[0,0,2],[0,0,-2]]
-        v.extend((itertools.product([1, -1], repeat=3)))
+        v.extend(itertools.product([1, -1], repeat=3))
         return Polyhedron(vertices=v, base_ring=ZZ, backend=backend)
 
     def cuboctahedron(self, backend=None):

--- a/src/sage/geometry/polyhedron/plot.py
+++ b/src/sage/geometry/polyhedron/plot.py
@@ -144,7 +144,7 @@ def projection_func_identity(x):
     return list(x)
 
 
-class ProjectionFuncStereographic():
+class ProjectionFuncStereographic:
     """
     The stereographic (or perspective) projection onto a codimension-1 linear
     subspace with respect to a sphere centered at the origin.
@@ -238,7 +238,7 @@ class ProjectionFuncStereographic():
         return vector(RDF, [img[i] / denom for i in range(self.dim - 1)])
 
 
-class ProjectionFuncSchlegel():
+class ProjectionFuncSchlegel:
     """
     The Schlegel projection from the given input point.
 

--- a/src/sage/geometry/riemannian_manifolds/surface3d_generators.py
+++ b/src/sage/geometry/riemannian_manifolds/surface3d_generators.py
@@ -23,7 +23,7 @@ from sage.geometry.riemannian_manifolds.parametrized_surface3d import \
     ParametrizedSurface3D
 
 
-class SurfaceGenerators():
+class SurfaceGenerators:
     """
     A class consisting of generators for several common parametrized surfaces
     in 3D.

--- a/src/sage/geometry/toric_lattice.py
+++ b/src/sage/geometry/toric_lattice.py
@@ -677,7 +677,7 @@ class ToricLattice_generic(FreeModule_generic_pid):
             by Sublattice <N(1, 8, 0), N(0, 12, 0)>
 
         Attempting to quotient one lattice by a sublattice of another
-        will result in a ``ValueError``::
+        will result in a :class:`ValueError`::
 
             sage: N = ToricLattice(3)
             sage: M = ToricLattice(3, name='M')
@@ -1467,7 +1467,7 @@ class ToricLattice_quotient(FGP_Module_class):
             sage: ToricLattice_quotient(N, N.span([N(1,2,3)]))
             2-d lattice, quotient of 3-d lattice N by Sublattice <N(1, 2, 3)>
 
-        An ``ArithmeticError`` will be raised if ``W`` is not a
+        An :class:`ArithmeticError` will be raised if ``W`` is not a
         sublattice of ``V``::
 
             sage: N = ToricLattice(3)

--- a/src/sage/geometry/toric_lattice_element.pyx
+++ b/src/sage/geometry/toric_lattice_element.pyx
@@ -300,7 +300,7 @@ cdef class ToricLatticeElement(Vector_integer_dense):
     # is wrong from our point of view.
     cpdef _dot_product_(self, Vector right) noexcept:
         """
-        Raise a ``TypeError`` exception.
+        Raise a :class:`TypeError` exception.
 
         Dot product is not defined on toric lattices (there are actions of
         dual lattices on each other instead).
@@ -311,7 +311,7 @@ cdef class ToricLatticeElement(Vector_integer_dense):
 
         OUTPUT:
 
-        - ``TypeError`` exception is raised.
+        - :class:`TypeError` exception is raised.
 
         TESTS::
 

--- a/src/sage/geometry/toric_plotter.py
+++ b/src/sage/geometry/toric_plotter.py
@@ -746,7 +746,7 @@ def _unrecognized_option(option):
 
     OUTPUT:
 
-    - none, a ``KeyError`` exception is raised.
+    - none, a :class:`KeyError` exception is raised.
 
     TESTS::
 

--- a/src/sage/geometry/triangulation/base.pyx
+++ b/src/sage/geometry/triangulation/base.pyx
@@ -588,7 +588,7 @@ cdef class PointConfiguration_base(Parent):
 
     def _assert_is_affine(self):
         """
-        Raise a ``ValueError`` if the point configuration is not
+        Raise a :class:`ValueError` if the point configuration is not
         defined by affine points.
 
         EXAMPLES::

--- a/src/sage/geometry/triangulation/point_configuration.py
+++ b/src/sage/geometry/triangulation/point_configuration.py
@@ -733,7 +733,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         OUTPUT:
 
         A :class:`~sage.geometry.triangulation.element.Triangulation`
-        satisfying all restrictions imposed. Raises a ``ValueError``
+        satisfying all restrictions imposed. This raises a :class:`ValueError`
         if no such triangulation exists.
 
         EXAMPLES::
@@ -1037,7 +1037,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         OUTPUT:
 
         A :class:`~sage.geometry.triangulation.element.Triangulation`
-        satisfying all restrictions imposed. Raises a ``ValueError``
+        satisfying all restrictions imposed. This raises a :class:`ValueError`
         if no such triangulation exists.
 
         EXAMPLES::


### PR DESCRIPTION
This is fixing a few ruff details (code UP) and adding some links to errors in the doc, in the `geometry` folder.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.