### PR TITLE
`sage-logger`: Replace use of `/usr/bin/time` by bash keyword `time`

### DIFF
--- a/build/bin/sage-logger
+++ b/build/bin/sage-logger
@@ -63,21 +63,19 @@ fi
 
 timefile="$logdir/$logname.time"
 rm -f "$timefile"
-if /usr/bin/time -h -o /dev/null true 2>/dev/null; then
-    TIME="/usr/bin/time -h -o $timefile"
-else
-    TIME=""
-fi
+time_cmd() {
+    local max=$(($SECONDS+10))
+    exec 3>&1 4>&2
+    local out
+    TIME_OUTPUT=$((time 1>&3 2>&4 sh -c "$1") 2>&1)
+    local retstat=$?
+    [ "$SECONDS" -lt "$max" ] || echo "$TIME_OUTPUT" > "$timefile"
+    return $retstat
+}
 
 report_time ()
 {
-    time=$(echo $(cat $timefile 2>/dev/null))
-    case "$time" in
-        *m*real*|*h*real*|*[1-9][0-9].*real*|*[1-9][0-9],*real*)
-            # at least 10 seconds wall time
-            echo "$time"
-            ;;
-    esac
+    [ -r "$timefile" ] && echo $(< $timefile)
 }
 
 mkdir -p "$logdir"
@@ -94,8 +92,7 @@ if [ -n "$SAGE_SILENT_BUILD" -a ${use_prefix} = true ]; then
     # Silent build.
     # Similar to https://www.gnu.org/software/automake/manual/html_node/Automake-Silent-Rules.html#Automake-Silent-Rules
     echo "[$logname] installing. Log file: $logfile"
-    ( exec>> $logfile 2>&1 ; $TIME sh -c "$cmd"; status=$?;
-      [ -r $timefile ] && cat $timefile; exit $status )
+    ( exec>> $logfile 2>&1; time_cmd "$cmd"; status=$?; report_time; exit $status )
     status=$?
     if [[ $status != 0 ]]; then
         echo "  [$logname] error installing, exit status $status. End of log file:"
@@ -115,9 +112,7 @@ else
     # We trap SIGINT such that SIGINT interrupts the main process being
     # run, not the logging.
 
-    ( exec 2>&1;
-      $TIME sh -c "$cmd"; status=$?; report_time;
-      exit $status ) | \
+    ( exec 2>&1; time_cmd "$cmd"; status=$?; report_time; exit $status ) | \
         ( trap '' SIGINT; if [ -n "$GITHUB_ACTIONS" -a -n "$prefix" ]; then echo "::group::${logname}"; fi; tee -a "$logfile" | $SED; if [ -n "$GITHUB_ACTIONS" -a -n "$prefix" ]; then echo "::endgroup::"; fi )
 
     pipestatus=(${PIPESTATUS[*]})


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Follow-up after 
- https://github.com/sagemath/sage/pull/37391
- #37785

... to make the display of package build times available on Linux too.

Fixes https://github.com/sagemath/sage/pull/37785#issuecomment-2060170610, closes #37832. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
- Depends on #37785

