### PR TITLE
`sage.modular.hecke`: Deprecate `is_Hecke...` functions

### DIFF
--- a/src/sage/modular/hecke/algebra.py
+++ b/src/sage/modular/hecke/algebra.py
@@ -252,7 +252,7 @@ class HeckeAlgebra_base(CachedRepresentation, CommutativeRing):
             TypeError: Don't know how to construct an element of Anemic Hecke algebra acting on Modular Symbols space of dimension 3 for Gamma_0(11) of weight 2 with sign 0 over Rational Field from Hecke operator T_11 on Modular Symbols space of dimension 3 for Gamma_0(11) of weight 2 with sign 0 over Rational Field
 
         """
-        from .hecke_operator import HeckeAlgebraElement_matrix, HeckeOperator, is_HeckeOperator, is_HeckeAlgebraElement
+        from .hecke_operator import HeckeAlgebraElement_matrix, HeckeOperator, HeckeAlgebraElement
 
         if not isinstance(x, Element):
             x = self.base_ring()(x)
@@ -265,13 +265,13 @@ class HeckeAlgebra_base(CachedRepresentation, CommutativeRing):
         if parent is self:
             return x
 
-        if is_HeckeOperator(x):
+        if isinstance(x, HeckeOperator):
             if x.parent() == self \
                     or (not self.is_anemic() and x.parent() == self.anemic_subalgebra()) \
                     or (self.is_anemic() and x.parent().anemic_subalgebra() == self and gcd(x.index(), self.level()) == 1):
                 return HeckeOperator(self, x.index())
 
-        if is_HeckeAlgebraElement(x):
+        if isinstance(x, HeckeAlgebraElement):
             if x.parent() == self or (not self.is_anemic() and x.parent() == self.anemic_subalgebra()):
                 if x.parent().module().basis_matrix() == self.module().basis_matrix():
                     return HeckeAlgebraElement_matrix(self, x.matrix())

--- a/src/sage/modular/hecke/algebra.py
+++ b/src/sage/modular/hecke/algebra.py
@@ -52,10 +52,16 @@ def is_HeckeAlgebra(x) -> bool:
 
         sage: from sage.modular.hecke.algebra import is_HeckeAlgebra
         sage: is_HeckeAlgebra(CuspForms(1, 12).anemic_hecke_algebra())
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeAlgebra is deprecated;
+        use 'isinstance(..., HeckeAlgebra_base)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         True
         sage: is_HeckeAlgebra(ZZ)
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeAlgebra is deprecated; use 'isinstance(..., HeckeAlgebra_base)' instead")
     return isinstance(x, HeckeAlgebra_base)
 
 
@@ -177,8 +183,8 @@ class HeckeAlgebra_base(CachedRepresentation, CommutativeRing):
         """
         if isinstance(M, tuple):
             M = M[0]
-        from . import module
-        if not module.is_HeckeModule(M):
+        from .module import HeckeModule_generic
+        if not isinstance(M, HeckeModule_generic):
             msg = f"M (={M}) must be a HeckeModule"
             raise TypeError(msg)
         self.__M = M

--- a/src/sage/modular/hecke/ambient_module.py
+++ b/src/sage/modular/hecke/ambient_module.py
@@ -41,6 +41,10 @@ def is_AmbientHeckeModule(x) -> bool:
 
         sage: from sage.modular.hecke.ambient_module import is_AmbientHeckeModule
         sage: is_AmbientHeckeModule(ModularSymbols(6))
+        doctest:warning...
+        DeprecationWarning: the function is_AmbientHeckeModule is deprecated;
+        use 'isinstance(..., AmbientHeckeModule)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         True
         sage: is_AmbientHeckeModule(ModularSymbols(6).cuspidal_subspace())
         False
@@ -49,6 +53,8 @@ def is_AmbientHeckeModule(x) -> bool:
         sage: is_AmbientHeckeModule(BrandtModule(2, 3))
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_AmbientHeckeModule is deprecated; use 'isinstance(..., AmbientHeckeModule)' instead")
     return isinstance(x, AmbientHeckeModule)
 
 
