### PR TITLE
`sage.doctest`: Remove most uses of SAGE_SRC in doctests

### DIFF
--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -1102,9 +1102,7 @@ class DocTestController(SageObject):
         EXAMPLES::
 
             sage: from sage.doctest.control import DocTestDefaults, DocTestController
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','util.py')
+            sage: filename = sage.doctest.util.__file__
             sage: DD = DocTestDefaults()
             sage: DC = DocTestController(DD, [filename])
             sage: DC.expand_files_into_sources()

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -575,11 +575,10 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD, optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: DTR.run(doctests[0], clear_globs=False) # indirect doctest
             TestResults(failed=0, attempted=4)
@@ -876,12 +875,11 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD,
             ....:                         optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: DTR.run(doctests[0], clear_globs=False)
             TestResults(failed=0, attempted=4)
@@ -1021,11 +1019,10 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os, hashlib
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD, optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: DTR.running_global_digest.hexdigest()
             'd41d8cd98f00b204e9800998ecf8427e'
@@ -1083,12 +1080,11 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.util import RecordingDict
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os, hashlib
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD,
             ....:           optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
             sage: DTR.running_doctest_digest = hashlib.md5()
-            sage: filename = os.path.join(SAGE_SRC, 'sage', 'doctest', 'forker.py')
+            sage: filename = sage.doctest.forker.__file__
             sage: FDS = FileDocTestSource(filename, DD)
             sage: globs = RecordingDict(globals())
             sage: 'doctest_var' in globs
@@ -1203,11 +1199,10 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD, optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
             sage: print(DTR._failure_header(doctests[0], ex))
@@ -1315,11 +1310,10 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=True, sage_options=DD, optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
             sage: DTR.report_start(sys.stdout.write, doctests[0], ex)
@@ -1369,11 +1363,10 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
             sage: from sage.misc.timing import walltime
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=True, sage_options=DD, optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
             sage: ex.walltime = 0.0
@@ -1410,11 +1403,10 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=True, sage_options=DD, optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
             sage: DTR.no_failure_yet = True
@@ -1544,11 +1536,10 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
             sage: from sage.misc.timing import walltime
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=True, sage_options=DD, optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
             sage: ex.walltime = 1.23
@@ -1672,11 +1663,10 @@ class SageDocTestRunner(doctest.DocTestRunner):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.sources import FileDocTestSource, DictAsObject
             sage: from sage.doctest.control import DocTestDefaults; DD = DocTestDefaults()
-            sage: from sage.env import SAGE_SRC
             sage: import doctest, sys, os
             sage: DTR = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD, optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: from sage.doctest.util import Timer
             sage: T = Timer().start()
@@ -1754,7 +1744,6 @@ class DocTestDispatcher(SageObject):
             sage: from sage.doctest.forker import DocTestDispatcher
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.util import Timer
-            sage: from sage.env import SAGE_SRC
             sage: import os
             sage: homset = os.path.join(SAGE_SRC, 'sage', 'rings', 'homset.py')
             sage: ideal = os.path.join(SAGE_SRC, 'sage', 'rings', 'ideal.py')
@@ -1801,7 +1790,6 @@ class DocTestDispatcher(SageObject):
             sage: from sage.doctest.forker import DocTestDispatcher
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.util import Timer
-            sage: from sage.env import SAGE_SRC
             sage: import os
             sage: crem = os.path.join(SAGE_SRC, 'sage', 'databases', 'cremona.py')
             sage: bigo = os.path.join(SAGE_SRC, 'sage', 'rings', 'big_oh.py')
@@ -2136,7 +2124,6 @@ class DocTestDispatcher(SageObject):
             sage: from sage.doctest.forker import DocTestDispatcher
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.util import Timer
-            sage: from sage.env import SAGE_SRC
             sage: import os
             sage: freehom = os.path.join(SAGE_SRC, 'sage', 'modules', 'free_module_homspace.py')
             sage: bigo = os.path.join(SAGE_SRC, 'sage', 'rings', 'big_oh.py')
