### PR TITLE
`DualMatroid`: Add `is_valid` and `relabel` methods

### DIFF
--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -193,13 +193,13 @@ cdef class BasisExchangeMatroid(Matroid):
 
     cdef _relabel(self, mapping):
         """
-        Relabel each element ``e`` as ``mapping[e]``, where ``mapping`` is a
+        Relabel each element `e` as ``mapping[e]``, where ``mapping`` is a
         given injective map.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
         OUTPUT: ``None``
 

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -525,16 +525,16 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -527,16 +527,16 @@ cdef class CircuitClosuresMatroid(Matroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -368,16 +368,16 @@ cdef class CircuitsMatroid(Matroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 

--- a/src/sage/matroids/database_matroids.py
+++ b/src/sage/matroids/database_matroids.py
@@ -2066,7 +2066,7 @@ def Z(r, t=True, groundset=None):
     - ``t`` -- boolean (default: ``True``); whether the spike is tipped
     - ``groundset`` -- a string (optional); the groundset of the matroid
 
-    OUTPUT: a matroid; the unique rank-`r` binary spike (tipped or tipless)
+    OUTPUT: matroid; the unique rank-`r` binary spike (tipped or tipless)
 
     EXAMPLES::
 
@@ -2172,7 +2172,7 @@ def Spike(r, t=True, C3=[], groundset=None):
       The default (i.e. the empty list) results in a free `r`-spike
     - ``groundset`` -- a string (optional); the groundset of the matroid
 
-    OUTPUT: a matroid; a rank-`r` spike (tipped or tipless)
+    OUTPUT: matroid; a rank-`r` spike (tipped or tipless)
 
     EXAMPLES::
 
@@ -2290,7 +2290,7 @@ def Theta(n, groundset=None):
     - ``n`` -- an integer (`n \ge 2`); the rank of the matroid
     - ``groundset`` -- a string (optional); the groundset of the matroid
 
-    OUTPUT: a matroid (`\Theta_n`)
+    OUTPUT: matroid (`\Theta_n`)
 
     EXAMPLES::
 
@@ -2363,7 +2363,7 @@ def Psi(r, groundset=None):
     - ``r`` -- an integer (`r \ge 3`); the rank of the matroid
     - ``groundset`` -- a string (optional); the groundset of the matroid
 
-    OUTPUT: a matroid (`\Psi_r`)
+    OUTPUT: matroid (`\Psi_r`)
 
     EXAMPLES::
 
@@ -5233,7 +5233,7 @@ def _rename_and_relabel(M, name=None, groundset=None):
     - ``name`` -- a string (optional)
     - ``groundset`` -- a string (optional)
 
-    OUTPUT: a matroid
+    OUTPUT: matroid
     """
     if groundset is not None:
         if len(groundset) != len(M.groundset()):

--- a/src/sage/matroids/database_matroids.py
+++ b/src/sage/matroids/database_matroids.py
@@ -1489,7 +1489,7 @@ def K5dual(groundset='abcdefghij'):
     EXAMPLES::
 
         sage: M = matroids.catalog.K5dual(); M
-        M*(K5): Matroid of rank 6 on 10 elements with 15 circuits
+        M*(K5): Dual of 'Graphic matroid of rank 4 on 10 elements'
         sage: M.is_3connected()
         True
         sage: G1 = M.automorphism_group()