@@ -367,7 +373,7 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
             ...
             ValueError: the characters of the domain and codomain must match
         """
-        if is_AmbientHeckeModule(codomain):
+        if isinstance(codomain, AmbientHeckeModule):
             M = codomain
             level = int(M.level())
         else:

--- a/src/sage/modular/hecke/ambient_module.py
+++ b/src/sage/modular/hecke/ambient_module.py
@@ -286,11 +286,11 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
         INPUT:
 
-        -  ``codomain`` - a Hecke module, which should be of the same type as
+        -  ``codomain`` -- a Hecke module, which should be of the same type as
            self, or a positive integer (in which case Sage will use
            :meth:`~hecke_module_of_level` to find the "natural" module of the
            corresponding level).
-        -  ``t`` - int, the parameter of the degeneracy map, i.e., the map is
+        -  ``t`` -- int, the parameter of the degeneracy map, i.e., the map is
            related to `f(q)` - `f(q^t)`.
 
         OUTPUT: A morphism from ``self`` to ``codomain``.
@@ -299,15 +299,16 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
             sage: M = ModularSymbols(11,sign=1)
             sage: d1 = M.degeneracy_map(33); d1
-            Hecke module morphism degeneracy map corresponding to f(q) |--> f(q) defined by the matrix
+            Hecke module morphism degeneracy map corresponding to f(q) |--> f(q)
+            defined by the matrix
             [ 1  0  0  0 -2 -1]
             [ 0 -1  1  0  0  0]
-            Domain: Modular Symbols space of dimension 2 for Gamma_0(11) of weight ...
+            Domain:   Modular Symbols space of dimension 2 for Gamma_0(11) of weight ...
             Codomain: Modular Symbols space of dimension 6 for Gamma_0(33) of weight ...
-            sage: M.degeneracy_map(33,3).matrix()
+            sage: M.degeneracy_map(33, 3).matrix()
             [ 3  2  0  2 -2  1]
             [ 0  0 -1  1  0  0]
-            sage: M = ModularSymbols(33,sign=1)
+            sage: M = ModularSymbols(33, sign=1)
             sage: d2 = M.degeneracy_map(11); d2.matrix()
             [ 1  0]
             [ 0 -2]
@@ -321,9 +322,10 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
         ::
 
-            sage: M = ModularSymbols(3,12,sign=1)
+            sage: M = ModularSymbols(3, 12, sign=1)
             sage: M.degeneracy_map(1)
-            Hecke module morphism degeneracy map corresponding to f(q) |--> f(q) defined by the matrix
+            Hecke module morphism degeneracy map corresponding to f(q) |--> f(q)
+            defined by the matrix
             [1 0]
             [0 0]
             [0 1]
@@ -348,8 +350,12 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
             sage: D = ModularSymbols(10,4).cuspidal_submodule().decomposition()
             sage: D
             [
-            Modular Symbols subspace of dimension 2 of Modular Symbols space of dimension 10 for Gamma_0(10) of weight 4 with sign 0 over Rational Field,
-            Modular Symbols subspace of dimension 4 of Modular Symbols space of dimension 10 for Gamma_0(10) of weight 4 with sign 0 over Rational Field
+             Modular Symbols subspace of dimension 2 of
+              Modular Symbols space of dimension 10 for
+               Gamma_0(10) of weight 4 with sign 0 over Rational Field,
+             Modular Symbols subspace of dimension 4 of
+              Modular Symbols space of dimension 10 for
+               Gamma_0(10) of weight 4 with sign 0 over Rational Field
             ]
             sage: D[1].degeneracy_map(5)
             Hecke module morphism defined by the matrix
@@ -357,13 +363,15 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
             [   0  1/2  3/2   -2]
             [   0   -1    1    0]
             [   0 -3/4 -1/4    1]
-            Domain: Modular Symbols subspace of dimension 4 of Modular Symbols space ...
+            Domain:   Modular Symbols subspace of dimension 4 of Modular Symbols space ...
             Codomain: Modular Symbols space of dimension 4 for Gamma_0(5) of weight ...
 
         We check for a subtle caching bug that came up in work on :issue:`10453`::
 
             sage: loads(dumps(J0(33).decomposition()[0].modular_symbols()))
-            Modular Symbols subspace of dimension 2 of Modular Symbols space of dimension 9 for Gamma_0(33) of weight 2 with sign 0 over Rational Field
+            Modular Symbols subspace of dimension 2 of
+             Modular Symbols space of dimension 9 for
+              Gamma_0(33) of weight 2 with sign 0 over Rational Field
 
         We check that certain absurd inputs are correctly caught::
 
@@ -436,9 +444,9 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
     def dual_free_module(self):
         r"""
