### PR TITLE
clean singular interface (full pep8) + use standard open and zip

### DIFF
--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -206,7 +206,6 @@ import sage.interfaces.abc
 
 import re
 import os
-import io
 import pexpect
 import time
 import platform
@@ -221,7 +220,7 @@ if SAGE_GAP_COMMAND is None:
     # Passing -A allows us to use a minimal GAP installation without
     # producing errors at start-up. The files sage.g and sage.gaprc are
     # used to load any additional packages that may be available.
-    gap_cmd  = f'gap -A -l "{GAP_ROOT_PATHS}"'
+    gap_cmd = f'gap -A -l "{GAP_ROOT_PATHS}"'
     if SAGE_GAP_MEMORY is not None:
         gap_cmd += " -s " + SAGE_GAP_MEMORY + " -o " + SAGE_GAP_MEMORY
 else:
@@ -1320,8 +1319,8 @@ class Gap(Gap_generic):
             sline = int(sline) - 1
             if self.is_remote():
                 self._get_tmpfile()
-            with io.open(self._local_tmpfile(), "r",
-                         encoding=gap_encoding) as fobj:
+            with open(self._local_tmpfile(), "r",
+                      encoding=gap_encoding) as fobj:
                 help = fobj.read()
             if pager:
                 from IPython.core.page import page

--- a/src/sage/interfaces/singular.py
+++ b/src/sage/interfaces/singular.py
@@ -335,7 +335,6 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-import io
 import os
 import re
 import sys
@@ -653,7 +652,7 @@ class Singular(ExtraTabCompletion, Expect):
         # through here.
 
         x = str(x).rstrip().rstrip(';')
-        x = x.replace("> ",">\t") #don't send a prompt  (added by Martin Albrecht)
+        x = x.replace("> ", ">\t")  # don't send a prompt  (added by Martin Albrecht)
         if not allow_semicolon and x.find(";") != -1:
             raise TypeError("singular input must not contain any semicolons:\n%s" % x)
         if len(x) == 0 or x[len(x) - 1] != ';':
@@ -703,7 +702,8 @@ class Singular(ExtraTabCompletion, Expect):
             '0'
 
         """
-        cmd = ''.join('if(defined(%s)){kill %s;};' % (v,v) for v in self.__to_clear)
+        cmd = ''.join('if(defined(%s)){kill %s;};' % (v, v)
+                      for v in self.__to_clear)
         cmd += '%s %s=%s;' % (type, name, value)
         self.__to_clear = []
         self.eval(cmd)
@@ -799,7 +799,7 @@ class Singular(ExtraTabCompletion, Expect):
             return x._singular_(self)
 
         # some convenient conversions
-        if type in ("module","list") and isinstance(x,(list,tuple,Sequence_generic)):
+        if type in ("module", "list") and isinstance(x, (list, tuple, Sequence_generic)):
             x = str(x)[1:-1]
 
         return SingularElement(self, type, x, False)
@@ -843,9 +843,9 @@ class Singular(ExtraTabCompletion, Expect):
             0.02
         """
         if t:
-            return float(self.eval('timer-(%d)' % (int(1000*t))))/1000.0
+            return float(self.eval('timer-(%d)' % (int(1000 * t)))) / 1000.0
         else:
-            return float(self.eval('timer'))/1000.0
+            return float(self.eval('timer')) / 1000.0
 
     ###########################################################
     # Singular libraries
@@ -1193,11 +1193,11 @@ class Singular(ExtraTabCompletion, Expect):
             True
         """
         ringlist = self.eval("listvar(ring)").splitlines()
-        p = re.compile(r"// ([a-zA-Z0-9_]*).*\[.*\].*\*.*") #do this in constructor?
+        p = re.compile(r"// ([a-zA-Z0-9_]*).*\[.*\].*\*.*")  # do this in constructor?
         for line in ringlist:
             m = p.match(line)
             if m:
-                return m.group(int(1))
+                return m.group(1)
         return None
 
     def current_ring(self):
@@ -1239,9 +1239,9 @@ class Singular(ExtraTabCompletion, Expect):
             ...
             'crossprod']
         """
