### PR TITLE
`setup.py`: Remove `lazy_import_cache` use

### DIFF
--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -76,6 +76,11 @@ else
     fi
 fi
 
+# Remove (potentially invalid) star import caches.
+# lazy star imports are not used by the Sage library, but could still be used by
+# downstream code.
+python3 -c 'import pathlib; from sage.misc.lazy_import_cache import get_cache_file; pathlib.Path(get_cache_file()).unlink(missing_ok=True)'
+
 # Issue #33103: The temp.* directories are large after a full build.
 # We remove them to save space; they are not needed for fast rebuilds.
 rm -rf build/temp.*

--- a/pkgs/sagemath-standard/setup.py
+++ b/pkgs/sagemath-standard/setup.py
@@ -60,15 +60,6 @@ cmdclass = dict(build_cython=sage_build_cython,
                 install=sage_install_and_clean)
 
 #########################################################
-### Testing related stuff
-#########################################################
-
-# Remove (potentially invalid) star import caches
-import sage.misc.lazy_import_cache
-if os.path.exists(sage.misc.lazy_import_cache.get_cache_file()):
-    os.unlink(sage.misc.lazy_import_cache.get_cache_file())
-
-#########################################################
 ### Discovering Sources
 #########################################################
 

--- a/src/sage/misc/lazy_import_cache.py
+++ b/src/sage/misc/lazy_import_cache.py
@@ -1,7 +1,5 @@
 """
 Lazy import cache
-
-This is a pure Python file with no dependencies so it can be used in setup.py.
 """
 import os
 import hashlib

--- a/src/setup.py
+++ b/src/setup.py
@@ -18,8 +18,6 @@ import multiprocessing.pool
 # PEP 517 builds do not have . in sys.path
 sys.path.insert(0, os.path.dirname(__file__))
 
-import sage.misc.lazy_import_cache
-
 from sage.misc.package import is_package_installed_and_updated
 from sage_setup.command.sage_build_ext_minimal import sage_build_ext_minimal
 from sage_setup.command.sage_install import sage_develop, sage_install
@@ -64,15 +62,6 @@ if len(sys.argv) > 1 and (sys.argv[1] in ["sdist", "egg_info", "dist_info"]):
     sdist = True
 else:
     sdist = False
-
-# ########################################################
-# ## Testing related stuff
-# ########################################################
-
-# Remove (potentially invalid) star import caches
-if os.path.exists(sage.misc.lazy_import_cache.get_cache_file()):
-    os.unlink(sage.misc.lazy_import_cache.get_cache_file())
-
 
 # ########################################################
 # ## Discovering Sources


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

Both versions of the sagelib `setup.py` have code that tries to remove the "lazy import cache".

The file name of the lazy import cache in `~/.sage` is keyed to `SAGE_LIB`, so any file name determined at build time is meaningless at runtime when installation goes through wheel building. We remove this code.

As `find ~/.sage -name "*-lazy_import*" | xargs ls -lat` shows, it has not been in use since 2021, as the Sage library no longer uses any `lazy_import` of `*`. But just in case some downstream / user code uses it, we reinstate the cache removal code in `build/pkgs/sagelib/spkg-install.in`

We deprecate the feature in #37433.

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
