### PR TITLE
`cmake`, `ninja_build`: Reject installations in inaccessible user schemes

### DIFF
--- a/build/pkgs/cmake/spkg-configure.m4
+++ b/build/pkgs/cmake/spkg-configure.m4
@@ -1,13 +1,17 @@
-SAGE_SPKG_CONFIGURE(
-    [cmake], [
-        AC_CACHE_CHECK([for cmake >= 3.11], [ac_cv_path_CMAKE], [
-        AC_PATH_PROGS_FEATURE_CHECK([CMAKE], [cmake], [
-            cmake_version=`$ac_path_CMAKE --version 2>&1 \
-                | $SED -n -e 's/cmake version *\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\)/\1/p'`
-            AS_IF([test -n "$cmake_version"], [
-                AX_COMPARE_VERSION([$cmake_version], [ge], [3.11], [
-                    ac_cv_path_CMAKE="$ac_path_CMAKE"
-                    ac_path_CMAKE_found=:
+SAGE_SPKG_CONFIGURE([cmake], [dnl
+        AC_CACHE_CHECK([for cmake >= 3.11], [ac_cv_path_CMAKE], [dnl
+        dnl Do not accept cmake installed via https://pypi.org/project/cmake/
+        dnl in the default user scheme; it will not work in our venv because
+        dnl we set PYTHONUSERBASE in sage-env.
+        WITH_SAGE_PYTHONUSERBASE([dnl
+            AC_PATH_PROGS_FEATURE_CHECK([CMAKE], [cmake], [dnl
+                cmake_version=`$ac_path_CMAKE --version 2>&1 \
+                    | $SED -n -e 's/cmake version *\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\)/\1/p'`
+                AS_IF([test -n "$cmake_version"], [dnl
+                    AX_COMPARE_VERSION([$cmake_version], [ge], [3.11], [dnl
+                        ac_cv_path_CMAKE="$ac_path_CMAKE"
+                        ac_path_CMAKE_found=:
+                    ])
                 ])
             ])
         ])

--- a/build/pkgs/ninja_build/spkg-configure.m4
+++ b/build/pkgs/ninja_build/spkg-configure.m4
@@ -1,16 +1,20 @@
-SAGE_SPKG_CONFIGURE(
-    [ninja_build], [
-        dnl meson_python needs 1.8.2 or later
-        AC_CACHE_CHECK([for ninja >= 1.8.2], [ac_cv_path_NINJA], [
-        AC_PATH_PROGS_FEATURE_CHECK([NINJA], [ninja], [
-            dnl support both two- and three-component version schemes
-            dnl since samurai (a ninja alternative) uses two
-            ninja_version=`$ac_path_NINJA --version 2>&1 \
-                | $SED -n -e 's/\([[0-9]]*\(\.[[0-9]]*\)\{1,2\}\).*/\1/p'`
-            AS_IF([test -n "$ninja_version"], [
-                AX_COMPARE_VERSION([$ninja_version], [ge], [1.8.2], [
-                    ac_cv_path_NINJA="$ac_path_NINJA"
-                    ac_path_NINJA_found=:
+SAGE_SPKG_CONFIGURE([ninja_build], [dnl
+    dnl meson_python needs 1.8.2 or later
+    AC_CACHE_CHECK([for ninja >= 1.8.2], [ac_cv_path_NINJA], [dnl
+        dnl Do not accept ninja installed from https://pypi.org/project/ninja/
+        dnl in the default user scheme; it will not work in our venv because
+        dnl we set PYTHONUSERBASE in sage-env.
+        WITH_SAGE_PYTHONUSERBASE([dnl
+            AC_PATH_PROGS_FEATURE_CHECK([NINJA], [ninja], [dnl
+                dnl support both two- and three-component version schemes
+                dnl since samurai (a ninja alternative) uses two
+                ninja_version=`$ac_path_NINJA --version 2>&1 \
+                    | $SED -n -e 's/\([[0-9]]*\(\.[[0-9]]*\)\{1,2\}\).*/\1/p'`
+                AS_IF([test -n "$ninja_version"], [dnl
+                    AX_COMPARE_VERSION([$ninja_version], [ge], [1.8.2], [
+                        ac_cv_path_NINJA="$ac_path_NINJA"
+                        ac_path_NINJA_found=:
+                    ])
                 ])
             ])
         ])


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

These two are installable via binary wheels on PyPI.
When they are installed with `pip install --user`, as appears to be becoming more popular, then our `configure` script will see them, but they will not work within the Sage environment because we set PYTHONUSERBASE.

Fix as done previously for `meson` in #37319.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
- Depends on #37319 (merged here)

