### PR TITLE
enable the generation of acyclic orientations with `nauty_directg`

### DIFF
--- a/src/sage/graphs/digraph_generators.py
+++ b/src/sage/graphs/digraph_generators.py
@@ -649,14 +649,16 @@ class DiGraphGenerators:
 
         INPUT:
 
-        - ``graphs`` -- a :class:`Graph` or an iterable containing :class:`Graph`
-          the graph6 string of these graphs is used as an input for ``directg``.
+        - ``graphs`` -- a :class:`Graph` or an iterable containing
+          :class:`Graph`.  The graph6 string of these graphs is used as an input
+          for ``directg``.
 
         - ``options`` (str) -- a string passed to directg as if it was run at
           a system command line. Available options from directg --help::
 
             -e<int> | -e<int>:<int>  specify a value or range of the total number of arcs
             -o       orient each edge in only one direction, never both
+            -a       only make acyclic orientations (implies -o)
             -f<int>  Use only the subgroup that fixes the first <int> vertices setwise
             -V       only output graphs with nontrivial groups (including exchange of
                      isolated vertices).  The -f option is respected.
@@ -679,6 +681,19 @@ class DiGraphGenerators:
             '001001000'
             sage: len(list(digraphs.nauty_directg(graphs.PetersenGraph(), options="-o")))
             324
+
+        Generate non-isomorphic acyclic orientations::
+
+            sage: K = graphs.CompleteGraph(4)
+            sage: all(d.is_directed_acyclic() for d in digraphs.nauty_directg(K, options='-a'))
+            True
+            sage: sum(1 for _ in digraphs.nauty_directg(K, options='-a'))
+            1
+            sage: S = graphs.StarGraph(4)
+            sage: all(d.is_directed_acyclic() for d in digraphs.nauty_directg(S, options='-a'))
+            True
+            sage: sum(1 for _ in digraphs.nauty_directg(S, options='-a'))
+            5
 
         TESTS::
 


### PR DESCRIPTION
Since version 2.8, nauty's `directg` has a new option `-a`  to generate only acyclic orientations. This option was already working but not documented. This PR documents this functionality.

This partially answer issue #37253 and is related to PR #35075.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
