### PR TITLE
Workaround warning in cython 3.0.9 (#37560)

### DIFF
--- a/src/sage/misc/cython.py
+++ b/src/sage/misc/cython.py
@@ -236,7 +236,7 @@ def cython(filename, verbose=0, compile_message=False,
         ...
         RuntimeError: Error compiling Cython file:
         ...
-        ...: 'sage/misc.pxd' not found
+        ...: 'sage/misc.pxd' not found...
     """
     if not filename.endswith('pyx'):
         print("Warning: file (={}) should have extension .pyx".format(filename), file=sys.stderr)
@@ -380,6 +380,12 @@ def cython(filename, verbose=0, compile_message=False,
         cython_messages = re.sub(
             "^.*The keyword 'nogil' should appear at the end of the function signature line. "
             "Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.\n",
+            "", cython_messages, 0, re.MULTILINE)
+
+        # workaround for https://github.com/sagemath/sage/issues/37560
+        # triggered by Cython 3.0.9
+        cython_messages = re.sub(
+            "^warning: .*noexcept clause is ignored for function returning Python object\n",
             "", cython_messages, 0, re.MULTILINE)
 
         sys.stderr.write(cython_messages)


### PR DESCRIPTION
A new warning in cython 3.0.9 breaks doctests https://github.com/cython/cython/pull/5999.

We filter this warning at runtime, as a quick workaround for 10.3.

For the future, we will need to remove the `noexcept` in question. Note that these were mostly added in #36507 guided by a different warning which is not quite right (see https://github.com/cython/cython/pull/5999#issuecomment-1986868208).

This has to be done with some care: about 2/3rds of the `noexcept` have to be removed, but the other 1/3rd has to be kept. These changes are no-ops as long as we use `legacy_implicit_noexcept=True` but it's important to get it right before removing the legacy option. Hopefully we'll soon have a version of cython which gives correct warnings so it's possible to eliminate both types of warnings. Once there are no warnings left, we can proceed to remove the legacy option.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.

Fixes: #37560