### PR TITLE
catch possible failure in random doctest when dimension of an ideal is 1 instead of 0

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1788,7 +1788,10 @@ class EllipticCurve_finite_field(EllipticCurve_field, HyperellipticCurve_finite_
             sage: eq = 1728*4*A**3 - j * (4*A**3 + 27*B**2)
             sage: twists2 = []
             sage: for _ in range(10):
-            ....:     V = Ideal([eq, A + B - F.random_element()]).variety()
+            ....:     try:
+            ....:         V = Ideal([eq, A + B - F.random_element()]).variety()
+            ....:     except ValueError:
+            ....:         continue
             ....:     if not V:
             ....:         continue
             ....:     sol = choice(V)

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1788,10 +1788,12 @@ class EllipticCurve_finite_field(EllipticCurve_field, HyperellipticCurve_finite_
             sage: eq = 1728*4*A**3 - j * (4*A**3 + 27*B**2)
             sage: twists2 = []
             sage: for _ in range(10):
+            ....:     I = Ideal([eq, A + B - F.random_element()])
             ....:     try:
-            ....:         V = Ideal([eq, A + B - F.random_element()]).variety()
+            ....:         V = I.variety()
             ....:     except ValueError:
-            ....:         continue
+            ....:         if I.dimension() == 0:
+            ....:              raise
             ....:     if not V:
             ....:         continue
             ....:     sol = choice(V)


### PR DESCRIPTION
See [here](https://github.com/sagemath/sage/actions/runs/7715956934/job/21039012695?pr=37096#step:14:16): That ideal can have dimension $1$ instead of $0$ in rare cases, which causes the doctest to fail very occasionally.