### PR TITLE
Make `sage -b` equivalent to `make sagelib-no-deps` regarding parallelism

### DIFF
--- a/src/bin/sage
+++ b/src/bin/sage
@@ -287,7 +287,7 @@ sage_setup() {
         echo >&2 '************************************************************************'
         echo >&2 'It seems that you are attempting to run Sage from an unpacked source'
         echo >&2 'tarball, but you have not compiled it yet (or maybe the build has not'
-        echo >&2 'finished). You should run `make` in the Sage root directory first.'
+        echo >&2 'finished). You should run `make` in the SAGE_ROOT directory first.'
         echo >&2 'If you did not intend to build Sage from source, you should download'
         echo >&2 'a binary tarball instead. Read README.txt for more information.'
         echo >&2 '************************************************************************'
@@ -869,7 +869,7 @@ fi
 # build/bin/sage-site. See #29111.
 
 build_sage() {
-    ( cd "$SAGE_ROOT/build/make" && ./install sagelib-no-deps ) || exit $?
+    ( cd "$SAGE_ROOT" && make sagelib-no-deps ) || exit $?
 }
 
 if [[ "$1" =~ ^--notebook=.* || "$1" =~ ^-n=.* || "$1" =~ ^-notebook=.* ]] ; then
@@ -924,13 +924,13 @@ if [ "$1" = '-ba-force' -o "$1" = '--ba-force' ]; then
     echo
     echo "WARNING: 'sage --ba-force' is deprecated; use 'sage -ba' instead."
     echo
-    ( cd "$SAGE_ROOT/build/make" && make sagelib-clean )
+    ( cd "$SAGE_ROOT" && make sagelib-clean )
     build_sage
     exit $?
 fi
 
 if [ "$1" = '-ba' ]; then
-    ( cd "$SAGE_ROOT/build/make" && make sagelib-clean )
+    ( cd "$SAGE_ROOT" && make sagelib-clean )
     build_sage
     exit $?
 fi

--- a/src/bin/sage
+++ b/src/bin/sage
@@ -216,6 +216,13 @@ if [ "$1" = '-patchbot' -o "$1" = "--patchbot" ]; then
     exit 127
 fi
 
+# build_sage, sage -b, sage -br, etc. could also be moved to
+# build/bin/sage-site. See #29111; but OTOH #34627.
+
+build_sage() {
+    ( cd "$SAGE_ROOT" && make sagelib-no-deps ) || exit $?
+}
+
 # Check for '-i' etc. before sourcing sage-env: running "make"
 # should be run outside of the Sage shell.
 case "$1" in
@@ -228,6 +235,28 @@ case "$1" in
         fi
         echo >&2 "Error: unknown option: $1"
         exit 1
+        ;;
+    -b)
+        build_sage
+        exit 0
+        ;;
+    -br|--br)
+        build_sage
+        shift; set -- -r "$@"  # delegate to handling of "-r" below, after sourcing sage-env
+        ;;
+    -bn|--build-and-notebook)
+        build_sage
+        shift; set -- -n "$@"  # delegate to handling of "-n" below, after sourcing sage-env
+        ;;
+    -ba)
+        ( cd "$SAGE_ROOT" && make sagelib-clean )
+        build_sage
+        exit 0
+        ;;
+    -bt*)
+        build_sage
+        switch_without_b=-${1#-b}
+        shift; set -- $switch_without_b "$@"  # delegate to handling of "-t...." below, after sourcing sage-env
         ;;
 esac
 
@@ -865,12 +894,6 @@ fi
 # The notebook, grep, building Sage, testing Sage
 #####################################################################
 
-# build_sage, sage -b, sage -br, etc. could be moved to
-# build/bin/sage-site. See #29111.
-
-build_sage() {
-    ( cd "$SAGE_ROOT" && make sagelib-no-deps ) || exit $?
-}
 
 if [[ "$1" =~ ^--notebook=.* || "$1" =~ ^-n=.* || "$1" =~ ^-notebook=.* ]] ; then
     sage-cleaner &>/dev/null &
@@ -905,34 +928,9 @@ if [ -n "$SAGE_SRC" -a -d "$SAGE_SRC" ]; then
     fi
 fi
 
-if [ "$1" = '-b' ]; then
-    build_sage
-    exit $?
-fi
-
-if [ "$1" = '-br' -o "$1" = "--br" ]; then
-    build_sage
-    interactive_sage
-fi
-
 if [ "$1" = '-r' ]; then
     shift
     interactive_sage
-fi
-
-if [ "$1" = '-ba-force' -o "$1" = '--ba-force' ]; then
-    echo
-    echo "WARNING: 'sage --ba-force' is deprecated; use 'sage -ba' instead."
-    echo
-    ( cd "$SAGE_ROOT" && make sagelib-clean )
-    build_sage
-    exit $?
-fi
-
-if [ "$1" = '-ba' ]; then
-    ( cd "$SAGE_ROOT" && make sagelib-clean )
-    build_sage
-    exit $?
 fi
 
 exec-runtests() {
@@ -941,11 +939,8 @@ exec-runtests() {
     exec sage-runtests "$@"
 }
 
-if [ "$1" = '-t' -o "$1" = '-bt' -o "$1" = '-tp' -o "$1" = '-btp' ]; then
-    if [ "$1" = '-bt' -o "$1" = '-btp' ]; then
-        build_sage
-    fi
-    if [ "$1" = '-tp' -o "$1" = '-btp' ]; then
+if [ "$1" = '-t' -o "$1" = '-tp' ]; then
+    if [ "$1" = '-tp' ]; then
         shift
         exec-runtests -p "$@"
     else
@@ -954,10 +949,7 @@ if [ "$1" = '-t' -o "$1" = '-bt' -o "$1" = '-tp' -o "$1" = '-btp' ]; then
     fi
 fi
 
-if [ "$1" = '-tnew' -o "$1" = '-btnew' ]; then
-    if [ "$1" = '-btnew' ]; then
-        build_sage
-    fi
+if [ "$1" = '-tnew' ]; then
     shift
     exec-runtests --new "$@"
 fi

--- a/src/setup.py
+++ b/src/setup.py
@@ -124,7 +124,7 @@ else:
                 aliases=cython_aliases(),
                 create_extension=create_extension,
                 gdb_debug=gdb_debug,
-                nthreads=4)
+                nthreads=sage_build_ext_minimal.get_default_number_build_jobs())
     except Exception as exception:
         log.warn(f"Exception while cythonizing source files: {repr(exception)}")
         raise

