### PR TITLE
fix debian.txt for qhull

### DIFF
--- a/build/pkgs/qhull/distros/debian.txt
+++ b/build/pkgs/qhull/distros/debian.txt
@@ -1,1 +1,2 @@
+qhull-bin
 libqhull-dev


### PR DESCRIPTION
added missing Debian package for qhull