-        The free module dual to self, as a submodule of the dual
+        The free module dual to ``self``, as a submodule of the dual
         module of the ambient space. As this space is ambient anyway,
-        this just returns self.free_module().
+        this just returns ``self.free_module()``.
 
         EXAMPLES::
 
@@ -456,19 +464,17 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
         INPUT:
 
+        -  ``self`` -- Hecke module invariant under the Hecke operator of index
+           `n`.
 
-        -  ``self`` - Hecke module invariant under the Hecke operator of index
-           n.
+        -  ``n`` -- a positive integer.
 
-        -  ``int n`` - a positive integer.
-
-        -  ``var`` - variable of polynomial (default `x`)
-
+        -  ``var`` -- variable of polynomial (default ``'x'``)
 
         OUTPUT:
 
-        -  ``list`` - list of the pairs (g,e), where g is an
-           irreducible factor of the characteristic polynomial of T_n, and e
+        -  ``list`` -- list of the pairs `(g,e)`, where `g` is an
+           irreducible factor of the characteristic polynomial of `T_n`, and `e`
            is its multiplicity.
 
         EXAMPLES::
@@ -503,13 +509,13 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
     def hecke_bound(self):
         r"""
-        Return an integer B such that the Hecke operators `T_n`, for `n\leq B`,
+        Return an integer `B` such that the Hecke operators `T_n`, for `n\leq B`,
         generate the full Hecke algebra as a module over the base ring. Note
         that we include the `n` with `n` not coprime to the level.
 
         At present this returns an unproven guess for non-cuspidal spaces which
-        appears to be valid for `M_k(\Gamma_0(N))`, where k and N are the
-        weight and level of self. (It is clearly valid for *cuspidal* spaces
+        appears to be valid for `M_k(\Gamma_0(N))`, where `k` and `N` are the
+        weight and level of ``self``. (It is clearly valid for *cuspidal* spaces
         of any fixed character, as a consequence of the Sturm bound theorem.)
         It returns a hopelessly wrong answer for spaces of full level
         `\Gamma_1`.
@@ -520,7 +526,7 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
             sage: ModularSymbols(17, 4).hecke_bound()
             15
-            sage: ModularSymbols(Gamma1(17), 4).hecke_bound() # wrong!
+            sage: ModularSymbols(Gamma1(17), 4).hecke_bound()  # wrong!
             15
         """
         from sage.misc.verbose import verbose
@@ -534,10 +540,10 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
     def hecke_module_of_level(self, level):
         r"""
-        Return the Hecke module corresponding to self at the given level, which
-        should be either a divisor or a multiple of the level of self.
+        Return the Hecke module corresponding to ``self`` at the given level, which
+        should be either a divisor or a multiple of the level of ``self``.
 
-        This raises NotImplementedError, and should be overridden in
+        This raises :class:`NotImplementedError`, and should be overridden in
         derived classes.
 
         EXAMPLES::
@@ -556,13 +562,13 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
         INPUT:
 
-        -  ``i`` - nonnegative integer
+        -  ``i`` -- nonnegative integer
 
-        -  ``v`` - a list of positive integer
+        -  ``v`` -- a list of positive integer
 
         OUTPUT:
 
-        -  ``matrix`` - whose rows are the Hecke images
+        -  ``matrix`` -- whose rows are the Hecke images
 
         EXAMPLES::
 
@@ -584,7 +590,7 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
     def intersection(self, other):
         """
-        Return the intersection of self and other, which must both lie in
+        Return the intersection of ``self`` and ``other``, which must both lie in
         a common ambient space of modular symbols.
 
         EXAMPLES::
@@ -609,8 +615,8 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
         .. warning::
 
