### PR TITLE
`sage.numerical.interactive_simplex_method`: improve support for base fields other than `QQ` and `RDF`

### DIFF
--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -650,7 +650,7 @@ class InteractiveLPProblem(SageObject):
         b = vector(b)
         c = vector(c)
         if base_ring is None:
-            base_ring = vector(A.list() + list(b) + list(c)).base_ring()
+            base_ring = vector(A.list() + list(b) + list(c) + [objective_constant_term]).base_ring()
         base_ring = base_ring.fraction_field()
         A = A.change_ring(base_ring)
         A.set_immutable()

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -304,11 +304,12 @@ def _latex_product(coefficients, variables,
     """
     entries = []
     for c, v in zip(coefficients, variables):
-        if c == 0:
+        t = latex(c)
+        if t == '0':
             entries.extend(["", ""])
             continue
         sign = "+"
-        if latex(c).strip().startswith("-"):
+        if t.strip().startswith("-"):
             sign = "-"
             c = - c
         if c == 1:

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -1145,9 +1145,13 @@ class InteractiveLPProblem(SageObject):
             objective_constant_term=self._constant_term)
 
     @cached_method
-    def feasible_set(self):
+    def feasible_set(self, backend=None):
         r"""
         Return the feasible set of ``self``.
+
+        INPUT:
+
+        - (optional) a backend for :mod:`Polyhedron <sage.geometry.polyhedron.constructor>`
 
         OUTPUT: a :mod:`Polyhedron <sage.geometry.polyhedron.constructor>`
 
@@ -1160,7 +1164,18 @@ class InteractiveLPProblem(SageObject):
             sage: P.feasible_set()
             A 2-dimensional polyhedron in QQ^2
             defined as the convex hull of 4 vertices
-        """
+            sage: P.feasible_set(backend='cdd')
+            A 2-dimensional polyhedron in QQ^2
+            defined as the convex hull of 4 vertices
+            sage: from sage.rings.real_double import RDF
+            sage: A = ([RDF(1),RDF(1)], [RDF(3), RDF(1)])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblem(A, b, c, ["C", "B"], variable_type=">=")
+            sage: P.feasible_set()
+            A 2-dimensional polyhedron in RDF^2
+            defined as the convex hull of 4 vertices
+            """
         ieqs = []
         eqns = []
         for a, r, b in zip(self.A().rows(), self._constraint_types, self.b()):
@@ -1175,6 +1190,8 @@ class InteractiveLPProblem(SageObject):
                 ieqs.append([0] + list(-n))
             elif r == ">=":
                 ieqs.append([0] + list(n))
+        if backend is not None:
+            return Polyhedron(ieqs=ieqs, eqns=eqns, backend=backend)
         return Polyhedron(ieqs=ieqs, eqns=eqns)
 
     def is_bounded(self):
@@ -2578,6 +2595,31 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             Entering: $x_{2}$. Leaving: $x_{3}$.
             ...
             The optimal value: $6250$. An optimal solution: $\left(250,\,750\right)$.
+
+        TESTS::
+
+            sage: from sage.rings.real_double import RDF
+            sage: A = ([RDF(1), RDF(1)], [RDF(3), RDF(1)], [RDF(-1), RDF(-1)])
+            sage: b = (RDF(1000), RDF(1500), RDF(-400))
+            sage: c = (RDF(10), RDF(5))
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: P.run_simplex_method()
+            \begin{equation*}
+            ...
+            \end{equation*}
+            The initial dictionary is infeasible, solving auxiliary problem.
+            ...
+            Entering: $x_{0}$. Leaving: $x_{5}$.
+            ...
+            Entering: $x_{1}$. Leaving: $x_{0}$.
+            ...
+            Back to the original problem.
+            ...
+            Entering: $x_{5}$. Leaving: $x_{4}$.
+            ...
+            Entering: $x_{2}$. Leaving: $x_{3}$.
+            ...
+            The optimal value: $6250.0$. An optimal solution: $\left(249.99999999999997,\,750.0\right)$.
         """
         output = []
         d = self.initial_dictionary()

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -1177,13 +1177,7 @@ class InteractiveLPProblem(SageObject):
                 ieqs.append([0] + list(-n))
             elif r == ">=":
                 ieqs.append([0] + list(n))
-        if self.base_ring() is QQ:
-            R = QQ
-        else:
-            R = RDF
-            ieqs = [[R(_) for _ in ieq] for ieq in ieqs]
-            eqns = [[R(_) for _ in eqn] for eqn in eqns]
-        return Polyhedron(ieqs=ieqs, eqns=eqns, base_ring=R)
+        return Polyhedron(ieqs=ieqs, eqns=eqns)
 
     def is_bounded(self):
         r"""

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -201,7 +201,6 @@ from sage.rings.polynomial.polynomial_ring import polygen
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.polynomial_element import Polynomial
 from sage.rings.rational_field import QQ
-from sage.rings.real_double import RDF
 from sage.rings.integer_ring import ZZ
 from sage.structure.all import SageObject
 
@@ -300,7 +299,7 @@ def _latex_product(coefficients, variables,
         sage: var("x, y")                                                               # needs sage.symbolic
         (x, y)
         sage: print(_latex_product([-1, 3], [x, y]))                                    # needs sage.symbolic
-        - \mspace{-6mu}&\mspace{-6mu} x \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} 3 y
+        - \mspace{-6mu}&\mspace{-6mu} 1 x \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} 3 y
     """
     entries = []
     for c, v in zip(coefficients, variables):
@@ -3910,8 +3909,8 @@ class LPDictionary(LPAbstractDictionary):
             \renewcommand{\arraystretch}{1.5} %notruncate
             \begin{array}{|rcrcrcr|}
             \hline
-            x_{3} \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 1000 \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} x_{1} \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} x_{2}\\
-            x_{4} \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 1500 \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 3 x_{1} \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} x_{2}\\
+            x_{3} \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 1000 \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 1 x_{1} \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 1 x_{2}\\
+            x_{4} \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 1500 \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 3 x_{1} \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 1 x_{2}\\
             \hline
             z \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 0 \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} 10 x_{1} \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} 5 x_{2}\\
             \hline

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -299,7 +299,11 @@ def _latex_product(coefficients, variables,
         sage: var("x, y")                                                               # needs sage.symbolic
         (x, y)
         sage: print(_latex_product([-1, 3], [x, y]))                                    # needs sage.symbolic
-        - \mspace{-6mu}&\mspace{-6mu} 1 x \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} 3 y
+        - \mspace{-6mu}&\mspace{-6mu} x \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} 3 y
+        sage: var("x, y, z")
+        (x, y, z)
+        sage: print(_latex_product([-pi, log(2), pi**0], [x, y, z]))
+        - \mspace{-6mu}&\mspace{-6mu} \pi x \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} \log\left(2\right) y \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} z
     """
     entries = []
     for c, v in zip(coefficients, variables):
