### PR TITLE
Adding pivot rules to interactive_simplex_method - #30810

### DIFF
--- a/src/doc/en/reference/numerical/index.rst
+++ b/src/doc/en/reference/numerical/index.rst
@@ -13,6 +13,7 @@ Numerical Optimization
    sage/numerical/linear_tensor_constraints
    sage/numerical/optimize
    sage/numerical/interactive_simplex_method
+   sage/numerical/pivot_rules_for_simplex_method
    sage/numerical/gauss_legendre
 
 Linear Optimization (LP) and Mixed Integer Linear Optimization (MIP) Solver backends

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -607,10 +607,10 @@ REFERENCES:
               Smith: Faster computation of isogenies of large prime degree.
               ANTS XIV, Open Book Series Vol. 4, No. 1, 2020.
               :arxiv:`2003.10118`
-              
-.. [BDLS2022] Alexander E. Black and Jesús A. De Loera and Niklas Lütjeharms
+
+.. [BDLS2022] Alexander E. Black, Jesús A. De Loera, Niklas Lütjeharms,
               and Raman Sanyal. *The Polyhedral Geometry of Pivot Rules and
-              Monotone Paths* :arxiv: `2201.05134`
+              Monotone Paths*. :arxiv:`2201.05134`
 
 .. [BD1989] \R. J. Bradford and J. H. Davenport, *Effective tests for
             cyclotomic polynomials*, Symbolic and Algebraic
@@ -2728,9 +2728,9 @@ REFERENCES:
               doubles of finite groups*. PhD Thesis,
               University of California, Santa Cruz. 1999.
 
-.. [GoMa2010] Christopher Goff and Geoffrey Mason, 
+.. [GoMa2010] Christopher Goff and Geoffrey Mason,
             *Generalized twisted quantum doubles and the McKay correspondence*,
-            J. Algebra 324 (2010), no. 11, 3007–3016. 
+            J. Algebra 324 (2010), no. 11, 3007–3016.
 
 .. [GJ2016] Muddappa Seetharama Gowda and Juyoung Jeong.
             Spectral cones in Euclidean Jordan algebras.
@@ -2859,6 +2859,9 @@ REFERENCES:
              to Use a Short Basis: Trapdoors for Hard Lattices and New
              Cryptographic
              Constructions*. STOC 2008. http://www.cc.gatech.edu/~cpeikert/pubs/trap_lattice.pdf
+
+.. [GR1977] \D. Goldfarb and J. K. Reid, *A practicable steepest-edge simplex algorithm*
+            Mathematical Programming, Vol 12, pp. 361-371, 1997. :doi:`10.1007/BF01593804`
 
 .. [GR2001] Chris Godsil and Gordon Royle, *Algebraic Graph Theory*. Graduate
             Texts in Mathematics, Springer, 2001.
@@ -3763,6 +3766,11 @@ REFERENCES:
              modules for cyclotomic Hecke algebras*,
              Proc. London Math. Soc. (2012) 105 (6): 1245-1289.
              :arxiv:`1102.3519v1`
+
+.. [KMT2019] Tomonari Kitachara, Ryyhei Miyashiro, and Masaya Tano. *Steepest-edge rule
+             and its number of simplex iterations for a nondegenerate LP*
+             Operation Reserach Letters, Vol 47, pp 151-156, (2019).
+             :doi:`10.1016/j.orl.2019.02.003`
 
 .. [KN1963] \S. Kobayashi & K. Nomizu : *Foundations of Differential
             Geometry*, vol. 1, Interscience Publishers (New York)
@@ -6149,6 +6157,11 @@ REFERENCES:
             increasing tableaux, with applications to K-theoretic Schubert
             calculus*, Algebra and Number Theory 3 (2009), 121-148,
             https://projecteuclid.org/euclid.ant/1513797353
+
+.. [TZ1993] Tamas Terlaky and Shuzhong Zhang, *Pivot rules for linear
+            programming: A survey on recent theoretical developments*,
+            Annals of Operation Research, Vol 46, 203-223, 1993.
+            :doi:`10.1007/BF02096264`
 
 .. _ref-U:
 

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -3769,7 +3769,7 @@ REFERENCES:
 
 .. [KMT2019] Tomonari Kitachara, Ryyhei Miyashiro, and Masaya Tano. *Steepest-edge rule
              and its number of simplex iterations for a nondegenerate LP*
-             Operation Reserach Letters, Vol 47, pp 151-156, (2019).
+             Operations Research Letters, Vol 47, pp 151-156, 2019.
              :doi:`10.1016/j.orl.2019.02.003`
 
 .. [KN1963] \S. Kobayashi & K. Nomizu : *Foundations of Differential
@@ -6158,7 +6158,7 @@ REFERENCES:
             calculus*, Algebra and Number Theory 3 (2009), 121-148,
             https://projecteuclid.org/euclid.ant/1513797353
 
-.. [TZ1993] Tamas Terlaky and Shuzhong Zhang, *Pivot rules for linear
+.. [TZ1993] Tamás Terlaky and Shuzhong Zhang, *Pivot rules for linear
             programming: A survey on recent theoretical developments*,
             Annals of Operation Research, Vol 46, 203-223, 1993.
             :doi:`10.1007/BF02096264`

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -607,6 +607,10 @@ REFERENCES:
               Smith: Faster computation of isogenies of large prime degree.
               ANTS XIV, Open Book Series Vol. 4, No. 1, 2020.
               :arxiv:`2003.10118`
+              
+.. [BDLS2022] Alexander E. Black and Jesús A. De Loera and Niklas Lütjeharms
+              and Raman Sanyal. *The Polyhedral Geometry of Pivot Rules and
+              Monotone Paths* :arxiv: `2201.05134`
 
 .. [BD1989] \R. J. Bradford and J. H. Davenport, *Effective tests for
             cyclotomic polynomials*, Symbolic and Algebraic

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -206,6 +206,7 @@ from sage.rings.integer_ring import ZZ
 from sage.structure.all import SageObject
 from sage.symbolic.ring import SR
 
+
 # We produce rather complicated LaTeX code which needs some tweaks to be
 # displayed nicely by MathJax, which make it look slightly different from real
 # LaTeX. We use our own variable as it may be convenient to override it.
@@ -2708,7 +2709,7 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             sage: P = InteractiveLPProblemStandardForm(A, b, c)
             sage: def eta(v):
             ....:     return v.norm()
-            sage: P.run_simplex_method(pivot_rule='NW_rule', normalization=eta, weight=[1,2])
+            sage: P.run_simplex_method(pivot_rule='NW_rule', normalization=eta, weight=(1,2))
             Traceback (most recent call last):
             ...
             TypeError: unsupported operand parent(s) for *: 'Ambient free module of rank 2 over the principal ideal domain Integer Ring' and 'Vector space of dimension 3 over Rational Field'
@@ -2722,8 +2723,8 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             # Phase I
             ad = self.auxiliary_problem().initial_dictionary()
             ad.enter(self.auxiliary_variable())
-            pivot = SimplexMethodPivot(pivot_rule)
-            pivot(ad, False, **kwrds)
+            pivot = SimplexMethodPivot(pivot_rule, **kwrds)
+            pivot(ad, False)
             ad.leave(min(zip(ad.constant_terms(), ad.basic_variables()))[1])
             output.append(ad.run_simplex_method(pivot_rule=pivot_rule, **kwrds))
             if ad.objective_value() < 0:
@@ -3867,10 +3868,10 @@ class LPAbstractDictionary(SageObject):
             \end{equation*}
             The problem is unbounded in $x_{2}$ direction.
         """
-        pivot = SimplexMethodPivot(pivot_rule)
+        pivot = SimplexMethodPivot(pivot_rule, **kwrds)
         output = []
         while not self.is_optimal():
-            pivot(self, False, **kwrds) # Sets entering and leaving variables
+            pivot(self, False) # Sets entering and leaving variables
             output.append(self._html_())
             if self.leaving() is None:
                 output.append("The problem is unbounded in ${}$ direction."
@@ -5498,4 +5499,4 @@ class LPRevisedDictionary(LPAbstractDictionary):
     x_N = nonbasic_variables
 
 
-from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot  # do not move. this breaks :mod:`sage.pivot_rules_for_simplex_method` if moved.

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -2548,17 +2548,18 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
                 x_B[self.b().list().index(bm)] = self.auxiliary_variable()
         return LPRevisedDictionary(self, x_B)
 
-    def run_revised_simplex_method(self, pivot_rule = None, *args):
+    def run_revised_simplex_method(self, pivot_rule=None, *args):
         r"""
         Apply the revised simplex method and return all steps.
-                
+
         INPUT:
-        
-        - :string: or :SimplexMethodPivot: Optional- set a pivot rule. 
-          Supported rules are "steepest_edge", "blands_rule", "dantzig", "NW_rule".
-          One can pass in a custom instance of `SimplexMethodPivot` too.
-        
-        - :*args: Optional - arguments needed for pivot rule.
+
+        - ``pivot_rule`` -- string or :class:`~sage.src.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot` (default: None);
+          Supported rules are ``"steepest_edge"``, ``"blands_rule"``, ``"dantzig"``, ``"NW_rule"``.
+          One can pass in a custom instance of :class:`~sage.src.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot` too.
+
+        - Additional arguments are passed directly into the method.
+          Not specifiying additional arguments will use the default parameters set by the class.
 
         OUTPUT:
 
@@ -2620,17 +2621,17 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
         self._final_revised_dictionary = d
         return HtmlFragment("\n".join(output))
 
-    def run_simplex_method(self, pivot_rule = None, *args):
+    def run_simplex_method(self, pivot_rule=None, *args):
         r"""
         Apply the simplex method and return all steps and intermediate states.
-        
+
         INPUT:
-        
-        - :string: or :SimplexMethodPivot: Optional- set a pivot rule. 
-          Supported rules are "steepest_edge", "blands_rule", "dantzig", "NW_rule".
-          One can pass in a custom instance of `SimplexMethodPivot` too.
-        
-        - :*args: Optional - arguments needed for pivot rule.
+
+        - ``pivot_rule`` -- string or :class:`~sage.src.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot` (default: None);
+          Supported rules are ``"steepest_edge"``, ``"blands_rule"``, ``"dantzig"``, ``"NW_rule"``.
+          One can pass in a custom instance of :class:`~sage.src.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot` too.
+
+        - :\*args: Optional -- arguments needed for pivot rule.
 
         OUTPUT:
 
@@ -2674,9 +2675,9 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             Entering: $x_{2}$. Leaving: $x_{3}$.
             ...
             The optimal value: $6250$. An optimal solution: $\left(250,\,750\right)$.
-            
-        Using a differnt pivot rule::
-        
+
+        Using a different pivot rule.::
+
             sage: A = ([1, 1], [3, 1], [-1, -1])
             sage: b = (1000, 1500, -400)
             sage: c = (10, 5)
@@ -2698,19 +2699,19 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             Entering: $x_{2}$. Leaving: $x_{3}$.
             ...
             The optimal value: $6250$. An optimal solution: $\left(250,\,750\right)$.
-            
-        Normalized weight rules are not suppored for problems which require both phase I and Phase II. See :NWRule: for detials. :: 
-        
-        sage: A = ([1, 1], [3, 1], [-1, -1])
-        sage: b = (1000, 1500, -400)
-        sage: c = (10, 5)
-        sage: P = InteractiveLPProblemStandardForm(A, b, c)
-        sage: def eta(v):
-        ....:     return v.norm() 
-        sage: P.run_simplex_method('NW_rule', eta, [1,2])
-        Traceback (most recent call last):
-        ...
-        TypeError: unsupported operand parent(s) for *: 'Ambient free module of rank 2 over the principal ideal domain Integer Ring' and 'Vector space of dimension 3 over Rational Field'
+
+        Normalized weight rules are not supported for problems which require both Phase I and Phase II. See :class:`~sage.src.numerical.pivot_rules_for_simplex_method.NWRule` for details.::
+
+            sage: A = ([1, 1], [3, 1], [-1, -1])
+            sage: b = (1000, 1500, -400)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: def eta(v):
+            ....:     return v.norm()
+            sage: P.run_simplex_method('NW_rule', eta, [1,2])
+            Traceback (most recent call last):
+            ...
+            TypeError: unsupported operand parent(s) for *: 'Ambient free module of rank 2 over the principal ideal domain Integer Ring' and 'Vector space of dimension 3 over Rational Field'
         """
         output = []
         d = self.initial_dictionary()