-           self can only be ambient by being of type
-           AmbientHeckeModule.
+           ``self`` can only be ambient by being of type
+           :class:`AmbientHeckeModule`.
 
            For example, decomposing a simple ambient space yields a
            single factor, and that factor is *not* considered an
@@ -705,7 +711,7 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
     def linear_combination_of_basis(self, v):
         r"""
-        Given a list or vector of length equal to the dimension of self,
+        Given a list or vector of length equal to the dimension of ``self``,
         construct the appropriate linear combination of the basis vectors of
         self.
 
@@ -719,18 +725,18 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
     def new_submodule(self, p=None):
         """
-        Return the new or p-new submodule of self.
+        Return the new or `p`-new submodule of ``self``.
 
         INPUT:
 
-        -  ``p`` - (default: None); if not None, return only
-           the p-new submodule.
+        -  ``p`` - (default: ``None``); if not ``None``, return only
+           the `p`-new submodule.
 
-        OUTPUT: the new or p-new submodule of self, i.e. the intersection of
+        OUTPUT: the new or `p`-new submodule of ``self``, i.e. the intersection of
         the kernel of the degeneracy lowering maps to level `N/p` (for the
         given prime `p`, or for all prime divisors of `N` if `p` is not given).
 
-        If self is cuspidal this is a Hecke-invariant complement of the
+        If ``self`` is cuspidal, this is a Hecke-invariant complement of the
         corresponding old submodule, but this may break down on Eisenstein
         subspaces (see the amusing example in William Stein's book of a form
         which is new and old at the same time).
@@ -805,7 +811,7 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
     def nonembedded_free_module(self):
         r"""
-        Return the free module corresponding to self as an abstract free module
+        Return the free module corresponding to ``self`` as an abstract free module
         (rather than as a submodule of an ambient free module).
 
         As this module is ambient anyway, this just returns
@@ -821,16 +827,16 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
     def old_submodule(self, p=None):
         """
-        Return the old or p-old submodule of self, i.e. the sum of the images
+        Return the old or `p`-old submodule of ``self``, i.e. the sum of the images
         of the degeneracy maps from level `N/p` (for the given prime `p`, or
         for all primes `p` dividing `N` if `p` is not given).
 
         INPUT:
 
-        - ``p`` - (default: None); if not None, return only the p-old
+        - ``p`` - (default: ``None``); if not ``None``, return only the `p`-old
           submodule.
 
-        OUTPUT: the old or p-old submodule of self
+        OUTPUT: the old or `p`-old submodule of ``self``
 
         EXAMPLES::
 
@@ -847,14 +853,19 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
 
             sage: e = DirichletGroup(16)([-1, 1])
             sage: M = ModularSymbols(e, 3, sign=1); M
-            Modular Symbols space of dimension 4 and level 16, weight 3, character [-1, 1], sign 1, over Rational Field
+            Modular Symbols space of dimension 4 and level 16, weight 3,
+             character [-1, 1], sign 1, over Rational Field
             sage: M.old_submodule()
-            Modular Symbols subspace of dimension 3 of Modular Symbols space of dimension 4 and level 16, weight 3, character [-1, 1], sign 1, over Rational Field
+            Modular Symbols subspace of dimension 3 of
+             Modular Symbols space of dimension 4 and level 16, weight 3,
+              character [-1, 1], sign 1, over Rational Field
 
         Illustrate that :issue:`10664` is fixed::
 
             sage: ModularSymbols(DirichletGroup(42)[7], 6, sign=1).old_subspace(3)
-            Modular Symbols subspace of dimension 0 of Modular Symbols space of dimension 40 and level 42, weight 6, character [-1, -1], sign 1, over Rational Field
+            Modular Symbols subspace of dimension 0 of
+             Modular Symbols space of dimension 40 and level 42, weight 6,
+              character [-1, -1], sign 1, over Rational Field
 
         """
         try:
@@ -924,13 +935,15 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
     def submodule(self, M, Mdual=None, check=True):
         """
         Return the Hecke submodule of ``self`` generated by `M`, which may be a
-        submodule of the free module of self, or a list of elements of self.
+        submodule of the free module of ``self``, or a list of elements of ``self``.
 
         EXAMPLES::
 
             sage: M = ModularForms(37, 2)
             sage: A = M.submodule([M.newforms()[0].element(), M.newforms()[1].element()]); A
