### PR TITLE
Sphinx extlinks for ecl, gap, giac, maxima, meson, ppl, qepcad, scip, singular, soplex

### DIFF
--- a/src/doc/en/developer/sage_manuals.rst
+++ b/src/doc/en/developer/sage_manuals.rst
@@ -144,8 +144,8 @@ by Sage, you can link toward it without specifying its full path:
      - :gap:`Groups <chap39>`
 
    * -
-     - ``:gap_package:`guava```
-     - :gap_package:`guava`
+     - ``:gap_package:`GAP package QuaGroup <quagroup/doc/chap0_mj.html>```
+     - :gap_package:`GAP package QuaGroup <quagroup/doc/chap0_mj.html>`
 
    * - :ref:`Giac <spkg_giac>`
      - ``:giac_cascmd:`gbasis <node280>```

--- a/src/doc/en/developer/sage_manuals.rst
+++ b/src/doc/en/developer/sage_manuals.rst
@@ -159,21 +159,37 @@ by Sage, you can link toward it without specifying its full path:
      - ``:maxima:`struve_h <index-struve_005fh>```
      - :maxima:`struve_h <index-struve_005fh>`
 
+   * - :ref:`Meson <spkg_meson>`
+     - ``:meson:`install_subdir <Reference-manual_functions.html#install_subdir>```
+     - :meson:`install_subdir <Reference-manual_functions.html#install_subdir>`
+
    * - :ref:`Pari <spkg_pari>`
      - ``:pari:`lfungenus2```
      - :pari:`lfungenus2`
 
+   * - :ref:`polymake <spkg_polymake>`
+     - ``:polymake:`matroid```
+     - :polymake:`matroid`
+
    * - :ref:`PPL <spkg_ppl>`
-     - ``:ppl:`Linear_Expression <classParma__Polyhedra__Library_1_1Linear__Expression>```
+     - ``:ppl:`Linear_Expression <classParma__Polyhedra__Library_1_1 Linear__Expression>```
      - :ppl:`Linear_Expression <classParma__Polyhedra__Library_1_1Linear__Expression>`
 
    * - :ref:`QEPCAD <spkg_qepcad>`
      - ``:qepcad:`QEPCAD: Entering formulas <user/EnterForm>```
      - :qepcad:`QEPCAD: Entering formulas <user/EnterForm>`
 
+   * - :ref:`SCIP <spkg_scip>`
+     - ``:scip:`SCIPsolve <group__PublicSolveMethods>```
+     - :scip:`SCIPsolve <group__PublicSolveMethods>`
+
    * - :ref:`Singular <spkg_singular>`
      - ``:singular:`stdfglm <sing_358>```
      - :singular:`stdfglm <sing_358>`
+
+   * - :ref:`SoPlex <spkg_soplex>`
+     - ``:soplex:`soplex::LinSolverRational <classsoplex_1_1SLinSolverRational>```
+     - :soplex:`soplex::LinSolverRational <classsoplex_1_1SLinSolverRational>`
 
 **http links:** copy/pasting a http link in the documentation works. If you want
 a specific link name, use ```link name <http://www.example.com>`_``

--- a/src/doc/en/developer/sage_manuals.rst
+++ b/src/doc/en/developer/sage_manuals.rst
@@ -131,6 +131,30 @@ by Sage, you can link toward it without specifying its full path:
      - ``:mathscinet:`MR0100971```
      - :mathscinet:`MR0100971`
 
+   * - :ref:`Giac <spkg_giac>`
+     - ``:giac_cascmd:`gbasis <node280>```
+     - :giac_cascmd:`gbasis <node280>`
+
+   * -
+     - ``:giac_us:`Unary-functions```
+     - :giac_us:`Unary-functions`
+
+   * - :ref:`Maxima <spkg_maxima>`
+     - ``:maxima:`struve_h <index-struve_005fh>```
+     - :maxima:`struve_h <index-struve_005fh>`
+
+   * - :ref:`Pari <spkg_pari>`
+     - ``:pari:`lfungenus2```
+     - :pari:`lfungenus2`
+
+   * - :ref:`PPL <spkg_ppl>`
+     - ``:ppl:`Linear_Expression <classParma__Polyhedra__Library_1_1Linear__Expression>```
+     - :ppl:`Linear_Expression <classParma__Polyhedra__Library_1_1Linear__Expression>`
+
+   * - :ref:`Singular <spkg_singular>`
+     - ``:singular:`stdfglm <sing_358>```
+     - :singular:`stdfglm <sing_358>`
+
 **http links:** copy/pasting a http link in the documentation works. If you want
 a specific link name, use ```link name <http://www.example.com>`_``
 

