### PR TITLE
Cache matroid bases and circuits upon computation

### DIFF
--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -601,17 +601,19 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             28
         """
         cdef long r, n
-        r = self.full_rank()
-        n = len(self)
         cdef SetSystem BB
-        BB = SetSystem(self._E, capacity=bitset_len(self._bb))
         cdef long b
-        b = bitset_first(self._bb)
-        while b >= 0:
-            index_to_set(self._b, b, r, n)
-            BB._append(self._b)
-            b = bitset_next(self._bb, b + 1)
-        return BB
+        if not self._B:
+            r = self.full_rank()
+            n = len(self)
+            BB = SetSystem(self._E, capacity=bitset_len(self._bb))
+            b = bitset_first(self._bb)
+            while b >= 0:
+                index_to_set(self._b, b, r, n)
+                BB._append(self._b)
+                b = bitset_next(self._bb, b + 1)
+            self._B = BB
+        return self._B
 
     cpdef nonbases(self) noexcept:
         r"""

--- a/src/sage/matroids/matroid.pxd
+++ b/src/sage/matroids/matroid.pxd
@@ -1,10 +1,13 @@
 from sage.structure.sage_object cimport SageObject
+from sage.matroids.set_system cimport SetSystem
 
 cdef class Matroid(SageObject):
     cdef public _SageObject__custom_name
     cdef public _cached_info
     cdef int _stored_full_rank
     cdef int _stored_size
+    cdef SetSystem _B # bases
+    cdef SetSystem _C # circuits
 
     # virtual methods
     cpdef groundset(self) noexcept

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -2394,11 +2394,14 @@ cdef class Matroid(SageObject):
             ['b', 'd', 'f', 'g'], ['b', 'e', 'g'], ['c', 'd', 'e', 'g'],
             ['c', 'f', 'g'], ['d', 'e', 'f']]
         """
-        C = set()
-        for B in self.bases():
-            C.update([self._circuit(B.union(set([e])))
-                      for e in self.groundset().difference(B)])
-        return list(C)
+        if not self._C:
+            C = set()
+            for B in self.bases():
+                C.update([self._circuit(B.union(set([e])))
+                        for e in self.groundset().difference(B)])
+            self._C = SetSystem(list(self.groundset()), frozenset([frozenset(c)
+                                                                  for c in C]))
+        return self._C
 
     cpdef nonspanning_circuits(self) noexcept:
         """
@@ -2643,11 +2646,13 @@ cdef class Matroid(SageObject):
 
         """
         cdef SetSystem res
-        res = SetSystem(list(self.groundset()))
-        for X in combinations(self.groundset(), self.full_rank()):
-            if self._rank(frozenset(X)) == len(X):
-                res.append(X)
-        return res
+        if not self._B:
+            res = SetSystem(list(self.groundset()))
+            for X in combinations(self.groundset(), self.full_rank()):
+                if self._rank(frozenset(X)) == len(X):
+                    res.append(X)
+            self._B = res
+        return self._B
 
     cpdef independent_sets(self) noexcept:
         r"""

--- a/src/sage/matroids/union_matroid.pyx
+++ b/src/sage/matroids/union_matroid.pyx
@@ -22,7 +22,7 @@ cdef class MatroidUnion(Matroid):
         Matroid of rank 1 on 2 elements with 2 bases
         sage: M.bases()
         Iterator over a system of subsets
-        sage: M.circuits()
+        sage: list(M.circuits())
         [frozenset({3, 4})]
 
     INPUT:


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
By adding two empty SetSystem placeholders ._B (for bases) and ._C (for circuits), the bases and circuits can be cached upon 1st computation. This significantly accelerates future calls to the .bases() or .circuits() functions.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->
This PR fixes #36820:

```
sage: M = matroids.CompleteGraphic(7)
sage: %time C1 = M.circuits()
CPU times: user 12 s, sys: 0 ns, total: 12 s
Wall time: 12 s
sage: %time C2 = M.circuits()
CPU times: user 24 µs, sys: 1 µs, total: 25 µs
Wall time: 37.9 µs
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
