### PR TITLE
fix doctest in gap_packages (using empty table)

### DIFF
--- a/src/sage/misc/table.py
+++ b/src/sage/misc/table.py
@@ -432,7 +432,7 @@ class table(SageObject):
             widths = w
         return tuple(widths)
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         r"""
         String representation of a table.
 
@@ -470,7 +470,8 @@ class table(SageObject):
 
         for row in rows[:-1]:
             s += self._str_table_row(row, header_row=False)
-        s += self._str_table_row(rows[-1], header_row=False, last_row=True)
+        if rows:
+            s += self._str_table_row(rows[-1], header_row=False, last_row=True)
         return s.strip("\n")
 
     def _rich_repr_(self, display_manager, **kwds):

--- a/src/sage/tests/gap_packages.py
+++ b/src/sage/tests/gap_packages.py
@@ -8,7 +8,7 @@ TESTS::
     sage: pkgs = all_installed_packages(ignore_dot_gap=True)
     sage: test_packages(pkgs, only_failures=True)    # optional - gap_packages
       Status   Package   GAP Output
-    +--------+---------+------------+
+    ├────────┼─────────┼────────────┤
 
     sage: test_packages(['primgrp', 'smallgrp'])
         Status   Package    GAP Output
@@ -51,13 +51,13 @@ def test_packages(packages, only_failures=False):
 
         sage: pkgs = all_installed_packages()
         sage: test_packages(pkgs)    # random output
-          Status    Package      GAP Output
-        +---------+------------+------------+
-                   Alnuth       true
-                   GAPDoc       true
-                   sonata       true
-                   tomlib       true
-                   toric        true
+            Status   Package   GAP Output
+          ├────────┼─────────┼────────────┤
+                     Alnuth    true
+                     GAPDoc    true
+                     sonata    true
+                     tomlib    true
+                     toric     true
     """
     rows = [['Status', 'Package', 'GAP Output']]
     for pkgdir in packages:


### PR DESCRIPTION
This is fixing a misbehaviour of empty tables, in their new unicode clothes.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
