### PR TITLE
`.github/workflows/docker_hub.yml`: Do not fail when there are no credentials

### DIFF
--- a/.github/workflows/docker_hub.yml
+++ b/.github/workflows/docker_hub.yml
@@ -10,6 +10,9 @@ on:
         default: make-build
         type: string
 
+env:
+  CAN_LOGIN: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+
 jobs:
   build-and-push:
     name: Build Docker image and push to DockerHub
@@ -71,11 +74,12 @@ jobs:
         if: env.JOB_DONE == 'false'
 
       - name: Login to Docker Hub
+        id: login
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: env.JOB_DONE == 'false'
+        if: env.JOB_DONE == 'false' && env.CAN_DEPLOY == 'true'
 
       - name: Build and push make-build
         uses: docker/build-push-action@v5
@@ -85,8 +89,9 @@ jobs:
           target: ${{ inputs.dockerfile_target }}
           build-args: |
             MAKE_BUILD=${{ env.BASE }}
-          push: true
+          push: ${{ steps.login.outcome == 'success' }}
           tags: ${{ env.TAG_LIST }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-        if: env.JOB_DONE == 'false'
+        # run even if there are no push credentials (just don't push)
+        if: (success() || failure()) && env.JOB_DONE == 'false'

--- a/.github/workflows/docker_hub.yml
+++ b/.github/workflows/docker_hub.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: env.JOB_DONE == 'false' && env.CAN_DEPLOY == 'true'
+        if: env.JOB_DONE == 'false' && env.CAN_LOGIN == 'true'
 
       - name: Build and push make-build
         uses: docker/build-push-action@v5


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Sometimes I push mock release tags to my repo to test workflows relevant to making a release.

Currently, the workflow "Build Docker images and push to DockerHub" fails in this situation when it tries to log in to DockerHub; example: https://github.com/mkoeppe/sage/actions/runs/9045501088/job/24855325483

This PR modifies it to just skip the "login" step when the secrets are not set. It then still builds the image, but does not try to push. Example: https://github.com/mkoeppe/sage/actions/runs/9046681672/job/24857769764

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


