### PR TITLE
`sage -package dependencies`

### DIFF
--- a/build/bin/sage-spkg-info
+++ b/build/bin/sage-spkg-info
@@ -23,7 +23,12 @@ else
     code ()  { echo "$1"; }
     tab ()   { echo "$1:"; }
 fi
-PKG_SCRIPTS="$SAGE_ROOT/build/pkgs/$PKG_BASE"
+if ! props=$(sage-package properties $PKG_BASE 2> /dev/null); then
+    echo >&2 "sage-spkg-info: unknown package $PKG_BASE"
+    exit 1
+fi
+eval "$props"
+eval PKG_SCRIPTS=\$path_$PKG_BASE
 for ext in rst txt; do
     SPKG_FILE="$PKG_SCRIPTS/SPKG.$ext"
     if [ -f "$SPKG_FILE" ]; then
@@ -44,29 +49,23 @@ echo
 echo "Dependencies"
 echo "------------"
 echo
-dep=
-for dep_file in dependencies dependencies_order_only; do
-    if [ -r "$PKG_SCRIPTS/$dep_file" ] ; then
-        for dep in $(sed 's/^ *//; s/ *#.*//; q' "$PKG_SCRIPTS/$dep_file"); do
-            case "$dep" in
-                # Do not use order-only syntax, too much information
-                \|)         ;;
-                # Suppress dependencies on source file of the form $(SAGE_ROOT)/..., $(SAGE_SRC)/...
-                \$\(SAGE_*) ;;
+eval $(sage-package properties :all:)
+for dep in $(sage-package dependencies $PKG_BASE); do
+    case "$dep" in
+                # Suppress dependencies on source files, e.g. of the form $(SAGE_ROOT)/..., $(SAGE_SRC)/...
+                */*) ;;
                 # Suppress FORCE
                 FORCE)      ;;
                 # Dependencies like $(BLAS)
                 \$\(*)      echo "- $dep";;
                 # Looks like a package
-                *)          if [ -r "$SAGE_ROOT/build/pkgs/$dep/SPKG.rst" ]; then
+                *)          if eval test -r "\$path_$dep/SPKG.rst"; then
                                 # This RST label is set in src/doc/bootstrap
                                 echo "- $(spkg $dep)"
                             else
                                 echo "- $dep"
                             fi;;
-            esac
-        done
-    fi
+    esac
 done
 echo
 echo "Version Information"

--- a/build/bin/sage-spkg-info
+++ b/build/bin/sage-spkg-info
@@ -16,12 +16,14 @@ if [ -n "$OUTPUT_RST" ]; then
     issue () { echo ":issue:\`$1\`"; }
     code ()  { echo "\`\`$*\`\`"; }
     tab ()   { echo ".. tab:: $1"; }
+    FORMAT=rst
 else
     ref ()   { echo "$1"; }
     spkg ()  { echo "$1"; }
     issue () { echo "https://github.com/sagemath/sage/issues/$1"; }
     code ()  { echo "$1"; }
     tab ()   { echo "$1:"; }
+    FORMAT=plain
 fi
 if ! props=$(sage-package properties --format=shell $PKG_BASE 2> /dev/null); then
     echo >&2 "sage-spkg-info: unknown package $PKG_BASE"
@@ -49,24 +51,7 @@ echo
 echo "Dependencies"
 echo "------------"
 echo
-eval $(sage-package properties --format=shell :all:)
-for dep in $(sage-package dependencies $PKG_BASE); do
-    case "$dep" in
-                # Suppress dependencies on source files, e.g. of the form $(SAGE_ROOT)/..., $(SAGE_SRC)/...
-                */*) ;;
-                # Suppress FORCE
-                FORCE)      ;;
-                # Dependencies like $(BLAS)
-                \$\(*)      echo "- $dep";;
-                # Looks like a package
-                *)          if eval test -r "\$path_$dep/SPKG.rst"; then
-                                # This RST label is set in src/doc/bootstrap
-                                echo "- $(spkg $dep)"
-                            else
-                                echo "- $dep"
-                            fi;;
-    esac
-done
+${SAGE_PACKAGE-sage-package} dependencies --format=$FORMAT $PKG_BASE
 echo
 echo "Version Information"
 echo "-------------------"

