### PR TITLE
dft for symmetric group algebra when p|n!

### DIFF
--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1950,8 +1950,8 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
 
         EXAMPLES::
 
-            sage: GF3S3 = SymmetricGroupAlgebra(GF(2),3)
-            sage: GF3S3._dft_modular()
+            sage: GF2S3 = SymmetricGroupAlgebra(GF(2),3)
+            sage: GF2S3._dft_modular()
             [1 0 0 0 1 0]
             [0 1 0 0 0 1]
             [0 0 1 0 0 1]
@@ -1977,7 +1977,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             for pair in list(b):
                 coord_vector[sym_group_list.index(pair[0])] = pair[1]
             change_of_basis_matrix.append(coord_vector)
-        return Matrix(self.base_ring(),change_of_basis_matrix)
+        return matrix(self.base_ring(),change_of_basis_matrix)
 
     def epsilon_ik(self, itab, ktab, star=0, mult='l2r'):
         r"""

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1977,7 +1977,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             for pair in list(b):
                 coord_vector[sym_group_list.index(pair[0])] = pair[1]
             change_of_basis_matrix.append(coord_vector)
-        return matrix(self.base_ring(),change_of_basis_matrix)
+        return matrix(self.base_ring(),change_of_basis_matrix).transpose()
 
     def epsilon_ik(self, itab, ktab, star=0, mult='l2r'):
         r"""

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1945,8 +1945,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
 
     def _dft_modular(self):
         """
-        Return the discrete Foruier transform when the characterisc divides the order of the group.
-        The usual .dft() throws ZeroDivisionError when p|n.
+        Return the discrete Foruier transform when the characteristic divides the order of the group.
 
         EXAMPLES::
 

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1913,7 +1913,6 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             return self._dft_modular()
         else:
             raise ValueError("invalid form (= %s)" % form)
-        
     def _dft_seminormal(self, mult='l2r'):
         """
         Return the seminormal form of the discrete Fourier transform for ``self``.

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1950,14 +1950,14 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
 
         EXAMPLES::
 
-            sage: GF3S3 = SymmetricGroupAlgebra(GF(3),3)
+            sage: GF3S3 = SymmetricGroupAlgebra(GF(2),3)
             sage: GF3S3._dft_modular()
-            [1   0   0   0   0   0]
-            [0   0   0   1   0   0]
-            [0   0   0   0   0   1]
-            [0   0   1   0   0   0]
-            [0   1   0   0   0   0]
-            [0   0   0   0   1   0]
+            [1 0 0 0 1 0]
+            [0 1 0 0 0 1]
+            [0 0 1 0 0 1]
+            [0 0 0 1 1 0]
+            [1 0 0 1 1 0]
+            [0 1 1 0 0 1]
         """
         #create a spanning set for the block corresponding to an idempotent
         spanning_set = lambda idem: [self(sigma)*idem for sigma in self.group()]

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1962,19 +1962,14 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             [0 0 0 0 1 0]
 
         """
-        #helper function to flatten a list
-        def flatten(l):
-            return [item for sublist in l for item in sublist]
         #create a spanning set for the block corresponding to an idempotent
-        def spanning_set(idem):
-            return [self(sigma)*idem for sigma in self.group()]
-        #compute all the blocks
-        def symmetric_group_blocks():
-            idempotents = self.central_orthogonal_idempotents()
-            #compute the submodule corresponding to span_GF(p){\sigma*e_i | \sigma \in S_n}
-            return [self.submodule(spanning_set(idem)) for idem in idempotents]
+        spanning_set = lambda idem: [self(sigma)*idem for sigma in self.group()]
+        #compute central primitive orthogonal idempotents
+        idempotents = self.central_orthogonal_idempotents()
         #project v onto each block U_i = F_p[S_n]*e_i via \pi_i: v |--> v*e_i
