### PR TITLE
add links to standard errors in toric folder

### DIFF
--- a/src/sage/schemes/toric/chow_group.py
+++ b/src/sage/schemes/toric/chow_group.py
@@ -230,12 +230,14 @@ class ChowCycle(FGP_Element):
 
     def degree(self) -> int:
         r"""
-        The degree of the Chow cycle.
+        Return the degree of the Chow cycle.
 
         OUTPUT:
 
         Integer. The complex dimension of the subvariety representing
-        the Chow cycle. Raises a ``ValueError`` if the Chow cycle is a
+        the Chow cycle.
+
+        This raises a :class:`ValueError` if the Chow cycle is a
         sum of mixed degree cycles.
 
         EXAMPLES::
@@ -354,7 +356,7 @@ class ChowCycle(FGP_Element):
         OUTPUT:
 
         A new :class:`ChowCycle`. If the divisor is not Cartier then
-        this method potentially raises a ``ValueError``, indicating
+        this method potentially raises a :class:`ValueError`, indicating
         that the divisor cannot be made transversal to the Chow cycle.
 
         EXAMPLES::
@@ -471,7 +473,7 @@ class ChowCycle(FGP_Element):
         If the toric variety is not simplicial, that is, has worse
         than orbifold singularities, there is no way to associate a
         cohomology class of the correct degree. In this case,
-        :meth:`cohomology_class` raises a ``ValueError``.
+        :meth:`cohomology_class` raises a :class:`ValueError`.
 
         EXAMPLES::
 

--- a/src/sage/schemes/toric/divisor.py
+++ b/src/sage/schemes/toric/divisor.py
@@ -567,7 +567,7 @@ class ToricDivisor_generic(Divisor_generic):
           returned.
 
         - If there is no such vector (i.e. ``self`` is not even a
-          `\QQ`-Cartier divisor), a ``ValueError`` is raised.
+          `\QQ`-Cartier divisor), a :class:`ValueError` is raised.
 
         EXAMPLES::
 
@@ -773,7 +773,7 @@ class ToricDivisor_generic(Divisor_generic):
         .. NOTE::
 
             A divisor that is Weil but not Cartier might be impossible
-            to move away. In this case, a ``ValueError`` is raised.
+            to move away. In this case, a :class:`ValueError` is raised.
 
         EXAMPLES::
 

--- a/src/sage/schemes/toric/divisor_class.pyx
+++ b/src/sage/schemes/toric/divisor_class.pyx
@@ -204,7 +204,7 @@ cdef class ToricRationalDivisorClass(Vector_rational_dense):
 
     cpdef _dot_product_(self, Vector right):
         r"""
-        Raise a ``TypeError`` exception.
+        Raise a :class:`TypeError` exception.
 
         Dot product is not defined on toric rational divisor classes.
 
@@ -214,7 +214,7 @@ cdef class ToricRationalDivisorClass(Vector_rational_dense):
 
         OUTPUT:
 
-        - ``TypeError`` exception is raised.
+        A :class:`TypeError` exception is raised.
 
         TESTS::
 

--- a/src/sage/schemes/toric/ideal.py
+++ b/src/sage/schemes/toric/ideal.py
@@ -161,7 +161,7 @@ class ToricIdeal(MPolynomialIdeal):
 
       You may specify the ambient polynomial ring via the
       ``polynomial_ring`` parameter or via the ``names`` and
-      ``base_ring`` parameter. A ``ValueError`` is raised if you
+      ``base_ring`` parameter. A :class:`ValueError` is raised if you
       specify both.
 
     - ``algorithm`` -- string (optional). The algorithm to use. For

