### PR TITLE
Doctester: Abbreviate tracebacks in warnings

### DIFF
--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -258,8 +258,7 @@ def showwarning_with_traceback(message, category, filename, lineno, file=None, l
 
         sage: from sage.doctest.forker import showwarning_with_traceback
         sage: showwarning_with_traceback("bad stuff", UserWarning, "myfile.py", 0)
-        doctest:warning
-          ...
+        doctest:warning...
           File "<doctest sage.doctest.forker.showwarning_with_traceback[1]>", line 1, in <module>
             showwarning_with_traceback("bad stuff", UserWarning, "myfile.py", Integer(0))
         :

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -271,6 +271,10 @@ def showwarning_with_traceback(message, category, filename, lineno, file=None, l
     # Get traceback to display in warning
     tb = traceback.extract_stack()
     tb = tb[:-1]  # Drop this stack frame for showwarning_with_traceback()
+    for i, frame_summary in enumerate(tb):
+        if frame_summary.filename.endswith('sage/doctest/forker.py') and frame_summary.name == 'compile_and_execute':
+            tb = tb[i + 1:]
+            break
 
     # Format warning
     lines = ["doctest:warning\n"]  # Match historical warning messages in doctests


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Warnings during doctesting show tracebacks that include too much of the irrelevant details of the doctester. In particular, in the CI, where we run the doctester under the Coverage.py framework, we see
```
Failed example:: Got: doctest:warning
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/site-packages/coverage/__main__.py", line 10, in <module>
    sys.exit(main())
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/site-packages/coverage/cmdline.py", line 970, in main
    status = CoverageScript().command_line(argv)
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/site-packages/coverage/cmdline.py", line 681, in command_line
    return self.do_run(options, args)
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/site-packages/coverage/cmdline.py", line 858, in do_run
    runner.run()
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/site-packages/coverage/execfile.py", line 211, in run
    exec(code, main_mod.__dict__)
  File "/sage/src/bin/sage-runtests", line 166, in <module>
    err = DC.run()
  File "/sage/src/sage/doctest/control.py", line 1565, in run
    self.run_doctests()
  File "/sage/src/sage/doctest/control.py", line 1177, in run_doctests
    self.dispatcher.dispatch()
  File "/sage/src/sage/doctest/forker.py", line 2156, in dispatch
    self.parallel_dispatch()
  File "/sage/src/sage/doctest/forker.py", line 2049, in parallel_dispatch
    w.start()  # This might take some time
  File "/sage/src/sage/doctest/forker.py", line 2329, in start
    super().start()
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/multiprocessing/context.py", line 281, in _Popen
    return Popen(process_obj)
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/multiprocessing/popen_fork.py", line 71, in _launch
    code = process_obj._bootstrap(parent_sentinel=child_r)
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/site-packages/coverage/multiproc.py", line 50, in _bootstrap
    return original_bootstrap(self, *args, **kwargs)
  File "/sage/local/var/lib/sage/venv-python3.11.1/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/sage/src/sage/doctest/forker.py", line 2300, in run
    task(self.options, self.outtmpfile, msgpipe, self.result_queue,
  File "/sage/src/sage/doctest/forker.py", line 2622, in __call__
    doctests, extras = self._run(runner, options, results)
  File "/sage/src/sage/doctest/forker.py", line 2670, in _run
    result = runner.run(test)
  File "/sage/src/sage/doctest/forker.py", line 911, in run
    return self._run(test, compileflags, out)
  File "/sage/src/sage/doctest/forker.py", line 712, in _run
    self.compile_and_execute(example, compiler, test.globs)
  File "/sage/src/sage/doctest/forker.py", line 1147, in compile_and_execute
    exec(compiled, globs)
  File "<doctest sage.combinat.chas.fsym.FreeSymmetricFunctions[7]>", line 1, in <module>
    all(FF(G[t].coproduct()) == F(G[t]).coproduct()
  File "<doctest sage.combinat.chas.fsym.FreeSymmetricFunctions[7]>", line 1, in <genexpr>
    all(FF(G[t].coproduct()) == F(G[t]).coproduct()
  File "/sage/src/sage/categories/coalgebras.py", line 124, in coproduct
    return self.parent().coproduct(self)
  File "/sage/src/sage/modules/with_basis/morphism.py", line 404, in __call__
    return self.codomain().linear_combination(
  File "/sage/src/sage/combinat/free_module.py", line 1067, in linear_combination
    return self._from_dict(blas.linear_combination(((element._monomial_coefficients, coeff)
  File "/sage/src/sage/combinat/free_module.py", line 1067, in <genexpr>
    return self._from_dict(blas.linear_combination
```

Here we omit all of the irrelevant frames.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


