### PR TITLE
LPDictionary: Make it safe to copy dictionaries

### DIFF
--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -3910,7 +3910,16 @@ class LPDictionary(LPAbstractDictionary):
         c = copy(c)
         B = vector(basic_variables)
         N = vector(nonbasic_variables)
+        # Sadly, vector does not guarantee that the result is freshly allocated
+        # if the input was already a vector: #29101
+        if B is basic_variables:
+            B = copy(B)
+        if N is nonbasic_variables:
+            N = copy(N)
         self._AbcvBNz = [A, b, c, objective_value, B, N, polygen(ZZ, objective_name)]
+
+    def __copy__(self):
+        return type(self)(*self._AbcvBNz)
 
     @staticmethod
     def random_element(m, n, bound=5, special_probability=0.2):

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -3920,7 +3920,10 @@ class LPDictionary(LPAbstractDictionary):
 
     def __copy__(self):
         r"""
-        TESTS::
+        TESTS:
+
+        Test that copies do not share state with the original::
+
             sage: A = ([1, 1], [3, 1])
             sage: b = (1000, 1500)
             sage: c = (10, 5)

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -3919,6 +3919,22 @@ class LPDictionary(LPAbstractDictionary):
         self._AbcvBNz = [A, b, c, objective_value, B, N, polygen(ZZ, objective_name)]
 
     def __copy__(self):
+        r"""
+        TESTS::
+            sage: A = ([1, 1], [3, 1])
+            sage: b = (1000, 1500)
+            sage: c = (10, 5)
+            sage: P = InteractiveLPProblemStandardForm(A, b, c)
+            sage: D = P.initial_dictionary()
+            sage: D_2 = copy(D)
+            sage: D is D_2
+            False
+            sage: D.enter('x1')
+            sage: D.leave('x3')
+            sage: D.update()
+            sage: D_2 == D
+            False
+        """
         return type(self)(*self._AbcvBNz)
 
     @staticmethod

--- a/src/sage/numerical/interactive_simplex_method.py
+++ b/src/sage/numerical/interactive_simplex_method.py
@@ -3910,8 +3910,8 @@ class LPDictionary(LPAbstractDictionary):
         c = copy(c)
         B = vector(basic_variables)
         N = vector(nonbasic_variables)
-        # Sadly, vector does not guarantee that the result is freshly allocated
-        # if the input was already a vector: #29101
+        # Issue #29101: vector does not guarantee that the result is freshly allocated
+        # if the input was already a vector
         if B is basic_variables:
             B = copy(B)
         if N is nonbasic_variables:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Dictionaries are mutable, and copying them using `copy` results in dictionaries that share internal objects, which causes unwelcome surprises.

- rebased from #31308

Author: @mkoeppe, @ComboProblem

Fixes #31308.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


