### PR TITLE
Add `.is_cyclic()` method for elliptic curves isogenies, and `cyclic_after` flag for `.isogenies_prime_degree()`

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1364,7 +1364,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
           This is only used if ``l`` is None.
 
         - ``cyclic_after`` -- (default: ``None``) an isogeny with codomain equal to
-          `self`. If set, then only isogenies that are cyclic continuations of
+          ``self``. If set, then only isogenies that are cyclic continuations of
           the given isogeny are returned.
 
         OUTPUT:

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1363,7 +1363,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         - ``max_l`` -- (default: 31) a bound on the primes to be tested.
           This is only used if ``l`` is None.
 
-        - ``cyclic_after`` -- (default: None) an isogeny with codomain equal to
+        - ``cyclic_after`` -- (default: ``None``) an isogeny with codomain equal to
           `self`. If set, then only isogenies that are cyclic continuations of
           the given isogeny are returned.
 
@@ -1533,8 +1533,8 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             sage: E.isogenies_prime_degree(5)
             []
 
-        The optional argument `cyclic_after` can be used to easily construct cyclic
-        isogeny chains (i.e., avoid hitting dual isogenies):
+        The optional argument ``cyclic_after`` can be used to easily construct cyclic
+        isogeny chains (i.e., avoid hitting dual isogenies)::
 
             sage: E = EllipticCurve(GF(13^6), [2,8])
             sage: phi1 = choice(E.isogenies_prime_degree(3))
@@ -1627,7 +1627,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             ...
             ValueError: 4 is not prime.
 
-        Test for bug in PR#37388::
+        Test for bug in :issue:`37388`::
 
             sage: E0 = EllipticCurve(GF(19), [4, 0])
             sage: phi1 = E0.isogenies_prime_degree(5)[0]
@@ -1662,9 +1662,9 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         else:
             dom = cyclic_after.domain()
             if cyclic_after.codomain() != self:
-                raise ValueError("The codomain of `cyclic_after` must be the same curve")
+                raise ValueError("the codomain of `cyclic_after` must be the same curve")
             if not cyclic_after.is_separable():
-                raise ValueError("The `cyclic_after` isogeny must be separable")
+                raise ValueError("the `cyclic_after` isogeny must be separable")
             ret = []
             for d in L:
                 for phi in isogenies_prime_degree(self, d):
@@ -1672,7 +1672,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                     # but also do some overhead (construct composte map, check degrees
                     # are primes, etc.)
                     # So we check j-invariants here to make most cases pass fast
-                    if (cyclic_after.degree().is_prime() and phi.codomain().j_invariant() != dom.j_invariant()):
+                    if cyclic_after.degree().is_prime() and phi.codomain().j_invariant() != dom.j_invariant():
                         ret.append(phi)
                     elif (phi * cyclic_after).is_cyclic():
                         ret.append(phi)

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1658,7 +1658,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         from .isogeny_small_degree import isogenies_prime_degree
         if cyclic_after is None:
-            return sum([isogenies_prime_degree(self, d) for d in L], [])
+            return [phi for d in L for phi in isogenies_prime_degree(self, d)]
 
         dom = cyclic_after.domain()
         if cyclic_after.codomain() != self:

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -936,14 +936,12 @@ class EllipticCurveHom(Morphism):
         ALGORITHM:
 
         Separable isogenies with squarefree degrees are cyclic.
-        For each $\ell \ne p$ such that its square divides the degree of the isogeny,
-        test if $E[\ell]$ is mapped to 0 by reducing the kernel polynomial
-        modulo the division polynomial. If for all $\ell$ it does not happen,
+        For each `\ell \ne p` such that its square divides the degree of the isogeny,
+        test if `E[\ell]` is mapped to `0` by reducing the kernel polynomial
+        modulo the division polynomial. If for all `\ell` it does not happen,
         then the result is cyclic.
 
