### PR TITLE
Remove unused parameter in coleman integral

### DIFF
--- a/src/sage/modular/btquotients/pautomorphicform.py
+++ b/src/sage/modular/btquotients/pautomorphicform.py
@@ -2089,8 +2089,7 @@ class pAdicAutomorphicFormElement(ModuleElement):
 
     # So far we cannot break it into two integrals because of the pole
     # at infinity.
-    def coleman(self, t1, t2, E=None, method='moments', mult=False,
-                delta=-1):
+    def coleman(self, t1, t2, E=None, method='moments', mult=False):
         r"""
         If ``self`` is a `p`-adic automorphic form that
         corresponds to a rigid modular form, then this computes the


### PR DESCRIPTION
This PR removes the unused parameter `delta` of the Coleman integral.

### :memo: Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
