### PR TITLE
Tensor, exterior, and symmetric product of semigroup representations

### DIFF
--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -51,7 +51,7 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
     A facade parent for the indices of Clifford algebra.
     Users should not create instances of this class directly.
     """
-    def __init__(self, Qdim):
+    def __init__(self, Qdim, degree=None):
         r"""
         Initialize ``self``.
 
@@ -67,9 +67,22 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             1111
             sage: type(i)
             <class 'sage.data_structures.bitset.FrozenBitset'>
+
+            sage: idx = CliffordAlgebraIndices(7, 3)
+            sage: idx._nbits
+            7
+            sage: idx._degree
+            3
+            sage: idx._cardinality
+            35
         """
         self._nbits = Qdim
-        self._cardinality = 2 ** Qdim
+        if degree is None:
+            self._cardinality = 2 ** Qdim
+        else:
+            from sage.functions.other import binomial
+            self._cardinality = binomial(Qdim, degree)
+        self._degree = degree
         # the if statement here is in case Qdim is 0.
         category = FiniteEnumeratedSets().Facade()
         Parent.__init__(self, category=category, facade=True)
@@ -129,6 +142,12 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             True
             sage: len(idx) == 2^7
             True
+
+            sage: idx = CliffordAlgebraIndices(7, 3)
+            sage: idx.cardinality() == binomial(7, 3)
+            True
+            sage: len(idx) == binomial(7, 3)
+            True
         """
         return self._cardinality
 
@@ -149,14 +168,20 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             Subsets of {0}
             sage: CliffordAlgebraIndices(2)
             Subsets of {0,1}
+            sage: CliffordAlgebraIndices(5, 3)
+            Subsets of {0,1,...,4} of size 3
         """
+        if self._degree is not None:
+            extra = f" of size {self._degree}"
+        else:
+            extra = ""
         if self._nbits == 0:
-            return "Subsets of {}"
+            return "Subsets of {}" + extra
         if self._nbits == 1:
-            return "Subsets of {0}"
+            return "Subsets of {0}" + extra
         if self._nbits == 2:
-            return "Subsets of {0,1}"
-        return f"Subsets of {{0,1,...,{self._nbits-1}}}"
+            return "Subsets of {0,1}" + extra
+        return f"Subsets of {{0,1,...,{self._nbits-1}}}" + extra
 
     def _latex_(self):
         r"""
@@ -166,21 +191,27 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
 
             sage: from sage.algebras.clifford_algebra import CliffordAlgebraIndices
             sage: latex(CliffordAlgebraIndices(7))
-            \mathcal{P}({0,1,\ldots,6})
+            \mathcal{P}(\{0,1,\ldots,6\})
             sage: latex(CliffordAlgebraIndices(0))
             \mathcal{P}(\emptyset)
             sage: latex(CliffordAlgebraIndices(1))
-            \mathcal{P}({0})
+            \mathcal{P}(\{0\})
             sage: latex(CliffordAlgebraIndices(2))
-            \mathcal{P}({0,1})
+            \mathcal{P}(\{0,1\})
+            sage: latex(CliffordAlgebraIndices(2, 1))
+            \mathcal{P}(\{0,1\}, 1)
         """
+        if self._degree is not None:
+            extra = f", {self._degree}"
+        else:
+            extra = ""
         if self._nbits == 0:
-            return "\\mathcal{P}(\\emptyset)"
+            return f"\\mathcal{{P}}(\\emptyset{extra})"
         if self._nbits == 1:
-            return "\\mathcal{P}({0})"
+            return f"\\mathcal{{P}}(\\{{0\\}}{extra})"
         if self._nbits == 2:
-            return "\\mathcal{P}({0,1})"
-        return f"\\mathcal{{P}}({{0,1,\\ldots,{self._nbits-1}}})"
+            return f"\\mathcal{{P}}(\\{{0,1\\}}{extra})"
+        return f"\\mathcal{{P}}(\\{{0,1,\\ldots,{self._nbits-1}\\}}{extra})"
 
     def __iter__(self):
         r"""