-        p = re.compile("// *([a-z0-9A-Z_]*).*") #compiles regular expression
+        p = re.compile("// *([a-z0-9A-Z_]*).*")  # compiles regular expression
         proclist = self.eval("listvar(proc)").splitlines()
-        return [p.match(line).group(int(1)) for line in proclist]
+        return [p.match(line).group(1) for line in proclist]
 
     def console(self):
         r"""
@@ -1317,17 +1317,17 @@ class Singular(ExtraTabCompletion, Expect):
             10321
         """
         if cmd is None:
-            return SingularFunction(self,"option")()
+            return SingularFunction(self, "option")()
         elif cmd == "get":
-            #return SingularFunction(self,"option")("\"get\"")
-            return self(self.eval("option(get)"),"intvec")
+            # return SingularFunction(self, "option")("\"get\"")
+            return self(self.eval("option(get)"), "intvec")
         elif cmd == "set":
-            if not isinstance(val,SingularElement):
+            if not isinstance(val, SingularElement):
                 raise TypeError("singular.option('set') needs SingularElement as second parameter")
-            #SingularFunction(self,"option")("\"set\"",val)
+            # SingularFunction(self,"option")("\"set\"",val)
             self.eval("option(set,%s)" % val.name())
         else:
-            SingularFunction(self,"option")("\""+str(cmd)+"\"")
+            SingularFunction(self, "option")("\"" + str(cmd) + "\"")
 
     def _keyboard_interrupt(self):
         print("Interrupting %s..." % self)
@@ -1547,7 +1547,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
             sage: f.sage_polystring()
             'x**3+3*y**11+5'
         """
-        return str(self).replace('^','**')
+        return str(self).replace('^', '**')
 
     def sage_global_ring(self):
         """
