### PR TITLE
Add additional lattice methods for matrices over QQ

### DIFF
--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -2743,8 +2743,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
     def BKZ(self, delta=None, algorithm="fpLLL", fp=None, block_size=10, prune=0,
             use_givens=False, precision=0, proof=None, **kwds):
         """
-        Run Block Korkin-Zolotarev reduction on ``self`` interpreted
-        as a lattice, and return the result.
+        Return the result of running Block Korkin-Zolotarev reduction on
+        ``self`` interpreted as a lattice.
 
         INPUT:
 

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -2743,7 +2743,8 @@ cdef class Matrix_integer_dense(Matrix_dense):
     def BKZ(self, delta=None, algorithm="fpLLL", fp=None, block_size=10, prune=0,
             use_givens=False, precision=0, proof=None, **kwds):
         """
-        Block Korkin-Zolotarev reduction.
+        Run Block Korkin-Zolotarev reduction on ``self`` interpreted
+        as a lattice, and return the result.
 
         INPUT:
 

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -2927,6 +2927,24 @@ cdef class Matrix_rational_dense(Matrix_dense):
     # LLL
     # ###############################################
 
+    def BKZ(self, *args, **kwargs):
+        """
+        Block Korkin-Zolotarev reduction.
+
+        For details on input parameters, see
+        :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.BKZ`.
+
+        EXAMPLES::
+
+            sage: A = Matrix(QQ, 3, 3, [1/n for n in range(1, 10)])
+            sage: A.BKZ()
+            [ 1/28 -1/40 -1/18]
+            [ 1/28 -1/40  1/18]
+            [-1/14 -1/40     0]
+        """
+        A, d = self._clear_denom()
+        return A.BKZ(*args, **kwargs) / d
+
     def LLL(self, *args, **kwargs):
         """
         Return an LLL reduced or approximated LLL reduced lattice for
@@ -2945,6 +2963,23 @@ cdef class Matrix_rational_dense(Matrix_dense):
         """
         A, d = self._clear_denom()
         return A.LLL(*args, **kwargs) / d
+
+    def is_LLL_reduced(self, delta=None, eta=None):
+        """
+        Return ``True`` if this lattice is `(\delta, \eta)`-LLL reduced.
+        For a definition of LLL reduction, see
+        :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.LLL`.
+
+        EXAMPLES:
+            sage: A = random_matrix(QQ, 10, 10)
+            sage: L = A.LLL()
+            sage: A.is_LLL_reduced()
+            False
+            sage: L.is_LLL_reduced()
+            True
+        """
+        A, _ = self._clear_denom()
+        return A.is_LLL_reduced(delta, eta)
 
 
 cdef new_matrix_from_pari_GEN(parent, GEN d) noexcept:

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -2929,7 +2929,8 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
     def BKZ(self, *args, **kwargs):
         """
-        Block Korkin-Zolotarev reduction.
+        Return the result of running Block Korkin-Zolotarev reduction on
+        ``self`` interpreted as a lattice.
 
         For details on input parameters, see
         :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.BKZ`.
@@ -2970,7 +2971,8 @@ cdef class Matrix_rational_dense(Matrix_dense):
         For a definition of LLL reduction, see
         :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.LLL`.
 
-        EXAMPLES:
+        EXAMPLES::
+
             sage: A = random_matrix(QQ, 10, 10)
             sage: L = A.LLL()
             sage: A.is_LLL_reduced()

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -2966,7 +2966,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
         return A.LLL(*args, **kwargs) / d
 
     def is_LLL_reduced(self, delta=None, eta=None):
-        """
+        r"""
         Return ``True`` if this lattice is `(\delta, \eta)`-LLL reduced.
         For a definition of LLL reduction, see
         :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.LLL`.

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -2932,8 +2932,9 @@ cdef class Matrix_rational_dense(Matrix_dense):
         Return the result of running Block Korkin-Zolotarev reduction on
         ``self`` interpreted as a lattice.
 
-        For details on input parameters, see
-        :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.BKZ`.
+        The arguments ``*args`` and ``**kwargs`` are passed onto
+        :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.BKZ`,
+        see there for more details.
 
         EXAMPLES::
 
@@ -2942,6 +2943,11 @@ cdef class Matrix_rational_dense(Matrix_dense):
             [ 1/28 -1/40 -1/18]
             [ 1/28 -1/40  1/18]
             [-1/14 -1/40     0]
+
+            sage: A = random_matrix(QQ, 10, 10)
+            sage: d = lcm(a.denom() for a in A.list())
+            sage: A.BKZ() == (A * d).change_ring(ZZ).BKZ() / d
+            True
         """
         A, d = self._clear_denom()
         return A.BKZ(*args, **kwargs) / d
@@ -2951,8 +2957,9 @@ cdef class Matrix_rational_dense(Matrix_dense):
         Return an LLL reduced or approximated LLL reduced lattice for
         ``self`` interpreted as a lattice.
 
-        For details on input parameters, see
-        :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.LLL`.
+        The arguments ``*args`` and ``**kwargs`` are passed onto
+        :meth:`sage.matrix.matrix_integer_dense.Matrix_integer_dense.LLL`,
+        see there for more details.
 
         EXAMPLES::
 
@@ -2961,6 +2968,11 @@ cdef class Matrix_rational_dense(Matrix_dense):
             [ 1/28 -1/40 -1/18]
             [ 1/28 -1/40  1/18]
             [    0 -3/40     0]
+
+            sage: A = random_matrix(QQ, 10, 10)
+            sage: d = lcm(a.denom() for a in A.list())
+            sage: A.LLL() == (A * d).change_ring(ZZ).LLL() / d
+            True
         """
         A, d = self._clear_denom()
         return A.LLL(*args, **kwargs) / d


### PR DESCRIPTION
LLL has long been implemented for matrices over QQ by clearing the denominator and doing LLL over ZZ, but this was not done for BKZ() or is_LLL_reduced()

This PR adds BKZ() and is_LLL_reduced() to rational matrices, using the same techniques as the current LLL method.