@@ -200,9 +231,18 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             101
             011
             111
+
+            sage: idx = CliffordAlgebraIndices(5, 3)
+            sage: list(idx)
+            [111, 1101, 11001, 1011, 10101, 10011, 0111, 01101, 01011, 00111]
         """
         import itertools
         n = self._nbits
+        if self._degree is not None:
+            for C in itertools.combinations(range(n), self._degree):
+                yield FrozenBitset(C)
+            return
+
         yield FrozenBitset()
         k = 1
         while k <= n:
@@ -226,10 +266,24 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             True
             sage: FrozenBitset('000001') in idx
             False
+
+            sage: idx = CliffordAlgebraIndices(6, 3)
+            sage: FrozenBitset('01011') in idx
+            True
+            sage: FrozenBitset('00011') in idx
+            False
+            sage: int(7) in idx
+            True
+            sage: int(8) in idx
+            False
         """
         if isinstance(elt, int):
+            if self._degree is not None and sum(ZZ(elt).bits()) != self._degree:
+                return False
             return elt < self._cardinality and elt >= 0
         if not isinstance(elt, FrozenBitset):
+            return False
+        if self._degree is not None and len(elt) != self._degree:
             return False
         return elt.capacity() <= self._nbits
 
@@ -252,13 +306,20 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             sage: idx = CliffordAlgebraIndices(3)
             sage: idx._an_element_()
             11
+            sage: idx = CliffordAlgebraIndices(5, 3)
+            sage: idx._an_element_()
+            111
         """
         if not self._nbits:
             return FrozenBitset()
 
+        if self._degree is not None:
+            return FrozenBitset(range(self._degree))
+
         from sage.combinat.subset import SubsetsSorted
         X = SubsetsSorted(range(self._nbits))
         return FrozenBitset(X.an_element())
+
 
 class CliffordAlgebra(CombinatorialFreeModule):
     r"""

--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -75,6 +75,14 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             3
             sage: idx._cardinality
             35
+
+            sage: idx = CliffordAlgebraIndices(7, 0)
+            sage: idx._nbits
+            7
+            sage: idx._degree
+            0
+            sage: idx._cardinality
+            1
         """
         self._nbits = Qdim
         if degree is None:
@@ -235,10 +243,17 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             sage: idx = CliffordAlgebraIndices(5, 3)
             sage: list(idx)
             [111, 1101, 11001, 1011, 10101, 10011, 0111, 01101, 01011, 00111]
+
+            sage: idx = CliffordAlgebraIndices(7, 0)
+            sage: list(idx)
+            [0]
         """
         import itertools
         n = self._nbits
         if self._degree is not None:
+            if self._degree == 0:  # special corner case
+                yield FrozenBitset()
+                return
             for C in itertools.combinations(range(n), self._degree):
                 yield FrozenBitset(C)
             return
@@ -276,6 +291,16 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             True
             sage: int(8) in idx
             False
+
+            sage: idx = CliffordAlgebraIndices(7, 0)
+            sage: FrozenBitset() in idx
+            True
+            sage: FrozenBitset('01') in idx
+            False
+            sage: int(0) in idx
+            True
+            sage: int(5) in idx
+            False
         """
         if isinstance(elt, int):
             if self._degree is not None and sum(ZZ(elt).bits()) != self._degree:
@@ -309,11 +334,16 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             sage: idx = CliffordAlgebraIndices(5, 3)
             sage: idx._an_element_()
             111
+            sage: idx = CliffordAlgebraIndices(7, 0)
+            sage: idx._an_element_()
+            0
         """
         if not self._nbits:
             return FrozenBitset()
 
         if self._degree is not None:
+            if self._degree == 0:  # special corner case
+                return FrozenBitset()
             return FrozenBitset(range(self._degree))
 
         from sage.combinat.subset import SubsetsSorted

--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -88,7 +88,7 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
         if degree is None:
             self._cardinality = 2 ** Qdim
         else:
