### PR TITLE
use Parent for the Pari pseudo-ring

### DIFF
--- a/src/sage/rings/pari_ring.py
+++ b/src/sage/rings/pari_ring.py
@@ -14,10 +14,11 @@ AUTHORS:
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 # ****************************************************************************
 import sage.libs.pari.all as pari
-from sage.rings.ring import Ring
+from sage.categories.rings import Rings
+from sage.structure.parent import Parent
 from sage.structure.element import RingElement
 from sage.structure.richcmp import richcmp
 from sage.misc.fast_methods import Singleton
@@ -27,7 +28,7 @@ class Pari(RingElement):
     """
     Element of Pari pseudo-ring.
     """
-    def __init__(self, x, parent=None):
+    def __init__(self, x, parent=None) -> None:
         """
         EXAMPLES::
 
@@ -45,7 +46,7 @@ class Pari(RingElement):
         RingElement.__init__(self, parent)
         self.__x = pari.pari(x)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         EXAMPLES::
 
@@ -138,7 +139,7 @@ class Pari(RingElement):
         """
         return self.__class__(~self.__x, parent=_inst)
 
-    def _richcmp_(self, other, op):
+    def _richcmp_(self, other, op) -> bool:
         """
         EXAMPLES::
 
@@ -154,11 +155,11 @@ class Pari(RingElement):
         """
         return richcmp(self.__x, other.__x, op)
 
-    def __int__(self):
+    def __int__(self) -> int:
         return int(self.__x)
 
 
-class PariRing(Singleton, Ring):
+class PariRing(Singleton, Parent):
     """
     EXAMPLES::
 
@@ -170,9 +171,9 @@ class PariRing(Singleton, Ring):
     Element = Pari
 
     def __init__(self):
-        Ring.__init__(self, self)
+        Parent.__init__(self, self, category=Rings())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Pseudoring of all PARI objects.'
 
     def _element_constructor_(self, x):
@@ -180,7 +181,7 @@ class PariRing(Singleton, Ring):
             return x
         return self.element_class(x, parent=self)
 
-    def is_field(self, proof=True):
+    def is_field(self, proof=True) -> bool:
         return False
 
     def characteristic(self):


### PR DESCRIPTION
switch the Pari pseudoring to use `Parent` instead of the auld `Ring` class

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.