@@ -2191,10 +2178,9 @@ class DocTestWorker(multiprocessing.Process):
         sage: from sage.doctest.sources import FileDocTestSource
         sage: from sage.doctest.reporting import DocTestReporter
         sage: from sage.doctest.control import DocTestController, DocTestDefaults
-        sage: from sage.env import SAGE_SRC
-        sage: filename = os.path.join(SAGE_SRC,'sage','doctest','util.py')
+        sage: filename = sage.doctest.util.__file__
         sage: DD = DocTestDefaults()
-        sage: FDS = FileDocTestSource(filename,DD)
+        sage: FDS = FileDocTestSource(filename, DD)
         sage: W = DocTestWorker(FDS, DD)
         sage: W.start()
         sage: DC = DocTestController(DD, filename)
@@ -2316,10 +2302,9 @@ class DocTestWorker(multiprocessing.Process):
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
-            sage: from sage.env import SAGE_SRC
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','util.py')
+            sage: filename = sage.doctest.util.__file__
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: W = DocTestWorker(FDS, DD)
             sage: W.start()
             sage: try:
@@ -2356,10 +2341,9 @@ class DocTestWorker(multiprocessing.Process):
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
-            sage: from sage.env import SAGE_SRC
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','util.py')
+            sage: filename = sage.doctest.util.__file__
             sage: DD = DocTestDefaults(verbose=True,nthreads=2)
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: W = DocTestWorker(FDS, DD)
             sage: W.start()
             sage: while W.rmessages is not None:
@@ -2391,10 +2375,9 @@ class DocTestWorker(multiprocessing.Process):
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
-            sage: from sage.env import SAGE_SRC
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','util.py')
+            sage: filename = sage.doctest.util.__file__
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: W = DocTestWorker(FDS, DD)
             sage: W.start()
             sage: W.join()
@@ -2452,10 +2435,9 @@ class DocTestWorker(multiprocessing.Process):
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
-            sage: from sage.env import SAGE_SRC
             sage: filename = os.path.join(SAGE_SRC,'sage','doctest','tests','99seconds.rst')
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: FDS = FileDocTestSource(filename, DD)
 
         We set up the worker to start by blocking ``SIGQUIT``, such that
         killing will fail initially::
@@ -2522,11 +2504,10 @@ class DocTestTask():
         sage: from sage.doctest.forker import DocTestTask
         sage: from sage.doctest.sources import FileDocTestSource
         sage: from sage.doctest.control import DocTestDefaults, DocTestController
-        sage: from sage.env import SAGE_SRC
         sage: import os
-        sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
+        sage: filename = sage.doctest.sources.__file__
         sage: DD = DocTestDefaults()
-        sage: FDS = FileDocTestSource(filename,DD)
+        sage: FDS = FileDocTestSource(filename, DD)
         sage: DTT = DocTestTask(FDS)
         sage: DC = DocTestController(DD,[filename])
         sage: ntests, results = DTT(options=DD)
@@ -2545,10 +2526,9 @@ class DocTestTask():
             sage: from sage.doctest.forker import DocTestTask
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults
-            sage: from sage.env import SAGE_SRC
             sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: DocTestTask(FDS)
             <sage.doctest.forker.DocTestTask object at ...>
         """
@@ -2588,11 +2568,10 @@ class DocTestTask():
             sage: from sage.doctest.forker import DocTestTask
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults, DocTestController
-            sage: from sage.env import SAGE_SRC
             sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','parsing.py')
+            sage: filename = sage.doctest.parsing.__file__
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: DTT = DocTestTask(FDS)
             sage: DC = DocTestController(DD, [filename])
             sage: ntests, runner = DTT(options=DD)

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -782,10 +782,8 @@ class OriginalSource():
 
         sage: from sage.doctest.sources import FileDocTestSource
         sage: from sage.doctest.control import DocTestDefaults
-        sage: from sage.env import SAGE_SRC
-        sage: import os
-        sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-        sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+        sage: filename = sage.doctest.forker.__file__
+        sage: FDS = FileDocTestSource(filename, DocTestDefaults())
         sage: doctests, extras = FDS.create_doctests(globals())
         sage: ex = doctests[0].examples[0]
         sage: ex.sage_source
@@ -809,10 +807,8 @@ class OriginalSource():
 
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
             sage: from sage.doctest.parsing import OriginalSource
@@ -827,10 +823,8 @@ class OriginalSource():
 
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
             sage: from sage.doctest.parsing import OriginalSource
@@ -847,10 +841,8 @@ class OriginalSource():
 
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.control import DocTestDefaults
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','forker.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.forker.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: ex = doctests[0].examples[0]
             sage: from sage.doctest.parsing import OriginalSource

--- a/src/sage/doctest/reporting.py
+++ b/src/sage/doctest/reporting.py
@@ -109,10 +109,8 @@ class DocTestReporter(SageObject):
 
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','reporting.py')
-            sage: DC = DocTestController(DocTestDefaults(),[filename])
+            sage: filename = sage.doctest.reporting.__file__
+            sage: DC = DocTestController(DocTestDefaults(), [filename])
             sage: DTR = DocTestReporter(DC)
         """
         self.controller = controller
