### PR TITLE
Add matroid `relabel`

### DIFF
--- a/src/sage/matroids/basis_exchange_matroid.pxd
+++ b/src/sage/matroids/basis_exchange_matroid.pxd
@@ -15,7 +15,7 @@ cdef class BasisExchangeMatroid(Matroid):
     cdef _weak_invariant_var, _strong_invariant_var, _heuristic_invariant_var
     cdef SetSystem _weak_partition_var, _strong_partition_var, _heuristic_partition_var
 
-    cdef _relabel(self, l)
+    cdef _relabel(self, mapping)
 
     cdef _pack(self, bitset_t, X)
     cdef __unpack(self, bitset_t)

--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -213,9 +213,9 @@ cdef class BasisExchangeMatroid(Matroid):
         cdef long i
         E = []
         for i in range(self._groundset_size):
-            if self._E[i] in mapping:
+            try:
                 E.append(mapping[self._E[i]])
-            else:
+            except LookupError:
                 E.append(self._E[i])
         self._E = tuple(E)
         self._groundset = frozenset(E)

--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -191,27 +191,30 @@ cdef class BasisExchangeMatroid(Matroid):
         bitset_free(self._output)
         bitset_free(self._temp)
 
-    cdef _relabel(self, l):
+    cdef _relabel(self, mapping):
         """
-        Relabel each element `e` as `l[e]`, where `l` is a given injective map.
+        Relabel each element ``e`` as ``mapping[e]``, where ``mapping`` is a
+        given injective map.
 
         INPUT:
 
-        - `l`, a python object such that `l[e]` is the new label of e.
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT:
+        OUTPUT: ``None``
 
-        ``None``.
+        .. NOTE::
 
-        NOTE:
-        For internal use. Matroids are immutable but this method does modify the matroid. The use this method will only
-        be safe in very limited circumstances, such as perhaps on a fresh copy of a matroid.
+            For internal use. Matroids are immutable but this method does
+            modify the matroid. The use of this method will only be safe in
+            very limited circumstances, such as perhaps on a fresh copy of a
+            matroid.
         """
         cdef long i
         E = []
         for i in range(self._groundset_size):
-            if self._E[i] in l:
-                E.append(l[self._E[i]])
+            if self._E[i] in mapping:
+                E.append(mapping[self._E[i]])
             else:
                 E.append(self._E[i])
         self._E = tuple(E)
@@ -222,12 +225,12 @@ cdef class BasisExchangeMatroid(Matroid):
             self._idx[self._E[i]] = i
 
         if self._weak_partition_var:
-            self._weak_partition_var._relabel(l)
+            self._weak_partition_var._relabel(mapping)
 
         if self._strong_partition_var:
-            self._strong_partition_var._relabel(l)
+            self._strong_partition_var._relabel(mapping)
         if self._heuristic_partition_var:
-            self._heuristic_partition_var._relabel(l)
+            self._heuristic_partition_var._relabel(mapping)
 
     # the engine
     cdef _pack(self, bitset_t I, F):

--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -199,7 +199,7 @@ cdef class BasisExchangeMatroid(Matroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: ``None``
 

--- a/src/sage/matroids/basis_matroid.pxd
+++ b/src/sage/matroids/basis_matroid.pxd
@@ -25,7 +25,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
     cpdef truncation(self)
     cpdef _extension(self, e, H)
     cpdef _with_coloop(self, e)
-    cpdef relabel(self, l)
+    # cpdef relabel(self, mapping)
 
     cpdef _bases_invariant(self)
     cpdef _bases_partition(self)

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -77,6 +77,7 @@ from sage.structure.richcmp cimport rich_to_bool
 from sage.matroids.matroid cimport Matroid
 from sage.matroids.basis_exchange_matroid cimport BasisExchangeMatroid
 from sage.matroids.set_system cimport SetSystem
+from sage.matroids.utilities import cmp_elements_key
 from cpython.object cimport Py_EQ, Py_NE
 
 from itertools import combinations
@@ -189,15 +190,19 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         if M is not None:
             rank = M.full_rank()
             nonbases = M.nonbases()
-            groundset = sorted(M.groundset())
+            groundset = sorted(M.groundset(), key=cmp_elements_key)
 
         if groundset is None:
             groundset = frozenset()
         if rank is None:
             if bases is not None:
-                rank = len(min(bases))
+                for B in bases:
+                    rank = len(B)
+                    break
             elif nonbases is not None:
-                rank = len(min(nonbases))
+                for N in nonbases:
+                    rank = len(N)
+                    break
             else:
                 rank = 0
 
@@ -515,42 +520,46 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         cdef frozenset se = frozenset([e])
         return BasisMatroid(groundset=self._E + (e,), bases=[B | se for B in self.bases()])
 
-    cpdef relabel(self, l):
-        """
+    cpdef relabel(self, f):
+        r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``l[e]``,
-        where ``l`` is a given injective map. If ``e not in l`` then the
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
         identity map is assumed.
 
         INPUT:
 
-        - ``l`` -- a python object such that `l[e]` is the new label of `e`.
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
 
-        OUTPUT:
-
-        A matroid.
-
-        .. TODO::
-
-            Write abstract ``RelabeledMatroid`` class, and add ``relabel()``
-            method to the main ``Matroid`` class, together with ``_relabel()``
-            method that can be replaced by subclasses. Use the code from
-            ``is_isomorphism()`` in ``relabel()`` to deal with a variety of
-            input methods for the relabeling.
+        OUTPUT: a matroid
 
         EXAMPLES::
 
-            sage: from sage.matroids.advanced import *
+            sage: from sage.matroids.advanced import BasisMatroid
             sage: M = BasisMatroid(matroids.catalog.Fano())
             sage: sorted(M.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'g']
-            sage: N = M.relabel({'g':'x'})
-            sage: sorted(N.groundset())
-            ['a', 'b', 'c', 'd', 'e', 'f', 'x']
+            sage: N = M.relabel({'a':0, 'g':'x'})
+            sage: from sage.matroids.utilities import cmp_elements_key
+            sage: sorted(N.groundset(), key=cmp_elements_key)
+            [0, 'b', 'c', 'd', 'e', 'f', 'x']
+            sage: N.is_isomorphic(M)
+            True
+
+        TESTS::
+
+            sage: from sage.matroids.advanced import BasisMatroid
+            sage: M = BasisMatroid(matroids.catalog.Fano())
+            sage: f = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        M = BasisMatroid(M=self)
-        M._relabel(l)
+        d = self._relabel_map(f)
+        E = [d[x] for x in self.groundset()]
+        B = [[d[y] for y in list(x)] for x in self.bases()]
+        M = BasisMatroid(groundset=E, bases=B)
         return M
 
     # enumeration
@@ -691,8 +700,8 @@ cdef class BasisMatroid(BasisExchangeMatroid):
                 bi[bc[e]].append(e)
             else:
                 bi[bc[e]] = [e]
-        self._bases_invariant_var = hash(tuple([(c, len(bi[c])) for c in sorted(bi)]))
-        self._bases_partition_var = SetSystem(self._E, [[self._E[e] for e in bi[c]] for c in sorted(bi)])
+        self._bases_invariant_var = hash(tuple([(c, len(bi[c])) for c in sorted(bi, key=cmp_elements_key)]))
+        self._bases_partition_var = SetSystem(self._E, [[self._E[e] for e in bi[c]] for c in sorted(bi, key=cmp_elements_key)])
         return self._bases_invariant_var
 
     cpdef _bases_partition(self):

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -263,7 +263,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             sage: repr(M)  # indirect doctest
             'Matroid of rank 3 on 7 elements with 28 bases'
         """
-        return Matroid._repr_(self) + " with " + str(self.bases_count()) + " bases"
+        return f'{Matroid._repr_(self)} with {self.bases_count()} bases'
 
     # support for parent BasisExchangeMatroid
 
@@ -531,7 +531,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of ``e``
 
         OUTPUT: a matroid

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -540,7 +540,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             sage: M = BasisMatroid(matroids.catalog.Fano())
             sage: sorted(M.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'g']
-            sage: N = M.relabel({'a':0, 'g':'x'})
+            sage: N = M.relabel({'a': 0, 'g': 'x'})
             sage: from sage.matroids.utilities import cmp_elements_key
             sage: sorted(N.groundset(), key=cmp_elements_key)
             [0, 'b', 'c', 'd', 'e', 'f', 'x']

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -79,7 +79,7 @@ from sage.matroids.basis_exchange_matroid cimport BasisExchangeMatroid
 from sage.matroids.set_system cimport SetSystem
 from sage.matroids.utilities import cmp_elements_key
 from cpython.object cimport Py_EQ, Py_NE
-
+from sage.misc.decorators import rename_keyword
 from itertools import combinations
 
 # class of general matroids, represented by their list of bases
@@ -520,17 +520,19 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         cdef frozenset se = frozenset([e])
         return BasisMatroid(groundset=self._E + (e,), bases=[B | se for B in self.bases()])
 
-    cpdef relabel(self, f):
+    @rename_keyword(deprecation=37775, l='mapping')
+    def relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -556,7 +558,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset()]
         B = [[d[y] for y in list(x)] for x in self.bases()]
         M = BasisMatroid(groundset=E, bases=B)

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -532,7 +532,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         INPUT:
 
         - ``mapping`` -- a python object such that `mapping[e]` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -560,7 +560,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         """
         d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset()]
-        B = [[d[y] for y in list(x)] for x in self.bases()]
+        B = [[d[y] for y in x] for x in self.bases()]
         M = BasisMatroid(groundset=E, bases=B)
         return M
 

--- a/src/sage/matroids/circuit_closures_matroid.pxd
+++ b/src/sage/matroids/circuit_closures_matroid.pxd
@@ -13,4 +13,4 @@ cdef class CircuitClosuresMatroid(Matroid):
     cpdef _circuit(self, F)
     cpdef circuit_closures(self)
     cpdef _is_isomorphic(self, other, certificate=*)
-    cpdef relabel(self, f)
+    cpdef relabel(self, mapping)

--- a/src/sage/matroids/circuit_closures_matroid.pxd
+++ b/src/sage/matroids/circuit_closures_matroid.pxd
@@ -13,3 +13,4 @@ cdef class CircuitClosuresMatroid(Matroid):
     cpdef _circuit(self, F)
     cpdef circuit_closures(self)
     cpdef _is_isomorphic(self, other, certificate=*)
+    cpdef relabel(self, f)

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -579,7 +579,7 @@ cdef class CircuitClosuresMatroid(Matroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -578,7 +578,7 @@ cdef class CircuitClosuresMatroid(Matroid):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 
@@ -588,7 +588,7 @@ cdef class CircuitClosuresMatroid(Matroid):
             sage: M = CircuitClosuresMatroid(matroids.catalog.RelaxedNonFano())
             sage: sorted(M.groundset())
             [0, 1, 2, 3, 4, 5, 6]
-            sage: N = M.relabel({'g':'x', 0:'z'}) # 'g':'x' is ignored
+            sage: N = M.relabel({'g': 'x', 0: 'z'})  # 'g': 'x' is ignored
             sage: from sage.matroids.utilities import cmp_elements_key
             sage: sorted(N.groundset(), key=cmp_elements_key)
             [1, 2, 3, 4, 5, 6, 'z']

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -568,4 +568,48 @@ cdef class CircuitClosuresMatroid(Matroid):
         version = 0
         return sage.matroids.unpickling.unpickle_circuit_closures_matroid, (version, data)
 
+    cpdef relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: from sage.matroids.circuit_closures_matroid import CircuitClosuresMatroid
+            sage: M = CircuitClosuresMatroid(matroids.catalog.RelaxedNonFano())
+            sage: sorted(M.groundset())
+            [0, 1, 2, 3, 4, 5, 6]
+            sage: N = M.relabel({'g':'x', 0:'z'}) # 'g':'x' is ignored
+            sage: from sage.matroids.utilities import cmp_elements_key
+            sage: sorted(N.groundset(), key=cmp_elements_key)
+            [1, 2, 3, 4, 5, 6, 'z']
+            sage: M.is_isomorphic(N)
+            True
+
+        TESTS::
+
+            sage: from sage.matroids.circuit_closures_matroid import CircuitClosuresMatroid
+            sage: M = CircuitClosuresMatroid(matroids.catalog.RelaxedNonFano())
+            sage: f = {0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f', 6: 'g'}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self.groundset()]
+        CC = {}
+        for i in self.circuit_closures():
+            CC[i] = [[d[y] for y in x] for x in list(self._circuit_closures[i])]
+        M = CircuitClosuresMatroid(groundset=E, circuit_closures=CC)
+        return M
+
 # todo: customized minor, extend methods.

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -568,17 +568,18 @@ cdef class CircuitClosuresMatroid(Matroid):
         version = 0
         return sage.matroids.unpickling.unpickle_circuit_closures_matroid, (version, data)
 
-    cpdef relabel(self, f):
+    cpdef relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -604,7 +605,7 @@ cdef class CircuitClosuresMatroid(Matroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset()]
         CC = {}
         for i in self.circuit_closures():

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -609,7 +609,7 @@ cdef class CircuitClosuresMatroid(Matroid):
         E = [d[x] for x in self.groundset()]
         CC = {}
         for i in self.circuit_closures():
-            CC[i] = [[d[y] for y in x] for x in list(self._circuit_closures[i])]
+            CC[i] = [[d[y] for y in x] for x in self._circuit_closures[i]]
         M = CircuitClosuresMatroid(groundset=E, circuit_closures=CC)
         return M
 

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -578,7 +578,7 @@ cdef class CircuitClosuresMatroid(Matroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid

--- a/src/sage/matroids/circuits_matroid.pxd
+++ b/src/sage/matroids/circuits_matroid.pxd
@@ -24,8 +24,9 @@ cdef class CircuitsMatroid(Matroid):
     cpdef girth(self)
     cpdef is_paving(self)
 
-    # isomorphism
+    # isomorphism and relabeling
     cpdef _is_isomorphic(self, other, certificate=*)
+    cpdef relabel(self, f)
 
     # verification
     cpdef is_valid(self)

--- a/src/sage/matroids/circuits_matroid.pxd
+++ b/src/sage/matroids/circuits_matroid.pxd
@@ -26,7 +26,7 @@ cdef class CircuitsMatroid(Matroid):
 
     # isomorphism and relabeling
     cpdef _is_isomorphic(self, other, certificate=*)
-    cpdef relabel(self, f)
+    cpdef relabel(self, mapping)
 
     # verification
     cpdef is_valid(self)

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -269,9 +269,9 @@ cdef class CircuitsMatroid(Matroid):
             NonDesargues: Matroid of rank 3 on 10 elements with 9 nonspanning circuits
         """
         if self._nsc_defined:
-            return Matroid._repr_(self) + " with " + str(len(self.nonspanning_circuits())) + " nonspanning circuits"
+            return f'{Matroid._repr_(self)} with {len(self.nonspanning_circuits())} nonspanning circuits'
         else:
-            return Matroid._repr_(self) + " with " + str(len(self._C)) + " circuits"
+            return f'{Matroid._repr_(self)} with {len(self._C)} circuits'
 
     # comparison
 

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -413,6 +413,50 @@ cdef class CircuitsMatroid(Matroid):
         version = 0
         return sage.matroids.unpickling.unpickle_circuits_matroid, (version, data)
 
