### PR TITLE
Add legend_label to implicit plots

### DIFF
--- a/src/sage/plot/contour_plot.py
+++ b/src/sage/plot/contour_plot.py
@@ -209,12 +209,12 @@ class ContourPlot(GraphicPrimitive):
                                  extent=(x0, x1, y0, y1),
                                  linewidths=linewidths, linestyles=linestyles)
 
-        if options.get('legend_label',None):
+        if options.get('legend_label', None):
             if plot_subtype == 'implicit':
-                        CSartists, CSlabels = CS.legend_elements()
-                        CSartists[0].set_label(options['legend_label'])
-                        subplot.add_line(CSartists[0])
-                        subplot.legend()
+                CSartists, CSlabels = CS.legend_elements()
+                CSartists[0].set_label(options['legend_label'])
+                subplot.add_line(CSartists[0])
+                subplot.legend()
 
         if options.get('labels', False):
             label_options = options['label_options']

--- a/src/sage/plot/contour_plot.py
+++ b/src/sage/plot/contour_plot.py
@@ -61,7 +61,7 @@ class ContourPlot(GraphicPrimitive):
         ....:              plot_points=121, cmap='hsv')
         Graphics object consisting of 1 graphics primitive
     """
-    def __init__(self, xy_data_array, xrange, yrange, subtype, options):
+    def __init__(self, xy_data_array, xrange, yrange, options, subtype=None):
         """
         Initialize base class ``ContourPlot``.
 
@@ -1036,7 +1036,7 @@ def contour_plot(f, xrange, yrange, **options):
 
         xy_data_array[mask] = numpy.ma.masked
 
-    g.add_primitive(ContourPlot(xy_data_array, xrange, yrange, plot_subtype, options))
+    g.add_primitive(ContourPlot(xy_data_array, xrange, yrange, options, plot_subtype))
 
     return g
 
@@ -1743,10 +1743,10 @@ def region_plot(f, xrange, yrange, **options):
                                                       ignore=['xmin', 'xmax']))
 
     if neqs == 0:
-        g.add_primitive(ContourPlot(xy_data_array, xrange, yrange, 'region',
+        g.add_primitive(ContourPlot(xy_data_array, xrange, yrange,
                                     dict(contours=[-1e-20, 0, 1e-20],
                                          cmap=cmap,
-                                         fill=True, **options)))
+                                         fill=True, **options), 'region'))
     else:
         mask = numpy.asarray([[elt > 0 for elt in rows]
                               for rows in xy_data_array],
@@ -1763,12 +1763,12 @@ def region_plot(f, xrange, yrange, **options):
         linestyles = [borderstyle] if borderstyle else None
         linewidths = [borderwidth] if borderwidth else None
         g.add_primitive(ContourPlot(xy_data_array, xrange, yrange,
-                                    'region_border' if neqs == 0 and
-                                    plot_subtype == 'region' else 'implicit',
                                     dict(linestyles=linestyles,
                                          linewidths=linewidths,
                                          contours=[0], cmap=[bordercol],
-                                         fill=False, **options)))
+                                         fill=False, **options),
+                                    'region_border' if neqs == 0 and
+                                    plot_subtype == 'region' else 'implicit'))
 
     return g
 

--- a/src/sage/plot/contour_plot.py
+++ b/src/sage/plot/contour_plot.py
@@ -215,7 +215,7 @@ class ContourPlot(GraphicPrimitive):
                         CSartists[0].set_label(options['legend_label'])
                         subplot.add_line(CSartists[0])
                         subplot.legend()
-            
+
         if options.get('labels', False):
             label_options = options['label_options']
             label_options['fontsize'] = int(label_options['fontsize'])


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Fixes #15903.

- Introduces an internal `plot_subtype` parameter that is used to determine when legend_label should be added.
- If `plot_subtype == implicit`, adds legend_label by adding a label to the ContourSet artist and directly adding it to the plot.
- It is possible to do something similar for region_plot by using a proxy artist like [here](https://matplotlib.org/stable/users/explain/axes/legend_guide.html#creating-artists-specifically-for-adding-to-the-legend-aka-proxy-artists), but this isn't attempted in this PR because I wasn't sure what to do about the inside, outside, and border regions separately.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies
None
<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


