### PR TITLE
Change `SetSystem` representation

### DIFF
--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -1923,7 +1923,7 @@ cdef class BasisExchangeMatroid(Matroid):
 
             sage: M = matroids.catalog.N1()
             sage: M._characteristic_setsystem()
-            Iterator over a system of subsets
+            SetSystem of 23 sets over 10 elements
             sage: len(M._characteristic_setsystem())
             23
         """

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -481,7 +481,7 @@ cdef class CircuitsMatroid(Matroid):
             sage: from sage.matroids.circuits_matroid import CircuitsMatroid
             sage: M = CircuitsMatroid(matroids.Uniform(2, 4))
             sage: M.circuits()
-            Iterator over a system of subsets
+            SetSystem of 4 sets over 4 elements
             sage: list(M.circuits(0))
             []
             sage: sorted(M.circuits(3), key=str)
@@ -544,7 +544,7 @@ cdef class CircuitsMatroid(Matroid):
             sage: from sage.matroids.circuits_matroid import CircuitsMatroid
             sage: M = CircuitsMatroid(matroids.Uniform(2, 4))
             sage: M.nonspanning_circuits()
-            Iterator over a system of subsets
+            SetSystem of 0 sets over 4 elements
         """
         cdef list NSC = []
         for i in self._k_C:

--- a/src/sage/matroids/set_system.pyx
+++ b/src/sage/matroids/set_system.pyx
@@ -40,7 +40,7 @@ cdef class SetSystem:
 
         sage: M = matroids.catalog.Fano()
         sage: M.circuits()
-        Iterator over a system of subsets
+        SetSystem of 14 sets over 7 elements
 
     To access the sets in this structure, simply iterate over them. The
     simplest way must be::
@@ -75,7 +75,7 @@ cdef class SetSystem:
             sage: from sage.matroids.set_system import SetSystem
             sage: S = SetSystem([1, 2, 3, 4], [[1, 2], [3, 4], [1, 2, 4]])
             sage: S
-            Iterator over a system of subsets
+            SetSystem of 3 sets over 4 elements
         """
         cdef long i
         if not isinstance(groundset, tuple):
@@ -110,7 +110,7 @@ cdef class SetSystem:
             sage: from sage.matroids.set_system import SetSystem
             sage: S = SetSystem([1, 2, 3, 4], [[1, 2], [3, 4], [1, 2, 4]])
             sage: S
-            Iterator over a system of subsets
+            SetSystem of 3 sets over 4 elements
             sage: sorted(S[1])
             [3, 4]
             sage: for s in S: print(sorted(s))
@@ -138,7 +138,7 @@ cdef class SetSystem:
             sage: from sage.matroids.set_system import SetSystem
             sage: S = SetSystem([1, 2, 3, 4], [[1, 2], [3, 4], [1, 2, 4]])
             sage: S
-            Iterator over a system of subsets
+            SetSystem of 3 sets over 4 elements
             sage: len(S)
             3
         """
@@ -196,9 +196,9 @@ cdef class SetSystem:
             sage: from sage.matroids.set_system import SetSystem
             sage: S = SetSystem([1, 2, 3, 4], [[1, 2], [3, 4], [1, 2, 4]])
             sage: repr(S)  # indirect doctest
-            'Iterator over a system of subsets'
+            'SetSystem of 3 sets over 4 elements'
         """
-        return "Iterator over a system of subsets"
+        return f'SetSystem of {self._len} sets over {self._groundset_size} elements'
 
     cdef copy(self):
         cdef SetSystem S

--- a/src/sage/matroids/union_matroid.pyx
+++ b/src/sage/matroids/union_matroid.pyx
@@ -21,7 +21,7 @@ cdef class MatroidUnion(Matroid):
         {}
         Matroid of rank 1 on 2 elements with 2 bases
         sage: M.bases()
-        Iterator over a system of subsets
+        SetSystem of 2 sets over 5 elements
         sage: list(M.circuits())
         [frozenset({3, 4})]
 

--- a/src/sage/matroids/utilities.py
+++ b/src/sage/matroids/utilities.py
@@ -70,7 +70,7 @@ def setprint(X):
         sage: from sage.matroids.advanced import setprint
         sage: M = matroids.catalog.Fano().delete('efg')
         sage: M.bases()
-        Iterator over a system of subsets
+        SetSystem of 3 sets over 4 elements
         sage: setprint(M.bases())
         [{'a', 'b', 'c'}, {'a', 'b', 'd'}, {'a', 'c', 'd'}]
 


### PR DESCRIPTION
This is an attempt to represent `SetSystem` in a more informative and user-friendly way.

Previous:
```
sage: M = matroids.CompleteGraphic(7)
sage: M.bases()
Iterator over a system of subsets
```
Current:
```
sage: M = matroids.CompleteGraphic(7)
sage: M.bases()
SetSystem of 16807 sets over 21 elements
```

I think this is an improvement from resorting to calling, e.g., `len`, in order to to get some info, after you get struck with `Iterator over a system of subsets`.
Note that a `SetSystem` is not an iterator but simply an iterable (so `__repr__` is also misleading). The previous developers were planning to make it into an _actual_ iterator, as can be seen on [L66](https://github.com/sagemath/sage/blob/f1dc325cf01ac542d42257b77aa322cd92e74de8/src/sage/matroids/set_system.pyx#L66) of `set_system.pyx`.



