### PR TITLE
`sage.features.threejs`: Fix modularization regression after #37024

### DIFF
--- a/src/sage/features/threejs.py
+++ b/src/sage/features/threejs.py
@@ -50,6 +50,11 @@ class Threejs(StaticFile):
         """
         Return the version of threejs that Sage requires.
 
+        Defining what version is required is delegated to the distribution package
+        that provides the file ``threejs-version.txt`` in :mod:`sage.ext_data.threejs`.
+
+        If the file is not provided, :class:`FileNotFoundError` is raised.
+
         EXAMPLES::
 
             sage: from sage.features.threejs import Threejs

--- a/src/sage/features/threejs.py
+++ b/src/sage/features/threejs.py
@@ -25,8 +25,6 @@ class Threejs(StaticFile):
         """
         from sage.env import SAGE_SHARE, THREEJS_DIR
 
-        version = self.required_version()
-
         threejs_search_path = THREEJS_DIR or (
             os.path.join(SAGE_SHARE, "jupyter", "nbextensions", "threejs-sage"),
             os.path.join(SAGE_SHARE, "sagemath", "threejs-sage"),
@@ -34,9 +32,15 @@ class Threejs(StaticFile):
             os.path.join(SAGE_SHARE, "threejs-sage")
             )
 
+        try:
+            version = self.required_version()
+            filename = os.path.join(version, "three.min.js")
+        except FileNotFoundError:
+            filename = 'unknown'
+
         StaticFile.__init__(
             self, name="threejs",
-            filename=os.path.join(version, "three.min.js"),
+            filename=filename,
             spkg="threejs",
             type="standard",
             search_path=threejs_search_path,


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
`sage.features` is shipped by **sagemath-environment**, but the version file that the Feature introduced in #37024 uses is shipped by **sagemath-repl**. 

This breaks doctesting in a modularized environment. As seen in https://github.com/ipython/ipython/pull/14317 (https://github.com/ipython/ipython/actions/runs/7731330166/job/21078723213?pr=14317#step:9:136)


<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
