### PR TITLE
fixed bug in `.map_coefficients`, `.map_support`, `.map_item` for matrix operation

### DIFF
--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -2065,6 +2065,16 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: a = s([2,1]) + 2*s([3,2])                                         # needs sage.combinat sage.modules
                 sage: a.map_coefficients(lambda x: x * 2)                               # needs sage.combinat sage.modules
                 2*s[2, 1] + 4*s[3, 2]
+
+            TESTS:
+
+            map_coefficients works on Matrix::
+
+                sage: M = Matrix([[1, 0], [0, 1]])
+                sage: f = lambda x: x + 1
+                sage: M.map_coefficients(f)             # This actually failed at some point!!! See #37320
+                [2 0]
+                [0 2]
             """
             return self.parent().sum_of_terms( (m, f(c)) for m,c in self.monomial_coefficients(copy=False).items() )
 
@@ -2175,6 +2185,14 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: a = s([2,1]) + s([1,1,1])                                         # needs sage.combinat sage.modules
                 sage: a.map_item(f)                                                     # needs sage.combinat sage.modules
                 2*s[2, 1] + 2*s[3]
+
+            To apply the function on all entries including 0 coefficient::
+
+                sage: M = Matrix([[1, 0], [0, 1]])
+                sage: f = lambda x: x + 1
+                sage: M.parent()(map(f, M.list()))
+                [2 1]
+                [1 2]
             """
             return self.parent().sum_of_terms( f(m,c) for m,c in self.monomial_coefficients(copy=False).items() )
 

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -2066,7 +2066,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: a.map_coefficients(lambda x: x * 2)                               # needs sage.combinat sage.modules
                 2*s[2, 1] + 4*s[3, 2]
             """
-            return self.parent().sum_of_terms( (m, f(c)) for m,c in self )
+            return self.parent().sum_of_terms( (m, f(c)) for m,c in self.monomial_coefficients(copy=False).items() )
 
         def map_support(self, f):
             """
@@ -2108,7 +2108,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: y.parent() is B                                                   # needs sage.modules
                 True
             """
-            return self.parent().sum_of_terms( (f(m), c) for m,c in self )
+            return self.parent().sum_of_terms( (f(m), c) for m,c in self.monomial_coefficients(copy=False).items() )
 
         def map_support_skip_none(self, f):
             """
@@ -2142,7 +2142,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: y.parent() is B                                                   # needs sage.modules
                 True
             """
-            return self.parent().sum_of_terms( (fm,c) for (fm,c) in ((f(m), c) for m,c in self) if fm is not None)
+            return self.parent().sum_of_terms( (fm,c) for (fm,c) in ((f(m), c) for m,c in self.monomial_coefficients(copy=False).items()) if fm is not None)
 
         def map_item(self, f):
             """
@@ -2176,7 +2176,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: a.map_item(f)                                                     # needs sage.combinat sage.modules
                 2*s[2, 1] + 2*s[3]
             """
-            return self.parent().sum_of_terms( f(m,c) for m,c in self )
+            return self.parent().sum_of_terms( f(m,c) for m,c in self.monomial_coefficients(copy=False).items() )
 
         def tensor(*elements):
             """


### PR DESCRIPTION
Fixed bug in `.map_coefficients`, `.map_support`, `.map_item` methods for Marrix.

`.map_coefficients`: This maps the given function to all the coefficients of equations in the matrix.
`.map_support`: This maps the given function to all the variables of equations in matrix.
`.map_item`: This maps the given function to all the elements in the matrix.

Fixes: #37320

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