@@ -1502,7 +1502,6 @@ def K5dual(groundset='abcdefghij'):
     [Oxl2011]_, p. 656.
     """
     M = CompleteGraphic(5).dual()
-    M = Matroid(circuits=list(M.circuits()))
     M = _rename_and_relabel(M, "M*(K5)", groundset)
     return M
 

--- a/src/sage/matroids/dual_matroid.py
+++ b/src/sage/matroids/dual_matroid.py
@@ -507,13 +507,13 @@ class DualMatroid(Matroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
-        ``e not in mapping`` then the identity map is assumed.
+        ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that `mapping[e]` is the new
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
           label of `e`
 
         OUTPUT: matroid

--- a/src/sage/matroids/dual_matroid.py
+++ b/src/sage/matroids/dual_matroid.py
@@ -4,7 +4,7 @@ Dual matroids
 Theory
 ======
 
-Let `M` be a matroid with ground set `E`. If `B` is the set of bases of `M`,
+Let `M` be a matroid with groundset `E`. If `B` is the set of bases of `M`,
 then the set `\{E - b : b \in B\}` is the set of bases of another matroid, the
 dual of `M`.
 
@@ -24,10 +24,9 @@ Implementation
 
 The class ``DualMatroid`` wraps around a matroid instance to represent its
 dual. Only useful for classes that don't have an explicit construction of the
-dual (such as :class:`RankMatroid <sage.matroids.rank_matroid.RankMatroid>`
-and
+dual (such as :class:`RankMatroid <sage.matroids.rank_matroid.RankMatroid>` and
 :class:`CircuitClosuresMatroid <sage.matroids.circuit_closures_matroid.CircuitClosuresMatroid>`).
-It is also used as default implementation of the method
+It is also used as the default implementation of the method
 :meth:`M.dual() <sage.matroids.matroid.Matroid.dual>`.
 For direct access to the ``DualMatroid`` constructor, run::
 
@@ -35,14 +34,11 @@ For direct access to the ``DualMatroid`` constructor, run::
 
 See also :mod:`sage.matroids.advanced`.
 
-
 AUTHORS:
 
 - Rudi Pendavingh, Michael Welsh, Stefan van Zwam (2013-04-01): initial version
-
-Methods
-=======
 """
+
 # ****************************************************************************
 #       Copyright (C) 2013 Rudi Pendavingh <rudi.pendavingh@gmail.com>
 #       Copyright (C) 2013 Michael Welsh <michael@welsh.co.nz>
@@ -57,19 +53,18 @@ Methods
 
 from .matroid import Matroid
 
-
 class DualMatroid(Matroid):
     r"""
     Dual of a matroid.
 
     For some matroid representations it can be computationally expensive to
     derive an explicit representation of the dual. This class wraps around any
-    matroid to provide an abstract dual. It also serves as default
-    implementation.
+    matroid to provide an abstract dual. It also serves as the default
+    implementation of the dual.
 
     INPUT:
 
-    - ``matroid`` - a matroid.
+    - ``matroid`` -- matroid
 
     EXAMPLES::
 
@@ -103,9 +98,17 @@ class DualMatroid(Matroid):
                  {'a', 'b', 'g', 'h'}, {'c', 'd', 'e', 'f'},
                  {'e', 'f', 'g', 'h'}},
              4: {{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'}}}'
+
+        TESTS::
+
+            sage: from sage.matroids.dual_matroid import DualMatroid
+            sage: DualMatroid([])
+            Traceback (most recent call last):
+            ...
+            TypeError: no matroid provided to take the dual of
         """
         if not isinstance(matroid, Matroid):
-            raise TypeError("no matroid provided to take dual of.")
+            raise TypeError("no matroid provided to take the dual of")
         self._matroid = matroid
 
     def groundset(self):
@@ -114,9 +117,7 @@ class DualMatroid(Matroid):
 
         The groundset is the set of elements that comprise the matroid.
 
-        OUTPUT:
-
-        A set.
+        OUTPUT: set
 
         EXAMPLES::
 
@@ -135,11 +136,9 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``X`` -- an object with Python's ``frozenset`` interface.
+        - ``X`` -- an object with Python's ``frozenset`` interface
 
-        OUTPUT:
-
-        The rank of ``X`` in the matroid.
+        OUTPUT: integer
 
         EXAMPLES::
 
@@ -155,12 +154,10 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``X`` -- An object with Python's ``frozenset`` interface
-          containing a subset of ``self.groundset()``.
+        - ``X`` -- an object with Python's ``frozenset`` interface
+          containing a subset of ``self.groundset()``
 
-        OUTPUT:
-
-        The corank of ``X``.
+        OUTPUT: integer
 
         EXAMPLES::
 
