### PR TITLE
Use PARI when computing the Tate pairing

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -1917,12 +1917,32 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
 
         TESTS:
 
+        Check that the PARI output matches the original Sage implementation::
+
+            sage: # needs sage.rings.finite_rings
+            sage: GF(65537^2).inject_variables()
+            Defining z2
+            sage: E = EllipticCurve(GF(65537^2), [0,1])
+            sage: P = E(22, 28891)
+            sage: Q = E(-93, 40438*z2 + 31573)
+            sage: P.tate_pairing(Q, 7282, 2)
+            34585*z2 + 4063
+
         The point ``P (self)`` must have ``n`` torsion::
 
             P.tate_pairing(Q, 163, 2)
             Traceback (most recent call last):
             ...
-            ValueError:  The point P must be in the n-torsion
+            ValueError: The point P must be in the n-torsion
+
+        The Tate pairing is only defined for points on curves defined over finite fields::
+
+            sage: E = EllipticCurve([0,1])
+            sage: P = E(2,3)
+            sage: P.tate_pairing(P, 6, 1)
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: Reduced Tate pairing is currently only implemented for fintie fields
 
         ALGORITHM:
 
@@ -1943,7 +1963,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
 
         K = E.base_ring()
         if not K.is_finite():
-            raise NotImplementedError("Reduced Tate pairing is currently only implemented for fintie fields")
+            raise NotImplementedError("Reduced Tate pairing is currently only implemented for finite fields")
 
         d = K.degree()
         if q is None:
@@ -1961,6 +1981,8 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
         # must perform the exponentation ourselves using the supplied
         # k value
         ePQ = pari.elltatepairing(E, P, Q, n)
+        # TODO: if n or k is chosen badly, this could error, should we
+        # handle this explicitly by ensuring n divides q^k - 1?
         exp = Integer((q**k - 1)/n)
         return K(ePQ**exp) # Cast the PARI type back to the base ring
 

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -1933,7 +1933,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             sage: P.tate_pairing(Q, 163, 2)
             Traceback (most recent call last):
             ...
-            ValueError: The point P must be in the n-torsion
+            ValueError: The point P must be n-torsion
 
         The Tate pairing is only defined for points on curves defined over finite fields::
 
@@ -1975,7 +1975,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
                 raise ValueError("Unexpected field degree: set keyword argument q equal to the size of the base field (big field is GF(q^%s))." % k)
 
         if pari.ellmul(E, P, n) != [0]:
-            raise ValueError("The point P must be in the n-torsion")
+            raise ValueError("The point P must be n-torsion")
 
         # NOTE: Pari returns the non-reduced Tate pairing, so we
         # must perform the exponentation ourselves using the supplied

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -1942,7 +1942,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             sage: P.tate_pairing(P, 6, 1)
             Traceback (most recent call last):
             ...
-            NotImplementedError: Reduced Tate pairing is currently only implemented for fintie fields
+            NotImplementedError: Reduced Tate pairing is currently only implemented for finite fields
 
         ALGORITHM:
 

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -130,6 +130,7 @@ from sage.rings.infinity import Infinity as oo
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
+from sage.rings.finite_rings.integer_mod import Mod
 from sage.rings.real_mpfr import RealField
 from sage.rings.real_mpfr import RR
 import sage.groups.generic as generic
@@ -1935,6 +1936,13 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             ...
             ValueError: The point P must be n-torsion
 
+        We must have that ``n`` divides ``q^k - 1``, this is only checked when q is supplied::
+
+            sage: P.tate_pairing(Q, 7282, 2, q=123)
+            Traceback (most recent call last):
+            ...
+            ValueError: n does not divide (q^k - 1) for the supplied value of q
+
         The Tate pairing is only defined for points on curves defined over finite fields::
 
             sage: E = EllipticCurve([0,1])
@@ -1973,6 +1981,9 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
                 q = K.base_ring().order()
             else:
                 raise ValueError("Unexpected field degree: set keyword argument q equal to the size of the base field (big field is GF(q^%s))." % k)
+        # The user has supplied q, so we check here that it's a sensible value
+        elif Mod(q, n)**k != 1:
+            raise ValueError("n does not divide (q^k - 1) for the supplied value of q")
 
         if pari.ellmul(E, P, n) != [0]:
             raise ValueError("The point P must be n-torsion")
@@ -1981,8 +1992,6 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
         # must perform the exponentation ourselves using the supplied
         # k value
         ePQ = pari.elltatepairing(E, P, Q, n)
-        # TODO: if n or k is chosen badly, this could error, should we
-        # handle this explicitly by ensuring n divides q^k - 1?
         exp = Integer((q**k - 1)/n)
         return K(ePQ**exp) # Cast the PARI type back to the base ring
 

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -1930,7 +1930,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
 
         The point ``P (self)`` must have ``n`` torsion::
 
-            P.tate_pairing(Q, 163, 2)
+            sage: P.tate_pairing(Q, 163, 2)
             Traceback (most recent call last):
             ...
             ValueError: The point P must be in the n-torsion

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -1823,7 +1823,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
         - ``q`` -- positive integer: size of base field (the "big"
           field is `GF(q^k)`. `q` needs to be set only if its value
           cannot be deduced.)
-    
+
         - ``algorithm`` (default: ``None``) -- choices are ``pari``
           and ``sage``. PARI is usually significantly faster, but it
           only works over finite fields. When ``None`` is given, a
@@ -1943,8 +1943,8 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
         ALGORITHM:
 
         - For ``algorithm='pari'``: :pari:`elltatepairing` computes the
