### PR TITLE
sagemath-standard: fix manifest

### DIFF
--- a/pkgs/sagemath-standard/setup.py
+++ b/pkgs/sagemath-standard/setup.py
@@ -24,6 +24,11 @@ try:
 except ImportError:
     pass
 
+# Different workaround: disable `walk_revctrl` in setuptools
+# This is needed for setuptools_scm >= 8, should work for any version
+import setuptools.command.egg_info
+setuptools.command.egg_info.walk_revctrl = lambda: ()
+
 #########################################################
 ### Set source directory
 #########################################################

--- a/src/MANIFEST.in
+++ b/src/MANIFEST.in
@@ -1,6 +1,6 @@
 include VERSION.txt
 
-global-include *.pxi *.pxd *.h *.hpp
+recursive-include sage *.pxi *.pxd *.h *.hpp
 
 prune sage/ext/interpreters   # In particular, __init__.py must not be present in the distribution; or sage_setup.autogen.interpreters.rebuild will not generate the code
 prune sage_setup


### PR DESCRIPTION
This PR fixes two issues with the manifest for sagemath-standard:

- src/MANIFEST.in: don't include stuff outside src/sage

The use of `global-include <PATTERN>` is inconvenient since it will
include any file matching the pattern anywhere; replace it with
`recursive-include sage <PATTERN>` which is what we really mean.

- sagemath-standard/setup.py: workaround setuptools_scm

The workaround already there is not good for setuptools_scm >= 8.
Implement a more robust workaround (should work for any version of
setuptools_scm but I have not tested, so I did not remove the old
workaround -- it's harmless to apply both).

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
