### PR TITLE
Add the downward monotonic cone to the cone catalogue

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -4989,6 +4989,11 @@ REFERENCES:
 .. [Nie] Johan S. R. Nielsen, Codinglib,
          https://bitbucket.org/jsrn/codinglib/.
 
+.. [Niez1998] Marek Niezgoda.
+              Group majorization and Schur type inequalities.
+              Linear Algebra and its Applications, 268(1):9-30, 1998.
+              :doi:`10.1016/S0024-3795(97)89322-6`.
+
 .. [NW1978] \A. Nijenhuis and H. Wilf, Combinatorial Algorithms,
             Academic Press (1978).
 

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -194,9 +194,10 @@ def downward_monotonic(ambient_dim=None, lattice=None):
 
     OUTPUT:
 
-    A :class:`.ConvexRationalPolyhedralCone` living in ``lattice``
-    whose elements' entries are arranged in nonincreasing order. Each
-    generating ray has the integer ring as its base ring.
+    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone` living
+    in ``lattice`` whose elements' entries are arranged in
+    nonincreasing order. Each generating ray has the integer ring as
+    its base ring.
 
     A ``ValueError`` can be raised if the inputs are incompatible or
     insufficient. See the INPUT documentation for details.

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -187,9 +187,9 @@ def downward_monotonic(ambient_dim=None, lattice=None):
     rank of ``lattice``. If the ``lattice`` is omitted, then the
     default lattice of rank ``ambient_dim`` will be used.
 
-    A ``ValueError`` is raised if neither ``ambient_dim`` nor
-    ``lattice`` are specified. It is also a ``ValueError`` to specify
-    both ``ambient_dim`` and ``lattice`` unless the rank of
+    A :class:`ValueError` is raised if neither ``ambient_dim`` nor
+    ``lattice`` are specified. It is also a :class:`ValueError` to
+    specify both ``ambient_dim`` and ``lattice`` unless the rank of
     ``lattice`` is equal to ``ambient_dim``.
 
     OUTPUT:
@@ -199,8 +199,8 @@ def downward_monotonic(ambient_dim=None, lattice=None):
     nonincreasing order. Each generating ray has the integer ring as
     its base ring.
 
-    A ``ValueError`` can be raised if the inputs are incompatible or
-    insufficient. See the INPUT documentation for details.
+    A :class:`ValueError` can be raised if the inputs are incompatible
+    or insufficient. See the INPUT documentation for details.
 
     .. SEEALSO::
 
@@ -318,20 +318,20 @@ def nonnegative_orthant(ambient_dim=None, lattice=None):
     rank of ``lattice``. If the ``lattice`` is omitted, then the
     default lattice of rank ``ambient_dim`` will be used.
 
-    A ``ValueError`` is raised if neither ``ambient_dim`` nor
-    ``lattice`` are specified. It is also a ``ValueError`` to specify
-    both ``ambient_dim`` and ``lattice`` unless the rank of
+    A :class:`ValueError` is raised if neither ``ambient_dim`` nor
+    ``lattice`` are specified. It is also a :class:`ValueError` to
+    specify both ``ambient_dim`` and ``lattice`` unless the rank of
     ``lattice`` is equal to ``ambient_dim``.
 
     OUTPUT:
 
-    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone` living in ``lattice``
-    and having ``ambient_dim`` standard basis vectors as its
-    generators. Each generating ray has the integer ring as its
+    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone` living
+    in ``lattice`` and having ``ambient_dim`` standard basis vectors
+    as its generators. Each generating ray has the integer ring as its
     base ring.
 
-    A ``ValueError`` can be raised if the inputs are incompatible or
-    insufficient. See the INPUT documentation for details.
+    A :class:`ValueError` can be raised if the inputs are incompatible
+    or insufficient. See the INPUT documentation for details.
 
     REFERENCES:
 
@@ -426,22 +426,22 @@ def rearrangement(p, ambient_dim=None, lattice=None):
     rank of ``lattice``. If the ``lattice`` is omitted, then the
     default lattice of rank ``ambient_dim`` will be used.
 
-    A ``ValueError`` is raised if neither ``ambient_dim`` nor
-    ``lattice`` are specified. It is also a ``ValueError`` to specify
-    both ``ambient_dim`` and ``lattice`` unless the rank of
+    A :class:`ValueError` is raised if neither ``ambient_dim`` nor
+    ``lattice`` are specified. It is also a :class:`ValueError` to
+    specify both ``ambient_dim`` and ``lattice`` unless the rank of
     ``lattice`` is equal to ``ambient_dim``.
 
-    It is also a ``ValueError`` to specify a non-integer ``p``.
+    It is also a :class:`ValueError` to specify a non-integer ``p``.
 
     OUTPUT:
 
-    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone` representing the
-    rearrangement cone of order ``p`` living in ``lattice``, with
-    ambient dimension ``ambient_dim``. Each generating ray has the
-    integer ring as its base ring.
+    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone`
+    representing the rearrangement cone of order ``p`` living in
+    ``lattice``, with ambient dimension ``ambient_dim``. Each
+    generating ray has the integer ring as its base ring.
 
-    A ``ValueError`` can be raised if the inputs are incompatible or
-    insufficient. See the INPUT documentation for details.
+    A :class:`ValueError` can be raised if the inputs are incompatible
+    or insufficient. See the INPUT documentation for details.
 
     ALGORITHM:
 
@@ -647,19 +647,20 @@ def schur(ambient_dim=None, lattice=None):
     rank of ``lattice``. If the ``lattice`` is omitted, then the
     default lattice of rank ``ambient_dim`` will be used.
 
-    A ``ValueError`` is raised if neither ``ambient_dim`` nor
-    ``lattice`` are specified. It is also a ``ValueError`` to specify
-    both ``ambient_dim`` and ``lattice`` unless the rank of
+    A :class:`ValueError` is raised if neither ``ambient_dim`` nor
+    ``lattice`` are specified. It is also a :class:`ValueError` to
+    specify both ``ambient_dim`` and ``lattice`` unless the rank of
     ``lattice`` is equal to ``ambient_dim``.
 
     OUTPUT:
 
-    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone` representing the Schur
-    cone living in ``lattice``, with ambient dimension ``ambient_dim``.
-    Each generating ray has the integer ring as its base ring.
+    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone`
+    representing the Schur cone living in ``lattice``, with ambient
+    dimension ``ambient_dim``.  Each generating ray has the integer
+    ring as its base ring.
 
-    A ``ValueError`` can be raised if the inputs are incompatible or
-    insufficient. See the INPUT documentation for details.
+    A :class:`ValueError` can be raised if the inputs are incompatible
+    or insufficient. See the INPUT documentation for details.
 
     .. SEEALSO::
 
@@ -785,19 +786,19 @@ def trivial(ambient_dim=None, lattice=None):
     rank of ``lattice``. If the ``lattice`` is omitted, then the
     default lattice of rank ``ambient_dim`` will be used.
 
-    A ``ValueError`` is raised if neither ``ambient_dim`` nor
-    ``lattice`` are specified. It is also a ``ValueError`` to specify
-    both ``ambient_dim`` and ``lattice`` unless the rank of
+    A :class:`ValueError` is raised if neither ``ambient_dim`` nor
+    ``lattice`` are specified. It is also a :class:`ValueError` to
+    specify both ``ambient_dim`` and ``lattice`` unless the rank of
     ``lattice`` is equal to ``ambient_dim``.
 
     OUTPUT:
 
-    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone` representing the
-    trivial cone with no nonzero generators living in ``lattice``,
-    with ambient dimension ``ambient_dim``.
+    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone`
+    representing the trivial cone with no nonzero generators living in
+    ``lattice``, with ambient dimension ``ambient_dim``.
 
-    A ``ValueError`` can be raised if the inputs are incompatible or
-    insufficient. See the INPUT documentation for details.
+    A :class:`ValueError` can be raised if the inputs are incompatible
+    or insufficient. See the INPUT documentation for details.
 
     EXAMPLES:
 

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -283,7 +283,7 @@ def downward_monotonic(ambient_dim=None, lattice=None):
     from sage.matrix.constructor import matrix
     from sage.rings.integer_ring import ZZ
 
-    (ambient_dim, lattice) = _preprocess_args(ambient_dim, lattice)
+    ambient_dim, lattice = _preprocess_args(ambient_dim, lattice)
 
     # The generators for this cone are mentioned in Niezgoda's
     # Example 2.2 if you don't want to compute them yourself.
@@ -386,7 +386,7 @@ def nonnegative_orthant(ambient_dim=None, lattice=None):
     from sage.matrix.constructor import matrix
     from sage.rings.integer_ring import ZZ
 
-    (ambient_dim, lattice) = _preprocess_args(ambient_dim, lattice)
+    ambient_dim, lattice = _preprocess_args(ambient_dim, lattice)
 
     I = matrix.identity(ZZ, ambient_dim)
     return Cone(I.rows(), lattice)
@@ -612,7 +612,7 @@ def rearrangement(p, ambient_dim=None, lattice=None):
     from sage.matrix.constructor import matrix
     from sage.rings.integer_ring import ZZ
 
-    (ambient_dim, lattice) = _preprocess_args(ambient_dim, lattice)
+    ambient_dim, lattice = _preprocess_args(ambient_dim, lattice)
 
     if p < 1 or p > ambient_dim or p not in ZZ:
         raise ValueError("order p=%s should be an integer between 1 "
@@ -753,7 +753,7 @@ def schur(ambient_dim=None, lattice=None):
     from sage.matrix.constructor import matrix
     from sage.rings.integer_ring import ZZ
 
-    (ambient_dim, lattice) = _preprocess_args(ambient_dim, lattice)
+    ambient_dim, lattice = _preprocess_args(ambient_dim, lattice)
 
     def _f(i,j):
         if i == j:
@@ -841,6 +841,6 @@ def trivial(ambient_dim=None, lattice=None):
     """
     from sage.geometry.cone import Cone
 
-    (ambient_dim, lattice) = _preprocess_args(ambient_dim, lattice)
+    ambient_dim, lattice = _preprocess_args(ambient_dim, lattice)
 
     return Cone([], lattice)

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -219,12 +219,12 @@ def downward_monotonic(ambient_dim=None, lattice=None):
 
         sage: ambient_dim = ZZ.random_element(10)
         sage: K = cones.downward_monotonic(ambient_dim)
-        sage: all( x[i] >= x[i+1]
+        sage: all( x[i] >= x[i + 1]
         ....:      for i in range(ambient_dim - 1)
         ....:      for x in K.rays() )
         True
         sage: x = K.random_element()
-        sage: all( x[i] >= x[i+1] for i in range(ambient_dim - 1) )
+        sage: all( x[i] >= x[i + 1] for i in range(ambient_dim - 1) )
         True
 
     A nontrivial downward-monotonic cone is solid but not proper,
@@ -289,7 +289,7 @@ def downward_monotonic(ambient_dim=None, lattice=None):
     # Example 2.2 if you don't want to compute them yourself.
     G = matrix.identity(ZZ, ambient_dim)
     for i in range(1, ambient_dim):
-        G.add_multiple_of_row(i, i-1, 1)
+        G.add_multiple_of_row(i, i - 1, 1)
 
     if G.nrows() > 0:
         # Special case for when the ambient space is trivial.
@@ -723,7 +723,7 @@ def schur(ambient_dim=None, lattice=None):
         True
         sage: x = V.random_element()
         sage: y = V.random_element()
-        sage: majorized_by(x,y) == ((rearrange(y)-rearrange(x)) in S)
+        sage: majorized_by(x,y) == ((rearrange(y) - rearrange(x)) in S)
         True
 
     If a ``lattice`` was given, it is actually used::

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -5,7 +5,7 @@ Catalog of common polyhedral convex cones
 This module provides shortcut functions, grouped under the
 globally-available ``cones`` prefix, to create some common cones:
 
-- The downward-monotonic cone,
+- The downward-monotone cone,
 - The nonnegative orthant,
 - The rearrangement cone of order ``p``,
 - The Schur cone,
@@ -20,7 +20,7 @@ the ambient space.
 
 Here are some typical usage examples::
 
-    sage: cones.downward_monotonic(3).rays()
+    sage: cones.downward_monotone(3).rays()
     N( 1,  0,  0),
     N( 1,  1,  0),
     N( 1,  1,  1),
@@ -161,18 +161,18 @@ def _preprocess_args(ambient_dim, lattice):
     return (ambient_dim, lattice)
 
 
-def downward_monotonic(ambient_dim=None, lattice=None):
+def downward_monotone(ambient_dim=None, lattice=None):
     r"""
-    The downward-monotonic cone in ``ambient_dim`` dimensions, or
+    The downward-monotone cone in ``ambient_dim`` dimensions, or
     living in ``lattice``.
 
-    The elements of the downward-monotonic cone are vectors whose
+    The elements of the downward-monotone cone are vectors whose
     components are arranged in non-increasing order. Vectors whose
     entries are arranged in the reverse (non-decreasing) order are
     sometimes called isotone vectors, and are used in statistics
     for isotonic regression.
 
-    The downward-monotonic cone is the dual of the Schur cone. It
+    The downward-monotone cone is the dual of the Schur cone. It
     is also often referred to as the downward-monotone cone.
 
     INPUT:
@@ -214,11 +214,11 @@ def downward_monotonic(ambient_dim=None, lattice=None):
 
     EXAMPLES:
 
-    The entries of the elements of the downward-monotonic cone are in
+    The entries of the elements of the downward-monotone cone are in
     non-increasing order::
 
         sage: ambient_dim = ZZ.random_element(10)
-        sage: K = cones.downward_monotonic(ambient_dim)
+        sage: K = cones.downward_monotone(ambient_dim)
         sage: all( x[i] >= x[i + 1]
         ....:      for i in range(ambient_dim - 1)
         ....:      for x in K.rays() )
@@ -227,12 +227,12 @@ def downward_monotonic(ambient_dim=None, lattice=None):
         sage: all( x[i] >= x[i + 1] for i in range(ambient_dim - 1) )
         True
 
-    A nontrivial downward-monotonic cone is solid but not proper,
+    A nontrivial downward-monotone cone is solid but not proper,
     since it contains both the vector of all ones and its negation;
     that, however, is the only subspace it contains::
 
         sage: ambient_dim = ZZ.random_element(1,10)
-        sage: K = cones.downward_monotonic(ambient_dim)
+        sage: K = cones.downward_monotone(ambient_dim)
         sage: K.is_solid()
         True
         sage: K.is_proper()
@@ -240,40 +240,40 @@ def downward_monotonic(ambient_dim=None, lattice=None):
         sage: K.lineality()
         1
 
-    The dual of the downward-monotonic cone is the Schur cone
+    The dual of the downward-monotone cone is the Schur cone
     [GS2010]_ that induces the majorization preordering::
 
         sage: ambient_dim = ZZ.random_element(10)
-        sage: K = cones.downward_monotonic(ambient_dim).dual()
+        sage: K = cones.downward_monotone(ambient_dim).dual()
         sage: J = cones.schur(ambient_dim, K.lattice())
         sage: K.is_equivalent(J)
         True
 
     TESTS:
 
-    We can construct the trivial cone as the downward-monotonic cone
+    We can construct the trivial cone as the downward-monotone cone
     in a trivial vector space::
 
-        sage: cones.downward_monotonic(0)
+        sage: cones.downward_monotone(0)
         0-d cone in 0-d lattice N
 
     If a ``lattice`` was given, it is actually used::
 
         sage: L = ToricLattice(3, 'M')
-        sage: cones.downward_monotonic(lattice=L)
+        sage: cones.downward_monotone(lattice=L)
         3-d cone in 3-d lattice M
 
     Unless the rank of the lattice disagrees with ``ambient_dim``::
 
         sage: L = ToricLattice(1, 'M')
-        sage: cones.downward_monotonic(3, lattice=L)
+        sage: cones.downward_monotone(3, lattice=L)
         Traceback (most recent call last):
         ...
         ValueError: lattice rank=1 and ambient_dim=3 are incompatible
 
     We also get an error if no arguments are given::
 
-        sage: cones.downward_monotonic()
+        sage: cones.downward_monotone()
         Traceback (most recent call last):
         ...
         ValueError: either the ambient dimension or the lattice must
@@ -633,7 +633,7 @@ def schur(ambient_dim=None, lattice=None):
     preordering on the ambient space. If `\left\{e_{1}, e_{2}, \ldots,
     e_{n}\right\}` is the standard basis for the space, then its
     generators are `\left\{e_{i} - e_{i+1}\ |\ 1 \le i \le
-    n-1\right\}`. Its dual is the downward monotonic cone.
+    n-1\right\}`. Its dual is the downward monotone cone.
 
     INPUT:
 