+    cpdef relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: from sage.matroids.circuits_matroid import CircuitsMatroid
+            sage: M = CircuitsMatroid(matroids.catalog.RelaxedNonFano())
+            sage: sorted(M.groundset())
+            [0, 1, 2, 3, 4, 5, 6]
+            sage: N = M.relabel({'g':'x', 0:'z'}) # 'g':'x' is ignored
+            sage: from sage.matroids.utilities import cmp_elements_key
+            sage: sorted(N.groundset(), key=cmp_elements_key)
+            [1, 2, 3, 4, 5, 6, 'z']
+            sage: M.is_isomorphic(N)
+            True
+
+        TESTS::
+
+            sage: from sage.matroids.circuits_matroid import CircuitsMatroid
+            sage: M = CircuitsMatroid(matroids.catalog.RelaxedNonFano())
+            sage: f = {0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f', 6: 'g'}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self._groundset]
+        C = []
+        for i in self._k_C:
+            C += [[d[y] for y in list(x)] for x in self._k_C[i]]
+        M = CircuitsMatroid(groundset=E, circuits=C)
+        return M
+
     # enumeration
 
     cpdef bases(self):

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -423,7 +423,7 @@ cdef class CircuitsMatroid(Matroid):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 
@@ -433,7 +433,7 @@ cdef class CircuitsMatroid(Matroid):
             sage: M = CircuitsMatroid(matroids.catalog.RelaxedNonFano())
             sage: sorted(M.groundset())
             [0, 1, 2, 3, 4, 5, 6]
-            sage: N = M.relabel({'g':'x', 0:'z'}) # 'g':'x' is ignored
+            sage: N = M.relabel({'g': 'x', 0: 'z'})  # 'g': 'x' is ignored
             sage: from sage.matroids.utilities import cmp_elements_key
             sage: sorted(N.groundset(), key=cmp_elements_key)
             [1, 2, 3, 4, 5, 6, 'z']

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -413,17 +413,18 @@ cdef class CircuitsMatroid(Matroid):
         version = 0
         return sage.matroids.unpickling.unpickle_circuits_matroid, (version, data)
 
-    cpdef relabel(self, f):
+    cpdef relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -449,7 +450,7 @@ cdef class CircuitsMatroid(Matroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self._groundset]
         C = []
         for i in self._k_C:

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -423,7 +423,7 @@ cdef class CircuitsMatroid(Matroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -424,7 +424,7 @@ cdef class CircuitsMatroid(Matroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -454,7 +454,7 @@ cdef class CircuitsMatroid(Matroid):
         E = [d[x] for x in self._groundset]
         C = []
         for i in self._k_C:
-            C += [[d[y] for y in list(x)] for x in self._k_C[i]]
+            C += [[d[y] for y in x] for x in self._k_C[i]]
         M = CircuitsMatroid(groundset=E, circuits=C)
         return M
 

--- a/src/sage/matroids/database_matroids.py
+++ b/src/sage/matroids/database_matroids.py
@@ -314,7 +314,7 @@ def P6(groundset=None):
     [Oxl2011]_, p. 641-2.
     """
     CC = {2: ['abc'], 3: ['abcdef']}
-    M = Matroid(groundset='abcdef', circuit_closures=CC)
+    M = Matroid(circuit_closures=CC)
     M = _rename_and_relabel(M, "P6", groundset)
     return M
 
@@ -724,7 +724,7 @@ def AG32prime(groundset=None):
         ],
         4: ['abcdefgh'],
     }
-    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = Matroid(circuit_closures=CC)
     M = _rename_and_relabel(M, "AG(3, 2)'", groundset)
     return M
 
@@ -824,7 +824,7 @@ def F8(groundset=None):
         ],
         4: ['abcdefgh'],
     }
-    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = Matroid(circuit_closures=CC)
     M = _rename_and_relabel(M, "F8", groundset)
     return M
 
@@ -873,7 +873,7 @@ def Q8(groundset=None):
         ],
         4: ['abcdefgh'],
     }
-    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = Matroid(circuit_closures=CC)
     M = _rename_and_relabel(M, "Q8", groundset)
     return M
 
@@ -920,7 +920,7 @@ def L8(groundset=None):
     """
     CC = {3: ['abfg', 'bcdg', 'defg', 'cdeh', 'aefh', 'abch', 'aceg', 'bdfh'],
           4: ['abcdefgh']}
-    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = Matroid(circuit_closures=CC)
     M = _rename_and_relabel(M, "L8", groundset)
     return M
 
@@ -1009,7 +1009,7 @@ def Vamos(groundset=None):
     [Oxl2011]_, p. 649.
     """
     CC = {3: ['abcd', 'abef', 'cdef', 'abgh', 'efgh'], 4: ['abcdefgh']}
-    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = Matroid(circuit_closures=CC)
     M = _rename_and_relabel(M, "Vamos", groundset)
     return M
 
@@ -1160,7 +1160,7 @@ def P8pp(groundset=None):
     [Oxl2011]_, p. 651.
     """
     NSC = ['abfh', 'bceg', 'cdfh', 'adeg', 'acef', 'bdfg', 'acgh', 'bdeh']
-    M = Matroid(groundset='abcdefgh', rank=4, nonspanning_circuits=NSC)
+    M = Matroid(rank=4, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "P8''", groundset)
     return M
 
@@ -1410,7 +1410,7 @@ def Pappus(groundset=None):
     [Oxl2011]_, p. 655.
     """
     NSC = ['abc', 'def', 'ceg', 'bfg', 'cdh', 'afh', 'bdi', 'aei', 'ghi']
-    M = Matroid(groundset='abcdefghi', rank=3, nonspanning_circuits=NSC)
+    M = Matroid(rank=3, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "Pappus", groundset)
     return M
 
@@ -1444,7 +1444,7 @@ def NonPappus(groundset=None):
     [Oxl2011]_, p. 655.
     """
     NSC = ['abc', 'ceg', 'bfg', 'cdh', 'afh', 'bdi', 'aei', 'ghi']
-    M = Matroid(groundset='abcdefghi', rank=3, nonspanning_circuits=NSC)
+    M = Matroid(rank=3, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "NonPappus", groundset)
     return M
 
@@ -2239,7 +2239,7 @@ def Spike(r, t=True, C3=[], groundset=None):
         planes = [['t', 'x'+str(i), 'y'+str(i), 'x'+str(j), 'y'+str(j)]
                   for i in range(1, r+1) for j in range(i+1, r+1)]
         CC = {2: lines, 3: planes, r: [E]}
-        M = Matroid(groundset=E, circuit_closures=CC)
+        M = Matroid(circuit_closures=CC)
     else:
         for S in C3:
             for xy in S:
@@ -2261,7 +2261,7 @@ def Spike(r, t=True, C3=[], groundset=None):
             for j in range(i+1, r+1):
                 NSC += [['x'+str(i), 'y'+str(i), 'x'+str(j), 'y'+str(j)]]
 
-        M = Matroid(groundset=E, rank=r, nonspanning_circuits=NSC)
+        M = Matroid(rank=r, nonspanning_circuits=NSC)
 
     free = "Free " if C3 == [] else ""
     tip = "" if t else "\\t"
@@ -2343,7 +2343,7 @@ def Theta(n, groundset=None):
                     Yu = [Y[i] for i in range(len(Y)) if i != u]
                     C += [Yu + ['x'+str(s)] + ['x'+str(t)]]
 
-    M = Matroid(groundset=E, circuits=C)
+    M = Matroid(circuits=C)
     M = _rename_and_relabel(M, "Theta_" + str(n), groundset)
     return M
 
@@ -4715,7 +4715,7 @@ def NonVamos(groundset=None):
         3: ['abcd', 'abef', 'cdef', 'abgh', 'cdgh', 'efgh'],
         4: ['abcdefgh']
     }
-    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = Matroid(circuit_closures=CC)
     M = _rename_and_relabel(M, "NonVamos", groundset)
     return M
 
@@ -4773,7 +4773,7 @@ def AG23minus(groundset=None):
     """
     CC = {2: ['abc', 'ceh', 'fgh', 'adf', 'aeg', 'cdg', 'bdh', 'bef'],
           3: ['abcdefgh']}
-    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = Matroid(circuit_closures=CC)
     M = _rename_and_relabel(M, "AG23minus", groundset)
     return M
 
@@ -4823,7 +4823,7 @@ def R9A(groundset=None):
     """
     NSC = ['abch', 'abde', 'abfi', 'acdi', 'aceg', 'adgh', 'aefh', 'bcdf',
            'bdhi', 'begi', 'cehi', 'defi', 'fghi']
-    M = Matroid(groundset='abcdefghi', rank=4, nonspanning_circuits=NSC)
+    M = Matroid(rank=4, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "R9A", groundset)
     return M
 
@@ -4846,7 +4846,7 @@ def R9B(groundset=None):
     """
     NSC = ['abde', 'bcdf', 'aceg', 'abch', 'befh', 'cdgh', 'bcei', 'adfi',
            'abgi', 'degi', 'bdhi', 'aehi', 'fghi']
-    M = Matroid(groundset='abcdefghi', rank=4, nonspanning_circuits=NSC)
+    M = Matroid(rank=4, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "R9B", groundset)
     return M
 
@@ -4870,7 +4870,7 @@ def Block_9_4(groundset=None):
     NSC = ['abcd', 'acef', 'bdef', 'cdeg', 'abfg', 'adeh', 'bcfh', 'acgh',
            'begh', 'dfgh', 'abei', 'cdfi', 'bcgi', 'adgi', 'efgi', 'bdhi',
            'cehi', 'afhi']
-    M = Matroid(groundset='abcdefghi', rank=4, nonspanning_circuits=NSC)
+    M = Matroid(rank=4, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "Block(9, 4)", groundset)
     return M
 
@@ -4895,7 +4895,7 @@ def TicTacToe(groundset=None):
     """
     NSC = ['abcdg', 'adefg', 'abceh', 'abcfi', 'cdefi', 'adghi', 'beghi',
            'cfghi']
-    M = Matroid(groundset='abcdefghi', rank=5, nonspanning_circuits=NSC)
+    M = Matroid(rank=5, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "TicTacToe", groundset)
     return M
 
@@ -4953,7 +4953,7 @@ def Block_10_5(groundset=None):
            'cdegj', 'bcfgj', 'acdhj', 'bcehj', 'defhj', 'bdghj', 'afghj',
            'abcij', 'bdeij', 'cdfij', 'adgij', 'efgij', 'aehij', 'bfhij',
            'cghij']
-    M = Matroid(groundset='abcdefghij', rank=5, nonspanning_circuits=NSC)
+    M = Matroid(rank=5, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "Block(10, 5)", groundset)
     return M
 
@@ -5021,7 +5021,7 @@ def BetsyRoss(groundset=None):
     NSC = ['acf', 'acg', 'adi', 'adj', 'afg', 'ahk', 'aij', 'bdg', 'bdh',
            'bef', 'bej', 'bfj', 'bgh', 'bik', 'ceh', 'cei', 'cfg', 'chi',
            'cjk', 'dfk', 'dgh', 'dij', 'efj', 'egk', 'ehi']
-    M = Matroid(groundset='abcdefghijk', rank=3, nonspanning_circuits=NSC)
+    M = Matroid(rank=3, nonspanning_circuits=NSC)
     M = _rename_and_relabel(M, "BetsyRoss", groundset)
     return M
 

--- a/src/sage/matroids/database_matroids.py
+++ b/src/sage/matroids/database_matroids.py
@@ -1362,7 +1362,7 @@ def R9(groundset=None):
         R9: Matroid of rank 3 on 9 elements with 15 nonspanning circuits
         sage: M.is_valid()
         True
-        sage: len(list(M.nonspanning_circuits()))
+        sage: len(M.nonspanning_circuits())
         15
         sage: M.is_simple() and M.is_ternary()
         True
@@ -1834,7 +1834,7 @@ def Wheel(r, field=None, ring=None, groundset=None):
         M = RegularMatroid(A)
     else:
         M = Matroid(A)
-    M = _rename_and_relabel(M, "Wheel(" + str(r) + ")", groundset)
+    M = _rename_and_relabel(M, f'Wheel({r})', groundset)
     return M
 
 
@@ -1903,7 +1903,7 @@ def Whirl(r, groundset=None):
         else:
             A[i, 2 * r - 1] = 1
     M = TernaryMatroid(A)
-    M = _rename_and_relabel(M, "Whirl(" + str(r) + ")", groundset)
+    M = _rename_and_relabel(M, f'Whirl({r})', groundset)
     return M
 
 
@@ -1955,7 +1955,7 @@ def Uniform(r, n, groundset=None):
     else:
         CC = {}
     M = Matroid(groundset=E, circuit_closures=CC)
-    M = _rename_and_relabel(M, "U(" + str(r) + ", " + str(n) + ")", groundset)
+    M = _rename_and_relabel(M, f'U({r}, {n})', groundset)
     return M
 
 
@@ -1998,7 +1998,7 @@ def PG(n, q, x=None, groundset=None):
     P = ProjectiveSpace(n, F)
     A = Matrix(F, [list(p) for p in list(P)]).transpose()
     M = Matroid(A)
-    M = _rename_and_relabel(M, "PG(" + str(n) + ", " + str(q) + ")", groundset)
+    M = _rename_and_relabel(M, f'PG({n}, {q})', groundset)
     return M
 
 
@@ -2045,7 +2045,7 @@ def AG(n, q, x=None, groundset=None):
         F, [list(p) for p in list(P) if not list(p)[0] == 0]
     ).transpose()
     M = Matroid(A)
-    M = _rename_and_relabel(M, "AG(" + str(n) + ", " + str(q) + ")", groundset)
+    M = _rename_and_relabel(M, f'AG({n}, {q})', groundset)
     return M
 
 
@@ -2129,15 +2129,15 @@ def Z(r, t=True, groundset=None):
     A = Id.augment(J-Id).augment(tip)
 
     M = Matroid(A)
-    X = ['x'+str(i) for i in range(1, r+1)]
-    Y = ['y'+str(i) for i in range(1, r+1)]
+    X = [f'x{i}' for i in range(1, r + 1)]
+    Y = [f'y{i}' for i in range(1, r + 1)]
     if t:
-        M = M.relabel(X+Y+['t'])
-        M.rename("Z_" + str(r) + ": " + repr(M))
+        M = M.relabel(X + Y + ['t'])
+        M.rename(f'Z_{r}: ' + repr(M))
     else:
-        M = M.delete(2*r)
-        M = M.relabel(X+Y)
-        M.rename("Z_" + str(r) + "\\t: " + repr(M))
+        M = M.delete(2 * r)
+        M = M.relabel(X + Y)
+        M.rename(f'Z_{r}\\t: ' + repr(M))
     M = _rename_and_relabel(M, groundset=groundset)
     return M
 
@@ -2176,7 +2176,7 @@ def Spike(r, t=True, C3=[], groundset=None):
          nonspanning circuits
         sage: M.is_isomorphic(matroids.Uniform(3, 6))
         True
-        sage: len(list(matroids.Spike(8).bases()))
+        sage: len(matroids.Spike(8).bases())
         4864
         sage: import random
         sage: r = random.choice(range(3, 20))
@@ -2228,16 +2228,16 @@ def Spike(r, t=True, C3=[], groundset=None):
     E = ['t']
     X, Y = [], []
     for i in range(1, r + 1):
-        X.append('x' + str(i))
-        Y.append('y' + str(i))
+        X.append(f'x{i}')
+        Y.append(f'y{i}')
     E += X
     E += Y
 
     if C3 == [] and r > 3:
         # free spike (can be defined fast through circuit closures)
-        lines = [['t', 'x'+str(i), 'y'+str(i)] for i in range(1, r+1)]
-        planes = [['t', 'x'+str(i), 'y'+str(i), 'x'+str(j), 'y'+str(j)]
-                  for i in range(1, r+1) for j in range(i+1, r+1)]
+        lines = [['t', f'x{i}', f'y{i}'] for i in range(1, r + 1)]
+        planes = [['t', f'x{i}', f'y{i}', f'x{j}', f'y{j}']
+                  for i in range(1, r + 1) for j in range(i + 1, r + 1)]
         CC = {2: lines, 3: planes, r: [E]}
         M = Matroid(circuit_closures=CC)
     else:
@@ -2256,17 +2256,17 @@ def Spike(r, t=True, C3=[], groundset=None):
 
         NSC = []  # nonspanning_circuits
         NSC += C3
-        for i in range(1, r+1):
-            NSC += [['t', 'x'+str(i), 'y'+str(i)]]
-            for j in range(i+1, r+1):
-                NSC += [['x'+str(i), 'y'+str(i), 'x'+str(j), 'y'+str(j)]]
+        for i in range(1, r + 1):
+            NSC += [['t', f'x{i}', f'y{i}']]
+            for j in range(i + 1, r + 1):
+                NSC += [[f'x{i}', f'y{i}', f'x{j}', f'y{j}']]
 
         M = Matroid(rank=r, nonspanning_circuits=NSC)
 
     free = "Free " if C3 == [] else ""
     tip = "" if t else "\\t"
     M = M if t else M.delete('t')
-    M = _rename_and_relabel(M, free + str(r) + "-spike" + tip, groundset)
+    M = _rename_and_relabel(M, f'{free}{r}-spike{tip}', groundset)
     return M
 
 
@@ -2325,26 +2325,25 @@ def Theta(n, groundset=None):
 
     [Oxl2011]_, p. 663-4.
     """
-    X = ['x'+str(i) for i in range(n)]
-    Y = ['y'+str(i) for i in range(n)]
-    E = X + Y
+    X = [f'x{i}' for i in range(n)]
+    Y = [f'y{i}' for i in range(n)]
 
     import itertools
     C = []
     C += list(itertools.combinations(X, 3))
     for i in range(n):
         Yi = [Y[j] for j in range(len(Y)) if j != i]
-        C += [Yi + ['x'+str(i)]]
+        C += [Yi + [f'x{i}']]
 
     for u in range(n):
         for s in range(n):
-            for t in range(s+1, n):
+            for t in range(s + 1, n):
                 if u != s and u != t and s != t:
                     Yu = [Y[i] for i in range(len(Y)) if i != u]
-                    C += [Yu + ['x'+str(s)] + ['x'+str(t)]]
+                    C += [Yu + [f'x{s}'] + [f'x{t}']]
 
     M = Matroid(circuits=C)
-    M = _rename_and_relabel(M, "Theta_" + str(n), groundset)
+    M = _rename_and_relabel(M, f'Theta_{n}', groundset)
     return M
 
 
@@ -2395,8 +2394,8 @@ def Psi(r, groundset=None):
 
     [Oxl2011]_, p. 664.
     """
-    A = ['a'+str(i) for i in range(0, r)]
-    B = ['b'+str(i) for i in range(0, r)]
+    A = [f'a{i}' for i in range(0, r)]
+    B = [f'b{i}' for i in range(0, r)]
     E = A + B
 
     def generate_binary_strings(bit_count):
@@ -2414,20 +2413,20 @@ def Psi(r, groundset=None):
 
     NSC = []  # nonspanning circuits
     for i in range(0, r):
-        for k in range(1, r-2):
-            I0 = ['a'+str(i), 'b'+str(i)]
-            IK = ['a'+str((i+k) % r), 'b'+str((i+k) % r)]
-            for AB in generate_binary_strings(k-1):
+        for k in range(1, r - 2):
+            I0 = [f'a{i}', f'b{i}']
+            IK = [f'a{(i+k) % r}', f'b{(i+k) % r}']
+            for AB in generate_binary_strings(k - 1):
                 C = []
                 C += I0 + IK
                 j = 1
                 for z in AB:
-                    C += [z+str((i+j) % r)]
+                    C += [f'{z}{(i+j) % r}']
                     j += 1
                 NSC += [C]
 
     M = Matroid(groundset=E, rank=r, nonspanning_circuits=NSC)
