### PR TITLE
Parent in plural

### DIFF
--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -126,7 +126,7 @@ from sage.rings.polynomial.multi_polynomial_libsingular cimport MPolynomialRing_
 from sage.rings.polynomial.multi_polynomial_ideal import NCPolynomialIdeal
 
 from sage.rings.polynomial.polydict import ETuple
-from sage.rings.ring import check_default_category, Ring
+from sage.rings.ring import check_default_category, CommutativeRing
 from sage.structure.element cimport CommutativeRingElement, Element, RingElement
 from sage.structure.factory import UniqueFactory
 from sage.structure.richcmp cimport rich_to_bool
@@ -2878,8 +2878,8 @@ cpdef MPolynomialRing_libsingular new_CRing(RingWrap rw, base_ring) noexcept:
     self._term_order = TermOrder(rw.ordering_string(), force=True)
 
     names = tuple(rw.var_names())
-    Ring.__init__(self, base_ring, names, category=Algebras(base_ring),
-                  normalize=False)
+    CommutativeRing.__init__(self, base_ring, names, category=Algebras(base_ring),
+                             normalize=False)
 
     self._has_singular = True
 

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -334,7 +334,7 @@ cdef class NCPolynomialRing_plural(Ring):
         self._ngens = n
         self._term_order = order
 
-        Ring.__init__(self, base_ring, names, category=category)
+        Parent.__init__(self, base=base_ring, names=names, category=category)
         self._populate_coercion_lists_()
 
         assert n == len(self._names)

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -2946,7 +2946,7 @@ cpdef NCPolynomialRing_plural new_NRing(RingWrap rw, base_ring) noexcept:
     self._ngens = rw.ngens()
     self._term_order = TermOrder(rw.ordering_string(), force=True)
 
-    Ring.__init__(self, base_ring, rw.var_names(), category=Algebras(base_ring))
+    Parent.__init__(self, base=base_ring, names=rw.var_names(), category=Algebras(base_ring))
 
     self._has_singular = True
     self._relations = self.relations()


### PR DESCRIPTION
Using `Parent` and `CommutativeRing` in the plural file

This is a little move towards getting rid of the old coercion framework.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.