### PR TITLE
some pep8 fixes in coding, in particular E275

### DIFF
--- a/src/sage/coding/abstract_code.py
+++ b/src/sage/coding/abstract_code.py
@@ -128,7 +128,7 @@ def _explain_constructor(cl):
         var = "It accepts unspecified arguments as well.\n"
     else:
         var = ""
-    return("{}\n{}\n{}See the documentation of {}.{} for more details."
+    return ("{}\n{}\n{}See the documentation of {}.{} for more details."
             .format(reqs, opts, var, cl.__module__, cl.__name__))
 
 

--- a/src/sage/coding/code_bounds.py
+++ b/src/sage/coding/code_bounds.py
@@ -221,7 +221,7 @@ def _check_n_q_d(n, q, d, field_based=True):
         raise ValueError("The alphabet size must be an integer >1")
     if field_based and not is_prime_power(q):
         raise ValueError("The alphabet size does not make sense for a code over a field")
-    if not(0 < d <= n and n in ZZ and d in ZZ):
+    if not (0 < d <= n and n in ZZ and d in ZZ):
         raise ValueError("The length or minimum distance does not make sense")
     return True
 

--- a/src/sage/coding/cyclic_code.py
+++ b/src/sage/coding/cyclic_code.py
@@ -577,7 +577,7 @@ class CyclicCode(AbstractLinearCode):
               To:   Finite Field in z3 of size 2^3
               Defn: 1 |--> 1
         """
-        if not(hasattr(self, "_field_embedding")):
+        if not (hasattr(self, "_field_embedding")):
             self.defining_set()
         return self._field_embedding
 

--- a/src/sage/coding/cyclic_code.py
+++ b/src/sage/coding/cyclic_code.py
@@ -577,16 +577,17 @@ class CyclicCode(AbstractLinearCode):
               To:   Finite Field in z3 of size 2^3
               Defn: 1 |--> 1
         """
-        if not (hasattr(self, "_field_embedding")):
+        if not hasattr(self, "_field_embedding"):
             self.defining_set()
         return self._field_embedding
 
     def defining_set(self, primitive_root=None):
         r"""
         Return the set of exponents of the roots of ``self``'s generator
-        polynomial over the extension field. Of course, it depends on the
-        choice of the primitive root of the splitting field.
+        polynomial over the extension field.
 
+        Of course, it depends on the choice of the primitive root of
+        the splitting field.
 
         INPUT:
 

--- a/src/sage/coding/grs_code.py
+++ b/src/sage/coding/grs_code.py
@@ -258,11 +258,11 @@ class GeneralizedReedSolomonCode(AbstractLinearCode):
             True
         """
         return isinstance(other, GeneralizedReedSolomonCode) \
-                and self.base_field() == other.base_field() \
-                and self.length() == other.length() \
-                and self.dimension() == other.dimension() \
-                and self.evaluation_points() == other.evaluation_points() \
-                and self.column_multipliers() == other.column_multipliers()
+            and self.base_field() == other.base_field() \
+            and self.length() == other.length() \
+            and self.dimension() == other.dimension() \
+            and self.evaluation_points() == other.evaluation_points() \
+            and self.column_multipliers() == other.column_multipliers()
 
     def __hash__(self):
         """
@@ -298,9 +298,9 @@ class GeneralizedReedSolomonCode(AbstractLinearCode):
             [40, 12, 29] Generalized Reed-Solomon Code over GF(59)
         """
         return "[%s, %s, %s] %sReed-Solomon Code over GF(%s)"\
-                % (self.length(), self.dimension(), self.minimum_distance(),
-                   "Generalized " if self.is_generalized() else "",
-                   self.base_field().cardinality())
+            % (self.length(), self.dimension(), self.minimum_distance(),
+               "Generalized " if self.is_generalized() else "",
+               self.base_field().cardinality())
 
     def _latex_(self):
         r"""
@@ -319,9 +319,9 @@ class GeneralizedReedSolomonCode(AbstractLinearCode):
             [40, 12, 29] \textnormal{ Generalized Reed-Solomon Code over } \Bold{F}_{59}
         """
         return "[%s, %s, %s] \\textnormal{ %sReed-Solomon Code over } %s"\
-                % (self.length(), self.dimension(), self.minimum_distance(),
-                   "Generalized " if self.is_generalized() else "",
-                   self.base_field()._latex_())
+            % (self.length(), self.dimension(), self.minimum_distance(),
+               "Generalized " if self.is_generalized() else "",
+               self.base_field()._latex_())
 
     def minimum_distance(self):
         r"""
@@ -390,7 +390,7 @@ class GeneralizedReedSolomonCode(AbstractLinearCode):
             sage: C2.is_generalized()
             True
         """
-        return not all( beta.is_one() for beta in self.column_multipliers() )
+        return not all(beta.is_one() for beta in self.column_multipliers())
 
     @cached_method
     def multipliers_product(self):
@@ -538,7 +538,7 @@ class GeneralizedReedSolomonCode(AbstractLinearCode):
         q = self.base_ring().order()
         s = SR.var('s')
         wd = [1] + [0] * (d - 1)
-        for i in range(d, n+1):
+        for i in range(d, n + 1):
             tmp = binomial(n, i) * (q - 1)
             wd.append(tmp * symbolic_sum(binomial(i-1, s) * (-1)**s * q**(i - d - s), s, 0, i-d))
         return wd
@@ -647,9 +647,9 @@ def ReedSolomonCode(base_field, length, dimension, primitive_root=None):
     else:
         if primitive_root.multiplicative_order() != length:
             raise ValueError("Supplied primitive_root is not a primitive n'th root of unity")
-    return GeneralizedReedSolomonCode([ primitive_root**i for i in range(length) ], dimension)
+    return GeneralizedReedSolomonCode([primitive_root**i for i in range(length)], dimension)
 
-####################### encoders ###############################
+# ###################### encoders ###############################
 
 
 class GRSEvaluationVectorEncoder(Encoder):
@@ -723,7 +723,7 @@ class GRSEvaluationVectorEncoder(Encoder):
             False
         """
         return isinstance(other, GRSEvaluationVectorEncoder) \
-                and self.code() == other.code()
+            and self.code() == other.code()
 
     def _repr_(self):
         r"""
@@ -788,7 +788,7 @@ class GRSEvaluationVectorEncoder(Encoder):
         C = self.code()
         alphas = C.evaluation_points()
         col_mults = C.column_multipliers()
-        g = matrix(C.base_field(), C.dimension(), C.length(), lambda i,j: col_mults[j] * alphas[j]**i)
+        g = matrix(C.base_field(), C.dimension(), C.length(), lambda i, j: col_mults[j] * alphas[j]**i)
         g.set_immutable()
         return g
 
@@ -1086,7 +1086,7 @@ class GRSEvaluationPolynomialEncoder(Encoder):
     polynomial_ring = message_space
 
 
-####################### decoders ###############################
+# ###################### decoders ###############################
 
 
 class GRSBerlekampWelchDecoder(Decoder):
@@ -1184,7 +1184,7 @@ class GRSBerlekampWelchDecoder(Decoder):
              \textnormal{ Reed-Solomon Code over } \Bold{F}_{59}
         """
         return "\\textnormal{Berlekamp Welch decoder for }%s"\
-                % self.code()._latex_()
+            % self.code()._latex_()
 
     def _decode_to_code_and_message(self, r):
         r"""
@@ -1235,8 +1235,8 @@ class GRSBerlekampWelchDecoder(Decoder):
         l0 = n-1-t
         l1 = n-1-t-(k-1)
         S = matrix(C.base_field(), n, l0+l1+2,
-                    lambda i, j: (C.evaluation_points()[i])**j if j < (l0+1)
-                    else r_list[i]*(C.evaluation_points()[i])**(j-(l0+1)))
+                   lambda i, j: (C.evaluation_points()[i])**j if j < (l0+1)
+                   else r_list[i]*(C.evaluation_points()[i])**(j-(l0+1)))
         S = S.right_kernel()
         S = S.basis_matrix().row(0)
         R = C.base_field()['x']
