### PR TITLE
less usage of method .is_commutative

### DIFF
--- a/src/sage/combinat/descent_algebra.py
+++ b/src/sage/combinat/descent_algebra.py
@@ -19,6 +19,7 @@ from sage.misc.lazy_attribute import lazy_attribute
 from sage.structure.parent import Parent
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.categories.algebras import Algebras
+from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.realizations import Realizations, Category_realization_of_parent
 from sage.categories.finite_dimensional_algebras_with_basis import FiniteDimensionalAlgebrasWithBasis
 from sage.rings.integer_ring import ZZ
@@ -929,7 +930,7 @@ class DescentAlgebraBases(Category_realization_of_parent):
                 return self.base_ring().is_field()
             return False
 
-        def is_commutative(self):
+        def is_commutative(self) -> bool:
             """
             Return whether this descent algebra is commutative.
 
@@ -942,8 +943,8 @@ class DescentAlgebraBases(Category_realization_of_parent):
                 sage: B.is_commutative()
                 True
             """
-            return self.base_ring().is_commutative() \
-                and self.realization_of()._n <= 2
+            return (self.base_ring() in CommutativeRings()
+                    and self.realization_of()._n <= 2)
 
         @lazy_attribute
         def to_symmetric_group_algebra(self):

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -221,6 +221,7 @@ from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.polynomial_element import Polynomial
 from sage.rings.polynomial.multi_polynomial import MPolynomial
 from sage.combinat.partition import _Partitions, Partitions, Partitions_n, Partition
+from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.hopf_algebras import HopfAlgebras
 from sage.categories.hopf_algebras_with_basis import HopfAlgebrasWithBasis
 from sage.categories.principal_ideal_domains import PrincipalIdealDomains
@@ -428,7 +429,7 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
             """
             return False
 
-        def is_commutative(self):
+        def is_commutative(self) -> bool:
             """
             Return whether this symmetric function algebra is commutative.
 
@@ -442,7 +443,7 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
                 sage: s.is_commutative()
                 True
             """
-            return self.base_ring().is_commutative()
+            return self.base_ring() in CommutativeRings()
 
         def _repr_(self):
             """
@@ -1050,7 +1051,7 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
             corresponding_result = corresponding_parent_over_QQ.gessel_reutenauer(lam)
             comp_base_ring = comp_parent.base_ring()
             result = comp_parent.sum_of_terms((nu, comp_base_ring(c))
-                                               for nu, c in corresponding_result)
+                                              for nu, c in corresponding_result)
             return self(result)    # just in case comp_parent != self.
 
         higher_lie_character = gessel_reutenauer
@@ -1187,8 +1188,8 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
 
                 def component(i, g): # == h_g[L_i] or e_g[L_i]
                     L_i = p.sum_of_terms(((_Partitions([d] * (i//d)), R(mu(d)))
-                                           for d in squarefree_divisors(i)),
-                                          distinct=True) / i
+                                          for d in squarefree_divisors(i)),
+                                         distinct=True) / i
                     if not i % 2:
                         return p(e[g]).plethysm(L_i.omega())
                     else:
@@ -1221,7 +1222,7 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
             corresponding_result = corresponding_parent_over_QQ.lehrer_solomon(lam)
             comp_base_ring = comp_parent.base_ring()
             result = comp_parent.sum_of_terms((nu, comp_base_ring(c))
-                                               for nu, c in corresponding_result)
+                                              for nu, c in corresponding_result)
             return self(result)    # just in case comp_parent != self.
 
         whitney_homology_character = lehrer_solomon
@@ -1765,11 +1766,11 @@ class GradedSymmetricFunctionsBases(Category_realization_of_parent):
             return len(m) <= 1 and self.coefficient([]).is_unit()
 
 
-#SymmetricFunctionsBases.Filtered = FilteredSymmetricFunctionsBases
-#SymmetricFunctionsBases.Graded = GradedSymmetricFunctionsBases
+# SymmetricFunctionsBases.Filtered = FilteredSymmetricFunctionsBases
+# SymmetricFunctionsBases.Graded = GradedSymmetricFunctionsBases
 
 #####################################################################
