### PR TITLE
Link with -rpath and -rpath-link

### DIFF
--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -386,7 +386,7 @@ if [ -n "$SAGE_LOCAL" ]; then
         LDFLAGS="-L$SAGE_LOCAL/lib -Wl,-rpath,$SAGE_LOCAL/lib $LDFLAGS"
     fi
     if [ "$UNAME" = "Linux" ]; then
-        LDFLAGS="-Wl,-rpath-link,$SAGE_LOCAL/lib $LDFLAGS"
+        LDFLAGS="-Wl,-rpath,$SAGE_LOCAL/lib -Wl,-rpath-link,$SAGE_LOCAL/lib $LDFLAGS"
     fi
     export LDFLAGS
 fi


### PR DESCRIPTION
The former is for the binary, the latter is for dependencies between shared libraries. Only setting -rpath-link does not set the ELF RUNPATH any more on gcc-14, you have to specify -rpath now. This causes some applications to not find their shared libraries (ppl, gfan)

Otherwise, gfan fails to build/run on Fedora 40:
```
Using cached file /home/release/Sage/upstream/gfan0.6.2.tar.gz
Setting up build directory /home/release/Sage/local/var/tmp/sage/build/gfan-0.6.2.p1
Applying patches from ../patches...
Applying ../patches/Makefile.patch
[...]
[spkg-install] g++ -std=gnu++11 -g -O2 -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O2          -g     -c src/app_tropicalcurve.cpp -o src/app_tropicalcurve.o
[spkg-install] g++ -std=gnu++11 -g -O2 -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O2          -g     -c src/app_tropicalhomotopy.cpp -o src/app_tropicalhomotopy.o
[spkg-install] g++ -std=gnu++11 -g -O2 -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O2          -g     -c src/app_integerfactorization.cpp -o src/app_integerfactorization.o
[spkg-install] g++ -std=gnu++11 -g -O2 -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O2          -g     -c src/app_tropicalvarietyspan.cpp -o src/app_tropicalvarietyspan.o
[spkg-install] g++ -std=gnu++11 -g -O2 -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O2          -g     -c src/app_chowbetti.cpp -o src/app_chowbetti.o
[spkg-install] g++ -std=gnu++11 -g -O2 -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O2          -g     -c src/symmetrictraversal.cpp -o src/symmetrictraversal.o
[spkg-install] g++ -std=gnu++11 -g -O2 -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O2          -g     -pthread -o gfan -Wl,-rpath-link,/home/release/Sage/local/lib -L/home/release/Sage/local/lib -Wl,-rpath-link,/home/release/Sage/local/lib -L/home/release/Sage/local/lib   src/polynomialgcd.o src/lp_cdd.o src/parser.o src/field.o src/monomial.o src/printer.o src/polynomial.o src/termorder.o src/term.o src/vektor.o src/division.o src/buchberger.o src/wallideal.o src/lp.o src/enumeration.o src/ep_standard.o src/ep_xfig.o src/reversesearch.o src/application.o src/timer.o src/renderer.o src/field_rationals.o src/symmetry.o src/breadthfirstsearch.o src/genericwalk.o src/minkowskisum.o src/newtonpolytope.o src/tropical.o src/dimension.o src/bergman.o src/subspace.o src/polyhedralcone.o src/gfanapplication.o src/polyhedralfan.o src/tropical2.o src/field_zmodpz.o src/binomial.o src/matrix.o src/latticeideal.o src/scarf.o src/xfig.o src/halfopencone.o src/lll.o src/multiplicity.o src/substitute.o src/polymakefile.o src/saturation.o src/determinant.o src/polynomialring.o src/log.o src/tropicalbasis.o src/symmetriccomplex.o src/linalg.o src/minors.o src/continuedfractions.o src/triangulation.o src/minkowskidual.o src/regularsubdivision.o src/fieldlp.o src/field_rationalfunctions.o src/tropical_weildivisor.o src/intsinpolytope.o src/lattice.o src/graph.o src/restrictedautoreduction.o src/tropicaltraverse.o src/groebnerengine.o src/ge_gfan.o src/nbody.o src/codimoneconnectedness.o src/tropicalmap.o src/traverser_tropical.o src/traverser_groebnerfan.o src/field_rationalfunctions2.o src/mixedvolume.o src/traverser_stableintersection.o src/traverser_secondaryfan.o src/linalgfloat.o src/primarydecomposition.o src/tropicaldeterminant.o src/determinantpoly.o src/traverser_sphere.o src/gfanlib_zcone.o src/gfanlib_symmetry.o src/gfanlib_symmetriccomplex.o src/gfanlib_polyhedralfan.o src/gfanlib_zfan.o src/gfanlib_polymakefile.o src/gfanlib_mixedvolume.o src/gfanlib_circuittableint.o src/gfanlib_paralleltraverser.o src/padic.o src/integergb.o src/traverser_resultantfan.o src/bsptree.o src/traverser_resultantfanspecialization.o src/myassert.o src/traverser_bsptree.o src/gfanlib_traversal.o src/tropicalcurve.o src/packedmonomial.o src/gmpallocator.o src/app_main.o src/app_buchberger.o src/app_doesidealcontain.o src/app_facets.o src/app_groebnercone.o src/app_homogeneityspace.o src/app_homogenize.o src/app_initialforms.o src/app_interactive.o src/app_isgroebnerbasis.o src/app_ismarkedgroebnerbasis.o src/app_krulldimension.o src/app_leadingterms.o src/app_multiplymatrix.o src/app_polynomialsetunion.o src/app_render.o src/app_renderstaircase.o src/app_stats.o src/app_substitute.o src/app_supportindices.o src/app_tolatex.o src/app_transposematrix.o src/app_tropicalbasis.o src/app_tropicalintersection.o src/app_tropicalstartingcone.o src/app_tropicaltraverse.o src/app_walk.o src/app_weightvector.o src/app_scarfisgeneric.o src/app_scarfvisualize.o src/app_scarfcomplex.o src/app_sturmsequence.o src/app_latticeideal.o src/app_lll.o src/app_tropicalmultiplicity.o src/app_idealintersection.o src/app_test.o src/app_saturation.o src/app_idealproduct.o src/app_representatives.o src/app_tropicallifting.o src/app_topolyhedralfan.o src/app_tropicalbruteforce.o src/app_secondaryfan.o src/app_composepermutations.o src/app_minors.o src/app_tropicalrank.o src/app_minkowski.o src/app_triangulate.o src/app_tropicallinearspace.o src/app_combinerays.o src/app_regularsubdivision.o src/app_lpsolve.o src/app_tropicalweildivisor.o src/app_lattice.o src/app_intsinpolytope.o src/app_tropicalevaluation.o src/app_smalessixth.o src/app_smalessixth2.o src/app_nbody.o src/app_spolynomial.o src/app_link.o src/app_normalfancleanup.o src/app_tropicalfunction.o src/app_volume.o src/app_isconnected.o src/app_tropicalhypersurface.o src/app_product.o src/app_commonrefinement.o src/app_tropicalimage.o src/app_groebnerfan.o src/app_fanhomology.o src/app_genericlinearchange.o src/app_mixedvolume.o src/app_fiberpolytope.o src/app_symmetries.o src/app_evaluate.o src/app_exponentlattice.o src/app_minimalassociatedprimes.o src/app_realroots.o src/app_initialdeterminant.o src/app_fansubfan.o src/app_fancones.o src/app_issmooth.o src/app_fancoarsening.o src/app_pointconfiguration.o src/app_librarytest.o src/app_padic.o src/app_integergb.o src/app_matrixproduct.o src/app_traversetropicalintersection.o src/app_markpolynomialset.o src/app_tropicalhypersurfacereconstruction.o src/app_resultantfan.o src/app_isbalanced.o src/app_polytopealgebra.o src/app_debug.o src/app_randompolynomials.o src/app_tropicalcurve.o src/app_tropicalhomotopy.o src/app_integerfactorization.o src/app_tropicalvarietyspan.o src/app_chowbetti.o src/symmetrictraversal.o -lpthread -lcddgmp -lgmp -lm   -g
[spkg-install] gfan -> /home/release/Sage/local/var/tmp/sage/build/gfan-0.6.2.p1/inst/home/release/Sage/local/bin
[spkg-install] Now running gfan to install links in '/home/release/Sage/local/bin/'...
[spkg-install] ./gfan: error while loading shared libraries: libcddgmp.so.0: cannot open shared object file: No such file or directory
```
because of a missing ELF RUNPATH:
```
$ ldd /home/release/Sage/local/var/tmp/sage/build/gfan-0.6.2.p1/src/gfan
	linux-vdso.so.1 (0x00007ffc113c5000)
	libcddgmp.so.0 => not found
	libgmp.so.10 => /lib64/libgmp.so.10 (0x00007ffb5eae2000)
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007ffb5e800000)
	libm.so.6 => /lib64/libm.so.6 (0x00007ffb5e71d000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007ffb5eab5000)
	libc.so.6 => /lib64/libc.so.6 (0x00007ffb5e530000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ffb5eba7000)
```