### PR TITLE
Add matroid attribute girth()

### DIFF
--- a/src/sage/matroids/matroid.pxd
+++ b/src/sage/matroids/matroid.pxd
@@ -177,6 +177,7 @@ cdef class Matroid(SageObject):
     cpdef _is_3connected_BC_recursion(self, basis, fund_cocircuits) noexcept
     cpdef is_paving(self) noexcept
     cpdef is_sparse_paving(self) noexcept
+    cpdef girth(self) noexcept
 
     # representability
     cpdef _local_binary_matroid(self, basis=*) noexcept

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -5986,8 +5986,8 @@ cdef class Matroid(SageObject):
 
         EXAMPLES::
 
-            sage: matroids.Uniform(5,5).girth()
-            inf
+            sage: matroids.Uniform(5, 5).girth()
+            +Infinity
             sage: matroids.catalog.K4().girth()
             3
             sage: matroids.catalog.Vamos().girth()
@@ -6002,7 +6002,8 @@ cdef class Matroid(SageObject):
                 X = frozenset(X)
                 if self._is_circuit(X):
                     return k
-        return float('inf')
+        from sage.rings.infinity import infinity
+        return infinity
 
     # representability
 

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -111,6 +111,7 @@ additional functionality (e.g. linear extensions).
     - :meth:`connectivity() <sage.matroids.matroid.Matroid.connectivity>`
     - :meth:`is_paving() <sage.matroids.matroid.Matroid.is_paving>`
     - :meth:`is_sparse_paving() <sage.matroids.matroid.Matroid.is_sparse_paving>`
+    - :meth:`girth() <sage.matroids.matroid.Matroid.girth>`
 
 - Representation
     - :meth:`binary_matroid() <sage.matroids.matroid.Matroid.binary_matroid>`
@@ -5975,6 +5976,33 @@ cdef class Matroid(SageObject):
             if len(C1 ^ C2) <= 2:
                 return False
         return True
+
+    cpdef girth(self) noexcept:
+        r"""
+        Return the girth of the matroid.
+
+        The girth is the size of the smallest circuit. In case the matroid has
+        no circuits the girth is `\infty`.
+
+        EXAMPLES::
+
+            sage: matroids.Uniform(5,5).girth()
+            inf
+            sage: matroids.catalog.K4().girth()
+            3
+            sage: matroids.catalog.Vamos().girth()
+            4
+
+        REFERENCES:
+
+        [Oxl2011]_, p. 327.
+        """
+        for k in range(self.rank() + 2):
+            for X in combinations(self.groundset(), k):
+                X = frozenset(X)
+                if self._is_circuit(X):
+                    return k
+        return float('inf')
 
     # representability
 


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
Added a function `girth()` to the main matroid class. This is a standard notion which corresponds to the size of the smallest circuit of the matroid. A similar notion exists for graphs.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
