### PR TITLE
fix typos and no "Algebra" in the doc

### DIFF
--- a/src/doc/en/developer/coding_basics.rst
+++ b/src/doc/en/developer/coding_basics.rst
@@ -1118,7 +1118,7 @@ framework. Here is a comprehensive list:
 
   This is mathematically correct, as it is
   guaranteed to terminate. However, there is a
-  nonzero probability of a timout.
+  nonzero probability of a timeout.
 
 - **long time:** The line is only tested if the ``--long`` option is given, e.g.
   ``sage -t --long f.py``.

--- a/src/doc/en/developer/coding_in_python.rst
+++ b/src/doc/en/developer/coding_in_python.rst
@@ -94,9 +94,9 @@ or from some other already existing Sage class:
 
 .. CODE-BLOCK:: python
 
-    from sage.rings.ring import Algebra
+    from sage.structure.parent import Parent
 
-    class MyFavoriteAlgebra(Algebra):
+    class MyFavoriteAlgebra(Parent):
         ...
 
 You should implement the ``_latex_`` and ``_repr_`` method for every

--- a/src/doc/en/developer/git_advanced.rst
+++ b/src/doc/en/developer/git_advanced.rst
@@ -359,7 +359,7 @@ Now we start by making an identical branch to the first branch::
     [alice@localhost sage]$ git rebase -i HEAD~3
 
 This will open an editor with the last 3 (corresponding to ``HEAD~3``)
-commits and instuctions for how to modify them:
+commits and instructions for how to modify them:
 
 .. CODE-BLOCK:: text
 

--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -367,7 +367,7 @@ package :mod:`sage.numerical.backends` and some modules in
   ``./sage -pytest -n auto`` will spawn a number of workers processes equal
   to the number of available CPUs.
 
-- VS Code: Install the `Python extension <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ and follow the `offical VS Code documentation <https://code.visualstudio.com/docs/python/testing>`__.
+- VS Code: Install the `Python extension <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ and follow the `official VS Code documentation <https://code.visualstudio.com/docs/python/testing>`__.
 
 *Configuration:* ``SAGE_ROOT/src/conftest.py``
 

--- a/src/doc/en/prep/Advanced-2DPlotting.rst
+++ b/src/doc/en/prep/Advanced-2DPlotting.rst
@@ -213,7 +213,7 @@ to put together.
     ....:                    axes = False
     ....:                    )
     sage: def sine_and_unit_circle( angle=30, instant_show = True, show_pi=True ):
-    ....:     ccenter_x, ccenter_y = -radius, 0  # center of cirlce on real coords
+    ....:     ccenter_x, ccenter_y = -radius, 0  # center of circle on real coords
     ....:     sine_x = angle # the big magic to sync both graphs :)
     ....:     current_y = circle_y = sine_y = radius * sin(angle*pi/180)
     ....:     circle_x = ccenter_x + radius * cos(angle*pi/180)

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -3888,7 +3888,7 @@ REFERENCES:
 .. [Kob1993] Neal Koblitz, *Introduction to Elliptic Curves and
              Modular Forms*.  Springer GTM 97, 1993.
 
-.. [Koe1999] Wolfram Koepf: Effcient Computation of Chebyshev
+.. [Koe1999] Wolfram Koepf: Efficient Computation of Chebyshev
              Polynomials in Computer Algebra Systems: A Practical
              Guide. John Wiley, Chichester (1999): 79-99.
 

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -1191,7 +1191,7 @@ REFERENCES:
 
 .. [BR2010] Matthew Baker and Robert Rumely. Potential theory and dynamics on the
             Berkovich projective line. Mathematical Surveys and Monographs,
-            Volumne 159. 2010.
+            Volume 159. 2010.
 
 .. [BR2010a] Jean Berstel and Christophe Reutenauer,
              *Noncommutative Rational Series With Applications*.
@@ -1584,7 +1584,7 @@ REFERENCES:
 .. [Cha18] Frédéric Chapoton, *Some properties of a new partial
            order on Dyck paths*, 2018, :arxiv:`1809.10981`
 
-.. [Cha22005] \B. Cha. Vanishing of some cohomology goups and bounds
+.. [Cha22005] \B. Cha. Vanishing of some cohomology groups and bounds
               for the Shafarevich-Tate groups of elliptic
               curves. J. Number Theory, 111:154-178, 2005.
 