@@ -1632,7 +1632,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
         """
         # extract the ring of coefficients
         singular = self.parent()
-        charstr = singular.eval('charstr(basering)').split(',',1)
+        charstr = singular.eval('charstr(basering)').split(',', 1)
         from sage.rings.integer_ring import ZZ
         is_extension = len(charstr) == 2
         if charstr[0] in ['integer', 'ZZ']:
@@ -1646,14 +1646,14 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
             from sage.functions.other import ceil
             from sage.misc.functional import log
             prec = singular.eval('ringlist(basering)[1][2][1]')
-            br = RealField(ceil((ZZ(prec)+1)/log(2,10)))
+            br = RealField(ceil((ZZ(prec) + 1) / log(2, 10)))
             is_extension = False
         elif charstr[0] == 'complex':
             from sage.rings.complex_mpfr import ComplexField
             from sage.functions.other import ceil
             from sage.misc.functional import log
             prec = singular.eval('ringlist(basering)[1][2][1]')
-            br = ComplexField(ceil((ZZ(prec)+1)/log(2,10)))
+            br = ComplexField(ceil((ZZ(prec) + 1) / log(2, 10)))
             is_extension = False
         else:
             # it ought to be a finite field
@@ -1662,7 +1662,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
             if q.is_prime():
                 br = GF(q)
             else:
-                br = GF(q,charstr[1])
+                br = GF(q, charstr[1])
                 # Singular has no extension of a non-prime field
                 is_extension = False
 
@@ -1681,7 +1681,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
                     singular.eval('short=%s' % is_short)
                 else:
                     minpoly = ZZ[charstr[1]](minpoly)
-                BR = br.extension(minpoly,names=charstr[1])
+                BR = br.extension(minpoly, names=charstr[1])
         else:
             BR = br
 
@@ -1829,13 +1829,13 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
                 self.parent().eval('short=%s' % is_short)
                 return out
             singular_poly_list = self.parent().eval("string(coef(%s,%s))" % (
-                self.name(),variable_str)).split(",")
+                self.name(), variable_str)).split(",")
             self.parent().eval('short=%s' % is_short)
         else:
             if isinstance(R, MPolynomialRing_libsingular):
                 return R(self)
             singular_poly_list = self.parent().eval("string(coef(%s,%s))" % (
-                self.name(),variable_str)).split(",")
+                self.name(), variable_str)).split(",")
 
         # Directly treat constants
         if singular_poly_list[0] in ['1', '(1.000e+00)']:
@@ -1861,47 +1861,47 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
                 monomial = singular_poly_list[i]
 
                 if monomial not in ['1', '(1.000e+00)']:
-                    variables = [var.split("^") for var in monomial.split("*") ]
+                    variables = [var.split("^") for var in monomial.split("*")]
                     for e in variables:
                         var = e[0]
-                        if len(e) == int(2):
+                        if len(e) == 2:
                             power = int(e[1])
                         else:
                             power = 1
                         exp[var_dict[var]] = power
 
                 if kcache is None:
-                    sage_repr[ETuple(exp,ngens)] = k(singular_poly_list[coeff_start+i])
+                    sage_repr[ETuple(exp, ngens)] = k(singular_poly_list[coeff_start + i])
                 else:
-                    elem = singular_poly_list[coeff_start+i]
+                    elem = singular_poly_list[coeff_start + i]
                     if elem not in kcache:
-                        kcache[elem] = k( elem )
-                    sage_repr[ETuple(exp,ngens)] = kcache[elem]
+                        kcache[elem] = k(elem)
+                    sage_repr[ETuple(exp, ngens)] = kcache[elem]
 
             return R(sage_repr)
 
         elif is_PolynomialRing(R) and (ring_is_fine or can_convert_to_singular(R)):
 
-            sage_repr = [0]*int(self.deg()+1)
+            sage_repr = [0] * int(self.deg() + 1)
 
             for i in range(coeff_start):
                 monomial = singular_poly_list[i]
-                exp = int(0)
+                exp = 0
 
                 if monomial not in ['1', '(1.000e+00)']:
                     term = monomial.split("^")
-                    if len(term) == int(2):
+                    if len(term) == 2:
                         exp = int(term[1])
                     else:
-                        exp = int(1)
+                        exp = 1
 
                 if kcache is None:
-                    sage_repr[exp] = k(singular_poly_list[coeff_start+i])
+                    sage_repr[exp] = k(singular_poly_list[coeff_start + i])
                 else:
-                    elem = singular_poly_list[coeff_start+i]
+                    elem = singular_poly_list[coeff_start + i]
                     if elem not in kcache:
-                        kcache[elem] = k( elem )
-                    sage_repr[ exp ] = kcache[elem]
+                        kcache[elem] = k(elem)
+                    sage_repr[exp] = kcache[elem]
 
             return R(sage_repr)
 
@@ -1933,22 +1933,22 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
             [0.0 0.0]
         """
         from sage.matrix.constructor import Matrix
-        nrows, ncols = int(self.nrows()),int(self.ncols())
+        nrows, ncols = int(self.nrows()), int(self.ncols())
 
         if R is None:
             R = self.sage_global_ring()
             A = Matrix(R, nrows, ncols, sparse=sparse)
-            #this is slow
+            # this is slow
             for x in range(nrows):
                 for y in range(ncols):
-                    A[x,y] = self[x+1,y+1].sage_poly(R)
+                    A[x, y] = self[x + 1, y + 1].sage_poly(R)
             return A
 
         A = Matrix(R, nrows, ncols, sparse=sparse)
-        #this is slow
+        # this is slow
         for x in range(nrows):
             for y in range(ncols):
-                A[x,y] = R(self[x+1,y+1])
+                A[x, y] = R(self[x + 1, y + 1])
 
         return A
 