@@ -1574,7 +1574,7 @@ class GRSGaoDecoder(Decoder):
 
         r = b
         prev_r = a
-        while(r.degree() >= stop):
+        while (r.degree() >= stop):
             q = prev_r.quo_rem(r)[0]
             (prev_r, r) = (r, prev_r - q * r)
             (prev_s, s) = (s, prev_s - q * s)
@@ -1858,9 +1858,9 @@ class GRSErrorErasureDecoder(Decoder):
             False
         """
         return isinstance(other, GRSErrorErasureDecoder) \
-                and self.code() == other.code()
+            and self.code() == other.code()
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         r"""
         Return a string representation of ``self``.
 
@@ -1890,7 +1890,7 @@ class GRSErrorErasureDecoder(Decoder):
              \textnormal{ Reed-Solomon Code over } \Bold{F}_{59}
         """
         return "\\textnormal{Error-Erasure decoder for }%s"\
-                % self.code()._latex_()
+            % self.code()._latex_()
 
     def decode_to_message(self, word_and_erasure_vector):
         r"""
@@ -2095,8 +2095,8 @@ class GRSKeyEquationSyndromeDecoder(Decoder):
             False
         """
         return isinstance(other, GRSKeyEquationSyndromeDecoder) \
-                and self.code() == other.code()\
-                and self.input_space() == other.input_space()
+            and self.code() == other.code()\
+            and self.input_space() == other.input_space()
 
     def _repr_(self):
         r"""
