### PR TITLE
`src/bin/sage-cython`: Repurpose as PEP 420 fixer

### DIFF
--- a/pkgs/sagemath-environment/pyproject.toml.m4
+++ b/pkgs/sagemath-environment/pyproject.toml.m4
@@ -50,6 +50,9 @@ script-files = [
     "bin/sage-version.sh",
     # Auxiliary script for invoking Python in the Sage environment
     "bin/sage-python",
+    # The following is freshly un-deprecated as a temporary workaround
+    # for defects in Cython 3.0.x support for PEP 420 implicit namespace packages
+    "bin/sage-cython",
     # Not included:
     # - bin/sage-env-config                  -- installed by sage_conf
     # - bin/sage-env-config.in               -- not to be installed

--- a/src/bin/sage-cython
+++ b/src/bin/sage-cython
@@ -1,39 +1,26 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python
 
-# This script is a deprecated wrapper around the "cython" program.
-# It is deprecated since Issue #27041 (Sage 8.7) because one should
+# This script is a wrapper around the "cython" program.
+# It was deprecated in Issue #27041 (Sage 8.7) because one should
 # simply use "cython" directly. We display deprecation messages whenever
 # "sage-cython" does something different from plain "cython".
 #
 # A stronger deprecation warning was added in #29923 (Sage 9.2).
+#
+# In Sage 10.3, the deprecated functionality is removed permanently.
+# However, the script is un-deprecated and re-purposed as a temporary workaround
+# for defects in Cython 3.0.x support for PEP 420 implicit namespace packages,
+# see https://github.com/sagemath/sage/pull/36228
+#
+# This script can be used as a replacement for "cython".
+# For example, to have meson use it, set the environment variable
+# CYTHON to sage-cython./
+# https://github.com/mesonbuild/meson/blob/e4bbc630b67ef97ad842badd00855e64cff12e13/mesonbuild/envconfig.py#L91
 
-import os
-import sys
-args = sys.argv[1:]
+from sage.misc.package_dir import cython_namespace_package_support
 
-sys.stderr.write("WARNING: the script sage-cython is deprecated; use cython instead.\n")
+# console scripts declared in https://github.com/cython/cython/blob/master/setup.py#L68
+from Cython.Compiler.Main import setuptools_main
 
-from sage.env import SAGE_SRC
-
-# args can have length 0, in case we're printing a usage message (see trac 12207)
-pyx_file = os.path.abspath(args[-1]) if len(args) else None
-include_sage_flags = False
-
-if pyx_file and pyx_file.startswith(SAGE_SRC):
-    sys.stderr.write("WARNING: in the future, sage --cython will not add special flags for files in Sage sources.\n")
-    include_sage_flags = True
-
-if '-sage' in args:
-    sys.stderr.write("WARNING: sage --cython -sage is deprecated.\n")
-    include_sage_flags = True
-    args.remove('-sage')
-elif '-no-sage' in args:
-    sys.stderr.write("WARNING: sage --cython -no-sage is deprecated, remove the -no-sage flag.\n")
-    include_sage_flags = False
-    args.remove('-no-sage')
-
-if include_sage_flags:
-    args = ['--embed-positions', '-I%s' % SAGE_SRC] + args
-
-args.insert(0, 'sage-cython')
-os.execlp('cython', *args)
+with cython_namespace_package_support():
+     setuptools_main()


### PR DESCRIPTION
We ship it with the distribution **sagemath-environment**.

This is needed for building the modularized distributions of the Sage library using meson-python.

With meson >= 1.4.0 (https://github.com/mesonbuild/meson/pull/12674), it then suffices to set `CYTHON=sage-cython`.

With earlier versions of meson, one can use a native file 
```
[binaries]
cython = 'sage-cython'
```

... as done in #37012 (54c95d60183) and #35095.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
