### PR TITLE
`MatrixMorphism_abstract`: Move endomorphism invariants to category

### DIFF
--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -11,8 +11,9 @@ Finite dimensional modules with basis
 # *****************************************************************************
 
 import operator
-from sage.categories.category_with_axiom import CategoryWithAxiom_over_base_ring
+from sage.categories.category_with_axiom import CategoryWithAxiom, CategoryWithAxiom_over_base_ring
 from sage.categories.fields import Fields
+from sage.categories.homsets import HomsetsCategory
 from sage.categories.tensor import TensorProductsCategory
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_attribute import lazy_attribute
@@ -800,168 +801,164 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             return C.submodule(self.image_basis(), already_echelonized=True,
                                category=self.category_for())
 
-        @lazy_attribute
-        def characteristic_polynomial(self):
-            r"""
-            Return the characteristic polynomial of this endomorphism.
+    class Homsets(HomsetsCategory):
 
-            :meth:`characteristic_polynomial` and :meth:`charpoly` are the same method.
+        class Endset(CategoryWithAxiom):
 
-            INPUT:
+            class ElementMethods:
 
-            - ``var`` -- variable
+                @lazy_attribute
+                def characteristic_polynomial(self):
+                    r"""
+                    Return the characteristic polynomial of this endomorphism.
 
-            EXAMPLES::
+                    :meth:`characteristic_polynomial` and :meth:`charpoly` are the same method.
 
-                sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
-                sage: phi.characteristic_polynomial()
-                x^2 - 3*x + 2
-                sage: phi.charpoly()
-                x^2 - 3*x + 2
-                sage: phi.matrix().charpoly()
-                x^2 - 3*x + 2
-                sage: phi.charpoly('T')
-                T^2 - 3*T + 2
+                    INPUT:
 
-                sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
-                sage: M = matrix(ZZ, [[1, 0], [1, 2]])
-                sage: psi = W.module_morphism(matrix=M, codomain=W)
-                sage: psi.charpoly()
-                x^2 - 3*x + 2
-            """
-            if not self.is_endomorphism():
-                return NotImplemented
-            return self.matrix().charpoly
+                    - ``var`` -- variable
 
-        charpoly = characteristic_polynomial
+                    EXAMPLES::
 
-        @lazy_attribute
-        def determinant(self):
-            """
-            Return the determinant of this endomorphism.
+                        sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                        sage: phi.characteristic_polynomial()
+                        x^2 - 3*x + 2
+                        sage: phi.charpoly()
+                        x^2 - 3*x + 2
+                        sage: phi.matrix().charpoly()
+                        x^2 - 3*x + 2
+                        sage: phi.charpoly('T')
+                        T^2 - 3*T + 2
 
-            :meth:`determinant` and :meth:`det` are the same method.
+                        sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
+                        sage: M = matrix(ZZ, [[1, 0], [1, 2]])
+                        sage: psi = W.module_morphism(matrix=M, codomain=W)
+                        sage: psi.charpoly()
+                        x^2 - 3*x + 2
+                    """
+                    return self.matrix().charpoly
 
-            EXAMPLES::
+                charpoly = characteristic_polynomial
 
-                sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
-                sage: phi.determinant()
-                2
-                sage: phi.det()
-                2
+                @lazy_attribute
+                def determinant(self):
+                    """
+                    Return the determinant of this endomorphism.
 
-                sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
-                sage: M = matrix(ZZ, [[1, 0], [1, 2]])
-                sage: psi = W.module_morphism(matrix=M, codomain=W)
-                sage: psi.det()
-                2
-            """
-            if not self.is_endomorphism():
-                return NotImplemented
-            return self.matrix().determinant
+                    :meth:`determinant` and :meth:`det` are the same method.
 
-        det = determinant
+                    EXAMPLES::
 
-        @lazy_attribute
-        def fcp(self):
-            """
-            Return the factorization of the characteristic polynomial.
+                        sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                        sage: phi.determinant()
+                        2
+                        sage: phi.det()
+                        2
 
-            INPUT:
+                        sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
+                        sage: M = matrix(ZZ, [[1, 0], [1, 2]])
+                        sage: psi = W.module_morphism(matrix=M, codomain=W)
+                        sage: psi.det()
+                        2
+                    """
+                    return self.matrix().determinant
 
-            - ``var`` -- variable
+                det = determinant
 
-            EXAMPLES::
+                @lazy_attribute
+                def fcp(self):
+                    """
+                    Return the factorization of the characteristic polynomial.
 
-                sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
-                sage: phi.fcp()                                                         # needs sage.libs.pari
-                (x - 2) * (x - 1)
-                sage: phi.fcp('T')                                                      # needs sage.libs.pari
-                (T - 2) * (T - 1)
+                    INPUT:
 
