### PR TITLE
links for errors in doc of groups

### DIFF
--- a/src/sage/groups/additive_abelian/qmodnz_element.py
+++ b/src/sage/groups/additive_abelian/qmodnz_element.py
@@ -112,7 +112,7 @@ class QmodnZ_Element(AdditiveGroupElement):
         Lift to `\Z`.
 
         This is the smallest non-negative integer reducing to this element,
-        or a ``ValueError`` if none exists.
+        or a :class:`ValueError` if none exists.
 
         TESTS::
 

--- a/src/sage/groups/affine_gps/affine_group.py
+++ b/src/sage/groups/affine_gps/affine_group.py
@@ -228,8 +228,10 @@ class AffineGroup(UniqueRepresentation, Group):
 
     def _element_constructor_check(self, A, b):
         """
-        Verify that ``A``, ``b`` define an affine group element and raises a
-        ``TypeError`` if the input does not define a valid group element.
+        Verify that ``A``, ``b`` define an affine group element.
+
+        This raises a :class:`TypeError` if the input does not define
+        a valid group element.
 
         This is called from the group element constructor and can be
         overridden for subgroups of the affine group. It is guaranteed

--- a/src/sage/groups/affine_gps/euclidean_group.py
+++ b/src/sage/groups/affine_gps/euclidean_group.py
@@ -170,7 +170,7 @@ class EuclideanGroup(AffineGroup):
 
         OUTPUT:
 
-        The return value is ignored. You must raise a ``TypeError`` if
+        The return value is ignored. You must raise a :class:`TypeError` if
         the input does not define a valid group element.
 
         TESTS::

--- a/src/sage/groups/artin.py
+++ b/src/sage/groups/artin.py
@@ -534,8 +534,8 @@ class ArtinGroup(FinitelyPresentedGroup):
         """
         Return an isomorphic permutation group.
 
-        Raises a ``ValueError`` error since Artin groups are infinite
-        and have no corresponding permutation group.
+        This raises a :class:`ValueError` error since Artin groups are
+        infinite and have no corresponding permutation group.
 
         EXAMPLES::
 

--- a/src/sage/groups/braid.py
+++ b/src/sage/groups/braid.py
@@ -2658,7 +2658,8 @@ class BraidGroup_class(FiniteTypeArtinGroup):
 
         OUTPUT:
 
-        Raises a ``ValueError`` error since braid groups are infinite.
+        This raises a :class:`ValueError` error since braid groups
+        are infinite.
 
         TESTS::
 

--- a/src/sage/groups/finitely_presented.py
+++ b/src/sage/groups/finitely_presented.py
@@ -416,7 +416,7 @@ def wrap_FpGroup(libgap_fpgroup):
     return FinitelyPresentedGroup(free_group, relations)
 
 
-class RewritingSystem():
+class RewritingSystem:
     """
     A class that wraps GAP's rewriting systems.
 
@@ -967,7 +967,7 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, UniqueRepresentation, Group, Pare
         A Sage
         :func:`~sage.groups.perm_gps.permgroup.PermutationGroup`. If
         the number of cosets exceeds the given ``limit``, a
-        ``ValueError`` is returned.
+        :class:`ValueError` is returned.
 
         EXAMPLES::
 

--- a/src/sage/groups/fqf_orthogonal.py
+++ b/src/sage/groups/fqf_orthogonal.py
@@ -488,6 +488,7 @@ class ActionOnFqf(Action):
             P = a.parent()
             return P.linear_combination_of_smith_form_gens(v)
 
+
 def _isom_fqf(A, B=None):
     r"""
     Return isometries from `A` to `B`.
@@ -500,8 +501,9 @@ def _isom_fqf(A, B=None):
     OUTPUT:
 
     A list of generators of the orthogonal group of A.
-    If ``B`` is given returns instead a single isometry of `A` and `B` or
-    raises an ``ValueError`` if `A` and `B` are not isometric.
+
+    If ``B`` is given, this returns instead a single isometry of `A` and `B`
+    or raises a :class:`ValueError` if `A` and `B` are not isometric.
 
     EXAMPLES::
 