--- a/src/sage/schemes/toric/morphism.py
+++ b/src/sage/schemes/toric/morphism.py
@@ -521,7 +521,8 @@ class SchemeMorphism_polynomial_toric_variety(SchemeMorphism_polynomial, Morphis
 
         OUTPUT: A :class:`SchemeMorphism_polynomial_toric_variety`.
 
-        Raises a ``TypeError`` if the morphism cannot be written in such a way.
+        This raises a :class:`TypeError` if the morphism cannot be written
+        in such a way.
 
         EXAMPLES::
 
@@ -680,9 +681,10 @@ class SchemeMorphism_orbit_closure_toric_variety(SchemeMorphism, Morphism):
 
         OUTPUT:
 
-        A :class:`SchemeMorphism_polynomial_toric_variety`. Raises a
-        ``TypeError`` if the morphism cannot be written in terms of
-        homogeneous polynomials.
+        A :class:`SchemeMorphism_polynomial_toric_variety`.
+
+        This raises a :class:`TypeError` if the morphism cannot be
+        written in terms of homogeneous polynomials.
 
         The defining polynomials are not necessarily unique. There are
         choices if multiple ambient space ray generators project to
@@ -716,7 +718,7 @@ class SchemeMorphism_orbit_closure_toric_variety(SchemeMorphism, Morphism):
         orbit = self.domain()
         codomain_fan = self.codomain().fan()
         R = orbit.coordinate_ring()
-        polys = [ R.one() ] * codomain_fan.nrays()
+        polys = [R.one()] * codomain_fan.nrays()
         for i in self._defining_cone.ambient_ray_indices():
             polys[i] = R.zero()
         ray_index_map = self._reverse_ray_map()
@@ -1070,8 +1072,8 @@ class SchemeMorphism_fan_toric_variety(SchemeMorphism, Morphism):
 
         OUTPUT: A :class:`SchemeMorphism_polynomial_toric_variety`.
 
-        Raises a ``TypeError`` if the morphism cannot be written in terms of
-        homogeneous polynomials.
+        This raises a :class:`TypeError` if the morphism cannot be written
+        in terms of homogeneous polynomials.
 
         EXAMPLES::
 
@@ -1104,8 +1106,8 @@ class SchemeMorphism_fan_toric_variety(SchemeMorphism, Morphism):
                                     'homogeneous polynomials')
                 polys[i] *= x**d
         if phi.domain_fan().virtual_rays():
-            raise NotImplementedError("polynomial representations for fans "
-                                    "with virtual rays are not implemented yet")
+            raise NotImplementedError("polynomial representations for fans with"
+                                      " virtual rays are not implemented yet")
         return SchemeMorphism_polynomial_toric_variety(self.parent(), polys)
 
     def is_bundle(self):
