### PR TITLE
Added `.is_isomorphic` for rational quaternion algebras

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -1091,6 +1091,9 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             sage: A == B
             False
         """
+        if not isinstance(A, QuaternionAlgebra_ab):
+            raise TypeError("A must be a quaternion algebra of the form (a,b)_K")
+
         if self.base_ring() != QQ or A.base_ring() != QQ:
             raise NotImplementedError("isomorphism check only implemented for rational quaternion algebras")
 

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -1074,6 +1074,28 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         # TODO: more examples
         return [f[0] for f in factor(self.discriminant())]
 
+    def is_isomorphic(self, A) -> bool:
+        r"""
+        Return ``True`` if ``self`` and ``A`` are isomorphic quaternion algebras over Q.
+
+        INPUT:
+
+        - ``A`` -- a quaternion algebra defined over the rationals Q
+
+        EXAMPLES::
+
+            sage: B = QuaternionAlgebra(-46, -87)
+            sage: A = QuaternionAlgebra(-58, -69)
+            sage: B.is_isomorphic(A)
+            True
+            sage: A == B
+            False
+        """
+        if self.base_ring() != QQ or A.base_ring() != QQ:
+            raise NotImplementedError("isomorphism check only implemented for rational quaternion algebras")
+
+        return self.discriminant() == A.discriminant()
+
     def _magma_init_(self, magma):
         """
         Return Magma version of this quaternion algebra.


### PR DESCRIPTION
Added `QuaternionAlgebra_ab.is_isomorphic()` to conveniently check whether two rational quaternion algebras are isomorphic.

TODO (future work):
- [] Extend isomorphism check to quaternion algebras over number fields.

#sd123
