### PR TITLE
add links to standard errors in various places

### DIFF
--- a/src/sage/data_structures/bitset.pyx
+++ b/src/sage/data_structures/bitset.pyx
@@ -72,7 +72,7 @@ cdef class FrozenBitset:
 
       - string -- If a nonempty string, then the bitset is initialized by
         including an element if the index of the string is ``1``. If the
-        string is empty, then raise a ``ValueError``.
+        string is empty, then raise a :class:`ValueError`.
 
       - iterable -- If an iterable, then it is assumed to contain a list of
         nonnegative integers and those integers are placed in the set.
@@ -1798,8 +1798,10 @@ cdef class Bitset(FrozenBitset):
 
     cpdef remove(self, unsigned long n):
         """
-        Update the bitset by removing ``n``.  Raises ``KeyError`` if ``n`` is
-        not contained in the bitset.
+        Update the bitset by removing ``n``.
+
+        This raises a :class:`KeyError` if ``n`` is not contained
+        in the bitset.
 
         EXAMPLES::
 
@@ -1871,8 +1873,9 @@ cdef class Bitset(FrozenBitset):
 
     cpdef pop(self):
         """
-        Remove and return an arbitrary element from the set. Raises
-        ``KeyError`` if the set is empty.
+        Remove and return an arbitrary element from the set.
+
+        This raises a :class:`KeyError` if the set is empty.
 
         EXAMPLES::
 
@@ -1899,7 +1902,7 @@ cdef class Bitset(FrozenBitset):
 
     cpdef clear(self):
         """
-        Removes all elements from the bitset.
+        Remove all elements from the bitset.
 
         EXAMPLES::
 

--- a/src/sage/data_structures/bitset_base.pxd
+++ b/src/sage/data_structures/bitset_base.pxd
@@ -455,7 +455,9 @@ cdef inline bint bitset_not_in(fused_bitset_t bits, mp_bitcnt_t n) noexcept:
 
 cdef inline bint bitset_remove(fused_bitset_t bits, mp_bitcnt_t n) except -1:
     """
-    Remove n from bits.  Raise KeyError if n is not contained in bits.
+    Remove ``n`` from ``bits``.
+
+    This raises a :class:`KeyError` if ``n`` is not contained in ``bits``.
     """
     if not bitset_in(bits, n):
         raise KeyError(n)
@@ -558,8 +560,9 @@ cdef inline long bitset_first_in_complement(fused_bitset_t a) noexcept:
 
 cdef inline long bitset_pop(fused_bitset_t a) except -1:
     """
-    Remove and return an arbitrary element from the set. Raise
-    KeyError if the set is empty.
+    Remove and return an arbitrary element from the set.
+
+    This raises a :class:`KeyError` if the set is empty.
     """
     cdef long i = bitset_first(a)
     if i == -1:

--- a/src/sage/data_structures/mutable_poset.py
+++ b/src/sage/data_structures/mutable_poset.py
@@ -2299,21 +2299,21 @@ class MutablePoset(SageObject):
         - ``key`` -- the key of an object.
 
         - ``raise_key_error`` -- (default: ``True``) switch raising
-          ``KeyError`` on and off.
+          :class:`KeyError` on and off.
 
         OUTPUT:
 
         Nothing.
 
         If the element is not a member and ``raise_key_error`` is set
-        (default), raise a ``KeyError``.
+        (default), raise a :class:`KeyError`.
 
         .. NOTE::
 
             As with Python's ``set``, the methods :meth:`remove`
             and :meth:`discard` only differ in their behavior when an
             element is not contained in the poset: :meth:`remove`
-            raises a ``KeyError`` whereas :meth:`discard` does not
+            raises a :class:`KeyError` whereas :meth:`discard` does not
             raise any exception.
 
             This default behavior can be overridden with the
@@ -2479,21 +2479,21 @@ class MutablePoset(SageObject):
         - ``key`` -- the key of an object.
 
         - ``raise_key_error`` -- (default: ``False``) switch raising
-          ``KeyError`` on and off.
+          :class:`KeyError` on and off.
 
         OUTPUT:
 
         Nothing.
 
         If the element is not a member and ``raise_key_error`` is set
-        (not default), raise a ``KeyError``.
+        (not default), raise a :class:`KeyError`.
 
         .. NOTE::
 
             As with Python's ``set``, the methods :meth:`remove`
             and :meth:`discard` only differ in their behavior when an
             element is not contained in the poset: :meth:`remove`
-            raises a ``KeyError`` whereas :meth:`discard` does not
+            raises a :class:`KeyError` whereas :meth:`discard` does not
             raise any exception.
 
             This default behavior can be overridden with the

--- a/src/sage/databases/cremona.py
+++ b/src/sage/databases/cremona.py
@@ -953,13 +953,14 @@ class MiniCremonaDatabase(SQLDatabase):
 
     def elliptic_curve_from_ainvs(self, ainvs):
         """
-        Return the elliptic curve in the database of with minimal
-        ``ainvs``, if it exists, or raises a ``RuntimeError`` exception
-        otherwise.
+        Return the elliptic curve in the database of with minimal ``ainvs``
+        if it exists.
+
+        This raises a :class:`RuntimeError` exception otherwise.
 
         INPUT:
 
-        -  ``ainvs`` - list (5-tuple of int's); the minimal
+        -  ``ainvs`` -- list (5-tuple of int's); the minimal
            Weierstrass model for an elliptic curve
 
         OUTPUT: EllipticCurve

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -608,8 +608,8 @@ class DocTestController(SageObject):
 
         Float. The wall time on your computer that would be equivalent
         to one second on a modern computer. Unless you have kick-ass
-        hardware this should always be >= 1.0. Raises a
-        ``RuntimeError`` if there are no stored timings to use as
+        hardware this should always be >= 1.0. This raises a
+        :class:`RuntimeError` if there are no stored timings to use as
         benchmark.
 
         EXAMPLES::

--- a/src/sage/functions/piecewise.py
+++ b/src/sage/functions/piecewise.py
@@ -113,7 +113,7 @@ class PiecewiseFunction(BuiltinFunction):
 
         OUTPUT:
 
-        A piecewise-defined function. A ``ValueError`` will be raised
+        A piecewise-defined function. A :class:`ValueError` will be raised
         if the domains of the pieces are not pairwise disjoint.
 
         EXAMPLES::


### PR DESCRIPTION
just adding a few links to python standard errors in our doc

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
