### PR TITLE
Fix hanging computation when calling `_isomorphic_ring()` with large characteristic

### DIFF
--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -218,7 +218,7 @@ class PolynomialQuotientRingFactory(UniqueFactory):
             raise TypeError("ring must be a polynomial ring")
         if not isinstance(polynomial, polynomial_element.Polynomial):
             raise TypeError("must be a polynomial")
-        if not polynomial.parent() is ring:
+        if polynomial.parent() is not ring:
             raise TypeError("polynomial must be in ring")
 
         c = polynomial.leading_coefficient()

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -2009,7 +2009,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             Univariate Quotient Polynomial Ring in b
              over Finite Field in a of size 2^2 with modulus b^2 + b + a
             sage: from_M, to_M, M = L._isomorphic_ring(); M
-            Finite Field in z4 of size 2^4
+            Finite Field in zn of size 2^4
             sage: R.<c> = L[]
             sage: M.<c> = L.extension(c^2 + b*c + b); M
             Univariate Quotient Polynomial Ring in c
@@ -2017,7 +2017,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
               over Finite Field in a of size 2^2 with modulus b^2 + b + a
               with modulus c^2 + b*c + b
             sage: from_N, to_N, N = M._isomorphic_ring(); N
-            Finite Field in z8 of size 2^8
+            Finite Field in zn of size 2^8
 
             sage: R.<x> = QQ[]
             sage: K = R.quo(x^2 + 1)
@@ -2092,7 +2092,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             # the underlying prime field
             N = self.cardinality()
             from sage.rings.finite_rings.finite_field_constructor import GF
-            isomorphic_ring = GF(N, names="a")
+            isomorphic_ring = GF(N, names="zn")
 
             # the map to GF(N) maps our generator to a root of our modulus in the isomorphic_ring
             base_image = self.base_ring().modulus().change_ring(isomorphic_ring).any_root()

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -2092,7 +2092,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             # the underlying prime field
             N = self.cardinality()
             from sage.rings.finite_rings.finite_field_constructor import GF
-            isomorphic_ring = GF(N)
+            isomorphic_ring = GF(N, names="a")
 
             # the map to GF(N) maps our generator to a root of our modulus in the isomorphic_ring
             base_image = self.base_ring().modulus().change_ring(isomorphic_ring).any_root()


### PR DESCRIPTION
When constructing a finite field of non-prime order, if no name is given then a conway polynomial is computed which is computationally very expensive for large characteristic.

This PR adds a name argument to the `GF()` construction in `_isomorphic_ring()` to stop this.

## Before PR

```py
def extend_to_finite_field(field, modulus):
    if not modulus.is_irreducible():
        raise ValueError

    if field != modulus.base_ring():
        raise ValueError

    R = modulus.parent()
    quo_ring = R.quotient_ring(modulus, "xbar")
    _, _, ff = quo_ring._isomorphic_ring()
    return ff

F.<a> = GF((2**255 - 19, 2))
f = PolynomialRing(F, names="x").irreducible_element(2)
%time F.extension(f)
CPU times: user 5.56 ms, sys: 4 µs, total: 5.57 ms
Wall time: 5.57 ms
%time _ = extend_to_finite_field(F, f)
# Doesn't finish
```

## After PR

```py
F.<a> = GF((2**255 - 19, 2))
f = PolynomialRing(F, names="x").irreducible_element(2)
%time _ = F.extension(f)
CPU times: user 3.38 ms, sys: 22 µs, total: 3.4 ms
Wall time: 3.4 ms
%time _ = extend_to_finite_field(F, f)
CPU times: user 270 ms, sys: 1.57 ms, total: 272 ms
Wall time: 271 ms
```

Fixes https://github.com/sagemath/sage/issues/37472