### PR TITLE
use directly OSError everywhere

### DIFF
--- a/src/sage/databases/cremona.py
+++ b/src/sage/databases/cremona.py
@@ -121,7 +121,7 @@ def build(name, data_tgz, largest_conductor=0, mini=False, decompress=True):
         raise RuntimeError('Please (re)move %s before building ' % db_path
                 + 'database')
     if not os.path.exists(data_tgz):
-        raise IOError("The data file is not at %s" % data_tgz)
+        raise OSError("The data file is not at %s" % data_tgz)
     t = walltime()
 
     if decompress:

--- a/src/sage/databases/cubic_hecke_db.py
+++ b/src/sage/databases/cubic_hecke_db.py
@@ -918,7 +918,7 @@ class CubicHeckeFileCache(SageObject):
         try:
             data_lib[section] = load(fname)
             verbose('... finished!')
-        except IOError:
+        except OSError:
             self.reset_library(section)
             verbose('... not found!')
         except (ImportError, ModuleNotFoundError):

--- a/src/sage/databases/db_modular_polynomials.py
+++ b/src/sage/databases/db_modular_polynomials.py
@@ -60,7 +60,7 @@ def _dbz_to_string(name):
     try:
         with open(filename, 'rb') as f:
             data = bz2.decompress(f.read())
-    except IOError:
+    except OSError:
         raise ValueError('file not found in the Kohel database')
     return bytes_to_str(data)
 

--- a/src/sage/databases/findstat.py
+++ b/src/sage/databases/findstat.py
@@ -881,7 +881,7 @@ def _get_code_from_callable(function):
                 code = inspect.getsource(function.f)
             else:
                 code = inspect.getsource(function)
-        except (IOError, TypeError):
+        except (OSError, TypeError):
             verbose("inspect.getsource could not get code from function provided",
                     caller_name='FindStat')
     return code

--- a/src/sage/databases/jones.py
+++ b/src/sage/databases/jones.py
@@ -152,7 +152,7 @@ class JonesDatabase:
         self.root = {}
         self.root[tuple()] = [x - 1]
         if not os.path.exists(path):
-            raise IOError("Path %s does not exist." % path)
+            raise OSError("Path %s does not exist." % path)
         for X in os.listdir(path):
             if X[-4:] == "solo":
                 Z = path + "/" + X

--- a/src/sage/databases/oeis.py
+++ b/src/sage/databases/oeis.py
@@ -187,8 +187,8 @@ def _fetch(url):
         result = f.read()
         f.close()
         return bytes_to_str(result)
-    except IOError as msg:
-        raise IOError("%s\nerror fetching %s" % (msg, url))
+    except OSError as msg:
+        raise OSError("%s\nerror fetching %s" % (msg, url))
 
 
 def _urls(html_string):

--- a/src/sage/databases/sloane.py
+++ b/src/sage/databases/sloane.py
@@ -197,20 +197,20 @@ class SloaneEncyclopediaClass:
         """
         # See if the encyclopedia already exists
         if not overwrite and os.path.exists(self.__file__):
-            raise IOError("Sloane encyclopedia is already installed")
+            raise OSError("Sloane encyclopedia is already installed")
 
         tm = verbose("Downloading stripped version of Sloane encyclopedia")
         ssl._create_default_https_context = ssl.create_default_context
         try:
             fname, _ = urlretrieve(oeis_url)
-        except IOError as msg:
-            raise IOError("%s\nError fetching the following website:\n    %s\nTry checking your internet connection." % (msg, oeis_url))
+        except OSError as msg:
+            raise OSError("%s\nError fetching the following website:\n    %s\nTry checking your internet connection." % (msg, oeis_url))
 
         if names_url is not None:
             try:
                 nname, _ = urlretrieve(names_url)
-            except IOError as msg:
-                raise IOError("%s\nError fetching the following website:\n    %s\nTry checking your internet connection." % (msg, names_url))
+            except OSError as msg:
+                raise OSError("%s\nError fetching the following website:\n    %s\nTry checking your internet connection." % (msg, names_url))
         else:
             nname = None
         verbose("Finished downloading", tm)
@@ -237,7 +237,7 @@ class SloaneEncyclopediaClass:
           old encyclopedia.
         """
         if not overwrite and os.path.exists(self.__file__):
