### PR TITLE
`Arch Linux`: Remove `libgiac` and rename `texlive-collection-luatex`

### DIFF
--- a/build/pkgs/giac/distros/arch.txt
+++ b/build/pkgs/giac/distros/arch.txt
@@ -1,2 +1,1 @@
-libgiac
 giac

--- a/build/pkgs/texlive_luatex/distros/arch.txt
+++ b/build/pkgs/texlive_luatex/distros/arch.txt
@@ -1,1 +1,1 @@
-texlive-collection-luatex
+texlive-luatex


### PR DESCRIPTION
Remove nonexistent `libgiac` and rename `texlive-collection-luatex` to `texlive-luatex`.

Resolves #38015.