### PR TITLE
ECM-related tests fail after an incremental build

### DIFF
--- a/build/pkgs/ecm/spkg-configure.m4
+++ b/build/pkgs/ecm/spkg-configure.m4
@@ -1,6 +1,6 @@
 SAGE_SPKG_CONFIGURE([ecm], [
+    # CHECK - test whether the package is already installed
     m4_pushdef([SAGE_ECM_MINVER],[7.0.4])
-    ECMBIN=ecm
     SAGE_SPKG_DEPCHECK([gmp], [
         AC_CHECK_HEADER(ecm.h, [
             AX_ABSOLUTE_HEADER([ecm.h])
@@ -35,5 +35,12 @@ SAGE_SPKG_CONFIGURE([ecm], [
         ], [sage_spkg_install_ecm=yes])
     ])
     m4_popdef([SAGE_ECM_MINVER])
+], [
+    # REQUIRED-check is empty
+], [
+    # PRE - always perform
+    ECMBIN=ecm
+], [
+    # POST - always perform
     AC_SUBST(SAGE_ECMBIN, $ECMBIN)
 ])

--- a/build/pkgs/ecm/spkg-configure.m4
+++ b/build/pkgs/ecm/spkg-configure.m4
@@ -38,5 +38,5 @@ SAGE_SPKG_CONFIGURE([ecm], [dnl CHECK - test whether the package is already inst
 ], [dnl PRE - always perform
     ECMBIN=ecm
 ], [dnl POST - always perform
-    AC_SUBST(SAGE_ECMBIN, $ECMBIN)
+    AC_SUBST([SAGE_ECMBIN], ["$ECMBIN"])
 ])

--- a/build/pkgs/ecm/spkg-configure.m4
+++ b/build/pkgs/ecm/spkg-configure.m4
@@ -34,12 +34,9 @@ SAGE_SPKG_CONFIGURE([ecm], [dnl CHECK - test whether the package is already inst
         ], [sage_spkg_install_ecm=yes])
     ])
     m4_popdef([SAGE_ECM_MINVER])
-], [
-    # REQUIRED-check is empty
-], [
-    # PRE - always perform
+], [dnl REQUIRED-check is empty
+], [dnl PRE - always perform
     ECMBIN=ecm
-], [
-    # POST - always perform
+], [dnl POST - always perform
     AC_SUBST(SAGE_ECMBIN, $ECMBIN)
 ])

--- a/build/pkgs/ecm/spkg-configure.m4
+++ b/build/pkgs/ecm/spkg-configure.m4
@@ -1,5 +1,4 @@
-SAGE_SPKG_CONFIGURE([ecm], [
-    # CHECK - test whether the package is already installed
+SAGE_SPKG_CONFIGURE([ecm], [dnl CHECK - test whether the package is already installed
     m4_pushdef([SAGE_ECM_MINVER],[7.0.4])
     SAGE_SPKG_DEPCHECK([gmp], [
         AC_CHECK_HEADER(ecm.h, [


### PR DESCRIPTION
### TL;DR:

This is because setting the default ECMBIN=ecm is only done when using the configure test, but not when skipping the configure test because the spkg is already installed.


### Steps to reproduce:
* ecm is not installed in the base os
* Sage make distclean && make succeeeds
* Tests succeed
* re-running ./bootstrap && ./configure && make works
* Tests now fail with PermissionError: [Errno 13] Permission denied: ''


### Dependencies
See also:
 * https://github.com/sagemath/sage/pull/37701
 * https://github.com/sagemath/sage/pull/37011#issuecomment-2023089743
