### PR TITLE
fix small mistake in BQFClassGroupQuotientMorphism documentation

### DIFF
--- a/src/sage/quadratic_forms/bqf_class_group.py
+++ b/src/sage/quadratic_forms/bqf_class_group.py
@@ -728,9 +728,6 @@ class BQFClassGroupQuotientMorphism(Morphism):
     is defined by finding a class representative `[a,b,c]` satisfying
     `f^2 \mid a` and `f \mid b` and substituting `x \mapsto x/f`.
 
-    Alternatively, one may pass the discriminants `f^2 D` and `D` instead
-    of the :class:`BQFClassGroup` objects `G` and `H`.
-
     This map is a well-defined group homomorphism.
 
     EXAMPLES::


### PR DESCRIPTION
The possibility to pass discriminants to the constructor instead of `BQFClassGroup` objects was present for an earlier version of #37074, but it was removed during review. However, it seems I forgot to update the docstring accordingly.