-            Modular Forms subspace of dimension 2 of Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(37) of weight 2 over Rational Field
+            Modular Forms subspace of dimension 2 of
+             Modular Forms space of dimension 3 for
+              Congruence Subgroup Gamma0(37) of weight 2 over Rational Field
         """
         if check:
             if not is_FreeModule(M):
@@ -962,39 +975,43 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
     def submodule_from_nonembedded_module(self, V, Vdual=None, check=True):
         """
         Create a submodule of this module, from a submodule of an ambient free
-        module of the same rank as the rank of self.
+        module of the same rank as the rank of ``self``.
 
         INPUT:
 
-        -  ``V`` - submodule of ambient free module of the same rank as the
+        -  ``V`` -- submodule of ambient free module of the same rank as the
            rank of self.
 
-        -  ``Vdual`` - used to pass in dual submodule (may be None)
+        -  ``Vdual`` -- used to pass in dual submodule (may be ``None``)
 
-        -  ``check`` - whether to check that submodule is Hecke equivariant
+        -  ``check`` -- whether to check that submodule is Hecke-equivariant
 
-        OUTPUT: Hecke submodule of self
+        OUTPUT: Hecke submodule of ``self``
 
         EXAMPLES::
 
             sage: V = QQ^8
             sage: ModularForms(24, 2).submodule_from_nonembedded_module(V.submodule([0]))
-            Modular Forms subspace of dimension 0 of Modular Forms space of dimension 8 for Congruence Subgroup Gamma0(24) of weight 2 over Rational Field
+            Modular Forms subspace of dimension 0 of
+             Modular Forms space of dimension 8 for
+              Congruence Subgroup Gamma0(24) of weight 2 over Rational Field
         """
         return self.submodule(V, Vdual, check=check)
 
     def submodule_generated_by_images(self, M):
         """
         Return the submodule of this ambient modular symbols space
-        generated by the images under all degeneracy maps of M.
+        generated by the images under all degeneracy maps of `M`.
 
-        The space M must have the same weight, sign, and group or
+        The space `M` must have the same weight, sign, and group or
         character as this ambient space.
 
         EXAMPLES::
 
             sage: ModularSymbols(6, 12).submodule_generated_by_images(ModularSymbols(1,12))
-            Modular Symbols subspace of dimension 12 of Modular Symbols space of dimension 22 for Gamma_0(6) of weight 12 with sign 0 over Rational Field
+            Modular Symbols subspace of dimension 12 of
+             Modular Symbols space of dimension 22 for
+              Gamma_0(6) of weight 12 with sign 0 over Rational Field
         """
         S = self.zero_submodule()
         if self.level() % M.level() == 0:

--- a/src/sage/modular/hecke/element.py
+++ b/src/sage/modular/hecke/element.py
@@ -35,10 +35,16 @@ def is_HeckeModuleElement(x):
     EXAMPLES::
 
         sage: sage.modular.hecke.all.is_HeckeModuleElement(0)
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeModuleElement is deprecated;
+        use 'isinstance(..., HeckeModuleElement)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         False
         sage: sage.modular.hecke.all.is_HeckeModuleElement(BrandtModule(37)([1,2,3]))
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeModuleElement is deprecated; use 'isinstance(..., HeckeModuleElement)' instead")
     return isinstance(x, HeckeModuleElement)
 
 

--- a/src/sage/modular/hecke/element.py
+++ b/src/sage/modular/hecke/element.py
@@ -156,7 +156,7 @@ class HeckeModuleElement(ModuleElement):
         EXAMPLES::
 
             sage: M = ModularSymbols(11, 2)
-            sage: M.0 == M.1 # indirect doctest
+            sage: M.0 == M.1  # indirect doctest
             False
             sage: M.0 == (M.1 + M.0 - M.1)
             True

--- a/src/sage/modular/hecke/hecke_operator.py
+++ b/src/sage/modular/hecke/hecke_operator.py
@@ -35,10 +35,16 @@ def is_HeckeOperator(x):
         sage: from sage.modular.hecke.hecke_operator import is_HeckeOperator
         sage: M = ModularSymbols(Gamma0(7), 4)
         sage: is_HeckeOperator(M.T(3))
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeOperator is deprecated;
+        use 'isinstance(..., HeckeOperator)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         True
         sage: is_HeckeOperator(M.T(3) + M.T(5))
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeOperator is deprecated; use 'isinstance(..., HeckeOperator)' instead")
     return isinstance(x, HeckeOperator)
 
 
@@ -51,10 +57,16 @@ def is_HeckeAlgebraElement(x):
         sage: from sage.modular.hecke.hecke_operator import is_HeckeAlgebraElement
         sage: M = ModularSymbols(Gamma0(7), 4)
         sage: is_HeckeAlgebraElement(M.T(3))
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeAlgebraElement is deprecated;
+        use 'isinstance(..., HeckeAlgebraElement)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         True
         sage: is_HeckeAlgebraElement(M.T(3) + M.T(5))
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeAlgebraElement is deprecated; use 'isinstance(..., HeckeAlgebraElement)' instead")
     return isinstance(x, HeckeAlgebraElement)
 
 
@@ -72,7 +84,7 @@ class HeckeAlgebraElement(AlgebraElement):
             sage: sage.modular.hecke.hecke_operator.HeckeAlgebraElement(R) # please don't do this!
             Generic element of a structure
         """