@@ -2165,7 +2165,7 @@ class GRSKeyEquationSyndromeDecoder(Decoder):
         prev_r = a
         r = b
 
-        while(r.degree() >= t.degree()):
+        while (r.degree() >= t.degree()):
             q = prev_r.quo_rem(r)[0]
             prev_r, r = r, prev_r - q * r
             prev_t, t = t, prev_t - q * t
@@ -2376,10 +2376,10 @@ class GRSKeyEquationSyndromeDecoder(Decoder):
             sage: D.decoding_radius()
             14
         """
-        return (self.code().minimum_distance()-1) // 2
+        return (self.code().minimum_distance() - 1) // 2
 
 
-####################### registration ###############################
+# ###################### registration ###############################
 
 GeneralizedReedSolomonCode._registered_encoders["EvaluationVector"] = GRSEvaluationVectorEncoder
 GeneralizedReedSolomonCode._registered_encoders["EvaluationPolynomial"] = GRSEvaluationPolynomialEncoder

--- a/src/sage/coding/grs_code.py
+++ b/src/sage/coding/grs_code.py
@@ -1229,14 +1229,15 @@ class GRSBerlekampWelchDecoder(Decoder):
         col_mults = C.column_multipliers()
 
         r_list = copy(r)
-        r_list = [r[i]/col_mults[i] for i in range(0, C.length())]
+        r_list = [r[i] / col_mults[i] for i in range(C.length())]
 
-        t = (C.minimum_distance()-1) // 2
-        l0 = n-1-t
-        l1 = n-1-t-(k-1)
-        S = matrix(C.base_field(), n, l0+l1+2,
-                   lambda i, j: (C.evaluation_points()[i])**j if j < (l0+1)
-                   else r_list[i]*(C.evaluation_points()[i])**(j-(l0+1)))
+        t = (C.minimum_distance() - 1) // 2
+        l0 = n - 1 - t
+        l1 = n - t - k
+        pts = C.evaluation_points()
+        S = matrix(C.base_field(), n, l0 + l1 + 2,
+                   lambda i, j: (pts[i]**j if j < (l0 + 1)
+                                 else r_list[i] * pts[i]**(j - (l0 + 1))))
         S = S.right_kernel()
         S = S.basis_matrix().row(0)
         R = C.base_field()['x']
@@ -1574,7 +1575,7 @@ class GRSGaoDecoder(Decoder):
 
         r = b
         prev_r = a
-        while (r.degree() >= stop):
+        while r.degree() >= stop:
             q = prev_r.quo_rem(r)[0]
             (prev_r, r) = (r, prev_r - q * r)
             (prev_s, s) = (s, prev_s - q * s)
@@ -2165,7 +2166,7 @@ class GRSKeyEquationSyndromeDecoder(Decoder):
         prev_r = a
         r = b
 
-        while (r.degree() >= t.degree()):
+        while r.degree() >= t.degree():
             q = prev_r.quo_rem(r)[0]
             prev_r, r = r, prev_r - q * r
             prev_t, t = t, prev_t - q * t

--- a/src/sage/coding/linear_code.py
+++ b/src/sage/coding/linear_code.py
@@ -277,11 +277,11 @@ def _dump_code_in_leon_format(C):
     from sage.misc.temporary_file import tmp_filename
     F = C.base_ring()
     p = F.order()  # must be prime and <11
-    s = "LIBRARY code;\n"+"code=seq(%s,%s,%s,seq(\n" % (p,C.dimension(),C.length())
-    Gr = [str(r)[1:-1].replace(" ","") for r in C.generator_matrix().rows()]
+    s = "LIBRARY code;\n" + "code=seq(%s,%s,%s,seq(\n" % (p, C.dimension(), C.length())
+    Gr = [str(r)[1:-1].replace(" ", "") for r in C.generator_matrix().rows()]
     s += ",\n".join(Gr) + "\n));\nFINISH;"
     file_loc = tmp_filename()
-    f = open(file_loc,"w")
+    f = open(file_loc, "w")
     f.write(s)
     f.close()
 
@@ -523,7 +523,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
         """
         aut_group_can_label = self._canonize(equivalence)
         return aut_group_can_label.get_autom_gens(), \
