### PR TITLE
`sage.groups.generic`: Fix incorrect identity testing

### DIFF
--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -119,7 +119,6 @@ from copy import copy
 
 from sage.arith.misc import integer_ceil, integer_floor, xlcm
 from sage.arith.srange import xsrange
-from sage.misc.functional import log
 from sage.misc.misc_c import prod
 import sage.rings.integer_ring as integer_ring
 import sage.rings.integer
@@ -171,9 +170,11 @@ def multiple(a, n, operation='*', identity=None, inverse=None, op=None):
         sage: E = EllipticCurve('389a1')
         sage: P = E(-1,1)
         sage: multiple(P, 10, '+')
-        (645656132358737542773209599489/22817025904944891235367494656 : 525532176124281192881231818644174845702936831/3446581505217248068297884384990762467229696 : 1)
+        (645656132358737542773209599489/22817025904944891235367494656 :
+         525532176124281192881231818644174845702936831/3446581505217248068297884384990762467229696 : 1)
         sage: multiple(P, -10, '+')
-        (645656132358737542773209599489/22817025904944891235367494656 : -528978757629498440949529703029165608170166527/3446581505217248068297884384990762467229696 : 1)
+        (645656132358737542773209599489/22817025904944891235367494656 :
+         -528978757629498440949529703029165608170166527/3446581505217248068297884384990762467229696 : 1)
     """
     from operator import inv, mul, neg, add
 
@@ -332,11 +333,11 @@ class multiples:
                 P0 = P.parent()(0)
             self.op = add
         else:
-            self.op = op
             if P0 is None:
                 raise ValueError("P0 must be supplied when operation is neither addition nor multiplication")
             if op is None:
                 raise ValueError("op() must both be supplied when operation is neither addition nor multiplication")
+            self.op = op
 
         self.P = copy(P)
         self.Q = copy(P0)
@@ -458,6 +459,7 @@ def bsgs(a, b, bounds, operation='*', identity=None, inverse=None, op=None):
         inverse = inv
         op = mul
     elif operation in addition_names:
+        # Should this be replaced with .zero()? With an extra AttributeError handler?
         identity = a.parent()(0)
         inverse = neg
         op = add
@@ -469,7 +471,7 @@ def bsgs(a, b, bounds, operation='*', identity=None, inverse=None, op=None):
     if lb < 0 or ub < lb:
         raise ValueError("bsgs() requires 0<=lb<=ub")
 
-    if a.is_zero() and not b.is_zero():
+    if a == identity and b != identity:
         raise ValueError("no solution in bsgs()")
 
     ran = 1 + ub - lb   # the length of the interval
@@ -1410,6 +1412,7 @@ def order_from_bounds(P, bounds, d=None, operation='+',
 
     return order_from_multiple(P, m, operation=operation, check=False)
 
+
 def has_order(P, n, operation='+'):
     r"""
     Generic function to test if a group element `P` has order
@@ -1497,8 +1500,8 @@ def has_order(P, n, operation='+'):
 
         fl = fn[::2]
         fr = fn[1::2]
-        l = prod(p**k for p,k in fl)
-        r = prod(p**k for p,k in fr)
+        l = prod(p**k for p, k in fl)
+        r = prod(p**k for p, k in fr)
         L, R = mult(Q, r), mult(Q, l)
         return _rec(L, fl) and _rec(R, fr)
 

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -481,7 +481,7 @@ def bsgs(a, b, bounds, operation='*', identity=None, inverse=None, op=None):
 
     if ran < 30:    # use simple search for small ranges
         d = c
-#        for i,d in multiples(a,ran,c,indexed=True,operation=operation):
+        #        for i,d in multiples(a,ran,c,indexed=True,operation=operation):
         for i0 in range(ran):
             i = lb + i0
             if identity == d:        # identity == b^(-1)*a^i, so return i
