### PR TITLE
fix random doctest failure in generic has_order() function

### DIFF
--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -1462,7 +1462,18 @@ def has_order(P, n, operation='+'):
         True
         sage: has_order(el, o.factor())
         True
-        sage: has_order(el, ZZ(randrange(100)*o + randrange(o)))
+        sage: not_o = ZZ(randrange(100*o))
+        sage: not_o += (not_o == o)
+        sage: has_order(el, not_o)
+        False
+
+    Check for :issue:`37102`::
+
+        sage: from sage.groups.generic import has_order
+        sage: x = Mod(9, 24)
+        sage: has_order(x, 0)
+        False
+        sage: has_order(x, -8)
         False
 
     .. NOTE::
@@ -1471,6 +1482,8 @@ def has_order(P, n, operation='+'):
         *computing* the order using :func:`order_from_multiple`.
     """
     if isinstance(n, sage.rings.integer.Integer):
+        if n <= 0:
+            return False
         n = n.factor()
 
     G = P.parent()


### PR DESCRIPTION
In this simple patch we fix [a random test failure](https://github.com/sagemath/sage/actions/runs/7577410381/job/20638145383#step:10:4436) in the `has_order()` function for generic groups.

#sd123