-            from sage.functions.other import binomial
+            from sage.arith.misc import binomial
             self._cardinality = binomial(Qdim, degree)
         self._degree = degree
         # the if statement here is in case Qdim is 0.

--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -113,10 +113,16 @@ class CliffordAlgebraIndices(UniqueRepresentation, Parent):
             00001
             000001
             0000001
+
+            sage: idx = CliffordAlgebraIndices(0)
+            sage: idx([])
+            0
         """
         if isinstance(x, (list, tuple, set, frozenset)):
             if len(x) > self._nbits:
                 raise ValueError(f"{x=} is too long")
+            if not x:
+                return FrozenBitset()
             return FrozenBitset(x)
 
         if isinstance(x, int):

--- a/src/sage/categories/coxeter_groups.py
+++ b/src/sage/categories/coxeter_groups.py
@@ -976,15 +976,24 @@ class CoxeterGroups(Category_singleton):
 
                 sage: W = CoxeterGroup(['D', 4])
                 sage: W.reflection_representation()
+                Reflection representation of Finite Coxeter group over
+                 Integer Ring with Coxeter matrix:
+                [1 3 2 2]
+                [3 1 3 3]
+                [2 3 1 2]
+                [2 3 2 1]
 
                 sage: W = CoxeterGroup(['I', 13])
                 sage: W.reflection_representation()
+                Reflection representation of Finite Coxeter group over
+                 Universal Cyclotomic Field with Coxeter matrix:
+                [ 1 13]
+                [13  1]
 
                 sage: W = WeylGroup(["B", 3, 1])
                 sage: W.reflection_representation(QQ)
-                Sign representation of
-                 Weyl Group of type ['A', 1, 1] (as a matrix group acting on the root space)
-                 over Integer Ring
+                Reflection representation of Weyl Group of type ['B', 3, 1]
+                 (as a matrix group acting on the root space)
             """
             from sage.modules.with_basis.representation import ReflectionRepresentation
             return ReflectionRepresentation(self, base_ring)

--- a/src/sage/categories/coxeter_groups.py
+++ b/src/sage/categories/coxeter_groups.py
@@ -952,13 +952,42 @@ class CoxeterGroups(Category_singleton):
                 Sign representation of
                  Weyl Group of type ['A', 1, 1] (as a matrix group acting on the root space)
                  over Integer Ring
-
             """
             if base_ring is None:
                 from sage.rings.integer_ring import ZZ
                 base_ring = ZZ
             from sage.modules.with_basis.representation import SignRepresentationCoxeterGroup
             return SignRepresentationCoxeterGroup(self, base_ring)
+
+        def reflection_representation(self, base_ring=None, side="left"):
+            r"""
+            Return the reflection representation of ``self``.
+
+            This is also the canonical faithful representation of a
+            Coxeter group.
+
+            INPUT:
+
+            - ``base_ring`` -- (optional) the base ring; the default is
+              the base ring of :meth:`canonical_representation`
+            - ``side`` -- ignored
+
+            EXAMPLES::
+
+                sage: W = CoxeterGroup(['D', 4])
+                sage: W.reflection_representation()
+
+                sage: W = CoxeterGroup(['I', 13])
+                sage: W.reflection_representation()
+
+                sage: W = WeylGroup(["B", 3, 1])
+                sage: W.reflection_representation(QQ)
+                Sign representation of
+                 Weyl Group of type ['A', 1, 1] (as a matrix group acting on the root space)
+                 over Integer Ring
+            """
+            from sage.modules.with_basis.representation import ReflectionRepresentation
+            return ReflectionRepresentation(self, base_ring)
 
         def demazure_product(self, Q):
             r"""