-                sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
-                sage: M = matrix(ZZ, [[1, 0], [1, 2]])
-                sage: psi = W.module_morphism(matrix=M, codomain=W)
-                sage: psi.fcp()                                                         # needs sage.libs.pari
-                (x - 2) * (x - 1)
-            """
-            if not self.is_endomorphism():
-                return NotImplemented
-            return self.matrix().fcp
+                    - ``var`` -- variable
 
-        @lazy_attribute
-        def minimal_polynomial(self):
-            r"""
-            Return the minimal polynomial of this endomorphism.
+                    EXAMPLES::
 
-            :meth:`minimal_polynomial` and :meth:`minpoly` are the same method.
+                        sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                        sage: phi.fcp()                                                         # needs sage.libs.pari
+                        (x - 2) * (x - 1)
+                        sage: phi.fcp('T')                                                      # needs sage.libs.pari
+                        (T - 2) * (T - 1)
 
-            INPUT:
+                        sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
+                        sage: M = matrix(ZZ, [[1, 0], [1, 2]])
+                        sage: psi = W.module_morphism(matrix=M, codomain=W)
+                        sage: psi.fcp()                                                         # needs sage.libs.pari
+                        (x - 2) * (x - 1)
+                    """
+                    return self.matrix().fcp
 
-            - ``var`` -- string (default: ``'x'``); a variable name
+                @lazy_attribute
+                def minimal_polynomial(self):
+                    r"""
+                    Return the minimal polynomial of this endomorphism.
 
-            EXAMPLES:
+                    :meth:`minimal_polynomial` and :meth:`minpoly` are the same method.
 
-            Compute the minimal polynomial, and check it. ::
+                    INPUT:
 
-                sage: V = GF(7)^3
-                sage: H = V.Hom(V)([[0,1,2], [-1,0,3], [2,4,1]]); H
-                Vector space morphism represented by the matrix:
-                [0 1 2]
-                [6 0 3]
-                [2 4 1]
-                Domain:   Vector space of dimension 3 over Finite Field of size 7
-                Codomain: Vector space of dimension 3 over Finite Field of size 7
-                sage: H.minpoly()                                                       # needs sage.libs.pari
-                x^3 + 6*x^2 + 6*x + 1
-                sage: H.minimal_polynomial()                                            # needs sage.libs.pari
-                x^3 + 6*x^2 + 6*x + 1
-                sage: H^3 + (H^2)*6 + H*6 + 1
-                Vector space morphism represented by the matrix:
-                [0 0 0]
-                [0 0 0]
-                [0 0 0]
-                Domain:   Vector space of dimension 3 over Finite Field of size 7
-                Codomain: Vector space of dimension 3 over Finite Field of size 7
+                    - ``var`` -- string (default: ``'x'``); a variable name
 
-                sage: # needs sage.rings.finite_rings
-                sage: k = GF(9, 'c')
-                sage: V = CombinatorialFreeModule(k, ['x', 'y', 'z', 'w'])
-                sage: A = matrix(k, 4, [1,1,0,0, 0,1,0,0, 0,0,5,0, 0,0,0,5])
-                sage: phi = V.module_morphism(matrix=A, codomain=V)
-                sage: factor(phi.minpoly())
-                (x + 1) * (x + 2)^2
-                sage: A.minpoly()(A) == 0
-                True
-                sage: factor(phi.charpoly())
-                (x + 1)^2 * (x + 2)^2
-            """
-            if not self.is_endomorphism():
-                return NotImplemented
-            return self.matrix().minimal_polynomial
+                    EXAMPLES:
 
-        minpoly = minimal_polynomial
+                    Compute the minimal polynomial, and check it. ::
 
-        @lazy_attribute
-        def trace(self):
-            r"""
-            Return the trace of this endomorphism.
+                        sage: V = GF(7)^3
+                        sage: H = V.Hom(V)([[0,1,2], [-1,0,3], [2,4,1]]); H
+                        Vector space morphism represented by the matrix:
+                        [0 1 2]
+                        [6 0 3]
+                        [2 4 1]
+                        Domain:   Vector space of dimension 3 over Finite Field of size 7
+                        Codomain: Vector space of dimension 3 over Finite Field of size 7
+                        sage: H.minpoly()                                                       # needs sage.libs.pari
+                        x^3 + 6*x^2 + 6*x + 1
+                        sage: H.minimal_polynomial()                                            # needs sage.libs.pari
+                        x^3 + 6*x^2 + 6*x + 1
+                        sage: H^3 + (H^2)*6 + H*6 + 1
+                        Vector space morphism represented by the matrix:
+                        [0 0 0]
+                        [0 0 0]
+                        [0 0 0]
+                        Domain:   Vector space of dimension 3 over Finite Field of size 7
+                        Codomain: Vector space of dimension 3 over Finite Field of size 7
 
