### PR TITLE
fix precision issue for 𝑗=0 and ℓ=3 in compute_isogeny_stark()

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3464,6 +3464,15 @@ def compute_isogeny_stark(E1, E2, ell):
         sage: E2 = phi.codomain()
         sage: compute_isogeny_stark(E, E2, 2)
         x
+
+    TESTS:
+
+    Check for :issue:`21883`::
+
+        sage: E1 = EllipticCurve([0,1])
+        sage: E2 = EllipticCurve([0,-27])
+        sage: E1.isogeny(None, E2, degree=3)
+        Isogeny of degree 3 from Elliptic Curve defined by y^2 = x^3 + 1 over Rational Field to Elliptic Curve defined by y^2 = x^3 - 27 over Rational Field
     """
     K = E1.base_field()
     R, x = PolynomialRing(K, 'x').objgen()
@@ -3477,8 +3486,8 @@ def compute_isogeny_stark(E1, E2, ell):
     for i in range(2*ell + 1):
         pe1 += wp1[2*i] * Z**i
         pe2 += wp2[2*i] * Z**i
-    pe1 = pe1.add_bigoh(2*ell+2)
-    pe2 = pe2.add_bigoh(2*ell+2)
+    pe1 = pe1.add_bigoh(2*ell+3)
+    pe2 = pe2.add_bigoh(2*ell+3)
 
     n = 1
     q = [R.one(), R.zero()]


### PR DESCRIPTION
For the specific case of curves with $j=0$ and isogeny degree $\ell=3$, the `compute_isogeny_stark()` function sometimes fails to find an isogeny even though it exists. In this simple patch we increase the precision of the power-series arithmetic in `compute_isogeny_stark()` by one digit, which makes the computation succeed for this special case too.

Fixes #21883.