### PR TITLE
sagemath-standard: don't require Cython to create sdist

### DIFF
--- a/src/sage/misc/package_dir.py
+++ b/src/sage/misc/package_dir.py
@@ -118,8 +118,7 @@ def read_distribution(src_file):
         sage: read_distribution(os.path.join(SAGE_SRC, 'sage', 'graphs', 'graph_decompositions', 'modular_decomposition.py'))
         ''
     """
-    from Cython.Utils import open_source_file
-    with open_source_file(src_file, error_handling='ignore') as fh:
+    with open(src_file, encoding='utf-8', errors='ignore') as fh:
         for line in fh:
             # Adapted from Cython's Build/Dependencies.py
             line = line.lstrip()


### PR DESCRIPTION
The implementation of sage.misc.package_dir.read_distributions uses the function `Cython.Utils.open_source_file()` to open a file instead of `io.open()`. This function was introduced in #29701 (b582789).

The only difference between `open_source_file()` and `io.open()` is that the former will open the file as binary to check the encoding. But all our files should be utf-8 so we don't need this trick.

In case I’m mistaken and there is a reason this trick is really necessary (@mkoeppe?) it seems better to include a version of open_source_file(), for two main reasons: (a) we don’t pull the whole of Cython just for a trivial function; (b) changes in Cython don’t affect sagemath (this is not a documented function of Cython, afaict)

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.