-            EXAMPLES::
+                        sage: # needs sage.rings.finite_rings
+                        sage: k = GF(9, 'c')
+                        sage: V = CombinatorialFreeModule(k, ['x', 'y', 'z', 'w'])
+                        sage: A = matrix(k, 4, [1,1,0,0, 0,1,0,0, 0,0,5,0, 0,0,0,5])
+                        sage: phi = V.module_morphism(matrix=A, codomain=V)
+                        sage: factor(phi.minpoly())
+                        (x + 1) * (x + 2)^2
+                        sage: A.minpoly()(A) == 0
+                        True
+                        sage: factor(phi.charpoly())
+                        (x + 1)^2 * (x + 2)^2
+                    """
+                    return self.matrix().minimal_polynomial
 
-                sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
-                sage: phi.trace()
-                3
+                minpoly = minimal_polynomial
 
-                sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
-                sage: M = matrix(ZZ, [[1, 0], [1, 2]])
-                sage: psi = W.module_morphism(matrix=M, codomain=W)
-                sage: psi.trace()
-                3
-            """
-            if not self.is_endomorphism():
-                return NotImplemented
-            return self.matrix().trace
+                @lazy_attribute
+                def trace(self):
+                    r"""
+                    Return the trace of this endomorphism.
+
+                    EXAMPLES::
+
+                        sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                        sage: phi.trace()
+                        3
+
+                        sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
+                        sage: M = matrix(ZZ, [[1, 0], [1, 2]])
+                        sage: psi = W.module_morphism(matrix=M, codomain=W)
+                        sage: psi.trace()
+                        3
+                    """
+                    return self.matrix().trace
 
     class TensorProducts(TensorProductsCategory):
 

--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -839,6 +839,12 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
                 sage: phi.det()
                 2
+
+                sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
+                sage: M = matrix(ZZ, [[1, 0], [1, 2]])
+                sage: psi = W.module_morphism(matrix=M, codomain=W)
+                sage: phi.det()
+                2
             """
             if not self.is_endomorphism():
                 return NotImplemented
@@ -856,10 +862,16 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             EXAMPLES::
 
                 sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
-                sage: phi.fcp()                                                             # needs sage.libs.pari
+                sage: phi.fcp()                                                         # needs sage.libs.pari
                 (x - 2) * (x - 1)
-                sage: phi.fcp('T')                                                          # needs sage.libs.pari
+                sage: phi.fcp('T')                                                      # needs sage.libs.pari
                 (T - 2) * (T - 1)
+
+                sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
+                sage: M = matrix(ZZ, [[1, 0], [1, 2]])
+                sage: psi = W.module_morphism(matrix=M, codomain=W)
+                sage: psi.fcp()                                                         # needs sage.libs.pari
+                (x - 2) * (x - 1)
             """
             if not self.is_endomorphism():
                 return NotImplemented
@@ -874,6 +886,12 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
 
                 sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
                 sage: phi.trace()
+                3
+
+                sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
+                sage: M = matrix(ZZ, [[1, 0], [1, 2]])
+                sage: psi = W.module_morphism(matrix=M, codomain=W)
+                sage: psi.trace()
                 3
             """
             if not self.is_endomorphism():

--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -15,6 +15,8 @@ from sage.categories.category_with_axiom import CategoryWithAxiom_over_base_ring
 from sage.categories.fields import Fields
 from sage.categories.tensor import TensorProductsCategory
 from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_attribute import lazy_attribute
+
 
 class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
     """
@@ -797,6 +799,86 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             C = self.codomain()
             return C.submodule(self.image_basis(), already_echelonized=True,
                                category=self.category_for())