@@ -1477,7 +1479,7 @@ class SchemeMorphism_fan_toric_variety_dominant(SchemeMorphism_fan_toric_variety
         embedding = SchemeMorphism_fan_fiber_component_toric_variety(self, domain_cone)
         if multiplicity:
             return embedding.domain(), \
-               self.fan_morphism().index(embedding.base_cone())
+                self.fan_morphism().index(embedding.base_cone())
         else:
             return embedding.domain()
 
@@ -1609,7 +1611,7 @@ class SchemeMorphism_fan_toric_variety_dominant(SchemeMorphism_fan_toric_variety
             except ValueError:
                 return False
 
-        m = matrix(ZZ, n, n, lambda i,j:is_union_in_fan(self,prim[i], prim[j]))
+        m = matrix(ZZ, n, n, lambda i, j: is_union_in_fan(self, prim[i], prim[j]))
 
         for i in range(n):
             m[i, i] = 0
@@ -1727,9 +1729,10 @@ class SchemeMorphism_fan_fiber_component_toric_variety(SchemeMorphism):
 
         OUTPUT:
 
-        A :class:`SchemeMorphism_polynomial_toric_variety`. Raises a
-        ``ValueError`` if the morphism cannot be written in terms of
-        homogeneous polynomials.
+        A :class:`SchemeMorphism_polynomial_toric_variety`.
+
+        This raises a :class:`ValueError` if the morphism cannot be
+        written in terms of homogeneous polynomials.
 
         EXAMPLES::
 
@@ -1830,7 +1833,7 @@ class SchemeMorphism_fan_fiber_component_toric_variety(SchemeMorphism):
         star_rays = set()
         for cone in fm.relative_star_generators(defining_cone):
             star_rays.update(cone.rays())
-            projected_rays = [ projection(r) for r in cone.rays() ]
+            projected_rays = [projection(r) for r in cone.rays()]
             cones.append(Cone(projected_rays))
         fiber_fan = Fan(cones)
 

--- a/src/sage/schemes/toric/variety.py
+++ b/src/sage/schemes/toric/variety.py
@@ -666,7 +666,8 @@ class ToricVariety_field(AmbientSpace):
         OUTPUT:
 
         - ``True`` if ``coordinates`` do define a valid point of ``self``,
-          otherwise a ``TypeError`` or ``ValueError`` exception is raised.
+          otherwise a :class:`TypeError` or :class:`ValueError` exception
+          is raised.
 
         TESTS::
 
@@ -927,7 +928,7 @@ class ToricVariety_field(AmbientSpace):
 
         - ``polynomials`` (the input parameter without any modifications) if
           ``polynomials`` do define valid polynomial functions on ``self``,
-          otherwise a ``ValueError`` exception is raised.
+          otherwise a :class:`ValueError` exception is raised.
 
         TESTS:
 
@@ -1102,7 +1103,7 @@ class ToricVariety_field(AmbientSpace):
         - :class:`scheme morphism
           <sage.schemes.generic.morphism.SchemeMorphism_polynomial_toric_variety>`
           if the default embedding morphism was defined for ``self``,
-          otherwise a ``ValueError`` exception is raised.
+          otherwise a :class:`ValueError` exception is raised.
 
         EXAMPLES::
 
@@ -1196,7 +1197,7 @@ class ToricVariety_field(AmbientSpace):
             while True:
                 scope = sys._getframe(depth).f_globals
                 if (scope["__name__"] == "__main__"
-                    and scope.get("__package__", None) is None):
+                        and scope.get("__package__", None) is None):
                     break
                 depth += 1
         try:
@@ -1216,7 +1217,7 @@ class ToricVariety_field(AmbientSpace):
         this method will return the dimension of the
         largest-dimensional component.
 
-        Returns -1 if the toric variety is smooth.
+        This returns -1 if the toric variety is smooth.
 
         EXAMPLES::
 
@@ -1227,7 +1228,7 @@ class ToricVariety_field(AmbientSpace):
             sage: toric_varieties.P2().dimension_singularities()
             -1
         """
-        for codim in range(self.dimension()+1):
+        for codim in range(self.dimension() + 1):
             if any(not cone.is_smooth() for cone in self.fan(codim)):
                 return self.dimension() - codim
         return -1
@@ -1291,7 +1292,7 @@ class ToricVariety_field(AmbientSpace):
             from sage.modules.free_module import FreeModule
             rays = fan.rays() + fan.virtual_rays()
             degrees_group = FreeModule(ZZ, len(rays)).quotient(
-                                                        rays.matrix().columns())
+                rays.matrix().columns())
             self._homogeneous_degrees_group = degrees_group
         degrees_group = self._homogeneous_degrees_group
         S = self.coordinate_ring()
@@ -1303,9 +1304,9 @@ class ToricVariety_field(AmbientSpace):
         monomials = polynomial.monomials()
         if not monomials:
             return True
-        degree = degrees_group(vector(ZZ,monomials[0].degrees()))
+        degree = degrees_group(vector(ZZ, monomials[0].degrees()))
         for monomial in monomials:
-            if degrees_group(vector(ZZ,monomial.degrees())) != degree:
+            if degrees_group(vector(ZZ, monomial.degrees())) != degree:
                 return False
         return True
 
@@ -1464,12 +1465,12 @@ class ToricVariety_field(AmbientSpace):
         from sage.schemes.toric.divisor import \
             ToricRationalDivisorClassGroup_basis_lattice
         L = ToricRationalDivisorClassGroup_basis_lattice(
-                                                self.rational_class_group())
+            self.rational_class_group())
         n = fan.nrays()
         K = None
         for cone in fan:
             sigma = Cone([GT[i] for i in range(n)
-                                if i not in cone.ambient_ray_indices()],
+                          if i not in cone.ambient_ray_indices()],
                          lattice=L)
             K = K.intersection(sigma) if K is not None else sigma
         return K
@@ -1477,7 +1478,7 @@ class ToricVariety_field(AmbientSpace):
     @cached_method
     def Mori_cone(self):
         r"""
-        Returns the Mori cone of ``self``.
+        Return the Mori cone of ``self``.
 
         OUTPUT: :class:`cone <sage.geometry.cone.ConvexRationalPolyhedralCone>`.
 
@@ -1515,7 +1516,7 @@ class ToricVariety_field(AmbientSpace):
         # so far this is not the case.
         rays = (ray * self._fan.Gale_transform()
                 for ray in self.Kaehler_cone().dual().rays())
-        return Cone(rays, lattice=ZZ**(self._fan.nrays()+1))
+        return Cone(rays, lattice=ZZ**(self._fan.nrays() + 1))
 
     def plot(self, **options):
         r"""
@@ -1604,7 +1605,7 @@ class ToricVariety_field(AmbientSpace):
             (( 0 | 0 | 1 ), ( 0 | 1 | 0 ), ( 1 | 0 | 0 ))
         """
         from sage.schemes.toric.chow_group import ChowGroup
-        return ChowGroup(self,base_ring)
+        return ChowGroup(self, base_ring)
 
     def cartesian_product(self, other,
                           coordinate_names=None, coordinate_indices=None):
@@ -2001,7 +2002,7 @@ class ToricVariety_field(AmbientSpace):
         A :class:`CohomologyClass`. If it exists, it is the class of
         the (properly normalized) volume form, that is, it is the
         Poincaré dual of a single point. If it does not exist, a
-        ``ValueError`` is raised.
+        :class:`ValueError` is raised.
 
         EXAMPLES::
 
@@ -2177,11 +2178,9 @@ class ToricVariety_field(AmbientSpace):
             True
         """
         assert self.is_orbifold(), "Requires the toric variety to be an orbifold."
-        c = prod([ 1+self.cohomology_ring().gen(i) for i in range(self._fan.nrays()) ])
-        if deg is None:
-            return c
-        else:
-            return c.part_of_degree(deg)
+        c = prod([1 + self.cohomology_ring().gen(i)
+                  for i in range(self._fan.nrays())])
+        return c if deg is None else c.part_of_degree(deg)
 
     @cached_method
     def Chern_character(self, deg=None):
@@ -2218,12 +2217,9 @@ class ToricVariety_field(AmbientSpace):
         """
         assert self.is_orbifold(), "Requires the toric variety to be an orbifold."
         n_rels = self._fan.nrays() - self.dimension()
-        ch = sum([ self.cohomology_ring().gen(i).exp()
-                   for i in range(self._fan.nrays()) ]) - n_rels
-        if deg is None:
-            return ch
-        else:
-            return ch.part_of_degree(deg)
+        ch = sum([self.cohomology_ring().gen(i).exp()
+                  for i in range(self._fan.nrays())]) - n_rels
+        return ch if deg is None else ch.part_of_degree(deg)
 
     @cached_method
     def Todd_class(self, deg=None):
@@ -2265,17 +2261,14 @@ class ToricVariety_field(AmbientSpace):
                 c2 = self.Chern_class(2)
                 Td += QQ.one() / 12 * (c1**2 + c2)
                 if dim >= 3:
-                    Td += QQ.one() / 24 * c1*c2
+                    Td += QQ.one() / 24 * c1 * c2
                     if dim >= 4:
                         c3 = self.Chern_class(3)
                         c4 = self.Chern_class(4)
                         Td += -QQ.one() / 720 * (c1**4 - 4*c1**2*c2 - 3*c2**2 - c1*c3 + c4)
                         if dim >= 5:
                             raise NotImplementedError('Todd class is currently only implemented up to degree 4')
-        if deg is None:
-            return Td
-        else:
-            return Td.part_of_degree(deg)
+        return Td if deg is None else Td.part_of_degree(deg)
 
     c = Chern_class
     ch = Chern_character
@@ -2308,7 +2301,7 @@ class ToricVariety_field(AmbientSpace):
             else:
                 chi = 0
                 H = self.cohomology_basis()
-                for d in range(self.dimension()+1):
+                for d in range(self.dimension() + 1):
                     chi += (-1)**d * len(H[d])
             self._chi = chi
         return self._chi
@@ -2317,7 +2310,7 @@ class ToricVariety_field(AmbientSpace):
 
     def K(self):
         r"""
-        Returns the canonical divisor of the toric variety.
+        Return the canonical divisor of the toric variety.
 
         EXAMPLES:
 
@@ -2331,7 +2324,7 @@ class ToricVariety_field(AmbientSpace):
             6
         """
         from sage.schemes.toric.divisor import ToricDivisor
-        return ToricDivisor(self, [-1]*self._fan.nrays())
+        return ToricDivisor(self, [-1] * self._fan.nrays())
 
     def divisor(self, arg, base_ring=None, check=True, reduce=True):
         r"""
@@ -2632,8 +2625,8 @@ class ToricVariety_field(AmbientSpace):
           This quotient lattice is the ambient lattice for the fan of the orbit
           closure corresponding to ``cone``.
 
-        If ``x`` is a cone not in the star of ``cone``, an ``IndexError`` is
-        raised.
+        If ``x`` is a cone not in the star of ``cone``, an :class:`IndexError`
+        is raised.
 
         See :meth:`orbit_closure` for more details.
 
@@ -2719,11 +2712,10 @@ class ToricVariety_field(AmbientSpace):
             sage: A2.orbit_closure(A2.fan(2)[0])
             0-d affine toric variety
         """
-        cone = self.fan().embed(cone)
-        cones = []
-        for star_cone in cone.star_generators():
-            cones.append( self._orbit_closure_projection(cone, star_cone) )
         from sage.geometry.fan import discard_faces
+        cone = self.fan().embed(cone)
+        cones = [self._orbit_closure_projection(cone, star_cone)
+                 for star_cone in cone.star_generators()]
         fan = Fan(discard_faces(cones), check=False)
         orbit_closure = ToricVariety(fan)
 
@@ -2809,7 +2801,7 @@ class ToricVariety_field(AmbientSpace):
         antiK = -self.K()
         fan_rays = self.fan().rays()
         roots = [m for m in antiK.sections()
-                 if [ray*m for ray in fan_rays].count(-1) == 1]
+                 if [ray * m for ray in fan_rays].count(-1) == 1]
         return tuple(roots)
 
     def Aut_dimension(self):
