### PR TITLE
`sage -t`: Fix handling of `--probe all` broken by #36989

### DIFF
--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -877,7 +877,7 @@ class SageDocTestParser(doctest.DocTestParser):
     optional_tags: Union[bool, set[str]]
     optional_only: bool
     optionals: dict[str, int]
-    probed_tags: set[str]
+    probed_tags: Union[bool, set[str]]
 
     def __init__(self, optional_tags=(), long=False, *, probed_tags=(), file_optional_tags=()):
         r"""
@@ -916,7 +916,10 @@ class SageDocTestParser(doctest.DocTestParser):
                 self.optional_tags.remove('sage')
             else:
                 self.optional_only = True
-        self.probed_tags = set(probed_tags)
+        if probed_tags is True:
+            self.probed_tags = True
+        else:
+            self.probed_tags = set(probed_tags)
         self.file_optional_tags = set(file_optional_tags)
 
     def __eq__(self, other):


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
Broken in 10.3.beta6:
```
./sage -tp --probe all src/sage/doctest/util.py
...
  File "/Users/mkoeppe/s/sage/sage-rebasing/worktree-pristine/src/sage/doctest/parsing.py", line 919, in __init__
    self.probed_tags = set(probed_tags)
                       ^^^^^^^^^^^^^^^^
TypeError: 'bool' object is not iterable

----------------------------------------------------------------------
sage -t --random-seed=131361480585541724191127226366213696278 src/sage/doctest/util.py  # TypeError in doctesting framework
```

<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
