### PR TITLE
Fix a bug in reduction of element modulo ideal in exterior algebra

### DIFF
--- a/src/sage/algebras/exterior_algebra_groebner.pyx
+++ b/src/sage/algebras/exterior_algebra_groebner.pyx
@@ -477,13 +477,32 @@ cdef class GroebnerStrategy:
             0
             sage: I._groebner_strategy.reduce(E.zero())
             0
+
+        Check #37108 is fixed::
+
+            sage: E = ExteriorAlgebra(QQ, 6)
+            ....: E.inject_variables(verbose=False)
+            ....: gens = [-e0*e1*e2 + e0*e1*e5 - e0*e2*e3 - e0*e3*e5 + e1*e2*e3 + e1*e3*e5,
+            ....:  e1*e2 - e1*e5 + e2*e5,
+            ....:  e0*e2 - e0*e4 + e2*e4,
+            ....:  e3*e4 - e3*e5 + e4*e5,
+            ....:  e0*e1 - e0*e3 + e1*e3]
+            ....: I = E.ideal(gens)
+            ....: S = E.quo(I)
+            ....: I.reduce(e1*e3*e4*e5)
+            0
         """
         if not f:
             return f
         # Make a copy to mutate
         f = type(f)(f._parent, copy(f._monomial_coefficients))
-        for g in self.groebner_basis:
-            self.reduce_single(f, g)
+        was_reduced = True
+        while was_reduced:
+            was_reduced = False
+            for g in self.groebner_basis:
+                was_reduced = self.reduce_single(f, g)
+                if was_reduced:
+                    break
         return f
 
     cdef bint reduce_single(self, CliffordAlgebraElement f, CliffordAlgebraElement g) except -1:

--- a/src/sage/algebras/exterior_algebra_groebner.pyx
+++ b/src/sage/algebras/exterior_algebra_groebner.pyx
@@ -481,15 +481,15 @@ cdef class GroebnerStrategy:
         Check #37108 is fixed::
 
             sage: E = ExteriorAlgebra(QQ, 6)
-            ....: E.inject_variables(verbose=False)
-            ....: gens = [-e0*e1*e2 + e0*e1*e5 - e0*e2*e3 - e0*e3*e5 + e1*e2*e3 + e1*e3*e5,
+            sage: E.inject_variables(verbose=False)
+            sage: gens = [-e0*e1*e2 + e0*e1*e5 - e0*e2*e3 - e0*e3*e5 + e1*e2*e3 + e1*e3*e5,
             ....:  e1*e2 - e1*e5 + e2*e5,
             ....:  e0*e2 - e0*e4 + e2*e4,
             ....:  e3*e4 - e3*e5 + e4*e5,
             ....:  e0*e1 - e0*e3 + e1*e3]
-            ....: I = E.ideal(gens)
-            ....: S = E.quo(I)
-            ....: I.reduce(e1*e3*e4*e5)
+            sage: I = E.ideal(gens)
+            sage: S = E.quo(I)
+            sage: I.reduce(e1*e3*e4*e5)
             0
         """
         if not f:

--- a/src/sage/algebras/exterior_algebra_groebner.pyx
+++ b/src/sage/algebras/exterior_algebra_groebner.pyx
@@ -483,10 +483,8 @@ cdef class GroebnerStrategy:
             sage: E = ExteriorAlgebra(QQ, 6)
             sage: E.inject_variables(verbose=False)
             sage: gens = [-e0*e1*e2 + e0*e1*e5 - e0*e2*e3 - e0*e3*e5 + e1*e2*e3 + e1*e3*e5,
-            ....:  e1*e2 - e1*e5 + e2*e5,
-            ....:  e0*e2 - e0*e4 + e2*e4,
-            ....:  e3*e4 - e3*e5 + e4*e5,
-            ....:  e0*e1 - e0*e3 + e1*e3]
+            ....:         e1*e2 - e1*e5 + e2*e5, e0*e2 - e0*e4 + e2*e4,
+            ....:         e3*e4 - e3*e5 + e4*e5, e0*e1 - e0*e3 + e1*e3]
             sage: I = E.ideal(gens)
             sage: S = E.quo(I)
             sage: I.reduce(e1*e3*e4*e5)

--- a/src/sage/algebras/exterior_algebra_groebner.pyx
+++ b/src/sage/algebras/exterior_algebra_groebner.pyx
@@ -478,7 +478,7 @@ cdef class GroebnerStrategy:
             sage: I._groebner_strategy.reduce(E.zero())
             0
 
-        Check #37108 is fixed::
+        Check :issue:`37108` is fixed::
 
             sage: E = ExteriorAlgebra(QQ, 6)
             sage: E.inject_variables(verbose=False)


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

This adds a loop to continue doing reduction modulo a Grobner basis for an element modulo an ideal in the exterior algebra. This guarantees a unique representative for each element, and that representative will be $0$ if the element is in the ideal. This fixes #37108.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->
None.

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
