### PR TITLE
Construct the composition series of Garsia-Procesi modules

### DIFF
--- a/src/sage/categories/finite_dimensional_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_algebras_with_basis.py
@@ -1434,17 +1434,29 @@ class FiniteDimensionalAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
 
                 EXAMPLES::
 
-                    sage: S = SymmetricGroupAlgebra(QQ, 4)                              # needs sage.groups sage.modules
-                    sage: S.simple_module_parameterization()                            # needs sage.groups sage.modules
-                    ([1, 1, 1, 1], [2, 1, 1], [2, 2], [3, 1], [4])
+                    sage: TL = TemperleyLiebAlgebra(5, 30, QQ)  # semisimple
+                    sage: len(TL.radical_basis())
+                    0
+                    sage: TL.simple_module_parameterization()
+                    (1, 3, 5)
 
-                    sage: S = SymmetricGroupAlgebra(GF(3), 4)                           # needs sage.groups sage.modules
-                    sage: S.simple_module_parameterization()                            # needs sage.groups sage.modules
-                    ([2, 1, 1], [2, 2], [3, 1], [4])
+                    sage: TL = TemperleyLiebAlgebra(5, 1, QQ)  # not semisimple
+                    sage: len(TL.radical_basis())
+                    24
+                    sage: TL.simple_module_parameterization()
+                    (1, 3, 5)
 
-                    sage: S = SymmetricGroupAlgebra(GF(4), 4)                           # needs sage.groups sage.modules
-                    sage: S.simple_module_parameterization()                            # needs sage.groups sage.modules
-                    ([3, 1], [4])
+                    sage: TL = TemperleyLiebAlgebra(6, 30, QQ)  # semisimple
+                    sage: all(TL.cell_module(la).dimension()
+                    ....:     == TL.cell_module(la).simple_module().dimension()
+                    ....:     for la in TL.simple_module_parameterization())
+                    True
+                    sage: TL.simple_module_parameterization()
+                    (0, 2, 4, 6)
+
+                    sage: TL = TemperleyLiebAlgebra(6, 0, QQ)  # not semisimple
+                    sage: TL.simple_module_parameterization()
+                    (2, 4, 6)
                 """
                 return tuple([mu for mu in self.cell_poset()
                               if self.cell_module(mu).nonzero_bilinear_form()])

--- a/src/sage/categories/group_algebras.py
+++ b/src/sage/categories/group_algebras.py
@@ -303,34 +303,6 @@ class GroupAlgebras(AlgebrasCategory):
             """
             return self.base_ring().sum(x.coefficients())
 
-        def representation(self, module, on_basis, side="left", *args, **kwargs):
-            r"""
-            Return a representation of ``self`` on ``module`` with
-            the action of the semigroup given by ``on_basis``.
-
-            INPUT:
-
-            - ``module`` -- a module with a basis
-            - ``on_basis`` -- function which takes as input ``g``, ``m``, where
-              ``g`` is an element of the semigroup and ``m`` is an element of the
-              indexing set for the basis, and returns the result of ``g`` acting
-              on ``m``
-            - ``side`` -- (default: ``"left"``) whether this is a
-              ``"left"`` or ``"right"`` representation
-
-            EXAMPLES::
-
-                sage: G = groups.permutation.Dihedral(5)
-                sage: CFM = CombinatorialFreeModule(GF(2), [1, 2, 3, 4, 5])
-                sage: A = G.algebra(GF(2))
-                sage: R = A.representation(CFM, lambda g, i: CFM.basis()[g(i)], side='right')
-                sage: R
-                Representation of Dihedral group of order 10 as a permutation
-                 group indexed by {1, 2, 3, 4, 5} over Finite Field of size 2
-            """
-            from sage.modules.with_basis.representation import Representation
-            return Representation(self.group(), module, on_basis, side, *args, **kwargs)
-
         def is_integral_domain(self, proof=True):
             r"""
             Return ``True`` if ``self`` is an integral domain.

--- a/src/sage/categories/group_algebras.py
+++ b/src/sage/categories/group_algebras.py
@@ -303,6 +303,34 @@ class GroupAlgebras(AlgebrasCategory):
             """
             return self.base_ring().sum(x.coefficients())
 
+        def representation(self, module, on_basis, side="left", *args, **kwargs):
+            r"""
+            Return a representation of ``self`` on ``module`` with
+            the action of the semigroup given by ``on_basis``.
+
+            INPUT:
+
+            - ``module`` -- a module with a basis
+            - ``on_basis`` -- function which takes as input ``g``, ``m``, where
+              ``g`` is an element of the semigroup and ``m`` is an element of the
+              indexing set for the basis, and returns the result of ``g`` acting
+              on ``m``
+            - ``side`` -- (default: ``"left"``) whether this is a
+              ``"left"`` or ``"right"`` representation
+
+            EXAMPLES::
+
+                sage: G = groups.permutation.Dihedral(5)
+                sage: CFM = CombinatorialFreeModule(GF(2), [1, 2, 3, 4, 5])
+                sage: A = G.algebra(GF(2))
+                sage: R = A.representation(CFM, lambda g, i: CFM.basis()[g(i)], side='right')
+                sage: R
+                Representation of Dihedral group of order 10 as a permutation
+                 group indexed by {1, 2, 3, 4, 5} over Finite Field of size 2
+            """
+            from sage.modules.with_basis.representation import Representation
+            return Representation(self.group(), module, on_basis, side, *args, **kwargs)
+
         def is_integral_domain(self, proof=True):
             r"""
             Return ``True`` if ``self`` is an integral domain.

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -729,7 +729,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
 
         def submodule(self, gens, check=True, already_echelonized=False,
                       unitriangular=False, support_order=None, category=None,
-                      *args, **opts):
+                      parent_class=None, *args, **opts):
             r"""
             The submodule spanned by a finite set of elements.
 
@@ -746,6 +746,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
             - ``support_order`` -- (optional) either something that can
               be converted into a tuple or a key function
             - ``category`` -- (optional) the category of the submodule
+            - ``parent_class`` -- (optional) the class of the parent to return
 
             If ``already_echelonized`` is ``False``, then the
             generators are put in reduced echelon form using
@@ -908,11 +909,12 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
             if not already_echelonized:
                 gens = self.echelon_form(gens, unitriangular, order=support_order)
 
-            from sage.modules.with_basis.subquotient import SubmoduleWithBasis
-            return SubmoduleWithBasis(gens, ambient=self,
-                                      support_order=support_order,
-                                      unitriangular=unitriangular,
-                                      category=category, *args, **opts)
+            if parent_class is None:
+                from sage.modules.with_basis.subquotient import SubmoduleWithBasis as parent_class
+            return parent_class(gens, ambient=self,
+                                support_order=support_order,
+                                unitriangular=unitriangular,
+                                category=category, *args, **opts)
 
         def quotient_module(self, submodule, check=True, already_echelonized=False, category=None):
             r"""
@@ -1077,7 +1079,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 sage: GroupAlgebra(AbelianGroup(1), IntegerModRing(10)).is_finite()     # needs sage.groups sage.modules
                 False
             """
-            return (self.base_ring().is_finite() and self.group().is_finite())
+            return (self.base_ring().is_finite() and self.basis().keys().is_finite())
 
         def monomial(self, i):
             """

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -729,7 +729,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
 
         def submodule(self, gens, check=True, already_echelonized=False,
                       unitriangular=False, support_order=None, category=None,
-                      parent_class=None, *args, **opts):
+                      submodule_class=None, *args, **opts):
             r"""
             The submodule spanned by a finite set of elements.
 
@@ -746,7 +746,8 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
             - ``support_order`` -- (optional) either something that can
               be converted into a tuple or a key function
             - ``category`` -- (optional) the category of the submodule
-            - ``parent_class`` -- (optional) the class of the parent to return
+            - ``submodule_class`` -- (optional) the class of the submodule
+              to return
 
             If ``already_echelonized`` is ``False``, then the
             generators are put in reduced echelon form using
@@ -909,12 +910,12 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
             if not already_echelonized:
                 gens = self.echelon_form(gens, unitriangular, order=support_order)
 
-            if parent_class is None:
-                from sage.modules.with_basis.subquotient import SubmoduleWithBasis as parent_class
-            return parent_class(gens, ambient=self,
-                                support_order=support_order,
-                                unitriangular=unitriangular,
-                                category=category, *args, **opts)
+            if submodule_class is None:
+                from sage.modules.with_basis.subquotient import SubmoduleWithBasis as submodule_class
+            return submodule_class(gens, ambient=self,
+                                   support_order=support_order,
+                                   unitriangular=unitriangular,
+                                   category=category, *args, **opts)
 
         def quotient_module(self, submodule, check=True, already_echelonized=False, category=None):
             r"""

--- a/src/sage/categories/semigroups.py
+++ b/src/sage/categories/semigroups.py
@@ -1044,3 +1044,31 @@ class Semigroups(CategoryWithAxiom):
                 """
                 S = self.basis().keys()
                 return S.regular_representation(self.base_ring(), side)
+
+            def representation(self, module, on_basis, side="left", *args, **kwargs):
+                r"""
+                Return a representation of ``self`` on ``module`` with
+                the action of the semigroup given by ``on_basis``.
+
+                INPUT:
+
+                - ``module`` -- a module with a basis
+                - ``on_basis`` -- function which takes as input ``g``, ``m``, where
+                  ``g`` is an element of the semigroup and ``m`` is an element of the
+                  indexing set for the basis, and returns the result of ``g`` acting
+                  on ``m``
+                - ``side`` -- (default: ``"left"``) whether this is a
+                  ``"left"`` or ``"right"`` representation
+
+                EXAMPLES::
+
+                    sage: G = groups.permutation.Dihedral(5)
+                    sage: CFM = CombinatorialFreeModule(GF(2), [1, 2, 3, 4, 5])
+                    sage: A = G.algebra(GF(2))
+                    sage: R = A.representation(CFM, lambda g, i: CFM.basis()[g(i)], side='right')
+                    sage: R
+                    Representation of Dihedral group of order 10 as a permutation
+                     group indexed by {1, 2, 3, 4, 5} over Finite Field of size 2
+                """
+                from sage.modules.with_basis.representation import Representation
+                return Representation(self.group(), module, on_basis, side, *args, **kwargs)

--- a/src/sage/categories/semigroups.py
+++ b/src/sage/categories/semigroups.py
@@ -497,6 +497,36 @@ class Semigroups(CategoryWithAxiom):
             from sage.modules.with_basis.representation import RegularRepresentation
             return RegularRepresentation(self, base_ring, side)
 