@@ -2032,11 +2032,11 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
         elif typ == 'int':
             return sage.rings.integer.Integer(repr(self))
         elif typ == 'module':
-            return self.sage_matrix(R,sparse=True)
+            return self.sage_matrix(R, sparse=True)
         elif typ == 'matrix':
-            return self.sage_matrix(R,sparse=False)
+            return self.sage_matrix(R, sparse=False)
         elif typ == 'list':
-            return [ f._sage_(R) for f in self ]
+            return [f._sage_(R) for f in self]
         elif typ == 'intvec':
             from sage.modules.free_module_element import vector
             return vector([sage.rings.integer.Integer(str(e)) for e in self])
@@ -2046,7 +2046,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
             A = matrix(ZZ, int(self.nrows()), int(self.ncols()))
             for i in range(A.nrows()):
                 for j in range(A.ncols()):
-                    A[i,j] = sage.rings.integer.Integer(str(self[i+1,j+1]))
+                    A[i, j] = sage.rings.integer.Integer(str(self[i + 1, j + 1]))
             return A
         elif typ == 'string':
             return repr(self)
@@ -2113,7 +2113,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
         s = str(self)
         c = r'\[[0-9]*\]:'
         r = re.compile(c)
-        s = r.sub('',s).strip()
+        s = r.sub('', s).strip()
         return s.split()
 
     def sage_structured_str_list(self):
@@ -2259,7 +2259,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
         if value is None:
             return int(self.parent().eval('attrib(%s,"%s")' % (self.name(), name)))
         else:
-            self.parent().eval('attrib(%s,"%s",%d)' % (self.name(), name,value))
+            self.parent().eval('attrib(%s,"%s",%d)' % (self.name(), name, value))
 
 
 @instancedoc
@@ -2274,8 +2274,7 @@ class SingularFunction(ExpectFunction):
         if not nodes:
             generate_docstring_dictionary()
 
-        prefix = \
-"""
+        prefix = """
 This function is an automatically generated pexpect wrapper around the Singular
 function '%s'.
 
@@ -2288,8 +2287,7 @@ EXAMPLES::
     x+y,
     y^2-y
 """ % (self._name,)
-        prefix2 = \
-"""
+        prefix2 = """
 
 The Singular documentation for '%s' is given below.
 """ % (self._name,)
@@ -2318,6 +2316,7 @@ class SingularFunctionElement(FunctionElement):
         except KeyError:
             return ""
 
+
 def is_SingularElement(x):
     r"""
     Return True is ``x`` is of type :class:`SingularElement`.
@@ -2343,6 +2342,7 @@ def is_SingularElement(x):
 
 nodes = {}
 node_names = {}
+
 
 def generate_docstring_dictionary():
     """
@@ -2370,8 +2370,8 @@ def generate_docstring_dictionary():
     singular_info_file = get_resource('i')
 
     # singular.hlp contains a few iso-8859-1 encoded special characters
-    with io.open(singular_info_file,
-                 encoding='latin-1') as f:
+    with open(singular_info_file,
+              encoding='latin-1') as f:
         for line in f:
             m = re.match(new_node, line)
             if m:
