### PR TITLE
`src/setup.py`, `sage_setup`: Use `logging` instead of `distutils.log` and `print`

### DIFF
--- a/pkgs/sagemath-bliss/setup.py
+++ b/pkgs/sagemath-bliss/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from distutils import log
 from setuptools import setup
 
 # Work around a Cython problem in Python 3.8.x on macOS

--- a/pkgs/sagemath-bliss/setup.py
+++ b/pkgs/sagemath-bliss/setup.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
+import logging
+
 from setuptools import setup
+
+logging.basicConfig(format='%(levelname)-8s%(relativeCreated)6dms: %(message)s [%(pathname)s:%(lineno)d]', level=logging.INFO)
+log = logging.getLogger(__name__)
 
 # Work around a Cython problem in Python 3.8.x on macOS
 # https://github.com/cython/cython/issues/3262

--- a/src/sage_setup/autogen/interpreters/__init__.py
+++ b/src/sage_setup/autogen/interpreters/__init__.py
@@ -109,6 +109,7 @@ compatibility.
 # that will have to be changed.
 #####################################################################
 
+import logging
 import os
 
 from os.path import getmtime
@@ -119,6 +120,8 @@ from .memory import *
 from .specs.base import *
 from .storage import *
 from .utils import *
+
+log = logging.getLogger(__name__)
 
 
 # Tuple of (filename_root, extension, method) where filename_root is the
