### PR TITLE
build/pkgs/pillow: Add workaround for openjpeg 2.5.1

### DIFF
--- a/build/pkgs/pillow/spkg-install.in
+++ b/build/pkgs/pillow/spkg-install.in
@@ -10,4 +10,7 @@ fi
 
 PILLOW_CONFIG_SETTINGS="-C debug=true $PILLOW_CONFIG_SETTINGS"
 
+# https://github.com/python-pillow/Pillow/pull/7837#issuecomment-1966361559
+export CPPFLAGS="$CPPFLAGS -DOPJ_VERSION_MAJOR=2"
+
 eval sdh_pip_install $PILLOW_CONFIG_SETTINGS .


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

openjpeg 2.5.1 (released 2024-02-26) was broken, leading to the error building pillow on homebrew reported in https://groups.google.com/g/sage-release/c/5oeGMBJ2Jek/m/l2nNztc5AgAJ

Here on the PR: A simple workaround. Not tested whether this breaks anything on another supported platform that may be shipping some older version of openjpeg.

[openjpeg 2.5.2 (released 2024-02-28)](https://github.com/uclouvain/openjpeg/releases/v2.5.2) has fixed the problem and is already shipped by homebrew. So the workaround is no longer needed after an upgrade. The Pillow project has not merged a workaround for the broken openjpeg version.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