-               aut_group_can_label.get_autom_order()
+            aut_group_can_label.get_autom_order()
 
     def assmus_mattson_designs(self, t, mode=None):
         r"""
@@ -605,29 +605,29 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
         n = len(G.columns())
         Cp = C.dual_code()
         wts = C.weight_distribution()
-        d = min([i for i in range(1,len(wts)) if wts[i] != 0])
+        d = min([i for i in range(1, len(wts)) if wts[i] != 0])
         if t >= d:
             return 0
-        nonzerowts = [i for i in range(len(wts)) if wts[i] != 0 and i <= n and i >= d]
+        nonzerowts = [i for i in range(len(wts)) if wts[i] != 0 and d <= i <= n]
         if mode == "verbose":
             for w in nonzerowts:
                 print("The weight w={} codewords of C* form a t-(v,k,lambda) design, where\n \
-                        t={}, v={}, k={}, lambda={}. \nThere are {} block of this design.".format(
-                            w,t,n,w,wts[w]*binomial(w,t)//binomial(n,t),wts[w]))
+                t={}, v={}, k={}, lambda={}. \nThere are {} block of this design.".format(
+                    w, t, n, w, wts[w] * binomial(w, t) // binomial(n, t), wts[w]))
         wtsp = Cp.weight_distribution()
-        dp = min([i for i in range(1,len(wtsp)) if wtsp[i] != 0])
+        dp = min([i for i in range(1, len(wtsp)) if wtsp[i] != 0])
         nonzerowtsp = [i for i in range(len(wtsp)) if wtsp[i] != 0 and i <= n-t and i >= dp]
-        s = len([i for i in range(1,n) if wtsp[i] != 0 and i <= n-t and i > 0])
+        s = len([i for i in range(1, n) if wtsp[i] != 0 and 0 < i <= n-t])
         if mode == "verbose":
             for w in nonzerowtsp:
                 print("The weight w={} codewords of C* form a t-(v,k,lambda) design, where\n \
-                        t={}, v={}, k={}, lambda={}. \nThere are {} block of this design.".format(
-                            w,t,n,w,wts[w]*binomial(w,t)//binomial(n,t),wts[w]))
+                t={}, v={}, k={}, lambda={}. \nThere are {} block of this design.".format(
+                    w, t, n, w, wts[w] * binomial(w, t) // binomial(n, t), wts[w]))
         if s <= d-t:
-            des = [[t,(n,w,wts[w]*binomial(w,t)//binomial(n,t))] for w in nonzerowts]
-            ans = ans + ["weights from C: ",nonzerowts,"designs from C: ",des]
-            desp = [[t,(n,w,wtsp[w]*binomial(w,t)//binomial(n,t))] for w in nonzerowtsp]
-            ans = ans + ["weights from C*: ",nonzerowtsp,"designs from C*: ",desp]
+            des = [[t, (n, w, wts[w] * binomial(w, t) // binomial(n, t))] for w in nonzerowts]
+            ans = ans + ["weights from C: ", nonzerowts, "designs from C: ", des]
+            desp = [[t, (n, w, wtsp[w] * binomial(w, t) // binomial(n, t))] for w in nonzerowtsp]
+            ans = ans + ["weights from C*: ", nonzerowtsp, "designs from C*: ", desp]
             return ans
         return 0
 
@@ -669,15 +669,15 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
         d = self.minimum_distance()
         F = self.base_ring()
         q = F.order()
-        J = range(1,n+1)
+        J = range(1, n+1)
         Cp = self.dual_code()
         dp = Cp.minimum_distance()
         if i < d:
             return 0
-        if i > n-dp and i <= n:
-            return binomial(n,i)*(q**(i+k-n) - 1)//(q-1)
+        if n - dp < i <= n:
+            return binomial(n, i)*(q**(i+k-n) - 1)//(q-1)
         from sage.combinat.set_partition import SetPartitions
-        P = SetPartitions(J,2).list()
+        P = SetPartitions(J, 2).list()
         b = QQ(0)
         for p in P:
             p = list(p)
@@ -794,7 +794,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
         """
         aut_group_can_label = self._canonize(equivalence)
         return aut_group_can_label.get_canonical_form(), \