@@ -1189,7 +1189,7 @@ def linear_relation(P, Q, operation='+', identity=None, inverse=None, op=None):
 
 
 def order_from_multiple(P, m, plist=None, factorization=None, check=True,
-                        operation='+'):
+                        operation='+', identity=None, inverse=None, op=None):
     r"""
     Generic function to find order of a group element given a multiple
     of its order.
@@ -1259,14 +1259,23 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
     elif operation in addition_names:
         identity = P.parent()(0)
     else:
-        raise ValueError("unknown group operation")
+        if identity is None or inverse is None or op is None:
+            raise ValueError("identity, inverse and operation must all be specified")
+
+    def _multiple(A, B):
+        return multiple(A,
+                        B,
+                        operation=operation,
+                        identity=identity,
+                        inverse=inverse,
+                        op=op)
 
     if P == identity:
         return Z.one()
 
     M = Z(m)
     if check:
-        assert multiple(P, M, operation=operation) == identity
+        assert _multiple(P, M) == identity
 
     if factorization:
         F = factorization
@@ -1295,7 +1304,7 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
             p, e = L[0]
             e0 = 0
             while (Q != identity) and (e0 < e - 1):
-                Q = multiple(Q, p, operation=operation)
+                Q = _multiple(Q, p)
                 e0 += 1
             if Q != identity:
                 e0 += 1
@@ -1314,12 +1323,8 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
             L2 = L[k:]
             # recursive calls
             o1 = _order_from_multiple_helper(
-                multiple(Q, prod([p**e for p, e in L2]), operation),
-                L1,
-                sum_left)
-            o2 = _order_from_multiple_helper(multiple(Q, o1, operation),
-                                             L2,
-                                             S - sum_left)
+                _multiple(Q, prod([p**e for p, e in L2])), L1, sum_left)
+            o2 = _order_from_multiple_helper(_multiple(Q, o1), L2, S - sum_left)
             return o1 * o2
 
     return _order_from_multiple_helper(P, F, sage.functions.log.log(float(M)))

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -183,7 +183,7 @@ def multiple(a, n, operation='*', identity=None, inverse=None, op=None):
         inverse = inv
         op = mul
     elif operation in addition_names:
-        identity = a.parent()(0)
+        identity = a.parent().zero()
         inverse = neg
         op = add
     else:
@@ -330,7 +330,7 @@ class multiples:
             self.op = mul
         elif operation in addition_names:
             if P0 is None:
-                P0 = P.parent()(0)
+                P0 = P.parent().zero()
             self.op = add
         else:
             if P0 is None:
@@ -443,7 +443,7 @@ def bsgs(a, b, bounds, operation='*', identity=None, inverse=None, op=None):
 
     This will return a multiple of the order of P::
 
-        sage: bsgs(P, P.parent()(0), Hasse_bounds(F.order()), operation='+')            # needs sage.rings.finite_rings sage.schemes
+        sage: bsgs(P, P.parent().zero(), Hasse_bounds(F.order()), operation='+')            # needs sage.rings.finite_rings sage.schemes
         69327408
 
     AUTHOR:
@@ -460,7 +460,7 @@ def bsgs(a, b, bounds, operation='*', identity=None, inverse=None, op=None):
         op = mul
     elif operation in addition_names:
         # Should this be replaced with .zero()? With an extra AttributeError handler?
-        identity = a.parent()(0)
+        identity = a.parent().zero()
         inverse = neg
         op = add
     else:
@@ -1010,7 +1010,7 @@ def discrete_log_lambda(a, base, bounds, operation='*', identity=None, inverse=N
 
     This will return a multiple of the order of P::
 
-        sage: discrete_log_lambda(P.parent()(0), P, Hasse_bounds(F.order()),            # needs sage.rings.finite_rings sage.schemes
+        sage: discrete_log_lambda(P.parent().zero(), P, Hasse_bounds(F.order()),            # needs sage.rings.finite_rings sage.schemes
         ....:                     operation='+')
         69327408
 
@@ -1262,7 +1262,7 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
     if operation in multiplication_names:
         identity = P.parent().one()
     elif operation in addition_names:
-        identity = P.parent()(0)
+        identity = P.parent().zero()
     else:
         if identity is None or inverse is None or op is None:
             raise ValueError("identity, inverse and operation must all be specified")
@@ -1401,7 +1401,7 @@ def order_from_bounds(P, bounds, d=None, operation='+',
         identity = P.parent().one()
     elif operation in addition_names:
         op = add
-        identity = P.parent()(0)
+        identity = P.parent().zero()
     else:
         if op is None:
             raise ValueError("operation and identity must be specified")
@@ -1581,7 +1581,7 @@ def merge_points(P1, P2, operation='+',
         identity = g1.parent().one()
     elif operation in addition_names:
         op = add
-        identity = g1.parent()(0)
+        identity = g1.parent().zero()
     else:
         if op is None:
             raise ValueError("operation and identity must be specified")

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -341,7 +341,8 @@ class multiples:
 
         self.P = copy(P)
         self.Q = copy(P0)
-        assert self.P is not None and self.Q is not None
+        if self.P is None or self.Q is None:
+            raise ValueError("P and Q must not be None")
         self.i = 0
         self.bound = n
         self.indexed = indexed
@@ -1279,8 +1280,8 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
         return Z.one()
 
     M = Z(m)
-    if check:
-        assert _multiple(P, M) == identity
+    if check and _multiple(P, M) != identity:
+        raise ValueError(f"The order of P(={P}) does not divide {M}")
 
     if factorization:
         F = factorization
@@ -1587,8 +1588,8 @@ def merge_points(P1, P2, operation='+',
             raise ValueError("operation and identity must be specified")
 
     if check:
-        assert multiple(g1, n1, operation=operation) == identity
-        assert multiple(g2, n2, operation=operation) == identity
+        if multiple(g1, n1, operation=operation) != identity or multiple(g2, n2, operation=operation) != identity:
+            raise ValueError("the orders provided do not divide the orders of the points provided")
 
     # trivial cases
     if n1.divides(n2):

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -481,7 +481,7 @@ def bsgs(a, b, bounds, operation='*', identity=None, inverse=None, op=None):
 
     if ran < 30:    # use simple search for small ranges
         d = c
-        #        for i,d in multiples(a,ran,c,indexed=True,operation=operation):
+        # for i,d in multiples(a,ran,c,indexed=True,operation=operation):
         for i0 in range(ran):
             i = lb + i0
             if identity == d:        # identity == b^(-1)*a^i, so return i

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -1194,6 +1194,8 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
     Generic function to find order of a group element given a multiple
     of its order.
 
+    See :meth:`bsgs` for full explanation of the inputs.
+
     INPUT:
 
     - ``P`` -- a Sage object which is a group element;
@@ -1203,9 +1205,12 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
       really is a multiple of the order;
     - ``factorization`` -- the factorization of ``m``, or ``None`` in which
       case this function will need to factor ``m``;
-    - ``plist`` -- a list of the prime factors of ``m``, or ``None`` - kept for compatibility only,
+    - ``plist`` -- a list of the prime factors of ``m``, or ``None``. Kept for compatibility only,
       prefer the use of ``factorization``;
-    - ``operation`` -- string: ``'+'`` (default) or ``'*'``.
+    - ``operation`` -- string: ``'+'`` (default), ``'*'`` or ``None``;
+    - ``identity`` -- the identity element of the group;
+    - ``inverse()`` -- function of 1 argument ``x``, returning inverse of ``x``;
+    - ``op()`` - function of 2 arguments ``x``, ``y`` returning ``x*y`` in the group.
 
     .. note::
 

--- a/src/sage/schemes/curves/point.py
+++ b/src/sage/schemes/curves/point.py
@@ -451,7 +451,7 @@ class IntegralAffineCurvePoint_finite_field(IntegralAffineCurvePoint):
 
 class IntegralAffinePlaneCurvePoint(IntegralAffineCurvePoint, AffinePlaneCurvePoint_field):
     """
