### PR TITLE
Workaround for multiprocessing shared memory limits

### DIFF
--- a/src/sage/features/__init__.py
+++ b/src/sage/features/__init__.py
@@ -162,7 +162,7 @@ class Feature(TrivialUniqueRepresentation):
         # shared among subprocesses. Thus we use the Value class from the
         # multiprocessing module (cf. self._seen of class AvailableSoftware)
         from multiprocessing import Value
-        self._num_hidings = Value('i', 0)
+        self._num_hidings = Value('i', 0, lock=False)
 
         try:
             from sage.misc.package import spkg_type


### PR DESCRIPTION
This affects musl libc and macos, see:
https://github.com/sagemath/sage/pull/36741#issuecomment-2027357414

We are working on a better fix to avoid using multiprocessing in sage.features (cf https://github.com/sagemath/sage/pull/36741#issuecomment-2028145753), but this will do meanwhile.

There is agreement that disabling the lock is completely harmless, since the counter is not really used for anything; disabling the lock fixes the issues that we had on 10.4.beta0.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.