--- a/src/sage/groups/libgap_mixin.py
+++ b/src/sage/groups/libgap_mixin.py
@@ -9,7 +9,7 @@ the parent/element.
 If your group implementation uses libgap, then you should add
 :class:`GroupMixinLibGAP` as the first class that you are deriving
 from. This ensures that it properly overrides any default methods that
-just raise ``NotImplementedError``.
+just raise :class:`NotImplementedError`.
 """
 
 from sage.libs.gap.libgap import libgap
@@ -19,7 +19,8 @@ from sage.misc.cachefunc import cached_method
 from sage.groups.class_function import ClassFunction_libgap
 from sage.groups.libgap_wrapper import ElementLibGAP
 
-class GroupMixinLibGAP():
+
+class GroupMixinLibGAP:
     def __contains__(self, elt):
         r"""
         TESTS::

--- a/src/sage/groups/matrix_gps/finitely_generated_gap.py
+++ b/src/sage/groups/matrix_gps/finitely_generated_gap.py
@@ -336,7 +336,7 @@ class FinitelyGeneratedMatrixGroup_gap(MatrixGroup_gap):
             VarStr = 'y'
         else:
             VarStr = 'x'
-        VarNames = '(' + ','.join((VarStr+str(i) for i in range(1, n+1)))+')'
+        VarNames = '(' + ','.join(VarStr+str(i) for i in range(1, n+1))+')'
         # The function call and affectation below have side-effects. Do not remove!
         # (even if pyflakes say so)
         R = singular.ring(FieldStr, VarNames, 'dp')
@@ -344,7 +344,7 @@ class FinitelyGeneratedMatrixGroup_gap(MatrixGroup_gap):
             # we have to define minpoly
             singular.eval('minpoly = '+str(F.polynomial()).replace('x',str(F.gen())))
         A = [singular.matrix(n,n,str((x.matrix()).list())) for x in gens]
-        Lgens = ','.join((x.name() for x in A))
+        Lgens = ','.join(x.name() for x in A)
         PR = PolynomialRing(F, n, [VarStr+str(i) for i in range(1,n+1)])
 
         if q == 0 or (q > 0 and self.cardinality() % q):

--- a/src/sage/groups/matrix_gps/matrix_group.py
+++ b/src/sage/groups/matrix_gps/matrix_group.py
@@ -133,7 +133,7 @@ class MatrixGroup_base(Group):
 
         OUTPUT:
 
-        A ``TypeError`` must be raised if ``x`` is invalid.
+        A :class:`TypeError` must be raised if ``x`` is invalid.
 
         EXAMPLES::
 

--- a/src/sage/groups/matrix_gps/matrix_group_gap.py
+++ b/src/sage/groups/matrix_gps/matrix_group_gap.py
@@ -204,7 +204,7 @@ class MatrixGroup_gap(GroupMixinLibGAP, MatrixGroup_generic, ParentLibGAP):
 
         OUTPUT:
 
-        A ``TypeError`` must be raised if ``x`` is invalid.
+        A :class:`TypeError` must be raised if ``x`` is invalid.
 
         EXAMPLES::
 

--- a/src/sage/groups/pari_group.py
+++ b/src/sage/groups/pari_group.py
@@ -12,7 +12,7 @@ from sage.rings.integer import Integer
 lazy_import('sage.groups.perm_gps.permgroup_named', 'TransitiveGroup')
 
 
-class PariGroup():
+class PariGroup:
     def __init__(self, x, degree):
         """
         EXAMPLES::

--- a/src/sage/groups/perm_gps/symgp_conjugacy_class.py
+++ b/src/sage/groups/perm_gps/symgp_conjugacy_class.py
@@ -15,7 +15,7 @@ from sage.sets.set import Set
 import itertools
 
 
-class SymmetricGroupConjugacyClassMixin():
+class SymmetricGroupConjugacyClassMixin:
     r"""
     Mixin class which contains methods for conjugacy classes of
     the symmetric group.


### PR DESCRIPTION
just adding a few link to python standard errors in the doc of `groups` folder

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.