### PR TITLE
fix `relabel` for permutation groups

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -23067,6 +23067,14 @@ class GenericGraph(GenericGraph_pyx):
             [0 0 1]
             [0 0 1]
             [1 1 0]
+            sage: G = graphs.CycleGraph(5)
+            sage: G.relabel({u: str(u) for u in G}, inplace=True)
+            sage: ar = G.automorphism_group().random_element()                          # needs sage.groups
+            sage: H = G.relabel(ar, inplace=False)                                      # needs sage.groups
+            sage: G.is_isomorphic(H, certificate=True)[1]                               # needs sage.groups
+            {'0': '3', '1': '2', '2': '1', '3': '0', '4': '4'}
+            sage: {u: ar(u) for u in G}                                                 # needs sage.groups
+            {'0': '3', '1': '2', '2': '1', '3': '0', '4': '4'}
 
         A way to get a random relabeling::
 
@@ -23225,13 +23233,8 @@ class GenericGraph(GenericGraph_pyx):
             perm = dict(perm)
 
         elif isinstance(perm, PermutationGroupElement):
-            n = self.order()
-            ddict = {}
-            for i in range(1, n):
-                ddict[i] = perm(i) % n
-            if n > 0:
-                ddict[0] = perm(n) % n
-            perm = ddict
+            # Each vertex is relabeled according to the permutation group
+            perm = {u: perm(u) for u in self}
 
         else:
             # Check for generic iterable/callable

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -23064,12 +23064,14 @@ class GenericGraph(GenericGraph_pyx):
             [0 0 1]
             [0 0 1]
             [1 1 0]
+
+            sage: # needs sage.groups
             sage: C5 = graphs.CycleGraph(5)
             sage: C5.relabel({u: str(u) for u in C5}, inplace=True)
-            sage: ar = C5.automorphism_group().random_element()                         # needs sage.groups
-            sage: R = C5.relabel(ar, inplace=False)                                     # needs sage.groups
-            sage: perm = C5.is_isomorphic(R, certificate=True)[1]                       # needs sage.groups
-            sage: perm == {u: ar(u) for u in C5}                                        # needs sage.groups
+            sage: ar = C5.automorphism_group().random_element()                         
+            sage: R = C5.relabel(ar, inplace=False)
+            sage: perm = C5.is_isomorphic(R, certificate=True)[1]
+            sage: perm == {u: ar(u) for u in C5}
             True
 
         A way to get a random relabeling::

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -22999,10 +22999,7 @@ class GenericGraph(GenericGraph_pyx):
         is relabeled to ``l[0]``, the second to ``l[1]``, ...
 
         If ``perm`` is a permutation, then each vertex ``v`` is
-        relabeled to ``perm(v)``. Caveat: this assumes that the
-        vertices are labelled `\{0,1,...,n-1\}`; since permutations
-        act by default on the set `\{1,2,...,n\}`, this is achieved by
-        identifying `n` and `0`.
+        relabeled to ``perm(v)``.
 
         If ``perm`` is ``None``, the graph is relabeled to be on the
         vertices `\{0,1,...,n-1\}`. This is *not* any kind of canonical

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -23064,14 +23064,13 @@ class GenericGraph(GenericGraph_pyx):
             [0 0 1]
             [0 0 1]
             [1 1 0]
-            sage: G = graphs.CycleGraph(5)
-            sage: G.relabel({u: str(u) for u in G}, inplace=True)
-            sage: ar = G.automorphism_group().random_element()                          # needs sage.groups
-            sage: H = G.relabel(ar, inplace=False)                                      # needs sage.groups
-            sage: G.is_isomorphic(H, certificate=True)[1]                               # needs sage.groups
-            {'0': '3', '1': '2', '2': '1', '3': '0', '4': '4'}
-            sage: {u: ar(u) for u in G}                                                 # needs sage.groups
-            {'0': '3', '1': '2', '2': '1', '3': '0', '4': '4'}
+            sage: C5 = graphs.CycleGraph(5)
+            sage: C5.relabel({u: str(u) for u in C5}, inplace=True)
+            sage: ar = C5.automorphism_group().random_element()                         # needs sage.groups
+            sage: R = C5.relabel(ar, inplace=False)                                     # needs sage.groups
+            sage: perm = C5.is_isomorphic(R, certificate=True)[1]                       # needs sage.groups
+            sage: perm == {u: ar(u) for u in C5}                                        # needs sage.groups
+            True
 
         A way to get a random relabeling::
 

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -23068,7 +23068,7 @@ class GenericGraph(GenericGraph_pyx):
             sage: # needs sage.groups
             sage: C5 = graphs.CycleGraph(5)
             sage: C5.relabel({u: str(u) for u in C5}, inplace=True)
-            sage: ar = C5.automorphism_group().random_element()                         
+            sage: ar = C5.automorphism_group().random_element()
             sage: R = C5.relabel(ar, inplace=False)
             sage: perm = C5.is_isomorphic(R, certificate=True)[1]
             sage: perm == {u: ar(u) for u in C5}


### PR DESCRIPTION
Fixes #37379.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
