### PR TITLE
Adapt length check in `sage.databases.conway` in preparation for database update

### DIFF
--- a/src/sage/databases/conway.py
+++ b/src/sage/databases/conway.py
@@ -138,11 +138,16 @@ class ConwayPolynomials(Mapping):
         """
         Return the number of polynomials in this database.
 
-        TESTS::
+        TESTS:
+
+        The database currently contains `35357` polynomials, but due to
+        :issue:`35357` it will be extended by Conway polynomials of
+        degrees `1`, `2` and `3` for primes between `65537` and `110000`,
+        thus leading to a new total of `47090` entries::
 
             sage: c = ConwayPolynomials()
-            sage: len(c)
-            35357
+            sage: len(c) in [35357, 47090]
+            True
         """
         try:
             return self._len


### PR DESCRIPTION
Motivated by #35357, the database of Conway polynomials will be enlarged to ensure compatibility in the generation of finite fields (see https://github.com/sagemath/conway-polynomials/pull/5 for details). To prepare for this update, we slightly relax the length check in `sage.databases.conway` to be compatible with both the old and the new version of the database.

