### PR TITLE
Fix LaTeX output of FreeModuleTensor.display_comp

### DIFF
--- a/src/sage/tensor/modules/free_module_tensor.py
+++ b/src/sage/tensor/modules/free_module_tensor.py
@@ -826,11 +826,11 @@ class FreeModuleTensor(ModuleElementWithMutability):
         The LaTeX output for the notebook::
 
             sage: latex(t.display_comp())
-            \begin{array}{lcl} T_{\phantom{\, 1}\phantom{\, 2}\,1}^{\,1\,2\phantom{\, 1}}
-             & = & \frac{2}{3} \\ T_{\phantom{\, 1}\phantom{\, 2}\,2}^{\,1\,2\phantom{\, 2}}
-             & = & -\frac{1}{4} \\ T_{\phantom{\, 2}\phantom{\, 1}\,1}^{\,2\,1\phantom{\, 1}}
-             & = & \frac{2}{3} \\ T_{\phantom{\, 2}\phantom{\, 1}\,2}^{\,2\,1\phantom{\, 2}}
-             & = & -\frac{1}{4} \\ T_{\phantom{\, 2}\phantom{\, 2}\,2}^{\,2\,2\phantom{\, 2}}
+            \begin{array}{lcl} {T}_{\phantom{\, 1}\phantom{\, 2}\,1}^{\,1\,2\phantom{\, 1}}
+             & = & \frac{2}{3} \\ {T}_{\phantom{\, 1}\phantom{\, 2}\,2}^{\,1\,2\phantom{\, 2}}
+             & = & -\frac{1}{4} \\ {T}_{\phantom{\, 2}\phantom{\, 1}\,1}^{\,2\,1\phantom{\, 1}}
+             & = & \frac{2}{3} \\ {T}_{\phantom{\, 2}\phantom{\, 1}\,2}^{\,2\,1\phantom{\, 2}}
+             & = & -\frac{1}{4} \\ {T}_{\phantom{\, 2}\phantom{\, 2}\,2}^{\,2\,2\phantom{\, 2}}
              & = & 3 \end{array}
 
         By default, only the non-vanishing components are displayed; to see
@@ -888,7 +888,7 @@ class FreeModuleTensor(ModuleElementWithMutability):
                 symbol = 'X'
         if latex_symbol is None:
             if self._latex_name is not None:
-                latex_symbol = self._latex_name
+                latex_symbol = r'{' + self._latex_name + r'}'
             else:
                 latex_symbol = 'X'
         index_positions = self._tensor_type[0]*'u' + self._tensor_type[1]*'d'


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

None.

This PR fixes an issue of the method `display_comp` of class `FreeModuleTensor`, which arises when the LaTeX name of a tensor contains the symbol `^` or `_`. For instance, in Sage 10.4.beta3, we have:

```
sage: E.<x,y> = EuclideanSpace()
sage: g = E.metric()
sage: latex(g.inverse().display_comp())
\begin{array}{lcl} g^{-1}_{\phantom{\, x}\phantom{\, x}}^{ \, x \, x } & = & 1 \\ 
g^{-1}_{\phantom{\, y}\phantom{\, y}}^{ \, y \, y } & = & 1 \end{array}
```
This is incorrect LaTeX syntax: the symbol  `g` gets two exponent markers  (`^`). Consequently, in a Jupyter notebook in  `%display latex` mode, the command `g.inverse().display_comp()` will not generate any typeset output.

This is fixed here by making the LaTeX output of `display_comp` more robust: the LaTeX symbol of the tensor (`g^{-1}` in the above example) is now enclosed between two braces (e.g. `g^{-1}` is changed into `{g^{-1}}`) before adding indices to it. 