### PR TITLE
CI Conda: Add to known-test-failures

### DIFF
--- a/.github/workflows/ci-conda-known-test-failures.json
+++ b/.github/workflows/ci-conda-known-test-failures.json
@@ -62,6 +62,9 @@
     "sage.rings.polynomial.skew_polynomial_finite_field": {
         "failed": true
     },
+    "sage.schemes.elliptic_curves.descent_two_isogeny": {
+        "failed": "random segfault (macOS) https://github.com/sagemath/sage/issues/36949"
+    },
     "sage.schemes.elliptic_curves.ell_field": {
         "failed": "random failure https://github.com/sagemath/sage/issues/36832"
     },

--- a/.github/workflows/ci-conda-known-test-failures.json
+++ b/.github/workflows/ci-conda-known-test-failures.json
@@ -53,6 +53,9 @@
     "sage.schemes.elliptic_curves.ell_field": {
         "failed": true
     },
+    "sage.structure.coerce_actions": {
+        "failed": true
+    },
     "sage.tests.gap_packages": {
         "failed": true
     }

--- a/.github/workflows/ci-conda-known-test-failures.json
+++ b/.github/workflows/ci-conda-known-test-failures.json
@@ -3,13 +3,13 @@
         "failed": true
     },
     "sage.algebras.fusion_rings.fusion_ring": {
-        "failed": true
+        "failed": "see https://github.com/sagemath/sage/pull/36372"
     },
     "sage.combinat.cluster_algebra_quiver.quiver": {
-        "failed": true
+        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6836592771/job/18591690058#step:11:10059"
     },
     "sage.geometry.cone": {
-        "failed": true
+        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6827937663/job/18571052628#step:11:12362"
     },
     "sage.groups.matrix_gps.finitely_generated_gap": {
         "failed": true
@@ -18,31 +18,31 @@
         "failed": true
     },
     "sage.libs.gap.element": {
-        "failed": true
+        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6840579851/job/18600012965#step:11:13016"
     },
     "sage.libs.singular.singular": {
         "failed": true
     },
     "sage.matrix.matrix2": {
-        "failed": true
+        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6835143781/job/18588599649#step:11:16939"
     },
     "sage.matrix.matrix_integer_sparse": {
-        "failed": true
+        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6827937663/job/18571052628#step:11:12362"
     },
     "sage.misc.lazy_import": {
         "failed": true
     },
     "sage.misc.weak_dict": {
-        "failed": true
+        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6870325919/job/18684964234#step:11:10059"
     },
     "sage.modular.modform.l_series_gross_zagier": {
-        "failed": true
+        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6859244281/job/18651257775#step:11:10102"
     },
     "sage.parallel.map_reduce": {
-        "failed": true
+        "failed": "random failure https://github.com/sagemath/sage/issues/36939"
     },
     "sage.rings.function_field.drinfeld_modules.morphism": {
-        "failed": true
+        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6840502530/job/18599835766#step:11:10107"
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "failed": true
@@ -51,19 +51,19 @@
         "failed": true
     },
     "sage.rings.polynomial.polynomial_element": {
-        "failed": true
+        "failed": "see https://github.com/sagemath/sage/pull/36372"
     },
     "sage.rings.polynomial.skew_polynomial_finite_field": {
         "failed": true
     },
     "sage.schemes.elliptic_curves.ell_field": {
-        "failed": true
+        "failed": "random failure https://github.com/sagemath/sage/issues/36832"
     },
     "sage.sets.recursively_enumerated_set": {
-        "failed": true
+        "failed": "see https://github.com/sagemath/sage/pull/36372"
     },
     "sage.structure.coerce_actions": {
-        "failed": true
+        "failed": "random failure https://github.com/sagemath/sage/issues/35973"
     },
     "sage.tests.gap_packages": {
         "failed": true

--- a/.github/workflows/ci-conda-known-test-failures.json
+++ b/.github/workflows/ci-conda-known-test-failures.json
@@ -2,6 +2,9 @@
     "sage_setup.clean": {
         "failed": true
     },
+    "sage.algebras.fusion_rings.fusion_ring": {
+        "failed": true
+    },
     "sage.combinat.cluster_algebra_quiver.quiver": {
         "failed": true
     },
@@ -47,10 +50,16 @@
     "sage.rings.polynomial.multi_polynomial_libsingular": {
         "failed": true
     },
+    "sage.rings.polynomial.polynomial_element": {
+        "failed": true
+    },
     "sage.rings.polynomial.skew_polynomial_finite_field": {
         "failed": true
     },
     "sage.schemes.elliptic_curves.ell_field": {
+        "failed": true
+    },
+    "sage.sets.recursively_enumerated_set": {
         "failed": true
     },
     "sage.structure.coerce_actions": {

--- a/.github/workflows/ci-conda-known-test-failures.json
+++ b/.github/workflows/ci-conda-known-test-failures.json
@@ -47,6 +47,9 @@
     "sage.rings.polynomial.skew_polynomial_finite_field": {
         "failed": true
     },
+    "sage.schemes.elliptic_curves.ell_field": {
+        "failed": true
+    },
     "sage.tests.gap_packages": {
         "failed": true
     }

--- a/.github/workflows/ci-conda-known-test-failures.json
+++ b/.github/workflows/ci-conda-known-test-failures.json
@@ -1,15 +1,18 @@
 {
+    "doc.en.constructions.calculus": {
+        "failed": "unreported random failures in plotting"
+    },
     "sage_setup.clean": {
-        "failed": true
+        "failed": "_find_stale_files finds some stale files under sage/tests when executed under conda"
     },
     "sage.algebras.fusion_rings.fusion_ring": {
-        "failed": "see https://github.com/sagemath/sage/pull/36372"
+        "failed": "unreported random timeouts"
     },
     "sage.combinat.cluster_algebra_quiver.quiver": {
         "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6836592771/job/18591690058#step:11:10059"
     },
     "sage.geometry.cone": {
-        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6827937663/job/18571052628#step:11:12362"
+        "failed": "unreported random timeouts seen in https://github.com/sagemath/sage/actions/runs/6827937663/job/18571052628#step:11:12362"
     },
     "sage.groups.matrix_gps.finitely_generated_gap": {
         "failed": true
@@ -36,13 +39,16 @@
         "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6870325919/job/18684964234#step:11:10059"
     },
     "sage.modular.modform.l_series_gross_zagier": {
-        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6859244281/job/18651257775#step:11:10102"
+        "failed": "unreported failure seen in https://github.com/sagemath/sage/actions/runs/6859244281/job/18651257775#step:11:10102"
     },
     "sage.parallel.map_reduce": {
         "failed": "random failure https://github.com/sagemath/sage/issues/36939"
     },
+    "sage.plot.plot": {
+        "failed": "unreported random failure (macOS)"
+    },
     "sage.rings.function_field.drinfeld_modules.morphism": {
-        "failed": "failure seen in https://github.com/sagemath/sage/actions/runs/6840502530/job/18599835766#step:11:10107"
+        "failed": "unreported random failure seen in https://github.com/sagemath/sage/actions/runs/6840502530/job/18599835766#step:11:10107"
     },
     "sage.rings.polynomial.multi_polynomial_ideal": {
         "failed": true
@@ -51,7 +57,7 @@
         "failed": true
     },
     "sage.rings.polynomial.polynomial_element": {
-        "failed": "see https://github.com/sagemath/sage/pull/36372"
+        "failed": "unreported random failure in symbolic 'roots' (macOS)"
     },
     "sage.rings.polynomial.skew_polynomial_finite_field": {
         "failed": true
@@ -60,7 +66,7 @@
         "failed": "random failure https://github.com/sagemath/sage/issues/36832"
     },
     "sage.sets.recursively_enumerated_set": {
-        "failed": "see https://github.com/sagemath/sage/pull/36372"
+        "failed": "random failures related to AlarmInterrupt (macOS)"
     },
     "sage.structure.coerce_actions": {
         "failed": "random failure https://github.com/sagemath/sage/issues/35973"

--- a/.github/workflows/ci-conda-known-test-failures.json
+++ b/.github/workflows/ci-conda-known-test-failures.json
@@ -35,6 +35,9 @@
     "sage.modular.modform.l_series_gross_zagier": {
         "failed": true
     },
+    "sage.parallel.map_reduce": {
+        "failed": true
+    },
     "sage.rings.function_field.drinfeld_modules.morphism": {
         "failed": true
     },

--- a/.github/workflows/ci-conda-known-test-failures.json
+++ b/.github/workflows/ci-conda-known-test-failures.json
@@ -41,6 +41,9 @@
     "sage.modular.modform.l_series_gross_zagier": {
         "failed": "unreported failure seen in https://github.com/sagemath/sage/actions/runs/6859244281/job/18651257775#step:11:10102"
     },
+    "sage.numerical.linear_tensor_element": {
+        "failed": "random segfaults https://github.com/sagemath/sage/issues/28559"
+    },
     "sage.parallel.map_reduce": {
         "failed": "random failure https://github.com/sagemath/sage/issues/36939"
     },

--- a/src/sage/doctest/reporting.py
+++ b/src/sage/doctest/reporting.py
@@ -213,10 +213,13 @@ class DocTestReporter(SageObject):
         baseline = self.controller.source_baseline(source)
         if fail_msg:
             cmd += "  # " + fail_msg
-        if baseline.get('failed', False):
+        if failed := baseline.get('failed', False):
             if not fail_msg:
                 cmd += "  #"
-            cmd += " [failed in baseline]"
+            if failed is True:
+                cmd += " [failed in baseline]"
+            else:
+                cmd += f" [failed in baseline: {failed}]"
         return cmd
 
     def report(self, source, timeout, return_code, results, output, pid=None):


### PR DESCRIPTION
Not all of the added failures are conda-specific, but the 6 instances of CI Conda amplify the error probability (https://github.com/sagemath/sage/pull/36694#issuecomment-1824871551)

We also add info (ideally a link to the GitHub Issue where the failure is reported) to the failures and arrange for it to be printed by the doctester as part of the `[failed in baseline]` message.

Marked as blocker so it takes effect in CI runs -- to reduce the noise from failures of the Conda CI that PR authors and reviewers find distracting.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->
- Depends on #36936 (which refactors the `[failed in baseline]` printing)

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
