### PR TITLE
add a specialized parent object for elliptic-curve morphisms

### DIFF
--- a/src/sage/categories/all.py
+++ b/src/sage/categories/all.py
@@ -104,7 +104,7 @@ from sage.categories.commutative_algebra_ideals import CommutativeAlgebraIdeals
 
 # schemes and varieties
 from sage.categories.modular_abelian_varieties import ModularAbelianVarieties
-from sage.categories.schemes import Schemes
+from sage.categories.schemes import Schemes, AbelianVarieties
 
 # * with basis
 from sage.categories.modules_with_basis import ModulesWithBasis

--- a/src/sage/categories/category.py
+++ b/src/sage/categories/category.py
@@ -2598,6 +2598,7 @@ def category_sample():
          Category of Hopf algebras with basis over Rational Field,
          Category of Lie algebras over Rational Field,
          Category of Weyl groups,
+         Category of abelian varieties over Rational Field,
          Category of additive magmas, ...,
          Category of fields, ...,
          Category of graded Hopf algebras with basis over Rational Field, ...,

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1555,6 +1555,8 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: sage0.eval("l")
             '...if self.discriminant() == 0:...raise ArithmeticError...'
             sage: sage0.eval("u")
+            '...-> super().__init__(R, data, category=category)'
+            sage: sage0.eval("u")
             '...EllipticCurve_field.__init__(self, K, ainvs)'
             sage: sage0.eval("p ainvs")
             '(0, 0, 0, 0, 0)'

--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -204,7 +204,7 @@ class ProjectiveCurve(Curve_generic, AlgebraicScheme_subscheme_projective):
          by -x^2 + (-u)*z^2 + y*w, x*w + (-3*u^2)*z*w
     """
 
-    def __init__(self, A, X):
+    def __init__(self, A, X, category=None):
         """
         Initialize.
 
@@ -218,7 +218,7 @@ class ProjectiveCurve(Curve_generic, AlgebraicScheme_subscheme_projective):
         if not is_ProjectiveSpace(A):
             raise TypeError("A (=%s) must be a projective space" % A)
 
-        Curve_generic.__init__(self, A, X)
+        Curve_generic.__init__(self, A, X, category=category)
 
     def _repr_type(self):
         r"""
@@ -610,7 +610,7 @@ class ProjectivePlaneCurve(ProjectiveCurve):
          defined by y^2*z - x*z^2 - z^3
     """
 
-    def __init__(self, A, f):
+    def __init__(self, A, f, category=None):
         """
         Initialize.
 
@@ -624,7 +624,7 @@ class ProjectivePlaneCurve(ProjectiveCurve):
         if not (is_ProjectiveSpace(A) and A.dimension != 2):
             raise TypeError("the ambient space is not a projective plane")
 
-        super().__init__(A, [f])
+        super().__init__(A, [f], category=category)
 
     def _repr_type(self):
         r"""
