### PR TITLE
Fix `sage-get-system-packages install-requires` after #29665

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -108,8 +108,8 @@ EOF
             if test -f "$DIR/requirements.txt" -o -f "$DIR/install-requires.txt"; then
                 # A Python package
                 SPKG_TREE_VAR=SAGE_VENV
-                echo "define(>>>SPKG_INSTALL_REQUIRES_${pkgname}<<<, >>>$(echo $(ENABLE_SYSTEM_SITE_PACKAGES=yes sage-get-system-packages install-requires ${pkgname}))<<<)dnl" >> m4/sage_spkg_versions.m4
-                echo "define(>>>SPKG_INSTALL_REQUIRES_${pkgname}<<<, >>>$(echo $(ENABLE_SYSTEM_SITE_PACKAGES=yes sage-get-system-packages install-requires-toml ${pkgname}))<<<)dnl" >> m4/sage_spkg_versions_toml.m4
+                echo "define(>>>SPKG_INSTALL_REQUIRES_${pkgname}<<<, >>>$(echo $(sage-get-system-packages install-requires ${pkgname}))<<<)dnl" >> m4/sage_spkg_versions.m4
+                echo "define(>>>SPKG_INSTALL_REQUIRES_${pkgname}<<<, >>>$(echo $(sage-get-system-packages install-requires-toml ${pkgname}))<<<)dnl" >> m4/sage_spkg_versions_toml.m4
             fi
         fi
         spkg_finalizes="$spkg_finalizes

--- a/build/bin/sage-get-system-packages
+++ b/build/bin/sage-get-system-packages
@@ -49,11 +49,15 @@ for PKG_BASE in $SPKGS; do
 
     case "$SYSTEM:$ENABLE_SYSTEM_SITE_PACKAGES" in
         install-requires*|pip*)
+            # This is output for installation of packages into a Python environment.
+            # So it's OK to use any Python packages.
             ;;
         *:)
-            # Skip this package if it uses the SAGE_PYTHON_PACKAGE_CHECK
-            # macro and if --enable-system-site-packages was NOT passed
-            # to ./configure (or if ./configure has not yet been run).
+            # --enable-system-site-packages was NOT passed to configure
+            # (or script was run outside of the sage-build-env).
+            #
+            # Skip this package if it uses the SAGE_PYTHON_PACKAGE_CHECK macro.
+            #
             SPKG_CONFIGURE="${SAGE_ROOT}/build/pkgs/${PKG_BASE}/spkg-configure.m4"
             if grep -q SAGE_PYTHON_PACKAGE_CHECK "${SPKG_CONFIGURE}" 2>/dev/null;
             then
@@ -61,6 +65,8 @@ for PKG_BASE in $SPKGS; do
             fi
             ;;
         *)
+            # --enable-system-site-packages was passed to configure.
+            # So any package (Python, non-Python) is fine.
             ;;
     esac
 

--- a/build/bin/sage-get-system-packages
+++ b/build/bin/sage-get-system-packages
@@ -47,16 +47,22 @@ case "$SYSTEM" in
 esac
 for PKG_BASE in $SPKGS; do
 
-    # Skip this package if it uses the SAGE_PYTHON_PACKAGE_CHECK
-    # macro and if --enable-system-site-packages was NOT passed
-    # to ./configure (or if ./configure has not yet been run).
-    SPKG_CONFIGURE="${SAGE_ROOT}/build/pkgs/${PKG_BASE}/spkg-configure.m4"
-    if [ -z "${ENABLE_SYSTEM_SITE_PACKAGES}" ]; then
-        if grep -q SAGE_PYTHON_PACKAGE_CHECK "${SPKG_CONFIGURE}" 2>/dev/null;
-        then
-            continue;
-        fi
-    fi
+    case "$SYSTEM:$ENABLE_SYSTEM_SITE_PACKAGES" in
+        install-requires*|pip*)
+            ;;
+        *:)
+            # Skip this package if it uses the SAGE_PYTHON_PACKAGE_CHECK
+            # macro and if --enable-system-site-packages was NOT passed
+            # to ./configure (or if ./configure has not yet been run).
+            SPKG_CONFIGURE="${SAGE_ROOT}/build/pkgs/${PKG_BASE}/spkg-configure.m4"
+            if grep -q SAGE_PYTHON_PACKAGE_CHECK "${SPKG_CONFIGURE}" 2>/dev/null;
+            then
+                continue
+            fi
+            ;;
+        *)
+            ;;
+    esac
 
     for NAME in $SYSTEM_PACKAGES_FILE_NAMES; do
         SYSTEM_PACKAGES_FILE="$SAGE_ROOT"/build/pkgs/$PKG_BASE/$NAME


### PR DESCRIPTION
Currently broken (since #29665):
```
$ build/bin/sage-get-system-packages install-requires zipp
$ build/bin/sage-get-system-packages install-requires-toml zipp
```
This causes `pkgs/sagemath-standard/pyproject.toml` to be broken; as noted in https://github.com/sagemath/sage/pull/36964#issuecomment-1871672884

The correct output:
```
$  build/bin/sage-get-system-packages install-requires zipp
zipp >=0.5.2
$ build/bin/sage-get-system-packages install-requires-toml zipp
'zipp >=0.5.2',
```

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
