### PR TITLE
Fixed doc_test in `database.findstat` by adding new collection

### DIFF
--- a/src/sage/databases/findstat.py
+++ b/src/sage/databases/findstat.py
@@ -4318,6 +4318,7 @@ class FindStatCollection(Element,
             Cc0027: Signed permutations 4282 True
             Cc0028: Skew partitions 1250 True
             Cc0029: Lattices 1378 True
+            Cc0030: Ordered set partitions 5316 True
         """
         return self._data["Code"].element_level(element) in self._data["LevelsWithSizes"]
 
@@ -4711,7 +4712,8 @@ class FindStatCollections(UniqueRepresentation, Parent):
          Cc0026: Decorated permutations,
          Cc0027: Signed permutations,
          Cc0028: Skew partitions,
-         Cc0029: Lattices]
+         Cc0029: Lattices,
+         Cc0030: Ordered set partitions]
     """
     def __init__(self):
         """
@@ -4787,7 +4789,8 @@ class FindStatCollections(UniqueRepresentation, Parent):
              Cc0026: Decorated permutations,
              Cc0027: Signed permutations,
              Cc0028: Skew partitions,
-             Cc0029: Lattices]
+             Cc0029: Lattices,
+             Cc0030: Ordered set partitions]
 
             sage: FindStatCollection(Permutation([1,2,3]))                      # optional -- internet
             Cc0001: Permutations


### PR DESCRIPTION
This pull request addresses the doctest failures reported when testing the `findstat` module. The failures are related to the addition of a new collection, causing discrepancies in the expected and actual results.

The doctest failures were observed with the following optional packages:
```
--optional=4ti2,antic,build,cbc,ccache,cryptominisat,debian,dot2tex,e_antic,external,fricas,glucose,kissat,latte_int,lidia,normaliz,pip,sage,sage_numerical_backends_coin,sage_spkg
```
I have updated the doctests to include the new collection in the expected results.
Fixes #36481
### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.