@@ -2469,10 +2469,12 @@ class SingularGBLogPrettyPrinter:
     A device which prints Singular Groebner basis computation logs
     more verbatim.
     """
-    rng_chng = re.compile(r"\[\d+:\d+\]")# [m:n] internal ring change to
-                                        # poly representation with
-                                        # exponent bound m and n words in
-                                        # exponent vector
+    rng_chng = re.compile(r"\[\d+:\d+\]")
+    # [m:n] internal ring change to
+    # poly representation with
+    # exponent bound m and n words in
+    # exponent vector
+
     new_elem = re.compile("s")          # found a new element of the standard basis
     red_zero = re.compile("-")          # reduced a pair/S-polynomial to 0
     red_post = re.compile(r"\.")         # postponed a reduction of a pair/S-polynomial
@@ -2483,7 +2485,7 @@ class SingularGBLogPrettyPrinter:
     deg_lead = re.compile(r"\d+")        # the degree of the leading terms is currently d
 
     # SlimGB
-    red_para = re.compile(r"M\[(\d+),(\d+)\]") # parallel reduction of n elements with m non-zero output elements
+    red_para = re.compile(r"M\[(\d+),(\d+)\]")  # parallel reduction of n elements with m non-zero output elements
     red_betr = re.compile("b")                # exchange of a reductor by a 'better' one
     non_mini = re.compile("e")                # a new reductor with non-minimal leading term
 
@@ -2515,16 +2517,16 @@ class SingularGBLogPrettyPrinter:
         """
         self.verbosity = verbosity
 
-        self.curr_deg = 0 # current degree
-        self.max_deg = 0  # maximal degree in total
+        self.curr_deg = 0  # current degree
+        self.max_deg = 0   # maximal degree in total
 
-        self.nf = 0 # number of normal forms computed (SlimGB only)
-        self.prod = 0 # number of S-polynomials discarded using product criterion
-        self.ext_prod = 0 # number of S-polynomials discarded using extended product criterion
-        self.chain = 0 # number of S-polynomials discarded using chain criterion
+        self.nf = 0    # number of normal forms computed (SlimGB only)
+        self.prod = 0  # number of S-polynomials discarded using product criterion
+        self.ext_prod = 0  # number of S-polynomials discarded using extended product criterion
+        self.chain = 0  # number of S-polynomials discarded using chain criterion
 