-    M = _rename_and_relabel(M, "Psi_" + str(r), groundset)
+    M = _rename_and_relabel(M, f'Psi_{r}', groundset)
     return M
 
 
@@ -5209,7 +5208,7 @@ def CompleteGraphic(n, groundset=None):
         groundset=list(range((n * (n - 1)) // 2)),
         graph=graphs.CompleteGraph(n)
     )
-    M = _rename_and_relabel(M, "M(K" + str(n) + ")", groundset)
+    M = _rename_and_relabel(M, f'M(K{n})', groundset)
     return M
 
 
@@ -5229,9 +5228,7 @@ def _rename_and_relabel(M, name=None, groundset=None):
     - ``name`` -- a string (optional)
     - ``groundset`` -- a string (optional)
 
-    OUTPUT:
-
-    a matroid
+    OUTPUT: a matroid
     """
     if groundset is not None:
         if len(groundset) != len(M.groundset()):

--- a/src/sage/matroids/database_matroids.py
+++ b/src/sage/matroids/database_matroids.py
@@ -38,7 +38,6 @@ collection, see the associated publications, [Bre2023]_ and [BP2023]_.
 
 from sage.matrix.constructor import Matrix
 from sage.matroids.constructor import Matroid
-from sage.matroids.circuit_closures_matroid import CircuitClosuresMatroid
 from sage.matroids.linear_matroid import (
     RegularMatroid,
     BinaryMatroid,
@@ -59,7 +58,7 @@ from sage.schemes.projective.projective_space import ProjectiveSpace
 # The order is the same as in Oxley.
 
 
-def U24():
+def U24(groundset='abcd'):
     r"""
     The uniform matroid of rank `2` on `4` elements.
 
@@ -70,7 +69,7 @@ def U24():
 
         sage: M = matroids.catalog.U24(); M
         U(2, 4): Matroid of rank 2 on 4 elements with circuit-closures
-        {2: {{0, 1, 2, 3}}}
+        {2: {{'a', 'b', 'c', 'd'}}}
         sage: N = matroids.Uniform(2, 4)
         sage: M.is_isomorphic(N)
         True
@@ -96,12 +95,21 @@ def U24():
     REFERENCES:
 
     [Oxl2011]_, p. 639.
+
+    TESTS::
+
+        sage: M = matroids.catalog.U24(range(4))
+        sage: sorted(M.groundset())
+        [0, 1, 2, 3]
+        sage: M.is_isomorphic(matroids.catalog.U24())
+        True
     """
     M = Uniform(2, 4)
+    M = _rename_and_relabel(M, "U(2, 4)", groundset)
     return M
 
 
-def U25():
+def U25(groundset='abcde'):
     """
     The uniform matroid of rank `2` on `5` elements.
 
@@ -111,7 +119,7 @@ def U25():
 
         sage: U25 = matroids.catalog.U25(); U25
         U(2, 5): Matroid of rank 2 on 5 elements with circuit-closures
-        {2: {{0, 1, 2, 3, 4}}}
+        {2: {{'a', 'b', 'c', 'd', 'e'}}}
         sage: U35 = matroids.catalog.U35()
         sage: U25.is_isomorphic(U35.dual())
         True
@@ -119,12 +127,19 @@ def U25():
     REFERENCES:
 
     [Oxl2011]_, p. 640.
+
+    TESTS::
+
+        sage: M = matroids.catalog.U25(range(5))
+        sage: sorted(M.groundset())
+        [0, 1, 2, 3, 4]
     """
     M = Uniform(2, 5)
+    M = _rename_and_relabel(M, "U(2, 5)", groundset)
     return M
 
 
-def U35():
+def U35(groundset='abcde'):
     """
     The uniform matroid of rank `3` on `5` elements.
 
@@ -134,7 +149,7 @@ def U35():
 
         sage: U35 = matroids.catalog.U35(); U35
         U(3, 5): Matroid of rank 3 on 5 elements with circuit-closures
-        {3: {{0, 1, 2, 3, 4}}}
+        {3: {{'a', 'b', 'c', 'd', 'e'}}}
         sage: U25 = matroids.catalog.U25()
         sage: U35.is_isomorphic(U25.dual())
         True
@@ -142,12 +157,19 @@ def U35():
     REFERENCES:
 
     [Oxl2011]_, p. 640.
+
+    TESTS::
+
+        sage: M = matroids.catalog.U35(range(5))
+        sage: sorted(M.groundset())
+        [0, 1, 2, 3, 4]
     """
     M = Uniform(3, 5)
+    M = _rename_and_relabel(M, "U(3, 5)", groundset)
     return M
 
 
-def K4():
+def K4(groundset='abcdef'):
     r"""
     The graphic matroid of the complete graph `K_4`.
 
@@ -176,12 +198,19 @@ def K4():
     REFERENCES:
 
     [Oxl2011]_, p. 640.
+
+    TESTS::
+
+        sage: M = matroids.catalog.K4(range(6))
+        sage: sorted(M.groundset())
+        [0, 1, 2, 3, 4, 5]
     """
     M = CompleteGraphic(4)
+    M = _rename_and_relabel(M, "M(K4)", groundset)
     return M
 
 
-def Whirl3():
+def Whirl3(groundset='abcdef'):
     r"""
     The rank-`3` whirl.
 
@@ -211,12 +240,19 @@ def Whirl3():
     REFERENCES:
 
     [Oxl2011]_, p. 641.
+
+    TESTS::
+
+        sage: W = matroids.catalog.Whirl3(range(6))
+        sage: sorted(W.groundset())
+        [0, 1, 2, 3, 4, 5]
     """
     M = Whirl(3)
+    M = _rename_and_relabel(M, "Whirl(3)", groundset)
     return M
 
 
-def Q6():
+def Q6(groundset='abcdef'):
     """
     Return the matroid `Q_6`, represented over `GF(4)`.
 
@@ -245,12 +281,12 @@ def Q6():
     F = GF(4, 'x')
     x = F.gens()[0]
     A = Matrix(F, [[1, 0, 0, 1, 0, 1], [0, 1, 0, 1, 1, x], [0, 0, 1, 0, 1, 1]])
-    M = QuaternaryMatroid(A, 'abcdef')
-    M.rename("Q6: " + repr(M))
+    M = QuaternaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "Q6")
     return M
 
 
-def P6():
+def P6(groundset=None):
     """
     Return the matroid `P_6`, represented as circuit closures.
 
@@ -277,14 +313,13 @@ def P6():
 
     [Oxl2011]_, p. 641-2.
     """
-    E = 'abcdef'
-    CC = {2: ['abc'], 3: [E]}
-    M = CircuitClosuresMatroid(groundset=E, circuit_closures=CC)
-    M.rename("P6: " + repr(M))
+    CC = {2: ['abc'], 3: ['abcdef']}
+    M = Matroid(groundset='abcdef', circuit_closures=CC)
+    M = _rename_and_relabel(M, "P6", groundset)
     return M
 
 
-def U36():
+def U36(groundset='abcdef'):
     """
     The uniform matroid of rank `3` on `6` elements.
 
@@ -295,7 +330,7 @@ def U36():
 
         sage: U36 = matroids.catalog.U36(); U36
         U(3, 6): Matroid of rank 3 on 6 elements with circuit-closures
-        {3: {{0, 1, 2, 3, 4, 5}}}
+        {3: {{'a', 'b', 'c', 'd', 'e', 'f'}}}
         sage: Z = matroids.Spike(3, False)
         sage: U36.is_isomorphic(Z)
         True
@@ -307,12 +342,21 @@ def U36():
     REFERENCES:
 
     [Oxl2011]_, p. 642.
+
+    TESTS::
+
+        sage: M = matroids.catalog.U36(range(6))
+        sage: sorted(M.groundset())
+        [0, 1, 2, 3, 4, 5]
+        sage: M.is_isomorphic(matroids.catalog.U36())
+        True
     """
     M = Uniform(3, 6)
+    M = _rename_and_relabel(M, "U(3, 6)", groundset)
     return M
 
 
-def R6():
+def R6(groundset='abcdef'):
     """
     Return the matroid `R_6`, represented over `GF(3)`.
 
@@ -340,12 +384,12 @@ def R6():
     A = Matrix(
         GF(3), [[1, 0, 0, 1, 1, 1], [0, 1, 0, 1, 2, 1], [0, 0, 1, 1, 0, 2]]
     )
-    M = TernaryMatroid(A, 'abcdef')
-    M.rename("R6: " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "R6")
     return M
 
 
-def Fano():
+def Fano(groundset='abcdefg'):
     r"""
     Return the Fano matroid, represented over `GF(2)`.
 
@@ -390,12 +434,12 @@ def Fano():
         GF(2),
         [[1, 0, 0, 0, 1, 1, 1], [0, 1, 0, 1, 0, 1, 1], [0, 0, 1, 1, 1, 0, 1]]
     )
-    M = BinaryMatroid(A, 'abcdefg')
-    M.rename("Fano: " + repr(M))
+    M = BinaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "Fano")
     return M
 
 
-def FanoDual():
+def FanoDual(groundset='abcdefg'):
     """
     Return the dual of the Fano matroid.
 
@@ -424,13 +468,19 @@ def FanoDual():
     REFERENCES:
 
     [Oxl2011]_, p. 643.
+
+    TESTS::
+
+        sage: F7D = matroids.catalog.FanoDual(range(7))
+        sage: sorted(F7D.groundset())
+        [0, 1, 2, 3, 4, 5, 6]
     """
     M = Fano().dual()
-    M.rename("F7*: " + repr(M))
+    M = _rename_and_relabel(M, "F7*", groundset)
     return M
 
 
-def NonFano():
+def NonFano(groundset='abcdefg'):
     """
     Return the non-Fano matroid, represented over `GF(3)`.
 
@@ -459,12 +509,12 @@ def NonFano():
         GF(3),
         [[1, 0, 0, 0, 1, 1, 1], [0, 1, 0, 1, 0, 1, 1], [0, 0, 1, 1, 1, 0, 1]]
     )
-    M = TernaryMatroid(A, 'abcdefg')
-    M.rename("NonFano: " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "NonFano")
     return M
 
 
-def NonFanoDual():
+def NonFanoDual(groundset='abcdefg'):
     r"""
     Return the dual of the non-Fano matroid.
 
@@ -492,13 +542,21 @@ def NonFanoDual():
     REFERENCES:
 
     [Oxl2011]_, p. 643-4.
+
+    TESTS::
+
+        sage: M = matroids.catalog.NonFanoDual(range(7))
+        sage: sorted(M.groundset())
+        [0, 1, 2, 3, 4, 5, 6]
+        sage: M.is_isomorphic(matroids.catalog.NonFanoDual())
+        True
     """
     M = NonFano().dual()
-    M.rename("NonFano*: " + repr(M))
+    M = _rename_and_relabel(M, "NonFano*", groundset)
     return M
 
 
-def O7():
+def O7(groundset='abcdefg'):
     """
     Return the matroid `O_7`, represented over `GF(3)`.
 
@@ -523,12 +581,12 @@ def O7():
         GF(3),
         [[1, 0, 0, 1, 1, 1, 1], [0, 1, 0, 0, 1, 2, 2], [0, 0, 1, 1, 0, 1, 0]]
     )
-    M = TernaryMatroid(A, 'abcdefg')
-    M.rename("O7: " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "O7")
     return M
 
 
-def P7():
+def P7(groundset='abcdefg'):
     """
     Return the matroid `P_7`, represented over `GF(3)`.
 
@@ -556,12 +614,12 @@ def P7():
         GF(3),
         [[1, 0, 0, 2, 1, 1, 0], [0, 1, 0, 1, 1, 0, 1], [0, 0, 1, 1, 0, 1, 1]]
     )
-    M = TernaryMatroid(A, 'abcdefg')
-    M.rename("P7: " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "P7")
     return M
 
 
-def AG32():
+def AG32(groundset='abcdefgh'):
     """
     Return the matroid `AG(3, 2)`.
 
@@ -601,10 +659,11 @@ def AG32():
     [Oxl2011]_, p. 645.
     """
     M = AG(3, 2)
+    M = _rename_and_relabel(M, "AG(3, 2)", groundset)
     return M
 
 
-def AG32prime():
+def AG32prime(groundset=None):
     """
     Return the matroid `AG(3, 2)'`, represented as circuit closures.
 
@@ -629,7 +688,7 @@ def AG32prime():
          {'b', 'c', 'd', 'g'}, {'b', 'c', 'e', 'f'}, {'b', 'd', 'f', 'h'},
          {'b', 'e', 'g', 'h'}, {'c', 'd', 'e', 'h'}, {'c', 'f', 'g', 'h'},
          {'d', 'e', 'f', 'g'}]
-        sage: M.is_valid()  # long time
+        sage: M.is_valid()
         True
         sage: M.automorphism_group().is_transitive()
         False
@@ -665,12 +724,12 @@ def AG32prime():
         ],
         4: ['abcdefgh'],
     }
-    M = CircuitClosuresMatroid(groundset='abcdefgh', circuit_closures=CC)
-    M.rename("AG(3, 2)': " + repr(M))
+    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = _rename_and_relabel(M, "AG(3, 2)'", groundset)
     return M
 
 
-def R8():
+def R8(groundset='abcdefgh'):
     """
     Return the matroid `R_8`, represented over `GF(3)`.
 
@@ -717,12 +776,12 @@ def R8():
             [0, 0, 0, 1, 1, 1, 1, 2],
         ],
     )
-    M = TernaryMatroid(A, 'abcdefgh')
-    M.rename("R8: " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "R8")
     return M
 
 
-def F8():
+def F8(groundset=None):
     """
     Return the matroid `F_8`, represented as circuit closures.
 
@@ -765,12 +824,12 @@ def F8():
         ],
         4: ['abcdefgh'],
     }
-    M = CircuitClosuresMatroid(groundset='abcdefgh', circuit_closures=CC)
-    M.rename("F8: " + repr(M))
+    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = _rename_and_relabel(M, "F8", groundset)
     return M
 
 
-def Q8():
+def Q8(groundset=None):
     """
     Return the matroid `Q_8`, represented as circuit closures.
 
@@ -814,12 +873,12 @@ def Q8():
         ],
         4: ['abcdefgh'],
     }
-    M = CircuitClosuresMatroid(groundset='abcdefgh', circuit_closures=CC)
-    M.rename("Q8: " + repr(M))
+    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = _rename_and_relabel(M, "Q8", groundset)
     return M
 
 
-def L8():
+def L8(groundset=None):
     """
     Return the matroid `L_8`, represented as circuit closures.
 
@@ -846,7 +905,7 @@ def L8():
     Every single-element contraction is isomorphic to the free extension of
     `M(K_4)`::
 
-        sage: K4 = matroids.catalog.K4()
+        sage: K4 = matroids.catalog.K4(range(6))
         sage: Bext = [list(b) for b in K4.bases()] + [list(I)+[6] for I in
         ....:                                         K4.independent_r_sets(2)]
         sage: K4ext = Matroid(bases=Bext)
@@ -861,12 +920,12 @@ def L8():
     """
     CC = {3: ['abfg', 'bcdg', 'defg', 'cdeh', 'aefh', 'abch', 'aceg', 'bdfh'],
           4: ['abcdefgh']}
-    M = CircuitClosuresMatroid(groundset='abcdefgh', circuit_closures=CC)
-    M.rename("L8: " + repr(M))
+    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = _rename_and_relabel(M, "L8", groundset)
     return M
 
 
-def S8():
+def S8(groundset='abcdefgh'):
     """
     Return the matroid `S_8`, represented over `GF(2)`.
 
@@ -912,12 +971,12 @@ def S8():
             [0, 0, 0, 1, 1, 1, 1, 1],
         ],
     )
-    M = BinaryMatroid(A, 'abcdefgh')
-    M.rename("S8: " + repr(M))
+    M = BinaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "S8")
     return M
 
 
-def Vamos():
+def Vamos(groundset=None):
     r"""
     Return the `V\acute{a}mos` matroid, represented as circuit closures.
 
@@ -938,7 +997,7 @@ def Vamos():
          {'c', 'd', 'e', 'f'}, {'e', 'f', 'g', 'h'}]
         sage: M.is_dependent(['c', 'd', 'g', 'h'])
         False
-        sage: M.is_valid()  # long time
+        sage: M.is_valid() and M.is_paving()  # long time
         True
         sage: M.is_isomorphic(M.dual()) and not M.equals(M.dual())
         True
@@ -950,12 +1009,12 @@ def Vamos():
     [Oxl2011]_, p. 649.
     """
     CC = {3: ['abcd', 'abef', 'cdef', 'abgh', 'efgh'], 4: ['abcdefgh']}
-    M = CircuitClosuresMatroid(groundset='abcdefgh', circuit_closures=CC)
-    M.rename("Vamos: " + repr(M))
+    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = _rename_and_relabel(M, "Vamos", groundset)
     return M
 
 
-def T8():
+def T8(groundset='abcdefgh'):
     """
     Return the matroid `T_8`, represented over `GF(3)`.
 
@@ -991,12 +1050,12 @@ def T8():
             [0, 0, 0, 1, 1, 1, 1, 0],
         ],
     )
-    M = TernaryMatroid(A, 'abcdefgh')
-    M.rename("T8: " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "T8")
     return M
 
 
-def J():
+def J(groundset='abcdefgh'):
     """
     Return the matroid `J`, represented over `GF(3)`.
 
@@ -1032,12 +1091,12 @@ def J():
             [0, 0, 0, 1, 1, 0, 0, 1],
         ],
     )
