### PR TITLE
Deprecate `FiniteEnumeratedSet` in the global namespace, add method `is_subset` to `Sets.ParentMethods`

### DIFF
--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -268,6 +268,52 @@ class EnumeratedSets(CategoryWithAxiom):
             else:
                 return False
 
+        def is_subset(self, other):
+            r"""
+            Return whether ``self`` is a subset of ``other``.
+
+            .. WARNING::
+
+                This method has clear semantics when the elements of ``self``
+                and ``other`` have the same parent. When coercion of elements
+                is involved, violations of the hash/equality contract and
+                non-injective coercions can lead to unexpected results.
+
+            EXAMPLES::
+
+                sage: S = Set([1, 2])
+                sage: T = Set(Integers(2))
+                sage: S
+                {1, 2}
+                sage: T
+                {0, 1}
+                sage: S.is_subset(T)
+                False
+                sage: all(x in T for x in S)
+                True
+                sage: [hash(x) for x in S]
+                [1, 2]
+                sage: [hash(x) for x in T]
+                [0, 1]
+            """
+            if not self:
+                return True
+            other = Set(other)
+            cardinality = self.cardinality()
+            if cardinality == Infinity:
+                if other.cardinality() < Infinity():
+                    return False
+                raise NotImplementedError
+            if cardinality < other.cardinality():
+                return False
+            try:
+                other = other.frozenset()
+            except NotImplementedError:
+                pass
+            else:
+                return self.frozenset().issubset(other)
+            return all(x in other for x in self)
+
         def iterator_range(self, start=None, stop=None, step=None):
             r"""
             Iterate over the range of elements of ``self`` starting
@@ -660,6 +706,10 @@ class EnumeratedSets(CategoryWithAxiom):
             except AttributeError:
                 pass
             return list(result)
+
+        @cached_method
+        def frozenset(self):
+            return frozenset(self.tuple())
 
         def _first_from_iterator(self):
             """

--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -306,6 +306,17 @@ class EnumeratedSets(CategoryWithAxiom):
                 raise NotImplementedError
             if cardinality < other.cardinality():
                 return False
+
+            coercion = other.coerce_map_from(self)
+            # do we need to be concerned about partial maps?
+            if coercion and coercion.is_injective():
+                return True   # assumes no partial map...
+            # handle case of "other" a Facade
+            if not coercion:
+                # Try to find injective pushout?
+
+
+
             try:
                 other = other.frozenset()
             except NotImplementedError:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

- Rebased version of #34398

Fixes #34398


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