-    Point of an integral affine plane curve over a finite field.
+    Point of an integral affine plane curve.
     """
     pass
 

--- a/src/sage/schemes/generic/homset.py
+++ b/src/sage/schemes/generic/homset.py
@@ -656,7 +656,7 @@ class SchemeHomset_points(SchemeHomset_generic):
         """
         if len(v) == 1:
             v = v[0]
-        return self.codomain()._point(self, v, **kwds)
+        return self.extended_codomain()._point(self, v, **kwds)
 
     def extended_codomain(self):
         """
@@ -692,6 +692,12 @@ class SchemeHomset_points(SchemeHomset_generic):
             X = self.codomain()
         self._extended_codomain = X
         return X
+
+    def zero(self):
+        """
+        Return the identity of the codomain with extended base, if necessary.
+        """
+        return self.extended_codomain().zero()
 
     def _repr_(self):
         """

--- a/src/sage/schemes/projective/projective_morphism.py
+++ b/src/sage/schemes/projective/projective_morphism.py
@@ -372,7 +372,7 @@ class SchemeMorphism_polynomial_projective_space(SchemeMorphism_polynomial):
             sage: F.<a> = GF(4)
             sage: P = T(F)(1, a)
             sage: h(P)                                                                  # needs sage.libs.singular
-            (a : a)
+            (1 : 1)
             sage: h(P).domain()
             Spectrum of Finite Field in a of size 2^2
             sage: h.change_ring(F)(P)


### PR DESCRIPTION
The `bsgs` function used to check `is_zero`, when it should check `== identity` (which is given). It also allows me to use the method for "ad-hoc classes":

```sage
sage: # modulo arithmetic lmao
....: # I'll just carry around the modulus
....: n = int(12)
....: G_id = (int(0), n)
....: G_gen = (int(1), n)
....: def G_op(P, Q):
....:     return (int((P[0] + Q[0]) % P[1]), P[1])
....: def G_inv(P):
....:     return (int(-P[0] % P[1]), P[1])
....: P = (int(5), n)
....: 
....: from sage.groups.generic import discrete_log
....: discrete_log(P, G_gen, operation=None, ord=n, op=G_op, identity=G_id, inverse=G_inv)
```

Also fixed styling, that's why there are some random edits