### PR TITLE
`src/sage/{categories,coding,plot,quadratic_forms}/`: Fix various doctest warnings

### DIFF
--- a/src/sage/categories/finite_complex_reflection_groups.py
+++ b/src/sage/categories/finite_complex_reflection_groups.py
@@ -555,22 +555,22 @@ class FiniteComplexReflectionGroups(CategoryWithAxiom):
                 sage: sum(x**P.rank(elt) for elt in P)
                 18*x^2 + 15*x + 1
 
-                sage: W = ReflectionGroup(4)                     # optional - gap3
-                sage: P = W.milnor_fiber_poset()                 # optional - gap3
-                sage: P                                          # optional - gap3
+                sage: # optional - gap3
+                sage: W = ReflectionGroup(4)
+                sage: P = W.milnor_fiber_poset(); P
                 Finite meet-semilattice containing 41 elements
-                sage: sum(x**P.rank(elt) for elt in P)           # optional - gap3
+                sage: sum(x**P.rank(elt) for elt in P)
                 24*x^2 + 16*x + 1
 
-                sage: W = ReflectionGroup([4,2,2])               # optional - gap3
-                sage: W.is_well_generated()                      # optional - gap3
+                sage: # optional - gap3
+                sage: W = ReflectionGroup([4,2,2])
+                sage: W.is_well_generated()
                 False
-                sage: P = W.milnor_fiber_poset()                 # optional - gap3
-                sage: P                                          # optional - gap3
+                sage: P = W.milnor_fiber_poset(); P
                 Finite poset containing 47 elements
-                sage: sum(x**P.rank(elt) for elt in P)           # optional - gap3
+                sage: sum(x**P.rank(elt) for elt in P)
                 16*x^3 + 24*x^2 + 6*x + 1
-                sage: P.is_meet_semilattice()                    # optional - gap3
+                sage: P.is_meet_semilattice()
                 False
             """
             I = self.index_set()

--- a/src/sage/coding/ag_code_decoders.pyx
+++ b/src/sage/coding/ag_code_decoders.pyx
@@ -29,17 +29,18 @@ EXAMPLES::
 The ``decoder`` is now ready for correcting vectors received from a noisy
 channel::
 
-    sage: channel = channels.StaticErrorRateChannel(code.ambient_space(), tau)  # long time
-    sage: message_space = decoder.message_space()                   # long time
-    sage: message = message_space.random_element()                  # long time
-    sage: encoder = decoder.connected_encoder()                     # long time
-    sage: sent_codeword = encoder.encode(message)                   # long time
-    sage: received_vector = channel(sent_codeword)                  # long time
-    sage: (received_vector - sent_codeword).hamming_weight()        # long time
+    sage: # long time
+    sage: channel = channels.StaticErrorRateChannel(code.ambient_space(), tau)
+    sage: message_space = decoder.message_space()
+    sage: message = message_space.random_element()
+    sage: encoder = decoder.connected_encoder()
+    sage: sent_codeword = encoder.encode(message)
+    sage: received_vector = channel(sent_codeword)
+    sage: (received_vector - sent_codeword).hamming_weight()
     4
-    sage: decoder.decode_to_code(received_vector) == sent_codeword  # long time
+    sage: decoder.decode_to_code(received_vector) == sent_codeword
     True
-    sage: decoder.decode_to_message(received_vector) == message     # long time
+    sage: decoder.decode_to_message(received_vector) == message
     True
 
 AUTHORS:

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -1816,7 +1816,7 @@ class Graphics(WithEqualityById, SageObject):
         some examples.::
 
             sage: G = list_plot([10**i for i in range(10)])                         # long time, needs sage.symbolic
-            sage: G.show(scale='semilogy')                                          # long time
+            sage: G.show(scale='semilogy')                                          # long time, needs sage.symbolic
 
         ::
 

--- a/src/sage/quadratic_forms/ternary_qf.py
+++ b/src/sage/quadratic_forms/ternary_qf.py
@@ -921,7 +921,7 @@ class TernaryQF(SageObject):
 
         Test that it works with (0, 0, 1)::
 
-            sage: Q.find_p_neighbor_from_vec(3, (0,0,1))
+            sage: Q.find_p_neighbor_from_vec(3, (0,0,1))                                # needs sage.libs.pari
             Ternary quadratic form with integer coefficients:
             [1 3 3]
             [-2 0 -1]


### PR DESCRIPTION
We fix the following warnings
```
File "src/sage/categories/finite_complex_reflection_groups.py", line 558, in sage.categories.finite_complex_reflection_groups.FiniteComplexReflectionGroups.ParentMethods.milnor_fiber_poset
Warning: Consider using a block-scoped tag by inserting the line 'sage: # optional - gap3' just before this line to avoid repeating the tag 4 times
    W = ReflectionGroup(4)                     # optional - gap3
**********************************************************************
File "src/sage/categories/finite_complex_reflection_groups.py", line 565, in sage.categories.finite_complex_reflection_groups.FiniteComplexReflectionGroups.ParentMethods.milnor_fiber_poset
Warning: Consider using a block-scoped tag by inserting the line 'sage: # optional - gap3' just before this line to avoid repeating the tag 6 times
    W = ReflectionGroup([4,2,2])               # optional - gap3

File "src/sage/coding/ag_code_decoders.pyx", line 32, in sage.coding.ag_code_decoders
Warning: Consider using a block-scoped tag by inserting the line 'sage: # long time' just before this line to avoid repeating the tag 9 times
    channel = channels.StaticErrorRateChannel(code.ambient_space(), tau)  # long time

File "src/sage/plot/graphics.py", line 1819, in sage.plot.graphics.Graphics.show
Warning: Variable 'G' referenced here was set only in doctest marked '# needs sage.symbolic'; '# long time, needs sage.symbolic'
    G.show(scale='semilogy')                                          # long time

File "src/sage/quadratic_forms/ternary_qf.py", line 924, in sage.quadratic_forms.ternary_qf.TernaryQF.find_p_neighbor_from_vec
Warning: Variable 'Q' referenced here was set only in doctest marked '# needs sage.libs.pari'
    Q.find_p_neighbor_from_vec(3, (0,0,1))
    [315 tests, 0.38 s]
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
