### PR TITLE
gap: don't use deprecated LaTeX() and LaTeXObj()

### DIFF
--- a/src/sage/groups/libgap_wrapper.pyx
+++ b/src/sage/groups/libgap_wrapper.pyx
@@ -602,14 +602,11 @@ cdef class ElementLibGAP(MultiplicativeGroupElement):
             sage: from sage.groups.libgap_group import GroupLibGAP
             sage: G = GroupLibGAP(libgap.FreeGroup('a', 'b'))
             sage: g = G.gen(0) * G.gen(1)
-            sage: g._latex_()
-            "ab%\n"
+            sage: latex(g)
+            \text{\texttt{a*b}}
         """
-        try:
-            return self.gap().LaTeX()
-        except ValueError:
-            from sage.misc.latex import latex
-            return latex(self._repr_())
+        from sage.misc.latex import latex
+        return latex(self._repr_())
 
     cpdef _mul_(left, right):
         """

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -1562,16 +1562,10 @@ class GapElement(GapElement_generic, sage.interfaces.abc.GapElement):
 
             sage: s = gap("[[1,2], [3/4, 5/6]]")
             sage: latex(s)
-            \left(\begin{array}{rr} 1&2\\ 3/4&\frac{5}{6}\\ \end{array}\right)
+            \left[\left[1, 2\right], \left[\frac{3}{4}, \frac{5}{6}\right]\right]
         """
-        P = self._check_valid()
-        try:
-            s = P.eval('LaTeXObj(%s)' % self.name())
-            s = s.replace('\\\\', '\\').replace('"', '')
-            s = s.replace('%\\n', ' ')
-            return s
-        except RuntimeError:
-            return str(self)
+        from sage.misc.latex import latex
+        return latex(self._sage_())
 
     @cached_method
     def _tab_completion(self):


### PR DESCRIPTION
These functions were removed in 4.13, but they weren't very good anyway.

This PR replaces its usage. It should work fine on old gap so this can be merged just fine.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.