@@ -176,12 +173,10 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``X`` -- An object with Python's ``frozenset`` interface containing
-          a subset of ``self.groundset()``.
+        - ``X`` -- an object with Python's ``frozenset`` interface containing
+          a subset of ``self.groundset()``
 
-        OUTPUT:
-
-        A maximal independent subset of ``X``.
+        OUTPUT: a maximal independent subset of ``X``
 
         EXAMPLES::
 
@@ -202,13 +197,11 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``X`` -- An object with Python's ``frozenset`` interface containing
-          a subset of ``self.groundset()``.
+        - ``X`` -- an object with Python's ``frozenset`` interface containing
+          a subset of ``self.groundset()``
 
-        OUTPUT:
-
-        A circuit contained in ``X``, if it exists. Otherwise an error is
-        raised.
+        OUTPUT: a circuit contained in ``X``, if it exists; otherwise, an error is
+        raised
 
         EXAMPLES::
 
@@ -230,12 +223,10 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``X`` -- An object with Python's ``frozenset`` interface containing
-          a subset of ``self.groundset()``.
+        - ``X`` -- an object with Python's ``frozenset`` interface containing
+          a subset of ``self.groundset()``
 
-        OUTPUT:
-
-        The smallest closed set containing ``X``.
+        OUTPUT: the smallest closed set containing ``X``
 
         EXAMPLES::
 
@@ -251,12 +242,10 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``X`` -- An object with Python's ``frozenset`` interface containing
-          a subset of ``self.groundset()``.
+        - ``X`` -- an object with Python's ``frozenset`` interface containing
+          a subset of ``self.groundset()``
 
-        OUTPUT:
-
-        A maximal coindependent subset of ``X``.
+        OUTPUT: a maximal coindependent subset of ``X``
 
         EXAMPLES::
 
@@ -277,12 +266,10 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``X`` -- An object with Python's ``frozenset`` interface containing
-          a subset of ``self.groundset()``.
+        - ``X`` -- an object with Python's ``frozenset`` interface containing
+          a subset of ``self.groundset()``
 
-        OUTPUT:
-
-        The smallest coclosed set containing ``X``.
+        OUTPUT: the smallest coclosed set containing ``X``
 
         EXAMPLES::
 
@@ -298,13 +285,11 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``X`` -- An object with Python's ``frozenset`` interface containing
-          a subset of ``self.groundset()``.
+        - ``X`` -- an object with Python's ``frozenset`` interface containing
+          a subset of ``self.groundset()``
 
-        OUTPUT:
-
-        A cocircuit contained in ``X``, if it exists. Otherwise an error is
-        raised.
+        OUTPUT: a cocircuit contained in ``X``, if it exists; otherwise, an error is
+        raised
 
         EXAMPLES::
 
@@ -324,14 +309,12 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``contractions`` -- An object with Python's ``frozenset`` interface
-          containing a subset of ``self.groundset()``.
-        - ``deletions`` -- An object with Python's ``frozenset`` interface
-          containing a subset of ``self.groundset()``.
+        - ``contractions`` -- an object with Python's ``frozenset`` interface
+          containing a subset of ``self.groundset()``
+        - ``deletions`` -- an object with Python's ``frozenset`` interface
+          containing a subset of ``self.groundset()``
 
-        OUTPUT:
-
-        A ``DualMatroid`` instance representing
+        OUTPUT: a :class:`DualMatroid` representing
         `(``self._matroid`` / ``deletions`` \ ``contractions``)^*`
 
         .. NOTE::
@@ -339,8 +322,8 @@ class DualMatroid(Matroid):
             This method does NOT do any checks. Besides the assumptions above,
             we assume the following:
 
-            - ``contractions`` is independent
-            - ``deletions`` is coindependent
+            - ``contractions`` is independent;
+            - ``deletions`` is coindependent;
             - ``contractions`` and ``deletions`` are disjoint.
 
         EXAMPLES::
