### PR TITLE
provide a construction functor using a single functor for families

### DIFF
--- a/src/sage/combinat/sf/dual.py
+++ b/src/sage/combinat/sf/dual.py
@@ -292,7 +292,7 @@ class SymmetricFunctionAlgebra_dual(classical.SymmetricFunctionAlgebra_classical
         Return the name of the basis of ``self``.
 
         This is used for output and, for the classical bases of
-        symmetric functions, to connect this basis with Symmetrica.
+        symmetric functions, to connect this basis with :ref:`Symmetrica <spkg_symmetrica>`.
 
         EXAMPLES::
 

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -641,7 +641,8 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
                 sage: Sym = SymmetricFunctions(P)
                 sage: mj = Sym.macdonald().J()
                 sage: mj.corresponding_basis_over(Integers(13)['q','t'])
-                Symmetric Functions over Multivariate Polynomial Ring in q, t over Ring of integers modulo 13 in the Macdonald J basis
+                Symmetric Functions over Multivariate Polynomial Ring in q, t over 
+                 Ring of integers modulo 13 in the Macdonald J basis
 
             TESTS:
 

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -641,7 +641,7 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
                 sage: Sym = SymmetricFunctions(P)
                 sage: mj = Sym.macdonald().J()
                 sage: mj.corresponding_basis_over(Integers(13)['q','t'])
-                Symmetric Functions over Multivariate Polynomial Ring in q, t over 
+                Symmetric Functions over Multivariate Polynomial Ring in q, t over
                  Ring of integers modulo 13 in the Macdonald J basis
 
             TESTS:

--- a/src/sage/combinat/sf/witt.py
+++ b/src/sage/combinat/sf/witt.py
@@ -23,7 +23,6 @@ from . import multiplicative
 from sage.arith.misc import divisors
 from sage.combinat.integer_lists.invlex import IntegerListsLex
 from sage.combinat.partitions import ZS1_iterator
-from sage.matrix.constructor import matrix
 from sage.misc.cachefunc import cached_method
 
 


### PR DESCRIPTION
We enable sage to find common parents also when symmetric functions are involved. In particular, we provide a functorial construction that takes a commutative (coefficient) ring and produces a (commutative) ring of symmetric functions over this ring.

For Macdonald polynomials and other symmetric functions that involve parameters we cheat a bit: the categories should actually be commutative rings with distinguished elements (namely, the parameters). However, having these is very likely overkill.

This is an alternative to #37220, relying on individual construction functors instead of passing around strings, and #37686, which provides an individual functor for each family.