### PR TITLE
Add minimal_normal_subgroups function for permutation groups

### DIFF
--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -101,12 +101,19 @@ class FiniteGroups(CategoryWithAxiom):
                 sage: G.cardinality()
                 384
             """
+
+            # Check whether the object has _deg attribute or not 
+            # Note for developers - It will have _deg attribute if it is derived from  MatrixGroup_generic class
+            # And if it has _deg attribute then return the value of that attribute
+            if hasattr(self, '_deg'):
+                return self._deg
+
+            # If object does not have _deg attribute then try to find its order with the help of order function.
             try:
                 o = self.order
+                return o()
             except AttributeError:
                 return self._cardinality_from_iterator()
-            else:
-                return o()
 
         def some_elements(self):
             """

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -102,7 +102,7 @@ class FiniteGroups(CategoryWithAxiom):
                 384
             """
 
-            # Check whether the object has _deg attribute or not 
+            # Check whether the object has _deg attribute or not
             # Note for developers - It will have _deg attribute if it is derived from  MatrixGroup_generic class
             # And if it has _deg attribute then return the value of that attribute
             if hasattr(self, '_deg'):

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -101,10 +101,6 @@ class FiniteGroups(CategoryWithAxiom):
                 sage: G.cardinality()
                 384
             """
-            # If the group is special group and finite then there is only one possibility that the degree
-            # and cardinality will be one.
-            if hasattr(self,'_special') and self._special==True:
-                return 1
             try:
                 o = self.order
                 return o()

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -102,13 +102,10 @@ class FiniteGroups(CategoryWithAxiom):
                 384
             """
 
-            # Check whether the object has _deg attribute or not
-            # Note for developers - It will have _deg attribute if it is derived from  MatrixGroup_generic class
-            # And if it has _deg attribute then return the value of that attribute
+            # Note for developers - self will have _deg attribute if it is derived from  MatrixGroup_generic class
             if hasattr(self, '_deg'):
                 return self._deg
 
-            # If object does not have _deg attribute then try to find its order with the help of order function.
             try:
                 o = self.order
                 return o()

--- a/src/sage/categories/finite_groups.py
+++ b/src/sage/categories/finite_groups.py
@@ -101,11 +101,10 @@ class FiniteGroups(CategoryWithAxiom):
                 sage: G.cardinality()
                 384
             """
-
-            # Note for developers - self will have _deg attribute if it is derived from  MatrixGroup_generic class
-            if hasattr(self, '_deg'):
-                return self._deg
-
+            # If the group is special group and finite then there is only one possibility that the degree
+            # and cardinality will be one.
+            if hasattr(self,'_special') and self._special==True:
+                return 1
             try:
                 o = self.order
                 return o()

--- a/src/sage/groups/group.pyx
+++ b/src/sage/groups/group.pyx
@@ -321,6 +321,3 @@ cdef class FiniteGroup(Group):
             True
         """
         return True
-
-    def minimum_generating_set(self):
-        pass

--- a/src/sage/groups/group.pyx
+++ b/src/sage/groups/group.pyx
@@ -321,3 +321,6 @@ cdef class FiniteGroup(Group):
             True
         """
         return True
+
+    def minimum_generating_set(self):
+        pass

--- a/src/sage/groups/libgap_mixin.py
+++ b/src/sage/groups/libgap_mixin.py
@@ -963,3 +963,10 @@ class GroupMixinLibGAP():
             (False, False, False)
         """
         return self.gap().IsomorphismGroups(H.gap()) != libgap.fail
+    
+    def d(slef):
+        # name change karte h
+        pass
+
+    def MinimumGeneratingSet(self):
+        def iterator_function(g, N, t):

--- a/src/sage/groups/libgap_mixin.py
+++ b/src/sage/groups/libgap_mixin.py
@@ -964,9 +964,17 @@ class GroupMixinLibGAP():
         """
         return self.gap().IsomorphismGroups(H.gap()) != libgap.fail
     
-    def d(slef):
-        # name change karte h
-        pass
+    def minimum_generating_set(self):
+        if not self.is_finite():
+            raise NotImplementedError("Only implemented for finite groups")
 