+
+        @lazy_attribute
+        def characteristic_polynomial(self):
+            r"""
+            Return the characteristic polynomial of this endomorphism.
+
+            :meth:`characteristic_polynomial` and :meth:`char_poly` are the same method.
+
+            INPUT:
+
+            - ``var`` -- variable
+
+            EXAMPLES::
+
+                sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                sage: phi.characteristic_polynomial()
+                x^2 - 3*x + 2
+                sage: phi.charpoly()
+                x^2 - 3*x + 2
+                sage: phi.matrix().charpoly()
+                x^2 - 3*x + 2
+                sage: phi.charpoly('T')
+                T^2 - 3*T + 2
+            """
+            if not self.is_endomorphism():
+                return NotImplemented
+            return self.matrix().charpoly
+
+        charpoly = characteristic_polynomial
+
+        @lazy_attribute
+        def det(self):
+            """
+            Return the determinant of this endomorphism.
+
+            EXAMPLES::
+
+                sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                sage: phi.det()
+                2
+            """
+            if not self.is_endomorphism():
+                return NotImplemented
+            return self.matrix().determinant
+
+        @lazy_attribute
+        def fcp(self):
+            """
+            Return the factorization of the characteristic polynomial.
+
+            INPUT:
+
+            - ``var`` -- variable
+
+            EXAMPLES::
+
+                sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                sage: phi.fcp()                                                             # needs sage.libs.pari
+                (x - 2) * (x - 1)
+                sage: phi.fcp('T')                                                          # needs sage.libs.pari
+                (T - 2) * (T - 1)
+            """
+            if not self.is_endomorphism():
+                return NotImplemented
+            return self.matrix().fcp
+
+        @lazy_attribute
+        def trace(self):
+            r"""
+            Return the trace of this endomorphism.
+
+            EXAMPLES::
+
+                sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                sage: phi.trace()
+                3
+            """
+            if not self.is_endomorphism():
+                return NotImplemented
+            return self.matrix().trace
 
     class TensorProducts(TensorProductsCategory):
 

--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -805,7 +805,7 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             r"""
             Return the characteristic polynomial of this endomorphism.
 
-            :meth:`characteristic_polynomial` and :meth:`char_poly` are the same method.
+            :meth:`characteristic_polynomial` and :meth:`charpoly` are the same method.
 
             INPUT:
 
@@ -822,6 +822,12 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 x^2 - 3*x + 2
                 sage: phi.charpoly('T')
                 T^2 - 3*T + 2
+
+                sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
+                sage: M = matrix(ZZ, [[1, 0], [1, 2]])
+                sage: psi = W.module_morphism(matrix=M, codomain=W)
+                sage: psi.charpoly()
+                x^2 - 3*x + 2
             """
             if not self.is_endomorphism():
                 return NotImplemented
@@ -847,7 +853,7 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: W = CombinatorialFreeModule(ZZ, ['x', 'y'])
                 sage: M = matrix(ZZ, [[1, 0], [1, 2]])
                 sage: psi = W.module_morphism(matrix=M, codomain=W)
-                sage: phi.det()
+                sage: psi.det()
                 2
             """
             if not self.is_endomorphism():
@@ -882,6 +888,37 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             if not self.is_endomorphism():
                 return NotImplemented
             return self.matrix().fcp
+
+        @lazy_attribute
+        def minimal_polynomial(self):
+            r"""
+            Return the minimal polynomial of this endomorphism.
+
+            :meth:`minimal_polynomial` and :meth:`minpoly` are the same method.
+
+            INPUT:
+
+            - ``var`` -- variable
+
+            EXAMPLES::
+
+                sage: # needs sage.rings.finite_rings
+                sage: k = GF(9, 'c')
+                sage: V = CombinatorialFreeModule(k, ['x', 'y', 'z', 'w'])
+                sage: A = matrix(k, 4, [1,1,0,0, 0,1,0,0, 0,0,5,0, 0,0,0,5])
+                sage: phi = V.module_morphism(matrix=A, codomain=V)
+                sage: factor(phi.minpoly())
+                (x + 1) * (x + 2)^2
+                sage: A.minpoly()(A) == 0
+                True
+                sage: factor(phi.charpoly())
+                (x + 1)^2 * (x + 2)^2
+            """
+            if not self.is_endomorphism():
+                return NotImplemented
+            return self.matrix().minimal_polynomial
+
+        minpoly = minimal_polynomial
 
         @lazy_attribute
         def trace(self):

--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -830,13 +830,17 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
         charpoly = characteristic_polynomial
 
         @lazy_attribute
-        def det(self):
+        def determinant(self):
             """
             Return the determinant of this endomorphism.
+
+            :meth:`determinant` and :meth:`det` are the same method.
 
             EXAMPLES::
 
                 sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
+                sage: phi.determinant()
+                2
                 sage: phi.det()
                 2
 
@@ -849,6 +853,8 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             if not self.is_endomorphism():
                 return NotImplemented
             return self.matrix().determinant
+
+        det = determinant
 
         @lazy_attribute
         def fcp(self):

--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -898,9 +898,31 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
 
             INPUT:
 
-            - ``var`` -- variable
+            - ``var`` -- string (default: ``'x'``); a variable name
 
