### PR TITLE
GAP: make GAP_ROOT_PATHS configuration unnecessary

### DIFF
--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -236,6 +236,7 @@ NTL_INCDIR = var("NTL_INCDIR")
 NTL_LIBDIR = var("NTL_LIBDIR")
 LIE_INFO_DIR = var("LIE_INFO_DIR", join(SAGE_LOCAL, "lib", "LiE"))
 SINGULAR_BIN = var("SINGULAR_BIN") or "Singular"
+GAP_BIN = var("GAP_BIN", "gap")
 
 # OpenMP
 OPENMP_CFLAGS = var("OPENMP_CFLAGS", "")

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -1073,7 +1073,7 @@ class Gap(Gap_generic):
             True
         """
         self.__use_workspace_cache = use_workspace_cache
-        cmd, self.__make_workspace = gap_command(use_workspace_cache, server is None)
+        cmd, _ = gap_command(use_workspace_cache, server is None)
         # -b: suppress banner
         # -p: enable "package output mode"; this confusingly named option
         #     causes GAP to output special control characters that are normally
@@ -1197,12 +1197,9 @@ class Gap(Gap_generic):
                 gap_reset_workspace(verbose=False)
                 Expect._start(self, "Failed to start GAP.")
                 self._session_number = n
-                self.__make_workspace = False
             else:
                 raise
 
-        if self.__use_workspace_cache and self.__make_workspace:
-            self.save_workspace()
         # Now, as self._expect exists, we can compile some useful pattern:
         self._compiled_full_pattern = self._expect.compile_pattern_list([
             r'@p\d+\.', '@@', '@[A-Z]', r'@[123456!"#$%&][^+]*\+',

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -229,6 +229,45 @@ if platform.processor() == 'ia64' and os.path.exists('/usr/bin/prctl'):
     gap_cmd = 'prctl --unaligned=silent ' + gap_cmd
 
 
+class KERNEL_INFO(dict):
+    """
+    doc
+    """
+
+    # singleton pattern
+    __instance = None
+
+    def __new__(cls):
+        if cls.__instance is None:
+            cls.__instance = super().__new__(cls)
+
+        return cls.__instance
+
+    def __init__(self):
+
+        if self.__dict__ is self:
+            # already initialized
+            return
+
+        from sage.misc.timing import cputime, walltime
+        t = cputime()
+        w = walltime()
+
+        # access keys as object attributes
+        self.__dict__ = self
+
+        from importlib.resources import files
+        import subprocess
+
+        gap_kernel_info = files(__package__).joinpath('gap_kernel_info.g')
+
+        for line in subprocess.getoutput(
+                f"{gap_cmd} --systemfile {gap_kernel_info}"
+                ).split('\n'):
+            var, value = line.split("=")
+            self[var] = value
+
+
 # ########### Classes with methods for both the GAP3 and GAP4 interface
 
 class Gap_generic(ExtraTabCompletion, Expect):

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -194,7 +194,7 @@ AUTHORS:
 
 from .expect import Expect, ExpectElement, FunctionElement, ExpectFunction
 from sage.cpython.string import bytes_to_str
-from sage.env import SAGE_EXTCODE, SAGE_GAP_COMMAND, SAGE_GAP_MEMORY
+from sage.env import GAP_BIN, SAGE_EXTCODE, SAGE_GAP_COMMAND, SAGE_GAP_MEMORY
 from sage.misc.misc import is_in_string
 from sage.misc.cachefunc import cached_method
 from sage.misc.instancedoc import instancedoc
@@ -217,7 +217,7 @@ if SAGE_GAP_COMMAND is None:
     # Passing -A allows us to use a minimal GAP installation without
     # producing errors at start-up. The files sage.g and sage.gaprc are
     # used to load any additional packages that may be available.
-    gap_cmd = f'gap -r -A'
+    gap_cmd = f'{GAP_BIN} -r -A'
     if SAGE_GAP_MEMORY is not None:
         gap_cmd += " -s " + SAGE_GAP_MEMORY + " -o " + SAGE_GAP_MEMORY
 else:

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -194,7 +194,7 @@ AUTHORS:
 
 from .expect import Expect, ExpectElement, FunctionElement, ExpectFunction
 from sage.cpython.string import bytes_to_str
-from sage.env import SAGE_EXTCODE, SAGE_GAP_COMMAND, SAGE_GAP_MEMORY, GAP_ROOT_PATHS
+from sage.env import SAGE_EXTCODE, SAGE_GAP_COMMAND, SAGE_GAP_MEMORY
 from sage.misc.misc import is_in_string
 from sage.misc.cachefunc import cached_method
 from sage.misc.instancedoc import instancedoc
@@ -217,7 +217,7 @@ if SAGE_GAP_COMMAND is None:
     # Passing -A allows us to use a minimal GAP installation without
     # producing errors at start-up. The files sage.g and sage.gaprc are
     # used to load any additional packages that may be available.
-    gap_cmd = f'gap -A -l "{GAP_ROOT_PATHS}"'
+    gap_cmd = f'gap -r -A'
     if SAGE_GAP_MEMORY is not None:
         gap_cmd += " -s " + SAGE_GAP_MEMORY + " -o " + SAGE_GAP_MEMORY
 else:

--- a/src/sage/interfaces/gap_kernel_info.g
+++ b/src/sage/interfaces/gap_kernel_info.g
@@ -1,0 +1,22 @@
+# Prints gap kernel info without initializing gap.
+#
+# Usage:
+#
+#   $ gap -r --systemfile gap_kernel_info.g
+#   KERNEL_VERSION=4.12.2
+#   GAP_ARCHITECTURE=x86_64-unknown-linux-gnu-default64-kv8
+#   GAP_ROOT_PATHS=/usr/lib64/gap/;/usr/share/gap/
+
+KernelInfo := KERNEL_INFO();
+
+PRINT_TO( "*stdout*", "KERNEL_VERSION=", KernelInfo.KERNEL_VERSION, "\n");
+PRINT_TO( "*stdout*", "GAP_ARCHITECTURE=", KernelInfo.GAP_ARCHITECTURE, "\n");
+
+p := KernelInfo.GAP_ROOT_PATHS;
+PRINT_TO( "*stdout*", "GAP_ROOT_PATHS=", p[1] );
+for i in [2 .. LENGTH(p)] do
+  PRINT_TO( "*stdout*", ";", p[i]);
+od;
+PRINT_TO( "*stdout*", "\n");
+
+QuitGap();

--- a/src/sage/interfaces/gap_workspace.py
+++ b/src/sage/interfaces/gap_workspace.py
@@ -17,7 +17,7 @@ import os
 import time
 import hashlib
 import subprocess
-from sage.env import DOT_SAGE, HOSTNAME, GAP_ROOT_PATHS
+from sage.env import DOT_SAGE, HOSTNAME
 
 
 def gap_workspace_file(system="gap", name="workspace", dir=None):
@@ -60,15 +60,10 @@ def gap_workspace_file(system="gap", name="workspace", dir=None):
     if dir is None:
         dir = os.path.join(DOT_SAGE, 'gap')
 
-    data = f'{GAP_ROOT_PATHS}'
-    for path in GAP_ROOT_PATHS.split(";"):
-        if not path:
-            # If GAP_ROOT_PATHS begins or ends with a semicolon,
-            # we'll get one empty path.
-            continue
-        sysinfo = os.path.join(path, "sysinfo.gap")
-        if os.path.exists(sysinfo):
-            data += subprocess.getoutput(f'. "{sysinfo}" && echo ":$GAP_VERSION:$GAParch"')
+    from sage.interfaces.gap import KERNEL_INFO
+    data = f'{KERNEL_INFO().GAP_ROOT_PATHS}'
+    data += f':{KERNEL_INFO().KERNEL_VERSION}'
+    data += f':{KERNEL_INFO().GAP_ARCHITECTURE}'
     h = hashlib.sha1(data.encode('utf-8')).hexdigest()
     return os.path.join(dir, f'{system}-{name}-{HOSTNAME}-{h}')
 

--- a/src/sage/libs/gap/saved_workspace.py
+++ b/src/sage/libs/gap/saved_workspace.py
@@ -8,8 +8,6 @@ workspaces.
 
 import os
 import glob
-from sage.env import GAP_ROOT_PATHS
-from sage.interfaces.gap_workspace import gap_workspace_file
 
 
 def timestamp():
@@ -29,10 +27,11 @@ def timestamp():
         sage: type(timestamp())
         <... 'float'>
     """
