### PR TITLE
fix dual_lattice() in free_quadratic_module_integer_symmetric.py

### DIFF
--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -773,7 +773,7 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
             sage: L.is_submodule(Ldual)                                                 # needs sage.graphs
             True
         """
-        return self.span(self.gram_matrix().inverse()*self.basis_matrix())
+        return self.span(self.basis_matrix()*self.gram_matrix().inverse())
 
     def discriminant_group(self, s=0):
         r"""


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fix #37907 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
None

### Discription
It returns self.span(self.gram_matrix().inverse()*self.basis_matrix()), which is wrong. The right one should be self.basis_matrix())*self.span(self.gram_matrix().inverse().



