### PR TITLE
sage_docbuild: add needs sphinx tags

### DIFF
--- a/src/sage_docbuild/__main__.py
+++ b/src/sage_docbuild/__main__.py
@@ -1,3 +1,4 @@
+# sage.doctest: needs sphinx
 r"""
 Sage docbuild main
 

--- a/src/sage_docbuild/builders.py
+++ b/src/sage_docbuild/builders.py
@@ -1,3 +1,4 @@
+# sage.doctest: needs sphinx
 """
 Documentation builders
 

--- a/src/sage_docbuild/sphinxbuild.py
+++ b/src/sage_docbuild/sphinxbuild.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# sage.doctest: needs sphinx
 r"""
 Sphinx build script
 


### PR DESCRIPTION
Add "needs sphinx" tags to some tests in `src/sage_docbuild` so there
is no failure when sphinx is not installed in the system.

See: https://github.com/sagemath/sage/issues/37263#issuecomment-1935113975

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
