### PR TITLE
Update Conda installation instructions to use Miniforge

### DIFF
--- a/src/doc/en/installation/conda.rst
+++ b/src/doc/en/installation/conda.rst
@@ -9,17 +9,17 @@ SageMath can be installed on Linux and macOS via Conda from the
 Both the ``x86_64`` (Intel) architecture and the ``arm64``/``aarch64``
 architectures (including Apple Silicon, M1) are supported.
 
-You will need a working Conda installation: either Mambaforge/Miniforge,
+You will need a working Conda installation: either Miniforge (or Mambaforge),
 Miniconda or Anaconda. If you don't have one yet, we recommend installing
-`Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_ as
+`Miniforge <https://github.com/conda-forge/miniforge>`_ as
 follows. In a terminal,
 
 .. code-block:: shell
 
-   $ curl -L -O https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh
-   $ sh Mambaforge-$(uname)-$(uname -m).sh
+   $ curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+   $ bash Miniforge3-$(uname)-$(uname -m).sh
 
-* Mambaforge and Miniforge use conda-forge as the default channel.
+* Miniforge (and Mambaforge) use conda-forge as the default channel.
 
 * If you are using Miniconda or Anaconda, set it up to use conda-forge:
 
@@ -27,14 +27,9 @@ follows. In a terminal,
 
   * Change channel priority to strict: ``conda config --set channel_priority strict``
 
-Optionally, use `mamba <https://github.com/mamba-org/mamba>`_,
+If you installed Miniforge (or Mambaforge), we recommend to use 
+`mamba <https://mamba.readthedocs.io/en/latest/index.html>`_ in the following, 
 which uses a faster dependency solver than ``conda``.
-If you installed Mambaforge, it is already provided. Otherwise, use
-
-.. code-block:: shell
-
-   $ conda install mamba
-
 
 .. _sec-installation-conda-binary:
 
@@ -43,10 +38,17 @@ Installing all of SageMath from conda (not for development)
 
 Create a new conda environment containing SageMath, either with ``mamba`` or ``conda``:
 
-.. code-block:: shell
+.. tab:: mamba
 
-    $ mamba create -n sage sage python=X        # either
-    $ conda create -n sage sage python=X        # or
+  .. code-block:: shell
+
+      $ mamba create -n sage sage python=X
+
+.. tab:: conda
+
+  .. code-block:: shell
+
+      $ conda create -n sage sage python=X
 
 where ``X`` is version of Python, e.g. ``3.9``.
 
@@ -109,17 +111,22 @@ Here we assume that you are using a git checkout.
 
       $ export SAGE_NUM_THREADS=24
 
-  - As a recommended step, install the ``mamba`` package manager. If
-    you skip this step, replace ``mamba`` by ``conda`` in the
-    following steps::
-
-      $ conda install mamba
-
   - Create and activate a new conda environment with the dependencies of Sage
     and a few additional developer tools::
 
-      $ mamba env create --file src/environment-dev-3.11-linux.yml --name sage-dev
-      $ conda activate sage-dev
+      .. tab:: mamba
+      
+        .. code-block:: shell
+      
+            $ mamba env create --file src/environment-dev-3.11-linux.yml --name sage-dev
+            $ conda activate sage-dev
+      
+      .. tab:: conda
+      
+        .. code-block:: shell
+      
+            $ conda env create --file src/environment-dev-3.11-linux.yml --name sage-dev
+            $ conda activate sage-dev
 
     Alternatively, you can use ``src/environment-3.11-linux.yml`` or
     ``src/environment-optional-3.11-linux.yml``, which will only install standard


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Based on the discussion in https://groups.google.com/g/sage-devel/c/GaQHdu0Q6UU and https://github.com/sagemath/sage/pull/37184, we now follow the offical recommendation and use Miniforge over the  soft-deprecated Mambaforge. Since we are exclusively testing on miniforge, this change also aligns the docs with the ci. 
 
Moreover, I've removed the recommendation to install mamba (using `conda install mamba`) which is not recommended according to the [offical docs](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html#existing-conda-install-not-recommended).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