-               aut_group_can_label.get_transporter()
+            aut_group_can_label.get_transporter()
 
     def characteristic(self):
         r"""
@@ -877,7 +877,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
             P = RT(C.zeta_polynomial())*T**(d - dperp)
             if is_even(n):
                 Pd = q**(k-n/2)*RT(Cd.zeta_polynomial())
-            if not(is_even(n)):
+            if not (is_even(n)):
                 Pd = s*q**(k-(n+1)/2)*RT(Cd.zeta_polynomial())
             CP = P+Pd
             f = CP/CP(1,s)
@@ -886,7 +886,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
             P = RT(C.zeta_polynomial())
             if is_even(n):
                 Pd = q**(k-n/2)*RT(Cd.zeta_polynomial())
-            if not(is_even(n)):
+            if not (is_even(n)):
                 Pd = s*q**(k-(n+1)/2)*RT(Cd.zeta_polynomial())
             CP = P+Pd
             f = CP/CP(1,s)
@@ -1660,13 +1660,13 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
                 matCwt = [c.VectorCodeword() for c in Cwt]            # for each i until stop = 1)
                 if len(matCwt) > 0:
                     A = libgap(matCwt).MatrixAutomorphisms()
-                    Gp = A.Intersection2(Gp)  #  bottleneck 3
+                    Gp = A.Intersection2(Gp)  # bottleneck 3
                     if Gp.Size() == 1:
                         return PermutationGroup([()])
                     gens = Gp.GeneratorsOfGroup()
                     stop = 1                    # get ready to stop
                     for x in gens:              # if one of these gens is not an auto then don't stop
-                        if not(self.is_permutation_automorphism(Sn_sage(x))):
+                        if not (self.is_permutation_automorphism(Sn_sage(x))):
                             stop = 0
                             break
             G = PermutationGroup(list(map(Sn_sage, gens)))
@@ -1877,7 +1877,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
             from sage.coding.binary_code import weight_dist
             return weight_dist(self.generator_matrix())
         elif algorithm == "leon":
-            if not(F.order() in [2,3,5,7]):
+            if not (F.order() in [2,3,5,7]):
                 raise NotImplementedError("The algorithm 'leon' is only implemented for q = 2,3,5,7.")
             # The GAP command DirectoriesPackageLibrary tells the location of the latest
             # version of the Guava libraries, so gives us the location of the Guava binaries too.
@@ -2030,16 +2030,16 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
         if d == 1 or dperp == 1:
             print("\n WARNING: There is no guarantee this function works when the minimum distance")
             print("            of the code or of the dual code equals 1.\n")
-        RT = PolynomialRing(QQ,"%s" % name)
-        R = PolynomialRing(QQ,3,"xy%s" % name)
-        x,y,T = R.gens()
+        RT = PolynomialRing(QQ, "%s" % name)
+        R = PolynomialRing(QQ, 3, "xy%s" % name)
+        x, y, T = R.gens()
         we = self.weight_enumerator()
         A = R(we)
-        #B = A(x+y,y,T)-(x+y)**n
-        B = A(x,x+y,T)-(x+y)**n
+        # B = A(x+y,y,T)-(x+y)**n
+        B = A(x, x+y, T)-(x+y)**n
         Bs = B.coefficients()
         Bs.reverse()
-        b = [Bs[i]/binomial(n,i+d) for i in range(len(Bs))]
+        b = [Bs[i]/binomial(n, i+d) for i in range(len(Bs))]
         r = n-d-dperp+2
         P_coeffs = []
         for i in range(len(b)):
@@ -2397,7 +2397,7 @@ class LinearCode(AbstractLinearCode):
             [7, 4]\textnormal{ Linear code over }\Bold{F}_{2}
         """
         return "[%s, %s]\\textnormal{ Linear code over }%s"\
