### PR TITLE
Return a vector of monomial instead of a matrix in PolynomialSequence.coefficient_matrix()

### DIFF
--- a/src/sage/groups/matrix_gps/finitely_generated_gap.py
+++ b/src/sage/groups/matrix_gps/finitely_generated_gap.py
@@ -936,11 +936,11 @@ def _new_invariant_is_linearly_independent(F, invariants):
         sage: gens = [matrix(QQ, [[-1,1],[-1,0]]), matrix(QQ, [[0,1],[1,0]])]
         sage: G = MatrixGroup(gens)
         sage: s = Sequence(G.invariants_of_degree(14))                                  # needs sage.rings.number_field
-        sage: s.coefficient_matrix()[0].rank()                                          # needs sage.rings.number_field
+        sage: s.coefficients_monomials()[0].rank()                                      # needs sage.rings.number_field
         3
         sage: len(s)                                                                    # needs sage.rings.number_field
         3
     """
     if len(invariants) == 0:
         return True
-    return PolynomialSequence(invariants).coefficient_matrix()[0].rank() != PolynomialSequence(list(invariants)+[F]).coefficient_matrix()[0].rank()
+    return PolynomialSequence(invariants).coefficients_monomials()[0].rank() != PolynomialSequence(list(invariants)+[F]).coefficients_monomials()[0].rank()

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -5333,7 +5333,7 @@ class MPolynomialIdeal(MPolynomialIdeal_singular_repr,
 
         2. We linearize and compute the echelon form::
 
-               sage: A, v = F.coefficient_matrix()
+               sage: A, v = F.coefficients_monomials()
                sage: A.echelonize()
 
         3. The result is the desired Gröbner basis::

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -768,9 +768,9 @@ class PolynomialSequence_generic(Sequence_generic):
         A = Matrix(R.base_ring(), len(f), nv, sparse=sparse)
 
         for x, poly in enumerate(f):
-            for m in poly.monomials():
+            for c, m in poly:
                 try:
-                    A[x, y[m]] = poly.monomial_coefficient(m)
+                    A[x, y[m]] = c
                 except KeyError:
                     raise ValueError("order argument does not contain all monomials")
         return A, vector(v)

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -141,7 +141,7 @@ easily::
     sage: A.rank()
     4056
     sage: A[4055] * v
-    (k001*k003)
+    k001*k003
 
 TESTS::
 
@@ -803,6 +803,9 @@ class PolynomialSequence_generic(Sequence_generic):
              b^2 + 2*a*c + 2*b*d - c]
             sage: F = Sequence(I)
             sage: A,v = F.coefficient_matrix()
+            DeprecationWarning: the function coefficient_matrix is deprecated; use coefficients_monomials instead
+            See https://github.com/sagemath/sage/issues/37035 for details.
+              A,v = F.coefficient_matrix()
             sage: A
             [  0   0   0   0   0   0   0   0   0   1   2   2   2 126]
             [  1   0   2   0   0   2   0   0   2 126   0   0   0   0]

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -803,9 +803,9 @@ class PolynomialSequence_generic(Sequence_generic):
              b^2 + 2*a*c + 2*b*d - c]
             sage: F = Sequence(I)
             sage: A,v = F.coefficient_matrix()
+            doctest:warning...
             DeprecationWarning: the function coefficient_matrix is deprecated; use coefficients_monomials instead
             See https://github.com/sagemath/sage/issues/37035 for details.
-              A,v = F.coefficient_matrix()
             sage: A
             [  0   0   0   0   0   0   0   0   0   1   2   2   2 126]
             [  1   0   2   0   0   2   0   0   2 126   0   0   0   0]

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -114,7 +114,7 @@ We separate the system in independent subsystems::
 
 and compute the coefficient matrix::
 
-    sage: A,v = Sequence(r2).coefficient_matrix()                                       # needs sage.rings.polynomial.pbori
+    sage: A,v = Sequence(r2).coefficients_monomials()                                   # needs sage.rings.polynomial.pbori
     sage: A.rank()                                                                      # needs sage.rings.polynomial.pbori
     32
 
@@ -134,7 +134,7 @@ easily::
     sage: len(monomials)
     190
     sage: F2 = Sequence(map(mul, cartesian_product_iterator((monomials, F))))
-    sage: A, v = F2.coefficient_matrix(sparse=False)
+    sage: A, v = F2.coefficients_monomials(sparse=False)
     sage: A.echelonize()
     sage: A
     6840 x 4474 dense matrix over Finite Field of size 2...
@@ -829,26 +829,13 @@ class PolynomialSequence_generic(Sequence_generic):
             [      2*a*b + 2*b*c + 2*c*d - b]
             [        b^2 + 2*a*c + 2*b*d - c]
         """
-        R = self.ring()
-
-        m = sorted(self.monomials(),reverse=True)
-        nm = len(m)
-        f = tuple(self)
-        nf = len(f)
-
-        #construct dictionary for fast lookups
-        v = dict( zip( m , range(len(m)) ) )
-
         from sage.matrix.constructor import Matrix
+        from sage.misc.superseded import deprecation
+        deprecation(37035, "the function coefficient_matrix is deprecated; use coefficients_monomials instead")
 
-        A = Matrix( R.base_ring(), nf, nm, sparse=sparse )
-
-        for x in range( nf ):
-            poly = f[x]
-            for y in poly.monomials():
-                A[ x , v[y] ] = poly.monomial_coefficient(y)
-
-        return A, Matrix(R,nm,1,m)
+        R = self.ring()
+        A, v = self.coefficients_monomials(sparse=sparse)
+        return A, Matrix(R,len(v),1,v)
 
     def subs(self, *args, **kwargs):
         """

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -750,9 +750,7 @@ class PolynomialSequence_generic(Sequence_generic):
         from sage.modules.free_module_element import vector
         from sage.matrix.constructor import Matrix
 
-        R = self.ring()
         f = tuple(self)
-
         if order is None:
             v = sorted(self.monomials(), reverse=True)
         else:
@@ -760,13 +758,9 @@ class PolynomialSequence_generic(Sequence_generic):
                 v = order
             else:
                 raise ValueError("order argument can only accept list or tuple")
-        nv = len(v)
 
-        # construct dictionary for fast lookups
-        y = dict(zip(v, range(nv)))
-
-        A = Matrix(R.base_ring(), len(f), nv, sparse=sparse)
-
+        y = dict(zip(v, range(len(v))))  # construct dictionary for fast lookups
+        A = Matrix(self.ring().base_ring(), len(f), len(v), sparse=sparse)
         for x, poly in enumerate(f):
             for c, m in poly:
                 try:

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -7637,10 +7637,10 @@ def gauss_on_polys(inp):
         sage: B.<a,b,c,d,e,f> = BooleanPolynomialRing()
         sage: from sage.rings.polynomial.pbori.pbori import *
         sage: l = [B.random_element() for _ in range(B.ngens())]
-        sage: A, v = Sequence(l, B).coefficient_matrix()
+        sage: A, v = Sequence(l, B).coefficients_monomials()
 
         sage: e = gauss_on_polys(l)
-        sage: E, v = Sequence(e, B).coefficient_matrix()
+        sage: E, v = Sequence(e, B).coefficients_monomials()
         sage: E == A.echelon_form()
         True
     """


### PR DESCRIPTION
- Final change to the function
- Added a deprecation message
This patch fixes #37027 by returning a vector of monomials instead of a matrix,
which follows the documentation.
I have also added a deprecation message.
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Does not matter.
