### PR TITLE
Fix a bug in `correlation_immunity` function

### DIFF
--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -852,7 +852,7 @@ cdef class BooleanFunction(SageObject):
         if self._correlation_immunity is None:
             c = self._nvariables
             W = self.walsh_hadamard_transform()
-            for i in range(len(W)):
+            for i in range(1, len(W)):
                 sig_check()
                 if W[i]:
                     c = min(c, hamming_weight(i))

--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -847,6 +847,16 @@ cdef class BooleanFunction(SageObject):
             sage: B = BooleanFunction("7969817CC5893BA6AC326E47619F5AD0")
             sage: B.correlation_immunity()
             2
+
+        TESTS:
+
+        Check if :trac:`28001` is fixed::
+
+            sage: from sage.crypto.boolean_function import BooleanFunction
+            sage: f = [False, False, True, False, False, True, False, False]
+            sage: f = BooleanFunction(f)
+            sage: f.correlation_immunity()
+            1
         """
         cdef long c, i
         if self._correlation_immunity is None:

--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -865,7 +865,8 @@ cdef class BooleanFunction(SageObject):
             for i in range(1, len(W)):
                 sig_check()
                 if W[i]:
-                    c = min(c, hamming_weight(i))
+                    c = hamming_weight(i)
+                    break
             self._correlation_immunity = ZZ(c-1)
         return self._correlation_immunity
 

--- a/src/sage/groups/libgap_wrapper.pyx
+++ b/src/sage/groups/libgap_wrapper.pyx
@@ -347,7 +347,7 @@ class ParentLibGAP(SageObject):
 
     def minimal_normal_subgroups(self):
         """
-        Return the nontrivial minimal normal subgroups ``self``.
+        Return the nontrivial minimal normal subgroups of ``self``.
 
         EXAMPLES::
 

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -4118,7 +4118,7 @@ class PermutationGroup_generic(FiniteGroup):
 
     def minimal_normal_subgroups(self):
         """
-        Return the nontrivial minimal normal subgroups ``self``.
+        Return the nontrivial minimal normal subgroups of ``self``.
 
         EXAMPLES::
 


### PR DESCRIPTION
This patch fixes #36294. This PR fixes the issue of wrong answer given by 
correlation_immunity function (As suggested in the [comment](https://github.com/sagemath/sage/issues/36294#issue-1900443599) of the issue). And I have also added some doctests in this.
﻿<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