-    M = TernaryMatroid(A, 'abcdefgh')
-    M.rename("J: " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "J")
     return M
 
 
-def P8():
+def P8(groundset='abcdefgh'):
     """
     Return the matroid `P_8`, represented over `GF(3)`.
 
@@ -1070,12 +1129,12 @@ def P8():
             [0, 0, 0, 1, 0, 1, 1, 2],
         ],
     )
-    M = TernaryMatroid(A, 'abcdefgh')
-    M.rename("P8: " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "P8")
     return M
 
 
-def P8pp():
+def P8pp(groundset=None):
     """
     Return the matroid `P_8^=`, represented as circuit closures.
 
@@ -1102,11 +1161,11 @@ def P8pp():
     """
     NSC = ['abfh', 'bceg', 'cdfh', 'adeg', 'acef', 'bdfg', 'acgh', 'bdeh']
     M = Matroid(groundset='abcdefgh', rank=4, nonspanning_circuits=NSC)
-    M.rename("P8'': " + repr(M))
+    M = _rename_and_relabel(M, "P8''", groundset)
     return M
 
 
-def Wheel4():
+def Wheel4(groundset='abcdefgh'):
     """
     Return the rank-`4` wheel.
 
@@ -1129,10 +1188,11 @@ def Wheel4():
     [Oxl2011]_, p. 651-2.
     """
     M = Wheel(4)
+    M = _rename_and_relabel(M, "Wheel(4)", groundset)
     return M
 
 
-def Whirl4():
+def Whirl4(groundset='abcdefgh'):
     """
     Return the rank-`4` whirl.
 
@@ -1155,10 +1215,11 @@ def Whirl4():
     [Oxl2011]_, p. 652.
     """
     M = Whirl(4)
+    M = _rename_and_relabel(M, "Whirl(4)", groundset)
     return M
 
 
-def K33dual():
+def K33dual(groundset='abcdefghi'):
     """
     Return the matroid `M*(K_{3, 3})`, represented over the regular partial
     field.
@@ -1185,13 +1246,13 @@ def K33dual():
     from sage.graphs.graph_generators import graphs
 
     G = graphs.CompleteBipartiteGraph(3, 3)
-    M = Matroid(groundset='abcdefghi', graph=G, regular=True)
+    M = Matroid(groundset=groundset, graph=G, regular=True)
     M = M.dual()
-    M.rename("M*(K3, 3): " + repr(M))
+    M = _rename_and_relabel(M, "M*(K3, 3)")
     return M
 
 
-def K33():
+def K33(groundset='abcdefghi'):
     r"""
     Return the graphic matroid `M(K_{3,3})`.
 
@@ -1215,12 +1276,12 @@ def K33():
     from sage.graphs.graph_generators import graphs
 
     G = graphs.CompleteBipartiteGraph(3, 3)
-    M = Matroid(groundset='abcdefghi', graph=G, regular=True)
-    M.rename("M(K3, 3): " + repr(M))
+    M = Matroid(groundset=groundset, graph=G, regular=True)
+    M = _rename_and_relabel(M, "M(K3, 3)")
     return M
 
 
-def AG23():
+def AG23(groundset='abcdefghi'):
     """
     Return the matroid `AG(2, 3)`.
 
@@ -1247,10 +1308,11 @@ def AG23():
     [Oxl2011]_, p. 653.
     """
     M = AG(2, 3)
+    M = _rename_and_relabel(M, "AG(2, 3)", groundset)
     return M
 
 
-def TernaryDowling3():
+def TernaryDowling3(groundset='abcdefghi'):
     r"""
     Return the matroid `Q_3(GF(3)^\times)`, represented over `GF(3)`.
 
@@ -1281,13 +1343,13 @@ def TernaryDowling3():
             [0, 0, 1, 0, 0, 2, 1, 2, 1],
         ],
     )
-    M = TernaryMatroid(A, 'abcdefghi')
-    M.rename("Q3(GF(3)x): " + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "Q3(GF(3)x)")
     return M
 
 
-def R9():
-    r"""
+def R9(groundset=None):
+    """
     Return the matroid `R_9`.
 
     The ternary Reid geometry. The only `9`-element rank-`3` simple ternary
@@ -1300,7 +1362,7 @@ def R9():
         R9: Matroid of rank 3 on 9 elements with 15 nonspanning circuits
         sage: M.is_valid()
         True
-        sage: len(M.nonspanning_circuits())
+        sage: len(list(M.nonspanning_circuits()))
         15
         sage: M.is_simple() and M.is_ternary()
         True
@@ -1314,7 +1376,7 @@ def R9():
     NSC = ['abc', 'abd', 'acd', 'aef', 'agh', 'bcd', 'bfh', 'bgi',
            'ceg', 'cfi', 'deh', 'dei', 'dfg', 'dhi', 'ehi']
     M = Matroid(rank=3, nonspanning_circuits=NSC)
-    M.rename("R9: " + repr(M))
+    M = _rename_and_relabel(M, "R9", groundset)
     return M
 
 
@@ -1338,7 +1400,7 @@ def Pappus(groundset=None):
          {'g', 'h', 'i'}]
         sage: M.is_dependent(['d', 'e', 'f'])
         True
-        sage: M.is_valid()  # long time
+        sage: M.is_valid()
         True
         sage: M.automorphism_group().is_transitive()
         True
@@ -1349,11 +1411,11 @@ def Pappus(groundset=None):
     """
     NSC = ['abc', 'def', 'ceg', 'bfg', 'cdh', 'afh', 'bdi', 'aei', 'ghi']
     M = Matroid(groundset='abcdefghi', rank=3, nonspanning_circuits=NSC)
-    M.rename("Pappus: " + repr(M))
+    M = _rename_and_relabel(M, "Pappus", groundset)
     return M
 
 
-def NonPappus():
+def NonPappus(groundset=None):
     """
     Return the non-Pappus matroid.
 
@@ -1363,15 +1425,16 @@ def NonPappus():
 
     EXAMPLES::
 
-        sage: from sage.matroids.advanced import setprint
         sage: M = matroids.catalog.NonPappus(); M
         NonPappus: Matroid of rank 3 on 9 elements with 8 nonspanning circuits
-        sage: setprint(M.nonspanning_circuits())
-        [{'a', 'b', 'c'}, {'a', 'e', 'i'}, {'a', 'f', 'h'}, {'b', 'd', 'i'},
-         {'b', 'f', 'g'}, {'c', 'd', 'h'}, {'c', 'e', 'g'}, {'g', 'h', 'i'}]
+        sage: NSC = set([('a', 'b', 'c'), ('a', 'e', 'i'), ('a', 'f', 'h'),
+        ....:            ('b', 'd', 'i'), ('b', 'f', 'g'), ('c', 'd', 'h'),
+        ....:            ('c', 'e', 'g'), ('g', 'h', 'i')])
+        sage: NSC == set(tuple(sorted(C)) for C in M.nonspanning_circuits())
+        True
         sage: M.is_dependent(['d', 'e', 'f'])
         False
-        sage: M.is_valid()  # long time
+        sage: M.is_valid() and M.is_paving()
         True
         sage: M.automorphism_group().is_transitive()
         False
@@ -1382,11 +1445,11 @@ def NonPappus():
     """
     NSC = ['abc', 'ceg', 'bfg', 'cdh', 'afh', 'bdi', 'aei', 'ghi']
     M = Matroid(groundset='abcdefghi', rank=3, nonspanning_circuits=NSC)
-    M.rename("NonPappus: " + repr(M))
+    M = _rename_and_relabel(M, "NonPappus", groundset)
     return M
 
 
-def K5():
+def K5(groundset='abcdefghij'):
     """
     Return the graphic matroid `M(K_5)`.
 
@@ -1407,10 +1470,11 @@ def K5():
     [Oxl2011]_, p. 656.
     """
     M = CompleteGraphic(5)
+    M = _rename_and_relabel(M, "M(K5)", groundset)
     return M
 
 
-def K5dual():
+def K5dual(groundset='abcdefghij'):
     """
     Return the matroid `M^*(K_5)`.
 
@@ -1419,7 +1483,7 @@ def K5dual():
     EXAMPLES::
 
         sage: M = matroids.catalog.K5dual(); M
-        M*(K5): Dual of 'M(K5): Graphic matroid of rank 4 on 10 elements'
+        M*(K5): Matroid of rank 6 on 10 elements with 15 circuits
         sage: M.is_3connected()
         True
         sage: G1 = M.automorphism_group()
@@ -1432,16 +1496,16 @@ def K5dual():
     [Oxl2011]_, p. 656.
     """
     M = CompleteGraphic(5).dual()
-    # M = Matroid(circuits=M.circuits())
-    M.rename("M*(K5): " + repr(M))
+    M = Matroid(circuits=list(M.circuits()))
+    M = _rename_and_relabel(M, "M*(K5)", groundset)
     return M
 
 
-def R10():
+def R10(groundset='abcdefghij'):
     """
     Return the matroid `R_{10}`, represented over the regular partial field.
 
-    The matroid `R_{10}` is a 10-element regular matroid of rank-5. It is the
+    The NonDesargues matroid is a `10`-element matroid of rank-5. It is the
     unique splitter for the class of regular matroids. It is the graft matroid
     of `K_{3, 3}` in which every vertex is coloured.
 
@@ -1492,8 +1556,8 @@ def R10():
             [0, 0, 0, 0, 1, 1, 0, 0, 1, -1],
         ],
     )
-    M = RegularMatroid(A, 'abcdefghij')
-    M.rename("R10: " + repr(M))
+    M = RegularMatroid(A, groundset)
+    M = _rename_and_relabel(M, "R10")
     return M
 
 
@@ -1520,7 +1584,7 @@ def NonDesargues(groundset=None):
     """
     NSC = ['acj', 'aef', 'bce', 'bfj', 'bgi', 'chi', 'dfg', 'dij', 'egh']
     M = Matroid(rank=3, nonspanning_circuits=NSC)
-    M.rename("NonDesargues: " + repr(M))
+    M = _rename_and_relabel(M, "NonDesargues", groundset)
     return M
 
 
@@ -1539,7 +1603,7 @@ def R12(groundset='abcdefghijkl'):
         R12: Regular matroid of rank 6 on 12 elements with 441 bases
         sage: M.is_isomorphic(M.dual()) and not M.equals(M.dual())
         True
-        sage: M.is_valid()  # long time
+        sage: M.is_valid()
         True
         sage: M.automorphism_group().is_transitive()
         False
@@ -1559,12 +1623,12 @@ def R12(groundset='abcdefghijkl'):
             [0, 0, 0, 0, 0, 1, 0, 0, 0, 1, -1, -1],
         ],
     )
-    M = RegularMatroid(A, 'abcdefghijkl')
-    M.rename("R12: " + repr(M))
+    M = RegularMatroid(A, groundset)
+    M = _rename_and_relabel(M, "R12")
     return M
 
 
-def ExtendedTernaryGolayCode():
+def ExtendedTernaryGolayCode(groundset='abcdefghijkl'):
     """
     Return the matroid of the extended ternary Golay code.
 
@@ -1576,13 +1640,14 @@ def ExtendedTernaryGolayCode():
         Extended Ternary Golay Code: Ternary matroid of rank 6 on 12 elements,
         type 6+
         sage: C = LinearCode(M.representation())
-        sage: C.is_permutation_equivalent(codes.GolayCode(GF(3)))  # long time
+        sage: C.is_permutation_equivalent(codes.GolayCode(GF(3)))
         True
         sage: M.is_valid()
         True
 
     The automorphism group is the `5`-transitive Mathieu group `M12`:
 
+        sage: # long time
         sage: G = M.automorphism_group()
         sage: G.is_transitive()
         True
@@ -1627,12 +1692,12 @@ def ExtendedTernaryGolayCode():
         [0, 0, 0, 0, 1, 0, 1, 0, 2, 2, 1, 1],
         [0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1]
     ])
-    M = TernaryMatroid(A, 'abcdefghijkl')
-    M.rename('Extended Ternary Golay Code: ' + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "Extended Ternary Golay Code")
     return M
 
 
-def T12():
+def T12(groundset='abcdefghijkl'):
     """
     Return the matroid `T_{12}`.
 
@@ -1668,12 +1733,12 @@ def T12():
             [0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1],
         ],
     )
-    M = BinaryMatroid(A, 'abcdefghijkl')
-    M.rename("T12: " + repr(M))
+    M = BinaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "T12")
     return M
 
 
-def PG23():
+def PG23(groundset=None):
     """
     Return the matroid `PG23`.
 
@@ -1694,10 +1759,11 @@ def PG23():
     [Oxl2011]_, p. 659.
     """
     M = PG(2, 3)
+    M = _rename_and_relabel(M, groundset=groundset)
     return M
 
 
-def Wheel(r, field=None, ring=None):
+def Wheel(r, field=None, ring=None, groundset=None):
     r"""
     Return the rank-`r` wheel.
 
@@ -1708,6 +1774,7 @@ def Wheel(r, field=None, ring=None):
       over the ring or field ``ring``. If the ring is `\ZZ`, then output
       will be a regular matroid.
     - ``field`` -- any field; same as ``ring``, but only fields are allowed
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: the rank-`r` wheel matroid, represented as a regular matroid
 
@@ -1767,11 +1834,11 @@ def Wheel(r, field=None, ring=None):
         M = RegularMatroid(A)
     else:
         M = Matroid(A)
-    M.rename("Wheel(" + str(r) + "): " + repr(M))
+    M = _rename_and_relabel(M, "Wheel(" + str(r) + ")", groundset)
     return M
 
 
-def Whirl(r):
+def Whirl(r, groundset=None):
     r"""
     Return the rank-`r` whirl.
 
@@ -1780,6 +1847,7 @@ def Whirl(r):
     INPUT:
 
     - ``r`` -- a positive integer; the rank of the desired matroid.
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: the rank-`r` whirl matroid, represented as a ternary matroid
 
@@ -1835,11 +1903,11 @@ def Whirl(r):
         else:
             A[i, 2 * r - 1] = 1
     M = TernaryMatroid(A)
-    M.rename("Whirl(" + str(r) + "): " + repr(M))
+    M = _rename_and_relabel(M, "Whirl(" + str(r) + ")", groundset)
     return M
 
 
-def Uniform(r, n):
+def Uniform(r, n, groundset=None):
     """
     Return the uniform matroid of rank `r` on `n` elements.
 
@@ -1852,6 +1920,7 @@ def Uniform(r, n):
     - ``r`` -- a nonnegative integer; the rank of the uniform matroid
     - ``n`` -- a nonnegative integer; the number of elements of the uniform
       matroid
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: the uniform matroid `U_{r,n}`
 
@@ -1885,12 +1954,12 @@ def Uniform(r, n):
         CC = {r: [E]}
     else:
         CC = {}
-    M = CircuitClosuresMatroid(groundset=E, circuit_closures=CC)
-    M.rename("U(" + str(r) + ", " + str(n) + "): " + repr(M))
+    M = Matroid(groundset=E, circuit_closures=CC)
+    M = _rename_and_relabel(M, "U(" + str(r) + ", " + str(n) + ")", groundset)
     return M
 
 
-def PG(n, q, x=None):
+def PG(n, q, x=None, groundset=None):
     """
     Return the projective geometry of dimension ``n`` over the finite field
     of order ``q``.
@@ -1904,6 +1973,7 @@ def PG(n, q, x=None):
     - ``x`` -- a string (default: ``None``); the name of the generator of a
       non-prime field, used for non-prime fields. If not supplied, ``'x'`` is
       used.
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: a linear matroid whose elements are the points of `PG(n, q)`
 
@@ -1928,11 +1998,11 @@ def PG(n, q, x=None):
     P = ProjectiveSpace(n, F)
     A = Matrix(F, [list(p) for p in list(P)]).transpose()
     M = Matroid(A)
-    M.rename("PG(" + str(n) + ", " + str(q) + "): " + repr(M))
+    M = _rename_and_relabel(M, "PG(" + str(n) + ", " + str(q) + ")", groundset)
     return M
 
 
-def AG(n, q, x=None):
+def AG(n, q, x=None, groundset=None):
     r"""
     Return the affine geometry of dimension ``n`` over the finite field of
     order ``q``.
@@ -1949,6 +2019,7 @@ def AG(n, q, x=None):
     - ``x`` -- a string (default: ``None``); the name of the generator of a
       non-prime field, used for non-prime fields. If not supplied, ``'x'`` is
       used.
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: a linear matroid whose elements are the points of `AG(n, q)`
 
@@ -1974,11 +2045,11 @@ def AG(n, q, x=None):
         F, [list(p) for p in list(P) if not list(p)[0] == 0]
     ).transpose()
     M = Matroid(A)
-    M.rename("AG(" + str(n) + ", " + str(q) + "): " + repr(M))
+    M = _rename_and_relabel(M, "AG(" + str(n) + ", " + str(q) + ")", groundset)
     return M
 
 
