### PR TITLE
Implement a more general method for computing dual isogenies of elliptic curves

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3050,37 +3050,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         self.__set_post_isomorphism(codomain, isom)
 
-    def decompose_inseparable(self):
-        """
-        Decompose the isogeny into purely inseparable part and a separable part.
-
-        OUTPUT: a pair of a purely inseparable (or identity) isogeny and a separable isogeny,
-        which equal to the current one when composed as (separable * purely inseparable).
-        """
-        F = self.__base_field
-        p = F.characteristic()
-        frob_k = self._degree.valuation(p)
-        deg = self._degree // p**frob_k
-        # degree = deg * p**k
-
-        from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
-        frob = EllipticCurveHom_frobenius(self._codomain, frob_k)
-
-        f = self.kernel_polynomial()
-
-        psi = self._domain.division_polynomial(p)
-        mu_num = self._domain._multiple_x_numerator(p)
-        mu_den = self._domain._multiple_x_denominator(p)
-
-        for _ in range(frob_k):
-            f //= f.gcd(psi)
-            S = f.parent().quotient_ring(f)
-            mu = S(mu_num) / S(mu_den)
-            f = mu.minpoly()
-
-        sep = self._domain.isogeny(f, codomain=frob.codomain())
-        return frob, sep
-
     def dual(self):
         r"""
         Return the isogeny dual to this isogeny.

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3081,7 +3081,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         sep = self._domain.isogeny(f, codomain=frob.codomain())
         return frob, sep
 
-
     def dual(self):
         r"""
         Return the isogeny dual to this isogeny.

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3113,15 +3113,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: (Xm, Ym) == E.multiplication_by_m(5)
             True
 
-        Duals of isogenies of large degree (compared to the characteristic)::
-
-            sage: E0 = EllipticCurve(GF(19**24), [10, 2])
-            sage: phi = choice(E0.isogenies_prime_degree(7))
-            sage: phi.dual().dual() == phi
-            True
-            sage: phi.dual() * phi == E0.scalar_multiplication(7)
-            True
-
         Inseparable duals should be computed correctly::
 
             sage: # needs sage.rings.finite_rings
@@ -3205,6 +3196,23 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             True
             sage: phi._EllipticCurveIsogeny__clear_cached_values()  # forget the dual
             sage: -phi.dual() == (-phi).dual()
+            True
+
+        Duals of isogenies of large degree (compared to the characteristic)::
+
+            sage: E0 = EllipticCurve(GF(19**24), [10, 2])
+            sage: phi = choice(E0.isogenies_prime_degree(7))
+            sage: phi.dual().dual() == phi
+            True
+            sage: phi.dual() * phi == E0.scalar_multiplication(7)
+            True
+
+            sage: from sage.all import *
+            sage: E0 = EllipticCurve(GF(5**2), [4, 0])
+            sage: phi = choice(E0.isogenies_prime_degree(13))
+            sage: phi.dual().dual() == phi
+            True
+            sage: phi.dual() * phi == E0.scalar_multiplication(13)
             True
         """
         if self.__base_field.characteristic() in (2, 3):
@@ -3300,7 +3308,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sc = self.scaling_factor() * pre_iso.scaling_factor() * post_iso.scaling_factor() / F(d)
             if not sc.is_one():
                 auts = self._codomain.automorphisms()
-                aut = [a for a in auts if a.u == sc]
+                aut = [a for a in auts if (a.u * sc).is_one()]
                 assert len(aut) == 1, "bug in dual()"
                 pre_iso *= aut[0]
 

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3113,7 +3113,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: (Xm, Ym) == E.multiplication_by_m(5)
             True
 
-        Duals of isogenies of degree large than the characteristic are also ok:
+        Duals of isogenies of large degree (compared to the characteristic)::
 
             sage: E0 = EllipticCurve(GF(19**24), [10, 2])
             sage: phi = choice(E0.isogenies_prime_degree(7))


### PR DESCRIPTION
Upgrade the `.dual()` method of separable elliptic curve isogenies for a more generic one (the current one is very restricted).
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
Current implementation of isogeny duals is based on computing some kind of normalized domain/codomain curves (isomorphic to the original codomain/domain curves respectively), and then computing an isogeny between these curves generically:

```py
phi_hat = EllipticCurveIsogeny(E1, None, E2, d)
```

This method has limitations as its not implemented for many cases (in particular, currently it requires 4d+4 < p or something like that). Also, I am not sure that, even if implemented, the normalization performed ensures a unique isogeny. In general there can be multiple isogenies between E1 and E2 but only one of them is the dual. I don't know how this can be correct.

Here is an alternative and a more direct, algebraic approach. Compute the rational x-coordinate isogeny map modulo the division polynomial on the source curve divided by its gcd with the map's denominator (i.e., excluding the isogeny kernel from the full torsion encoded by the division polynomial). This reduces the modulus degree from $\ell^2-1$ to $\ell^2-1-\ell$: we still have cosets of the remaining torsion subgroup, that's why it is still large. But now we can check the *image* of this set, which should be exactly the kernel of the dual isogeny. For this, we simply compute the minimal polynomial of the x-coordinate-map in the aforementioned quotient ring.

In fact, almost exactly the same method is already used for the inseparable part of the dual, in the same `dual()` method.

I am not sure if there are edge cases for this method and I do not fully understand the normalization process, but it seems to work well (passes all existing tests + new ones that did not work before), and is at least worth to explore.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
