### PR TITLE
Add Pseudomorphism Implementation for Free Modules

### DIFF
--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -3064,6 +3064,18 @@ class FreeModule_generic(Module_free_ambient):
             codomain = R**n
         return super().hom(im_gens, codomain, **kwds)
 
+    def pseudohom(self, morphism, twist=None, **kwds):
+        r"""
+        Created a pseudomorphism defined by a given morphism and twist.
+        Let A be a ring and M a free module over A. Let \theta: A \to A
+
+        """
+        from sage.modules.free_module_pseudomorphism import FreeModulePseudoMorphism
+        from sage.structure.element import is_Matrix
+        if is_Matrix(morphism):
+            return FreeModulePseudoMorphism(self.hom(morphism), twist)
+        return FreeModulePseudoMorphism(morphism, twist)
+
     def inner_product_matrix(self):
         """
         Return the default identity inner product matrix associated to this

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -212,6 +212,8 @@ from sage.structure.richcmp import (
     richcmp_not_equal,
 )
 from sage.structure.sequence import Sequence
+from sage.categories.morphism import Morphism
+from sage.matrix.constructor import matrix
 
 ###############################################################################
 #
@@ -3064,7 +3066,11 @@ class FreeModule_generic(Module_free_ambient):
             codomain = R**n
         return super().hom(im_gens, codomain, **kwds)
 
-    def pseudohom(self, morphism, twist=None, **kwds):
+    def PseudoHom(self, codomain=None, twist=None):
+        from sage.modules.free_module_pseudohomspace import FreeModulePseudoHomspace
+        return FreeModulePseudoHomspace(self, codomain, twist)
+
+    def pseudohom(self, morphism, twist=None, codomain=None, **kwds):
         r"""
         Created a pseudomorphism defined by a given morphism and twist.
         Let A be a ring and M a free module over A. Let \theta: A \to A
@@ -3072,9 +3078,7 @@ class FreeModule_generic(Module_free_ambient):
         """
         from sage.modules.free_module_pseudomorphism import FreeModulePseudoMorphism
         from sage.structure.element import is_Matrix
-        if is_Matrix(morphism):
-            return FreeModulePseudoMorphism(self.hom(morphism), twist)
-        return FreeModulePseudoMorphism(morphism, twist)
+        return FreeModulePseudoMorphism(self, morphism, twist, codomain)
 
     def inner_product_matrix(self):
         """

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -3098,9 +3098,7 @@ class FreeModule_generic(Module_free_ambient):
             Codomain: Vector space of dimension 2 over Finite Field in z2 of size 5^2
         """
         from sage.modules.free_module_pseudomorphism import FreeModulePseudoMorphism
-        from sage.structure.element import is_Matrix
-        side = kwds.get("side", "left")
-        return FreeModulePseudoMorphism(self, morphism, twist, codomain, side)
+        return FreeModulePseudoMorphism(self, morphism, twist, codomain, **kwds)
 
     def inner_product_matrix(self):
         """

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -3068,12 +3068,18 @@ class FreeModule_generic(Module_free_ambient):
 
     def PseudoHom(self, twist=None, codomain=None):
         r"""
-        Create the Pseudohomspace corresponding to given twist data.
+        Create the Pseudo Hom space corresponding to given twist data.
 
+        EXAMPLES::
+            
+            sage: F = GF(25); M = F^2; twist = F.frobenius_endomorphism()
+            sage: PHS = M.PseudoHom(twist); PHS
+            Set of Pseudomorphisms from Vector space of dimension 2 over Finite Field in z2 of size 5^2 to Vector space of dimension 2 over Finite Field in z2 of size 5^2
+            Twisted by the morphism Frobenius endomorphism z2 |--> z2^5 on Finite Field in z2 of size 5^2
 
         """
         from sage.modules.free_module_pseudohomspace import FreeModulePseudoHomspace
-        return FreeModulePseudoHomspace(self, codomain, twist)
+        return FreeModulePseudoHomspace(self, codomain, twist=twist)
 
     def pseudohom(self, morphism, twist=None, codomain=None, **kwds):
         r"""
@@ -3082,8 +3088,14 @@ class FreeModule_generic(Module_free_ambient):
 
         EXAMPLES::
 
-        sage: F = GF(25); M = F^2; twist = F.frobenius_endomorphism()
-        sage: 
+            sage: F = GF(25); M = F^2; twist = F.frobenius_endomorphism()
+            sage: ph = M.pseudohom([[1, 2], [0, 1]], twist, side="right"); ph
+            Free module pseudomorphism defined as left-multiplication by the matrix
+            [1 2]
+            [0 1]
+            twisted by the morphism Frobenius endomorphism z2 |--> z2^5 on Finite Field in z2 of size 5^2
+            Domain: Vector space of dimension 2 over Finite Field in z2 of size 5^2
+            Codomain: Vector space of dimension 2 over Finite Field in z2 of size 5^2
         """
         from sage.modules.free_module_pseudomorphism import FreeModulePseudoMorphism
         from sage.structure.element import is_Matrix

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -3078,7 +3078,8 @@ class FreeModule_generic(Module_free_ambient):
         """
         from sage.modules.free_module_pseudomorphism import FreeModulePseudoMorphism
         from sage.structure.element import is_Matrix
-        return FreeModulePseudoMorphism(self, morphism, twist, codomain)
+        side = kwds.get("side", "left")
+        return FreeModulePseudoMorphism(self, morphism, twist, codomain, side)
 
     def inner_product_matrix(self):
         """

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -3067,6 +3067,11 @@ class FreeModule_generic(Module_free_ambient):
         return super().hom(im_gens, codomain, **kwds)
 
     def PseudoHom(self, twist=None, codomain=None):
+        r"""
+        Create the Pseudohomspace corresponding to given twist data.
+
+
+        """
         from sage.modules.free_module_pseudohomspace import FreeModulePseudoHomspace
         return FreeModulePseudoHomspace(self, codomain, twist)
 
@@ -3075,9 +3080,9 @@ class FreeModule_generic(Module_free_ambient):
         Create a pseudomorphism defined by a given morphism and twist.
         Let A be a ring and M a free module over A. Let \theta: A \to A
 
-        EXAMPLE::
+        EXAMPLES::
 
-        sage: F = GF(25); M = F^2; twist = F.frobenius_endomorphism(5)
+        sage: F = GF(25); M = F^2; twist = F.frobenius_endomorphism()
         sage: 
         """
         from sage.modules.free_module_pseudomorphism import FreeModulePseudoMorphism

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -3066,15 +3066,19 @@ class FreeModule_generic(Module_free_ambient):
             codomain = R**n
         return super().hom(im_gens, codomain, **kwds)
 
-    def PseudoHom(self, codomain=None, twist=None):
+    def PseudoHom(self, twist=None, codomain=None):
         from sage.modules.free_module_pseudohomspace import FreeModulePseudoHomspace
         return FreeModulePseudoHomspace(self, codomain, twist)
 
     def pseudohom(self, morphism, twist=None, codomain=None, **kwds):
         r"""
