### PR TITLE
some cleanup in overconvergent and quaternion

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -332,7 +332,7 @@ class QuaternionAlgebra_abstract(Algebra):
             sage: Q.ngens()
             3
             sage: Q.gens()
-            [i, j, k]
+            (i, j, k)
         """
         return 3
 
@@ -681,7 +681,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         else:
             self.Element = QuaternionAlgebraElement_generic
         self._populate_coercion_lists_(coerce_list=[base_ring])
-        self._gens = [self([0, 1, 0, 0]), self([0, 0, 1, 0]), self([0, 0, 0, 1])]
+        self._gens = (self([0, 1, 0, 0]), self([0, 0, 1, 0]), self([0, 0, 0, 1]))
 
     @cached_method
     def maximal_order(self, take_shortcuts=True):
@@ -808,7 +808,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         # The following code should always work (over QQ)
         # Start with <1,i,j,k>
-        R = self.quaternion_order([1] + self.gens())
+        R = self.quaternion_order((1,) + self.gens())
         d_R = R.discriminant()
 
         e_new_gens = []
@@ -978,7 +978,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             sage: Q.gen(2)
             kk
             sage: Q.gens()
-            [ii, jj, kk]
+            (ii, jj, kk)
         """
         return self._gens[i]
 
@@ -1496,7 +1496,7 @@ class QuaternionOrder(Parent):
 
     def gens(self):
         """
-        Return generators for self.
+        Return generators for ``self``.
 
         EXAMPLES::
 

--- a/src/sage/modular/btquotients/btquotient.py
+++ b/src/sage/modular/btquotients/btquotient.py
@@ -3468,7 +3468,7 @@ class BruhatTitsQuotient(SageObject, UniqueRepresentation):
             OBasis = Omagma.Basis()
             self._A = QuaternionAlgebra((g[0] ** 2).sage(), (g[1] ** 2).sage())
             i, j, k = self._A.gens()
-            v = [1] + self._A.gens()
+            v = [1] + list(self._A.gens())
             self._B = [self._A(sum([OBasis[tt + 1][rr + 1].sage() * v[rr]
                                     for rr in range(4)])) for tt in range(4)]
             self._O = self._A.quaternion_order(self._B)
@@ -3478,7 +3478,7 @@ class BruhatTitsQuotient(SageObject, UniqueRepresentation):
             # Note that we can't work with non-maximal orders in sage
             assert self._Nplus == 1
             self._A = QuaternionAlgebra(self._Nminus)
-            v = [1] + self._A.gens()
+            v = [1] + list(self._A.gens())
             self._O = self._A.maximal_order()
             self._OMax = self._O
             OBasis = self._O.basis()
@@ -3623,8 +3623,8 @@ class BruhatTitsQuotient(SageObject, UniqueRepresentation):
         v0 = Vertex(p, num_verts, self._Mat_22([1, 0, 0, 1]),
                     determinant=1, valuation=0)
         V = deque([v0])
-        S = Graph(0, multiedges=True, weighted=True)
-        Sfun = Graph(0)
+        S = Graph(0, multiedges=True, weighted=True)  # noqa:F821
+        Sfun = Graph(0)  # noqa:F821
         edge_list = []
         vertex_list = [v0]
         num_edges = 0


### PR DESCRIPTION
Two different things:

- cleaning the file `overconvergent/genus0`, adding a `TestSuite` and making it pass ; getting rid of non-sensical `gens_dict` there

- making quaternion algebra return a tuple of generators

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.