### PR TITLE
Fix random test failures in `number_field_element_quadratic`

### DIFF
--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -2399,8 +2399,6 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
             ....:    assert round(a+b*sqrt(2.)) == round(a+b*sqrt2), (a, b)
             ....:    assert round(a+b*sqrt(3.)) == round(a+b*sqrt3), (a, b)
             ....:    assert round(a+b*sqrt(5.)) == round(a+b*sqrt5), (a, b)
-            doctest...: DeprecationWarning: the default rounding for rationals, currently `away`, will be changed to `even`.
-            See https://github.com/sagemath/sage/issues/35473 for details.
         """
         n = self.floor()
         test = 2 * (self - n).abs()

--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -2387,6 +2387,8 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
 
         TESTS::
 
+            sage: import warnings
+            sage: warnings.filterwarnings("ignore", category=DeprecationWarning)
             sage: K2.<sqrt2> = QuadraticField(2)
             sage: K3.<sqrt3> = QuadraticField(3)
             sage: K5.<sqrt5> = QuadraticField(5)


### PR DESCRIPTION
Fix #37296.

Add `warnings.filterwarnings` to ignore `DeprecationWarning` in the failing doctest, since it is an unrelated issue and does not affect correctness of the test.

To be more specific, the warning only appears when the rounding error will change, i.e. on $n + \frac{1}{2}$ (I believe). Here are some runs:

```python
sage: a = QQ.random_element(3, 3); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
<ipython-input-12-179149e36f01>:1: DeprecationWarning: the default rounding for rationals, currently `away`, will be changed to `even`.
See https://github.com/sagemath/sage/issues/35473 for details.
  a = QQ.random_element(Integer(3), Integer(3)); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
<ipython-input-14-179149e36f01>:1: DeprecationWarning: the default rounding for rationals, currently `away`, will be changed to `even`.
See https://github.com/sagemath/sage/issues/35473 for details.
  a = QQ.random_element(Integer(3), Integer(3)); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
sage: a = QQ.random_element(3, 3); _ = round(a)
```