### PR TITLE
Fix issue 37587 regarding the Link class plot method

### DIFF
--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -3607,36 +3607,55 @@ class Link(SageObject):
         # such that the resulting regions are in fact closed regions
         # with straight angles, and using the minimal number of bends.
         regions = sorted(self.regions(), key=len)
-        regions = regions[:-1]
         edges = list(set(flatten(pd_code)))
         edges.sort()
         MLP = MixedIntegerLinearProgram(maximization=False, solver=solver)
         # v will be the list of variables in the MLP problem. There will be
-        # two variables for each edge: number of right bendings and number of
-        # left bendings (at the end, since we are minimizing the total, only one
-        # of each will be nonzero
+        # two variables for each edge: number of bendings concerning the
+        # left-hand-side region (source, even index if positive oriented)
+        # and number of bendings concerning the right-hand-side region
+        # (sink, odd index if positive oriented). At the end, since
+        # we are minimizing the total, only one of each will be nonzero.
         v = MLP.new_variable(nonnegative=True, integer=True)
+
+        def flow_from_source(e):
+            r"""
+            Return the flow variable from the source.
+            """
+            if e > 0:
+                return v[2*edges.index(e)]
+            else:
+                return v[2*edges.index(-e)+1]
+
+        def flow_to_sink(e):
+            r"""
+            Return the flow variable to the sink.
+            """
+            return flow_from_source(-e)
+
         # one condition for each region
-        for i in range(len(regions)):
-            cond = 0
+        lr = len(regions)
+        for i in range(lr):
             r = regions[i]
-            for e in r:
-                if e > 0:
-                    cond = cond + v[2*edges.index(e)] - v[2*edges.index(e) + 1]
-                else:
-                    cond = cond - v[2*edges.index(-e)] + v[2*edges.index(-e) + 1]
-            MLP.add_constraint(cond == 4 - len(r))
+            if i <  lr - 1:
+                # capacity of interior region, sink if positive, source if negative
+                capacity = len(r) - 4
+            else:
+                # capacity of exterior region, only sink (added to fix :issue:`37587`).
+                capacity = len(r) + 4
+            flow = sum(flow_to_sink(e) - flow_from_source(e) for e in r)
+            MLP.add_constraint(flow == capacity)  # exterior region only sink
+
         MLP.set_objective(MLP.sum(v.values()))
         MLP.solve()
         # we store the result in a vector s packing right bends as negative left ones
         values = MLP.get_values(v, convert=ZZ, tolerance=1e-3)
-        s = [values[2*i] - values[2*i + 1]
-             for i in range(len(edges))]
+        s = [values[2*i] - values[2*i + 1] for i in range(len(edges))]
         # segments represents the different parts of the previous edges after bending
         segments = {e: [(e,i) for i in range(abs(s[edges.index(e)])+1)] for e in edges}
         pieces = {tuple(i): [i] for j in segments.values() for i in j}
         nregions = []
-        for r in regions:
+        for r in regions[:-1]:  # interior regions
             nregion = []
             for e in r:
                 if e > 0:
@@ -3689,16 +3708,16 @@ class Link(SageObject):
                 pieces[tuple(badregion[b][0])].append(N2)
 
             if a < b:
-                r1 = badregion[:a] + [[badregion[a][0],0], [N1,1]] + badregion[b:]
-                r2 = badregion[a+1:b] + [[N2,1],[N1,1]]
+                r1 = badregion[:a] + [[badregion[a][0], 0], [N1, 1]] + badregion[b:]
+                r2 = badregion[a + 1:b] + [[N2, 1],[N1, 1]]
             else:
-                r1 = badregion[b:a] + [[badregion[a][0],0], [N1,1]]
-                r2 = badregion[:b] + [[N2,1],[N1,1]] + badregion[a+1:]
+                r1 = badregion[b:a] + [[badregion[a][0], 0], [N1, 1]]
+                r2 = badregion[:b] + [[N2, 1],[N1, 1]] + badregion[a + 1:]
 
             if otherregion:
                 c = [x for x in otherregion if badregion[b][0] == x[0]]
                 c = otherregion.index(c[0])
-                otherregion.insert(c+1, [N2,otherregion[c][1]])
+                otherregion.insert(c + 1, [N2,otherregion[c][1]])
                 otherregion[c][1] = 0
             nregions.remove(badregion)
             nregions.append(r1)

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -3611,11 +3611,13 @@ class Link(SageObject):
         edges.sort()
         MLP = MixedIntegerLinearProgram(maximization=False, solver=solver)
         # v will be the list of variables in the MLP problem. There will be
