### PR TITLE
Deprecate `is_FGP_Module`, `is_FilteredVectorSpace`, `is_FreeQuadraticModule`, `is_FreeModule`, `is_FreeModuleHomspace`, `is_MatrixSpace`, `is_Module`, `is_VectorSpace`, `is_VectorSpaceHomspace`

### DIFF
--- a/src/sage/geometry/polyhedron/parent.py
+++ b/src/sage/geometry/polyhedron/parent.py
@@ -14,7 +14,7 @@ import sage.geometry.abc
 from sage.structure.parent import Parent
 from sage.structure.element import get_coercion_model
 from sage.structure.unique_representation import UniqueRepresentation
-from sage.modules.free_module import FreeModule, is_FreeModule
+from sage.modules.free_module import FreeModule, FreeModule_generic
 from sage.misc.cachefunc import cached_method, cached_function
 from sage.misc.lazy_import import lazy_import
 import sage.rings.abc
@@ -1009,7 +1009,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
         from sage.structure.coerce_actions import ActedUponAction
         from sage.categories.action import PrecomposedAction
 
-        if op is operator.add and is_FreeModule(other):
+        if op is operator.add and isinstance(other, FreeModule_generic):
             base_ring = self._coerce_base_ring(other)
             extended_self = self.base_extend(base_ring)
             extended_other = other.base_extend(base_ring)

--- a/src/sage/groups/matrix_gps/finitely_generated.py
+++ b/src/sage/groups/matrix_gps/finitely_generated.py
@@ -72,7 +72,7 @@ AUTHORS:
 from sage.groups.matrix_gps.group_element import is_MatrixGroupElement
 from sage.groups.matrix_gps.matrix_group import MatrixGroup_generic
 from sage.matrix.constructor import matrix
-from sage.matrix.matrix_space import is_MatrixSpace
+from sage.matrix.matrix_space import MatrixSpace
 from sage.misc.cachefunc import cached_method
 from sage.rings.integer_ring import ZZ
 from sage.structure.element import is_Matrix
@@ -130,7 +130,7 @@ def normalize_square_matrices(matrices):
         raise ValueError('not all matrices have the same size')
     gens = Sequence(gens, immutable=True)
     MS = gens.universe()
-    if not is_MatrixSpace(MS):
+    if not isinstance(MS, MatrixSpace):
         raise TypeError('all generators must be matrices')
     if MS.nrows() != MS.ncols():
         raise ValueError('matrices must be square')

--- a/src/sage/groups/matrix_gps/isometries.py
+++ b/src/sage/groups/matrix_gps/isometries.py
@@ -227,9 +227,9 @@ class GroupOfIsometries(FinitelyGeneratedMatrixGroup_gap):
                 return GroupActionOnSubmodule(self, S)
             if S is self._invariant_quotient_module:
                 return GroupActionOnQuotientModule(self, S)
-            from sage.modules.fg_pid.fgp_module import is_FGP_Module
+            from sage.modules.fg_pid.fgp_module import FGP_Module_class
             T = self._invariant_quotient_module
-            if is_FGP_Module(S):
+            if isinstance(S, FGP_Module_class):
                 if S.is_submodule(T):
                     V = S.V()
                     if all(V == V * f.matrix() for f in self.gens()):

--- a/src/sage/manifolds/subsets/pullback.py
+++ b/src/sage/manifolds/subsets/pullback.py
@@ -16,7 +16,7 @@ Manifold Subsets Defined as Pullbacks of Subsets under Continuous Maps
 from sage.categories.sets_cat import Sets, EmptySetError
 from sage.categories.metric_spaces import MetricSpaces
 from sage.misc.lazy_import import lazy_import
-from sage.modules.free_module import is_FreeModule
+from sage.modules.free_module import FreeModule_generic
 from sage.rings.infinity import infinity, minus_infinity
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
@@ -829,7 +829,7 @@ class ManifoldSubsetPullback(ManifoldSubset):
             # Regardless of their base_ring, we treat polyhedra as closed
             # convex subsets of R^n
             return True
-        elif is_FreeModule(self._codomain_subset) and self._codomain_subset.rank() != infinity:
+        elif isinstance(self._codomain_subset, FreeModule_generic) and self._codomain_subset.rank() != infinity:
             if self._codomain_subset.base_ring() in MetricSpaces().Complete():
                 # Closed topological vector subspace
                 return True

--- a/src/sage/matrix/action.pyx
+++ b/src/sage/matrix/action.pyx
@@ -66,7 +66,7 @@ AUTHOR:
 
 import operator
 
-from sage.matrix.matrix_space import MatrixSpace, is_MatrixSpace
+from sage.matrix.matrix_space import MatrixSpace
 from sage.modules.free_module import FreeModule, FreeModule_generic
 from sage.structure.coerce cimport coercion_model
 from sage.categories.homset import Hom, End
@@ -100,7 +100,7 @@ cdef class MatrixMulAction(Action):
          over Univariate Polynomial Ring in x over Rational Field
     """
     def __init__(self, G, S, is_left):
-        if not is_MatrixSpace(G):
+        if not isinstance(G, MatrixSpace):
             raise TypeError("Not a matrix space: %s" % G)
         if isinstance(S, SchemeHomset_generic):
             if G.base_ring() is not S.domain().base_ring():
@@ -160,7 +160,7 @@ cdef class MatrixMatrixAction(MatrixMulAction):
         example is good practice.
     """
     def __init__(self, G, S):
