### PR TITLE
Fix scaling of vector space morphisms on the left

### DIFF
--- a/src/sage/modular/abvar/homspace.py
+++ b/src/sage/modular/abvar/homspace.py
@@ -275,23 +275,19 @@ class Homspace(HomsetWithBase):
         """
         return MatrixSpace(ZZ, 2*self.domain().dimension(), 2*self.codomain().dimension())
 
-    def _element_constructor_from_element_class(self, *args, **keywords):
+    def _coerce_map_from_(self, other):
+        r"""
+        TESTS::
+
+            sage: t = J0(33).hecke_operator(2)
+            sage: t.parent().has_coerce_map_from(1)
+            True
         """
-        Used in the coercion framework. Unfortunately, the default method
-        would get the order of parent and data different from what is expected
-        in ``MatrixMorphism.__init__``.
+        if self.matrix_space().has_coerce_map_from(other):
+            return True
+        return super()._coerce_map_from_(other)
 
-        EXAMPLES::
-
-            sage: H = Hom(J0(11), J0(22))
-            sage: phi = H(matrix(ZZ,2,4,[5..12])); phi # indirect doctest
-            Abelian variety morphism:
-              From: Abelian variety J0(11) of dimension 1
-              To:   Abelian variety J0(22) of dimension 2
-        """
-        return self.element_class(self, *args, **keywords)
-
-    def __call__(self, M, **kwds):
+    def _element_constructor_(self, M, **kwds):
         r"""
         Create a homomorphism in this space from M. M can be any of the
         following:

--- a/src/sage/modular/abvar/homspace.py
+++ b/src/sage/modular/abvar/homspace.py
@@ -280,7 +280,7 @@ class Homspace(HomsetWithBase):
         TESTS::
 
             sage: t = J0(33).hecke_operator(2)
-            sage: t.parent().has_coerce_map_from(1)
+            sage: t.parent().has_coerce_map_from(ZZ)
             True
         """
         if self.matrix_space().has_coerce_map_from(other):

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -754,6 +754,10 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             If the two morphisms do not share the same ``side`` attribute, then
             the resulting morphism will be defined with the default value.
         """
+        if not isinstance(other, MatrixMorphism):
+            # The coercion only guarantees that they have the same parent,
+            # but homspaces can use multiple types of element classes.
+            return NotImplemented
         if self.side() == "left":
             if other.side() == "left":
                 return self.parent()(self.matrix() + other.matrix(), side=self.side())
@@ -819,6 +823,10 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             If the two morphisms do not share the same ``side`` attribute, then
             the resulting morphism will be defined with the default value.
         """
+        if not isinstance(other, MatrixMorphism):
+            # The coercion only guarantees that they have the same parent,
+            # but homspaces can use multiple types of element classes.
+            return NotImplemented
         if self.side() == "left":
             if other.side() == "left":
                 return self.parent()(self.matrix() - other.matrix(), side=self.side())

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -479,7 +479,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
         TESTS:
 
-        Check that :trac:`28272` is fixed::
+        Check that :issue:`28272` is fixed::
 
             sage: V = VectorSpace(QQ,2)
             sage: f = V.hom(identity_matrix(QQ,2))
@@ -491,6 +491,29 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             Vector space morphism represented by the matrix:
             [1/2   0]
             [  0 1/2]...
+
+        Check that :issue:`16830` is fixed::
+
+            sage: K = GF(7); K
+            Finite Field of size 7
+            sage: phi = End(K^2)([[1,1],[1,1]]); phi
+            Vector space morphism represented by the matrix:
+            [1 1]
+            [1 1]
+            Domain:   Vector space of dimension 2 over Finite Field of size 7
+            Codomain: Vector space of dimension 2 over Finite Field of size 7
+            sage: 2*phi
+            Vector space morphism represented by the matrix:
+            [2 2]
+            [2 2]
+            Domain:   Vector space of dimension 2 over Finite Field of size 7
+            Codomain: Vector space of dimension 2 over Finite Field of size 7
+            sage: K(2)*phi
+            Vector space morphism represented by the matrix:
+            [2 2]
+            [2 2]
+            Domain:   Vector space of dimension 2 over Finite Field of size 7
+            Codomain: Vector space of dimension 2 over Finite Field of size 7
         """
         R = self.base_ring()
         return self.parent()(R(left) * self.matrix(), side=self.side())

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -95,11 +95,11 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
     def __init__(self, parent, side='left'):
         """