@@ -664,7 +664,7 @@ def schur(ambient_dim=None, lattice=None):
 
     .. SEEALSO::
 
-        :func:`downward_monotonic`
+        :func:`downward_monotone`
 
     REFERENCES:
 
@@ -690,12 +690,12 @@ def schur(ambient_dim=None, lattice=None):
         sage: abs(actual - expected).n() < 1e-12
         True
 
-    The dual of the Schur cone is the downward-monotonic cone
+    The dual of the Schur cone is the downward-monotone cone
     [GS2010]_, whose elements' entries are in non-increasing order::
 
         sage: ambient_dim = ZZ.random_element(10)
         sage: K = cones.schur(ambient_dim).dual()
-        sage: J = cones.downward_monotonic(ambient_dim, K.lattice())
+        sage: J = cones.downward_monotone(ambient_dim, K.lattice())
         sage: K.is_equivalent(J)
         True
 

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -240,7 +240,7 @@ def downward_monotonic(ambient_dim=None, lattice=None):
         1
 
     The dual of the downward-monotonic cone is the Schur cone
-    [GS2010]_ that induces the majorization ordering::
+    [GS2010]_ that induces the majorization preordering::
 
         sage: ambient_dim = ZZ.random_element(10)
         sage: K = cones.downward_monotonic(ambient_dim).dual()
