### PR TITLE
declare the last arg to GAP_CallFunc3Args volatile

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2504,6 +2504,7 @@ cdef class GapElement_Function(GapElement):
         cdef Obj result = NULL
         cdef Obj arg_list
         cdef int n = len(args)
+        cdef volatile Obj v2
 
         if n > 0 and n <= 3:
             libgap = self.parent()
@@ -2522,10 +2523,11 @@ cdef class GapElement_Function(GapElement):
                                            (<GapElement>a[0]).value,
                                            (<GapElement>a[1]).value)
             elif n == 3:
+                v2 = (<GapElement>a[2]).value
                 result = GAP_CallFunc3Args(self.value,
                                            (<GapElement>a[0]).value,
                                            (<GapElement>a[1]).value,
-                                           (<GapElement>a[2]).value)
+                                           v2)
             else:
                 arg_list = make_gap_list(args)
                 result = GAP_CallFuncList(self.value, arg_list)


### PR DESCRIPTION
This appears to fix #37026 (segfaults in src/sage/libs/gap/element.pyx with Python 3.12 and gcc 13.2.1)

See also https://github.com/sagemath/sage/pull/36407#issuecomment-2068709126

The corresponding gcc 13.2.1's bug (or feature) is being dealt with here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114872 
### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