-def Z(r, t=True):
+def Z(r, t=True, groundset=None):
     r"""
     Return the unique rank-`r` binary spike.
 
@@ -1987,7 +2058,8 @@ def Z(r, t=True):
     INPUT:
 
     - ``r`` -- an integer (`r \ge 3`); the rank of the spike
-    - ``t`` -- a Boolean (default: ``True``); whether the spike is tipped
+    - ``t`` -- boolean (default: ``True``); whether the spike is tipped
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: a matroid; the unique rank-`r` binary spike (tipped or tipless)
 
@@ -2004,7 +2076,9 @@ def Z(r, t=True):
 
         sage: import random
         sage: Z3 = matroids.Z(3)
-        sage: e = random.choice(list(Z3.groundset()))
+        sage: E = sorted(Z3.groundset()); E
+        ['t', 'x1', 'x2', 'x3', 'y1', 'y2', 'y3']
+        sage: e = random.choice(E)
         sage: Z3.delete(e).is_isomorphic(matroids.catalog.K4())
         True
 
@@ -2020,6 +2094,18 @@ def Z(r, t=True):
         sage: Z4.is_isomorphic(matroids.catalog.AG32())
         True
 
+    and `Z_4 \setminus e \cong S_8`, for all `e \neq t`::
+
+        sage: Z4 = matroids.Z(4)
+        sage: E = sorted(Z4.groundset())
+        sage: E.remove('t')
+        sage: e = random.choice(E)
+        sage: S8 = matroids.catalog.S8()
+        sage: Z4.delete(e).is_isomorphic(S8)
+        True
+        sage: Z4.delete('t').is_isomorphic(S8)
+        False
+
     The tipless binary spike is self-dual; it is identically self-dual if and
     only if r is even. It also has a transitive automorphism group::
 
@@ -2029,7 +2115,7 @@ def Z(r, t=True):
         True
         sage: Z.equals(Z.dual()) != (r % 2 == 1)  # XOR
         True
-        sage: Z.automorphism_group().is_transitive()
+        sage: Z.automorphism_group().is_transitive()  # long time
         True
 
     REFERENCES:
@@ -2043,17 +2129,20 @@ def Z(r, t=True):
     A = Id.augment(J-Id).augment(tip)
 
     M = Matroid(A)
+    X = ['x'+str(i) for i in range(1, r+1)]
+    Y = ['y'+str(i) for i in range(1, r+1)]
     if t:
-        # M = M.relabel(X+Y+['t'])
+        M = M.relabel(X+Y+['t'])
         M.rename("Z_" + str(r) + ": " + repr(M))
     else:
         M = M.delete(2*r)
-        # M = M.relabel(X+Y)
+        M = M.relabel(X+Y)
         M.rename("Z_" + str(r) + "\\t: " + repr(M))
+    M = _rename_and_relabel(M, groundset=groundset)
     return M
 
 
-def Spike(r, t=True, C3=[]):
+def Spike(r, t=True, C3=[], groundset=None):
     r"""
     Return a rank-`r` spike.
 
@@ -2076,6 +2165,7 @@ def Spike(r, t=True, C3=[]):
     - ``t`` -- boolean (default: ``True``); whether the spike is tipped
     - ``C3`` -- a list (default: ``[]``); a list of extra nonspanning circuits.
       The default (i.e. the empty list) results in a free `r`-spike
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: a matroid; a rank-`r` spike (tipped or tipless)
 
@@ -2086,10 +2176,10 @@ def Spike(r, t=True, C3=[]):
          nonspanning circuits
         sage: M.is_isomorphic(matroids.Uniform(3, 6))
         True
-        sage: len(matroids.Spike(8).bases())
+        sage: len(list(matroids.Spike(8).bases()))
         4864
         sage: import random
-        sage: r = random.choice(range(3, 8))
+        sage: r = random.choice(range(3, 20))
         sage: M = matroids.Spike(r)
         sage: M.is_3connected()
         True
@@ -2169,21 +2259,21 @@ def Spike(r, t=True, C3=[]):
         for i in range(1, r+1):
             NSC += [['t', 'x'+str(i), 'y'+str(i)]]
             for j in range(i+1, r+1):
-                NSC += [['t', 'x'+str(i), 'y'+str(i), 'x'+str(j), 'y'+str(j)]]
+                NSC += [['x'+str(i), 'y'+str(i), 'x'+str(j), 'y'+str(j)]]
 
         M = Matroid(groundset=E, rank=r, nonspanning_circuits=NSC)
 
     free = "Free " if C3 == [] else ""
     tip = "" if t else "\\t"
     M = M if t else M.delete('t')
-    M.rename(free + str(r) + "-spike" + tip + ": " + repr(M))
+    M = _rename_and_relabel(M, free + str(r) + "-spike" + tip, groundset)
     return M
 
 
 # Q_r(A)
 
 
-def Theta(n):
+def Theta(n, groundset=None):
     r"""
     Return the matroid `\Theta_n`.
 
@@ -2193,11 +2283,14 @@ def Theta(n):
     INPUT:
 
     - ``n`` -- an integer (`n \ge 2`); the rank of the matroid
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: a matroid (`\Theta_n`)
 
     EXAMPLES::
 
+        sage: matroids.Theta(30)
+        Theta_30: Matroid of rank 30 on 60 elements with 16270 circuits
         sage: M = matroids.Theta(2)
         sage: U12 = matroids.Uniform(1, 2)
         sage: U = U12.direct_sum(U12)
@@ -2251,11 +2344,11 @@ def Theta(n):
                     C += [Yu + ['x'+str(s)] + ['x'+str(t)]]
 
     M = Matroid(groundset=E, circuits=C)
-    M.rename("Theta_" + str(n) + ": " + repr(M))
+    M = _rename_and_relabel(M, "Theta_" + str(n), groundset)
     return M
 
 
-def Psi(r):
+def Psi(r, groundset=None):
     r"""
     Return the matroid `\Psi_r`.
 
@@ -2264,6 +2357,7 @@ def Psi(r):
     INPUT:
 
     - ``r`` -- an integer (`r \ge 3`); the rank of the matroid
+    - ``groundset`` -- a string (optional); the groundset of the matroid
 
     OUTPUT: a matroid (`\Psi_r`)
 
@@ -2294,7 +2388,7 @@ def Psi(r):
         sage: M = matroids.Psi(r)
         sage: M.equals(M.dual())
         True
-        sage: M.automorphism_group().is_transitive()
+        sage: M.automorphism_group().is_transitive()  # long time
         True
 
     REFERENCES:
@@ -2333,7 +2427,7 @@ def Psi(r):
                 NSC += [C]
 
     M = Matroid(groundset=E, rank=r, nonspanning_circuits=NSC)
-    M.rename("Psi_" + str(r) + ": " + repr(M))
+    M = _rename_and_relabel(M, "Psi_" + str(r), groundset)
     return M
 
 
@@ -2346,7 +2440,7 @@ def Psi(r):
 # 7 elements:
 
 
-def RelaxedNonFano():
+def RelaxedNonFano(groundset=None):
     """
     Return the relaxed NonFano matroid.
 
@@ -2363,11 +2457,11 @@ def RelaxedNonFano():
     w = GF4('w')
     A = Matrix(GF4, [[1, 1, 0, 1], [1, 0, 1, 1], [0, 1, w, 1]])
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("F7=: " + repr(M))
+    M = _rename_and_relabel(M, "F7=", groundset)
     return M
 
 
-def TippedFree3spike():
+def TippedFree3spike(groundset=None):
     """
     Return the tipped free `3`-spike.
 
@@ -2387,14 +2481,14 @@ def TippedFree3spike():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[0, 3, 5, 1, 4, 6, 2]
     )
-    M.rename("Tipped rank-3 free spike: " + repr(M))
+    M = _rename_and_relabel(M, "Tipped rank-3 free spike", groundset)
     return M
 
 
 # 8 elements:
 
 
-def AG23minusDY():
+def AG23minusDY(groundset=None):
     r"""
     Return the matroid `AG23minusDY`.
 
@@ -2411,11 +2505,11 @@ def AG23minusDY():
     """
     A = Matrix(GF(3), [[1, 1, 1, 1], [1, 0, 1, 2], [2, 0, 1, 2], [2, 1, 1, 0]])
     M = TernaryMatroid(reduced_matrix=A)
-    M.rename("Delta-Y of AG(2,3)\\e: " + repr(M))
+    M = _rename_and_relabel(M, "Delta-Y of AG(2,3)\\e", groundset)
     return M
 
 
-def TQ8():
+def TQ8(groundset=None):
     """
     Return the matroid `TQ8`.
 
@@ -2436,11 +2530,11 @@ def TQ8():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[1, 7, 5, 3, 8, 6, 4, 2]
     )
-    M.rename("TQ8: " + repr(M))
+    M = _rename_and_relabel(M, "TQ8", groundset)
     return M
 
 
-def P8p():
+def P8p(groundset=None):
     """
     Return the matroid `P8^-`.
 
@@ -2463,11 +2557,11 @@ def P8p():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=['a', 'c', 'b', 'f', 'd', 'e', 'g', 'h']
     )
-    M.rename("P8-: " + repr(M))
+    M = _rename_and_relabel(M, "P8-", groundset)
     return M
 
 
-def KP8():
+def KP8(groundset=None):
     """
     Return the matroid `KP8`.
 
@@ -2490,11 +2584,11 @@ def KP8():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[1, 4, 3, 5, 6, 7, 0, 2]
     )
-    M.rename("KP8: " + repr(M))
+    M = _rename_and_relabel(M, "KP8", groundset)
     return M
 
 
-def Sp8():
+def Sp8(groundset=None):
     """
     Return the matroid `Sp8`.
 
@@ -2517,11 +2611,11 @@ def Sp8():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[1, 2, 3, 5, 4, 6, 7, 8]
     )
-    M.rename("Sp8: " + repr(M))
+    M = _rename_and_relabel(M, "Sp8", groundset)
     return M
 
 
-def Sp8pp():
+def Sp8pp(groundset=None):
     """
     Return the matroid `Sp8=`.
 
@@ -2542,11 +2636,11 @@ def Sp8pp():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[1, 5, 6, 7, 2, 3, 4, 8]
     )
-    M.rename("Sp8=: " + repr(M))
+    M = _rename_and_relabel(M, "Sp8=", groundset)
     return M
 
 
-def LP8():
+def LP8(groundset=None):
     """
     Return the matroid `LP8`.
 
@@ -2569,11 +2663,11 @@ def LP8():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=['a', 'b', 'd', 'e', 'c', 'f', 'g', 'h']
     )
-    M.rename("LP8: " + repr(M))
+    M = _rename_and_relabel(M, "LP8", groundset)
     return M
 
 
-def WQ8():
+def WQ8(groundset=None):
     r"""
     Return the matroid `WQ8`.
 
@@ -2596,14 +2690,14 @@ def WQ8():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[0, 1, 3, 4, 2, 5, 6, 7]
     )
-    M.rename("WQ8: " + repr(M))
+    M = _rename_and_relabel(M, "WQ8", groundset)
     return M
 
 
 # 9 elements:
 
 
-def BB9():
+def BB9(groundset=None):
     """
     Return the matroid `BB9`.
 
@@ -2638,11 +2732,11 @@ def BB9():
         reduced_matrix=A,
         groundset=['i', 'b', 'd', 'j', 'h', 'f', 'c', 'a', 'k']
     )
-    M.rename("BB9: " + repr(M))
+    M = _rename_and_relabel(M, "BB9", groundset)
     return M
 
 
-def TQ9():
+def TQ9(groundset=None):
     """
     Return the matroid `TQ9`.
 
@@ -2673,11 +2767,11 @@ def TQ9():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[1, 4, 6, 0, 2, 5, 3, 7, 8]
     )
-    M.rename("TQ9: " + repr(M))
+    M = _rename_and_relabel(M, "TQ9", groundset)
     return M
 
 
-def TQ9p():
+def TQ9p(groundset=None):
     """
     Return the matroid `TQ9^-`.
 
@@ -2712,11 +2806,11 @@ def TQ9p():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[1, 4, 7, 8, 0, 6, 5, 2, 3]
     )
-    M.rename("TQ9': " + repr(M))
+    M = _rename_and_relabel(M, "TQ9'", groundset)
     return M
 
 
-def M8591():
+def M8591(groundset=None):
     r"""
     Return the matroid `M8591`.
 
@@ -2740,11 +2834,11 @@ def M8591():
               [0, 0, 1, 1, 0]]
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("M8591: " + repr(M))
+    M = _rename_and_relabel(M, "M8591", groundset)
     return M
 
 
-def PP9():
+def PP9(groundset=None):
     """
     Return the matroid `PP9`.
 
@@ -2780,11 +2874,11 @@ def PP9():
         reduced_matrix=A,
         groundset=['a', 'c', 'b', 'f', 'd', 'e', 'g', 'h', 'z']
     )
-    M.rename("PP9: " + repr(M))
+    M = _rename_and_relabel(M, "PP9", groundset)
     return M
 
 
-def BB9gDY():
+def BB9gDY(groundset=None):
     r"""
     Return the matroid `BB9gDY`.
 
@@ -2818,11 +2912,11 @@ def BB9gDY():
         reduced_matrix=A,
         groundset=['c', 'd', 'i', 'f', 'h', 'a', 'j', 'k', 'b']
     )
-    M.rename("Segment cosegment exchange on BB9: " + repr(M))
+    M = _rename_and_relabel(M, "Segment cosegment exchange on BB9", groundset)
     return M
 
 
-def A9():
+def A9(groundset=None):
     """
     Return the matroid `A9`.
 
@@ -2847,11 +2941,11 @@ def A9():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[6, 5, 4, 1, 2, 3, 7, 8, 0]
     )
-    M.rename("A9: " + repr(M))
+    M = _rename_and_relabel(M, "A9", groundset)
     return M
 
 
-def FN9():
+def FN9(groundset=None):
     """
     Return the matroid `FN9`.
 
@@ -2881,11 +2975,11 @@ def FN9():
         reduced_matrix=A,
         groundset=['b0', 'a', 'y', 'z', 'x', "c0", 'b', 'c', 'a0']
     )
-    M.rename("FN9: " + repr(M))
+    M = _rename_and_relabel(M, "FN9", groundset)
     return M
 
 
-def FX9():
+def FX9(groundset=None):
     """
     Return the matroid `FX9`.
 
@@ -2913,11 +3007,11 @@ def FX9():
     )
     # M48806
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FX9: " + repr(M))
+    M = _rename_and_relabel(M, "FX9", groundset)
     return M
 
 
-def KR9():
+def KR9(groundset=None):
     """
     Return the matroid `KR9`.
 
@@ -2948,11 +3042,11 @@ def KR9():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[2, 4, 0, 6, 1, 5, 3, 7, 8]
     )
-    M.rename("KR9: " + repr(M))
+    M = _rename_and_relabel(M, "KR9", groundset)
     return M
 
 
-def KQ9():
+def KQ9(groundset=None):
     """
     Return the matroid `KQ9`.
 
@@ -2987,14 +3081,14 @@ def KQ9():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[5, 0, 4, 3, 2, 6, 8, 7, 1]
     )
-    M.rename("KQ9: " + repr(M))
+    M = _rename_and_relabel(M, "KQ9", groundset)
     return M
 
 
 # 10 elements:
 
 
-def UG10():
+def UG10(groundset=None):
     """
     Return the matroid `UG10`.
 
@@ -3024,11 +3118,11 @@ def UG10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("UG10: " + repr(M))
+    M = _rename_and_relabel(M, "UG10", groundset)
     return M
 
 
-def FF10():
+def FF10(groundset=None):
     """
     Return the matroid `FF10`.
 
@@ -3057,11 +3151,11 @@ def FF10():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     )
-    M.rename("FF10: " + repr(M))
+    M = _rename_and_relabel(M, "FF10", groundset)
     return M
 
 
-def GP10():
+def GP10(groundset=None):
     """
     Return the matroid `GP10`.
 
@@ -3087,11 +3181,11 @@ def GP10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("GP10: " + repr(M))
+    M = _rename_and_relabel(M, "GP10", groundset)
     return M
 
 
-def FZ10():
+def FZ10(groundset=None):
     """
     Return the matroid `FZ10`.
 
@@ -3118,11 +3212,11 @@ def FZ10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FZ10: " + repr(M))
+    M = _rename_and_relabel(M, "FZ10", groundset)
     return M
 
 
-def UQ10():
+def UQ10(groundset=None):
     """
     Return the matroid `UQ10`.
 
@@ -3150,11 +3244,11 @@ def UQ10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("UQ10: " + repr(M))
+    M = _rename_and_relabel(M, "UQ10", groundset)
     return M
 
 
-def FP10():
+def FP10(groundset=None):
     """
     Return the matroid `FP10`.
 
@@ -3181,11 +3275,11 @@ def FP10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FP10: " + repr(M))
+    M = _rename_and_relabel(M, "FP10", groundset)
     return M
 
 
-def TQ10():
+def TQ10(groundset=None):
     """
     Return the matroid `TQ10`.
 
@@ -3218,11 +3312,11 @@ def TQ10():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[1, 6, 8, 'c', 3, 7, 'd', 2, 5, 4]
     )
-    M.rename("TQ10: " + repr(M))
+    M = _rename_and_relabel(M, "TQ10", groundset)
     return M
 
 
-def FY10():
+def FY10(groundset=None):
     """
     Return the matroid `FY10`.
 
@@ -3249,11 +3343,11 @@ def FY10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FY10: " + repr(M))
+    M = _rename_and_relabel(M, "FY10", groundset)
     return M
 
 
-def PP10():
+def PP10(groundset=None):
     """
     Return the matroid `PP10`.
 
@@ -3290,11 +3384,11 @@ def PP10():
         reduced_matrix=A,
         groundset=['z', 'f', 'c', 'g', 'e', 'b', 'a', 'h', 'd', 'x']
     )
-    M.rename("PP10: " + repr(M))
+    M = _rename_and_relabel(M, "PP10", groundset)
     return M
 
 
-def FU10():
+def FU10(groundset=None):
     """
     Return the matroid `FU10`.
 
@@ -3320,11 +3414,11 @@ def FU10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FU10: " + repr(M))
+    M = _rename_and_relabel(M, "FU10", groundset)
     return M
 
 
