### PR TITLE
build: show all cython warnings

### DIFF
--- a/src/sage_setup/command/sage_build_cython.py
+++ b/src/sage_setup/command/sage_build_cython.py
@@ -226,6 +226,7 @@ class sage_build_cython(Command):
                 compiler_directives=self.cython_directives,
                 compile_time_env=self.compile_time_env,
                 create_extension=self.create_extension,
+                show_all_warnings=True,
                 # Debugging
                 gdb_debug=self.debug,
                 output_dir=os.path.join(self.build_lib, "sage"),

--- a/src/setup.py
+++ b/src/setup.py
@@ -117,6 +117,7 @@ else:
                 compiler_directives=compiler_directives(False),
                 aliases=aliases,
                 create_extension=create_extension,
+                show_all_warnings=True,
                 gdb_debug=gdb_debug,
                 nthreads=nthreads)
     except Exception as exception:


### PR DESCRIPTION
Motivated by https://github.com/sagemath/sage/pull/37792#issuecomment-2053663025, change cython configuration so we show all warnings.

This will lead to a number of warnings, but it's IMO better to know about that and works towards fixing as much warnings as possible (and we have a fair number of warnings that are indeed relevant and *not* just false positives).


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