-        # two variables for each edge: number of bendings concerning the
-        # left-hand-side region (source, even index if positive oriented)
-        # and number of bendings concerning the right-hand-side region
-        # (sink, odd index if positive oriented). At the end, since
-        # we are minimizing the total, only one of each will be nonzero.
+        # two variables for each edge counting the number of bendings needed.
+        # The one with even index corresponds to the flow of this number from
+        # the left-hand-side region to the right-hand-side region if the edge
+        # is positive oriented. The one with odd index corresponds to the
+        # flow in the opposite direction. For a negative oriented edge the
+        # same is true but with exchanged directions. At the end, since we
+        # are minimizing the total, only one of each will be nonzero.
         v = MLP.new_variable(nonnegative=True, integer=True)
 
         def flow_from_source(e):

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -3637,7 +3637,7 @@ class Link(SageObject):
         lr = len(regions)
         for i in range(lr):
             r = regions[i]
-            if i <  lr - 1:
+            if i < lr - 1:
                 # capacity of interior region, sink if positive, source if negative
                 capacity = len(r) - 4
             else:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

As suspected in https://github.com/sagemath/sage/issues/37587#issuecomment-2051141073 the issue can be fixed by adding the contraint for the exterior region.

In the differences of this branch just the lines below belong to the corresponding correction of the algorithm:


```
index 9d988d877c..33d0cae051 100644
--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -3607,36 +3607,55 @@ class Link(SageObject):
         # such that the resulting regions are in fact closed regions
         # with straight angles, and using the minimal number of bends.
         regions = sorted(self.regions(), key=len)
-        regions = regions[:-1]
         edges = list(set(flatten(pd_code)))
...
+            else:
+                # capacity of exterior region, only sink
+                capacity = len(r) + 4
...
         nregions = []
-        for r in regions:
+        for r in regions[:-1]:  # interior regions
             nregion = []
```

All other changes are intended to improve the readability of the code. To this end I change and introduce new variable names to make the origin of the ideas coming from the class [OrthogonalLinkDiagram](https://github.com/3-manifolds/Spherogram/blob/3062478dd69a52a16e55b967dd46dfe940af9ea7/spherogram_src/links/orthogonal.py#L118) of [Spherogram](https://github.com/3-manifolds/Spherogram) more explicit. Furthermore I make some codestyle fixes and change the sign of the capacity such that the sink appears to be positive and thus according to the usage in Spherogram and the literature cited there.

With this branch the knot reported in the issue is plotted like this:

```
sage: kn = Knots().from_dowker_code([30, 18, 20, 24, 22, 26, 28, 32, 2, 4, 6, 8, 12, 10, 16, 14])
sage: arcs = sorted(kn.arcs())
sage: cols = {tuple(arcs[i]): i for i in range(len(arcs))}
sage: kn.plot(color=cols)
```

### New plot

![kn_new_cols](https://github.com/sagemath/sage/assets/47305845/328ff242-2a99-48b1-b55a-657f13db0fae)

To make comparison with other results more convenient I used different colours for the arcs. The corresponding result for `PPL` is this:

```
sage: kn.plot(color=cols, solver='PPL')
```

### New plot with `PPL`

![kn_new_cols_ppl](https://github.com/sagemath/sage/assets/47305845/359b2404-91a4-44bc-a949-5cc7dec9ba0f)


Without this branch the `PPL` version with colours has been this:

### Old plot with `PPL`

![kn_cols_ppl](https://github.com/sagemath/sage/assets/47305845/5bc9809c-9aa5-4cb4-b700-7c833e5e598a)

The coloured wrong result has been this:

### Old plot

![kn_cols](https://github.com/sagemath/sage/assets/47305845/513651b5-8aa7-4394-b5e1-0d6715e7fbe1)


Note, that this branch also changes other plot results in the documentation. For example:

Previously:

### Old documentation

![grafik](https://github.com/sagemath/sage/assets/47305845/41ef8ad9-cbbd-42ed-a898-3cd565bab23e)


With this branch:

### New documentation

![grafik](https://github.com/sagemath/sage/assets/47305845/4bcff688-10e6-4a79-9823-12205d58ac75)




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


