### PR TITLE
Add functions to calculate the Hamming weight for Boolean functions and Boolean polynomials

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -4325,6 +4325,9 @@ REFERENCES:
               and Communication Technology, LNCS 2510, pp 858-865, 2002.
               :doi:`10.1007/3-540-36087-5_99`
 
+.. [LLL21] M. Liu, X. Lu, D. Lin, *Differential-Linear Cryptanalysis from an Algebraic 
+           Perspective.*; in CRYPTO, (2021), pp. 247-277.
+
 .. [LLM2003] \A. Lascoux, L. Lapointe, and J. Morse.  *Tableau atoms and a new
              Macdonald positivity conjecture.* Duke Math Journal, **116 (1)**,
              2003.  :arxiv:`math/0008073`

--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -747,6 +747,26 @@ cdef class BooleanFunction(SageObject):
                 d[abs(i)] = 1
         return d
 
+    def hamming_weight(self):
+        """
+        Return the Hamming weight of this function.
+
+        EXAMPLES::
+
+            sage: from sage.crypto.boolean_function import random_boolean_function
+            sage: B = random_boolean_function(5)
+            sage: B.hamming_weight() == sum(B.truth_table())
+            True
+
+            sage: B = random_boolean_function(12)
+            sage: B.hamming_weight() == sum(B.truth_table())
+            True
+        """
+        if self._nvariables < 6:
+            return sum(self.truth_table(format='int'))
+        else:
+            return bitset_len(self._truth_table)
+
     def is_balanced(self):
         """
         Return ``True`` if the function takes the value ``True`` half of the time.
@@ -761,7 +781,7 @@ cdef class BooleanFunction(SageObject):
             sage: B.is_balanced()
             True
         """
-        return self.walsh_hadamard_transform()[0] == 0
+        return self.hamming_weight() == 1 << (self._nvariables-1)
 
     def is_symmetric(self):
         """

--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -1367,13 +1367,13 @@ cdef class BooleanFunction(SageObject):
         """
         self._clear_cache()
 
-        if self._hamming_weight != -1 and self(int(i)) != int(y) & 1:
-            if int(y) & 1:
-                self._hamming_weight += 1
-            else:
-                self._hamming_weight -= 1
-        
-        bitset_set_to(self._truth_table, int(i), int(y)&1)
+        if self(int(i)) != int(y) & 1:
+            if self._hamming_weight != -1:
+                if int(y) & 1:
+                    self._hamming_weight += 1
+                else:
+                    self._hamming_weight -= 1
+            bitset_set_to(self._truth_table, int(i), int(y)&1)
 
     def __getitem__(self, i):
         """

--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -225,6 +225,7 @@ cdef class BooleanFunction(SageObject):
     cdef object _autocorrelation
     cdef object _absolute_indicator
     cdef object _sum_of_square_indicator
+    cdef long long _hamming_weight
 
     def __cinit__(self, x):
         r"""
@@ -347,6 +348,7 @@ cdef class BooleanFunction(SageObject):
             bitset_copy(self._truth_table,(<BooleanFunction>x)._truth_table)
         else:
             raise TypeError("unable to init the Boolean function")
+        self._hamming_weight = -1
 
     def __dealloc__(self):
         bitset_free(self._truth_table)
@@ -762,10 +764,15 @@ cdef class BooleanFunction(SageObject):
             sage: B.hamming_weight() == sum(B.truth_table())
             True
         """
+        if self._hamming_weight != -1:
+            return self._hamming_weight
+
         if self._nvariables < 6:
-            return sum(self.truth_table(format='int'))
+            self._hamming_weight = sum(self.truth_table(format='int'))
         else:
-            return bitset_len(self._truth_table)
+            self._hamming_weight = bitset_len(self._truth_table)
+
+        return self._hamming_weight
 
     def is_balanced(self):
         """
@@ -1360,6 +1367,7 @@ cdef class BooleanFunction(SageObject):
         """
         self._clear_cache()
         bitset_set_to(self._truth_table, int(i), int(y)&1)
+        self._hamming_weight = -1
 
     def __getitem__(self, i):
         """