-def D10():
+def D10(groundset=None):
     """
     Return the matroid `D10`.
 
@@ -3351,11 +3445,11 @@ def D10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("D10: " + repr(M))
+    M = _rename_and_relabel(M, "D10", groundset)
     return M
 
 
-def UK10():
+def UK10(groundset=None):
     """
     Return the matroid `UK10`.
 
@@ -3382,11 +3476,11 @@ def UK10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("UK10: " + repr(M))
+    M = _rename_and_relabel(M, "UK10", groundset)
     return M
 
 
-def PK10():
+def PK10(groundset=None):
     """
     Return the matroid `PK10`.
 
@@ -3413,11 +3507,11 @@ def PK10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("PK10: " + repr(M))
+    M = _rename_and_relabel(M, "PK10", groundset)
     return M
 
 
-def GK10():
+def GK10(groundset=None):
     """
     Return the matroid `GK10`.
 
@@ -3444,11 +3538,11 @@ def GK10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("GK10: " + repr(M))
+    M = _rename_and_relabel(M, "GK10", groundset)
     return M
 
 
-def FT10():
+def FT10(groundset=None):
     """
     Return the matroid `FT10`.
 
@@ -3475,11 +3569,11 @@ def FT10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FT10: " + repr(M))
+    M = _rename_and_relabel(M, "FT10", groundset)
     return M
 
 
-def TK10():
+def TK10(groundset=None):
     """
     Return the matroid `TK10`.
 
@@ -3506,11 +3600,11 @@ def TK10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("TK10: " + repr(M))
+    M = _rename_and_relabel(M, "TK10", groundset)
     return M
 
 
-def KT10():
+def KT10(groundset=None):
     """
     Return the matroid `KT10`.
 
@@ -3537,11 +3631,11 @@ def KT10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("KT10: " + repr(M))
+    M = _rename_and_relabel(M, "KT10", groundset)
     return M
 
 
-def TU10():
+def TU10(groundset=None):
     """
     Return the matroid `TU10`.
 
@@ -3568,11 +3662,11 @@ def TU10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("TU10: " + repr(M))
+    M = _rename_and_relabel(M, "TU10", groundset)
     return M
 
 
-def UT10():
+def UT10(groundset=None):
     """
     Return the matroid `UT10`.
 
@@ -3599,11 +3693,11 @@ def UT10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("UT10: " + repr(M))
+    M = _rename_and_relabel(M, "UT10", groundset)
     return M
 
 
-def FK10():
+def FK10(groundset=None):
     """
     Return the matroid `FK10`.
 
@@ -3630,11 +3724,11 @@ def FK10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FK10: " + repr(M))
+    M = _rename_and_relabel(M, "FK10", groundset)
     return M
 
 
-def KF10():
+def KF10(groundset=None):
     """
     Return the matroid `KF10`.
 
@@ -3661,14 +3755,14 @@ def KF10():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("KF10: " + repr(M))
+    M = _rename_and_relabel(M, "KF10", groundset)
     return M
 
 
 # 11 elements:
 
 
-def FA11():
+def FA11(groundset=None):
     """
     Return the matroid `FA11`.
 
@@ -3699,14 +3793,14 @@ def FA11():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[1, 3, 4, 2, 8, 7, 9, 0, 5, 10, 6]
     )
-    M.rename("FA11: " + repr(M))
+    M = _rename_and_relabel(M, "FA11", groundset)
     return M
 
 
 # 12 elements:
 
 
-def FR12():
+def FR12(groundset=None):
     """
     Return the matroid `FR12`.
 
@@ -3734,11 +3828,11 @@ def FR12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FR12: " + repr(M))
+    M = _rename_and_relabel(M, "FR12", groundset)
     return M
 
 
-def GP12():
+def GP12(groundset=None):
     """
     Return the matroid `GP12`.
 
@@ -3766,11 +3860,11 @@ def GP12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("GP12: " + repr(M))
+    M = _rename_and_relabel(M, "GP12", groundset)
     return M
 
 
-def FQ12():
+def FQ12(groundset=None):
     """
     Return the matroid `FQ12`.
 
@@ -3807,11 +3901,11 @@ def FQ12():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[7, 4, 5, 9, 2, 1, 0, 6, 'd', 'c', 8, 3]
     )
-    M.rename("FQ12: " + repr(M))
+    M = _rename_and_relabel(M, "FQ12", groundset)
     return M
 
 
-def FF12():
+def FF12(groundset=None):
     """
     Return the matroid `FF12`.
 
@@ -3846,11 +3940,11 @@ def FF12():
     M = QuaternaryMatroid(
         reduced_matrix=A, groundset=[0, 4, 'c', 3, 5, 'd', 8, 9, 2, 7, 1, 6]
     )
-    M.rename("FF12: " + repr(M))
+    M = _rename_and_relabel(M, "FF12", groundset)
     return M
 
 
-def FZ12():
+def FZ12(groundset=None):
     """
     Return the matroid `FZ12`.
 
@@ -3878,11 +3972,11 @@ def FZ12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FZ12: " + repr(M))
+    M = _rename_and_relabel(M, "FZ12", groundset)
     return M
 
 
-def UQ12():
+def UQ12(groundset=None):
     """
     Return the matroid `UQ12`.
 
@@ -3910,11 +4004,11 @@ def UQ12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("UQ12: " + repr(M))
+    M = _rename_and_relabel(M, "UQ12", groundset)
     return M
 
 
-def FP12():
+def FP12(groundset=None):
     """
     Return the matroid `FP12`.
 
@@ -3942,11 +4036,11 @@ def FP12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FP12: " + repr(M))
+    M = _rename_and_relabel(M, "FP12", groundset)
     return M
 
 
-def FS12():
+def FS12(groundset=None):
     """
     Return the matroid `FS12`.
 
@@ -3973,11 +4067,11 @@ def FS12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FS12: " + repr(M))
+    M = _rename_and_relabel(M, "FS12", groundset)
     return M
 
 
-def UK12():
+def UK12(groundset=None):
     """
     Return the matroid `UK12`.
 
@@ -4005,11 +4099,11 @@ def UK12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("UK12: " + repr(M))
+    M = _rename_and_relabel(M, "UK12", groundset)
     return M
 
 
-def UA12():
+def UA12(groundset=None):
     """
     Return the matroid `UA12`.
 
@@ -4037,11 +4131,11 @@ def UA12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("UA12: " + repr(M))
+    M = _rename_and_relabel(M, "UA12", groundset)
     return M
 
 
-def AK12():
+def AK12(groundset=None):
     """
     Return the matroid `AK12`.
 
@@ -4069,11 +4163,11 @@ def AK12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("AK12: " + repr(M))
+    M = _rename_and_relabel(M, "AK12", groundset)
     return M
 
 
-def FK12():
+def FK12(groundset=None):
     """
     Return the matroid `FK12`.
 
@@ -4101,11 +4195,11 @@ def FK12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FK12: " + repr(M))
+    M = _rename_and_relabel(M, "FK12", groundset)
     return M
 
 
-def KB12():
+def KB12(groundset=None):
     """
     Return the matroid `KB12`.
 
@@ -4133,11 +4227,11 @@ def KB12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("KB12: " + repr(M))
+    M = _rename_and_relabel(M, "KB12", groundset)
     return M
 
 
-def AF12():
+def AF12(groundset=None):
     """
     Return the matroid `AF12`.
 
@@ -4165,11 +4259,11 @@ def AF12():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("AF12: " + repr(M))
+    M = _rename_and_relabel(M, "AF12", groundset)
     return M
 
 
-def NestOfTwistedCubes():
+def NestOfTwistedCubes(groundset=None):
     r"""
     Return the NestOfTwistedCubes matroid.
 
@@ -4178,7 +4272,8 @@ def NestOfTwistedCubes():
 
     EXAMPLES::
 
-        sage: M = matroids.catalog.NestOfTwistedCubes()
+        sage: M = matroids.catalog.NestOfTwistedCubes(); M
+        NestOfTwistedCubes: Matroid of rank 6 on 12 elements with 57 circuits
         sage: M.is_3connected()
         True
     """
@@ -4188,7 +4283,7 @@ def NestOfTwistedCubes():
 
     gs = ["e1", "e2", "e3", "e4", "e5", "e6",
           "f1", "f2", "f3", "f4", "f5", "f6"]
-    M = CircuitClosuresMatroid(
+    M = Matroid(
         groundset=gs,
         circuit_closures={
             3: [
@@ -4228,15 +4323,15 @@ def NestOfTwistedCubes():
             6: [gs],
         },
     )
-    M = Matroid(circuits=M.circuits())
-    M.rename("NestOfTwistedCubes: " + repr(M))
+    M = Matroid(circuits=list(M.circuits()))
+    M = _rename_and_relabel(M, "NestOfTwistedCubes", groundset)
     return M
 
 
 # 13 elements:
 
 
-def XY13():
+def XY13(groundset=None):
     """
     Return the matroid `XY13`.
 
@@ -4264,14 +4359,14 @@ def XY13():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("XY13: " + repr(M))
+    M = _rename_and_relabel(M, "XY13", groundset)
     return M
 
 
 # 14 elements:
 
 
-def N3():
+def N3(groundset=None):
     """
     Return the matroid `N3`.
 
@@ -4302,11 +4397,11 @@ def N3():
         ],
     )
     M = TernaryMatroid(reduced_matrix=A)
-    M.rename("N3: " + repr(M))
+    M = _rename_and_relabel(M, "N3", groundset)
     return M
 
 
-def N3pp():
+def N3pp(groundset=None):
     """
     Return the matroid `N3pp`.
 
@@ -4338,11 +4433,11 @@ def N3pp():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("N3=: " + repr(M))
+    M = _rename_and_relabel(M, "N3=", groundset)
     return M
 
 
-def UP14():
+def UP14(groundset=None):
     """
     Return the matroid `UP14`.
 
@@ -4371,11 +4466,11 @@ def UP14():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("UP14: " + repr(M))
+    M = _rename_and_relabel(M, "UP14", groundset)
     return M
 
 
-def VP14():
+def VP14(groundset=None):
     """
     Return the matroid `VP14`.
 
@@ -4404,11 +4499,11 @@ def VP14():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("VP14: " + repr(M))
+    M = _rename_and_relabel(M, "VP14", groundset)
     return M
 
 
-def FV14():
+def FV14(groundset=None):
     """
     Return the matroid `FV14`
 
@@ -4437,11 +4532,11 @@ def FV14():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FV14: " + repr(M))
+    M = _rename_and_relabel(M, "FV14", groundset)
     return M
 
 
-def OW14():
+def OW14(groundset=None):
     """
     Return the matroid `OW14`.
 
@@ -4470,11 +4565,11 @@ def OW14():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("OW14: " + repr(M))
+    M = _rename_and_relabel(M, "OW14", groundset)
     return M
 
 
-def FM14():
+def FM14(groundset=None):
     """
     Return the matroid `FM14`.
 
@@ -4502,14 +4597,14 @@ def FM14():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FM14: " + repr(M))
+    M = _rename_and_relabel(M, "FM14", groundset)
     return M
 
 
 # 15 elements:
 
 
-def FA15():
+def FA15(groundset=None):
     """
     Return the matroid `FA15`.
 
@@ -4539,14 +4634,14 @@ def FA15():
         ],
     )
     M = QuaternaryMatroid(reduced_matrix=A)
-    M.rename("FA15: " + repr(M))
+    M = _rename_and_relabel(M, "FA15", groundset)
     return M
 
 
 # 16 elements:
 
 
-def N4():
+def N4(groundset=None):
     """
     Return the matroid `N4`.
 
@@ -4578,7 +4673,7 @@ def N4():
         ],
     )
     M = TernaryMatroid(reduced_matrix=A)
-    M.rename("N4: " + repr(M))
+    M = _rename_and_relabel(M, "N4", groundset)
     return M
 
 
@@ -4588,7 +4683,7 @@ def N4():
 # ******************************** #
 
 
-def NonVamos():
+def NonVamos(groundset=None):
     r"""
     Return the non-`V\acute{a}mos` matroid.
 
@@ -4616,17 +4711,16 @@ def NonVamos():
 
     [Oxl2011]_, p. 72, 84.
     """
-    E = 'abcdefgh'
     CC = {
         3: ['abcd', 'abef', 'cdef', 'abgh', 'cdgh', 'efgh'],
-        4: [E]
+        4: ['abcdefgh']
     }
-    M = CircuitClosuresMatroid(groundset=E, circuit_closures=CC)
-    M.rename('NonVamos: ' + repr(M))
+    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = _rename_and_relabel(M, "NonVamos", groundset)
     return M
 
 
-def NotP8():
+def NotP8(groundset='abcdefgh'):
     """
     Return the matroid ``NotP8``.
 
@@ -4650,12 +4744,12 @@ def NotP8():
         [0, 0, 1, 0, 1, 1, 0, 1],
         [0, 0, 0, 1, -1, 1, 1, 1]
     ])
-    M = TernaryMatroid(A, "abcdefgh")
-    M.rename('NotP8: ' + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "NotP8")
     return M
 
 
-def AG23minus():
+def AG23minus(groundset=None):
     """
     Return the ternary affine plane minus a point.
 
@@ -4677,15 +4771,14 @@ def AG23minus():
 
     [Oxl2011]_, p. 653.
     """
-    E = 'abcdefgh'
     CC = {2: ['abc', 'ceh', 'fgh', 'adf', 'aeg', 'cdg', 'bdh', 'bef'],
-          3: [E]}
-    M = CircuitClosuresMatroid(groundset=E, circuit_closures=CC)
-    M.rename('AG23minus: ' + repr(M))
+          3: ['abcdefgh']}
+    M = Matroid(groundset='abcdefgh', circuit_closures=CC)
+    M = _rename_and_relabel(M, "AG23minus", groundset)
     return M
 
 
-def P9():
+def P9(groundset='abcdefghi'):
     """
     Return the matroid `P_9`.
 
@@ -4707,12 +4800,12 @@ def P9():
         [0, 0, 1, 0, 0, 1, 1, 0, 1],
         [0, 0, 0, 1, 0, 0, 1, 1, 0]
     ])
-    M = BinaryMatroid(A, "abcdefghi")
-    M.rename('P9: ' + repr(M))
+    M = BinaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "P9")
     return M
 
 
-def R9A():
+def R9A(groundset=None):
     """
     Return the matroid `R_9^A`.
 
@@ -4731,11 +4824,11 @@ def R9A():
     NSC = ['abch', 'abde', 'abfi', 'acdi', 'aceg', 'adgh', 'aefh', 'bcdf',
            'bdhi', 'begi', 'cehi', 'defi', 'fghi']
     M = Matroid(groundset='abcdefghi', rank=4, nonspanning_circuits=NSC)
-    M.rename("R9A: " + repr(M))
+    M = _rename_and_relabel(M, "R9A", groundset)
     return M
 
 
-def R9B():
+def R9B(groundset=None):
     """
     Return the matroid `R_9^B`.
 
@@ -4754,11 +4847,11 @@ def R9B():
     NSC = ['abde', 'bcdf', 'aceg', 'abch', 'befh', 'cdgh', 'bcei', 'adfi',
            'abgi', 'degi', 'bdhi', 'aehi', 'fghi']
     M = Matroid(groundset='abcdefghi', rank=4, nonspanning_circuits=NSC)
-    M.rename("R9B: " + repr(M))
+    M = _rename_and_relabel(M, "R9B", groundset)
     return M
 
 
-def Block_9_4():
+def Block_9_4(groundset=None):
     """
     Return the paving matroid whose nonspanning circuits form the blocks of a
     `2-(9, 4, 3)` design.
@@ -4770,7 +4863,7 @@ def Block_9_4():
         circuits
         sage: M.is_valid() and M.is_paving()
         True
-        sage: BD = BlockDesign(M.groundset(), M.nonspanning_circuits())
+        sage: BD = BlockDesign(M.groundset(), list(M.nonspanning_circuits()))
         sage: BD.is_t_design(return_parameters=True)
         (True, (2, 9, 4, 3))
     """
@@ -4778,11 +4871,11 @@ def Block_9_4():
            'begh', 'dfgh', 'abei', 'cdfi', 'bcgi', 'adgi', 'efgi', 'bdhi',
            'cehi', 'afhi']
     M = Matroid(groundset='abcdefghi', rank=4, nonspanning_circuits=NSC)
-    M.rename("Block(9, 4): " + repr(M))
+    M = _rename_and_relabel(M, "Block(9, 4)", groundset)
     return M
 
 
-def TicTacToe():
+def TicTacToe(groundset=None):
     """
     Return the TicTacToe matroid.
 
@@ -4803,11 +4896,11 @@ def TicTacToe():
     NSC = ['abcdg', 'adefg', 'abceh', 'abcfi', 'cdefi', 'adghi', 'beghi',
            'cfghi']
     M = Matroid(groundset='abcdefghi', rank=5, nonspanning_circuits=NSC)
-    M.rename("TicTacToe: " + repr(M))
+    M = _rename_and_relabel(M, "TicTacToe", groundset)
     return M
 
 
-def N1():
+def N1(groundset='abcdefghij'):
     r"""
     Return the matroid `N_1`, represented over `\GF{3}`.
 
@@ -4833,12 +4926,12 @@ def N1():
         [0, 0, 0, 1, 0, 0, 0, 1, 2, 2],
         [0, 0, 0, 0, 1, 1, 1, 1, 2, 0]
     ])
-    M = TernaryMatroid(A, 'abcdefghij')
-    M.rename('N1: ' + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "N1")
     return M
 
 
