### PR TITLE
Implement an is_nilpotent() method for matrices

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -9915,8 +9915,11 @@ cdef class Matrix(Matrix1):
             ....:             [1,1,7,1,-5], [1,1,1,7,-5]])
             sage: B.is_nilpotent()
             True
-            sage: C = matrix(GF(7), [[1, 2], [2, 4]])
+            sage: C = matrix(GF(7), [[1, 2], [2, 6]])
             sage: C.is_nilpotent()
+            False
+            sage: D = matrix([[1,0],[0,0]])
+            sage: D.is_nilpotent()
             False
             sage: Z = matrix.zero(QQ, 5)
             sage: Z.is_nilpotent()
@@ -9933,6 +9936,8 @@ cdef class Matrix(Matrix1):
             sage: Z.is_nilpotent()
             True
         """
+        if self.trace():
+            return False
         chi = self.charpoly()
         return chi.is_monomial()
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -9898,6 +9898,44 @@ cdef class Matrix(Matrix1):
         self.cache(key, normal)
         return normal
 
+    def is_nilpotent(self) -> bool:
+        r"""
+        Return if ``self`` is a nilpotent matrix.
+
+        A matrix `A` is *nilpotent* if there exists a positive integer
+        `k` such that `A^k = 0`. We test this by using the Cayley-Hamilton
+        theorem to see if the characteristic polynomial is `x^n = 0`.
+
+        EXAMPLES::
+
+            sage: A = matrix([[0,2,1,6], [0,0,1,2], [0,0,0,3], [0,0,0,0]])
+            sage: A.is_nilpotent()
+            True
+            sage: B = matrix([[2,2,2,2,-4], [7,1,1,1,-5], [1,7,1,1,-5],
+            ....:             [1,1,7,1,-5], [1,1,1,7,-5]])
+            sage: B.is_nilpotent()
+            True
+            sage: C = matrix(GF(7), [[1, 2], [2, 4]])
+            sage: C.is_nilpotent()
+            False
+            sage: Z = matrix.zero(QQ, 5)
+            sage: Z.is_nilpotent()
+            True
+
+        TESTS:
+
+        Check the corner case of the `0 \times 0` matrix::
+
+            sage: Z = matrix.zero(QQ, 0); Z
+            []
+            sage: Z.charpoly()
+            1
+            sage: Z.is_nilpotent()
+            True
+        """
+        chi = self.charpoly()
+        return chi.is_monomial()
+
     def as_sum_of_permutations(self):
         r"""
         Returns the current matrix as a sum of permutation matrices

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -2845,9 +2845,7 @@ cdef class RingElement(ModuleElement):
             True
             sage: m = matrix(QQ, 3, [[3,2,3], [9,0,3], [-9,0,-3]])                      # needs sage.modules
             sage: m.is_nilpotent()                                                      # needs sage.modules
-            Traceback (most recent call last):
-            ...
-            AttributeError: '...' object has no attribute 'is_nilpotent'...
+            True
         """
         if self.is_unit():
             return False


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Checking if a matrix is nilpotent is a fundamental test that Sage is (surprisingly) missing. We check this by using the char poly.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