-        blocks = symmetric_group_blocks(p,n)
+        blocks = [self.submodule(spanning_set(idem)) for idem in idempotents]
+        #helper function to flatten a list
+        flatten = lambda l: [item for sublist in l for item in sublist]
         #compute the list of basis vectors lifed to the SGA from each block
         block_decomposition_basis = flatten([[u.lift() for u in block.basis()] for block in blocks])
         #the elements of the symmetric group are ordered, giving the map from the standard basis

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1945,11 +1945,14 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         """
         Return the discrete Foruier transform when the characteristic divides the order of the group.
         See [Mur1983]_ for contrstruction of central primitive orthogonal idempotents.
+        For each idempotent e_i we have a projection v |--> v*e_i. This is a homomorphism.
+        We choose a basis for each submodule spanning by {\sigma*e_i | \sigma \in S_n}.
+        The change-of-basis from the standard basis {\sigma}_\sigma is returned.
 
         EXAMPLES::
 
             sage: GF2S3 = SymmetricGroupAlgebra(GF(2),3)
-            sage: GF2S3.dft(form="modular")
+            sage: GF2S3.dft()
             [1 0 0 0 1 0]
             [0 1 0 0 0 1]
             [0 0 1 0 0 1]

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1952,13 +1952,12 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
 
             sage: GF3S3 = SymmetricGroupAlgebra(GF(3),3)
             sage: GF3S3._dft_modular()
-            [1 0 0 0 0 0]
-            [0 0 0 1 0 0]
-            [0 0 0 0 0 1]
-            [0 0 1 0 0 0]
-            [0 1 0 0 0 0]
-            [0 0 0 0 1 0]
-
+            [1   0   0   0   0   0]
+            [0   0   0   1   0   0]
+            [0   0   0   0   0   1]
+            [0   0   1   0   0   0]
+            [0   1   0   0   0   0]
+            [0   0   0   0   1   0]
         """
         #create a spanning set for the block corresponding to an idempotent
         spanning_set = lambda idem: [self(sigma)*idem for sigma in self.group()]

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1962,20 +1962,15 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         #helper function to flatten a list
         def flatten(l):
             return [item for sublist in l for item in sublist]
-        
         #create a spanning set for the block corresponding to an idempotent
         def spanning_set(idem,p,n):
             return [self(sigma)*idem for sigma in self.group()]
-        
         #compute all the blocks
-        #compute the submodule corresponding to span_GF(p){\sigma*e_i | \sigma \in S_n}
         def symmetric_group_blocks(p,n):
             idempotents = self.central_orthogonal_idempotents()
+            #compute the submodule corresponding to span_GF(p){\sigma*e_i | \sigma \in S_n}
             return [self.submodule(spanning_set(idem,p,n)) for idem in idempotents]
-        
-        #implements modular Fourier transform
-        #project v onto each block U_i = F_p[S_n]*e_i 
-        #use \pi_i: v |--> v*e_i as a projection
+        #project v onto each block U_i = F_p[S_n]*e_i via \pi_i: v |--> v*e_i
         def modular_fourier_transform(p,n):
             blocks = symmetric_group_blocks(p,n)
             #compute the list of basis vectors lifed to the SGA from each block

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1950,7 +1950,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         EXAMPLES::
 
             sage: GF2S3 = SymmetricGroupAlgebra(GF(2),3)
-            sage: GF2S3._dft_modular()
+            sage: GF2S3.dft(form="modular")
             [1 0 0 0 1 0]
             [0 1 0 0 0 1]
             [0 0 1 0 0 1]

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1950,10 +1950,8 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
 
         EXAMPLES::
 
-            p=3, n=3:
-
-            sage: SGA_3_3 = SymmetricGroupAlgebra(GF(3),3)
-            sage: SGA_3_3.dft(form="modular")
+            sage: GF3S3 = SymmetricGroupAlgebra(GF(3),3)
+            sage: GF3S3._dft_modular()
             [1 0 0 0 0 0]
             [0 0 0 1 0 0]
             [0 0 0 0 0 1]

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1913,7 +1913,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             return self._dft_modular()
         else:
             raise ValueError("invalid form (= %s)" % form)
-        
+
     def _dft_seminormal(self, mult='l2r'):
         """
         Return the seminormal form of the discrete Fourier transform for ``self``.
@@ -1942,7 +1942,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         """
         snb = self.seminormal_basis(mult=mult)
         return matrix([vector(b) for b in snb]).inverse().transpose()
-    
+
     def _dft_modular(self):
         """
         Return the discrete Foruier transform when the characterisc divides the order of the group.

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1913,6 +1913,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             return self._dft_modular()
         else:
             raise ValueError("invalid form (= %s)" % form)
+        
     def _dft_seminormal(self, mult='l2r'):
         """
         Return the seminormal form of the discrete Fourier transform for ``self``.
