### PR TITLE
`FiniteRankFreeModuleMorphism.display`: Show matrix decorated with basis element names

### DIFF
--- a/src/sage/manifolds/differentiable/diff_map.py
+++ b/src/sage/manifolds/differentiable/diff_map.py
@@ -133,9 +133,9 @@ class DiffMap(ContinuousMap):
         sage: Phi.display()
         Phi: S^2 → R^3
         on U: (x, y) ↦ (X, Y, Z) = (2*x/(x^2 + y^2 + 1), 2*y/(x^2 + y^2 + 1),
-         (x^2 + y^2 - 1)/(x^2 + y^2 + 1))
+                                    (x^2 + y^2 - 1)/(x^2 + y^2 + 1))
         on V: (u, v) ↦ (X, Y, Z) = (2*u/(u^2 + v^2 + 1), 2*v/(u^2 + v^2 + 1),
-         -(u^2 + v^2 - 1)/(u^2 + v^2 + 1))
+                                    -(u^2 + v^2 - 1)/(u^2 + v^2 + 1))
 
     It is possible to create the map via the method
     :meth:`~sage.manifolds.differentiable.manifold.DifferentiableManifold.diff_map`
@@ -163,7 +163,7 @@ class DiffMap(ContinuousMap):
         sage: Phi1.display()
         Phi: S^2 → R^3
         on U: (x, y) ↦ (X, Y, Z) = (2*x/(x^2 + y^2 + 1), 2*y/(x^2 + y^2 + 1),
-         (x^2 + y^2 - 1)/(x^2 + y^2 + 1))
+                                    (x^2 + y^2 - 1)/(x^2 + y^2 + 1))
 
     The definition can be completed by means of the method
     :meth:`~sage.manifolds.continuous_map.ContinuousMap.add_expr`::
@@ -173,9 +173,9 @@ class DiffMap(ContinuousMap):
         sage: Phi1.display()
         Phi: S^2 → R^3
         on U: (x, y) ↦ (X, Y, Z) = (2*x/(x^2 + y^2 + 1), 2*y/(x^2 + y^2 + 1),
-         (x^2 + y^2 - 1)/(x^2 + y^2 + 1))
+                                    (x^2 + y^2 - 1)/(x^2 + y^2 + 1))
         on V: (u, v) ↦ (X, Y, Z) = (2*u/(u^2 + v^2 + 1), 2*v/(u^2 + v^2 + 1),
-         -(u^2 + v^2 - 1)/(u^2 + v^2 + 1))
+                                    -(u^2 + v^2 - 1)/(u^2 + v^2 + 1))
 
     At this stage, ``Phi1`` and ``Phi`` are fully equivalent::
 
@@ -226,6 +226,14 @@ class DiffMap(ContinuousMap):
         sage: Phi.differential(np).codomain().default_basis()
         Basis (∂/∂X,∂/∂Y,∂/∂Z) on the Tangent space at Point Phi(N) on the
          3-dimensional differentiable manifold R^3
+
+    A convenient way to display the matrix of the differential::
+
+        sage: Phi.differential(np).display()
+             ∂/∂u ∂/∂v
+        ∂/∂X⎛   2    0⎞
+        ∂/∂Y⎜   0    2⎟
+        ∂/∂Z⎝   0    0⎠
 
     Differentiable maps can be composed by means of the operator ``*``: let
     us introduce the map `\RR^3\rightarrow \RR^2` corresponding to

--- a/src/sage/tensor/modules/free_module_morphism.py
+++ b/src/sage/tensor/modules/free_module_morphism.py
@@ -1022,6 +1022,24 @@ class FiniteRankFreeModuleMorphism(Morphism):
     # End of Morphism methods
     #
 
+    def _modules_and_bases(self, basis1=None, basis2=None):
+        fmodule1 = self.domain()
+        fmodule2 = self.codomain()
+        if basis1 is None:
+            basis1 = fmodule1.default_basis()
+        elif basis1 not in fmodule1.bases():
+            raise TypeError(str(basis1) + " is not a basis on the " +
+                            str(fmodule1) + ".")
+        if basis2 is None:
+            if self.is_endomorphism():
+                basis2 = basis1
+            else:
+                basis2 = fmodule2.default_basis()
+        elif basis2 not in fmodule2.bases():
+            raise TypeError(str(basis2) + " is not a basis on the " +
+                            str(fmodule2) + ".")
+        return fmodule1, fmodule2, basis1, basis2
+
     def matrix(self, basis1=None, basis2=None):
         r"""
         Return the matrix of ``self`` w.r.t to a pair of bases.
@@ -1109,21 +1127,7 @@ class FiniteRankFreeModuleMorphism(Morphism):
 
         """
         from sage.matrix.constructor import matrix
-        fmodule1 = self.domain()
-        fmodule2 = self.codomain()
-        if basis1 is None:
-            basis1 = fmodule1.default_basis()
-        elif basis1 not in fmodule1.bases():
-            raise TypeError(str(basis1) + " is not a basis on the " +
-                            str(fmodule1) + ".")
-        if basis2 is None:
-            if self.is_endomorphism():
-                basis2 = basis1
-            else:
-                basis2 = fmodule2.default_basis()
-        elif basis2 not in fmodule2.bases():
-            raise TypeError(str(basis2) + " is not a basis on the " +
-                            str(fmodule2) + ".")
+        fmodule1, fmodule2, basis1, basis2 = self._modules_and_bases(basis1, basis2)
         if (basis1, basis2) not in self._matrices:
             if self._is_identity:
                 # The identity endomorphism


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

`FiniteRankFreeModuleMorphism` gets a new method `display`, which shows the matrix with rows and columns decorated with the names of the basis elements like `\bordermatrix`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


