### PR TITLE
Work around inconsistent iteration in `multi_polynomial_sequence.py`

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -1752,13 +1752,13 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
             else:
                 raise ValueError("order argument can only accept list or tuple")
 
-        PolyRing = self.ring()
-        BaseRing = PolyRing.base_ring()
+        R = self.ring()
+        K = R.base_ring()
         y = dict(zip(v, range(len(v))))  # construct dictionary for fast lookups
-        A = Matrix(BaseRing, len(self), len(v), sparse=sparse)
+        A = Matrix(K, len(self), len(v), sparse=sparse)
 
-        if isinstance(PolyRing, BooleanPolynomialRing_base):
-            one = BaseRing.one()
+        if isinstance(R, BooleanPolynomialRing_base):
+            one = K.one()
             for x, poly in enumerate(self):
                 for m in poly:
                     try:

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -1741,6 +1741,8 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
         """
         from sage.modules.free_module_element import vector
         from sage.matrix.constructor import Matrix
+        from sage.rings.polynomial.multi_polynomial_ring_base import \
+            BooleanPolynomialRing_base
 
         if order is None:
             v = sorted(self.monomials(), reverse=True)
@@ -1750,18 +1752,27 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
             else:
                 raise ValueError("order argument can only accept list or tuple")
 
-        R = self.ring().base_ring()
-        one = R.one()
+        PolyRing = self.ring()
+        BaseRing = PolyRing.base_ring()
         y = dict(zip(v, range(len(v))))  # construct dictionary for fast lookups
-        A = Matrix(R, len(self), len(v), sparse=sparse)
-        for x, poly in enumerate(self):
-            for m in poly:
-                if isinstance(m, tuple):
-                    m = m[1]
-                try:
-                    A[x, y[m]] = one
-                except KeyError:
-                    raise ValueError("order argument does not contain all monomials")
+        A = Matrix(BaseRing, len(self), len(v), sparse=sparse)
+
+        if isinstance(PolyRing, BooleanPolynomialRing_base):
+            one = BaseRing.one()
+            for x, poly in enumerate(self):
+                for m in poly:
+                    try:
+                        A[x, y[m]] = one
+                    except KeyError:
+                        raise ValueError("order argument does not contain all monomials")
+        else:
+            for x, poly in enumerate(self):
+                for c, m in poly:
+                    try:
+                        A[x, y[m]] = c
+                    except KeyError:
+                        raise ValueError("order argument does not contain all monomials")
+
         return A, vector(v)
 
 

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -1725,6 +1725,19 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
             (x*y, y, z, 1)
             sage: A*v
             (x*y + y + 1, z + 1)
+
+        TESTS:
+
+        Check that :issue:`37837` has been fixed::
+
+            sage: R.<a,b,c> = PolynomialRing(GF(2), ['a', 'b', 'c'])
+            sage: A, v = Sequence([a+b+c]).coefficients_monomials()
+            sage: A
+            [1 1 1]
+            sage: v
+            (a, b, c)
+            sage: A*v
+            (a + b + c)
         """
         from sage.modules.free_module_element import vector
         from sage.matrix.constructor import Matrix
@@ -1743,6 +1756,8 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
         A = Matrix(R, len(self), len(v), sparse=sparse)
         for x, poly in enumerate(self):
             for m in poly:
+                if isinstance(m, tuple):
+                    m = m[1]
                 try:
                     A[x, y[m]] = one
                 except KeyError:


### PR DESCRIPTION
When iterating over a `pbori.BooleanPolynomial`, the iterator generates just the monomials, whereas iterating over a `MPolynomial_libsingular` defined over `GF(2)` yields a tuple of the monomial together with its coefficient $1$. This causes issues in the method `.coefficients_monomials()` of `PolynomialSequence_gf2`; we fix said issue by checking ~~whether the iteration yields tuples, in which case we simply replace the tuple by its second element (the actual monomial) in each iteration.~~ which type of polynomial ring we are working in before iterating.

Fixes #37837 (but there might be a more elegant solution).