### PR TITLE
Added some documentation in the developer's guide regarding deprecation

### DIFF
--- a/src/doc/en/developer/coding_in_cython.rst
+++ b/src/doc/en/developer/coding_in_cython.rst
@@ -191,3 +191,23 @@ original object. As an example, the following code snippet is the
 
 .. _python pickling documentation: http://docs.python.org/library/pickle.html#pickle-protocol
 
+Deprecation
+===========
+
+When making a **backward-incompatible** modification in Sage, the old code should
+keep working and display a message indicating how it should be updated/written
+in the future. We call this a *deprecation*.
+
+.. NOTE::
+
+    Deprecated code can only be removed one year after the first
+    stable release in which it appeared.
+
+Each deprecation warning contains the number of the GitHub PR that defines
+it. We use 666 in the example below.
+
+.. CODE-BLOCK:: cython
+
+      from sage.misc.superseded import deprecation_cython
+      deprecation_cython(666, "Do not use your computer to compute 1+1. Use your brain.")
+

--- a/src/doc/en/developer/coding_in_python.rst
+++ b/src/doc/en/developer/coding_in_python.rst
@@ -749,6 +749,13 @@ documentation for more information on its behaviour and optional arguments.
       from sage.misc.superseded import deprecation
       deprecation(666, "Do not use your computer to compute 1+1. Use your brain.")
 
+Note that these decorators only work for (pure) Python. There is no implementation
+of decorators in Cython. Hence, when in need to rename a keyword/function/method/...
+in a Cython (.pyx) file and/or to deprecate something, forget about decorators and
+just use :func:`~sage.misc.superseded.deprecation_cython` instead. The usage of
+:func:`~sage.misc.superseded.deprecation_cython` is exactly the same as
+:func:`~sage.misc.superseded.deprecation`.
+
 
 Experimental/unstable code
 --------------------------


### PR DESCRIPTION
In PR #37721, I attempted to deprecate the ``ring`` keyword argument in the ``matrix`` constructor
using ``@rename_keyword`` documented [here](https://doc.sagemath.org/html/en/developer/coding_in_python.html#deprecation). 
It did not work. The code compiled exactly as if the decorator wasn't there. 
I asked @mkoeppe why, he answered it "would be worth investigating and documenting". 
After some investigation, I came to the conclusion that developers cannot use ``@rename_keyword`` and 
other such decorators in Cython files. 
My solution was to use ``deprecation_cython`` (this was accepted and merged).
Since many other developers might end up having the exact same problem, I simply suggest redirecting them 
to ``deprecation_cython``, by adding what's necessary in the docs.
In this regard, I added a paragraph mentioning this in the Developer's guide, as all of this was **totally absent** from documentation.

This way other developers won't need to investigate and spend time debugging non-working code. :)

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


