### PR TITLE
Fix corners cases of free resolutions

### DIFF
--- a/src/sage/homology/free_resolution.py
+++ b/src/sage/homology/free_resolution.py
@@ -7,7 +7,7 @@ is a chain complex of free `R`-modules
 
 .. MATH::
 
-    R^{n_1} \xleftarrow{d_1}  R^{n_1} \xleftarrow{d_2}
+    R^{n_0} \xleftarrow{d_1}  R^{n_1} \xleftarrow{d_2}
     \cdots \xleftarrow{d_k} R^{n_k} \xleftarrow{d_{k+1}} 0
 
 terminating with a zero module at the end that is exact (all homology groups

--- a/src/sage/homology/free_resolution.py
+++ b/src/sage/homology/free_resolution.py
@@ -242,9 +242,20 @@ class FreeResolution(SageObject, metaclass=ClasscallMetaclass):
             'S^2'
             sage: r  # indirect doctest
             S^1 <-- S^3 <-- S^2 <-- 0
+
+        TESTS::
+
+            sage: S.<x,y,z> = PolynomialRing(QQ)
+            sage: I = S.ideal(0)
+            sage: C = I.free_resolution()
+            sage: C
+            S^1 <-- 0
         """
         if i == 0:
-            r = self._maps[0].nrows()
+            if self._length > 0:
+                r = self._maps[0].nrows()
+            else:
+                r = self._initial_differential.domain().dimension()
             s = f'{self._name}^{r}'
             return s
         elif i > self._length:
@@ -422,6 +433,8 @@ class FiniteFreeResolution(FreeResolution):
             raise IndexError('invalid index')
         elif i > self._length:
             F = FreeModule(self._base_ring, 0)
+        elif i == 0:
+            F = self.differential(0).domain()
         elif i == self._length:
             F = FreeModule(self._base_ring, self._maps[i - 1].ncols())
         else:
@@ -444,11 +457,12 @@ class FiniteFreeResolution(FreeResolution):
             sage: r
             S(0) <-- S(-2)⊕S(-2)⊕S(-2) <-- S(-3)⊕S(-3) <-- 0
             sage: r.differential(3)
-            Free module morphism defined by the matrix []
-              Domain:   Ambient free module of rank 0 over the integral domain
-                        Multivariate Polynomial Ring in x, y, z, w over Rational Field
-              Codomain: Ambient free module of rank 2 over the integral domain
-                        Multivariate Polynomial Ring in x, y, z, w over Rational Field
+            Free module morphism defined as left-multiplication by the matrix
+             []
+             Domain:   Ambient free module of rank 0 over the integral domain
+                       Multivariate Polynomial Ring in x, y, z, w over Rational Field
+             Codomain: Ambient free module of rank 2 over the integral domain
+                       Multivariate Polynomial Ring in x, y, z, w over Rational Field
             sage: r.differential(2)
             Free module morphism defined as left-multiplication by the matrix
               [-y  x]
@@ -476,6 +490,31 @@ class FiniteFreeResolution(FreeResolution):
                     [-z^2 + y*w]
                     [ y*z - x*w]
                     [-y^2 + x*z]
+
+        TESTS::
+
+            sage: P2.<x,y,z> = ProjectiveSpace(QQ, 2)
+            sage: S = P2.coordinate_ring()
+            sage: I = S.ideal(0)
+            sage: C = I.graded_free_resolution(); C
+            S(0) <-- 0
+            sage: C[1]
+            Ambient free module of rank 0 over the integral domain
+             Multivariate Polynomial Ring in x, y, z over Rational Field
+            sage: C[0]
+            Ambient free module of rank 1 over the integral domain
+             Multivariate Polynomial Ring in x, y, z over Rational Field
+            sage: C.differential(1)
+            Free module morphism defined as left-multiplication by the matrix
+            []
+            Domain: Ambient free module of rank 0 over the integral domain
+             Multivariate Polynomial Ring in x, y, z over Rational Field
+            Codomain: Ambient free module of rank 1 over the integral domain
+             Multivariate Polynomial Ring in x, y, z over Rational Field
+            sage: C.differential(1).matrix()
+            []
+            sage: C.differential(1).matrix().dimensions()
+            (1, 0)
         """
         if i < 0:
             raise IndexError('invalid index')
@@ -484,14 +523,17 @@ class FiniteFreeResolution(FreeResolution):
                 return self._initial_differential
             except AttributeError:
                 raise ValueError('0th differential map undefined')
-        elif i == self._length + 1:
-            s = FreeModule(self._base_ring, 0)
-            t = FreeModule(self._base_ring, self._maps[i - 2].ncols())
-            m = s.hom(0, t)
         elif i > self._length + 1:
             s = FreeModule(self._base_ring, 0)
             t = FreeModule(self._base_ring, 0)
-            m = s.hom(0, t)
+            m = s.hom(0, t, side='right')
+        elif i == self._length + 1:
+            s = FreeModule(self._base_ring, 0)
+            if self._length > 0:
+                t = FreeModule(self._base_ring, self._maps[i - 2].ncols())
+            else:
+                t = self._initial_differential.domain()
+            m = s.hom(0, t, side='right')
         else:
             s = FreeModule(self._base_ring, self._maps[i - 1].ncols())
             t = FreeModule(self._base_ring, self._maps[i - 1].nrows())


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
as seen in
```sage
sage: P2.<x,y,z> = ProjectiveSpace(QQ, 2)
sage: S = P2.coordinate_ring()
sage: I = S.ideal(0)
sage: C = I.graded_free_resolution(); C
S(0) <-- 0
sage: C[1]
Ambient free module of rank 0 over the integral domain Multivariate Polynomial Ring in x, y, z over Rational Field
sage: C[0]
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[5], line 1
----> 1 C[Integer(0)] 

File ~/GitHub/sage/src/sage/homology/free_resolution.py:426, in FiniteFreeResolution.__getitem__(self, i)
    424     F = FreeModule(self._base_ring, 0)
    425 elif i == self._length:
--> 426     F = FreeModule(self._base_ring, self._maps[i - 1].ncols())
    427 else:
    428     F = FreeModule(self._base_ring, self._maps[i].nrows())

IndexError: list index out of range
sage: C.differential(1)
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[6], line 1
----> 1 C.differential(Integer(1))  

File ~/GitHub/sage/src/sage/homology/free_resolution.py:489, in FiniteFreeResolution.differential(self, i)
    487 elif i == self._length + 1:
    488     s = FreeModule(self._base_ring, 0)
--> 489     t = FreeModule(self._base_ring, self._maps[i - 2].ncols())
    490     m = s.hom(0, t)
    491 elif i > self._length + 1:

IndexError: list index out of range
```


<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
