### PR TITLE
Append (not symlink) `config.log` to `logs/pkgs/config.log`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,6 @@ SPKG_COLLECT_FILES = build/pkgs/*/type build/pkgs/*/package-version.txt build/pk
 # Otherwise, run configure with argument $PREREQ_OPTIONS.
 build/make/Makefile: configure $(SPKG_COLLECT_FILES) $(CONFIG_FILES:%=%.in)
 	rm -f config.log
-	mkdir -p logs/pkgs
-	ln -s logs/pkgs/config.log config.log
 	@if [ -x config.status ]; then \
 		./config.status --recheck && ./config.status; \
 	else \

--- a/build/make/install
+++ b/build/make/install
@@ -32,6 +32,12 @@ sage_num_threads_array="${sage_num_threads_array% *}" # strip third item
 export SAGE_NUM_THREADS="${sage_num_threads_array% *}" # keep first item
 export SAGE_NUM_THREADS_PARALLEL="${sage_num_threads_array#* }" # keep second item
 
+if [ ! -e "$SAGE_ROOT"/logs/pkgs/config.log \
+       -o "$SAGE_ROOT"/config.log -nt "$SAGE_ROOT"/logs/pkgs/config.log ]; then
+    echo "$0: Appending config.log to logs/pkgs/config.log"
+    cat "$SAGE_ROOT"/config.log >> "$SAGE_ROOT"/logs/pkgs/config.log
+fi
+
 ###############################################################################
 # Skip the rest if nothing to do (i.e., to [re]build).
 ###############################################################################

--- a/src/doc/en/installation/troubles.rst
+++ b/src/doc/en/installation/troubles.rst
@@ -28,7 +28,7 @@ first, or run::
        grep -li "^Error" logs/pkgs/*
 
 from the top-level Sage directory to find log files with error
-messages in them.  Send the file ``config.log`` as well as the
+messages in them.  Send the file ``logs/pkgs/config.log`` as well as the
 log file(s) of the packages that have failed to build
 in their entirety to the sage-support mailing list
 at https://groups.google.com/group/sage-support; probably someone


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

We change the handling of `config.log`, previously set up as a symlink into `logs/pkgs/`. We sometimes get reports about build problems with a `config.log` attached that just shows "... already installed as an SPKG", so we cannot see what caused the SPKG to be installed in the first place. We fix this problem by appending the current contents of `config.log` (whenever it has changed) to `logs/pkgs/config.log`.

Split out from #33262.

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