@@ -133,10 +131,8 @@ class DocTestReporter(SageObject):
 
             sage: from sage.doctest.reporting import DocTestReporter
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','reporting.py')
-            sage: DC = DocTestController(DocTestDefaults(),[filename])
+            sage: filename = sage.doctest.reporting.__file__
+            sage: DC = DocTestController(DocTestDefaults(), [filename])
             sage: DTR = DocTestReporter(DC)
 
         ::
@@ -150,7 +146,7 @@ class DocTestReporter(SageObject):
         ``latex`` are run by default since :issue:`32174`::
 
             sage: filename = os.path.join(SAGE_SRC,'sage','misc','latex.py')
-            sage: DC = DocTestController(DocTestDefaults(),[filename])
+            sage: DC = DocTestController(DocTestDefaults(), [filename])
             sage: DTR = DocTestReporter(DC)
             sage: DTR.were_doctests_with_optional_tag_run('latex')   # optional - latex
             True
@@ -178,10 +174,9 @@ class DocTestReporter(SageObject):
             sage: from sage.doctest.control import DocTestController, DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.forker import SageDocTestRunner
-            sage: from sage.env import SAGE_SRC
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','reporting.py')
+            sage: filename = sage.doctest.reporting.__file__
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
+            sage: FDS = FileDocTestSource(filename, DD)
             sage: DC = DocTestController(DD, [filename])
             sage: DTR = DocTestReporter(DC)
             sage: print(DTR.report_head(FDS))
@@ -261,12 +256,11 @@ class DocTestReporter(SageObject):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.parsing import SageOutputChecker
             sage: from sage.doctest.util import Timer
-            sage: from sage.env import SAGE_SRC
-            sage: import os, sys, doctest
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','reporting.py')
+            sage: import doctest
+            sage: filename = sage.doctest.reporting.__file__
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
-            sage: DC = DocTestController(DD,[filename])
+            sage: FDS = FileDocTestSource(filename, DD)
+            sage: DC = DocTestController(DD, [filename])
             sage: DTR = DocTestReporter(DC)
 
         You can report a timeout::
@@ -339,13 +333,15 @@ class DocTestReporter(SageObject):
         Or tell the user that everything succeeded::
 
             sage: doctests, extras = FDS.create_doctests(globals())
-            sage: runner = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD,
-            ....:                            optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
+            sage: runner = SageDocTestRunner(
+            ....:     SageOutputChecker(), verbose=False, sage_options=DD,
+            ....:     optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
             sage: Timer().start().stop().annotate(runner)
             sage: D = DictAsObject({'err':None})
             sage: runner.update_results(D)
             0
-            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D), "Good tests")
+            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
+            ....:            "Good tests")
                 [... tests, ... s]
             sage: DTR.stats
             {'sage.doctest.reporting': {'ntests': ..., 'walltime': ...}}
@@ -355,7 +351,8 @@ class DocTestReporter(SageObject):
             sage: runner.failures = 1
             sage: runner.update_results(D)
             1