+        Initialize ``self``.
+
         INPUT:
 
-        - ``parent`` -- a homspace
-
-        - ``A`` -- matrix
+        -  ``parent`` -- a homspace
 
         EXAMPLES::
 
@@ -136,8 +136,8 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             True
             sage: psi == 5 * id
             True
-            sage: psi == 5  # no coercion
-            False
+            sage: psi == 5
+            True
             sage: id == End(V).identity()
             True
         """
@@ -476,9 +476,26 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             Free module morphism defined by the matrix
             [2 2]
             [0 4]...
+
+        TESTS:
+
+        Check that :trac:`28272` is fixed::
+
+            sage: V = VectorSpace(QQ,2)
+            sage: f = V.hom(identity_matrix(QQ,2))
+            sage: 1/2 * f
+            Vector space morphism represented by the matrix:
+            [1/2   0]
+            [  0 1/2]...
+            sage: f * 1/2
+            Vector space morphism represented by the matrix:
+            [1/2   0]
+            [  0 1/2]...
         """
         R = self.base_ring()
         return self.parent()(R(left) * self.matrix(), side=self.side())
+
+    _rmul_ = _lmul_ = __rmul__
 
     def __mul__(self, right):
         r"""
@@ -650,7 +667,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             else:
                 return H(right.matrix() * self.matrix().transpose(), side='left')
 
-    def __add__(self, right):
+    def _add_(self, other):
         """
         Sum of morphisms, denoted by +.
 
@@ -684,10 +701,9 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             sage: phi + psi
             Traceback (most recent call last):
             ...
-            ValueError: inconsistent number of rows: should be 2 but got 3
+            TypeError: unsupported operand parent(s) for +: ...
 
         ::
-
 
             sage: V = ZZ^2
             sage: m = matrix(2, [1,1,0,1])
@@ -715,12 +731,6 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             If the two morphisms do not share the same ``side`` attribute, then
             the resulting morphism will be defined with the default value.
         """
-        # TODO: move over to any coercion model!
-        if not isinstance(right, MatrixMorphism):
-            R = self.base_ring()
-            return self.parent()(self.matrix() + R(right))
-        if not right.parent() == self.parent():
-            right = self.parent()(right, side=right.side())
         if self.side() == "left":
             if right.side() == "left":
                 return self.parent()(self.matrix() + right.matrix(), side=self.side())
@@ -748,7 +758,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         """
         return self.parent()(-self.matrix(), side=self.side())
 
-    def __sub__(self, other):
+    def _sub_(self, other):
         """
         EXAMPLES::
 
@@ -786,12 +796,6 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             If the two morphisms do not share the same ``side`` attribute, then
             the resulting morphism will be defined with the default value.
         """
-        # TODO: move over to any coercion model!
-        if not isinstance(other, MatrixMorphism):
-            R = self.base_ring()
-            return self.parent()(self.matrix() - R(other), side=self.side())
-        if not other.parent() == self.parent():
-            other = self.parent()(other, side=other.side())
         if self.side() == "left":
             if other.side() == "left":
                 return self.parent()(self.matrix() - other.matrix(), side=self.side())

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -732,15 +732,15 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             the resulting morphism will be defined with the default value.
         """
         if self.side() == "left":
-            if right.side() == "left":
-                return self.parent()(self.matrix() + right.matrix(), side=self.side())
-            elif right.side() == "right":
-                return self.parent()(self.matrix() + right.matrix().transpose(), side='left')
+            if other.side() == "left":
+                return self.parent()(self.matrix() + other.matrix(), side=self.side())
+            elif other.side() == "right":
+                return self.parent()(self.matrix() + other.matrix().transpose(), side="left")
         if self.side() == "right":
-            if right.side() == "right":
-                return self.parent()(self.matrix() + right.matrix(), side=self.side())
-            elif right.side() == "left":
-                return self.parent()(self.matrix().transpose() + right.matrix(), side='left')
+            if other.side() == "right":
+                return self.parent()(self.matrix() + other.matrix(), side=self.side())
+            elif other.side() == "left":
+                return self.parent()(self.matrix().transpose() + other.matrix(), side="left")
 
     def __neg__(self):
         """

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -159,15 +159,15 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
             sage: V = QQ^3; W = QQ^2
             sage: H = Hom(V, W); H