--- a/src/doc/en/developer/sage_manuals.rst
+++ b/src/doc/en/developer/sage_manuals.rst
@@ -131,6 +131,14 @@ by Sage, you can link toward it without specifying its full path:
      - ``:mathscinet:`MR0100971```
      - :mathscinet:`MR0100971`
 
+   * - :ref:`GAP <spkg_gap>`
+     - ``:gap:`Groups <chap39>```
+     - :gap:`Groups <chap39>`
+
+   * -
+     - ``:gap_package:`guava```
+     - :gap_package:`guava`
+
    * - :ref:`Giac <spkg_giac>`
      - ``:giac_cascmd:`gbasis <node280>```
      - :giac_cascmd:`gbasis <node280>`

--- a/src/doc/en/developer/sage_manuals.rst
+++ b/src/doc/en/developer/sage_manuals.rst
@@ -131,6 +131,14 @@ by Sage, you can link toward it without specifying its full path:
      - ``:mathscinet:`MR0100971```
      - :mathscinet:`MR0100971`
 
+   * - :ref:`ECL <spkg_ecl>`
+     - ``:ecl:`Manipulating-Lisp-objects```
+     - :ecl:`Manipulating-Lisp-objects`
+
+   * -
+     - ``:common_lisp:`RENAME-PACKAGE <f_rn_pkg>```
+     - :common_lisp:`RENAME-PACKAGE <f_rn_pkg>`
+
    * - :ref:`GAP <spkg_gap>`
      - ``:gap:`Groups <chap39>```
      - :gap:`Groups <chap39>`
@@ -158,6 +166,10 @@ by Sage, you can link toward it without specifying its full path:
    * - :ref:`PPL <spkg_ppl>`
      - ``:ppl:`Linear_Expression <classParma__Polyhedra__Library_1_1Linear__Expression>```
      - :ppl:`Linear_Expression <classParma__Polyhedra__Library_1_1Linear__Expression>`
+
+   * - :ref:`QEPCAD <spkg_qepcad>`
+     - ``:qepcad:`QEPCAD: Entering formulas <user/EnterForm>```
+     - :qepcad:`QEPCAD: Entering formulas <user/EnterForm>`
 
    * - :ref:`Singular <spkg_singular>`
      - ``:singular:`stdfglm <sing_358>```

--- a/src/sage/algebras/quantum_groups/quantum_group_gap.py
+++ b/src/sage/algebras/quantum_groups/quantum_group_gap.py
@@ -6,9 +6,8 @@ AUTHORS:
 
 - Travis Scrimshaw (03-2017): initial version
 
-The documentation for GAP's QuaGroup package, originally authored by
-Willem Adriaan de Graaf, can be found at
-https://www.gap-system.org/Packages/quagroup.html.
+See the :gap_package:`documentation for GAP's QuaGroup package <quagroup/doc/chap0_mj.html>`,
+originally authored by Willem Adriaan de Graaf.
 """
 
 # ****************************************************************************

--- a/src/sage/combinat/designs/incidence_structures.py
+++ b/src/sage/combinat/designs/incidence_structures.py
@@ -1810,8 +1810,7 @@ class IncidenceStructure:
 
         REFERENCE:
 
-        - Soicher, Leonard, Design package manual, available at
-          https://www.gap-system.org/Manuals/pkg/design/htm/CHAP003.htm
+        - Soicher, Leonard, :gap_package:`Design package manual <design/htm/CHAP003.htm>`
         """
         if algorithm == "gap":
             libgap.load_package("design")

--- a/src/sage/combinat/designs/incidence_structures.py
+++ b/src/sage/combinat/designs/incidence_structures.py
@@ -1810,7 +1810,7 @@ class IncidenceStructure:
 
         REFERENCE:
 
