### PR TITLE
[WIP] Added function to check if a graph is trivially perfect or not

### DIFF
--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -909,6 +909,47 @@ class DiGraph(GenericGraph):
 
     # Attributes
 
+    def is_trivially_perfect(graph):
+        """
+        Check if the given directed graph is trivially perfect.
+    
+        A directed graph is trivially perfect if it does not contain induced subgraphs
+        isomorphic to C4 (cycle of length 4) or P4 (path of length 4).
+    
+        INPUT:
+        - ``graph`` -- a directed graph
+    
+        EXAMPLES:
+        ::
+            sage: G = DiGraph([(1, 2), (2, 3), (2, 4), (2, 5), (2, 6), (2, 7), (2, 8), (4, 5), (4, 6), (5, 6), (5, 7), (5, 8), (6, 8), (6,7), (7,8)])
+            sage: is_tp = is_trivially_perfect(G)
+            True
+    
+        """
+        induced_subgraphs = list(graph.connected_subgraph_iterator(k=4, exactly_k=True))
+        for subgraph in induced_subgraphs:
+            # Check for C4 (cycle of length 4)
+            c4_present = True
+            for vertex in subgraph:
+                if subgraph.degree(vertex) != 2:
+                    c4_present = False
+                    break
+            if c4_present:
+                return False
+            
+            # Check for P4 (path of length 4)
+            p4_present = True
+            for vertex in subgraph:
+                if subgraph.degree(vertex) > 2:
+                    p4_present = False
+                    break
+            if p4_present:
+                if subgraph.to_undirected().is_tree():
+                    return False
+                else:
+                    p4_present = False
+        return True
+
     def is_directed(self):
         """
         Since digraph is directed, return ``True``.

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -909,7 +909,7 @@ class DiGraph(GenericGraph):
 
     # Attributes
 
-    def is_trivially_perfect(graph):
+    def is_trivially_perfect(self):
         """
         Check if the given directed graph is trivially perfect.
     


### PR DESCRIPTION
### Describe your changes here in detail 
My implementation is based upon the following: "They are the graphs that do not have a P4 [path graph](https://en.wikipedia.org/wiki/Path_graph) or a C4 [cycle graph](https://en.wikipedia.org/wiki/Cycle_graph) as [induced subgraphs](https://en.wikipedia.org/wiki/Induced_subgraph).[[6]](https://en.wikipedia.org/wiki/Trivially_perfect_graph#cite_note-6)". I check all the connected induced subgraphs of size 4 for C4 and P4. If any of the induced subgraphs have a P4 or C4, the input graph is not trivially perfect.

### Why is this change required? What problem does it solve?
This change is required to provide functionality to check if a directed graph satisfies the trivial perfectness property. Fixes #37243

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

No dependancy on any open PR.

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->