-            Set of Morphisms (Linear Transformations) from
-            Vector space of dimension 3 over Rational Field to
-            Vector space of dimension 2 over Rational Field
+            Set of Morphisms (Linear Transformations)
+             from Vector space of dimension 3 over Rational Field
+               to Vector space of dimension 2 over Rational Field
             sage: phi = H(matrix(QQ, 3, 2, range(6))); phi
             Vector space morphism represented by the matrix:
             [0 1]
             [2 3]
             [4 5]
-            Domain: Vector space of dimension 3 over Rational Field
+            Domain:   Vector space of dimension 3 over Rational Field
             Codomain: Vector space of dimension 2 over Rational Field
             sage: phi(V.0)
             (0, 1)
@@ -189,11 +189,11 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
         We compute the image of some elements::
 
-            sage: phi(V.0)    #indirect doctest
+            sage: phi(V.0)    # indirect doctest
             (1, 2, 3)
             sage: phi(V.1)
             (4, 5, 6)
-            sage: phi(V.0  - 1/4*V.1)
+            sage: phi(V.0 - 1/4*V.1)
             (0, 3/4, 3/2)
 
         We restrict ``phi`` to ``W`` and compute the image of an element::
@@ -325,8 +325,10 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             Free module morphism defined as left-multiplication by the matrix
             [1 0]
             [1 1]
-            Domain: Ambient free module of rank 2 over the principal ideal domain Integer Ring
-            Codomain: Ambient free module of rank 2 over the principal ideal domain Integer Ring
+            Domain:   Ambient free module of rank 2 over the principal ideal domain
+                      Integer Ring
+            Codomain: Ambient free module of rank 2 over the principal ideal domain
+                      Integer Ring
             sage: h2.side()
             'right'
             sage: h2.side_switch().matrix()
@@ -361,14 +363,14 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             Vector space morphism represented by the matrix:
             [-1  3]
             [ 1 -2]
-            Domain: Vector space of degree 3 and dimension 2 over Rational Field
-            Basis matrix:
-            [1 0 0]
-            [0 0 1]
+            Domain:   Vector space of degree 3 and dimension 2 over Rational Field
+                      Basis matrix:
+                      [1 0 0]
+                      [0 0 1]
             Codomain: Vector space of degree 4 and dimension 2 over Rational Field
-            Basis matrix:
-            [1 0 0 0]
-            [0 0 0 1]
+                      Basis matrix:
+                      [1 0 0 0]
+                      [0 0 0 1]
             sage: inv(y) == x
             True
 
@@ -390,7 +392,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             [ -9   4  -3   2]
             [-20   8  -7   4]
             [ -6   2  -2   1]
-            Domain: Ambient free module of rank 4 over the principal ideal domain ...
+            Domain:   Ambient free module of rank 4 over the principal ideal domain ...
             Codomain: Ambient free module of rank 4 over the principal ideal domain ...
             sage: rho(y) == x
             True
@@ -456,9 +458,9 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             sage: m = matrix(QQ, [[2, 1], [3, 4]])
             sage: phi = V.hom(m, U)
             sage: inv = phi.inverse()
-            sage: (inv*phi).is_identity()
+            sage: (inv * phi).is_identity()
             True
-            sage: (phi*inv).is_identity()
+            sage: (phi * inv).is_identity()
             True
         """
         return ~self
@@ -467,12 +469,12 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         """
         EXAMPLES::
 
-            sage: V = ZZ^2; phi = V.hom([V.0+V.1, 2*V.1])
-            sage: 2*phi
+            sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+            sage: 2 * phi
             Free module morphism defined by the matrix
             [2 2]
             [0 4]...
-            sage: phi*2
+            sage: phi * 2
             Free module morphism defined by the matrix
             [2 2]
             [0 4]...
@@ -496,19 +498,19 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
             sage: K = GF(7); K
             Finite Field of size 7
-            sage: phi = End(K^2)([[1,1],[1,1]]); phi
+            sage: phi = End(K^2)([[1,1], [1,1]]); phi
             Vector space morphism represented by the matrix:
             [1 1]
             [1 1]
             Domain:   Vector space of dimension 2 over Finite Field of size 7
             Codomain: Vector space of dimension 2 over Finite Field of size 7
-            sage: 2*phi
+            sage: 2 * phi
             Vector space morphism represented by the matrix:
             [2 2]
             [2 2]
             Domain:   Vector space of dimension 2 over Finite Field of size 7
             Codomain: Vector space of dimension 2 over Finite Field of size 7