-            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D), "Doctest output including the failure...")
+            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
+            ....:            "Doctest output including the failure...")
                 [... tests, 1 failure, ... s]
 
         If the user has requested that we report on skipped doctests,
@@ -365,7 +362,7 @@ class DocTestReporter(SageObject):
             sage: from collections import defaultdict
             sage: optionals = defaultdict(int)
             sage: optionals['magma'] = 5; optionals['long time'] = 4; optionals[''] = 1; optionals['not tested'] = 2
-            sage: D = DictAsObject(dict(err=None,optionals=optionals))
+            sage: D = DictAsObject(dict(err=None, optionals=optionals))
             sage: runner.failures = 0
             sage: runner.update_results(D)
             0
@@ -391,20 +388,23 @@ class DocTestReporter(SageObject):
             sage: DC = DocTestController(DD, [filename])
             sage: DTR = DocTestReporter(DC)
             sage: doctests, extras = FDS.create_doctests(globals())
-            sage: runner = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD,
-            ....:                            optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
+            sage: runner = SageDocTestRunner(
+            ....:     SageOutputChecker(), verbose=False, sage_options=DD,
+            ....:     optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
             sage: Timer().start().stop().annotate(runner)
             sage: D = DictAsObject({'err':None})
             sage: runner.update_results(D)
             0
-            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D), "Good tests")
+            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
+            ....:            "Good tests")
 
         However, failures are still output in the errors-only mode::
 
             sage: runner.failures = 1
             sage: runner.update_results(D)
             1
-            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D), "Failed test")
+            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
+            ....:            "Failed test")
                 [... tests, 1 failure, ... s]
         """
         log = self.controller.log
@@ -598,12 +598,11 @@ class DocTestReporter(SageObject):
             sage: from sage.doctest.forker import SageDocTestRunner
             sage: from sage.doctest.parsing import SageOutputChecker
             sage: from sage.doctest.util import Timer
-            sage: from sage.env import SAGE_SRC
-            sage: import os, sys, doctest
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','reporting.py')
+            sage: import doctest
+            sage: filename = sage.doctest.reporting.__file__
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
-            sage: DC = DocTestController(DD,[filename])
+            sage: FDS = FileDocTestSource(filename, DD)
+            sage: DC = DocTestController(DD, [filename])
             sage: DTR = DocTestReporter(DC)
 
         Now we pretend to run some doctests::
@@ -621,19 +620,23 @@ class DocTestReporter(SageObject):
             Output before bad exit
             **********************************************************************
             sage: doctests, extras = FDS.create_doctests(globals())
-            sage: runner = SageDocTestRunner(SageOutputChecker(), verbose=False, sage_options=DD,optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
+            sage: runner = SageDocTestRunner(
+            ....:     SageOutputChecker(), verbose=False, sage_options=DD,
+            ....:     optionflags=doctest.NORMALIZE_WHITESPACE|doctest.ELLIPSIS)
             sage: t = Timer().start().stop()
             sage: t.annotate(runner)
             sage: DC.timer = t
             sage: D = DictAsObject({'err':None})
             sage: runner.update_results(D)
             0
-            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D), "Good tests")
+            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
+            ....:            "Good tests")
                 [... tests, ... s]
             sage: runner.failures = 1
             sage: runner.update_results(D)
             1
-            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D), "Doctest output including the failure...")
+            sage: DTR.report(FDS, False, 0, (sum([len(t.examples) for t in doctests]), D),
+            ....:            "Doctest output including the failure...")
                 [... tests, 1 failure, ... s]
 
         Now we can show the output of finalize::

--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -814,7 +814,7 @@ class FileDocTestSource(DocTestSource):
             sage: # not tested (because the output will change when source files are changed)
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-                sage: cwd = os.getcwd()
+            sage: cwd = os.getcwd()
             sage: os.chdir(SAGE_SRC)
             sage: import itertools
             sage: for path, dirs, files in itertools.chain(os.walk('sage'), os.walk('doc')):

--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -82,11 +82,10 @@ def get_basename(path):
     EXAMPLES::
 
         sage: from sage.doctest.sources import get_basename
-        sage: from sage.env import SAGE_SRC
         sage: import os
-        sage: get_basename(os.path.join(SAGE_SRC, 'sage', 'doctest', 'sources.py'))
+        sage: get_basename(sage.doctest.sources.__file__)
         'sage.doctest.sources'
-        sage: get_basename(os.path.join(SAGE_SRC, 'sage', 'structure', 'element.pxd'))
+        sage: get_basename(os.path.join(sage.structure.__path__[0], 'element.pxd'))
         'sage.structure.element.pxd'
     """
     if path is None:
@@ -140,10 +139,8 @@ class DocTestSource():
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: TestSuite(FDS).run()
         """
         self.options = options
@@ -156,12 +153,10 @@ class DocTestSource():
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
+            sage: filename = sage.doctest.sources.__file__
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
-            sage: FDS2 = FileDocTestSource(filename,DD)
+            sage: FDS = FileDocTestSource(filename, DD)
+            sage: FDS2 = FileDocTestSource(filename, DD)
             sage: FDS == FDS2
             True
         """
@@ -177,12 +172,10 @@ class DocTestSource():
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
+            sage: filename = sage.doctest.sources.__file__
             sage: DD = DocTestDefaults()
-            sage: FDS = FileDocTestSource(filename,DD)
-            sage: FDS2 = FileDocTestSource(filename,DD)
+            sage: FDS = FileDocTestSource(filename, DD)
+            sage: FDS2 = FileDocTestSource(filename, DD)
             sage: FDS != FDS2
             False
         """
@@ -217,10 +210,8 @@ class DocTestSource():
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.parsing import SageDocTestParser
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','util.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.util.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: doctests, _ = FDS.create_doctests({})
             sage: manual_doctests = []
             sage: for dt in doctests:
@@ -291,10 +282,8 @@ class DocTestSource():
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.util import NestedName
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS.qualified_name = NestedName('sage.doctest.sources')
             sage: doctests, extras = FDS._create_doctests({})
             sage: len(doctests)
@@ -523,10 +512,8 @@ class FileDocTestSource(DocTestSource):
 
         sage: from sage.doctest.control import DocTestDefaults
         sage: from sage.doctest.sources import FileDocTestSource
-        sage: from sage.env import SAGE_SRC
-        sage: import os
-        sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-        sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+        sage: filename = sage.doctest.sources.__file__
+        sage: FDS = FileDocTestSource(filename, DocTestDefaults())
         sage: FDS.basename
         'sage.doctest.sources'
 
@@ -539,7 +526,7 @@ class FileDocTestSource(DocTestSource):
         sage: from sage.doctest.control import DocTestDefaults
         sage: from sage.doctest.sources import FileDocTestSource
         sage: filename = tmp_filename(ext=".txtt")
-        sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+        sage: FDS = FileDocTestSource(filename, DocTestDefaults())
         Traceback (most recent call last):
         ...
         ValueError: unknown extension for the file to test (=...txtt),
@@ -554,10 +541,8 @@ class FileDocTestSource(DocTestSource):
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults(randorder=0))
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults(randorder=0))
             sage: FDS.options.randorder
             0
         """
@@ -645,16 +630,17 @@ class FileDocTestSource(DocTestSource):
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
             sage: import os
-            sage: root = os.path.realpath(os.path.join(SAGE_SRC,'sage'))
-            sage: filename = os.path.join(root,'doctest','sources.py')
+            sage: filename = os.path.realpath(sage.doctest.sources.__file__)
+            sage: root = os.path.join(os.path.dirname(filename), '..')
             sage: cwd = os.getcwd()
             sage: os.chdir(root)
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults(randorder=0,abspath=False))
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults(randorder=0,
+            ....:                                                   abspath=False))
             sage: FDS.printpath
             'doctest/sources.py'
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults(randorder=0,abspath=True))
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults(randorder=0,
+            ....:                                                   abspath=True))
             sage: FDS.printpath
             '.../sage/doctest/sources.py'
             sage: os.chdir(cwd)
