### PR TITLE
`sage --package`, `sage-get-system-packages`: Support PURLs `pkg:pypi/DISTRO-NAME`, obtain dependencies of wheels from PyPI

### DIFF
--- a/build/bin/sage-get-system-packages
+++ b/build/bin/sage-get-system-packages
@@ -51,7 +51,7 @@ case "$SYSTEM" in
 esac
 
 case "$SPKGS" in
-    *pkg:pypi/*)
+    *pkg:*|pypi/*|generic/*)
         PATH="${SAGE_ROOT}/build/bin:$PATH" SPKGS=$(sage-package list $SPKGS)
         ;;
 esac

--- a/build/bin/sage-get-system-packages
+++ b/build/bin/sage-get-system-packages
@@ -51,7 +51,7 @@ case "$SYSTEM" in
 esac
 
 case "$SPKGS" in
-    *pypi:*)
+    *pkg:pypi/*)
         PATH="${SAGE_ROOT}/build/bin:$PATH" SPKGS=$(sage-package list $SPKGS)
         ;;
 esac

--- a/build/bin/sage-get-system-packages
+++ b/build/bin/sage-get-system-packages
@@ -50,6 +50,12 @@ case "$SYSTEM" in
         ;;
 esac
 
+case "$SPKGS" in
+    *pypi:*)
+        PATH="${SAGE_ROOT}/build/bin:$PATH" SPKGS=$(sage-package list $SPKGS)
+        ;;
+esac
+
 for PKG_BASE in $SPKGS; do
     if [ $FROM_PYPROJECT_TOML -eq 1 ]; then
         if [ -f "$SAGE_ROOT/src/pyproject.toml" ]; then

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -88,7 +88,7 @@ class Application(object):
         source_maxima='normal'
         trees_maxima='SAGE_LOCAL'
         """
-        props = kwds.pop('props', ['path', 'version_with_patchlevel', 'type', 'source', 'trees'])
+        props = kwds.pop('props', ['path', 'version_with_patchlevel', 'type', 'source', 'trees', 'purl'])
         format = kwds.pop('format', 'plain')
         log.debug('Looking up properties')
         pc = PackageClass(*package_classes)

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -403,6 +403,8 @@ class Application(object):
 
         $ sage --package create jupyterlab_markup --pypi --source wheel --type optional
         """
+        if package_name.startswith('pypi/'):
+            package_name = 'pkg:' + package_name
         if package_name.startswith('pkg:pypi/'):
             pypi = True
             package_name = package_name[len('pkg:pypi/'):].lower().replace('-', '_')

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -395,9 +395,9 @@ class Application(object):
 
         $ sage --package create jupyterlab_markup --pypi --source wheel --type optional
         """
-        if package_name.startswith('pypi:'):
+        if package_name.startswith('pkg:pypi/'):
             pypi = True
-            package_name = package_name[len('pypi:'):].lower().replace('-', '_')
+            package_name = package_name[len('pkg:pypi/'):].lower().replace('-', '_')
         elif '-' in package_name:
             raise ValueError('package names must not contain dashes, use underscore instead')
         if pypi:

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -473,7 +473,8 @@ class Application(object):
         if description or license or upstream_contact:
             creator.set_description(description, license, upstream_contact)
         if pypi or source == 'pip':
-            creator.set_python_data_and_scripts(pypi_package_name=pypi_version.name, source=source)
+            creator.set_python_data_and_scripts(pypi_package_name=pypi_version.name, source=source,
+                                                dependencies=dependencies)
         if tarball:
             creator.set_tarball(tarball, upstream_url)
             if upstream_url and version:

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -10,7 +10,10 @@ AUTHORS:
 
 
 # ****************************************************************************
-#       Copyright (C) 2016 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2016      Volker Braun <vbraun.name@gmail.com>
+#                     2020-2024 Matthias Koeppe
+#                     2022      Thierry Monteil
+#                     2024      Marc Culler
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -438,16 +438,21 @@ class Application(object):
                     version = pypi_version.version
                 if dependencies is None:
                     requires_dist = pypi_version.requires_dist
-                    print(requires_dist)
                     if requires_dist:
                         dependencies = []
                         for item in requires_dist:
                             if "extra ==" in item:
                                 continue
                             try:
-                                dep = dep_re.match(item).groups()[0]
+                                dep = dep_re.match(item).groups()[0].strip()
                             except Exception:
                                 continue
+                            dep = 'pkg:pypi/' + dep
+                            try:
+                                dep = Package(dep).name
+                            except ValueError:
+                                self.create(dep, pkg_type=pkg_type)
+                                dep = Package(dep).name
                             dependencies.append(dep)
                 upstream_url = 'https://pypi.io/packages/{2}/{0:1.1}/{0}/{1}'.format(package_name, tarball, pypi_version.python_version)
             if not description:

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -395,7 +395,10 @@ class Application(object):
 
         $ sage --package create jupyterlab_markup --pypi --source wheel --type optional
         """
-        if '-' in package_name:
+        if package_name.startswith('pypi:'):
+            pypi = True
+            package_name = package_name[len('pypi:'):].lower().replace('-', '_')
+        elif '-' in package_name:
             raise ValueError('package names must not contain dashes, use underscore instead')
         if pypi:
             if source is None:

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -407,7 +407,7 @@ class Application(object):
             package_name = 'pkg:' + package_name
         if package_name.startswith('pkg:pypi/'):
             pypi = True
-            package_name = package_name[len('pkg:pypi/'):].lower().replace('-', '_')
+            package_name = package_name[len('pkg:pypi/'):].lower().replace('-', '_').replace('.', '_')
         elif '-' in package_name:
             raise ValueError('package names must not contain dashes, use underscore instead')
         if pypi:

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -256,6 +256,9 @@ class Application(object):
         Update a package to the latest version. This modifies the Sage sources.
         """
         pkg = Package(package_name)
+        if pkg.source not in ['normal', 'wheel']:
+            log.debug('update_latest can only update normal and wheel packages; %s is a %s package' % (pkg, pkg.source))
+            return
         dist_name = pkg.distribution_name
         if dist_name is None:
             log.debug('%s does not have Python distribution info in version_requirements.txt' % pkg)

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -40,7 +40,8 @@ from sage_bootstrap.expand_class import PackageClass
 from sage_bootstrap.env import SAGE_DISTFILES
 
 
-dep_re = re.compile('([^<>=]*)')
+# Approximation of https://peps.python.org/pep-0508/#names dependency specification
+dep_re = re.compile('^ *([-A-Z0-9._]+)', re.IGNORECASE)
 
 
 class Application(object):

--- a/build/sage_bootstrap/cmdline.py
+++ b/build/sage_bootstrap/cmdline.py
@@ -277,9 +277,10 @@ def make_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         help='Print a list of packages known to Sage')
     parser_list.add_argument(
-        'package_class', metavar='[package_name|:package_type:]',
+        'package_class', metavar='[PACKAGE_NAME|pypi:DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
         type=str, default=[':all-or-nothing:'], nargs='*',
-        help=('package name or designator for all packages of a given type '
+        help=('package name, pypi: followed by a distribution name, '
+              'or designator for all packages of a given type '
               '(one of :all:, :standard:, :optional:, and :experimental:); '
               'default: :all: (or nothing when --include-dependencies or --exclude-dependencies is given'))
     parser_list.add_argument(
@@ -305,9 +306,10 @@ def make_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         help='Print properties of given packages')
     parser_properties.add_argument(
-        'package_class', metavar='[package_name|:package_type:]',
+        'package_class', metavar='[PACKAGE_NAME|pypi:DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
         type=str, nargs='+',
-        help=('package name or designator for all packages of a given type '
+        help=('package name, pypi: followed by a distribution name, '
+              'or designator for all packages of a given type '
               '(one of :all:, :standard:, :optional:, and :experimental:)'))
     parser_properties.add_argument(
         '--format', type=str, default='plain',
@@ -410,11 +412,11 @@ def make_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         help='Fix the checksum of normal packages.')
     parser_fix_checksum.add_argument(
-        'package_class', metavar='[package_name|:package_type:]',
+        'package_class', metavar='[PACKAGE_NAME|pypi:DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
         type=str, default=[':all:'], nargs='*',
-        help=('package name or designator for all packages of a given type '
-              '(one of :all:, :standard:, :optional:, and :experimental:); '
-              'default: :all:'))
+        help=('package name, pypi: followed by a distribution name, '
+              'or designator for all packages of a given type '
+              '(one of :all:, :standard:, :optional:, and :experimental:; default: :all:)'))
 
     parser_create = subparsers.add_parser(
         'create', epilog=epilog_create,
@@ -453,9 +455,10 @@ def make_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         help='Print metrics of given packages')
     parser_metrics.add_argument(
-        'package_class', metavar='[package_name|:package_type:]',
+        'package_class', metavar='[PACKAGE_NAME|pypi:DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
         type=str, nargs='*', default=[':all:'],
-        help=('package name or designator for all packages of a given type '
+        help=('package name, pypi: followed by a distribution name, '
+              'or designator for all packages of a given type '
               '(one of :all:, :standard:, :optional:, and :experimental:; default: :all:)'))
 
     return parser

--- a/build/sage_bootstrap/cmdline.py
+++ b/build/sage_bootstrap/cmdline.py
@@ -277,9 +277,9 @@ def make_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         help='Print a list of packages known to Sage')
     parser_list.add_argument(
-        'package_class', metavar='[PACKAGE_NAME|pypi:DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
+        'package_class', metavar='[PACKAGE_NAME|pkg:pypi/DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
         type=str, default=[':all-or-nothing:'], nargs='*',
-        help=('package name, pypi: followed by a distribution name, '
+        help=('package name, pkg:pypi/ followed by a distribution name, '
               'or designator for all packages of a given type '
               '(one of :all:, :standard:, :optional:, and :experimental:); '
               'default: :all: (or nothing when --include-dependencies or --exclude-dependencies is given'))
@@ -306,9 +306,9 @@ def make_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         help='Print properties of given packages')
     parser_properties.add_argument(
-        'package_class', metavar='[PACKAGE_NAME|pypi:DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
+        'package_class', metavar='[PACKAGE_NAME|pkg:pypi/DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
         type=str, nargs='+',
-        help=('package name, pypi: followed by a distribution name, '
+        help=('package name, pkg:pypi/ followed by a distribution name, '
               'or designator for all packages of a given type '
               '(one of :all:, :standard:, :optional:, and :experimental:)'))
     parser_properties.add_argument(
@@ -412,9 +412,9 @@ def make_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         help='Fix the checksum of normal packages.')
     parser_fix_checksum.add_argument(
-        'package_class', metavar='[PACKAGE_NAME|pypi:DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
+        'package_class', metavar='[PACKAGE_NAME|pkg:pypi/DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
         type=str, default=[':all:'], nargs='*',
-        help=('package name, pypi: followed by a distribution name, '
+        help=('package name, pkg:pypi/ followed by a distribution name, '
               'or designator for all packages of a given type '
               '(one of :all:, :standard:, :optional:, and :experimental:; default: :all:)'))
 
@@ -455,9 +455,9 @@ def make_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         help='Print metrics of given packages')
     parser_metrics.add_argument(
-        'package_class', metavar='[PACKAGE_NAME|pypi:DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
+        'package_class', metavar='[PACKAGE_NAME|pkg:pypi/DISTRIBUTION-NAME|:PACKAGE_TYPE:]',
         type=str, nargs='*', default=[':all:'],
-        help=('package name, pypi: followed by a distribution name, '
+        help=('package name, pkg:pypi/ followed by a distribution name, '
               'or designator for all packages of a given type '
               '(one of :all:, :standard:, :optional:, and :experimental:; default: :all:)'))
 

--- a/build/sage_bootstrap/cmdline.py
+++ b/build/sage_bootstrap/cmdline.py
@@ -12,7 +12,9 @@ AUTHORS:
 """
 
 # ****************************************************************************
-#       Copyright (C) 2016 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2015-2016 Volker Braun <vbraun.name@gmail.com>
+#                     2020-2024 Matthias Koeppe
+#                     2022      Thierry Monteil
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/creator.py
+++ b/build/sage_bootstrap/creator.py
@@ -4,7 +4,8 @@ Package Creator
 """
 
 # ****************************************************************************
-#       Copyright (C) 2016 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2015-2016 Volker Braun <vbraun.name@gmail.com>
+#                     2020-2024 Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/creator.py
+++ b/build/sage_bootstrap/creator.py
@@ -105,7 +105,7 @@ class PackageCreator(object):
             except OSError:
                 pass
 
-    def set_python_data_and_scripts(self, pypi_package_name=None, source='normal'):
+    def set_python_data_and_scripts(self, pypi_package_name=None, source='normal', dependencies=None):
         """
         Write the file ``dependencies`` and other files for Python packages.
 
@@ -121,7 +121,15 @@ class PackageCreator(object):
         if pypi_package_name is None:
             pypi_package_name = self.package_name
         with open(os.path.join(self.path, 'dependencies'), 'w+') as f:
-            f.write(' | $(PYTHON_TOOLCHAIN) $(PYTHON)\n\n')
+            if dependencies:
+                dependencies = ' '.join(dependencies)
+            else:
+                dependencies = ''
+            if source == 'wheel':
+                dependencies_order_only = 'pip $(PYTHON)'
+            else:
+                dependencies_order_only = '$(PYTHON_TOOLCHAIN) $(PYTHON)'
+            f.write(dependencies + ' | ' + dependencies_order_only + '\n\n')
             f.write('----------\nAll lines of this file are ignored except the first.\n')
         if source == 'normal':
             with open(os.path.join(self.path, 'spkg-install.in'), 'w+') as f:

--- a/build/sage_bootstrap/download/cmdline.py
+++ b/build/sage_bootstrap/download/cmdline.py
@@ -6,7 +6,9 @@ This module handles the main "sage-download-file" commandline utility.
 """
 
 # ****************************************************************************
-#       Copyright (C) 2016 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2015-2016 Volker Braun <vbraun.name@gmail.com>
+#                     2015      Jeroen Demeyer
+#                     2020      Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/download/mirror_list.py
+++ b/build/sage_bootstrap/download/mirror_list.py
@@ -4,7 +4,9 @@ Access the List of Sage Download Mirrors
 """
 
 #*****************************************************************************
-#       Copyright (C) 2015 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2014-2016 Volker Braun <vbraun.name@gmail.com>
+#                     2015      Jeroen Demeyer
+#                     2023      Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/expand_class.py
+++ b/build/sage_bootstrap/expand_class.py
@@ -52,17 +52,20 @@ class PackageClass(object):
                 self._init_optional(predicate=included_in_filter)
             elif package_name_or_class == ':experimental:':
                 self._init_experimental(predicate=included_in_filter)
-            elif package_name_or_class.startswith('pkg:pypi/'):
+            elif any(package_name_or_class.startswith(prefix)
+                     for prefix in ["pkg:", "pypi/", "generic"]):
                 self.__names.add(Package(package_name_or_class).name)
             else:
                 if ':' in package_name_or_class:
-                    raise ValueError('a colon may only appear in pkg:pypi/DISTRIBUTION-NAME '
+                    raise ValueError('a colon may only appear in a PURL such as '
+                                     'pkg:pypi/DISTRIBUTION-NAME '
                                      'and in designators of package types, '
                                      'which must be one of '
                                      ':all:, :standard:, :optional:, or :experimental:'
                                      'got {}'.format(package_name_or_class))
                 if '-' in package_name_or_class:
-                    raise ValueError('dashes may only appear in pkg:pypi/DISTRIBUTION-NAME; '
+                    raise ValueError('dashes may only appear in a PURL such as '
+                                     'pkg:pypi/DISTRIBUTION-NAME; '
                                      'SPKG names use underscores')
                 self.__names.add(package_name_or_class)
 

--- a/build/sage_bootstrap/expand_class.py
+++ b/build/sage_bootstrap/expand_class.py
@@ -52,12 +52,18 @@ class PackageClass(object):
                 self._init_optional(predicate=included_in_filter)
             elif package_name_or_class == ':experimental:':
                 self._init_experimental(predicate=included_in_filter)
+            elif package_name_or_class.startswith('pypi:'):
+                self.__names.add(Package(package_name_or_class).name)
             else:
                 if ':' in package_name_or_class:
-                    raise ValueError('a colon may only appear in designators of package types, '
+                    raise ValueError('a colon may only appear in pypi:DISTRIBUTION-NAME '
+                                     'and in designators of package types, '
                                      'which must be one of '
                                      ':all:, :standard:, :optional:, or :experimental:'
                                      'got {}'.format(package_name_or_class))
+                if '-' in package_name_or_class:
+                    raise ValueError('dashes may only appear in pypi:DISTRIBUTION-NAME; '
+                                     'SPKG names use underscores')
                 self.__names.add(package_name_or_class)
 
         def include_recursive_dependencies(names, package_name):

--- a/build/sage_bootstrap/expand_class.py
+++ b/build/sage_bootstrap/expand_class.py
@@ -4,7 +4,8 @@ Utility to manage lists of packages
 """
 
 # ****************************************************************************
-#       Copyright (C) 2016 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2016      Volker Braun <vbraun.name@gmail.com>
+#                     2020-2024 Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/expand_class.py
+++ b/build/sage_bootstrap/expand_class.py
@@ -52,17 +52,17 @@ class PackageClass(object):
                 self._init_optional(predicate=included_in_filter)
             elif package_name_or_class == ':experimental:':
                 self._init_experimental(predicate=included_in_filter)
-            elif package_name_or_class.startswith('pypi:'):
+            elif package_name_or_class.startswith('pkg:pypi/'):
                 self.__names.add(Package(package_name_or_class).name)
             else:
                 if ':' in package_name_or_class:
-                    raise ValueError('a colon may only appear in pypi:DISTRIBUTION-NAME '
+                    raise ValueError('a colon may only appear in pkg:pypi/DISTRIBUTION-NAME '
                                      'and in designators of package types, '
                                      'which must be one of '
                                      ':all:, :standard:, :optional:, or :experimental:'
                                      'got {}'.format(package_name_or_class))
                 if '-' in package_name_or_class:
-                    raise ValueError('dashes may only appear in pypi:DISTRIBUTION-NAME; '
+                    raise ValueError('dashes may only appear in pkg:pypi/DISTRIBUTION-NAME; '
                                      'SPKG names use underscores')
                 self.__names.add(package_name_or_class)
 

--- a/build/sage_bootstrap/package.py
+++ b/build/sage_bootstrap/package.py
@@ -26,11 +26,11 @@ log = logging.getLogger()
 class Package(object):
 
     def __new__(cls, package_name):
-        if package_name.startswith("pypi:"):
+        if package_name.startswith("pkg:pypi/"):
             def normalize(name):
                 return name.lower().replace('_', '-')
 
-            pypi_name = normalize(package_name[len("pypi:"):])
+            pypi_name = normalize(package_name[len("pkg:pypi/"):])
             for pkg in cls.all():
                 distribution = pkg.distribution_name
                 if distribution and normalize(distribution) == pypi_name:
@@ -56,7 +56,7 @@ class Package(object):
         -- ``package_name`` -- string. Name of the package. The Sage
            convention is that all package names are lower case.
         """
-        if package_name.startswith("pypi:"):
+        if package_name.startswith("pkg:pypi/"):
             # Already initialized
             return
         if package_name != package_name.lower():

--- a/build/sage_bootstrap/package.py
+++ b/build/sage_bootstrap/package.py
@@ -29,6 +29,7 @@ class Package(object):
         if package_name.startswith("pypi/") or package_name.startswith("generic/"):
             package_name = "pkg:" + package_name
         if package_name.startswith("pkg:"):
+            package_name = package_name.replace('_', '-')
             if package_name.startswith("pkg:generic/"):  # fast path
                 try:
                     pkg = cls(package_name[len("pkg:generic/"):].replace('-', '_'))

--- a/build/sage_bootstrap/package.py
+++ b/build/sage_bootstrap/package.py
@@ -4,7 +4,9 @@ Sage Packages
 """
 
 # ****************************************************************************
-#       Copyright (C) 2015 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2015-2016 Volker Braun <vbraun.name@gmail.com>
+#                     2018      Jeroen Demeyer
+#                     2020-2024 Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/package.py
+++ b/build/sage_bootstrap/package.py
@@ -428,7 +428,7 @@ class Package(object):
                 continue
             try:
                 yield cls(subdir)
-            except BaseException:
+            except Exception:
                 log.error('Failed to open %s', subdir)
                 raise
 

--- a/build/sage_bootstrap/package.py
+++ b/build/sage_bootstrap/package.py
@@ -25,6 +25,21 @@ log = logging.getLogger()
 
 class Package(object):
 
+    def __new__(cls, package_name):
+        if package_name.startswith("pypi:"):
+            def normalize(name):
+                return name.lower().replace('_', '-')
+
+            pypi_name = normalize(package_name[len("pypi:"):])
+            for pkg in cls.all():
+                distribution = pkg.distribution_name
+                if distribution and normalize(distribution) == pypi_name:
+                    return pkg  # assume unique
+            raise ValueError('no package for distribution {0}'.format(pypi_name))
+        self = object.__new__(cls)
+        self.__init__(package_name)
+        return self
+
     def __init__(self, package_name):
         """
         Sage Package
@@ -41,6 +56,14 @@ class Package(object):
         -- ``package_name`` -- string. Name of the package. The Sage
            convention is that all package names are lower case.
         """
+        if package_name.startswith("pypi:"):
+            # Already initialized
+            return
+        if package_name != package_name.lower():
+            raise ValueError('package names should be lowercase, got {0}'.format(package_name))
+        if '-' in package_name:
+            raise ValueError('package names use underscores, not dashes, got {0}'.format(package_name))
+
         self.__name = package_name
         self.__tarball = None
         self._init_checksum()

--- a/build/sage_bootstrap/pypi.py
+++ b/build/sage_bootstrap/pypi.py
@@ -106,6 +106,13 @@ class PyPiVersion(object):
         """
         return self.json['info']['summary']
 
+    @property
+    def requires_dist(self):
+        """
+        Return the dependencies
+        """
+        return self.json['info']['requires_dist']
+
     def update(self, package=None):
         if package is None:
             package = Package(self.name)

--- a/build/sage_bootstrap/pypi.py
+++ b/build/sage_bootstrap/pypi.py
@@ -5,7 +5,8 @@ PyPi Version Information
 
 
 # ****************************************************************************
-#       Copyright (C) 2016 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2016      Volker Braun <vbraun.name@gmail.com>
+#                     2020-2023 Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/tarball.py
+++ b/build/sage_bootstrap/tarball.py
@@ -4,7 +4,9 @@ Third-Party Tarballs
 """
 
 # ****************************************************************************
-#       Copyright (C) 2015 Volker Braun <vbraun.name@gmail.com>
+#       Copyright (C) 2014-2015 Volker Braun <vbraun.name@gmail.com>
+#                     2017      Jeroen Demeyer
+#                     2020      Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build/sage_bootstrap/uninstall.py
+++ b/build/sage_bootstrap/uninstall.py
@@ -24,7 +24,9 @@ This performs two types of uninstallation:
        are also removed.
 """
 # ****************************************************************************
-#       Copyright (C) 2017 Erik M. Bray <erik.m.bray@gmail.com>
+#       Copyright (C) 2017-2018 Erik M. Bray <erik.m.bray@gmail.com>
+#                     2019      Jeroen Demeyer
+#                     2021-2022 Matthias Koeppe
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/doc/en/developer/packaging.rst
+++ b/src/doc/en/developer/packaging.rst
@@ -1077,22 +1077,27 @@ from PyPI and also obtains most of the necessary information by querying PyPI.
 In particular, the ``SPKG.rst`` file is created as a copy of the package's
 README file.
 
-The ``dependencies`` file may need editing (watch out for warnings regarding
-``--no-deps`` that Sage issues during installation of the package!).
+By default, when the package is available as a platform-independent
+wheel, the ``sage --package`` creates a ``wheel`` package. In this case,
+the ``dependencies`` file is automatically generated from the information
+on PyPI, but may still need some manual editing.
+
+For ``normal`` and ``pip`` packages, the ``dependencies`` file is initialized
+to the bare minimum and will need manual editing. (Watch out for warnings
+regarding ``--no-deps`` that Sage issues during installation of the package!).
 
 Also you may want to set lower and upper bounds for acceptable package versions
 in the file ``version_requirements.txt``. (Make sure that the version in
 ``package-version.txt`` falls within this acceptable version range!)
 
-By default, when the package is available as a platform-independent
-wheel, the ``sage --package`` creates a wheel package. To create a normal package
-instead (for example, when the package requires patching), you can use::
+To create a ``normal`` package instead of a ``wheel`` package (for example, when the
+package requires patching), you can use::
 
     [alice@localhost sage]$ ./sage --package create pkg:pypi/scikit-spatial \
                                                --source normal              \
                                                --type optional
 
-To create a pip package rather than a normal or wheel package, you can use::
+To create a ``pip`` package rather than a ``normal`` or ``wheel`` package, you can use::
 
     [alice@localhost sage]$ ./sage --package create pkg:pypi/scikit-spatial \
                                                --source pip                 \

--- a/src/doc/en/developer/packaging.rst
+++ b/src/doc/en/developer/packaging.rst
@@ -14,7 +14,7 @@ The installation of packages is done through a bash script located in
 :sage_root:`build/bin/sage-spkg`. This script is typically invoked by
 giving the command::
 
-    [alice@localhost sage]$ sage -i <options> <package name>...
+    [alice@localhost sage]$ ./sage -i <options> <package name>...
 
 options can be:
 
@@ -1049,10 +1049,10 @@ Creating packages
 Assuming that you have downloaded
 ``$SAGE_ROOT/upstream/FoO-1.3.tar.gz``, you can use::
 
-    [alice@localhost sage]$ sage --package create foo                     \
-                                             --version 1.3                \
-                                             --tarball FoO-VERSION.tar.gz \
-                                             --type experimental
+    [alice@localhost sage]$ ./sage --package create foo                     \
+                                               --version 1.3                \
+                                               --tarball FoO-VERSION.tar.gz \
+                                               --type experimental
 
 to create ``$SAGE_ROOT/build/pkgs/foo/package-version.txt``,
 ``checksums.ini``, and ``type`` in one step.
@@ -1061,15 +1061,21 @@ You can skip the manual downloading of the upstream tarball by using
 the additional argument ``--upstream-url``.  This command will also
 set the ``upstream_url`` field in ``checksums.ini`` described above.
 
-For Python packages available from PyPI, you can use::
+For Python packages available from PyPI, use a PURL (Package URL,
+see `PEP 725 <https://peps.python.org/pep-0725/#concrete-package-specification-through-purl>`_)::
+
+    [alice@localhost sage]$ ./sage --package create pkg:pypi/scikit-spatial \
+                                               --type optional
+
+An equivalent command uses the SPKG name of the new package::
 
     [alice@localhost sage]$ sage --package create scikit_spatial --pypi   \
                                              --type optional
 
-This automatically downloads the most recent version from PyPI and also
-obtains most of the necessary information by querying PyPI. In particular,
-the ``SPKG.rst`` file is created as a copy of the package's README file.
-
+Either of these two commands automatically downloads the most recent version
+from PyPI and also obtains most of the necessary information by querying PyPI.
+In particular, the ``SPKG.rst`` file is created as a copy of the package's
+README file.
 
 The ``dependencies`` file may need editing (watch out for warnings regarding
 ``--no-deps`` that Sage issues during installation of the package!).
@@ -1082,15 +1088,15 @@ By default, when the package is available as a platform-independent
 wheel, the ``sage --package`` creates a wheel package. To create a normal package
 instead (for example, when the package requires patching), you can use::
 
-    [alice@localhost sage]$ sage --package create scikit_spatial --pypi   \
-                                             --source normal              \
-                                             --type optional
+    [alice@localhost sage]$ ./sage --package create pkg:pypi/scikit-spatial \
+                                               --source normal              \
+                                               --type optional
 
 To create a pip package rather than a normal or wheel package, you can use::
 
-    [alice@localhost sage]$ sage --package create scikit_spatial --pypi   \
-                                             --source pip                 \
-                                             --type optional
+    [alice@localhost sage]$ ./sage --package create pkg:pypi/scikit-spatial \
+                                               --source pip                 \
+                                               --type optional
 
 When the package already exists, ``sage --package create`` overwrites it.
 
@@ -1101,14 +1107,14 @@ Updating packages to a new version
 A package that has the ``upstream_url`` information can be updated by
 simply typing::
 
-    [alice@localhost sage]$ sage --package update numpy 3.14.59
+    [alice@localhost sage]$ ./sage --package update openblas 0.3.79
 
 which will automatically download the archive and update the
-information in ``build/pkgs/numpy/``.
+information in ``build/pkgs/openblas/``.
 
 For Python packages available from PyPI, there is another shortcut::
 
-    [alice@localhost sage]$ sage --package update-latest matplotlib
+    [alice@localhost sage]$ ./sage --package update-latest pkg:pypi/matplotlib
     Updating matplotlib: 3.3.0 -> 3.3.1
     Downloading tarball to ...matplotlib-3.3.1.tar.bz2
     [...............................................................]
@@ -1122,10 +1128,10 @@ version range!
 If you pass the switch ``--commit``, the script will run ``git commit``
 for you.
 
-If you prefer to make update a package ``foo`` by making manual
+If you prefer to update a package ``foo`` by making manual
 changes to the files in ``build/pkgs/foo``, you will need to run::
 
-    [alice@localhost sage]$ sage --package fix-checksum foo
+    [alice@localhost sage]$ ./sage --package fix-checksum foo
 
 which will modify the ``checksums.ini`` file with the correct
 checksums.
@@ -1138,7 +1144,7 @@ The command ``sage --package metrics`` computes machine-readable
 aggregated metrics for all packages in the Sage distribution or a
 given list of packages::
 
-    [alice@localhost sage]$ sage --package metrics
+    [alice@localhost sage]$ ./sage --package metrics
     has_file_distros_arch_txt=181
     has_file_distros_conda_txt=289
     has_file_distros_debian_txt=172
@@ -1212,20 +1218,20 @@ Sage (``FoO-1.3.tar.gz`` in the example of section
 
 Now you can install the package using::
 
-    [alice@localhost sage]$ sage -i package_name
+    [alice@localhost sage]$ ./sage -i package_name
 
 or::
 
-    [alice@localhost sage]$ sage -f package_name
+    [alice@localhost sage]$ ./sage -f package_name
 
 to force a reinstallation. If your package contains a ``spkg-check``
 script (see :ref:`section-spkg-check`) it can be run with::
 
-    [alice@localhost sage]$ sage -i -c package_name
+    [alice@localhost sage]$ ./sage -i -c package_name
 
 or::
 
-    [alice@localhost sage]$ sage -f -c package_name
+    [alice@localhost sage]$ ./sage -f -c package_name
 
 If all went fine, open a PR with the code under
 :sage_root:`build/pkgs`.

--- a/src/doc/en/developer/packaging.rst
+++ b/src/doc/en/developer/packaging.rst
@@ -1084,7 +1084,7 @@ on PyPI, but may still need some manual editing.
 
 For ``normal`` and ``pip`` packages, the ``dependencies`` file is initialized
 to the bare minimum and will need manual editing. (Watch out for warnings
-regarding ``--no-deps`` that Sage issues during installation of the package!).
+regarding ``--no-deps`` that Sage issues during installation of the package!)
 
 Also you may want to set lower and upper bounds for acceptable package versions
 in the file ``version_requirements.txt``. (Make sure that the version in

--- a/src/doc/en/developer/packaging.rst
+++ b/src/doc/en/developer/packaging.rst
@@ -1069,8 +1069,8 @@ see `PEP 725 <https://peps.python.org/pep-0725/#concrete-package-specification-t
 
 An equivalent command uses the SPKG name of the new package::
 
-    [alice@localhost sage]$ sage --package create scikit_spatial --pypi   \
-                                             --type optional
+    [alice@localhost sage]$ ./sage --package create scikit_spatial --pypi   \
+                                               --type optional
 
 Either of these two commands automatically downloads the most recent version
 from PyPI and also obtains most of the necessary information by querying PyPI.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

We make it possible to refer to Python packages via their PURL (see [draft PEP 725](https://peps.python.org/pep-0725/#concrete-package-specification-through-purl)) instead of their SPKG name.

For now a string of the form `pkg:pypi/DISTRO-NAME` is simply a nickname for the (unique) SPKG that has DISTRO-NAME in their `version_requirements.txt` or `requirements.txt`. The scheme can also be omitted: `pypi/DISTRO-NAME` also works. And we also map `pkg:generic/PACKAGE-NAME` to `PACKAGE_NAME`.

Based on code by @culler, `sage --package create --pypi` now also fills `dependencies` from the PyPI metadata of wheel packages. When some of the Python dependencies obtained in this way do not have SPKGs yet, they are also automatically created.

- Preparation for #31136.
- Split out from #37250.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