+        def representation(self, module, on_basis, side="left", *args, **kwargs):
+            r"""
+            Return a representation of ``self`` on ``module`` with
+            the action given by ``on_basis``.
+
+            INPUT:
+
+            - ``module`` -- a module with a basis
+            - ``on_basis`` -- function which takes as input ``g``, ``m``, where
+              ``g`` is an element of the semigroup and ``m`` is an element of the
+              indexing set for the basis, and returns the result of ``g`` acting
+              on ``m``
+            - ``side`` -- (default: ``"left"``) whether this is a
+              ``"left"`` or ``"right"`` representation
+
+            EXAMPLES::
+
+                sage: G = CyclicPermutationGroup(3)
+                sage: M = algebras.Exterior(QQ, 'x', 3)
+                sage: def on_basis(g, m):  # cyclically permute generators
+                ....:     return M.prod([M.monomial(FrozenBitset([g(j+1)-1])) for j in m])
+                sage: from sage.categories.algebras import Algebras
+                sage: R = G.representation(M, on_basis, category=Algebras(QQ).WithBasis().FiniteDimensional())
+                sage: R
+                Representation of Cyclic group of order 3 as a permutation group
+                 indexed by Subsets of {0,1,...,2} over Rational Field
+            """
+            from sage.modules.with_basis.representation import Representation
+            return Representation(self, module, on_basis, side, *args, **kwargs)
+
     class ElementMethods:
 
         def _pow_int(self, n):

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -5715,6 +5715,35 @@ class Partition(CombinatorialElement):
         R = SymmetricGroupAlgebra(base_ring, sum(self))
         return SpechtModule(R, self)
 
+    def garsia_procesi_module(self, base_ring=None):
+        r"""
+        Return the :class:`Garsia-Procesi module
+        <sage.combinat.symmetric_group_representations.GarsiaProcesiModule>`
+        corresponding to ``self``.
+
+        INPUT:
+
+        - ``base_ring`` -- (default: `\QQ`) the base ring
+
+        EXAMPLES::
+
+            sage: GP = Partition([3,2,1]).garsia_procesi_module(QQ); GP
+            Garsia-Procesi module of shape [3, 2, 1] over Rational Field
+            sage: GP.graded_frobenius_image()
+            q^4*s[3, 2, 1] + q^3*s[3, 3] + q^3*s[4, 1, 1] + (q^3+q^2)*s[4, 2]
+             + (q^2+q)*s[5, 1] + s[6]
+
+            sage: Partition([3,2,1]).garsia_procesi_module(GF(3))
+            Garsia-Procesi module of shape [3, 2, 1] over Finite Field of size 3
+        """
+        from sage.combinat.symmetric_group_representations import GarsiaProcesiModule
+        from sage.combinat.symmetric_group_algebra import SymmetricGroupAlgebra
+        if base_ring is None:
+            from sage.rings.rational_field import QQ
+            base_ring = QQ
+        R = SymmetricGroupAlgebra(base_ring, sum(self))
+        return GarsiaProcesiModule(R, self)
+
     def specht_module_dimension(self, base_ring=None):
         r"""
         Return the dimension of the Specht module corresponding to ``self``.

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -717,9 +717,24 @@ class Permutation(CombinatorialElement):
             sage: Permutation([3,4,1,2,5]).size()
             5
         """
-        return len(self)
+        return Integer(len(self))
 
     grade = size  # for the category SetsWithGrading()
+
+    def order(self) -> Integer:
+        """
+        Return the order of ``self``.
+
+        EXAMPLES::
+
+            sage: sigma = Permutation([3,4,1,2,5])
+            sage: sigma.order()
+            2
+            sage: sigma * sigma
+            [1, 2, 3, 4, 5]
+        """
+        from sage.arith.functions import lcm
+        return lcm(self.cycle_type())
 
     def cycle_string(self, singletons=False) -> str:
         """

--- a/src/sage/combinat/specht_module.py
+++ b/src/sage/combinat/specht_module.py
@@ -37,7 +37,7 @@ from sage.modules.with_basis.subquotient import SubmoduleWithBasis, QuotientModu
 from sage.modules.free_module_element import vector
 from sage.categories.modules_with_basis import ModulesWithBasis
 
-class SymmetricGroupRepresentation:
+class SymmetricGroupRepresentation(Representation_abstract):
     """
     Mixin class for symmetric group (algebra) representations.
     """
@@ -48,22 +48,11 @@ class SymmetricGroupRepresentation:
         EXAMPLES::
 
             sage: SM = Partition([3,1,1]).specht_module(GF(3))
-            sage: TestSuite(SM).run()
-        """
-        self._semigroup = SGA.group()
-        self._semigroup_algebra = SGA
-
-    def side(self):
-        r"""
-        Return the side of the action defining ``self``.
-
-        EXAMPLES::
-
-            sage: SM = Partition([3,1,1]).specht_module(GF(3))
             sage: SM.side()
             'left'
+            sage: TestSuite(SM).run()
         """
-        return "left"
+        Representation_abstract.__init__(self, SGA.group(), "left", SGA)
 
     @cached_method
     def frobenius_image(self):
@@ -127,143 +116,8 @@ class SymmetricGroupRepresentation:
         return s(p.sum(QQ(sum((elt * B[k])[k] for k in B.keys())) / la.centralizer_size() * p[la]
                        for elt, la in CCR))
 
-    # TODO: Move these methods up to methods of general representations
 
-    def representation_matrix(self, elt):
-        r"""
-        Return the matrix corresponding to the left action of the symmetric
-        group (algebra) element ``elt`` on ``self``.
-
-        EXAMPLES::
-
-            sage: SM = Partition([3,1,1]).specht_module(QQ)
-            sage: SM.representation_matrix(Permutation([2,1,3,5,4]))
-            [-1  0  0  0  0  0]
-            [ 0  0  0 -1  0  0]
-            [ 1  0  0 -1  1  0]
-            [ 0 -1  0  0  0  0]
-            [ 1 -1  1  0  0  0]
-            [ 0 -1  0  1  0 -1]
-
-            sage: SGA = SymmetricGroupAlgebra(QQ, 5)
-            sage: SM = SGA.specht_module([(0,0), (0,1), (0,2), (1,0), (2,0)])
-            sage: SM.representation_matrix(Permutation([2,1,3,5,4]))
-            [-1  0  0  1 -1  0]
-            [ 0  0  1  0 -1  1]
-            [ 0  1  0 -1  0  1]
-            [ 0  0  0  0 -1  0]
-            [ 0  0  0 -1  0  0]
-            [ 0  0  0  0  0 -1]
-            sage: SGA = SymmetricGroupAlgebra(QQ, 5)
-            sage: SM.representation_matrix(SGA([3,1,5,2,4]))
-            [ 0 -1  0  1  0 -1]
-            [ 0  0  0  0  0 -1]
-            [ 0  0  0 -1  0  0]
-            [ 0  0 -1  0  1 -1]
-            [ 1  0  0 -1  1  0]
-            [ 0  0  0  0  1  0]
-        """
-        return matrix(self.base_ring(), [(elt * b).to_vector() for b in self.basis()])
-
-    @cached_method
-    def character(self):
-        r"""
-        Return the character of ``self``.
-
-        EXAMPLES::
-
-            sage: SGA = SymmetricGroupAlgebra(QQ, 5)
-            sage: SM = SGA.specht_module([3,2])
-            sage: SM.character()
-            (5, 1, 1, -1, 1, -1, 0)
-            sage: matrix(SGA.specht_module(la).character() for la in Partitions(5))
-            [ 1  1  1  1  1  1  1]
-            [ 4  2  0  1 -1  0 -1]
-            [ 5  1  1 -1  1 -1  0]
-            [ 6  0 -2  0  0  0  1]
-            [ 5 -1  1 -1 -1  1  0]
-            [ 4 -2  0  1  1  0 -1]
-            [ 1 -1  1  1 -1 -1  1]
-
-            sage: SGA = SymmetricGroupAlgebra(QQ, SymmetricGroup(5))
-            sage: SM = SGA.specht_module([3,2])
-            sage: SM.character()
-            Character of Symmetric group of order 5! as a permutation group
-            sage: SM.character().values()
-            [5, 1, 1, -1, 1, -1, 0]
-            sage: matrix(SGA.specht_module(la).character().values() for la in reversed(Partitions(5)))
-            [ 1 -1  1  1 -1 -1  1]
-            [ 4 -2  0  1  1  0 -1]
-            [ 5 -1  1 -1 -1  1  0]
-            [ 6  0 -2  0  0  0  1]
-            [ 5  1  1 -1  1 -1  0]
-            [ 4  2  0  1 -1  0 -1]
-            [ 1  1  1  1  1  1  1]
-            sage: SGA.group().character_table()
-            [ 1 -1  1  1 -1 -1  1]
-            [ 4 -2  0  1  1  0 -1]
-            [ 5 -1  1 -1 -1  1  0]
-            [ 6  0 -2  0  0  0  1]
-            [ 5  1  1 -1  1 -1  0]
-            [ 4  2  0  1 -1  0 -1]
-            [ 1  1  1  1  1  1  1]
-        """
-        G = self._semigroup
-        B = self.basis()
-        chi = [sum((g * B[k])[k] for k in B.keys())
-               for g in G.conjugacy_classes_representatives()]
-        try:
-            return G.character(chi)
-        except AttributeError:
-            return vector(chi, immutable=True)
-
-    @cached_method
-    def brauer_character(self):
-        r"""
-        Return the Brauer character of ``self``.
-
-        EXAMPLES::
-
-            sage: SGA = SymmetricGroupAlgebra(GF(2), 5)
-            sage: SM = SGA.specht_module([3,2])
-            sage: SM.brauer_character()
-            (5, -1, 0)
-            sage: SM.simple_module().brauer_character()
-            (4, -2, -1)
-        """
-        from sage.rings.number_field.number_field import CyclotomicField
-        from sage.arith.functions import lcm
-        G = self._semigroup
-        p = self.base_ring().characteristic()
-        # We manually compute the order since a Permutation does not implement order()
-        chi = []
-        for g in G.conjugacy_classes_representatives():
-            if p.divides(lcm(g.cycle_type())):
-                # ignore the non-p-regular elements
-                continue
-            evals = self.representation_matrix(g).eigenvalues()
-            K = evals[0].parent()
-            val = 0
-            orders = {la: la.multiplicative_order() for la in evals if la != K.one()}
-            zetas = {o: CyclotomicField(o).gen() for o in orders.values()}
-            prims = {o: K.zeta(o) for o in orders.values()}
-            for la in evals:
-                if la == K.one():
-                    val += 1
-                    continue
-                o = la.multiplicative_order()
-                zeta = zetas[o]
-                prim = prims[o]
-                for deg in range(o):
-                    if prim ** deg == la:
-                        val += zeta ** deg
-                        break
-            chi.append(val)
-
-        return vector(chi, immutable=True)
-
-
-class SpechtModule(SubmoduleWithBasis, SymmetricGroupRepresentation, Representation_abstract):
+class SpechtModule(SymmetricGroupRepresentation, SubmoduleWithBasis):
     r"""
     A Specht module.
 
@@ -543,7 +397,7 @@ class SpechtModule(SubmoduleWithBasis, SymmetricGroupRepresentation, Representat
             return None
 
 
-class TabloidModule(SymmetricGroupRepresentation, Representation_abstract):
+class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
     r"""
     The vector space of all tabloids of a fixed shape with the natural
     symmetric group action.