-        EXAMPLES:
-
-        Here we include also special cases which do not use the general algorithm. ::
+        EXAMPLES::
 
             sage: E = EllipticCurve(GF(79), [7,7])
             sage: phi = E.scalar_multiplication(5)

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -1000,9 +1000,9 @@ class EllipticCurveHom(Morphism):
         if self.is_zero() or not self.is_separable():
             return False
 
-        deg_fac = ZZ(self.degree()).factor()
+        deg_fac = self.degree().factor()
         # squarefree => cyclic
-        if not deg_fac or max(e for ell, e in deg_fac) <= 1:
+        if all(e <= 1 for ell, e in deg_fac) <= 1:
             return True
 
         E0 = self.domain()

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -973,6 +973,9 @@ class EllipticCurveHom(Morphism):
             sage: from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
             sage: E0 = EllipticCurve(GF(37), [4, 0])
             sage: frob = EllipticCurveHom_frobenius(E0, 0)  # note zero power (identity morphism)
+            sage: frob.is_cyclic()
+            True
+
             sage: phi1 = E0.isogenies_prime_degree(3)[2]
             sage: phi = phi1.dual() * phi1 * frob
             sage: phi.is_cyclic()
@@ -980,6 +983,15 @@ class EllipticCurveHom(Morphism):
             sage: super(type(phi), phi).is_cyclic()  # previous incorrectly returned True
             False
             sage: t = factor(phi.x_rational_map().denominator())  # previously raised AttributeError
+
+            sage: E0.scalar_multiplication(0).is_cyclic()
+            False
+            sage: E0.scalar_multiplication(37).is_cyclic()
+            False
+            sage: EllipticCurveHom_frobenius(E0, 0).is_cyclic()
+            True
+            sage: EllipticCurveHom_frobenius(E0, 1).is_cyclic()
+            False
 
         .. SEEALSO::
 

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -966,6 +966,21 @@ class EllipticCurveHom(Morphism):
             sage: (phi.dual() * phi).is_cyclic()
             False
 
+        TESTS:
+
+        Regression test (failed because of :issue:`37374`)::
+
+            sage: from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
+            sage: E0 = EllipticCurve(GF(37), [4, 0])
+            sage: frob = EllipticCurveHom_frobenius(E0, 0)  # note zero power (identity morphism)
+            sage: phi1 = E0.isogenies_prime_degree(3)[2]
+            sage: phi = phi1.dual() * phi1 * frob
+            sage: phi.is_cyclic()
+            False
+            sage: super(type(phi), phi).is_cyclic()  # previous incorrectly returned True
+            False
+            sage: t = factor(phi.x_rational_map().denominator())  # previously raised AttributeError
+
         .. SEEALSO::
 
         - :meth:`sage.schemes.elliptic_curves.hom_composie.EllipticCurveHom_composite.is_cyclic`

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -903,26 +903,25 @@ class EllipticCurveHom_composite(EllipticCurveHom):
 
         ALGORITHM:
 
-        For each prime $\ell$ with $\ell^2$ dividing the isogeny degree,
-        test that $\ell$-torsion is not fully nullified. This is done by
+        For each prime `\ell` with `\ell^2` dividing the isogeny degree,
+        test that `\ell`-torsion is not fully nullified. This is done by
         evaluating the isogeny modulo the division polynomial of the domain curve,
         reducing the modulus on the way when parts of the torsion get nullified.
 
         For each $\ell$, only the smallest segment of isogenies is considered,
         such that it includes all isogenies whose degrees are divisible by $\ell$.
 
-        INPUT: The following optimization flags are intended only for debugging
-        and testing.
+        INPUT:
 
-        If `_check_j` is set, then the segment is further shrinked by eliminating
-        prefix/suffix chains of $\ell$-isogenies via j-invariant checks. In many
-        applications, the isogeny degrees would be ordered, so that only
-        j-invariant checks would be performed (unless there is a "backtracking"
-        j-invariant step, which is not necessarily the dual).
+        - ``_check_j`` -- (bool, default: ``True``); if set, the segment is further shrinked by eliminating
+          prefix/suffix chains of `\ell`-isogenies via j-invariant checks. In many
+          applications, the isogeny degrees would be ordered, so that only
+          j-invariant checks would be performed (unless there is a "backtracking"
+          j-invariant step, which is not necessarily the dual). For internal use only.
 
