### PR TITLE
pkgs/sagemath-repl/pyproject.toml.m4: Declare extra 'sphinx'

### DIFF
--- a/pkgs/sagemath-repl/pyproject.toml.m4
+++ b/pkgs/sagemath-repl/pyproject.toml.m4
@@ -19,6 +19,12 @@ dependencies = [
 dynamic = ["version"]
 include(`pyproject_toml_metadata.m4')dnl'
 
+[project.optional-dependencies]
+# Improved formatting of docstrings in the help system
+sphinx = [
+    SPKG_INSTALL_REQUIRES_sphinx
+]
+
 [project.readme]
 file = "README.rst"
 content-type = "text/x-rst"

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -42,7 +42,7 @@ Python classes::
 
     sage: sage_getfile(BlockFinder)
     '.../sage/misc/sageinspect.py'
-    sage: sage_getdoc(BlockFinder).lstrip()[:50]
+    sage: sage_getdoc(BlockFinder).lstrip()[:50]                                        # needs sphinx
     'Provide a "tokeneater()" method to detect the end '
     sage: sage_getsource(BlockFinder)
     'class BlockFinder:...'


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

As discussed in https://github.com/sagemath/sage/pull/37589#issuecomment-2030456264, the Sage documentation system uses Sphinx to format the documentation in the terminal, for example in the help system.

For the modularization project, a simple fallback for the case of Sphinx not being present was added.

Here we declare the corresponding "extra" so that users can do `pip install sagemath-repl[sphinx]`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


