### PR TITLE
Improve genus method of function fields and curves

### DIFF
--- a/src/sage/rings/function_field/function_field_polymod.py
+++ b/src/sage/rings/function_field/function_field_polymod.py
@@ -34,11 +34,15 @@ from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.integer import Integer
 from sage.categories.homset import Hom
 from sage.categories.function_fields import FunctionFields
+from sage.categories.number_fields import NumberFields
 
 from .element import FunctionFieldElement
 from .element_polymod import FunctionFieldElement_polymod
 from .function_field import FunctionField
 from .function_field_rational import RationalFunctionField
+
+_FunctionFields = FunctionFields()
+_NumberFields = NumberFields()
 
 
 class FunctionField_polymod(FunctionField):
@@ -160,7 +164,7 @@ class FunctionField_polymod(FunctionField):
         self._polynomial = polynomial
 
         FunctionField.__init__(self, base_field, names=names,
-                               category=FunctionFields().or_subcategory(category))
+                               category=_FunctionFields.or_subcategory(category))
 
         from .place_polymod import FunctionFieldPlace_polymod
         self._place_class = FunctionFieldPlace_polymod
@@ -1842,11 +1846,27 @@ class FunctionField_simple(FunctionField_polymod):
             sage: L.genus()
             6
 
+            sage: # needs sage.rings.number_field
+            sage: R.<T> = QQ[]
+            sage: N.<a> = NumberField(T^2 + 1)
+            sage: K.<x> = FunctionField(N); K
+            Rational function field in x over Number Field in a with defining polynomial T^2 + 1
+            sage: K.genus()
+            0
+            sage: S.<t> = PolynomialRing(K)
+            sage: L.<y> = K.extension(t^2 - x^3 + x)
+            sage: L.genus()
+            1
+
         The genus is computed by the Hurwitz genus formula.
         """
         k, _ = self.exact_constant_field()
+        if k in _NumberFields:
+            k_degree = k.relative_degree()
+        else:
+            k_degree = k.degree()
         different_degree = self.different().degree()  # must be even
-        return Integer(different_degree // 2 - self.degree() / k.degree()) + 1
+        return Integer(different_degree // 2 - self.degree() / k_degree) + 1
 
     def residue_field(self, place, name=None):
         """

--- a/src/sage/rings/function_field/function_field_polymod.py
+++ b/src/sage/rings/function_field/function_field_polymod.py
@@ -41,9 +41,6 @@ from .element_polymod import FunctionFieldElement_polymod
 from .function_field import FunctionField
 from .function_field_rational import RationalFunctionField
 
-_FunctionFields = FunctionFields()
-_NumberFields = NumberFields()
-
 
 class FunctionField_polymod(FunctionField):
     """
@@ -164,7 +161,7 @@ class FunctionField_polymod(FunctionField):
         self._polynomial = polynomial
 
         FunctionField.__init__(self, base_field, names=names,
-                               category=_FunctionFields.or_subcategory(category))
+                               category=FunctionFields().or_subcategory(category))
 
         from .place_polymod import FunctionFieldPlace_polymod
         self._place_class = FunctionFieldPlace_polymod
@@ -1861,7 +1858,7 @@ class FunctionField_simple(FunctionField_polymod):
         The genus is computed by the Hurwitz genus formula.
         """
         k, _ = self.exact_constant_field()