-        If `_reduce_kernel` is set, then, after the first step in the segment,
-        the modulus is replaced by the kernel polynomial of the dual isogeny,
-        which has degree (l-1)/2 instead of (l^2-1)/2.
+        - ``_reduce_kernel`` -- (bool, default: ``True``); if set, after the first step in the segment,
+          the modulus is replaced by the kernel polynomial of the dual isogeny,
+          which has degree `(\ell-1)/2` instead of `(\ell^2-1)/2`. For internal use only.
 
         EXAMPLES::
 
@@ -936,8 +935,8 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             sage: sorted((phi2 * phi1).is_cyclic() for phi2 in phi2_list)
             [False, True, True]
 
-        Works even if the cyclicity is broken across more than 2 isogenies:
-        (e.g., when commuting isogenies are swapped: degrees 2-2-5 <-> 2-5-2)
+        The method works even if the cyclicity is broken across more than 2 isogenies
+        such as when the order of commuting isogenies are swapped from 2-2-5 to 2-5-2::
 
             sage: phi2 = phi1.codomain().isogenies_prime_degree(5)[0]
             sage: phi3_list = phi2.codomain().isogenies_prime_degree(2)
@@ -969,7 +968,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
 
         This test involves multiple "backtracking" edges which are not duals. We have only 2 supersingular
         j-invariants, and so all supersingular isogenies have to be between them. In particular,
-        there are $7^2$-isogenies on j-invariants 7-7-7 which is cyclic.
+        there are `7^2`-isogenies on j-invariants 7-7-7 which is cyclic::
 
             sage: [j for j in GF(19**2) if EllipticCurve(j=j).is_supersingular()]
             [7, 18]
@@ -1085,11 +1084,11 @@ def _sieve_torsion_through_isogenies(phis, ell, use_second_curve=True):
 
     INPUT:
 
-    - phis (list of isogenies) -- list of isogenies to propagate the torsion through
+    - ``phis`` -- a list of isogenies to propagate the torsion through.
 
-    - ell -- an integer defining the torsion $E[\ell]$
+    - ``ell`` -- an integer defining the torsion `E[\ell]`.
 
-    - use_second_curve (optional, default: ``True``): whether to base
+    - ``use_second_curve`` (optional, default: ``True``): whether to base
       the remaining torsion representation to the second curve (which is faster
       because of lower degree).
 