@@ -1168,6 +1197,11 @@ class CoxeterGroups(Category_singleton):
         def canonical_representation(self):
             r"""
             Return the canonical faithful representation of ``self``.
+
+            .. SEEALSO::
+
+                To obtain the underlying module with the action, use
+                :meth:`reflection_representation`.
 
             EXAMPLES::
 

--- a/src/sage/groups/artin.py
+++ b/src/sage/groups/artin.py
@@ -57,7 +57,7 @@ class ArtinGroupElement(FinitelyPresentedGroupElement):
 
         TESTS::
 
-            sage: A = ArtinGroup(['B',3])                                               # needs sage.rings.number_field
+            sage: A = ArtinGroup(['B', 3])                                              # needs sage.rings.number_field
             sage: b = A([1, 2, 3, -1, 2, -3])                                           # needs sage.rings.number_field
             sage: b._latex_()                                                           # needs sage.rings.number_field
             '\\sigma_{1}\\sigma_{2}\\sigma_{3}\\sigma_{1}^{-1}\\sigma_{2}\\sigma_{3}^{-1}'
@@ -66,9 +66,14 @@ class ArtinGroupElement(FinitelyPresentedGroupElement):
             sage: b = B([1, 2, 3, -1, 2, -3])
             sage: b._latex_()
             '\\sigma_{1}\\sigma_{2}\\sigma_{3}\\sigma_{1}^{-1}\\sigma_{2}\\sigma_{3}^{-1}'
+            sage: B.one()._latex_()
+            '1'
         """
+        word = self.Tietze()
+        if not word:
+            return '1'
         return ''.join(r"\sigma_{%s}^{-1}" % (-i) if i < 0 else r"\sigma_{%s}" % i
-                       for i in self.Tietze())
+                       for i in word)
 
     def exponent_sum(self):
         """

--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -948,10 +948,15 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
             sage: S = SymmetricGroup(['a', 'b'])
             sage: latex(S.gens())
             \left((\text{\texttt{a}},\text{\texttt{b}})\right)
+            sage: latex(S.one())
+            1
         """
+        cycle_tuples = self.cycle_tuples()
+        if not cycle_tuples:
+            return '1'
         from sage.misc.latex import latex
         return "".join(("(" + ",".join(latex(x) for x in cycle) + ")")
-                       for cycle in self.cycle_tuples())
+                       for cycle in cycle_tuples)
 
     def __getitem__(self, i):
         r"""

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -363,6 +363,15 @@ cdef class IndexedFreeModuleElement(ModuleElement):
                *      *       **
                *      *       *
                *
+
+        We can get the unicode art when there is no ``one_basis`` method
+        (and the basis keys do not compare with ``None``)::
+
+            sage: DC3 = groups.permutation.DiCyclic(3)
+            sage: L = DC3.regular_representation(QQ, side='left')
+            sage: E2 = L.exterior_power(2)
+            sage: ascii_art(E2.an_element())
+            2*()/\(5,6,7) + 2*()/\(5,7,6) + 3*()/\(1,2)(3,4)
         """
         from sage.misc.repr import coeff_repr
         terms = self._sorted_items_for_printing()
@@ -395,7 +404,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
                     elif coeff == "-1":
                         coeff = "-"
                     elif b._l > 0:
-                        if len(coeff) > 0 and monomial == one_basis and strip_one:
+                        if one_basis is not None and len(coeff) > 0 and monomial == one_basis and strip_one:
                             b = empty_ascii_art # ""
                         else:
                             b = AsciiArt([scalar_mult]) + b
@@ -437,6 +446,15 @@ cdef class IndexedFreeModuleElement(ModuleElement):
 
             sage: unicode_art([M.zero()])  # indirect doctest                           # needs sage.combinat
             [ 0 ]
