### PR TITLE
Deprecate `is_Category`, `is_Endset`, `is_Homset`, `is_Parent`, `is_RingHomset`, `is_SimplicialComplexHomset`

### DIFF
--- a/src/sage/categories/category.py
+++ b/src/sage/categories/category.py
@@ -2575,6 +2575,8 @@ def is_Category(x):
         sage: sage.categories.category.is_Category(ZZ)
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37922, "the function is_Category is deprecated; use 'isinstance(..., Category)' instead")
     return isinstance(x, Category)
 
 

--- a/src/sage/categories/category.py
+++ b/src/sage/categories/category.py
@@ -2571,6 +2571,10 @@ def is_Category(x):
     EXAMPLES::
 
         sage: sage.categories.category.is_Category(CommutativeAdditiveSemigroups())
+        doctest:warning...
+        DeprecationWarning: the function is_Category is deprecated;
+        use 'isinstance(..., Category)' instead
+        See https://github.com/sagemath/sage/issues/37922 for details.
         True
         sage: sage.categories.category.is_Category(ZZ)
         False

--- a/src/sage/categories/functor.pyx
+++ b/src/sage/categories/functor.pyx
@@ -179,9 +179,9 @@ cdef class Functor(SageObject):
             Finite Field of size 2
 
         """
-        if not category.is_Category(domain):
+        if not isinstance(domain, category.Category):
             raise TypeError("domain (=%s) must be a category" % domain)
-        if not category.is_Category(codomain):
+        if not isinstance(codomain, category.Category):
             raise TypeError("codomain (=%s) must be a category" % codomain)
         self.__domain = domain
         self.__codomain = codomain

--- a/src/sage/categories/homset.py
+++ b/src/sage/categories/homset.py
@@ -522,9 +522,6 @@ def End(X, category=None):
          from Alternating group of order 3!/2 as a permutation group
          to Alternating group of order 3!/2 as a permutation group
          in Category of finite enumerated permutation groups
-        sage: from sage.categories.homset import is_Endset
-        sage: is_Endset(S)
-        True
         sage: S.domain()
         Alternating group of order 3!/2 as a permutation group
 
@@ -1298,6 +1295,10 @@ def is_Homset(x):
         sage: P.<t> = ZZ[]
         sage: f = P.hom([1/2*t])
         sage: is_Homset(f)
+        doctest:warning...
+        DeprecationWarning: the function is_Homset is deprecated;
+        use 'isinstance(..., Homset)' instead
+        See https://github.com/sagemath/sage/issues/37922 for details.
         False
         sage: is_Homset(f.category())
         False
@@ -1319,6 +1320,10 @@ def is_Endset(x):
         sage: P.<t> = ZZ[]
         sage: f = P.hom([1/2*t])
         sage: is_Endset(f.parent())
+        doctest:warning...
+        DeprecationWarning: the function is_Endset is deprecated;
+        use 'isinstance(..., Homset) and ....is_endomorphism_set()' instead
+        See https://github.com/sagemath/sage/issues/37922 for details.
         False
         sage: g = P.hom([2*t])
         sage: is_Endset(g.parent())

--- a/src/sage/categories/homset.py
+++ b/src/sage/categories/homset.py
@@ -1304,7 +1304,10 @@ def is_Homset(x):
         sage: is_Homset(f.parent())
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37922, "the function is_Homset is deprecated; use 'isinstance(..., Homset)' instead")
     return isinstance(x, Homset)
+
 
 def is_Endset(x):
     """
@@ -1321,4 +1324,6 @@ def is_Endset(x):
         sage: is_Endset(g.parent())
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37922, "the function is_Endset is deprecated; use 'isinstance(..., Homset) and ....is_endomorphism_set()' instead")
     return isinstance(x, Homset) and x.is_endomorphism_set()

--- a/src/sage/categories/poor_man_map.py
+++ b/src/sage/categories/poor_man_map.py
@@ -225,8 +225,8 @@ class PoorManMap(sage.structure.sage_object.SageObject):
             other_codomain = None
 
         if self_domain is not None and other_codomain is not None:
-            from sage.structure.parent import is_Parent
-            if is_Parent(self_domain) and is_Parent(other_codomain):
+            from sage.structure.parent import Parent
+            if isinstance(self_domain, Parent) and isinstance(other_codomain, Parent):
                 if not self_domain.has_coerce_map_from(other_codomain):
                     raise ValueError("the codomain %r does not coerce into the domain %r" % (other_codomain, self_domain))
 

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -112,7 +112,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             sage: loads(A.dumps()) == A
             True
         """
-        if not sage.categories.homset.is_Homset(parent):
+        if not isinstance(parent, sage.categories.homset.Homset):
             raise TypeError("parent must be a Hom space")
         if side not in ["left", "right"]:
             raise ValueError("the argument side must be either 'left' or 'right'")

--- a/src/sage/rings/asymptotic/misc.py
+++ b/src/sage/rings/asymptotic/misc.py
@@ -95,8 +95,8 @@ def repr_short_to_parent(s):
     if type(P) is LazyImport:
         P = P._get_object()
 
-    from sage.structure.parent import is_Parent
-    if not is_Parent(P):
+    from sage.structure.parent import Parent
+    if not isinstance(P, Parent):
         raise ValueError("'%s' does not describe a parent." % (s,))
     return P
 

--- a/src/sage/rings/homset.py
+++ b/src/sage/rings/homset.py
@@ -34,6 +34,8 @@ def is_RingHomset(H):
         sage: is_RH(Hom(FreeModule(ZZ,1), FreeModule(QQ,1)))                            # needs sage.modules
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37922, "the function is_RingHomset is deprecated; use 'isinstance(..., RingHomset_generic)' instead")
     return isinstance(H, RingHomset_generic)
 
 

--- a/src/sage/rings/homset.py
+++ b/src/sage/rings/homset.py
@@ -26,6 +26,10 @@ def is_RingHomset(H):
 
         sage: from sage.rings.homset import is_RingHomset as is_RH
         sage: is_RH(Hom(ZZ, QQ))
+        doctest:warning...
+        DeprecationWarning: the function is_RingHomset is deprecated;
+        use 'isinstance(..., RingHomset_generic)' instead
+        See https://github.com/sagemath/sage/issues/37922 for details.
         True
         sage: is_RH(ZZ)
         False

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -426,7 +426,7 @@ cdef class Ring(ParentWithGens):
             coerce = True
 
         from sage.rings.ideal import Ideal_generic
-        from sage.structure.parent import is_Parent
+        from sage.structure.parent import Parent
         gens = args
         while isinstance(gens, (list, tuple)) and len(gens) == 1:
             first = gens[0]
@@ -445,7 +445,7 @@ cdef class Ring(ParentWithGens):
                 break
             elif isinstance(first, (list, tuple)):
                 gens = first
-            elif is_Parent(first) and self.has_coerce_map_from(first):
+            elif isinstance(first, Parent) and self.has_coerce_map_from(first):
                 gens = first.gens()  # we have a ring as argument
             else:
                 break

--- a/src/sage/sets/image_set.py
+++ b/src/sage/sets/image_set.py
@@ -27,7 +27,7 @@ from sage.rings.infinity import Infinity
 from sage.rings.integer import Integer
 from sage.modules.free_module import FreeModule
 from sage.structure.element import Expression
-from sage.structure.parent import Parent, is_Parent
+from sage.structure.parent import Parent
 
 from .set import Set_base, Set_add_sub_operators, Set_boolean_operators
 
@@ -82,7 +82,7 @@ class ImageSubobject(Parent):
             sage: TestSuite(Im).run(skip=['_test_an_element', '_test_pickling',
             ....:                         '_test_some_elements', '_test_elements'])
         """
-        if not is_Parent(domain_subset):
+        if not isinstance(domain_subset, Parent):
             from sage.sets.set import Set
             domain_subset = Set(domain_subset)
 

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -148,6 +148,10 @@ def is_Parent(x):
 
         sage: from sage.structure.parent import is_Parent
         sage: is_Parent(2/3)
+        doctest:warning...
+        DeprecationWarning: the function is_Parent is deprecated;
+        use 'isinstance(..., Parent)' instead
+        See https://github.com/sagemath/sage/issues/37922 for details.
         False
         sage: is_Parent(ZZ)
         True

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -154,6 +154,8 @@ def is_Parent(x):
         sage: is_Parent(Primes())
         True
     """
+    from sage.misc.superseded import deprecation_cython
+    deprecation_cython(37922, "the function is_Parent is deprecated; use 'isinstance(..., Parent)' instead")
     return isinstance(x, Parent)
 
 

--- a/src/sage/topology/simplicial_complex_homset.py
+++ b/src/sage/topology/simplicial_complex_homset.py
@@ -77,6 +77,10 @@ def is_SimplicialComplexHomset(x) -> bool:
          in Category of finite simplicial complexes
         sage: from sage.topology.simplicial_complex_homset import is_SimplicialComplexHomset
         sage: is_SimplicialComplexHomset(H)
+        doctest:warning...
+        DeprecationWarning: the function is_SimplicialComplexHomset is deprecated;
+        use 'isinstance(..., SimplicialComplexHomset)' instead
+        See https://github.com/sagemath/sage/issues/37922 for details.
         True
     """
     from sage.misc.superseded import deprecation

--- a/src/sage/topology/simplicial_complex_homset.py
+++ b/src/sage/topology/simplicial_complex_homset.py
@@ -79,6 +79,8 @@ def is_SimplicialComplexHomset(x) -> bool:
         sage: is_SimplicialComplexHomset(H)
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37922, "the function is_SimplicialComplexHomset is deprecated; use 'isinstance(..., SimplicialComplexHomset)' instead")
     return isinstance(x, SimplicialComplexHomset)
 
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