@@ -677,10 +663,8 @@ class FileDocTestSource(DocTestSource):
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
             sage: filename = os.path.join(SAGE_SRC,'sage','rings','integer.pyx')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS.basename
             'sage.rings.integer'
         """
@@ -700,7 +684,6 @@ class FileDocTestSource(DocTestSource):
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
             sage: import os
             sage: filename = os.path.join(SAGE_SRC, 'sage', 'rings', 'integer.pyx')
             sage: FDS = FileDocTestSource(filename, DocTestDefaults())
@@ -713,10 +696,10 @@ class FileDocTestSource(DocTestSource):
 
         You can override the default::
 
-            sage: FDS = FileDocTestSource("hello_world.py",DocTestDefaults())
+            sage: FDS = FileDocTestSource("hello_world.py", DocTestDefaults())
             sage: FDS.in_lib
             False
-            sage: FDS = FileDocTestSource("hello_world.py",DocTestDefaults(force_lib=True))
+            sage: FDS = FileDocTestSource("hello_world.py", DocTestDefaults(force_lib=True))
             sage: FDS.in_lib
             True
         """
@@ -732,9 +715,7 @@ class FileDocTestSource(DocTestSource):
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC, 'sage', 'repl', 'user_globals.py')
+            sage: filename = sage.repl.user_globals.__file__
             sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS.file_optional_tags
             {'sage.modules': None}
@@ -760,10 +741,8 @@ class FileDocTestSource(DocTestSource):
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: doctests, extras = FDS.create_doctests(globals())
             sage: len(doctests)
             43
@@ -774,8 +753,8 @@ class FileDocTestSource(DocTestSource):
 
             sage: doctests[20].name
             'sage.doctest.sources.FileDocTestSource.create_doctests'
-            sage: doctests[20].examples[10].source
-            'doctests[Integer(20)].examples[Integer(10)].source\n'
+            sage: doctests[20].examples[8].source
+            'doctests[Integer(20)].examples[Integer(8)].source\n'
 
         TESTS:
 
@@ -787,7 +766,7 @@ class FileDocTestSource(DocTestSource):
             sage: gp.get_precision() == 38                                              # needs sage.libs.pari
             False # 32-bit
             True  # 64-bit
-            sage: ex = doctests[20].examples[13]
+            sage: ex = doctests[20].examples[11]
             sage: ((bitness == '64' and ex.want == 'True  \n')                          # needs sage.libs.pari
             ....:  or (bitness == '32' and ex.want == 'False \n'))
             True
@@ -835,8 +814,7 @@ class FileDocTestSource(DocTestSource):
             sage: # not tested (because the output will change when source files are changed)
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: cwd = os.getcwd()
+                sage: cwd = os.getcwd()
             sage: os.chdir(SAGE_SRC)
             sage: import itertools
             sage: for path, dirs, files in itertools.chain(os.walk('sage'), os.walk('doc')):
@@ -942,10 +920,8 @@ class SourceLanguage:
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.parsing import SageDocTestParser
             sage: from sage.doctest.util import NestedName
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','util.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.util.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: doctests, _ = FDS.create_doctests({})
             sage: for dt in doctests:
             ....:     FDS.qualified_name = dt.name
@@ -964,10 +940,8 @@ class PythonSource(SourceLanguage):
 
         sage: from sage.doctest.control import DocTestDefaults
         sage: from sage.doctest.sources import FileDocTestSource
