### PR TITLE
Allow custom degree in `random_element` of polynomial quotient ring

### DIFF
--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -1260,12 +1260,18 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
 
     cover_ring = polynomial_ring
 
-    def random_element(self, *args, **kwds):
+    def random_element(self, degree=None, *args, **kwds):
         """
         Return a random element of this quotient ring.
 
         INPUT:
 
+        - ``degree`` - Optional argument: either an integer for fixing the
+          degree, or a tuple of the minimum and maximum degree. By default the
+          degree is n - 1 with n the degree of the polynomial ring. Note that
+          the degree of the polynomial is fixed before the modulo calculation.
+          So when `degree` is bigger then the degree of the polynomial ring, the
+          degree of the returned polynomial would be lower than `degree`.
         - ``*args``, ``**kwds`` - Arguments for randomization that are passed
           on to the ``random_element`` method of the polynomial ring, and from
           there to the base ring
@@ -1283,8 +1289,11 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             sage: F2.random_element().parent() is F2
             True
         """
+        if degree is None:
+            degree = self.degree() - 1
+
         return self(self.polynomial_ring().random_element(
-            degree=self.degree() - 1, *args, **kwds))
+            degree=degree, *args, **kwds))
 
     @cached_method
     def _S_decomposition(self, S):

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -1270,7 +1270,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
           degree, or a tuple of the minimum and maximum degree. By default the
           degree is n - 1 with n the degree of the polynomial ring. Note that
           the degree of the polynomial is fixed before the modulo calculation.
-          So when `degree` is bigger then the degree of the polynomial ring, the
+          So when `degree` is bigger than the degree of the polynomial ring, the
           degree of the returned polynomial would be lower than `degree`.
         - ``*args``, ``**kwds`` - Arguments for randomization that are passed
           on to the ``random_element`` method of the polynomial ring, and from


### PR DESCRIPTION
Currently, the `random_element` function of the polynomial quotient ring passes all arguments through to the base ring. However, the random_element function itself passes a default degree to the base ring, based on the degree of the quotient ring. So, overwriting the degree in kwargs gives a TypeError. Therefore, detect the `degree` argument manually, such that the user can overrride the default degree.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
