### PR TITLE
remove a stray leftover in in sa2si_ZZmod()

### DIFF
--- a/src/sage/libs/singular/singular.pyx
+++ b/src/sage/libs/singular/singular.pyx
@@ -1545,7 +1545,6 @@ cdef inline number *sa2si_ZZmod(IntegerMod_abstract d, ring *_ring) noexcept:
         sage: P(3)
         3
     """
-    nr2mModul = d.parent().characteristic()
     if _ring != currRing: rChangeCurrRing(_ring)
 
     cdef number *nn


### PR DESCRIPTION
As reported on [sage-devel](https://groups.google.com/g/sage-devel/c/r7IpxjZTz5Y/m/d0I95VSnAAAJ) and reproduced, the following crashes Sage with probability about 1/3.
```python
x,y=var('x,y');n=10**6
while True: so=solve_mod(x*y-1,n)
#press CTL-C, crashes with probability about 1/3
``` 
The backtrace points to is a meaningless assignment in `sa2si_ZZmod()` 
```python
nr2mModul = d.parent().characteristic()  
```
where this happens.  `nr2mModul` is not used anywhere in the code. Removing it appears to make the crash to go away.




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.



