### PR TITLE
use Parent in free_algebra_quotient

### DIFF
--- a/src/sage/algebras/free_algebra_quotient.py
+++ b/src/sage/algebras/free_algebra_quotient.py
@@ -213,7 +213,7 @@ class FreeAlgebraQuotient(UniqueRepresentation, Parent):
 
     def gen(self, i):
         """
-        Return the i-th generator of the algebra.
+        Return the ``i``-th generator of the algebra.
 
         EXAMPLES::
 

--- a/src/sage/algebras/free_algebra_quotient.py
+++ b/src/sage/algebras/free_algebra_quotient.py
@@ -60,14 +60,15 @@ Test comparison by equality::
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.modules.free_module import FreeModule
-from sage.rings.ring import Algebra
 from sage.algebras.free_algebra import is_FreeAlgebra
 from sage.algebras.free_algebra_quotient_element import FreeAlgebraQuotientElement
+from sage.categories.algebras import Algebras
+from sage.modules.free_module import FreeModule
 from sage.structure.unique_representation import UniqueRepresentation
+from sage.structure.parent import Parent
 
 
-class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
+class FreeAlgebraQuotient(UniqueRepresentation, Parent):
     @staticmethod
     def __classcall__(cls, A, mons, mats, names):
         """
@@ -151,10 +152,9 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
         TESTS::
 
             sage: TestSuite(H2).run()
-
         """
         if not is_FreeAlgebra(A):
-            raise TypeError("argument A must be an algebra")
+            raise TypeError("argument A must be a free algebra")
         R = A.base_ring()
         n = A.ngens()
         assert n == len(mats)
@@ -164,7 +164,8 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
         self.__module = FreeModule(R, self.__dim)
         self.__matrix_action = mats
         self.__monomial_basis = mons  # elements of free monoid
-        Algebra.__init__(self, R, names, normalize=True)
+        Parent.__init__(self, base=R, names=names,
+                        normalize=True, category=Algebras(R))
 
     def _element_constructor_(self, x):
         """
@@ -196,7 +197,7 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
         """
         return S == self or self.__free_algebra.has_coerce_map_from(S)
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         EXAMPLES::
 
@@ -208,11 +209,11 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
         n = self.__ngens
         r = self.__module.dimension()
         x = self.variable_names()
-        return "Free algebra quotient on %s generators %s and dimension %s over %s" % (n, x, r, R)
+        return f"Free algebra quotient on {n} generators {x} and dimension {r} over {R}"
 
     def gen(self, i):
         """
-        The i-th generator of the algebra.
+        Return the i-th generator of the algebra.
 
         EXAMPLES::
 
@@ -238,14 +239,29 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
         """
         n = self.__ngens
         if i < 0 or not i < n:
-            raise IndexError("argument i (= %s) must be between 0 and %s" % (i, n - 1))
-        R = self.base_ring()
+            raise IndexError(f"argument i (= {i}) must be between 0 and {n - 1}")
+        one = self.base_ring().one()
         F = self.__free_algebra.monoid()
-        return self.element_class(self, {F.gen(i): R.one()})
+        return self.element_class(self, {F.gen(i): one})
+
+    def gens(self) -> tuple:
+        """
+        Return the tuple of generators of ``self``.
+
+        EXAMPLES::
+
+            sage: H, (i,j,k) = sage.algebras.free_algebra_quotient.hamilton_quatalg(QQ)
+            sage: H.gens()
+            (i, j, k)
+        """
+        one = self.base_ring().one()
+        F = self.__free_algebra.monoid()
+        return tuple(self.element_class(self, {F.gen(i): one})
+                     for i in range(self.__ngens))
 
     def ngens(self):
         """
-        The number of generators of the algebra.
+        Return the number of generators of the algebra.
 
         EXAMPLES::
 
@@ -256,7 +272,7 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
 
     def dimension(self):
         """
-        The rank of the algebra (as a free module).
+        Return the rank of the algebra (as a free module).
 
         EXAMPLES::
 
@@ -267,6 +283,8 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
 
     def matrix_action(self):
         """
+        Return the matrix action used to define the algebra.
+
         EXAMPLES::
 
             sage: sage.algebras.free_algebra_quotient.hamilton_quatalg(QQ)[0].matrix_action()
@@ -293,7 +311,7 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
 
     def rank(self):
         """
-        The rank of the algebra (as a free module).
+        Return the rank of the algebra (as a free module).
 
         EXAMPLES::
 
@@ -304,7 +322,7 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
 
     def module(self):
         """
-        The free module of the algebra.
+        Return the free module of the algebra.
 
         EXAMPLES::
 
@@ -317,7 +335,7 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
 
     def monoid(self):
         """
-        The free monoid of generators of the algebra.
+        Return the free monoid of generators of the algebra.
 
         EXAMPLES::
 
@@ -328,7 +346,7 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
 
     def free_algebra(self):
         """
-        The free algebra generating the algebra.
+        Return the free algebra generating the algebra.
 
         EXAMPLES::
 
@@ -340,17 +358,17 @@ class FreeAlgebraQuotient(UniqueRepresentation, Algebra):
 
 def hamilton_quatalg(R):
     """
-    Hamilton quaternion algebra over the commutative ring R,
+    Hamilton quaternion algebra over the commutative ring ``R``,
     constructed as a free algebra quotient.
 
     INPUT:
 
-    - R -- a commutative ring
+    - ``R`` -- a commutative ring
 
     OUTPUT:
 
-    - Q -- quaternion algebra
-    - gens -- generators for Q
+    - ``Q`` -- quaternion algebra
+    - ``gens`` -- generators for ``Q``
 
     EXAMPLES::
 
@@ -363,19 +381,18 @@ def hamilton_quatalg(R):
         sage: i in H
         True
 
-    Note that there is another vastly more efficient models for
+    Note that there is another vastly more efficient model for
     quaternion algebras in Sage; the one here is mainly for testing
     purposes::
 
         sage: R.<i,j,k> = QuaternionAlgebra(QQ,-1,-1)  # much fast than the above
     """
-    n = 3
     from sage.algebras.free_algebra import FreeAlgebra
     from sage.matrix.matrix_space import MatrixSpace
-    A = FreeAlgebra(R, n, 'i')
+    A = FreeAlgebra(R, 3, 'i')
     F = A.monoid()
     i, j, k = F.gens()
-    mons = [F(1), i, j, k]
+    mons = [F.one(), i, j, k]
     M = MatrixSpace(R, 4)
     mats = [M([0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0]),
             M([0, 0, 1, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, -1, 0, 0]),


### PR DESCRIPTION
change to use `Parent` in the modified file

a little step towards removal the old coercion framework

also making a little refreshing for doc and pep8

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.