-        Created a pseudomorphism defined by a given morphism and twist.
+        Create a pseudomorphism defined by a given morphism and twist.
         Let A be a ring and M a free module over A. Let \theta: A \to A
 
+        EXAMPLE::
+
+        sage: F = GF(25); M = F^2; twist = F.frobenius_endomorphism(5)
+        sage: 
         """
         from sage.modules.free_module_pseudomorphism import FreeModulePseudoMorphism
         from sage.structure.element import is_Matrix

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -3079,7 +3079,7 @@ class FreeModule_generic(Module_free_ambient):
 
         """
         from sage.modules.free_module_pseudohomspace import FreeModulePseudoHomspace
-        return FreeModulePseudoHomspace(self, codomain, twist=twist)
+        return FreeModulePseudoHomspace(self, codomain=codomain, twist=twist)
 
     def pseudohom(self, morphism, twist=None, codomain=None, **kwds):
         r"""
@@ -3098,7 +3098,8 @@ class FreeModule_generic(Module_free_ambient):
             Codomain: Vector space of dimension 2 over Finite Field in z2 of size 5^2
         """
         from sage.modules.free_module_pseudomorphism import FreeModulePseudoMorphism
-        return FreeModulePseudoMorphism(self, morphism, twist, codomain, **kwds)
+        side = kwds.get("side", "left")
+        return FreeModulePseudoMorphism(self.PseudoHom(twist=twist, codomain=codomain), morphism, side)
 
     def inner_product_matrix(self):
         """

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -3071,7 +3071,7 @@ class FreeModule_generic(Module_free_ambient):
         Create the Pseudo Hom space corresponding to given twist data.
 
         EXAMPLES::
-            
+
             sage: F = GF(25); M = F^2; twist = F.frobenius_endomorphism()
             sage: PHS = M.PseudoHom(twist); PHS
             Set of Pseudomorphisms from Vector space of dimension 2 over Finite Field in z2 of size 5^2 to Vector space of dimension 2 over Finite Field in z2 of size 5^2

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -60,6 +60,18 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
     def __call__(self, A, **kwds):
         r"""
         Coerce a matrix or free module homomorphism into a pseudomorphism.
+
+        EXAMPLES::
+
+            sage: F = GF(125); M = F^2; twist = F.frobenius_endomorphism()
+            sage: PHS = M.PseudoHom(twist)
+            sage: h = PHS([[1, 2], [1, 1]]); h
+            Free module pseudomorphism defined by the                 matrix
+            [1 2]
+            [1 1]
+            twisted by the morphism Frobenius endomorphism z3 |--> z3^5 on Finite Field in z3 of size 5^3
+            Domain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
+            Codomain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
         """
         from . import free_module_pseudomorphism
         side = kwds.get("side", "left")
@@ -110,7 +122,15 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
 
     def zero(self):
         r"""
-        Return the zero pseudomorphism.
+        Return the zero pseudomorphism. This corresponds to the zero matrix.
+
+        EXAMPLES::
+
+            sage: F = GF(125); M = F^2; twist = F.frobenius_endomorphism()
+            sage: PHS = M.PseudoHom(twist)
+            sage: PHS.zero().matrix()
+            [0 0]
+            [0 0]
         """
         return self.base_homspace.zero()
 
@@ -126,5 +146,13 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
     def identity(self):
         r"""
         Return the pseudomorphism corresponding to the identity transformation
+        EXAMPLES::
+
+            sage: F = GF(125); M = F^2; twist = F.frobenius_endomorphism()
+            sage: PHS = M.PseudoHom(twist)
+            sage: PHS.zero().matrix()
+            [1 0]
+            [0 1]
+
         """
         return self.base_homspace.identity()

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -1,4 +1,11 @@
+"""
+Space of Pseudomorphisms of free modules
 
+AUTHORS:
+
+    - Yossef Musleh (2024-02): initial version
+
+"""
 # ****************************************************************************
 #  Copyright (C) 2024 Yossef Musleh <jbobicus@gmail.com>
 #
@@ -72,7 +79,7 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
             sage: F = GF(125); M = F^2; twist = F.frobenius_endomorphism()
             sage: PHS = M.PseudoHom(twist)
             sage: h = PHS([[1, 2], [1, 1]]); h
-            Free module pseudomorphism defined by the                 matrix
+            Free module pseudomorphism defined by the matrix
             [1 2]
             [1 1]
             twisted by the morphism Frobenius endomorphism z3 |--> z3^5 on Finite Field in z3 of size 5^3
@@ -114,6 +121,10 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
 
         EXAMPLE::
 
+            sage: Fq = GF(343); M = Fq^2; frob = Fq.frobenius_endomorphism()
+            sage: PHS = M.PseudoHom(frob); PHS
+            Set of Pseudomorphisms from Vector space of dimension 2 over Finite Field in z3 of size 7^3 to Vector space of dimension 2 over Finite Field in z3 of size 7^3
+            Twisted by the morphism Frobenius endomorphism z3 |--> z3^7 on Finite Field in z3 of size 7^3
         """
         r = "Set of Pseudomorphisms from {} to {} {} {}"
         morph = ""
@@ -141,11 +152,47 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
         return self.base_homspace.zero()
 
     def _matrix_space(self):
+        r"""
+        Return the full matrix space of the underlying morphisms.
+
+        EXAMPLES::
+
+            sage: Fq = GF(343); M = Fq^2; frob = Fq.frobenius_endomorphism()
+            sage: PHS = M.PseudoHom(frob)
+            sage: PHS._matrix_space()
+            Full MatrixSpace of 2 by 2 dense matrices over Finite Field in z3 of size 7^3
+        """
         return self.base_homspace._matrix_space()
 
     def basis(self, side="left"):
         r"""
         Return a basis for the underlying matrix space.
+
+        EXAMPLES::
+
+            sage: Fq = GF(343); M = Fq^2; frob = Fq.frobenius_endomorphism()
+            sage: PHS = M.PseudoHom(frob)
+            sage: PHS.basis()
+            (Vector space morphism represented by the matrix:
+             [1 0]
+             [0 0]
+            Domain: Vector space of dimension 2 over Finite Field in z3 of size 7^3
+             Codomain: Vector space of dimension 2 over Finite Field in z3 of size 7^3,
+             Vector space morphism represented by the matrix:
+             [0 1]
+             [0 0]
+             Domain: Vector space of dimension 2 over Finite Field in z3 of size 7^3
+             Codomain: Vector space of dimension 2 over Finite Field in z3 of size 7^3,
+             Vector space morphism represented by the matrix:
+             [0 0]
+             [1 0]
+             Domain: Vector space of dimension 2 over Finite Field in z3 of size 7^3
+             Codomain: Vector space of dimension 2 over Finite Field in z3 of size 7^3,
+             Vector space morphism represented by the matrix:
+             [0 0]
+             [0 1]
+             Domain: Vector space of dimension 2 over Finite Field in z3 of size 7^3
+             Codomain: Vector space of dimension 2 over Finite Field in z3 of size 7^3)
         """
         return self.base_homspace.basis(side)
 
