### PR TITLE
Fix build when linbox is build with fplll support

### DIFF
--- a/src/sage/libs/flint/flint_wrap.h
+++ b/src/sage/libs/flint/flint_wrap.h
@@ -168,4 +168,10 @@
 
 #pragma pop_macro("ulong")
 
+/* CPU_SIZE_1 and SIZE_RED_FAILURE_THRESH are defined as macros in flint/fmpz_lll.h
+ * and as variables in fplll/defs.h, which breaks build if linbox is compiled with fplll */
+
+#undef CPU_SIZE_1
+#undef SIZE_RED_FAILURE_THRESH
+
 #endif


### PR DESCRIPTION
Undefine flint macros that conflict with fplll variables and break build when both are included

See https://github.com/sagemath/sage/pull/36449#issuecomment-1891095354