@@ -1579,7 +1579,7 @@ class ProjectiveCurve_field(ProjectiveCurve, AlgebraicScheme_subscheme_projectiv
     """
     _point = ProjectiveCurvePoint_field
 
-    def __init__(self, A, X):
+    def __init__(self, A, X, category=None):
         """
         Initialize.
 
@@ -1590,7 +1590,7 @@ class ProjectiveCurve_field(ProjectiveCurve, AlgebraicScheme_subscheme_projectiv
             sage: loads(dumps(C)) == C
             True
         """
-        super().__init__(A, X)
+        super().__init__(A, X, category=category)
 
         if not A.base_ring() in Fields():
             raise TypeError("curve not defined over a field")

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -130,7 +130,7 @@ class EllipticCurveFactory(UniqueFactory):
         sage: type(E)
         <class 'sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field_with_category'>
         sage: E.category()
-        Category of schemes over Ring of integers modulo 101
+        Category of abelian varieties over Ring of integers modulo 101
 
     In contrast, elliptic curves over `\ZZ/N\ZZ` with `N` composite
     are of type "generic elliptic curve"::
@@ -282,7 +282,7 @@ class EllipticCurveFactory(UniqueFactory):
         sage: type(E)
         <class 'sage.schemes.elliptic_curves.ell_field.EllipticCurve_field_with_category'>
         sage: E.category()
-        Category of schemes over Symbolic Ring
+        Category of abelian varieties over Symbolic Ring
         sage: SR in Fields()
         True
 
@@ -294,7 +294,7 @@ class EllipticCurveFactory(UniqueFactory):
         sage: type(E)
         <class 'sage.schemes.elliptic_curves.ell_field.EllipticCurve_field_with_category'>
         sage: E.category()
-        Category of schemes over
+        Category of abelian varieties over
          Fraction Field of Univariate Polynomial Ring in t over Rational Field
 
     See :trac:`12517`::

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1113,7 +1113,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             L = L, F_to_K.post_compose(K_to_L)
         return L
 
-    def _Hom_(*args, **kwds):
+    def _Hom_(self, other, category=None):
         r"""
         Hook to make :class:`~sage.categories.homset.Hom`
         set the correct parent
@@ -1128,8 +1128,11 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             sage: type(E._Hom_(E))
             <class 'sage.schemes.elliptic_curves.homset.EllipticCurveHomset_with_category'>
         """
-        from . import homset
-        return homset.EllipticCurveHomset(*args, **kwds)
+        if isinstance(other, ell_generic.EllipticCurve_generic) and self.base_ring() == other.base_ring():
+            from . import homset
+            return homset.EllipticCurveHomset(self, other, category=category)
+        from sage.schemes.generic.homset import SchemeHomset_generic
+        return SchemeHomset_generic(self, other, category=category)
 
     def isogeny(self, kernel, codomain=None, degree=None, model=None, check=True, algorithm=None):
         r"""

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1113,6 +1113,24 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             L = L, F_to_K.post_compose(K_to_L)
         return L
 
+    def _Hom_(*args, **kwds):
+        r"""
+        Hook to make :class:`~sage.categories.homset.Hom`
+        set the correct parent
+        :class:`~sage.schemes.elliptic_curves.homset.EllipticCurveHomset`
+        for
+        :class:`~sage.schemes.elliptic_curves.hom.EllipticCurveHom`
+        objects.
+
+        EXAMPLES::
+
+            sage: E = EllipticCurve(GF(19), [1,0])
+            sage: type(E._Hom_(E))
+            <class 'sage.schemes.elliptic_curves.homset.EllipticCurveHomset_with_category'>
+        """
+        from . import homset
+        return homset.EllipticCurveHomset(*args, **kwds)
+
     def isogeny(self, kernel, codomain=None, degree=None, model=None, check=True, algorithm=None):
         r"""
         Return an elliptic-curve isogeny from this elliptic curve.

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2069,6 +2069,45 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         GL = G.relabel(labels, inplace=False)
         return GL
 
+    def endomorphism_ring_is_commutative(self):
+        r"""
+        Check whether the endomorphism ring of this elliptic curve
+        *over its base field* is commutative.
+
+        ALGORITHM: The endomorphism ring is always commutative in
+        characteristic zero. Over finite fields, it is commutative
+        if and only if the Frobenius endomorphism is not in `\ZZ`.
+        All elliptic curves with non-commutative endomorphism ring
+        are supersingular. (The converse holds over the algebraic
+        closure, but here we consider endomorphisms *over the field
+        of definition*.)
+
+        EXAMPLES::
+
+            sage: EllipticCurve(QQ, [1,1]).endomorphism_ring_is_commutative()
+            True
+            sage: EllipticCurve(QQ, [1,0]).endomorphism_ring_is_commutative()
+            True
+            sage: EllipticCurve(GF(19), [1,1]).endomorphism_ring_is_commutative()
+            True
+            sage: EllipticCurve(GF(19^2), [1,1]).endomorphism_ring_is_commutative()
+            True
+            sage: EllipticCurve(GF(19), [1,0]).endomorphism_ring_is_commutative()
+            True
+            sage: EllipticCurve(GF(19^2), [1,0]).endomorphism_ring_is_commutative()
+            False
+            sage: EllipticCurve(GF(19^3), [1,0]).endomorphism_ring_is_commutative()
+            True
+        """
+        k = self.base()
+        if k.characteristic() == 0 or self.is_ordinary():
+            return True
+
+        if not k.is_finite():
+            raise NotImplementedError
+
+        return self.frobenius() not in ZZ
+
 
 def compute_model(E, name):
     r"""

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -28,6 +28,28 @@ from . import ell_generic
 
 class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurve_field):
 
+    def __init__(self, R, data, category=None):
+        r"""
+        Constructor for elliptic curves over fields.
+
+        Identical to the constructor for elliptic curves over
+        general rings, except for setting the default category
+        to :class:`AbelianVarieties`.
+
+        EXAMPLES::
+
+            sage: E = EllipticCurve(QQ, [1,1])
+            sage: E.category()
+            Category of abelian varieties over Rational Field
+            sage: E = EllipticCurve(GF(101), [1,1])
+            sage: E.category()
+            Category of abelian varieties over Finite Field of size 101
+        """
+        from sage.categories.schemes import AbelianVarieties
+        if category is None:
+            category = AbelianVarieties(R)
+        super().__init__(R, data, category=category)
+
     base_field = ell_generic.EllipticCurve_generic.base_ring
 
     _point = EllipticCurvePoint_field

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -72,7 +72,7 @@ class EllipticCurve_finite_field(EllipticCurve_field, HyperellipticCurve_finite_
         sage: type(E)
         <class 'sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field_with_category'>
         sage: E.category()
-        Category of schemes over Ring of integers modulo 101
+        Category of abelian varieties over Ring of integers modulo 101
 
     Elliptic curves over `\ZZ/N\ZZ` with `N` composite are of type
     "generic elliptic curve"::

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -2533,6 +2533,23 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
         return EllipticCurveHom_frobenius(self, n)
 
+    def identity_morphism(self):
+        r"""
+        Return the identity endomorphism of this elliptic curve
+        as an :class:`EllipticCurveHom` object.
+
+        EXAMPLES::
+
+            sage: E = EllipticCurve(j=42)
+            sage: E.identity_morphism()
+            Elliptic-curve endomorphism of Elliptic Curve defined by y^2 = x^3 + 5901*x + 1105454 over Rational Field
+              Via:  (u,r,s,t) = (1, 0, 0, 0)
+            sage: E.identity_morphism() == E.scalar_multiplication(1)
+            True
+        """
+        from sage.schemes.elliptic_curves.weierstrass_morphism import identity_morphism
+        return identity_morphism(self)
+
     def isomorphism_to(self, other):
         """
         Given another weierstrass model ``other`` of ``self``, return an

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -121,7 +121,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         sage: -5*P
         (179051/80089 : -91814227/22665187 : 1)
     """
-    def __init__(self, K, ainvs):
+    def __init__(self, K, ainvs, category=None):
         r"""
         Construct an elliptic curve from Weierstrass `a`-coefficients.
 
@@ -167,7 +167,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         a1, a2, a3, a4, a6 = ainvs
         f = y**2*z + (a1*x + a3*z)*y*z \
             - (x**3 + a2*x**2*z + a4*x*z**2 + a6*z**3)
-        plane_curve.ProjectivePlaneCurve.__init__(self, PP, f)
+        plane_curve.ProjectivePlaneCurve.__init__(self, PP, f, category=category)
 
         self.__divpolys = ({}, {}, {})
 

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -160,8 +160,11 @@ class EllipticCurveHom(Morphism):
             phis += other.summands()
         else:
             phis.append(other)
+
         #TODO should probably try to simplify some more?
-        return EllipticCurveHom_sum(phis)
+
+        assert other.domain() == self.domain() and other.codomain() == self.codomain()
+        return EllipticCurveHom_sum(phis, domain=self.domain(), codomain=self.codomain())
 
     def _sub_(self, other):
         r"""

--- a/src/sage/schemes/elliptic_curves/hom_scalar.py
+++ b/src/sage/schemes/elliptic_curves/hom_scalar.py
@@ -194,7 +194,7 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
         EXAMPLES::
 
             sage: from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
-            sage: E = EllipticCurve(j=Mod(1728,419))
+            sage: E = EllipticCurve(j=GF(419)(1728))
             sage: psi = EllipticCurveHom_scalar(E, 13)
             sage: P = E.change_ring(GF(419**2)).lift_x(5)
             sage: P = min({P, -P})  # fix choice of y

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -406,8 +406,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
         """
         if self._degree is not None:
             return
-        if len(self._phis) == 0:
-            self._degree = 0
+        if not self._phis:
+            self._degree = ZZ.zero()
         elif len(self._phis) == 1:
             self._degree = self._phis[0].degree()
         else:

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -114,21 +114,50 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         super().__init__(E1, E2, category=category, base=base)
 
-        if self.domain() == self.codomain():
+    def _coerce_map_from_(self, other):
+        r"""
+        Check if this homset has a coercion map from another
+        parent ``other``.
 
-            # set up automated coercion of integers to scalar multiplications
-            from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
+        The only currently supported case is when this homset has
+        equal domain and codomain: In this case elements from `\ZZ`
+        are embedded as scalar multiplications.
 
-            class ScalarMultiplicationEmbedding(Morphism):
+        EXAMPLES::
 
-                def __init__(self, End):
-                    assert End.domain() is End.codomain()
-                    super().__init__(ZZ, End)
+            sage: E1 = EllipticCurve(j=42)
+            sage: E2 = EllipticCurve(j=43)
+            sage: Hom(E1, E1)._coerce_map_from_(ZZ)
+            True
+            sage: Hom(E1, E2)._coerce_map_from_(ZZ)
+            False
+        """
+        return self.is_endomorphism_set() and other is ZZ
 
-                def _call_(self, m):
-                    return EllipticCurveHom_scalar(self.codomain().domain(), m)
+    def _element_constructor_(self, data):
+        r"""
+        Construct an element of this homset from the given ``data``.
 
-            self.register_coercion(ScalarMultiplicationEmbedding(self))
+        The only currently supported case is when this homset has
+        equal domain and codomain: In this case elements from `\ZZ`
+        are embedded as scalar multiplications.
+
+        EXAMPLES::
+
+            sage: E1 = EllipticCurve(j=42)
+            sage: E2 = EllipticCurve(j=43)
+            sage: Hom(E1, E1)(5)
+            Scalar-multiplication endomorphism [5] of Elliptic Curve defined by y^2 = x^3 + 5901*x + 1105454 over Rational Field
+            sage: Hom(E1, E2)(5)
+            Traceback (most recent call last):
+            ...
+            ValueError: domain and codomain must be equal
+        """
+        if self.codomain() != self.domain():
+            raise ValueError('domain and codomain must be equal')
+        m = ZZ(data)
+        from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
+        return EllipticCurveHom_scalar(self.domain(), m)
 
     def _repr_(self):
         r"""

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -105,14 +105,19 @@ class EllipticCurveHomset(SchemeHomset_generic):
         super().__init__(*args, **kwds)
 
         if self.domain() == self.codomain():
+
             # set up automated coercion of integers to scalar multiplications
             from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
+
             class ScalarMultiplicationEmbedding(Morphism):
+
                 def __init__(self, End):
                     assert End.domain() is End.codomain()
                     super().__init__(ZZ, End)
+
                 def _call_(self, m):
                     return EllipticCurveHom_scalar(self.codomain().domain(), m)
+
             self.register_coercion(ScalarMultiplicationEmbedding(self))
 
     def _repr_(self):
@@ -144,4 +149,3 @@ class EllipticCurveHomset(SchemeHomset_generic):
         s += f'\n  From: {self.domain()}'
         s += f'\n  To:   {self.codomain()}'
         return s
-

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -91,9 +91,16 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         TESTS::
 
-            sage: E = EllipticCurve('37a1')                                             # needs sage.schemes
-            sage: Hom(E, E).__class__                                                   # needs sage.schemes
-            <class 'sage.schemes.elliptic_curves.homset.EllipticCurveHomset_with_category'>
+            sage: E = EllipticCurve(GF(101), [1,1])
+            sage: H = End(E)
+            sage: TestSuite(H).run()
+
+        ::
+
+            sage: E1 = EllipticCurve(GF(101), [1,1])
+            sage: E2 = EllipticCurve(GF(101), [4,9])
+            sage: H = Hom(E1, E2)
+            sage: TestSuite(H).run()
 
         ::
 

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -93,14 +93,14 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
             sage: E = EllipticCurve(GF(101), [1,1])
             sage: H = End(E)
-            sage: TestSuite(H).run()
+            sage: TestSuite(H).run(skip='_test_elements')
 
         ::
 
             sage: E1 = EllipticCurve(GF(101), [1,1])
             sage: E2 = EllipticCurve(GF(101), [4,9])
             sage: H = Hom(E1, E2)
-            sage: TestSuite(H).run()
+            sage: TestSuite(H).run(skip='_test_elements')
 
         ::
 

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -204,9 +204,12 @@ class EllipticCurveHomset(SchemeHomset_generic):
             ...
             ValueError: domain and codomain must be equal
         """
-        if not self.is_endomorphism_set():
-            raise ValueError('domain and codomain must be equal')
         m = ZZ(data)
+        if not self.is_endomorphism_set():
+            if m:
+                raise ValueError('domain and codomain must be equal')
+            from sage.schemes.elliptic_curves.hom_sum import EllipticCurveHom_sum
+            return EllipticCurveHom_sum([], domain=self.domain(), codomain=self.codomain())
         from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
         return EllipticCurveHom_scalar(self.domain(), m)
 

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -1,0 +1,141 @@
+r"""
+Homsets and endomorphism rings of elliptic curves
+
+The set of homomorphisms between two elliptic curves (:class:`EllipticCurveHom`)
+forms an abelian group under addition. Moreover, if the two curves are the same,
+it even forms a (not always commutative) ring under composition.
+
+This module encapsulates the set of homomorphisms between two given elliptic
+curves as a Sage object.
+
+.. NOTE::
+
+    Currently only little nontrivial functionality is available, but this will
+    hopefully change in the future.
+
+EXAMPLES:
+
+The only useful thing this class does at the moment is coercing integers into
+the endomorphism ring as scalar multiplications::
+
+    sage: E = EllipticCurve([1,2,3,4,5])
+    sage: f = End(E)(7); f
+    Scalar-multiplication endomorphism [7] of Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5 over Rational Field
+    sage: f == E.scalar_multiplication(7)
+    True
+
+::
+
+    sage: E = EllipticCurve(GF(431^2), [0,1])
+    sage: E.automorphisms()[0] == 1
+    True
+    sage: E.automorphisms()[1] == -1
+    True
+    sage: omega = E.automorphisms()[2]
+    sage: omega == 1
+    False
+    sage: omega^3 == 1
+    True
+    sage: (1 + omega + omega^2) == 0
+    True
+    sage: (2*omega + 1)^2 == -3
+    True
+
+AUTHORS:
+
+- Lorenz Panny (2023)
+"""
+
+# ****************************************************************************
+#       Copyright (C) 2023 Lorenz Panny
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
+
+from sage.rings.integer_ring import ZZ
+from sage.categories.morphism import Morphism
+from sage.schemes.generic.homset import SchemeHomset_generic
+
+
+class EllipticCurveHomset(SchemeHomset_generic):
+    r"""
+    This class represents the set of all homomorphisms between two fixed
+    elliptic curves.
+
+    EXAMPLES::
+
+        sage: E = EllipticCurve(GF(419^2), [1,0])
+        sage: E.frobenius_isogeny() in End(E)
+        True
+        sage: phi = E.isogenies_prime_degree(7)[0]
+        sage: phi in End(E)
+        False
+        sage: phi in Hom(E, phi.codomain())
+        True
+
+    Note that domain and codomain are *not* taken up to isomorphism::
+
+        sage: iso = E.isomorphism_to(EllipticCurve(GF(419^2), [2,0]))
+        sage: iso in End(E)
+        False
+    """
+    def __init__(self, *args, **kwds):
+        r"""
+        Construct the homset for a given pair of curves.
+
+        TESTS::
+
+            sage: E1 = EllipticCurve(j=42)
+            sage: E2 = EllipticCurve(j=43)
+            sage: Hom(E1, E2)
+            Group of elliptic-curve morphisms
+              From: Elliptic Curve defined by y^2 = x^3 + 5901*x + 1105454 over Rational Field
+              To:   Elliptic Curve defined by y^2 + x*y = x^3 + x^2 + 1510*x - 140675 over Rational Field
+        """
+        super().__init__(*args, **kwds)
+
+        if self.domain() == self.codomain():
+            # set up automated coercion of integers to scalar multiplications
+            from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
+            class ScalarMultiplicationEmbedding(Morphism):
+                def __init__(self, End):
+                    assert End.domain() is End.codomain()
+                    super().__init__(ZZ, End)
+                def _call_(self, m):
+                    return EllipticCurveHom_scalar(self.codomain().domain(), m)
+            self.register_coercion(ScalarMultiplicationEmbedding(self))
+
+    def _repr_(self):
+        r"""
+        Output a description of this homset, with special formatting
+        for endomorphism rings.
+
+        EXAMPLES::
+
+            sage: E1 = EllipticCurve([1,1])
+            sage: E2 = EllipticCurve([2,2])
+            sage: End(E1)
+            Ring of elliptic-curve endomorphisms
+              From: Elliptic Curve defined by y^2 = x^3 + x + 1 over Rational Field
+              To:   Elliptic Curve defined by y^2 = x^3 + x + 1 over Rational Field
+            sage: Hom(E1, E1)
+            Ring of elliptic-curve endomorphisms
+              From: Elliptic Curve defined by y^2 = x^3 + x + 1 over Rational Field
+              To:   Elliptic Curve defined by y^2 = x^3 + x + 1 over Rational Field
+            sage: Hom(E1, E2)
+            Group of elliptic-curve morphisms
+              From: Elliptic Curve defined by y^2 = x^3 + x + 1 over Rational Field
+              To:   Elliptic Curve defined by y^2 = x^3 + 2*x + 2 over Rational Field
+        """
+        if self.domain() == self.codomain():
+            s = 'Ring of elliptic-curve endomorphisms'
+        else:
+            s = 'Group of elliptic-curve morphisms'
+        s += f'\n  From: {self.domain()}'
+        s += f'\n  To:   {self.codomain()}'
+        return s
+

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -197,7 +197,7 @@ class EllipticCurveHomset(SchemeHomset_generic):
             ...
             ValueError: domain and codomain must be equal
         """
-        if self.codomain() != self.domain():
+        if not self.is_endomorphism_set():
             raise ValueError('domain and codomain must be equal')
         m = ZZ(data)
         from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
@@ -225,7 +225,7 @@ class EllipticCurveHomset(SchemeHomset_generic):
               From: Elliptic Curve defined by y^2 = x^3 + x + 1 over Rational Field
               To:   Elliptic Curve defined by y^2 = x^3 + 2*x + 2 over Rational Field
         """
-        if self.domain() == self.codomain():
+        if self.is_endomorphism_set():
             s = 'Ring of elliptic-curve endomorphisms'
         else:
             s = 'Additive group of elliptic-curve morphisms'

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -59,6 +59,7 @@ AUTHORS:
 from sage.rings.integer_ring import ZZ
 from sage.categories.morphism import Morphism
 from sage.schemes.generic.homset import SchemeHomset_generic
+from sage.schemes.elliptic_curves.ell_generic import EllipticCurve_generic
 
 
 class EllipticCurveHomset(SchemeHomset_generic):
@@ -83,9 +84,10 @@ class EllipticCurveHomset(SchemeHomset_generic):
         sage: iso in End(E)
         False
     """
-    def __init__(self, *args, **kwds):
+    def __init__(self, E1, E2, category=None):
         r"""
-        Construct the homset for a given pair of curves.
+        Construct the homset for a given pair of elliptic curves
+        defined over the same base ring.
 
         TESTS::
 
@@ -102,7 +104,15 @@ class EllipticCurveHomset(SchemeHomset_generic):
               From: Elliptic Curve defined by y^2 = x^3 + 5901*x + 1105454 over Rational Field
               To:   Elliptic Curve defined by y^2 + x*y = x^3 + x^2 + 1510*x - 140675 over Rational Field
         """
-        super().__init__(*args, **kwds)
+        if not isinstance(E1, EllipticCurve_generic):
+            raise ValueError('domain must be an elliptic curve')
+        if not isinstance(E2, EllipticCurve_generic):
+            raise ValueError('codomain must be an elliptic curve')
+        base = E1.base_ring()
+        if base != E2.base_ring():
+            raise ValueError('domain and codomain must have the same base ring')
+
+        super().__init__(E1, E2, category=category, base=base)
 
         if self.domain() == self.codomain():
 

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -89,6 +89,12 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         TESTS::
 
+            sage: E = EllipticCurve('37a1')                                             # needs sage.schemes
+            sage: Hom(E, E).__class__                                                   # needs sage.schemes
+            <class 'sage.schemes.elliptic_curves.homset.EllipticCurveHomset_with_category'>
+
+        ::
+
             sage: E1 = EllipticCurve(j=42)
             sage: E2 = EllipticCurve(j=43)
             sage: Hom(E1, E2)

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -242,3 +242,21 @@ class EllipticCurveHomset(SchemeHomset_generic):
         s += f'\n  From: {self.domain()}'
         s += f'\n  To:   {self.codomain()}'
         return s
+
+    def identity(self):
+        r"""
+        Return the identity morphism in this elliptic-curve homset
+        as an :class:`EllipticCurveHom` object.
+
+        EXAMPLES::
+
+            sage: E = EllipticCurve(j=42)
+            sage: End(E).identity()
+            Elliptic-curve endomorphism of Elliptic Curve defined by y^2 = x^3 + 5901*x + 1105454 over Rational Field
+              Via:  (u,r,s,t) = (1, 0, 0, 0)
+            sage: End(E).identity() == E.scalar_multiplication(1)
+            True
+        """
+        if not self.is_endomorphism_set():
+            raise ValueError('domain and codomain must be equal')
+        return self.domain().identity_morphism()

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -148,8 +148,9 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         super().__init__(E1, E2, category=category, base=base)
 
-        #TODO: We should also add CommutativeRings to the category of self
-        # whenever this holds true; see _endomorphism_ring_is_commutative().
+        #TODO: We should also add CommutativeRings to the category
+        # of self whenever this holds true; see the method
+        # EllipticCurve_field.endomorphism_ring_is_commutative().
         # Is there a way to perform this check lazily?
 
     def _coerce_map_from_(self, other):
@@ -253,7 +254,7 @@ class EllipticCurveHomset(SchemeHomset_generic):
         Assuming this homset is an endomorphism ring, check whether
         it is a commutative ring.
 
-        ALGORITHM: :func:`_endomorphism_ring_is_commutative`
+        ALGORITHM: :meth:`EllipticCurve_field.endomorphism_ring_is_commutative`
 
         EXAMPLES::
 
@@ -266,44 +267,4 @@ class EllipticCurveHomset(SchemeHomset_generic):
         """
         if not self.is_endomorphism_set():
             raise ValueError('commutativity does not make sense for homsets between different objects')
-        return _endomorphism_ring_is_commutative(self.domain())
-
-def _endomorphism_ring_is_commutative(E):
-    r"""
-    Check whether the endomorphism ring of an elliptic curve `E`
-    *over its base field* is commutative.
-
-    ALGORITHM: The endomorphism ring is always commutative in
-    characteristic zero. Over finite fields, it is commutative
-    if and only if the Frobenius endomorphism is not in `\ZZ`.
-    All elliptic curves with non-commutative endomorphism ring
-    are supersingular. (The converse holds over the algebraic
-    closure, but here we consider endomorphisms *over the field
-    of definition*.)
-
-    EXAMPLES::
-
-        sage: from sage.schemes.elliptic_curves.homset import _endomorphism_ring_is_commutative
-        sage: _endomorphism_ring_is_commutative(EllipticCurve(QQ, [1,1]))
-        True
-        sage: _endomorphism_ring_is_commutative(EllipticCurve(QQ, [1,0]))
-        True
-        sage: _endomorphism_ring_is_commutative(EllipticCurve(GF(19), [1,1]))
-        True
-        sage: _endomorphism_ring_is_commutative(EllipticCurve(GF(19^2), [1,1]))
-        True
-        sage: _endomorphism_ring_is_commutative(EllipticCurve(GF(19), [1,0]))
-        True
-        sage: _endomorphism_ring_is_commutative(EllipticCurve(GF(19^2), [1,0]))
-        False
-        sage: _endomorphism_ring_is_commutative(EllipticCurve(GF(19^3), [1,0]))
-        True
-    """
-    k = E.base()
-    if k.characteristic() == 0 or E.is_ordinary():
-        return True
-
-    if not k.is_finite():
-        raise NotImplementedError
-
-    return E.frobenius() not in ZZ
+        return self.domain().endomorphism_ring_is_commutative()

--- a/src/sage/schemes/generic/algebraic_scheme.py
+++ b/src/sage/schemes/generic/algebraic_scheme.py
@@ -214,7 +214,7 @@ class AlgebraicScheme(scheme.Scheme):
     defined by equations in affine, projective, or toric ambient
     spaces.
     """
-    def __init__(self, A):
+    def __init__(self, A, category=None):
         """
         TESTS::
 
@@ -231,7 +231,7 @@ class AlgebraicScheme(scheme.Scheme):
             raise TypeError("A (=%s) must be an ambient space")
         self.__A = A
         self.__divisor_group = {}
-        scheme.Scheme.__init__(self, A.base_scheme())
+        scheme.Scheme.__init__(self, A.base_scheme(), category=category)
 
     def _latex_(self):
         r"""
@@ -917,7 +917,7 @@ class AlgebraicScheme_subscheme(AlgebraicScheme):
           x^2 - y*z
     """
 
-    def __init__(self, A, polynomials):
+    def __init__(self, A, polynomials, category=None):
         """
         See ``AlgebraicScheme_subscheme`` for documentation.
 
@@ -934,7 +934,7 @@ class AlgebraicScheme_subscheme(AlgebraicScheme):
         """
         from sage.rings.polynomial.multi_polynomial_sequence import is_PolynomialSequence
 
-        AlgebraicScheme.__init__(self, A)
+        AlgebraicScheme.__init__(self, A, category=category)
         self._base_ring = A.base_ring()
         R = A.coordinate_ring()
         if is_Ideal(polynomials):

--- a/src/sage/schemes/generic/scheme.py
+++ b/src/sage/schemes/generic/scheme.py
@@ -645,10 +645,6 @@ class Scheme(Parent):
             sage: S._Hom_(P).__class__
             <class 'sage.schemes.generic.homset.SchemeHomset_generic_with_category'>
 
-            sage: E = EllipticCurve('37a1')                                             # needs sage.schemes
-            sage: Hom(E, E).__class__                                                   # needs sage.schemes
-            <class 'sage.schemes.projective.projective_homset.SchemeHomset_polynomial_projective_space_with_category'>
-
             sage: Hom(Spec(ZZ), Spec(ZZ)).__class__
             <class 'sage.schemes.generic.homset.SchemeHomset_generic_with_category_with_equality_by_id'>
         """


### PR DESCRIPTION
Currently, the set of morphisms between elliptic curves is a generic `SchemeHomset`. However, the morphisms between abelian varieties such as elliptic curves have a lot more structure, which should be reflected in Sage by a specialized parent object.
This patch adds such a parent. The current implementation does not really do much except to enable convenience syntax for scalar multiplications. More advanced functionality (structure computation, finding elements, ...) can be added later.