### PR TITLE
Fix cvxopt build with suitesparse homebrew; fixes #37149.

### DIFF
--- a/.homebrew-build-env
+++ b/.homebrew-build-env
@@ -45,3 +45,9 @@ for l in ; do
     fi
 done
 export ACLOCAL_PATH
+
+# Add cvxopt library path
+if [ -d "$HOMEBREW/include/suitesparse" ]; then
+    export CVXOPT_SUITESPARSE_INC_DIR="$HOMEBREW/include/suitesparse"
+    export CVXOPT_SUITESPARSE_LIB_DIR="$HOMEBREW/lib"
+fi


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

This PR tries to fix issue #37149.

The problem is that cvxopt doesn't build correctly when using the homebrew-provided version of SuiteSparse.

As suggested in the discussion of the issue, I added the `CVXOPT_SUITESPARSE_INC_DIR` environment variable in the `.homebrew-build-env` file.

This is an ugly workaround, and should probably be reported/discussed also on the cvxopt repo, since the issue seems to be that they do `#include "umfpack.h"` instead of a more proper `#include "suitesparse/umfpack.h"`.
Indeed, for Linux system, their `setup.py` script then has to set the include folder to be `whatever/include/suitesparse` instead of the default system one.

Also, I don't have a way to check if this breaks other installations.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