@@ -1130,9 +1129,9 @@ def _sieve_torsion_through_isogenies(phis, ell, use_second_curve=True):
         - :meth:`sage.schemes.elliptic_curves.hom_composit.EllipticCurveHom_composite.is_cyclic`
     """
     if not phis:
-        raise ValueError("List of isogenies must be nonempty")
+        raise ValueError("list of isogenies must be nonempty")
     if any(phi.is_zero() or not phi.is_separable() for phi in phis):
-        return phis[0].domain().base_ring()['x'](1)
+        return phis[0].domain().base_ring()['x'].one()
 
     E0 = phis[0].domain()
     p = E0.base_ring().characteristic()

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -1104,7 +1104,7 @@ def _sieve_torsion_through_isogenies(phis, ell, use_second_curve=True):
         sage: _sieve_torsion_through_isogenies([], 2)
         Traceback (most recent call last):
         ...
-        ValueError: List of isogenies must be nonempty
+        ValueError: list of isogenies must be nonempty
 
         sage: E0 = EllipticCurve(GF(37), [4, 0])
         sage: phi = E0.scalar_multiplication(0)

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -941,16 +941,6 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             sage: sorted((phi3 * phi2 * phi1).is_cyclic() for phi3 in phi3_list)
             [False, True, True]
 
-        "Recursive" composite isogenies are not flattened, but should still
-        return correct results:
-
-            sage: from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
-            sage: EllipticCurveHom_composite.from_factors([phi1.dual() * phi1]).is_cyclic()
-            False
-            sage: phi2 = choice([phi2 for phi2 in phi2_list if (phi2 * phi1).is_cyclic()])
-            sage: EllipticCurveHom_composite.from_factors([phi2 * phi1]).is_cyclic()
-            True
-
         TESTS::
 
             sage: from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
@@ -982,6 +972,16 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             sage: n_cyclic = sum((phi2 * phi1).is_cyclic() for phi2 in phi2_list)
             sage: n_cyclic, len(phi2_list)
             (7, 8)
+
+        Nested composite isogenies are not flattened, but should still
+        return correct results:
+
+            sage: from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
+            sage: EllipticCurveHom_composite.from_factors([phi1.dual() * phi1]).is_cyclic()
+            False
+            sage: phi2 = choice([phi2 for phi2 in phi2_list if (phi2 * phi1).is_cyclic()])
+            sage: EllipticCurveHom_composite.from_factors([phi2 * phi1]).is_cyclic()
+            True
 
         .. SEEALSO::
 

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -89,7 +89,7 @@ from sage.structure.sequence import Sequence
 
 from sage.rings.integer_ring import ZZ
 
-from sage.arith.misc import prod, is_prime, gcd
+from sage.arith.misc import prod, is_prime
 from sage.structure.factorization import Factorization
 
 from sage.schemes.elliptic_curves.ell_generic import EllipticCurve_generic
@@ -1029,7 +1029,7 @@ def _propagate_torsion_through_isogenies(phis, ell, _reduce_kernel=True):
     # i.e. "working with full torsion" at the same time
     # gradually removing torsion factors that are being nullified
     mod = E0.division_polynomial(ell)
-    if gcd(p, ell) != 1:
+    if ZZ(p).gcd(ell) != 1:
         # if the order is not coprime with the characteristic,
         # we may get repeated roots
         mod = mod.radical()
@@ -1044,7 +1044,7 @@ def _propagate_torsion_through_isogenies(phis, ell, _reduce_kernel=True):
         x_rational_map = phi.x_rational_map()
 
         den = x_rational_map.denominator()(y)
-        g = gcd(den.lift(), mod)
+        g = den.lift().gcd(mod)
         if g != 1:
             # a new part of torsion is nullified
             # so we need to update the modulus and the quotient ring

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -911,6 +911,19 @@ class EllipticCurveHom_composite(EllipticCurveHom):
         For each $\ell$, only the smallest segment of isogenies is considered,
         such that it includes all isogenies whose degrees are divisible by $\ell$.
 
+        INPUT: The following optimization flags are intended only for debugging
+        and testing.
+
+        If `_check_j` is set, then the segment is further shrinked by eliminating
+        prefix/suffix chains of $\ell$-isogenies via j-invariant checks. In many
+        applications, the isogeny degrees would be ordered, so that only
+        j-invariant checks would be performed (unless there is a "backtracking"
+        j-invariant step, which is not necessarily the dual).
+
+        If `_reduce_kernel` is set, then, after the first step in the segment,
+        the modulus is replaced by the kernel polynomial of the dual isogeny,
+        which has degree (l-1)/2 instead of (l^2-1)/2.
+
         EXAMPLES::
 
             sage: E0 = EllipticCurve(GF((2**64+13)**2), [4, 0])
@@ -924,12 +937,22 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             [False, True, True]
 
         Works even if the cyclicity is broken across more than 2 isogenies:
-        (e.g., when commuting isogenies are swapped: degrees 2-2-3 <-> 2-3-2)
+        (e.g., when commuting isogenies are swapped: degrees 2-2-5 <-> 2-5-2)
 
             sage: phi2 = phi1.codomain().isogenies_prime_degree(5)[0]
             sage: phi3_list = phi2.codomain().isogenies_prime_degree(2)
             sage: sorted((phi3 * phi2 * phi1).is_cyclic() for phi3 in phi3_list)
             [False, True, True]
+
+        "Recursive" composite isogenies are not flattened, but should still
+        return correct results:
+
+            sage: from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
+            sage: EllipticCurveHom_composite.from_factors([phi1.dual() * phi1]).is_cyclic()
+            False
+            sage: phi2 = choice([phi2 for phi2 in phi2_list if (phi2 * phi1).is_cyclic()])
+            sage: EllipticCurveHom_composite.from_factors([phi2 * phi1]).is_cyclic()
+            True
 
         .. SEEALSO::
 

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -87,8 +87,6 @@ from sage.structure.richcmp import op_EQ
 from sage.misc.cachefunc import cached_method
 from sage.structure.sequence import Sequence
 
-from sage.rings.integer_ring import ZZ
-
 from sage.arith.misc import prod, is_prime
 from sage.structure.factorization import Factorization
 
@@ -996,10 +994,10 @@ class EllipticCurveHom_composite(EllipticCurveHom):
         # even without separate prime test
         # deg_fac = Factorization(())
         # for phi in self._phis:
-        #     deg_fac *= ZZ(phi.degree()).factor()
+        #     deg_fac *= phi.degree().factor()
         deg_fac = {}
         for phi in self._phis:
-            phi_deg = ZZ(phi.degree())
+            phi_deg = phi.degree()
             # note: prime degrees are a very typical case in HomComposite
             # so the optimization is worth it
             if phi_deg.is_prime():
@@ -1141,7 +1139,7 @@ def _sieve_torsion_through_isogenies(phis, ell, use_second_curve=True):
     # i.e. "working with full torsion" at the same time
     # gradually removing torsion factors that are being nullified
     mod = E0.division_polynomial(ell)
-    if ZZ(p).gcd(ell) != 1:
+    if p.gcd(ell) != 1:
         # if the order is not coprime with the characteristic,
         # we may get repeated roots
         mod = mod.radical()

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -967,6 +967,25 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             sage: EllipticCurveHom_composite.from_factors([EllipticCurveHom_frobenius(E0, 1)]).is_cyclic()
             False
 
+        This test involves multiple "backtracking" edges which are not duals. We have only 2 supersingular
+        j-invariants, and so all supersingular isogenies have to be between them. In particular,
+        there are $7^2$-isogenies on j-invariants 7-7-7 which is cyclic.
+
+            sage: [j for j in GF(19**2) if EllipticCurve(j=j).is_supersingular()]
+            [7, 18]
+            sage: 1728 % 19
+            18
+
+            sage: E0 = EllipticCurve(GF(19**24), [10, 2])  # field of definition of the full 7-torsion
+            sage: E0.j_invariant()  # 7 is not 1728
+            7
+
+            sage: phi1 = choice(E0.isogenies_prime_degree(7))
+            sage: phi2_list = phi1.codomain().isogenies_prime_degree(7)
+            sage: n_cyclic = sum((phi2 * phi1).is_cyclic() for phi2 in phi2_list)
+            sage: n_cyclic, len(phi2_list)
+            (7, 8)
+
         .. SEEALSO::
 
         - :meth:`sage.schemes.elliptic_curves.hom.EllipticCurveHom.is_cyclic`

--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -519,3 +519,30 @@ class EllipticCurveHom_frobenius(EllipticCurveHom):
             True
         """
         return self._degree
