### PR TITLE
Add is_(sparse_)paving() and automorphism_group()

### DIFF
--- a/src/sage/matroids/matroid.pxd
+++ b/src/sage/matroids/matroid.pxd
@@ -175,6 +175,8 @@ cdef class Matroid(SageObject):
     cpdef _is_3connected_CE(self, certificate=*) noexcept
     cpdef _is_3connected_BC(self, certificate=*) noexcept
     cpdef _is_3connected_BC_recursion(self, basis, fund_cocircuits) noexcept
+    cpdef is_paving(self) noexcept
+    cpdef is_sparse_paving(self) noexcept
 
     # representability
     cpdef _local_binary_matroid(self, basis=*) noexcept
@@ -213,6 +215,7 @@ cdef class Matroid(SageObject):
     cpdef flat_cover(self, solver=*, verbose=*, integrality_tolerance=*) noexcept
 
     # misc
+    cpdef automorphism_group(self) noexcept
     cpdef bergman_complex(self) noexcept
     cpdef augmented_bergman_complex(self) noexcept
 

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -5964,14 +5964,13 @@ cdef class Matroid(SageObject):
 
         OUTPUT:
 
-        a Boolean
+        boolean
 
         EXAMPLES::
 
             sage: M = matroids.named_matroids.Vamos()
             sage: M.is_paving()
             True
-
         """
         for C in self.circuits():
             if len(C) < self.rank():
@@ -5987,7 +5986,7 @@ cdef class Matroid(SageObject):
 
         OUTPUT:
 
-        a Boolean
+        boolean
 
         EXAMPLES::
 
@@ -5997,7 +5996,6 @@ cdef class Matroid(SageObject):
             sage: M = matroids.named_matroids.Fano()
             sage: M.is_sparse_paving()
             True
-
         """
         if not self.is_paving():
             return False
@@ -8000,8 +7998,7 @@ cdef class Matroid(SageObject):
 
         REFERENCES:
 
-        [Oxl2011], p. 189.
-
+        [Oxl2011]_, p. 189.
         """
         from sage.topology.simplicial_complex import SimplicialComplex
         return SimplicialComplex(self.bases()).automorphism_group()

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -109,6 +109,8 @@ additional functionality (e.g. linear extensions).
     - :meth:`is_4connected() <sage.matroids.matroid.Matroid.is_4connected>`
     - :meth:`is_kconnected() <sage.matroids.matroid.Matroid.is_kconnected>`
     - :meth:`connectivity() <sage.matroids.matroid.Matroid.connectivity>`
+    - :meth:`is_paving() <sage.matroids.matroid.Matroid.is_paving>`
+    - :meth:`is_sparse_paving() <sage.matroids.matroid.Matroid.is_sparse_paving>`
 
 - Representation
     - :meth:`binary_matroid() <sage.matroids.matroid.Matroid.binary_matroid>`
@@ -133,9 +135,10 @@ additional functionality (e.g. linear extensions).
 
 - Construction
     - :meth:`union() <sage.matroids.matroid.Matroid.union>`
-    - :math:`direct_sum() <sage.matroids.matroid.Matroid.direct_sum>`
+    - :meth:`direct_sum() <sage.matroids.matroid.Matroid.direct_sum>`
 
 - Misc
+    - :meth:`automorphism_group() <sage.matroids.matroid.Matroid.automorphism_group>`
     - :meth:`broken_circuit_complex() <sage.matroids.matroid.Matroid.broken_circuit_complex>`
     - :meth:`chow_ring() <sage.matroids.matroid.Matroid.chow_ring>`
     - :meth:`matroid_polytope() <sage.matroids.matroid.Matroid.matroid_polytope>`
@@ -5953,6 +5956,57 @@ cdef class Matroid(SageObject):
                 return False
         return True
 
+    cpdef is_paving(self) noexcept:
+        """
+        Return if ``self`` is paving.
+
+        A matroid is paving if each of its circuits has size `r` or `r+1`.
+
+        OUTPUT:
+
+        a Boolean
+
+        EXAMPLES::
+
+            sage: M = matroids.named_matroids.Vamos()
+            sage: M.is_paving()
+            True
+
+        """
+        for C in self.circuits():
+            if len(C) < self.rank():
+                return False
+        return True
+
+    cpdef is_sparse_paving(self) noexcept:
+        """
+        Return if ``self`` is sparse-paving.
+
+        A matroid is sparse-paving if the symmetric difference of every pair
+        of circuits is greater than 2.
+
+        OUTPUT:
+
+        a Boolean
+
+        EXAMPLES::
+
+            sage: M = matroids.named_matroids.Vamos()
+            sage: M.is_sparse_paving()
+            False
+            sage: M = matroids.named_matroids.Fano()
+            sage: M.is_sparse_paving()
+            True
+
+        """
+        if not self.is_paving():
+            return False
+        from itertools import combinations
+        for (C1, C2) in combinations(self.circuits(), 2):
+            if len(C1 ^ C2) <= 2:
+                return False
+        return True
+
     # representability
 
     cpdef _local_binary_matroid(self, basis=None) noexcept:
@@ -7915,6 +7969,42 @@ cdef class Matroid(SageObject):
         """
         from sage.topology.simplicial_complex import SimplicialComplex
         return SimplicialComplex(self.no_broken_circuits_sets(ordering))
+
+    cpdef automorphism_group(self) noexcept:
+        r"""
+        Return the automorphism group of ``self``.
+
+        For a matroid `M`, an automorphism is a permutation `\sigma` of `E(M)`
+        (the groundset) such that `r(X) = r(\sigma(X))` for all `X \subseteq
+        E(M)`. The set of automorphisms of `M` forms a group under composition.
+        This automorphism group is transitive if, for every two elements `x`
+        and `y` of `M`, there is an automorphism that maps `x` to `y`.
+
+        EXAMPLES::
+
+            sage: M = matroids.named_matroids.Fano()
+            sage: G = M.automorphism_group()
+            sage: G.is_transitive()
+            True
+            sage: G.structure_description()
+            'PSL(3,2)'
+            sage: M = matroids.named_matroids.P8pp()
+            sage: M.automorphism_group().is_transitive()
+            True
+            sage: M = matroids.named_matroids.ExtendedTernaryGolayCode()
+            sage: G = M.automorphism_group()
+            sage: G.is_transitive()
+            True
+            sage: G.structure_description()
+            'M12'
+
+        REFERENCES:
+
+        [Oxl2011], p. 189.
+
+        """
+        from sage.topology.simplicial_complex import SimplicialComplex
+        return SimplicialComplex(self.bases()).automorphism_group()
 
     cpdef bergman_complex(self) noexcept:
         r"""


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
Added three functions to the main matroid class.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->
These correspond to two connectivity check algorithms, `is_paving()` and `is_sparse_paving()`, and a miscellaneous function `automorphism_group()`. These are all standard and regularly used notions in matroid theory.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
