### PR TITLE
sagemath-standard: some fixes in build dependencies

### DIFF
--- a/build/pkgs/networkx/version_requirements.txt
+++ b/build/pkgs/networkx/version_requirements.txt
@@ -1,1 +1,1 @@
-networkx >=2.4, <3.3
+networkx >=2.4

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -11,12 +11,9 @@ requires = [
     # Exclude 3.0.3 because of https://github.com/cython/cython/issues/5748
     'cython >=3.0, != 3.0.3, <4.0',
     'gmpy2 ~=2.1.b999',
-    'jupyter_core >=4.6.3',
     'memory_allocator',
     'numpy >=1.19',
     'pkgconfig',
-    # pplpy 0.8.4 and earlier do not declare dependencies correctly (see https://github.com/sagemath/sage/issues/30922)
-    'pplpy >=0.8.6',
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
- [build-system] requires: neither jupyter_core nor ppl are needed to build sagemath-standard.
- networkx: remove upper bound since 3.3 works just fine.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.