+
+    def is_cyclic(self):
+        """
+        Determine whether the isogeny is cyclic (separable with cyclic kernel).
+
+        Since this class implements only purely inseparable isogenies,
+        they are only cyclic in the trivial case (degree = p^0 = 1).
+
+        EXAMPLES::
+
+            sage: from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
+            sage: E = EllipticCurve(GF(11), [1,1])
+            sage: pi = EllipticCurveHom_frobenius(E)
+            sage: pi.is_cyclic()
+            False
+            sage: pi = EllipticCurveHom_frobenius(E, 4)
+            sage: pi.is_cyclic()
+            False
+            sage: pi = EllipticCurveHom_frobenius(E, 0)
+            sage: pi.is_cyclic()
+            True
+
+        .. SEEALSO::
+
+        - :meth:`sage.schemes.elliptic_curves.hom.EllipticCurveHom.is_cyclic`
+        """
+        return self._degree == 1

--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -525,7 +525,7 @@ class EllipticCurveHom_frobenius(EllipticCurveHom):
         Determine whether the isogeny is cyclic (separable with cyclic kernel).
 
         Since this class implements only purely inseparable isogenies,
-        they are only cyclic in the trivial case (degree = p^0 = 1).
+        they are only cyclic in the trivial case i.e. when degree is `1`.
 
         EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/hom_scalar.py