-## ABC for bases of the symmetric functions
+#  ABC for bases of the symmetric functions
 
 class SymmetricFunctionAlgebra_generic(CombinatorialFreeModule):
     r"""
@@ -5885,7 +5886,7 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
         elif isinstance(nu, list) and all(isinstance(a, (int,Integer)) for a in nu):
             return P(s.sum(t**la.size() * c * d * s(la) *
                      s._repeated_bernstein_creation_operator_on_basis(ga, nu)
-                     for ((la,mu),c) in s(self).coproduct()
+                     for ((la, mu), c) in s(self).coproduct()
                      for (ga, d) in s(mu).plethysm((1-t)*s[1]) ))
         else:
             raise ValueError("nu must be a list of integers")

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -186,7 +186,8 @@ import sage.rings.infinity
 import sage.rings.integer
 import sage.rings.integer_ring
 import sage.rings.rational_field
-from sage.rings.ring import IntegralDomain, is_Ring
+from sage.rings.ring import IntegralDomain
+from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.fields import Fields
 from sage.categories.infinite_enumerated_sets import InfiniteEnumeratedSets
 from sage.categories.integral_domains import IntegralDomains
@@ -266,16 +267,16 @@ class FreeModuleFactory(UniqueFactory):
             from sage.modules.free_quadratic_module import FreeQuadraticModule
             return FreeQuadraticModule(base_ring, rank, inner_product_matrix=inner_product_matrix, sparse=sparse)
 
-        if not isinstance(sparse,bool):
+        if not isinstance(sparse, bool):
             raise TypeError("Argument sparse (= %s) must be True or False" % sparse)
 
-        if not (hasattr(base_ring,'is_commutative') and base_ring.is_commutative()):
+        if base_ring not in CommutativeRings():
             warn("You are constructing a free module\n"
                  "over a noncommutative ring. Sage does not have a concept\n"
                  "of left/right and both sided modules, so be careful.\n"
                  "It's also not guaranteed that all multiplications are\n"
                  "done from the right side.")
-            #raise TypeError, "The base_ring must be a commutative ring."
+            # raise TypeError("The base_ring must be a commutative ring.")
 
         if not sparse and isinstance(base_ring, sage.rings.abc.RealDoubleField):
             return RealDoubleVectorSpace_class(rank)
@@ -727,7 +728,7 @@ def span(gens, base_ring=None, check=True, already_echelonized=False):
         TypeError: generators must be lists of ring elements
         or free module elements!
     """
-    if is_Ring(gens):
+    if gens in CommutativeRings():
         # we allow the old input format with first input the base_ring.
         # Do we want to deprecate it?..
         base_ring, gens = gens, base_ring
@@ -1966,7 +1967,7 @@ class FreeModule_generic(Module_free_ambient):
             <class 'sage.modules.free_module_element.FreeModuleElement_generic_sparse'>
 
         """
-        if not base_ring.is_commutative():
+        if base_ring not in CommutativeRings():
             warn("You are constructing a free module\n"
                  "over a noncommutative ring. Sage does not have a concept\n"
                  "of left/right and both sided modules, so be careful.\n"

--- a/src/sage/modules/free_quadratic_module.py
+++ b/src/sage/modules/free_quadratic_module.py
@@ -67,11 +67,12 @@ AUTHORS:
 # ****************************************************************************
 import weakref
 
-import sage.matrix.matrix_space
-import sage.misc.latex as latex
-from sage.rings.ring import Field, IntegralDomain
+from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.principal_ideal_domains import PrincipalIdealDomains
 from sage.modules import free_module
+from sage.rings.ring import Field, IntegralDomain
+import sage.matrix.matrix_space
+import sage.misc.latex as latex
 
 # #############################################################################
 #
@@ -157,7 +158,7 @@ def FreeQuadraticModule(base_ring, rank, inner_product_matrix,
         if M is not None:
             return M
 
-    if not base_ring.is_commutative():
+    if base_ring not in CommutativeRings():
         raise TypeError("base_ring must be a commutative ring")
 
     # elif not sparse and isinstance(base_ring,sage.rings.real_double.RealDoubleField_class):


### PR DESCRIPTION
changing a few calls of `R.is_commutative()` for rings, in favour of the syntax `R in CommutativeRings()`

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.