### PR TITLE
`minimum_generating_set` function for non-solvable groups

### DIFF
--- a/src/sage/categories/groups.py
+++ b/src/sage/categories/groups.py
@@ -451,6 +451,51 @@ class Groups(CategoryWithAxiom):
             from sage.groups.conjugacy_classes import ConjugacyClass
             return ConjugacyClass(self, g)
 
+        def minimum_generating_set(self):
+            """
+            Return a list of the minimum generating set of this group.
+
+            EXAMPLES::
+
+                sage: G = GL(2,GF(3))
+                sage: G.minimum_generating_set()
+                [
+                [1 2]  [1 2]
+                [0 1], [1 1]
+                ]
+
+                sage: G = SymmetricGroup(3)
+                sage: s = G.minimum_generating_set(); s
+                [(2,3), (1,2,3)]
+                sage: s[0].parent()
+                Symmetric group of order 3! as a permutation group
+
+                sage: A5 = AlternatingGroup(5)
+                sage: A5.minimum_generating_set()
+                [(1,2,3,4,5), (3,4,5)]
+
+                sage: H = groups.matrix.Heisenberg(1,3); H
+                Heisenberg group of degree 1 over Ring of integers modulo 3
+                sage: H.minimum_generating_set()
+                [
+                [1 1 0]  [1 0 0]
+                [0 1 0]  [0 1 1]
+                [0 0 1], [0 0 1]
+                ]
+
+            TESTS:
+
+            Test that function gives an error for infinite groups::
+
+                sage: G = GL(2, ZZ)
+                sage: G.minimum_generating_set()
+                Traceback (most recent call last):
+                ...
+                NotImplementedError: only implemented for finite groups
+            """
+            from sage.groups.libgap_mixin import minimum_generating_set
+            return [self(x) for x in minimum_generating_set(self)]
+
     class ElementMethods:
         def conjugacy_class(self):
             r"""

--- a/src/sage/groups/libgap_mixin.py
+++ b/src/sage/groups/libgap_mixin.py
@@ -947,3 +947,218 @@ class GroupMixinLibGAP:
             (False, False, False)
         """
         return self.gap().IsomorphismGroups(H.gap()) != libgap.fail