@@ -311,7 +315,7 @@ def _latex_product(coefficients, variables,
         if t.strip().startswith("-"):
             sign = "-"
             c = - c
-        if t.strip() == '1':
+        if t.strip() == '1' or t.strip() == '-1':
             t = latex(v)
         else:
             t = latex(c)
@@ -668,7 +672,7 @@ class InteractiveLPProblem(SageObject):
         R = PolynomialRing(base_ring, x, order='neglex')
         x = vector(R, R.gens()) # All variables as a vector
         self._Abcx = A, b, c, x
-        self._constant_term = objective_constant_term
+        self._constant_term = base_ring(objective_constant_term)
 
         if constraint_type in ["<=", ">=", "=="]:
             constraint_type = (constraint_type, ) * m
@@ -2620,6 +2624,28 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             Entering: $x_{2}$. Leaving: $x_{3}$.
             ...
             The optimal value: $6250.0$. An optimal solution: $\left(249.99999999999997,\,750.0\right)$.
+            sage: A = Matrix(([1, 1], [3, 1], [-1, -1])) * pi
+            sage: b = vector((1000, 1500, -400)) * pi
+            sage: c = vector((10, 5)) * pi
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: P.run_simplex_method()
+            \begin{equation*}
+            ...
+            \end{equation*}
+            The initial dictionary is infeasible, solving auxiliary problem.
+            ...
+            Entering: $x_{0}$. Leaving: $x_{5}$.
+            ...
+            Entering: $x_{1}$. Leaving: $x_{0}$.
+            ...
+            Back to the original problem.
+            ...
+            Entering: $x_{5}$. Leaving: $x_{4}$.
+            ...
+            Entering: $x_{2}$. Leaving: $x_{3}$.
+            ...
+            The optimal value: $6250 \, \pi$. An optimal solution: $\left(250,\,750\right)$.
+
         """
         output = []
         d = self.initial_dictionary()
@@ -3951,8 +3977,8 @@ class LPDictionary(LPAbstractDictionary):
             \renewcommand{\arraystretch}{1.5} %notruncate
             \begin{array}{|rcrcrcr|}
             \hline
-            x_{3} \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 1000 \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 1 x_{1} \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 1 x_{2}\\
-            x_{4} \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 1500 \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 3 x_{1} \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 1 x_{2}\\
+            x_{3} \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 1000 \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} x_{1} \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} x_{2}\\
+            x_{4} \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 1500 \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} 3 x_{1} \mspace{-6mu}&\mspace{-6mu} - \mspace{-6mu}&\mspace{-6mu} x_{2}\\
             \hline
             z \mspace{-6mu}&\mspace{-6mu} = \mspace{-6mu}&\mspace{-6mu} 0 \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} 10 x_{1} \mspace{-6mu}&\mspace{-6mu} + \mspace{-6mu}&\mspace{-6mu} 5 x_{2}\\
             \hline

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -312,7 +312,7 @@ def _latex_product(coefficients, variables,
         if t.strip().startswith("-"):
             sign = "-"
             c = - c
-        if c == 1:
+        if t.strip() == '1':
             t = latex(v)
         else:
             t = latex(c)

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -316,9 +316,7 @@ def _latex_product(coefficients, variables,
         else:
             t = latex(c)
             if '+' in t or '-' in t:
-                from sage.symbolic.ring import SR
-                if SR(c).operator() in [operator.add, operator.sub]:
-                    t = r"\left( " + t + r" \right)"
+                t = r"\left( " + t + r" \right)"
             t += " " + latex(v)
         entries.extend([sign, t])
     if drop_plus:   # Don't start with +

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -1165,20 +1165,35 @@ class InteractiveLPProblem(SageObject):
             sage: b = (1000, 1500)
             sage: c = (10, 5)
             sage: P = InteractiveLPProblem(A, b, c, ["C", "B"], variable_type='>=')
-            sage: P.feasible_set()
+            sage: F = P.feasible_set(); F
             A 2-dimensional polyhedron in QQ^2
             defined as the convex hull of 4 vertices
-            sage: P.feasible_set(backend='cdd')
+            sage: F.backend()
+            'ppl'
+            sage: F_cdd = P.feasible_set(backend='cdd'); F_cdd
             A 2-dimensional polyhedron in QQ^2
             defined as the convex hull of 4 vertices
+            sage: F_cdd.backend()
+            'cdd'
+
+        An algebraic polyhedron::
+
+            sage: A = ([1, sqrt(2)], [sqrt(3), 1])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblem(A, b, c, ["C", "B"], variable_type='>=')
+            sage: F = P.feasible_set(backend='number_field'); F
+            A 2-dimensional polyhedron in (Symbolic Ring)^2
+            defined as the convex hull of 4 vertices
+            sage: F.backend()
+            'number_field'
 
         Using ``RDF``::
 
-            sage: from sage.rings.real_double import RDF
             sage: A = ([RDF(1), RDF(1)], [RDF(3), RDF(1)])
             sage: b = (1000, 1500)
             sage: c = (10, 5)
-            sage: P = InteractiveLPProblem(A, b, c, ["C", "B"], variable_type=">=")
+            sage: P = InteractiveLPProblem(A, b, c, ["C", "B"], variable_type='>=')
             sage: P.feasible_set()
             A 2-dimensional polyhedron in RDF^2
             defined as the convex hull of 4 vertices

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -1155,7 +1155,7 @@ class InteractiveLPProblem(SageObject):
 
         INPUT:
 
-        - (optional) a backend for :mod:`Polyhedron <sage.geometry.polyhedron.constructor>`
+        - ``backend`` -- (optional) a backend for :mod:`Polyhedron <sage.geometry.polyhedron.constructor>`
 
         OUTPUT: a :mod:`Polyhedron <sage.geometry.polyhedron.constructor>`
 
@@ -1171,15 +1171,18 @@ class InteractiveLPProblem(SageObject):
             sage: P.feasible_set(backend='cdd')
             A 2-dimensional polyhedron in QQ^2
             defined as the convex hull of 4 vertices
+
+        Using ``RDF``::
+
             sage: from sage.rings.real_double import RDF
-            sage: A = ([RDF(1),RDF(1)], [RDF(3), RDF(1)])
+            sage: A = ([RDF(1), RDF(1)], [RDF(3), RDF(1)])
             sage: b = (1000, 1500)
             sage: c = (10, 5)
             sage: P = InteractiveLPProblem(A, b, c, ["C", "B"], variable_type=">=")
             sage: P.feasible_set()
             A 2-dimensional polyhedron in RDF^2
             defined as the convex hull of 4 vertices
-            """
+        """
         ieqs = []
         eqns = []
         for a, r, b in zip(self.A().rows(), self._constraint_types, self.b()):
@@ -2624,6 +2627,9 @@ class InteractiveLPProblemStandardForm(InteractiveLPProblem):
             Entering: $x_{2}$. Leaving: $x_{3}$.
             ...
             The optimal value: $6250.0$. An optimal solution: $\left(249.99999999999997,\,750.0\right)$.
+
+        Using constants in the symbolic ring::
+
             sage: A = Matrix(([1, 1], [3, 1], [-1, -1])) * pi
             sage: b = vector((1000, 1500, -400)) * pi
             sage: c = vector((10, 5)) * pi


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

We remove the ad-hoc conversion of data to `RDF` in `InteractiveLPProblem.feasible_set`.  This is outdated and problematic:
- the polyhedra code over `RDF` is not robust at all 
- Sage has good support for algebraic polyhedra, in particular via normaliz.

We also make the printing code in `_latex_product` more robust: 
- it no longer relies on `SR` to decide whether a coefficient needs to be wrapped in parens; instead, we use the same simple test that `sage.misc.repr.coeff_repr` already uses
- recognizing trivial coefficients (0, 1) is switched to comparing text instead of comparing elements - in order to support fields such as `SR` where `==` is magic

Rebased version of:
- #31312

Author: @mkoeppe, @ComboProblem

Resolves #31312.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


