### PR TITLE
Fixed `.random_element()` for fractional ideals in rational quaternion algebras

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -2295,6 +2295,20 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         """
         return 'Fractional ideal %s' % (self.gens(),)
 
+    def random_element(self, *args, **kwds):
+        """
+        Return a random element in the rational fractional ideal ``self``.
+
+        EXAMPLES::
+
+            sage: B.<i,j,k> = QuaternionAlgebra(211)
+            sage: I = B.ideal([1, 1/4*j, 20*(i+k), 2/3*i])
+            sage: x = I.random_element()  # random
+            sage: x in I
+            True
+        """
+        return sum(ZZ.random_element(*args, **kwds) * g for g in self.gens())
+
     def quaternion_order(self):
         """
         Return the order for which this ideal is a left or right


### PR DESCRIPTION
Added `QuaternionFractionalIdeal_rational.random_element()` to fix random sampling in fractional ideals of quaternion algebras.

The method `.random_element()` of the ideal class refers to the ring over which the ideal is defined, but for fractional ideals Sage often (incorrectly) gives the base field of the algebra as a base ring. To work around this, we implement a new function `QuaternionFractionalIdeal_rational.random_element()` that hardcodes $\mathbb{Z}$ to return a random $\mathbb{Z}$-linear combination of the (lattice) generators of the fractional ideal.

Note: The deeper issue of separating ideals and fractional ideals still remains - see #3680.

#sd123