-        if not is_MatrixSpace(S):
+        if not isinstance(S, MatrixSpace):
             raise TypeError("Not a matrix space: %s" % S)
 
         MatrixMulAction.__init__(self, G, S, True)

--- a/src/sage/matrix/action.pyx
+++ b/src/sage/matrix/action.pyx
@@ -67,7 +67,7 @@ AUTHOR:
 import operator
 
 from sage.matrix.matrix_space import MatrixSpace, is_MatrixSpace
-from sage.modules.free_module import FreeModule, is_FreeModule
+from sage.modules.free_module import FreeModule, FreeModule_generic
 from sage.structure.coerce cimport coercion_model
 from sage.categories.homset import Hom, End
 
@@ -304,7 +304,7 @@ cdef class MatrixVectorAction(MatrixMulAction):
             ...
             TypeError: incompatible dimensions 3, 4
             """
-        if not is_FreeModule(S):
+        if not isinstance(S, FreeModule_generic):
             raise TypeError("Not a free module: %s" % S)
         MatrixMulAction.__init__(self, G, S, True)
 
@@ -355,7 +355,7 @@ cdef class VectorMatrixAction(MatrixMulAction):
             ...
             TypeError: incompatible dimensions 5, 3
         """
-        if not is_FreeModule(S):
+        if not isinstance(S, FreeModule_generic):
             raise TypeError("Not a free module: %s" % S)
         MatrixMulAction.__init__(self, G, S, False)
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -5786,7 +5786,7 @@ cdef class Matrix(Matrix1):
             sage: t.decomposition_of_subspace(v, check_restrict=False) == t.decomposition_of_subspace(v)                # needs sage.libs.pari
             True
         """
-        if not sage.modules.free_module.is_FreeModule(M):
+        if not isinstance(M, sage.modules.free_module.FreeModule_generic):
             raise TypeError("M must be a free module.")
         if not self.is_square():
             raise ArithmeticError("self must be a square matrix")

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -80,6 +80,8 @@ def is_MatrixSpace(x):
         sage: is_MatrixSpace(5)
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37924, "the function is_MatrixSpace is deprecated; use 'isinstance(..., MatrixSpace)' instead")
     return isinstance(x, MatrixSpace)
 
 
@@ -1265,7 +1267,7 @@ class MatrixSpace(UniqueRepresentation, Parent):
             if op is operator.mul:
                 from . import action as matrix_action
                 if self_on_left:
-                    if is_MatrixSpace(S):
+                    if isinstance(S, MatrixSpace):
                         # matrix multiplications
                         return matrix_action.MatrixMatrixAction(self, S)
                     elif isinstance(S, sage.modules.free_module.FreeModule_generic):
@@ -1278,7 +1280,7 @@ class MatrixSpace(UniqueRepresentation, Parent):
                         # action of base ring
                         return sage.structure.coerce_actions.RightModuleAction(S, self)
                 else:
-                    if is_MatrixSpace(S):
+                    if isinstance(S, MatrixSpace):
                         # matrix multiplications
                         return matrix_action.MatrixMatrixAction(S, self)
                     elif isinstance(S, sage.modules.free_module.FreeModule_generic):

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -1268,7 +1268,7 @@ class MatrixSpace(UniqueRepresentation, Parent):
                     if is_MatrixSpace(S):
                         # matrix multiplications
                         return matrix_action.MatrixMatrixAction(self, S)
-                    elif sage.modules.free_module.is_FreeModule(S):
+                    elif isinstance(S, sage.modules.free_module.FreeModule_generic):
                         return matrix_action.MatrixVectorAction(self, S)
                     elif isinstance(S, SchemeHomset_points):
                         return matrix_action.MatrixSchemePointAction(self, S)
@@ -1281,7 +1281,7 @@ class MatrixSpace(UniqueRepresentation, Parent):
                     if is_MatrixSpace(S):
                         # matrix multiplications
                         return matrix_action.MatrixMatrixAction(S, self)
-                    elif sage.modules.free_module.is_FreeModule(S):
+                    elif isinstance(S, sage.modules.free_module.FreeModule_generic):
                         return matrix_action.VectorMatrixAction(self, S)
                     elif isinstance(S, SchemeHomset_generic):
                         return matrix_action.PolymapMatrixAction(self, S)

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -74,6 +74,10 @@ def is_MatrixSpace(x):
         sage: MS = MatrixSpace(QQ,2)
         sage: A = MS.random_element()
         sage: is_MatrixSpace(MS)
+        doctest:warning...
+        DeprecationWarning: the function is_MatrixSpace is deprecated;
+        use 'isinstance(..., MatrixSpace)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         True
         sage: is_MatrixSpace(A)
         False

--- a/src/sage/modular/abvar/abvar.py
+++ b/src/sage/modular/abvar/abvar.py
@@ -51,7 +51,7 @@ from sage.modular.modform.constructor import Newform
 from sage.modular.modsym.modsym import ModularSymbols
 from sage.modular.modsym.space import ModularSymbolsSpace
 from sage.modular.quatalg.brandt import BrandtModule
-from sage.modules.free_module import is_FreeModule
+from sage.modules.free_module import FreeModule_generic
 from sage.modules.free_module_element import vector
 from sage.rings.fast_arith import prime_range
 from sage.rings.infinity import infinity
@@ -4009,7 +4009,7 @@ class ModularAbelianVariety(ModularAbelianVariety_abstract):
             lattice = ZZ**(2 * self._ambient_dimension())
         if check:
             n = self._ambient_dimension()
-            if not is_FreeModule(lattice):
+            if not isinstance(lattice, FreeModule_generic):
                 raise TypeError("lattice must be a free module")
             if lattice.base_ring() != ZZ:
                 raise TypeError("lattice must be over ZZ")

--- a/src/sage/modular/abvar/finite_subgroup.py
+++ b/src/sage/modular/abvar/finite_subgroup.py
@@ -103,7 +103,7 @@ import sage.rings.abc
 from sage.misc.lazy_import import lazy_import
 from sage.modular.abvar.torsion_point import TorsionPoint
 from sage.modules.module import Module
-from sage.modules.free_module import is_FreeModule
+from sage.modules.free_module import FreeModule_generic
 from sage.structure.gens_py import abelian_iterator
 from sage.structure.sequence import Sequence
 from sage.structure.richcmp import richcmp_method, richcmp
@@ -871,7 +871,7 @@ class FiniteSubgroup_lattice(FiniteSubgroup):
             from sage.rings.qqbar import QQbar as field_of_definition
         if check:
             from .abvar import is_ModularAbelianVariety
-            if not is_FreeModule(lattice) or lattice.base_ring() != ZZ:
+            if not isinstance(lattice, FreeModule_generic) or lattice.base_ring() != ZZ:
                 raise TypeError("lattice must be a free module over ZZ")
             if not is_ModularAbelianVariety(abvar):
                 raise TypeError("abvar must be a modular abelian variety")

--- a/src/sage/modular/hecke/ambient_module.py
+++ b/src/sage/modular/hecke/ambient_module.py
@@ -22,7 +22,7 @@ from . import degenmap
 from . import module
 from . import submodule
 
-from sage.modules.free_module import FreeModule, is_FreeModule
+from sage.modules.free_module import FreeModule, FreeModule_generic
 from sage.rings.integer import Integer
 
 import sage.arith.all as arith
@@ -927,7 +927,7 @@ class AmbientHeckeModule(module.HeckeModule_free_module):
             Modular Forms subspace of dimension 2 of Modular Forms space of dimension 3 for Congruence Subgroup Gamma0(37) of weight 2 over Rational Field
         """
         if check:
-            if not is_FreeModule(M):
+            if not isinstance(M, FreeModule_generic):
                 V = self.free_module()
                 if isinstance(M, (list, tuple)):
                     M = V.span([V(x.element()) for x in M])

--- a/src/sage/modular/hecke/submodule.py
+++ b/src/sage/modular/hecke/submodule.py
@@ -22,7 +22,7 @@ Submodules of Hecke modules
 import sage.arith.all as arith
 from sage.misc.verbose import verbose
 from sage.misc.cachefunc import cached_method
-from sage.modules.free_module import is_FreeModule
+from sage.modules.free_module import FreeModule_generic
 from sage.structure.richcmp import richcmp_method, richcmp_not_equal
 
 from . import module
@@ -81,7 +81,7 @@ class HeckeSubmodule(module.HeckeModule_free_module):
         from . import ambient_module
         if not isinstance(ambient, ambient_module.AmbientHeckeModule):
             raise TypeError("ambient must be an ambient Hecke module")
-        if not is_FreeModule(submodule):
+        if not isinstance(submodule, FreeModule_generic):
             raise TypeError("submodule must be a free module")
         if not submodule.is_submodule(ambient.free_module()):
             raise ValueError("submodule must be a submodule of the ambient free module")
@@ -96,7 +96,7 @@ class HeckeSubmodule(module.HeckeModule_free_module):
                                                 ambient.level(),
                                                 ambient.weight())
         if dual_free_module is not None:
-            if not is_FreeModule(dual_free_module):
+            if not isinstance(dual_free_module, FreeModule_generic):
                 raise TypeError("dual_free_module must be a free module")
             if dual_free_module.rank() != submodule.rank():
                 raise ArithmeticError("dual_free_module must have the same rank as submodule")
@@ -912,7 +912,7 @@ class HeckeSubmodule(module.HeckeModule_free_module):
             sage: S.submodule(S[0].free_module())
             Modular Symbols subspace of dimension 2 of Modular Symbols space of dimension 18 for Gamma_0(18) of weight 4 with sign 0 over Rational Field
         """
-        if not is_FreeModule(M):
+        if not isinstance(M, FreeModule_generic):
             V = self.ambient_module().free_module()
             if isinstance(M, (list, tuple)):
                 M = V.span([V(x.element()) for x in M])

--- a/src/sage/modular/modsym/ambient.py
+++ b/src/sage/modular/modsym/ambient.py
@@ -88,7 +88,7 @@ from sage.modular.modsym.manin_symbol_list import (ManinSymbolList_gamma0,
                                                    ManinSymbolList_gamma1,
                                                    ManinSymbolList_gamma_h,
                                                    ManinSymbolList_character)
-from sage.modules.free_module import is_FreeModule
+from sage.modules.free_module import FreeModule_generic
 from sage.modules.free_module_element import FreeModuleElement
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
@@ -2133,7 +2133,7 @@ class ModularSymbolsAmbient(ModularSymbolsSpace, AmbientHeckeModule):
            Stein, 2007-07-27
         """
         if check:
