### PR TITLE
`graphs.triangulations(3)` cannot return a triangle

### DIFF
--- a/src/sage/graphs/graph_generators.py
+++ b/src/sage/graphs/graph_generators.py
@@ -2237,6 +2237,12 @@ class GraphGenerators:
             sage: g.is_isomorphic(graphs.OctahedralGraph())           # optional - plantri
             True
 
+        The minimum degree of a triangulation is 3, so the method can not output
+        a triangle::
+
+            sage: list(graphs.triangulations(3))                      # optional - plantri
+            []
+
         An overview of the number of 5-connected triangulations on up to 22 vertices. This
         agrees with :oeis:`A081621`::
 


### PR DESCRIPTION
Fixes #37562.

As proposed in https://github.com/sagemath/sage/issues/37562#issuecomment-1993924068, this PR adds a doctest showing that `graphs.triangulations(3)` returns nothing.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


