### PR TITLE
BooleanPolynomialRing issue with names parameter

### DIFF
--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -1015,8 +1015,7 @@ def BooleanPolynomialRing_constructor(n=None, names=None, order="lex"):
         n = -1
 
     if names is None:
-       raise TypeError("you must specify the names of the variables")
-
+        raise TypeError("you must specify the names of the variables")
 
     names = normalize_names(n, names)
     n = len(names)

--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -10,6 +10,10 @@ There is also a function :func:`BooleanPolynomialRing_constructor`, used for
 constructing Boolean polynomial rings, which are not technically polynomial
 rings but rather quotients of them (see module
 :mod:`sage.rings.polynomial.pbori` for more details).
+
+AUTHORS:
+
+- Asimina Hamakiotes (2024-02-09): Added a TypeError to ``BooleanPolynomialRing``
 """
 # ****************************************************************************
 #       Copyright (C) 2006 William Stein <wstein@gmail.com>
@@ -984,6 +988,13 @@ def BooleanPolynomialRing_constructor(n=None, names=None, order="lex"):
         sage: BooleanPolynomialRing(names='x,y')                                        # needs sage.rings.polynomial.pbori
         Boolean PolynomialRing in x, y
 
+    This example shows that the bug reported at :issue:`34481` has been fixed::
+
+        sage: BooleanPolynomialRing(1)
+        Traceback (most recent call last):
+        ...
+        TypeError: you must specify the names of the variables
+
     TESTS::
 
         sage: P.<x,y> = BooleanPolynomialRing(2, order='deglex')                        # needs sage.rings.polynomial.pbori
@@ -1002,6 +1013,10 @@ def BooleanPolynomialRing_constructor(n=None, names=None, order="lex"):
         n = -1
     elif n is None:
         n = -1
+
+    if names is None:
+       raise TypeError("you must specify the names of the variables")
+
 
     names = normalize_names(n, names)
     n = len(names)


### PR DESCRIPTION
Added a TypeError to the BooleanPolynomialRing method if no variable name is specified. Fixed #34481.

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [X] The title is concise, informative, and self-explanatory.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