-        - Soicher, Leonard, :gap_package:`Design package manual <design/htm/CHAP003.htm>`
+        - Leonard Soicher, :gap_package:`Design package manual <design/htm/CHAP003.htm>`
         """
         if algorithm == "gap":
             libgap.load_package("design")

--- a/src/sage/groups/cubic_braid.py
+++ b/src/sage/groups/cubic_braid.py
@@ -274,8 +274,8 @@ class CubicBraidElement(FinitelyPresentedGroupElement):
         :class:`FinitelyPresentedGroupElement` (via Gap) does not terminate
         in the case of more than 5 strands (not only infinite cases).
         On less than 5 strands comparison is not assumed to be deterministic
-        (see the :issue:`33498` and section 47.3-2 of the
-        `Gap Reference manual <https://www.gap-system.org/Manuals/doc/ref/chap47.html>`__).
+        (see the :issue:`33498` and :gap:`section 47.3-2 of the
+        Gap Reference manual <chap47>`).
 
         Therefore, the comparison is done via the Burau representation.
 

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -1611,8 +1611,7 @@ def structure_description(G, latex=False):
     This methods wraps GAP's ``StructureDescription`` method.
 
     For full details, including the form of the returned string and the
-    algorithm to build it, see `GAP's documentation
-    <https://www.gap-system.org/Manuals/doc/ref/chap39.html>`_.
+    algorithm to build it, see :gap:`GAP's documentation <chap39>`.
 
     INPUT:
 

--- a/src/sage/groups/matrix_gps/finitely_generated_gap.py
+++ b/src/sage/groups/matrix_gps/finitely_generated_gap.py
@@ -223,8 +223,7 @@ class FinitelyGeneratedMatrixGroup_gap(MatrixGroup_gap):
         Type ``G.module_composition_factors(algorithm='verbose')`` to get a
         more verbose version.
 
-        For more on MeatAxe notation, see
-        https://www.gap-system.org/Manuals/doc/ref/chap69.html
+        For more on MeatAxe notation, see :gap:`chap69`.
         """
         from sage.libs.gap.libgap import libgap
         F = self.base_ring()

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -188,8 +188,8 @@ cdef initialize() noexcept:
     """
     Initialize the GAP library, if it hasn't already been
     initialized.  It is safe to call this multiple times. One can set
-    :envvar:`SAGE_GAP_MEMORY` to a particular value, as desribed in
-    `GAP Manual <https://www.gap-system.org/Manuals/doc/ref/chap3.html>`_
+    :envvar:`SAGE_GAP_MEMORY` to a particular value, as described in
+    the :gap:`GAP Manual <chap3>`.
     Specifically, the value is for `-s` and `-o` options.
 
     TESTS::

--- a/src/sage/misc/sagedoc.py
+++ b/src/sage/misc/sagedoc.py
@@ -517,7 +517,7 @@ extlinks = {
     'common_lisp': ('https://www.lispworks.com/documentation/lw50/CLHS/Body/%s.htm', 'Common Lisp: %s'),
     'ecl': ('https://ecl.common-lisp.dev/static/manual/%s.html', 'ECL: %s'),
     'gap': ('https://docs.gap-system.org/doc/ref/%s_mj.html', 'GAP: %s'),
-    'gap_package': ('https://www.gap-system.org/Packages/%s.html', 'GAP package %s'),
+    'gap_package': ('https://docs.gap-system.org/pkg/%s', 'GAP package %s'),
     'giac_cascmd': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac/doc/en/cascmd_en/%s.html', 'Giac: %s'),
     'giac_us': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac_us.html#%s', 'Giac API: %s'),
     'maxima': ('https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#%s', 'Maxima: %s'),

--- a/src/sage/misc/sagedoc.py
+++ b/src/sage/misc/sagedoc.py
@@ -516,7 +516,7 @@ extlinks = {
     'mathscinet': ('https://www.ams.org/mathscinet-getitem?mr=%s', 'MathSciNet %s'),
     'common_lisp': ('https://www.lispworks.com/documentation/lw50/CLHS/Body/%s.htm', 'Common Lisp: %s'),
     'ecl': ('https://ecl.common-lisp.dev/static/manual/%s.html', 'ECL: %s'),
-    'gap': ('https://gap-system.org/Manuals/doc/ref/%s_mj.html', 'GAP: %s'),
+    'gap': ('https://docs.gap-system.org/doc/ref/%s_mj.html', 'GAP: %s'),
     'gap_package': ('https://www.gap-system.org/Packages/%s.html', 'GAP package %s'),
     'giac_cascmd': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac/doc/en/cascmd_en/%s.html', 'Giac: %s'),
     'giac_us': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac_us.html#%s', 'Giac API: %s'),

--- a/src/sage/misc/sagedoc.py
+++ b/src/sage/misc/sagedoc.py
@@ -514,12 +514,15 @@ extlinks = {
     'doi': ('https://doi.org/%s', 'doi:%s'),
     'pari': ('https://pari.math.u-bordeaux.fr/dochtml/help/%s', 'pari:%s'),
     'mathscinet': ('https://www.ams.org/mathscinet-getitem?mr=%s', 'MathSciNet %s'),
+    'common_lisp': ('https://www.lispworks.com/documentation/lw50/CLHS/Body/%s.htm', 'Common Lisp: %s'),
+    'ecl': ('https://ecl.common-lisp.dev/static/manual/%s.html', 'ECL: %s'),
     'gap': ('https://gap-system.org/Manuals/doc/ref/%s_mj.html', 'GAP: %s'),
     'gap_package': ('https://www.gap-system.org/Packages/%s.html', 'GAP package %s'),
     'giac_cascmd': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac/doc/en/cascmd_en/%s.html', 'Giac: %s'),
     'giac_us': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac_us.html#%s', 'Giac API: %s'),
     'maxima': ('https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#%s', 'Maxima: '),
     'ppl': ('https://www.bugseng.com/products/ppl/documentation/user/ppl-user-1.2-html/%s.html', 'PPL: %s'),
+    'qepcad': ('https://www.usna.edu/CS/qepcadweb/B/%s.html', 'QEPCAD: %s'),
     'singular': ('https://www.singular.uni-kl.de/Manual/4-3-2/%s.htm', 'Singular: %s'),
 
 }

--- a/src/sage/misc/sagedoc.py
+++ b/src/sage/misc/sagedoc.py
@@ -520,11 +520,14 @@ extlinks = {
     'gap_package': ('https://www.gap-system.org/Packages/%s.html', 'GAP package %s'),
     'giac_cascmd': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac/doc/en/cascmd_en/%s.html', 'Giac: %s'),
     'giac_us': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac_us.html#%s', 'Giac API: %s'),
-    'maxima': ('https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#%s', 'Maxima: '),
+    'maxima': ('https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#%s', 'Maxima: %s'),
+    'meson': ('https://mesonbuild.com/%s', 'Meson: %s'),
+    'polymake': ('https://polymake.org/doku.php/documentation/latest/%s', 'polymake: %s'),
     'ppl': ('https://www.bugseng.com/products/ppl/documentation/user/ppl-user-1.2-html/%s.html', 'PPL: %s'),
     'qepcad': ('https://www.usna.edu/CS/qepcadweb/B/%s.html', 'QEPCAD: %s'),
+    'scip': ('https://scipopt.org/doc/html/%s.php', 'SCIP: %s'),
     'singular': ('https://www.singular.uni-kl.de/Manual/4-3-2/%s.htm', 'Singular: %s'),
-
+    'soplex': ('https://soplex.zib.de/doc/html/%s.php', 'SoPlex: %s'),
 }
 
 

--- a/src/sage/misc/sagedoc.py
+++ b/src/sage/misc/sagedoc.py
@@ -514,6 +514,8 @@ extlinks = {
     'doi': ('https://doi.org/%s', 'doi:%s'),
     'pari': ('https://pari.math.u-bordeaux.fr/dochtml/help/%s', 'pari:%s'),
     'mathscinet': ('https://www.ams.org/mathscinet-getitem?mr=%s', 'MathSciNet %s'),
+    'gap': ('https://gap-system.org/Manuals/doc/ref/%s_mj.html', 'GAP: %s'),
+    'gap_package': ('https://www.gap-system.org/Packages/%s.html', 'GAP package %s'),
     'giac_cascmd': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac/doc/en/cascmd_en/%s.html', 'Giac: %s'),
     'giac_us': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac_us.html#%s', 'Giac API: %s'),
     'maxima': ('https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#%s', 'Maxima: '),

--- a/src/sage/misc/sagedoc.py
+++ b/src/sage/misc/sagedoc.py
@@ -513,7 +513,13 @@ extlinks = {
     'oeis': ('https://oeis.org/%s', 'OEIS sequence %s'),
     'doi': ('https://doi.org/%s', 'doi:%s'),
     'pari': ('https://pari.math.u-bordeaux.fr/dochtml/help/%s', 'pari:%s'),
-    'mathscinet': ('https://www.ams.org/mathscinet-getitem?mr=%s', 'MathSciNet %s')
+    'mathscinet': ('https://www.ams.org/mathscinet-getitem?mr=%s', 'MathSciNet %s'),
+    'giac_cascmd': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac/doc/en/cascmd_en/%s.html', 'Giac: %s'),
+    'giac_us': ('https://www-fourier.ujf-grenoble.fr/~parisse/giac_us.html#%s', 'Giac API: %s'),
+    'maxima': ('https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#%s', 'Maxima: '),
+    'ppl': ('https://www.bugseng.com/products/ppl/documentation/user/ppl-user-1.2-html/%s.html', 'PPL: %s'),
+    'singular': ('https://www.singular.uni-kl.de/Manual/4-3-2/%s.htm', 'Singular: %s'),
+
 }
 
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

We create a standard way to refer to the online manuals of these packages, which are generated by tools other than Sphinx and therefore cannot be linked to using Intersphinx.

This extends what has been already done with Pari.

Examples:
- [Examples in the Developer Guide](https://deploy-preview-37598--sagemath.netlify.app/html/en/developer/sage_manuals#hyperlinks)

Fixes #27495.

Outside of the scope of this PR:
- adding such extlinks everywhere
- working with upstream projects to upgrade to better documentation tools
- projects that can be linked to using Intersphinx; that's #37575
- any consideration how to link instead to local copies of those manuals, whether installed from SPKG or system packages.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