@@ -203,7 +206,7 @@ def rebuild(dirname, force=False, interpreters=None, distribution=None):
     """
     # This line will show up in "sage -b" (once per upgrade, not every time
     # you run it).
-    print("Building interpreters for fast_callable")
+    log.info("Building interpreters for fast_callable")
 
     if interpreters is None:
         interpreters = ['CDF', 'Element', 'Python', 'RDF', 'RR', 'CC']
@@ -253,7 +256,7 @@ def rebuild(dirname, force=False, interpreters=None, distribution=None):
                         raise NeedToRebuild("-> Rebuilding interpreters because {} changed".format(src_file))
     except NeedToRebuild as E:
         # Rebuild
-        print(E)
+        log.info('%s', E)
     else:
         return  # Up-to-date
 

--- a/src/sage_setup/autogen/interpreters/__init__.py
+++ b/src/sage_setup/autogen/interpreters/__init__.py
@@ -109,8 +109,6 @@ compatibility.
 # that will have to be changed.
 #####################################################################
 
-from __future__ import print_function, absolute_import
-
 import os
 
 from os.path import getmtime

--- a/src/sage_setup/autogen/interpreters/generator.py
+++ b/src/sage_setup/autogen/interpreters/generator.py
@@ -11,7 +11,6 @@
 
 """Implements the generic interpreter generator."""
 
-from __future__ import print_function, absolute_import
 
 from collections import defaultdict
 from io import StringIO

--- a/src/sage_setup/autogen/interpreters/instructions.py
+++ b/src/sage_setup/autogen/interpreters/instructions.py
@@ -11,7 +11,6 @@
 
 """Implements generic interpreter instructions and related utilities."""
 
-from __future__ import print_function, absolute_import
 
 import re
 

--- a/src/sage_setup/autogen/interpreters/memory.py
+++ b/src/sage_setup/autogen/interpreters/memory.py
@@ -11,7 +11,6 @@
 
 """General purpose MemoryChunk types and related utilities"""
 
-from __future__ import print_function, absolute_import
 
 from .utils import je, reindent_lines as ri
 

--- a/src/sage_setup/autogen/interpreters/specs/base.py
+++ b/src/sage_setup/autogen/interpreters/specs/base.py
@@ -11,7 +11,6 @@
 
 """Base classes for interpreter specs."""
 
-from __future__ import print_function, absolute_import
 
 from ..memory import (MemoryChunkConstants, MemoryChunkArguments,
                       MemoryChunkScratch)

--- a/src/sage_setup/autogen/interpreters/specs/cdf.py
+++ b/src/sage_setup/autogen/interpreters/specs/cdf.py
@@ -9,7 +9,6 @@
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from __future__ import print_function, absolute_import
 
 from .base import StackInterpreter
 from ..instructions import (params_gen, instr_infix, instr_funcall_2args,

--- a/src/sage_setup/autogen/interpreters/specs/element.py
+++ b/src/sage_setup/autogen/interpreters/specs/element.py
@@ -9,7 +9,6 @@
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from __future__ import print_function, absolute_import
 
 from .base import StackInterpreter
 from .python import (MemoryChunkPyConstant, MemoryChunkPythonArguments,

--- a/src/sage_setup/autogen/interpreters/specs/rdf.py
+++ b/src/sage_setup/autogen/interpreters/specs/rdf.py
@@ -9,7 +9,6 @@
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from __future__ import print_function, absolute_import
 
 from .base import StackInterpreter
 from ..instructions import (params_gen, instr_infix, instr_funcall_2args,

--- a/src/sage_setup/autogen/interpreters/storage.py
+++ b/src/sage_setup/autogen/interpreters/storage.py
@@ -11,7 +11,6 @@
 
 """Implements different data storage types."""
 
-from __future__ import print_function, absolute_import
 
 from .utils import je, reindent_lines as ri
 

--- a/src/sage_setup/autogen/interpreters/utils.py
+++ b/src/sage_setup/autogen/interpreters/utils.py
@@ -11,7 +11,6 @@
 
 """Miscellaneous utility routines used for the interpreter generator."""
 
-from __future__ import print_function, absolute_import
 
 import os
 import textwrap

--- a/src/sage_setup/command/sage_build_cython.py
+++ b/src/sage_setup/command/sage_build_cython.py
@@ -5,6 +5,7 @@
 ########################################################################
 
 import os
+import logging
 import sys
 import time
 import json
@@ -13,12 +14,13 @@ import json
 # can replace distutils by its own vendored copy.
 import setuptools
 
-from distutils import log
 from setuptools import Command
 
 from sage_setup.util import stable_uniq
 from sage_setup.find import find_extra_files
 from sage_setup.cython_options import compiler_directives, compile_time_env_variables
+
+log = logging.getLogger(__name__)
 
 # Do not put all, but only the most common libraries and their headers
 # (that are likely to change on an upgrade) here:

--- a/src/sage_setup/command/sage_build_ext.py
+++ b/src/sage_setup/command/sage_build_ext.py
@@ -1,11 +1,11 @@
 import os
+import logging
 import errno
 
 # Import setuptools before importing distutils, so that setuptools
 # can replace distutils by its own vendored copy.
 import setuptools
 
-from distutils import log
 from setuptools.command.build_ext import build_ext
 from distutils.dep_util import newer_group
 try:
@@ -14,6 +14,9 @@ try:
 except ImportError:
     from distutils.errors import DistutilsSetupError
 from sage_setup.run_parallel import execute_list_of_commands
+
+log = logging.getLogger(__name__)
+
 
 class sage_build_ext(build_ext):
     def finalize_options(self):

--- a/src/sage_setup/command/sage_install.py
+++ b/src/sage_setup/command/sage_install.py
@@ -2,6 +2,7 @@
 ### Install Jupyter kernel spec
 #########################################################
 
+import logging
 import os
 import time
 
@@ -9,9 +10,10 @@ import time
 # can replace distutils by its own vendored copy.
 import setuptools
 
-from distutils import log
 from distutils.command.install import install
 from setuptools.command.develop import develop
+
+log = logging.getLogger(__name__)
 
 
 class install_kernel_spec_mixin:

--- a/src/setup.py
+++ b/src/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_namespace_packages
 from setuptools.dist import Distribution
 import multiprocessing.pool
 
-logging.basicConfig(format='%(levelname)-8s%(relativeCreated)6dms: %(message)s [%(pathname)s:%(lineno)d]', level=logging.DEBUG)
+logging.basicConfig(format='%(levelname)-8s%(relativeCreated)6dms: %(message)s [%(pathname)s:%(lineno)d]', level=logging.INFO)
 log = logging.getLogger(__name__)
 log.info('setup.py started')
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -6,14 +6,18 @@
 ## Distribution packaging should use build/pkgs/sagelib/src/setup.py
 ## instead.
 
+import logging
 import os
 import platform
 import sys
 import time
 from setuptools import setup, find_namespace_packages
 from setuptools.dist import Distribution
-from distutils import log
 import multiprocessing.pool
+
+logging.basicConfig(format='%(levelname)-8s%(relativeCreated)6dms: %(message)s [%(pathname)s:%(lineno)d]', level=logging.DEBUG)
+log = logging.getLogger(__name__)
+log.info('setup.py started')
 
 # PEP 517 builds do not have . in sys.path
 sys.path.insert(0, os.path.dirname(__file__))


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
This takes care of most of:
- #33065.

By replacing `print` with logging commands, some messages are no longer printed out of order.
Also setting a logging format that shows the elapsed time. 
Together this makes it easier to see where time is spent.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
