### PR TITLE
use strings as label in modular-decomposition trees

### DIFF
--- a/src/sage/combinat/rooted_tree.py
+++ b/src/sage/combinat/rooted_tree.py
@@ -191,7 +191,7 @@ class RootedTree(AbstractClonableTree, NormalizedClonableList,
         try:
             children = list(children)
         except TypeError:
-            raise TypeError("input ({}) is not a valid tree".format(children))
+            raise TypeError(f"input ({children}) is not a valid tree")
         #if not (children.__class__ is self.__class__
         #        and children.parent() == parent):
         children = [self.__class__(parent, x) for x in children]
@@ -215,7 +215,7 @@ class RootedTree(AbstractClonableTree, NormalizedClonableList,
         .. NOTE::
 
             The tree ``self`` must be normalized before calling this
-            method (see :meth:`normalize`). This doesn't matter
+            method (see :meth:`normalize`). This does not matter
             unless you are inside the :meth:`clone` context manager,
             because outside of it every rooted tree is already
             normalized.
@@ -813,6 +813,10 @@ class LabelledRootedTree(AbstractLabelledClonableTree, RootedTree):
 
     - ``label`` -- any hashable Sage object (default is ``None``)
 
+    .. NOTE::
+
+        It is required that all labels are comparable.
+
     EXAMPLES::
 
         sage: x = LabelledRootedTree([], label = 3); x
@@ -904,7 +908,7 @@ class LabelledRootedTree(AbstractLabelledClonableTree, RootedTree):
         .. NOTE::
 
             The tree ``self`` must be normalized before calling this
-            method (see :meth:`normalize`). This doesn't matter
+            method (see :meth:`normalize`). This does not matter
             unless you are inside the :meth:`clone` context manager,
             because outside of it every rooted tree is already
             normalized.

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -8096,7 +8096,7 @@ class Graph(GenericGraph):
 
             sage: G = Graph('GxJEE?')
             sage: G.modular_decomposition(style='tree')
-            PRIME[2[], PARALLEL[3[], 4[]], SERIES[0[], 1[]],
+            PRIME[2[], SERIES[0[], 1[]], PARALLEL[3[], 4[]],
                   PARALLEL[5[], 6[], 7[]]]
         """
         from sage.graphs.graph_decompositions.modular_decomposition import (NodeType,
@@ -8137,7 +8137,7 @@ class Graph(GenericGraph):
                 if x.node_type == NodeType.NORMAL:
                     return LabelledRootedTree([], label=str(x.children[0]))
                 return LabelledRootedTree([to_tree(y) for y in x.children],
-                                          label=str(x.node_type))
+                                          label=x.node_type)
 
             return to_tree(D)
 

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -8135,7 +8135,7 @@ class Graph(GenericGraph):
 
             def to_tree(x):
                 if x.node_type == NodeType.NORMAL:
-                    return LabelledRootedTree([], label=str(x.children[0]))
+                    return LabelledRootedTree([], label=x.children[0])
                 return LabelledRootedTree([to_tree(y) for y in x.children],
                                           label=x.node_type)
 
@@ -8144,7 +8144,7 @@ class Graph(GenericGraph):
         raise ValueError("style must be 'tuple' or 'tree'")
 
     @doc_index("Graph properties")
-    def is_polyhedral(self):
+    def is_polyhedral(self) -> bool:
         """
         Check whether the graph is the graph of the polyhedron.
 

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -8091,6 +8091,13 @@ class Graph(GenericGraph):
             (PRIME, [1, 2, 5, 6, 0, (PARALLEL, [3, 4])])
             sage: G2.modular_decomposition()
             (PRIME, [5, 6, 3, 4, 2, (PARALLEL, [0, 1])])
+
+        Check that :issue:`37631` is fixed::
+
+            sage: G = Graph('GxJEE?')
+            sage: G.modular_decomposition(style='tree')
+            PRIME[2[], PARALLEL[3[], 4[]], SERIES[0[], 1[]],
+                  PARALLEL[5[], 6[], 7[]]]
         """
         from sage.graphs.graph_decompositions.modular_decomposition import (NodeType,
                                                                             habib_maurer_algorithm,
@@ -8128,8 +8135,9 @@ class Graph(GenericGraph):
 
             def to_tree(x):
                 if x.node_type == NodeType.NORMAL:
-                    return LabelledRootedTree([], label=x.children[0])
-                return LabelledRootedTree([to_tree(y) for y in x.children], label=x.node_type)
+                    return LabelledRootedTree([], label=str(x.children[0]))
+                return LabelledRootedTree([to_tree(y) for y in x.children],
+                                          label=str(x.node_type))
 
             return to_tree(D)
 

--- a/src/sage/graphs/graph_decompositions/modular_decomposition.py
+++ b/src/sage/graphs/graph_decompositions/modular_decomposition.py
@@ -11,10 +11,10 @@ of undirected graphs.
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from enum import Enum
+from enum import Enum, IntEnum
 
 from sage.misc.lazy_import import lazy_import
 from sage.misc.random_testing import random_testing
@@ -22,7 +22,7 @@ from sage.misc.random_testing import random_testing
 lazy_import('sage.groups.perm_gps.permgroup_element', 'PermutationGroupElement')
 
 
-class NodeType(Enum):
+class NodeType(IntEnum):
     """
     NodeType is an enumeration class used to define the various types of nodes
     in modular decomposition tree.
@@ -45,7 +45,7 @@ class NodeType(Enum):
     NORMAL = 3
     FOREST = -1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         r"""
         String representation of this node type.
 


### PR DESCRIPTION
Fixing #37631

and adding a note saying that labels of rooted trees must be comparable

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.



