### PR TITLE
using Parent in integer rings instead of ParentWithGens

### DIFF
--- a/src/sage/rings/integer_ring.pyx
+++ b/src/sage/rings/integer_ring.pyx
@@ -61,7 +61,7 @@ from sage.categories.infinite_enumerated_sets import InfiniteEnumeratedSets
 from sage.rings.number_field.number_field_element_base import NumberFieldElement_base
 from sage.structure.coerce cimport is_numpy_type
 from sage.structure.element cimport parent
-from sage.structure.parent_gens import ParentWithGens
+from sage.structure.parent cimport Parent
 from sage.structure.richcmp cimport rich_to_bool
 
 from sage.misc.misc_c import prod
@@ -311,8 +311,8 @@ cdef class IntegerRing_class(PrincipalIdealDomain):
             sage: A in InfiniteEnumeratedSets()
             True
         """
-        ParentWithGens.__init__(self, self, ('x',), normalize=False,
-                                category=(EuclideanDomains(), InfiniteEnumeratedSets().Metric()))
+        Parent.__init__(self, base=self, names=('x',), normalize=False,
+                        category=(EuclideanDomains(), InfiniteEnumeratedSets().Metric()))
         self._populate_coercion_lists_(init_no_parent=True,
                                        convert_method_name='_integer_')
 


### PR DESCRIPTION
Let's try to get rid of the last direct inheritance to `ParentWithGens`.

(not quite the last one, see #37158 )

There remains many indirect inheritance, mostly through `Ring`, `Algebra`, `CommutativeRing` and their subclasses. This is a step towards cleaning and simplifying the old coercion framework.

The present changes is close to the heart of sage, so appropriate timings should be checked.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.