@@ -3696,14 +3697,14 @@ class LPAbstractDictionary(SageObject):
 
         If either entering or leaving variables were already set, they will be
         used.
-                
+
         INPUT:
-        
-        - :string: or :SimplexMethodPivot: Optional- set a pivot rule. 
-          Supported rules are "steepest_edge", "blands_rule", "dantzig", "NW_rule".
-          One can pass in a custom instance of `SimplexMethodPivot` too.
-        
-        - :*args: Optional - arguments needed for pivot rule.
+
+        - ``pivot_rule`` -- string or :class:`~sage.src.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot` (default: None);
+          Supported rules are ``"steepest_edge"``, ``"blands_rule"``, ``"dantzig"``, ``"NW_rule"``.
+          One can pass in a custom instance of :class:`~sage.src.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot` too.
+
+        - :\*args: Optional -- arguments needed for pivot rule.
 
         OUTPUT:
 
@@ -3754,17 +3755,13 @@ class LPAbstractDictionary(SageObject):
             ...
             \end{equation*}
             The problem is infeasible because of $x_{3}$ constraint.
-            
-        Differnet pivot rules can be used.
+
+        Different pivot rules can be used.
         """
         pivot = SimplexMethodPivot(pivot_rule)
-        if pivot.has_dual_method():
-            pivot.set_mode("dual")
-        else:
-            raise ValueError("The pivot rule defined does not have a dual method implemented.")
         output = []
         while not self.is_optimal():
-            pivot(self, *args)
+            pivot(self, True, *args)
             output.append(self._html_())
             if self.entering() is None:
                 output.append("The problem is infeasible because of "
@@ -3776,21 +3773,20 @@ class LPAbstractDictionary(SageObject):
             output.append(self._html_())
         return HtmlFragment("\n".join(output))
 
-    def run_simplex_method(self, pivot_rule = None, *args):
+    def run_simplex_method(self, pivot_rule=None, *args):
         r"""
         Apply the simplex method and return all steps and intermediate states.
 
         If either entering or leaving variables were already set, they will be
         used.
-        
-                
+
         INPUT:
-        
-        - :string: or :SimplexMethodPivot: Optional- set a pivot rule. 
-          Supported rules are "steepest_edge", "blands_rule", "dantzig", "NW_rule".
-          One can pass in a custom instance of `SimplexMethodPivot` too.
-        
-        - :*args: Optional - arguments needed for pivot rule.
+
+        - string or :class:`~sage.src.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot` Optional- set a pivot rule.
+          Supported rules are ``"steepest_edge"``, ``"blands_rule"``, ``"dantzig"``, ``"NW_rule"``.
+          One can pass in a custom instance of :class:`~sage.src.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot` too.
+
+        - :\*args: Optional - arguments needed for pivot rule.
 
         OUTPUT:
 
@@ -3847,10 +3843,9 @@ class LPAbstractDictionary(SageObject):
             The problem is unbounded in $x_{2}$ direction.
         """
         pivot = SimplexMethodPivot(pivot_rule)
-        pivot.set_mode("primal")
         output = []
         while not self.is_optimal():
-            pivot(self, *args) # Sets entering and leaving variables 
+            pivot(self, False, *args) # Sets entering and leaving variables
             output.append(self._html_())
             if self.leaving() is None:
                 output.append("The problem is unbounded in ${}$ direction."
@@ -5476,5 +5471,6 @@ class LPRevisedDictionary(LPAbstractDictionary):
     # Aliases for the standard notation
     x_B = basic_variables
     x_N = nonbasic_variables
-    
+
+
 from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -23,6 +23,8 @@ AUTHORS:
 
 - Matthias Koeppe, Peijun Xiao (2015-07-05): allow different output styles.
 
+- Acadia Larsen (2024-03-01): allow for different pivot rules.
+
 EXAMPLES:
 
 Most of the module functionality is demonstrated on the following problem.
@@ -203,7 +205,6 @@ from sage.rings.real_double import RDF
 from sage.rings.integer_ring import ZZ
 from sage.structure.all import SageObject
 from sage.symbolic.ring import SR
-
 
 # We produce rather complicated LaTeX code which needs some tweaks to be
 # displayed nicely by MathJax, which make it look slightly different from real
@@ -2547,9 +2548,17 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
                 x_B[self.b().list().index(bm)] = self.auxiliary_variable()
         return LPRevisedDictionary(self, x_B)
 
-    def run_revised_simplex_method(self):
+    def run_revised_simplex_method(self, pivot_rule = None, *args):
         r"""
         Apply the revised simplex method and return all steps.
+                
+        INPUT:
+        
+        - :string: or :SimplexMethodPivot: Optional- set a pivot rule. 
+          Supported rules are "steepest_edge", "blands_rule", "dantzig", "NW_rule".
+          One can pass in a custom instance of `SimplexMethodPivot` too.
+        
+        - :*args: Optional - arguments needed for pivot rule.
 
         OUTPUT:
 
@@ -2597,7 +2606,7 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             The optimal value: $6250$. An optimal solution: $\left(250,\,750\right)$.
         """
         d = self.revised_dictionary()
-        output = [d.run_simplex_method()]
+        output = [d.run_simplex_method(pivot_rule, *args)]
         if d.is_optimal():
             if self.auxiliary_variable() in d.basic_variables():
                 output.append("The problem is infeasible.")
@@ -2611,9 +2620,17 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
         self._final_revised_dictionary = d
         return HtmlFragment("\n".join(output))
 
-    def run_simplex_method(self):
+    def run_simplex_method(self, pivot_rule = None, *args):
         r"""
         Apply the simplex method and return all steps and intermediate states.
+        
+        INPUT:
+        
+        - :string: or :SimplexMethodPivot: Optional- set a pivot rule. 
+          Supported rules are "steepest_edge", "blands_rule", "dantzig", "NW_rule".
+          One can pass in a custom instance of `SimplexMethodPivot` too.
+        
+        - :*args: Optional - arguments needed for pivot rule.
 
         OUTPUT:
 
@@ -2657,6 +2674,43 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             Entering: $x_{2}$. Leaving: $x_{3}$.
             ...
             The optimal value: $6250$. An optimal solution: $\left(250,\,750\right)$.
+            
+        Using a differnt pivot rule::
+        
+            sage: A = ([1, 1], [3, 1], [-1, -1])
+            sage: b = (1000, 1500, -400)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: P.run_simplex_method('steepest_edge')
+            \begin{equation*}
+            ...
+            \end{equation*}
+            The initial dictionary is infeasible, solving auxiliary problem.
+            ...
+            Entering: $x_{0}$. Leaving: $x_{5}$.
+            ...
+            Entering: $x_{1}$. Leaving: $x_{0}$.
+            ...
+            Back to the original problem.
+            ...
+            Entering: $x_{5}$. Leaving: $x_{4}$.
+            ...
+            Entering: $x_{2}$. Leaving: $x_{3}$.
+            ...
+            The optimal value: $6250$. An optimal solution: $\left(250,\,750\right)$.
+            
+        Normalized weight rules are not suppored for problems which require both phase I and Phase II. See :NWRule: for detials. :: 
+        
+        sage: A = ([1, 1], [3, 1], [-1, -1])
+        sage: b = (1000, 1500, -400)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: def eta(v):
+        ....:     return v.norm() 
+        sage: P.run_simplex_method('NW_rule', eta, [1,2])
+        Traceback (most recent call last):
+        ...
+        TypeError: unsupported operand parent(s) for *: 'Ambient free module of rank 2 over the principal ideal domain Integer Ring' and 'Vector space of dimension 3 over Rational Field'
         """
         output = []
         d = self.initial_dictionary()
@@ -2668,7 +2722,7 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             ad = self.auxiliary_problem().initial_dictionary()
             ad.enter(self.auxiliary_variable())
             ad.leave(min(zip(ad.constant_terms(), ad.basic_variables()))[1])
-            output.append(ad.run_simplex_method())
+            output.append(ad.run_simplex_method(pivot_rule, *args))
             if ad.objective_value() < 0:
                 output.append("The original problem is infeasible.")
                 self._final_dictionary = ad
@@ -2677,7 +2731,7 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
                 d = self.feasible_dictionary(ad)
         if d.is_feasible():
             # Phase II
-            output.append(d.run_simplex_method())
+            output.append(d.run_simplex_method(pivot_rule, *args))
             if d.is_optimal():
                 v = d.objective_value()
                 if self._is_negative:
@@ -3636,12 +3690,20 @@ class LPAbstractDictionary(SageObject):
             (1/10, -1/5)
         """
 
-    def run_dual_simplex_method(self):
+    def run_dual_simplex_method(self, pivot_rule=None, *args):
         r"""
         Apply the dual simplex method and return all steps/intermediate states.
 
         If either entering or leaving variables were already set, they will be
         used.
+                
+        INPUT:
+        
+        - :string: or :SimplexMethodPivot: Optional- set a pivot rule. 
+          Supported rules are "steepest_edge", "blands_rule", "dantzig", "NW_rule".
+          One can pass in a custom instance of `SimplexMethodPivot` too.
+        
+        - :*args: Optional - arguments needed for pivot rule.
 
         OUTPUT:
 
@@ -3692,15 +3754,17 @@ class LPAbstractDictionary(SageObject):
             ...
             \end{equation*}
             The problem is infeasible because of $x_{3}$ constraint.
+            
+        Differnet pivot rules can be used.
         """
+        pivot = SimplexMethodPivot(pivot_rule)
+        if pivot.has_dual_method():
+            pivot.set_mode("dual")
+        else:
+            raise ValueError("The pivot rule defined does not have a dual method implemented.")
         output = []
         while not self.is_optimal():
