### PR TITLE
Remove comment about python2 longs

### DIFF
--- a/src/doc/en/developer/coding_in_python.rst
+++ b/src/doc/en/developer/coding_in_python.rst
@@ -259,9 +259,9 @@ replacements are made:
       3 * 29
 
 - Raw literals are not preparsed, which can be useful from an
-  efficiency point of view. Just like Python ints are denoted by an L,
-  in Sage raw integer and floating literals are followed by an "r" (or
-  "R") for raw, meaning not preparsed. For example::
+  efficiency point of view. In Sage raw integer and floating
+  literals are followed by an "r" (or "R") for raw, meaning
+  not preparsed. For example::
 
       sage: a = 393939r
       sage: a

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -116,9 +116,8 @@ valid)::
 Raw literals:
 
 Raw literals are not preparsed, which can be useful from an efficiency
-point of view.  Just like Python ints are denoted by an L, in Sage raw
-integer and floating literals are followed by an"r" (or "R") for raw,
-meaning not preparsed.
+point of view. In Sage raw integer and floating literals are followed
+by an"r" (or "R") for raw, meaning not preparsed.
 
 We create a raw integer::
 


### PR DESCRIPTION
<!-- v Describe your changes below in detail. -->

Python2 had long integer literals. For example `12L` was valid. In python3 this is no longer valid.
This PR removes an outdated documentation that mentions this old feature.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have updated the documentation accordingly.


