### PR TITLE
ModulesWithBasis.ParentMethods.cardinality() for 0 dimensional modules

### DIFF
--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -996,10 +996,10 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: S = SymmetricGroupAlgebra(QQ, 4)
                 sage: S.cardinality()
                 +Infinity
-                sage: S = SymmetricGroupAlgebra(GF(2), 4)       # not tested
-                sage: S.cardinality()                           # not tested
+                sage: S = SymmetricGroupAlgebra(GF(2), 4)
+                sage: S.cardinality()
                 16777216
-                sage: S.cardinality().factor()                  # not tested
+                sage: S.cardinality().factor()
                 2^24
 
                 sage: # needs sage.modules
@@ -1013,10 +1013,19 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: s = SymmetricFunctions(GF(2)).s()                                 # needs sage.combinat sage.modules
                 sage: s.cardinality()                                                   # needs sage.combinat sage.modules
                 +Infinity
+
+                sage: M = CombinatorialFreeModule(QQ, [])
+                sage: M.dimension()
+                0
+                sage: M.cardinality()
+                1
             """
             from sage.rings.infinity import Infinity
             if self.dimension() == Infinity:
                 return Infinity
+            if self.dimension() == 0:
+                from sage.rings.integer_ring import ZZ
+                return ZZ.one()
             return self.base_ring().cardinality() ** self.dimension()
 
         def is_finite(self):


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

Currently this is not handled properly as $\infty^0$ is not well-defined but we know a 0 dimensional free module is $\\{0\\}$ with one element.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
