### PR TITLE
Fix segfault for Weil polynomials

### DIFF
--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
@@ -540,7 +540,10 @@ class WeilPolynomials():
         sage: list(WeilPolynomials(10, 2, lead=(1,-3,5,-5,5,-5)))
         [x^10 - 3*x^9 + 5*x^8 - 5*x^7 + 5*x^6 - 5*x^5 + 10*x^4 - 20*x^3 + 40*x^2 - 48*x + 32]
 
+    Test that :issue:`37860` is resolved::
 
+        sage: list(WeilPolynomials(0, 1, sign=-1))
+        []
     """
     def __init__(self, d, q, sign=1, lead=1, node_limit=None, parallel=False, squarefree=False, polring=None):
         r"""

--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
@@ -268,6 +268,9 @@ class WeilPolynomials_iter():
             raise ValueError("Invalid sign")
         if not q.is_integer() or q <= 0:
             raise ValueError("q must be a positive integer")
+        if d == 0 and sign == -1: # No results
+            self.process = None
+            return
         if d % 2 == 0:
             if sign == 1:
                 d2 = d//2

--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
@@ -268,9 +268,6 @@ class WeilPolynomials_iter():
             raise ValueError("Invalid sign")
         if not q.is_integer() or q <= 0:
             raise ValueError("q must be a positive integer")
-        if d == 0 and sign == -1: # No results
-            self.process = None
-            return
         if d % 2 == 0:
             if sign == 1:
                 d2 = d//2
@@ -327,7 +324,7 @@ class WeilPolynomials_iter():
         if node_limit is None:
             node_limit = -1
         force_squarefree = Integer(squarefree)
-        self.process = dfs_manager(d2, q, coefflist, modlist, coeffsign,
+        self.process = None if d2<0 else dfs_manager(d2, q, coefflist, modlist, coeffsign,
                                    num_cofactor, node_limit, parallel,
                                    force_squarefree)
         self.q = q
@@ -542,6 +539,8 @@ class WeilPolynomials():
 
     Test that :issue:`37860` is resolved::
 
+        sage: list(WeilPolynomials(-1, 1))
+        []
         sage: list(WeilPolynomials(0, 1, sign=-1))
         []
     """


### PR DESCRIPTION
Fix segfault for Weil polynomials

Eliminate a segfault that occurs when asking for Weil polynomials of degree 0 and sign -1 (which do not exist, so the iterator should return empty). This fixes #37860.