@@ -2984,7 +2976,7 @@ def normalize_names(names=None, ngens=None, prefix=None, indices=None,
             names = list(names)
         except TypeError:
             raise TypeError(
-                    "names must be a string or a list or tuple of them")
+                "names must be a string or a list or tuple of them")
         for name in names:
             if not isinstance(name, str):
                 raise TypeError(
@@ -3137,7 +3129,7 @@ class CohomologyRing(QuotientRing_generic, UniqueRepresentation):
         """
         return fr'H^\ast\left({self._variety._latex_()},{latex(QQ)}\right)'
 
-    def _element_constructor_(self,x):
+    def _element_constructor_(self, x):
         r"""
         Construct a :class:`CohomologyClass`.
 
@@ -3260,7 +3252,8 @@ class CohomologyRing(QuotientRing_generic, UniqueRepresentation):
             ([z], [z], [z])
         """
         if "_gens" not in self.__dict__:
-            self._gens = tuple( self.gen(i) for i in range(self._variety.fan().nrays()) )
+            self._gens = tuple(self.gen(i)
+                               for i in range(self._variety.fan().nrays()))
         return self._gens
 
     def gen(self, i):
@@ -3469,7 +3462,7 @@ class CohomologyClass(QuotientRingElement):
         OUTPUT:
 
         The cohomology class `\exp(` ``self`` `)` if the constant part
-        vanishes, otherwise a ``ValueError`` is raised.
+        vanishes, otherwise a :class:`ValueError` is raised.
 
         EXAMPLES::
 
@@ -3484,6 +3477,6 @@ class CohomologyClass(QuotientRingElement):
         if not self.part_of_degree(0).is_zero():
             raise ValueError('must not have a constant part')
         exp_x = self.parent().one()
-        for d in range(1, self.parent()._variety.dimension()+1):
+        for d in range(1, self.parent()._variety.dimension() + 1):
             exp_x += self**d / factorial(d)
         return exp_x

--- a/src/sage/schemes/toric/variety.py
+++ b/src/sage/schemes/toric/variety.py
@@ -1217,7 +1217,7 @@ class ToricVariety_field(AmbientSpace):
         this method will return the dimension of the
         largest-dimensional component.
 
-        This returns -1 if the toric variety is smooth.
+        This returns `-1` if the toric variety is smooth.
 
         EXAMPLES::
 

--- a/src/sage/schemes/toric/weierstrass.py
+++ b/src/sage/schemes/toric/weierstrass.py
@@ -177,7 +177,7 @@ def Discriminant(polynomial, variables=None):
         -1/16
     """
     f, g = WeierstrassForm(polynomial, variables)
-    return 4 * f**3 + 27 * g**2
+    return 4*f**3 + 27*g**2
 
 
 ######################################################################
@@ -221,7 +221,7 @@ def j_invariant(polynomial, variables=None):
         ValueError: curve is singular and has no well-defined j-invariant
     """
     f, g = WeierstrassForm(polynomial, variables)
-    disc = 4 * f**3 + 27 * g**2
+    disc = 4*f**3 + 27*g**2
     if disc != 0:
         return 1728 * 4 * f**3 / disc
     if f != 0:
@@ -286,7 +286,7 @@ def Newton_polytope_vars_coeffs(polynomial, variables):
         e = m.exponents()[0]
         v = tuple([e[i] for i in var_indices])
         m_red = m // prod(x**i for x, i in zip(variables, v))
-        result[v] = result.get(v, R.zero()) + c * m_red
+        result[v] = result.get(v, R.zero()) + c*m_red
     return result
 
 
@@ -552,8 +552,8 @@ def _check_homogeneity(polynomial, variables, weights, total_weight=None):
             total_weight = weight_e
         else:
             if weight_e != total_weight:
-                raise ValueError('the polynomial is not homogeneous with '
-                                 'weights ' + str(weights))
+                msg = f'the polynomial is not homogeneous with weights {weights}'
+                raise ValueError(msg)
 
 
 ######################################################################
@@ -599,11 +599,11 @@ def _extract_coefficients(polynomial, monomials, variables):
     coeffs = {}
     for c, m in polynomial:
         i = index(m)
-        coeffs[i] = c * m + coeffs.pop(i, R.zero())
+        coeffs[i] = c*m + coeffs.pop(i, R.zero())
     result = tuple(coeffs.pop(index(m), R.zero()) // m for m in monomials)
     if coeffs:
-        raise ValueError('the polynomial contains more monomials than '
-                         'given: ' + str(coeffs))
+        msg = f'the polynomial contains more monomials than given: {coeffs}'
+        raise ValueError(msg)
     return result
 
 
@@ -856,7 +856,7 @@ def _partial_discriminant(quadric, y0, y1=None):
         monomials = (y1**2, y0 * y1, y0**2)
         variables = [y0, y1]
     c = _extract_coefficients(quadric, monomials, variables)
-    return c[1]**2 - 4 * c[0] * c[2]
+    return c[1]**2 - 4*c[0]*c[2]
 
 
 ######################################################################

--- a/src/sage/schemes/toric/weierstrass.py
+++ b/src/sage/schemes/toric/weierstrass.py
@@ -176,8 +176,8 @@ def Discriminant(polynomial, variables=None):
         sage: Discriminant([quadratic1, quadratic2])
         -1/16
     """
-    (f, g) = WeierstrassForm(polynomial, variables)
-    return 4*f**3+27*g**2
+    f, g = WeierstrassForm(polynomial, variables)
+    return 4 * f**3 + 27 * g**2
 
 
 ######################################################################
@@ -199,7 +199,7 @@ def j_invariant(polynomial, variables=None):
     * A nodal cubic: `j(-y^2 + x^2 + x^3) = \infty`
 
     * A cuspidal cubic `y^2=x^3` has undefined `j`-invariant. In this
-      case, a ``ValueError`` is raised.
+      case, a :class:`ValueError` is raised.
 
     EXAMPLES::
 
@@ -220,10 +220,10 @@ def j_invariant(polynomial, variables=None):
         ...
         ValueError: curve is singular and has no well-defined j-invariant
     """
-    (f, g) = WeierstrassForm(polynomial, variables)
-    disc = 4*f**3+27*g**2
+    f, g = WeierstrassForm(polynomial, variables)
+    disc = 4 * f**3 + 27 * g**2
     if disc != 0:
-        return 1728 * 4*f**3/disc
+        return 1728 * 4 * f**3 / disc
     if f != 0:
         return Infinity
     raise ValueError('curve is singular and has no well-defined j-invariant')
@@ -286,7 +286,7 @@ def Newton_polytope_vars_coeffs(polynomial, variables):
         e = m.exponents()[0]
         v = tuple([e[i] for i in var_indices])
         m_red = m // prod(x**i for x, i in zip(variables, v))
-        result[v] = result.get(v, R.zero()) + c*m_red
+        result[v] = result.get(v, R.zero()) + c * m_red
     return result
 
 
@@ -505,7 +505,7 @@ def WeierstrassForm(polynomial, variables=None, transformation=False):
 ######################################################################
 def _check_homogeneity(polynomial, variables, weights, total_weight=None):
     """
-    Raise ``ValueError`` if the polynomial is not weighted
+    Raise :class:`ValueError` if the polynomial is not weighted
     homogeneous.
 
     INPUT:
@@ -526,7 +526,7 @@ def _check_homogeneity(polynomial, variables, weights, total_weight=None):
     OUTPUT:
 
     This function returns nothing. If the polynomial is not weighted
-    homogeneous, a ``ValueError`` is raised.
+    homogeneous, a :class:`ValueError` is raised.
 
     EXAMPLES::
 
@@ -553,7 +553,7 @@ def _check_homogeneity(polynomial, variables, weights, total_weight=None):
         else:
             if weight_e != total_weight:
                 raise ValueError('the polynomial is not homogeneous with '
-                                 'weights '+str(weights))
+                                 'weights ' + str(weights))
 
 
 ######################################################################
