### PR TITLE
tox.ini (local-homebrew): Fix homebrew auto-update breakage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -722,7 +722,7 @@ commands =
     # local-homebrew
     #
     # https://docs.brew.sh/Installation
-    homebrew:      bash -c 'if [ ! -x {env:HOMEBREW}/bin/brew ]; then mkdir -p {env:HOMEBREW} && cd {env:HOMEBREW} && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 ; fi'
+    homebrew:      bash -c 'if [ ! -x {env:HOMEBREW}/bin/brew ]; then git clone --depth 1 https://github.com/Homebrew/brew {env:HOMEBREW}; fi'
     homebrew:      bash -c 'case "{env:SKIP_SYSTEM_PKG_INSTALL:}" in 1|y*|Y*);; *) export PATH="build/bin:$PATH" && PACKAGES=$(sage-get-system-packages homebrew $(sage-package list {env:SAGE_PACKAGE_LIST_ARGS}) {env:ALL_EXTRA_SAGE_PACKAGES}); {env:HOMEBREW}/bin/brew install $PACKAGES; {env:HOMEBREW}/bin/brew upgrade $PACKAGES;; esac'
     #
     # local-macports


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

`tox -e local-homebrew` followed the instructions in https://docs.brew.sh/Installation#untar-anywhere-unsupported to download and unpack a homebrew tarball. Unfortunately when the homebrew auto-update is invoked, it assumes that it can use `git` on this tarball, which leads to `git` operations on the Sage repository instead.

```
$ tox -e local-homebrew-macos-standard -- config.status
local-homebrew-macos-standard: commands[0] worktree-green> bash -c 'if [ ! -d /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/Library/Caches ]; then mkdir -p /Users/mkoeppe/s/sage/sage-rebasing/.tox/Caches && mkdir -p /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/Library && ln -sf /Users/mkoeppe/s/sage/sage-rebasing/.tox/Caches /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/Library/; fi'
local-homebrew-macos-standard: commands[1] worktree-green> bash -c 'if [ -n "" ]; then sudo xcode-select -s /Applications/Xcode_.app; fi;'
local-homebrew-macos-standard: commands[2] worktree-green> bash -c 'if [ ! -x /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/homebrew/bin/brew ]; then mkdir -p /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/homebrew && cd /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/homebrew && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 ; fi'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 3307k  100 3307k    0     0  2327k      0  0:00:01  0:00:01 --:--:-- 4159k
local-homebrew-macos-standard: commands[3] worktree-green> bash -c 'case "" in 1|y*|Y*);; *) export PATH="build/bin:$PATH" && PACKAGES=$(sage-get-system-packages homebrew $(sage-package list --has-file=spkg-configure.m4 :standard:) _bootstrap      ); /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/homebrew/bin/brew install $PACKAGES; /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/homebrew/bin/brew upgrade $PACKAGES;; esac'
==> Downloading https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:34312337c0add491f876b04e8b273a258453d6b633226130ef3105373a97c950
################################################################################################################################################################################################# 100.0%
==> Pouring portable-ruby-3.3.1.el_capitan.bottle.tar.gz
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
fatal: not a valid object name: 'origin/master'
[... various warnings about stuff in my Sage worktree ...]
To restore the stashed changes to /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/homebrew, run:
  cd /Users/mkoeppe/s/sage/sage-rebasing/.tox/local-homebrew-macos-standard/homebrew && git stash pop
```

We fix it by switching to a git checkout instead (the 2nd variant shown in https://docs.brew.sh/Installation#untar-anywhere-unsupported). We use a shallow checkout.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