@@ -160,6 +207,5 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
             sage: PHS.identity().matrix()
             [1 0]
             [0 1]
-
         """
         return self.base_homspace.identity()

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -1,0 +1,61 @@
+
+# ****************************************************************************
+#  Copyright (C) 2005 William Stein <wstein@gmail.com>
+#
+#  Distributed under the terms of the GNU General Public License (GPL)
+#
+#    This code is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty
+#    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License for more details; the full text
+#  is available at:
+#
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
+import sage.categories.homset
+from sage.structure.element import is_Matrix
+from sage.matrix.constructor import matrix, identity_matrix
+from sage.matrix.matrix_space import MatrixSpace
+from sage.misc.cachefunc import cached_method
+from sage.categories.morphism import Morphism
+from sage.misc.lazy_import import lazy_import
+
+lazy_import('sage.rings.derivation', 'RingDerivation')
+
+class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
+    def __init__(self, X, Y, twist=None):
+        self._domain = X
+        self._codomain = X
+        if Y is not None:
+            self._codomain = Y
+        if (twist.domain() is not self.domain().coordinate_ring()
+          or twist.codomain() is not self.codomain().coordinate_ring()):
+            raise TypeError("twisting morphism domain/codomain do not match coordinate rings of the modules")
+        elif isinstance(twist, Morphism) or isinstance(twist, RingDerivation):
+            self.twist = twist
+        else:
+            raise TypeError("twist is not a ring morphism or derivation")
+
+    def __call__(self, A, **kwds):
+        from . import free_module_pseudomorphism
+        side = kwds.get("side", "left")
+        if not is_Matrix(A):
+            C = self.codomain()
+            try:
+                if callable(A):
+                    v = [C(A(g)) for g in self.domain().gens()]
+                    A = matrix([C.coordinates(a) for a in v], ncols=C.rank())
+                    if side == "right":
+                        A = A.transpose()
+                else:
+                    v = [C(a) for a in A]
+                    if side == "right":
+                        A = matrix([C.coordinates(a) for a in v], ncols=C.rank()).transpose()
+                    else:
+                        A = matrix([C.coordinates(a) for a in v], ncols=C.rank())
+            except TypeError:
+                pass
+        if not self.codomain().base_ring().has_coerce_map_from(self.domain().base_ring()) and not A.is_zero():
+            raise TypeError("nontrivial morphisms require a coercion map from the base ring of the domain to the base ring of the codomain")
+        return free_module_pseudomorphism.FreeModulePseudoMorphism(self.domain(), A, twist=self.twist, codomain = self.codomain()) 

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -99,27 +99,27 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
                 else:
                     v = [C(a) for a in A]
                     if side == "right":
-                        A = matrix([C.coordinates(a) for a in v], \
+                        A = matrix([C.coordinates(a) for a in v],
                                     ncols=C.rank()).transpose()
                     else:
-                        A = matrix([C.coordinates(a) for a in v], \
+                        A = matrix([C.coordinates(a) for a in v],
                                     ncols=C.rank())
             except TypeError:
                 pass
-        if not self.codomain().base_ring().has_coerce_map_from(\
+        if not self.codomain().base_ring().has_coerce_map_from(
                 self.domain().base_ring()) and not A.is_zero():
-            raise TypeError("nontrivial morphisms require a coercion map \
-                    from the base ring of the domain to the base ring of the \
-                    codomain")
-        return free_module_pseudomorphism.FreeModulePseudoMorphism(\
-                                self.domain(), A, twist=self.twist, \
-                                codomain = self.codomain())
+            raise TypeError("nontrivial morphisms require a coercion map"
+                    "from the base ring of the domain to the base ring of the"
+                    "codomain")
+        return free_module_pseudomorphism.FreeModulePseudoMorphism(
+                                self.domain(), A, twist=self.twist,
+                                codomain=self.codomain())
 
     def __repr__(self):
         r"""
         Returns the string representation of the pseudomorphism space.
 
-        EXAMPLE::
+        EXAMPLES::
 
             sage: Fq = GF(343); M = Fq^2; frob = Fq.frobenius_endomorphism()
             sage: PHS = M.PseudoHom(frob); PHS

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -145,11 +145,15 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
 
             sage: F = GF(125); M = F^2; twist = F.frobenius_endomorphism()
             sage: PHS = M.PseudoHom(twist)
-            sage: PHS.zero().matrix()
+            sage: PHS.zero()
+            Free module pseudomorphism defined by the matrix
             [0 0]
             [0 0]
+            twisted by the morphism Frobenius endomorphism z3 |--> z3^5 on Finite Field in z3 of size 5^3
+            Domain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
+            Codomain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
         """
-        return self.base_homspace.zero()
+        return self(self.base_homspace.zero())
 
     def _matrix_space(self):
         r"""
@@ -204,8 +208,12 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
 
             sage: F = GF(125); M = F^2; twist = F.frobenius_endomorphism()
             sage: PHS = M.PseudoHom(twist)
-            sage: PHS.identity().matrix()
+            sage: PHS.identity()
+            Free module pseudomorphism defined by the matrix
             [1 0]
             [0 1]
+            twisted by the morphism Frobenius endomorphism z3 |--> z3^5 on Finite Field in z3 of size 5^3
+            Domain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
+            Codomain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
         """
-        return self.base_homspace.identity()
+        return self(self.base_homspace.identity())

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -1,6 +1,6 @@
 
 # ****************************************************************************
-#  Copyright (C) 2005 William Stein <wstein@gmail.com>
+#  Copyright (C) 2024 Yossef Musleh <jbobicus@gmail.com>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #
@@ -24,6 +24,17 @@ from sage.misc.lazy_import import lazy_import
 lazy_import('sage.rings.derivation', 'RingDerivation')
 
 class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
+    r"""
+    This class implements the space of Pseudomorphisms with a fixed twist.
+
+
+
+    EXAMPLES::
+
+        sage: F = GF(25); M = F^2; twist = F.frobenius_endomorphism(5)
+        sage: PHS = F.PseudoHom(twist)
+
+    """
     def __init__(self, X, Y, twist=None):
         self._domain = X
         self._codomain = X
@@ -58,4 +69,7 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
                 pass
         if not self.codomain().base_ring().has_coerce_map_from(self.domain().base_ring()) and not A.is_zero():
             raise TypeError("nontrivial morphisms require a coercion map from the base ring of the domain to the base ring of the codomain")
-        return free_module_pseudomorphism.FreeModulePseudoMorphism(self.domain(), A, twist=self.twist, codomain = self.codomain()) 
+        return free_module_pseudomorphism.FreeModulePseudoMorphism(self.domain(), A, twist=self.twist, codomain = self.codomain())
+
+    def __repr__(self):
+        pass

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -159,40 +159,20 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
             sage: morph = M.hom(matrix([[1, 2], [1, 1]]))
             sage: phi = PHS._element_constructor_(morph, side="right"); phi
             Free module pseudomorphism defined as left-multiplication by the matrix
+            [1 2]
             [1 1]
-            [2 1]
             twisted by the morphism Frobenius endomorphism z3 |--> z3^5 on Finite Field in z3 of size 5^3
             Domain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
             Codomain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
         """