-            if not is_FreeModule(M):
+            if not isinstance(M, FreeModule_generic):
                 V = self.free_module()
                 if not isinstance(M, (list, tuple)):
                     M = M.gens()

--- a/src/sage/modules/fg_pid/fgp_module.py
+++ b/src/sage/modules/fg_pid/fgp_module.py
@@ -214,7 +214,7 @@ AUTHOR:
 from itertools import product
 
 from sage.modules.module import Module
-from sage.modules.free_module import is_FreeModule
+from sage.modules.free_module import FreeModule_generic
 from sage.structure.all import parent
 from sage.structure.sequence import Sequence
 from .fgp_element import DEBUG, FGP_Element
@@ -356,9 +356,9 @@ class FGP_Module_class(Module):
             <class 'sage.modules.fg_pid.fgp_module.FGP_Module_class_with_category'>
         """
         if check:
-            if not is_FreeModule(V):
+            if not isinstance(V, FreeModule_generic):
                 raise TypeError("V must be a FreeModule")
-            if not is_FreeModule(W):
+            if not isinstance(W, FreeModule_generic):
                 raise TypeError("W must be a FreeModule")
             if not W.is_submodule(V):
                 raise ValueError("W must be a submodule of V")
@@ -501,7 +501,7 @@ class FGP_Module_class(Module):
             Finitely generated module V/W over Integer Ring with invariants ()
         """
         if not is_FGP_Module(other):
-            if is_FreeModule(other):
+            if isinstance(other, FreeModule_generic):
                 other = other / other.zero_submodule()
             else:
                 raise TypeError("other must be an FGP module")
@@ -1598,7 +1598,7 @@ class FGP_Module_class(Module):
                 N = codomain
                 im_gens = Sequence(im_gens, universe=N)
 
-        if is_FreeModule(N):
+        if isinstance(N, FreeModule_generic):
             # If im_smith_gens are not in an R-module, but are in a Free-module,
             # then we quotient out by the 0 submodule and get an R-module.
             N = FGP_Module(N, N.zero_submodule(), check=DEBUG)

--- a/src/sage/modules/fg_pid/fgp_module.py
+++ b/src/sage/modules/fg_pid/fgp_module.py
@@ -284,6 +284,8 @@ def is_FGP_Module(x):
         sage: sage.modules.fg_pid.fgp_module.is_FGP_Module(Q)
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37924, "the function is_FGP_Module is deprecated; use 'isinstance(..., FGP_Module_class)' instead")
     return isinstance(x, FGP_Module_class)
 
 
@@ -441,7 +443,7 @@ class FGP_Module_class(Module):
             sage: Q._coerce_map_from_(V.scale(2))
             True
         """
-        if is_FGP_Module(S):
+        if isinstance(S, FGP_Module_class):
             return S.has_canonical_map_to(self)
         return self._V.has_coerce_map_from(S)
 
@@ -500,7 +502,7 @@ class FGP_Module_class(Module):
             sage: Q/Q
             Finitely generated module V/W over Integer Ring with invariants ()
         """
-        if not is_FGP_Module(other):
+        if not isinstance(other, FGP_Module_class):
             if isinstance(other, FreeModule_generic):
                 other = other / other.zero_submodule()
             else:
@@ -525,7 +527,7 @@ class FGP_Module_class(Module):
             sage: Q == V/V.zero_submodule()
             False
         """
-        if not is_FGP_Module(other):
+        if not isinstance(other, FGP_Module_class):
             return False
         return self._V == other._V and self._W == other._W
 
@@ -745,7 +747,7 @@ class FGP_Module_class(Module):
             ...
             ValueError: x.V() must be contained in self's V.
         """
-        if is_FGP_Module(x):
+        if isinstance(x, FGP_Module_class):
             if not x._W.is_submodule(self._W):
                 raise ValueError("x.W() must be contained in self's W.")
 
@@ -759,7 +761,7 @@ class FGP_Module_class(Module):
             raise TypeError("x must be a list, tuple, or FGP module")
 
         x = Sequence(x)
-        if is_FGP_Module(x.universe()):
+        if isinstance(x.universe(), FGP_Module_class):
             # TODO: possibly inefficient in some cases
             x = [self(v).lift() for v in x]
         V = self._V.submodule(x) + self._W
@@ -791,7 +793,7 @@ class FGP_Module_class(Module):
             False
 
         """
-        if not is_FGP_Module(A):
+        if not isinstance(A, FGP_Module_class):
             return False
         if self.cardinality() == 0 and self.base_ring() == A.base_ring():
             return True
@@ -2047,7 +2049,7 @@ def random_fgp_morphism_0(*args, **kwds):
         sage: mor = fgp.random_fgp_morphism_0(4)
         sage: mor.domain() == mor.codomain()
         True
-        sage: fgp.is_FGP_Module(mor.domain())
+        sage: isinstance(mor.domain(), fgp.FGP_Module_class)
         True
 
     Each generator is sent to a random multiple of itself::

--- a/src/sage/modules/fg_pid/fgp_module.py
+++ b/src/sage/modules/fg_pid/fgp_module.py
@@ -280,6 +280,10 @@ def is_FGP_Module(x):
         sage: V = span([[1/2,1,1],[3/2,2,1],[0,0,1]],ZZ)
         sage: W = V.span([2*V.0 + 4*V.1, 9*V.0 + 12*V.1, 4*V.2]); Q = V/W
         sage: sage.modules.fg_pid.fgp_module.is_FGP_Module(V)
+        doctest:warning...
+        DeprecationWarning: the function is_FGP_Module is deprecated;
+        use 'isinstance(..., FGP_Module_class)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         False
         sage: sage.modules.fg_pid.fgp_module.is_FGP_Module(Q)
         True

--- a/src/sage/modules/fg_pid/fgp_morphism.py
+++ b/src/sage/modules/fg_pid/fgp_morphism.py
@@ -277,8 +277,8 @@ class FGP_Morphism(Morphism):
             sage: phi(8*Q.1) == phi(x)
             True
         """
