### PR TITLE
Fix broken pytest integration (including CI failure in `src/conftest_test.py`)

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -89,6 +89,7 @@ class SageDoctestModule(DoctestModule):
                     self.path,
                     mode=ImportMode.importlib,
                     root=self.config.rootpath,
+                    consider_namespace_packages=True,
                 )
             except ImportError:
                 if self.config.getvalue("doctest_ignore_import_errors"):
@@ -97,7 +98,7 @@ class SageDoctestModule(DoctestModule):
                     raise
         # Uses internal doctest module parsing mechanism.
         finder = MockAwareDocTestFinder()
-        optionflags = get_optionflags(self)
+        optionflags = get_optionflags(self.config)
         runner = _get_runner(
             verbose=False,
             optionflags=optionflags,

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -325,6 +325,8 @@ python_files = *_test.py
 norecursedirs = local prefix venv build pkgs .git src/doc src/bin
 addopts = --import-mode importlib
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
+# https://docs.pytest.org/en/stable/reference/reference.html#confval-consider_namespace_packages
+consider_namespace_packages = True
 
 [coverage:run]
 source = sage


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Frequently seen in the CI, for example https://github.com/sagemath/sage/actions/runs/9055116851/job/24875749181?pr=37862#step:12:27
```
Doctesting files changed since last git commit
No files to doctest
Features detected for doctesting: 
Running pytest on ['/sage/src'] with options []
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.2.0, pluggy-1.5.0
rootdir: /sage/src
configfile: tox.ini
plugins: xdist-3.6.1, mock-3.14.0, anyio-4.0.0, hypothesis-6.100.7
collected 63 items / 2 skipped

src/conftest_test.py .F                                                  [  3%]
src/sage/doctest/parsing_test.py ...........                             [ 20%]
src/sage/manifolds/differentiable/examples/symplectic_space_test.py .... [ [26](https://github.com/sagemath/sage/actions/runs/9055116851/job/24875749181?pr=37862#step:12:27)%]
                                                                         [ 26%]
src/sage/manifolds/differentiable/symplectic_form_test.py .............. [ 49%]
.....................                                                    [ 82%]
src/sage/manifolds/differentiable/tensorfield_paral_test.py .            [ 84%]
src/sage/numerical/backends/cvxopt_backend_test.py ..                    [ 87%]
src/sage/numerical/backends/glpk_backend_test.py ..                      [ 90%]
src/sage/numerical/backends/glpk_exact_backend_test.py ..                [ 93%]
src/sage/numerical/backends/interactivelp_backend_test.py ..             [ 96%]
src/sage/numerical/backends/ppl_backend_test.py ..                       [100%]

=================================== FAILURES ===================================
______________ TestPytestSageScript.test_invoke_on_inputtest_file ______________

self = <conftest_test.TestPytestSageScript object at 0x7f0d91ecdae0>

    def test_invoke_on_inputtest_file(self):
        result = subprocess.run(
            ["sage", "--pytest", input_file],
            capture_output=True,
            text=True,
        )
>       assert result.returncode == 1  # There are failures in the input test
E       assert 2 == 1
E        +  where 2 = CompletedProcess(args=['sage', '--pytest', PosixPath('/sage/src/conftest_inputtest.py')], returncode=2, stdout="======...n !!!!!!!!!!!!!!!!!!!!\n=============================== 1 error in 0.18s ===============================\n", stderr='').returncode

src/conftest_test.py:40: AssertionError
=========================== short test summary info ============================
FAILED src/conftest_test.py::TestPytestSageScript::test_invoke_on_inputtest_file
============== 1 failed, 62 passed, 2 skipped in 97.56s (0:01:[37](https://github.com/sagemath/sage/actions/runs/9055116851/job/24875749181?pr=37862#step:12:38)) ==============Running pytest on ['/sage/src'] with options []
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.2.0, pluggy-1.5.0
rootdir: /sage/src
configfile: tox.ini
plugins: xdist-3.6.1, mock-3.14.0, anyio-4.0.0, hypothesis-6.100.7
collected 63 items / 2 skipped

src/conftest_test.py .F                                                  [  3%]
src/sage/doctest/parsing_test.py ...........                             [ 20%]
src/sage/manifolds/differentiable/examples/symplectic_space_test.py .... [ 26%]
                                                                         [ 26%]
src/sage/manifolds/differentiable/symplectic_form_test.py .............. [ 49%]
.....................                                                    [ 82%]
src/sage/manifolds/differentiable/tensorfield_paral_test.py .            [ 84%]
src/sage/numerical/backends/cvxopt_backend_test.py ..                    [ 87%]
src/sage/numerical/backends/glpk_backend_test.py ..                      [ 90%]
src/sage/numerical/backends/glpk_exact_backend_test.py ..                [ 93%]
src/sage/numerical/backends/interactivelp_backend_test.py ..             [ 96%]
src/sage/numerical/backends/ppl_backend_test.py ..                       [100%]

=================================== FAILURES ===================================
______________ TestPytestSageScript.test_invoke_on_inputtest_file ______________

self = <conftest_test.TestPytestSageScript object at 0x7f0d91ecdae0>

    def test_invoke_on_inputtest_file(self):
        result = subprocess.run(
            ["sage", "--pytest", input_file],
            capture_output=True,
            text=True,
        )
>       assert result.returncode == 1  # There are failures in the input test
E       assert 2 == 1
E        +  where 2 = CompletedProcess(args=['sage', '--pytest', PosixPath('/sage/src/conftest_inputtest.py')], returncode=2, stdout="======...n !!!!!!!!!!!!!!!!!!!!\n=============================== 1 error in 0.18s ===============================\n", stderr='').returncode

src/conftest_test.py:40: AssertionError
=========================== short test summary info ============================
FAILED src/conftest_test.py::TestPytestSageScript::test_invoke_on_inputtest_file
============== 1 failed, 62 passed, 2 skipped in 97.56s (0:01:[37](https://github.com/sagemath/sage/actions/runs/9055116851/job/24875749181?pr=37862#step:12:38)) ==============
```

- Fixes #37536. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