@@ -599,7 +599,7 @@ def _extract_coefficients(polynomial, monomials, variables):
     coeffs = {}
     for c, m in polynomial:
         i = index(m)
-        coeffs[i] = c*m + coeffs.pop(i, R.zero())
+        coeffs[i] = c * m + coeffs.pop(i, R.zero())
     result = tuple(coeffs.pop(index(m), R.zero()) // m for m in monomials)
     if coeffs:
         raise ValueError('the polynomial contains more monomials than '
@@ -623,7 +623,7 @@ def _check_polynomial_P2(cubic, variables):
     OUTPUT:
 
     This functions returns ``variables``, potentially guessed from the
-    polynomial ring. A ``ValueError`` is raised if the polynomial is
+    polynomial ring. A :class:`ValueError` is raised if the polynomial is
     not homogeneous.
 
     EXAMPLES::
@@ -757,7 +757,7 @@ def WeierstrassForm_P2(polynomial, variables=None):
     F = polynomial.base_ring()
     S = cubic.S_invariant()
     T = cubic.T_invariant()
-    return (27*S, -27/F(4)*T)
+    return (27 * S, -27 / F(4) * T)
 
 
 ######################################################################
@@ -780,7 +780,7 @@ def _check_polynomial_P1xP1(biquadric, variables):
     OUTPUT:
 
     This functions returns ``variables``, potentially guessed from the
-    polynomial ring. A ``ValueError`` is raised if the polynomial is
+    polynomial ring. A :class:`ValueError` is raised if the polynomial is
     not homogeneous.
 
     EXAMPLES::
@@ -853,10 +853,10 @@ def _partial_discriminant(quadric, y0, y1=None):
         monomials = (quadric.parent().one(), y0, y0**2)
         variables = [y0]
     else:
-        monomials = (y1**2, y0*y1, y0**2)
+        monomials = (y1**2, y0 * y1, y0**2)
         variables = [y0, y1]
     c = _extract_coefficients(quadric, monomials, variables)
-    return c[1]**2 - 4*c[0]*c[2]
+    return c[1]**2 - 4 * c[0] * c[2]
 
 
 ######################################################################
@@ -941,7 +941,7 @@ def WeierstrassForm_P1xP1(biquadric, variables=None):
     Q = invariant_theory.binary_quartic(delta, x, y)
     g2 = Q.EisensteinD()
     g3 = -Q.EisensteinE()
-    return (-g2/4, -g3/4)
+    return (-g2 / 4, -g3 / 4)
 
 
 ######################################################################
@@ -964,7 +964,7 @@ def _check_polynomial_P2_112(polynomial, variables):
     OUTPUT:
 
     This functions returns ``variables``, potentially guessed from the
-    polynomial ring. A ``ValueError`` is raised if the polynomial is
+    polynomial ring. A :class:`ValueError` is raised if the polynomial is
     not homogeneous.
 
     EXAMPLES::
@@ -1076,4 +1076,4 @@ def WeierstrassForm_P2_112(polynomial, variables=None):
     Q = invariant_theory.binary_quartic(delta, x, z)
     g2 = Q.EisensteinD()
     g3 = -Q.EisensteinE()
-    return (-g2/4, -g3/4)
+    return (-g2 / 4, -g3 / 4)

--- a/src/sage/schemes/toric/weierstrass_higher.py
+++ b/src/sage/schemes/toric/weierstrass_higher.py
@@ -81,7 +81,7 @@ def _check_polynomials_P3(quadratic1, quadratic2, variables):
     OUTPUT:
 
     This function returns ``variables``, potentially guessed from the
-    polynomial ring. A ``ValueError`` is raised if the polynomial is
+    polynomial ring. A :class:`ValueError` is raised if the polynomial is
     not homogeneous.
 
     EXAMPLES::


### PR DESCRIPTION
adding links to standard python errors in the doc inside the `schemes/toric` folder

plus a few pep8 cleanups

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.