-        non-reduced tate pairing and the exponentiation is handled by 
-        Sage using user input for `k`.
+          non-reduced tate pairing and the exponentiation is handled by
+          Sage using user input for `k`.
 
         - For ``algorithm='sage'``:
           This function uses Miller's algorithm, followed by a naive
@@ -1984,12 +1984,12 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
                 algorithm = 'sage'
 
         if algorithm == 'pari':
-            if pari.ellmul(E,P,n) != [0]:
+            if pari.ellmul(E, P, n) != [0]:
                 raise ValueError("The point P must be in the n-torsion")
             # Note: Pari returns the non-reduced Tate pairing, so we
             # must perform the exponentation ourselves using the supplied
             # k value
-            ePQ =  pari.elltatepairing(E, P, Q, n)
+            ePQ = pari.elltatepairing(E, P, Q, n)
             e = Integer((q**k - 1)/n)
             return E.base_field()(ePQ**e)
 

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -1802,7 +1802,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
         except ZeroDivisionError:
             return one
 
-    def tate_pairing(self, Q, n, k, q=None):
+    def tate_pairing(self, Q, n, k, q=None, algorithm=None):
         r"""
         Return Tate pairing of `n`-torsion point `P = self` and point `Q`.
 
@@ -1823,6 +1823,11 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
         - ``q`` -- positive integer: size of base field (the "big"
           field is `GF(q^k)`. `q` needs to be set only if its value
           cannot be deduced.)
+    
+        - ``algorithm`` (default: ``None``) -- choices are ``pari``
+          and ``sage``. PARI is usually significantly faster, but it
+          only works over finite fields. When ``None`` is given, a
+          suitable algorithm is chosen automatically.
 
         OUTPUT:
 
@@ -1915,18 +1920,44 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             sage: Px.weil_pairing(Qx, 41)^e == num/den
             True
 
-        .. NOTE::
+        TESTS:
 
-            This function uses Miller's algorithm, followed by a naive
-            exponentiation. It does not do anything fancy. In the case
-            that there is an issue with `Q` being on one of the lines
-            generated in the `r*P` calculation, `Q` is offset by a random
-            point `R` and ``P.tate_pairing(Q+R,n,k)/P.tate_pairing(R,n,k)``
-            is returned.
+        Check that the original Sage implementation still works::
+
+            sage: # needs sage.rings.finite_rings
+            sage: GF(65537^2).inject_variables()
+            Defining z2
+            sage: E = EllipticCurve(GF(65537^2), [0,1])
+            sage: P = E(22, 28891)
+            sage: Q = E(-93, 40438*z2 + 31573)
+            sage: P.tate_pairing(Q, 7282, 2, algorithm='sage')
+            34585*z2 + 4063
+
+        Passing an unknown ``algorithm=`` argument should fail::
+
+            sage: P.tate_pairing(Q, 7282, 2, algorithm='_invalid_')                        # needs sage.rings.finite_rings
+            Traceback (most recent call last):
+            ...
+            ValueError: unknown algorithm
+
+        ALGORITHM:
+
+        - For ``algorithm='pari'``: :pari:`elltatepairing` computes the
+        non-reduced tate pairing and the exponentiation is handled by 
+        Sage using user input for `k`.
+
+        - For ``algorithm='sage'``:
+          This function uses Miller's algorithm, followed by a naive
+          exponentiation. It does not do anything fancy. In the case
+          that there is an issue with `Q` being on one of the lines
+          generated in the `r*P` calculation, `Q` is offset by a random
+          point `R` and ``P.tate_pairing(Q+R,n,k)/P.tate_pairing(R,n,k)``
+          is returned.
 
         AUTHORS:
 
         - Mariah Lenox (2011-03-07)
+        - Giacomo Pope (2024): ``algorithm='pari'``
         """
         P = self
         E = P.curve()
@@ -1943,6 +1974,27 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
                 q = K.base_ring().order()
             else:
                 raise ValueError("Unexpected field degree: set keyword argument q equal to the size of the base field (big field is GF(q^%s))." % k)
+
+        # When appropriate we can use Pari for faster computation
+        # of the Tate pairing
+        if algorithm is None:
+            if E.base_field().is_finite():
+                algorithm = 'pari'
+            else:
+                algorithm = 'sage'
+
+        if algorithm == 'pari':
+            if pari.ellmul(E,P,n) != [0]:
+                raise ValueError("The point P must be in the n-torsion")
+            # Note: Pari returns the non-reduced Tate pairing, so we
+            # must perform the exponentation ourselves using the supplied
+            # k value
+            ePQ =  pari.elltatepairing(E, P, Q, n)
+            e = Integer((q**k - 1)/n)
+            return E.base_field()(ePQ**e)
+
+        if algorithm != 'sage':
+            raise ValueError('unknown algorithm')
 
         if n*P != E(0):
             raise ValueError('This point is not of order n=%s' % n)


### PR DESCRIPTION
To match `weil_pairing()` this pull request now uses PARI to compute the non-reduced Tate pairing for elliptic curves over finite fields. 

This has been included for efficiency, with PARI offering a significant performance speed up:

```py
sage: GF(65537^2).inject_variables()
Defining z2
sage: E = EllipticCurve(GF(65537^2), [0,1])
sage: P = E(22, 28891)
sage: Q = E.random_point()
sage: # Old timing
sage: %timeit P.tate_pairing(Q, 7282, 2)
1.4 ms ± 66 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
sage: # New timing
sage: %timeit P.tate_pairing(Q, 7282, 2)
50.8 µs ± 674 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.