### PR TITLE
fix a wrong reference in installation manual

### DIFF
--- a/src/doc/en/installation/launching.rst
+++ b/src/doc/en/installation/launching.rst
@@ -9,9 +9,9 @@ Notebook from the command line.
 
 If you did install the Windows version or the macOS application you
 should have icons available on your desktops or launching menus. Otherwise
-you are strongly advised to create shortcuts for Sage as indicated at the end
-of the "Linux" Section in :ref:`build-from-source-step-by-step`. Assuming
-that you have this shortcut, running
+you are strongly advised to create shortcuts for Sage as indicated in the part
+6 of the "Installation steps" Section in :ref:`build-from-source-step-by-step`.
+Assuming that you have this shortcut, running
 
 .. CODE-BLOCK:: bash
 

--- a/src/doc/en/installation/launching.rst
+++ b/src/doc/en/installation/launching.rst
@@ -10,7 +10,7 @@ Notebook from the command line.
 If you did install the Windows version or the macOS application you
 should have icons available on your desktops or launching menus. Otherwise
 you are strongly advised to create shortcuts for Sage as indicated at the end
-of the "Linux" Section in :ref:`sec-installation-from-binaries`. Assuming
+of the "Linux" Section in :ref:`build-from-source-step-by-step`. Assuming
 that you have this shortcut, running
 
 .. CODE-BLOCK:: bash


### PR DESCRIPTION
In the second paragraph of "https://doc.sagemath.org/html/en/installation/launching.html", the reader is "strongly advised to create shortcuts for Sage as indicated at the end of the “Linux” Section in [Install from Pre-Built Binaries](https://doc.sagemath.org/html/en/installation/binary.html#sec-installation-from-binaries)". However, the indicated part in the reference "[Install from Pre-Built Binaries](https://doc.sagemath.org/html/en/installation/binary.html#sec-installation-from-binaries)" does not exist anymore, and should be replaced by "[Installation steps](https://deploy-preview-37213--sagemath.netlify.app/html/en/installation/source#build-from-source-step-by-step)".

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