-            EXAMPLES::
+            EXAMPLES:
+
+            Compute the minimal polynomial, and check it. ::
+
+                sage: V = GF(7)^3
+                sage: H = V.Hom(V)([[0,1,2], [-1,0,3], [2,4,1]]); H
+                Vector space morphism represented by the matrix:
+                [0 1 2]
+                [6 0 3]
+                [2 4 1]
+                Domain:   Vector space of dimension 3 over Finite Field of size 7
+                Codomain: Vector space of dimension 3 over Finite Field of size 7
+                sage: H.minpoly()                                                       # needs sage.libs.pari
+                x^3 + 6*x^2 + 6*x + 1
+                sage: H.minimal_polynomial()                                            # needs sage.libs.pari
+                x^3 + 6*x^2 + 6*x + 1
+                sage: H^3 + (H^2)*6 + H*6 + 1
+                Vector space morphism represented by the matrix:
+                [0 0 0]
+                [0 0 0]
+                [0 0 0]
+                Domain:   Vector space of dimension 3 over Finite Field of size 7
+                Codomain: Vector space of dimension 3 over Finite Field of size 7
 
                 sage: # needs sage.rings.finite_rings
                 sage: k = GF(9, 'c')

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -116,9 +116,10 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
     Some more playing around with categories and higher order homsets::
 
         sage: H.category()                                                              # needs sage.modules
-        Category of homsets of modules with basis over Rational Field
+        Category of homsets of finite dimensional modules with basis over Rational Field
         sage: Hom(H, H).category()                                                      # needs sage.modules
-        Category of endsets of homsets of modules with basis over Rational Field
+        Category of endsets of
+         homsets of finite dimensional modules with basis over Rational Field
 
     .. TODO:: ``End(X)`` is an algebra.
 

--- a/src/sage/geometry/fan_morphism.py
+++ b/src/sage/geometry/fan_morphism.py
@@ -89,8 +89,7 @@ from sage.misc.cachefunc import cached_method
 from sage.misc.latex import latex
 from sage.misc.misc import walltime
 from sage.misc.misc_c import prod
-from sage.modules.free_module_morphism import (FreeModuleMorphism,
-                                               is_FreeModuleMorphism)
+from sage.modules.free_module_morphism import FreeModuleMorphism
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
 from sage.rings.infinity import is_Infinite
@@ -277,7 +276,7 @@ class FanMorphism(FreeModuleMorphism):
             codomain, codomain_fan = codomain.lattice(), codomain
         else:
             codomain_fan = None
-        if is_FreeModuleMorphism(morphism):
+        if isinstance(morphism, FreeModuleMorphism):
             parent = morphism.parent()
             A = morphism.matrix()
         elif is_Matrix(morphism):

--- a/src/sage/modular/abvar/morphism.py
+++ b/src/sage/modular/abvar/morphism.py
@@ -870,6 +870,20 @@ class HeckeOperator(Morphism):
         """
         return self.characteristic_polynomial(var)
 
+    def fcp(self, var='x'):
+        """
+        Return the factorization of the characteristic polynomial.
+
+        EXAMPLES::
+
+            sage: t2 = J0(33).hecke_operator(2)
+            sage: t2.charpoly()
+            x^3 + 3*x^2 - 4
+            sage: t2.fcp()
+            (x - 1) * (x + 2)^2
+        """
+        return self.charpoly(var).factor()
+
     def action_on_homology(self, R=ZZ):
         r"""
         Return the action of this Hecke operator on the homology

--- a/src/sage/modules/free_module_morphism.py
+++ b/src/sage/modules/free_module_morphism.py
@@ -74,7 +74,7 @@ def is_FreeModuleMorphism(x):
 
 class FreeModuleMorphism(matrix_morphism.MatrixMorphism):
 
-    minimal_polynomial = minpoly = FiniteDimensionalModulesWithBasis.MorphismMethods.minimal_polynomial
+    minimal_polynomial = minpoly = FiniteDimensionalModulesWithBasis.Homsets.Endset.ElementMethods.minimal_polynomial
 
     def __init__(self, parent, A, side="left"):
         """

--- a/src/sage/modules/free_module_morphism.py
+++ b/src/sage/modules/free_module_morphism.py
@@ -51,14 +51,24 @@ from sage.structure.sequence import Sequence
 
 def is_FreeModuleMorphism(x):
     """
+    This function is deprecated.
+
     EXAMPLES::
 
         sage: V = ZZ^2; f = V.hom([V.1, -2*V.0])
         sage: sage.modules.free_module_morphism.is_FreeModuleMorphism(f)
+        doctest:warning...
+        DeprecationWarning: is_FreeModuleMorphism is deprecated;
+        use isinstance(..., FreeModuleMorphism) or categories instead
+        See https://github.com/sagemath/sage/issues/37731 for details.
         True
         sage: sage.modules.free_module_morphism.is_FreeModuleMorphism(0)
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37731,
+                "is_FreeModuleMorphism is deprecated; "
+                "use isinstance(..., FreeModuleMorphism) or categories instead")
     return isinstance(x, FreeModuleMorphism)
 
 