+    from sage.interfaces.gap import KERNEL_INFO
     libgap_dir = os.path.dirname(__file__)
     libgap_files = glob.glob(os.path.join(libgap_dir, '*'))
     gap_packages = []
-    for d in GAP_ROOT_PATHS.split(";"):
+    for d in KERNEL_INFO().GAP_ROOT_PATHS.split(";"):
         if d:
             # If GAP_ROOT_PATHS begins or ends with a semicolon,
             # we'll get one empty d.
@@ -71,6 +70,7 @@ def workspace(name='workspace'):
         sage: isinstance(up_to_date, bool)
         True
     """
+    from sage.interfaces.gap_workspace import gap_workspace_file
     workspace = gap_workspace_file("libgap", name)
     try:
         workspace_mtime = os.path.getmtime(workspace)

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -28,6 +28,7 @@ from sage.libs.gap.gap_includes cimport *
 from sage.libs.gap.element cimport *
 from sage.cpython.string import FS_ENCODING
 from sage.cpython.string cimport str_to_bytes, char_to_str
+from sage.interfaces.gap import KERNEL_INFO
 from sage.interfaces.gap_workspace import prepare_workspace_dir
 
 
@@ -219,7 +220,9 @@ cdef initialize() noexcept:
     argv[0] = "sage"
     argv[1] = "-A"
     argv[2] = "-l"
-    s = str_to_bytes(sage.env.GAP_ROOT_PATHS, FS_ENCODING, "surrogateescape")
+    s = str_to_bytes(KERNEL_INFO().GAP_ROOT_PATHS,
+                     FS_ENCODING,
+                     "surrogateescape")
     argv[3] = s
 
     argv[4] = "-m"

--- a/src/setup.cfg.m4
+++ b/src/setup.cfg.m4
@@ -97,6 +97,7 @@ sage.libs.gap =
     sage.gaprc
 
 sage.interfaces =
+    gap_kernel_info.g
     sage-maxima.lisp
 
 sage.doctest =


### PR DESCRIPTION
As shown in #37308, running with `GAP_ROOT_PATHS` misconfigured results in awful breakage, and there are several situations where it's difficult to get this rigth (#37263, https://github.com/sagemath/sage/issues/37308#issuecomment-1939941434).

The current PR makes minimal changes in `gap` and `libgap` to make this configuration unnecessary. Instead, we obtain the necessary information from the `gap` command.

Note that the user can still change the gap command with `SAGE_GAP_COMMAND`. This includes the possibility to change the paths to a custom with something like `SAGE_GAP_COMMAND='gap -l "path1;path2;path3"'`, etc.

### Details:

- interfaces/gap: remove __make_workspace, not used since 6be205b03c9
- interfaces/gap: cleanup gap_command()
- interfaces/gap: replace global WORKSPACE by Gap() attribute

The first three commits are cleanup to replace global WORKSPACE by an attribute. This necessary to prevent circular references, and it's also good form and simplifies a number of tests which want running a gap instance with a temporary workspace file.

- interfaces/gap: don't use GAP_ROOT_PATHS

This one is trivial since the `gap` command knows the paths.

- gap: fast implementation of KERNEL_INFO()

Implements a fast version of KERNEL_INFO() which obtains the configuration we need by running the `gap` command but avoiding the full initialization of gap which is costly.

See https://github.com/sagemath/sage/issues/33446#comment:48 and https://github.com/sagemath/sage/issues/33446#comment:40 for this idea, which I discarded previously because it was pretty slow. Compare:
```
sage: from sage.interfaces.gap import KERNEL_INFO
sage: KERNEL_INFO._KERNEL_INFO__instance = None # force reload
sage: %time KERNEL_INFO()
CPU times: user 3.53 ms, sys: 1.04 ms, total: 4.57 ms
Wall time: 28.6 ms
{'KERNEL_VERSION': '4.12.2', 'GAP_ARCHITECTURE': 'x86_64-unknown-linux-gnu-default64-kv8', 'GAP_ROOT_PATHS': '/usr/lib64/gap/;/usr/share/gap/'}
```
with
```
sage: import subprocess
sage: %time subprocess.getoutput('gap -q --nointeract --bare -r -c \'Display(JoinStringsWithSeparator(KERNEL_INFO().GAP_ROOT_PATHS,";"));\'')
CPU times: user 0 ns, sys: 1.7 ms, total: 1.7 ms
Wall time: 790 ms
'/usr/lib64/gap/;/usr/share/gap/'
```

The implementation returns only a few selected variables from `KERNEL_INFO()` but it would be easy to add more variables as needed in `src/sage/interfaces/gap_kernel_info.g`.

**TODO: add documentation and tests for `KERNEL_INFO()`.**

- interfaces/gap_workspace: use KERNEL_INFO() to create filename
- libs/gap/saved_workspace: use KERNEL_INFO() to compute gap timestamp
- libgap: get GAP_ROOT_PATHS from KERNEL_INFO()

It is now very easy to rid of all usages of `GAP_ROOT_PATHS`, replacing it by use of `KERNEL_INFO()`.

This even makes some code easier, e.g., `gap_workspace_file()` previously had to find and parse `sysinfo.gap` to read version and architecture, now it can obtain all the required information directly from `KERNEL_INFO()`.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

EDIT: formatting