### PR TITLE
normalize projective points over (quotients of) Euclidean domains

### DIFF
--- a/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
+++ b/src/sage/dynamics/arithmetic_dynamics/projective_ds.py
@@ -1081,8 +1081,7 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
             sage: f.nth_iterate(P(0, 1), 3)
             Traceback (most recent call last):
             ...
-            ValueError: [0, 0] does not define a point in Projective Space of
-            dimension 1 over Rational Field since all entries are zero
+            ValueError: [0, 0] does not define a valid projective point since all entries are zero
 
         ::
 
@@ -1597,8 +1596,7 @@ class DynamicalSystem_projective(SchemeMorphism_polynomial_projective_space,
             sage: f.orbit(P(0, 1), 3)
             Traceback (most recent call last):
             ...
-            ValueError: [0, 0] does not define a point in Projective Space of
-            dimension 1 over Rational Field since all entries are zero
+            ValueError: [0, 0] does not define a valid projective point since all entries are zero
             sage: f.orbit(P(0, 1), 3, check=False)
             [(0 : 1), (0 : 0), (0 : 0), (0 : 0)]
 

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -921,7 +921,7 @@ def EllipticCurve_from_cubic(F, P=None, morphism=True):
         sage: f([1,-1,1])
         Traceback (most recent call last):
         ...
-        ValueError: [0, 0, 0] does not define a valid point since all entries are 0
+        ValueError: [0, 0, 0] does not define a valid projective point since all entries are zero
 
     Using the group law on the codomain elliptic curve, which has rank
     1 and full 2-torsion, and the inverse morphism, we can find many

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -963,6 +963,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         else:
             ys = [y1, y2]
         ys.sort()  # ensure deterministic behavior
+        x = M(x)
         one = M.one()
         if all:
             return [EM.point([x, y, one], check=False) for y in ys]

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -277,6 +277,8 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
         SchemeMorphism_point_abelian_variety_field.__init__(self, point_homset, v, check=check)
         # AdditiveGroupElement.__init__(self, point_homset)
 
+        self.normalize_coordinates()
+
     def _repr_(self):
         """
         Return a string representation of this point.
@@ -398,8 +400,9 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             sage: pari(E).elladd(O, P)
             [Mod(1, 11), Mod(2, 11)]
         """
-        if self[2]:
-            return pari([self[0]/self[2], self[1]/self[2]])
+        x,y,z = self._coords
+        if z:
+            return pari([x/z, y/z])
         else:
             return pari([0])
 
@@ -504,7 +507,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             sage: P.is_zero()
             False
         """
-        return bool(self[2])
+        return bool(self._coords[2])
 
     def has_order(self, n):
         r"""
@@ -838,7 +841,7 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             ...
             ZeroDivisionError: rational division by zero
         """
-        if self[2] == 1:
+        if self[2].is_one():
             return self[0], self[1]
         else:
             return self[0]/self[2], self[1]/self[2]

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -273,42 +273,8 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             v = list(v)
         elif v == 0:
             v = (R.zero(), R.one(), R.zero())
-        if check:
-            # mostly from SchemeMorphism_point_projective_field
-            d = point_homset.codomain().ambient_space().ngens()
-            if not isinstance(v, (list, tuple)):
-                raise TypeError("Argument v (= %s) must be a scheme point, list, or tuple." % str(v))
-            if len(v) != d and len(v) != d-1:
-                raise TypeError("v (=%s) must have %s components" % (v, d))
-            v = Sequence(v, R)
-            if len(v) == d-1:     # very common special case
-                v.append(v.universe()(1))
 
-            n = len(v)
-            all_zero = True
-            for i in range(n):
-                c = v[n-1-i]
-                if c:
-                    all_zero = False
-                    if c == 1:
-                        break
-                    for j in range(n-i):
-                        v[j] /= c
-                    break
-            if all_zero:
-                raise ValueError("%s does not define a valid point "
-                                 "since all entries are 0" % repr(v))
-
-            x, y, z = v
-            if z == 0:
-                test = x
-            else:
-                a1, a2, a3, a4, a6 = curve.ainvs()
-                test = y**2 + (a1*x+a3)*y - (((x+a2)*x+a4)*x+a6)
-            if not test == 0:
-                raise TypeError("Coordinates %s do not define a point on %s" % (list(v), curve))
-
-        SchemeMorphism_point_abelian_variety_field.__init__(self, point_homset, v, check=False)
+        SchemeMorphism_point_abelian_variety_field.__init__(self, point_homset, v, check=check)
         # AdditiveGroupElement.__init__(self, point_homset)
 
     def _repr_(self):


### PR DESCRIPTION
Currently, projective points *over fields* are normalized to always have $1$ as their last non-zero coordinate, but projective points over non-fields are not normalized at all.

In this patch, we add similar normalization functionality for base rings which are (1) Euclidean domains, or (2) quotients of Euclidean domains. The most important examples are probably $\mathbb Z$ and $\mathbb Z/n$ for composite $n$.