-                % (self.length(), self.dimension(), self.base_ring()._latex_())
+            % (self.length(), self.dimension(), self.base_ring()._latex_())
 
     def generator_matrix(self, encoder_name=None, **kwargs):
         r"""
@@ -2428,7 +2428,7 @@ class LinearCode(AbstractLinearCode):
         return g
 
 
-####################### encoders ###############################
+# ###################### encoders ###############################
 
 class LinearCodeGeneratorMatrixEncoder(Encoder):
     r"""
@@ -2467,7 +2467,7 @@ class LinearCodeGeneratorMatrixEncoder(Encoder):
             True
         """
         return isinstance(other, LinearCodeGeneratorMatrixEncoder)\
-                and self.code() == other.code()
+            and self.code() == other.code()
 
     def _repr_(self):
         r"""
@@ -2519,7 +2519,7 @@ class LinearCodeGeneratorMatrixEncoder(Encoder):
         return g
 
 
-####################### decoders ###############################
+# ###################### decoders ###############################
 
 class LinearCodeSyndromeDecoder(Decoder):
     r"""
@@ -2812,18 +2812,18 @@ class LinearCodeSyndromeDecoder(Decoder):
         F = C.base_ring()
         l = list(F)
         zero = F.zero()
-        #Builds a list of generators of all error positions for all
-        #possible error weights
+        # Builds a list of generators of all error positions for all
+        # possible error weights
         if zero in l:
             l.remove(zero)
         # Remember to include the no-error-vector to handle codes of minimum
         # distance 1 gracefully
-        zero_syndrome = vector(F,[F.zero()]*(n-k))
+        zero_syndrome = vector(F, [F.zero()]*(n-k))
         zero_syndrome.set_immutable()
-        lookup = {zero_syndrome: vector(F,[F.zero()]*n)}
+        lookup = {zero_syndrome: vector(F, [F.zero()]*n)}
         error_position_tables = [cartesian_product([l]*i) for i in range(1, t+1)]
         first_collision = True
-        #Filling the lookup table
+        # Filling the lookup table
         for i in range(1, t+1):
             stop = True
             patterns = Subsets(range(n), i)
@@ -2839,16 +2839,16 @@ class LinearCodeSyndromeDecoder(Decoder):
                     s.set_immutable()
                     try:
                         e_cur = lookup[s]
-                        #if this is the first time we see a collision
-                        #we learn the minimum distance of the code
+                        # if this is the first time we see a collision
+                        # we learn the minimum distance of the code
                         if first_collision:
                             self._code_minimum_distance = e.hamming_weight() + e_cur.hamming_weight()
                             first_collision = False
                     except KeyError:
                         stop = False
                         lookup[s] = copy(e)
-            #if we reached the early termination condition
-            #we learn the covering radius of the code
+            # if we reached the early termination condition
+            # we learn the covering radius of the code
             if stop:
                 self._code_covering_radius = i - 1
                 self._maximum_error_weight = self._code_covering_radius
@@ -3001,9 +3001,9 @@ class LinearCodeNearestNeighborDecoder(Decoder):
             True
         """
         return isinstance(other, LinearCodeNearestNeighborDecoder)\