-        sage: from sage.env import SAGE_SRC
-        sage: import os
-        sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-        sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+        sage: filename = sage.doctest.sources.__file__
+        sage: FDS = FileDocTestSource(filename, DocTestDefaults())
         sage: type(FDS)
         <class 'sage.doctest.sources.PythonFileSource'>
     """
@@ -982,10 +956,8 @@ class PythonSource(SourceLanguage):
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS.last_indent
             -1
@@ -1019,10 +991,8 @@ class PythonSource(SourceLanguage):
 
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS._update_quotetype('\"\"\"'); print(" ".join(list(FDS.quotetype)))
             " " "
@@ -1116,10 +1086,8 @@ class PythonSource(SourceLanguage):
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.util import NestedName
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS.starting_docstring("r'''")
             <...Match object...>
@@ -1185,7 +1153,7 @@ class PythonSource(SourceLanguage):
         OUTPUT:
 
         - an object that, when evaluated in a boolean context, gives
-          True or False depending on whether the input line marks the
+          ``True`` or ``False`` depending on whether the input line marks the
           end of a docstring.
 
         EXAMPLES::
@@ -1193,10 +1161,8 @@ class PythonSource(SourceLanguage):
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.util import NestedName
-            sage: from sage.env import SAGE_SRC
-            sage: import os
-            sage: filename = os.path.join(SAGE_SRC,'sage','doctest','sources.py')
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: filename = sage.doctest.sources.__file__
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS.quotetype = "'''"
             sage: FDS.ending_docstring("'''")
@@ -1229,7 +1195,8 @@ class PythonSource(SourceLanguage):
             sage: from sage.doctest.sources import StringDocTestSource, PythonSource
             sage: from sage.structure.dynamic_class import dynamic_class
             sage: s = "'''\n    sage: 2 + 2\n    4\n'''"
-            sage: PythonStringSource = dynamic_class('PythonStringSource',(StringDocTestSource, PythonSource))
+            sage: PythonStringSource = dynamic_class('PythonStringSource',
+            ....:                                    (StringDocTestSource, PythonSource))
             sage: PSS = PythonStringSource('<runtime>', s, DocTestDefaults(), 'runtime')
             sage: print(PSS._neutralize_doctests(0))
             '''
@@ -1264,7 +1231,7 @@ class TexSource(SourceLanguage):
         sage: from sage.doctest.control import DocTestDefaults
         sage: from sage.doctest.sources import FileDocTestSource
         sage: filename = "sage_paper.tex"
-        sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+        sage: FDS = FileDocTestSource(filename, DocTestDefaults())
         sage: type(FDS)
         <class 'sage.doctest.sources.TexFileSource'>
     """
@@ -1280,7 +1247,7 @@ class TexSource(SourceLanguage):
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: filename = "sage_paper.tex"
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS.skipping
             False
@@ -1312,7 +1279,7 @@ class TexSource(SourceLanguage):
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: filename = "sage_paper.tex"
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
 
         We start docstrings with \begin{verbatim} or \begin{lstlisting}::
@@ -1391,7 +1358,7 @@ class TexSource(SourceLanguage):
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: filename = "sage_paper.tex"
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS.ending_docstring(r"\end{verbatim}")
             True
@@ -1442,7 +1409,7 @@ class RestSource(SourceLanguage):
         sage: from sage.doctest.control import DocTestDefaults
         sage: from sage.doctest.sources import FileDocTestSource
         sage: filename = "sage_doc.rst"
-        sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+        sage: FDS = FileDocTestSource(filename, DocTestDefaults())
         sage: type(FDS)
         <class 'sage.doctest.sources.RestFileSource'>
     """
@@ -1458,7 +1425,7 @@ class RestSource(SourceLanguage):
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: filename = "sage_doc.rst"
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS.link_all
             False
@@ -1490,7 +1457,7 @@ class RestSource(SourceLanguage):
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: filename = "sage_doc.rst"
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS.starting_docstring("Hello world::")
             True
@@ -1548,7 +1515,7 @@ class RestSource(SourceLanguage):
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: filename = "sage_doc.rst"
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS._init()
             sage: FDS.starting_docstring("Hello world::")
             True
@@ -1594,7 +1561,7 @@ class RestSource(SourceLanguage):
             sage: from sage.doctest.parsing import SageDocTestParser
             sage: from sage.doctest.util import NestedName
             sage: filename = "sage_doc.rst"
-            sage: FDS = FileDocTestSource(filename,DocTestDefaults())
+            sage: FDS = FileDocTestSource(filename, DocTestDefaults())
             sage: FDS.parser = SageDocTestParser(set(['sage']))
             sage: FDS.qualified_name = NestedName('sage_doc')
             sage: s = "Some text::\n\n    def example_python_function(a, \


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Using `sage.doctest.forker.__file__` whenever Python files are used as inputs for the doctester, instead of going through `SAGE_SRC`. This makes more of the doctests testable in installations where no source tree is available.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


