### PR TITLE
Define behaviour of < and > for fractional ideals in a quaternion algebra

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -2394,7 +2394,8 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
             sage: I != I                # indirect doctest
             False
 
-        TESTS:
+        TESTS::
+
             sage: B = QuaternionAlgebra(QQ,-1,-11)
             sage: i,j,k = B.gens()
             sage: I = B.ideal([1,i,j,i*j])
@@ -2419,7 +2420,6 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
             True
             sage: O >= O
             True
-
         """
         return self.free_module().__richcmp__(right.free_module(), op)
 

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -2393,8 +2393,35 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
             sage: I != I                # indirect doctest
             False
+
+        TESTS:
+            sage: B = QuaternionAlgebra(QQ,-1,-11)
+            sage: i,j,k = B.gens()
+            sage: I = B.ideal([1,i,j,i*j])
+            sage: I == I
+            True
+            sage: O = B.ideal([1,i,(i+j)/2,(1+i*j)/2])
+            sage: I <= O
+            True
+            sage: I >= O
+            False
+            sage: I != O
+            True
+            sage: I == O
+            False
+            sage: I != I
+            False
+            sage: I < I
+            False
+            sage: I < O
+            True
+            sage: I <= I
+            True
+            sage: O >= O
+            True
+
         """
-        return self.basis_matrix()._richcmp_(right.basis_matrix(), op)
+        return self.free_module().__richcmp__(right.free_module(), op)
 
     def __hash__(self):
         """

--- a/src/sage/modular/quatalg/brandt.py
+++ b/src/sage/modular/quatalg/brandt.py
@@ -1365,7 +1365,8 @@ class BrandtModule_class(AmbientHeckeModule):
                             ideals_theta[J_theta] = [J]
                         verbose("found %s of %s ideals" % (len(ideals), self.dimension()), level=2)
                         if len(ideals) >= self.dimension():
-                            ideals = tuple(sorted(ideals))
+                            #order by basis matrix (as ideals were previously ordered) for backward compatibility and deterministic order of the output
+                            ideals = tuple(sorted(ideals, key=lambda x: x.basis_matrix()))
                             self.__right_ideals = ideals
                             return ideals
                         got_something_new = True

--- a/src/sage/modular/quatalg/brandt.py
+++ b/src/sage/modular/quatalg/brandt.py
@@ -1365,7 +1365,9 @@ class BrandtModule_class(AmbientHeckeModule):
                             ideals_theta[J_theta] = [J]
                         verbose("found %s of %s ideals" % (len(ideals), self.dimension()), level=2)
                         if len(ideals) >= self.dimension():
-                            #order by basis matrix (as ideals were previously ordered) for backward compatibility and deterministic order of the output
+                            # order by basis matrix (as ideals were previously
+                            # ordered) for backward compatibility and
+                            # deterministic order of the output
                             ideals = tuple(sorted(ideals, key=lambda x: x.basis_matrix()))
                             self.__right_ideals = ideals
                             return ideals


### PR DESCRIPTION
Previously, comparison of quaternion algebra fractional ideals (in a quaternion algebra over QQ) was documented only for equality and did compare the matrices under HNF of bases of the ideals. This gave strange and undocumented behavior when comparing two ideals with inequalities.

This comparison is now replaced by the comparison of the fractional ideals as free modules. 

Now "smaller than" means "included in".

#sd123