-def Block_10_5():
+def Block_10_5(groundset=None):
     """
     Return the paving matroid whose nonspanning circuits form the blocks of a
     `3-(10, 5, 3)` design.
@@ -4850,7 +4943,7 @@ def Block_10_5():
         circuits
         sage: M.is_valid() and M.is_paving()
         True
-        sage: BD = BlockDesign(M.groundset(), M.nonspanning_circuits())
+        sage: BD = BlockDesign(M.groundset(), list(M.nonspanning_circuits()))
         sage: BD.is_t_design(return_parameters=True)
         (True, (3, 10, 5, 3))
     """
@@ -4861,11 +4954,11 @@ def Block_10_5():
            'abcij', 'bdeij', 'cdfij', 'adgij', 'efgij', 'aehij', 'bfhij',
            'cghij']
     M = Matroid(groundset='abcdefghij', rank=5, nonspanning_circuits=NSC)
-    M.rename("Block(10, 5): " + repr(M))
+    M = _rename_and_relabel(M, "Block(10, 5)", groundset)
     return M
 
 
-def Q10():
+def Q10(groundset='abcdefghij'):
     r"""
     Return the matroid `Q_{10}`, represented over `\GF{4}`.
 
@@ -4876,7 +4969,8 @@ def Q10():
 
     EXAMPLES::
 
-        sage: M = matroids.catalog.Q10()
+        sage: M = matroids.catalog.Q10(); M
+        Q10: Quaternary matroid of rank 5 on 10 elements
         sage: M.is_isomorphic(M.dual())
         True
         sage: M.is_valid()
@@ -4901,12 +4995,12 @@ def Q10():
         [0, 0, 0, 1, 0, 0, 0, x + 1, 1, x],
         [0, 0, 0, 0, 1, x, 0, 0, x + 1, 1]
     ])
-    M = QuaternaryMatroid(A, "abcdefghij")
-    M.rename('Q10: ' + repr(M))
+    M = QuaternaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "Q10")
     return M
 
 
-def BetsyRoss():
+def BetsyRoss(groundset=None):
     """
     Return the Betsy Ross matroid, represented by circuit closures.
 
@@ -4928,11 +5022,11 @@ def BetsyRoss():
            'bef', 'bej', 'bfj', 'bgh', 'bik', 'ceh', 'cei', 'cfg', 'chi',
            'cjk', 'dfk', 'dgh', 'dij', 'efj', 'egk', 'ehi']
     M = Matroid(groundset='abcdefghijk', rank=3, nonspanning_circuits=NSC)
-    M.rename("BetsyRoss: " + repr(M))
+    M = _rename_and_relabel(M, "BetsyRoss", groundset)
     return M
 
 
-def N2():
+def N2(groundset='abcdefghijkl'):
     r"""
     Return the matroid `N_2`, represented over `\GF{3}`.
 
@@ -4959,8 +5053,8 @@ def N2():
         [0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1],
         [0, 0, 0, 0, 0, 1, 1, 2, 2, 1, 0, 1]
     ])
-    M = TernaryMatroid(A, "abcdefghijkl")
-    M.rename('N2: ' + repr(M))
+    M = TernaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "N2")
     return M
 
 
@@ -4994,12 +5088,12 @@ def D16(groundset='abcdefghijklmnop'):  # A.K.A. the Carolyn Chun Matroid
         [0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0]
     ])
-    M = BinaryMatroid(A, "abcdefghijklmnop")
-    M.rename('D16: ' + repr(M))
+    M = BinaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "D16")
     return M
 
 
-def Terrahawk():  # A.K.A. the Dillon Mayhew Matroid
+def Terrahawk(groundset='abcdefghijklmnop'):  # aka the Dillon Mayhew Matroid
     """
     Return the Terrahawk matroid.
 
@@ -5027,12 +5121,12 @@ def Terrahawk():  # A.K.A. the Dillon Mayhew Matroid
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0]
     ])
-    M = BinaryMatroid(A, "abcdefghijklmnop")
-    M.rename('Terrahawk: ' + repr(M))
+    M = BinaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "Terrahawk")
     return M
 
 
-def ExtendedBinaryGolayCode():
+def ExtendedBinaryGolayCode(groundset='abcdefghijklmnopqrstuvwx'):
     """
     Return the matroid of the extended binary Golay code.
 
@@ -5076,12 +5170,12 @@ def ExtendedBinaryGolayCode():
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     ])
-    M = BinaryMatroid(A, "abcdefghijklmnopqrstuvwx")
-    M.rename('Extended Binary Golay Code: ' + repr(M))
+    M = BinaryMatroid(A, groundset)
+    M = _rename_and_relabel(M, "Extended Binary Golay Code")
     return M
 
 
-def CompleteGraphic(n):
+def CompleteGraphic(n, groundset=None):
     """
     Return the cycle matroid of the complete graph on `n` vertices.
 
