### PR TITLE
Modify tests in `ell_point.py` to be more generic for Conway database update

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -1833,16 +1833,20 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
 
         TESTS:
 
-        Check that the original Sage implementation still works::
+        Check that the original Sage implementation still works and
+        that the result coincides with the PARI implementation::
 
             sage: # needs sage.rings.finite_rings
             sage: GF(65537^2).inject_variables()
             Defining z2
             sage: E = EllipticCurve(GF(65537^2), [0,1])
-            sage: P = E(22, 28891)
-            sage: Q = E(-93, 40438*z2 + 31573)
-            sage: P.weil_pairing(Q, 7282, algorithm='sage')
-            19937*z2 + 65384
+            sage: R, S = E.torsion_basis(7282)
+            sage: a, b = ZZ.random_element(), ZZ.random_element()
+            sage: P = a*R + b*S
+            sage: c, d = ZZ.random_element(), ZZ.random_element()
+            sage: Q = c*R + d*S
+            sage: P.weil_pairing(Q, 7282, algorithm='sage') == P.weil_pairing(Q, 7282, algorithm='pari')
+            True
 
         Passing an unknown ``algorithm=`` argument should fail::
 
@@ -2048,17 +2052,6 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             True
 
         TESTS:
-
-        Check that the PARI output matches the original Sage implementation::
-
-            sage: # needs sage.rings.finite_rings
-            sage: GF(65537^2).inject_variables()
-            Defining z2
-            sage: E = EllipticCurve(GF(65537^2), [0,1])
-            sage: P = E(22, 28891)
-            sage: Q = E(-93, 40438*z2 + 31573)
-            sage: P.tate_pairing(Q, 7282, 2)
-            34585*z2 + 4063
 
         The point ``P (self)`` must have ``n`` torsion::
 

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -1818,6 +1818,17 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             sage: z.multiplicative_order()
             360
 
+        Another larger example::
+
+            sage: F = GF(65537^2, modulus=[3,-1,1], name='a')
+            sage: F.inject_variables()
+            Defining a
+            sage: E = EllipticCurve(F, [0,1])
+            sage: P = E(22, 28891)
+            sage: Q = E(-93, 2728*a + 64173)
+            sage: P.weil_pairing(Q, 7282, algorithm='sage')
+            53278*a + 36700
+
         An example over a number field::
 
             sage: # needs sage.rings.number_field
@@ -2050,6 +2061,17 @@ class EllipticCurvePoint_field(SchemeMorphism_point_abelian_variety_field):
             25575
             sage: Px.weil_pairing(Qx, 41)^e == num/den
             True
+
+        An example over a large base field::
+
+            sage: F = GF(65537^2, modulus=[3,46810,1], name='z2')
+            sage: F.inject_variables()
+            Defining z2
+            sage: E = EllipticCurve(F, [0,1])
+            sage: P = E(22, 28891)
+            sage: Q = E(-93, 40438*z2 + 31573)
+            sage: P.tate_pairing(Q, 7282, 2)
+            34585*z2 + 4063
 
         TESTS:
 


### PR DESCRIPTION
As part of the Conway polynomials database update, two tests in `schemes.elliptic_curves.ell_point` caused issues due to their dependency on the precise implementation of the finite field `GF(65537^2)`:
- The first test (of `.weil_pairing`) checks whether the Sage implementation still works for an example of fixed `7282`-torsion points
- The second test (of `.tate_pairing`) checks whether the new implementation, which uses PARI up to reduction of the pairing, coincides with the old Sage implementation (still used e.g. in SageMathCell, but not available in the current code anymore)

To help with the database update, we adapt these tests to not be dependent on the exact minimal polynomial used for finite field generation:
- We turn both tests into examples (with fixed moduli) for their respective methods
- We modify the test of `.weil_pairing` to check for two randomly chosen `7282`-torsion points whether `algorithm="sage"` and `algorithm="pari"` yield the same result

Please let me know if you think other polynomial-independent tests are better suited as replacements.

See sagemath/conway-polynomials#5 (especially [comment 10](https://github.com/sagemath/conway-polynomials/pull/5#issuecomment-2101462886) and Update 2 in [comment 11](https://github.com/sagemath/conway-polynomials/pull/5#issuecomment-2101498241)) for more details.

CC: @yyyyx4 @GiacomoPope @JohnCremona 