+++ b/src/sage/schemes/elliptic_curves/hom_scalar.py
@@ -520,7 +520,7 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
         Determine whether the isogeny is cyclic (separable with cyclic kernel).
 
         Since this class implements only scalar multiplication isogenies,
-        they are never cyclic, except the trivial [1].
+        they are never cyclic except for the trivial `[1]`.
 
         EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/hom_scalar.py
+++ b/src/sage/schemes/elliptic_curves/hom_scalar.py
@@ -514,3 +514,29 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
             w = negation_morphism(self._domain).rational_maps()
             result._rational_maps = tuple(f(*w) if f is not None else None for f in self._rational_maps)
         return result
+
+    def is_cyclic(self):
+        """
+        Determine whether the isogeny is cyclic (separable with cyclic kernel).
+
+        Since this class implements only scalar multiplication isogenies,
+        they are never cyclic, except the trivial [1].
+
+        EXAMPLES::
+
+            sage: E = EllipticCurve(GF(79), [7,7])
+            sage: phi = E.scalar_multiplication(5)
+            sage: phi.is_cyclic()
+            False
+            sage: phi = E.scalar_multiplication(1)
+            sage: phi.is_cyclic()
+            True
+            sage: phi = E.scalar_multiplication(79)
+            sage: phi.is_cyclic()
+            False
+
+        .. SEEALSO::
+
+        - :meth:`sage.schemes.elliptic_curves.hom.EllipticCurveHom.is_cyclic`
+        """
+        return self._m == 1


### PR DESCRIPTION
This PR provides method to check if an isogeny between elliptic curves is cyclic (i.e., separable with cyclic degree).

<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

This includes a generic method in `sage.schemes.elliptic_curves.hom.EllipticCurveHom.is_cyclic` which checks for separability and being non-zero first. Then, for each divisor $\ell^2$ of the isogeny degree, $\ell$ prime not equal to the characteristic, it checks that the division polynomial $\psi_{\ell}$ on the domain curve does not divide the kernel polynomial of the isogeny.

Then, it also includes methods for specific isogeny subclasses (scalar multiplication, frobenius, composite isogeny).

For composite isogenies, the algorithm is more involved. Again, we first check separability and check all suitable $\ell$ as follows. We skip isogenies with degrees non-divisible by $\ell$ and also skip the longest prefix of $\ell$-isogenies for which by checking j-invariants we see that they are non-backtracking. Then, we are left with one contiguous sub-list of isogenies. We start with the $\ell$-th division polynomial $m=\psi_{\ell}$ on the first curve of the sublist, and propagate it through the isogenies in the sublist, reducing $m$ by its gcd with each kernel polynomial. If it's fully destroyed ($m=1$), the isogeny is non-cyclic. There is also an optimization which replaces $m$ by its image on the second curve, which is essentiall the kernel polynomial of the dual of the first isogeny. This is useful because $m$ then has degree $\ell-1$ instead of $\ell^2-1-\ell$. (This happens because on the first curve only the subgroup is killed, but not its cosets; so we rather look at the image).

Small benchmark for the optimizations: https://gist.github.com/hellman/409ba128c67d6887c9a130c19b66f01a

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

This method is also very useful to construct isogeny chains (for example, for isogeny search, meet-in-the-middle, #35949 ). For this purpose, I also added an option `cyclic_after` for `E.isogenies_prime_degree` which allows to consider only non-backtracking (in the sense of being non-dual) isogenies.

Thanks to @yyyyx4 @rtb123 @remyoudompheng @grhkm21 @GiacomoPope  for helpful discussions! I hope I didn't mess it up with my understanding.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

- #37377 : arithmetic error causes two tests to fail.