### PR TITLE
splitting_field: polred -> polredbest

### DIFF
--- a/src/sage/rings/number_field/splitting_field.py
+++ b/src/sage/rings/number_field/splitting_field.py
@@ -147,7 +147,7 @@ def splitting_field(poly, name, map=False, degree_multiple=None, abort_degree=No
 
     - ``simplify`` -- (default: ``True``) during the algorithm, try
       to find a simpler defining polynomial for the intermediate
-      number fields using PARI's ``polred()``.  This usually speeds
+      number fields using PARI's ``polredbest()``.  This usually speeds
       up the computation but can also considerably slow it down.
       Try and see what works best in the given situation.
 
@@ -549,11 +549,9 @@ def splitting_field(poly, name, map=False, degree_multiple=None, abort_degree=No
             # Find a simpler defining polynomial Lpol for Mpol
             verbose("New field before simplifying: %s" % Mpol, t)
             t = cputime()
-            M = Mpol.polred(flag=3)
-            n = len(M[0])-1
-            Lpol = M[1][n].change_variable_name("y")
-            LtoM = M[0][n].change_variable_name("y").Mod(Mpol.change_variable_name("y"))
-            MtoL = LtoM.modreverse()
+            M = Mpol.polredbest(1)
+            Lpol = M[0].change_variable_name("y")
+            MtoL = M[1].lift().change_variable_name("y").Mod(Lpol)
         else:
             # Lpol = Mpol
             Lpol = Mpol.change_variable_name("y")


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

This PR partially addresses https://github.com/sagemath/sage/issues/22165. It removes one (in `splitting_field`) of the two uses of the Pari deprecated function `polred`. The other one is less trivial to remove and should probably be discussed in the issue.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes. [the code is meant to be functionally equivalent]
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies
None
<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