--- a/src/sage/modules/free_module_morphism.py
+++ b/src/sage/modules/free_module_morphism.py
@@ -42,6 +42,7 @@ TESTS::
 # be coercible into vector space of appropriate dimension.
 
 import sage.modules.free_module as free_module
+from sage.categories.finite_dimensional_modules_with_basis import FiniteDimensionalModulesWithBasis
 from sage.categories.morphism import Morphism
 from sage.modules import free_module_homspace, matrix_morphism
 from sage.structure.richcmp import rich_to_bool, richcmp
@@ -62,6 +63,9 @@ def is_FreeModuleMorphism(x):
 
 
 class FreeModuleMorphism(matrix_morphism.MatrixMorphism):
+
+    minimal_polynomial = minpoly = FiniteDimensionalModulesWithBasis.MorphismMethods.minimal_polynomial
+
     def __init__(self, parent, A, side="left"):
         """
         INPUT:

--- a/src/sage/modules/free_module_morphism.py
+++ b/src/sage/modules/free_module_morphism.py
@@ -42,7 +42,7 @@ TESTS::
 # be coercible into vector space of appropriate dimension.
 
 import sage.modules.free_module as free_module
-from sage.categories.finite_dimensional_modules_with_basis import FiniteDimensionalModulesWithBasis
+
 from sage.categories.morphism import Morphism
 from sage.modules import free_module_homspace, matrix_morphism
 from sage.structure.richcmp import rich_to_bool, richcmp
@@ -73,8 +73,6 @@ def is_FreeModuleMorphism(x):
 
 
 class FreeModuleMorphism(matrix_morphism.MatrixMorphism):
-
-    minimal_polynomial = minpoly = FiniteDimensionalModulesWithBasis.Homsets.Endset.ElementMethods.minimal_polynomial
 
     def __init__(self, parent, A, side="left"):
         """

--- a/src/sage/modules/free_module_morphism.py
+++ b/src/sage/modules/free_module_morphism.py
@@ -636,55 +636,6 @@ class FreeModuleMorphism(matrix_morphism.MatrixMorphism):
         return [(vec[0], Sequence(vec[1]).universe().subspace(vec[1]))
                 for vec in ev]
 
-    def minimal_polynomial(self, var='x'):
-        r"""
-        Computes the minimal polynomial.
-
-        ``minpoly()`` and ``minimal_polynomial()`` are the same method.
-
-        INPUT:
-
-        - ``var`` - string (default: 'x') a variable name
-
-        OUTPUT:
-
-        polynomial in var - the minimal polynomial of the endomorphism.
-
-        EXAMPLES:
-
-        Compute the minimal polynomial, and check it. ::
-
-            sage: V = GF(7)^3
-            sage: H = V.Hom(V)([[0,1,2], [-1,0,3], [2,4,1]])
-            sage: H
-            Vector space morphism represented by the matrix:
-            [0 1 2]
-            [6 0 3]
-            [2 4 1]
-            Domain:   Vector space of dimension 3 over Finite Field of size 7
-            Codomain: Vector space of dimension 3 over Finite Field of size 7
-
-            sage: H.minpoly()                                                           # needs sage.libs.pari
-            x^3 + 6*x^2 + 6*x + 1
-
-            sage: H.minimal_polynomial()                                                # needs sage.libs.pari
-            x^3 + 6*x^2 + 6*x + 1
-
-            sage: H^3 + (H^2)*6 + H*6 + 1
-            Vector space morphism represented by the matrix:
-            [0 0 0]
-            [0 0 0]
-            [0 0 0]
-            Domain:   Vector space of dimension 3 over Finite Field of size 7
-            Codomain: Vector space of dimension 3 over Finite Field of size 7
-        """
-        if self.is_endomorphism():
-            return self.matrix().minpoly(var)
-        else:
-            raise TypeError("not an endomorphism")
-
-    minpoly = minimal_polynomial
-
 
 class BaseIsomorphism1D(Morphism):
     """

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -61,6 +61,8 @@ def is_MatrixMorphism(x):
     """
     Return True if x is a Matrix morphism of free modules.
 
+    This function is deprecated.
+
     EXAMPLES::
 
         sage: V = ZZ^2; phi = V.hom([3*V.0, 2*V.1])
