### PR TITLE
Precompute orders of twists of EllipticCurve

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -5463,6 +5463,10 @@ REFERENCES:
              imaginary quadratic fields. Invent. Math. 103 (1991),
              no. 1, 25--68.
 
+.. [RS2010] RUBIN, K., & SILVERBERG, A. (2010). CHOOSING THE CORRECT ELLIPTIC
+            CURVE IN THE CM METHOD. Mathematics of Computation, 79(269),
+            545–561. :doi:`10.1090/S0025-5718-09-02266-2`
+
 .. [Rud1958] \M. E. Rudin. *An unshellable triangulation of a
              tetrahedron*. Bull. Amer. Math. Soc. 64 (1958), 90-91.
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1900,7 +1900,7 @@ def curves_with_j_0(K):
     curves = [EllipticCurve(K, [0, D**i]) for i in range(6)]
     # TODO (grhkm): Precompute orders of sextic twists
     # The idea should be to evaluate the character (D / q) or something
-    # Probably reference [Connell1999]_
+    # Probably reference [RS2010]_ and [Connell1999]_
     # Also a necessary change is `curves_with_j_0` should take in an optional "starting curve"
     # (passed from the original .twists call), because if you start twisting from that curve,
     # then you can also compute the orders!


### PR DESCRIPTION
Let `E` be an EllipticCurve. If its order is known, then so is the order of its quadratic twist, as given by $$|E| + |E^t| = 2p + 2$$. This can also be done for the quartic twists and sextic twists. This PR sets the order of the returned elliptic curve.

For example, the second call to `.order` below is faster:
```python
E = EllipticCurve(GF(2**255 - 19), [3, 5])
assert E.order() == 57896044618658097711785492504343953926540591650149308728870074001824607516706
Et = E.quadratic_twist()
print(Et.order()) # fast
```

TODO List:
- [ ] Precompute orders of quartic twists
- [ ] Precompute orders of sextic twists
- [ ] Write documentations
- [ ] Make twists deterministic

#sd123 