### PR TITLE
Adding add_bigoh methods to lazy power/Laurent series and coercions to the finite precision implementations

### DIFF
--- a/src/sage/rings/laurent_series_ring.py
+++ b/src/sage/rings/laurent_series_ring.py
@@ -63,8 +63,12 @@ def is_LaurentSeriesRing(x):
         sage: K.<q> = LaurentSeriesRing(QQ)
         sage: is_LaurentSeriesRing(K)
         True
+        sage: L.<z> = LazyLaurentSeriesRing(QQ)
+        sage: is_LaurentSeriesRing(L)
+        True
     """
-    return isinstance(x, LaurentSeriesRing)
+    from sage.rings.lazy_series_ring import LazyLaurentSeriesRing
+    return isinstance(x, (LaurentSeriesRing, LazyLaurentSeriesRing))
 
 
 class LaurentSeriesRing(UniqueRepresentation, CommutativeRing):
@@ -439,6 +443,17 @@ class LaurentSeriesRing(UniqueRepresentation, CommutativeRing):
             1/64*I*u^10 - 1/128*u^12 - 1/256*I*u^14 + 1/512*u^16 +
             1/1024*I*u^18 + O(u^20)
 
+        Lazy series::
+
+            sage: L.<z> = LazyLaurentSeriesRing(ZZ)
+            sage: R = LaurentSeriesRing(QQ, names='z')
+            sage: R(z^-5 + 1/(1-z))
+            z^-5 + 1 + z + z^2 + z^3 + z^4 + z^5 + z^6 + z^7 + z^8 + z^9 + z^10
+             + z^11 + z^12 + z^13 + z^14 + z^15 + z^16 + z^17 + z^18 + z^19 + O(z^20)
+            sage: L.<z> = LazyPowerSeriesRing(QQ)
+            sage: R(5 + z - 5*z^7)
+            5 + z - 5*z^7
+
         TESTS:
 
         Check that :issue:`28993` is fixed::
@@ -488,6 +503,7 @@ class LaurentSeriesRing(UniqueRepresentation, CommutativeRing):
             x^-3
         """
         from sage.rings.fraction_field_element import is_FractionFieldElement
+        from sage.rings.lazy_series import LazyPowerSeries, LazyLaurentSeries
         from sage.rings.polynomial.multi_polynomial import MPolynomial
         from sage.rings.polynomial.polynomial_element import Polynomial
         from sage.structure.element import parent
@@ -524,6 +540,14 @@ class LaurentSeriesRing(UniqueRepresentation, CommutativeRing):
               and isinstance(x.numerator(), (Polynomial, MPolynomial))):
             x = self(x.numerator()) / self(x.denominator())
             return (x << n).add_bigoh(prec)
+        elif isinstance(x, (LazyPowerSeries, LazyLaurentSeries)):
+            if prec is infinity:
+                try:
+                    x = self.power_series_ring()(x.polynomial())
+                except ValueError:
+                    x = x.add_bigoh(self.default_prec())
+            else:
+                x = x.add_bigoh(prec)
         return self.element_class(self, x, n).add_bigoh(prec)
 
     def random_element(self, algorithm='default'):
@@ -616,6 +640,10 @@ class LaurentSeriesRing(UniqueRepresentation, CommutativeRing):
             sage: S.has_coerce_map_from(PowerSeriesRing(ZZ, 't'))
             True
             sage: S.has_coerce_map_from(S)
+            True
+            sage: S.has_coerce_map_from(LazyLaurentSeriesRing(QQ, 't'))
+            True
+            sage: S.has_coerce_map_from(LazyPowerSeriesRing(ZZ, 't'))
             True
 
             sage: S.has_coerce_map_from(QQ)

--- a/src/sage/rings/laurent_series_ring.py
+++ b/src/sage/rings/laurent_series_ring.py
@@ -641,7 +641,7 @@ class LaurentSeriesRing(UniqueRepresentation, CommutativeRing):
             True
             sage: S.has_coerce_map_from(S)
             True
-            sage: S.has_coerce_map_from(LazyLaurentSeriesRing(QQ, 't'))
+            sage: S.has_coerce_map_from(LazyLaurentSeriesRing(ZZ, 't'))
             True
             sage: S.has_coerce_map_from(LazyPowerSeriesRing(ZZ, 't'))
             True
@@ -667,6 +667,10 @@ class LaurentSeriesRing(UniqueRepresentation, CommutativeRing):
             sage: R.has_coerce_map_from(ZZ['t']['x'])
             False
             sage: R.has_coerce_map_from(ZZ['x'])
+            True
+            sage: R.has_coerce_map_from(LazyLaurentSeriesRing(ZZ, 't'))
+            True
+            sage: R.has_coerce_map_from(LazyLaurentSeriesRing(ZZ['x'], 't'))
             True
         """
         A = self.base_ring()

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -6071,7 +6071,8 @@ class LazyPowerSeries(LazyCauchyProductSeries):
     def add_bigoh(self, prec):
         r"""
         Return the power series of precision at most ``prec`` obtained by
-        adding `O(q^\text{prec})` to `f`, where `q` is the variable(s).
+        adding `O(q^\text{prec})` to `f`, where `q` is the (tuple of)
+        variable(s).
 
         EXAMPLES::
 

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -4746,6 +4746,9 @@ class LazyLaurentSeries(LazyCauchyProductSeries):
             R = PowerSeriesRing(S.base_ring(), name=name)
             return R([self[i] for i in range(prec)]).add_bigoh(prec)
 