-                and self.code() == other.code()
+            and self.code() == other.code()
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         r"""
         Return a string representation of ``self``.
 
@@ -3079,7 +3079,7 @@ class LinearCodeNearestNeighborDecoder(Decoder):
         return (self.code().minimum_distance()-1) // 2
 
 
-####################### registration ###############################
+# ###################### registration ###############################
 
 LinearCode._registered_encoders["GeneratorMatrix"] = LinearCodeGeneratorMatrixEncoder
 

--- a/src/sage/coding/linear_code.py
+++ b/src/sage/coding/linear_code.py
@@ -877,7 +877,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
             P = RT(C.zeta_polynomial())*T**(d - dperp)
             if is_even(n):
                 Pd = q**(k-n/2)*RT(Cd.zeta_polynomial())
-            if not (is_even(n)):
+            if not is_even(n):
                 Pd = s*q**(k-(n+1)/2)*RT(Cd.zeta_polynomial())
             CP = P+Pd
             f = CP/CP(1,s)
@@ -886,7 +886,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
             P = RT(C.zeta_polynomial())
             if is_even(n):
                 Pd = q**(k-n/2)*RT(Cd.zeta_polynomial())
-            if not (is_even(n)):
+            if not is_even(n):
                 Pd = s*q**(k-(n+1)/2)*RT(Cd.zeta_polynomial())
             CP = P+Pd
             f = CP/CP(1,s)
@@ -1666,7 +1666,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
                     gens = Gp.GeneratorsOfGroup()
                     stop = 1                    # get ready to stop
                     for x in gens:              # if one of these gens is not an auto then don't stop
-                        if not (self.is_permutation_automorphism(Sn_sage(x))):
+                        if not self.is_permutation_automorphism(Sn_sage(x)):
                             stop = 0
                             break
             G = PermutationGroup(list(map(Sn_sage, gens)))
@@ -1877,7 +1877,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
             from sage.coding.binary_code import weight_dist
             return weight_dist(self.generator_matrix())
         elif algorithm == "leon":
-            if not (F.order() in [2,3,5,7]):
+            if F.order() not in [2, 3, 5, 7]:
                 raise NotImplementedError("The algorithm 'leon' is only implemented for q = 2,3,5,7.")
             # The GAP command DirectoriesPackageLibrary tells the location of the latest
             # version of the Guava libraries, so gives us the location of the Guava binaries too.

--- a/src/sage/coding/linear_code_no_metric.py
+++ b/src/sage/coding/linear_code_no_metric.py
@@ -891,12 +891,9 @@ class AbstractLinearCodeNoMetric(AbstractCode, Module):
             True
         """
         G = self.generator_matrix()
-        for r in G.rows():
-            if not (r in other):
-                return False
-        return True
+        return all(r in other for r in G.rows())
 
-    def is_permutation_automorphism(self,g):
+    def is_permutation_automorphism(self, g):
         r"""
         Return `1` if `g` is an element of `S_n` (`n` = length of ``self``) and
         if `g` is an automorphism of ``self``.

--- a/src/sage/coding/linear_code_no_metric.py
+++ b/src/sage/coding/linear_code_no_metric.py
@@ -892,7 +892,7 @@ class AbstractLinearCodeNoMetric(AbstractCode, Module):
         """
         G = self.generator_matrix()
         for r in G.rows():
-            if not(r in other):
+            if not (r in other):
                 return False
         return True
 

--- a/src/sage/coding/punctured_code.py
+++ b/src/sage/coding/punctured_code.py
@@ -328,7 +328,7 @@ class PuncturedCode(AbstractLinearCode):
         C = self.original_code()
         pts = copy(self.punctured_positions())
         list_pts = list(pts)
