### PR TITLE
`sage-logger`: Suppress "No such file or directory" messages

### DIFF
--- a/build/bin/sage-logger
+++ b/build/bin/sage-logger
@@ -63,7 +63,7 @@ fi
 
 timefile="$logdir/$logname.time"
 rm -f "$timefile"
-if /usr/bin/time -h -o /dev/null true; then
+if /usr/bin/time -h -o /dev/null true 2>/dev/null; then
     TIME="/usr/bin/time -h -o $timefile"
 else
     TIME=""
@@ -71,7 +71,7 @@ fi
 
 report_time ()
 {
-    time=$(echo $(cat $timefile))
+    time=$(echo $(cat $timefile 2>/dev/null))
     case "$time" in
         *m*real*|*h*real*|*[1-9][0-9].*real*|*[1-9][0-9],*real*)
             # at least 10 seconds wall time


### PR DESCRIPTION

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

A minor follow-up after #37391:

Seen for example in 
https://github.com/sagemath/sage/actions/runs/8626379356/job/23644513913?pr=37570#step:11:3227:
```
#24 4091.8 /sage/build/bin/sage-logger: line 66: /usr/bin/time: No such file or directory
#24 4091.8 [sagemath_doc_html-none] installing. Log file: /sage/logs/pkgs/sagemath_doc_html-none.log
#24 5807.5 cat: /sage/logs/pkgs/sagemath_doc_html-none.time: No such file or directory
```
We suppress these (harmless) messages which show up when `/usr/bin/time` is not available.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


