### PR TITLE
Removed whitespaces in `ncsym.py`

### DIFF
--- a/src/sage/combinat/ncsym/ncsym.py
+++ b/src/sage/combinat/ncsym/ncsym.py
@@ -109,7 +109,7 @@ def nesting(la, nu):
         1
         sage: nesting(B, A)
         1
-        
+
     ::
 
         sage: lst = list(SetPartitions(4))


### PR DESCRIPTION
Removed the whitespaces in `ncsym.py`, which currently cause all PR tests to fail at Lint.