-        while (isinstance(C, PuncturedCode)):
+        while isinstance(C, PuncturedCode):
             cur_pts = list(C.punctured_positions())
             list_len = len(list_pts)
             for p in cur_pts:

--- a/src/sage/coding/punctured_code.py
+++ b/src/sage/coding/punctured_code.py
@@ -328,7 +328,7 @@ class PuncturedCode(AbstractLinearCode):
         C = self.original_code()
         pts = copy(self.punctured_positions())
         list_pts = list(pts)
-        while(isinstance(C, PuncturedCode)):
+        while (isinstance(C, PuncturedCode)):
             cur_pts = list(C.punctured_positions())
             list_len = len(list_pts)
             for p in cur_pts:

--- a/src/sage/coding/reed_muller_code.py
+++ b/src/sage/coding/reed_muller_code.py
@@ -258,9 +258,9 @@ class QAryReedMullerCode(AbstractLinearCode):
         # input sanitization
         if base_field not in FiniteFields():
             raise ValueError("the input `base_field` must be a FiniteField")
-        if not(isinstance(order, (Integer, int))):
+        if not (isinstance(order, (Integer, int))):
             raise ValueError("The order of the code must be an integer")
-        if not(isinstance(num_of_var, (Integer, int))):
+        if not (isinstance(num_of_var, (Integer, int))):
             raise ValueError("The number of variables must be an integer")
         q = base_field.cardinality()
         if order >= q:
@@ -425,9 +425,9 @@ class BinaryReedMullerCode(AbstractLinearCode):
             ValueError: The order of the code must be an integer
         """
         # input sanitization
-        if not(isinstance(order, (Integer, int))):
+        if not (isinstance(order, (Integer, int))):
             raise ValueError("The order of the code must be an integer")
-        if not(isinstance(num_of_var, (Integer, int))):
+        if not (isinstance(num_of_var, (Integer, int))):
             raise ValueError("The number of variables must be an integer")
         if (num_of_var < order):
             raise ValueError(
@@ -836,7 +836,7 @@ class ReedMullerPolynomialEncoder(Encoder):
             False
         """
         return isinstance(other, ReedMullerPolynomialEncoder) \
-               and self.code() == other.code()
+            and self.code() == other.code()
 
     def encode(self, p):
         r"""
@@ -984,7 +984,7 @@ class ReedMullerPolynomialEncoder(Encoder):
         return ((code.base_field())**code.number_of_variables()).list()
 
 
-####################### registration ###############################
+# --------------- registration --------------
 
 QAryReedMullerCode._registered_encoders["EvaluationVector"] = ReedMullerVectorEncoder
 QAryReedMullerCode._registered_encoders["EvaluationPolynomial"] = ReedMullerPolynomialEncoder

--- a/src/sage/coding/reed_muller_code.py
+++ b/src/sage/coding/reed_muller_code.py
@@ -258,9 +258,9 @@ class QAryReedMullerCode(AbstractLinearCode):
         # input sanitization
         if base_field not in FiniteFields():
             raise ValueError("the input `base_field` must be a FiniteField")
-        if not (isinstance(order, (Integer, int))):
+        if not isinstance(order, (Integer, int)):
             raise ValueError("The order of the code must be an integer")
-        if not (isinstance(num_of_var, (Integer, int))):
+        if not isinstance(num_of_var, (Integer, int)):
             raise ValueError("The number of variables must be an integer")
         q = base_field.cardinality()
         if order >= q:
@@ -425,9 +425,9 @@ class BinaryReedMullerCode(AbstractLinearCode):
             ValueError: The order of the code must be an integer
         """
         # input sanitization
-        if not (isinstance(order, (Integer, int))):
+        if not isinstance(order, (Integer, int)):
             raise ValueError("The order of the code must be an integer")
-        if not (isinstance(num_of_var, (Integer, int))):
+        if not isinstance(num_of_var, (Integer, int)):
             raise ValueError("The number of variables must be an integer")
         if (num_of_var < order):
             raise ValueError(


### PR DESCRIPTION
this fixes various pycodestyle warnings in coding, in particular E275

`E275 missing whitespace after keyword`

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.