-            raise IOError("Sloane encyclopedia is already installed")
+            raise OSError("Sloane encyclopedia is already installed")
 
         copy_gz_file(stripped_file, self.__file__)
 
@@ -262,8 +262,8 @@ class SloaneEncyclopediaClass:
             return
         try:
             file_seq = bz2.BZ2File(self.__file__, 'r')
-        except IOError:
-            raise IOError("The Sloane Encyclopedia database must be installed."
+        except OSError:
+            raise OSError("The Sloane Encyclopedia database must be installed."
                           " Use e.g. 'SloaneEncyclopedia.install()' to download and install it.")
 
         self.__data__ = {}
@@ -296,7 +296,7 @@ class SloaneEncyclopediaClass:
             # Some sequence in the names file is not in the database
             raise KeyError("Sloane OEIS sequence and name files do not match."
                            " Try reinstalling, e.g. SloaneEncyclopedia.install(overwrite=True).")
-        except IOError:
+        except OSError:
             # The names database is not installed
             self.__loaded_names__ = False
 
@@ -323,7 +323,7 @@ class SloaneEncyclopediaClass:
         """
         self.load()
         if not self.__loaded_names__:
-            raise IOError("The Sloane OEIS names file is not installed."
+            raise OSError("The Sloane OEIS names file is not installed."
                           " Try reinstalling, e.g. SloaneEncyclopedia.install(overwrite=True).")
 
         if N not in self.__data__:  # sequence N does not exist
@@ -364,8 +364,8 @@ def copy_gz_file(gz_source, bz_destination):
         gz_input = gzip.open(gz_source, 'r')
         db_text = gz_input.read()
         gz_input.close()
-    except IOError as msg:
-        raise IOError("Error reading gzipped input file:\n%s" % msg)
+    except OSError as msg:
+        raise OSError("Error reading gzipped input file:\n%s" % msg)
 
     # Write the bzipped output
     try:
@@ -373,5 +373,5 @@ def copy_gz_file(gz_source, bz_destination):
         bz2_output = bz2.BZ2File(bz_destination, 'w')
         bz2_output.write(db_text)
         bz2_output.close()
-    except IOError as msg:
-        raise IOError("Error writing bzipped output file:\n%s" % msg)
+    except OSError as msg:
+        raise OSError("Error writing bzipped output file:\n%s" % msg)

--- a/src/sage/databases/stein_watkins.py
+++ b/src/sage/databases/stein_watkins.py
@@ -214,8 +214,8 @@ class SteinWatkinsAllData:
         """
         try:
             file = bz2.open(self._file, 'rt', encoding="utf-8")
-        except IOError:
-            raise IOError("The Stein-Watkins data file %s must be installed." % self._file)
+        except OSError:
+            raise OSError("The Stein-Watkins data file %s must be installed." % self._file)
         C = None
         for L in file:
             if len(L) == 0:

--- a/src/sage/databases/symbolic_data.py
+++ b/src/sage/databases/symbolic_data.py
@@ -149,11 +149,11 @@ class SymbolicData:
         try:
             name = self.__intpath + name + ".xml"
             open(name)
-        except IOError:
+        except OSError:
             try:
                 name = self.__genpath + name + ".xml"
                 open(name)
-            except IOError:
+            except OSError:
                 raise AttributeError("No ideal matching '%s' found in database." % orig_name)
 
         dom = parse(name)

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -532,7 +532,7 @@ class DocTestController(SageObject):
                 # string from DocTestDefaults
                 try:
                     self.logfile = open(options.logfile, 'a')
-                except IOError:
+                except OSError:
                     print("Unable to open logfile {!r}\nProceeding without logging.".format(options.logfile))
                     self.logfile = None
         else:

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -283,7 +283,7 @@ def showwarning_with_traceback(message, category, filename, lineno, file=None, l
     try:
         file.writelines(lines)
         file.flush()
-    except IOError:
+    except OSError:
         pass  # the file is invalid
 
 

--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -798,7 +798,7 @@ class FileDocTestSource(DocTestSource):
         """
         if not os.path.exists(self.path):
             import errno
-            raise IOError(errno.ENOENT, "File does not exist", self.path)
+            raise OSError(errno.ENOENT, "File does not exist", self.path)
         base, filename = os.path.split(self.path)
         _, ext = os.path.splitext(filename)
         if not self.in_lib and ext in ('.py', '.pyx', '.sage', '.spyx'):

--- a/src/sage/interfaces/axiom.py
+++ b/src/sage/interfaces/axiom.py
@@ -350,7 +350,7 @@ class PanAxiom(ExtraTabCompletion, Expect):
                 try:
                     self.__tab_completion = sage.misc.persist.load(self._COMMANDS_CACHE)
                     return self.__tab_completion
-                except IOError:
+                except OSError:
                     pass
             if verbose:
                 print("\nBuilding %s command completion list (this takes" % self)

--- a/src/sage/interfaces/expect.py
+++ b/src/sage/interfaces/expect.py
@@ -158,7 +158,7 @@ class Expect(Interface):
         else:
             self.__path = os.path.join(SAGE_EXTCODE, name, script_subdirectory)
         if not os.path.isdir(self.__path):
-            raise EnvironmentError("path %r does not exist" % self.__path)
+            raise OSError("path %r does not exist" % self.__path)
         self.__initialized = False
         self.__seq = -1
         self._session_number = 0

--- a/src/sage/interfaces/four_ti_2.py
+++ b/src/sage/interfaces/four_ti_2.py
@@ -208,7 +208,7 @@ class FourTi2():
             f = open(os.path.join(self.directory(), filename))
             lines = f.readlines()
             f.close()
-        except IOError:
+        except OSError:
             return matrix(ZZ, 0, 0)
 
         nrows, ncols = map(ZZ, lines.pop(0).strip().split())

--- a/src/sage/interfaces/fricas.py
+++ b/src/sage/interfaces/fricas.py
@@ -435,7 +435,7 @@ http://fricas.sourceforge.net.
                 try:
                     self.__tab_completion = sage.misc.persist.load(self._COMMANDS_CACHE)
                     return self.__tab_completion
-                except IOError:
+                except OSError:
                     pass
             if verbose:
                 print("\nBuilding %s command completion list (this takes" % self)

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -591,7 +591,7 @@ class Gap_generic(ExtraTabCompletion, Expect):
         except pexpect.EOF:
             if not expect_eof:
                 raise RuntimeError("Unexpected EOF from %s executing %s" % (self, line))
-        except IOError:
+        except OSError:
             raise RuntimeError("IO Error from %s executing %s" % (self, line))
         return (b"".join(normal_outputs), b"".join(error_outputs))
 

--- a/src/sage/interfaces/giac.py
+++ b/src/sage/interfaces/giac.py
@@ -559,7 +559,7 @@ If you got giac from the spkg then ``$PREFIX`` is ``$SAGE_LOCAL``
                 try:
                     self.__tab_completion = sage.misc.persist.load(COMMANDS_CACHE)
                     return self.__tab_completion
-                except IOError:
+                except OSError:
                     pass
             if verbose:
                 print("\nBuilding Giac command completion list (this takes")

--- a/src/sage/interfaces/lie.py
+++ b/src/sage/interfaces/lie.py
@@ -395,7 +395,7 @@ class LiE(ExtraTabCompletion, Expect):
                 self._tab_completion_dict = trait_dict
                 self._help_dict = help_dict
                 return
-            except IOError:
+            except OSError:
                 pass
 
         # Go through INFO.3 and get the necessary information

--- a/src/sage/interfaces/magma.py
+++ b/src/sage/interfaces/magma.py
@@ -262,8 +262,8 @@ def extcode_dir(iface=None):
                 ans = os.system(command)
                 EXTCODE_DIR = "%s/data/" % tmp
                 if ans != 0:
-                    raise IOError
-            except (OSError, IOError):
+                    raise OSError
+            except OSError:
                 out_str = 'Tried to copy the file structure in "%s/magma/" to "%s:%s/data" and failed (possibly because scp is not installed in the system).\nFor the remote Magma to work you should populate the remote directory by some other method, or install scp in the system and retry.' % (SAGE_EXTCODE, iface._server, tmp)
                 from warnings import warn
                 warn(out_str)
@@ -1495,7 +1495,7 @@ class Magma(ExtraTabCompletion, Expect):
                 try:
                     self.__tab_completion = sage.misc.persist.load(INTRINSIC_CACHE)
                     return self.__tab_completion
-                except IOError:
+                except OSError:
                     pass
             if verbose:
                 print("\nCreating list of all Magma intrinsics for use in tab completion.")

--- a/src/sage/interfaces/maple.py
+++ b/src/sage/interfaces/maple.py
@@ -556,7 +556,7 @@ connection to a server running Maple; for hints, type
                 try:
                     self.__tab_completion = sage.misc.persist.load(COMMANDS_CACHE)
                     return self.__tab_completion
-                except IOError:
+                except OSError:
                     pass
             if verbose:
                 print("\nBuilding Maple command completion list (this takes")

--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -356,7 +356,7 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
                 try:
                     self.__tab_completion = sage.misc.persist.load(COMMANDS_CACHE)
                     return self.__tab_completion
-                except IOError:
+                except OSError:
                     pass
             if verbose:
                 print("\nBuilding Maxima command completion list (this takes")

--- a/src/sage/interfaces/mupad.py
+++ b/src/sage/interfaces/mupad.py
@@ -408,7 +408,7 @@ command-line version of MuPAD.
                 try:
                     self.__tab_completion = sage.misc.persist.load(COMMANDS_CACHE)
                     return self.__tab_completion
-                except IOError:
+                except OSError:
                     pass
             if verbose:
                 print("\nBuilding MuPAD command completion list (this takes")

--- a/src/sage/interfaces/quit.py
+++ b/src/sage/interfaces/quit.py
@@ -46,7 +46,7 @@ def register_spawned_process(pid, cmd=''):
     try:
         with open(sage_spawned_process_file(), 'a') as o:
             o.write('%s %s\n' % (pid, cmd))
-    except IOError:
+    except OSError:
         pass
     else:
         # If sage is being used as a python library, we need to launch

--- a/src/sage/interfaces/r.py
+++ b/src/sage/interfaces/r.py
@@ -1239,7 +1239,7 @@ class R(ExtraTabCompletion, Interface):
                 try:
                     self.__tab_completion = sage.misc.persist.load(COMMANDS_CACHE)
                     return self.__tab_completion
-                except IOError:
+                except OSError:
                     pass
             if verbose and use_disk_cache:
                 print("\nBuilding R command completion list (this takes")

--- a/src/sage/parallel/use_fork.py
+++ b/src/sage/parallel/use_fork.py
@@ -209,7 +209,7 @@ class p_iter_fork():
                         try:
                             with open(sobj, "rb") as file:
                                 data = file.read()
-                        except IOError:
+                        except OSError:
                             answer = "NO DATA" + W.failure
                         else:
                             os.unlink(sobj)
@@ -223,7 +223,7 @@ class p_iter_fork():
                             with open(out) as file:
                                 sys.stdout.write(file.read())
                             os.unlink(out)
-                        except IOError:
+                        except OSError:
                             pass
 
                         yield (W.input, answer)

--- a/src/sage/repl/image.py
+++ b/src/sage/repl/image.py
@@ -306,7 +306,7 @@ class Image(SageObject):
                 stream = io.BytesIO()
                 try:
                     self.pil.save(stream, format=format)
-                except IOError:
+                except OSError:
                     # not all formats support all modes, e.g. no alpha support in gif
                     continue
                 buf = OutputBuffer(stream.getvalue())

--- a/src/sage/repl/inputhook.py
+++ b/src/sage/repl/inputhook.py
@@ -37,7 +37,7 @@ def sage_inputhook(context):
             r, _, _ = select.select([f], [], [], TIMEOUT)
             if f in r:
                 return  # IPython signalled us to stop
-        except select.error as e:
+        except OSError as e:
             if e[0] != errno.EINTR:
                 raise
 

--- a/src/sage/repl/ipython_extension.py
+++ b/src/sage/repl/ipython_extension.py
@@ -489,7 +489,7 @@ class SageCustomizations():
         try:
             with open(SAGE_STARTUP_FILE, 'r') as f:
                 self.shell.run_cell(f.read(), store_history=False)
-        except IOError:
+        except OSError:
             pass
 
     def init_inspector(self):

--- a/src/sage/repl/load.py
+++ b/src/sage/repl/load.py
@@ -242,7 +242,7 @@ def load(filename, globals, attach=False):
         if os.path.isfile(fpath):
             break
     else:
-        raise IOError('did not find file %r to load or attach' % filename)
+        raise OSError('did not find file %r to load or attach' % filename)
 
     ext = os.path.splitext(fpath)[1].lower()
     if ext == '.py':

--- a/src/sage/sandpiles/sandpile.py
+++ b/src/sage/sandpiles/sandpile.py
@@ -5189,7 +5189,7 @@ class SandpileDivisor(dict):
             os.system(shlex.quote(path_to_zsolve) + ' -q ' + lin_sys + ' > ' + lin_sys_log)
             # process the results
             zhom_file = open(lin_sys_zhom, 'r')
-        except IOError:
+        except OSError:
             print("""
                  **********************************
                  *** This method requires 4ti2. ***

--- a/src/sage/sets/set_from_iterator.py
+++ b/src/sage/sets/set_from_iterator.py
@@ -482,7 +482,7 @@ class Decorator():
                 filename = sage_getfile_relative(f)
                 file_info = "File: %s (starting at line %d)\n" % (filename, sourcelines[1])
                 doc = file_info + doc
-            except IOError:
+            except OSError:
                 pass
         return doc
 

--- a/src/sage_docbuild/builders.py
+++ b/src/sage_docbuild/builders.py
@@ -884,7 +884,7 @@ class ReferenceSubBuilder(DocBuilder):
                 env.config.values = env.app.config.values
                 logger.debug("Opened Sphinx environment: %s", env_pickle)
                 return env
-        except (IOError, EOFError) as err:
+        except (OSError, EOFError) as err:
             logger.debug(
                 f"Failed to open Sphinx environment '{env_pickle}'", exc_info=True)
 

--- a/src/sage_docbuild/ext/inventory_builder.py
+++ b/src/sage_docbuild/ext/inventory_builder.py
@@ -47,7 +47,7 @@ class InventoryBuilder(DummyBuilder):
                 srcmtime = path.getmtime(self.env.doc2path(docname))
                 if srcmtime > targetmtime:
                     yield docname
-            except EnvironmentError:
+            except OSError:
                 # source doesn't exist anymore
                 pass
 

--- a/src/sage_docbuild/ext/multidocs.py
+++ b/src/sage_docbuild/ext/multidocs.py
@@ -115,7 +115,7 @@ def get_env(app, curdoc):
         app.env.doctreedir, curdoc, ENV_PICKLE_FILENAME)
     try:
         f = open(filename, 'rb')
-    except IOError:
+    except OSError:
         logger.debug(f"Unable to load pickled environment '{filename}'", exc_info=True)
         return None
     docenv = pickle.load(f)
@@ -181,7 +181,7 @@ def get_js_index(app, curdoc):
     indexfile = os.path.join(app.outdir, curdoc, 'searchindex.js')
     try:
         f = open(indexfile, 'r')
-    except IOError:
+    except OSError:
         logger.info("")
         logger.warning("Unable to fetch %s " % indexfile)
         return None

--- a/src/sage_setup/autogen/interpreters/utils.py
+++ b/src/sage_setup/autogen/interpreters/utils.py
@@ -145,7 +145,7 @@ def write_if_changed(fn, value):
     try:
         with open(fn) as file:
             old_value = file.read()
-    except IOError:
+    except OSError:
         pass
 
     if value != old_value:

--- a/src/sage_setup/command/sage_build_cython.py
+++ b/src/sage_setup/command/sage_build_cython.py
@@ -167,7 +167,7 @@ class sage_build_cython(Command):
                 # we remove the version_file now to force a
                 # recythonization the next time we build Sage.
                 os.unlink(self._version_file)
-        except IOError:
+        except OSError:
             # Most likely, the version_file does not exist
             # => (re)cythonize all Cython code.
             force = True


### PR DESCRIPTION
fixed by `ruff --fix --select=UP024 src/`

OSError has replaced several errors since python 3.3:

https://stackoverflow.com/questions/29347790/difference-between-ioerror-and-oserror

https://peps.python.org/pep-3151/#confusing-set-of-os-related-exceptions

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.