### PR TITLE
correct URL for symengine_py

### DIFF
--- a/build/pkgs/symengine_py/checksums.ini
+++ b/build/pkgs/symengine_py/checksums.ini
@@ -2,4 +2,4 @@ tarball=symengine.py-VERSION.tar.gz
 sha1=4a8da0d0a057c8709c5b28543dbb3d26a060f013
 md5=d10f4ba5c27b09ef234fcafddf824ce5
 cksum=1332096394
-upstream_url=https://pypi.io/packages/source/p/symengine/symengine-VERSION.tar.gz
+upstream_url=https://pypi.io/packages/source/s/symengine/symengine-VERSION.tar.gz


### PR DESCRIPTION
Correct URL for the symengine_py package.

This is a 1-char typo made in https://github.com/sagemath/sage/pull/36677