+    add_bigoh = approximate_series
+    O = approximate_series
+
     def polynomial(self, degree=None, name=None):
         r"""
         Return ``self`` as a Laurent polynomial if ``self`` is actually so.
@@ -6064,6 +6067,44 @@ class LazyPowerSeries(LazyCauchyProductSeries):
         if S._arity == 1:
             return R(self[0:m])
         return R.sum(self[0:m])
+
+    def add_bigoh(self, prec):
+        r"""
+        Return the power series of precision at most ``prec`` obtained by
+        adding `O(q^\text{prec})` to `f`, where `q` is the variable(s).
+
+        EXAMPLES::
+
+            sage: L.<x,y> = LazyPowerSeriesRing(QQ)
+            sage: f = 1 / (1 - x + y)
+            sage: f
+            1 + (x-y) + (x^2-2*x*y+y^2) + (x^3-3*x^2*y+3*x*y^2-y^3)
+             + (x^4-4*x^3*y+6*x^2*y^2-4*x*y^3+y^4)
+             + (x^5-5*x^4*y+10*x^3*y^2-10*x^2*y^3+5*x*y^4-y^5)
+             + (x^6-6*x^5*y+15*x^4*y^2-20*x^3*y^3+15*x^2*y^4-6*x*y^5+y^6)
+             + O(x,y)^7
+            sage: f3 = f.add_bigoh(3); f3
+            1 + x - y + x^2 - 2*x*y + y^2 + O(x, y)^3
+            sage: f3.parent()
+            Multivariate Power Series Ring in x, y over Rational Field
+
+            sage: R.<t> = QQ[]
+            sage: L.<x> = LazyPowerSeriesRing(R)
+            sage: f = 1 / (1 - t^3*x)
+            sage: f
+            1 + t^3*x + t^6*x^2 + t^9*x^3 + t^12*x^4 + t^15*x^5 + t^18*x^6 + O(x^7)
+            sage: f3 = f.add_bigoh(3); f3
+            1 + t^3*x + t^6*x^2 + O(x^3)
+            sage: f3.parent()
+            Power Series Ring in x over Univariate Polynomial Ring in t
+             over Rational Field
+        """
+        from sage.rings.power_series_ring import PowerSeriesRing
+        P = self.parent()
+        PSR = PowerSeriesRing(P.base_ring(), names=P.variable_names())
+        return PSR(self.polynomial(degree=prec-1), prec=prec)
+
+    O = add_bigoh
 
     def _floordiv_(self, other):
         r"""

--- a/src/sage/rings/power_series_ring.py
+++ b/src/sage/rings/power_series_ring.py
@@ -470,8 +470,13 @@ def is_PowerSeriesRing(R):
         False
         sage: is_PowerSeriesRing(QQ[['x']])
         True
+        sage: is_PowerSeriesRing(LazyPowerSeriesRing(QQ, 'x'))
+        True
+        sage: is_PowerSeriesRing(LazyPowerSeriesRing(QQ, 'x, y'))
+        False
     """
-    if isinstance(R, PowerSeriesRing_generic):
+    from sage.rings.lazy_series_ring import LazyPowerSeriesRing
+    if isinstance(R, (PowerSeriesRing_generic, LazyPowerSeriesRing)):
         return R.ngens() == 1
     else:
         return False
@@ -684,8 +689,8 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
 
     def _coerce_map_from_(self, S):
         """
-        A coercion from `S` exists, if `S` coerces into ``self``'s base ring,
-        or if `S` is a univariate polynomial or power series ring with the
+        A coercion from ``S`` exists, if ``S`` coerces into ``self``'s base ring,
+        or if ``S`` is a univariate polynomial or power series ring with the
         same variable name as self, defined over a base ring that coerces into
         ``self``'s base ring.
 
@@ -700,7 +705,8 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
             False
             sage: A.has_coerce_map_from(ZZ[['x']])
             True
-
+            sage: A.has_coerce_map_from(LazyPowerSeriesRing(ZZ, 'x'))
+            True
         """
         if self.base_ring().has_coerce_map_from(S):
             return True
@@ -712,8 +718,8 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
         """
         Coerce object to this power series ring.
 
-        Returns a new instance unless the parent of f is self, in which
-        case f is returned (since f is immutable).
+        Returns a new instance unless the parent of ``f`` is ``self``, in
+        which case ``f`` is returned (since ``f`` is immutable).
 
         INPUT:
 
@@ -725,7 +731,6 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
 
         -  ``check`` -- bool (default: ``True``), whether to verify
            that the coefficients, etc., coerce in correctly.
-
 
         EXAMPLES::
 
@@ -803,6 +808,14 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
             ...
             ValueError: prec (= -5) must be non-negative
 
+        From lazy series::
+
+            sage: L.<x> = LazyPowerSeriesRing(QQ)
+            sage: R = PowerSeriesRing(QQ, 'x')
+            sage: R(1 / (1 + x^3))
+            1 - x^3 + x^6 - x^9 + x^12 - x^15 + x^18 + O(x^20)
+            sage: R(2 - x^2 + x^6)
+            2 - x^2 + x^6
         """
         if prec is not infinity:
             prec = integer.Integer(prec)
@@ -832,6 +845,16 @@ class PowerSeriesRing_generic(UniqueRepresentation, ring.CommutativeRing, Nonexa
                                           f.degree(f.default_variable()), check=check)
                 else:
                     raise TypeError("Can only convert series into ring with same variable name.")
+        else:
+            from sage.rings.lazy_series import LazyPowerSeries
+            if isinstance(f, LazyPowerSeries):
+                if prec is infinity:
+                    try:
+                        f = f.polynomial()
+                    except ValueError:
+                        f = f.add_bigoh(self.default_prec())
+                else:
+                    f = f.add_bigoh(prec)
         return self.element_class(self, f, prec, check=check)
 
     def construction(self):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

It is natural to go from the lazy series (infinite precision) to the finite precision cases. We provide these coercion maps and the analogous methods `add_bigoh` and `O` for better compatibility.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


