### PR TITLE
Fixes in save_session()

### DIFF
--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -2477,19 +2477,6 @@ class DocTestTask():
         ['cputime', 'err', 'failures', 'optionals', 'tests', 'walltime', 'walltime_skips']
     """
 
-    extra_globals = {}
-    """
-    Extra objects to place in the global namespace in which tests are run.
-    Normally this should be empty but there are special cases where it may
-    be useful.
-
-    For example, in Sage versions 9.1 and earlier, on Python 3 add
-    ``long`` as an alias for ``int`` so that tests that use the
-    ``long`` built-in (of which there are many) still pass.  We did
-    this so that the test suite could run on Python 3 while Python 2
-    was still the default.
-    """
-
     def __init__(self, source):
         """
         Initialization.
@@ -2614,10 +2601,6 @@ class DocTestTask():
         # Remove '__package__' item from the globals since it is not
         # always in the globals in an actual Sage session.
         dict_all.pop('__package__', None)
-
-        # Add any other special globals for testing purposes only
-        dict_all.update(self.extra_globals)
-
         sage_namespace = RecordingDict(dict_all)
         sage_namespace['__name__'] = '__main__'
         doctests, extras = self.source.create_doctests(sage_namespace)

--- a/src/sage/misc/session.pyx
+++ b/src/sage/misc/session.pyx
@@ -27,7 +27,7 @@ This saves a dictionary with ``w`` as one of the keys::
 
     sage: z = load(os.path.join(d.name, 'session'))
     sage: list(z)
-    ['d', 'w']
+    ['w', 'd']
     sage: z['w']
     2/3
 
@@ -200,7 +200,7 @@ def show_identifiers(hidden=False):
         sage: a = 10
         sage: factor = 20
         sage: show_identifiers()
-        ['a', 'factor']
+        ['factor', 'a']
 
     To get the actual value of a variable from the list, use the
     :func:`globals()` function.::
@@ -214,7 +214,7 @@ def show_identifiers(hidden=False):
 
         sage: _hello = 10
         sage: show_identifiers()
-        ['a', 'factor']
+        ['factor', 'a']
         sage: '_hello' in show_identifiers(hidden=True)
         True
 
@@ -222,10 +222,13 @@ def show_identifiers(hidden=False):
     least in command line mode.::
 
         sage: show_identifiers(hidden=True)        # random output
-        ['__', '_i', '_6', '_4', '_3', '_1', '_ii', '__doc__', '__builtins__', '___', '_9', '__name__', '_', 'a', '_i12', '_i14', 'factor', '__file__', '_hello', '_i13', '_i11', '_i10', '_i15', '_i5', '_13', '_10', '_iii', '_i9', '_i8', '_i7', '_i6', '_i4', '_i3', '_i2', '_i1', '_init_cmdline', '_14']
+        ['__builtin__', '_ih', '_oh', '_dh', 'exit', 'quit', '_', '__', '___',
+        '_i', '_ii', '_iii', '_i1', 'factor', '_i2', '_2', '_i3', 'a', '_i4',
+        '_i5', '_5', '_i6', '_6', '_i7', '_hello', '_i8', '_8', '_i9', '_9',
+        '_i10']
     """
     state = caller_locals()
-    return sorted([x for x, v in state.items() if _is_new_var(x, v, hidden)])
+    return [x for x, v in state.items() if _is_new_var(x, v, hidden)]
 
 
 def save_session(name='sage_session', verbose=False):
@@ -288,17 +291,15 @@ def save_session(name='sage_session', verbose=False):
         sage: f = lambda x : x^2
         sage: save_session(tmp_f)
         sage: save_session(tmp_f, verbose=True)
-        Saving...
-        Not saving f: f is a function or method
         ...
+        Not saving f: f is a function or method
 
     Something similar happens for cython-defined functions::
 
         sage: g = cython_lambda('double x', 'x*x + 1.5')
         sage: save_session(tmp_f, verbose=True)
-        Saving...
-        Not saving g: g is a cython function or method
         ...
+        Not saving g: g is a cython function or method
 
     And the same for a lazy import::
 
@@ -307,7 +308,6 @@ def save_session(name='sage_session', verbose=False):
         sage: save_session(tmp_f, verbose=True)
         ...
         Not saving lazy_ZZ: lazy_ZZ is a lazy import
-        ...
     """
     state = caller_locals()
     # This dict D will contain the session -- as a dict -- that we will save to disk.


### PR DESCRIPTION
1. fix test for cython functions in save_session()
   This fixes #37003 
2. fix handling of lazy import variables in save_session()
   This fixes #37002 
3. remove unused `extra_globals` attribute in class DocTestTask
   This was introduced for the transition from python 2 to 3, no longer used
4. don't sort the output of `sage.misc.session.show_identifiers()`
   There's no need to sort here... sorting was introduced in baedc413164 in order to fix doctest errors, but dictionaries now keep the insertion order. Thus `show_identifiers()` will return the variables in the order they were introduced for the first time which seems reasonable and it's fine to test.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.

Fixes: #37002, #37003