### PR TITLE
Directly convert PermutationGroup element into sized Permutation

### DIFF
--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7101,8 +7101,11 @@ class StandardPermutations_n_abstract(Permutations):
             sage: P5(p)
             [4, 5, 1, 2, 3]
         """
-        if not isinstance(x, Permutation):
-            x = x.domain()
+        try:
+            if not isinstance(x, Permutation):
+                x = x.domain()
+        except AttributeError:
+            pass
         if len(x) < self.n:
             x = list(x) + list(range(len(x) + 1, self.n + 1))
         return self.element_class(self, x, check=check)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7102,7 +7102,7 @@ class StandardPermutations_n_abstract(Permutations):
             [4, 5, 1, 2, 3]
         """
         if not isinstance(x, Permutation):
-            x = Permutation(x)
+            x = x.domain()
         if len(x) < self.n:
             x = list(x) + list(range(len(x) + 1, self.n + 1))
         return self.element_class(self, x, check=check)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7093,7 +7093,7 @@ class StandardPermutations_n_abstract(Permutations):
             sage: Permutations(6)(x)            # known bug
             [1, 4, 5, 2, 3, 6]
 
-            check if :trac:`37284` is fixed::
+        Ensure that :issue:`37284` is fixed::
 
             sage: S5 = SymmetricGroup(5)
             sage: P5 = Permutations(5)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7098,7 +7098,9 @@ class StandardPermutations_n_abstract(Permutations):
             sage: PG = PermutationGroup([[(1,2,3),(5,6)],[(7,8)]])
             sage: P8 = Permutations(8)
             sage: p = PG.an_element()
-            sage: P8(p).parent()
+            sage: q = P8(p); q
+            [2, 3, 1, 4, 6, 5, 8, 7]
+            sage: q.parent()
             Standard permutations of 8
         """
         if isinstance(x, PermutationGroupElement):

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7101,6 +7101,8 @@ class StandardPermutations_n_abstract(Permutations):
             sage: x = PG([4,3,5,1,2])
             sage: s = P5(x); s
             [4, 3, 5, 1, 2]
+            sage: s.parent()
+            Standard permutations of 5
         """
         if isinstance(x, PermutationGroupElement):
             return self. _from_permutation_group_element(x)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7092,7 +7092,17 @@ class StandardPermutations_n_abstract(Permutations):
             [1, 4, 5, 2, 3, 6]
             sage: Permutations(6)(x)            # known bug
             [1, 4, 5, 2, 3, 6]
+
+            check if :trac:`37284` is fixed::
+
+            sage: S5 = SymmetricGroup(5)
+            sage: P5 = Permutations(5)
+            sage: p = S5.list()[3]
+            sage: P5(p)
+            [4, 5, 1, 2, 3]
         """
+        if not isinstance(x, Permutation):
+            x = Permutation(x)
         if len(x) < self.n:
             x = list(x) + list(range(len(x) + 1, self.n + 1))
         return self.element_class(self, x, check=check)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7097,9 +7097,10 @@ class StandardPermutations_n_abstract(Permutations):
 
             sage: PG = PermutationGroup(SymmetricGroup(5).gens())
             sage: P5 = Permutations(5)
-            sage: p = PG.list()[0]
-            sage: s = P5(p); s
-            [1, 2, 3, 4, 5]
+            sage: p = PG.an_element()
+            sage: x = PG([4,3,5,1,2])
+            sage: s = P5(x); s
+            [4, 3, 5, 1, 2]
         """
         if isinstance(x, PermutationGroupElement):
             return self. _from_permutation_group_element(x)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7096,9 +7096,9 @@ class StandardPermutations_n_abstract(Permutations):
         Ensure that :issue:`37284` is fixed::
 
             sage: PG = PermutationGroup([[(1,2,3),(5,6)],[(7,8)]])
-            sage: P5 = Permutations(8)
+            sage: P8 = Permutations(8)
             sage: p = PG.an_element()
-            sage: P5(p).parent()
+            sage: P8(p).parent()
             Standard permutations of 8
         """
         if isinstance(x, PermutationGroupElement):

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7095,11 +7095,11 @@ class StandardPermutations_n_abstract(Permutations):
 
         Ensure that :issue:`37284` is fixed::
 
-            sage: S5 = SymmetricGroup(5)
+            sage: PG = PermutationGroup(SymmetricGroup(5).gens())
             sage: P5 = Permutations(5)
-            sage: p = S5.list()[3]
-            sage: P5(p)
-            [4, 5, 1, 2, 3]
+            sage: p = PG.list()[0]
+            sage: s = P5(p); s
+            [1, 2, 3, 4, 5]
         """
         if isinstance(x, PermutationGroupElement):
             return self. _from_permutation_group_element(x)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7101,11 +7101,8 @@ class StandardPermutations_n_abstract(Permutations):
             sage: P5(p)
             [4, 5, 1, 2, 3]
         """
-        try:
-            if not isinstance(x, Permutation):
-                x = x.domain()
-        except AttributeError:
-            pass
+        if isinstance(x, PermutationGroupElement):
+            x = x.domain()
         if len(x) < self.n:
             x = list(x) + list(range(len(x) + 1, self.n + 1))
         return self.element_class(self, x, check=check)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7102,7 +7102,7 @@ class StandardPermutations_n_abstract(Permutations):
             [4, 5, 1, 2, 3]
         """
         if isinstance(x, PermutationGroupElement):
-            x = x.domain()
+            return self. _from_permutation_group_element(x)
         if len(x) < self.n:
             x = list(x) + list(range(len(x) + 1, self.n + 1))
         return self.element_class(self, x, check=check)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -7095,14 +7095,11 @@ class StandardPermutations_n_abstract(Permutations):
 
         Ensure that :issue:`37284` is fixed::
 
-            sage: PG = PermutationGroup(SymmetricGroup(5).gens())
-            sage: P5 = Permutations(5)
+            sage: PG = PermutationGroup([[(1,2,3),(5,6)],[(7,8)]])
+            sage: P5 = Permutations(8)
             sage: p = PG.an_element()
-            sage: x = PG([4,3,5,1,2])
-            sage: s = P5(x); s
-            [4, 3, 5, 1, 2]
-            sage: s.parent()
-            Standard permutations of 5
+            sage: P5(p).parent()
+            Standard permutations of 8
         """
         if isinstance(x, PermutationGroupElement):
             return self. _from_permutation_group_element(x)


### PR DESCRIPTION
This patch fixes #37284 by converting the input into a Permutation class object if 
it is the object of another class.
﻿<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
