### PR TITLE
Fix bug in PermutationGroupElement.word_problem occuring with >= 10 word elements

### DIFF
--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -2048,7 +2048,7 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
 
         def convert_back(string):
             L = copy.copy(string)
-            for i, w_i in enumerate(words):
+            for i, w_i in reversed(list(enumerate(words))):
                 L = L.replace("x" + str(i + 1), str(w_i))
             return L
 


### PR DESCRIPTION
Fix bug in PermutationGroupElement.word_problem occuring with >= 10 word elements

Bug: 'x1' is a substring of 'x10', 'x11', 'x100', 'x101', ...

This leads to multiple incorrect behaviors

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [ ] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
