### PR TITLE
Disable most documentation notifications on GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 - [ ] The description explains in detail what this PR is about.
 - [ ] I have linked a relevant issue or discussion.
 - [ ] I have created tests covering the changes.
-- [ ] I have updated the documentation and checked the generated documentation. <!-- You do not need to build the documentation locally. A bot is recreating the documentation whenever there is a change to this PR and will maintain a link to the latest preview once it's ready. -->
+- [ ] I have updated the documentation and checked the generated documentation.
 
 ### :hourglass: Dependencies
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 - [ ] The description explains in detail what this PR is about.
 - [ ] I have linked a relevant issue or discussion.
 - [ ] I have created tests covering the changes.
-- [ ] I have updated the documentation accordingly.
+- [ ] I have updated the documentation and checked the generated documentation. <!-- You do not need to build the documentation locally. A bot is recreating the documentation whenever there is a change to this PR and will maintain a link to the latest preview once it's ready. -->
 
 ### :hourglass: Dependencies
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 - [ ] The description explains in detail what this PR is about.
 - [ ] I have linked a relevant issue or discussion.
 - [ ] I have created tests covering the changes.
-- [ ] I have updated the documentation and checked the generated documentation.
+- [ ] I have updated the documentation and checked the documentation preview.
 
 ### :hourglass: Dependencies
 

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -72,7 +72,8 @@ jobs:
           header: preview-comment
           recreate: false
           message: |
-            [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/html/en) (built with commit ${{ steps.source-run-info.outputs.sourceHeadSha }}; [changes](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/CHANGES.html)) is ready! :tada: This preview will update shortly after each push to this PR.
+            [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/html/en) (built with commit ${{ steps.source-run-info.outputs.sourceHeadSha }}; [changes](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/CHANGES.html)) is ready! :tada:
+            This preview will update shortly after each push to this PR.
 
       - name: Update deployment status PR check
         uses: myrotvorets/set-commit-status-action@v2.0.0
@@ -134,4 +135,3 @@ jobs:
       - name: Report deployment url
         run: |
           echo "::notice::The live documentation has been deployed - ${{ steps.deploy-netlify.outputs.NETLIFY_URL }}"
-

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -72,7 +72,7 @@ jobs:
           header: preview-comment
           recreate: false
           message: |
-            [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/html/en) (built with commit ${{ steps.source-run-info.outputs.sourceHeadSha }}; [changes](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/CHANGES.html)) is ready! :tada:
+            [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/html/en) (built with commit ${{ steps.source-run-info.outputs.sourceHeadSha }}; [changes](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/CHANGES.html)) is ready! :tada: This preview will update shortly after each push to this PR.
 
       - name: Update deployment status PR check
         uses: myrotvorets/set-commit-status-action@v2.0.0

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           number: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           header: preview-comment
-          recreate: true
+          recreate: false
           message: |
             [Documentation preview for this PR](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/html/en) (built with commit ${{ steps.source-run-info.outputs.sourceHeadSha }}; [changes](${{ steps.deploy-netlify.outputs.NETLIFY_URL }}/CHANGES.html)) is ready! :tada:
 


### PR DESCRIPTION
Previously, the documentation comment on GitHub would be removed and then recreated whenever there is a change to a PR which creates notification emails and to some feels like it's polluting their GitHub inbox.

Here, we change this behavior so that only the initial build of the documentation causes such a notification. Further updates to the documentation do update the links in the comment but do not trigger a notification.

This is meant as an alternative to #37387. See #37739 for futher ideas about a smarter behavior here.

An actual preview of the result can be seen here: https://github.com/saraedum/sage/pull/2

Note that the links on that PR do not work because my fork does not have netlify credentials configured.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes; this is fairly hard to test automatically. I'll test this manually if there is interest in merging this.
- [x] I have updated the documentation accordingly; kind of, I updated the PR checklist.