### PR TITLE
build/pkgs/ninja_build: support samurai version scheme

### DIFF
--- a/build/pkgs/ninja_build/spkg-configure.m4
+++ b/build/pkgs/ninja_build/spkg-configure.m4
@@ -3,8 +3,10 @@ SAGE_SPKG_CONFIGURE(
         dnl meson_python needs 1.8.2 or later
         AC_CACHE_CHECK([for ninja >= 1.8.2], [ac_cv_path_NINJA], [
         AC_PATH_PROGS_FEATURE_CHECK([NINJA], [ninja], [
+            dnl support both two- and three-component version schemes
+            dnl since samurai (a ninja alternative) uses two
             ninja_version=`$ac_path_NINJA --version 2>&1 \
-                | $SED -n -e 's/\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\).*/\1/p'`
+                | $SED -n -e 's/\([[0-9]]*\(\.[[0-9]]*\)\{1,2\}\).*/\1/p'`
             AS_IF([test -n "$ninja_version"], [
                 AX_COMPARE_VERSION([$ninja_version], [ge], [1.8.2], [
                     ac_cv_path_NINJA="$ac_path_NINJA"


### PR DESCRIPTION
Samurai is a C99 ninja implementation with an almost-compatible version scheme, except that it has only two version components instead of the three that ninja has. We update the "sed" call used to parse the version number out of `ninja --version` so that it can parse a samurai version too.

This should only matter on systems where (for example) /usr/bin/ninja points to samurai. That's not typical, but it recently became possible to do on Gentoo in an "official" way.
