### PR TITLE
enable coercion for tensor constructions

### DIFF
--- a/src/sage/categories/tensor.py
+++ b/src/sage/categories/tensor.py
@@ -13,10 +13,11 @@ AUTHORS:
 # ****************************************************************************
 
 from sage.categories.covariant_functorial_construction import CovariantFunctorialConstruction, CovariantConstructionCategory
+from sage.categories.pushout import MultivariateConstructionFunctor
 from sage.typeset.unicode_characters import unicode_otimes
 
 
-class TensorProductFunctor(CovariantFunctorialConstruction):
+class TensorProductFunctor(CovariantFunctorialConstruction, MultivariateConstructionFunctor):
     """
     A singleton class for the tensor functor.
 
@@ -51,7 +52,24 @@ class TensorProductFunctor(CovariantFunctorialConstruction):
     _functor_category = "TensorProducts"
     symbol = " # "
     unicode_symbol = f" {unicode_otimes} "
+    def __init__(self, category=None):
+        r"""
+        Constructor. See :class:`TensorProductFunctor` for details.
 
+        TESTS::
+
+            sage: from sage.categories.tensor import TensorProductFunctor
+            sage: TensorProductFunctor()
+            The tensor functorial construction
+        """
+        CovariantFunctorialConstruction.__init__(self)
+        self._forced_category = category
+        from sage.categories.rings import Rings
+        if self._forced_category is not None:
+            codomain = self._forced_category
+        else:
+            codomain = Rings()
+        MultivariateConstructionFunctor.__init__(self, Rings(), codomain)
 
 tensor = TensorProductFunctor()
 

--- a/src/sage/combinat/free_module.py
+++ b/src/sage/combinat/free_module.py
@@ -1262,8 +1262,8 @@ class CombinatorialFreeModule_Tensor(CombinatorialFreeModule):
             Category of tensor products of
              finite dimensional modules with basis over Integer Ring
 
-            sage: T.construction() # todo: not implemented
-            [tensor, ]
+            sage: T.construction()
+            (The tensor functorial construction, (F, G))
 
         T is a free module, with same base ring as F and G::
 
@@ -1350,7 +1350,8 @@ class CombinatorialFreeModule_Tensor(CombinatorialFreeModule):
             assert (all(module in ModulesWithBasis(R)) for module in modules)
             # should check the base ring
             # flatten the list of modules so that tensor(A, tensor(B,C)) gets rewritten into tensor(A, B, C)
-            modules = sum([module._sets if isinstance(module, CombinatorialFreeModule_Tensor) else (module,) for module in modules], ())
+            modules = sum([module._sets if isinstance(module, CombinatorialFreeModule_Tensor) else (module,)
+                           for module in modules], ())
             if all('FiniteDimensional' in M.category().axioms() for M in modules):
                 options['category'] = options['category'].FiniteDimensional()
             return super(CombinatorialFreeModule.Tensor, cls).__classcall__(cls, modules, **options)

--- a/src/sage/combinat/free_module.py
+++ b/src/sage/combinat/free_module.py
@@ -503,10 +503,13 @@ class CombinatorialFreeModule(UniqueRepresentation, Module, IndexedGenerators):
             return self
         construction = self.construction()
         if construction is not None:
-            functor, _ = construction
+            functor, args = construction
             from sage.categories.pushout import VectorFunctor
+            from sage.categories.tensor import TensorProductFunctor
             if isinstance(functor, VectorFunctor):
                 return functor(R)
+            if isinstance(functor, TensorProductFunctor):
+                return functor([f.change_ring(R) for f in args])
         raise NotImplementedError('the method change_ring() has not yet been implemented')
 
     # For backwards compatibility


### PR DESCRIPTION
We want to allow acting with an extension of the base ring on a tensor product.  For example:

```
sage: R.<x> = QQ[]
sage: M = CombinatorialFreeModule(QQ, [1,2,3])
sage: m = M.an_element(); m
2*B[1] + 2*B[2] + 3*B[3]
sage: r = x + 1
sage: r * m
(2*x+2)*B[1] + (2*x+2)*B[2] + (3*x+3)*B[3]
sage: T = M.tensor(M)
sage: t = T.an_element(); t
2*B[1] # B[1] + 2*B[1] # B[2] + 3*B[1] # B[3]
sage: r * t
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[19], line 1
----> 1 r * t

File ~/sage-trac/src/sage/structure/element.pyx:1506, in sage.structure.element.Element.__mul__()
   1504     return (<Element>left)._mul_(right)
   1505 if BOTH_ARE_ELEMENT(cl):
-> 1506     return coercion_model.bin_op(left, right, mul)
   1507 
   1508 cdef long value

File ~/sage-trac/src/sage/structure/coerce.pyx:1278, in sage.structure.coerce.CoercionModel.bin_op()
   1276     # We should really include the underlying error.
   1277     # This causes so much headache.
-> 1278     raise bin_op_exception(op, x, y)
   1279 
   1280 cpdef canonical_coercion(self, x, y) noexcept:

TypeError: unsupported operand parent(s) for *: 'Univariate Polynomial Ring in x over Rational Field' and 'Free module generated by {1, 2, 3} over Rational Field # Free module generated by {1, 2, 3} over Rational Field'
```