### PR TITLE
`SetPartition` return empty iterator instead of erroring out in degenerate cases

### DIFF
--- a/src/sage/combinat/set_partition.py
+++ b/src/sage/combinat/set_partition.py
@@ -2061,18 +2061,17 @@ class SetPartitions(UniqueRepresentation, Parent):
                 pass
             s = frozenset(s)
 
-        if part is not None:
+        if part is None:
+            return SetPartitions_set(s)
+        else:
             if isinstance(part, (int, Integer)):
-                if len(s) < part:
-                    raise ValueError("part must be <= len(set)")
                 return SetPartitions_setn(s, part)
             else:
                 part = sorted(part, reverse=True)
                 if part not in Partitions(len(s)):
                     raise ValueError("part must be an integer partition of %s" % len(s))
                 return SetPartitions_setparts(s, Partition(part))
-        else:
-            return SetPartitions_set(s)
+            
 
     def __contains__(self, x):
         """

--- a/src/sage/combinat/set_partition.py
+++ b/src/sage/combinat/set_partition.py
@@ -2033,6 +2033,14 @@ class SetPartitions(UniqueRepresentation, Parent):
         sage: SetPartitions('aabcd').cardinality()                                      # needs sage.libs.flint
         15
 
+    If the number of parts exceeds the length of the set,
+    an empty iterator is returned (:issue:`37643`)::
+
+        sage: SetPartitions(range(3), 4).list()
+        []
+        sage: SetPartitions('abcd', 6).list()
+        []
+
     REFERENCES:
 
     - :wikipedia:`Partition_of_a_set`

--- a/src/sage/combinat/set_partition.py
+++ b/src/sage/combinat/set_partition.py
@@ -2071,7 +2071,6 @@ class SetPartitions(UniqueRepresentation, Parent):
                 if part not in Partitions(len(s)):
                     raise ValueError("part must be an integer partition of %s" % len(s))
                 return SetPartitions_setparts(s, Partition(part))
-            
 
     def __contains__(self, x):
         """

--- a/src/sage/combinat/set_partition_iterator.pyx
+++ b/src/sage/combinat/set_partition_iterator.pyx
@@ -129,5 +129,6 @@ def set_partition_iterator_blocks(base_set, Py_ssize_t k):
     cdef Py_ssize_t n = len(base)
     cdef list a = list(range(n))
     # TODO: implement _set_partition_block_gen as an iterative algorithm
-    for P in _set_partition_block_gen(n, k, a):
-        yield from_word(<list> P, base)
+    if n >= k:
+        for P in _set_partition_block_gen(n, k, a):
+            yield from_word(<list> P, base)

--- a/src/sage/combinat/set_partition_iterator.pyx
+++ b/src/sage/combinat/set_partition_iterator.pyx
@@ -129,6 +129,7 @@ def set_partition_iterator_blocks(base_set, Py_ssize_t k):
     cdef Py_ssize_t n = len(base)
     cdef list a = list(range(n))
     # TODO: implement _set_partition_block_gen as an iterative algorithm
-    if n >= k:
-        for P in _set_partition_block_gen(n, k, a):
-            yield from_word(<list> P, base)
+    if n < k:
+        return
+    for P in _set_partition_block_gen(n, k, a):
+        yield from_word(<list> P, base)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Replaced the error raised by `SetPartition` in a degenerate case (see below) by an empty iterator, to match the behaviour of similar functions such as `Partitions` and `OrderedSetPartitions`. Old behaviour:
```Python
sage: list( Partitions(3,length=4) )
[]
sage: list( OrderedSetPartitions(range(3),4) )
[]
sage: list( SetPartitions(range(3),4) )
...
ValueError: part must be <= len(set)
```
New behaviour
```Python
sage: list( SetPartitions(range(3),4) )
[]
```
This solves issue #37643.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