-            sage: K(2)*phi
+            sage: K(2) * phi
             Vector space morphism represented by the matrix:
             [2 2]
             [2 2]
@@ -526,29 +528,29 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
         EXAMPLES::
 
-            sage: V = ZZ^2; phi = V.hom([V.0+V.1, 2*V.1])
-            sage: phi*phi
+            sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+            sage: phi * phi
             Free module morphism defined by the matrix
             [1 3]
             [0 4]
-            Domain: Ambient free module of rank 2 over the principal ideal domain ...
+            Domain:   Ambient free module of rank 2 over the principal ideal domain ...
             Codomain: Ambient free module of rank 2 over the principal ideal domain ...
 
             sage: V = QQ^3
             sage: E = V.endomorphism_ring()
-            sage: phi = E(Matrix(QQ,3,range(9))) ; phi
+            sage: phi = E(Matrix(QQ, 3, range(9))); phi
             Vector space morphism represented by the matrix:
             [0 1 2]
             [3 4 5]
             [6 7 8]
-            Domain: Vector space of dimension 3 over Rational Field
+            Domain:   Vector space of dimension 3 over Rational Field
             Codomain: Vector space of dimension 3 over Rational Field
-            sage: phi*phi
+            sage: phi * phi
             Vector space morphism represented by the matrix:
             [ 15  18  21]
             [ 42  54  66]
             [ 69  90 111]
-            Domain: Vector space of dimension 3 over Rational Field
+            Domain:   Vector space of dimension 3 over Rational Field
             Codomain: Vector space of dimension 3 over Rational Field
             sage: phi.matrix()**2
             [ 15  18  21]
@@ -559,25 +561,26 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
             sage: W = QQ**4
             sage: E_VW = V.Hom(W)
-            sage: psi = E_VW(Matrix(QQ,3,4,range(12))) ; psi
+            sage: psi = E_VW(Matrix(QQ, 3, 4, range(12))); psi
             Vector space morphism represented by the matrix:
             [ 0  1  2  3]
             [ 4  5  6  7]
             [ 8  9 10 11]
-            Domain: Vector space of dimension 3 over Rational Field
+            Domain:   Vector space of dimension 3 over Rational Field
             Codomain: Vector space of dimension 4 over Rational Field
-            sage: psi*phi
+            sage: psi * phi
             Vector space morphism represented by the matrix:
             [ 20  23  26  29]
             [ 56  68  80  92]
             [ 92 113 134 155]
-            Domain: Vector space of dimension 3 over Rational Field
+            Domain:   Vector space of dimension 3 over Rational Field
             Codomain: Vector space of dimension 4 over Rational Field
-            sage: phi*psi
+            sage: phi * psi
             Traceback (most recent call last):
             ...
-            TypeError: Incompatible composition of morphisms: domain of left morphism must be codomain of right.
-            sage: phi.matrix()*psi.matrix()
+            TypeError: Incompatible composition of morphisms:
+            domain of left morphism must be codomain of right.
+            sage: phi.matrix() * psi.matrix()
             [ 20  23  26  29]
             [ 56  68  80  92]
             [ 92 113 134 155]
@@ -588,22 +591,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 + 23)
             sage: V, VtoK, KtoV = K.vector_space()
-            sage: f = V.hom([V.0 - V.1, V.0 + V.1])*KtoV; f
-            Composite map:
-            From: Number Field in a with defining polynomial x^2 + 23
-            To:   Vector space of dimension 2 over Rational Field
-            Defn:   Isomorphism map:
-                    From: Number Field in a with defining polynomial x^2 + 23
-                    To:   Vector space of dimension 2 over Rational Field
-                    then
-                    Vector space morphism represented by the matrix:
-                    [ 1 -1]
-                    [ 1  1]
-                    Domain: Vector space of dimension 2 over Rational Field
-                    Codomain: Vector space of dimension 2 over Rational Field
-            sage: f(a)
-            (1, 1)
-            sage: V.hom([V.0 - V.1, V.0 + V.1], side='right')*KtoV
+            sage: f = V.hom([V.0 - V.1, V.0 + V.1]) * KtoV; f
             Composite map:
               From: Number Field in a with defining polynomial x^2 + 23
               To:   Vector space of dimension 2 over Rational Field
