### PR TITLE
eclib: fix doctests after 20240408 update

### DIFF
--- a/src/sage/libs/eclib/interface.py
+++ b/src/sage/libs/eclib/interface.py
@@ -728,7 +728,7 @@ class mwrank_MordellWeil(SageObject):
         P1 = [-3:0:1]     is generator number 1
         saturating up to 20...Saturation index bound (for points of good reduction)  = 3
         Reducing saturation bound from given value 20 to computed index bound 3
-        Tamagawa index primes are [ 2 ]
+        Tamagawa index primes are [ 2 ]...
         Checking saturation at [ 2 3 ]
         Checking 2-saturation
         Points were proved 2-saturated (max q used = 7)
@@ -738,7 +738,7 @@ class mwrank_MordellWeil(SageObject):
         P2 = [-2:3:1]     is generator number 2
         saturating up to 20...Saturation index bound (for points of good reduction)  = 4
         Reducing saturation bound from given value 20 to computed index bound 4
-        Tamagawa index primes are [ 2 ]
+        Tamagawa index primes are [ 2 ]...
         Checking saturation at [ 2 3 ]
         Checking 2-saturation
         possible kernel vector = [1,1]
@@ -753,7 +753,7 @@ class mwrank_MordellWeil(SageObject):
         P3 = [-14:25:8]   is generator number 3
         saturating up to 20...Saturation index bound (for points of good reduction)  = 3
         Reducing saturation bound from given value 20 to computed index bound 3
-        Tamagawa index primes are [ 2 ]
+        Tamagawa index primes are [ 2 ]...
         Checking saturation at [ 2 3 ]
         Checking 2-saturation
         Points were proved 2-saturated (max q used = 11)
@@ -908,7 +908,7 @@ class mwrank_MordellWeil(SageObject):
             saturating basis...Saturation index bound (for points of good reduction)  = 93
             Only p-saturating for p up to given value 2.
             The resulting points may not be p-saturated for p between this and the computed index bound 93
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 ]
             Checking 2-saturation
             possible kernel vector = [1,0,0]
@@ -930,7 +930,7 @@ class mwrank_MordellWeil(SageObject):
             saturating basis...Saturation index bound (for points of good reduction)  = 46
             Only p-saturating for p up to given value 3.
             The resulting points may not be p-saturated for p between this and the computed index bound 46
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 3 ]
             Checking 2-saturation
             Points were proved 2-saturated (max q used = 11)
@@ -954,7 +954,7 @@ class mwrank_MordellWeil(SageObject):
             saturating basis...Saturation index bound (for points of good reduction)  = 15
             Only p-saturating for p up to given value 5.
             The resulting points may not be p-saturated for p between this and the computed index bound 15
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 3 5 ]
             Checking 2-saturation
             Points were proved 2-saturated (max q used = 11)
@@ -978,7 +978,7 @@ class mwrank_MordellWeil(SageObject):
             0.417143558758384
             sage: EQ.saturate()   # points are now saturated
             saturating basis...Saturation index bound (for points of good reduction)  = 3
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 3 ]
             Checking 2-saturation
             Points were proved 2-saturated (max q used = 11)
@@ -1189,7 +1189,7 @@ class mwrank_MordellWeil(SageObject):
 
             sage: EQ.saturate()   # points are now saturated
             saturating basis...Saturation index bound (for points of good reduction) = 3
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 3 ]
             Checking 2-saturation
             Points were proved 2-saturated (max q used = 11)
@@ -1217,7 +1217,7 @@ class mwrank_MordellWeil(SageObject):
 
             sage: EQ.saturate()
             saturating basis...Saturation index bound (for points of good reduction) = 3
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 3 ]
             Checking 2-saturation
             Points were proved 2-saturated (max q used = 11)

--- a/src/sage/libs/eclib/mwrank.pyx
+++ b/src/sage/libs/eclib/mwrank.pyx
@@ -590,7 +590,7 @@ cdef class _mw:
             P1 = [-3:0:1]         is generator number 1
             saturating up to 20...Saturation index bound (for points of good reduction)  = 3
             Reducing saturation bound from given value 20 to computed index bound 3
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 3 ]
             Checking 2-saturation
             Points were proved 2-saturated (max q used = 7)
@@ -600,7 +600,7 @@ cdef class _mw:
             P2 = [-2:3:1]         is generator number 2
             saturating up to 20...Saturation index bound (for points of good reduction)  = 4
             Reducing saturation bound from given value 20 to computed index bound 4
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 3 ]
             Checking 2-saturation
             possible kernel vector = [1,1]
@@ -615,7 +615,7 @@ cdef class _mw:
             P3 = [-14:25:8]       is generator number 3
             saturating up to 20...Saturation index bound (for points of good reduction)  = 3
             Reducing saturation bound from given value 20 to computed index bound 3
-            Tamagawa index primes are [ 2 ]
+            Tamagawa index primes are [ 2 ]...
             Checking saturation at [ 2 3 ]
             Checking 2-saturation
             Points were proved 2-saturated (max q used = 11)


### PR DESCRIPTION
With the update to 20240408 and later, the output of eclib has some extra information that makes some doctests fail. This PR adds some `...` in the right spots so the tests still pass after the update, without affecting previous versions of eclib


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.