-        self.storage = "" # stores incomplete strings
-        self.sync = None # should we expect a sync integer?
+        self.storage = ""  # stores incomplete strings
+        self.sync = None   # should we expect a sync integer?
 
     def write(self, s):
         """
@@ -2545,7 +2547,7 @@ class SingularGBLogPrettyPrinter:
 
         for line in s.splitlines():
             # deal with the Sage <-> Singular syncing code
-            match = re.match(SingularGBLogPrettyPrinter.pat_sync,line)
+            match = re.match(SingularGBLogPrettyPrinter.pat_sync, line)
             if match:
                 self.sync = int(match.groups()[0])
                 continue
@@ -2563,14 +2565,14 @@ class SingularGBLogPrettyPrinter:
                 continue
 
             # collect stats returned about avoided reductions to zero
-            match = re.match(SingularGBLogPrettyPrinter.crt_lne1,line)
+            match = re.match(SingularGBLogPrettyPrinter.crt_lne1, line)
             if match:
-                self.prod,self.chain = map(int,re.match(SingularGBLogPrettyPrinter.crt_lne1,line).groups())
+                self.prod, self.chain = map(int, re.match(SingularGBLogPrettyPrinter.crt_lne1, line).groups())
                 self.storage = ""
                 continue
-            match = re.match(SingularGBLogPrettyPrinter.crt_lne2,line)
+            match = re.match(SingularGBLogPrettyPrinter.crt_lne2, line)
             if match:
-                self.nf,self.prod,self.ext_prod = map(int,re.match(SingularGBLogPrettyPrinter.crt_lne2,line).groups())
+                self.nf, self.prod, self.ext_prod = map(int, re.match(SingularGBLogPrettyPrinter.crt_lne2, line).groups())
                 self.storage = ""
                 continue
 
@@ -2584,13 +2586,13 @@ class SingularGBLogPrettyPrinter:
                 token, = match.groups()
                 line = line[len(token):]
 
-                if re.match(SingularGBLogPrettyPrinter.rng_chng,token):
+                if re.match(SingularGBLogPrettyPrinter.rng_chng, token):
                     continue
 
-                elif re.match(SingularGBLogPrettyPrinter.new_elem,token) and verbosity >= 3:
+                elif re.match(SingularGBLogPrettyPrinter.new_elem, token) and verbosity >= 3:
                     print("New element found.")
 
-                elif re.match(SingularGBLogPrettyPrinter.red_zero,token) and verbosity >= 2:
+                elif re.match(SingularGBLogPrettyPrinter.red_zero, token) and verbosity >= 2:
                     print("Reduction to zero.")
 
                 elif re.match(SingularGBLogPrettyPrinter.red_post, token) and verbosity >= 2:
@@ -2603,7 +2605,7 @@ class SingularGBLogPrettyPrinter:
                     print("Maximal degree found: %s" % token)
 
                 elif re.match(SingularGBLogPrettyPrinter.num_crit, token) and verbosity >= 1:
-                    print("Leading term degree: %2d. Critical pairs: %s." % (self.curr_deg,token[1:-1]))
+                    print("Leading term degree: %2d. Critical pairs: %s." % (self.curr_deg, token[1:-1]))
 
                 elif re.match(SingularGBLogPrettyPrinter.red_num, token) and verbosity >= 3:
                     print("Performing complete reduction of %s elements." % token[3:-1])
@@ -2616,7 +2618,7 @@ class SingularGBLogPrettyPrinter:
                         self.max_deg = self.curr_deg
 
                 elif re.match(SingularGBLogPrettyPrinter.red_para, token) and verbosity >= 3:
-                    m,n = re.match(SingularGBLogPrettyPrinter.red_para,token).groups()
+                    m, n = re.match(SingularGBLogPrettyPrinter.red_para, token).groups()
                     print("Parallel reduction of %s elements with %s non-zero output elements." % (m, n))
 
                 elif re.match(SingularGBLogPrettyPrinter.red_betr, token) and verbosity >= 3:
@@ -2715,13 +2717,13 @@ class SingularGBDefaultContext:
         try:
             self.bck_degBound = int(self.singular.eval('degBound'))
         except SingularError:
-            self.bck_degBound = int(0)
+            self.bck_degBound = 0
         try:
             self.bck_multBound = int(self.singular.eval('multBound'))
         except SingularError:
-            self.bck_multBound = int(0)
+            self.bck_multBound = 0
         self.o = self.singular.option("get")
-        self.singular.option('set',self.singular._saved_options)
+        self.singular.option('set', self.singular._saved_options)
         self.singular.option("redSB")
         self.singular.option("redTail")
         try:

--- a/src/sage/interfaces/singular.py
+++ b/src/sage/interfaces/singular.py
@@ -829,7 +829,7 @@ class Singular(ExtraTabCompletion, Expect):
 
     def cputime(self, t=None):
         r"""
-        Returns the amount of CPU time that the Singular session has used.
+        Return the amount of CPU time that the Singular session has used.
         If ``t`` is not None, then it returns the difference
         between the current CPU time and ``t``.
 
@@ -1181,7 +1181,7 @@ class Singular(ExtraTabCompletion, Expect):
 
     def current_ring_name(self):
         """
-        Returns the Singular name of the currently active ring in
+        Return the Singular name of the currently active ring in
         Singular.
 
         OUTPUT: currently active ring's name
@@ -1202,7 +1202,7 @@ class Singular(ExtraTabCompletion, Expect):
 
     def current_ring(self):
         """
-        Returns the current ring of the running Singular session.
+        Return the current ring of the running Singular session.
 
         EXAMPLES::
 
@@ -1327,7 +1327,7 @@ class Singular(ExtraTabCompletion, Expect):
             # SingularFunction(self,"option")("\"set\"",val)
             self.eval("option(set,%s)" % val.name())
         else:
-            SingularFunction(self, "option")("\"" + str(cmd) + "\"")
+            SingularFunction(self, "option")(f'"{str(cmd)}"')
 
     def _keyboard_interrupt(self):
         print("Interrupting %s..." % self)