-        from .fgp_module import is_FGP_Module
-        if is_FGP_Module(x):
+        from .fgp_module import FGP_Module_class
+        if isinstance(x, FGP_Module_class):
             if not x.is_submodule(self.domain()):
                 raise ValueError("x must be a submodule or element of the domain")
             # perhaps can be optimized with a matrix multiply; but note
@@ -355,8 +355,8 @@ class FGP_Morphism(Morphism):
             ...
             ValueError: A must be a submodule of the codomain
         """
-        from .fgp_module import is_FGP_Module
-        if not is_FGP_Module(A):
+        from .fgp_module import FGP_Module_class
+        if not isinstance(A, FGP_Module_class):
             raise TypeError("A must be a finitely generated quotient module")
         if not A.is_submodule(self.codomain()):
             raise ValueError("A must be a submodule of the codomain")

--- a/src/sage/modules/fg_pid/fgp_morphism.py
+++ b/src/sage/modules/fg_pid/fgp_morphism.py
@@ -506,8 +506,8 @@ class FGP_Homset_class(Homset):
             <class 'sage.modules.fg_pid.fgp_morphism.FGP_Homset_class_with_category'>
         """
         if category is None:
-            from sage.modules.free_module import is_FreeModule
-            if is_FreeModule(X) and is_FreeModule(Y):
+            from sage.modules.free_module import FreeModule_generic
+            if isinstance(X, FreeModule_generic) and isinstance(Y, FreeModule_generic):
                 from sage.categories.modules_with_basis import ModulesWithBasis
                 category = ModulesWithBasis(X.base_ring())
             else:

--- a/src/sage/modules/filtered_vector_space.py
+++ b/src/sage/modules/filtered_vector_space.py
@@ -144,6 +144,10 @@ def is_FilteredVectorSpace(X):
         sage: from sage.modules.filtered_vector_space import is_FilteredVectorSpace
         sage: V = FilteredVectorSpace(2, 1)
         sage: is_FilteredVectorSpace(V)
+        doctest:warning...:
+        DeprecationWarning: the function is_FilteredVectorSpace is deprecated;
+        use 'isinstance(..., FilteredVectorSpace_class)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         True
         sage: is_FilteredVectorSpace('ceci n\'est pas une pipe')
         False

--- a/src/sage/modules/filtered_vector_space.py
+++ b/src/sage/modules/filtered_vector_space.py
@@ -148,6 +148,8 @@ def is_FilteredVectorSpace(X):
         sage: is_FilteredVectorSpace('ceci n\'est pas une pipe')
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37924, "the function is_FilteredVectorSpace is deprecated; use 'isinstance(..., FilteredVectorSpace_class)' instead")
     return isinstance(X, FilteredVectorSpace_class)
 
 

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -858,6 +858,8 @@ def is_FreeModule(M):
         sage: is_FreeModule(W)
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37924, "the function is_FreeModule is deprecated; use 'isinstance(..., FreeModule_generic)' instead")
     return isinstance(M, FreeModule_generic)
 
 
@@ -2745,7 +2747,7 @@ class FreeModule_generic(Module_free_ambient):
             [  0   1  -3   0   0   0]
             [  0   0   0 1/2   4   2]
         """
-        if not is_FreeModule(other):
+        if not isinstance(other, FreeModule_generic):
             raise TypeError("other must be a free module")
         if other.base_ring() != self.base_ring():
             raise TypeError("base rings of self and other must be the same")
@@ -2867,7 +2869,7 @@ class FreeModule_generic(Module_free_ambient):
             [ 0  1  1  0 -2  1 -1  1 -1 -2  2  0  0  0  0  0  0  0  0]
             [ 0  0  3  0 -3  2 -1  2 -1 -4  2 -1 -2  1  2  0  0 -1  1]
         """
-        if not is_FreeModule(V):
+        if not isinstance(V, FreeModule_generic):
             raise ValueError("V must be a free module")
         A = self.basis_matrix()
         A = A.matrix_from_columns(A.pivots()).transpose()
@@ -4144,7 +4146,7 @@ class FreeModule_generic_pid(FreeModule_generic_domain):
             ...
             ValueError: The given basis vectors must be linearly independent.
         """
-        if is_FreeModule(basis):
+        if isinstance(basis, FreeModule_generic):
             basis = basis.gens()
         if base_ring is None or base_ring == self.base_ring():
             try:
@@ -4306,7 +4308,7 @@ class FreeModule_generic_pid(FreeModule_generic_domain):
             Basis matrix:
             [  1 3/2   2]
         """
-        if is_FreeModule(gens):
+        if isinstance(gens, FreeModule_generic):
             gens = gens.gens()
         return FreeModule_submodule_field(self.ambient_vector_space(), gens, check=check)
 