@@ -800,7 +654,7 @@ class TabloidModule(SymmetricGroupRepresentation, Representation_abstract):
                 return None
             P = self.parent()
             if x in P._semigroup_algebra:
-                return P.sum(c * (perm * self) for perm, c in x.monomial_coefficients().items())
+                return P.linear_combination((perm * self, c) for perm, c in x.monomial_coefficients().items())
             if x in P._semigroup_algebra.indices():
                 return P.element_class(P, {P._symmetric_group_action(T, x): c
                                            for T, c in self._monomial_coefficients.items()})
@@ -997,7 +851,7 @@ class SpechtModuleTableauxBasis(SpechtModule):
         return SimpleModule(self)
 
 
-class MaximalSpechtSubmodule(SubmoduleWithBasis, SymmetricGroupRepresentation):
+class MaximalSpechtSubmodule(SymmetricGroupRepresentation, SubmoduleWithBasis):
     r"""
     The maximal submodule `U^{\lambda}` of the Specht module `S^{\lambda}`.
 
@@ -1082,7 +936,7 @@ class MaximalSpechtSubmodule(SubmoduleWithBasis, SymmetricGroupRepresentation):
     Element = SpechtModule.Element
 
 
-class SimpleModule(QuotientModuleWithBasis, SymmetricGroupRepresentation):
+class SimpleModule(SymmetricGroupRepresentation, QuotientModuleWithBasis):
     r"""
     The simgle `S_n`-module associated with a partition `\lambda`.
 

--- a/src/sage/combinat/specht_module.py
+++ b/src/sage/combinat/specht_module.py
@@ -123,7 +123,8 @@ class SymmetricGroupRepresentation:
         s = SymmetricFunctions(QQ).s()
         G = self._semigroup
         CCR = [(elt, elt.cycle_type()) for elt in G.conjugacy_classes_representatives()]