-    def MinimumGeneratingSet(self):
-        def iterator_function(g, N, t):
+        if self.is_simple():
+            if self.is_abelian():
+                return self.random_element()
+            
+            group_elements = self.list()
+            n = len(group_elements)
+
+            for i in range(n):
+                for j in range(i+1,n):
+                    print(self.gap().IsGeneratorsOfGroup().sage())

--- a/src/sage/groups/libgap_mixin.py
+++ b/src/sage/groups/libgap_mixin.py
@@ -964,17 +964,3 @@ class GroupMixinLibGAP():
         """
         return self.gap().IsomorphismGroups(H.gap()) != libgap.fail
     
-    def minimum_generating_set(self):
-        if not self.is_finite():
-            raise NotImplementedError("Only implemented for finite groups")
-
-        if self.is_simple():
-            if self.is_abelian():
-                return self.random_element()
-            
-            group_elements = self.list()
-            n = len(group_elements)
-
-            for i in range(n):
-                for j in range(i+1,n):
-                    print(self.gap().IsGeneratorsOfGroup().sage())

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -277,6 +277,18 @@ def SL(n, R, var='a'):
         sage: S = SL(2,FqTN)
         sage: S.is_finite()
         True
+
+        Check if is_finite() function is giving correct answer for the special linear group which is not finite::
+
+        sage: SL(2, QQ).is_finite()
+        False
+
+        Check if the cardinality or order of infinite special linear group is +Infinity or not::
+
+        sage: SL(2, QQ).cardinality()
+        +Infinity
+        sage: SL(2, QQ).order()
+        +Infinity
     """
     degree, ring = normalize_args_vectorspace(n, R, var='a')
     try:

--- a/src/sage/groups/matrix_gps/linear.py
+++ b/src/sage/groups/matrix_gps/linear.py
@@ -256,6 +256,27 @@ def SL(n, R, var='a'):
 
         sage: groups.matrix.SL(2, 3)
         Special Linear Group of degree 2 over Finite Field of size 3
+
+        Check if :trac:`36876` is fixed: The cardinality or order of a special linear group with degree=1 over any field is 1::
+
+        sage: SL(1, QQ).cardinality()
+        1
+        sage: SL(1, RR).cardinality()
+        1
+        sage: SL(1, QQ).order()
+        1
+        sage: SL(1, CC).order()
+        1
+
+        Check if :trac:`35490` is fixed: The special linear group with degree=1 is finite::
+
+        sage: q = 7
+        sage: FqT.<T> = GF(q)[]
+        sage: N = T^2+1
+        sage: FqTN = QuotientRing(FqT, N*FqT)
+        sage: S = SL(2,FqTN)
+        sage: S.is_finite()
+        True
     """
     degree, ring = normalize_args_vectorspace(n, R, var='a')
     try:

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -4115,8 +4115,14 @@ class PermutationGroup_generic(FiniteGroup):
             sage: G = SymmetricGroup(4)
             sage: G.minimal_normal_subgroups()
             [ Group([ (1,4)(2,3), (1,3)(2,4) ]) ]
+
+        TESTS::
+
+            sage: G = SymmetricGroup(8)
+            sage: G.minimal_normal_subgroups()
+            [ Alt( [ 1 .. 8 ] ) ]
         """
-        return self._libgap_().MinimalNormalSubgroups().sage()
+        return self._libgap_().MinimalNormalSubgroups()
 
     ######################  Boolean tests #####################
 

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -4106,6 +4106,18 @@ class PermutationGroup_generic(FiniteGroup):
         else:
             raise TypeError("group must be simple")
 
+    def minimal_normal_subgroups(self):
+        """
+        Return all minimal normal subgroups of the group.
+
+        EXAMPLES::
+
+            sage: G = SymmetricGroup(4)
+            sage: G.minimal_normal_subgroups()
+            [ Group([ (1,4)(2,3), (1,3)(2,4) ]) ]
+        """
+        return self._libgap_().MinimalNormalSubgroups().sage()
+
     ######################  Boolean tests #####################
 
     def is_abelian(self):


### PR DESCRIPTION
- Added the minimal_normal_subgroups function for permutation group

This patch implements a minimal_normal_subgroups function in PermutationGroup_generic class.
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
NA