@@ -1638,7 +1638,7 @@ REFERENCES:
          Wiley, 1989.
 
 .. [CK2008] Derek G. Corneil and Richard M. Krueger, *A Unified View
-            of Graph Searching*, SIAM Jounal on Discrete Mathematics,
+            of Graph Searching*, SIAM Journal on Discrete Mathematics,
             22(4), 1259–-1276, 2008.
             :doi:`10.1137/050623498`
 

--- a/src/doc/en/thematic_tutorials/lie/branching_rules.rst
+++ b/src/doc/en/thematic_tutorials/lie/branching_rules.rst
@@ -222,7 +222,7 @@ to the right of the colon onto the command line::
     sage:branching_rule("E7","A2","miscellaneous")
     miscellaneous branching rule E7 => A2
 
-There are two distict embeddings of `A_1=\hbox{SL}(2)` into
+There are two distinct embeddings of `A_1=\hbox{SL}(2)` into
 `E_7` as maximal subgroups, so the ``maximal_subgroup``
 method will return a list of rules::
 

--- a/src/doc/en/thematic_tutorials/lie/crystals.rst
+++ b/src/doc/en/thematic_tutorials/lie/crystals.rst
@@ -731,7 +731,7 @@ and `(2,1,0)`. This decomposition is predicted by Frobenius-Schur
 duality: the multiplicity of `\pi_\lambda^{GL(n)}` in
 `\otimes^3\mathbf{C}^3` is the degree of `\pi_\lambda^{S_3}`.
 
-It is useful to be able to select one irreducible constitutent of
+It is useful to be able to select one irreducible constituent of
 ``T``. If we only want one of the irreducible constituents of ``T``,
 we can specify a list of highest weight vectors by the option
 ``generators``. If the list has only one element, then we get an
@@ -881,7 +881,7 @@ subcrystal of ``Cspin`` `\otimes \mathcal{B}_\mu`, where
     B3(1/2,1/2,1/2) + B3(3/2,1/2,1/2) + B3(3/2,3/2,1/2)
 
 We see that just taking the tensor product of these two crystals will
-produce a reducible crystal with three constitutents, and we want to
+produce a reducible crystal with three constituents, and we want to
 extract the one we want. We do that as follows::
 
     sage: B3 = WeylCharacterRing("B3")

--- a/src/doc/en/thematic_tutorials/numerical_sage/cvxopt.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/cvxopt.rst
@@ -101,7 +101,7 @@ For a simple linear programming example, if we want to solve
 .. math::
 
    \begin{array}{cc}
-   \text{minimze} & -4x_1-5x_2\\
+   \text{minimize} & -4x_1-5x_2\\
    \text{subject to} & 2x_1 +x_2\le 3\\
                      & x_1+2x_2\le 3\\
                      & x_1 \ge 0 \\

--- a/src/doc/en/thematic_tutorials/numerical_sage/numerical_tools.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/numerical_tools.rst
@@ -18,7 +18,7 @@ packages.
 Before we start let us point out
 http://www.scipy.org/NumPy_for_Matlab_Users, which has a
 comparison between matlab and numpy and gives numpy equivalents of
-matlab commands. If you're not familiar with matlab, thats fine, even
+matlab commands. If you are not familiar with matlab, that's fine, even
 better, it means you won't have any pre-conceived notions of how
 things should work.  Also this
 http://www.scipy.org/Wiki/Documentation?action=AttachFile&do=get&target=scipy_tutorial.pdf

--- a/src/doc/en/thematic_tutorials/sws2rst.rst
+++ b/src/doc/en/thematic_tutorials/sws2rst.rst
@@ -17,7 +17,7 @@ this with the path to your Sage installation, such as
 ``/Applications/Sage-9.2.app/Contents/Resources/sage/sage`` if you are
 using the Mac app and have placed it in your Applications directory.
 
-* Next, you will need an optional package to covert your worksheet.  Use the
+* Next, you will need an optional package to convert your worksheet.  Use the
   command:
 
   .. CODE-BLOCK:: shell-session


### PR DESCRIPTION
This fixes a bunch of typos in the doc, and also rewrites one example to use `Parent` instead of the auld `Algebra`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.