@@ -4360,7 +4362,7 @@ class FreeModule_generic_pid(FreeModule_generic_domain):
         """
         # Calling is_subspace may be way too slow and repeat work done below.
         # It will be very desirable to somehow do this step better.
-        if check and (not is_FreeModule(sub) or not sub.is_submodule(self)):
+        if check and (not isinstance(sub, FreeModule_generic) or not sub.is_submodule(self)):
             try:
                 sub = self.submodule(sub)
             except (TypeError, ArithmeticError):
@@ -4695,7 +4697,7 @@ class FreeModule_generic_field(FreeModule_generic_pid):
             ...
             ValueError: The given basis vectors must be linearly independent.
         """
-        if is_FreeModule(basis):
+        if isinstance(basis, FreeModule_generic):
             basis = basis.gens()
         if base_ring is None:
             return FreeModule_submodule_with_basis_field(
@@ -5189,9 +5191,9 @@ class FreeModule_generic_field(FreeModule_generic_pid):
         """
         # Calling is_submodule may be way too slow and repeat work done below.
         # It will be very desirable to somehow do this step better.
-        if is_FreeModule(sub) and self.base_ring() != sub.base_ring():
+        if isinstance(sub, FreeModule_generic) and self.base_ring() != sub.base_ring():
             raise ValueError("base rings must be the same")
-        if check and (not is_FreeModule(sub) or not sub.is_subspace(self)):
+        if check and (not isinstance(sub, FreeModule_generic) or not sub.is_subspace(self)):
             try:
                 sub = self.subspace(sub)
             except (TypeError, ArithmeticError):
@@ -5342,7 +5344,7 @@ class FreeModule_generic_field(FreeModule_generic_pid):
         """
         # Calling is_subspace may be way too slow and repeat work done below.
         # It will be very desirable to somehow do this step better.
-        if check and (not is_FreeModule(sub) or not sub.is_subspace(self)):
+        if check and (not isinstance(sub, FreeModule_generic) or not sub.is_subspace(self)):
             try:
                 sub = self.subspace(sub)
             except (TypeError, ArithmeticError):
@@ -8015,7 +8017,7 @@ class FreeModule_submodule_field(FreeModule_submodule_with_basis_field):
             [ 1  0 -1]
             [ 0  1  2]
         """
-        if is_FreeModule(gens):
+        if isinstance(gens, FreeModule_generic):
             gens = gens.gens()
         FreeModule_submodule_with_basis_field.__init__(self, ambient,
                                                        basis=gens, check=check,

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -853,6 +853,10 @@ def is_FreeModule(M):
         sage: from sage.modules.free_module import is_FreeModule
         sage: V = ZZ^3
         sage: is_FreeModule(V)
+        doctest:warning...
+        DeprecationWarning: the function is_FreeModule is deprecated;
+        use 'isinstance(..., FreeModule_generic)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         True
         sage: W = V.span([ V.random_element() for i in range(2) ])
         sage: is_FreeModule(W)

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -5804,8 +5804,8 @@ class FreeModule_ambient(FreeModule_generic):
         """
         if self.base_ring() is R:
             return self
-        from sage.modules.free_quadratic_module import is_FreeQuadraticModule
-        if is_FreeQuadraticModule(self):
+        from sage.modules.free_quadratic_module import FreeQuadraticModule_generic
+        if isinstance(self, FreeQuadraticModule_generic):
             return FreeModule(R, self.rank(),
                               inner_product_matrix=self.inner_product_matrix(),
                               sparse=self.is_sparse())

--- a/src/sage/modules/free_module_homspace.py
+++ b/src/sage/modules/free_module_homspace.py
@@ -97,6 +97,10 @@ def is_FreeModuleHomspace(x):
         sage: type(H)
         <class 'sage.modules.free_module_homspace.FreeModuleHomspace_with_category'>
         sage: sage.modules.free_module_homspace.is_FreeModuleHomspace(H)
+        doctest:warning...
+        DeprecationWarning: the function is_FreeModuleHomspace is deprecated;
+        use 'isinstance(..., FreeModuleHomspace)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         True
 
         sage: K = Hom(QQ^3, ZZ^2)

--- a/src/sage/modules/free_module_homspace.py
+++ b/src/sage/modules/free_module_homspace.py
@@ -120,6 +120,8 @@ def is_FreeModuleHomspace(x):
         sage: sage.modules.free_module_homspace.is_FreeModuleHomspace('junk')
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37924, "the function is_FreeModuleHomspace is deprecated; use 'isinstance(..., FreeModuleHomspace)' instead")
     return isinstance(x, FreeModuleHomspace)
 
 

--- a/src/sage/modules/free_module_morphism.py
+++ b/src/sage/modules/free_module_morphism.py
@@ -90,7 +90,7 @@ class FreeModuleMorphism(matrix_morphism.MatrixMorphism):
             sage: type(phi)
             <class 'sage.modules.free_module_morphism.FreeModuleMorphism'>
         """
-        if not free_module_homspace.is_FreeModuleHomspace(parent):
+        if not isinstance(parent, free_module_homspace.FreeModuleHomspace):
             raise TypeError("parent (=%s) must be a free module hom space" % parent)
         if isinstance(A, matrix_morphism.MatrixMorphism):
             A = A.matrix()

--- a/src/sage/modules/free_module_morphism.py
+++ b/src/sage/modules/free_module_morphism.py
@@ -128,7 +128,7 @@ class FreeModuleMorphism(matrix_morphism.MatrixMorphism):
             sage: phi(2*W.1)
             (6, 0, 8/3)
         """
