### PR TITLE
Allow construction of classical Lie algebras over finite fields

### DIFF
--- a/src/sage/algebras/lie_algebras/classical_lie_algebra.py
+++ b/src/sage/algebras/lie_algebras/classical_lie_algebra.py
@@ -1700,6 +1700,26 @@ class LieAlgebraChevalleyBasis(LieAlgebraWithStructureCoefficients):
             [((alpha[1], -alpha[1]), {alphacheck[1]: 1}),
              ((alpha[1], alphacheck[1]), {alpha[1]: -2}),
              ((alphacheck[1], -alpha[1]), {-alpha[1]: -2})]
+
+        TESTS:
+
+        Check that we can construct Lie algebras over positive characteristic
+        fields (:issue:`37773`)::
+
+            sage: sl4 = lie_algebras.sl(GF(3), 4)
+            sage: sl4.is_nilpotent()
+            False
+            sage: sl4.lower_central_series()
+            (Lie algebra of ['A', 3] in the Chevalley basis,)
+            sage: sl4.is_solvable()
+            False
+            sage: sl4.is_semisimple()
+            True
+            sage: sl4.killing_form_matrix().det()
+            2
+            sage: sl5 = lie_algebras.sl(GF(3), 5)
+            sage: sl5.killing_form_matrix().det()
+            2
         """
         alphacheck = self._Q.simple_coroots()
         roots = frozenset(self._Q.roots())
@@ -1727,12 +1747,12 @@ class LieAlgebraChevalleyBasis(LieAlgebraWithStructureCoefficients):
                     continue
 
                 if b - x in roots:
-                    t1 = ((b-x).norm_squared() / b.norm_squared()
+                    t1 = (R((b-x).norm_squared()) / R(b.norm_squared())
                           * sp_sign[(x, b-x)] * sp_sign[(a, y-a)])
                 else:
                     t1 = 0
                 if a - x in roots:
-                    t2 = ((a-x).norm_squared() / a.norm_squared()
+                    t2 = (R((a-x).norm_squared()) / R(a.norm_squared())
                           * sp_sign[(x, a-x)] * sp_sign[(b, y-b)])
                 else:
                     t2 = 0

--- a/src/sage/algebras/lie_algebras/classical_lie_algebra.py
+++ b/src/sage/algebras/lie_algebras/classical_lie_algebra.py
@@ -1706,7 +1706,12 @@ class LieAlgebraChevalleyBasis(LieAlgebraWithStructureCoefficients):
         Check that we can construct Lie algebras over positive characteristic
         fields (:issue:`37773`)::
 
+            sage: sl3 = LieAlgebra(GF(3), cartan_type=['A',2])
+            sage: sl3.center().basis()
+            Family (2*h1 + h2,)
             sage: sl4 = lie_algebras.sl(GF(3), 4)
+            sage: sl4.center().dimension()
+            0
             sage: sl4.is_nilpotent()
             False
             sage: sl4.lower_central_series()
@@ -1720,10 +1725,28 @@ class LieAlgebraChevalleyBasis(LieAlgebraWithStructureCoefficients):
             sage: sl5 = lie_algebras.sl(GF(3), 5)
             sage: sl5.killing_form_matrix().det()
             2
+
+        This also includes characteristic 2::
+
+            sage: sl4 = LieAlgebra(GF(2), cartan_type=['A',3])
+            sage: sl4.center().basis()
+            Family (h1 + h3,)
+            sage: sp6 = LieAlgebra(GF(2), cartan_type=['C',3])
+            sage: sp6.killing_form_matrix().det()
+            0
+            sage: F4 = LieAlgebra(GF(2), cartan_type=['F',4])
+            sage: F4.killing_form_matrix().det()  # long time
+            0
+            sage: G2 = LieAlgebra(GF(2), cartan_type=['G',2])
+            sage: G2.killing_form_matrix().det()
+            0
         """
         alphacheck = self._Q.simple_coroots()
         roots = frozenset(self._Q.roots())
-        one = R.one()
+        # We do everything initially over QQ and then convert to R at the end
+        #   since this is a ZZ-basis.
+        from sage.rings.rational_field import QQ
+        one = QQ.one()
 
         # Determine the signs for the structure coefficients from the root system
         # We first create the special roots
@@ -1747,12 +1770,12 @@ class LieAlgebraChevalleyBasis(LieAlgebraWithStructureCoefficients):
                     continue
 
                 if b - x in roots:
-                    t1 = (R((b-x).norm_squared()) / R(b.norm_squared())
+                    t1 = ((b-x).norm_squared() / b.norm_squared()
                           * sp_sign[(x, b-x)] * sp_sign[(a, y-a)])
                 else:
                     t1 = 0
                 if a - x in roots:
-                    t2 = (R((a-x).norm_squared()) / R(a.norm_squared())
+                    t2 = ((a-x).norm_squared() / a.norm_squared()
                           * sp_sign[(x, a-x)] * sp_sign[(b, y-b)])
                 else:
                     t2 = 0
@@ -1775,15 +1798,15 @@ class LieAlgebraChevalleyBasis(LieAlgebraWithStructureCoefficients):
         for i,r in enumerate(p_roots):
             # [e_r, h_i] and [h_i, f_r]
             for ac in alphacheck:
-                c = r.scalar(ac)
+                c = R(r.scalar(ac))
                 if c == 0:
                     continue
                 s_coeffs[(r, ac)] = {r: -c}
                 s_coeffs[(ac, -r)] = {-r: -c}
 
             # [e_r, f_r]
-            s_coeffs[(r, -r)] = {alphacheck[j]: c
-                                 for j, c in r.associated_coroot()}
+            s_coeffs[(r, -r)] = {alphacheck[j]: Rc
+                                 for j, c in r.associated_coroot() if (Rc := R(c))}
 
             # [e_r, e_s] and [e_r, f_s] with r != +/-s
             # We assume s is positive, as otherwise we negate
@@ -1799,16 +1822,19 @@ class LieAlgebraChevalleyBasis(LieAlgebraWithStructureCoefficients):
                         c *= -sp_sign[(b, a)]
                     else:
                         c *= sp_sign[(a, b)]
-                    s_coeffs[(-r, s)] = {a: -c}
-                    s_coeffs[(r, -s)] = {-a: c}
+                    c = R(c)
+                    if c:
+                        s_coeffs[(-r, s)] = {a: -c}
+                        s_coeffs[(r, -s)] = {-a: c}
 
                 # [e_r, e_s]
                 a = r + s
                 if a in p_roots:
                     # (r, s) is a special pair
-                    c = e_coeff(r, s) * sp_sign[(r, s)]
-                    s_coeffs[(r, s)] = {a: c}
-                    s_coeffs[(-r, -s)] = {-a: -c}
+                    c = R(e_coeff(r, s) * sp_sign[(r, s)])
+                    if c:
+                        s_coeffs[(r, s)] = {a: c}
+                        s_coeffs[(-r, -s)] = {-a: -c}
 
         return s_coeffs
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Many classical Lie algebras are unable to be constructed because they multiply a rational number times an element in the base ring. If the base ring is, say, `GF(3)`, then there is no coercion (since not every element is defined), so we need to force all elements to be in the base ring during the computation (which might perform a division that goes to the fraction field, but it will eventually brings us back to a $\mathbb{Z}$-basis).

Before, this would fail with a `QQ` to `GF(3)` coercion error:
```
sage: sl4 = lie_algebras.sl(GF(3), 4)
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


