### PR TITLE
unit group of number field: do not expand product when S is empty

### DIFF
--- a/src/sage/rings/number_field/unit_group.py
+++ b/src/sage/rings/number_field/unit_group.py
@@ -305,6 +305,13 @@ class UnitGroup(AbelianGroupWithValues_class):
             sage: tuple(US(K(u)) for u in US.gens()) == US.gens()
             True
 
+        Bug #36386 (pari stack overflow while expanding units)
+            sage: d = 12936642
+            sage: K = QuadraticField(d)
+            sage: K.unit_group(proof=False)
+            Unit group with structure C2 x Z of Number Field in a with defining polynomial x^2 - 12936642 with a = 3596.754370262167?
+
+
         """
         proof = get_flag(proof, "number_field")
         K = number_field
@@ -340,20 +347,20 @@ class UnitGroup(AbelianGroupWithValues_class):
         # compute the additional S-unit generators:
         if S:
             self.__S_unit_data = pK.bnfunits(pS)
+            # TODO: converting the factored matrix representation of bnfunits into polynomial
+            # form is a *big* waste of time
+            su = [pK.nfbasistoalg(pK.nffactorback(z)) for z in self.__S_unit_data[0][0:len(S)]]
+            su = [K(u, check=False) for u in su]
         else:
-            self.__S_unit_data = pK.bnfunits()
-        # TODO: converting the factored matrix representation of bnfunits into polynomial
-        # form is a *big* waste of time
-        su_fu_tu = [pK.nfbasistoalg(pK.nffactorback(z)) for z in self.__S_unit_data[0]]
+            su = []
 
-        self.__nfu = len(pK.bnf_get_fu())           # number of fundamental units
-        self.__nsu = len(su_fu_tu) - self.__nfu - 1 # number of S-units
-        self.__ntu = pK.bnf_get_tu()[0]             # order of torsion
+        self.__nfu = len(fu)            # number of fundamental units
+        self.__nsu = len(su)            # number of S-units
+        self.__ntu = pK.bnf_get_tu()[0] # order of torsion
         self.__rank = self.__nfu + self.__nsu
 
-        # Move the torsion unit first, then fundamental units then S-units
-        gens = [K(u, check=False) for u in su_fu_tu]
-        gens = [gens[-1]] + gens[self.__nsu:-1] + gens[:self.__nsu]
+        # Put the torsion unit first, then fundamental units then S-units
+        gens = [K(pK.bnf_get_tu()[1], check=False)] + fu + su
 
         # Construct the abstract group:
         gens_orders = tuple([ZZ(self.__ntu)]+[ZZ(0)]*(self.__rank))

--- a/src/sage/rings/number_field/unit_group.py
+++ b/src/sage/rings/number_field/unit_group.py
@@ -305,7 +305,8 @@ class UnitGroup(AbelianGroupWithValues_class):
             sage: tuple(US(K(u)) for u in US.gens()) == US.gens()
             True
 
-        Bug #36386 (pari stack overflow while expanding units)
+        Bug :issue:`36386` (pari stack overflow while expanding units)::
+
             sage: d = 12936642
             sage: K = QuadraticField(d)
             sage: K.unit_group(proof=False)


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

This PR fixes https://github.com/sagemath/sage/issues/36386, at least for unit group computations (S-units will still suffer from the problem, or when the units are even larger). This PR does **not** address https://github.com/sagemath/sage/issues/31754, which would be a better (but more complicated) solution for the problem.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies
None
<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
