### PR TITLE
structure/coerce actions

### DIFF
--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -35,7 +35,7 @@ lazy_import('sage.categories.commutative_additive_groups', 'CommutativeAdditiveG
 lazy_import('sage.categories.commutative_rings', 'CommutativeRings')
 lazy_import('sage.categories.groups', 'Groups')
 lazy_import('sage.categories.objects', 'Objects')
-lazy_import('sage.categories.rings', 'Rings', at_startup=True)
+lazy_import('sage.categories.rings', 'Rings')
 
 # TODO, think through the rankings, and override pushout where necessary.
 

--- a/src/sage/structure/coerce_actions.pyx
+++ b/src/sage/structure/coerce_actions.pyx
@@ -313,6 +313,23 @@ cdef class ModuleAction(Action):
             sage: 1/S.0
             1/x
 
+        If there is a coercion from ``G`` to ``S``, we do not create
+        the module action of ``G`` on the pushout of ``G`` and ``S``::
+
+            sage: G = PolynomialRing(QQ, "x")
+            sage: S = PolynomialRing(MatrixSpace(QQ, 2), "x")
+            sage: G.gen() * S.gen()
+            [1 0]
+            [0 1]*x^2
+
+        Contrast the previous example with the following, where we
+        have no coercion from ``G`` to ``S``::
+
+            sage: S = PolynomialRing(MatrixSpace(QQ, 2), "y")
+            sage: G.gen() * S.gen()
+            [x 0]
+            [0 x]*y
+
         """
         Action.__init__(self, G, S, not isinstance(self, RightModuleAction), operator.mul)
         if not isinstance(G, Parent):
@@ -328,6 +345,8 @@ cdef class ModuleAction(Action):
             # first we try the easy case of coercing G to the base ring of S
             self.connecting = base._internal_coerce_map_from(G)
             if self.connecting is None:
+                if S._internal_coerce_map_from(G) is not None:
+                    raise CoercionException("Best viewed as standard coercion multiplication.")
                 # otherwise, we try and find a base extension
                 from sage.categories.pushout import pushout
                 # this may raise a type error, which we propagate


### PR DESCRIPTION
We modify `ModuleAction` to prefer coercion of the base ring over creating an action.  More precisely, before this branch, we have

```
sage: G = PolynomialRing(QQ, "x")
sage: S = PolynomialRing(MatrixSpace(QQ, 2), "x")
sage: G.gen() * S.gen()
[x 0]
[0 x]*x
```
instead of
```
            [1 0]
            [0 1]*x^2
```
and
```
sage: G = PolynomialRing(QQ, "x")
sage: S = PolynomialRing(InfinitePolynomialRing(QQ, "a"), "x")
sage: G.gen() * S.an_element()
x*x
```
instead of
```
x^2
```
which is at least surprising.

In the end, this is needed to make #37033 work.

Authors: @tscrim and @mantepse.