### PR TITLE
`.devcontainer/downstream-archlinux-latest`: Fix maxima

### DIFF
--- a/.devcontainer/downstream-archlinux-latest/devcontainer.json
+++ b/.devcontainer/downstream-archlinux-latest/devcontainer.json
@@ -3,7 +3,7 @@
     "name": "archlinux:latest downstream Sage",
     "image": "archlinux:latest",
     // Create an empty bashrc to avoid the error "No such file or directory" when opening a terminal.
-    "onCreateCommand": "EXTRA_SYSTEM_PACKAGES='sagemath sagemath-doc' EXTRA_SAGE_PACKAGES='notebook pip' .devcontainer/onCreate.sh && touch ~/.bashrc",
+    "onCreateCommand": "sed -i '/^NoExtract/d' /etc/pacman.conf; EXTRA_SYSTEM_PACKAGES='sagemath sagemath-doc' EXTRA_SAGE_PACKAGES='notebook pip' .devcontainer/onCreate.sh && touch ~/.bashrc",
     // There's no SAGE_LOCAL, so remove the symlink 'prefix'.
     "updateContentCommand": "rm -f prefix && ln -sf /usr venv",
     "extensions": [


### PR DESCRIPTION
Dev container configurations `.devcontainer/downstream-*` give easy access to Sage as provided by downstream packagers (see https://doc.sagemath.org/html/en/developer/portability_testing.html#using-our-pre-built-docker-images-for-development-in-vs-code, bottom).

Unfortunately maxima is defective when the archlinux sage package is installed in the official archlinux Docker container because of NoExtract directives that make the maxima help system inoperable.

Here we apply the same fix that we used in #36391 for the portability CI: Removing the NoExtract directives before installing the package.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