--- a/build/bin/sage-spkg-info
+++ b/build/bin/sage-spkg-info
@@ -51,7 +51,7 @@ echo
 echo "Dependencies"
 echo "------------"
 echo
-${SAGE_PACKAGE-sage-package} dependencies --format=$FORMAT $PKG_BASE
+sage-package dependencies --format=$FORMAT $PKG_BASE
 echo
 echo "Version Information"
 echo "-------------------"

--- a/build/bin/sage-spkg-info
+++ b/build/bin/sage-spkg-info
@@ -23,7 +23,7 @@ else
     code ()  { echo "$1"; }
     tab ()   { echo "$1:"; }
 fi
-if ! props=$(sage-package properties $PKG_BASE 2> /dev/null); then
+if ! props=$(sage-package properties --format=shell $PKG_BASE 2> /dev/null); then
     echo >&2 "sage-spkg-info: unknown package $PKG_BASE"
     exit 1
 fi
@@ -49,7 +49,7 @@ echo
 echo "Dependencies"
 echo "------------"
 echo
-eval $(sage-package properties :all:)
+eval $(sage-package properties --format=shell :all:)
 for dep in $(sage-package dependencies $PKG_BASE); do
     case "$dep" in
                 # Suppress dependencies on source files, e.g. of the form $(SAGE_ROOT)/..., $(SAGE_SRC)/...

--- a/build/pkgs/giac/dependencies
+++ b/build/pkgs/giac/dependencies
@@ -1,4 +1,4 @@
-readline libpng $(MP_LIBRARY) mpfr mpfi ntl gsl pari glpk curl cliquer ecm $(findstring libnauty,$(OPTIONAL_INSTALLED_PACKAGES))
+readline libpng $(MP_LIBRARY) mpfr mpfi ntl gsl pari glpk curl cliquer ecm
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/giac/dependencies_optional
+++ b/build/pkgs/giac/dependencies_optional
@@ -1,0 +1,1 @@
+libnauty

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -133,27 +133,28 @@ class Application(object):
         else:
             raise ValueError('format must be one of "plain", "rst", and "shell"')
 
-        if format == 'plain':
-            indent1 = "        "
-            indent2 = "                "
-        elif format == 'rst':
-            indent1 = ""
-            indent2 = "    "
-
         for package_name in pc.names:
             package = Package(package_name)
             if len(pc.names) > 1:
                 if format == 'plain':
                     print("{0}:".format(package_name))
+                    indent1 = "        "
                 elif format == 'rst':
                     print("\n{0}\n{1}\n".format(package_name, "~" * len(package_name)))
+                    indent1 = ""
+            else:
+                indent1 = ""
 
             for typeset in typesets:
                 if len(typesets) > 1:
                     if format == 'plain':
                         print(indent1 + "{0}: ".format('/'.join(typeset)))
+                        indent2 = indent1 + "        "
                     elif format == 'rst':
                         print("\n" + indent1 + ".. tab:: {0}\n".format('/'.join(typeset)))
+                        indent2 = indent1 + "    "
+                else:
+                    indent2 = indent1
 
                 deps = []
                 for t in typeset:

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -108,6 +108,39 @@ class Application(object):
                 else:
                     print("{0}_{1}='{2}'".format(p, package_name, value))
 
+    def dependencies(self, *package_classes, types=None, format='plain'):
+        """
+        Find the dependencies given package names
+
+        $ sage --package dependencies maxima --runtime --order-only
+        ecl
+        info
+        """
+        log.debug('Looking up dependencies')
+        pc = PackageClass(*package_classes)
+        if format == 'plain':
+            if types is None:
+                types = ['order_only', 'runtime']
+            deps = []
+            for package_name in pc.names:
+                package = Package(package_name)
+                for t in types:
+                    deps.extend(getattr(package, 'dependencies_' + t))
+            for dep in sorted(set(deps)):
+                print(dep)
+        elif format == 'shell':
+            if types is None:
+                types = ['order_only', 'optional', 'runtime', 'check']
+            for package_name in pc.names:
+                package = Package(package_name)
+                for t in types:
+                    # We single-quote the values because dependencies
+                    # may contain Makefile variable substitutions
+                    deps = getattr(package, 'dependencies_' + t)
+                    print("{0}_deps_{1}='{2}'".format(t, package_name, ' '.join(deps)))
+        else:
+            raise ValueError('format must be one of "plain" and "shell"')
+
     def name(self, tarball_filename):
         """
         Find the package name given a tarball filename

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -108,7 +108,7 @@ class Application(object):
                 else:
                     print("{0}_{1}='{2}'".format(p, package_name, value))
 
-    def dependencies(self, *package_classes, types=None, format='plain'):
+    def dependencies(self, *package_classes, **kwds):
         """
         Find the dependencies given package names
 