--- a/src/setup.py
+++ b/src/setup.py
@@ -85,8 +85,7 @@ else:
     from sage_setup.autogen import autogen_all
     autogen_all()
 
-    log.info("Discovering Python/Cython source code....")
-    t = time.time()
+    log.info("Discovering Python/Cython source code...")
 
     # Exclude a few files if the corresponding distribution is not loaded
     optional_packages = ['mcqd', 'bliss', 'tdlib',
@@ -103,13 +102,19 @@ else:
     python_packages = find_namespace_packages(where=SAGE_SRC, include=['sage', 'sage.*'])
     log.debug(f"python_packages = {python_packages}")
 
-    log.info(f"Discovered Python/Cython sources, time: {(time.time() - t):.2f} seconds.")
+    log.info(f"Discovering Python/Cython source code... done")
 
     # from sage_build_cython:
     import Cython.Compiler.Options
     Cython.Compiler.Options.embed_pos_in_docstring = True
     gdb_debug = os.environ.get('SAGE_DEBUG', None) != 'no'
 
+    aliases = cython_aliases()
+    log.debug(f"aliases = {aliases}")
+    include_path = sage_include_directories(use_sources=True) + ['.']
+    log.debug(f"include_path = {include_path}")
+    nthreads = sage_build_ext_minimal.get_default_number_build_jobs()
+    log.info(f"Cythonizing with {nthreads} threads...")
     try:
         from Cython.Build import cythonize
         from sage.env import cython_aliases, sage_include_directories
@@ -118,16 +123,17 @@ else:
             extensions = cythonize(
                 ["sage/**/*.pyx"],
                 exclude=files_to_exclude,
-                include_path=sage_include_directories(use_sources=True) + ['.'],
+                include_path=include_path,
                 compile_time_env=compile_time_env_variables(),
                 compiler_directives=compiler_directives(False),
-                aliases=cython_aliases(),
+                aliases=aliases,
                 create_extension=create_extension,
                 gdb_debug=gdb_debug,
-                nthreads=sage_build_ext_minimal.get_default_number_build_jobs())
+                nthreads=nthreads)
     except Exception as exception:
         log.warn(f"Exception while cythonizing source files: {repr(exception)}")
         raise
+    log.info(f"Cythonizing with {nthreads} threads... done")
 
 # ########################################################
 # ## Distutils


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->
After `export MAKE='make -j16'`:
- the secret command for building the Sage library without dependencies, `make sagelib-no-deps` uses 4 threads for cythonizing and 16 threads for compiling extension modules
- the advertised command for doing the same, `./sage -b` uses 4 threads for cythonizing and 1 thread for compiling extension modules.

This longstanding discrepancy is from the strange handling of `SAGE_NUM_THREADS` when passing from the runtime environment to the build environment, already noticed in https://github.com/sagemath/sage/issues/34328#issuecomment-1418182391

Here we
- avoid this problem by handling all `sage -b...` commands as `sage -i` is already handled: Enter the build environment directly without going through the runtime environment first;
- replace the hardcoded 4 by the same mechanism that obtains the (default) number of threads for compiling extension modules;
- also remove some unnecessary use of internals of the build system.

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
