### PR TITLE
use Parent in Weyl algebra

### DIFF
--- a/src/sage/algebras/weyl_algebra.py
+++ b/src/sage/algebras/weyl_algebra.py
@@ -654,7 +654,7 @@ class DifferentialWeylAlgebraElement(Element):
         return self.parent().diff_action(self, p)
 
 
-class DifferentialWeylAlgebra(Parent, UniqueRepresentation):
+class DifferentialWeylAlgebra(UniqueRepresentation, Parent):
     r"""
     The differential Weyl algebra of a polynomial ring.
 

--- a/src/sage/algebras/weyl_algebra.py
+++ b/src/sage/algebras/weyl_algebra.py
@@ -30,7 +30,6 @@ from sage.categories.rings import Rings
 from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.sets.family import Family
 import sage.data_structures.blas_dict as blas
-from sage.rings.ring import Algebra
 from sage.rings.polynomial.polynomial_ring import PolynomialRing_general
 from sage.rings.polynomial.multi_polynomial_ring_base import MPolynomialRing_base
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
@@ -655,7 +654,7 @@ class DifferentialWeylAlgebraElement(Element):
         return self.parent().diff_action(self, p)
 
 
-class DifferentialWeylAlgebra(Algebra, UniqueRepresentation):
+class DifferentialWeylAlgebra(Parent, UniqueRepresentation):
     r"""
     The differential Weyl algebra of a polynomial ring.
 
@@ -780,7 +779,7 @@ class DifferentialWeylAlgebra(Algebra, UniqueRepresentation):
             sage: DifferentialWeylAlgebra(R)
             Differential Weyl algebra of polynomials in x, y, z over Rational Field
         """
-        poly_gens = ', '.join(repr(x) for x in self.gens()[:self._n])
+        poly_gens = ', '.join(repr(x) for x in self.variables())
         return "Differential Weyl algebra of polynomials in {} over {}".format(
             poly_gens, self.base_ring())
 
@@ -985,6 +984,8 @@ class DifferentialWeylAlgebra(Algebra, UniqueRepresentation):
         """
         d = {x: self.gen(i) for i, x in enumerate(self.variable_names())}
         return Family(self.variable_names(), lambda x: d[x])
+
+    gens = algebra_generators
 
     @cached_method
     def variables(self):

--- a/src/sage/structure/category_object.pyx
+++ b/src/sage/structure/category_object.pyx
@@ -365,7 +365,12 @@ cdef class CategoryObject(SageObject):
             sage: z.minpoly()                                                           # needs sage.rings.number_field
             x^2 + 3
         """
-        return self._defining_names()[:n]
+        names = self._defining_names()
+        if isinstance(names, (list, tuple)):
+            return names[:n]
+        # case of Family
+        it = iter(names)
+        return tuple(next(it) for i in range(n))
 
     @cached_method
     def _defining_names(self):


### PR DESCRIPTION
replace the auld-class `Algebra` by `Parent` in Weyl algebras

this requires a tweak in the `_first_n_gens` mechanism to handle families

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.