### PR TITLE
Fix sign error in the Kerr metric of the manifold catalog

### DIFF
--- a/src/sage/manifolds/catalog.py
+++ b/src/sage/manifolds/catalog.py
@@ -129,10 +129,10 @@ def Kerr(m=1, a=0, coordinates="BL", names=None):
         [Chart (M, (t, r, th, ph))]
         sage: K.metric().display()
         g = (2*m*r/(a^2*cos(th)^2 + r^2) - 1) dt⊗dt
-         + 2*a*m*r*sin(th)^2/(a^2*cos(th)^2 + r^2) dt⊗dph
+         - 2*a*m*r*sin(th)^2/(a^2*cos(th)^2 + r^2) dt⊗dph
          + (a^2*cos(th)^2 + r^2)/(a^2 - 2*m*r + r^2) dr⊗dr
          + (a^2*cos(th)^2 + r^2) dth⊗dth
-         + 2*a*m*r*sin(th)^2/(a^2*cos(th)^2 + r^2) dph⊗dt
+         - 2*a*m*r*sin(th)^2/(a^2*cos(th)^2 + r^2) dph⊗dt
          + (2*a^2*m*r*sin(th)^2/(a^2*cos(th)^2 + r^2) + a^2 + r^2)*sin(th)^2 dph⊗dph
 
         sage: K.<t, r, th, ph> = manifolds.Kerr()
@@ -205,7 +205,7 @@ def Kerr(m=1, a=0, coordinates="BL", names=None):
         g[0, 0], g[1, 1], g[2, 2], g[3, 3] = -(1-2*m*r/rho**2), \
             rho**2/(r**2-2*m*r+a**2), rho**2, \
             (r**2+a**2+2*m*r*a**2/rho**2*sin(th)**2)*sin(th)**2
-        g[0, 3] = 2*m*r*a*sin(th)**2/rho**2
+        g[0, 3] = -2*m*r*a*sin(th)**2/rho**2
         return M
 
     raise NotImplementedError("coordinates system not implemented, see help"

--- a/src/sage/manifolds/catalog.py
+++ b/src/sage/manifolds/catalog.py
@@ -127,6 +127,9 @@ def Kerr(m=1, a=0, coordinates="BL", names=None):
         4-dimensional Lorentzian manifold M
         sage: K.atlas()
         [Chart (M, (t, r, th, ph))]
+
+    The Kerr metric in Boyer-Lindquist coordinates (cf. :wikipedia:`Kerr_metric`)::
+
         sage: K.metric().display()
         g = (2*m*r/(a^2*cos(th)^2 + r^2) - 1) dt⊗dt
          - 2*a*m*r*sin(th)^2/(a^2*cos(th)^2 + r^2) dt⊗dph
@@ -134,6 +137,8 @@ def Kerr(m=1, a=0, coordinates="BL", names=None):
          + (a^2*cos(th)^2 + r^2) dth⊗dth
          - 2*a*m*r*sin(th)^2/(a^2*cos(th)^2 + r^2) dph⊗dt
          + (2*a^2*m*r*sin(th)^2/(a^2*cos(th)^2 + r^2) + a^2 + r^2)*sin(th)^2 dph⊗dph
+
+    The Schwarzschild spacetime with the mass parameter set to 1::
 
         sage: K.<t, r, th, ph> = manifolds.Kerr()
         sage: K
@@ -143,6 +148,9 @@ def Kerr(m=1, a=0, coordinates="BL", names=None):
          + r^2 dth⊗dth + r^2*sin(th)^2 dph⊗dph
         sage: K.default_chart().coord_range()
         t: (-oo, +oo); r: (0, +oo); th: (0, pi); ph: [-pi, pi] (periodic)
+
+
+    The Kerr spacetime in Kerr coordinates::
 
         sage: m, a = var('m, a')
         sage: K.<t, r, th, ph> = manifolds.Kerr(m, a, coordinates="Kerr")


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

In the Kerr spacetime constructed from the manifold catalog (i.e. returned by  `manifolds.Kerr`), there was an error in the sign of the g_{03} component of the metric tensor with respect to Boyer-Lindquist coordinates. This is fixed here.  

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


