### PR TITLE
Deprecate `is_Cone`, `is_LatticePolytope`, `is_Polyhedron`, change uses to `isinstance`

### DIFF
--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -211,7 +211,6 @@ from sage.arith.functions import lcm
 from sage.combinat.posets.posets import FinitePoset
 from sage.geometry.point_collection import PointCollection
 from sage.geometry.polyhedron.constructor import Polyhedron
-from sage.geometry.polyhedron.base import is_Polyhedron
 from sage.geometry.hasse_diagram import lattice_from_incidences
 from sage.geometry.toric_lattice import (ToricLattice, is_ToricLattice,
                                          is_ToricLatticeQuotient)
@@ -242,31 +241,6 @@ lazy_import('ppl', ['C_Polyhedron', 'Generator_System', 'Constraint_System',
 lazy_import('ppl', ['ray', 'point'], as_=['PPL_ray', 'PPL_point'],
                     feature=PythonModule("ppl", spkg="pplpy", type="standard"))
 
-
-def is_Cone(x):
-    r"""
-    Check if ``x`` is a cone.
-
-    INPUT:
-
-    - ``x`` -- anything.
-
-    OUTPUT:
-
-    - ``True`` if ``x`` is a cone and ``False`` otherwise.
-
-    EXAMPLES::
-
-        sage: from sage.geometry.cone import is_Cone
-        sage: is_Cone(1)
-        False
-        sage: quadrant = Cone([(1,0), (0,1)])
-        sage: quadrant
-        2-d cone in 2-d lattice N
-        sage: is_Cone(quadrant)
-        True
-    """
-    return isinstance(x, ConvexRationalPolyhedralCone)
 
 
 def Cone(rays, lattice=None, check=True, normalize=True):
@@ -439,7 +413,7 @@ def Cone(rays, lattice=None, check=True, normalize=True):
         0-d cone in 2-d lattice N
     """
     # Cone from Polyhedron
-    if is_Polyhedron(rays):
+    if isinstance(rays, sage.geometry.abc.Polyhedron):
         polyhedron = rays
         if lattice is None:
             lattice = ToricLattice(polyhedron.ambient_dim())
@@ -1894,7 +1868,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             N+N(0, 1)
             in 2-d lattice N+N
         """
-        assert is_Cone(other)
+        assert isinstance(other, sage.geometry.abc.ConvexRationalPolyhedralCone)
         rc = super().cartesian_product(other, lattice)
         return ConvexRationalPolyhedralCone(rc.rays(), rc.lattice())
 
@@ -1952,7 +1926,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: c2 is c3
             False
         """
-        if is_Cone(right):
+        if isinstance(right, sage.geometry.abc.ConvexRationalPolyhedralCone):
             # We don't care about particular type of right in this case
             return richcmp((self.lattice(), self.rays()),
                            (right.lattice(), right.rays()), op)
@@ -2413,7 +2387,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             ValueError: 2-d cone in 3-d lattice N is not a face
             of 3-d cone in 3-d lattice N!
         """
-        assert is_Cone(cone)
+        assert isinstance(cone, sage.geometry.abc.ConvexRationalPolyhedralCone)
         if cone.ambient() is self:
             return cone
         if self.is_strictly_convex():
@@ -2935,7 +2909,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         L = self._ambient._face_lattice_function()
         H = L.hasse_diagram()
         return self._sort_faces(
-            f for f in H.neighbors_out(L(self)) if is_Cone(f))
+            f for f in H.neighbors_out(L(self)) if isinstance(f, sage.geometry.abc.ConvexRationalPolyhedralCone))
 
     def facets(self):
         r"""
@@ -6387,9 +6361,8 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
     It's hard to test the output of a random process, but we can at
     least make sure that we get a cone back::
 
-        sage: from sage.geometry.cone import is_Cone
         sage: K = random_cone(max_ambient_dim=6, max_rays=10)
-        sage: is_Cone(K)
+        sage: isinstance(K, sage.geometry.abc.ConvexRationalPolyhedralCone)
         True
 
     The upper/lower bounds are respected::

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -245,7 +245,6 @@ from sage.geometry.cone import (_ambient_space_point,
                                 Cone,
                                 ConvexRationalPolyhedralCone,
                                 IntegralRayCollection,
-                                is_Cone,
                                 normalize_rays)
 from sage.geometry.hasse_diagram import lattice_from_incidences
 from sage.geometry.point_collection import PointCollection
@@ -571,7 +570,7 @@ def Fan(cones, rays=None, lattice=None, check=True, normalize=True,
         cones = ((), )
         rays = ()
         return result()
-    if is_Cone(cones[0]):
+    if isinstance(cones[0], sage.geometry.abc.ConvexRationalPolyhedralCone):
         # Construct the fan from Cone objects
         if lattice is None:
             lattice = cones[0].lattice()
@@ -749,11 +748,11 @@ def FaceFan(polytope, lattice=None):
         ValueError: face fans are defined only for
         polytopes containing the origin as an interior point!
     """
-    from sage.geometry.lattice_polytope import is_LatticePolytope
+    
     interior_point_error = ValueError(
         "face fans are defined only for polytopes containing "
         "the origin as an interior point!")
-    if is_LatticePolytope(polytope):
+    if isinstance(polytope, sage.geometry.abc.LatticePolytope):
         if any(d <= 0 for d in polytope.distances([0] * polytope.dim())):
             raise interior_point_error
         cones = (f.ambient_vertex_indices() for f in polytope.facets())
@@ -843,8 +842,7 @@ def NormalFan(polytope, lattice=None):
     """
     dimension_error = ValueError(
         'the normal fan is only defined for full-dimensional polytopes')
-    from sage.geometry.lattice_polytope import is_LatticePolytope
-    if is_LatticePolytope(polytope):
+    if isinstance(polytope, sage.geometry.abc.LatticePolytope):
         if polytope.dim() != polytope.lattice_dim():
             raise dimension_error
         rays = polytope.facet_normals()
@@ -2425,7 +2423,7 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
             ValueError: 2-d cone in 3-d lattice N does not belong
             to Rational polyhedral fan in 3-d lattice N!
         """
-        if not is_Cone(cone):
+        if not isinstance(cone, sage.geometry.abc.ConvexRationalPolyhedralCone):
             raise TypeError("%s is not a cone!" % cone)
         if cone.ambient() is self:
             return cone

--- a/src/sage/geometry/hyperplane_arrangement/hyperplane.py
+++ b/src/sage/geometry/hyperplane_arrangement/hyperplane.py
@@ -460,9 +460,8 @@ class Hyperplane(LinearExpression):
             sage: h.intersection(polytopes.cube())
             A 2-dimensional polyhedron in QQ^3 defined as the convex hull of 3 vertices
         """
-        from sage.geometry.polyhedron.base import is_Polyhedron
         from sage.geometry.polyhedron.constructor import Polyhedron
-        if not is_Polyhedron(other):
+        if not isinstance(other, sage.geometry.abc.Polyhedron):
             try:
                 other = other.polyhedron()
             except AttributeError:

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -463,32 +463,6 @@ def ReflexivePolytopes(dim):
     return _rp[dim]
 
 
-def is_LatticePolytope(x):
-    r"""
-    Check if ``x`` is a lattice polytope.
-
-    INPUT:
-
-    - ``x`` -- anything.
-
-    OUTPUT:
-
-    - ``True`` if ``x`` is a :class:`lattice polytope <LatticePolytopeClass>`,
-      ``False`` otherwise.
-
-    EXAMPLES::
-
-        sage: from sage.geometry.lattice_polytope import is_LatticePolytope
-        sage: is_LatticePolytope(1)
-        False
-        sage: p = LatticePolytope([(1,0), (0,1), (-1,-1)])
-        sage: p                                                                         # needs palp
-        2-d reflexive polytope #0 in 2-d lattice M
-        sage: is_LatticePolytope(p)
-        True
-    """
-    return isinstance(x, LatticePolytopeClass)
-
 @richcmp_method
 class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.LatticePolytope):
     r"""

--- a/src/sage/geometry/newton_polygon.py
+++ b/src/sage/geometry/newton_polygon.py
@@ -22,7 +22,6 @@ from sage.misc.cachefunc import cached_method
 
 from sage.rings.infinity import Infinity
 from sage.geometry.polyhedron.constructor import Polyhedron
-from sage.geometry.polyhedron.base import is_Polyhedron
 
 
 class NewtonPolygon_element(Element):
@@ -716,7 +715,7 @@ class ParentNewtonPolygon(Parent, UniqueRepresentation):
             sage: NewtonPolygon(1)
             Finite Newton polygon with 1 vertex: (0, 0)
         """
-        if is_Polyhedron(arg):
+        if isinstance(arg, sage.geometry.abc.Polyhedron):
             return self.element_class(arg, parent=self)
         if arg == 0:
             polyhedron = Polyhedron(base_ring=self.base_ring(), ambient_dim=2)

--- a/src/sage/geometry/polyhedral_complex.py
+++ b/src/sage/geometry/polyhedral_complex.py
@@ -112,7 +112,6 @@ Classes and functions
 from copy import copy
 from sage.topology.cell_complex import GenericCellComplex
 from sage.geometry.polyhedron.constructor import Polyhedron
-from sage.geometry.polyhedron.base import is_Polyhedron
 from sage.modules.free_module_element import vector
 from sage.rings.integer_ring import ZZ
 from sage.graphs.graph import Graph
@@ -308,7 +307,7 @@ class PolyhedralComplex(GenericCellComplex):
                 ambient_dim = next(iter(cells_dict[self._dim])).ambient_dim()
         self._ambient_dim = ambient_dim
         self._maximal_cells = cells_dict
-        if not all((is_Polyhedron(cell) and
+        if not all((isinstance(cell, sage.geometry.abc.Polyhedron) and
                    cell.ambient_dim() == self._ambient_dim)
                    for cell in self.maximal_cell_iterator()):
             raise ValueError("the given cells are not polyhedra " +

--- a/src/sage/geometry/polyhedron/base.py
+++ b/src/sage/geometry/polyhedron/base.py
@@ -56,32 +56,6 @@ from .base7 import Polyhedron_base7
 #########################################################################
 
 
-#########################################################################
-def is_Polyhedron(X):
-    """
-    Test whether ``X`` is a Polyhedron.
-
-    INPUT:
-
-    - ``X`` -- anything.
-
-    OUTPUT:
-
-    Boolean.
-
-    EXAMPLES::
-
-        sage: p = polytopes.hypercube(2)
-        sage: from sage.geometry.polyhedron.base import is_Polyhedron
-        sage: is_Polyhedron(p)
-        True
-        sage: is_Polyhedron(123456)
-        False
-    """
-    return isinstance(X, Polyhedron_base)
-
-
-#########################################################################
 class Polyhedron_base(Polyhedron_base7):
     """
     Base class for Polyhedron objects

--- a/src/sage/geometry/polyhedron/parent.py
+++ b/src/sage/geometry/polyhedron/parent.py
@@ -22,8 +22,6 @@ from sage.rings.real_double import RDF
 from sage.categories.fields import Fields
 from sage.categories.rings import Rings
 from sage.categories.modules import Modules
-
-from sage.geometry.polyhedron.base import is_Polyhedron
 from .representation import Inequality, Equation, Vertex, Ray, Line
 
 
@@ -693,7 +691,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             if convert and Vrep:
                 Vrep = [convert_base_ring(_) for _ in Vrep]
             return self.element_class(self, Vrep, Hrep, **kwds)
-        if nargs == 1 and is_Polyhedron(args[0]):
+        if nargs == 1 and isinstance(args[0], sage.geometry.abc.Polyhedron):
             copy = kwds.pop('copy', args[0].parent() is not self)
             mutable = kwds.pop('mutable', False)
 

--- a/src/sage/schemes/toric/variety.py
+++ b/src/sage/schemes/toric/variety.py
@@ -2667,7 +2667,7 @@ class ToricVariety_field(AmbientSpace):
         # TODO: make the following work nicely.
         # if x in cone.lattice():
         # return quot(x)
-        # assert is_Cone(x)
+        # assert x is ConvexRationalPolyhedralCone object
         # return Cone(x.rays(), lattice=quot)
 
     def orbit_closure(self, cone):


### PR DESCRIPTION
Depricated 3 functions is_Polyhedron, is_Cone and is_LatticePolytope and replaced using the python function "isinstance"

<!--  -->

 Fixes #34307  
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x ] The title is concise, informative, and self-explanatory.
- [x ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->
The change seems simple so i don't know if there are any dependencies involved

Tried to change the comments(explanation) in the code don't know it counts as documentation
Would appreciate any kind of feedback from anyone