-        if free_module.is_FreeModule(x):
+        if isinstance(x, free_module.FreeModule_generic):
             V = self.domain().submodule(x)
             return self.restrict_domain(V).image()
         raise TypeError("`pushforward` is only defined for submodules")

--- a/src/sage/modules/free_quadratic_module.py
+++ b/src/sage/modules/free_quadratic_module.py
@@ -249,6 +249,8 @@ def is_FreeQuadraticModule(M):
         sage: is_FreeQuadraticModule(W)
         True
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37924, "the function is_FreeQuadraticModule is deprecated; use 'isinstance(..., FreeQuadraticModule_generic)' instead")
     return isinstance(M, FreeQuadraticModule_generic)
 
 

--- a/src/sage/modules/free_quadratic_module.py
+++ b/src/sage/modules/free_quadratic_module.py
@@ -241,6 +241,10 @@ def is_FreeQuadraticModule(M):
         sage: from sage.modules.free_quadratic_module import is_FreeQuadraticModule
         sage: U = FreeModule(QQ,3)
         sage: is_FreeQuadraticModule(U)
+        doctest:warning...
+        DeprecationWarning: the function is_FreeQuadraticModule is deprecated;
+        use 'isinstance(..., FreeQuadraticModule_generic)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         False
         sage: V = FreeModule(QQ,3,inner_product_matrix=diagonal_matrix([1,1,1]))
         sage: is_FreeQuadraticModule(V)

