### PR TITLE
fixing ruff UP037 (about type annotation)

### DIFF
--- a/src/sage/manifolds/differentiable/tensorfield.py
+++ b/src/sage/manifolds/differentiable/tensorfield.py
@@ -476,8 +476,9 @@ class TensorField(ModuleElementWithMutability):
         self._vmodule = vector_field_module
         self._tensor_type = tuple(tensor_type)
         self._tensor_rank = self._tensor_type[0] + self._tensor_type[1]
-        self._is_zero = False # a priori, may be changed below or via
-                              # method __bool__()
+        self._is_zero = False
+        # a priori, may be changed below or via  method __bool__()
+
         self._name = name
         if latex_name is None:
             self._latex_name = self._name
@@ -503,7 +504,7 @@ class TensorField(ModuleElementWithMutability):
         # Initialization of derived quantities:
         self._init_derived()
 
-    ####### Required methods for ModuleElement (beside arithmetic) #######
+    # ###### Required methods for ModuleElement (beside arithmetic) #######
 
     def __bool__(self):
         r"""
@@ -547,7 +548,7 @@ class TensorField(ModuleElementWithMutability):
         self._is_zero = True
         return False
 
-    ##### End of required methods for ModuleElement (beside arithmetic) #####
+    # #### End of required methods for ModuleElement (beside arithmetic) #####
 
     def _repr_(self):
         r"""
@@ -3742,7 +3743,7 @@ class TensorField(ModuleElementWithMutability):
         self,
         non_degenerate_form: Union[PseudoRiemannianMetric, SymplecticForm, PoissonTensorField],
         pos: Optional[int] = None,
-    ) -> "TensorField":
+    ) -> TensorField:
         r"""
         Compute a dual of the tensor field by raising some index with the
         given tensor field (usually, a pseudo-Riemannian metric, a symplectic form or a Poisson tensor).

--- a/src/sage/modular/etaproducts.py
+++ b/src/sage/modular/etaproducts.py
@@ -183,7 +183,7 @@ class EtaGroupElement(Element):
         P = self.parent()
         return P.element_class(P, newdict)
 
-    def is_one(self):
+    def is_one(self) -> bool:
         r"""
         Return whether ``self`` is the one of the monoid.
 
@@ -323,7 +323,7 @@ class EtaGroupElement(Element):
         """
         return self.q_expansion(n)
 
-    def order_at_cusp(self, cusp: 'CuspFamily') -> Integer:
+    def order_at_cusp(self, cusp: CuspFamily) -> Integer:
         r"""
         Return the order of vanishing of ``self`` at the given cusp.
 
@@ -492,7 +492,7 @@ class EtaGroup_class(UniqueRepresentation, Parent):
         """
         return self._N
 
-    def basis(self, reduce=True):
+    def basis(self, reduce=True) -> list:
         r"""
         Produce a basis for the free abelian group of eta-products of level
         N (under multiplication), attempting to find basis vectors of the
@@ -570,7 +570,7 @@ class EtaGroup_class(UniqueRepresentation, Parent):
         else:
             return [self(d) for d in dicts]
 
-    def reduce_basis(self, long_etas):
+    def reduce_basis(self, long_etas) -> list:
         r"""
         Produce a more manageable basis via LLL-reduction.
 
@@ -693,7 +693,7 @@ def num_cusps_of_width(N, d) -> Integer:
     return euler_phi(d.gcd(N // d))
 
 
-def AllCusps(N):
+def AllCusps(N) -> list:
     r"""
     Return a list of CuspFamily objects corresponding to the cusps of
     `X_0(N)`.


### PR DESCRIPTION
namely, quotes are no longer needed around type annotations

this only appeared in two files

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.