@@ -611,17 +599,32 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
                       From: Number Field in a with defining polynomial x^2 + 23
                       To:   Vector space of dimension 2 over Rational Field
                     then
-                      Vector space morphism represented as left-multiplication by the matrix:
-                    [ 1  1]
-                    [-1  1]
-                    Domain: Vector space of dimension 2 over Rational Field
-                    Codomain: Vector space of dimension 2 over Rational Field
+                      Vector space morphism represented by the matrix:
+                      [ 1 -1]
+                      [ 1  1]
+                      Domain:   Vector space of dimension 2 over Rational Field
+                      Codomain: Vector space of dimension 2 over Rational Field
+            sage: f(a)
+            (1, 1)
+            sage: V.hom([V.0 - V.1, V.0 + V.1], side="right") * KtoV
+            Composite map:
+              From: Number Field in a with defining polynomial x^2 + 23
+              To:   Vector space of dimension 2 over Rational Field
+              Defn:   Isomorphism map:
+                      From: Number Field in a with defining polynomial x^2 + 23
+                      To:   Vector space of dimension 2 over Rational Field
+                    then
+                      Vector space morphism represented as left-multiplication
+                      by the matrix:
+                      [ 1  1]
+                      [-1  1]
+                      Domain:   Vector space of dimension 2 over Rational Field
+                      Codomain: Vector space of dimension 2 over Rational Field
 
-
-        We can test interraction between morphisms with different ``side``::
+        We can test interaction between morphisms with different ``side``::
 
             sage: V = ZZ^2
-            sage: m = matrix(2, [1,1,0,1])
+            sage: m = matrix(2, [1,1, 0,1])
             sage: hl = V.hom(m)
             sage: hr = V.hom(m, side='right')
             sage: hl * hl
@@ -696,7 +699,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
         EXAMPLES::
 
-            sage: phi = (ZZ**2).endomorphism_ring()(Matrix(ZZ,2,[2..5])) ; phi
+            sage: phi = (ZZ**2).endomorphism_ring()(Matrix(ZZ, 2, [2..5])); phi
             Free module morphism defined by the matrix
             [2 3]
             [4 5]
@@ -714,7 +717,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             [ 8 10]
             Domain: Ambient free module of rank 2 over the principal ideal domain ...
             Codomain: Ambient free module of rank 2 over the principal ideal domain ...
-            sage: psi = (ZZ**3).endomorphism_ring()(Matrix(ZZ,3,[22..30])) ; psi
+            sage: psi = (ZZ**3).endomorphism_ring()(Matrix(ZZ, 3, [22..30])); psi
             Free module morphism defined by the matrix
             [22 23 24]
             [25 26 27]
@@ -729,7 +732,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         ::
 
             sage: V = ZZ^2
-            sage: m = matrix(2, [1,1,0,1])
+            sage: m = matrix(2, [1,1, 0,1])
             sage: hl = V.hom(m)
             sage: hr = V.hom(m, side='right')
             sage: hl + hl
@@ -773,7 +776,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         """
         EXAMPLES::
 
-            sage: V = ZZ^2; phi = V.hom([V.0+V.1, 2*V.1])
+            sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
             sage: -phi
             Free module morphism defined by the matrix
             [-1 -1]
@@ -789,7 +792,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         """
         EXAMPLES::
 
-            sage: V = ZZ^2; phi = V.hom([V.0+V.1, 2*V.1])
+            sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
             sage: phi - phi
             Free module morphism defined by the matrix
             [0 0]
@@ -798,7 +801,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         ::
 
             sage: V = ZZ^2
-            sage: m = matrix(2, [1,1,0,1])
+            sage: m = matrix(2, [1,1, 0,1])
             sage: hl = V.hom(m)
             sage: hr = V.hom(m, side='right')
             sage: hl - hr
@@ -813,7 +816,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             Free module morphism defined as left-multiplication by the matrix
             [0 0]
             [0 0]...
-            sage: hr-hl
+            sage: hr - hl
             Free module morphism defined by the matrix
             [ 0 -1]
             [ 1  0]...


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Based on a rebased version of the first commit ([328125f6292de28326dda0e2497c2474aa54c7b7](https://github.com/sagemath/sagetrac-mirror/commit/328125f6292de28326dda0e2497c2474aa54c7b7) from #28272 by @tscrim 

- Fixes #28272
- Fixes #16830

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


