### PR TITLE
Fix tolerance for scipy 1.13

### DIFF
--- a/src/sage/matrix/matrix_double_dense.pyx
+++ b/src/sage/matrix/matrix_double_dense.pyx
@@ -3683,7 +3683,7 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             sage: A = matrix(CDF, 2, [1,2+I,3*I,4]); A                                  # needs sage.symbolic
             [        1.0 2.0 + 1.0*I]
             [      3.0*I         4.0]
-            sage: A.exp()  # tol 1.1e-14                                                # needs sage.symbolic
+            sage: A.exp()  # tol 3e-14                                                  # needs sage.symbolic
             [-19.614602953804912 + 12.517743846762578*I   3.7949636449582176 + 28.88379930658099*I]
             [ -32.383580980922254 + 21.88423595789845*I   2.269633004093535 + 44.901324827684824*I]
 


### PR DESCRIPTION
After updating scipy to 1.13:
```
**********************************************************************
File "pkgs/sagemath-standard/build/lib.linux-x86_64-cpython-312/sage/matrix/matrix_double_dense.pyx", line 3686, in sage.matrix.matrix_double_dense.Matrix_double_dense.exp
Failed example:
    A.exp()  # tol 1.1e-14                                                # needs sage.symbolic
Expected:
    [-19.614602953804912 + 12.517743846762578*I   3.7949636449582176 + 28.88379930658099*I]
    [ -32.383580980922254 + 21.88423595789845*I   2.269633004093535 + 44.901324827684824*I]
Got:
    [-19.61460295380496 + 12.517743846762578*I  3.7949636449581874 + 28.88379930658104*I]
    [-32.38358098092232 + 21.884235957898436*I 2.2696330040934853 + 44.901324827684896*I]
Tolerance exceeded in 1 of 8:
    2.269633004093535 vs 2.2696330040934853, tolerance 3e-14 > 1.1e-14
********************************************************************** 
```

This PR raises the tolerance to `3e-14` to fix this.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.