@@ -628,8 +628,8 @@ def schur(ambient_dim=None, lattice=None):
     The Schur cone in ``ambient_dim`` dimensions, or living
     in ``lattice``.
 
-    The Schur cone in `n` dimensions induces the majorization ordering
-    on the ambient space. If `\left\{e_{1}, e_{2}, \ldots,
+    The Schur cone in `n` dimensions induces the majorization
+    preordering on the ambient space. If `\left\{e_{1}, e_{2}, \ldots,
     e_{n}\right\}` is the standard basis for the space, then its
     generators are `\left\{e_{i} - e_{i+1}\ |\ 1 \le i \le
     n-1\right\}`. Its dual is the downward monotonic cone.
@@ -704,21 +704,25 @@ def schur(ambient_dim=None, lattice=None):
         sage: cones.schur(0).is_trivial()
         True
 
-    The Schur cone induces the majorization ordering, as in Iusem
-    and Seeger's [IS2005]_ Example 7.3::
+    The Schur cone induces the majorization preordering, as in Iusem
+    and Seeger's [IS2005]_ Example 7.3 or Niezgoda's [Niez1998]_
+    Example 2.2::
 
+        sage: ambient_dim = ZZ.random_element(10)
+        sage: V = VectorSpace(QQ, ambient_dim)
+        sage: rearrange = lambda z: V(sorted(z.list(),reverse=True))
         sage: def majorized_by(x,y):
+        ....:     x = rearrange(x)
+        ....:     y = rearrange(y)
         ....:     return (all(sum(x[0:i]) <= sum(y[0:i])
         ....:                 for i in range(x.degree()-1))
         ....:             and sum(x) == sum(y))
-        sage: ambient_dim = ZZ.random_element(10)
-        sage: V = VectorSpace(QQ, ambient_dim)
         sage: S = cones.schur(ambient_dim)
         sage: majorized_by(V.zero(), S.random_element())
         True
         sage: x = V.random_element()
         sage: y = V.random_element()
-        sage: majorized_by(x,y) == ( (y-x) in S )
+        sage: majorized_by(x,y) == ((rearrange(y)-rearrange(x)) in S)
         True
 
     If a ``lattice`` was given, it is actually used::


### PR DESCRIPTION
 This an an old PR that I never migrated from trac. We have a catalogue of convex cones accessible through `cones.foo()`, and this PR adds the downward monotonic cone to the catalogue. It will also close https://github.com/sagemath/sage/issues/30200.