+
+        We can get the unicode art when there is no ``one_basis`` method
+        (and the basis keys do not compare with ``None``)::
+
+            sage: DC3 = groups.permutation.DiCyclic(3)
+            sage: L = DC3.regular_representation(QQ, side='left')
+            sage: E2 = L.exterior_power(2)
+            sage: unicode_art(E2.an_element())
+            2*()∧(5,6,7) + 2*()∧(5,7,6) + 3*()∧(1,2)(3,4)
         """
         from sage.misc.repr import coeff_repr
         terms = self._sorted_items_for_printing()
@@ -469,7 +487,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
                     elif coeff == "-1":
                         coeff = "-"
                     elif b._l > 0:
-                        if len(coeff) > 0 and monomial == one_basis and strip_one:
+                        if one_basis is not None and len(coeff) > 0 and monomial == one_basis and strip_one:
                             b = empty_unicode_art  # ""
                         else:
                             b = UnicodeArt([scalar_mult]) + b

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -364,7 +364,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
                *      *       *
                *
 
-        We can get the unicode art when there is no ``one_basis`` method
+        We can get the ascii art when there is no ``one_basis`` method
         (and the basis keys do not compare with ``None``)::
 
             sage: DC3 = groups.permutation.DiCyclic(3)

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -388,10 +388,12 @@ cdef class IndexedFreeModuleElement(ModuleElement):
         if scalar_mult is None:
             scalar_mult = "*"
 
+        one_basis = None
         try:
-            one_basis = self.parent().one_basis()
-        except AttributeError:
-            one_basis = None
+            if self.parent().one_basis is not NotImplemented:
+                one_basis = self.parent().one_basis()
+        except (AttributeError, NotImplementedError, ValueError, TypeError):
+            pass
 
         for monomial, c in terms:
             b = repr_monomial(monomial) # PCR
@@ -471,10 +473,12 @@ cdef class IndexedFreeModuleElement(ModuleElement):
         if scalar_mult is None:
             scalar_mult = "*"
 
+        one_basis = None
         try:
-            one_basis = self.parent().one_basis()
-        except AttributeError:
-            one_basis = None
+            if self.parent().one_basis is not NotImplemented:
+                one_basis = self.parent().one_basis()
+        except (AttributeError, NotImplementedError, ValueError, TypeError):
+            pass
 
         for (monomial, c) in terms:
             b = repr_monomial(monomial)  # PCR

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -343,7 +343,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
                             strip_one = True)
 
     def _ascii_art_(self):
-        """
+        r"""
         TESTS::
 
             sage: # needs sage.combinat
@@ -430,7 +430,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
             return s
 
     def _unicode_art_(self):
-        """
+        r"""
         TESTS::
 
             sage: M = QuasiSymmetricFunctions(QQ).M()                                   # needs sage.combinat

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -216,7 +216,7 @@ class Representation_abstract(CombinatorialFreeModule):
 
         return super().twisted_invariant_module(G, chi, side=side, **kwargs)
 
-    def matrix_representation(self, g, side=None, sparse=False):
+    def representation_matrix(self, g, side=None, sparse=False):
         r"""
         Return the matrix representation of ``g`` acting on ``self``.
 
@@ -227,14 +227,14 @@ class Representation_abstract(CombinatorialFreeModule):
             (2,3)
             sage: L = S3.regular_representation(side="left")
             sage: R = S3.regular_representation(side="right")
-            sage: R.matrix_representation(g)
+            sage: R.representation_matrix(g)
             [0 0 0 1 0 0]
             [0 0 0 0 0 1]
             [0 0 0 0 1 0]
             [1 0 0 0 0 0]
             [0 0 1 0 0 0]
             [0 1 0 0 0 0]
-            sage: L.matrix_representation(g)
+            sage: L.representation_matrix(g)
             [0 0 0 1 0 0]
             [0 0 0 0 1 0]
             [0 0 0 0 0 1]
@@ -242,7 +242,7 @@ class Representation_abstract(CombinatorialFreeModule):
             [0 1 0 0 0 0]
             [0 0 1 0 0 0]
             sage: A = S3.algebra(ZZ)
-            sage: R.matrix_representation(sum(A.basis()), side='right')
+            sage: R.representation_matrix(sum(A.basis()), side='right')
             [1 1 1 1 1 1]
             [1 1 1 1 1 1]
             [1 1 1 1 1 1]
@@ -254,9 +254,9 @@ class Representation_abstract(CombinatorialFreeModule):
 
             sage: T = tensor([L, R])
             sage: for g in S3:
-            ....:     gL = L.matrix_representation(g, side='left')
-            ....:     gR = R.matrix_representation(g, side='left')
-            ....:     gT = T.matrix_representation(g, side='left')
+            ....:     gL = L.representation_matrix(g, side='left')
+            ....:     gR = R.representation_matrix(g, side='left')
+            ....:     gT = T.representation_matrix(g, side='left')
             ....:     assert gL.tensor_product(gR) == gT
         """
         if self.dimension() == float('inf'):
@@ -1750,7 +1750,7 @@ class ReflectionRepresentation(Representation_abstract):
 
         sage: W = CoxeterGroup(['B', 4])
         sage: R = W.reflection_representation()
-        sage: all(g.matrix() == R.matrix_representation(g) for g in W)
+        sage: all(g.matrix() == R.representation_matrix(g) for g in W)
         True
     """
     @staticmethod

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -750,12 +750,27 @@ class Representation_Tensor(CombinatorialFreeModule_Tensor, Representation_abstr
             True
             sage: tensor([L, tensor([S, R])]) == tensor([L, S, R])
             True
+
+        Check that the tensor product with more general modules
+        can be constructed::
+
+            sage: C = CombinatorialFreeModule(ZZ, ['a','b'])
+            sage: T = tensor([C, R])
+            sage: type(T)
+            <class 'sage.combinat.free_module.CombinatorialFreeModule_Tensor_with_category'>
+            sage: T = tensor([R, C])
+            sage: type(T)
+            <class 'sage.combinat.free_module.CombinatorialFreeModule_Tensor_with_category'>
         """
-        assert (len(reps) > 0)
-        R = reps[0].base_ring()
+        assert len(reps) > 0
+        assert isinstance(reps[0], Representation_abstract)
         S = reps[0].semigroup()
-        if not all(module in Modules(R).WithBasis() and module.semigroup() is S for module in reps):
-            raise ValueError("not all representations of the same semigroup over the same base ring")
+        if not all(isinstance(module, Representation_abstract)
+                   and module.semigroup() == S for module in reps):
+            return CombinatorialFreeModule_Tensor(reps, **options)
+        R = reps[0].base_ring()
+        if not all(module in Modules(R).WithBasis() for module in reps):
+            raise ValueError("not all representations over the same base ring")
         # flatten the list of modules so that tensor(A, tensor(B,C)) gets rewritten into tensor(A, B, C)
         reps = sum((module._sets if isinstance(module, Representation_Tensor) else (module,) for module in reps), ())
         if all('FiniteDimensional' in M.category().axioms() for M in reps):

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -329,11 +329,14 @@ class Representation_abstract(CombinatorialFreeModule):
         """
         return Representation_Symmetric(self, degree)
 
-    @abstract_method
+    @abstract_method(optional=True)
     def _semigroup_action(self, g, vec, vec_on_left):
         """
         Return the action of the semigroup element ``g`` on the
         vector ``vec`` of ``self``.
+
+        If this is not defined, the representation element must
+        override ``_acted_upon_``.
 
         EXAMPLES::
 

--- a/src/sage/structure/indexed_generators.py
+++ b/src/sage/structure/indexed_generators.py
@@ -491,6 +491,8 @@ class IndexedGenerators():
             return ascii_art(ret)
 
         pref = AsciiArt([self.prefix()])
+        if not pref:
+            return ascii_art(m)
         r = pref * (AsciiArt([" " * len(pref)]) + ascii_art(m))
         r._baseline = r._h - 1
         return r
@@ -530,6 +532,8 @@ class IndexedGenerators():
             return unicode_art(ret)
 
         pref = UnicodeArt([self.prefix()])
+        if not pref:
+            return unicode_art(m)
         r = pref * (UnicodeArt([" " * len(pref)]) + unicode_art(m))
         r._baseline = r._h - 1
         return r


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

This allows us to take tensor,. exterior, and symmetric products of semigroup representations.
We also provide the following additional changes/improvements to help build examples and fix bugs:

- Reflection representation of Coxeter groups.
- Latex output of the identity in Artin groups and permutation groups.
- ascii and unicode art of CFMs that do not have a `one_basis()`.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