--- a/src/sage/modules/free_quadratic_module.py
+++ b/src/sage/modules/free_quadratic_module.py
@@ -753,7 +753,7 @@ class FreeQuadraticModule_generic_field(free_module.FreeModule_generic_field,
             Basis matrix:
             [1 1 1]
         """
-        if free_module.is_FreeModule(gens):
+        if isinstance(gens, free_module.FreeModule_generic):
             gens = gens.gens()
         if not isinstance(gens, (list, tuple)):
             raise TypeError("gens (=%s) must be a list or tuple" % gens)

--- a/src/sage/modules/module.pyx
+++ b/src/sage/modules/module.pyx
@@ -318,6 +318,10 @@ def is_VectorSpace(x):
         True
         sage: M = FreeModule(IntegerRing(),30)
         sage: is_Module(M)
+        doctest:warning...
+        DeprecationWarning: the function is_Module is deprecated;
+        use 'isinstance(..., Module)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         True
         sage: is_VectorSpace(M)
         False

--- a/src/sage/modules/module.pyx
+++ b/src/sage/modules/module.pyx
@@ -284,6 +284,10 @@ def is_Module(x):
         sage: from sage.modules.module import is_Module
         sage: M = FreeModule(RationalField(),30)                                        # needs sage.modules
         sage: is_Module(M)                                                              # needs sage.modules
+        doctest:warning...
+        DeprecationWarning: the function is_Module is deprecated;
+        use 'isinstance(..., Module)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         True
         sage: is_Module(10)
         False
@@ -307,6 +311,10 @@ def is_VectorSpace(x):
         sage: from sage.modules.module import is_Module, is_VectorSpace
         sage: M = FreeModule(RationalField(),30)
         sage: is_VectorSpace(M)
+        doctest:warning...
+        DeprecationWarning: the function is_VectorSpace is deprecated;
+        use 'isinstance(..., Module)' and check the base ring instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         True
         sage: M = FreeModule(IntegerRing(),30)
         sage: is_Module(M)
@@ -318,6 +326,6 @@ def is_VectorSpace(x):
     from sage.misc.superseded import deprecation_cython
     deprecation_cython(37924, "the function is_VectorSpace is deprecated; use 'isinstance(..., Module)' and check the base ring instead")
     try:
-        return is_Module(x) and x.base_ring().is_field()
+        return isinstance(x, Module) and x.base_ring().is_field()
     except AttributeError:
         return False

--- a/src/sage/modules/module.pyx
+++ b/src/sage/modules/module.pyx
@@ -174,9 +174,9 @@ cdef class Module(Parent):
 
         """
         try:
-            if (is_Module(M)
-                and self.base_ring().has_coerce_map_from(M.base_ring())
-                and M.change_ring(self.base_ring()).is_submodule(self)):
+            if (isinstance(M, Module)
+                    and self.base_ring().has_coerce_map_from(M.base_ring())
+                    and M.change_ring(self.base_ring()).is_submodule(self)):
                 return M.hom([self._element_constructor_(x) for x in M.gens()], self)
         except (TypeError, NotImplementedError, AttributeError, ArithmeticError):
             pass
@@ -288,6 +288,8 @@ def is_Module(x):
         sage: is_Module(10)
         False
     """
+    from sage.misc.superseded import deprecation_cython
+    deprecation_cython(37924, "the function is_Module is deprecated; use 'isinstance(..., Module)' instead")
     return isinstance(x, Module)
 
 
@@ -313,6 +315,8 @@ def is_VectorSpace(x):
         False
 
     """
+    from sage.misc.superseded import deprecation_cython
+    deprecation_cython(37924, "the function is_VectorSpace is deprecated; use 'isinstance(..., Module)' and check the base ring instead")
     try:
         return is_Module(x) and x.base_ring().is_field()
     except AttributeError:

--- a/src/sage/modules/vector_space_homspace.py
+++ b/src/sage/modules/vector_space_homspace.py
@@ -238,6 +238,8 @@ def is_VectorSpaceHomspace(x):
         sage: sage.modules.vector_space_homspace.is_VectorSpaceHomspace('junk')
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(37924, "the function is_VectorSpaceHomspace is deprecated; use 'isinstance(..., VectorSpaceHomspace)' instead")
     return isinstance(x, VectorSpaceHomspace)
 
 

--- a/src/sage/modules/vector_space_homspace.py
+++ b/src/sage/modules/vector_space_homspace.py
@@ -221,6 +221,10 @@ def is_VectorSpaceHomspace(x):
         sage: type(H)
         <class 'sage.modules.vector_space_homspace.VectorSpaceHomspace_with_category'>
         sage: sage.modules.vector_space_homspace.is_VectorSpaceHomspace(H)
+        doctest:warning...
+        DeprecationWarning: the function is_VectorSpaceHomspace is deprecated;
+        use 'isinstance(..., VectorSpaceHomspace)' instead
+        See https://github.com/sagemath/sage/issues/37924 for details.
         True
 
         sage: K = Hom(QQ^3, ZZ^2)

--- a/src/sage/modules/vector_space_morphism.py
+++ b/src/sage/modules/vector_space_morphism.py
@@ -696,7 +696,7 @@ def linear_transformation(arg0, arg1=None, arg2=None, side='left'):
     from sage.categories.homset import Hom
     from sage.matrix.constructor import matrix
     from sage.modules.free_module import VectorSpace
-    from sage.modules.module import is_VectorSpace
+    from sage.modules.module import Module
     try:
         from sage.modules.vector_callable_symbolic_dense import (
             Vector_callable_symbolic_dense,
@@ -706,8 +706,6 @@ def linear_transformation(arg0, arg1=None, arg2=None, side='left'):
 
     if side not in ['left', 'right']:
         raise ValueError("side must be 'left' or 'right', not {}".format(side))
-    if not (is_Matrix(arg0) or is_VectorSpace(arg0)):
-        raise TypeError('first argument must be a matrix or a vector space, not {}'.format(arg0))
     if is_Matrix(arg0):
         R = arg0.base_ring()
         if not R.is_field():
@@ -722,14 +720,15 @@ def linear_transformation(arg0, arg1=None, arg2=None, side='left'):
         arg2 = arg0
         arg0 = VectorSpace(R, arg2.nrows())
         arg1 = VectorSpace(R, arg2.ncols())
-    elif is_VectorSpace(arg0):
-        if not is_VectorSpace(arg1):
+    elif isinstance(arg0, Module) and arg0.base_ring().is_field():
+        if not (isinstance(arg1, Module) and arg1.base_ring().is_field()):
             msg = 'if first argument is a vector space, then second argument must be a vector space, not {0}'
             raise TypeError(msg.format(arg1))
         if arg0.base_ring() != arg1.base_ring():
             msg = 'vector spaces must have the same field of scalars, not {0} and {1}'
             raise TypeError(msg.format(arg0.base_ring(), arg1.base_ring()))
-
+    else:
+        raise TypeError('first argument must be a matrix or a vector space, not {}'.format(arg0))
     # Now arg0 = domain D, arg1 = codomain C, and
     #   both are vector spaces with common field of scalars
     #   use these to make a VectorSpaceHomSpace

--- a/src/sage/modules/vector_space_morphism.py
+++ b/src/sage/modules/vector_space_morphism.py
@@ -869,7 +869,7 @@ class VectorSpaceMorphism(free_module_morphism.FreeModuleMorphism):
             sage: type(rho)
             <class 'sage.modules.vector_space_morphism.VectorSpaceMorphism'>
         """
-        if not vector_space_homspace.is_VectorSpaceHomspace(homspace):
+        if not isinstance(homspace, vector_space_homspace.VectorSpaceHomspace):
             raise TypeError('homspace must be a vector space hom space, not {}'.format(homspace))
         if isinstance(A, matrix_morphism.MatrixMorphism):
             A = A.matrix()

--- a/src/sage/numerical/linear_tensor.py
+++ b/src/sage/numerical/linear_tensor.py
@@ -269,8 +269,8 @@ class LinearTensorParent_class(Parent):
             sage: LF.tensor(RDF^(2,2)).is_vector_space()
             False
         """
-        from sage.modules.free_module import is_FreeModule
-        return is_FreeModule(self.free_module())
+        from sage.modules.free_module import FreeModule_generic
+        return isinstance(self.free_module(), FreeModule_generic)
 
     def is_matrix_space(self):
         """

--- a/src/sage/numerical/linear_tensor.py
+++ b/src/sage/numerical/linear_tensor.py
@@ -290,8 +290,8 @@ class LinearTensorParent_class(Parent):
             sage: LF.tensor(RDF^(2,2)).is_matrix_space()
             True
         """
-        from sage.matrix.matrix_space import is_MatrixSpace
-        return is_MatrixSpace(self.free_module())
+        from sage.matrix.matrix_space import MatrixSpace
+        return isinstance(self.free_module(), MatrixSpace)
 
     def linear_functions(self):
         """


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