@@ -116,6 +116,8 @@ class Application(object):
         ecl
         info
         """
+        types = kwds.pop('types', None)
+        format = kwds.pop('format', 'plain')
         log.debug('Looking up dependencies')
         pc = PackageClass(*package_classes)
         if format == 'plain':

--- a/build/sage_bootstrap/cmdline.py
+++ b/build/sage_bootstrap/cmdline.py
@@ -99,6 +99,20 @@ EXAMPLE:
 """
 
 
+epilog_dependencies = \
+"""
+Print the list of packages that are dependencies of given package.
+By default, list the build, order-only, and runtime dependencies.
+
+EXAMPLE:
+
+    $ sage --package dependencies maxima --runtime
+    ecl
+    $ sage --package dependencies maxima --order-only
+    info
+"""
+
+
 epilog_name = \
 """
 Find the package name given a tarball filename
@@ -286,6 +300,31 @@ def make_parser():
         '--format', type=str, default='plain',
         help='output format (one of plain and shell; default: plain)')
 
+    parser_dependencies = subparsers.add_parser(
+        'dependencies', epilog=epilog_dependencies,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        help='Print the list of packages that are dependencies of given packages')
+    parser_dependencies.add_argument(
+        'package_class', metavar='[package_name|:package_type:]',
+        type=str, nargs='+',
+        help=('package name or designator for all packages of a given type '
+              '(one of :all:, :standard:, :optional:, and :experimental:)'))
+    parser_dependencies.add_argument(
+        '--order-only', action='store_true',
+        help='list the order-only build dependencies')
+    parser_dependencies.add_argument(
+        '--optional', action='store_true',
+        help='list the optional build dependencies')
+    parser_dependencies.add_argument(
+        '--runtime', action='store_true',
+        help='list the runtime dependencies')
+    parser_dependencies.add_argument(
+        '--check', action='store_true',
+        help='list the check dependencies')
+    parser_dependencies.add_argument(
+        '--format', type=str, default='plain',
+        help='output format (one of plain and shell; default: plain)')
+
     parser_name = subparsers.add_parser(
         'name', epilog=epilog_name,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -435,6 +474,19 @@ def run():
                      exclude_dependencies=args.exclude_dependencies)
     elif args.subcommand == 'properties':
         app.properties(*args.package_class, format=args.format)
+    elif args.subcommand == 'dependencies':
+        types = []
+        if args.order_only:
+            types.append('order_only')
+        if args.optional:
+            types.append('optional')
+        if args.runtime:
+            types.append('runtime')
+        if args.check:
+            types.append('check')
+        if not types:
+            types = None
+        app.dependencies(*args.package_class, types=types, format=args.format)
     elif args.subcommand == 'name':
         app.name(args.tarball_filename)
     elif args.subcommand == 'tarball':

--- a/build/sage_bootstrap/cmdline.py
+++ b/build/sage_bootstrap/cmdline.py
@@ -109,12 +109,23 @@ EXAMPLE:
 
     $ sage --package dependencies maxima openblas
     maxima:
-                    - ecl
-                    - info
+            - ecl
+            - info
     openblas:
-                    - gfortran
+            - gfortran
     $ sage --package dependencies maxima --runtime
+    - ecl
+
+    $ sage --package dependencies maxima openblas --runtime --order-only
+    maxima:
+            order_only:
+                    - info
+            runtime:
                     - ecl
+    openblas:
+            order_only:
+            runtime:
+                    - gfortran
 """
 
 

