### PR TITLE
Workaround for passing givaro library to linker on OSX

### DIFF
--- a/build/pkgs/fflas_ffpack/spkg-install.in
+++ b/build/pkgs/fflas_ffpack/spkg-install.in
@@ -29,6 +29,13 @@ if [ -z "$CONFIG_SHELL" ]; then
     export CONFIG_SHELL=`command -v bash`
 fi
 
+# Dirty	workaround to link on OSX
+# https://github.com/linbox-team/fflas-ffpack/issues/391
+# https://github.com/sagemath/sage/issues/38002
+if [ "$UNAME" = Darwin ]; then
+    LDFLAGS="-lgivaro $LDFLAGS"
+fi
+
 # We disable openmp because of build failures, see
 # https://github.com/sagemath/sage/issues/17635#comment:67
 sdh_configure --with-default="$SAGE_LOCAL" --with-blas-libs="$LINBOX_BLAS" \

--- a/build/pkgs/linbox/patches/310-backport.patch
+++ b/build/pkgs/linbox/patches/310-backport.patch
@@ -27,7 +27,7 @@ index 59006d6c5f..2604f47b81 100644
 +				const_cast<data_it>(_data_beg)  = iter._data_beg ;
 +				const_cast<data_it>(_data_end)  = iter._data_end  ;
 +				const_cast<Field &>(_field)     = iter._field ;
-+				const_cast<size_t&>(ld)         = iter._ld ;
++				const_cast<size_t&>(_ld)         = iter._ld ;
  				_row       = iter._row ;
  
  				return *this;
@@ -48,7 +48,7 @@ index 498a5525db..a60943868b 100644
 +				const_cast<element_iterator>(_data_end)= iter._data_end  ;
 +				const_cast<Field &>(_field) = iter._field  ;
 +				const_cast<std::vector<size_t>&>(_rowid) = iter._rowid;
-+				const_cast<size_t&>(ld) = iter._ld ;
++				const_cast<size_t&>(_ld) = iter._ld ;
  				_row = iter._row ;
  
  				return *this;
@@ -63,7 +63,7 @@ index 498a5525db..a60943868b 100644
 +				const_cast<data_it>(_data_beg) = iter._data_beg ;
 +				const_cast<data_it>(_data_end) = iter._data_end  ;
 +				const_cast<Field &>(_field)    = iter._field ;
-+				const_cast<size_t&>(ld)= iter._ld ;
++				const_cast<size_t&>(_ld)= iter._ld ;
  				_row       = iter._row ;
  
  				return *this;


### PR DESCRIPTION
Just hack the missing -lgivaro into the linker command, see also https://github.com/linbox-team/fflas-ffpack/issues/391 for the real bug

Closes https://github.com/sagemath/sage/issues/38002