### PR TITLE
Avoid algebra in polynomials

### DIFF
--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -47,6 +47,24 @@ class CommutativeRings(CategoryWithAxiom):
 
     """
     class ParentMethods:
+        def is_commutative(self) -> bool:
+            """
+            Return whether the ring is commutative.
+
+            The answer is ``True`` only if the category is a sub-category of
+            ``CommutativeRings``.
+
+            It is recommended to use instead ``R in Rings().Commutative()``.
+
+            EXAMPLES::
+
+                sage: QQ.is_commutative()
+                True
+                sage: QQ['x,y,z'].is_commutative()
+                True
+            """
+            return True
+
         def _test_divides(self, **options):
             r"""
             Run generic tests on the method :meth:`divides`.

--- a/src/sage/categories/rings.py
+++ b/src/sage/categories/rings.py
@@ -322,6 +322,23 @@ class Rings(CategoryWithAxiom):
             """
             return True
 
+        def is_commutative(self) -> bool:
+            """
+            Return whether the ring is commutative.
+
+            The answer is ``True`` only if the category is a sub-category of
+            ``CommutativeRings``.
+
+            It is recommended to use instead ``R in Rings().Commutative()``.
+
+            EXAMPLES::
+
+                sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -1, -1)                             # needs sage.combinat sage.modules
+                sage: Q.is_commutative()                                                    # needs sage.combinat sage.modules
+                False
+            """
+            return False
+
         def is_zero(self) -> bool:
             """
             Return ``True`` if this is the zero ring.

--- a/src/sage/graphs/chrompoly.pyx
+++ b/src/sage/graphs/chrompoly.pyx
@@ -31,7 +31,7 @@ from memory_allocator cimport MemoryAllocator
 from sage.libs.gmp.mpz cimport *
 from sage.rings.integer_ring import ZZ
 from sage.rings.integer cimport Integer
-from sage.rings.ring cimport Algebra
+from sage.rings.ring cimport Ring
 from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 
@@ -436,7 +436,7 @@ def chromatic_polynomial_with_cache(G, cache=None):
         ...
         TypeError: parameter cache must be a dictionary or None
     """
-    cdef Algebra R = PolynomialRing(ZZ, "x", implementation="FLINT")
+    cdef Ring R = PolynomialRing(ZZ, "x", implementation="FLINT")
     cdef Polynomial_integer_dense_flint one = R.one()
     cdef Polynomial_integer_dense_flint zero = R.zero()
     cdef Polynomial_integer_dense_flint x = R.gen()

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -130,15 +130,15 @@ Check that :trac:`5562` has been fixed::
 
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2006 William Stein <wstein@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 
 import sys
@@ -148,7 +148,7 @@ from sage.structure.element import Element
 import sage.categories as categories
 from sage.categories.morphism import IdentityMorphism
 
-from sage.rings.ring import (Algebra, CommutativeAlgebra, IntegralDomain,
+from sage.rings.ring import (Ring, IntegralDomain,
                              PrincipalIdealDomain, is_Ring)
 from sage.structure.element import is_RingElement
 import sage.rings.rational_field as rational_field
@@ -226,7 +226,7 @@ def is_PolynomialRing(x):
 
 #########################################################################################
 
-class PolynomialRing_general(Algebra):
+class PolynomialRing_general(Ring):
     """
     Univariate polynomial ring over a ring.
     """
@@ -303,7 +303,7 @@ class PolynomialRing_general(Algebra):
         self.Element = self._polynomial_class
         self.__cyclopoly_cache = {}
         self._has_singular = False
-        Algebra.__init__(self, base_ring, names=name, normalize=True, category=category)
+        Ring.__init__(self, base_ring, names=name, normalize=True, category=category)
         self._populate_coercion_lists_(convert_method_name='_polynomial_')
 
     def __reduce__(self):
@@ -1709,7 +1709,7 @@ class PolynomialRing_general(Algebra):
         raise ValueError("you should pass exactly one of of_degree and max_degree")
 
 
-class PolynomialRing_commutative(PolynomialRing_general, CommutativeAlgebra):
+class PolynomialRing_commutative(PolynomialRing_general):
     """
     Univariate polynomial ring over a commutative ring.
     """

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -686,24 +686,6 @@ cdef class Ring(ParentWithGens):
             return x
         return self._one_element
 
-    def is_commutative(self):
-        """
-        Return ``True`` if this ring is commutative.
-
-        EXAMPLES::
-
-            sage: QQ.is_commutative()
-            True
-            sage: QQ['x,y,z'].is_commutative()
-            True
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -1, -1)                             # needs sage.combinat sage.modules
-            sage: Q.is_commutative()                                                    # needs sage.combinat sage.modules
-            False
-        """
-        if self.is_zero():
-            return True
-        raise NotImplementedError
-
     def is_field(self, proof = True):
         """
         Return ``True`` if this ring is a field.

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -2655,11 +2655,11 @@ cdef class RingElement(ModuleElement):
 
     cpdef _pow_int(self, n) noexcept:
         """
-        Return the (integral) power of self.
+        Return the (integral) power of ``self``.
 
         EXAMPLES::
 
-            sage: a = Integers(389)['x']['y'](37)
+            sage: a = GF(389)['x']['y'](37)
             sage: p = sage.structure.element.RingElement.__pow__
             sage: p(a,2)
             202

--- a/src/sage/tests/books/computational-mathematics-with-sagemath/polynomes_doctest.py
+++ b/src/sage/tests/books/computational-mathematics-with-sagemath/polynomes_doctest.py
@@ -120,7 +120,7 @@ Sage example in ./polynomes.tex, line 666::
   sage: (t^2+t)/t
   Traceback (most recent call last):
   ...
-  TypeError: self must be an integral domain.
+  TypeError: unsupported operand parent(s) for /: 'Univariate Polynomial Ring in t over Ring of integers modulo 42' and 'Univariate Polynomial Ring in t over Ring of integers modulo 42'
 
 Sage example in ./polynomes.tex, line 685::
 


### PR DESCRIPTION
One avoids using `Algebra` and `CommutativeAlgebra` in the polynomial classes.

And the general method `is_commutative` is delegated to the categories of Rings and CommutativeRings.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
