### PR TITLE
Deprecating coordinate_ring() and replacing with ambient_base_ring() for free modules

### DIFF
--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -1,3 +1,10 @@
+import warnings
+
+# custom_warning function which displays warning as warning_category : warning_message
+def custom_warning(message, category, filename, lineno, file=None, line=None):
+    return f"{category.__name__}: {message}\n"
+warnings.formatwarning = custom_warning
+
 r"""
 Free modules
 
@@ -2938,6 +2945,11 @@ class FreeModule_generic(Module_free_ambient):
             sage: L.span([]).coordinate_ring()
             Univariate Polynomial Ring in x over Rational Field
         """
+        warnings.warn("coordinate_ring is deprecated; use ambient_base_ring instead", DeprecationWarning)
+        return self.ambient_base_ring()
+    
+    def ambient_base_ring(self):
+        
         return self.__coordinate_ring
 
     def free_module(self):

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -1,10 +1,3 @@
-import warnings
-
-# custom_warning function which displays warning as warning_category : warning_message
-def custom_warning(message, category, filename, lineno, file=None, line=None):
-    return f"{category.__name__}: {message}\n"
-warnings.formatwarning = custom_warning
-
 r"""
 Free modules
 
@@ -221,7 +214,7 @@ from sage.structure.richcmp import (
     richcmp_not_equal,
 )
 from sage.structure.sequence import Sequence
-
+from sage.misc.superseded import deprecation
 
 ###############################################################################
 #
@@ -2919,9 +2912,19 @@ class FreeModule_generic(Module_free_ambient):
         was given over the fraction field.
 
         EXAMPLES::
-
+        
+        The following feature has been deprecated::
+        
             sage: M = ZZ^2
             sage: M.coordinate_ring()
+            DeprecationWarning: the method 'coordinate_ring' is deprecated for free modules; use the method 'ambient_base_ring' instead
+            See https://github.com/sagemath/sage/issues/35348 for details.
+            M.coordinate_ring()
+            Integer Ring
+            
+        Instead, use::
+        
+            sage: M.ambient_base_ring()
             Integer Ring
 
         ::
@@ -2945,7 +2948,8 @@ class FreeModule_generic(Module_free_ambient):
             sage: L.span([]).coordinate_ring()
             Univariate Polynomial Ring in x over Rational Field
         """
-        warnings.warn("coordinate_ring is deprecated; use ambient_base_ring instead", DeprecationWarning)
+        deprecation(35348,f"the method 'coordinate_ring' is deprecated for free modules; "
+                        "use the method 'ambient_base_ring' instead")
         return self.ambient_base_ring()
     
     def ambient_base_ring(self):


### PR DESCRIPTION
Fixes #35348

### Description

`coordinate_ring()` method is defined for free modules as well as for algebraic schemes. 

In order to avoid any confusion, the `coordinate_ring()` method of free modules is deprecated and replaced with `ambient_base_ring()`

NOTE : `coordinate_ring()` method is not entirely eliminated, instead a warning is shown to use `ambient_base_ring()` for free modules
(All other functionalities are intact)

See the example below for free modules

```
sage: V = QQ^3
sage: V.coordinate_ring()
DeprecationWarning: coordinate_ring is deprecated; use ambient_base_ring instead
Rational Field
sage: V.ambient_base_ring()
Rational Field
```
Whereas, the functioning of `coordinate_ring()` is as expected for algebraic schemes

```
sage: A3.<x,y,z> = AffineSpace(3, QQ)
sage: A3.coordinate_ring()
Multivariate Polynomial Ring in x, y, z over Rational Field
```

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

None.

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


