### PR TITLE
do not use xargs -P 0 - not all systems allow 0

### DIFF
--- a/src/doc/bootstrap
+++ b/src/doc/bootstrap
@@ -210,4 +210,4 @@ cat <<EOF
 
 EOF
 ) > "$OUTPUT_INDEX"
-sage-package list --has-file SPKG.rst | OUTPUT_DIR=$OUTPUT_DIR OUTPUT_RST=1 xargs -P 0 -n 1 sage-spkg-info
+sage-package list --has-file SPKG.rst | OUTPUT_DIR=$OUTPUT_DIR OUTPUT_RST=1 xargs -P 99 -n 1 sage-spkg-info


### PR DESCRIPTION
E.g. on OpenBSD this fails, they need something >0

