### PR TITLE
Allow the computation of random points on hyperelliptic curves and their Jacobians.

### DIFF
--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_finite_field.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_finite_field.py
@@ -1985,7 +1985,7 @@ class HyperellipticCurve_finite_field(hyperelliptic_generic.HyperellipticCurve_g
             sage: P in H
             True
 
-        Ensure that the entire point set is reachable
+        Ensure that the entire point set is reachable::
 
             sage: R.<x> = PolynomialRing(GF(7))
             sage: f = x^5 + x^2 + 1

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_finite_field.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_finite_field.py
@@ -1937,10 +1937,10 @@ class HyperellipticCurve_finite_field(hyperelliptic_generic.HyperellipticCurve_g
 
         .. SEEALSO::
 
-            This function is effectively the same as the function 
+            This function is effectively the same as the function
             :meth:`~sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.random_element`
             defined for elliptic curves over finite fields.
-    
+
         AUTHORS:
 
         - Gareth Ma, Luciano Maino, Elif Özbay, Giacomo Pope (Sage Days 123 2024)

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
@@ -265,9 +265,9 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
 
         OUTPUT:
 
-        A bool stating whether or not `x` o
+        A bool stating whether or not `x` is a x-coordinate of a point on the curve
 
-        EXAMPLES::
+        EXAMPLES:
 
         When `x` is the `x`-coordinate of a rational point on the
         curve, we can request these::
@@ -377,7 +377,11 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
 
         :meth:`is_x_coord`
 
-        EXAMPLES::
+        AUTHORS:
+
+        - Giacomo Pope (2024): Allowed for the case of characteristic two
+
+        EXAMPLES:
 
         When `x` is the `x`-coordinate of a rational point on the
         curve, we can request these::
@@ -426,9 +430,6 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
             sage: H.lift_x(z4^3 + z4^2 + z4, all=True)
             [(z4^3 + z4^2 + z4 : z4^2 + z4 + 1 : 1), (z4^3 + z4^2 + z4 : z4^3 : 1)]
 
-        AUTHORS:
-
-        - Giacomo Pope (2024): Allowed for the case of characteristic two
 
         TESTS::
 
@@ -444,6 +445,17 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
             Traceback (most recent call last):
             ...
             TypeError: x must be coercible into the base ring of the curve
+
+        Ensure that :issue:`37097` is fixed::
+
+            sage: # needs sage.rings.finite_rings
+            sage: F.<z4> = GF(2^4)
+            sage: R.<x> = PolynomialRing(F)
+            sage: f = x^7 + x^3 + 1
+            sage: h = x + 1
+            sage: H = HyperellipticCurve(f, h)
+            sage: H.lift_x(z4^3 + z4^2 + z4, all=True)
+            [(z4^3 + z4^2 + z4 : z4^2 + z4 + 1 : 1), (z4^3 + z4^2 + z4 : z4^3 : 1)]
         """
         f, h = self.hyperelliptic_polynomials()
         K = self.base_ring()

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
@@ -375,7 +375,7 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
 
         .. SEEALSO::
 
-        :meth:`is_x_coord`
+            :meth:`is_x_coord`
 
         AUTHORS:
 

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
@@ -343,7 +343,7 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
         if not h:
             y2 = f(x)
             return y2.is_square()
-        # Generic case for h != 0 
+        # Generic case for h != 0
         a = f(x)
         b = h(x)
         # Special case for char 2
@@ -360,7 +360,7 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
         Return one or all points with given `x`-coordinate.
 
         This method is deterministic: It returns the same data each time when called again with the same.
-        
+
         INPUT:
 
         - ``x`` -- an element of the base ring of the curve

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
@@ -430,10 +430,7 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
             sage: H.lift_x(z4^3 + z4^2 + z4, all=True)
             [(z4^3 + z4^2 + z4 : z4^2 + z4 + 1 : 1), (z4^3 + z4^2 + z4 : z4^3 : 1)]
 
-
         TESTS::
-
-        The `x`-coordinate must be defined over the base field of the curve::
 
             sage: # needs sage.rings.finite_rings
             sage: F = GF(11)

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_padic_field.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_padic_field.py
@@ -506,10 +506,10 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: K = pAdicField(11,5)
             sage: x = polygen(K)
             sage: C = HyperellipticCurve(x^5 + 33/16*x^4 + 3/4*x^3 + 3/8*x^2 - 1/4*x + 1/16)
-            sage: P = C.lift_x(11^(-2))
-            sage: Q = C.lift_x(3*11^(-2))
+            sage: P = C.lift_x(11^(-2), all=True)[1]
+            sage: Q = C.lift_x(3*11^(-2), all=True)[1]
             sage: C.coleman_integrals_on_basis(P, Q)
-            (5*11^3 + 7*11^4 + 2*11^5 + 6*11^6 + 11^7 + O(11^8), 10*11 + 2*11^3 + 3*11^4 + 5*11^5 + O(11^6), 5*11^-1 + 8 + 4*11 + 10*11^2 + 7*11^3 + O(11^4), 2*11^-3 + 11^-2 + 11^-1 + 10 + 8*11 + O(11^2))
+            (6*11^3 + 3*11^4 + 8*11^5 + 4*11^6 + 9*11^7 + O(11^8), 11 + 10*11^2 + 8*11^3 + 7*11^4 + 5*11^5 + O(11^6), 6*11^-1 + 2 + 6*11 + 3*11^3 + O(11^4), 9*11^-3 + 9*11^-2 + 9*11^-1 + 2*11 + O(11^2))
 
         ::
 

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_padic_field.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_padic_field.py
@@ -506,8 +506,8 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: K = pAdicField(11,5)
             sage: x = polygen(K)
             sage: C = HyperellipticCurve(x^5 + 33/16*x^4 + 3/4*x^3 + 3/8*x^2 - 1/4*x + 1/16)
-            sage: P = C.lift_x(11^(-2), all=True)[1]
-            sage: Q = C.lift_x(3*11^(-2), all=True)[1]
+            sage: P = C(11^-2, 10*11^-5 + 10*11^-4 + 10*11^-3 + 2*11^-2 + 10*11^-1)
+            sage: Q = C(3*11^-2, 11^-5 + 11^-3 + 10*11^-2 + 7*11^-1)
             sage: C.coleman_integrals_on_basis(P, Q)
             (6*11^3 + 3*11^4 + 8*11^5 + 4*11^6 + 9*11^7 + O(11^8), 11 + 10*11^2 + 8*11^3 + 7*11^4 + 5*11^5 + O(11^6), 6*11^-1 + 2 + 6*11 + 3*11^3 + O(11^4), 9*11^-3 + 9*11^-2 + 9*11^-1 + 2*11 + O(11^2))
 
@@ -792,7 +792,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: HK = H.change_ring(K)
             sage: w = HK.invariant_differential()
             sage: P = HK(0,1)
-            sage: Q = HK.lift_x(5, all=True)[1]
+            sage: QQ = HK(5, 1 + 3*5^3 + 2*5^4 + 2*5^5 + 3*5^7)
             sage: x,y = HK.monsky_washnitzer_gens()
             sage: (2*y*w).coleman_integral(P,Q)
             5 + O(5^9)

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_padic_field.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_padic_field.py
@@ -103,7 +103,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: x,y,z = HK.local_analytic_interpolation(P,HK(1,0))
             Traceback (most recent call last):
             ...
-            ValueError: (5^-2 + O(5^6) : 5^-3 + 4*5^2 + 5^3 + 3*5^4 + O(5^5) : 1 + O(5^8)) and (1 + O(5^8) : 0 : 1 + O(5^8)) are not in the same residue disc
+            ValueError: (5^-2 + O(5^6) : 4*5^-3 + 4*5^-2 + 4*5^-1 + 4 + 4*5 + 3*5^3 + 5^4 + O(5^5) : 1 + O(5^8)) and (1 + O(5^8) : 0 : 1 + O(5^8)) are not in the same residue disc
 
         TESTS:
 
@@ -186,7 +186,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: HK.is_in_weierstrass_disc(S)
             True
             sage: T = HK.lift_x(1+3*5^2); T
-            (1 + 3*5^2 + O(5^8) : 2*5 + 4*5^3 + 3*5^4 + 5^5 + 3*5^6 + O(5^7) : 1 + O(5^8))
+            (1 + 3*5^2 + O(5^8) : 3*5 + 4*5^2 + 5^4 + 3*5^5 + 5^6 + O(5^7) : 1 + O(5^8))
             sage: HK.is_in_weierstrass_disc(T)
             True
 
@@ -216,7 +216,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: HK.is_weierstrass(S)
             True
             sage: T = HK.lift_x(1+3*5^2); T
-            (1 + 3*5^2 + O(5^8) : 2*5 + 4*5^3 + 3*5^4 + 5^5 + 3*5^6 + O(5^7) : 1 + O(5^8))
+            (1 + 3*5^2 + O(5^8) : 3*5 + 4*5^2 + 5^4 + 3*5^5 + 5^6 + O(5^7) : 1 + O(5^8))
             sage: HK.is_weierstrass(T)
             False
 
@@ -364,7 +364,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: P = C.lift_x(11^(-2))
             sage: Q = C.lift_x(3*11^(-2))
             sage: C.tiny_integrals([1],P,Q)
-            (3*11^3 + 7*11^4 + 4*11^5 + 7*11^6 + 5*11^7 + O(11^8))
+            (5*11^3 + 7*11^4 + 2*11^5 + 6*11^6 + 11^7 + O(11^8))
 
         Note that this fails if the points are not in the same residue disc::
 
@@ -426,7 +426,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: P = C.lift_x(11^(-2))
             sage: Q = C.lift_x(3*11^(-2))
             sage: C.tiny_integrals_on_basis(P,Q)
-            (3*11^3 + 7*11^4 + 4*11^5 + 7*11^6 + 5*11^7 + O(11^8), 3*11 + 10*11^2 + 8*11^3 + 9*11^4 + 7*11^5 + O(11^6), 4*11^-1 + 2 + 6*11 + 6*11^2 + 7*11^3 + O(11^4), 11^-3 + 6*11^-2 + 2*11^-1 + 2 + O(11^2))
+            (5*11^3 + 7*11^4 + 2*11^5 + 6*11^6 + 11^7 + O(11^8), 10*11 + 2*11^3 + 3*11^4 + 5*11^5 + O(11^6), 5*11^-1 + 8 + 4*11 + 10*11^2 + 7*11^3 + O(11^4), 2*11^-3 + 11^-2 + 11^-1 + 10 + 8*11 + O(11^2))
 
 
         Note that this fails if the points are not in the same residue disc::
@@ -497,9 +497,9 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: P = C.lift_x(2)
             sage: Q = C.lift_x(3)
             sage: C.coleman_integrals_on_basis(P, Q)
-            (10*11 + 6*11^3 + 2*11^4 + O(11^5), 11 + 9*11^2 + 7*11^3 + 9*11^4 + O(11^5), 3 + 10*11 + 5*11^2 + 9*11^3 + 4*11^4 + O(11^5), 3 + 11 + 5*11^2 + 4*11^4 + O(11^5))
+            (9*11^2 + 7*11^3 + 5*11^4 + O(11^5), 11 + 3*11^2 + 7*11^3 + 11^4 + O(11^5), 10*11 + 11^2 + 5*11^3 + 5*11^4 + O(11^5), 3 + 9*11^2 + 6*11^3 + 11^4 + O(11^5))
             sage: C.coleman_integrals_on_basis(P, Q, algorithm='teichmuller')
-            (10*11 + 6*11^3 + 2*11^4 + O(11^5), 11 + 9*11^2 + 7*11^3 + 9*11^4 + O(11^5), 3 + 10*11 + 5*11^2 + 9*11^3 + 4*11^4 + O(11^5), 3 + 11 + 5*11^2 + 4*11^4 + O(11^5))
+            (9*11^2 + 7*11^3 + 5*11^4 + O(11^5), 11 + 3*11^2 + 7*11^3 + 11^4 + O(11^5), 10*11 + 11^2 + 5*11^3 + 5*11^4 + O(11^5), 3 + 9*11^2 + 6*11^3 + 11^4 + O(11^5))
 
         ::
 
@@ -509,7 +509,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: P = C.lift_x(11^(-2))
             sage: Q = C.lift_x(3*11^(-2))
             sage: C.coleman_integrals_on_basis(P, Q)
-            (3*11^3 + 7*11^4 + 4*11^5 + 7*11^6 + 5*11^7 + O(11^8), 3*11 + 10*11^2 + 8*11^3 + 9*11^4 + 7*11^5 + O(11^6), 4*11^-1 + 2 + 6*11 + 6*11^2 + 7*11^3 + O(11^4), 11^-3 + 6*11^-2 + 2*11^-1 + 2 + O(11^2))
+            (5*11^3 + 7*11^4 + 2*11^5 + 6*11^6 + 11^7 + O(11^8), 10*11 + 2*11^3 + 3*11^4 + 5*11^5 + O(11^6), 5*11^-1 + 8 + 4*11 + 10*11^2 + 7*11^3 + O(11^4), 2*11^-3 + 11^-2 + 11^-1 + 10 + 8*11 + O(11^2))
 
         ::
 
@@ -538,9 +538,9 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: HK.coleman_integrals_on_basis(P,S) == -HK.coleman_integrals_on_basis(S,P)
             True
             sage: HK.coleman_integrals_on_basis(S,Q)
-            (4*5 + 4*5^2 + 4*5^3 + O(5^4), 5^-1 + O(5^3))
+            (5 + O(5^4), 4*5^-1 + 4 + 4*5 + 4*5^2 + O(5^3))
             sage: HK.coleman_integrals_on_basis(Q,R)
-            (4*5 + 2*5^2 + 2*5^3 + 2*5^4 + 5^5 + 5^6 + 5^7 + 3*5^8 + O(5^9), 2*5^-1 + 4 + 4*5 + 4*5^2 + 4*5^3 + 2*5^4 + 3*5^5 + 2*5^6 + O(5^7))
+            (5 + 2*5^2 + 2*5^3 + 2*5^4 + 3*5^5 + 3*5^6 + 3*5^7 + 5^8 + O(5^9), 3*5^-1 + 2*5^4 + 5^5 + 2*5^6 + O(5^7))
             sage: HK.coleman_integrals_on_basis(S,R) == HK.coleman_integrals_on_basis(S,Q) + HK.coleman_integrals_on_basis(Q,R)
             True
             sage: HK.coleman_integrals_on_basis(T,T)
@@ -748,7 +748,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             (O(71^4), O(71^4))
             sage: R, R1 = C.lift_x(4, all=True)
             sage: w.integrate(P, R)
-            21*71 + 67*71^2 + 27*71^3 + O(71^4)
+            50*71 + 3*71^2 + 43*71^3 + O(71^4)
             sage: w.integrate(P, R) + w.integrate(P1, R1)
             O(71^4)
 
@@ -792,7 +792,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: HK = H.change_ring(K)
             sage: w = HK.invariant_differential()
             sage: P = HK(0,1)
-            sage: Q = HK.lift_x(5)
+            sage: Q = HK.lift_x(5, all=True)[1]
             sage: x,y = HK.monsky_washnitzer_gens()
             sage: (2*y*w).coleman_integral(P,Q)
             5 + O(5^9)
@@ -881,11 +881,11 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
             sage: E = HyperellipticCurve(x^5 - 21*x - 20)
             sage: P = E.lift_x(2)
             sage: E.frobenius(P)
-            (2 + 10*11 + 5*11^2 + 11^3 + O(11^5) : 5 + 9*11 + 2*11^2 + 2*11^3 + O(11^5) : 1 + O(11^5))
+            (2 + 10*11 + 5*11^2 + 11^3 + O(11^5) : 6 + 11 + 8*11^2 + 8*11^3 + 10*11^4 + O(11^5) : 1 + O(11^5))
             sage: Q = E.teichmuller(P); Q
-            (2 + 10*11 + 4*11^2 + 9*11^3 + 11^4 + O(11^5) : 5 + 9*11 + 6*11^2 + 11^3 + 6*11^4 + O(11^5) : 1 + O(11^5))
+            (2 + 10*11 + 4*11^2 + 9*11^3 + 11^4 + O(11^5) : 6 + 11 + 4*11^2 + 9*11^3 + 4*11^4 + O(11^5) : 1 + O(11^5))
             sage: E.frobenius(Q)
-            (2 + 10*11 + 4*11^2 + 9*11^3 + 11^4 + O(11^5) : 5 + 9*11 + 6*11^2 + 11^3 + 6*11^4 + O(11^5) : 1 + O(11^5))
+            (2 + 10*11 + 4*11^2 + 9*11^3 + 11^4 + O(11^5) : 6 + 11 + 4*11^2 + 9*11^3 + 4*11^4 + O(11^5) : 1 + O(11^5))
 
         ::
 

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
@@ -198,7 +198,7 @@ class HyperellipticJacobian_generic(Jacobian_generic):
             True
             sage: type(D)
             <class 'sage.schemes.hyperelliptic_curves.jacobian_morphism.JacobianMorphism_divisor_class_field'>
-        
+
         ::
 
             sage: # needs sage.rings.finite_rings
@@ -245,7 +245,7 @@ class HyperellipticJacobian_generic(Jacobian_generic):
 
         # We randomly sample 2g + 1 points on the hyperelliptic curve
         points = [H.random_point() for _ in range(2*g + 1)]
-        
+
         # We create 2g + 1 divisors of the form (P) - infty
         divisors = [self(P) for P in points if P[2] != 0]
 

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
@@ -198,62 +198,8 @@ class HyperellipticJacobian_generic(Jacobian_generic):
             True
             sage: type(D)
             <class 'sage.schemes.hyperelliptic_curves.jacobian_morphism.JacobianMorphism_divisor_class_field'>
-
-        ::
-
-            sage: # needs sage.rings.finite_rings
-            sage: F = GF(163^2)
-            sage: R.<x> = PolynomialRing(F)
-            sage: f = x^5 + x^3 + 1
-            sage: h = x + 3
-            sage: H = HyperellipticCurve(f, h)
-            sage: J = H.jacobian()
-            sage: D = J.random_element()
-            sage: u, v = D
-            sage: (v**2 + h*v - f) % u == 0
-            True
-
-        ::
-
-            sage: # needs sage.rings.finite_rings
-            sage: F = GF(2^4)
-            sage: R.<x> = PolynomialRing(F)
-            sage: f = x^9 + x^3 + 1
-            sage: h = x + 3
-            sage: H = HyperellipticCurve(f, h)
-            sage: J = H.jacobian()
-            sage: D = J.random_element()
-            sage: u, v = D
-            sage: (v**2 + h*v - f) % u == 0
-            True
-
-        Ensure that the entire point set is reachable::
-
-            sage: # needs sage.rings.finite_rings
-            sage: R.<x> = PolynomialRing(GF(7))
-            sage: f = x^5 + x^2 + 1
-            sage: H = HyperellipticCurve(f)
-            sage: J = H.jacobian()
-            sage: S = set()
-            sage: order = H.zeta_function().numerator()(1)
-            sage: while len(S) < order:
-            ....:     S.add(tuple(J.random_element()))
-
         """
-        H = self.curve()
-        g = H.genus()
-
-        # We randomly sample 2g + 1 points on the hyperelliptic curve
-        points = [H.random_point() for _ in range(2*g + 1)]
-
-        # We create 2g + 1 divisors of the form (P) - infty
-        divisors = [self(P) for P in points if P[2] != 0]
-
-        # If we happened to only sample the point at infinity, we return this
-        # Otherwise we compute the sum of all divisors.
-        if not divisors:
-            return self(0)
-        return sum(divisors)
+        return self(self.base_ring()).random_element()
 
     ####################################################################
     # Some properties of geometric Endomorphism ring and algebra

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
@@ -175,6 +175,86 @@ class HyperellipticJacobian_generic(Jacobian_generic):
     def _point(self, *args, **kwds):
         return jacobian_morphism.JacobianMorphism_divisor_class_field(*args, **kwds)
 
+    def random_element(self):
+        """
+        Returns a random element from the Jacobian. Distribution is not
+        uniformly random, but returns the entire group.
+
+        AUTHORS:
+
+        - Gareth Ma, Luciano Maino, Elif Özbay, Giacomo Pope (Sage Days 123 2024)
+
+        EXAMPLES::
+
+            sage: # needs sage.rings.finite_rings
+            sage: F = GF(163)
+            sage: R.<x> = PolynomialRing(F)
+            sage: f = x^7 + x^3 + 1
+            sage: H = HyperellipticCurve(f)
+            sage: J = H.jacobian()
+            sage: D = J.random_element()
+            sage: u, v = D
+            sage: (v**2 - f) % u == 0
+            True
+            sage: type(D)
+            <class 'sage.schemes.hyperelliptic_curves.jacobian_morphism.JacobianMorphism_divisor_class_field'>
+        
+        ::
+
+            sage: # needs sage.rings.finite_rings
+            sage: F = GF(163^2)
+            sage: R.<x> = PolynomialRing(F)
+            sage: f = x^5 + x^3 + 1
+            sage: h = x + 3
+            sage: H = HyperellipticCurve(f, h)
+            sage: J = H.jacobian()
+            sage: D = J.random_element()
+            sage: u, v = D
+            sage: (v**2 + h*v - f) % u == 0
+            True
+
+        ::
+
+            sage: # needs sage.rings.finite_rings
+            sage: F = GF(2^4)
+            sage: R.<x> = PolynomialRing(F)
+            sage: f = x^9 + x^3 + 1
+            sage: h = x + 3
+            sage: H = HyperellipticCurve(f, h)
+            sage: J = H.jacobian()
+            sage: D = J.random_element()
+            sage: u, v = D
+            sage: (v**2 + h*v - f) % u == 0
+            True
+
+        Ensure that the entire point set is reachable::
+
+            sage: # needs sage.rings.finite_rings
+            sage: R.<x> = PolynomialRing(GF(7))
+            sage: f = x^5 + x^2 + 1
+            sage: H = HyperellipticCurve(f)
+            sage: J = H.jacobian()
+            sage: S = set()
+            sage: order = H.zeta_function().numerator()(1)
+            sage: while len(S) < order:
+            ....:     S.add(tuple(J.random_element()))
+
+        """
+        H = self.curve()
+        g = H.genus()
+
+        # We randomly sample 2g + 1 points on the hyperelliptic curve
+        points = [H.random_point() for _ in range(2*g + 1)]
+        
+        # We create 2g + 1 divisors of the form (P) - infty
+        divisors = [self(P) for P in points if P[2] != 0]
+
+        # If we happened to only sample the point at infinity, we return this
+        # Otherwise we compute the sum of all divisors.
+        if not divisors:
+            return self(0)
+        return sum(divisors)
+
     ####################################################################
     # Some properties of geometric Endomorphism ring and algebra
     ####################################################################

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_generic.py
@@ -198,6 +198,19 @@ class HyperellipticJacobian_generic(Jacobian_generic):
             True
             sage: type(D)
             <class 'sage.schemes.hyperelliptic_curves.jacobian_morphism.JacobianMorphism_divisor_class_field'>
+
+        Ensure that the entire point set is reachable::
+
+            sage: # needs sage.rings.finite_rings
+            sage: F = GF(7)
+            sage: R.<x> = PolynomialRing(F)
+            sage: f = x^5 + x^2 + 1
+            sage: H = HyperellipticCurve(f)
+            sage: J = H.jacobian()
+            sage: s = set()
+            sage: order = H.zeta_function().numerator()(1)
+            sage: while len(s) < order:
+            ....:     s.add(tuple(J.random_element()))
         """
         return self(self.base_ring()).random_element()
 

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_homset.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_homset.py
@@ -238,7 +238,7 @@ class JacobianHomset_divisor_classes(SchemeHomset_points):
             sage: s = set()
             sage: order = H.zeta_function().numerator()(1)
             sage: while len(s) < order:
-            ....:     s.add(tuple(J.random_element()))
+            ....:     s.add(tuple(S.random_element()))
 
         """
         H = self.curve().change_ring(self.value_ring())

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_homset.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_homset.py
@@ -174,9 +174,18 @@ class JacobianHomset_divisor_classes(SchemeHomset_points):
         return self
 
     def random_element(self):
-        """
+        r"""
         Returns a random element from the Jacobian. Distribution is not
-        uniformly random, but returns the entire group.
+        uniformly random, but returns the entire group for Jacobians of
+        hyperelliptic curves with an odd degree model.
+
+        .. WARNING::
+
+            For Jacobians of curves with an even degree model, SageMath currently
+            is unable to represent all elements of the Jacobian, see :issue:`37101`.
+            For a Jacobian of order `N` of a hyperelliptic curve with `M` points,
+            we can only compute `N - M` elements of the Jacobian as there is no
+            way to currently distinguish between `P - (\infty_+)` and `P - (\infty_-)`.
 
         AUTHORS:
 
@@ -226,7 +235,7 @@ class JacobianHomset_divisor_classes(SchemeHomset_points):
             sage: (v**2 + h*v - f) % u == 0
             True
 
-        Ensure that the entire point set is reachable::
+        Ensure that the entire point set is reachable for odd degree models::
 
             sage: # needs sage.rings.finite_rings
             sage: F = GF(7)
@@ -238,6 +247,24 @@ class JacobianHomset_divisor_classes(SchemeHomset_points):
             sage: s = set()
             sage: order = H.zeta_function().numerator()(1)
             sage: while len(s) < order:
+            ....:     s.add(tuple(S.random_element()))
+
+        TESTS:
+
+        For the case of the even degree model, some elements cannot be
+        represented::
+
+            sage: # needs sage.rings.finite_rings
+            sage: F = GF(7)
+            sage: R.<x> = PolynomialRing(F)
+            sage: f = x^6 + x + 1
+            sage: H = HyperellipticCurve(f)
+            sage: J = H.jacobian()
+            sage: S = J(F)
+            sage: s = set()
+            sage: num_points = H.count_points()[0]
+            sage: order = H.zeta_function().numerator()(1)
+            sage: while len(s) < (order - num_points):
             ....:     s.add(tuple(S.random_element()))
 
         """

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_morphism.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_morphism.py
@@ -158,7 +158,6 @@ def cantor_reduction_simple(a, b, f, genus):
         sage: R.<x> = PolynomialRing(F)
         sage: f = x^6 + x^2 + 1
         sage: H = HyperellipticCurve(f)
-        sage: 
         sage: J = H.jacobian()
         sage: sum(J.random_element() for _ in range(10)) # random
         (x^2 + 115*x + 98, y + 100*x + 110)

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_morphism.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_morphism.py
@@ -210,11 +210,11 @@ def cantor_reduction(a, b, f, h, genus):
     The next point is not 2-torsion::
 
         sage: P = J(H.lift_x(-1)); P
-        (x + 1, y - 1)
+        (x + 1, y)
         sage: 2 * J(H.lift_x(-1)) # indirect doctest
-        (x^2 + 2*x + 1, y - 3*x - 4)
+        (x^2 + 2*x + 1, y + 4*x + 4)
         sage: 3 * J(H.lift_x(-1)) # indirect doctest
-        (x^2 - 487*x - 324, y - 10754*x - 7146)
+        (x^2 - 487*x - 324, y + 10755*x + 7146)
     """
     assert a.degree() < 2*genus+1
     assert b.degree() < a.degree()
@@ -262,15 +262,15 @@ def cantor_composition_simple(D1,D2,f,genus):
 
         sage: # needs sage.rings.number_field
         sage: P = J(H.lift_x(F(1))); P
-        (x - 1, y - a)
+        (x - 1, y + a)
         sage: Q = J(H.lift_x(F(0))); Q
         (x, y)
         sage: 2*P + 2*Q # indirect doctest
-        (x^2 - 2*x + 1, y - 3/2*a*x + 1/2*a)
+        (x^2 - 2*x + 1, y + 3/2*a*x - 1/2*a)
         sage: 2*(P + Q) # indirect doctest
-        (x^2 - 2*x + 1, y - 3/2*a*x + 1/2*a)
+        (x^2 - 2*x + 1, y + 3/2*a*x - 1/2*a)
         sage: 3*P # indirect doctest
-        (x^2 - 25/32*x + 49/32, y - 45/256*a*x - 315/256*a)
+        (x^2 - 25/32*x + 49/32, y + 45/256*a*x + 315/256*a)
     """
     a1, b1 = D1
     a2, b2 = D2
@@ -309,17 +309,16 @@ def cantor_composition(D1,D2,f,h,genus):
     ::
 
         sage: Q = J(H.lift_x(F(1))); Q                                                  # needs sage.rings.finite_rings
-        (x + 6, y + 2*a + 2)
+        (x + 6, y + 5*a)
         sage: 10*Q  # indirect doctest                                                  # needs sage.rings.finite_rings
-        (x^3 + (3*a + 1)*x^2 + (2*a + 5)*x + a + 5,
-         y + (4*a + 5)*x^2 + (a + 1)*x + 6*a + 3)
+        (x^3 + (3*a + 1)*x^2 + (2*a + 5)*x + a + 5, y + (3*a + 2)*x^2 + (6*a + 1)*x + a + 4)
         sage: 7*8297*Q                                                                  # needs sage.rings.finite_rings
         (1)
 
     ::
 
         sage: Q = J(H.lift_x(F(a+1))); Q                                                # needs sage.rings.finite_rings
-        (x + 6*a + 6, y + 2*a)
+        (x + 6*a + 6, y + 2)
         sage: 7*8297*Q  # indirect doctest                                              # needs sage.rings.finite_rings
         (1)
 
@@ -444,7 +443,7 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
         ::
 
             sage: Q = J(H.lift_x(F(1))); Q  # indirect doctest                          # needs sage.rings.finite_rings
-            (x + 6, y + 2*a + 2)
+            (x + 6, y + 5*a)
         """
         a, b = self.__polys
         P = self.parent()._printing_ring
@@ -470,9 +469,9 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
             sage: Q = J(0); Q  # indirect doctest                                       # needs sage.rings.finite_rings
             (1)
             sage: Q = J(H.lift_x(F(1))); Q  # indirect doctest                          # needs sage.rings.finite_rings
-            (x + 6, y + 2*a + 2)
+            (x + 6, y + 5*a)
             sage: Q + Q  # indirect doctest                                             # needs sage.rings.finite_rings
-            (x^2 + 5*x + 1, y + 3*a*x + 6*a + 2)
+            (x^2 + 5*x + 1, y + (4*a + 2)*x + a + 5)
         """
         if self.is_zero():
             return "(1)"
@@ -497,12 +496,12 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
             sage: Q = J(0); print(latex(Q))  # indirect doctest                         # needs sage.rings.finite_rings
             \left(1\right)
             sage: Q = J(H.lift_x(F(1))); print(latex(Q))  # indirect doctest            # needs sage.rings.finite_rings
-            \left(x + 6, y + 2 \alpha + 2\right)
+            \left(x + 6, y + 5 \alpha\right)
 
         ::
 
             sage: print(latex(Q + Q))                                                   # needs sage.rings.finite_rings
-            \left(x^{2} + 5 x + 1, y + 3 \alpha x + 6 \alpha + 2\right)
+            \left(x^{2} + 5 x + 1, y + \left(4 \alpha + 2\right) x + \alpha + 5\right)
         """
         if self.is_zero():
             return "\\left(1\\right)"
@@ -560,7 +559,7 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
 
             sage: P = J(H.lift_x(F(1)))                                                 # needs sage.rings.number_field
             sage: list(P)  # indirect doctest                                           # needs sage.rings.number_field
-            [x - 1, a]
+            [x - 1, -a]
         """
         return list(self.__polys)
 
@@ -584,7 +583,7 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
 
             sage: P = J(H.lift_x(F(1)))                                                 # needs sage.rings.number_field
             sage: tuple(P)  # indirect doctest                                          # needs sage.rings.number_field
-            (x - 1, a)
+            (x - 1, -a)
         """
         return tuple(self.__polys)
 
@@ -611,9 +610,9 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
             sage: P[0] # indirect doctest
             x - 1
             sage: P[1] # indirect doctest
-            a
+            -a
             sage: P[-1] # indirect doctest
-            a
+            -a
             sage: P[:1] # indirect doctest
             [x - 1]
         """
@@ -719,9 +718,9 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
             sage: H2 = HyperellipticCurve(x^5 + 12*x^4 + 13*x^3 + 15*x^2 + 33*x, x)
             sage: J2 = H2.jacobian()(GF(37))
             sage: P2 = J2(H2.lift_x(2)); P2
-            (x + 35, y + 15)
-            sage: - P2  # indirect doctest
             (x + 35, y + 24)
+            sage: - P2  # indirect doctest
+            (x + 35, y + 15)
             sage: P2 + (-P2)  # indirect doctest
             (1)
 


### PR DESCRIPTION
This PR included functionality to compute random points on a hyperelliptic curve over a finite field as well as random divisors of the jacobian of this curve.

The work completed here was performed during Sage Days 123 #sd123 and is joint work with myself as well as @grhkm21, @LucianoMaino and @ozbayelif.

For the sampling of the hyperelliptic curve, the code is essentially the same as the case of elliptic curves and should be uniformly sampled.

For the sampling of the Jacobian, to allow this sampling to be fast enough for testing and other methods in the future, we compute rational divisors by sampling random points on the curve $P_i$ and then compute $D_i = (P_i) - \infty$. We sample $2*g + 1$ elements of this form and sum them. This does not guarantee uniform distribution, but from experimentation this does cover the entire group.

During adding these, it was noticed that `H.lift_x()` would fail in characteristic two. This is now fixed and tested for. I also implemented a `H.is_x_coord()` which exists currently only for elliptic curves. This fixes #37097.

Additionally, this includes a modification to `cantor_reduction_simple()` which removes a `XXX` (which I assume was a TODO) which means the divisor is properly reduced for the case where the curve has an even degree model. This fixes #37093.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