-            if self.leaving() is None:
-                self.leave(min(self.possible_leaving()))
-            if self.entering() is None:
-                possible = self.possible_entering()
-                if possible:
-                    self.enter(min(possible))
+            pivot(self, *args)
             output.append(self._html_())
             if self.entering() is None:
                 output.append("The problem is infeasible because of "
@@ -3712,12 +3776,21 @@ class LPAbstractDictionary(SageObject):
             output.append(self._html_())
         return HtmlFragment("\n".join(output))
 
-    def run_simplex_method(self):
+    def run_simplex_method(self, pivot_rule = None, *args):
         r"""
         Apply the simplex method and return all steps and intermediate states.
 
         If either entering or leaving variables were already set, they will be
         used.
+        
+                
+        INPUT:
+        
+        - :string: or :SimplexMethodPivot: Optional- set a pivot rule. 
+          Supported rules are "steepest_edge", "blands_rule", "dantzig", "NW_rule".
+          One can pass in a custom instance of `SimplexMethodPivot` too.
+        
+        - :*args: Optional - arguments needed for pivot rule.
 
         OUTPUT:
 
@@ -3773,14 +3846,11 @@ class LPAbstractDictionary(SageObject):
             \end{equation*}
             The problem is unbounded in $x_{2}$ direction.
         """
+        pivot = SimplexMethodPivot(pivot_rule)
+        pivot.set_mode("primal")
         output = []
         while not self.is_optimal():
-            if self.entering() is None:
-                self.enter(min(self.possible_entering()))
-            if self.leaving() is None:
-                possible = self.possible_leaving()
-                if possible:
-                    self.leave(min(possible))
+            pivot(self, *args) # Sets entering and leaving variables 
             output.append(self._html_())
             if self.leaving() is None:
                 output.append("The problem is unbounded in ${}$ direction."
@@ -5406,3 +5476,5 @@ class LPRevisedDictionary(LPAbstractDictionary):
     # Aliases for the standard notation
     x_B = basic_variables
     x_N = nonbasic_variables
+    
+from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot

--- a/src/sage/numerical/pivot_rules_for_simplex_method.py
+++ b/src/sage/numerical/pivot_rules_for_simplex_method.py
@@ -3,23 +3,21 @@ Pivot Rules for Simplex Method
 
 This module is an addendum to the Interactive Simplex Method
 to draw connection between active research on simplex method pivot rules
-and an educational settings. 
+and an educational settings.
 
-A pivot rule is a function or algorithm on an linear program (LP) `\min\{cx: Ax<=b\}` 
-and a vertex `v` of `P = \{x: Ax<=b\}` to a vertex `u` of `P` such that 
-(a) `v` is adjacent to `u` in the graph of $P$ and
-(b) `cu \leq cv`.
+A pivot rule is a function or algorithm on an linear program (LP) `\min\{cx: Ax<=b\}`
+- (a) `v` is adjacent to `u` in the graph of $P$ and
+- (b) `cu \leq cv`.
 
-The module offers a number of predefined pivot rules and classes which serve as plug and play for defining/experimenting with pivot rules. 
+The module offers a number of predefined pivot rules and classes which serve as plug and play for defining/experimenting with pivot rules.
 
 Authors:
 
--Acadia Larsen (March 1, 2024): Initial Version. 
+-Acadia Larsen (March 1, 2024): Initial Version.
 
-EXAMPLES::
+EXAMPLES:
 
-The module is plug and play with ``interactive_simplex_method``.
-
+This module is designed for use with :mod:`sage.interactive_simplex_method`::
     sage: A = ([1, 1], [3, 1], [-1, -1])
     sage: b = (1000, 1500, -400)
     sage: c = (10, 5)
@@ -41,15 +39,15 @@ The module is plug and play with ``interactive_simplex_method``.
     Entering: $x_{2}$. Leaving: $x_{3}$.
     ...
     The optimal value: $6250$. An optimal solution: $\left(250,\,750\right)$.
-            
-It allows one to explore different rules such as the Normalized Weight pivot rule::
+
+It allows one to explore different pivot rules such as the Normalized Weight pivot rule ([BDLS2022]_.)::
 
     sage: A = ([1, 1], [3, 1], [-1, -1])
     sage: b = (1000, 1500, -400)
     sage: c = (10, 5)
     sage: P = InteractiveLPProblemStandardForm(A, b, c)
     sage: def eta(v):
-    ....:     return v.norm() 
+    ....:     return v.norm()
     sage: D = P.auxiliary_problem().initial_dictionary() # Phase I
     sage: D.enter('x0')
     sage: D.leave('x5')
@@ -76,7 +74,7 @@ It allows one to explore different rules such as the Normalized Weight pivot rul
     ...
     \end{equation*}
 
-Pivot Rules can be used to manipulate dictonaries on a step by step basis::
+Pivot Rules can be used to manipulate dictionaries defined by an :class:`~sage.src.numerical.interactive_simplex_method.LPDictionary` on a step by step basis::
 
     sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
     sage: A = ([1, 1], [3, 1])
@@ -89,9 +87,9 @@ Pivot Rules can be used to manipulate dictonaries on a step by step basis::
     sage: D.entering()
     x1
     sage: D.leaving()
-    x4       
-    
-The module makes it easy to define one's own pivot rule::
+    x4
+
+Define custom pivot rules::
 
     sage: from sage.numerical.pivot_rules_for_simplex_method import AbstractSimplexMethodPivotRule
     sage: class MyPivotRule(AbstractSimplexMethodPivotRule):
@@ -109,7 +107,7 @@ The module makes it easy to define one's own pivot rule::
     x1
     sage: D.leaving()
     x4
-    
+
 Classes and functions
 ---------------------
 """
@@ -131,42 +129,37 @@ from sage.rings.infinity import InfinityRing
 from numpy import argmax
 #from sage.numerical.interactive_simplex_method import LPAbstractDictionary
 
-class AbstractSimplexMethodPivotRule(UniqueRepresentation): 
+class AbstractSimplexMethodPivotRule(UniqueRepresentation):
     r"""
     Abstract class for memoryless pivot rules.
-    
-    A pivot rule is a function or algorithm on an linear program (LP) `\min\{cx: Ax<=b\}` 
-    and a vertex `v` of `P = \{x: Ax<=b\}` to a vertex `u` of `P` such that 
-    (a) `v` is adjacent to `u` in the graph of $P$ and
-    (b) `cu \leq cv`.
-            
-    Individual pivot rules are not in Sage's namespace. 
-    Using a pivot rule should be instantiated via `SimplexMethodPivot`. 
+
+    Individual pivot rules are not in Sage's namespace.
+    Using a pivot rule should be instantiated via :class:`~sage.numerical.pivot_rules_for_simplex_method.SimplexMethodPivot`.
     """
     @classmethod
     def has_dual_method(self):
-        r""" For use in SimplexMethodPivot to identify if a dual pivot rule has been written. 
-        
-        Overwrite this method after implementing a dual pivot method. See ``BlandsRule`` for exmaple.
-        
+        r""" For use in SimplexMethodPivot to identify if a dual pivot rule has been written.
+
+        Overwrite this method after implementing a dual pivot method. See ``BlandsRule`` for example.
+
         OUTPUT: bool
         """
         return False
     @abstract_method
     def dictionary_pivot(dictionary, *args):
         r"""
-        Abstract method for computing a pivot for the primal simplex method based on an ``LPDictionary``.
-        
-        Sets the entering and leaving variables of ``LPDictionary`` or ``AbstractLPDictionary`` for the primal simplex method. 
-        
-        INPUT: 
-        
-        - ``dictionary`` -- an instance of ``LPDictionary`` 
-        
-        - ``*args`` -- required inputs for specific method 
-        
+        Abstract method for computing a pivot for the primal simplex method based on an :class:`sage.numerical.interactive_simplex_method.LPDictionary`.
+
+        Sets the entering and leaving variables of :class:`sage.numerical.interactive_simplex_method.LPDictionary` for the primal simplex method.
+
+        INPUT:
+
+        - ``dictionary`` -- an instance of :class:`sage.numerical.interactive_simplex_method.LPDictionary`
+
+        - ``*args`` -- required inputs for specific method
+
         EXAMPLES::
-        
+
             sage: from sage.numerical.pivot_rules_for_simplex_method import BlandsRule
             sage: A = ([1, 1], [3, 1])
             sage: b = (1000, 1500)
@@ -174,9 +167,9 @@ class AbstractSimplexMethodPivotRule(UniqueRepresentation):
             sage: P = InteractiveLPProblemStandardForm(A, b, c)
             sage: D = P.initial_dictionary()
             sage: D.entering()
-            
+
             sage: D.leaving()
-            
+
             sage: BlandsRule.dictionary_pivot(D)
             sage: D.entering()
             x1
@@ -184,7 +177,7 @@ class AbstractSimplexMethodPivotRule(UniqueRepresentation):
             x4
 
         Handling unboundedness, feasibility, and optimality should be left to the solver.::
-        
+
             sage: A = ([1, 0],)
             sage: b = (1,)
             sage: c = (0, 1)
@@ -195,17 +188,17 @@ class AbstractSimplexMethodPivotRule(UniqueRepresentation):
             ...
             \end{equation*}
             The problem is unbounded in $x_{2}$ direction.
-            
-        The leaving variable should be `None` if a dictionary represents unboundedness in a problem::
-        
+
+        The leaving variable should be ``None`` if a dictionary represents unboundedness in a problem::
+
             sage: D = P.initial_dictionary()
             sage: BlandsRule.dictionary_pivot(D)
             sage: D.entering()
             x2
             sage: D.leaving() is None
             True
-            
-        The `__call__` method of `SimplexMethodPivot` is responsible checking for type input:: 
+
+        The :meth:`__call__` method of :class:`SimplexMethodPivot` is responsible checking for type input::
 
             sage: LP_tablaux = Matrix([[0, 10, 5], [1, 1, 1000], [3, 1, 1500]])
             sage: BlandsRule.dictionary_pivot(LP_tablaux)
@@ -217,20 +210,18 @@ class AbstractSimplexMethodPivotRule(UniqueRepresentation):
     @abstract_method
     def dual_dictionary_pivot(dictionary, *args):
         r"""
-        Abstract method for computing a pivot for the dual simplex method based on an ``LPDictionary``.
-        
-        Sets the entering and leaving variables of ``LPDictionary`` for the dual simplex method. 
-        
-        One does not need to define a dual_dictionary_pivot unless one intends to use a dual method.
-        
-            NPUT: 
-        
-        - ``dictionary`` -- an instance of ``LPDictionary`` 
-        
-        - ``*args`` -- required inputs for specific methods
-        
-        EXAMPLES:: 
-            
+        Abstract method for computing a pivot for the dual simplex method based on an :class:`sage.numerical.interactive_simplex_method.LPDictionary`.
+
+        Sets the entering and leaving variables of :class:`sage.numerical.interactive_simplex_method.LPDictionary` for the dual simplex method.
+
+        One does not need to define a :meth:`dual_dictionary_pivot` unless intending to run a dual simplex algorithm.
+
+        INPUT:
+
+        - ``dictionary`` -- an instance of :class:`sage.numerical.interactive_simplex_method.LPDictionary`.
+
+        EXAMPLES::
+
             sage: from sage.numerical.pivot_rules_for_simplex_method import BlandsRule
             sage: A = ([1, 1], [3, 1], [-1, -1])
             sage: b = (1000, 1500, -400)
@@ -238,66 +229,60 @@ class AbstractSimplexMethodPivotRule(UniqueRepresentation):
             sage: P = InteractiveLPProblemStandardForm(A, b, c)
             sage: D = P.dictionary(2, 3, 5)
             sage: D.entering()
-            
+
             sage: D.leaving()
-            
+
             sage: BlandsRule.dual_dictionary_pivot(D)
             sage: D.entering()
             x1
             sage: D.leaving()
             x3
-            
-        Some pivot rules do not have dual methods defined at the momement.::
-        
+
+        Some pivot rules do not have dual methods implemented::
+
             sage: from sage.numerical.pivot_rules_for_simplex_method import SteepestEdge
             sage: SteepestEdge.has_dual_method()
             False
-            
         """
 
-        
-class SimplexMethodPivot(SageObject, UniqueRepresentation): 
+class SimplexMethodPivot(SageObject, UniqueRepresentation):
     r"""
-    A class to preform pivots in the simplex method of solving Linear Programs. 
-    
-    INPUT: 
-    
-    - ``name`` -- a string or a ``SimplexMethodPivotRule`` object
-        
+    A class to perform pivots in the simplex method of solving Linear Programs.
+
+    INPUT:
+
+    - ``name`` -- a string or a ``SimplexMethodPivotRule`` object.
+
     EXAMPLES::
-    
-            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
-            sage: A = ([1, 1], [3, 1])
-            sage: b = (1000, 1500)
-            sage: c = (10, 5)
-            sage: P = InteractiveLPProblemStandardForm(A, b, c)
-            sage: blands_rule = SimplexMethodPivot()
-            sage: D = P.initial_dictionary()
-            
-            sage: D.entering()
 
-            sage: D.leaving()
+        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+        sage: A = ([1, 1], [3, 1])
+        sage: b = (1000, 1500)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: blands_rule = SimplexMethodPivot()
+        sage: D = P.initial_dictionary()
+        sage: D.entering()
 
-            sage: blands_rule(D)
+        sage: D.leaving()
 
-            sage: D.entering()
-            x1
-            sage: D.leaving()
-            x4     
-
-        
+        sage: blands_rule(D)
+        sage: D.entering()
+        x1
+        sage: D.leaving()
+        x4
     """
     @staticmethod
     def __classcall__(cls, name=None):
         r"""
         Normalize init agrugments.
-        
+
         INPUT:
-        
+
         - ``name`` -- a string or a ``SimplexMethodPivotRule`` object
-        
+
         TESTS::
-        
+
             sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
             sage: from sage.numerical.pivot_rules_for_simplex_method import BlandsRule
             sage: SimplexMethodPivot("blands_rule") is SimplexMethodPivot()
@@ -315,63 +300,61 @@ class SimplexMethodPivot(SageObject, UniqueRepresentation):
             return super().__classcall__(cls, pivot_rule=NWRule)
         if issubclass(name, AbstractSimplexMethodPivotRule):
             return super().__classcall__(cls, pivot_rule=name)
-        else: 
+        else:
             raise TypeError("Input is required to be a string with the name of a predefined pivot rule or an instance of ``AbstractSimplexMethodPivotRule``")
 
     def __init__(self, pivot_rule):
         r"""
-        Initalize a pivot rule. This is never directly called. 
-        
+        Initialize a pivot rule. This is never directly called.
+
         INPUT:
-        
+
         - ``pivot_rule`` -- a ``SimplexMethodPivotRule``
-        
-        EXAMPLES :: 
-        
+
+        EXAMPLES::
+
             sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
-        
+
         Create Blands Rule::
-        
+
             sage: blands_rule = SimplexMethodPivot("blands_rule")
-        
-        No input of a named pivot rule uses Blands Rule instead:: 
-        
+
+        No input of a named pivot rule uses Blands Rule instead::
+
             sage: generic_pivot_rule = SimplexMethodPivot()
             sage: blands_rule is generic_pivot_rule
             True
-        
+
         Create Steepest Edge Pivot Rule::
-        
+
             sage: steepest_edge = SimplexMethodPivot("steepest_edge")
-            
+
         Create Dantzigs Pivot Rule::
-        
+
             sage: dantzigs_rule =  SimplexMethodPivot("dantzig")
-            
+
         Create Normalized Weight Pivot Rule::
-        
+
             sage: NW_rule =  SimplexMethodPivot("NW_rule")
         """
         self._pivot_rule = pivot_rule
-        self._mode = "primal"
         super().__init__()
 
-        
-    def __call__(self, dictionary, *args):
+    def __call__(self, dictionary, dual_mode=False, *args):
         r"""
         Makes pivot rules have a function like notation and normalizes inputs.
 
-        Input:
-        
+        INPUT:
+
         - ``dictionary`` -- instance of :LPDictionary:
-        
+
         - ``args`` --  arguments for pivot rule
 
         EXAMPLES::
-        
-        A pivot rule applied to an ``LPDictionary`` sets the entering 
-        and leaving variables::
-        
+
+            A pivot rule applied to an :class:`sage.numerical.interactive_simplex_method.LPDictionary` sets the entering
+            and leaving variables::
+
             sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
             sage: A = ([1, 1], [3, 1])
             sage: b = (1000, 1500)
@@ -388,10 +371,10 @@ class SimplexMethodPivot(SageObject, UniqueRepresentation):
             sage: D.entering()
             x1
             sage: D.leaving()
-            x4     
+            x4
 
         The call method also checks types::
-        
+
             sage: LP_tablaux = Matrix([[0, 10, 5], [1, 1, 1000], [3, 1, 1500]])
             sage: blands_rule = SimplexMethodPivot()
             sage: blands_rule(LP_tablaux)
@@ -399,10 +382,13 @@ class SimplexMethodPivot(SageObject, UniqueRepresentation):
             ...
             TypeError: Input is required to be an instance of `LPAbstractDictionary`
         """
-        if self._mode == "dual" and self.has_dual_method():
-            pivot = self._pivot_rule.dual_dictionary_pivot
-        else: 
-            pivot =  self._pivot_rule.dictionary_pivot
+        if dual_mode:
+            if self._pivot_rule.has_dual_method():
+                pivot = self._pivot_rule.dual_dictionary_pivot
+            else:
+                raise NotImplementedError("The selected pivot rule does not have an implementation that is compatible with the dual simplex method.")
+        else:
+            pivot = self._pivot_rule.dictionary_pivot
         if isinstance(dictionary, LPAbstractDictionary):
             if args:
                 pivot(dictionary, *args)
@@ -411,91 +397,13 @@ class SimplexMethodPivot(SageObject, UniqueRepresentation):
         else:
             raise TypeError("Input is required to be an instance of `LPAbstractDictionary`")
 
-    def has_dual_method(self):
-        r""" 
-        True if pivot rule has a dual method written for it.
-        
-        OUTPUT: 
-        
-        - bool 
-        
-        EXAMPLES::
-
-            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
-            sage: steepest_edge = SimplexMethodPivot("steepest_edge")
-            sage: steepest_edge.has_dual_method()
-            False
-            sage: pivot = SimplexMethodPivot()
-            sage: pivot.has_dual_method()
-            True
-        """
-        return self._pivot_rule.has_dual_method()
-    def set_mode(self, mode = "primal"):
-        r"""
-        Changes functionality between primal and dual method of simplex method.
-        
-        INPUT: 
-        
-        - ``mode`` -- string either "dual" or "primal" 
-        
-        EXAMPLES::
-
-            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
-            sage: steepest_edge = SimplexMethodPivot("steepest_edge")
-            sage: steepest_edge.has_dual_method()
-            False
-            sage: steepest_edge.set_mode("dual")
-            sage: steepest_edge.get_mode()
-            'primal'
-            sage: pivot = SimplexMethodPivot()
-            sage: pivot.has_dual_method()
-            True
-            sage: pivot.set_mode("dual")
-            sage: pivot.get_mode()
-            'dual'
-            
-        We do not check validity of input:: 
-        
-            sage: pivot.set_mode("banana")
-            sage: pivot.get_mode()
-            'banana'
-        """
-        if self.has_dual_method():
-            self._mode = mode
-
-    def get_mode(self):
-        r"""
-        Method to describe if making a primal pivot or dual pivot. 
-        
-        OUTPUT: 
-        
-        - string either `dual` or `primal`
-        
-        EXAMPLES::
-        
-            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot        
-            sage: steepest_edge = SimplexMethodPivot("steepest_edge")
-            sage: steepest_edge.has_dual_method()
-            False
-            sage: steepest_edge.set_mode("dual")
-            sage: steepest_edge.get_mode()
-            'primal'
-            sage: pivot = SimplexMethodPivot()
-            sage: pivot.has_dual_method()
-            True
-            sage: pivot.set_mode("dual")
-            sage: pivot.get_mode()
-            'dual'
-        """
-        return self._mode
-            
-    
 class BlandsRule(AbstractSimplexMethodPivotRule):
     r"""
-    Defines Blands Rule as a ``AbstractSimplexMethodPivotRule``. 
-    
+    Defines Blands Rule as a ``AbstractSimplexMethodPivotRule``.
     Ref. [TZ1993]_
+
     EXAMPLES::
+
         sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
         sage: A = ([1, 1], [3, 1])
         sage: b = (1000, 1500)
@@ -503,11 +411,10 @@ class BlandsRule(AbstractSimplexMethodPivotRule):
         sage: P = InteractiveLPProblemStandardForm(A, b, c)
         sage: D = P.initial_dictionary()
         sage: D.entering()
-        
+
         sage: D.leaving()
-        
+
         sage: pivot = SimplexMethodPivot("blands_rule")
-        sage: pivot.set_mode("primal")
         sage: pivot(D)
         sage: D.entering()
         x1
@@ -519,12 +426,12 @@ class BlandsRule(AbstractSimplexMethodPivotRule):
 
     def dictionary_pivot(current_dictionary):
         r"""
-        Sets the entering and leaving variables of ``LPDictionary`` as defined by Blands rule.
-        
-        Input:
-        
-        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
-        
+        Sets the entering and leaving variables of :class:`sage.numerical.interactive_simplex_method.LPDictionary` as defined by Blands rule.
+
+        INPUT:
+
+        - ``current_dictionary`` -- an instance of :class:`sage.numerical.interactive_simplex_method.LPDictionary`
+
         EXAMPLES::
 
             sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
@@ -538,7 +445,7 @@ class BlandsRule(AbstractSimplexMethodPivotRule):
             sage: D.entering()
             x1
             sage: D.leaving()
-            x4            
+            x4
         """
         if current_dictionary.entering() is None:
             entering_variable = min(current_dictionary.possible_entering())
@@ -548,14 +455,15 @@ class BlandsRule(AbstractSimplexMethodPivotRule):
             if possible:
                 leaving_variable = min(possible)
                 current_dictionary.leave(leaving_variable)
+
     def dual_dictionary_pivot(current_dictionary):
         r"""
-        Sets the entering and leaving variables of ``LPDictionary`` as defined by Blands rule for dual simplex method.
-        
-        Input:
-        
-        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
-        
+        Sets the entering and leaving variables of :class:`sage.numerical.interactive_simplex_method.LPDictionary` as defined by Blands rule for dual simplex method.
+
+        INPUT:
+
+        - ``current_dictionary`` --  an instance of :class:`sage.numerical.interactive_simplex_method.LPDictionary`
+
         EXAMPLES::
 
             sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
@@ -563,10 +471,9 @@ class BlandsRule(AbstractSimplexMethodPivotRule):
             sage: b = (1000, 1500, -400)
             sage: c = (10, 5)
             sage: P = InteractiveLPProblemStandardForm(A, b, c)
-            sage: D = P.dictionary(2, 3, 5) # dual feasible dicitonary
+            sage: D = P.dictionary(2, 3, 5) # dual feasible dictionary
             sage: pivot = SimplexMethodPivot()
-            sage: pivot.set_mode("dual")
-            sage: pivot(D)
+            sage: pivot(D, True)
             sage: D.leaving()
             x3
             sage: D.entering()
@@ -580,20 +487,17 @@ class BlandsRule(AbstractSimplexMethodPivotRule):
             if possible:
                 leaving_variable = min(possible)
                 current_dictionary.enter(leaving_variable)
-        
 
 class SteepestEdge(AbstractSimplexMethodPivotRule):
     r"""
-    Defines the steepest edge pivot rule as a ``AbstractSimplexMethodPivotRule``.
-    
+    Defines the steepest edge pivot rule as a :class:`AbstractSimplexMethodPivotRule`.
     The entering variable is selected by finding the steepest edge.
     The leaving variable is selected by finding the minimal ratio of the possible leaving variables.
-    
-    This method is generalized to selection based on the `p` norm with `p \\geq 1`.
-    
-    For more information see [GR1977]_ and [KMT2019]_. 
+    This method is generalized to selection based on the `p` norm with `p \geq 1`.
+    For more information see [GR1977]_ and [KMT2019]_.
+
     EXAMPLES::
-    
+
         sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
         sage: A = ([1, 1], [3, 1])
         sage: b = (1000, 1500)
@@ -601,85 +505,84 @@ class SteepestEdge(AbstractSimplexMethodPivotRule):
         sage: P = InteractiveLPProblemStandardForm(A, b, c)
         sage: D = P.initial_dictionary()
         sage: D.entering()
-        
+
         sage: D.leaving()
-        
-        sage: pivot = SimplexMethodPivot("steepest_edge") 
+
+        sage: pivot = SimplexMethodPivot("steepest_edge")
         sage: pivot(D)
         sage: D.entering()
         x1
         sage: D.leaving()
-        x4    
+        x4
     """
+
     def dictionary_pivot(current_dictionary, p=2):
         r"""
-        Sets the entering and leaving variables of ``LPDictionary`` as defined by steepest edge rule.
-        
-        Input:
-        
-        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
-        
-        - ``p`` -- optional real number with `p\\geq 1`
-        
-        EXAMPLES::
-        
-        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
-        sage: A = ([1, 1], [3, 1])
-        sage: b = (1000, 1500)
-        sage: c = (10, 5)
-        sage: P = InteractiveLPProblemStandardForm(A, b, c)
-        sage: D = P.initial_dictionary()
-        sage: pivot = SimplexMethodPivot("steepest_edge") # indirect test
-        sage: pivot(D, 1) # let's use the 1 norm.
-        sage: D.entering()
-        x1
-        sage: D.leaving()
-        x4
+        Sets the entering and leaving variables of :class:`sage.numerical.interactive_simplex_method.LPDictionary` as defined by steepest edge rule.
 
-        Values of p are checked::
-        
-        sage: D.update()
-        sage: pivot(D,0)
-        Traceback (most recent call last):
-        ...
-        ValueError: p must be at least 1
-        """            
+        Input:
+
+        - ``current_dictionary`` -- an instance of :class:`sage.numerical.interactive_simplex_method.LPDictionary`
+
+        - ``p`` -- optional real number with `p\\geq 1`
+
+        EXAMPLES::
+
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: A = ([1, 1], [3, 1])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.initial_dictionary()
+            sage: pivot = SimplexMethodPivot("steepest_edge") # indirect test
+            sage: pivot(D, False, 1) # let's use the 1 norm.
+            sage: D.entering()
+            x1
+            sage: D.leaving()
+            x4
+
+            Values of p are checked::
+
+            sage: D.update()
+            sage: pivot(D, False, 0)
+            Traceback (most recent call last):
+            ...
+            ValueError: p must be at least 1
+        """
         if p < 1:
             raise ValueError("p must be at least 1")
         if current_dictionary.entering() is None:
             thetas = []
             for v in current_dictionary.basic_variables():
                 # We want to avoid p-root complications, so work with the pth power.
-                thetas.append((1+sum([i**p for i in current_dictionary.row_coefficients(v)]))) 
-            best_value = -1*current_dictionary.objective_coefficients()[0]/thetas[0] 
-            index_to_select = 0 
-            # This loop selects the index that corresponds to the steepest edge. 
-            for i in range(1,len(current_dictionary.nonbasic_variables())): 
-                decent_direction = -1*current_dictionary.objective_coefficients()[i]/thetas[i-1] 
+                thetas.append((1+sum([i**p for i in current_dictionary.row_coefficients(v)])))
+            best_value = -1*current_dictionary.objective_coefficients()[0]/thetas[0]
+            index_to_select = 0
+            # This loop selects the index that corresponds to the steepest edge.
+            for i in range(1,len(current_dictionary.nonbasic_variables())):
+                decent_direction = -1*current_dictionary.objective_coefficients()[i]/thetas[i-1]
                 if decent_direction < best_value:
                     best_value = decent_direction
                     index_to_select = i
             entering_variable = current_dictionary.nonbasic_variables()[index_to_select]
             current_dictionary.enter(entering_variable)
-                
         if current_dictionary.leaving() is None:
             possible = current_dictionary.possible_leaving()
             if possible:
-                # We select leaving variables based on ratios. 
-                leaving_variable = min(current_dictionary.ratios())[1] 
+                # We select leaving variables based on ratios.
+                leaving_variable = min(current_dictionary.ratios())[1]
                 current_dictionary.leave(leaving_variable)
-                
-                
+
 class DantzigsRule(AbstractSimplexMethodPivotRule):
     r"""
-    For a linear program `min(cx: Ax\leq b)`, selects the entering variable to be the variable with the most negative reduced cost. 
-    
-    Originally proposed by Dantzig in the formulation of linear programming. Also know as greatest improvement rule. 
-    
-    See [TZ1993]_. 
-    
+    Selects the entering variable to be the variable with the most negative reduced cost.
+
+    Originally proposed by Dantzig in the formulation of linear programming. Also know as greatest improvement rule.
+
+    See [TZ1993]_.
+
     EXAMPLES::
-    
+
         sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
         sage: A = ([1, 1], [3, 1])
         sage: b = (1000, 1500)
@@ -687,26 +590,25 @@ class DantzigsRule(AbstractSimplexMethodPivotRule):
         sage: P = InteractiveLPProblemStandardForm(A, b, c)
         sage: D = P.initial_dictionary()
         sage: D.entering()
-        
+
         sage: D.leaving()
-        
+
         sage: pivot = SimplexMethodPivot("dantzig")
         sage: pivot(D)
         sage: D.entering()
         x1
         sage: D.leaving()
-        x4        
+        x4
     """
     def dictionary_pivot(current_dictionary):
         r"""
-        Sets the entering and leaving variables of ``LPDictionary`` as defined by Dantzig's rule.
-        
+        Sets the entering and leaving variables of :class:`sage.numerical.interactive_simplex_method.LPDictionary` as defined by Dantzig's rule.
+
         Input:
-        
-        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
-        
-        EXAMPLES::
-        
+        - ``current_dictionary`` -- an instance of :class:`sage.numerical.interactive_simplex_method.LPDictionary`
+
+    EXAMPLES::
+
         sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
         sage: A = ([1, 1], [3, 1])
         sage: b = (1000, 1500)
@@ -718,8 +620,8 @@ class DantzigsRule(AbstractSimplexMethodPivotRule):
         sage: D.entering()
         x1
         sage: D.leaving()
-        x4       
-        """        
+        x4
+        """
         if current_dictionary.entering() is None:
             entering_index = argmax(current_dictionary.objective_coefficients())
             entering_variable = current_dictionary.nonbasic_variables()[entering_index]
@@ -727,17 +629,19 @@ class DantzigsRule(AbstractSimplexMethodPivotRule):
         if current_dictionary.leaving() is None:
             possible = current_dictionary.possible_leaving()
             if possible:
-                leaving_variable = min(current_dictionary.ratios())[1] 
+                leaving_variable = min(current_dictionary.ratios())[1]
                 current_dictionary.leave(leaving_variable)
 
-        
 class NWRule(AbstractSimplexMethodPivotRule):
     r"""
-    For a linear program `min(cx: Ax\leq b) = min(cx: x\in P)`, an NW-rule is defined by a normalization \eta: \R^d\to R and a weight w\in R^n.
-    Given `v\in P` s.t. `cv \neq cv_{opt}`, pick the next vertex `u_* = argmax\{ w^t(u-v)/\eta(u-v): u adjacent to v and c^tu>c^tv\}`. 
-    See [BDLS2022]_. 
-    
+    Selects the entering and leaving variable based on a Normalzied Weight (NW) pivot rule.
+
+    For a linear program `min(cx: Ax\leq b) = min(cx: x\in P)`, an NW-rule is defined by a normalization `\eta: \mathbb{R}^d\to \mathbb{R}` and a weight `w\in \mathbb{R}^n`.
+    Given `v\in P` s.t. `cv \neq cv_{\text{opt}}`, pick the next vertex `u_* = \text{argmax}\{ \frac{w^t(u-v)}{\eta(u-v)}:` `u` adjacent to `v` and `c^tu>c^tv\}`.
+    See [BDLS2022]_.
+
     EXAMPLES::
+
         sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
         sage: A = ([1, 1], [3, 1])
         sage: b = (1000, 1500)
@@ -747,33 +651,33 @@ class NWRule(AbstractSimplexMethodPivotRule):
         sage: pivot = SimplexMethodPivot("NW_rule")
         sage: def eta(v): # use 2 norm as normalization
         ....:     return v.norm()
-        sage: pivot(D, eta, [1,2])
+        sage: pivot(D, False, eta, [1,2])
         sage: D.entering()
         x2
         sage: D.leaving()
-        x3 
-        
-    NW rule is not eqipped to solve both a Phase I and a phase II with the `run_simplex_method`:: 
-        
+        x3
+
+    NW rule is not eqipped to solve both a Phase I and a phase II with :meth:`run_simplex_method`::
+
         sage: A = ([1, 1], [3, 1], [-1, -1])
         sage: b = (1000, 1500, -400)
         sage: c = (10, 5)
         sage: P = InteractiveLPProblemStandardForm(A, b, c)
         sage: def eta(v):
-        ....:     return v.norm() 
+        ....:     return v.norm()
         sage: P.run_simplex_method('NW_rule', eta, [1,2])
         Traceback (most recent call last):
         ...
         TypeError: unsupported operand parent(s) for *: 'Ambient free module of rank 2 over the principal ideal domain Integer Ring' and 'Vector space of dimension 3 over Rational Field'
-        
-    A Phase I and a Prase II problem require different NW rules due to the differnce in ambient dimension of the respective problems:: 
-    
+
+    A Phase I and a Prase II problem require different NW rules due to the difference in ambient dimension of the respective problems::
+
         sage: A = ([1, 1], [3, 1], [-1, -1])
         sage: b = (1000, 1500, -400)
         sage: c = (10, 5)
         sage: P = InteractiveLPProblemStandardForm(A, b, c)
         sage: def eta(v):
-        ....:     return v.norm() 
+        ....:     return v.norm()
         sage: D = P.auxiliary_problem().initial_dictionary() # Phase I
         sage: D.enter('x0')
         sage: D.leave('x5')
@@ -802,46 +706,47 @@ class NWRule(AbstractSimplexMethodPivotRule):
     """
     def dictionary_pivot(current_dictionary, eta, weight):
         r"""
-        INPUT:: 
-        
-        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
-        
-        - ``eta`` -- callable function from ambient space of current_dictionary to the real numbers.
-        
-        - ``weight`` -- object convertable to ``vector`` in the ambient space of current_dictionary.
-                
-        EXAMPLES:: 
-        
-        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot     
-        sage: A = ([1, 1], [3, 1])
-        sage: b = (1000, 1500)
-        sage: c = (10, 5)
-        sage: P = InteractiveLPProblemStandardForm(A, b, c)
-        sage: D = P.initial_dictionary()
-        sage: D.entering()
-        
-        sage: D.leaving()
-        
-        sage: def eta(v): # use 2 norm as normalization
-        ....:     return v.norm()
-        sage: pivot = SimplexMethodPivot("NW_rule")
-        sage: pivot(D, eta, [1,1]) 
-        sage: D.entering()
-        x1
-        sage: D.leaving()
-        x4
-        
-        Inputs are assumed to be correct for the current problem::
-        sage: D.update()
-        sage: pivot(D, eta, 1)
-        Traceback (most recent call last):
-        ...
-        TypeError: 'sage.rings.integer.Integer' object is not iterable
-        sage: eta = [1,2,1]
-        sage: pivot(D, eta, [1,1])
-        Traceback (most recent call last):
-        ...
-        TypeError: 'list' object is not callable
+        Sets the entering and leaving variables of `:class:`~sage.numerical.interactive_simplex_method.LPDictionary` as defined by Normalized Weight pivot rule.
+
+        Input:
+        - ``current_dictionary`` -- an instance of `:class:`~sage.numerical.interactive_simplex_method.LPDictionary`
+
+        - ``eta`` -- callable function from ambient space of ``current_dictionary`` to the real numbers.
+
+        - ``weight`` -- object convertible to a sage ``vector`` in the ambient space of current_dictionary.
+
+        EXAMPLES::
+
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: A = ([1, 1], [3, 1])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.initial_dictionary()
+            sage: D.entering()
+
+            sage: D.leaving()
+
+            sage: def eta(v): # use 2 norm as normalization
+            ....:     return v.norm()
+            sage: pivot = SimplexMethodPivot("NW_rule")
+            sage: pivot(D, False, eta, [1,1])
+            sage: D.entering()
+            x1
+            sage: D.leaving()
+            x4
+
+            Inputs are assumed to be correct for the current problem::
+            sage: D.update()
+            sage: pivot(D, False, eta, 1)
+            Traceback (most recent call last):
+            ...
+            TypeError: 'sage.rings.integer.Integer' object is not iterable
+            sage: eta = [1,2,1]
+            sage: pivot(D, False, eta, [1,1])
+            Traceback (most recent call last):
+            ...
+            TypeError: 'list' object is not callable
         """
         eta = eta
         weight = vector(weight)
@@ -852,14 +757,14 @@ class NWRule(AbstractSimplexMethodPivotRule):
             for var_in in current_dictionary.possible_entering(): # Explore adjacent vertices to v such that c^tu>c^tv.
                 copy_of_dict = deepcopy(current_dictionary) # TODO: custom copy method for LPAbstractDictionary or better way to explore multiple vertices.
                 copy_of_dict.enter(var_in)
-                for var_out in copy_of_dict.possible_leaving(): 
+                for var_out in copy_of_dict.possible_leaving():
                     copy_of_dict.leave(var_out)
                     copy_of_dict.update()
-                    next_vertex =  copy_of_dict.basic_solution() # Vertex u adjacent to v in gr(P).
+                    next_vertex = copy_of_dict.basic_solution() # Vertex u adjacent to v in gr(P).
                     if eta(next_vertex - current_vertex) != 0:
                         current_value = (weight * (next_vertex - current_vertex)) / eta(next_vertex - current_vertex) # NW-rule
-                        if current_value > best_value: 
-                            best_vars  = var_in, var_out 
+                        if current_value > best_value:
+                            best_vars = var_in, var_out
                             best_value = current_value
                     copy_of_dict = deepcopy(current_dictionary)
             if best_vars is not None: # Don't set entering or leaving variables if we haven't found any strict improvement.
@@ -867,4 +772,5 @@ class NWRule(AbstractSimplexMethodPivotRule):
                 if current_dictionary.leaving() is None:
                     current_dictionary.leave(best_vars[1])
 
-from sage.numerical.interactive_simplex_method import LPAbstractDictionary 
+
+from sage.numerical.interactive_simplex_method import LPAbstractDictionary

--- a/src/sage/numerical/pivot_rules_for_simplex_method.py
+++ b/src/sage/numerical/pivot_rules_for_simplex_method.py
@@ -1,0 +1,870 @@
+r"""
+Pivot Rules for Simplex Method
+
+This module is an addendum to the Interactive Simplex Method
+to draw connection between active research on simplex method pivot rules
+and an educational settings. 
+
+A pivot rule is a function or algorithm on an linear program (LP) `\min\{cx: Ax<=b\}` 
+and a vertex `v` of `P = \{x: Ax<=b\}` to a vertex `u` of `P` such that 
+(a) `v` is adjacent to `u` in the graph of $P$ and
+(b) `cu \leq cv`.
+
+The module offers a number of predefined pivot rules and classes which serve as plug and play for defining/experimenting with pivot rules. 
+
+Authors:
+
+-Acadia Larsen (March 1, 2024): Initial Version. 
+
+EXAMPLES::
+
+The module is plug and play with ``interactive_simplex_method``.
+
+    sage: A = ([1, 1], [3, 1], [-1, -1])
+    sage: b = (1000, 1500, -400)
+    sage: c = (10, 5)
+    sage: P = InteractiveLPProblemStandardForm(A, b, c)
+    sage: P.run_simplex_method('steepest_edge')
+    \begin{equation*}
+    ...
+    \end{equation*}
+    The initial dictionary is infeasible, solving auxiliary problem.
+    ...
+    Entering: $x_{0}$. Leaving: $x_{5}$.
+    ...
+    Entering: $x_{1}$. Leaving: $x_{0}$.
+    ...
+    Back to the original problem.
+    ...
+    Entering: $x_{5}$. Leaving: $x_{4}$.
+    ...
+    Entering: $x_{2}$. Leaving: $x_{3}$.
+    ...
+    The optimal value: $6250$. An optimal solution: $\left(250,\,750\right)$.
+            
+It allows one to explore different rules such as the Normalized Weight pivot rule::
+
+    sage: A = ([1, 1], [3, 1], [-1, -1])
+    sage: b = (1000, 1500, -400)
+    sage: c = (10, 5)
+    sage: P = InteractiveLPProblemStandardForm(A, b, c)
+    sage: def eta(v):
+    ....:     return v.norm() 
+    sage: D = P.auxiliary_problem().initial_dictionary() # Phase I
+    sage: D.enter('x0')
+    sage: D.leave('x5')
+    sage: D.update()
+    sage: D.run_simplex_method('NW_rule', eta, [1,1,4])
+    \begin{equation*}
+    ...
+    \end{equation*}
+    Entering: $x_{2}$. Leaving: $x_{0}$.
+    \begin{equation*}
+    ...
+    \end{equation*}
+    sage: d = P.feasible_dictionary(D) # Phase II
+    sage: d.run_simplex_method('NW_rule', eta, [1,1])
+    \begin{equation*}
+    ...
+    \end{equation*}
+    Entering: $x_{5}$. Leaving: $x_{3}$.
+    \begin{equation*}
+    ...
+    \end{equation*}
+    Entering: $x_{1}$. Leaving: $x_{4}$.
+    \begin{equation*}
+    ...
+    \end{equation*}
+
+Pivot Rules can be used to manipulate dictonaries on a step by step basis::
+
+    sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+    sage: A = ([1, 1], [3, 1])
+    sage: b = (1000, 1500)
+    sage: c = (10, 5)
+    sage: P = InteractiveLPProblemStandardForm(A, b, c)
+    sage: D = P.initial_dictionary()
+    sage: pivot = SimplexMethodPivot("dantzig")
+    sage: pivot(D)
+    sage: D.entering()
+    x1
+    sage: D.leaving()
+    x4       
+    
+The module makes it easy to define one's own pivot rule::
+
+    sage: from sage.numerical.pivot_rules_for_simplex_method import AbstractSimplexMethodPivotRule
+    sage: class MyPivotRule(AbstractSimplexMethodPivotRule):
+    ....:     def dictionary_pivot(dict):
+    ....:         dict.enter('x1')
+    ....:         dict.leave('x4')
+    sage: my_pivot = SimplexMethodPivot(MyPivotRule)
+    sage: A = ([1, 1], [3, 1])
+    sage: b = (1000, 1500)
+    sage: c = (10, 5)
+    sage: P = InteractiveLPProblemStandardForm(A, b, c)
+    sage: D = P.initial_dictionary()
+    sage: my_pivot(D)
+    sage: D.entering()
+    x1
+    sage: D.leaving()
+    x4
+    
+Classes and functions
+---------------------
+"""
+# ****************************************************************************
+#       Copyright (C) 2024 Acadia Larsen acadia.larsen@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
+from copy import deepcopy
+from sage.structure.unique_representation import UniqueRepresentation
+from sage.structure.all import SageObject
+from sage.misc.abstract_method import abstract_method
+from sage.modules.free_module_element import free_module_element as vector
+from sage.rings.infinity import InfinityRing
+from numpy import argmax
+#from sage.numerical.interactive_simplex_method import LPAbstractDictionary
+
+class AbstractSimplexMethodPivotRule(UniqueRepresentation): 
+    r"""
+    Abstract class for memoryless pivot rules.
+    
+    A pivot rule is a function or algorithm on an linear program (LP) `\min\{cx: Ax<=b\}` 
+    and a vertex `v` of `P = \{x: Ax<=b\}` to a vertex `u` of `P` such that 
+    (a) `v` is adjacent to `u` in the graph of $P$ and
+    (b) `cu \leq cv`.
+            
+    Individual pivot rules are not in Sage's namespace. 
+    Using a pivot rule should be instantiated via `SimplexMethodPivot`. 
+    """
+    @classmethod
+    def has_dual_method(self):
+        r""" For use in SimplexMethodPivot to identify if a dual pivot rule has been written. 
+        
+        Overwrite this method after implementing a dual pivot method. See ``BlandsRule`` for exmaple.
+        
+        OUTPUT: bool
+        """
+        return False
+    @abstract_method
+    def dictionary_pivot(dictionary, *args):
+        r"""
+        Abstract method for computing a pivot for the primal simplex method based on an ``LPDictionary``.
+        
+        Sets the entering and leaving variables of ``LPDictionary`` or ``AbstractLPDictionary`` for the primal simplex method. 
+        
+        INPUT: 
+        
+        - ``dictionary`` -- an instance of ``LPDictionary`` 
+        
+        - ``*args`` -- required inputs for specific method 
+        
+        EXAMPLES::
+        
+            sage: from sage.numerical.pivot_rules_for_simplex_method import BlandsRule
+            sage: A = ([1, 1], [3, 1])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.initial_dictionary()
+            sage: D.entering()
+            
+            sage: D.leaving()
+            
+            sage: BlandsRule.dictionary_pivot(D)
+            sage: D.entering()
+            x1
+            sage: D.leaving()
+            x4
+
+        Handling unboundedness, feasibility, and optimality should be left to the solver.::
+        
+            sage: A = ([1, 0],)
+            sage: b = (1,)
+            sage: c = (0, 1)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.initial_dictionary()
+            sage: D.run_simplex_method()
+            \begin{equation*}
+            ...
+            \end{equation*}
+            The problem is unbounded in $x_{2}$ direction.
+            
+        The leaving variable should be `None` if a dictionary represents unboundedness in a problem::
+        
+            sage: D = P.initial_dictionary()
+            sage: BlandsRule.dictionary_pivot(D)
+            sage: D.entering()
+            x2
+            sage: D.leaving() is None
+            True
+            
+        The `__call__` method of `SimplexMethodPivot` is responsible checking for type input:: 
+
+            sage: LP_tablaux = Matrix([[0, 10, 5], [1, 1, 1000], [3, 1, 1500]])
+            sage: BlandsRule.dictionary_pivot(LP_tablaux)
+            Traceback (most recent call last):
+            ...
+            AttributeError: 'sage.matrix.matrix_integer_dense.Matrix_integer_dense' object has no attribute 'entering'
+
+            """
+    @abstract_method
+    def dual_dictionary_pivot(dictionary, *args):
+        r"""
+        Abstract method for computing a pivot for the dual simplex method based on an ``LPDictionary``.
+        
+        Sets the entering and leaving variables of ``LPDictionary`` for the dual simplex method. 
+        
+        One does not need to define a dual_dictionary_pivot unless one intends to use a dual method.
+        
+            NPUT: 
+        
+        - ``dictionary`` -- an instance of ``LPDictionary`` 
+        
+        - ``*args`` -- required inputs for specific methods
+        
+        EXAMPLES:: 
+            
+            sage: from sage.numerical.pivot_rules_for_simplex_method import BlandsRule
+            sage: A = ([1, 1], [3, 1], [-1, -1])
+            sage: b = (1000, 1500, -400)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.dictionary(2, 3, 5)
+            sage: D.entering()
+            
+            sage: D.leaving()
+            
+            sage: BlandsRule.dual_dictionary_pivot(D)
+            sage: D.entering()
+            x1
+            sage: D.leaving()
+            x3
+            
+        Some pivot rules do not have dual methods defined at the momement.::
+        
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SteepestEdge
+            sage: SteepestEdge.has_dual_method()
+            False
+            
+        """
+
+        
+class SimplexMethodPivot(SageObject, UniqueRepresentation): 
+    r"""
+    A class to preform pivots in the simplex method of solving Linear Programs. 
+    
+    INPUT: 
+    
+    - ``name`` -- a string or a ``SimplexMethodPivotRule`` object
+        
+    EXAMPLES::
+    
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: A = ([1, 1], [3, 1])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: blands_rule = SimplexMethodPivot()
+            sage: D = P.initial_dictionary()
+            
+            sage: D.entering()
+
+            sage: D.leaving()
+
+            sage: blands_rule(D)
+
+            sage: D.entering()
+            x1
+            sage: D.leaving()
+            x4     
+
+        
+    """
+    @staticmethod
+    def __classcall__(cls, name=None):
+        r"""
+        Normalize init agrugments.
+        
+        INPUT:
+        
+        - ``name`` -- a string or a ``SimplexMethodPivotRule`` object
+        
+        TESTS::
+        
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: from sage.numerical.pivot_rules_for_simplex_method import BlandsRule
+            sage: SimplexMethodPivot("blands_rule") is SimplexMethodPivot()
+            True
+            sage: SimplexMethodPivot("blands_rule") is SimplexMethodPivot(BlandsRule)
+            True
+        """
+        if name == "blands_rule" or name is None:
+            return super().__classcall__(cls, pivot_rule=BlandsRule)
+        if name == "steepest_edge":
+            return super().__classcall__(cls, pivot_rule=SteepestEdge)
+        if name == "dantzig":
+            return super().__classcall__(cls, pivot_rule=DantzigsRule)
+        if name == "NW_rule":
+            return super().__classcall__(cls, pivot_rule=NWRule)
+        if issubclass(name, AbstractSimplexMethodPivotRule):
+            return super().__classcall__(cls, pivot_rule=name)
+        else: 
+            raise TypeError("Input is required to be a string with the name of a predefined pivot rule or an instance of ``AbstractSimplexMethodPivotRule``")
+
+    def __init__(self, pivot_rule):
+        r"""
+        Initalize a pivot rule. This is never directly called. 
+        
+        INPUT:
+        
+        - ``pivot_rule`` -- a ``SimplexMethodPivotRule``
+        
+        EXAMPLES :: 
+        
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+        
+        Create Blands Rule::
+        
+            sage: blands_rule = SimplexMethodPivot("blands_rule")
+        
+        No input of a named pivot rule uses Blands Rule instead:: 
+        
+            sage: generic_pivot_rule = SimplexMethodPivot()
+            sage: blands_rule is generic_pivot_rule
+            True
+        
+        Create Steepest Edge Pivot Rule::
+        
+            sage: steepest_edge = SimplexMethodPivot("steepest_edge")
+            
+        Create Dantzigs Pivot Rule::
+        
+            sage: dantzigs_rule =  SimplexMethodPivot("dantzig")
+            
+        Create Normalized Weight Pivot Rule::
+        
+            sage: NW_rule =  SimplexMethodPivot("NW_rule")
+        """
+        self._pivot_rule = pivot_rule
+        self._mode = "primal"
+        super().__init__()
+
+        
+    def __call__(self, dictionary, *args):
+        r"""
+        Makes pivot rules have a function like notation and normalizes inputs.
+
+        Input:
+        
+        - ``dictionary`` -- instance of :LPDictionary:
+        
+        - ``args`` --  arguments for pivot rule
+
+        EXAMPLES::
+        
+        A pivot rule applied to an ``LPDictionary`` sets the entering 
+        and leaving variables::
+        
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: A = ([1, 1], [3, 1])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.initial_dictionary()
+            sage: blands_rule = SimplexMethodPivot()
+            sage: D.entering()
+
+            sage: D.leaving()
+
+            sage: blands_rule(D)
+
+            sage: D.entering()
+            x1
+            sage: D.leaving()
+            x4     
+
+        The call method also checks types::
+        
+            sage: LP_tablaux = Matrix([[0, 10, 5], [1, 1, 1000], [3, 1, 1500]])
+            sage: blands_rule = SimplexMethodPivot()
+            sage: blands_rule(LP_tablaux)
+            Traceback (most recent call last):
+            ...
+            TypeError: Input is required to be an instance of `LPAbstractDictionary`
+        """
+        if self._mode == "dual" and self.has_dual_method():
+            pivot = self._pivot_rule.dual_dictionary_pivot
+        else: 
+            pivot =  self._pivot_rule.dictionary_pivot
+        if isinstance(dictionary, LPAbstractDictionary):
+            if args:
+                pivot(dictionary, *args)
+            else:
+                pivot(dictionary)
+        else:
+            raise TypeError("Input is required to be an instance of `LPAbstractDictionary`")
+
+    def has_dual_method(self):
+        r""" 
+        True if pivot rule has a dual method written for it.
+        
+        OUTPUT: 
+        
+        - bool 
+        
+        EXAMPLES::
+
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: steepest_edge = SimplexMethodPivot("steepest_edge")
+            sage: steepest_edge.has_dual_method()
+            False
+            sage: pivot = SimplexMethodPivot()
+            sage: pivot.has_dual_method()
+            True
+        """
+        return self._pivot_rule.has_dual_method()
+    def set_mode(self, mode = "primal"):
+        r"""
+        Changes functionality between primal and dual method of simplex method.
+        
+        INPUT: 
+        
+        - ``mode`` -- string either "dual" or "primal" 
+        
+        EXAMPLES::
+
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: steepest_edge = SimplexMethodPivot("steepest_edge")
+            sage: steepest_edge.has_dual_method()
+            False
+            sage: steepest_edge.set_mode("dual")
+            sage: steepest_edge.get_mode()
+            'primal'
+            sage: pivot = SimplexMethodPivot()
+            sage: pivot.has_dual_method()
+            True
+            sage: pivot.set_mode("dual")
+            sage: pivot.get_mode()
+            'dual'
+            
+        We do not check validity of input:: 
+        
+            sage: pivot.set_mode("banana")
+            sage: pivot.get_mode()
+            'banana'
+        """
+        if self.has_dual_method():
+            self._mode = mode
+
+    def get_mode(self):
+        r"""
+        Method to describe if making a primal pivot or dual pivot. 
+        
+        OUTPUT: 
+        
+        - string either `dual` or `primal`
+        
+        EXAMPLES::
+        
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot        
+            sage: steepest_edge = SimplexMethodPivot("steepest_edge")
+            sage: steepest_edge.has_dual_method()
+            False
+            sage: steepest_edge.set_mode("dual")
+            sage: steepest_edge.get_mode()
+            'primal'
+            sage: pivot = SimplexMethodPivot()
+            sage: pivot.has_dual_method()
+            True
+            sage: pivot.set_mode("dual")
+            sage: pivot.get_mode()
+            'dual'
+        """
+        return self._mode
+            
+    
+class BlandsRule(AbstractSimplexMethodPivotRule):
+    r"""
+    Defines Blands Rule as a ``AbstractSimplexMethodPivotRule``. 
+    
+    Ref. [TZ1993]_
+    EXAMPLES::
+        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+        sage: A = ([1, 1], [3, 1])
+        sage: b = (1000, 1500)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: D = P.initial_dictionary()
+        sage: D.entering()
+        
+        sage: D.leaving()
+        
+        sage: pivot = SimplexMethodPivot("blands_rule")
+        sage: pivot.set_mode("primal")
+        sage: pivot(D)
+        sage: D.entering()
+        x1
+        sage: D.leaving()
+        x4
+    """
+    def has_dual_method():
+        return True
+
+    def dictionary_pivot(current_dictionary):
+        r"""
+        Sets the entering and leaving variables of ``LPDictionary`` as defined by Blands rule.
+        
+        Input:
+        
+        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
+        
+        EXAMPLES::
+
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: A = ([1, 1], [3, 1])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.initial_dictionary()
+            sage: pivot = SimplexMethodPivot("blands_rule") #indirect test
+            sage: pivot(D)
+            sage: D.entering()
+            x1
+            sage: D.leaving()
+            x4            
+        """
+        if current_dictionary.entering() is None:
+            entering_variable = min(current_dictionary.possible_entering())
+            current_dictionary.enter(entering_variable)
+        if current_dictionary.leaving() is None:
+            possible = current_dictionary.possible_leaving()
+            if possible:
+                leaving_variable = min(possible)
+                current_dictionary.leave(leaving_variable)
+    def dual_dictionary_pivot(current_dictionary):
+        r"""
+        Sets the entering and leaving variables of ``LPDictionary`` as defined by Blands rule for dual simplex method.
+        
+        Input:
+        
+        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
+        
+        EXAMPLES::
+
+            sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+            sage: A = ([1, 1], [3, 1], [-1, -1])
+            sage: b = (1000, 1500, -400)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.dictionary(2, 3, 5) # dual feasible dicitonary
+            sage: pivot = SimplexMethodPivot()
+            sage: pivot.set_mode("dual")
+            sage: pivot(D)
+            sage: D.leaving()
+            x3
+            sage: D.entering()
+            x1
+        """
+        if current_dictionary.leaving() is None:
+            entering_variable = min(current_dictionary.possible_leaving())
+            current_dictionary.leave(entering_variable)
+        if current_dictionary.entering() is None:
+            possible = current_dictionary.possible_entering()
+            if possible:
+                leaving_variable = min(possible)
+                current_dictionary.enter(leaving_variable)
+        
+
+class SteepestEdge(AbstractSimplexMethodPivotRule):
+    r"""
+    Defines the steepest edge pivot rule as a ``AbstractSimplexMethodPivotRule``.
+    
+    The entering variable is selected by finding the steepest edge.
+    The leaving variable is selected by finding the minimal ratio of the possible leaving variables.
+    
+    This method is generalized to selection based on the `p` norm with `p \\geq 1`.
+    
+    For more information see [GR1977]_ and [KMT2019]_. 
+    EXAMPLES::
+    
+        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+        sage: A = ([1, 1], [3, 1])
+        sage: b = (1000, 1500)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: D = P.initial_dictionary()
+        sage: D.entering()
+        
+        sage: D.leaving()
+        
+        sage: pivot = SimplexMethodPivot("steepest_edge") 
+        sage: pivot(D)
+        sage: D.entering()
+        x1
+        sage: D.leaving()
+        x4    
+    """
+    def dictionary_pivot(current_dictionary, p=2):
+        r"""
+        Sets the entering and leaving variables of ``LPDictionary`` as defined by steepest edge rule.
+        
+        Input:
+        
+        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
+        
+        - ``p`` -- optional real number with `p\\geq 1`
+        
+        EXAMPLES::
+        
+        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+        sage: A = ([1, 1], [3, 1])
+        sage: b = (1000, 1500)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: D = P.initial_dictionary()
+        sage: pivot = SimplexMethodPivot("steepest_edge") # indirect test
+        sage: pivot(D, 1) # let's use the 1 norm.
+        sage: D.entering()
+        x1
+        sage: D.leaving()
+        x4
+
+        Values of p are checked::
+        
+        sage: D.update()
+        sage: pivot(D,0)
+        Traceback (most recent call last):
+        ...
+        ValueError: p must be at least 1
+        """            
+        if p < 1:
+            raise ValueError("p must be at least 1")
+        if current_dictionary.entering() is None:
+            thetas = []
+            for v in current_dictionary.basic_variables():
+                # We want to avoid p-root complications, so work with the pth power.
+                thetas.append((1+sum([i**p for i in current_dictionary.row_coefficients(v)]))) 
+            best_value = -1*current_dictionary.objective_coefficients()[0]/thetas[0] 
+            index_to_select = 0 
+            # This loop selects the index that corresponds to the steepest edge. 
+            for i in range(1,len(current_dictionary.nonbasic_variables())): 
+                decent_direction = -1*current_dictionary.objective_coefficients()[i]/thetas[i-1] 
+                if decent_direction < best_value:
+                    best_value = decent_direction
+                    index_to_select = i
+            entering_variable = current_dictionary.nonbasic_variables()[index_to_select]
+            current_dictionary.enter(entering_variable)
+                
+        if current_dictionary.leaving() is None:
+            possible = current_dictionary.possible_leaving()
+            if possible:
+                # We select leaving variables based on ratios. 
+                leaving_variable = min(current_dictionary.ratios())[1] 
+                current_dictionary.leave(leaving_variable)
+                
+                
+class DantzigsRule(AbstractSimplexMethodPivotRule):
+    r"""
+    For a linear program `min(cx: Ax\leq b)`, selects the entering variable to be the variable with the most negative reduced cost. 
+    
+    Originally proposed by Dantzig in the formulation of linear programming. Also know as greatest improvement rule. 
+    
+    See [TZ1993]_. 
+    
+    EXAMPLES::
+    
+        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+        sage: A = ([1, 1], [3, 1])
+        sage: b = (1000, 1500)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: D = P.initial_dictionary()
+        sage: D.entering()
+        
+        sage: D.leaving()
+        
+        sage: pivot = SimplexMethodPivot("dantzig")
+        sage: pivot(D)
+        sage: D.entering()
+        x1
+        sage: D.leaving()
+        x4        
+    """
+    def dictionary_pivot(current_dictionary):
+        r"""
+        Sets the entering and leaving variables of ``LPDictionary`` as defined by Dantzig's rule.
+        
+        Input:
+        
+        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
+        
+        EXAMPLES::
+        
+        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+        sage: A = ([1, 1], [3, 1])
+        sage: b = (1000, 1500)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: D = P.initial_dictionary()
+        sage: pivot = SimplexMethodPivot("dantzig")
+        sage: pivot(D)
+        sage: D.entering()
+        x1
+        sage: D.leaving()
+        x4       
+        """        
+        if current_dictionary.entering() is None:
+            entering_index = argmax(current_dictionary.objective_coefficients())
+            entering_variable = current_dictionary.nonbasic_variables()[entering_index]
+            current_dictionary.enter(entering_variable)
+        if current_dictionary.leaving() is None:
+            possible = current_dictionary.possible_leaving()
+            if possible:
+                leaving_variable = min(current_dictionary.ratios())[1] 
+                current_dictionary.leave(leaving_variable)
+
+        
+class NWRule(AbstractSimplexMethodPivotRule):
+    r"""
+    For a linear program `min(cx: Ax\leq b) = min(cx: x\in P)`, an NW-rule is defined by a normalization \eta: \R^d\to R and a weight w\in R^n.
+    Given `v\in P` s.t. `cv \neq cv_{opt}`, pick the next vertex `u_* = argmax\{ w^t(u-v)/\eta(u-v): u adjacent to v and c^tu>c^tv\}`. 
+    See [BDLS2022]_. 
+    
+    EXAMPLES::
+        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot
+        sage: A = ([1, 1], [3, 1])
+        sage: b = (1000, 1500)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: D = P.initial_dictionary()
+        sage: pivot = SimplexMethodPivot("NW_rule")
+        sage: def eta(v): # use 2 norm as normalization
+        ....:     return v.norm()
+        sage: pivot(D, eta, [1,2])
+        sage: D.entering()
+        x2
+        sage: D.leaving()
+        x3 
+        
+    NW rule is not eqipped to solve both a Phase I and a phase II with the `run_simplex_method`:: 
+        
+        sage: A = ([1, 1], [3, 1], [-1, -1])
+        sage: b = (1000, 1500, -400)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: def eta(v):
+        ....:     return v.norm() 
+        sage: P.run_simplex_method('NW_rule', eta, [1,2])
+        Traceback (most recent call last):
+        ...
+        TypeError: unsupported operand parent(s) for *: 'Ambient free module of rank 2 over the principal ideal domain Integer Ring' and 'Vector space of dimension 3 over Rational Field'
+        
+    A Phase I and a Prase II problem require different NW rules due to the differnce in ambient dimension of the respective problems:: 
+    
+        sage: A = ([1, 1], [3, 1], [-1, -1])
+        sage: b = (1000, 1500, -400)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: def eta(v):
+        ....:     return v.norm() 
+        sage: D = P.auxiliary_problem().initial_dictionary() # Phase I
+        sage: D.enter('x0')
+        sage: D.leave('x5')
+        sage: D.update()
+        sage: D.run_simplex_method('NW_rule', eta, [1,1,4])
+        \begin{equation*}
+        ...
+        \end{equation*}
+        Entering: $x_{2}$. Leaving: $x_{0}$.
+        \begin{equation*}
+        ...
+        \end{equation*}
+        sage: d = P.feasible_dictionary(D)
+        sage: d.run_simplex_method('NW_rule', eta, [1,1])
+        \begin{equation*}
+        ...
+        \end{equation*}
+        Entering: $x_{5}$. Leaving: $x_{3}$.
+        \begin{equation*}
+        ...
+        \end{equation*}
+        Entering: $x_{1}$. Leaving: $x_{4}$.
+        \begin{equation*}
+        ...
+        \end{equation*}
+    """
+    def dictionary_pivot(current_dictionary, eta, weight):
+        r"""
+        INPUT:: 
+        
+        - ``current_dictionary`` -- an instance of ``LPDictionary`` 
+        
+        - ``eta`` -- callable function from ambient space of current_dictionary to the real numbers.
+        
+        - ``weight`` -- object convertable to ``vector`` in the ambient space of current_dictionary.
+                
+        EXAMPLES:: 
+        
+        sage: from sage.numerical.pivot_rules_for_simplex_method import SimplexMethodPivot     
+        sage: A = ([1, 1], [3, 1])
+        sage: b = (1000, 1500)
+        sage: c = (10, 5)
+        sage: P = InteractiveLPProblemStandardForm(A, b, c)
+        sage: D = P.initial_dictionary()
+        sage: D.entering()
+        
+        sage: D.leaving()
+        
+        sage: def eta(v): # use 2 norm as normalization
+        ....:     return v.norm()
+        sage: pivot = SimplexMethodPivot("NW_rule")
+        sage: pivot(D, eta, [1,1]) 
+        sage: D.entering()
+        x1
+        sage: D.leaving()
+        x4
+        
+        Inputs are assumed to be correct for the current problem::
+        sage: D.update()
+        sage: pivot(D, eta, 1)
+        Traceback (most recent call last):
+        ...
+        TypeError: 'sage.rings.integer.Integer' object is not iterable
+        sage: eta = [1,2,1]
+        sage: pivot(D, eta, [1,1])
+        Traceback (most recent call last):
+        ...
+        TypeError: 'list' object is not callable
+        """
+        eta = eta
+        weight = vector(weight)
+        if current_dictionary.entering() is None:
+            current_vertex = current_dictionary.basic_solution() # This current vertex v of P.
+            best_value = InfinityRing(float('-inf'))
+            best_vars = None
+            for var_in in current_dictionary.possible_entering(): # Explore adjacent vertices to v such that c^tu>c^tv.
+                copy_of_dict = deepcopy(current_dictionary) # TODO: custom copy method for LPAbstractDictionary or better way to explore multiple vertices.
+                copy_of_dict.enter(var_in)
+                for var_out in copy_of_dict.possible_leaving(): 
+                    copy_of_dict.leave(var_out)
+                    copy_of_dict.update()
+                    next_vertex =  copy_of_dict.basic_solution() # Vertex u adjacent to v in gr(P).
+                    if eta(next_vertex - current_vertex) != 0:
+                        current_value = (weight * (next_vertex - current_vertex)) / eta(next_vertex - current_vertex) # NW-rule
+                        if current_value > best_value: 
+                            best_vars  = var_in, var_out 
+                            best_value = current_value
+                    copy_of_dict = deepcopy(current_dictionary)
+            if best_vars is not None: # Don't set entering or leaving variables if we haven't found any strict improvement.
+                current_dictionary.enter(best_vars[0])
+                if current_dictionary.leaving() is None:
+                    current_dictionary.leave(best_vars[1])
+
+from sage.numerical.interactive_simplex_method import LPAbstractDictionary 


### PR DESCRIPTION
Added a new module `pivot_rules_for_simplex_method` which implements several pivot rules and provides a framework for implementing new pivot rules. Modified `interactive_simplex_method` to support pivot rules in `pivot_rules_for_simplex_method`. Fixes #30810. 

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

