### PR TITLE
Fix Help menu breakdown in external jupyterlab case

### DIFF
--- a/src/sage/repl/ipython_kernel/kernel.py
+++ b/src/sage/repl/ipython_kernel/kernel.py
@@ -108,14 +108,13 @@ class SageKernel(IPythonKernel):
         # src/bin/sage-notebook.
 
         from sage.env import SAGE_DOC_SERVER_URL
+        from sage.env import SAGE_DOC_LOCAL_PORT as port
         from sage.features.sagemath import sagemath_doc_html
 
         if SAGE_DOC_SERVER_URL:
             def doc_url(path):
                 return f'{SAGE_DOC_SERVER_URL}/{path}'
-        elif sagemath_doc_html().is_present():
-            from sage.env import SAGE_DOC_LOCAL_PORT as port
-
+        elif sagemath_doc_html().is_present() and int(port):
             def doc_url(path):
                 return f'http://127.0.0.1:{port}/{path}'
         else:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

#37878 introduced a local documentation server for jupyterlab. But it missed a case for which the Help menu of jupyterlab may break down.

In the setup explained in https://doc.sagemath.org/html/en/installation/launching.html#setting-up-sagemath-as-a-jupyter-kernel-in-an-existing-jupyter-notebook-or-jupyterlab-installation, external jupyterlab is launched and connected to sage kernel. In this case, the local doc server does not run, but the Help menu of the jupyterlab still expects a local doc server, and thus the Help menu does not work well.

In this PR, local doc server is detected by testing the port number, and the Help menu uses the online official documentation if local doc server is not running.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


