### PR TITLE
provide Q.log(P) instead of P.discrete_log(Q) for elliptic-curve points

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1053,8 +1053,8 @@ class EllipticCurve_finite_field(EllipticCurve_field, HyperellipticCurve_finite_
 
             S = n//nQ * P
             T = n2 * Q
-            S.set_order(nQ//n2, check=False)    # for .discrete_log()
-            x = S.discrete_log(T)
+            S.set_order(nQ//n2, check=False)    # for .log()
+            x = T.log(S)
             Q -= x * n1//nQ * P
 
             assert not n2 * Q                   # by construction


### PR DESCRIPTION
Here's an attempt to resolve #37150. I'm not suggesting to remove `.discrete_log()` any time soon, but I do feel this inconsistency should be corrected *at some point*, so we may as well start with it now.

Cc: @JohnCremona