### PR TITLE
Support optional debugpy

### DIFF
--- a/build/pkgs/debugpy/distros/gentoo.txt
+++ b/build/pkgs/debugpy/distros/gentoo.txt
@@ -1,1 +1,0 @@
-dev-python/debugpy

--- a/build/pkgs/debugpy/spkg-configure.m4
+++ b/build/pkgs/debugpy/spkg-configure.m4
@@ -1,1 +1,14 @@
-SAGE_SPKG_CONFIGURE([debugpy], [SAGE_PYTHON_PACKAGE_CHECK([debugpy])])
+SAGE_SPKG_CONFIGURE([debugpy], [
+  SAGE_PYTHON_PACKAGE_CHECK([debugpy])
+], [
+  dnl REQUIRED-CHECK
+  dnl
+  dnl Skip debugpy if ipykernel from the system will be used.
+  dnl This allows downstream packagers to treat debugpy (a
+  dnl somewhat problematic package) as optional.
+  AC_REQUIRE([SAGE_SPKG_CONFIGURE_IPYKERNEL])
+  sage_require_debugpy=yes
+  AS_VAR_IF([sage_spkg_install_ipykernel], [no], [
+    sage_require_debugpy=no
+  ])
+])


### PR DESCRIPTION
Gentoo is removing it, but since only ipykernel has it as a dependency, we can skip debugpy entirely when ipykernel from the system is installed. This lets the system ipykernel package decide if it wants to pull in debugpy.