-        if not algebra.is_HeckeAlgebra(parent):
+        if not isinstance(parent, algebra.HeckeAlgebra):
             raise TypeError("parent (=%s) must be a Hecke algebra" % parent)
         AlgebraElement.__init__(self, parent)
 

--- a/src/sage/modular/hecke/hecke_operator.py
+++ b/src/sage/modular/hecke/hecke_operator.py
@@ -81,7 +81,7 @@ class HeckeAlgebraElement(AlgebraElement):
         EXAMPLES::
 
             sage: R = ModularForms(Gamma0(7), 4).hecke_algebra()
-            sage: sage.modular.hecke.hecke_operator.HeckeAlgebraElement(R) # please don't do this!
+            sage: sage.modular.hecke.hecke_operator.HeckeAlgebraElement(R)  # please don't do this!
             Generic element of a structure
         """
         if not isinstance(parent, algebra.HeckeAlgebra):
@@ -97,9 +97,9 @@ class HeckeAlgebraElement(AlgebraElement):
 
             sage: R = ModularForms(Gamma0(7), 4).hecke_algebra()
             sage: sage.modular.hecke.hecke_operator.HeckeAlgebraElement(R).domain()
-             Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) of weight 4 over Rational Field
+            Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7)
+             of weight 4 over Rational Field
         """
-
         return self.parent().module()
 
     def codomain(self):
@@ -111,7 +111,8 @@ class HeckeAlgebraElement(AlgebraElement):
 
             sage: R = ModularForms(Gamma0(7), 4).hecke_algebra()
             sage: sage.modular.hecke.hecke_operator.HeckeAlgebraElement(R).codomain()
-            Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) of weight 4 over Rational Field
+            Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7)
+             of weight 4 over Rational Field
         """
         return self.parent().module()
 
@@ -125,7 +126,8 @@ class HeckeAlgebraElement(AlgebraElement):
             sage: M = ModularSymbols(Gamma1(13))
             sage: t = M.hecke_operator(2)
             sage: t
-            Hecke operator T_2 on Modular Symbols space of dimension 15 for Gamma_1(13) of weight 2 with sign 0 over Rational Field
+            Hecke operator T_2 on Modular Symbols space of dimension 15 for Gamma_1(13)
+             of weight 2 with sign 0 over Rational Field
             sage: t.hecke_module_morphism()
             Hecke module morphism T_2 defined by the matrix
             [ 2  0  0  0  0  0  0  1  0  0  1  0  0  0  0]
@@ -143,7 +145,7 @@ class HeckeAlgebraElement(AlgebraElement):
             [ 0  0  0  0  0  1  1  0  0  1  0  0  0  0  0]
             [ 0  0  0  0  0  1  0  0  1 -1  2  0  0  0 -1]
             [ 0  0  0  0  0  0  0  0  0  1  0 -1  2  0 -1]
-            Domain: Modular Symbols space of dimension 15 for Gamma_1(13) of weight ...
+            Domain:   Modular Symbols space of dimension 15 for Gamma_1(13) of weight ...
             Codomain: Modular Symbols space of dimension 15 for Gamma_1(13) of weight ...
         """
         try:

--- a/src/sage/modular/hecke/hecke_operator.py
+++ b/src/sage/modular/hecke/hecke_operator.py
@@ -84,7 +84,7 @@ class HeckeAlgebraElement(AlgebraElement):
             sage: sage.modular.hecke.hecke_operator.HeckeAlgebraElement(R)  # please don't do this!
             Generic element of a structure
         """
-        if not isinstance(parent, algebra.HeckeAlgebra):
+        if not isinstance(parent, algebra.HeckeAlgebra_base):
             raise TypeError("parent (=%s) must be a Hecke algebra" % parent)
         AlgebraElement.__init__(self, parent)
 

--- a/src/sage/modular/hecke/homspace.py
+++ b/src/sage/modular/hecke/homspace.py
@@ -106,21 +106,21 @@ class HeckeModuleHomspace(HomsetWithBase):
             [ -7   0   0]
             [  0   1 240]
             [  0   0 343]
-            Domain: Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
+            Domain:   Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
             Codomain: Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
             sage: H(H(M.hecke_operator(7)))
             Hecke module morphism T_7 defined by the matrix
             [ -7   0   0]
             [  0   1 240]
             [  0   0 343]
-            Domain: Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
+            Domain:   Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
             Codomain: Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
             sage: H(matrix(QQ, 3, srange(9)))
             Hecke module morphism defined by the matrix
             [0 1 2]
             [3 4 5]
             [6 7 8]
-            Domain: Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
+            Domain:   Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
             Codomain: Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(7) ...
 
         TESTS:
@@ -128,7 +128,7 @@ class HeckeModuleHomspace(HomsetWithBase):
         Make sure that the element is created correctly when the codomain is
         not the full module (related to :issue:`21497`)::
 
-            sage: M = ModularSymbols(Gamma0(3),weight=22,sign=1)
+            sage: M = ModularSymbols(Gamma0(3), weight=22, sign=1)
             sage: S = M.cuspidal_subspace()
             sage: H = S.Hom(S)
             sage: H(S.gens())
@@ -139,7 +139,7 @@ class HeckeModuleHomspace(HomsetWithBase):
             [0 0 0 1 0 0]
             [0 0 0 0 1 0]
             [0 0 0 0 0 1]
-            Domain: Modular Symbols subspace of dimension 6 of Modular Symbols space ...
+            Domain:   Modular Symbols subspace of dimension 6 of Modular Symbols space ...
             Codomain: Modular Symbols subspace of dimension 6 of Modular Symbols space ...
 
             sage: H.zero() in H
@@ -195,7 +195,7 @@ class HeckeModuleHomspace(HomsetWithBase):
             Hecke module morphism defined by the matrix
             [      260 -2108/135]
             [     4860      -284]
-            Domain: Modular Symbols subspace of dimension 2 of Modular Symbols space ...
+            Domain:   Modular Symbols subspace of dimension 2 of Modular Symbols space ...
             Codomain: Modular Symbols subspace of dimension 2 of Modular Symbols space ...
         """
         if self.domain() != self.codomain():

--- a/src/sage/modular/hecke/homspace.py
+++ b/src/sage/modular/hecke/homspace.py
@@ -20,7 +20,7 @@ from sage.matrix.constructor import matrix
 from sage.matrix.matrix_space import MatrixSpace
 from sage.categories.homset import HomsetWithBase
 from .morphism import HeckeModuleMorphism_matrix
-from .module import is_HeckeModule
+from .module import HeckeModule_generic
 
 
 def is_HeckeModuleHomspace(x):
@@ -31,10 +31,16 @@ def is_HeckeModuleHomspace(x):
 
         sage: M = ModularForms(Gamma0(7), 4)
         sage: sage.modular.hecke.homspace.is_HeckeModuleHomspace(Hom(M, M))
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeModuleHomspace is deprecated;
+        use 'isinstance(..., HeckeModuleHomspace)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         True
         sage: sage.modular.hecke.homspace.is_HeckeModuleHomspace(Hom(M, QQ))
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeModuleHomspace is deprecated; use 'isinstance(..., HeckeModuleHomspace)' instead")
     return isinstance(x, HeckeModuleHomspace)
 
 
