### PR TITLE
Remove trailing spaces in latex representations.

### DIFF
--- a/src/sage/combinat/crystals/monomial_crystals.py
+++ b/src/sage/combinat/crystals/monomial_crystals.py
@@ -294,7 +294,7 @@ class NakajimaMonomial(Element):
 
             sage: M = crystals.infinity.NakajimaMonomials(['G',2,1])
             sage: M.module_generators[0].f_string([1,0,2])._latex_Y()
-            'Y_{0,0}^{-1} Y_{1,0}^{-1} Y_{1,1}^{2} Y_{2,0} Y_{2,1}^{-1} '
+            'Y_{0,0}^{-1} Y_{1,0}^{-1} Y_{1,1}^{2} Y_{2,0} Y_{2,1}^{-1}'
         """
         if not self._Y:
             return "\\boldsymbol{1}"
@@ -303,9 +303,9 @@ class NakajimaMonomial(Element):
         return_str = ''
         for x in L:
             if x[1] != 1:
-                return_str += "Y_{%s,%s}" % (x[0][0],x[0][1]) + "^{%s} " % x[1]
+                return_str += "Y_{%s,%s}" % (x[0][0],x[0][1]) + "^{%s}" % x[1]
             else:
-                return_str += "Y_{%s,%s} " % (x[0][0],x[0][1])
+                return_str += "Y_{%s,%s}" % (x[0][0],x[0][1])
         return return_str
 
     def _latex_A(self):

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -273,11 +273,11 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
             sage: E = EllipticCurve(QQ, [1,1])
             sage: E._latex_()
-            'y^2 = x^{3} + x + 1 '
+            'y^2 = x^{3} + x + 1'
 
             sage: E = EllipticCurve(QQ, [1,2,3,4,5])
             sage: E._latex_()
-            'y^2 + x y + 3 y = x^{3} + 2 x^{2} + 4 x + 5 '
+            'y^2 + x y + 3 y = x^{3} + 2 x^{2} + 4 x + 5'
 
         Check that :issue:`12524` is solved::
 
@@ -285,7 +285,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
             sage: K.<phi> = NumberField(x^2 - x - 1)                                    # needs sage.rings.number_field
             sage: E = EllipticCurve([0, 0, phi, 27*phi - 43, -80*phi + 128])            # needs sage.rings.number_field
             sage: E._latex_()                                                           # needs sage.rings.number_field
-            'y^2 + \\phi y = x^{3} + \\left(27 \\phi - 43\\right) x - 80 \\phi + 128 '
+            'y^2 + \\phi y = x^{3} + \\left(27 \\phi - 43\\right) x - 80 \\phi + 128'
         """
         from sage.rings.polynomial.polynomial_ring import polygen
         a = self.ainvs()
@@ -295,7 +295,6 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
             s += " + " + (a[0]*x*y + a[2]*y)._latex_()
         s += " = "
         s += (x**3 + a[1]*x**2 + a[3]*x + a[4])._latex_()
-        s += " "
         s = s.replace("+ -","- ")
         return s
 


### PR DESCRIPTION
While rendering elliptic curves in markdown, I found that rendering the following f-string didn't work as expected:
```
f"${latex(EllipticCurve("38.b1"))}$"
```

This is because the latex representation has a trailing space.
Using `rg -U -A 2 "sage: .*_latex_.*\\n.* '.* '"` I found another object that has the same problem.
Another reason for this PR is to have more consistency in the latex representations.

Let me know if I missed some other instance.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.