-        from . import free_module_pseudomorphism
+        from . import free_module_pseudomorphism as pseudo
         side = kwds.get("side", "left")
-        if not is_Matrix(A):
-            C = self.codomain()
-            try:
-                if callable(A):
-                    v = [C(A(g)) for g in self.domain().gens()]
-                    A = matrix([C.coordinates(a) for a in v], ncols=C.rank())
-                    if side == "right":
-                        A = A.transpose()
-                else:
-                    v = [C(a) for a in A]
-                    if side == "right":
-                        A = matrix([C.coordinates(a) for a in v],
-                                    ncols=C.rank()).transpose()
-                    else:
-                        A = matrix([C.coordinates(a) for a in v],
-                                    ncols=C.rank())
-            except TypeError:
-                pass
         if not self.codomain().base_ring().has_coerce_map_from(
                 self.domain().base_ring()) and not A.is_zero():
             raise TypeError("nontrivial morphisms require a coercion map"
                     "from the base ring of the domain to the base ring of the"
                     "codomain")
-        return free_module_pseudomorphism.FreeModulePseudoMorphism(
-                                self.domain(), A, twist=self.twist,
-                                codomain=self.codomain(), side=side)
+        return pseudo.FreeModulePseudoMorphism(self, A, side=side)
 
     def _matrix_space(self):
         r"""

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -37,7 +37,7 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
         sage: h = PHS([[1, 2], [1, 1]])
         sage: e = M((4*F.gen()^2 + F.gen() + 2, 4*F.gen()^2 + 4*F.gen() + 4))
         sage: h(e)
-        (3*z3^2 + z3, 4*z3^2 + 3*z3 + 3)
+        (z3, 2*z3^2 + 3*z3 + 3)
 
     """
     def __init__(self, X, Y, twist=None):
@@ -146,11 +146,12 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
     def identity(self):
         r"""
         Return the pseudomorphism corresponding to the identity transformation
+
         EXAMPLES::
 
             sage: F = GF(125); M = F^2; twist = F.frobenius_endomorphism()
             sage: PHS = M.PseudoHom(twist)
-            sage: PHS.zero().matrix()
+            sage: PHS.identity().matrix()
             [1 0]
             [0 1]
 

--- a/src/sage/modules/free_module_pseudohomspace.py
+++ b/src/sage/modules/free_module_pseudohomspace.py
@@ -45,15 +45,21 @@ class FreeModulePseudoHomspace(sage.categories.homset.HomsetWithBase):
         self._codomain = X
         if Y is not None:
             self._codomain = Y
+        super().__init__(self._domain, self._codomain, category=None)
         self.base_homspace = self._domain.Hom(self._codomain)
+        self.twist = twist
+        self.twist_morphism = None
+        self.derivation = None
         if twist is None:
             return
         if (twist.domain() is not self.domain().coordinate_ring()
           or twist.codomain() is not self.codomain().coordinate_ring()):
             raise TypeError("twisting morphism domain/codomain do not match\
                             coordinate rings of the modules")
-        elif isinstance(twist, Morphism) or isinstance(twist, RingDerivation):
-            self.twist = twist
+        elif isinstance(twist, Morphism):
+            self.twist_morphism = twist
+        elif isinstance(twist, RingDerivation):
+            self.derivation = twist
         else:
             raise TypeError("twist is not a ring morphism or derivation")
 

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -1,0 +1,109 @@
+"""
+Pseudomorphisms of free modules
+
+AUTHORS:
+
+
+TESTS::
+
+    sage: V = ZZ^2; f = V.hom([V.1, -2*V.0])
+"""
+
+####################################################################################
+#       Copyright (C) 2009 William Stein <wstein@gmail.com>
+#
+#  Distributed under the terms of the GNU General Public License (GPL)
+#
+#    This code is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    General Public License for more details.
+#
+#  The full text of the GPL is available at:
+#
+#                  http://www.gnu.org/licenses/
+####################################################################################
+
+# A matrix morphism is a morphism that is defined by multiplication by a
+# matrix.  Elements of domain must either have a method "vector()" that
+# returns a vector that the defining matrix can hit from the left, or
+# be coercible into vector space of appropriate dimension.
+import sage.modules.free_module as free_module
+from sage.categories.morphism import Morphism
+from sage.modules import free_module_homspace, matrix_morphism
+from sage.structure.richcmp import rich_to_bool, richcmp
+from sage.structure.sequence import Sequence
+from sage.structure.all import parent
+from sage.misc.lazy_import import lazy_import
+
+lazy_import('sage.rings.derivation', 'RingDerivation')
+
+class FreeModulePseudoMorphism():
+    def __init__(self, morphism, twist=None, side="left"):
+        """
+        INPUT:
+
+            -  ``parent`` - a homspace in a (sub) category of free modules
+
+            -  ``A`` - matrix
+
+            - side -- side of the vectors acted on by the matrix  (default: ``"left"``)
+
+        EXAMPLES::
+
+            sage: V = ZZ^3; W = span([[1,2,3],[-1,2,8]], ZZ)
+            sage: phi = V.hom(matrix(ZZ,3,[1..9]))
+            sage: type(phi)
+            <class 'sage.modules.free_module_morphism.FreeModuleMorphism'>
+        """
+        self.derivation = None
+        if isinstance(twist, Morphism):
+            self.twist_morphism = twist
+        elif isinstance(twist, RingDerivation):
+            self.twist_morphism = twist.parent().twisting_morphism()
+            if twist:
+                self.derivation = twist
+            else:
+                self.derivation = None
+        self.side = side
+        self.base_morphism = morphism
+		
+    def __call__(self, x):
+        if self.twist_morphism is None and self.derivation is None:
+            return self.base_morphism(x)
+        else:
+            try:
+                if parent(x) is not self.domain():
+                    x = self.domain()(x)
+            except TypeError:
+                raise TypeError("%s must be coercible into %s" % (x,self.domain()))
+            if self.domain().is_ambient():
+                x = x.element()
+            else:
+                x = self.domain().coordinate_vector(x)
+            if self.twist_morphism is None:
+                x_twistmorphism = x
+            else:
+                x_twistmorphism = self.domain()(list(map(self.twist_morphism, x)))
+            C = self.codomain()
+            if self.side == "left":
+                v = x_twistmorphism * self.matrix()
+            else:
+                v = self.matrix() * x_twistmorphism
+            if self.derivation is not None:
+                v += self.domain()(list(map(self.derivation, x)))
+            if not C.is_ambient():
+                v = C.linear_combination_of_basis(v)
+            return C._element_constructor_(v)
+
+    def domain(self):
+        return self.base_morphism.domain()
+
+    def codomain(self):
+        return self.base_morphism.codomain()
+
+    def matrix(self):
+        return self.base_morphism.matrix()
+
+    def base_morphism(self):
+        return self.base_morphism

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -83,18 +83,18 @@ class FreeModulePseudoMorphism(Morphism):
         Constructs a pseudomorphism of free modules.
 
         INPUT:
-            -  ``domain``   - the domain of the pseudomorphism; a free module 
+            -  ``domain``   - the domain of the pseudomorphism; a free module
 
             -  ``base_morphism`` - either a morphism or a matrix defining a
                                    morphism
 
-            -  ``twist`` - a twisting morphism, this is either a morphism or 
+            -  ``twist`` - a twisting morphism, this is either a morphism or
                            a derivation (default: None)
 
             -  ``codomain`` - the codomain of the pseudomorphism; a free
                               module  (default: None)
 
-            - side -- side of the vectors acted on by the matrix 
+            - side -- side of the vectors acted on by the matrix
                       (default: ``"left"``)
 
         EXAMPLES::
@@ -111,7 +111,7 @@ class FreeModulePseudoMorphism(Morphism):
         elif isinstance(base_morphism, Morphism):
             self._base_matrix = base_morphism.matrix()
         else:
-            self._base_matrix = matrix(domain.coordinate_ring(), \
+            self._base_matrix = matrix(domain.coordinate_ring(),
                                         base_morphism)
         self.derivation = None
         self.twist_morphism = None
@@ -186,7 +186,7 @@ class FreeModulePseudoMorphism(Morphism):
         if self.derivation is not None:
             deriv = "\ntwisted by the derivation {}"
             deriv = deriv.format(self.derivation.__repr__())
-        return r.format(act, self.matrix(), morph, deriv, \
+        return r.format(act, self.matrix(), morph, deriv,
                         self.domain(), self.codomain())
 
     def matrix(self):

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -6,7 +6,6 @@ AUTHORS:
     - Yossef Musleh (2024-02): initial version
 
 """