@@ -1406,7 +1406,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
 
     def __copy__(self):
         r"""
-        Returns a copy of ``self``.
+        Return a copy of ``self``.
 
         EXAMPLES::
 
@@ -1458,7 +1458,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
 
     def __len__(self):
         """
-        Returns the size of this Singular element.
+        Return the size of this Singular element.
 
         EXAMPLES::
 
@@ -1514,7 +1514,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
 
     def __bool__(self):
         """
-        Returns ``True`` if this Singular element is not zero.
+        Return ``True`` if this Singular element is not zero.
 
         EXAMPLES::
 
@@ -1699,7 +1699,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
 
     def sage_poly(self, R=None, kcache=None):
         """
-        Returns a Sage polynomial in the ring r matching the provided poly
+        Return a Sage polynomial in the ring r matching the provided poly
         which is a singular polynomial.
 
         INPUT:
@@ -1910,7 +1910,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
 
     def sage_matrix(self, R, sparse=True):
         """
-        Returns Sage matrix for self
+        Return Sage matrix for ``self``.
 
         INPUT:
 
@@ -2155,7 +2155,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
 
     def _tab_completion(self):
         """
-        Returns the possible tab-completions for self. In this case, we
+        Return the possible tab-completions for self. In this case, we
         just return all the tab completions for the Singular object.
 
         EXAMPLES::
@@ -2170,7 +2170,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
 
     def type(self):
         """
-        Returns the internal type of this element.
+        Return the internal type of this element.
 
         EXAMPLES::
 

--- a/src/sage/interfaces/singular.py
+++ b/src/sage/interfaces/singular.py
@@ -2149,14 +2149,16 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
             sage: RL.sage_structured_str_list()
             ['0', ['x', 'y'], [['dp', '1,\n1'], ['C', '0']], '0']
         """
-        if not (self.type() == 'list'):
+        if self.type() != 'list':
             return str(self)
         return [X.sage_structured_str_list() for X in self]
 
-    def _tab_completion(self):
+    def _tab_completion(self) -> list:
         """
-        Return the possible tab-completions for self. In this case, we
-        just return all the tab completions for the Singular object.
+        Return the possible tab-completions for ``self``.
+
+        In this case, we just return all the :kbd:`Tab` completions
+        for the Singular object.
 
         EXAMPLES::
 

--- a/src/sage/rings/asymptotic/asymptotic_ring.py
+++ b/src/sage/rings/asymptotic/asymptotic_ring.py
@@ -908,7 +908,6 @@ class AsymptoticExpansion(CommutativeAlgebraElement):
         """
         if len(self.summands) != len(other.summands):
             return False
-        from builtins import zip
         return all(s == o for s, o in
                    zip(self.summands.elements_topological(),
                        other.summands.elements_topological()))

--- a/src/sage/rings/asymptotic/growth_group_cartesian.py
+++ b/src/sage/rings/asymptotic/growth_group_cartesian.py
@@ -346,7 +346,6 @@ class GenericProduct(CartesianProductPoset, GenericGrowthGroup):
              x^(2/3)*log(x)^(-4)*(6/7)^y,
              x^(-2/3)*log(x)^5*(7/6)^y)
         """
-        from builtins import zip
         return iter(
             self(c) for c in
             zip(*tuple(F.some_elements() for F in self.cartesian_factors())))

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -121,7 +121,6 @@ from . import structure
 from . import number_field_morphisms
 from itertools import count
 from collections import Counter
-from builtins import zip
 
 from sage.categories.homset import Hom
 from sage.categories.sets_cat import Sets

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -126,7 +126,6 @@ class CartesianProduct(UniqueRepresentation, Parent):
         if self in _Rings and isinstance(x, numbers.Integral):
             return x * self.one()
 
-        from builtins import zip
         x = tuple(x)
 
         if len(x) != len(self._sets):


### PR DESCRIPTION
This is

- cleaning for pep8 compliance the `singular` pexpect interface
- making sure to use everywhere the standard `zip` and `open`

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.