@@ -1947,8 +1948,10 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         Return the discrete Foruier transform when the characterisc divides the order of the group.
         The usual .dft() throws ZeroDivisionError when p|n.
 
-        EXAMPLES: 
+        EXAMPLES::
+
             p=3, n=3:
+
             sage: SGA_3_3 = SymmetricGroupAlgebra(GF(3),3)
             sage: SGA_3_3.dft(form="modular")
             [1 0 0 0 0 0]
@@ -1963,27 +1966,26 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         def flatten(l):
             return [item for sublist in l for item in sublist]
         #create a spanning set for the block corresponding to an idempotent
-        def spanning_set(idem,p,n):
+        def spanning_set(idem):
             return [self(sigma)*idem for sigma in self.group()]
         #compute all the blocks
-        def symmetric_group_blocks(p,n):
+        def symmetric_group_blocks():
             idempotents = self.central_orthogonal_idempotents()
             #compute the submodule corresponding to span_GF(p){\sigma*e_i | \sigma \in S_n}
-            return [self.submodule(spanning_set(idem,p,n)) for idem in idempotents]
+            return [self.submodule(spanning_set(idem)) for idem in idempotents]
         #project v onto each block U_i = F_p[S_n]*e_i via \pi_i: v |--> v*e_i
-        def modular_fourier_transform(p,n):
-            blocks = symmetric_group_blocks(p,n)
-            #compute the list of basis vectors lifed to the SGA from each block
-            block_decomposition_basis = flatten([[u.lift() for u in block.basis()] for block in blocks])
-            #the elements of the symmetric group are ordered, giving the map from the standard basis
-            sym_group_list = list(self.group())
-            change_of_basis_matrix = []
-            for b in block_decomposition_basis:
-                coord_vector = [0]*len(sym_group_list)
-                for pair in list(b):
-                    coord_vector[sym_group_list.index(pair[0])] = pair[1]
-                change_of_basis_matrix.append(coord_vector)
-            return Matrix(self.base_ring(),change_of_basis_matrix)
+        blocks = symmetric_group_blocks(p,n)
+        #compute the list of basis vectors lifed to the SGA from each block
+        block_decomposition_basis = flatten([[u.lift() for u in block.basis()] for block in blocks])
+        #the elements of the symmetric group are ordered, giving the map from the standard basis
+        sym_group_list = list(self.group())
+        change_of_basis_matrix = []
+        for b in block_decomposition_basis:
+            coord_vector = [0]*len(sym_group_list)
+            for pair in list(b):
+                coord_vector[sym_group_list.index(pair[0])] = pair[1]
+            change_of_basis_matrix.append(coord_vector)
+        return Matrix(self.base_ring(),change_of_basis_matrix)
 
     def epsilon_ik(self, itab, ktab, star=0, mult='l2r'):
         r"""

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1885,7 +1885,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
                     basis.append(self.epsilon_ik(t1, t2, mult=mult))
         return basis
 
-    def dft(self, form="seminormal", mult='l2r'):
+    def dft(self, mult='l2r'):
         """
         Return the discrete Fourier transform for ``self``.
 
@@ -1907,12 +1907,10 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             [   1 -1/2    1 -1/2 -1/2 -1/2]
             [   1   -1   -1    1    1   -1]
         """
-        if form == "seminormal":
-            return self._dft_seminormal(mult=mult)
-        if form == "modular":
+        if self.base_ring().characteristic().divides(len(self.group())):
             return self._dft_modular()
         else:
-            raise ValueError("invalid form (= %s)" % form)
+            return self._dft_seminormal(mult=mult)
 
     def _dft_seminormal(self, mult='l2r'):
         """
@@ -1946,6 +1944,7 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
     def _dft_modular(self):
         """
         Return the discrete Foruier transform when the characteristic divides the order of the group.
+        See [Mur1983]_ for contrstruction of central primitive orthogonal idempotents.
 
         EXAMPLES::
 


### PR DESCRIPTION
The DFT for the SGA throws a ZeroDivisionError when p|n. Uses the idempotents as computed in [Murphy '83] to build the Pierce decomposition of the symmetric group algebra over a finite field. There is a homomorphic projection onto each block via v |--> v*e_i. The change of basis matrix is the modular Fourier transform, and works even when p|n.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