-        if k in _NumberFields:
+        if k in NumberFields():
             k_degree = k.relative_degree()
         else:
             k_degree = k.degree()

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -1569,13 +1569,20 @@ class MPolynomialIdeal_singular_repr(
     @handle_AA_and_QQbar
     def genus(self):
         r"""
-        Return the genus of the projective curve defined by this ideal,
-        which must be 1 dimensional.
+        Return the geometric genus of the projective curve defined by this
+        ideal.
+
+        OUTPUT:
+
+        If the ideal is homogeneous and defines a curve in a projective space,
+        then the genus of the curve is returned. If the ideal is not
+        homogeneous and defines a curve in an affine space, the genus of the
+        projective closure of the curve is returned.
 
         EXAMPLES:
 
-        Consider the hyperelliptic curve `y^2 = 4x^5 - 30x^3 + 45x -
-        22` over `\QQ`, it has genus 2::
+        Consider the hyperelliptic curve `y^2 = 4x^5 - 30x^3 + 45x - 22` over
+        `\QQ`, it has genus 2::
 
             sage: P.<x> = QQ[]
             sage: f = 4*x^5 - 30*x^3 + 45*x - 22
@@ -1592,18 +1599,25 @@ class MPolynomialIdeal_singular_repr(
             sage: I.genus()
             2
 
-        TESTS:
-
-        Check that the answer is correct for reducible curves::
+        Geometric genus is only defined for geometrically irreducible curves.
+        You may get a nonsensical answer if the condition is not met.  A curve
+        reducible over a quadratic extension of `\QQ`::
 
             sage: R.<x, y, z> = QQ[]
             sage: C = Curve(x^2 - 2*y^2)
-            sage: C.is_singular()
-            True
             sage: C.genus()
             -1
-            sage: Ideal(x^4+y^2*x+x).genus()
+
+        TESTS:
+
+        An ideal that does not define a curve but we get a result! ::
+
+            sage: R.<x, y, z> = QQ[]
+            sage: Ideal(x^4 + y^2*x + x).genus()
             0
+
+        An ideal that defines a geometrically reducible affine curve::
+
             sage: T.<t1,t2,u1,u2> = QQ[]
             sage: TJ = Ideal([t1^2 + u1^2 - 1,t2^2 + u2^2 - 1, (t1-t2)^2 + (u1-u2)^2 -1])
             sage: TJ.genus()
@@ -1611,9 +1625,10 @@ class MPolynomialIdeal_singular_repr(
 
         Check that this method works over QQbar (:trac:`25351`)::
 
-            sage: P.<x,y> = QQbar[]                                                     # needs sage.rings.number_field
-            sage: I = ideal(y^3*z + x^3*y + x*z^3)                                      # needs sage.rings.number_field
-            sage: I.genus()                                                             # needs sage.rings.number_field
+            sage: # needs sage.rings.number_field
+            sage: P.<x,y> = QQbar[]
+            sage: I = ideal(y^3*z + x^3*y + x*z^3)
+            sage: I.genus()
             3
         """
         from sage.libs.singular.function_factory import ff

--- a/src/sage/schemes/curves/affine_curve.py
+++ b/src/sage/schemes/curves/affine_curve.py
@@ -2068,6 +2068,7 @@ class IntegralAffineCurve(AffineCurve_field):
 
         TESTS::
 
+            sage: # needs sage.rings.number_field
             sage: R.<T> = QQ[]
             sage: N.<a> = NumberField(T^2 + 1)
             sage: A2.<x,y> = AffineSpace(N, 2)

--- a/src/sage/schemes/curves/affine_curve.py
+++ b/src/sage/schemes/curves/affine_curve.py
@@ -2065,13 +2065,20 @@ class IntegralAffineCurve(AffineCurve_field):
             sage: C = Curve(x^5 + y^5 + x*y + 1)
             sage: C.genus()   # indirect doctest
             1
-        """
-        k = self.base_ring()
 
+        TESTS::
+
+            sage: R.<T> = QQ[]
+            sage: N.<a> = NumberField(T^2 + 1)
+            sage: A2.<x,y> = AffineSpace(N, 2)
+            sage: C = Curve(y^2 - x^3 + x, A2)
+            sage: C.genus()
+            1
+        """
         # Singular's genus command is usually much faster than the genus method
         # of function fields in Sage. But unfortunately Singular's genus
-        # command does not yet work over non-prime finite fields.
-        if k.is_finite() and k.degree() > 1:
+        # command does not work over extension fields.
+        if self.base_ring().degree() > 1:
             return self._function_field.genus()
 
         # call Singular's genus command

--- a/src/sage/schemes/curves/constructor.py
+++ b/src/sage/schemes/curves/constructor.py
@@ -72,9 +72,6 @@ from .affine_curve import (AffineCurve,
                            IntegralAffinePlaneCurve,
                            IntegralAffinePlaneCurve_finite_field)
 
-_Fields = Fields()
-_NumberFields = NumberFields()
-
 
 def _is_irreducible_and_reduced(F) -> bool:
     """
@@ -312,7 +309,7 @@ def Curve(F, A=None):
             if A.coordinate_ring().ideal(F).is_zero():
                 if isinstance(k, FiniteField):
                     return IntegralAffineCurve_finite_field(A, F)
-                if k in _Fields:
+                if k in Fields():
                     return IntegralAffineCurve(A, F)
                 return AffineCurve(A, F)
             raise TypeError(f"{F} does not define a curve in one-dimensional affine space")
@@ -320,8 +317,8 @@ def Curve(F, A=None):
             if isinstance(k, FiniteField):
                 if A.coordinate_ring().ideal(F).is_prime():
                     return IntegralAffineCurve_finite_field(A, F)
-            if k in _Fields:
-                if (k == QQ or k in _NumberFields) and A.coordinate_ring().ideal(F).is_prime():
+            if k in Fields():
+                if (k == QQ or k in NumberFields()) and A.coordinate_ring().ideal(F).is_prime():
                     return IntegralAffineCurve(A, F)
                 return AffineCurve_field(A, F)
             return AffineCurve(A, F)
@@ -334,8 +331,8 @@ def Curve(F, A=None):
             if _is_irreducible_and_reduced(F):
                 return IntegralAffinePlaneCurve_finite_field(A, F)
             return AffinePlaneCurve_finite_field(A, F)
-        if k in _Fields:
-            if (k == QQ or k in _NumberFields) and _is_irreducible_and_reduced(F):
+        if k in Fields():
+            if (k == QQ or k in NumberFields()) and _is_irreducible_and_reduced(F):
                 return IntegralAffinePlaneCurve(A, F)
             return AffinePlaneCurve_field(A, F)
         return AffinePlaneCurve(A, F)
@@ -345,7 +342,7 @@ def Curve(F, A=None):
             if A.coordinate_ring().ideal(F).is_zero():
                 if isinstance(k, FiniteField):
                     return IntegralProjectiveCurve_finite_field(A, F)
-                if k in _Fields:
+                if k in Fields():
                     return IntegralProjectiveCurve(A, F)
                 return ProjectiveCurve(A, F)
             raise TypeError(f"{F} does not define a curve in one-dimensional projective space")
@@ -355,8 +352,8 @@ def Curve(F, A=None):
             if isinstance(k, FiniteField):
                 if A.coordinate_ring().ideal(F).is_prime():
                     return IntegralProjectiveCurve_finite_field(A, F)
-            if k in _Fields:
-                if (k == QQ or k in _NumberFields) and A.coordinate_ring().ideal(F).is_prime():
+            if k in Fields():
+                if (k == QQ or k in NumberFields()) and A.coordinate_ring().ideal(F).is_prime():
                     return IntegralProjectiveCurve(A, F)
                 return ProjectiveCurve_field(A, F)
             return ProjectiveCurve(A, F)
@@ -374,8 +371,8 @@ def Curve(F, A=None):
             if _is_irreducible_and_reduced(F):
                 return IntegralProjectivePlaneCurve_finite_field(A, F)
             return ProjectivePlaneCurve_finite_field(A, F)
-        if k in _Fields:
-            if (k == QQ or k in _NumberFields) and _is_irreducible_and_reduced(F):
+        if k in Fields():
+            if (k == QQ or k in NumberFields()) and _is_irreducible_and_reduced(F):
                 return IntegralProjectivePlaneCurve(A, F)
             return ProjectivePlaneCurve_field(A, F)
         return ProjectivePlaneCurve(A, F)

--- a/src/sage/schemes/curves/constructor.py
+++ b/src/sage/schemes/curves/constructor.py
@@ -37,24 +37,20 @@ AUTHORS:
 # ********************************************************************
 
 from sage.categories.fields import Fields
+from sage.categories.number_fields import NumberFields
 
 from sage.rings.polynomial.multi_polynomial import MPolynomial
 from sage.rings.polynomial.multi_polynomial_ring import is_MPolynomialRing
 from sage.rings.finite_rings.finite_field_base import FiniteField
-
 from sage.rings.rational_field import QQ
 
 from sage.structure.all import Sequence
 
-from sage.schemes.affine.affine_space import is_AffineSpace
 from sage.schemes.generic.ambient_space import is_AmbientSpace
 from sage.schemes.generic.algebraic_scheme import is_AlgebraicScheme
-from sage.schemes.projective.projective_space import is_ProjectiveSpace
-
-from sage.schemes.affine.affine_space import AffineSpace
-
-from sage.schemes.projective.projective_space import ProjectiveSpace
-
+from sage.schemes.affine.affine_space import AffineSpace, is_AffineSpace
+from sage.schemes.projective.projective_space import ProjectiveSpace, is_ProjectiveSpace
+from sage.schemes.plane_conics.constructor import Conic
 
 from .projective_curve import (ProjectiveCurve,
                                ProjectivePlaneCurve,
@@ -76,8 +72,8 @@ from .affine_curve import (AffineCurve,
                            IntegralAffinePlaneCurve,
                            IntegralAffinePlaneCurve_finite_field)
 
-
-from sage.schemes.plane_conics.constructor import Conic
+_Fields = Fields()
+_NumberFields = NumberFields()
 
 
 def _is_irreducible_and_reduced(F) -> bool:
@@ -113,11 +109,13 @@ def Curve(F, A=None):
 
     INPUT:
 
-    - ``F`` -- a multivariate polynomial, or a list or tuple of polynomials, or an algebraic scheme.
+    - ``F`` -- a multivariate polynomial, or a list or tuple of polynomials, or an algebraic scheme
 
-    - ``A`` -- (default: None) an ambient space in which to create the curve.
+    - ``A`` -- (default: None) an ambient space in which to create the curve
 
-    EXAMPLES: A projective plane curve.  ::
+    EXAMPLES:
+
+    A projective plane curve::
 
         sage: x,y,z = QQ['x,y,z'].gens()
         sage: C = Curve(x^3 + y^3 + z^3); C
@@ -215,7 +213,7 @@ def Curve(F, A=None):
         sage: Curve(P1)
         Projective Line over Finite Field of size 5
 
-    ::
+    An affine line::
 
         sage: A1.<x> = AffineSpace(1, QQ)
         sage: R = A1.coordinate_ring()
@@ -224,6 +222,18 @@ def Curve(F, A=None):
         sage: Curve(A1)
         Affine Line over Rational Field
 
+    A projective line::
+
+        sage: R.<x> = QQ[]
+        sage: N.<a> = NumberField(x^2 + 1)
+        sage: P1.<x,y> = ProjectiveSpace(N, 1)
+        sage: C = Curve(P1)
+        sage: C
+        Projective Line over Number Field in a with defining polynomial x^2 + 1
+        sage: C.geometric_genus()
+        0
+        sage: C.arithmetic_genus()
+        0
     """
     if A is None:
         if is_AmbientSpace(F) and F.dimension() == 1:
@@ -298,12 +308,20 @@ def Curve(F, A=None):
     k = A.base_ring()
 
     if is_AffineSpace(A):
+        if n == 1:
+            if A.coordinate_ring().ideal(F).is_zero():
+                if isinstance(k, FiniteField):
+                    return IntegralAffineCurve_finite_field(A, F)
+                if k in _Fields:
+                    return IntegralAffineCurve(A, F)
+                return AffineCurve(A, F)
+            raise TypeError(f"{F} does not define a curve in one-dimensional affine space")
         if n != 2:
             if isinstance(k, FiniteField):
                 if A.coordinate_ring().ideal(F).is_prime():
                     return IntegralAffineCurve_finite_field(A, F)
-            if k in Fields():
-                if k == QQ and A.coordinate_ring().ideal(F).is_prime():
+            if k in _Fields:
+                if (k == QQ or k in _NumberFields) and A.coordinate_ring().ideal(F).is_prime():
                     return IntegralAffineCurve(A, F)
                 return AffineCurve_field(A, F)
             return AffineCurve(A, F)
@@ -316,21 +334,29 @@ def Curve(F, A=None):
             if _is_irreducible_and_reduced(F):
                 return IntegralAffinePlaneCurve_finite_field(A, F)
             return AffinePlaneCurve_finite_field(A, F)
-        if k in Fields():
-            if k == QQ and _is_irreducible_and_reduced(F):
+        if k in _Fields:
+            if (k == QQ or k in _NumberFields) and _is_irreducible_and_reduced(F):
                 return IntegralAffinePlaneCurve(A, F)
             return AffinePlaneCurve_field(A, F)
         return AffinePlaneCurve(A, F)
 
     elif is_ProjectiveSpace(A):
+        if n == 1:
+            if A.coordinate_ring().ideal(F).is_zero():
+                if isinstance(k, FiniteField):
+                    return IntegralProjectiveCurve_finite_field(A, F)
+                if k in _Fields:
+                    return IntegralProjectiveCurve(A, F)
+                return ProjectiveCurve(A, F)
+            raise TypeError(f"{F} does not define a curve in one-dimensional projective space")
         if n != 2:
             if not all(f.is_homogeneous() for f in F):
                 raise TypeError("polynomials defining a curve in a projective space must be homogeneous")
             if isinstance(k, FiniteField):
                 if A.coordinate_ring().ideal(F).is_prime():
                     return IntegralProjectiveCurve_finite_field(A, F)
-            if k in Fields():
-                if k == QQ and A.coordinate_ring().ideal(F).is_prime():
+            if k in _Fields:
+                if (k == QQ or k in _NumberFields) and A.coordinate_ring().ideal(F).is_prime():
                     return IntegralProjectiveCurve(A, F)
                 return ProjectiveCurve_field(A, F)
             return ProjectiveCurve(A, F)
@@ -348,8 +374,8 @@ def Curve(F, A=None):
             if _is_irreducible_and_reduced(F):
                 return IntegralProjectivePlaneCurve_finite_field(A, F)
             return ProjectivePlaneCurve_finite_field(A, F)
-        if k in Fields():
-            if k == QQ and _is_irreducible_and_reduced(F):
+        if k in _Fields:
+            if (k == QQ or k in _NumberFields) and _is_irreducible_and_reduced(F):
                 return IntegralProjectivePlaneCurve(A, F)
             return ProjectivePlaneCurve_field(A, F)
         return ProjectivePlaneCurve(A, F)

--- a/src/sage/schemes/curves/curve.py
+++ b/src/sage/schemes/curves/curve.py
@@ -209,17 +209,9 @@ class Curve_generic(AlgebraicScheme_subscheme):
         r"""
         Return the geometric genus of the curve.
 
-        This is by definition the genus of the normalization of the projective
-        closure of the curve over the algebraic closure of the base field; the
-        base field must be a prime field.
-
-        .. NOTE::
-
-            This calls Singular's genus command.
-
         EXAMPLES:
 
-        Examples of projective curves. ::
+        Examples of projective curves::
 
             sage: P2 = ProjectiveSpace(2, GF(5), names=['x','y','z'])
             sage: x, y, z = P2.coordinate_ring().gens()
@@ -233,7 +225,7 @@ class Curve_generic(AlgebraicScheme_subscheme):
             sage: C.geometric_genus()
             3
 
-        Examples of affine curves. ::
+        Examples of affine curves::
 
             sage: x, y = PolynomialRing(GF(5), 2, 'xy').gens()
             sage: C = Curve(y^2 - x^3 - 17*x + y)
@@ -246,12 +238,22 @@ class Curve_generic(AlgebraicScheme_subscheme):
             sage: C.geometric_genus()
             3
 
+        Note that the geometric genus is only defined for `geometrically
+        irreducible curve <https://stacks.math.columbia.edu/tag/0BYE>`_. This
+        method does not check the condition. Be warned that you may get a
+        nonsensical result if the curve is not geometrically irreducible.
+
+        A curve that is not geometrically irreducible::
+
+            sage: P2.<x,y,z> = ProjectiveSpace(QQ, 2)
+            sage: C = Curve(x^2 + y^2, P2)
+            sage: C.geometric_genus()  # nonsense!
+            -1
         """
         try:
             return self._genus
         except AttributeError:
-            self._genus = self.defining_ideal().genus()
-            return self._genus
+            raise NotImplementedError
 
     def union(self, other):
         """

--- a/src/sage/schemes/curves/curve.py
+++ b/src/sage/schemes/curves/curve.py
@@ -238,17 +238,17 @@ class Curve_generic(AlgebraicScheme_subscheme):
             sage: C.geometric_genus()
             3
 
-        Note that the geometric genus is only defined for `geometrically
-        irreducible curve <https://stacks.math.columbia.edu/tag/0BYE>`_. This
-        method does not check the condition. Be warned that you may get a
-        nonsensical result if the curve is not geometrically irreducible.
+        .. WARNING::
 
-        A curve that is not geometrically irreducible::
+            Geometric genus is only defined for `geometrically irreducible curve
+            <https://stacks.math.columbia.edu/tag/0BYE>`_. This method does not
+            check the condition. You may get a nonsensical result if the curve is
+            not geometrically irreducible::
 
-            sage: P2.<x,y,z> = ProjectiveSpace(QQ, 2)
-            sage: C = Curve(x^2 + y^2, P2)
-            sage: C.geometric_genus()  # nonsense!
-            -1
+                sage: P2.<x,y,z> = ProjectiveSpace(QQ, 2)
+                sage: C = Curve(x^2 + y^2, P2)
+                sage: C.geometric_genus()  # nonsense!
+                -1
         """
         try:
             return self._genus

--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -1595,13 +1595,30 @@ class ProjectiveCurve_field(ProjectiveCurve, AlgebraicScheme_subscheme_projectiv
         if not A.base_ring() in Fields():
             raise TypeError("curve not defined over a field")
 
+    @lazy_attribute
+    def _genus(self):
+        """
+        The geometric genus of this projective curve.
+
+        TESTS:
+
+        Geometric genus is not defined for geometrically reducible curves. You
+        may get a nonsensical answer if the condition is not met::
+
+            sage: P2.<x,y,z> = ProjectiveSpace(QQ, 2)
+            sage: C = Curve(x^2 + y^2)
+            sage: C.genus()  # indirect test
+            -1
+        """
+        return self.defining_ideal().genus()
+
     def arithmetic_genus(self):
         r"""
         Return the arithmetic genus of this projective curve.
 
-        This is the arithmetic genus `g_a(C)` as defined in [Har1977]_. If `P` is the
-        Hilbert polynomial of the defining ideal of this curve, then the arithmetic genus
-        of this curve is `1 - P(0)`. This curve must be irreducible.
+        This is the arithmetic genus `p_a(C)` as defined in [Har1977]_. If `P`
+        is the Hilbert polynomial of the defining ideal of this curve, then the
+        arithmetic genus of this curve is `1 - P(0)`.
 
         EXAMPLES::
 
@@ -1617,8 +1634,6 @@ class ProjectiveCurve_field(ProjectiveCurve, AlgebraicScheme_subscheme_projectiv
             sage: C.arithmetic_genus()
             10
         """
-        if not self.is_irreducible():
-            raise TypeError("this curve must be irreducible")
         return 1 - self.defining_ideal().hilbert_polynomial()(0)
 
     def is_complete_intersection(self):
@@ -1687,10 +1702,11 @@ class ProjectivePlaneCurve_field(ProjectivePlaneCurve, ProjectiveCurve_field):
         r"""
         Return the arithmetic genus of this projective curve.
 
-        This is the arithmetic genus `g_a(C)` as defined in [Har1977]_. For a
-        projective plane curve of degree `d`, this is simply `(d-1)(d-2)/2`. It
-        need *not* equal the geometric genus (the genus of the normalization of
-        the curve). This curve must be irreducible.
+        This is the arithmetic genus `p_a(C)` as defined in [Har1977]_.
+
+        For an irreducible projective plane curve of degree `d`, this is simply
+        `(d - 1)(d - 2)/2`. It need *not* equal the geometric genus (the genus
+        of the normalization of the curve).
 
         EXAMPLES::
 
@@ -1700,7 +1716,7 @@ class ProjectivePlaneCurve_field(ProjectivePlaneCurve, ProjectiveCurve_field):
              defined by -x^9 + y^2*z^7 - x*z^8
             sage: C.arithmetic_genus()
             28
-            sage: C.genus()
+            sage: C.genus()  # geometric
             4
 
         ::
@@ -1710,10 +1726,11 @@ class ProjectivePlaneCurve_field(ProjectivePlaneCurve, ProjectiveCurve_field):
             sage: C.arithmetic_genus()
             3
         """
-        if not self.is_irreducible():
-            raise TypeError("this curve must be irreducible")
-        d = self.defining_polynomial().total_degree()
-        return Integer(d - 1).binomial(2)
+        if self.is_irreducible():
+            # use genus-degree formula
+            d = self.defining_polynomial().total_degree()
+            return Integer(d - 1).binomial(2)
+        return super().arithmetic_genus()
 
     def fundamental_group(self):
         r"""
@@ -2290,9 +2307,9 @@ class IntegralProjectiveCurve(ProjectiveCurve_field):
 
         EXAMPLES::
 
-            sage: P.<x,y,z> = ProjectiveSpace(GF(4), 2)                                 # needs sage.rings.finite_rings
-            sage: C = Curve(x^5 + y^5 + x*y*z^3 + z^5)                                  # needs sage.rings.finite_rings
-            sage: C.genus()  # indirect doctest                                         # needs sage.rings.finite_rings
+            sage: P.<x,y,z> = ProjectiveSpace(GF(4), 2)
+            sage: C = Curve(x^5 + y^5 + x*y*z^3 + z^5)
+            sage: C.genus()  # indirect doctest
             1
         """
         return self._open_affine.genus()


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

- make genus method of function fields over number fields work. 
```sage
sage: R.<T> = QQ[]
sage: N.<a> = NumberField(T^2 + 1)
sage: K.<x> = FunctionField(N)
sage: K.genus()
0
sage: S.<t> = PolynomialRing(K)
sage: L.<y> = K.extension(t^2 - x^3 + x)
sage: L.genus()  # not working without this PR
1
```

- allow integral curves to be defined over number fields
- make geometric genus method of integral curves defined over number fields work
```sage
sage: R.<x> = QQ[]
sage: N.<a> = NumberField(x^2 + 1)
sage: P2.<x,y,z> = ProjectiveSpace(N, 2)
sage: C = Curve(y^2*z - x^3 + x*z^2, P2)
sage: C.geometric_genus() # not working without this PR
1
```

- allow integral curves to be defined from one-dimensional ambient space
```sage
sage: R.<x> = QQ[]
sage: N.<a> = NumberField(x^2 + 1)
sage: P1.<x,y> = ProjectiveSpace(N, 1)
sage: C = Curve(P1)
sage: C.geometric_genus()  # not working without this PR
0
```

- add comments warning for nonsensical result of geometric genus method applied to geometrically-reducible curves
```sage
sage: P2.<x,y,z> = ProjectiveSpace(QQ, 2)
sage: C = Curve(x^2 + y^2, P2)
sage: C.geometric_genus()  # negative geometric genus!
-1
```

- remove unnecessary condition (irreducibility) on arithmetic genus of curves
```sage
sage: P.<x,y,z> = ProjectiveSpace(QQ, 2)
sage: C = Curve(x^2 - y^2, P)
sage: C.is_irreducible()
False
sage: C.arithmetic_genus()  # not working without this PR
0
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