--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -1366,8 +1366,14 @@ cdef class BooleanFunction(SageObject):
             True
         """
         self._clear_cache()
+
+        if self._hamming_weight != -1 and self(int(i)) != int(y) & 1:
+            if int(y) & 1:
+                self._hamming_weight += 1
+            else:
+                self._hamming_weight -= 1
+        
         bitset_set_to(self._truth_table, int(i), int(y)&1)
-        self._hamming_weight = -1
 
     def __getitem__(self, i):
         """

--- a/src/sage/rings/polynomial/pbori/pbori.pxd
+++ b/src/sage/rings/polynomial/pbori/pbori.pxd
@@ -21,6 +21,7 @@ cdef class BooleanPolynomialRing(BooleanPolynomialRing_base):
 
 cdef class BooleanPolynomial(MPolynomial):
     cdef PBPoly _pbpoly
+    cdef object _hamming_weight
     cpdef _add_(self, other)
     cpdef _mul_(self, other)
 

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -4162,7 +4162,7 @@ cdef class BooleanPolynomial(MPolynomial):
         from sage.crypto.boolean_function import BooleanFunction
 
         if threshold > 30:
-            raise ValueError("the threshold should be at most than 30")
+            raise ValueError("the threshold should be at most 30")
 
         for var in self.variables():
             if self / var == 1:

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -4142,8 +4142,8 @@ cdef class BooleanPolynomial(MPolynomial):
 
         INPUT:
 
-        -  ``threshold`` - (optional, default: 15) the threshold used
-           in the Algorithm 2 of [LLL21]_
+        - ``threshold`` -- (optional, default: 15) the threshold used
+          in the Algorithm 2 of [LLL21]_
 
         EXAMPLES::
 

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -4108,7 +4108,7 @@ cdef class BooleanPolynomial(MPolynomial):
 
     def separate(self):
         r"""
-        Returns a list of polynomials whose sum is ``self`` and 
+        Returns a list of polynomials whose sum is ``self`` and
         whose sets of variables are mutually disjoint
 
 
@@ -4125,7 +4125,7 @@ cdef class BooleanPolynomial(MPolynomial):
         var_intersec = set(fp.variables()) & set(fq.variables())
         while len(var_intersec) > 0:
             for var in var_intersec:
-                fp += (fq/var) * var 
+                fp += (fq/var) * var
                 fq = fq.subs({var: 0})
             var_intersec = set(fq.variables()) & set(fp.variables())
         if fq.is_constant():
@@ -4167,7 +4167,7 @@ cdef class BooleanPolynomial(MPolynomial):
         for var in self.variables():
             if self / var == 1:
                 return 1<<(self.nvariables() - 1)
-        
+
         epsilon = 1
 
         for fi in self.separate():
@@ -4193,7 +4193,7 @@ cdef class BooleanPolynomial(MPolynomial):
                 fi1 = fi.subs({guessed_var: 1})
                 epsiloni = fi0.hamming_weight()*(1<<(fi.nvariables()-fi0.nvariables()-1)) + \
                     fi1.hamming_weight()*(1<<(fi.nvariables()-fi1.nvariables()-1))
-            
+
             # piling-up lemma
             epsilon *= 2 * ((1<<fi.nvariables()-1)-epsiloni)
             if epsilon == 0:

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -4162,7 +4162,7 @@ cdef class BooleanPolynomial(MPolynomial):
         from sage.crypto.boolean_function import BooleanFunction
 
         if threshold > 30:
-            raise ValueError("The threshold should be not greater than 30")
+            raise ValueError("the threshold should be at most than 30")
 
         for var in self.variables():
             if self / var == 1:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Implementation for #37754.

We use `bitset_len()` to calculate the sum of the truth table for Boolean functions.

In the function for computing the Hamming weight of a Boolean polynomial, we implement Algorithm 2 from [[LLL21]](https://dx.doi.org/10.1007/978-3-030-84252-9_9), which is a divide-and-conquer algorithm based on the piling-up lemma.

The performance of our implementation has been mentioned in #37754.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
