### PR TITLE
Fix doctest for `multiplication_by_m`

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -2448,10 +2448,8 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         ::
 
             sage: p = 7
-            sage: K.<i> = GF(p^2)
-            sage: a, b = K.random_element(), K.random_element()
-            sage: while 4*a^3 + 27*b^2 == 0: a, b = K.random_element(), K.random_element()
-            sage: E = EllipticCurve(K, a, b)
+            sage: K.<a> = GF(p^2)
+            sage: E = EllipticCurve(j=K.random_element())
             sage: E.multiplication_by_m(p * 2)[0] == E.multiplication_by_m(p * 2, x_only=True)
             True
         """

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -2448,8 +2448,10 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         ::
 
             sage: p = 7
-            sage: K.<a> = GF(p^2)
-            sage: E = EllipticCurve(K, [K.random_element(), K.random_element()])
+            sage: K.<i> = GF(p^2)
+            sage: a, b = K.random_element(), K.random_element()
+            sage: while 4*a^3 + 27*b^2 == 0: a, b = K.random_element(), K.random_element()
+            sage: E = EllipticCurve(K, a, b)
             sage: E.multiplication_by_m(p * 2)[0] == E.multiplication_by_m(p * 2, x_only=True)
             True
         """


### PR DESCRIPTION
The current doctest can create a singular curve, for example with `random-seed=129979402993014347526756638208394445987`.