### PR TITLE
Lazy q-expansions for modular forms

### DIFF
--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -557,8 +557,15 @@ class ModularForm_abstract(ModuleElement):
             ...
             ValueError: prec (= -1) must be non-negative
         """
+        from sage.rings.infinity import PlusInfinity
         if prec is None:
             prec = self.parent().prec()
+        if prec is PlusInfinity():
+            from sage.rings.lazy_series_ring import LazyPowerSeriesRing
+            L = LazyPowerSeriesRing(self.base_ring(),
+                                    names=defaults.DEFAULT_VARIABLE)
+            an = lambda n: self._compute([n])[0]
+            return L(an)
         prec = Integer(prec)
         try:
             current_prec, f = self.__q_expansion


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR aims to implement q-expansion of modular forms as Lazy power series as suggested by @mantepse in PR #36269. In short we want to make the following code work:
```
sage: M = ModularForms(1, 12)
sage: f = M.0
sage: fqexp = f.q_expansion(oo)
sage: fqexp
q - 24*q^2 + 252*q^3 - 1472*q^4 + 4830*q^5 - 6048*q^6 + O(q^7)
sage: fqexp.parent()
Lazy Taylor Series Ring in q over Rational Field
sage: fqexp[1000]
-30328412970240000
```
I'm marking this as a draft right now, but the initial commit does implement the desired functionality. Note that I also plan to implement this for quasimodular forms and graded modular forms (elements of modular forms ring).

#### Quick facts about modular forms (if you don't know about them)

Modular forms are holomorphic functions $f:\mathcal{H} \rightarrow \mathbb{C}$, where $\mathcal{H}$ is the complex upper half plane, satisfying two conditions:
* an invariance condition under the action of $\mathrm{SL}_2(\mathbb{Z})$ on $\mathcal{H}$ (given by linear fractional transformations)
* it admits a $q$-expansion of the form: $f = \sum_{n \geq 0} a_n q^n$

The "weight" of a modular form is an integer related with the first condition. Lastly, an important fact about spaces of modular forms of fixed weight is that they are finite dimensional vector spaces (over $\mathbb{C}$). We can furthermore compute a basis such that its elements have $q$-expansion with algebraic (even rational in some case) coefficients.

In this PR, we want to implement the $q$-expansion of any modular forms $f$ as a Lazy power series.

CC: @mantepse @tscrim I'm tagging you because you both are involved with Lazy power series and I'm hoping that you bring valuable input (I'm not an expert of Lazy power series). 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