@@ -364,16 +347,13 @@ class DualMatroid(Matroid):
         r"""
         Return the dual of the matroid.
 
-        Let `M` be a matroid with ground set `E`. If `B` is the set of bases
+        Let `M` be a matroid with groundset `E`. If `B` is the set of bases
         of `M`, then the set `\{E - b : b \in B\}` is the set of bases of
         another matroid, the *dual* of `M`. Note that the dual of the dual of
-        `M` equals `M`, so if this is the
-        :class:`DualMatroid` instance
+        `M` equals `M`, so if this is the :class:`DualMatroid` instance
         wrapping `M` then the returned matroid is `M`.
 
-        OUTPUT:
-
-        The dual matroid.
+        OUTPUT: the dual matroid
 
         EXAMPLES::
 
@@ -439,11 +419,9 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``other`` -- A matroid.
+        - ``other`` -- matroid
 
-        OUTPUT:
-
-        Boolean.
+        OUTPUT: boolean
 
         EXAMPLES::
 
@@ -471,11 +449,9 @@ class DualMatroid(Matroid):
 
         INPUT:
 
-        - ``other`` -- A matroid.
+        - ``other`` -- matroid
 
-        OUTPUT:
-
-        Boolean.
+        OUTPUT: boolean
 
         EXAMPLES::
 
@@ -526,3 +502,64 @@ class DualMatroid(Matroid):
         data = (self._matroid, self.get_custom_name())
         version = 0
         return sage.matroids.unpickling.unpickle_dual_matroid, (version, data)
+
+    def relabel(self, mapping):
+        r"""
+        Return an isomorphic matroid with relabeled groundset.
+
+        The output is obtained by relabeling each element ``e`` by
+        ``mapping[e]``, where ``mapping`` is a given injective map. If
+        ``e not in mapping`` then the identity map is assumed.
+
+        INPUT:
+
+        - ``mapping`` -- a python object such that `mapping[e]` is the new
+          label of `e`
+
+        OUTPUT: matroid
+
+        EXAMPLES::
+
+            sage: M = matroids.catalog.K5dual(range(10))
+            sage: type(M)
+            <class 'sage.matroids.dual_matroid.DualMatroid'>
+            sage: sorted(M.groundset())
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            sage: N = M.dual().relabel({0:10})
+            sage: sorted(N.groundset())
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            sage: N.is_isomorphic(matroids.catalog.K5())
+            True
+
+        TESTS::
+
+            sage: M = matroids.catalog.K5dual(range(10))
+            sage: f = {0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e',
+            ....:      5: 'f', 6: 'g', 7: 'h', 8: 'i', 9: 'j'}
+            sage: N = M.relabel(f)
+            sage: for S in powerset(M.groundset()):
+            ....:     assert M.rank(S) == N.rank([f[x] for x in S])
+        """
+        M = self._matroid.relabel(mapping).dual()
+        return M
+
+    def is_valid(self):
+        """
+        Test if ``self`` obeys the matroid axioms.
+
+        For a :class:`DualMatroid`, we check its dual.
+
+        OUTPUT: boolean
+
+        EXAMPLES::
+
+            sage: M = matroids.catalog.K5dual()
+            sage: type(M)
+            <class 'sage.matroids.dual_matroid.DualMatroid'>
+            sage: M.is_valid()
+            True
+            sage: M = Matroid([[0, 1], [2, 3]])
+            sage: M.dual().is_valid()
+            False
+        """
+        return self._matroid.is_valid()

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -304,16 +304,16 @@ cdef class FlatsMatroid(Matroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 

--- a/src/sage/matroids/graphic_matroid.pyx
+++ b/src/sage/matroids/graphic_matroid.pyx
@@ -1982,16 +1982,16 @@ cdef class GraphicMatroid(Matroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -2977,16 +2977,16 @@ cdef class LinearMatroid(BasisExchangeMatroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 
@@ -4029,16 +4029,16 @@ cdef class BinaryMatroid(LinearMatroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 
@@ -4911,16 +4911,16 @@ cdef class TernaryMatroid(LinearMatroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 
@@ -5623,16 +5623,16 @@ cdef class QuaternaryMatroid(LinearMatroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 
@@ -6552,16 +6552,16 @@ cdef class RegularMatroid(LinearMatroid):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -1149,7 +1149,7 @@ cdef class Matroid(SageObject):
             - ``deletions`` is coindependent
             - ``contractions`` and ``deletions`` are disjoint.
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 
@@ -1260,7 +1260,7 @@ cdef class Matroid(SageObject):
         - ``hyperplanes`` -- the set of hyperplanes of a linear subclass of
           ``self``.
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 
@@ -4006,7 +4006,7 @@ cdef class Matroid(SageObject):
         - ``deletions`` -- (default: ``None``) an element or set of elements
           to be deleted
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         .. NOTE::
 
@@ -4294,7 +4294,7 @@ cdef class Matroid(SageObject):
         can be obtained by adding an element freely to the span of the matroid
         and then contracting that element.
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         .. SEEALSO::
 
@@ -4493,7 +4493,7 @@ cdef class Matroid(SageObject):
           each of these. If not specified, the element is assumed to be in the
           span of the full groundset.
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         .. NOTE::
 
@@ -4570,7 +4570,7 @@ cdef class Matroid(SageObject):
           of each of these. If not specified, the element is assumed to be in
           the cospan of the full groundset.
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         .. SEEALSO::
 
@@ -4899,7 +4899,7 @@ cdef class Matroid(SageObject):
         parallel class (a closed set of rank 1, that is, each pair in it forms
         a circuit of length 2).
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         .. SEEALSO::
 
@@ -4935,7 +4935,7 @@ cdef class Matroid(SageObject):
         element from each series class (a coclosed set of rank 1, that is,
         each pair in it forms a cocircuit of length 2).
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         .. SEEALSO::
 
@@ -8555,9 +8555,9 @@ cdef class Matroid(SageObject):
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``; if ``mapping[e]`` is not defined then the identity
-          map is assumed
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`; if ``mapping[e]`` is not defined then the identity map
+          is assumed
 
         EXAMPLES::
 
@@ -8586,16 +8586,16 @@ cdef class Matroid(SageObject):
         r"""
         Return an isomorphic matroid with relabeled groundset.
 
