### PR TITLE
`sage.misc.sageinspect`: Remove deprecated `loadable_module_extension`

### DIFF
--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -167,28 +167,6 @@ def is_function_or_cython_function(obj):
     return hasattr(type(obj), "__code__")
 
 
-def loadable_module_extension():
-    r"""
-    Return the filename extension of loadable modules, including the dot.
-
-    This function is deprecated.
-
-    EXAMPLES::
-
-        sage: from sage.misc.sageinspect import loadable_module_extension
-        sage: from importlib.machinery import EXTENSION_SUFFIXES
-        sage: loadable_module_extension() in EXTENSION_SUFFIXES
-        doctest:warning...
-        DeprecationWarning: loadable_module_extension is deprecated; use importlib.machinery.EXTENSION_SUFFIXES instead
-        See https://github.com/sagemath/sage/issues/33636 for details.
-        True
-    """
-    from sage.misc.superseded import deprecation
-    deprecation(33636, "loadable_module_extension is deprecated; use importlib.machinery.EXTENSION_SUFFIXES instead")
-    # Return the full platform-specific extension module suffix
-    return import_machinery.EXTENSION_SUFFIXES[0]
-
-
 def isclassinstance(obj):
     r"""
     Check if argument is instance of non built-in class


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

- Deprecated in #33636 (2022)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