@@ -5115,5 +5209,39 @@ def CompleteGraphic(n):
         groundset=list(range((n * (n - 1)) // 2)),
         graph=graphs.CompleteGraph(n)
     )
-    M.rename("M(K" + str(n) + "): " + repr(M))
+    M = _rename_and_relabel(M, "M(K" + str(n) + ")", groundset)
+    return M
+
+
+# helper function
+
+
+def _rename_and_relabel(M, name=None, groundset=None):
+    """
+    Return a renamed and relabeled matroid.
+
+    This is a helper function for easily renaming and relabeling matroids upon
+    definition in the context of the database of matroids.
+
+    INPUT:
+
+    - ``M`` -- a matroid
+    - ``name`` -- a string (optional)
+    - ``groundset`` -- a string (optional)
+
+    OUTPUT:
+
+    a matroid
+    """
+    if groundset is not None:
+        if len(groundset) != len(M.groundset()):
+            raise ValueError(
+                "The groundset should be of size %s (%s given)." %
+                (len(M.groundset()), len(groundset))
+            )
+        M = M.relabel(dict(zip(M.groundset(), groundset)))
+
+    if name is not None:
+        M.rename(name+": " + repr(M))
+
     return M

--- a/src/sage/matroids/flats_matroid.pxd
+++ b/src/sage/matroids/flats_matroid.pxd
@@ -13,8 +13,9 @@ cdef class FlatsMatroid(Matroid):
     cpdef flats(self, k)
     cpdef whitney_numbers2(self)
 
-    # isomorphism
+    # isomorphism and relabeling
     cpdef _is_isomorphic(self, other, certificate=*)
+    cpdef relabel(self, f)
 
     # verification
     cpdef is_valid(self)

--- a/src/sage/matroids/flats_matroid.pxd
+++ b/src/sage/matroids/flats_matroid.pxd
@@ -15,7 +15,7 @@ cdef class FlatsMatroid(Matroid):
 
     # isomorphism and relabeling
     cpdef _is_isomorphic(self, other, certificate=*)
-    cpdef relabel(self, f)
+    cpdef relabel(self, mapping)
 
     # verification
     cpdef is_valid(self)

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -205,7 +205,7 @@ cdef class FlatsMatroid(Matroid):
             Matroid of rank 6 on 6 elements with 64 flats
         """
         flats_num = sum(1 for i in self._F for F in self._F[i])
-        return Matroid._repr_(self) + " with " + str(flats_num) + " flats"
+        return f'{Matroid._repr_(self)} with {flats_num} flats'
 
     # comparison
 

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -311,7 +311,7 @@ cdef class FlatsMatroid(Matroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -342,7 +342,7 @@ cdef class FlatsMatroid(Matroid):
         F = {}
         for i in self._F:
             F[i] = []
-            F[i] += [[d[y] for y in list(x)] for x in self._F[i]]
+            F[i] += [[d[y] for y in x] for x in self._F[i]]
         M = FlatsMatroid(groundset=E, flats=F)
         return M
 

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -300,6 +300,51 @@ cdef class FlatsMatroid(Matroid):
         version = 0
         return sage.matroids.unpickling.unpickle_flats_matroid, (version, data)
 
+    cpdef relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: from sage.matroids.flats_matroid import FlatsMatroid
+            sage: M = FlatsMatroid(matroids.catalog.RelaxedNonFano())
+            sage: sorted(M.groundset())
+            [0, 1, 2, 3, 4, 5, 6]
+            sage: N = M.relabel({'g':'x', 0:'z'}) # 'g':'x' is ignored
+            sage: from sage.matroids.utilities import cmp_elements_key
+            sage: sorted(N.groundset(), key=cmp_elements_key)
+            [1, 2, 3, 4, 5, 6, 'z']
+            sage: M.is_isomorphic(N)
+            True
+
+        TESTS::
+
+            sage: from sage.matroids.flats_matroid import FlatsMatroid
+            sage: M = FlatsMatroid(matroids.catalog.RelaxedNonFano())
+            sage: f = {0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f', 6: 'g'}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self._groundset]
+        F = {}
+        for i in self._F:
+            F[i] = []
+            F[i] += [[d[y] for y in list(x)] for x in self._F[i]]
+        M = FlatsMatroid(groundset=E, flats=F)
+        return M
+
     # enumeration
 
     cpdef flats(self, k):

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -320,7 +320,7 @@ cdef class FlatsMatroid(Matroid):
             sage: M = FlatsMatroid(matroids.catalog.RelaxedNonFano())
             sage: sorted(M.groundset())
             [0, 1, 2, 3, 4, 5, 6]
-            sage: N = M.relabel({'g':'x', 0:'z'}) # 'g':'x' is ignored
+            sage: N = M.relabel({'g': 'x', 0: 'z'})  # 'g': 'x' is ignored
             sage: from sage.matroids.utilities import cmp_elements_key
             sage: sorted(N.groundset(), key=cmp_elements_key)
             [1, 2, 3, 4, 5, 6, 'z']

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -310,7 +310,7 @@ cdef class FlatsMatroid(Matroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -300,17 +300,18 @@ cdef class FlatsMatroid(Matroid):
         version = 0
         return sage.matroids.unpickling.unpickle_flats_matroid, (version, data)
 
-    cpdef relabel(self, f):
+    cpdef relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -336,7 +337,7 @@ cdef class FlatsMatroid(Matroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self._groundset]
         F = {}
         for i in self._F:

--- a/src/sage/matroids/graphic_matroid.py
+++ b/src/sage/matroids/graphic_matroid.py
@@ -2012,7 +2012,7 @@ class GraphicMatroid(Matroid):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 

--- a/src/sage/matroids/graphic_matroid.py
+++ b/src/sage/matroids/graphic_matroid.py
@@ -2001,3 +2001,41 @@ class GraphicMatroid(Matroid):
         from sage.matroids.constructor import Matroid as ConstructorMatroid
         X = [l for u, v, l in self._G.edge_iterator()]
         return ConstructorMatroid(groundset=X, graph=self._G, regular=True)
+
+    def relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: M = matroids.CompleteGraphic(4)
+            sage: sorted(M.groundset())
+            [0, 1, 2, 3, 4, 5]
+            sage: N = M.relabel({0:6, 5:'e'})
+            sage: sorted(N.groundset(), key=str)
+            [1, 2, 3, 4, 6, 'e']
+            sage: N.is_isomorphic(M)
+            True
+
+        TESTS::
+
+            sage: M = matroids.CompleteGraphic(4)
+            sage: f = {0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f', 6: 'g'}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self.groundset()]
+        M = GraphicMatroid(self.graph(), groundset=E)
+        return M

--- a/src/sage/matroids/graphic_matroid.py
+++ b/src/sage/matroids/graphic_matroid.py
@@ -2013,7 +2013,7 @@ class GraphicMatroid(Matroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 

--- a/src/sage/matroids/graphic_matroid.py
+++ b/src/sage/matroids/graphic_matroid.py
@@ -2012,7 +2012,7 @@ class GraphicMatroid(Matroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid
@@ -2022,7 +2022,7 @@ class GraphicMatroid(Matroid):
             sage: M = matroids.CompleteGraphic(4)
             sage: sorted(M.groundset())
             [0, 1, 2, 3, 4, 5]
-            sage: N = M.relabel({0:6, 5:'e'})
+            sage: N = M.relabel({0: 6, 5: 'e'})
             sage: sorted(N.groundset(), key=str)
             [1, 2, 3, 4, 6, 'e']
             sage: N.is_isomorphic(M)

--- a/src/sage/matroids/graphic_matroid.py
+++ b/src/sage/matroids/graphic_matroid.py
@@ -306,8 +306,7 @@ class GraphicMatroid(Matroid):
         """
         self._mrank = str(self._rank(self._groundset))
         self._elts = str(len(self._groundset))
-
-        return "Graphic matroid of rank " + self._mrank + " on " + self._elts + " elements"
+        return f'Graphic matroid of rank {self._mrank} on {self._elts} elements'
 
     # Comparison:
 

--- a/src/sage/matroids/graphic_matroid.py
+++ b/src/sage/matroids/graphic_matroid.py
@@ -2002,17 +2002,18 @@ class GraphicMatroid(Matroid):
         X = [l for u, v, l in self._G.edge_iterator()]
         return ConstructorMatroid(groundset=X, graph=self._G, regular=True)
 
-    def relabel(self, f):
+    def relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -2035,7 +2036,7 @@ class GraphicMatroid(Matroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset()]
         M = GraphicMatroid(self.graph(), groundset=E)
         return M

--- a/src/sage/matroids/linear_matroid.pxd
+++ b/src/sage/matroids/linear_matroid.pxd
@@ -28,6 +28,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
     cpdef is_field_isomorphism(self, other, morphism)
     # cpdef is_field_isomorphic(self, other)  # TODO: currently only works as ``def``
     cpdef _fast_isom_test(self, other)
+    cpdef relabel(self, f)
 
     cpdef _minor(self, contractions, deletions)
     cpdef dual(self)
@@ -88,6 +89,7 @@ cdef class BinaryMatroid(LinearMatroid):
     cpdef BinaryMatrix _projection(self)
     cpdef BinaryMatrix _projection_partition(self)
     cpdef _fast_isom_test(self, other)
+    cpdef relabel(self, f)
 
     cpdef is_graphic(self)
     cpdef is_valid(self)
@@ -118,6 +120,7 @@ cdef class TernaryMatroid(LinearMatroid):
     cpdef _principal_quadripartition(self)
     cpdef TernaryMatrix _projection(self)
     cpdef _fast_isom_test(self, other)
+    cpdef relabel(self, f)
 
     cpdef is_valid(self)
 
@@ -144,6 +147,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
     cpdef bicycle_dimension(self)
     cpdef _principal_tripartition(self)
     cpdef _fast_isom_test(self, other)
+    cpdef relabel(self, f)
 
     cpdef is_valid(self)
 
@@ -159,6 +163,7 @@ cdef class RegularMatroid(LinearMatroid):
 
     cpdef _invariant(self)
     cpdef _fast_isom_test(self, other)
+    cpdef relabel(self, f)
 
     cpdef bases_count(self)
     cpdef _projection(self)

--- a/src/sage/matroids/linear_matroid.pxd
+++ b/src/sage/matroids/linear_matroid.pxd
@@ -28,7 +28,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
     cpdef is_field_isomorphism(self, other, morphism)
     # cpdef is_field_isomorphic(self, other)  # TODO: currently only works as ``def``
     cpdef _fast_isom_test(self, other)
-    cpdef relabel(self, f)
+    cpdef relabel(self, mapping)
 
     cpdef _minor(self, contractions, deletions)
     cpdef dual(self)
@@ -89,7 +89,7 @@ cdef class BinaryMatroid(LinearMatroid):
     cpdef BinaryMatrix _projection(self)
     cpdef BinaryMatrix _projection_partition(self)
     cpdef _fast_isom_test(self, other)
-    cpdef relabel(self, f)
+    cpdef relabel(self, mapping)
 
     cpdef is_graphic(self)
     cpdef is_valid(self)
@@ -120,7 +120,7 @@ cdef class TernaryMatroid(LinearMatroid):
     cpdef _principal_quadripartition(self)
     cpdef TernaryMatrix _projection(self)
     cpdef _fast_isom_test(self, other)
-    cpdef relabel(self, f)
+    cpdef relabel(self, mapping)
 
     cpdef is_valid(self)
 
@@ -147,7 +147,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
     cpdef bicycle_dimension(self)
     cpdef _principal_tripartition(self)
     cpdef _fast_isom_test(self, other)
-    cpdef relabel(self, f)
+    cpdef relabel(self, mapping)
 
     cpdef is_valid(self)
 
@@ -163,7 +163,7 @@ cdef class RegularMatroid(LinearMatroid):
 
     cpdef _invariant(self)
     cpdef _fast_isom_test(self, other)
-    cpdef relabel(self, f)
+    cpdef relabel(self, mapping)
 
     cpdef bases_count(self)
     cpdef _projection(self)

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -2983,7 +2983,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid
@@ -4085,7 +4085,7 @@ cdef class BinaryMatroid(LinearMatroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid
@@ -5016,7 +5016,7 @@ cdef class TernaryMatroid(LinearMatroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid
@@ -5778,7 +5778,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid
@@ -6734,7 +6734,7 @@ cdef class RegularMatroid(LinearMatroid):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -466,8 +466,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             'Linear matroid of rank 2 on 5 elements represented over the
             Finite Field of size 5'
         """
-        S = "Linear matroid of rank " + str(self.rank()) + " on " + str(self.size()) + " elements represented over the " + repr(self.base_ring())
-        return S
+        return f'Linear matroid of rank {self.rank()} on {self.size()} elements represented over the {repr(self.base_ring())}'
 
     # representations
 
@@ -3247,8 +3246,7 @@ cdef class BinaryMatroid(LinearMatroid):
             sage: repr(M)  # indirect doctest
             'Binary matroid of rank 3 on 7 elements, type (3, 0)'
         """
-        S = "Binary matroid of rank " + str(self.rank()) + " on " + str(self.size()) + " elements, type (" + str(self.bicycle_dimension()) + ', ' + str(self.brown_invariant()) + ')'
-        return S
+        return f'Binary matroid of rank {self.rank()} on {self.size()} elements, type ({self.bicycle_dimension()}, {self.brown_invariant()})'
 
     cpdef _current_rows_cols(self, B=None):
         """
@@ -4351,7 +4349,7 @@ cdef class TernaryMatroid(LinearMatroid):
             sage: repr(M)  # indirect doctest
             'Ternary matroid of rank 3 on 7 elements, type 0-'
         """
-        S = "Ternary matroid of rank " + str(self.rank()) + " on " + str(self.size()) + " elements, type " + str(self.bicycle_dimension())
+        S = f'Ternary matroid of rank {self.rank()} on {self.size()} elements, type {self.bicycle_dimension()}'
         if self.character() == 1:
             S = S + '+'
         else:
@@ -5278,8 +5276,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
             sage: repr(M)  # indirect doctest                                           # needs sage.rings.finite_rings
             'Quaternary matroid of rank 2 on 3 elements'
         """
-        S = "Quaternary matroid of rank " + str(self.rank()) + " on " + str(self.size()) + " elements"
-        return S
+        return f'Quaternary matroid of rank {self.rank()} on {self.size()} elements'
 
     cpdef _current_rows_cols(self, B=None):
         """
@@ -6023,8 +6020,7 @@ cdef class RegularMatroid(LinearMatroid):
             sage: repr(M)  # indirect doctest
             'Regular matroid of rank 5 on 10 elements with 162 bases'
         """
-        S = "Regular matroid of rank " + str(self.rank()) + " on " + str(self.size()) + " elements with " + str(self.bases_count()) + " bases"
-        return S
+        return f'Regular matroid of rank {self.rank()} on {self.size()} elements with {self.bases_count()} bases'
 
     cpdef bases_count(self):
         """

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -2983,7 +2983,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 
@@ -2992,7 +2992,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             sage: M = matroids.catalog.Fano()
             sage: sorted(M.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'g']
-            sage: N = M.relabel({'g':'x'})
+            sage: N = M.relabel({'g': 'x'})
             sage: sorted(N.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'x']
 
@@ -4084,7 +4084,7 @@ cdef class BinaryMatroid(LinearMatroid):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 
@@ -4093,7 +4093,7 @@ cdef class BinaryMatroid(LinearMatroid):
             sage: M = matroids.catalog.Fano()
             sage: sorted(M.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'g']
-            sage: N = M.relabel({'g':'x'})
+            sage: N = M.relabel({'g': 'x'})
             sage: sorted(N.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'x']
 
@@ -5014,7 +5014,7 @@ cdef class TernaryMatroid(LinearMatroid):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 
@@ -5023,7 +5023,7 @@ cdef class TernaryMatroid(LinearMatroid):
             sage: M = matroids.catalog.NonFano()
             sage: sorted(M.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'g']
-            sage: N = M.relabel({'g':'x'})
+            sage: N = M.relabel({'g': 'x'})
             sage: sorted(N.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'x']
 
@@ -5775,7 +5775,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 
@@ -6730,7 +6730,7 @@ cdef class RegularMatroid(LinearMatroid):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 
@@ -6739,7 +6739,7 @@ cdef class RegularMatroid(LinearMatroid):
             sage: M = matroids.catalog.R10()
             sage: sorted(M.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
-            sage: N = M.relabel({'g':'x'})
+            sage: N = M.relabel({'g': 'x'})
             sage: sorted(N.groundset())
             ['a', 'b', 'c', 'd', 'e', 'f', 'h', 'i', 'j', 'x']
 

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -2984,7 +2984,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 
@@ -4086,7 +4086,7 @@ cdef class BinaryMatroid(LinearMatroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 
@@ -5017,7 +5017,7 @@ cdef class TernaryMatroid(LinearMatroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 
@@ -5779,7 +5779,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 
@@ -6735,7 +6735,7 @@ cdef class RegularMatroid(LinearMatroid):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -2973,17 +2973,18 @@ cdef class LinearMatroid(BasisExchangeMatroid):
         data = (A, gs, reduced, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_linear_matroid, (version, data)
 
-    cpdef relabel(self, f):
+    cpdef relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -3004,7 +3005,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
         M = LinearMatroid(groundset=E, matrix=self._matrix_())
         return M
@@ -4074,17 +4075,18 @@ cdef class BinaryMatroid(LinearMatroid):
         data = (A, gs, basis, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_binary_matroid, (version, data)
 
-    cpdef relabel(self, f):
+    cpdef relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -4105,7 +4107,7 @@ cdef class BinaryMatroid(LinearMatroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
         M = BinaryMatroid(groundset=E, matrix=self._matrix_())
         return M
@@ -5004,17 +5006,18 @@ cdef class TernaryMatroid(LinearMatroid):
         data = (A, gs, basis, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_ternary_matroid, (version, data)
 
-    cpdef relabel(self, f):
+    cpdef relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -5035,7 +5038,7 @@ cdef class TernaryMatroid(LinearMatroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
         M = TernaryMatroid(groundset=E, matrix=self._matrix_())
         return M
@@ -5765,17 +5768,18 @@ cdef class QuaternaryMatroid(LinearMatroid):
         data = (A, gs, basis, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_quaternary_matroid, (version, data)
 
-    cpdef relabel(self, f):
+    cpdef relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -5796,7 +5800,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
         M = QuaternaryMatroid(groundset=E, matrix=self._matrix_())
         return M
@@ -6720,17 +6724,18 @@ cdef class RegularMatroid(LinearMatroid):
         data = (A, gs, reduced, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_regular_matroid, (version, data)
 
-    cpdef relabel(self, f):
+    cpdef relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -6751,7 +6756,7 @@ cdef class RegularMatroid(LinearMatroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([M._relabel_map(f)[x] for x in S])
         """
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
         M = RegularMatroid(groundset=E, matrix=self._matrix_())
         return M

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -466,7 +466,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             'Linear matroid of rank 2 on 5 elements represented over the
             Finite Field of size 5'
         """
-        return f'Linear matroid of rank {self.rank()} on {self.size()} elements represented over the {repr(self.base_ring())}'
+        return f'Linear matroid of rank {self.rank()} on {self.size()} elements represented over the {self.base_ring()!r}'
 
     # representations
 

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -2973,6 +2973,42 @@ cdef class LinearMatroid(BasisExchangeMatroid):
         data = (A, gs, reduced, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_linear_matroid, (version, data)
 
+    cpdef relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: M = matroids.catalog.Fano()
+            sage: sorted(M.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+            sage: N = M.relabel({'g':'x'})
+            sage: sorted(N.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'x']
+
+        TESTS::
+
+            sage: M = matroids.catalog.Fano()
+            sage: f = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self.groundset_list()]
+        M = LinearMatroid(groundset=E, matrix=self._matrix_())
+        return M
+
 # Binary matroid
 
 cdef class BinaryMatroid(LinearMatroid):
@@ -4038,6 +4074,42 @@ cdef class BinaryMatroid(LinearMatroid):
         data = (A, gs, basis, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_binary_matroid, (version, data)
 
+    cpdef relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: M = matroids.catalog.Fano()
+            sage: sorted(M.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+            sage: N = M.relabel({'g':'x'})
+            sage: sorted(N.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'x']
+
+        TESTS::
+
+            sage: M = matroids.catalog.Fano()
+            sage: f = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self.groundset_list()]
+        M = BinaryMatroid(groundset=E, matrix=self._matrix_())
+        return M
+
 cdef class TernaryMatroid(LinearMatroid):
     r"""
     Ternary matroids.
@@ -4932,6 +5004,42 @@ cdef class TernaryMatroid(LinearMatroid):
         data = (A, gs, basis, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_ternary_matroid, (version, data)
 
+    cpdef relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: M = matroids.catalog.NonFano()
+            sage: sorted(M.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+            sage: N = M.relabel({'g':'x'})
+            sage: sorted(N.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'x']
+
+        TESTS::
+
+            sage: M = matroids.catalog.NonFano()
+            sage: f = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self.groundset_list()]
+        M = TernaryMatroid(groundset=E, matrix=self._matrix_())
+        return M
+
 # Quaternary Matroids
 
 cdef class QuaternaryMatroid(LinearMatroid):
@@ -5656,6 +5764,42 @@ cdef class QuaternaryMatroid(LinearMatroid):
             basis = self._current_rows_cols()[0]
         data = (A, gs, basis, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_quaternary_matroid, (version, data)
+
+    cpdef relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: M = matroids.catalog.RelaxedNonFano("abcdefg")
+            sage: sorted(M.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+            sage: N = M.relabel({'g':'x'})
+            sage: sorted(N.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'x']
+
+        TESTS::
+
+            sage: M = matroids.catalog.RelaxedNonFano("abcdefg")
+            sage: f = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self.groundset_list()]
+        M = QuaternaryMatroid(groundset=E, matrix=self._matrix_())
+        return M
 
 # Regular Matroids
 
@@ -6575,3 +6719,39 @@ cdef class RegularMatroid(LinearMatroid):
             reduced = True
         data = (A, gs, reduced, self.get_custom_name())
         return sage.matroids.unpickling.unpickle_regular_matroid, (version, data)
+
+    cpdef relabel(self, f):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by ``f[e]``,
+        where ``f`` is a given injective map. If ``e not in f`` then the
+        identity map is assumed.
+
+        INPUT:
+
+        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+
+        OUTPUT: a matroid
+
+        EXAMPLES::
+
+            sage: M = matroids.catalog.R10()
+            sage: sorted(M.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+            sage: N = M.relabel({'g':'x'})
+            sage: sorted(N.groundset())
+            ['a', 'b', 'c', 'd', 'e', 'f', 'h', 'i', 'j', 'x']
+
+        TESTS::
+
+            sage: M = matroids.catalog.R10()
+            sage: f = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6, 'g': 7}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([M._relabel_map(f)[x] for x in S])
+        """
+        d = self._relabel_map(f)
+        E = [d[x] for x in self.groundset_list()]
+        M = RegularMatroid(groundset=E, matrix=self._matrix_())
+        return M

--- a/src/sage/matroids/matroid.pxd
+++ b/src/sage/matroids/matroid.pxd
@@ -141,7 +141,7 @@ cdef class Matroid(SageObject):
     cpdef equals(self, other)
     cpdef is_isomorphism(self, other, morphism)
     cpdef _is_isomorphism(self, other, morphism)
-    cpdef _relabel_map(self, f)
+    cpdef _relabel_map(self, mapping)
 
     # minors, dual, truncation
     cpdef minor(self, contractions=*, deletions=*)

--- a/src/sage/matroids/matroid.pxd
+++ b/src/sage/matroids/matroid.pxd
@@ -141,6 +141,7 @@ cdef class Matroid(SageObject):
     cpdef equals(self, other)
     cpdef is_isomorphism(self, other, morphism)
     cpdef _is_isomorphism(self, other, morphism)
+    cpdef _relabel_map(self, f)
 
     # minors, dual, truncation
     cpdef minor(self, contractions=*, deletions=*)

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8398,15 +8398,15 @@ cdef class Matroid(SageObject):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`; if
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`; if
           ``e not in f`` then the identity map is assumed
 
         EXAMPLES::
 
-            sage: M = matroids.catalog.Vamos([1,2,3,4,5,6,7,8])
-            sage: M._relabel_map({1:'a', 8:'h', 9:'i'})
+            sage: M = matroids.catalog.Vamos([1, 2, 3, 4, 5, 6, 7, 8])
+            sage: M._relabel_map({1: 'a', 8: 'h', 9: 'i'})
             {1: 'a', 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 'h'}
-            sage: M._relabel_map({1:2})
+            sage: M._relabel_map({1: 2})
             Traceback (most recent call last):
             ...
             ValueError: given map doesn't relabel the groundset properly
@@ -8434,7 +8434,7 @@ cdef class Matroid(SageObject):
 
         INPUT:
 
-        - ``f`` -- a python object such that `f[e]` is the new label of `e`
+        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
 
         OUTPUT: a matroid
 
@@ -8445,7 +8445,7 @@ cdef class Matroid(SageObject):
             sage: M = RankMatroid(groundset=N.groundset(), rank_function=N.rank)
             sage: sorted(M.groundset())
             [1, 2, 3, 4, 5, 6, 7, 8]
-            sage: N = M.relabel({8:0})
+            sage: N = M.relabel({8: 0})
             sage: sorted(N.groundset())
             [0, 1, 2, 3, 4, 5, 6, 7]
             sage: M.is_isomorphic(N)
@@ -8456,7 +8456,7 @@ cdef class Matroid(SageObject):
             sage: from sage.matroids.rank_matroid import RankMatroid
             sage: N = matroids.catalog.Sp8pp()
             sage: M = RankMatroid(groundset=N.groundset(), rank_function=N.rank)
-            sage: f = {1:'a', 2:'b', 3:'c', 4:'d', 5:'e', 6:'f', 7:'g', 8:'h'}
+            sage: f = {1: 'a', 2: 'b', 3: 'c', 4: 'd', 5: 'e', 6: 'f', 7: 'g', 8: 'h'}
             sage: N = M.relabel(f)
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8424,17 +8424,18 @@ cdef class Matroid(SageObject):
             raise ValueError("given map doesn't relabel the groundset properly")
         return d
 
-    def relabel(self, f):
+    def relabel(self, mapping):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by ``f[e]``,
-        where ``f`` is a given injective map. If ``e not in f`` then the
-        identity map is assumed.
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
 
         OUTPUT: a matroid
 
@@ -8462,7 +8463,7 @@ cdef class Matroid(SageObject):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
         from sage.matroids.rank_matroid import RankMatroid
-        d = self._relabel_map(f)
+        d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset()]
 
         def f_relabel(X):

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8434,7 +8434,7 @@ cdef class Matroid(SageObject):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: a matroid

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -1197,9 +1197,7 @@ cdef class Matroid(SageObject):
             sage: sage.matroids.matroid.Matroid._repr_(M)
             'Matroid of rank 4 on 8 elements'
         """
-        S = "Matroid of rank "
-        S = S + str(self.rank()) + " on " + str(self.size()) + " elements"
-        return S
+        return f'Matroid of rank {self.rank()} on {self.size()} elements'
 
     # cpdef show(self):
     # Show either the graph, or the matrix with labels, or the lattice,

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8436,7 +8436,7 @@ cdef class Matroid(SageObject):
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: a matroid
 

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8391,15 +8391,16 @@ cdef class Matroid(SageObject):
         matroids.insert(0, self)
         return union_matroid.MatroidSum(iter(matroids))
 
-    cpdef _relabel_map(self, f):
+    cpdef _relabel_map(self, mapping):
         """
         Return a dictionary from the groundset to the relabeled groundset
-        and check that the mapping defined by ``f`` is valid.
+        and check that the mapping defined by ``mapping`` is valid.
 
         INPUT:
 
-        - ``f`` -- a python object such that ``f[e]`` is the new label of `e`; if
-          ``e not in f`` then the identity map is assumed
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
+          label of ``e``; if ``mapping[e]`` is not defined then the identity
+          map is assumed
 
         EXAMPLES::
 
@@ -8415,8 +8416,8 @@ cdef class Matroid(SageObject):
         d = {}
         for x in self.groundset():
             try:
-                E.add(f[x])
-                d[x] = f[x]
+                E.add(mapping[x])
+                d[x] = mapping[x]
             except LookupError:
                 E.add(x)
                 d[x] = x

--- a/src/sage/matroids/set_system.pxd
+++ b/src/sage/matroids/set_system.pxd
@@ -9,7 +9,7 @@ cdef class SetSystem:
     cdef bitset_t _temp
 
     cdef copy(self)
-    cdef _relabel(self, l)
+    cdef _relabel(self, mapping)
     cpdef _complements(self)
 
     cdef resize(self, k=*)

--- a/src/sage/matroids/set_system.pyx
+++ b/src/sage/matroids/set_system.pyx
@@ -215,7 +215,7 @@ cdef class SetSystem:
         INPUT:
 
         - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of `e`
+          label of ``e``
 
         OUTPUT: ``None``
         """

--- a/src/sage/matroids/set_system.pyx
+++ b/src/sage/matroids/set_system.pyx
@@ -207,24 +207,23 @@ cdef class SetSystem:
             S._append(self._subsets[i])
         return S
 
-    cdef _relabel(self, l):
+    cdef _relabel(self, mapping):
         """
-        Relabel each element `e` of the ground set as `l(e)`, where `l` is a
-        given injective map.
+        Relabel each element ``e`` of the ground set as ``mapping[e]``, where
+        ``mapping`` is a given injective map.
 
         INPUT:
 
-        - ``l`` -- a python object such that `l[e]` is the new label of e.
+        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT:
-
-        ``None``.
+        OUTPUT: ``None``
         """
         cdef long i
         E = []
         for i in range(self._groundset_size):
-            if self._groundset[i] in l:
-                E.append(l[self._E[i]])
+            if self._groundset[i] in mapping:
+                E.append(mapping[self._E[i]])
             else:
                 E.append(self._E[i])
         self._groundset = E


### PR DESCRIPTION
The present PR adds a matroid groundset `relabel` function. It is optimized for each matroid subclass. It also adds an optional `groundset` argument to the matroids defined in `database_matroids.py`.

This resolves two `TODO`s left from previous developers.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.