+
+
+def gen_combinations(g: list, N: list, t: int):
+    """
+    generates all variations of ``g``, a subset of group ``G``,
+    found by multiplying its first ``t`` elements with elements from ``N``,
+    which is supposed to be a list of coset representatives
+    of some factor group in chief series of ``G``.
+
+    INPUT:
+
+    -``g`` -- a list of elements from some group G
+
+    -``N`` -- a list of elements from G
+
+    -``t`` -- number of elements in ``g`` to modify
+
+    """
+    if t == 0:
+        yield g
+        return
+    for gm in gen_combinations(g, N, t-1):
+        for n in N:
+            old = gm[t-1]
+            gm[t-1] = old * n
+            yield gm
+            gm[t-1] = old
+
+
+def lift(G_by_Gim1_mingen_reps, Gim1_by_Gi, G_by_Gi, phi_G_by_Gi, phi_Gim1_by_Gi) -> list:
+    """
+    Returns the minimum generating set (MGS) as coset representatives (CR)
+    of the quotient of ``G`` with a normal subgroup ``Gi`` in a chief series,
+    given the MGS (as CR) of the quotient of ``G``
+    with the normal group ``Gim1`` just larger than ``Gi``.
+    This MGS (as CR) are what we are calling ``G_by_Gim1_mingen_reps`` in the code)
+    and what we'll call 'g' in the algorithm.
+
+    INPUT:
+
+    -``G_by_Gim1_mingen_reps`` -- CR of MGS of factor group ``G_by_Gim1``
+
+    -``Gim1_by_Gi`` -- factor (quotient) group of two adjacent groups
+      (``Gi``,``Gim1``) in a chief series.
+
+    -``G_by_Gi`` -- quotient group for a group ``G`` with a normal subgroup
+      ``Gi`` in its chief series.
+
+    -``phi_G_by_Gi`` -- Natural Homomorphism for ``G_by_Gi``
+
+    -``phi_Gim1_by_Gi`` -- Natural Homomorphism for ``Gim1_by_Gi``
+
+    ALGORITHM:
+
+    First, we compute some essential quantities:
+
+    'n' is a list of CR of any (prefferably small, but not necessarily minimal) generating set of
+    the factor group ``Gim1_by_Gi`` of the two normal subgroups.
+
+    'N' is simply a list of CR of that factor group.
+
+    Here, we have two cases to consider.
+
+    First, if the factor group is abelian :
+
+    if the cosets of ``G`` with the smaller group (``Gi``) with CR same as g, return g.
+    Otherwise we modiy g by multiplying one of its elements with some elemet from n.
+    We try all variations. One of them is guaranteed to work.
+
+    Second, if the factor group is not abelian:
+
+    First, modify g by multiplying all of its elements by all variations of
+    (not necessarily distinct or non-identity) elements from N.
+    This is done using ``gen_combinations`` generator.
+    If any variation works as CR of MGS of the bigger quotient group ``G_by_Gi``,
+    return that variation.
+
+    Then if above process fails, do the same thing, but add an extra element from N
+    into the modified g before checking if it works as CR of MGS of the factor group.
+    This can be done by first adding the identity element into g and then doing the same
+    procedure as above step.
+
+    By now, we must have exhausted our search.
+    """
+    s = len(G_by_Gim1_mingen_reps)
+    Gim1_by_Gi_L = list(Gim1_by_Gi.AsList())
+    Gim1_by_Gi_elem_reps = [
+        phi_Gim1_by_Gi.PreImagesRepresentative(x) for x in Gim1_by_Gi_L]
+    Gim1_by_Gi_gen = list(libgap.SmallGeneratingSet(Gim1_by_Gi))
+    Gim1_by_Gi_gen_reps = [
+        phi_Gim1_by_Gi.PreImagesRepresentative(x) for x in Gim1_by_Gi_gen]
+
+    if Gim1_by_Gi.IsAbelian().sage():
+        if (G_by_Gi == libgap.GroupByGenerators([phi_G_by_Gi.ImagesRepresentative(x)
+                                                 for x in G_by_Gim1_mingen_reps])):
+            return G_by_Gim1_mingen_reps
+
+        for i in range(s):
+            for j in range(len(Gim1_by_Gi_gen_reps)):
+                temp = G_by_Gim1_mingen_reps[i]
+                G_by_Gim1_mingen_reps[i] = G_by_Gim1_mingen_reps[i] * \
+                    Gim1_by_Gi_gen_reps[j]
+                if (G_by_Gi == libgap.GroupByGenerators([phi_G_by_Gi.ImagesRepresentative(x)
+                                                         for x in G_by_Gim1_mingen_reps])):
+                    return G_by_Gim1_mingen_reps
+
+                G_by_Gim1_mingen_reps[i] = temp
+
+        return G_by_Gim1_mingen_reps + [Gim1_by_Gi_gen_reps[0]]
+
+    for raw_gens in gen_combinations(G_by_Gim1_mingen_reps, Gim1_by_Gi_elem_reps, s):
+        if (G_by_Gi == libgap.GroupByGenerators([phi_G_by_Gi.ImagesRepresentative(x)
+                                                 for x in raw_gens])):
+            return raw_gens
+
+    for raw_gens in gen_combinations(G_by_Gim1_mingen_reps+[Gim1_by_Gi_elem_reps[0]],
+                                     Gim1_by_Gi_elem_reps, s+1):
+        if (G_by_Gi == libgap.GroupByGenerators([phi_G_by_Gi.ImagesRepresentative(x)
+                                                 for x in raw_gens])):
+            return raw_gens
+
+
+def minimum_generating_set(G) -> list:
+    """
+    Return a list of the minimum generating set of ``G``.
+
+    INPUT:
+
+    - ``G`` -- a group
+
+    OUTPUT:
+
+    A list of GAP objects that generate the group.
+
+    .. SEEALSO::
+
+        :meth:`sage.categories.groups.Groups.ParentMethods.minimum_generating_set`
+
+    ALGORITHM:
+
+    We follow the algorithm described in the research paper "Algorithms for
+    the minimum generating set problem" by Bireswar Das and Dhara Thakkar (:doi:`10.48550/arXiv.2305.08405`).
+
+    When group ``G`` is a simple or solvable then we directly use
+    the ``MinimalGeneratingSet`` function from GAP which gives us the minimum generating set
+    of that group.
+
+    If ``libgap.MinimalGeneratingSet`` gives any error, then it is guaranteed
+    that the group ``G`` is not a simple group and it will have a cheif series of length 2.
+
+    The minimum generating set (MGS) of first factor group in the chief series can be found easily,
+    since it is a simple group. We do this using ``libgap.SmallGeneratingSet``.
+
+    Then using the ``lift`` function we find the MGS of each
+    quotient group of ``G`` by one of the normal groups in the series, one by one.
+    We iterate over the normal subgroups, from largest
+    (the index 1 element in series; thus the quotient group is the factor group we found MGS for initially)
+    to the smallest (the group containing identity only;
+    thus the quotient group is essentially the group G and the coset representatives (CR) are a MGS of G).
+
+    TESTS:
+
+    Test that the resultant list is able to generate the original group::
+
+        sage: from sage.groups.libgap_mixin import minimum_generating_set
+        sage: p = libgap.eval("DirectProduct(AlternatingGroup(5),AlternatingGroup(5))")
+        sage: s = minimum_generating_set(p); s
+        [(1,5,4,3,2)(8,9,10), (2,4,3)(6,7,8)]
+        sage: set(p.AsList()) == set(libgap.GroupByGenerators(s).AsList())
+        True
+        sage: len(s)
+        2
+
+    Test that elements of resultant list are GAP objects::
+
+        sage: from sage.groups.libgap_mixin import minimum_generating_set
+        sage: G = PermutationGroup([(1,2,3), (2,3), (4,5)])
+        sage: s = minimum_generating_set(G); s
+        [(2,3), (1,3,2)(4,5)]
+        sage: s[0].parent()
+        C library interface to GAP
+    """
+    if not isinstance(G, GapElement):
+        try:
+            G = G.gap()
+        except (AttributeError, ValueError, TypeError):
+            raise NotImplementedError(
+                "only implemented for groups that can construct a gap group")
+
+    if not G.IsFinite().sage():
+        raise NotImplementedError("only implemented for finite groups")
+
+    try:
+        return list(G.MinimalGeneratingSet())
+    except (AttributeError, ValueError, TypeError):
+        pass
+
+    cs = G.ChiefSeries()
+    phi_GbyG1 = G.NaturalHomomorphismByNormalSubgroup(cs[1])
+    GbyG1 = phi_GbyG1.ImagesSource()
+    # k = 1 initially
+    mingenset_k_reps = [phi_GbyG1.PreImagesRepresentative(
+        x) for x in list(libgap.SmallGeneratingSet(GbyG1))]
+
+    for k in range(2, len(cs)):
+        mingenset_km1_reps = mingenset_k_reps
+        Gk, Gkm1 = cs[k], cs[k-1]
+        phi_GbyGk = G.NaturalHomomorphismByNormalSubgroup(Gk)
+        GbyGk = phi_GbyGk.ImagesSource()
+        phi_Gkm1byGk = Gkm1.NaturalHomomorphismByNormalSubgroup(Gk)
+        Gkm1byGk = phi_Gkm1byGk.ImagesSource()
+        mingenset_k_reps = lift(
+            mingenset_km1_reps, Gkm1byGk, GbyGk, phi_GbyGk, phi_Gkm1byGk)
+
+    return mingenset_k_reps


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

