### PR TITLE
new methods for weighted polynomial rings

### DIFF
--- a/src/sage/rings/polynomial/term_order.py
+++ b/src/sage/rings/polynomial/term_order.py
@@ -1908,6 +1908,16 @@ class TermOrder(SageObject):
         """
         return self._weights
 
+    def set_weights(self, weights):
+        weights = tuple(int(weight) for weight in weights)
+        if any(weight <= 0 for weight in weights):
+            raise ValueError("the degree weights must be positive integers")
+
+        if self._length != len(weights):
+            raise ValueError("the length of the given term order ({}) differs from the number of variables ({})"
+                            .format(self._length, len(weights)))
+        self._weights = weights
+
     def __eq__(self, other):
         """
         Return ``True`` if ``self`` and ``other`` are equal.

--- a/src/sage/rings/polynomial/term_order.py
+++ b/src/sage/rings/polynomial/term_order.py
@@ -1909,6 +1909,24 @@ class TermOrder(SageObject):
         return self._weights
 
     def set_weights(self, weights):
+        """
+        Set new weights for term order.
+
+        EXAMPLES::
+
+            sage: t = TermOrder('wdeglex',(2,3))
+            sage: t.set_weights([3,2])
+            sage: t.weights()
+            (3, 2)
+            sage: t.set_weights([3,0])
+            Traceback (most recent call last):
+            ...
+            ValueError: the degree weights must be positive integers
+            sage: t.set_weights([3])
+            Traceback (most recent call last):
+            ...
+            ValueError: the length of the given term order (2) differs from the number of variables (1)
+        """
         weights = tuple(int(weight) for weight in weights)
         if any(weight <= 0 for weight in weights):
             raise ValueError("the degree weights must be positive integers")


### PR DESCRIPTION
Added a new method, `set_weights()`, to modify weights in `TermOrder`.
Fixes #37155

### :memo: TODO:
- [x] Simpler API to access term order related attributes, and to modify them. - (1)
- [ ] Simpler monomial ordering names. - (2)
- [ ] Fix .homogenize and .is_homogeneous.
- [x] Fix weird TermOrder bug? - (3)


<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->
### :memo: Checklist
- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