@@ -74,7 +76,7 @@ def is_MatrixMorphism(x):
         False
     """
     from sage.misc.superseded import deprecation
-    deprecation(99999,
+    deprecation(37731,
                 "is_MatrixMorphism is deprecated; "
                 "use isinstance(..., MatrixMorphism_abstract) or categories instead")
     return isinstance(x, MatrixMorphism_abstract)

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -70,7 +70,7 @@ def is_MatrixMorphism(x):
         doctest:warning...
         DeprecationWarning: is_MatrixMorphism is deprecated;
         use isinstance(..., MatrixMorphism_abstract) or categories instead
-        See https://github.com/sagemath/sage/issues/99999 for details.
+        See https://github.com/sagemath/sage/issues/37731 for details.
         True
         sage: sage.modules.matrix_morphism.is_MatrixMorphism(3)
         False

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -806,35 +806,6 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         """
         return self.domain().base_ring()
 
-    def characteristic_polynomial(self, var='x'):
-        r"""
-        Return the characteristic polynomial of this endomorphism.
-
-        ``characteristic_polynomial`` and ``char_poly`` are the same method.
-
-        INPUT:
-
-        - var -- variable
-
-        EXAMPLES::
-
-            sage: V = ZZ^2; phi = V.hom([V.0+V.1, 2*V.1])
-            sage: phi.characteristic_polynomial()
-            x^2 - 3*x + 2
-            sage: phi.charpoly()
-            x^2 - 3*x + 2
-            sage: phi.matrix().charpoly()
-            x^2 - 3*x + 2
-            sage: phi.charpoly('T')
-            T^2 - 3*T + 2
-        """
-        if not self.is_endomorphism():
-            raise ArithmeticError("charpoly only defined for endomorphisms "
-                                  "(i.e., domain = range)")
-        return self.matrix().charpoly(var)
-
-    charpoly = characteristic_polynomial
-
     def decomposition(self, *args, **kwds):
         """
         Return decomposition of this endomorphism, i.e., sequence of
@@ -883,46 +854,6 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             return Sequence([D.submodule((V.basis_matrix() * B).row_module(R),
                                          check=False) for V, _ in E],
                             cr=True, check=False)
-
-    def trace(self):
-        r"""
-        Return the trace of this endomorphism.
-
-        EXAMPLES::
-
-            sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
-            sage: phi.trace()
-            3
-        """
-        return self._matrix.trace()
-
-    def det(self):
-        """
-        Return the determinant of this endomorphism.
-
-        EXAMPLES::
-
-            sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
-            sage: phi.det()
-            2
-        """
-        if not self.is_endomorphism():
-            raise ArithmeticError("matrix morphism must be an endomorphism")
-        return self.matrix().determinant()
-
-    def fcp(self, var='x'):
-        """
-        Return the factorization of the characteristic polynomial.
-
-        EXAMPLES::
-
-            sage: V = ZZ^2; phi = V.hom([V.0 + V.1, 2*V.1])
-            sage: phi.fcp()                                                             # needs sage.libs.pari
-            (x - 2) * (x - 1)
-            sage: phi.fcp('T')                                                          # needs sage.libs.pari
-            (T - 2) * (T - 1)
-        """
-        return self.charpoly(var).factor()
 
     def kernel(self):
         """

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -89,10 +89,10 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
     # for use with parents that are merely set up as additive abelian groups,
     # but not as ZZ-modules; see sage.modular.abvar.
 
-    characteristic_polynomial = charpoly = FiniteDimensionalModulesWithBasis.MorphismMethods.characteristic_polynomial
-    det = determinant = FiniteDimensionalModulesWithBasis.MorphismMethods.determinant
-    fcp = FiniteDimensionalModulesWithBasis.MorphismMethods.fcp
-    trace = FiniteDimensionalModulesWithBasis.MorphismMethods.trace
+    characteristic_polynomial = charpoly = FiniteDimensionalModulesWithBasis.Homsets.Endset.ElementMethods.characteristic_polynomial
+    det = determinant = FiniteDimensionalModulesWithBasis.Homsets.Endset.ElementMethods.determinant
+    fcp = FiniteDimensionalModulesWithBasis.Homsets.Endset.ElementMethods.fcp
+    trace = FiniteDimensionalModulesWithBasis.Homsets.Endset.ElementMethods.trace
 
     def __init__(self, parent, side='left'):
         """

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -20,8 +20,6 @@ EXAMPLES::
     [1 0 0]
     [0 1 0]
     [0 0 1]
-    sage: is_MatrixMorphism(m)
-    True
     sage: m.charpoly('x')                                                               # needs sage.libs.pari
     x^3 - 3*x^2 + 3*x - 1
     sage: m.base_ring()
@@ -66,10 +64,18 @@ def is_MatrixMorphism(x):
 
         sage: V = ZZ^2; phi = V.hom([3*V.0, 2*V.1])
         sage: sage.modules.matrix_morphism.is_MatrixMorphism(phi)
+        doctest:warning...
+        DeprecationWarning: is_MatrixMorphism is deprecated;
+        use isinstance(..., MatrixMorphism_abstract) or categories instead
+        See https://github.com/sagemath/sage/issues/99999 for details.
         True
         sage: sage.modules.matrix_morphism.is_MatrixMorphism(3)
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(99999,
+                "is_MatrixMorphism is deprecated; "
+                "use isinstance(..., MatrixMorphism_abstract) or categories instead")
     return isinstance(x, MatrixMorphism_abstract)
 
 
@@ -1367,7 +1373,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
 
         - Rob Beezer (2011-07-15)
         """