This PR is about implementing the $O(\text{Poly}(|G|))$ algorithm mentioned in [this paper](https://www.sciencedirect.com/science/article/pii/S0021869323005720?via%3Dihub).

### Changes

1. Added the `minimum_generating_set` function (and helper functions `gen_combinations` and `lift`) in the `libgap_mixin.py` file, which is a dynamic programming based algorithm that uses Chief Series to compute the minimum generating set of a group.. The algorithm can be understood with this flowchart :

![MinGenSet](https://github.com/RuchitJagodara/sage/assets/108942295/fc2eac21-f989-4b19-89cb-6ed0e92ce98b)

2. Added `minimum_generating_set` method to `ParentMethods` class in `categories/groups.py`.

### Timing Analysis
The function is poly-time in $|G|$, as stated in the paper, and evident from this graph:

![A_5^n](https://github.com/sagemath/sage/assets/108942295/0968c321-38a4-43df-ba20-54c8c91b707f)

 The function can compute minimum generating set of large groups like $A_5^7$ easily.

### Relevant issues and discussions

1. In [this pull request](https://github.com/sagemath/sage/pull/37481), we (me and my teammate Ruchit Jagodara) had issue with building the documentation. In hopes that it might be because of sage itself and not our commits, I am making this PR.
2. Fixes [issue 37362](https://github.com/sagemath/sage/issues/37362#issue-2137079364)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.

### :hourglass: Dependencies
NA