-
 ####################################################################################
 #       Copyright (C) 2024 Yossef Musleh <jbobicus@gmail.com>
 #

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -107,12 +107,12 @@ class FreeModulePseudoMorphism(Morphism):
         from sage.structure.element import is_Matrix
         Morphism.__init__(self, domain.PseudoHom(twist, codomain))
         if is_Matrix(base_morphism):
-            self.base_morphism = domain.hom(base_morphism, codomain)
+            self._base_matrix = base_morphism
         elif isinstance(base_morphism, Morphism):
-            self.base_morphism = base_morphism
+            self._base_matrix = base_morphism.matrix()
         else:
-            self.base_morphism = domain.hom(matrix(domain.coordinate_ring(), \
-                                            base_morphism), codomain)
+            self._base_matrix = matrix(domain.coordinate_ring(), \
+                                        base_morphism)
         self.derivation = None
         self.twist_morphism = None
         if isinstance(twist, Morphism):
@@ -138,8 +138,6 @@ class FreeModulePseudoMorphism(Morphism):
             sage: ph(e)
             (z3^2 + 6*z3 + 2, z3^2 + 2*z3 + 1, 2*z3^2 + 4*z3)
         """
-        if self.twist_morphism is None and self.derivation is None:
-            return self.base_morphism(x)
         if self.domain().is_ambient():
             x = x.element()
         else:
@@ -150,9 +148,9 @@ class FreeModulePseudoMorphism(Morphism):
         else:
             x_twist = self.domain()(list(map(self.twist_morphism, x)))
         if self.side == "left":
-            v = x_twist * self.matrix()
+            v = x_twist * self._base_matrix
         else:
-            v = self.matrix() * x_twist
+            v = self._base_matrix * x_twist
         if self.derivation is not None:
             v += self.domain()(list(map(self.derivation, x)))
         if not C.is_ambient():
@@ -216,26 +214,7 @@ class FreeModulePseudoMorphism(Morphism):
             sage: ph(e) == ph.matrix()*vector([frob(c) for c in e])
             True
         """
-        return self.base_morphism.matrix()
-
-    def _base_morphism(self):
-        r"""
-        Return the underlying morphism of a pseudomorphism. This is an element
-        of the Hom space of the free module.
-
-        EXAMPLES::
-
-            sage: Fq = GF(343); M = Fq^3; frob = Fq.frobenius_endomorphism()
-            sage: ph = M.pseudohom([[1, 2, 3], [0, 1, 1], [2, 1, 1]], frob, side="right")
-            sage: ph._base_morphism()
-            Vector space morphism represented by the matrix:
-            [1 2 3]
-            [0 1 1]
-            [2 1 1]
-            Domain: Vector space of dimension 3 over Finite Field in z3 of size 7^3
-            Codomain: Vector space of dimension 3 over Finite Field in z3 of size 7^3
-        """
-        return self.base_morphism
+        return self._base_matrix
 
     def twisting_morphism(self):
         r"""

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -136,7 +136,7 @@ class FreeModulePseudoMorphism(Morphism):
         sage: ph = M.pseudohom([[1, 2, 3], [0, 1, 1], [2, 1, 1]], frob, side="right")
         sage: e = M((3*Fq.gen()^2 + 5*Fq.gen() + 2, 6*Fq.gen()^2 + 2*Fq.gen() + 2, Fq.gen() + 4))
         sage: ph(e)
-        (3*z3 + 3, 2*z3^2, 5*z3^2 + 4)
+        (2*z3^2 + 3*z3 + 2, z3^2 + 2*z3 + 1, 2*z3^2 + 4*z3)
         """
         if self.twist_morphism is None and self.derivation is None:
             return self.base_morphism(x)
@@ -151,13 +151,14 @@ class FreeModulePseudoMorphism(Morphism):
             else:
                 x = self.domain().coordinate_vector(x)
             C = self.codomain()
-            if self.side == "left":
-                v = x * self.matrix()
+            if self.twist_morphism is None:
+                x_twist = x
             else:
-                v = self.matrix() * x
-            if self.twist_morphism is not None:
-                for i in range(len(v)):
-                    v[i] *= self.twist_morphism(x[i])
+                x_twist = self.domain()(list(map(self.twist_morphism, x)))
+            if self.side == "left":
+                v = x_twist * self.matrix()
+            else:
+                v = self.matrix() * x_twist
             if self.derivation is not None:
                 v += self.domain()(list(map(self.derivation, x)))
             if not C.is_ambient():

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -37,10 +37,10 @@ lazy_import('sage.rings.derivation', 'RingDerivation')
 class FreeModulePseudoMorphism(Morphism):
     r"""
     Let `M, M'` be free modules over a ring `R`, `\theta: R \to R` a ring
-    homomorphism, and `\theta: R \to R` a derivation i.e. an additive
-    map such that
+    homomorphism, and `\delta: R \to R` a `\theta`-derivation, which is a map
+    such that:
 
-    `\delta(xy) = x\delta(y) + \delta(x)y`.
+    `\delta(xy) = \theta(x)\delta(y) + \delta(x)y`.
 
     Then a pseudomorphism `f : M to M` is a map such that
 
@@ -99,10 +99,22 @@ class FreeModulePseudoMorphism(Morphism):
 
         EXAMPLES::
 
-            sage: F = GF(25); V = F^3; twist = F.frobenius_endomorphism(5)
-            sage: phi = V.pseudohom(matrix(F,3,[1..9]), twist)
+            sage: F = GF(25); M = F^3; twist = F.frobenius_endomorphism(5)
+            sage: phi = M.pseudohom(matrix(F,3,[1..9]), twist)
             sage: type(phi)
             <class 'sage.modules.free_module_pseudomorphism.FreeModulePseudoMorphism'>
+
+        ::
+
+            sage: F = GF(125); M = F^2; twist = F.frobenius_endomorphism()
+            sage: morph = M.hom(matrix([[1,2],[0,1]]))
+            sage: phi = M.pseudohom(morph, twist, side="right"); phi
+            Free module pseudomorphism defined as left-multiplication by the matrix
+            [1 2]
+            [0 1]
+            twisted by the morphism Frobenius endomorphism z3 |--> z3^5 on Finite Field in z3 of size 5^3
+            Domain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
+            Codomain: Vector space of dimension 2 over Finite Field in z3 of size 5^3
         """
         from sage.structure.element import is_Matrix
         Morphism.__init__(self, domain.PseudoHom(twist, codomain))
@@ -115,6 +127,7 @@ class FreeModulePseudoMorphism(Morphism):
                                         base_morphism)
         self.derivation = None
         self.twist_morphism = None
+        self.side = side
         if isinstance(twist, Morphism):
             self.twist_morphism = twist
         elif isinstance(twist, RingDerivation):
@@ -123,7 +136,8 @@ class FreeModulePseudoMorphism(Morphism):
                 self.derivation = twist
             else:
                 self.derivation = None
-        self.side = side
+        elif twist is not None:
+            raise TypeError("twist is not a ring morphism or derivation")
 
     def _call_(self, x):
         r"""
@@ -216,19 +230,6 @@ class FreeModulePseudoMorphism(Morphism):
         """
         return self._base_matrix
 
-    def twisting_morphism(self):
-        r"""
-        Return the twisting homomorphism of the pseudomorphism.
-
-        EXAMPLES::
-
-            sage: Fq = GF(343); M = Fq^3; frob = Fq.frobenius_endomorphism()
-            sage: ph = M.pseudohom([[1, 2, 3], [0, 1, 1], [2, 1, 1]], frob, side="right")
-            sage: ph.twisting_morphism()
-            Frobenius endomorphism z3 |--> z3^7 on Finite Field in z3 of size 7^3
-        """
-        return self.twist_morphism
-
     def twisting_derivation(self):
         r"""
         Return the twisting derivation of the pseudomorphism.
@@ -241,3 +242,16 @@ class FreeModulePseudoMorphism(Morphism):
             d/dx
         """
         return self.derivation
+
+    def twisting_morphism(self):
+        r"""
+        Return the twisting homomorphism of the pseudomorphism.
+
+        EXAMPLES::
+
+            sage: Fq = GF(343); M = Fq^3; frob = Fq.frobenius_endomorphism()
+            sage: ph = M.pseudohom([[1, 2, 3], [0, 1, 1], [2, 1, 1]], frob, side="right")
+            sage: ph.twisting_morphism()
+            Frobenius endomorphism z3 |--> z3^7 on Finite Field in z3 of size 7^3
+        """
+        return self.twist_morphism

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -5,48 +5,6 @@ AUTHORS:
 
     - Yossef Musleh (2024-02): initial version
 