-        if not is_MatrixMorphism(other):
+        if not isinstance(other, MatrixMorphism_abstract):
             msg = 'can only compare to a matrix morphism, not {0}'
             raise TypeError(msg.format(other))
         if self.domain() != other.domain():

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -52,6 +52,7 @@ AUTHOR:
 
 import sage.categories.morphism
 import sage.categories.homset
+from sage.categories.finite_dimensional_modules_with_basis import FiniteDimensionalModulesWithBasis
 from sage.structure.all import Sequence, parent
 from sage.structure.richcmp import richcmp, op_NE, op_EQ
 
@@ -80,6 +81,17 @@ def is_MatrixMorphism(x):
 
 
 class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
+
+    # Copy in methods that delegate to self.matrix.
+    # This is needed because MatrixMorphism_abstract is subclassed
+    # for use with parents that are merely set up as additive abelian groups,
+    # but not as ZZ-modules; see sage.modular.abvar.
+
+    characteristic_polynomial = charpoly = FiniteDimensionalModulesWithBasis.MorphismMethods.characteristic_polynomial
+    det = determinant = FiniteDimensionalModulesWithBasis.MorphismMethods.determinant
+    fcp = FiniteDimensionalModulesWithBasis.MorphismMethods.fcp
+    trace = FiniteDimensionalModulesWithBasis.MorphismMethods.trace
+
     def __init__(self, parent, side='left'):
         """
         INPUT:

--- a/src/sage/modules/vector_space_homspace.py
+++ b/src/sage/modules/vector_space_homspace.py
@@ -369,14 +369,14 @@ class VectorSpaceHomspace(sage.modules.free_module_homspace.FreeModuleHomspace):
         Previously the above code resulted in a :class:`TypeError` because the
         dimensions of the matrix were incorrect.
         """
-        from .vector_space_morphism import is_VectorSpaceMorphism, VectorSpaceMorphism
+        from .vector_space_morphism import VectorSpaceMorphism
         D = self.domain()
         C = self.codomain()
         side = kwds.get("side", "left")
         from sage.structure.element import is_Matrix
         if is_Matrix(A):
             pass
-        elif is_VectorSpaceMorphism(A):
+        elif isinstance(A, VectorSpaceMorphism):
             A = A.matrix()
         elif callable(A):
             try:

--- a/src/sage/modules/vector_space_morphism.py
+++ b/src/sage/modules/vector_space_morphism.py
@@ -785,6 +785,8 @@ def is_VectorSpaceMorphism(x) -> bool:
     r"""
     Returns ``True`` if ``x`` is a vector space morphism (a linear transformation).
 
+    This function is deprecated.
+
     INPUT:
 
     ``x`` - anything
@@ -798,10 +800,18 @@ def is_VectorSpaceMorphism(x) -> bool:
 
         sage: V = QQ^2; f = V.hom([V.1,-2*V.0])
         sage: sage.modules.vector_space_morphism.is_VectorSpaceMorphism(f)
+        doctest:warning...
+        DeprecationWarning: is_VectorSpaceMorphism is deprecated;
+        use isinstance(..., VectorSpaceMorphism) or categories instead
+        See https://github.com/sagemath/sage/issues/37731 for details.
         True
         sage: sage.modules.vector_space_morphism.is_VectorSpaceMorphism('junk')
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37731,
+                "is_VectorSpaceMorphism is deprecated; "
+                "use isinstance(..., VectorSpaceMorphism) or categories instead")
     return isinstance(x, VectorSpaceMorphism)
 
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

We move the methods `charpoly`, `det`, `fcp`, `trace` from `MatrixMorphism_abstract` to the `Homsets.Endset.ElementMethods` of the category `FiniteDimensionalModulesWithBasis`. Likewise, we move the method `minpoly` there from `FreeModuleMorphism`.

This makes them also available to endomorphisms of `CombinatorialFreeModule`.

We also deprecate the functions `is_MatrixMorphism`, `is_FreeModuleMorphism`, `is_VectorSpaceMorphism` (as part of #32414); they were almost unused.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


