### PR TITLE
fixed bug in `is_linearly_dependent()`, returns true for linearly dependent univariate polynomial.

### DIFF
--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -5940,20 +5940,22 @@ cdef class Polynomial(CommutativePolynomial):
             return a*self
 
     def coefficients(self, sparse=True):
-        """
-        Return the coefficients of the monomials appearing in self.
+        r"""
+        Return the coefficients of the monomials appearing in ``self``.
+
         If ``sparse=True`` (the default), it returns only the non-zero coefficients.
         Otherwise, it returns the same value as ``self.list()``.
         (In this case, it may be slightly faster to invoke ``self.list()`` directly.)
+        In either case, the coefficients are ordered by increasing degree.
 
         EXAMPLES::
 
             sage: _.<x> = PolynomialRing(ZZ)
-            sage: f = x^4 + 2*x^2 + 1
+            sage: f = 3*x^4 + 2*x^2 + 1
             sage: f.coefficients()
-            [1, 2, 1]
+            [1, 2, 3]
             sage: f.coefficients(sparse=False)
-            [1, 0, 2, 0, 1]
+            [1, 0, 2, 0, 3]
         """
         zero = self._parent.base_ring().zero()
         if sparse:

--- a/src/sage/rings/polynomial/toy_variety.py
+++ b/src/sage/rings/polynomial/toy_variety.py
@@ -120,7 +120,10 @@ def coefficient_matrix(polys):
     M = matrix(R, len(polys), len(mons))
     for i in range(len(polys)):
         imons = polys[i].monomials()
-        icoeffs = polys[i].coefficients()
+        if polys[0].parent().ngens() == 1:
+            icoeffs = polys[i].coefficients()[::-1]
+        else:
+            icoeffs = polys[i].coefficients()
         for j in range(len(imons)):
             M[i, mons.index(imons[j])] = icoeffs[j]
     return M

--- a/src/sage/rings/polynomial/toy_variety.py
+++ b/src/sage/rings/polynomial/toy_variety.py
@@ -169,6 +169,13 @@ def is_linearly_dependent(polys) -> bool:
         False
         sage: is_linearly_dependent([])
         False
+        sage: R.<x> = PolynomialRing(QQ)
+        sage: B = [x^147 + x^99,
+        ....:      2*x^123 + x^75,
+        ....:      x^147 + 2*x^123 + 2*x^75,
+        ....:      2*x^147 + x^99 + x^75]
+        sage: is_linearly_dependent(B)
+        True
     """
     if not polys:
         return False


### PR DESCRIPTION
`is_linearly_dependent()` returned wrong results for the univariate polynomial ring because the `coefficients()` method of univariate polynomials returns coefficients in the opposite order of `monomials()`:
```
sage: R.<q> = QQ[]
sage: p = q^4 + 3*q + 5
sage: p.monomials()
[q^4, q, 1]
sage: p.coefficients()
[5, 3, 1]
```

We fix this by making the `coefficient_matrix()` method to check for univariate polynomial ring and make the order consistent.

Fixes: #37075

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

