### PR TITLE
Remove invariants commands in global namespace

### DIFF
--- a/src/sage/schemes/hyperelliptic_curves/all.py
+++ b/src/sage/schemes/hyperelliptic_curves/all.py
@@ -1,45 +1,4 @@
-"""
-Tests for deprecations of imports in global namespace from :trac:`28064`::
-
-    sage: igusa_clebsch_invariants
-    doctest:warning...:
-    DeprecationWarning:
-    Importing igusa_clebsch_invariants from here is deprecated;
-    please use "from sage.schemes.hyperelliptic_curves.invariants import igusa_clebsch_invariants" instead.
-    See https://github.com/sagemath/sage/issues/28064 for details.
-    ...
-
-    sage: absolute_igusa_invariants_kohel
-    doctest:warning...:
-    DeprecationWarning:
-    Importing absolute_igusa_invariants_kohel from here is deprecated;
-    please use "from sage.schemes.hyperelliptic_curves.invariants import absolute_igusa_invariants_kohel" instead.
-    See https://github.com/sagemath/sage/issues/28064 for details.
-    ...
-
-    sage: absolute_igusa_invariants_wamelen
-    doctest:warning...:
-    DeprecationWarning:
-    Importing absolute_igusa_invariants_wamelen from here is deprecated;
-    please use "from sage.schemes.hyperelliptic_curves.invariants import absolute_igusa_invariants_wamelen" instead.
-    See https://github.com/sagemath/sage/issues/28064 for details.
-    ...
-
-    sage: clebsch_invariants
-    doctest:warning...:
-    DeprecationWarning:
-    Importing clebsch_invariants from here is deprecated;
-    please use "from sage.schemes.hyperelliptic_curves.invariants import clebsch_invariants" instead.
-    See https://github.com/sagemath/sage/issues/28064 for details.
-    ...
-"""
-from sage.misc.lazy_import import lazy_import
-
 from .constructor import HyperellipticCurve
 from .kummer_surface import KummerSurface
-lazy_import('sage.schemes.hyperelliptic_curves.invariants',
-            ['igusa_clebsch_invariants', 'absolute_igusa_invariants_kohel',
-             'absolute_igusa_invariants_wamelen', 'clebsch_invariants'],
-            deprecation=28064)
 from .mestre import (Mestre_conic, HyperellipticCurve_from_invariants)
 from . import monsky_washnitzer

--- a/src/sage/schemes/hyperelliptic_curves/invariants.py
+++ b/src/sage/schemes/hyperelliptic_curves/invariants.py
@@ -322,6 +322,7 @@ def igusa_clebsch_invariants(f):
         sage: igusa_clebsch_invariants(x^5 + a*x^4 + b*x^3 + c*x^2 + d*x + e)[0]
         6*b^2 - 16*a*c + 40*d
 
+        sage: from sage.schemes.hyperelliptic_curves.invariants import absolute_igusa_invariants_wamelen
         sage: absolute_igusa_invariants_wamelen(GF(5)['x'](x^6 - 2*x))
         Traceback (most recent call last):
         ...


### PR DESCRIPTION
This PR removes the depreciated invariants from #28064 (2019). It's been long enough and we should declutter the tab-autocomplete from these very specific functions.

As an aside, I'm not sure why we have:

```py
from . import monsky_washnitzer
```

Instead of importing objects from this module, but I have not worked with this myself so am loathed to modify this without further input from the community.