@@ -66,7 +72,7 @@ class HeckeModuleHomspace(HomsetWithBase):
             sage: H = M.Hom(M)
             sage: TestSuite(H).run(skip='_test_elements')
         """
-        if not is_HeckeModule(X) or not is_HeckeModule(Y):
+        if not isinstance(X, HeckeModule_generic) or not isinstance(Y, HeckeModule_generic):
             raise TypeError("X and Y must be Hecke modules")
         if X.base_ring() != Y.base_ring():
             raise TypeError("X and Y must have the same base ring")

--- a/src/sage/modular/hecke/module.py
+++ b/src/sage/modular/hecke/module.py
@@ -38,12 +38,18 @@ def is_HeckeModule(x):
 
         sage: from sage.modular.hecke.module import is_HeckeModule
         sage: is_HeckeModule(ModularForms(Gamma0(7), 4))
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeModule is deprecated;
+        use 'isinstance(..., HeckeModule_generic)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         True
         sage: is_HeckeModule(QQ^3)
         False
         sage: is_HeckeModule(J0(37).homology())
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeModule is deprecated; use 'isinstance(..., HeckeModule_generic)' instead")
     return isinstance(x, HeckeModule_generic)
 
 
@@ -652,7 +658,7 @@ class HeckeModule_free_module(HeckeModule_generic):
             sage: M._element_eigenvalue(M.0)
             1
         """
-        if not element.is_HeckeModuleElement(x):
+        if not isinstance(x, element.HeckeModuleElement):
             raise TypeError("x must be a Hecke module element.")
         if x not in self.ambient_hecke_module():
             raise ArithmeticError("x must be in the ambient Hecke module.")

--- a/src/sage/modular/hecke/morphism.py
+++ b/src/sage/modular/hecke/morphism.py
@@ -42,8 +42,14 @@ def is_HeckeModuleMorphism(x):
     EXAMPLES::
 
         sage: sage.modular.hecke.morphism.is_HeckeModuleMorphism(ModularSymbols(6).hecke_operator(7).hecke_module_morphism())
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeModuleMorphism is deprecated;
+        use 'isinstance(..., HeckeModuleMorphism)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeModuleMorphism is deprecated; use 'isinstance(..., HeckeModuleMorphism)' instead")
     return isinstance(x, HeckeModuleMorphism)
 
 
@@ -53,8 +59,14 @@ def is_HeckeModuleMorphism_matrix(x):
     EXAMPLES::
 
         sage: sage.modular.hecke.morphism.is_HeckeModuleMorphism_matrix(ModularSymbols(6).hecke_operator(7).matrix_form().hecke_module_morphism())
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeModuleMorphism_matrix is deprecated;
+        use 'isinstance(..., HeckeModuleMorphism_matrix)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeModuleMorphism_matrix is deprecated; use 'isinstance(..., HeckeModuleMorphism_matrix)' instead")
     return isinstance(x, HeckeModuleMorphism_matrix)
 
 

--- a/src/sage/modular/hecke/submodule.py
+++ b/src/sage/modular/hecke/submodule.py
@@ -35,10 +35,16 @@ def is_HeckeSubmodule(x):
     EXAMPLES::
 
         sage: sage.modular.hecke.submodule.is_HeckeSubmodule(ModularForms(1, 12))
+        doctest:warning...
+        DeprecationWarning: the function is_HeckeSubmodule is deprecated;
+        use 'isinstance(..., HeckeSubmodule)' instead
+        See https://github.com/sagemath/sage/issues/37895 for details.
         False
         sage: sage.modular.hecke.submodule.is_HeckeSubmodule(CuspForms(1, 12))
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37895, "the function is_HeckeSubmodule is deprecated; use 'isinstance(..., HeckeSubmodule)' instead")
     return isinstance(x, HeckeSubmodule)
 
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Replacing the old-style `is_...` functions by just using `isinstance`.

Also some docstring/doctest cosmetics.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