-        return s(p.sum(QQ(self.representation_matrix(elt).trace()) / la.centralizer_size() * p[la]
+        B = self.basis()
+        return s(p.sum(QQ(sum((elt * B[k])[k] for k in B.keys())) / la.centralizer_size() * p[la]
                        for elt, la in CCR))
 
     # TODO: Move these methods up to methods of general representations
@@ -208,7 +209,8 @@ class SymmetricGroupRepresentation:
             [ 1  1  1  1  1  1  1]
         """
         G = self._semigroup
-        chi = [self.representation_matrix(g).trace()
+        B = self.basis()
+        chi = [sum((g * B[k])[k] for k in B.keys())
                for g in G.conjugacy_classes_representatives()]
         try:
             return G.character(chi)

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -1764,6 +1764,15 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         from sage.combinat.specht_module import simple_module_rank
         return simple_module_rank(la, self.base_ring())
 
+    def garsia_procesi_module(self, la):
+        """
+        Return the Garsia-Procesi module of ``self`` indexed by ``la``.
+        """
+        if sum(la) != self.n:
+            raise ValueError(f"{la} is not a partition of {self.n}")
+        from sage.combinat.symmetric_group_representations import GarsiaProcesiModule
+        return GarsiaProcesiModule(self, la)
+
     def jucys_murphy(self, k):
         r"""
         Return the Jucys-Murphy element `J_k` (also known as a

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -16,7 +16,7 @@ from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.combinat.permutation import Permutation, Permutations, from_permutation_group_element
 from sage.combinat.permutation_cython import (left_action_same_n, right_action_same_n)
-from sage.combinat.partition import _Partitions, Partitions_n
+from sage.combinat.partition import _Partitions, Partitions, Partitions_n
 from sage.combinat.tableau import Tableau, StandardTableaux_size, StandardTableaux_shape, StandardTableaux
 from sage.algebras.group_algebra import GroupAlgebra_class
 from sage.algebras.cellular_basis import CellularBasis
@@ -293,6 +293,10 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         category = category.Unital().FiniteDimensional().WithBasis().Cellular()
         GroupAlgebra_class.__init__(self, R, W, prefix='',
                                     latex_prefix='', category=category)
+
+        # Mixin class for extra methods for representations
+        from sage.combinat.specht_module import SymmetricGroupRepresentation
+        self._representation_mixin_class = SymmetricGroupRepresentation
 
     def _repr_(self):
         """
@@ -1717,6 +1721,28 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         span_set = specht_module_spanning_set(D, self)
         return matrix(self.base_ring(), [v.to_vector() for v in span_set]).rank()
 
+    def simple_module_parameterization(self):
+        r"""
+        Return a parameterization of the simple modules of ``self``.
+
+        The symmetric group algebra of `S_n` over a field of characteristic `p`
+        has its simple modules indexed by all `p`-regular partitions of `n`.
+
+        EXAMPLES::
+
+            sage: SGA = SymmetricGroupAlgebra(QQ, 6)
+            sage: SGA.simple_module_parameterization()
+            Partitions of the integer 6
+
+            sage: SGA = SymmetricGroupAlgebra(GF(2), 6)
+            sage: SGA.simple_module_parameterization()
+            2-Regular Partitions of the integer 6
+        """
+        p = self.base_ring().characteristic()
+        if p > 0:
+            return Partitions(self.n, regular=p)
+        return Partitions_n(self.n)
+
     def simple_module(self, la):
         r"""
         Return the simple module of ``self`` indexed by the partition ``la``.
@@ -1765,11 +1791,17 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         return simple_module_rank(la, self.base_ring())
 
     def garsia_procesi_module(self, la):
+        r"""
+        Return the :class:`Garsia-Procesi module
+        <sage.combinat.symmetric_group_representations.GarsiaProcesiModule>`
+        of ``self`` indexed by ``la``.
+
+        EXAMPLES::
+
+            sage: SGA = SymmetricGroupAlgebra(GF(2), 6)
+            sage: SGA.garsia_procesi_module(Partition([2,2,1,1]))
+            Garsia-Procesi module of shape [2, 2, 1, 1] over Finite Field of size 2
         """
-        Return the Garsia-Procesi module of ``self`` indexed by ``la``.
-        """
-        if sum(la) != self.n:
-            raise ValueError(f"{la} is not a partition of {self.n}")
         from sage.combinat.symmetric_group_representations import GarsiaProcesiModule
         return GarsiaProcesiModule(self, la)
 

--- a/src/sage/combinat/symmetric_group_representations.py
+++ b/src/sage/combinat/symmetric_group_representations.py
@@ -1355,8 +1355,25 @@ class GarsiaProcesiModule(UniqueRepresentation, QuotientRing_generic, SymmetricG
 
     class Element(QuotientRing_generic.Element):
         def _acted_upon_(self, scalar, self_on_left=True):
-            """
+            r"""
             Return the action of ``scalar`` on ``self``.
+
+            EXAMPLES::
+
+                sage: SGA = SymmetricGroupAlgebra(GF(3), 4)
+                sage: GP22 = SGA.garsia_procesi_module([2, 2])
+                sage: x = SGA.an_element(); x
+                [1, 2, 3, 4] + 2*[1, 2, 4, 3] + [4, 1, 2, 3]
+                sage: v = GP22.an_element(); v
+                -gp1 - gp2 - gp3
+                sage: g = SGA.group().an_element(); g
+                [4, 1, 2, 3]
+                sage: g * v
+                gp3
+                sage: x * v
+                gp3
+                sage: 2 * v
+                gp1 + gp2 + gp3
             """
             P = self.parent()
             if scalar in P.base_ring():
@@ -1372,8 +1389,17 @@ class GarsiaProcesiModule(UniqueRepresentation, QuotientRing_generic, SymmetricG
             return super()._acted_upon_(scalar, self_on_left)
 
         def to_vector(self, order=None):
-            """
+            r"""
             Return ``self`` as a (dense) free module vector.
+
+            EXAMPLES::
+
+                sage: SGA = SymmetricGroupAlgebra(GF(3), 4)
+                sage: GP22 = SGA.garsia_procesi_module([2, 2])
+                sage: v = GP22.an_element(); v
+                -gp1 - gp2 - gp3
+                sage: v.to_vector()
+                (0, 0, 2, 2, 2, 0)
             """
             P = self.parent()
             B = P.basis()
@@ -1384,23 +1410,74 @@ class GarsiaProcesiModule(UniqueRepresentation, QuotientRing_generic, SymmetricG
         _vector_ = to_vector
 
         def monomial_coefficients(self, copy=None):
-            """
+            r"""
             Return the monomial coefficients of ``self``.
+
+            EXAMPLES::
+
+                sage: SGA = SymmetricGroupAlgebra(GF(3), 4)
+                sage: GP31 = SGA.garsia_procesi_module([3, 1])
+                sage: v = GP31.an_element(); v
+                -gp1 - gp2 - gp3
+                sage: v.monomial_coefficients()
+                {0: 2, 1: 2, 2: 2, 3: 0}
             """
             B = self.parent().basis()
             f = self.lift()
             return {i: f.monomial_coefficient(b.lift()) for i, b in enumerate(B)}
 
         def degree(self):
-            """
+            r"""
             Return the degree of ``self``.
+
+            EXAMPLES::
+
+                sage: SGA = SymmetricGroupAlgebra(GF(3), 4)
+                sage: GP22 = SGA.garsia_procesi_module([2, 2])
+                sage: for b in GP22.basis():
+                ....:     print(b, b.degree())
+                gp2*gp3 2
+                gp1*gp3 2
+                gp3 1
+                gp2 1
+                gp1 1
+                1 0
+                sage: v = sum(GP22.basis())
+                sage: v.degree()
+                2
             """
             return self.lift().degree()
 
         def homogeneous_degree(self):
-            """
+            r"""
             Return the (homogeneous) degree of ``self`` if homogeneous
             otherwise raise an error.
+
+            EXAMPLES::
+
+                sage: SGA = SymmetricGroupAlgebra(GF(2), 4)
+                sage: GP31 = SGA.garsia_procesi_module([3, 1])
+                sage: for b in GP31.basis():
+                ....:     print(b, b.homogeneous_degree())
+                gp3 1
+                gp2 1
+                gp1 1
+                1 0
+                sage: v = sum(GP31.basis()); v
+                gp1 + gp2 + gp3 + 1
+                sage: v.homogeneous_degree()
+                Traceback (most recent call last):
+                ...
+                ValueError: element is not homogeneous
+
+            TESTS::
+
+                sage: SGA = SymmetricGroupAlgebra(GF(3), 4)
+                sage: GP4 = SGA.garsia_procesi_module([4])
+                sage: GP4.zero().homogeneous_degree()
+                Traceback (most recent call last):
+                ...
+                ValueError: the zero element does not have a well-defined degree
             """
             if not self:
                 raise ValueError("the zero element does not have a well-defined degree")

--- a/src/sage/combinat/symmetric_group_representations.py
+++ b/src/sage/combinat/symmetric_group_representations.py
@@ -1464,11 +1464,11 @@ class GarsiaProcesiModule(UniqueRepresentation, QuotientRing_generic, SymmetricG
                 -gp1 - gp2 - gp3
                 sage: g = SGA.group().an_element(); g
                 [4, 1, 2, 3]
-                sage: g * v
+                sage: g * v  # indirect doctest
                 gp3
-                sage: x * v
+                sage: x * v  # indirect doctest
                 gp3
-                sage: 2 * v
+                sage: 2 * v  # indirect doctest
                 gp1 + gp2 + gp3
             """
             P = self.parent()

--- a/src/sage/modules/with_basis/morphism.py
+++ b/src/sage/modules/with_basis/morphism.py
@@ -979,7 +979,9 @@ class TriangularModuleMorphism(ModuleMorphism):
                 # this is not possible?
                 c = c.parent()(c / s[j])
 
-            remainder -= s._lmul_(c)
+            # Before this was ``remainder -= s._lmul_(c)`` for speed, but
+            #   not every module implements scalar multiplication this way.
+            remainder -= s * c
             out += F.term(j_preimage, c)
 
         return out
@@ -1071,7 +1073,9 @@ class TriangularModuleMorphism(ModuleMorphism):
                 assert j == self._dominant_item(s)[0]
                 if not self._unitriangular:
                     c = c / s[j]  # the base ring is a field
-                remainder -= s._lmul_(c)
+                # Before this was ``remainder -= s._lmul_(c)`` for speed, but
+                #   not every module implements scalar multiplication this way.
+                remainder -= s * c
         return result
 
     def cokernel_basis_indices(self):

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -33,7 +33,10 @@ class Representation_abstract:
     INPUT:
 
     - ``semigroup`` -- a semigroup
-    - ``base_ring`` -- a commutative ring
+    - ``side`` -- (default: ``"left"``) whether this is a
+      ``"left"`` or ``"right"`` representation
+    - ``algebra`` -- (default: ``semigroup.algebra(self.base_ring())``)
+      the semigroup algebra
 
     .. NOTE::
 
@@ -50,7 +53,7 @@ class Representation_abstract:
             sage: T = G.trivial_representation()
             sage: TestSuite(T).run()
 
-        Verify that the dynamic mixin classes works::
+        Verify that the dynamic mixin classes work::
 
             sage: SGA = SymmetricGroupAlgebra(QQ, 3)
             sage: S21 = SGA.specht_module([2,1])
@@ -652,7 +655,9 @@ class Representation_abstract:
 
         - ``gens`` -- the generators of the submodule
         - ``check`` -- ignored
-        - ``already_echelonized`` --
+        - ``already_echelonized`` -- (default: ``False``) whether
+           the elements of ``gens`` are already in (not necessarily
+           reduced) echelon form
         - ``is_closed`` -- (keyword only; default: ``False``) whether ``gens``
           already spans the subspace closed under the semigroup action
 
@@ -780,8 +785,8 @@ class Representation_abstract:
                     S_basis = [self.element_class(self, linear_combination((V._basis[i]._monomial_coefficients, coeff)
                                                                            for i, coeff in b._monomial_coefficients.items()))
                                for b in S._basis]
-                # Lift the basis of W', which is W as a subrepr of ``self ``
-                # This is equivanlent to [b.lift() for b in series[cur+1].basis()]
+                # Lift the basis of W', which is W as a subrepresentation of ``self``
+                # This is equivalent to [b.lift() for b in series[cur+1].basis()]
                 Wp_basis = list(series[cur+1]._basis)
                 Wp = self.subrepresentation(S_basis + Wp_basis, is_closed=True)
                 series.insert(cur+1, Wp)

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -687,7 +687,7 @@ class Representation_abstract:
             gens = [self.from_vector(v) for v in SM.rows()]
             # it might not be echelonized w.r.t. the module's basis ordering
             already_echelonized = False
-        return self.submodule(gens, *args, parent_class=Subrepresentation, check=check,
+        return self.submodule(gens, *args, submodule_class=Subrepresentation, check=check,
                               already_echelonized=already_echelonized, **opts)
 
     def quotient_representation(self, subrepr, already_echelonized=False, **kwds):

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -95,9 +95,8 @@ class Representation_abstract:
 
             sage: G = SymmetricGroup(4)
             sage: M = CombinatorialFreeModule(QQ, ['v'])
-            sage: from sage.modules.with_basis.representation import Representation
             sage: on_basis = lambda g,m: M.term(m, g.sign())
-            sage: R = Representation(G, M, on_basis)
+            sage: R = G.representation(M, on_basis)
             sage: R.semigroup()
             Symmetric group of order 4! as a permutation group
         """
@@ -111,9 +110,8 @@ class Representation_abstract:
 
             sage: G = SymmetricGroup(4)
             sage: M = CombinatorialFreeModule(QQ, ['v'])
-            sage: from sage.modules.with_basis.representation import Representation
             sage: on_basis = lambda g,m: M.term(m, g.sign())
-            sage: R = Representation(G, M, on_basis)
+            sage: R = G.representation(M, on_basis)
             sage: R.semigroup_algebra()
             Symmetric group algebra of order 4 over Rational Field
         """
@@ -688,8 +686,20 @@ class Representation_abstract:
                               already_echelonized=already_echelonized, **opts)
 
     def quotient_representation(self, subrepr, already_echelonized=False, **kwds):
-        """
+        r"""
         Construct a quotient representation of ``self`` by ``subrepr``.
+
+        EXAMPLES::
+
+            sage: SGA = SymmetricGroupAlgebra(GF(2), 5)
+            sage: SM = SGA.specht_module([3, 2])
+            sage: v = sum(list(SM.basis())[1:])
+            sage: Q = SM.quotient_representation([v]); Q
+            Quotient representation with basis {[[1, 3, 5], [2, 4]],
+             [[1, 3, 4], [2, 5]], [[1, 2, 4], [3, 5]], [[1, 2, 3], [4, 5]]}
+             of Specht module of [3, 2] over Finite Field of size 2
+            sage: Q.is_irreducible()
+            True
         """
         if not isinstance(subrepr, Subrepresentation):
             subrepr = self.subrepresentation(subrepr, unitriangular=True,
@@ -831,6 +841,26 @@ class Representation_abstract:
         for testing purposes::
 
             sage: set_random_seed(0)
+            sage: G = groups.permutation.Dihedral(5)
+            sage: CFM = CombinatorialFreeModule(GF(2), [1, 2, 3, 4, 5],
+            ....:                               bracket=False, prefix='e')
+            sage: CFM.an_element()
+            e3
+            sage: R = G.representation(CFM, lambda g, i: CFM.basis()[g(i)], side='right')
+            sage: CS = R.composition_series()
+            sage: len(CS)
+            3
+            sage: [[R(b) for b in F.basis()] for F in CS]
+            [[e1, e2, e3, e4, e5], [e1 + e5, e2 + e5, e3 + e5, e4 + e5], []]
+            sage: [F.brauer_character() for F in CS]
+            [(5, 0, 0), (4, -1, -1), (0, 0, 0)]
+            sage: [F.brauer_character() for F in R.composition_factors()]
+            [(1, 1, 1), (4, -1, -1)]
+            sage: Reg = G.regular_representation(GF(2))
+            sage: simple_brauer_chars = set([F.brauer_character()
+            ....:                            for F in Reg.composition_factors()])
+            sage: sorted(simple_brauer_chars)
+            [(1, 1, 1), (4, -1, -1)]
         """
         return self._composition_series_data()[0]
 
@@ -1006,9 +1036,8 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
 
         sage: G = SymmetricGroup(4)
         sage: M = CombinatorialFreeModule(QQ, ['v'])
-        sage: from sage.modules.with_basis.representation import Representation
         sage: on_basis = lambda g,m: M.term(m, g.sign())
-        sage: R = Representation(G, M, on_basis)
+        sage: R = G.representation(M, on_basis)
         sage: x = R.an_element(); x
         2*B['v']
         sage: c,s = G.gens()
@@ -1052,17 +1081,17 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
 
             sage: G = SymmetricGroup(4)
             sage: M = CombinatorialFreeModule(QQ, ['v'])
-            sage: from sage.modules.with_basis.representation import Representation
-            sage: on_basis = lambda g,m: M.term(m, g.sign())
-            sage: R = Representation(G, M, on_basis)
+            sage: def on_basis(g, m):
+            ....:     return M.term(m, g.sign())
+            sage: R = G.representation(M, on_basis)
             sage: R._test_representation()
 
             sage: G = CyclicPermutationGroup(3)
             sage: M = algebras.Exterior(QQ, 'x', 3)
-            sage: from sage.modules.with_basis.representation import Representation
-            sage: on_basis = lambda g,m: M.prod([M.monomial(FrozenBitset([g(j+1)-1])) for j in m]) #cyclically permute generators
+            sage: def on_basis(g, m):  # cyclically permute generators
+            ....:     return M.prod([M.monomial(FrozenBitset([g(j+1)-1])) for j in m])
             sage: from sage.categories.algebras import Algebras
-            sage: R = Representation(G, M, on_basis, category=Algebras(QQ).WithBasis().FiniteDimensional())
+            sage: R = G.representation(M, on_basis, category=Algebras(QQ).WithBasis().FiniteDimensional())
             sage: r = R.an_element(); r
             1 + 2*x0 + x0*x1 + 3*x1
             sage: r*r
@@ -1081,11 +1110,10 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
 
             sage: G = SymmetricGroup(4)
             sage: A = SymmetricGroup(4).algebra(QQ)
-            sage: from sage.categories.algebras import Algebras
-            sage: from sage.modules.with_basis.representation import Representation
-            sage: action = lambda g,x: A.monomial(g*x)
+            sage: def action(g, x):
+            ....:     return A.monomial(g*x)
             sage: category = Algebras(QQ).WithBasis().FiniteDimensional()
-            sage: R = Representation(G, A, action, 'left', category=category)
+            sage: R = G.representation(A, action, 'left', category=category)
             sage: r = R.an_element(); r
             () + (2,3,4) + 2*(1,3)(2,4) + 3*(1,4)(2,3)
             sage: r^2
@@ -1129,9 +1157,9 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
 
             sage: G = CoxeterGroup(['A',4,1], base_ring=ZZ)
             sage: M = CombinatorialFreeModule(QQ, ['v'])
-            sage: from sage.modules.with_basis.representation import Representation
-            sage: on_basis = lambda g,m: M.term(m, (-1)**g.length())
-            sage: R = Representation(G, M, on_basis, side="right")
+            sage: def on_basis(g, m):
+            ....:     return M.term(m, (-1)**g.length())
+            sage: R = G.representation(M, on_basis, side="right")
             sage: R._test_representation(max_runs=500)
         """
         from sage.misc.functional import sqrt
@@ -1159,9 +1187,8 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
 
             sage: P = Permutations(4)
             sage: M = CombinatorialFreeModule(QQ, ['v'])
-            sage: from sage.modules.with_basis.representation import Representation
             sage: on_basis = lambda g,m: M.term(m, g.sign())
-            sage: Representation(P, M, on_basis)
+            sage: P.representation(M, on_basis)
             Representation of Standard permutations of 4 indexed by {'v'}
              over Rational Field
         """
@@ -1222,8 +1249,7 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
             sage: G = groups.permutation.KleinFour()
             sage: E = algebras.Exterior(QQ,'e',4)
             sage: on_basis = lambda g,m: E.monomial(m) # the trivial representation
-            sage: from sage.modules.with_basis.representation import Representation
-            sage: R = Representation(G, E, on_basis)
+            sage: R = G.representation(E, on_basis)
             sage: r = R.an_element(); r
             1 + 2*e0 + 3*e1 + e1*e2
             sage: g = G.an_element();
@@ -1240,7 +1266,7 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
 
             sage: from sage.categories.algebras import Algebras
             sage: category = Algebras(QQ).FiniteDimensional().WithBasis()
-            sage: T = Representation(G, E, on_basis, category=category)
+            sage: T = G.representation(E, on_basis, category=category)
             sage: t = T.an_element(); t
             1 + 2*e0 + 3*e1 + e1*e2
             sage: g * t == t  # indirect doctest
@@ -1266,8 +1292,7 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
             sage: G = groups.permutation.KleinFour()
             sage: E = algebras.Exterior(QQ,'e',4)
             sage: on_basis = lambda g,m: E.monomial(m) # the trivial representation
-            sage: from sage.modules.with_basis.representation import Representation
-            sage: R = Representation(G, E, on_basis)
+            sage: R = G.representation(E, on_basis)
             sage: R._semigroup_action(G.an_element(), R.an_element(), True)
             1 + 2*e0 + 3*e1 + e1*e2
         """
@@ -1278,8 +1303,12 @@ class Representation(Representation_abstract, CombinatorialFreeModule):
 
 
 class Subrepresentation(Representation_abstract, SubmoduleWithBasis):
-    """
+    r"""
     A subrepresentation.
+
+    Let `R` be a representation of an algebraic object `X`. A
+    subrepresentation is a submodule of `R` that is closed under
+    the action of `X`.
     """
     # Use the same normalization as the base class
     __classcall_private__ = SubmoduleWithBasis.__classcall_private__
@@ -1314,6 +1343,36 @@ class Subrepresentation(Representation_abstract, SubmoduleWithBasis):
 
     class Element(SubmoduleWithBasis.Element):
         def _acted_upon_(self, scalar, self_on_left=True):
+            """
+            Return the action of ``scalar`` on ``self``.
+
+            EXAMPLES::
+
+                sage: G = groups.permutation.Dihedral(4)
+                sage: CFM = CombinatorialFreeModule(GF(2), [1, 2, 3, 4],
+                ....:                               bracket=False, prefix='e')
+                sage: R = G.representation(CFM, lambda g, i: CFM.basis()[g(i)], side='right')
+                sage: e1, e2, e3, e4 = R.basis()
+                sage: S = R.subrepresentation([e1 + e3, e2 + e4], is_closed=True)
+                sage: x = G.an_element(); x
+                (1,3)
+                sage: v = sum(S.basis()); v
+                B[0] + B[1]
+                sage: x * v
+                B[0] + B[1]
+                sage: [x * b for b in S.basis()]
+                [B[0], B[1]]
+                sage: [[g * b for g in G] for b in S.basis()]
+                [[B[0], B[0], B[1], B[1], B[0], B[0], B[1], B[1]],
+                 [B[1], B[1], B[0], B[0], B[1], B[1], B[0], B[0]]]
+                sage: 2 * v
+                0
+
+                sage: Q = R.quotient_representation(S)
+                sage: [[g * b for g in G] for b in Q.basis()]
+                [[B[3], B[3], B[4], B[4], B[3], B[3], B[4], B[4]],
+                 [B[4], B[4], B[3], B[3], B[4], B[4], B[3], B[3]]]
+            """
             ret = super()._acted_upon_(scalar, self_on_left)
             if ret is not None:
                 return ret

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -7,11 +7,10 @@ AUTHORS:
 - Travis Scrimshaw (2015-11-21): initial version
 - Siddharth Singh  (2020-03-21): signed representation
 - Travis Scrimshaw (2024-02-17): tensor products
-
 """
 
 ##############################################################################
-#       Copyright (C) 2015 Travis Scrimshaw <tscrimsh at umn.edu>
+#       Copyright (C) 2015-2024 Travis Scrimshaw <tcscrims at gmail.com>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #  The full text of the GPL is available at:
@@ -24,8 +23,10 @@ from sage.structure.element import Element
 from sage.combinat.free_module import CombinatorialFreeModule, CombinatorialFreeModule_Tensor
 from sage.categories.modules import Modules
 from sage.matrix.constructor import matrix
+from sage.modules.free_module_element import vector
+from sage.modules.with_basis.subquotient import SubmoduleWithBasis, QuotientModuleWithBasis
 
-class Representation_abstract(CombinatorialFreeModule):
+class Representation_abstract:
     """
     Abstract base class for representations of semigroups.
 
@@ -33,8 +34,13 @@ class Representation_abstract(CombinatorialFreeModule):
 
     - ``semigroup`` -- a semigroup
     - ``base_ring`` -- a commutative ring
+
+    .. NOTE::
+
+        This class should come before :class:`CombinatorialFreeModule` in the
+        MRO in order for tensor products to use the correct class.
     """
-    def __init__(self, semigroup, base_ring, side, *args, **opts):
+    def __init__(self, semigroup, side, algebra=None):
         """
         Initialize ``self``.
 
@@ -43,15 +49,43 @@ class Representation_abstract(CombinatorialFreeModule):
             sage: G = FreeGroup(3)
             sage: T = G.trivial_representation()
             sage: TestSuite(T).run()
+
+        Verify that the dynamic mixin classes works::
+
+            sage: SGA = SymmetricGroupAlgebra(QQ, 3)
+            sage: S21 = SGA.specht_module([2,1])
+            sage: T = tensor([S21, S21])
+            sage: s21 = S21.frobenius_image()
+            sage: T.frobenius_image() == s21.kronecker_product(s21)
+            True
         """
         self._semigroup = semigroup
-        self._semigroup_algebra = semigroup.algebra(base_ring)
+        if algebra is None:
+            algebra = semigroup.algebra(self.base_ring())
+        self._semigroup_algebra = algebra
         self._side = side
         if side not in ["left", "right", "twosided"]:
             raise ValueError("the side must be either 'left', 'right', or 'twosided'")
         self._left_repr = bool(side == "left" or side == "twosided")
         self._right_repr = bool(side == "right" or side == "twosided")
-        CombinatorialFreeModule.__init__(self, base_ring, *args, **opts)
+
+        if hasattr(self._semigroup_algebra, "_representation_mixin_class"):
+            mixin = self._semigroup_algebra._representation_mixin_class
+            # No need to do anything if it is already in the MRO
+            if mixin not in self.__class__.__mro__:
+                from sage.structure.dynamic_class import dynamic_class
+                cat = self.category()
+                # perhaps the category has not been initialized yet
+                if not isinstance(self, cat.parent_class):
+                    self.__class__ = dynamic_class(f"{type(self).__name__}_with_mixin",
+                                                   (type(self), mixin),
+                                                   doccls=type(self))
+                else:
+                    base = self.__class__.__base__  # strip off the category dynamic class
+                    # recreate the dynamic class with adding the mixin
+                    self.__class__ = dynamic_class(f"{base.__name__}_with_category",
+                                                   (base, mixin, cat.parent_class),
+                                                   doccls=base)
 
     def semigroup(self):
         """
@@ -259,6 +293,46 @@ class Representation_abstract(CombinatorialFreeModule):
             ....:     gR = R.representation_matrix(g, side='left')
             ....:     gT = T.representation_matrix(g, side='left')
             ....:     assert gL.tensor_product(gR) == gT
+
+        Some examples with Specht modules::
+
+            sage: SM = Partition([3,1,1]).specht_module(QQ)
+            sage: SM.representation_matrix(Permutation([2,1,3,5,4]))
+            [-1  0  1  0  1  0]
+            [ 0  0  0 -1 -1 -1]
+            [ 0  0  0  0  1  0]
+            [ 0 -1 -1  0  0  1]
+            [ 0  0  1  0  0  0]
+            [ 0  0  0  0  0 -1]
+
+            sage: SGA = SymmetricGroupAlgebra(QQ, 5)
+            sage: SM = SGA.specht_module([(0,0), (0,1), (0,2), (1,0), (2,0)])
+            sage: SM.representation_matrix(Permutation([2,1,3,5,4]))
+            [-1  0  0  0  0  0]
+            [ 0  0  1  0  0  0]
+            [ 0  1  0  0  0  0]
+            [ 1  0 -1  0 -1  0]
+            [-1 -1  0 -1  0  0]
+            [ 0  1  1  0  0 -1]
+            sage: SM.representation_matrix(SGA([3,1,5,2,4]))
+            [ 0  0  0  0  1  0]
+            [-1  0  0  0  0  0]
+            [ 0  0  0 -1  0  0]
+            [ 1  0 -1  0 -1  0]
+            [ 0  0  0  1  1  1]
+            [-1 -1  0 -1  0  0]
+
+            sage: SGA = SymmetricGroupAlgebra(QQ, 4)
+            sage: SM = SGA.specht_module([3, 1])
+            sage: all(SM.representation_matrix(g) * b.to_vector() == (g * b).to_vector()
+            ....:     for b in SM.basis() for g in SGA.group())
+            True
+
+            sage: SGA = SymmetricGroupAlgebra(QQ, SymmetricGroup(4))
+            sage: SM = SGA.specht_module([3, 1])
+            sage: all(SM.representation_matrix(g) * b.to_vector() == (g * b).to_vector()
+            ....:     for b in SM.basis() for g in SGA.group())
+            True
         """
         if self.dimension() == float('inf'):
             raise NotImplementedError("only implemented for finite dimensional modules")
@@ -278,12 +352,126 @@ class Representation_abstract(CombinatorialFreeModule):
                 temp = g * B[k]
             else:
                 temp = B[k] * g
-            for m, c in temp._monomial_coefficients.items():
+            for m, c in temp.monomial_coefficients(copy=False).items():
                 if not use_left:
                     ret[i, inv_order[m]] = c
                 else:
                     ret[inv_order[m], i] = c
         return ret
+
+    @cached_method
+    def character(self):
+        r"""
+        Return the character of ``self``.
+
+        EXAMPLES::
+
+            sage: SGA = SymmetricGroupAlgebra(QQ, 5)
+            sage: SM = SGA.specht_module([3,2])
+            sage: SM.character()
+            (5, 1, 1, -1, 1, -1, 0)
+            sage: matrix(SGA.specht_module(la).character() for la in Partitions(5))
+            [ 1  1  1  1  1  1  1]
+            [ 4  2  0  1 -1  0 -1]
+            [ 5  1  1 -1  1 -1  0]
+            [ 6  0 -2  0  0  0  1]
+            [ 5 -1  1 -1 -1  1  0]
+            [ 4 -2  0  1  1  0 -1]
+            [ 1 -1  1  1 -1 -1  1]
+
+            sage: SGA = SymmetricGroupAlgebra(QQ, SymmetricGroup(5))
+            sage: SM = SGA.specht_module([3,2])
+            sage: SM.character()
+            Character of Symmetric group of order 5! as a permutation group
+            sage: SM.character().values()
+            [5, 1, 1, -1, 1, -1, 0]
+            sage: matrix(SGA.specht_module(la).character().values() for la in reversed(Partitions(5)))
+            [ 1 -1  1  1 -1 -1  1]
+            [ 4 -2  0  1  1  0 -1]
+            [ 5 -1  1 -1 -1  1  0]
+            [ 6  0 -2  0  0  0  1]
+            [ 5  1  1 -1  1 -1  0]
+            [ 4  2  0  1 -1  0 -1]
+            [ 1  1  1  1  1  1  1]
+            sage: SGA.group().character_table()
+            [ 1 -1  1  1 -1 -1  1]
+            [ 4 -2  0  1  1  0 -1]
+            [ 5 -1  1 -1 -1  1  0]
+            [ 6  0 -2  0  0  0  1]
+            [ 5  1  1 -1  1 -1  0]
+            [ 4  2  0  1 -1  0 -1]
+            [ 1  1  1  1  1  1  1]
+        """
+        G = self._semigroup
+        B = self.basis()
+        chi = [sum((g * B[k])[k] for k in B.keys())
+               for g in G.conjugacy_classes_representatives()]
+        try:
+            return G.character(chi)
+        except AttributeError:
+            return vector(chi, immutable=True)
+
+    @cached_method
+    def brauer_character(self):
+        r"""
+        Return the Brauer character of ``self``.
+
+        EXAMPLES::
+
+            sage: SGA = SymmetricGroupAlgebra(GF(2), 5)
+            sage: SM = SGA.specht_module([3, 2])
+            sage: SM.brauer_character()
+            (5, -1, 0)
+            sage: SM.simple_module().brauer_character()
+            (4, -2, -1)
+
+            sage: T = SM.subrepresentation([])
+            sage: T.brauer_character()
+            (0, 0, 0)
+
+            sage: W = CoxeterGroup(['D', 4], implementation="permutation")
+            sage: R = W.reflection_representation(GF(2))
+            sage: R.brauer_character()
+            (4, 1)
+            sage: T = R.subrepresentation([])
+            sage: T.brauer_character()
+            (0, 0)
+        """
+        G = self._semigroup
+        p = self.base_ring().characteristic()
+
+        if self.dimension() == 0:
+            from sage.rings.rational_field import QQ
+            ccrep = [g for g in G.conjugacy_classes_representatives()
+                     if not p.divides(g.order())]
+            return vector(QQ, [QQ.zero()] * len(ccrep))
+
+        from sage.rings.number_field.number_field import CyclotomicField
+        chi = []
+        for g in G.conjugacy_classes_representatives():
+            if p.divides(g.order()):
+                # ignore the non-p-regular elements
+                continue
+            evals = self.representation_matrix(g).eigenvalues()
+            K = evals[0].parent()
+            val = 0
+            orders = {la: la.multiplicative_order() for la in evals if la != K.one()}
+            zetas = {o: CyclotomicField(o).gen() for o in orders.values()}
+            prims = {o: K.zeta(o) for o in orders.values()}
+            for la in evals:
+                if la == K.one():
+                    val += 1
+                    continue
+                o = la.multiplicative_order()
+                zeta = zetas[o]
+                prim = prims[o]
+                for deg in range(o):
+                    if prim ** deg == la:
+                        val += zeta ** deg
+                        break
+            chi.append(val)
+
+        return vector(chi, immutable=True)
 
     def exterior_power(self, degree=None):
         r"""
@@ -345,6 +533,357 @@ class Representation_abstract(CombinatorialFreeModule):
             sage: T._semigroup_action(DC3.an_element(), T.basis()['v'], True)
             B['v']
         """
+
+    @cached_method
+    def is_irreducible(self) -> bool:
+        r"""
+        Return if ``self`` is an irreducible module or not.
+
+        A representation `M` is *irreducible* (also known as simple)
+        if the only subrepresentations of `M` are the trivial module
+        `\{0\}` and `M` itself.
+
+        EXAMPLES::
+
+            sage: DC3 = groups.permutation.DiCyclic(3)
+            sage: L = DC3.regular_representation(GF(3), side='left')
+            sage: L.is_irreducible()
+            False
+            sage: E3 = L.exterior_power(3)
+            sage: E3.is_irreducible()
+            False
+            sage: E12 = L.exterior_power(12)
+            sage: E12.is_irreducible()
+            True
+
+            sage: SGA = SymmetricGroupAlgebra(GF(2), 5)
+            sage: SGA.specht_module([3, 2]).is_irreducible()
+            False
+            sage: SGA.specht_module([4, 1]).is_irreducible()
+            True
+        """
+        return bool(self.find_subrepresentation() is None)
+
+    def find_subrepresentation(self):
+        r"""
+        Return a nontrivial (not ``self`` or the trivial module) submodule
+        of ``self`` or ``None`` if ``self`` is irreducible.
+
+        EXAMPLES::
+
+            sage: SGA = SymmetricGroupAlgebra(GF(2), 5)
+            sage: SM = SGA.specht_module([3, 2])
+            sage: U = SM.find_subrepresentation()
+            sage: [SM(b) for b in U.basis()]
+            [S[[1, 2, 3], [4, 5]] + S[[1, 2, 4], [3, 5]]
+             + S[[1, 2, 5], [3, 4]] + S[[1, 3, 4], [2, 5]]]
+            sage: B = U.basis()[0].lift()
+            sage: all(g * B == B for g in SGA.gens())
+            True
+            sage: SGA.specht_module([4, 1]).find_subrepresentation() is None
+            True
+            sage: SGA.specht_module([5]).find_subrepresentation() is None
+            True
+        """
+        if self.dimension() <= 1:  # trivially irreducible
+            return None
+
+        if not self.is_finite():
+            raise NotImplementedError("only implemented for finite modules")
+
+        if self._semigroup.cardinality() < 2:
+            return self.subrepresentation([next(iter(self.basis()))], is_closed=True)
+
+        R = self.base_ring()
+        gens = [self.representation_matrix(g) for g in self._semigroup.gens()]
+        try:
+            # add the identity to the generators (if it exists)
+            gens.append(self.representation_matrix(self._semigroup.one()))
+        except (AttributeError, NotImplementedError, TypeError, ValueError):
+            pass
+        gens_transpose = tuple([g.transpose() for g in gens])
+        amb_dim = self.dimension()
+
+        def check_submodule(xi, G):
+            N = xi.right_kernel_matrix()
+            SM = N[:1]
+            dim = 0
+            while dim < SM.nrows() < amb_dim:
+                dim = SM.nrows()
+                added = matrix([g * vec for g in G for vec in SM.rows()])
+                SM = SM.stack(added)
+                SM.echelonize()
+                SM = SM[:SM.rank()]
+            if SM.nrows() < amb_dim:
+                return SM
+            return None
+
+        def generate_elements():
+            cur = sum(R.random_element() * g for g in gens)
+            while True:
+                if cur.is_zero():
+                    cur = sum(R.random_element() * g for g in gens)
+                yield cur
+                cur *= sum(R.random_element() * g for g in gens)
+
+        for theta in generate_elements():
+            chi = theta.charpoly()
+            factors = sorted(chi.factor(), key=lambda c: c[0].degree())
+            for f, _ in factors:
+                xi = f(theta)
+                if not xi.is_singular():  # no nullspaces
+                    continue
+                SM = check_submodule(xi, gens)
+                if SM is not None:
+                    return self.subrepresentation([self.from_vector(v) for v in SM.rows()],
+                                                  is_closed=True)
+                SM = check_submodule(xi.transpose(), gens_transpose)
+                if SM is not None:
+                    # We instead want the submodule given by the orthogonal complement
+                    return self.subrepresentation([self.from_vector(v) for v in SM.right_kernel_matrix().rows()],
+                                                  is_closed=True)
+                if xi.right_kernel_matrix().nrows() == f.degree():  # good factor
+                    return None  # irreducible
+
+    def subrepresentation(self, gens, check=True, already_echelonized=False,
+                          *args, is_closed=False, **opts):
+        """
+        Construct a subrepresentation of ``self`` generated by ``gens``.
+
+        INPUT:
+
+        - ``gens`` -- the generators of the submodule
+        - ``check`` -- ignored
+        - ``already_echelonized`` --
+        - ``is_closed`` -- (keyword only; default: ``False``) whether ``gens``
+          already spans the subspace closed under the semigroup action
+
+        EXAMPLES::
+
+            sage: SGA = SymmetricGroupAlgebra(GF(2), 5)
+            sage: SM = SGA.specht_module([3, 2])
+            sage: B = next(iter(SM.basis()))
+            sage: U = SM.subrepresentation([B])
+            sage: U.dimension()
+            5
+        """
+        if not is_closed and gens:
+            R = self.base_ring()
+            repr_mats = [self.representation_matrix(g) for g in self._semigroup.gens()]
+            amb_dim = self.dimension()
+            SM = matrix([v._vector_() for v in gens])
+            SM.echelonize()
+            SM = SM[:SM.rank()]
+            dim = 0
+            while dim < SM.nrows() < amb_dim:
+                dim = SM.nrows()
+                added = matrix([g * vec for g in repr_mats for vec in SM.rows()])
+                SM = SM.stack(added)
+                SM.echelonize()
+                SM = SM[:SM.rank()]
+            gens = [self.from_vector(v) for v in SM.rows()]
+            # it might not be echelonized w.r.t. the module's basis ordering
+            already_echelonized = False
+        return self.submodule(gens, *args, parent_class=Subrepresentation, check=check,
+                              already_echelonized=already_echelonized, **opts)
+
+    def quotient_representation(self, subrepr, already_echelonized=False, **kwds):
+        """
+        Construct a quotient representation of ``self`` by ``subrepr``.
+        """
+        if not isinstance(subrepr, Subrepresentation):
+            subrepr = self.subrepresentation(subrepr, unitriangular=True,
+                                             already_echelonized=already_echelonized)
+        return QuotientRepresentation(subrepr, **kwds)
+
+    @cached_method
+    def _composition_series_data(self):
+        r"""
+        Return a composition series and the simple quotients (i.e.,
+        the composition factors) of ``self``.
+
+        EXAMPLES:
+
+        The algorithm used here uses random elements, so we set the seed
+        for testing purposes::
+
+            sage: set_random_seed(0)
+            sage: G = groups.permutation.Cyclic(6)
+            sage: R = G.regular_representation(GF(3))
+            sage: CS, CF = R._composition_series_data()
+            sage: [[R(b) for b in F.basis()] for F in CS]
+            [[(),
+              (1,2,3,4,5,6),
+              (1,3,5)(2,4,6),
+              (1,4)(2,5)(3,6),
+              (1,5,3)(2,6,4),
+              (1,6,5,4,3,2)],
+             [() + 2*(1,6,5,4,3,2),
+              (1,2,3,4,5,6) + 2*(1,6,5,4,3,2),
+              (1,3,5)(2,4,6) + 2*(1,6,5,4,3,2),
+              (1,4)(2,5)(3,6) + 2*(1,6,5,4,3,2),
+              (1,5,3)(2,6,4) + 2*(1,6,5,4,3,2)],
+             [() + (1,5,3)(2,6,4) + (1,6,5,4,3,2),
+              (1,2,3,4,5,6) + 2*(1,5,3)(2,6,4),
+              (1,3,5)(2,4,6) + 2*(1,6,5,4,3,2),
+              (1,4)(2,5)(3,6) + (1,5,3)(2,6,4) + (1,6,5,4,3,2)],
+             [() + 2*(1,4)(2,5)(3,6),
+              (1,2,3,4,5,6) + 2*(1,5,3)(2,6,4),
+              (1,3,5)(2,4,6) + 2*(1,6,5,4,3,2)],
+             [() + 2*(1,3,5)(2,4,6) + 2*(1,4)(2,5)(3,6) + (1,6,5,4,3,2),
+              (1,2,3,4,5,6) + (1,3,5)(2,4,6) + 2*(1,5,3)(2,6,4) + 2*(1,6,5,4,3,2)],
+             [() + 2*(1,2,3,4,5,6) + (1,3,5)(2,4,6) + 2*(1,4)(2,5)(3,6)
+              + (1,5,3)(2,6,4) + 2*(1,6,5,4,3,2)],
+             []]
+            sage: [F.dimension() for F in CF]
+            [1, 1, 1, 1, 1, 1]
+        """
+        from sage.data_structures.blas_dict import linear_combination
+        series = [self]
+        cur = 0
+        # The natural condition is ``while cur < len(series)``. However, the
+        #   loop will always terminate from the break statement. So we skip
+        #   this test for speed.
+        while True:
+            V = series[cur]
+            if cur == len(series) - 1:
+                W = V.find_subrepresentation()
+                if W is None:  # V is irreducible
+                    break
+                # Construct W as a subrepresentation of ``self`` for consistency
+                Wp = self.subrepresentation([self(b) for b in W._basis],
+                                            already_echelonized=True, is_closed=True)
+                series.append(Wp)
+            else:
+                W = V.subrepresentation([V.retract(b) for b in series[cur+1]._basis],
+                                        already_echelonized=True, is_closed=True)
+
+            Q = V.quotient_representation(W)
+            S = Q.find_subrepresentation()
+            while S is not None:  # found a nontrivial subrepresentation
+                # Lift S -> Q -> V -> self
+                # S_basis = [b.lift().lift().lift() for b in S.basis()]
+                # Fast version not creating transient elements
+                if V is self:
+                    S_basis = [self.element_class(self, b._monomial_coefficients) for b in S._basis]
+                else:
+                    S_basis = [self.element_class(self, linear_combination((V._basis[i]._monomial_coefficients, coeff)
+                                                                           for i, coeff in b._monomial_coefficients.items()))
+                               for b in S._basis]
+                # Lift the basis of W', which is W as a subrepr of ``self ``
+                # This is equivanlent to [b.lift() for b in series[cur+1].basis()]
+                Wp_basis = list(series[cur+1]._basis)
+                Wp = self.subrepresentation(S_basis + Wp_basis, is_closed=True)
+                series.insert(cur+1, Wp)
+                if V is self:
+                    W = Wp
+                else:
+                    W = V.subrepresentation([V.retract(b) for b in series[cur+1]._basis],
+                                            already_echelonized=True, is_closed=True)
+                Q = V.quotient_representation(W)
+                S = Q.find_subrepresentation()
+
+            cur += 1
+
+        # Special case when ``self`` is irreducible
+        if len(series) == 1:
+            simples = (self,)
+            series.append(self.subrepresentation([], is_closed=True))
+            return (tuple(series), simples)
+
+        # Convert series to a tower and include the 0 dimensional
+        #   representation at the end.
+        ret = [self, series[1]]
+        prev = series[1]
+        lift = prev.lift
+        retract = lift.section()
+        for W in series[2:]:
+            prev = prev.subrepresentation([retract(b) for b in W._basis],
+                                          already_echelonized=True, is_closed=True)
+            ret.append(prev)
+
+            # Construct the lift map prev -> self
+            data = {i: lift(prev._basis[i]) for i in prev._basis.keys()}
+            lift = prev.module_morphism(data.__getitem__,
+                                        codomain=self,
+                                        triangular="lower",
+                                        unitriangular=False,
+                                        key=W._support_key,
+                                        inverse_on_support="compute")
+            retract = lift.section()
+
+        ret.append(ret[-1].subrepresentation([], is_closed=True))
+
+        # Construct the simples
+        simples = [ret[i].quotient_representation(ret[i+1])
+                   for i in range(len(ret)-2)]
+        simples.append(ret[-2])
+
+        return (tuple(ret), tuple(simples))
+
+    def composition_series(self):
+        r"""
+        Return a composition series of ``self``.
+
+        EXAMPLES:
+
+        The algorithm used here uses random elements, so we set the seed
+        for testing purposes::
+
+            sage: set_random_seed(0)
+        """
+        return self._composition_series_data()[0]
+
+    def composition_factors(self):
+        r"""
+        Return the composition factors of ``self``.
+
+        Given a composition series `V = V_0 \subseteq V_1 \subseteq \cdots
+        \subseteq V_{\ell} = 0`, the composition factor `S_i` is defined as
+        `V_i / V_{i+1}`.
+
+        EXAMPLES:
+
+        The algorithm used here uses random elements, so we set the seed
+        for testing purposes::
+
+            sage: set_random_seed(0)
+            sage: SGA = SymmetricGroupAlgebra(GF(3), 6)
+            sage: SM = SGA.specht_module([4, 1, 1])
+            sage: CF = SM.composition_factors()
+            sage: CF
+            (Quotient representation with basis
+              {[[1, 2, 5, 6], [3], [4]], [[1, 2, 4, 6], [3], [5]], [[1, 2, 3, 6], [4], [5]],
+               [[1, 2, 4, 5], [3], [6]], [[1, 2, 3, 5], [4], [6]], [[1, 2, 3, 4], [5], [6]]}
+              of Specht module of [4, 1, 1] over Finite Field of size 3,
+             Subrepresentation with basis {0, 1, 2, 3} of Specht module
+              of [4, 1, 1] over Finite Field of size 3)
+            sage: x = SGA.an_element()
+            sage: v = CF[1].an_element(); v
+            2*B[0] + 2*B[1]
+            sage: x * v
+            B[1] + B[2]
+
+        We reproduce the decomposition matrix for `S_5` over `\GF{2}`::
+
+            sage: SGA = SymmetricGroupAlgebra(GF(2), 5)
+            sage: simples = [SGA.simple_module(la).brauer_character()
+            ....:            for la in SGA.simple_module_parameterization()]
+            sage: D = []
+            sage: for la in Partitions(5):
+            ....:     SM = SGA.specht_module(la)
+            ....:     data = [CF.brauer_character() for CF in SM.composition_factors()]
+            ....:     D.append([data.count(bc) for bc in simples])
+            sage: matrix(D)
+            [1 0 0]
+            [0 1 0]
+            [1 0 1]
+            [2 0 1]
+            [1 0 1]
+            [0 1 0]
+            [1 0 0]
+        """
+        return self._composition_series_data()[1]
 
     class Element(CombinatorialFreeModule.Element):
         def _acted_upon_(self, scalar, self_on_left=False):
@@ -446,7 +985,7 @@ class Representation_abstract(CombinatorialFreeModule):
             return CombinatorialFreeModule.Element._acted_upon_(self, scalar, self_on_left)
 
 
-class Representation(Representation_abstract):
+class Representation(Representation_abstract, CombinatorialFreeModule):
     r"""
     Representation of a semigroup.
 
@@ -573,8 +1112,9 @@ class Representation(Representation_abstract):
         if 'FiniteDimensional' in module.category().axioms():
             category = category.FiniteDimensional()
 
-        Representation_abstract.__init__(self, semigroup, module.base_ring(), side, indices,
-                                         category=category, **module.print_options())
+        CombinatorialFreeModule.__init__(self, module.base_ring(), indices, category=category,
+                                         **module.print_options())
+        Representation_abstract.__init__(self, semigroup, side)
 
     def _test_representation(self, **options):
         """
@@ -737,7 +1277,97 @@ class Representation(Representation_abstract):
                                        for m, c in vec._monomial_coefficients.items()), not vec_on_left)
 
 
-class Representation_Tensor(CombinatorialFreeModule_Tensor, Representation_abstract):
+class Subrepresentation(Representation_abstract, SubmoduleWithBasis):
+    """
+    A subrepresentation.
+    """
+    # Use the same normalization as the base class
+    __classcall_private__ = SubmoduleWithBasis.__classcall_private__
+
+    def __init__(self, basis, support_order, ambient, *args, **opts):
+        r"""
+        Initialize ``self``.
+
+        EXAMPLES::
+
+            sage: G = groups.permutation.Dihedral(4)
+            sage: R = G.regular_representation(QQ)
+            sage: S = R.subrepresentation([sum(R.basis())])
+            sage: TestSuite(S).run()
+        """
+        SubmoduleWithBasis.__init__(self, basis, support_order, ambient, *args, **opts)
+        Representation_abstract.__init__(self, ambient.semigroup(), ambient.side(), ambient.semigroup_algebra())
+
+    def _repr_(self):
+        r"""
+        Return a string representation of ``self``.
+
+        EXAMPLES::
+
+            sage: G = groups.permutation.Dihedral(4)
+            sage: R = G.regular_representation()
+            sage: R.subrepresentation([sum(R.basis())], is_closed=True)
+            Subrepresentation with basis {0} of Left Regular Representation of
+             Dihedral group of order 8 as a permutation group over Integer Ring
+        """
+        return "Subrepresentation with basis {} of {}".format(self.basis().keys(), self._ambient)
+
+    class Element(SubmoduleWithBasis.Element):
+        def _acted_upon_(self, scalar, self_on_left=True):
+            ret = super()._acted_upon_(scalar, self_on_left)
+            if ret is not None:
+                return ret
+            P = self.parent()
+            if scalar in P._semigroup or scalar in P._semigroup_algebra:
+                return P.retract(self.lift()._acted_upon_(scalar, self_on_left))
+            return None
+
+
+class QuotientRepresentation(Representation_abstract, QuotientModuleWithBasis):
+    """
+    The quotient of a representation by another representation, which
+    admits a natural structure of a representation.
+    """
+    # Use the same normalization as the base class
+    __classcall_private__ = QuotientModuleWithBasis.__classcall_private__
+
+    def __init__(self, *args, **kwds):
+        r"""
+        Initialize ``self``.
+
+        EXAMPLES::
+
+            sage: G = groups.permutation.Dihedral(4)
+            sage: R = G.regular_representation(QQ)
+            sage: S = R.subrepresentation([sum(R.basis())], is_closed=True)
+            sage: Q = R.quotient_representation(S)
+            sage: TestSuite(Q).run()
+        """
+        QuotientModuleWithBasis.__init__(self, *args, **kwds)
+        amb = self.ambient()
+        Representation_abstract.__init__(self, amb.semigroup(), amb.side(), amb.semigroup_algebra())
+
+    def _repr_(self):
+        r"""
+        Return a string representation of ``self``.
+
+        EXAMPLES::
+
+            sage: G = groups.permutation.Dihedral(4)
+            sage: R = G.regular_representation(QQ)
+            sage: S = R.subrepresentation([sum(R.basis())], is_closed=True)
+            sage: R.quotient_representation(S)
+            Quotient representation with basis
+             {(1,3)(2,4), (1,4,3,2), (1,2,3,4), (2,4), (1,3), (1,4)(2,3), (1,2)(3,4)}
+             of Left Regular Representation of Dihedral group of order 8
+             as a permutation group over Rational Field
+        """
+        return "Quotient representation with basis {} of {}".format(self.basis().keys(), self._ambient)
+
+    Element = Subrepresentation.Element
+
+
+class Representation_Tensor(Representation_abstract, CombinatorialFreeModule_Tensor):
     r"""
     Tensor product of representations.
     """
@@ -797,16 +1427,13 @@ class Representation_Tensor(CombinatorialFreeModule_Tensor, Representation_abstr
         """
         sides = set(M.side() for M in reps)
         if "left" and "right" in sides:
-            self._side = reps[0].side()  # make a choice as this is not fundamentally important
+            side = reps[0].side()  # make a choice as this is not fundamentally important
         else:
             if len(sides) == 2:  # mix of one side and twosided
                 sides.remove("twosided")
-            self._side, = sides  # get the unique side remaining
-        self._semigroup = reps[0].semigroup()
-        self._semigroup_algebra = reps[0].semigroup_algebra()
-        self._left_repr = bool(self._side == "left" or self._side == "twosided")
-        self._right_repr = bool(self._side == "right" or self._side == "twosided")
+            side, = sides  # get the unique side remaining
         CombinatorialFreeModule_Tensor.__init__(self, reps, **options)
+        Representation_abstract.__init__(self, reps[0].semigroup(), side)
 
     def _semigroup_action(self, g, vec, vec_on_left):
         """
@@ -842,7 +1469,7 @@ class Representation_Tensor(CombinatorialFreeModule_Tensor, Representation_abstr
 Representation_abstract.Tensor = Representation_Tensor
 
 
-class Representation_Exterior(Representation_abstract):
+class Representation_Exterior(Representation_abstract, CombinatorialFreeModule):
     r"""
     The exterior power representation (in a fixed degree).
     """
@@ -892,8 +1519,8 @@ class Representation_Exterior(Representation_abstract):
         ind = CliffordAlgebraIndices(dim, degree)
         R = rep.base_ring()
         category = Modules(R).WithBasis().or_subcategory(category)
-        Representation_abstract.__init__(self, rep.semigroup(), R, rep.side(),
-                                         ind, category=category, **options)
+        CombinatorialFreeModule.__init__(self, R, ind, category=category, **options)
+        Representation_abstract.__init__(self, rep.semigroup(), rep.side(), rep.semigroup_algebra())
 
     def _repr_(self):
         r"""
@@ -1155,7 +1782,7 @@ class Representation_ExteriorAlgebra(Representation_Exterior):
         return self.element_class(self, temp._monomial_coefficients)
 
 
-class Representation_Symmetric(Representation_abstract):
+class Representation_Symmetric(Representation_abstract, CombinatorialFreeModule):
     r"""
     The symmetric power representation in a fixed degree.
     """
@@ -1195,8 +1822,8 @@ class Representation_Symmetric(Representation_abstract):
         G = self._symalg.gens()
         self._inv_map = {b: G[i] for i, b in enumerate(self._basis_order)}
         ind = IntegerVectors(degree, dim)
-        Representation_abstract.__init__(self, rep.semigroup(), rep.base_ring(), rep.side(),
-                                         ind, **options)
+        CombinatorialFreeModule.__init__(self, rep.base_ring(), ind, **options)
+        Representation_abstract.__init__(self, rep.semigroup(), rep.side(), rep.semigroup_algebra())
 
     def _repr_(self):
         r"""
@@ -1502,7 +2129,7 @@ class RegularRepresentation(Representation):
         return self.monomial(m * g)
 
 
-class TrivialRepresentation(Representation_abstract):
+class TrivialRepresentation(Representation_abstract, CombinatorialFreeModule):
     """
     The trivial representation of a semigroup.
 
@@ -1534,7 +2161,8 @@ class TrivialRepresentation(Representation_abstract):
         cat = Modules(base_ring).WithBasis().FiniteDimensional()
         from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
         indices = FiniteEnumeratedSet(['v'])
-        Representation_abstract.__init__(self, semigroup, base_ring, "twosided", indices, category=cat)
+        CombinatorialFreeModule.__init__(self, base_ring, indices, category=cat)
+        Representation_abstract.__init__(self, semigroup, "twosided")
 
     def _repr_(self):
         """
@@ -1617,7 +2245,7 @@ class TrivialRepresentation(Representation_abstract):
             return CombinatorialFreeModule.Element._acted_upon_(self, scalar, self_on_left)
 
 
-class SignRepresentation_abstract(Representation_abstract):
+class SignRepresentation_abstract(Representation_abstract, CombinatorialFreeModule):
     """
     Generic implementation of a sign representation.
 
@@ -1658,7 +2286,8 @@ class SignRepresentation_abstract(Representation_abstract):
 
         cat = Modules(base_ring).WithBasis().FiniteDimensional()
 
-        Representation_abstract.__init__(self, group, base_ring, "twosided", ["v"], category=cat)
+        CombinatorialFreeModule.__init__(self, base_ring, ["v"], category=cat)
+        Representation_abstract.__init__(self, group, "twosided")
 
     def _repr_(self):
         """
@@ -1827,7 +2456,7 @@ class SignRepresentationCoxeterGroup(SignRepresentation_abstract):
         return -1 if elem.length() % 2 else 1
 
 
-class ReflectionRepresentation(Representation_abstract):
+class ReflectionRepresentation(Representation_abstract, CombinatorialFreeModule):
     r"""
     The reflection representation of a Coxeter group.
 
@@ -1875,7 +2504,8 @@ class ReflectionRepresentation(Representation_abstract):
         rk = W.coxeter_matrix().rank()
         from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
         indices = FiniteEnumeratedSet(range(rk))
-        super().__init__(W, base_ring, "left", indices, prefix='e', bracket=False)
+        CombinatorialFreeModule.__init__(self, base_ring, indices, prefix='e', bracket=False)
+        Representation_abstract.__init__(self, W, "left")
 
     def _repr_(self):
         r"""


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

We provide an implementation of Garsia-Procesi modules, which are an important class of representations of the symmetric group that comes from the cohomology of the Springer fiber. This provides an implementation as a representation on a quotient ring. This also does the following as part of getting the code to work (and a few related changes):

- Implement the meataxe algorithm over finite fields to compute the composition series.
- Move the (Brauer) character and other methods from symmetric group representation to the general representation class.
- Made the abstract representation class work more generically and streamlined the implementation.
- Expose the `Representation` class as part of the semigroup (algebras) API.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