-        The output is obtained by relabeling each element ``e`` by
+        The output is obtained by relabeling each element `e` by
         ``mapping[e]``, where ``mapping`` is a given injective map. If
         ``mapping[e]`` is not defined, then the identity map is assumed.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
-        OUTPUT: a matroid
+        OUTPUT: matroid
 
         EXAMPLES::
 

--- a/src/sage/matroids/set_system.pyx
+++ b/src/sage/matroids/set_system.pyx
@@ -209,13 +209,13 @@ cdef class SetSystem:
 
     cdef _relabel(self, mapping):
         """
-        Relabel each element ``e`` of the ground set as ``mapping[e]``, where
+        Relabel each element `e` of the ground set as ``mapping[e]``, where
         ``mapping`` is a given injective map.
 
         INPUT:
 
-        - ``mapping`` -- a python object such that ``mapping[e]`` is the new
-          label of ``e``
+        - ``mapping`` -- a Python object such that ``mapping[e]`` is the new
+          label of `e`
 
         OUTPUT: ``None``
         """

--- a/src/sage/matroids/utilities.py
+++ b/src/sage/matroids/utilities.py
@@ -493,7 +493,7 @@ def lift_cross_ratios(A, lift_map=None):
     INPUT:
 
     - ``A`` -- a matrix over a ring ``source_ring``.
-    - ``lift_map`` -- a python dictionary, mapping each cross ratio of ``A`` to some element
+    - ``lift_map`` -- a Python dictionary, mapping each cross ratio of ``A`` to some element
       of a target ring, and such that ``lift_map[source_ring(1)] = target_ring(1)``.
 
     OUTPUT:


### PR DESCRIPTION
Implement class-specific `is_valid` and `relabel` methods.
Previously, such functionality was achieved through the generic and very slow rank-based algorithms.

The PR also does a touch-up of the docstrings of `dual_matroid.py`.