-Let M be a free module over a ring R, and let $theta, delta: R to R$
-be a morphism and derivation of $R$ respectively such that 
-
-$delta(xy) = theta(x)delta(y) + x$.
-
-Then a pseudomorphism from $f : M to M$ is a map such that
-
-    $f(x + y) = f(x) + f(y)$
-    $f(lambda x) = theta(lambda)f(x) + delta(lambda)x$
-
-If $delta$ is the zero morphism, then we can relax the condition that the
-codomain is M and consider a free module $M'$ over a ring $R'$.
-
-
-TESTS::
-
-    sage: V = ZZ^2
-    sage: f = V.pseudohom([V.1, -2*V.0]); f
-    Free module pseudomorphism defined by the matrix
-    [ 0  1]
-    [-2  0]
-    Domain: Ambient free module of rank 2 over the principal ideal domain Integer Ring
-    Codomain: Ambient free module of rank 2 over the principal ideal domain Integer Ring
-    sage: f(V((1, 2)))
-    (-4, 1)
-
-    sage: P.<x> = ZZ[]; deriv = P.derivation()
-    sage: M = P^2
-    sage: f = M.pseudohom([[1, 2*x], [x, 1]], deriv, side="right"); f
-    Free module pseudomorphism defined as left-multiplication by the matrix
-    [  1 2*x]
-    [  x   1]
-    Twisted by the derivation d/dx
-    Domain: Ambient free module of rank 2 over the integral domain Univariate Polynomial Ring in x over Integer Ring
-    Codomain: Ambient free module of rank 2 over the integral domain Univariate Polynomial Ring in x over Integer Ring
-    sage: e = M((2*x^2 + 3*x + 1, x^3 + 7*x + 4))
-    sage: f(e)
-    (2*x^4 + 16*x^2 + 15*x + 4, 3*x^3 + 6*x^2 + 8*x + 11)
-    sage: f = M.pseudohom([[1, 2], [1, 1]], deriv)
-    sage: f(e)
-    (x^3 + 2*x^2 + 14*x + 8, x^3 + 7*x^2 + 13*x + 13)
-
 """
 
 ####################################################################################
@@ -78,6 +36,49 @@ from sage.matrix.constructor import matrix
 lazy_import('sage.rings.derivation', 'RingDerivation')
 
 class FreeModulePseudoMorphism(Morphism):
+    r"""
+    Let `M, M'` be free modules over a ring `R`, `\theta: R \to R` a ring
+    homomorphism, and `\theta: R \to R` a derivation i.e. an additive
+    map such that
+
+    `\delta(xy) = x\delta(y) + \delta(x)y`.
+
+    Then a pseudomorphism `f : M to M` is a map such that
+
+    `f(x + y) = f(x) + f(y)`
+    `f(\lambda x) = `\theta(\lambda)f(x) + \delta(\lambda)x`
+
+    The pair `(\theta, \delta)` may be referred to as the *twist* of
+    the morphism.
+
+    TESTS::
+
+        sage: V = ZZ^2
+        sage: f = V.pseudohom([V.1, -2*V.0]); f
+        Free module pseudomorphism defined by the matrix
+        [ 0  1]
+        [-2  0]
+        Domain: Ambient free module of rank 2 over the principal ideal domain Integer Ring
+        Codomain: Ambient free module of rank 2 over the principal ideal domain Integer Ring
+        sage: f(V((1, 2)))
+        (-4, 1)
+
+        sage: P.<x> = ZZ[]; deriv = P.derivation()
+        sage: M = P^2
+        sage: f = M.pseudohom([[1, 2*x], [x, 1]], deriv, side="right"); f
+        Free module pseudomorphism defined as left-multiplication by the matrix
+        [  1 2*x]
+        [  x   1]
+        twisted by the derivation d/dx
+        Domain: Ambient free module of rank 2 over the integral domain Univariate Polynomial Ring in x over Integer Ring
+        Codomain: Ambient free module of rank 2 over the integral domain Univariate Polynomial Ring in x over Integer Ring
+        sage: e = M((2*x^2 + 3*x + 1, x^3 + 7*x + 4))
+        sage: f(e)
+        (2*x^4 + 16*x^2 + 15*x + 4, 3*x^3 + 6*x^2 + 8*x + 11)
+        sage: f = M.pseudohom([[1, 2], [1, 1]], deriv)
+        sage: f(e)
+        (x^3 + 2*x^2 + 14*x + 8, x^3 + 7*x^2 + 13*x + 13)
+    """
     def __init__(self, domain, base_morphism, twist=None, codomain=None, side="left"):
         """
         Constructs a pseudomorphism of free modules.
@@ -85,13 +86,17 @@ class FreeModulePseudoMorphism(Morphism):
         INPUT:
             -  ``domain``   - the domain of the pseudomorphism; a free module 
 
-            -  ``base_morphism`` - either a morphism or a matrix defining a morphism
+            -  ``base_morphism`` - either a morphism or a matrix defining a
+                                   morphism
 
-            -  ``twist`` - a twisting morphism, this is either a morphism or a derivation (default: None)
+            -  ``twist`` - a twisting morphism, this is either a morphism or 
+                           a derivation (default: None)
 
-            -  ``codomain`` - the codomain of the pseudomorphism; a free module  (default: None)
+            -  ``codomain`` - the codomain of the pseudomorphism; a free
+                              module  (default: None)
 
-            - side -- side of the vectors acted on by the matrix  (default: ``"left"``)
+            - side -- side of the vectors acted on by the matrix 
+                      (default: ``"left"``)
 
         EXAMPLES::
 
@@ -106,7 +111,8 @@ class FreeModulePseudoMorphism(Morphism):
         elif isinstance(base_morphism, Morphism):
             self.base_morphism = base_morphism
         else:
-            self.base_morphism = domain.hom(matrix(domain.coordinate_ring(), base_morphism), codomain)
+            self.base_morphism = domain.hom(matrix(domain.coordinate_ring(), \
+                                            base_morphism), codomain)
         self.derivation = None
         self.twist_morphism = None
         if isinstance(twist, Morphism):
@@ -126,11 +132,11 @@ class FreeModulePseudoMorphism(Morphism):
 
         TESTS::
 
-        sage: Fq = GF(25); M = Fq^2; frob = Fq.frobenius_endomorphism(5)
-        sage: ph = M.pseudohom([[1, 2], [0, 1]], frob, side="right")
-        sage: e = M((3*Fq.gen() + 2, 2*Fq.gen() + 2))
+        sage: Fq = GF(343); M = Fq^3; frob = Fq.frobenius_endomorphism()
+        sage: ph = M.pseudohom([[1, 2, 3], [0, 1, 1], [2, 1, 1]], frob, side="right")
+        sage: e = M((3*Fq.gen()^2 + 5*Fq.gen() + 2, 6*Fq.gen()^2 + 2*Fq.gen() + 2, Fq.gen() + 4))
         sage: ph(e)
-        (z2 + 2, 1)
+        (3*z3 + 3, 2*z3^2, 5*z3^2 + 4)
         """
         if self.twist_morphism is None and self.derivation is None:
             return self.base_morphism(x)
@@ -164,19 +170,21 @@ class FreeModulePseudoMorphism(Morphism):
 
         TESTS::
         """
-        r = "Free module pseudomorphism defined {}by the matrix\n{!r}{}{}\nDomain: {}\nCodomain: {}"
+        r = "Free module pseudomorphism defined {}by the \
+                matrix\n{!r}{}{}\nDomain: {}\nCodomain: {}"
         act = ""
         if self.side == "right":
             act = "as left-multiplication "
         morph = ""
         if self.twist_morphism is not None:
-            morph = "\nTwisted by the morphism {}"
+            morph = "\ntwisted by the morphism {}"
             morph = morph.format(self.twist_morphism.__repr__())
         deriv = ""
         if self.derivation is not None:
-            deriv = "\nTwisted by the derivation {}"
+            deriv = "\ntwisted by the derivation {}"
             deriv = deriv.format(self.derivation.__repr__())
-        return r.format(act, self.matrix(), morph, deriv, self.domain(), self.codomain())
+        return r.format(act, self.matrix(), morph, deriv, \
+                        self.domain(), self.codomain())
 
     def domain(self):
         r"""
@@ -211,5 +219,6 @@ class FreeModulePseudoMorphism(Morphism):
 
     def derivation(self):
         r"""
+        Return the twisting derivation of the pseudomorphism.
         """
         return self.derivation

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -3,14 +3,54 @@ Pseudomorphisms of free modules
 
 AUTHORS:
 
+    - Yossef Musleh (2024-02): initial version
+
+Let M be a free module over a ring R, and let $theta, delta: R to R$
+be a morphism and derivation of $R$ respectively such that 
+
+$delta(xy) = theta(x)delta(y) + x$.
+
+Then a pseudomorphism from $f : M to M$ is a map such that
+
+    $f(x + y) = f(x) + f(y)$
+    $f(lambda x) = theta(lambda)f(x) + delta(lambda)x$
+
+If $delta$ is the zero morphism, then we can relax the condition that the
+codomain is M and consider a free module $M'$ over a ring $R'$.
+
 
 TESTS::
 
-    sage: V = ZZ^2; f = V.hom([V.1, -2*V.0])
+    sage: V = ZZ^2
+    sage: f = V.pseudohom([V.1, -2*V.0]); f
+    Free module pseudomorphism defined by the matrix
+    [ 0  1]
+    [-2  0]
+    Domain: Ambient free module of rank 2 over the principal ideal domain Integer Ring
+    Codomain: Ambient free module of rank 2 over the principal ideal domain Integer Ring
+    sage: f(V((1, 2)))
+    (-4, 1)
+
+    sage: P.<x> = ZZ[]; deriv = P.derivation()
+    sage: M = P^2
+    sage: f = M.pseudohom([[1, 2*x], [x, 1]], deriv, side="right"); f
+    Free module pseudomorphism defined as left-multiplication by the matrix
+    [  1 2*x]
+    [  x   1]
+    Twisted by the derivation d/dx
+    Domain: Ambient free module of rank 2 over the integral domain Univariate Polynomial Ring in x over Integer Ring
+    Codomain: Ambient free module of rank 2 over the integral domain Univariate Polynomial Ring in x over Integer Ring
+    sage: e = M((2*x^2 + 3*x + 1, x^3 + 7*x + 4))
+    sage: f(e)
+    (2*x^4 + 16*x^2 + 15*x + 4, 3*x^3 + 6*x^2 + 8*x + 11)
+    sage: f = M.pseudohom([[1, 2], [1, 1]], deriv)
+    sage: f(e)
+    (x^3 + 2*x^2 + 14*x + 8, x^3 + 7*x^2 + 13*x + 13)
+
 """
 
 ####################################################################################
-#       Copyright (C) 2009 William Stein <wstein@gmail.com>
+#       Copyright (C) 2024 Yossef Musleh <jbobicus@gmail.com>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #
@@ -24,10 +64,6 @@ TESTS::
 #                  http://www.gnu.org/licenses/
 ####################################################################################
 
-# A matrix morphism is a morphism that is defined by multiplication by a
-# matrix.  Elements of domain must either have a method "vector()" that
-# returns a vector that the defining matrix can hit from the left, or
-# be coercible into vector space of appropriate dimension.
 import sage.modules.free_module as free_module
 from sage.categories.morphism import Morphism
 from sage.modules import free_module_homspace, matrix_morphism
@@ -44,6 +80,8 @@ lazy_import('sage.rings.derivation', 'RingDerivation')
 class FreeModulePseudoMorphism(Morphism):
     def __init__(self, domain, base_morphism, twist=None, codomain=None, side="left"):
         """
+        Constructs a pseudomorphism of free modules.
+
         INPUT:
             -  ``domain``   - the domain of the pseudomorphism; a free module 
 
@@ -57,10 +95,10 @@ class FreeModulePseudoMorphism(Morphism):
 
         EXAMPLES::
 
-            sage: V = ZZ^3; W = span([[1,2,3],[-1,2,8]], ZZ)
-            sage: phi = V.hom(matrix(ZZ,3,[1..9]))
+            sage: F = GF(25); V = F^3; twist = F.frobenius_endomorphism(5)
+            sage: phi = V.pseudohom(matrix(F,3,[1..9]), twist)
             sage: type(phi)
-            <class 'sage.modules.free_module_morphism.FreeModuleMorphism'>
+            <class 'sage.modules.free_module_pseudomorphism.FreeModulePseudoMorphism'>
         """
         from sage.structure.element import is_Matrix
         if is_Matrix(base_morphism):
@@ -80,8 +118,20 @@ class FreeModulePseudoMorphism(Morphism):
             else:
                 self.derivation = None
         self.side = side
-		
+
     def __call__(self, x):
+        r"""
+        Return the result of applying a pseudomorphism to an element of the
+        free module.
+
+        TESTS::
+
+        sage: Fq = GF(25); M = Fq^2; frob = Fq.frobenius_endomorphism(5)
+        sage: ph = M.pseudohom([[1, 2], [0, 1]], frob, side="right")
+        sage: e = M((3*Fq.gen() + 2, 2*Fq.gen() + 2))
+        sage: ph(e)
+        (z2 + 2, 1)
+        """
         if self.twist_morphism is None and self.derivation is None:
             return self.base_morphism(x)
         else:
@@ -94,15 +144,14 @@ class FreeModulePseudoMorphism(Morphism):
                 x = x.element()
             else:
                 x = self.domain().coordinate_vector(x)
-            if self.twist_morphism is None:
-                x_twistmorphism = x
-            else:
-                x_twistmorphism = self.domain()(list(map(self.twist_morphism, x)))
             C = self.codomain()
             if self.side == "left":
-                v = x_twistmorphism * self.matrix()
+                v = x * self.matrix()
             else:
-                v = self.matrix() * x_twistmorphism
+                v = self.matrix() * x
+            if self.twist_morphism is not None:
+                for i in range(len(v)):
+                    v[i] *= self.twist_morphism(x[i])
             if self.derivation is not None:
                 v += self.domain()(list(map(self.derivation, x)))
             if not C.is_ambient():
@@ -110,6 +159,11 @@ class FreeModulePseudoMorphism(Morphism):
             return C._element_constructor_(v)
 
     def __repr__(self):
+        r"""
+        Return the string representation of a pseudomorphism.
+
+        TESTS::
+        """
         r = "Free module pseudomorphism defined {}by the matrix\n{!r}{}{}\nDomain: {}\nCodomain: {}"
         act = ""
         if self.side == "right":
@@ -125,13 +179,37 @@ class FreeModulePseudoMorphism(Morphism):
         return r.format(act, self.matrix(), morph, deriv, self.domain(), self.codomain())
 
     def domain(self):
+        r"""
+        Return the domain of the pseudomorphism.
+        """
         return self.base_morphism.domain()
 
     def codomain(self):
+        r"""
+        Return the codomain of the pseudomorphism.
+        """
         return self.base_morphism.codomain()
 
     def matrix(self):
+        r"""
+        Return the underlying matrix of a pseudomorphism.
+        """
         return self.base_morphism.matrix()
 
     def base_morphism(self):
+        r"""
+        Return the underlying morphism of a pseudomorphism. This is an element
+        of the Hom space of the free module.
+        """
         return self.base_morphism
+
+    def twisting_morphism(self):
+        r"""
+        Return the twisting homomorphism of the pseudomorphism.
+        """
+        return self.twist_morphism
+
+    def derivation(self):
+        r"""
+        """
+        return self.derivation


### PR DESCRIPTION
The goal of this PR is to add a basic implementation of pseudomorphisms of free modules.

Let $M$ be a free module over a ring $R$. Let $\theta: R \to R$ be a ring homomorphism and $\delta: R \to R$ a ring $\theta$-derivation.

A pseudomorphism $f: M \to M$ is a map *twisted* by $(\theta, \delta)$ such that

$f(\lambda x) = \theta(\lambda)f(x) + \delta(\lambda)x$

$f$ can be specified by a matrix representing its action on a basis for $M$.

Currently this PR implements the following functionality:

- Constructors for pseudomorphisms and the space of pseudomorphisms with a fixed twist
- Call methods to apply pseudomorphisms to a fixed element of the module
- Call method for pseudohomspace to coerce matrix or module morphisms to a pseudomorphism

See the documentation for more details. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

None