--- a/build/sage_bootstrap/cmdline.py
+++ b/build/sage_bootstrap/cmdline.py
@@ -102,14 +102,19 @@ EXAMPLE:
 epilog_dependencies = \
 """
 Print the list of packages that are dependencies of given package.
-By default, list the build, order-only, and runtime dependencies.
+By default, list a summary of the build, order-only, and runtime
+dependencies.
 
 EXAMPLE:
 
+    $ sage --package dependencies maxima openblas
+    maxima:
+                    - ecl
+                    - info
+    openblas:
+                    - gfortran
     $ sage --package dependencies maxima --runtime
-    ecl
-    $ sage --package dependencies maxima --order-only
-    info
+                    - ecl
 """
 
 
@@ -323,7 +328,7 @@ def make_parser():
         help='list the check dependencies')
     parser_dependencies.add_argument(
         '--format', type=str, default='plain',
-        help='output format (one of plain and shell; default: plain)')
+        help='output format (one of plain, rst, and shell; default: plain)')
 
     parser_name = subparsers.add_parser(
         'name', epilog=epilog_name,

--- a/build/sage_bootstrap/package.py
+++ b/build/sage_bootstrap/package.py
@@ -381,6 +381,23 @@ class Package(object):
         return self.__dependencies.partition('|')[2].strip().split() + self.__dependencies_order_only.strip().split()
 
     @property
+    def dependencies_optional(self):
+        """
+        Return a list of strings, the package names of the optional build dependencies
+        """
+        return self.__dependencies_optional.strip().split()
+
+    @property
+    def dependencies_runtime(self):
+        """
+        Return a list of strings, the package names of the runtime dependencies
+        """
+        # after a '|', we have order-only build dependencies
+        return self.__dependencies.partition('|')[0].strip().split()
+
+    dependencies = dependencies_runtime
+
+    @property
     def dependencies_check(self):
         """
         Return a list of strings, the package names of the check dependencies
@@ -511,6 +528,11 @@ class Package(object):
                 self.__dependencies_check = f.readline().strip()
         except IOError:
             self.__dependencies_check = ''
+        try:
+            with open(os.path.join(self.path, 'dependencies_optional')) as f:
+                self.__dependencies_optional = f.readline()
+        except IOError:
+            self.__dependencies_optional = ''
         try:
             with open(os.path.join(self.path, 'dependencies_order_only')) as f:
                 self.__dependencies_order_only = f.readline()

--- a/build/sage_bootstrap/package.py
+++ b/build/sage_bootstrap/package.py
@@ -520,22 +520,22 @@ class Package(object):
     def _init_dependencies(self):
         try:
             with open(os.path.join(self.path, 'dependencies')) as f:
-                self.__dependencies = f.readline().strip()
+                self.__dependencies = f.readline().partition('#')[0].strip()
         except IOError:
             self.__dependencies = ''
         try:
             with open(os.path.join(self.path, 'dependencies_check')) as f:
-                self.__dependencies_check = f.readline().strip()
+                self.__dependencies_check = f.readline().partition('#')[0].strip()
         except IOError:
             self.__dependencies_check = ''
         try:
             with open(os.path.join(self.path, 'dependencies_optional')) as f:
-                self.__dependencies_optional = f.readline()
+                self.__dependencies_optional = f.readline().partition('#')[0].strip()
         except IOError:
             self.__dependencies_optional = ''
         try:
             with open(os.path.join(self.path, 'dependencies_order_only')) as f:
-                self.__dependencies_order_only = f.readline()
+                self.__dependencies_order_only = f.readline().partition('#')[0].strip()
         except IOError:
             self.__dependencies_order_only = ''
 


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
We add a new command `sage --package dependencies`.
Like the command `sage --package properties` introduced in #37018, it can be used to eliminate direct references to `build/pkgs/` from various scripts and reduce code duplication in reading SPKG metadata.

Here we only make such changes in `sage-spkg-info`.
The only user-visible change is that the listed dependencies are now sorted alphabetically; this hides [subtle nuances that may be expressed in the sort order of some `dependencies` files](https://github.com/sagemath/sage/pull/36878#issuecomment-1876426258).

- Closes #33860

Split out from:
- #36740

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
