### PR TITLE
cython-lint for schemes

### DIFF
--- a/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
+++ b/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
@@ -204,7 +204,7 @@ cdef int lemma7(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
 
     if padic_square(g_of_x, p):
         mpz_clear(g_of_x)
-        return +1 # soluble
+        return +1  # soluble
 
     mpz_init_set(g_prime_of_x, x)
     mpz_mul(g_prime_of_x, a, x)
@@ -235,8 +235,8 @@ cdef int lemma7(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
             elif lambd+1 == mu+nu and (lambd & 1) == 0:
                 result = 1  # soluble
             elif lambd+2 == mu+nu and (lambd & 1) == 0 and g_of_x_odd_part_mod_4 == 1:
-                result = 1 # soluble
-        else: # nu <= mu
+                result = 1  # soluble
+        else:  # nu <= mu
             if lambd >= 2*nu:
                 result = 0  # undecided
             elif lambd+2 == 2*nu and g_of_x_odd_part_mod_4==1:
@@ -335,7 +335,7 @@ cdef bint Zp_soluble_siksek(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
         nmod_poly_set_coeff_ui(f, 4, mpz_fdiv_ui(a, pp_ui))
 
         result = 0
-        (<nmod_poly_factor_struct *>f_factzn)[0].num = 0 # reset data struct
+        (<nmod_poly_factor_struct *>f_factzn)[0].num = 0  # reset data struct
         qq = nmod_poly_factor(f_factzn, f)
         for i in range(f_factzn.num):
             if f_factzn.exp[i]&1:
@@ -352,7 +352,7 @@ cdef bint Zp_soluble_siksek(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
             for j in range(f_factzn.exp[i]>>1):
                 nmod_poly_mul(f, f, &f_factzn.p[i])
 
-        (<nmod_poly_factor_struct *>f_factzn)[0].num = 0 # reset data struct
+        (<nmod_poly_factor_struct *>f_factzn)[0].num = 0  # reset data struct
         nmod_poly_factor(f_factzn, f)
         has_roots = 0
         j = 0
@@ -371,13 +371,13 @@ cdef bint Zp_soluble_siksek(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
         mpz_init(ddd)
         mpz_init(eee)
 
-        if i == 0: # g == 1
+        if i == 0:  # g == 1
             mpz_set(aaa, a)
             mpz_set(bbb, b)
             mpz_set(ccc, c)
             mpz_set(ddd, d)
             mpz_sub_ui(eee, e, qq)
-        elif i == 1: # g == x + rr
+        elif i == 1:  # g == x + rr
             mpz_set(aaa, a)
             mpz_set(bbb, b)
             mpz_sub_ui(ccc, c, qq)
@@ -387,7 +387,7 @@ cdef bint Zp_soluble_siksek(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
             mpz_sub_ui(ddd, ddd, ss*2)
             mpz_set(eee,e)
             mpz_sub_ui(eee, eee, ss*rr)
-        elif i == 2: # g == x^2 + rr*x + ss
+        elif i == 2:  # g == x^2 + rr*x + ss
             mpz_sub_ui(aaa, a, qq)
             rr = nmod_poly_get_coeff_ui(f, 1)
             mpz_init(tt)
@@ -470,7 +470,7 @@ cdef bint Zp_soluble_siksek(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
         nmod_poly_set_coeff_ui(f, 2, mpz_fdiv_ui(c, pp_ui))
         nmod_poly_set_coeff_ui(f, 3, mpz_fdiv_ui(b, pp_ui))
         nmod_poly_set_coeff_ui(f, 4, mpz_fdiv_ui(a, pp_ui))
-        (<nmod_poly_factor_struct *>f_factzn)[0].num = 0 # reset data struct
+        (<nmod_poly_factor_struct *>f_factzn)[0].num = 0  # reset data struct
         nmod_poly_factor(f_factzn, f)
         has_roots = 0
         has_single_roots = 0
@@ -619,13 +619,13 @@ cdef bint Zp_soluble_siksek_large_p(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
         mpz_init(ddd)
         mpz_init(eee)
 
-        if i == 0: # g == 1
+        if i == 0:  # g == 1
             mpz_set(aaa, a)
             mpz_set(bbb, b)
             mpz_set(ccc, c)
             mpz_set(ddd, d)
             mpz_sub(eee, e, qq)
-        elif i == 1: # g == x + rr
+        elif i == 1:  # g == x + rr
             mpz_set(aaa, a)
             mpz_set(bbb, b)
             mpz_sub(ccc, c, qq)
@@ -639,7 +639,7 @@ cdef bint Zp_soluble_siksek_large_p(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e,
             mpz_mul(ss, ss, rr)
             mpz_sub(eee, eee, ss)
             mpz_divexact(ss, ss, rr)
-        elif i == 2: # g == x^2 + rr*x + ss
+        elif i == 2:  # g == x^2 + rr*x + ss
             mpz_sub(aaa, a, qq)
             A = Integer(f[1])
             mpz_set(rr, A.value)

--- a/src/sage/schemes/elliptic_curves/mod_sym_num.pyx
+++ b/src/sage/schemes/elliptic_curves/mod_sym_num.pyx
@@ -330,7 +330,7 @@ cdef int proj_normalise(llong N, llong u, llong  v,
     if `\gcd(u,v,N) \not= 1`, returns 0, 0, 0.
     """
     cdef llong d, k, g, s, t, min_v, min_t, Ng, vNg
-    #verbose("       enter proj_normalise with N=%s, u=%s, v=%s"%(N,u,v),
+    #verbose("       enter proj_normalise with N=%s, u=%s, v=%s" % (N,u,v),
     #        level=5)
     if N == 1:
         uu[0] = 0
@@ -343,7 +343,7 @@ cdef int proj_normalise(llong N, llong u, llong  v,
         v = N - ((-v) % N)
     u = u % N
     v = v % N
-    #verbose("       now N=%s, u=%s, v=%s"%(N,u,v), level=5)
+    #verbose("       now N=%s, u=%s, v=%s" % (N,u,v), level=5)
     if u == 0:
         uu[0] = 0
         if llgcd(v, N) == 1:
@@ -368,7 +368,7 @@ cdef int proj_normalise(llong N, llong u, llong  v,
         d = N / g
         while llgcd(s, N) != 1:
             s = (s+d) % N
-    #verbose("       now g=%s, s=%s, t=%s"%(g,s,t), level=5)
+    #verbose("       now g=%s, s=%s, t=%s" % (g,s,t), level=5)
 
     # Multiply [u,v] by s; then [s*u,s*v] = [g,s*v] (mod N)
     u = g
@@ -390,7 +390,7 @@ cdef int proj_normalise(llong N, llong u, llong  v,
     v = min_v
     uu[0] = u
     vv[0] = v
-    #verbose("       leaving proj_normalise with s=%s, t=%s"%(u,v), level=5)
+    #verbose("       leaving proj_normalise with s=%s, t=%s" % (u,v), level=5)
     return 0
 
 
@@ -430,7 +430,7 @@ cdef int best_proj_point(llong u, llong v, llong N,
     """
     cdef llong w, p, q, Nnew, r, a, b, si
     cdef llong x0, x1, y0, y1, t0, t1, s0, s1
-    #verbose("       enter best_proj_point with N=%s, u=%s, v=%s"%(N,u,v),
+    #verbose("       enter best_proj_point with N=%s, u=%s, v=%s" % (N,u,v),
     #        level=5)
     if u == 0:
         uu[0] = <llong>0
@@ -442,22 +442,22 @@ cdef int best_proj_point(llong u, llong v, llong N,
         return 0
 
     if llgcd(u, N) == 1:
-        w = (v * llinvmod(u, N) ) % N
+        w = (v * llinvmod(u, N)) % N
         y0 = <llong>0
         y1 = N
         x0 = <llong>1
         x1 = w
     elif llgcd(v, N) == 1:
-        w = (u * llinvmod(v,N) ) % N
+        w = (u * llinvmod(v, N)) % N
         y0 = N
         y1 = <llong>0
         x0 = w
         x1 = <llong>1
-    else: # cases like (p:q) mod p*q drop here
+    else:  # cases like (p:q) mod p*q drop here
         p = llgcd(u, N)
         q = llgcd(v, N)
         Nnew = N / p / q
-        w = ( (u/p) * llinvmod(v/q, Nnew) ) % Nnew
+        w = ((u/p) * llinvmod(v/q, Nnew)) % Nnew
         y0 = N/q
         y1 = <llong>0
         x0 = w*p
@@ -471,13 +471,13 @@ cdef int best_proj_point(llong u, llong v, llong N,
             r = (y0-y1) / (x0-x1)
         t0 = y0 - r * x0
         t1 = y1 - r * x1
-        s0 =  t0 - x0
-        s1 =  t1 - x1
+        s0 = t0 - x0
+        s1 = t1 - x1
         if llabs(s0)+llabs(s1) < llabs(t0)+llabs(t1):
             t0 = s0
             t1 = s1
         # t is now the shortest vector on the line y + RR x
-        #verbose("     reduced vector to (%s,%s)"%(t0,t1), level=4)
+        #verbose("     reduced vector to (%s,%s)" % (t0,t1), level=4)
         y0 = x0
         y1 = x1
         x0 = t0
@@ -496,7 +496,7 @@ cdef int best_proj_point(llong u, llong v, llong N,
         # not permitted, here we do a search until we hit a solution.
         #verbose("   both shortest vectors ((%s,%s) and (%s,%s)) are not "
         #        "permitted. The result is not guaranteed to "
-        #        "be best possible."%(x0, x1, y0, y1), level=3)
+        #        "be best possible." % (x0, x1, y0, y1), level=3)
         r = <llong>2
         a = <llong>1
         b = a
@@ -515,9 +515,9 @@ cdef int best_proj_point(llong u, llong v, llong N,
                 a = r-1
                 b = <llong>1
                 si = b
-            t0 =  a * x0 + b * y0
-            t1 =  a * x1 + b * y1
-        #verbose("works with t = %s*x+%s*y"%(a, b), level=3)
+            t0 = a * x0 + b * y0
+            t1 = a * x1 + b * y1
+        #verbose("works with t = %s*x+%s*y" % (a, b), level=3)
         uu[0] = t0
         vv[0] = t1
         return 0
@@ -564,7 +564,7 @@ cdef class _CuspsForModularSymbolNumerical:
     It is to only to be used internally.
     """
     cdef public llong _a, _m, _width
-    cdef public llong _N_level # trac 29290 renamed
+    cdef public llong _N_level  # trac 29290 renamed
     cdef public Rational _r
 
     def __init__(self, Rational r, llong N):
@@ -584,14 +584,14 @@ cdef class _CuspsForModularSymbolNumerical:
             sage: r = _CuspsForModularSymbolNumerical(3/7,99)
         """
         cdef llong a, m, B
-        #verbose("       enter __init__ of cusps with r=%s and N=%s"%(r,N),
+        #verbose("       enter __init__ of cusps with r=%s and N=%s" % (r,N),
         #        level=5)
-        a = <llong>( r.numerator() )
-        m = <llong>( r.denominator() )
+        a = <llong>(r.numerator())
+        m = <llong>(r.denominator())
         a = a % m
         if 2*a > m:
             a -= m
-        self._r = Rational( (a, m) )
+        self._r = Rational((a, m))
         B = llgcd(m, N)
         self._width = N / B
         self._a = a
@@ -622,20 +622,20 @@ cdef class _CuspsForModularSymbolNumerical:
         """
         cdef llong Q, B, c, x, y
 
-        #verbose("       enter atkin_lehner for cusp r=%s"%self._r, level=5)
+        #verbose("       enter atkin_lehner for cusp r=%s" % self._r, level=5)
         Q = self._width
         B = llgcd(self._m, self._N_level)
         c = self._m / B
         if llgcd(Q, B) != 1:
             raise ValueError("This cusp is not in the Atkin-Lehner "
                              "orbit of oo.")
-        _ = llxgcd( self._a * Q, self._m, &x, &y)
+        _ = llxgcd(self._a * Q, self._m, &x, &y)
         res[0] = Q * x
         res[1] = y
         res[2] = -c * self._N_level
-        res[3] =  Q * self._a
+        res[3] = Q * self._a
         #verbose("       leaving atkin_lehner with w_Q = "
-        #        "[%s, %s, %s, %s]"%(res[0], res[1], res[2], res[3]),
+        #        "[%s, %s, %s, %s]" % (res[0], res[1], res[2], res[3]),
         #        level=5)
         return 0
 
@@ -754,11 +754,13 @@ cdef class ModularSymbolNumerical:
             sage: M(12/11) # indirect doctest
             1/2
         """
-        self._ans_num = <double *> sig_malloc( 1002 * sizeof(double) )
-        self._ans = <int*> sig_malloc(1002 * sizeof(int) )
+        self._ans_num = <double *> sig_malloc(1002 * sizeof(double))
+        self._ans = <int*> sig_malloc(1002 * sizeof(int))
         if self._ans is NULL or self._ans_num is NULL:
-            if self._ans is not NULL: sig_free(self._ans)
-            if self._ans_num is not NULL: sig_free(self._ans_num)
+            if self._ans is not NULL:
+                sig_free(self._ans)
+            if self._ans_num is not NULL:
+                sig_free(self._ans_num)
             raise MemoryError("Memory.")
 
     def __init__(self, E, sign=+1):
@@ -780,7 +782,7 @@ cdef class ModularSymbolNumerical:
         self._E = E
         self._Epari= E.pari_mincurve()
         self._global_sign = <int>sign
-        self._N_E = <llong>( E.conductor() )
+        self._N_E = <llong>(E.conductor())
         self._D = -Integer(1)
         self._set_epsQs()
         self._initialise_an_coefficients()
@@ -795,7 +797,7 @@ cdef class ModularSymbolNumerical:
         # this is a bound to decide when to go directly to ioo
         # rather than using further convergents.
         # see symbol(r) where it is used
-        self._cut_val = <llong>( E.conductor().isqrt() // 4 )
+        self._cut_val = <llong>(E.conductor().isqrt() // 4)
         if self._cut_val < 100:
             self._cut_val = 100
         # this is can be used to disable it
@@ -881,11 +883,11 @@ cdef class ModularSymbolNumerical:
             sign = self._global_sign
 
         #verbose("       enter __call__ of modular symbols for r=%s"
-        #        "and sign=%s and use_twist=%s"%(r,sign,use_twist), level=5)
+        #        "and sign=%s and use_twist=%s" % (r,sign,use_twist), level=5)
         if isinstance(r, Rational):
             ra = r
         elif isinstance(r, Integer):
-            ra = Rational( (0,1) )
+            ra = Rational((0, 1))
         elif isinstance(r, sage.rings.infinity.PlusInfinity):
             return Rational(0)
         else:  # who knows
@@ -951,11 +953,11 @@ cdef class ModularSymbolNumerical:
             sign = self._global_sign
 
         #verbose("       enter approximative_value of modular symbols for r=%s,"
-        #        "sign=%s and prec=%s "%(r,sign,prec,), level=5)
+        #        "sign=%s and prec=%s " % (r,sign,prec,), level=5)
         if isinstance(r, Rational):
             ra = r
         elif isinstance(r, Integer):
-            ra = Rational( (0,1) )
+            ra = Rational((0, 1))
         else:  # who knows
             raise ValueError("The modular symbol can be evaluated at a"
                              "rational number only.")
@@ -963,8 +965,7 @@ cdef class ModularSymbolNumerical:
             if self._D == -1:
                 self._set_up_twist()
             if self._D != 1:
-                return self._twisted_approx(ra, sign=sign,
-                prec=prec)
+                return self._twisted_approx(ra, sign=sign, prec=prec)
 
         eps = <double>2
         eps = eps ** (-prec)
@@ -1029,7 +1030,7 @@ cdef class ModularSymbolNumerical:
             RealNumber E0om1, E0om2, q
 
         #verbose("       enter _set_bounds", level=5)
-        N = Integer( self._N_E )
+        N = Integer(self._N_E)
         E = self._E
         L = E.period_lattice().basis()
         self._om1 = L[0]
@@ -1041,15 +1042,15 @@ cdef class ModularSymbolNumerical:
         # find the best curve to compare it too.
         # if the curve is in the database,
         # we can compare to the X_0-optimal curve
-        isog =  E.isogeny_class()
+        isog = E.isogeny_class()
         if N <= CremonaDatabase().largest_conductor():
             E0 = E.optimal_curve()
         # otherwise, we take a "maximal" curve
         # that the worst that can happen and is sort of the
         # opposite of what we expect, but
         else:
-            ff = lambda C: C.period_lattice().complex_area()
-            E0 = min(isog.curves, key=ff)
+            E0 = min(isog.curves,
+                     key=lambda C: C.period_lattice().complex_area())
         # E0 has now conjecturally Manin constant = 1
 
         # now determine the bound for E0 coming from the
@@ -1071,13 +1072,13 @@ cdef class ModularSymbolNumerical:
         while co < 5 or p < max(100,10*delta) and p < self._lans:
             p += delta
             if p.is_prime() and N % p != 0:
-                t0 = t0.gcd( p + 1 - self._ans[p] )
+                t0 = t0.gcd(p + 1 - self._ans[p])
                 co += 1
             if (p-2).is_prime() and N % (p-2) != 0:
-                t0 = t0.gcd( (p-1)**2 - self._ans[p-2]**2 )
+                t0 = t0.gcd((p-1)**2 - self._ans[p-2]**2)
                 co += 1
         if E0.real_components() == 1:
-            t0 *= Integer(2) # slanted lattice
+            t0 *= Integer(2)  # slanted lattice
 
         # This is a not strictly necessary precaution:
         # Cremona is not always certain to have the optimal
@@ -1096,7 +1097,7 @@ cdef class ModularSymbolNumerical:
         if E0cinf == 1:
             E0om2 *= Integer(2)
 
-        maxdeg = max(max(x) for x in isog.matrix() )
+        maxdeg = max(max(x) for x in isog.matrix())
         q = self._om1 / E0om1 * maxdeg
         q_plus = q.round() / maxdeg
         q = self._om2 / E0om2 * maxdeg
@@ -1136,9 +1137,9 @@ cdef class ModularSymbolNumerical:
         #     N = E.conductor()
         #     Cu = Gamma0(N).cusps()
         #     m = E.modular_symbol()
-        #     d_plus = max( [ denominator(m(r)) for r in Cu if r != oo] )
+        #     d_plus = max([ denominator(m(r)) for r in Cu if r != oo])
         #     m = E.modular_symbol(-1)
-        #     d_minus = max( [ denominator(m(r)) for r in Cu if r != oo] )
+        #     d_minus = max([ denominator(m(r)) for r in Cu if r != oo])
         #     M = ModularSymbolNumerical(E)
         #     print(E.label(), (d_plus, d_minus), (M._t_plus, M._t_minus),
         #           (M._t_unitary_plus, M._t_unitary_plus))
@@ -1180,7 +1181,7 @@ cdef class ModularSymbolNumerical:
                 D = -D
             Et = self._E.quadratic_twist(D)
         self._D = D
-        verbose("  twisting by %s to get conductor %s"%(D,Et.conductor()),
+        verbose("  twisting by %s to get conductor %s" % (D, Et.conductor()),
                 level=2)
         # now set up period change
         if D != 1:
@@ -1192,14 +1193,14 @@ cdef class ModularSymbolNumerical:
             # are integers.
             if D > 0:
                 qq = self._om1 * Db/ self._Mt._om1 * 2
-                self._twist_q = Rational( (qq.round(), 2) )
+                self._twist_q = Rational((qq.round(), 2))
                 qq = self._om2 * Db/ self._Mt._om2 * 2
-                assert self._twist_q == Rational( (qq.round(),2) )
+                assert self._twist_q == Rational((qq.round(), 2))
             else:
-                qq =  self._om2 * Db/self._Mt._om1  * 2
-                self._twist_q =  Rational( (qq.round(), 2) )
+                qq = self._om2 * Db/self._Mt._om1 * 2
+                self._twist_q = Rational((qq.round(), 2))
                 qq = self._om1 * Db/self._Mt._om2 * 2
-                assert self._twist_q == Rational( ( qq.round(),2))
+                assert self._twist_q == Rational((qq.round(), 2))
 
     def _round(self, RealNumber val, int sign, int unitary):
         r"""
@@ -1232,7 +1233,7 @@ cdef class ModularSymbolNumerical:
             llong t, r
             RealNumber q, qt
 
-        #verbose("       enter _round with value=%s"%val, level=5)
+        #verbose("       enter _round with value=%s" % val, level=5)
         if sign == 1 and unitary:
             q = val/self._om1
             t = self._t_unitary_plus
@@ -1248,17 +1249,17 @@ cdef class ModularSymbolNumerical:
 
         qt = q * t
         r = qt.round()
-        res = Rational( (r, t) )
+        res = Rational((r, t))
         err = (q-res).abs()
 
         if err > 0.1:
             # the following did not work (compilation failed)
             #from warnings import warn
-            #warn(Rounded an error of %s, looks like a bug."%err,
+            #warn(Rounded an error of %s, looks like a bug." % err,
             # RuntimeWarning, stacklevel=5)
-            print ( "Warning: Rounded an error of ", err, ", looks like a bug "
-                    + "in mod_sym_num.pyx.")
-        verbose("    rounding with an error of %s"%err, level=3)
+            print ("Warning: Rounded an error of ", err, ", looks like a bug "
+                   + "in mod_sym_num.pyx.")
+        verbose("    rounding with an error of %s" % err, level=3)
         return res
 
     def _initialise_an_coefficients(self):
@@ -1304,25 +1305,27 @@ cdef class ModularSymbolNumerical:
             sage: M._add_an_coefficients(10000)
         """
         cdef llong n
-        #verbose("       enter add_an_coeffs with T=%s"%T, level=5)
+        #verbose("       enter add_an_coeffs with T=%s" % T, level=5)
         # we artificially add 100 extra terms, to avoid calling this
         # function again with only a few new terms
         T += 100
 
         self._ans_num = <double *> sig_realloc(self._ans_num,
-                                                (T+2)*sizeof(double))
-        self._ans = <int*> sig_realloc(self._ans, (T+2)*sizeof(int) )
+                                               (T+2)*sizeof(double))
+        self._ans = <int*> sig_realloc(self._ans, (T+2)*sizeof(int))
         if self._ans is NULL or self._ans_num is NULL:
-            if self._ans is not NULL: sig_free(self._ans)
-            if self._ans_num is not NULL: sig_free(self._ans_num)
+            if self._ans is not NULL:
+                sig_free(self._ans)
+            if self._ans_num is not NULL:
+                sig_free(self._ans_num)
             raise MemoryError("Memory error with coefficients.")
 
         verbose("   not enough precomputed coefficients, "
-                "adding %s"%(T - self._lans), level=3)
+                "adding %s" % (T - self._lans), level=3)
         # if we add more than 20% new values, redo it from scratch
         if 5* T > 6*self._lans:
             self_ans = self._E.anlist(T+1, python_ints=True)
-            n = self._lans # only copy new values
+            n = self._lans  # only copy new values
             while n <= T:
                 self._ans[n] = self_ans[n]
                 n += 1
@@ -1406,7 +1409,7 @@ cdef class ModularSymbolNumerical:
             0.41268108621256428 + 0.91370544691462463*I
         """
         #verbose("       enter _integration_to_tau with tau=%s, T=%s,"
-        #        "prec=%s"%(tau,number_of_terms,prec), level=5)
+        #        "prec=%s" % (tau,number_of_terms,prec), level=5)
         cdef ComplexNumber q, s
         cdef int n
 
@@ -1422,17 +1425,17 @@ cdef class ModularSymbolNumerical:
         q = 2 * CC.pi() * CC.gens()[0]
         q *= CC(tau)
         q = q.exp()
-        verbose("     start sum over %s terms "%number_of_terms, level=4)
+        verbose("     start sum over %s terms " % number_of_terms, level=4)
         s = CC(0)
         n = number_of_terms
         # using Horner's rule
         while n > 0:
             sig_check()
             s *= q
-            s +=  CC(self._ans[n])/n
+            s += CC(self._ans[n])/n
             n -= 1
-        s  *= q
-        #verbose("       leaving integration_to_tau with sum=%s"%s, level=5)
+        s *= q
+        #verbose("       leaving integration_to_tau with sum=%s" % s, level=5)
         return s
 
     # the version using double is 70-80 times faster it seems.
@@ -1465,7 +1468,7 @@ cdef class ModularSymbolNumerical:
             0.386771552192424 - 2.74574021880459*I
         """
         #verbose("       enter integrations_to_tau_double with tau=%s,"
-        #        " T=%s"%(tau,number_of_terms), level=5)
+        #        " T=%s" % (tau,number_of_terms), level=5)
         cdef complex q, s
         cdef int n
         #self.nc_sums += 1
@@ -1477,10 +1480,10 @@ cdef class ModularSymbolNumerical:
         if number_of_terms > self._lans:
             self._add_an_coefficients(number_of_terms)
 
-        q = complex(0,TWOPI) # 2 pi i
+        q = complex(0, TWOPI)  # 2 pi i
         q *= tau
         q = cexp(q)
-        verbose("     start sum over %s terms "%number_of_terms, level=4)
+        verbose("     start sum over %s terms " % number_of_terms, level=4)
         s = 0
         n = number_of_terms
         # using Horner's rule
@@ -1490,7 +1493,7 @@ cdef class ModularSymbolNumerical:
             s += self._ans_num[n]
             n -= 1
         s *= q
-        #verbose("       leaving integration_to_tau_double with sum=%s"%s,
+        #verbose("       leaving integration_to_tau_double with sum=%s" % s,
         #        level=5)
         return s
 
@@ -1523,7 +1526,7 @@ cdef class ModularSymbolNumerical:
             0.725681061936153
         """
         #verbose("       enter partial_real_sums_double with y=%s, m=%s,"
-        #        " T=%s"%(y,m,number_of_terms), level=5)
+        #        " T=%s" % (y,m,number_of_terms), level=5)
         cdef double q, qq
         cdef int n, i
         #self.nc_sums += 1
@@ -1540,7 +1543,7 @@ cdef class ModularSymbolNumerical:
         qq = q * <double>m
         q = exp(q)
         qq = exp(qq)
-        verbose("     start sum over %s terms "%number_of_terms, level=4)
+        verbose("     start sum over %s terms " % number_of_terms, level=4)
         i = 0
         while i < m:
             res[i] = 0
@@ -1550,7 +1553,7 @@ cdef class ModularSymbolNumerical:
         while n > 0:
             sig_check()
             res[i] *= qq
-            res[i] +=  self._ans_num[n]
+            res[i] += self._ans_num[n]
             n -= 1
             i -= 1
             if i == -1:
@@ -1561,12 +1564,12 @@ cdef class ModularSymbolNumerical:
             i += 1
         res[0] *= qq
         #verbose("       leaving _partial_real_sums_double with result %s,"
-        #        " %s, ... %s"%(res[0], res[1], res[m-1]), level=5)
+        #        " %s, ... %s" % (res[0], res[1], res[m-1]), level=5)
         return 0
 
     def _partial_real_sums(self, RealNumber y, int m,
-                                       int number_of_terms,
-                                       int prec):
+                           int number_of_terms,
+                           int prec):
         r"""
         Given a real positive number `y` (representing
         the imaginary part of a point in the upper half
@@ -1603,7 +1606,7 @@ cdef class ModularSymbolNumerical:
              0.0001771330855478248]
         """
         #verbose("       enter partial_real_sums with y=%s, m=%s,"
-        #        " T=%s"%(y,m,number_of_terms), level=5)
+        #        " T=%s" % (y,m,number_of_terms), level=5)
         cdef RealNumber q, qq
         cdef int n, i
         #self.nc_sums += 1
@@ -1621,7 +1624,7 @@ cdef class ModularSymbolNumerical:
         qq = q * m
         q = q.exp()
         qq = qq.exp()
-        verbose("     start sum over %s terms "%number_of_terms, level=4)
+        verbose("     start sum over %s terms " % number_of_terms, level=4)
         i = 0
         res = []
         while i < m:
@@ -1643,7 +1646,7 @@ cdef class ModularSymbolNumerical:
             i += 1
         res[0] *= qq
         #verbose("       leaving _partial_real_sums with result"
-        #        " %s, %s, ... %s"%(res[0], res[1], res[m-1]), level=5)
+        #        " %s, %s, ... %s" % (res[0], res[1], res[m-1]), level=5)
         return res
 
     #================
@@ -1686,7 +1689,7 @@ cdef class ModularSymbolNumerical:
             (-1, -1)
         """
         #verbose("       enter _get_truncation_and_prec with y=%s"
-        #        " and eps=%s"%(y,eps), level=5)
+        #        " and eps=%s" % (y,eps), level=5)
         # how much of the error comes from truncation and how much
         # from precision.
         DEF split_error_truncations = 0.99
@@ -1696,7 +1699,7 @@ cdef class ModularSymbolNumerical:
         cdef int T, B, T0
 
         twopiy = <double>TWOPI
-        twopiy *=  y
+        twopiy *= y
         tt = twopiy
         tt *= split_error_truncations * eps
         tt = log(tt)
@@ -1706,7 +1709,7 @@ cdef class ModularSymbolNumerical:
         else:
             T = -1
             return T, T
-        #verbose("      now tt =%s, twopiy=%s, T=%s"%(tt,twopiy,T), level=4)
+        #verbose("      now tt =%s, twopiy=%s, T=%s" % (tt,twopiy,T), level=4)
 
         # the justification for these numbers is explained at the
         # very end of this file
@@ -1734,23 +1737,23 @@ cdef class ModularSymbolNumerical:
 
         tt -= log(A)/twopiy
         T = min(T, max(<int>(ceil(tt)), T0))
-        #verbose("    now tt =%s, twopiy=%s, T=%s"%(tt,twopiy,T), level=4)
+        #verbose("    now tt =%s, twopiy=%s, T=%s" % (tt,twopiy,T), level=4)
 
-        bb =  split_error_prec * eps
-        bb /=  T + bb
-        bb /=  2
-        bb /=  T
+        bb = split_error_prec * eps
+        bb /= T + bb
+        bb /= 2
+        bb /= T
         bb = - log(bb)/ log(2)
         B = <int>(ceil(bb))
         B = max(B, 53)
         T = max(T, 100)
         #verbose("       leaving _get_truncation_and_prec with T=%s,"
-        #        " B=%s"%(T,B), level=5)
+        #        " B=%s" % (T,B), level=5)
         return T, B
 
-# ===============
+    # ===============
 
-    @cached_method # its modified below for max eps
+    @cached_method  # its modified below for max eps
     def _kappa(self, llong m, llong z, eps=None):
         r"""
         This returns all `\kappa_{j,m}(1/\sqrt{z})` for a given
@@ -1812,7 +1815,7 @@ cdef class ModularSymbolNumerical:
             -2.265525136998248e-05,
             2.3248943281270047e-06]
         """
-        #verbose("       enter _kappa with m=%s, z=%s and eps=%s"%(m,z,eps),
+        #verbose("       enter _kappa with m=%s, z=%s and eps=%s" % (m,z,eps),
         #        level=5)
         cdef:
             int T, prec, j
@@ -1850,7 +1853,7 @@ cdef class ModularSymbolNumerical:
                              + "summed up. Giving up.")
         T += m
         #verbose("   precision in _kappa set to %s,"
-        #        " summing over %s terms"%(prec,T), level=3)
+        #        " summing over %s terms" % (prec,T), level=3)
 
         if prec > 53:
             RR = RealField(prec)
@@ -1861,14 +1864,14 @@ cdef class ModularSymbolNumerical:
             # return a python list of doubles that we cache
             res = [<double>(res[j]) for j in range(m)]
         else:
-            ra = <double *> sig_malloc( m * sizeof(double))
+            ra = <double *> sig_malloc(m * sizeof(double))
             if ra is NULL:
                 raise MemoryError
             _ = self._partial_real_sums_double(y, m, T, ra)
             res = [ra[j] for j in range(m)]
             sig_free(ra)
         #verbose("       leaving _kappa with"
-        #        " [%s, %s, ... %s]"%(res[0], res[1], res[m-1]), level=5)
+        #        " [%s, %s, ... %s]" % (res[0], res[1], res[m-1]), level=5)
         return res
 
     def _from_ioo_to_r_approx(self, Rational r, double eps,
@@ -1919,7 +1922,7 @@ cdef class ModularSymbolNumerical:
             6.227531974630294568 - 1.480548268241443085*I
         """
         #verbose("       enter _from_ioo_to_r_approx with r=%s"
-        #        " and eps=%s"%(r,eps), level=5)
+        #        " and eps=%s" % (r,eps), level=5)
         cdef:
             llong m, Q, epsQ, a, u
             double yy, taui
@@ -1948,49 +1951,49 @@ cdef class ModularSymbolNumerical:
         if m == 1:
             use_partials = 0
         if use_partials == 2:
-            use_partials = (prec==53) and ( m**4 < self._N_E or m < PARTIAL_LIMIT)
+            use_partials = (prec==53) and (m**4 < self._N_E or m < PARTIAL_LIMIT)
 
         if not use_partials and prec > 53:
             CC = ComplexField(prec)
             tau = CC(-Q)
             tau = tau.sqrt()
             tau = r - 1/tau/m
-            tauph = (tau * wQ[0]  + wQ[1])/(wQ[2]*tau + wQ[3])
+            tauph = (tau * wQ[0] + wQ[1])/(wQ[2]*tau + wQ[3])
             verbose("  computing integral from i*oo to %s using %s terms "
-                    "and precision %s"%(tau, T, prec),level=2)
+                    "and precision %s" % (tau, T, prec),level=2)
             int1 = self._integration_to_tau(tau, T, prec)
-            verbose("  yields %s "%int1, level=2)
+            verbose("  yields %s " % int1, level=2)
             verbose("  compute integral from %s to %s by computing an "
-                    "integral from i*oo to %s"%(r, tau, tauph),level=2)
+                    "integral from i*oo to %s" % (r, tau, tauph),level=2)
             int2 = self._integration_to_tau(tauph, T, prec)
             int2 *= -epsQ
-            verbose("  yields %s"%int2, level=2)
+            verbose("  yields %s" % int2, level=2)
             return int2 + int1
 
-        elif not use_partials: # prec = 53
+        elif not use_partials:  # prec = 53
             taui = <double>(Q)
             taui = sqrt(taui)
-            taui =  1/taui/m
+            taui = 1/taui/m
             tauc = complex(r, taui)
-            #verbose("act on %s by [[%s,%s],[%s,%s]]"%(tauc, wQ[0],
+            #verbose("act on %s by [[%s,%s],[%s,%s]]" % (tauc, wQ[0],
             # wQ[1], wQ[2], wQ[3]), level =4)
             tauphc = (tauc * wQ[0] + wQ[1])/(wQ[2]*tauc + wQ[3])
             verbose("  computing integral from i*oo to %s using %s terms "
-                    "in fast double precision"%(tauc, T),level=2)
+                    "in fast double precision" % (tauc, T),level=2)
             int1c = self._integration_to_tau_double(tauc, T)
-            verbose("  yields %s "%int1c, level=2)
+            verbose("  yields %s " % int1c, level=2)
             verbose("  compute integral from %s to %s by computing an "
-                    "integral from i*oo to %s"%(r, tauc, tauphc),level=2)
+                    "integral from i*oo to %s" % (r, tauc, tauphc),level=2)
             int2c = self._integration_to_tau_double(tauphc, T)
             int2c *= -epsQ
-            verbose("  yields %s"%int2c, level=2)
+            verbose("  yields %s" % int2c, level=2)
             CC = ComplexField(prec)
             return CC(int2c + int1c)
 
-        else: # use_partial
+        else:  # use_partial
             verbose("  computing integral from i*oo to %s using "
                     "using partials with "
-                    "y =%s"%(r, yy), level=2)
+                    "y =%s" % (r, yy), level=2)
             ka = self._kappa(m, m*m*Q,eps/2)
             a = rc._a
             twopii = TWOPI * complex("j")
@@ -1998,23 +2001,23 @@ cdef class ModularSymbolNumerical:
             ze1 = cexp(ze1)
             u = llinvmod(Q * a, m)
             ze2 = - twopii / m * u
-            ze2 =  cexp(ze2)
+            ze2 = cexp(ze2)
             j = 0
             su = 0
             verbose("      summing up %s partial sums, having set u = %s,"
-                    " z1 =%s, z2=%s"%(m,u,ze1,ze2), level=4)
+                    " z1 =%s, z2=%s" % (m, u, ze1, ze2), level=4)
             while j < m:
                 sig_check()
-                su += ka[j] * ( (ze1 ** j) - epsQ * (ze2 ** j))
+                su += ka[j] * ((ze1 ** j) - epsQ * (ze2 ** j))
                 j += 1
             CC = ComplexField(prec)
             return CC(su)
 
     cdef _from_r_to_rr_approx_direct(self, Rational r, Rational rr,
                                      Integer epsQ, Integer epsQQ,
-                                    llong* wQ, llong* wQQ,
-                                    int T, int prec, double eps,
-                                    int use_partials=2):
+                                     llong* wQ, llong* wQQ,
+                                     int T, int prec, double eps,
+                                     int use_partials=2):
         r"""
         This is just a helper function for _from_r_to_rr_approx. In case
         the integral is evaluated directly this function is called.
@@ -2051,7 +2054,7 @@ cdef class ModularSymbolNumerical:
             double x1d, x2d, sd
 
         #verbose("       enter _from_r_to_rr_approx_direct with r=%s,"
-        #        " rr=%s,..."%(r,rr), level=5)
+        #        " rr=%s,..." % (r,rr), level=5)
         rc = _CuspsForModularSymbolNumerical(r, self._N_E)
         m = rc._m
         a = rc._a
@@ -2063,14 +2066,14 @@ cdef class ModularSymbolNumerical:
         oi = llxgcd(Q*a, m, &u, &v)
         oi = llxgcd(QQ*aa, mm, &uu, &vv)
         #verbose("  The inverses are (u,v)=(%s,%s) and
-        # (uu,vv)=%s,%s"%(u,v,uu,vv), level=3)
+        # (uu,vv)=%s,%s" % (u,v,uu,vv), level=3)
 
         if use_partials == 2:
-            g = llgcd(Q,QQ)
+            g = llgcd(Q, QQ)
             D = Q * QQ
             D /= g
-            D *=  llabs(a*mm-aa*m)
-            use_partials = (prec==53) and ( D**4 < self._N_E or D < PARTIAL_LIMIT)
+            D *= llabs(a*mm-aa*m)
+            use_partials = (prec==53) and (D**4 < self._N_E or D < PARTIAL_LIMIT)
 
         CC = ComplexField(prec)
         if not use_partials and prec > 53:
@@ -2088,17 +2091,17 @@ cdef class ModularSymbolNumerical:
             s = 1/s
             tau0 = CC(x1, s)
             tau1 = CC(x2, s)
-            #verbose("  two points are %s and %s"%(tau0, tau1), level=3)
+            #verbose("  two points are %s and %s" % (tau0, tau1), level=3)
             verbose("   computing integral from %s to tau by computing "
-                    "the integral from i*oo to %s"%(r,tau0), level=3)
+                    "the integral from i*oo to %s" % (r, tau0), level=3)
             int1 = self._integration_to_tau(tau0, T, prec)
             int1 *= - epsQ
-            verbose("   yields %s "%int1, level=3)
+            verbose("   yields %s " % int1, level=3)
             verbose("   computing integral from tau to %s by computing "
-                    "the integral from i*oo to %s"%(rr, tau1), level=3)
+                    "the integral from i*oo to %s" % (rr, tau1), level=3)
             int2 = self._integration_to_tau(tau1, T, prec)
             int2 *= epsQQ
-            verbose("   yields %s "%int2, level=3)
+            verbose("   yields %s " % int2, level=3)
             ans = int2 + int1
         elif not use_partials:
             x1d = Q
@@ -2115,23 +2118,23 @@ cdef class ModularSymbolNumerical:
             tau0c = complex(x1d,sd)
             tau1c = complex(x2d,sd)
             verbose("   computing integral from %s to tau by computing "
-                    "the integral from i*oo to %s"%(r,
-                    tau0c),level=3)
+                    "the integral from i*oo to %s" % (r, tau0c),
+                    level=3)
             int1c = self._integration_to_tau_double(tau0c, T)
-            int1c *=  - epsQ
-            verbose("   yields %s "%int1c, level=3)
+            int1c *= -epsQ
+            verbose("   yields %s " % int1c, level=3)
             verbose("   computing integral from tau to %s by computing "
                     "the integral from i*oo to "
-                    "%s"%(rr, tau1c), level=3)
+                    "%s" % (rr, tau1c), level=3)
             int2c = self._integration_to_tau_double(tau1c, T)
             int2c *= epsQQ
-            verbose("   yields %s "%int2c, level=3)
+            verbose("   yields %s " % int2c, level=3)
             ans = int2c + int1c
-        else: # use_partials
+        else:  # use_partials
             g = llgcd(Q,QQ)
             D = Q * QQ
             D /= g
-            D *=  llabs(a*mm-aa*m)
+            D *= llabs(a*mm-aa*m)
             xi = (Q*aa*u+v*mm) * QQ /g * llsign(a*mm-aa*m)
             xixi = (QQ*a*uu+vv*m) * Q /g * llsign(aa*m-a*mm)
             z = Q * QQ * (a*mm-aa*m)**2
@@ -2143,10 +2146,10 @@ cdef class ModularSymbolNumerical:
             ze2 = cexp(ze2)
             j = 0
             su = 0
-            verbose("     summing up %s partial sums"%D, level=4)
+            verbose("     summing up %s partial sums" % D, level=4)
             while j < D:
                 sig_check()
-                su += (ze1**j * epsQQ  - ze2**j * epsQ ) * ka[j]
+                su += (ze1**j * epsQQ - ze2**j * epsQ) * ka[j]
                 j += 1
             ans = su
         return CC(ans)
@@ -2226,7 +2229,7 @@ cdef class ModularSymbolNumerical:
             int  T=0, prec=0, T1=0, T2=0, oi
 
         #verbose("       enter _from_r_to_rr_approx with r=%s,"
-        #        " rr=%s, "%(r,rr), level=5)
+        #        " rr=%s, " % (r,rr), level=5)
         rc = _CuspsForModularSymbolNumerical(r, self._N_E)
         m = rc._m
         a = rc._a
@@ -2255,15 +2258,15 @@ cdef class ModularSymbolNumerical:
             s = sqrt(s)
             s = s * llabs(a*mm-aa*m)
             s = 1/s
-            #verbose("    direct method goes to s=%s and eps=%s"%(s,eps),
+            #verbose("    direct method goes to s=%s and eps=%s" % (s,eps),
             #        level=3)
             T, prec = self._get_truncation_and_prec(s, eps/2)
-            #verbose("    giving T=%s and prec=%s"%(T,prec), level=3)
+            #verbose("    giving T=%s and prec=%s" % (T,prec), level=3)
             if T == -1:
                 if method == "direct" or method == "both":
                     raise ValueError("Too many terms > 2^31 would have to"
                                      + " be summed up. Giving up.")
-                else: # method was None
+                else:  # method was None
                     method = "indirect"
 
         # now we compare it to the indirect integration via i*oo
@@ -2280,7 +2283,7 @@ cdef class ModularSymbolNumerical:
                 if method == "indirect" or method == "both":
                     raise ValueError("Too many terms > 2^31 would have to"
                                      + " be summed up. Giving up.")
-                else: # method was None
+                else:  # method was None
                     method = "direct"
 
         if method is None:
@@ -2295,7 +2298,7 @@ cdef class ModularSymbolNumerical:
 
         if method == "direct" or method == "both":
             verbose(" using the direct integration from %s to %s with "
-                    "%s terms to sum"%(r, rr, T), level=2)
+                    "%s terms to sum" % (r, rr, T), level=2)
             #self.nc_direct += 1
             ans = self._from_r_to_rr_approx_direct(r, rr, epsQ, epsQQ,
                                                    wQ, wQQ, T, prec, eps,
@@ -2305,20 +2308,21 @@ cdef class ModularSymbolNumerical:
 
         if method == "indirect" or method == "both":
             verbose("  using the indirect integration from %s to %s "
-                    "with %s terms to sum"%(r, rr, T1+T2), level=2)
+                    "with %s terms to sum" % (r, rr, T1+T2), level=2)
             #self.nc_indirect += 1
-            ans2 = ( self._from_ioo_to_r_approx(r, eps/2,
-                                                use_partials=use_partials)
+            ans2 = (self._from_ioo_to_r_approx(r, eps/2,
+                                               use_partials=use_partials)
                     - self._from_ioo_to_r_approx(rr, eps/2,
-                                                use_partials=use_partials) )
+                                                 use_partials=use_partials))
             if method != "both":
                 return ans2
 
         if method == "both":
-            if not use_partials:
-                assert (ans - ans2).abs() < eps, ("Bug in modular symbols. "
-                     + "The indirect and direct computation of the modular "
-                     + "symbol from %s to %s differ by too much"%(r, rr) )
+            if not use_partials and not (ans - ans2).abs() < eps:
+                txt = "Bug in modular symbols. "
+                txt += "The indirect and direct computation of the modular "
+                txt += "symbol from %s to %s differ by too much" % (r, rr)
+                raise RuntimeError(txt)
 
             return (ans + ans2)/2
 
@@ -2372,16 +2376,16 @@ cdef class ModularSymbolNumerical:
         This goes via i `\infty`::
 
             sage: M = ModularSymbolNumerical(EllipticCurve("5077a1"))
-            sage: M._transportable_approx( 0/1, -35/144, 0.001) #abs tol 1e-11
+            sage: M._transportable_approx(0/1, -35/144, 0.001) #abs tol 1e-11
             -6.22753189644996 + 3.23405342839145e-7*I
-            sage: M._from_r_to_rr_approx( 0/1, -35/144, 0.001) # abs tol 1e-10
+            sage: M._from_r_to_rr_approx(0/1, -35/144, 0.001) # abs tol 1e-10
             -6.22753204310913 - 1.31710951034592e-8*I
 
         While this one goes via 0::
 
-            sage: M._transportable_approx( 0/1, -7/31798, 0.001) #abs tol 1e-11
+            sage: M._transportable_approx(0/1, -7/31798, 0.001) #abs tol 1e-11
             -7.01577418382726e-9 - 7.40274138232394*I
-            sage: M._from_r_to_rr_approx( 0/1, -7/31798, 0.001) #abs tol 1e-5 #long time
+            sage: M._from_r_to_rr_approx(0/1, -7/31798, 0.001) #abs tol 1e-5 #long time
             -7.02253033502132e-9 - 7.40274138234031*I
         """
         cdef:
@@ -2392,7 +2396,7 @@ cdef class ModularSymbolNumerical:
             complex tau1c, tau2c, int1c, int2c
 
         #verbose("       enter transportable_symbol_approx with r=%s,"
-        #        " rr=%s"%(r,rr), level=5)
+        #        " rr=%s" % (r,rr), level=5)
 
         #this finds a gamma with smallest |c|
         from sage.modular.cusps import Cusp
@@ -2401,19 +2405,19 @@ cdef class ModularSymbolNumerical:
 
         if not boo:
             raise ValueError("The cusps %s and %s are not "
-                             "Gamma_0(%s)-equivalent"%(r, rr, self._N_E))
+                             "Gamma_0(%s)-equivalent" % (r, rr, self._N_E))
 
         # now find the same for the move to 0
         c = ga[1][0]
-        r0 = - Rational( (c/self._N_E, ga[0][0]) )
+        r0 = - Rational((c/self._N_E, ga[0][0]))
         rc0 = Cusp(r0)
         _, ga0 = rc0.is_gamma0_equiv(0, self._N_E, "matrix")
 
-        if c.abs() > ga0[1][0].abs(): # better at 0
+        if c.abs() > ga0[1][0].abs():  # better at 0
             ga = ga0
             c = ga[1][0]
             eN = -self._epsQs[self._N_E]
-        else: #better at i oo
+        else:  # better at i oo
             eN = 1
 
         a = ga[0][0]
@@ -2439,26 +2443,26 @@ cdef class ModularSymbolNumerical:
             tau1 = CC(-d/c, 1/c.abs())
             # computes the integral from tau to i*oo
             verbose("   computing integral from i*oo to %s using %s terms "
-                    "and precision %s"%(tau1, T, prec), level=3)
+                    "and precision %s" % (tau1, T, prec), level=3)
             int1 = self._integration_to_tau(tau1, T, prec)
-            verbose("   yields %s "%int1, level=3)
+            verbose("   yields %s " % int1, level=3)
             tau2 = (tau1 * a + b)/(c*tau1 + d)
             verbose("   computing integral from i*oo to %s using %s terms "
-                    "and precision %s"%(tau2, T, prec), level=3)
+                    "and precision %s" % (tau2, T, prec), level=3)
             int2 = self._integration_to_tau(tau2, T, prec)
             ans = eN * (int1 - int2)
         else:
             tau1c = complex(-d/c, 1/c.abs())
             # computes the integral from tau to i*oo
             verbose("   computing integral from i*oo to %s using %s terms "
-                    "and fast double precision"%(tau1c, T), level=3)
+                    "and fast double precision" % (tau1c, T), level=3)
             int1c = self._integration_to_tau_double(tau1c, T)
-            verbose("   yields %s "%int1c, level=3)
+            verbose("   yields %s " % int1c, level=3)
             tau2c = (tau1c * a + b)/(c*tau1c + d)
             verbose("   computing integral from i*oo to %s using %s terms "
-                    "and fast double precision"%(tau2c, T), level=3)
+                    "and fast double precision" % (tau2c, T), level=3)
             int2c = self._integration_to_tau_double(tau2c, T)
-            verbose("   yields %s"%int2c, level=3)
+            verbose("   yields %s" % int2c, level=3)
             ans = eN * ComplexField(53)(int1c - int2c)
         return ans
 
@@ -2504,7 +2508,7 @@ cdef class ModularSymbolNumerical:
             sage: M._value_ioo_to_r(-9/55,-1)
             -2
         """
-        #verbose("       enter _value_ioo_to_r with r=%s, sign=%s"%(r,sign),
+        #verbose("       enter _value_ioo_to_r with r=%s, sign=%s" % (r,sign),
         #        level=5)
         cdef:
             double eps
@@ -2575,7 +2579,7 @@ cdef class ModularSymbolNumerical:
             -1
         """
         #verbose("       enter _value_r_to_rr with r=%s, rr=%s,"
-        #        " sign=%s"%(r,rr,sign), level=5)
+        #        " sign=%s" % (r,rr,sign), level=5)
         cdef:
             double eps
             ComplexNumber la
@@ -2637,7 +2641,7 @@ cdef class ModularSymbolNumerical:
             -5
         """
         #verbose("       enter transportable_symbol with r=%s, rr=%s,"
-        #        " sign=%s"%(r,rr,sign), level=5)
+        #        " sign=%s" % (r,rr,sign), level=5)
         cdef:
             double eps
             ComplexNumber la
@@ -2691,7 +2695,7 @@ cdef class ModularSymbolNumerical:
             5/19
         """
         #verbose("       enter _symbol_non_unitary with r=%s,"
-        #        " sign=%s"%(r,sign), level=5)
+        #        " sign=%s" % (r,sign), level=5)
         cdef:
             llong m, B, N_ell, aell, u, N = self._N_E
             Integer ell
@@ -2728,7 +2732,7 @@ cdef class ModularSymbolNumerical:
             u += 1
         return -res/N_ell
 
-    @cached_method # one call to manin_symbol will set between 4 and 8 values in fact
+    @cached_method  # one call to manin_symbol will set between 4 and 8 values in fact
     def _manin_symbol_with_cache(self, llong u, llong v, int sign):
         r"""
         This helper function is called by manin_symbol below.
@@ -2776,7 +2780,7 @@ cdef class ModularSymbolNumerical:
             Rational r, rr, res
 
         #verbose("       enter _manin_symbol_with_cache with u=%s, v=%s,"
-        #        " sign =%s"%(u,v,sign), level=5)
+        #        " sign =%s" % (u,v,sign), level=5)
 
         if u == 0:
             verbose("   integrating from 0 to i*oo", level=3)
@@ -2793,7 +2797,7 @@ cdef class ModularSymbolNumerical:
             Qu = N/Mu
             Mv = llgcd(v,N)
             Qv = N/Mv
-            isunitary = ( llgcd(Qu,Mu) == 1 and llgcd(Qv,Mv) == 1 )
+            isunitary = (llgcd(Qu,Mu) == 1 and llgcd(Qv,Mv) == 1)
             if isunitary:  # unitary case
                 _ = best_proj_point(u, v, self._N_E, &c, &d)
             else:  # at least one of the two cusps is not unitary
@@ -2819,7 +2823,7 @@ cdef class ModularSymbolNumerical:
                     c = c % N
                     # now (u:v) = (c:d) with d as small as possible.
             #verbose("   better representant on P^1: "
-            #        "(%s : %s)"%(c, d), level=3)
+            #        "(%s : %s)" % (c, d), level=3)
             # _, x, y = c.xgcd(d)
             _ = llxgcd(c, d, &x, &y)
             #if above != 1 or (c*v-u*d) % N != 0:
@@ -2828,15 +2832,15 @@ cdef class ModularSymbolNumerical:
             y = y % N
             # [[y -x], [c,d]] has det 1
             if c > 0:
-                rr = Rational( (y,c) )
+                rr = Rational((y, c))
             else:
-                rr = - Rational( (y, (-c)) )
+                rr = - Rational((y, -c))
             if d > 0:
-                r = -Rational( (x,d) )
+                r = -Rational((x, d))
             else:
-                r = Rational( (x, (-d)) )
+                r = Rational((x, -d))
             if isunitary:
-                verbose("   integrate between %s and %s"%(r, rr), level=3)
+                verbose("   integrate between %s and %s" % (r, rr), level=3)
                 return self._value_r_to_rr(r, rr, sign, use_partials=2)
             else:
                 if dv > 1:
@@ -2889,7 +2893,7 @@ cdef class ModularSymbolNumerical:
             -1/2
         """
         #verbose("       enter manin_symbol with u=%s, v=%s,"
-        #        " sign =%s"%(u,v,sign), level=5)
+        #        " sign =%s" % (u,v,sign), level=5)
         cdef:
             llong un, vn
             int oi
@@ -2900,7 +2904,7 @@ cdef class ModularSymbolNumerical:
 
         oi = proj_normalise(self._N_E, u, v, &un, &vn)
         #verbose("   normalized representant on P^1: "
-        #        "(%s :%s)"%(un, vn), level=3)
+        #        "(%s :%s)" % (un, vn), level=3)
 
         # is it already in the cache ?
         c = self._cached_methods
@@ -2933,8 +2937,8 @@ cdef class ModularSymbolNumerical:
         oi = proj_normalise(self._N_E, -u, v, &un, &vn)
         c.set_cache(sign*res, un, vn, sign)
 
-        # (u:v) + ( u+v:-u) +(v,-u-v) = 0
-        # is ( u+v:-u) already computed, we set the third
+        # (u:v) + (u+v:-u) +(v,-u-v) = 0
+        # is (u+v:-u) already computed, we set the third
         oi = proj_normalise(self._N_E, u+v, -u, &un, &vn)
         if c.is_in_cache(un,vn,sign):
             r2 = - res - c(un,vn,sign)
@@ -2955,7 +2959,7 @@ cdef class ModularSymbolNumerical:
             oi = proj_normalise(self._N_E, -v, -u-v, &un, &vn)
             c.set_cache(sign*r2, un, vn, sign)
 
-        # is ( v,-u-v) already computed, we set ( u+v:-u)
+        # is (v,-u-v) already computed, we set (u+v:-u)
         oi = proj_normalise(self._N_E, v, -u-v, &un, &vn)
         if c.is_in_cache(un,vn,sign):
             r2 = - res - c(un,vn,sign)
@@ -3013,7 +3017,7 @@ cdef class ModularSymbolNumerical:
             sage: M._evaluate(1/99999)
             -4/5
 
-            sage: M = ModularSymbolNumerical( EllipticCurve("32a1") )
+            sage: M = ModularSymbolNumerical(EllipticCurve("32a1"))
             sage: M._evaluate(3/5)
             -1/4
 
@@ -3041,7 +3045,7 @@ cdef class ModularSymbolNumerical:
             sage: M._evaluate(1/123456789012345678901234567)
             -1
         """
-        #verbose("       enter _evaluate with r=%s, sign=%s"%(r,sign),
+        #verbose("       enter _evaluate with r=%s, sign=%s" % (r,sign),
         #         level=5)
         cdef:
             llong N = self._N_E, u, v
@@ -3065,7 +3069,7 @@ cdef class ModularSymbolNumerical:
 
         B = m.gcd(N)
         Q = N // B
-        #verbose("     cusp is %s/%s of width %s"%(a,m,Q), level=4)
+        #verbose("     cusp is %s/%s of width %s" % (a,m,Q), level=4)
 
         if r == 0:
             return self._value_ioo_to_r(r, sign=sign)
@@ -3085,7 +3089,7 @@ cdef class ModularSymbolNumerical:
                 y -= m
             x = (1-y*a) // m
             #verbose("     smallest xgcd is "
-            #        + " %s = %s * %s + %s * %s"%(a.gcd(m),a,y,x,m),
+            #        + " %s = %s * %s + %s * %s" % (a.gcd(m),a,y,x,m),
             #        level=4)
             # make the cusp -x/y unitary if possible.
             B = y.gcd(N)
@@ -3104,7 +3108,7 @@ cdef class ModularSymbolNumerical:
             v = <llong>vv
             r2 = - x/y
             verbose("  Next piece: integrate from %s to %s via the Manin"
-                    " symbol for (%s : %s)"%(r,r2,u,v), level=2)
+                    " symbol for (%s : %s)" % (r, r2, u, v), level=2)
             res = self.manin_symbol(u,v,sign=sign)
             res += self._evaluate(r2, sign=sign)
 
@@ -3165,7 +3169,7 @@ cdef class ModularSymbolNumerical:
             RealNumber val
             dict res
 
-        #verbose("       enter all_symbol with m=%s"%m, level=5)
+        #verbose("       enter all_symbol with m=%s" % m, level=5)
 
         if sign == 0:
             sign = self._global_sign
@@ -3176,7 +3180,7 @@ cdef class ModularSymbolNumerical:
         if llgcd(m,Q) > 1:
             raise NotImplementedError("Only implemented for cusps that are "
                                       "in the Atkin-Lehner orbit of oo")
-        #verbose("   compute all partial sums with denominator m=%s"%m,
+        #verbose("   compute all partial sums with denominator m=%s" % m,
         #        level=3)
         z = Q*m*m
         v = self._kappa(m, z)
@@ -3194,11 +3198,11 @@ cdef class ModularSymbolNumerical:
                     j = 0
                     resam = 0
                     while j < m:
-                        resam +=  (v[j]*(cos(twopim*j*a)
-                                   - epsQ*cos(twopim*j*astar)) )
+                        resam += (v[j]*(cos(twopim*j*a)
+                                        - epsQ*cos(twopim*j*astar)))
                         j += 1
                     val = RR(resam)
-                    res[Rational( (a,m) )] = self._round(val, 1, True)
+                    res[Rational((a, m))] = self._round(val, 1, True)
                 a += 1
         else:
             while a < m:
@@ -3207,11 +3211,11 @@ cdef class ModularSymbolNumerical:
                     j = 0
                     resam = 0
                     while j < m:
-                        resam +=  (v[j]*(sin(twopim *j *a)
-                                   + epsQ *sin(twopim*j*astar)) )
+                        resam += (v[j]*(sin(twopim *j *a)
+                                        + epsQ *sin(twopim*j*astar)))
                         j += 1
                     val = RR(resam)
-                    res[Rational( (a,m) )] = self._round(val, -1, True)
+                    res[Rational((a, m))] = self._round(val, -1, True)
                 a += 1
 
         return res
@@ -3246,7 +3250,7 @@ cdef class ModularSymbolNumerical:
         cdef Integer D, Da, a
         cdef Rational res, t
         #verbose("       enter _twisted symbol with ra=%s,
-        #        sign=%s"%(ra,sign),
+        #        sign=%s" % (ra,sign),
         #        level=5)
         if sign == 0:
             sign = self._global_sign
@@ -3255,9 +3259,9 @@ cdef class ModularSymbolNumerical:
         D = self._D
         Da = D.abs()
         a = Integer(1)
-        res = Rational( (0,1) )
+        res = Rational((0, 1))
         s = sign * D.sign()
-        verbose("     start sum of twisted symbols with disc %s"%D, level=4)
+        verbose("     start sum of twisted symbols with disc %s" % D, level=4)
         while a < Da:
             if a.gcd(Da) == 1:
                 t = self._Mt(ra - a/Da, sign=s, use_twist=False)
@@ -3294,7 +3298,7 @@ cdef class ModularSymbolNumerical:
             sage: m._evaluate_approx(1/17,0.000001) # abs tol 1e-11
             -9.01145713605445e-10 + 7.40274134212215*I
 
-            sage: M = ModularSymbolNumerical( EllipticCurve([-12,79]) )
+            sage: M = ModularSymbolNumerical(EllipticCurve([-12,79]))
             sage: M.elliptic_curve().conductor()
             287280
             sage: M._evaluate_approx(0/1,0.01)  # abs tol 1e-11
@@ -3309,7 +3313,7 @@ cdef class ModularSymbolNumerical:
             sage: m(1/2)          #abs tol 1e-4
             -0.166666666666667
         """
-        #verbose("       enter _evaluate_approx with r=%s, eps=%s"%(r,eps),
+        #verbose("       enter _evaluate_approx with r=%s, eps=%s" % (r,eps),
         #        level=5)
         cdef:
             llong N = self._N_E
@@ -3325,7 +3329,7 @@ cdef class ModularSymbolNumerical:
         r = a/m
         B = m.gcd(N)
         Q = N // B
-        verbose("     cusp is %s/%s of width %s"%(a,m,Q), level=4)
+        verbose("     cusp is %s/%s of width %s" % (a, m, Q), level=4)
 
         if r == 0:
             return self._from_ioo_to_r_approx(r, eps, use_partials=0)
@@ -3344,7 +3348,7 @@ cdef class ModularSymbolNumerical:
             y -= m
         x = (1-y*a) // m
         #verbose("     smallest xgcd is "
-        #        + " %s = %s * %s + %s * %s"%(a.gcd(m),a,y,x,m),
+        #        + " %s = %s * %s + %s * %s" % (a.gcd(m),a,y,x,m),
         #        level=4)
         # make the cusp -x/y unitary if possible.
         B = y.gcd(N)
@@ -3358,7 +3362,7 @@ cdef class ModularSymbolNumerical:
         r2 = - x / y
         B = y.gcd(N)
         Q = N // B
-        if Q.gcd(N // Q) != 1: # r2 is not unitary
+        if Q.gcd(N // Q) != 1:  # r2 is not unitary
             return self._symbol_non_unitary_approx(r, eps)
 
         r2 = - x / y
@@ -3406,7 +3410,7 @@ cdef class ModularSymbolNumerical:
             0.725215164486092 - 1.19349741385624*I
          """
         #verbose("       enter _symbol_nonunitary_approx with r=%s,"
-        #        " eps=%s"%(r,eps), level=5)
+        #        " eps=%s" % (r,eps), level=5)
         cdef:
             llong m, B, N_ell, aell, u, N = self._N_E
             Integer ell
@@ -3428,14 +3432,14 @@ cdef class ModularSymbolNumerical:
             aell = Integer(self._ans[ell])
         N_ell = ell + 1 - aell
         # {ell * r , r}
-        verbose("     Compute symbol {ell*r -> r} = {%s -> %s}"%(ell*r,r),
+        verbose("     Compute symbol {ell*r -> r} = {%s -> %s}" % (ell*r, r),
                 level=4)
         res = self._transportable_approx(ell * r, r, eps)
         # {(r + u)/ ell, r}
         u = Integer(0)
         while u < ell:
             r2 = (r+u) / ell
-            verbose("     Compute symbol {r2-> r} = {%s -> %s}"%(r2,r),
+            verbose("     Compute symbol {r2-> r} = {%s -> %s}" % (r2, r),
                     level=4)
             res += self._transportable_approx(r2, r, eps)
             u += 1
@@ -3477,7 +3481,7 @@ cdef class ModularSymbolNumerical:
         cdef Integer D, Da, a, s, precd
         cdef RealNumber res, t
         #verbose("       enter _twisted approx with ra=%s,
-        #        eps=%s"%(ra,eps),
+        #        eps=%s" % (ra,eps),
         #        level=5)
 
         if sign == 0:
@@ -3488,7 +3492,7 @@ cdef class ModularSymbolNumerical:
         precd = prec + euler_phi(Da).log(2,20).ceil()
         a = Integer(1)
         res = self._Mt.approximative_value(ra - a/Da, s, precd)
-        verbose("     start sum of twisted symbols with disc %s"%D, level=4)
+        verbose("     start sum of twisted symbols with disc %s" % D, level=4)
         a += 1
         while a < Da:
             if a.gcd(Da) == 1:
@@ -3685,7 +3689,7 @@ def _test_integration_via_partials(E, y, m, T):
         """
     cdef int mm = <int>(m)
     cdef double * ra
-    ra = <double *> sig_malloc( mm * sizeof(double))
+    ra = <double *> sig_malloc(mm * sizeof(double))
     if ra is NULL:
         raise MemoryError
     M = ModularSymbolNumerical(E)
@@ -3695,7 +3699,7 @@ def _test_integration_via_partials(E, y, m, T):
     return res
 
 
-def _test_against_table(range_of_conductors, other_implementation="sage", list_of_cusps=[], verb=False):
+def _test_against_table(range_of_conductors, other_implementation="sage", list_of_cusps=None, verb=False):
     r"""
     This test function checks the modular symbols here against the
     ones implemented already. Note that for some curves the current
@@ -3709,9 +3713,9 @@ def _test_against_table(range_of_conductors, other_implementation="sage", list_o
 
     - ``list_of_cusps`` -- a list of rationals to be tested
 
-    - ``verb`` -- if True (default) prints the values
+    - ``verb`` -- if ``True`` (default) prints the values
 
-    OUTPUT: Boolean. If False the function also prints information.
+    OUTPUT: Boolean. If ``False`` the function also prints information.
 
     EXAMPLES::
 
@@ -3722,6 +3726,8 @@ def _test_against_table(range_of_conductors, other_implementation="sage", list_o
     """
     boo = True
     from sage.schemes.elliptic_curves.ell_rational_field import cremona_curves
+    if list_of_cusps is None:
+        list_of_cusps = []
     for C in cremona_curves(range_of_conductors):
         if verb:
             print("testing curve ", C.label())
@@ -3744,7 +3750,7 @@ def _test_against_table(range_of_conductors, other_implementation="sage", list_o
             if mr != Mr or m2r != M2r:
                 print (("B u g : curve = {}, cusp = {}, sage's symbols"
                         + "({},{}), our symbols ({}, {})").format(C.label(), r,
-                                                                  mr, m2r, Mr, M2r) )
+                                                                  mr, m2r, Mr, M2r))
                 boo = False
         M.clear_cache()
     return boo

--- a/src/sage/schemes/elliptic_curves/mod_sym_num.pyx
+++ b/src/sage/schemes/elliptic_curves/mod_sym_num.pyx
@@ -97,11 +97,11 @@ this curve is positive::
 One can compute the numerical approximation to these rational numbers
 to any proven binary precision::
 
-    sage: M.approximative_value(13/17, prec=2) #abs tol 1e-4
+    sage: M.approximative_value(13/17, prec=2) # abs tol 1e-4
     -0.500003172770455
-    sage: M.approximative_value(13/17, prec=4) #abs tol 1e-6
+    sage: M.approximative_value(13/17, prec=4) # abs tol 1e-6
     -0.500000296037388
-    sage: M.approximative_value(0, sign=+1, prec=6) #abs tol 1e-8
+    sage: M.approximative_value(0, sign=+1, prec=6) # abs tol 1e-8
     0.000000000000000
 
 
@@ -330,7 +330,7 @@ cdef int proj_normalise(llong N, llong u, llong  v,
     if `\gcd(u,v,N) \not= 1`, returns 0, 0, 0.
     """
     cdef llong d, k, g, s, t, min_v, min_t, Ng, vNg
-    #verbose("       enter proj_normalise with N=%s, u=%s, v=%s" % (N,u,v),
+    # verbose("       enter proj_normalise with N=%s, u=%s, v=%s" % (N,u,v),
     #        level=5)
     if N == 1:
         uu[0] = 0
@@ -343,7 +343,7 @@ cdef int proj_normalise(llong N, llong u, llong  v,
         v = N - ((-v) % N)
     u = u % N
     v = v % N
-    #verbose("       now N=%s, u=%s, v=%s" % (N,u,v), level=5)
+    # verbose("       now N=%s, u=%s, v=%s" % (N,u,v), level=5)
     if u == 0:
         uu[0] = 0
         if llgcd(v, N) == 1:
@@ -368,7 +368,7 @@ cdef int proj_normalise(llong N, llong u, llong  v,
         d = N / g
         while llgcd(s, N) != 1:
             s = (s+d) % N
-    #verbose("       now g=%s, s=%s, t=%s" % (g,s,t), level=5)
+    # verbose("       now g=%s, s=%s, t=%s" % (g,s,t), level=5)
 
     # Multiply [u,v] by s; then [s*u,s*v] = [g,s*v] (mod N)
     u = g
@@ -390,7 +390,7 @@ cdef int proj_normalise(llong N, llong u, llong  v,
     v = min_v
     uu[0] = u
     vv[0] = v
-    #verbose("       leaving proj_normalise with s=%s, t=%s" % (u,v), level=5)
+    # verbose("       leaving proj_normalise with s=%s, t=%s" % (u,v), level=5)
     return 0
 
 
@@ -430,7 +430,7 @@ cdef int best_proj_point(llong u, llong v, llong N,
     """
     cdef llong w, p, q, Nnew, r, a, b, si
     cdef llong x0, x1, y0, y1, t0, t1, s0, s1
-    #verbose("       enter best_proj_point with N=%s, u=%s, v=%s" % (N,u,v),
+    # verbose("       enter best_proj_point with N=%s, u=%s, v=%s" % (N,u,v),
     #        level=5)
     if u == 0:
         uu[0] = <llong>0
@@ -477,7 +477,7 @@ cdef int best_proj_point(llong u, llong v, llong N,
             t0 = s0
             t1 = s1
         # t is now the shortest vector on the line y + RR x
-        #verbose("     reduced vector to (%s,%s)" % (t0,t1), level=4)
+        # verbose("     reduced vector to (%s,%s)" % (t0,t1), level=4)
         y0 = x0
         y1 = x1
         x0 = t0
@@ -494,7 +494,7 @@ cdef int best_proj_point(llong u, llong v, llong N,
     else:
         # we fall here if the first two shortest vector are both
         # not permitted, here we do a search until we hit a solution.
-        #verbose("   both shortest vectors ((%s,%s) and (%s,%s)) are not "
+        # verbose("   both shortest vectors ((%s,%s) and (%s,%s)) are not "
         #        "permitted. The result is not guaranteed to "
         #        "be best possible." % (x0, x1, y0, y1), level=3)
         r = <llong>2
@@ -517,7 +517,7 @@ cdef int best_proj_point(llong u, llong v, llong N,
                 si = b
             t0 = a * x0 + b * y0
             t1 = a * x1 + b * y1
-        #verbose("works with t = %s*x+%s*y" % (a, b), level=3)
+        # verbose("works with t = %s*x+%s*y" % (a, b), level=3)
         uu[0] = t0
         vv[0] = t1
         return 0
@@ -584,7 +584,7 @@ cdef class _CuspsForModularSymbolNumerical:
             sage: r = _CuspsForModularSymbolNumerical(3/7,99)
         """
         cdef llong a, m, B
-        #verbose("       enter __init__ of cusps with r=%s and N=%s" % (r,N),
+        # verbose("       enter __init__ of cusps with r=%s and N=%s" % (r,N),
         #        level=5)
         a = <llong>(r.numerator())
         m = <llong>(r.denominator())
@@ -622,7 +622,7 @@ cdef class _CuspsForModularSymbolNumerical:
         """
         cdef llong Q, B, c, x, y
 
-        #verbose("       enter atkin_lehner for cusp r=%s" % self._r, level=5)
+        # verbose("       enter atkin_lehner for cusp r=%s" % self._r, level=5)
         Q = self._width
         B = llgcd(self._m, self._N_level)
         c = self._m / B
@@ -634,7 +634,7 @@ cdef class _CuspsForModularSymbolNumerical:
         res[1] = y
         res[2] = -c * self._N_level
         res[3] = Q * self._a
-        #verbose("       leaving atkin_lehner with w_Q = "
+        # verbose("       leaving atkin_lehner with w_Q = "
         #        "[%s, %s, %s, %s]" % (res[0], res[1], res[2], res[3]),
         #        level=5)
         return 0
@@ -778,7 +778,7 @@ cdef class ModularSymbolNumerical:
             sage: M(1/3, -1)
             1/6
         """
-        #verbose("       enter __init_ of modular symbols", level=5)
+        # verbose("       enter __init_ of modular symbols", level=5)
         self._E = E
         self._Epari= E.pari_mincurve()
         self._global_sign = <int>sign
@@ -882,7 +882,7 @@ cdef class ModularSymbolNumerical:
         if sign == 0:
             sign = self._global_sign
 
-        #verbose("       enter __call__ of modular symbols for r=%s"
+        # verbose("       enter __call__ of modular symbols for r=%s"
         #        "and sign=%s and use_twist=%s" % (r,sign,use_twist), level=5)
         if isinstance(r, Rational):
             ra = r
@@ -952,7 +952,7 @@ cdef class ModularSymbolNumerical:
         if sign == 0:
             sign = self._global_sign
 
-        #verbose("       enter approximative_value of modular symbols for r=%s,"
+        # verbose("       enter approximative_value of modular symbols for r=%s,"
         #        "sign=%s and prec=%s " % (r,sign,prec,), level=5)
         if isinstance(r, Rational):
             ra = r
@@ -1029,7 +1029,7 @@ cdef class ModularSymbolNumerical:
             int co, cinf, E0cinf
             RealNumber E0om1, E0om2, q
 
-        #verbose("       enter _set_bounds", level=5)
+        # verbose("       enter _set_bounds", level=5)
         N = Integer(self._N_E)
         E = self._E
         L = E.period_lattice().basis()
@@ -1161,7 +1161,7 @@ cdef class ModularSymbolNumerical:
         cdef Integer D, ell
         cdef RealNumber qq, Db
 
-        #verbose("       enter _set_up_twist", level=5)
+        # verbose("       enter _set_up_twist", level=5)
         Et, D = self._E.minimal_quadratic_twist()
         # we now have to make sure that |D| is as small as
         # possible (the above may give a D != 1 and yet
@@ -1233,7 +1233,7 @@ cdef class ModularSymbolNumerical:
             llong t, r
             RealNumber q, qt
 
-        #verbose("       enter _round with value=%s" % val, level=5)
+        # verbose("       enter _round with value=%s" % val, level=5)
         if sign == 1 and unitary:
             q = val/self._om1
             t = self._t_unitary_plus
@@ -1273,7 +1273,7 @@ cdef class ModularSymbolNumerical:
             sage: M = E.modular_symbol(implementation="num") #indirect doctest
         """
         cdef int n
-        #verbose("       enter _initialise_an_coeffients", level=5)
+        # verbose("       enter _initialise_an_coeffients", level=5)
         n = 0
         self_ans = self._E.anlist(1000, python_ints=True)
         while n <= 1000:
@@ -1305,7 +1305,7 @@ cdef class ModularSymbolNumerical:
             sage: M._add_an_coefficients(10000)
         """
         cdef llong n
-        #verbose("       enter add_an_coeffs with T=%s" % T, level=5)
+        # verbose("       enter add_an_coeffs with T=%s" % T, level=5)
         # we artificially add 100 extra terms, to avoid calling this
         # function again with only a few new terms
         T += 100
@@ -1408,7 +1408,7 @@ cdef class ModularSymbolNumerical:
             sage: ms._integration_to_tau(0.3+0.01*I,1000,60) # abs tol 1e-11
             0.41268108621256428 + 0.91370544691462463*I
         """
-        #verbose("       enter _integration_to_tau with tau=%s, T=%s,"
+        # verbose("       enter _integration_to_tau with tau=%s, T=%s,"
         #        "prec=%s" % (tau,number_of_terms,prec), level=5)
         cdef ComplexNumber q, s
         cdef int n
@@ -1435,7 +1435,7 @@ cdef class ModularSymbolNumerical:
             s += CC(self._ans[n])/n
             n -= 1
         s *= q
-        #verbose("       leaving integration_to_tau with sum=%s" % s, level=5)
+        # verbose("       leaving integration_to_tau with sum=%s" % s, level=5)
         return s
 
     # the version using double is 70-80 times faster it seems.
@@ -1464,10 +1464,10 @@ cdef class ModularSymbolNumerical:
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("17a1"))
-            sage: M._from_ioo_to_r_approx(9/13,0.01,use_partials=0) #abs tol 1e-5
+            sage: M._from_ioo_to_r_approx(9/13,0.01,use_partials=0) # abs tol 1e-5
             0.386771552192424 - 2.74574021880459*I
         """
-        #verbose("       enter integrations_to_tau_double with tau=%s,"
+        # verbose("       enter integrations_to_tau_double with tau=%s,"
         #        " T=%s" % (tau,number_of_terms), level=5)
         cdef complex q, s
         cdef int n
@@ -1493,7 +1493,7 @@ cdef class ModularSymbolNumerical:
             s += self._ans_num[n]
             n -= 1
         s *= q
-        #verbose("       leaving integration_to_tau_double with sum=%s" % s,
+        # verbose("       leaving integration_to_tau_double with sum=%s" % s,
         #        level=5)
         return s
 
@@ -1522,10 +1522,10 @@ cdef class ModularSymbolNumerical:
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("37b2"))
-            sage: M._from_ioo_to_r_approx(0/1,0.01,use_partials=1) #abs tol 1e-5
+            sage: M._from_ioo_to_r_approx(0/1,0.01,use_partials=1) # abs tol 1e-5
             0.725681061936153
         """
-        #verbose("       enter partial_real_sums_double with y=%s, m=%s,"
+        # verbose("       enter partial_real_sums_double with y=%s, m=%s,"
         #        " T=%s" % (y,m,number_of_terms), level=5)
         cdef double q, qq
         cdef int n, i
@@ -1563,7 +1563,7 @@ cdef class ModularSymbolNumerical:
             res[i] *= q ** i
             i += 1
         res[0] *= qq
-        #verbose("       leaving _partial_real_sums_double with result %s,"
+        # verbose("       leaving _partial_real_sums_double with result %s,"
         #        " %s, ... %s" % (res[0], res[1], res[m-1]), level=5)
         return 0
 
@@ -1605,7 +1605,7 @@ cdef class ModularSymbolNumerical:
              4.706713577985852e-8,
              0.0001771330855478248]
         """
-        #verbose("       enter partial_real_sums with y=%s, m=%s,"
+        # verbose("       enter partial_real_sums with y=%s, m=%s,"
         #        " T=%s" % (y,m,number_of_terms), level=5)
         cdef RealNumber q, qq
         cdef int n, i
@@ -1645,7 +1645,7 @@ cdef class ModularSymbolNumerical:
             res[i] *= q ** i
             i += 1
         res[0] *= qq
-        #verbose("       leaving _partial_real_sums with result"
+        # verbose("       leaving _partial_real_sums with result"
         #        " %s, %s, ... %s" % (res[0], res[1], res[m-1]), level=5)
         return res
 
@@ -1688,7 +1688,7 @@ cdef class ModularSymbolNumerical:
             sage: M._get_truncation_and_prec(10^(-11),10^(-2))
             (-1, -1)
         """
-        #verbose("       enter _get_truncation_and_prec with y=%s"
+        # verbose("       enter _get_truncation_and_prec with y=%s"
         #        " and eps=%s" % (y,eps), level=5)
         # how much of the error comes from truncation and how much
         # from precision.
@@ -1709,7 +1709,7 @@ cdef class ModularSymbolNumerical:
         else:
             T = -1
             return T, T
-        #verbose("      now tt =%s, twopiy=%s, T=%s" % (tt,twopiy,T), level=4)
+        # verbose("      now tt =%s, twopiy=%s, T=%s" % (tt,twopiy,T), level=4)
 
         # the justification for these numbers is explained at the
         # very end of this file
@@ -1737,7 +1737,7 @@ cdef class ModularSymbolNumerical:
 
         tt -= log(A)/twopiy
         T = min(T, max(<int>(ceil(tt)), T0))
-        #verbose("    now tt =%s, twopiy=%s, T=%s" % (tt,twopiy,T), level=4)
+        # verbose("    now tt =%s, twopiy=%s, T=%s" % (tt,twopiy,T), level=4)
 
         bb = split_error_prec * eps
         bb /= T + bb
@@ -1747,7 +1747,7 @@ cdef class ModularSymbolNumerical:
         B = <int>(ceil(bb))
         B = max(B, 53)
         T = max(T, 100)
-        #verbose("       leaving _get_truncation_and_prec with T=%s,"
+        # verbose("       leaving _get_truncation_and_prec with T=%s,"
         #        " B=%s" % (T,B), level=5)
         return T, B
 
@@ -1815,7 +1815,7 @@ cdef class ModularSymbolNumerical:
             -2.265525136998248e-05,
             2.3248943281270047e-06]
         """
-        #verbose("       enter _kappa with m=%s, z=%s and eps=%s" % (m,z,eps),
+        # verbose("       enter _kappa with m=%s, z=%s and eps=%s" % (m,z,eps),
         #        level=5)
         cdef:
             int T, prec, j
@@ -1852,7 +1852,7 @@ cdef class ModularSymbolNumerical:
             raise ValueError("Too many terms > 2^31 would have to be"
                              + "summed up. Giving up.")
         T += m
-        #verbose("   precision in _kappa set to %s,"
+        # verbose("   precision in _kappa set to %s,"
         #        " summing over %s terms" % (prec,T), level=3)
 
         if prec > 53:
@@ -1870,7 +1870,7 @@ cdef class ModularSymbolNumerical:
             _ = self._partial_real_sums_double(y, m, T, ra)
             res = [ra[j] for j in range(m)]
             sig_free(ra)
-        #verbose("       leaving _kappa with"
+        # verbose("       leaving _kappa with"
         #        " [%s, %s, ... %s]" % (res[0], res[1], res[m-1]), level=5)
         return res
 
@@ -1913,7 +1913,7 @@ cdef class ModularSymbolNumerical:
             sage: m = ModularSymbolNumerical(E)
             sage: m._from_ioo_to_r_approx(-1/7,0.01, use_partials=1)  # abs tol 1e-11
             6.22747859174503 - 1.48055642530800*I
-            sage: m._from_ioo_to_r_approx(-1/7,0.01, use_partials=0) #abs tol 1e-11
+            sage: m._from_ioo_to_r_approx(-1/7,0.01, use_partials=0) # abs tol 1e-11
             6.22747410432385 - 1.48055182979493*I
 
         This uses 65 bits of precision::
@@ -1921,7 +1921,7 @@ cdef class ModularSymbolNumerical:
             sage: m._from_ioo_to_r_approx(-1/7,0.0000000001) # abs tol 1e-11
             6.227531974630294568 - 1.480548268241443085*I
         """
-        #verbose("       enter _from_ioo_to_r_approx with r=%s"
+        # verbose("       enter _from_ioo_to_r_approx with r=%s"
         #        " and eps=%s" % (r,eps), level=5)
         cdef:
             llong m, Q, epsQ, a, u
@@ -1975,7 +1975,7 @@ cdef class ModularSymbolNumerical:
             taui = sqrt(taui)
             taui = 1/taui/m
             tauc = complex(r, taui)
-            #verbose("act on %s by [[%s,%s],[%s,%s]]" % (tauc, wQ[0],
+            # verbose("act on %s by [[%s,%s],[%s,%s]]" % (tauc, wQ[0],
             # wQ[1], wQ[2], wQ[3]), level =4)
             tauphc = (tauc * wQ[0] + wQ[1])/(wQ[2]*tauc + wQ[3])
             verbose("  computing integral from i*oo to %s using %s terms "
@@ -2053,7 +2053,7 @@ cdef class ModularSymbolNumerical:
             int oi, j
             double x1d, x2d, sd
 
-        #verbose("       enter _from_r_to_rr_approx_direct with r=%s,"
+        # verbose("       enter _from_r_to_rr_approx_direct with r=%s,"
         #        " rr=%s,..." % (r,rr), level=5)
         rc = _CuspsForModularSymbolNumerical(r, self._N_E)
         m = rc._m
@@ -2065,7 +2065,7 @@ cdef class ModularSymbolNumerical:
         QQ = rrc._width
         oi = llxgcd(Q*a, m, &u, &v)
         oi = llxgcd(QQ*aa, mm, &uu, &vv)
-        #verbose("  The inverses are (u,v)=(%s,%s) and
+        # verbose("  The inverses are (u,v)=(%s,%s) and
         # (uu,vv)=%s,%s" % (u,v,uu,vv), level=3)
 
         if use_partials == 2:
@@ -2091,7 +2091,7 @@ cdef class ModularSymbolNumerical:
             s = 1/s
             tau0 = CC(x1, s)
             tau1 = CC(x2, s)
-            #verbose("  two points are %s and %s" % (tau0, tau1), level=3)
+            # verbose("  two points are %s and %s" % (tau0, tau1), level=3)
             verbose("   computing integral from %s to tau by computing "
                     "the integral from i*oo to %s" % (r, tau0), level=3)
             int1 = self._integration_to_tau(tau0, T, prec)
@@ -2185,9 +2185,9 @@ cdef class ModularSymbolNumerical:
             sage: M = ModularSymbolNumerical(EllipticCurve("11a1"))
             sage: M._from_r_to_rr_approx(0/1,2/5,0.01) # abs tol 1e-11
             1.90381395641933 - 1.45881661693850*I
-            sage: M._from_r_to_rr_approx(0/1,2/5,0.001, "both", use_partials=0) #abs tol 1e-11
+            sage: M._from_r_to_rr_approx(0/1,2/5,0.001, "both", use_partials=0) # abs tol 1e-11
             1.90381395641931 - 1.45881661693851*I
-            sage: M._from_r_to_rr_approx(0/1,2/5,0.001, "both", use_partials=1) #abs tol 1e-11
+            sage: M._from_r_to_rr_approx(0/1,2/5,0.001, "both", use_partials=1) # abs tol 1e-11
             1.90381395641933 - 1.45881661693850*I
 
             sage: M._from_r_to_rr_approx(1/11,1/7,0.001) # abs tol 1e-11
@@ -2198,18 +2198,18 @@ cdef class ModularSymbolNumerical:
             1.26920930437008 - 2.91763323391590*I
 
             sage: M = ModularSymbolNumerical(EllipticCurve("389a1"))
-            sage: M._from_r_to_rr_approx(0/1,1/5,0.0001, "both") #abs tol 1e-5
+            sage: M._from_r_to_rr_approx(0/1,1/5,0.0001, "both") # abs tol 1e-5
             -4.98042489791268 - 6.06124058444291e-8*I
-            sage: M._from_r_to_rr_approx(1/3,1/7,0.001, "both", use_partials=0) #abs tol 1e-5
+            sage: M._from_r_to_rr_approx(1/3,1/7,0.001, "both", use_partials=0) # abs tol 1e-5
             -2.49020330904154 + 5.91520739782657*I
-            sage: M._from_r_to_rr_approx(1/3,1/7,0.0001, "both", use_partials=0) #abs tol 1e-5
+            sage: M._from_r_to_rr_approx(1/3,1/7,0.0001, "both", use_partials=0) # abs tol 1e-5
             -2.49021239793944 + 5.91521298876557*I
-            sage: M._from_r_to_rr_approx(1/3,1/7,0.0001, "both") #abs tol 1e-5
+            sage: M._from_r_to_rr_approx(1/3,1/7,0.0001, "both") # abs tol 1e-5
             -2.49021247526015 + 5.91521314939661*I
 
 
             sage: M = ModularSymbolNumerical(EllipticCurve("5077a1"))
-            sage: M._from_r_to_rr_approx(0/1, -7/3179, 0.001) #abs tol 1e-5 #long time
+            sage: M._from_r_to_rr_approx(0/1, -7/3179, 0.001) # abs tol 1e-5 # long time
             -6.22753195853020 - 5.92219314384901*I
 
             sage: E = EllipticCurve([91,127])
@@ -2228,7 +2228,7 @@ cdef class ModularSymbolNumerical:
             ComplexNumber ans, ans2
             int  T=0, prec=0, T1=0, T2=0, oi
 
-        #verbose("       enter _from_r_to_rr_approx with r=%s,"
+        # verbose("       enter _from_r_to_rr_approx with r=%s,"
         #        " rr=%s, " % (r,rr), level=5)
         rc = _CuspsForModularSymbolNumerical(r, self._N_E)
         m = rc._m
@@ -2258,10 +2258,10 @@ cdef class ModularSymbolNumerical:
             s = sqrt(s)
             s = s * llabs(a*mm-aa*m)
             s = 1/s
-            #verbose("    direct method goes to s=%s and eps=%s" % (s,eps),
+            # verbose("    direct method goes to s=%s and eps=%s" % (s,eps),
             #        level=3)
             T, prec = self._get_truncation_and_prec(s, eps/2)
-            #verbose("    giving T=%s and prec=%s" % (T,prec), level=3)
+            # verbose("    giving T=%s and prec=%s" % (T,prec), level=3)
             if T == -1:
                 if method == "direct" or method == "both":
                     raise ValueError("Too many terms > 2^31 would have to"
@@ -2376,16 +2376,16 @@ cdef class ModularSymbolNumerical:
         This goes via i `\infty`::
 
             sage: M = ModularSymbolNumerical(EllipticCurve("5077a1"))
-            sage: M._transportable_approx(0/1, -35/144, 0.001) #abs tol 1e-11
+            sage: M._transportable_approx(0/1, -35/144, 0.001) # abs tol 1e-11
             -6.22753189644996 + 3.23405342839145e-7*I
             sage: M._from_r_to_rr_approx(0/1, -35/144, 0.001) # abs tol 1e-10
             -6.22753204310913 - 1.31710951034592e-8*I
 
         While this one goes via 0::
 
-            sage: M._transportable_approx(0/1, -7/31798, 0.001) #abs tol 1e-11
+            sage: M._transportable_approx(0/1, -7/31798, 0.001) # abs tol 1e-11
             -7.01577418382726e-9 - 7.40274138232394*I
-            sage: M._from_r_to_rr_approx(0/1, -7/31798, 0.001) #abs tol 1e-5 #long time
+            sage: M._from_r_to_rr_approx(0/1, -7/31798, 0.001) # abs tol 1e-5 # long time
             -7.02253033502132e-9 - 7.40274138234031*I
         """
         cdef:
@@ -2395,7 +2395,7 @@ cdef class ModularSymbolNumerical:
             ComplexNumber tau1, tau2, int1, int2
             complex tau1c, tau2c, int1c, int2c
 
-        #verbose("       enter transportable_symbol_approx with r=%s,"
+        # verbose("       enter transportable_symbol_approx with r=%s,"
         #        " rr=%s" % (r,rr), level=5)
 
         #this finds a gamma with smallest |c|
@@ -2508,7 +2508,7 @@ cdef class ModularSymbolNumerical:
             sage: M._value_ioo_to_r(-9/55,-1)
             -2
         """
-        #verbose("       enter _value_ioo_to_r with r=%s, sign=%s" % (r,sign),
+        # verbose("       enter _value_ioo_to_r with r=%s, sign=%s" % (r,sign),
         #        level=5)
         cdef:
             double eps
@@ -2578,7 +2578,7 @@ cdef class ModularSymbolNumerical:
             sage: M._value_r_to_rr(7/11,14/75) # long time
             -1
         """
-        #verbose("       enter _value_r_to_rr with r=%s, rr=%s,"
+        # verbose("       enter _value_r_to_rr with r=%s, rr=%s,"
         #        " sign=%s" % (r,rr,sign), level=5)
         cdef:
             double eps
@@ -2640,7 +2640,7 @@ cdef class ModularSymbolNumerical:
             sage: M.transportable_symbol(0/1, -7/31798, -1)
             -5
         """
-        #verbose("       enter transportable_symbol with r=%s, rr=%s,"
+        # verbose("       enter transportable_symbol with r=%s, rr=%s,"
         #        " sign=%s" % (r,rr,sign), level=5)
         cdef:
             double eps
@@ -2694,7 +2694,7 @@ cdef class ModularSymbolNumerical:
             sage: M._symbol_non_unitary(1/19)
             5/19
         """
-        #verbose("       enter _symbol_non_unitary with r=%s,"
+        # verbose("       enter _symbol_non_unitary with r=%s,"
         #        " sign=%s" % (r,sign), level=5)
         cdef:
             llong m, B, N_ell, aell, u, N = self._N_E
@@ -2779,7 +2779,7 @@ cdef class ModularSymbolNumerical:
             llong c, d, x, y, N = self._N_E, Mu, Mv, Qu, Qv, du=1, dv=1
             Rational r, rr, res
 
-        #verbose("       enter _manin_symbol_with_cache with u=%s, v=%s,"
+        # verbose("       enter _manin_symbol_with_cache with u=%s, v=%s,"
         #        " sign =%s" % (u,v,sign), level=5)
 
         if u == 0:
@@ -2822,7 +2822,7 @@ cdef class ModularSymbolNumerical:
                         c += N/Mv
                     c = c % N
                     # now (u:v) = (c:d) with d as small as possible.
-            #verbose("   better representant on P^1: "
+            # verbose("   better representant on P^1: "
             #        "(%s : %s)" % (c, d), level=3)
             # _, x, y = c.xgcd(d)
             _ = llxgcd(c, d, &x, &y)
@@ -2892,7 +2892,7 @@ cdef class ModularSymbolNumerical:
             sage: M.manin_symbol(-1,12)
             -1/2
         """
-        #verbose("       enter manin_symbol with u=%s, v=%s,"
+        # verbose("       enter manin_symbol with u=%s, v=%s,"
         #        " sign =%s" % (u,v,sign), level=5)
         cdef:
             llong un, vn
@@ -2903,20 +2903,20 @@ cdef class ModularSymbolNumerical:
             sign = self._global_sign
 
         oi = proj_normalise(self._N_E, u, v, &un, &vn)
-        #verbose("   normalized representant on P^1: "
+        # verbose("   normalized representant on P^1: "
         #        "(%s :%s)" % (un, vn), level=3)
 
         # is it already in the cache ?
         c = self._cached_methods
         if "_manin_symbol_with_cache" in c:
             c = c["_manin_symbol_with_cache"]
-            if c.is_in_cache(un,vn,sign):
-                res = self._manin_symbol_with_cache(un,vn,sign)
+            if c.is_in_cache(un, vn, sign):
+                res = self._manin_symbol_with_cache(un, vn, sign)
                 return res
 
         # the actual work in now done in a helper function
         # which does the correct caching
-        res = self._manin_symbol_with_cache(un,vn,sign)
+        res = self._manin_symbol_with_cache(un, vn, sign)
 
         # using the Manin relations coming from
         # complex conjugation, the matrices S and T in SL_2
@@ -2940,8 +2940,8 @@ cdef class ModularSymbolNumerical:
         # (u:v) + (u+v:-u) +(v,-u-v) = 0
         # is (u+v:-u) already computed, we set the third
         oi = proj_normalise(self._N_E, u+v, -u, &un, &vn)
-        if c.is_in_cache(un,vn,sign):
-            r2 = - res - c(un,vn,sign)
+        if c.is_in_cache(un, vn, sign):
+            r2 = - res - c(un, vn, sign)
 
             # (v:-u-v) = r2
             oi = proj_normalise(self._N_E, v, -u-v, &un, &vn)
@@ -2961,8 +2961,8 @@ cdef class ModularSymbolNumerical:
 
         # is (v,-u-v) already computed, we set (u+v:-u)
         oi = proj_normalise(self._N_E, v, -u-v, &un, &vn)
-        if c.is_in_cache(un,vn,sign):
-            r2 = - res - c(un,vn,sign)
+        if c.is_in_cache(un, vn, sign):
+            r2 = - res - c(un, vn, sign)
 
             # (u+v:-u) = r2
             oi = proj_normalise(self._N_E, u+v, -u, &un, &vn)
@@ -3045,7 +3045,7 @@ cdef class ModularSymbolNumerical:
             sage: M._evaluate(1/123456789012345678901234567)
             -1
         """
-        #verbose("       enter _evaluate with r=%s, sign=%s" % (r,sign),
+        # verbose("       enter _evaluate with r=%s, sign=%s" % (r,sign),
         #         level=5)
         cdef:
             llong N = self._N_E, u, v
@@ -3069,7 +3069,7 @@ cdef class ModularSymbolNumerical:
 
         B = m.gcd(N)
         Q = N // B
-        #verbose("     cusp is %s/%s of width %s" % (a,m,Q), level=4)
+        # verbose("     cusp is %s/%s of width %s" % (a,m,Q), level=4)
 
         if r == 0:
             return self._value_ioo_to_r(r, sign=sign)
@@ -3088,7 +3088,7 @@ cdef class ModularSymbolNumerical:
             if 2*y > m:
                 y -= m
             x = (1-y*a) // m
-            #verbose("     smallest xgcd is "
+            # verbose("     smallest xgcd is "
             #        + " %s = %s * %s + %s * %s" % (a.gcd(m),a,y,x,m),
             #        level=4)
             # make the cusp -x/y unitary if possible.
@@ -3169,7 +3169,7 @@ cdef class ModularSymbolNumerical:
             RealNumber val
             dict res
 
-        #verbose("       enter all_symbol with m=%s" % m, level=5)
+        # verbose("       enter all_symbol with m=%s" % m, level=5)
 
         if sign == 0:
             sign = self._global_sign
@@ -3180,7 +3180,7 @@ cdef class ModularSymbolNumerical:
         if llgcd(m,Q) > 1:
             raise NotImplementedError("Only implemented for cusps that are "
                                       "in the Atkin-Lehner orbit of oo")
-        #verbose("   compute all partial sums with denominator m=%s" % m,
+        # verbose("   compute all partial sums with denominator m=%s" % m,
         #        level=3)
         z = Q*m*m
         v = self._kappa(m, z)
@@ -3249,7 +3249,7 @@ cdef class ModularSymbolNumerical:
         """
         cdef Integer D, Da, a
         cdef Rational res, t
-        #verbose("       enter _twisted symbol with ra=%s,
+        # verbose("       enter _twisted symbol with ra=%s,
         #        sign=%s" % (ra,sign),
         #        level=5)
         if sign == 0:
@@ -3310,10 +3310,10 @@ cdef class ModularSymbolNumerical:
 
             sage: E = EllipticCurve("20a1")
             sage: m = E.modular_symbol_numerical()
-            sage: m(1/2)          #abs tol 1e-4
+            sage: m(1/2)          # abs tol 1e-4
             -0.166666666666667
         """
-        #verbose("       enter _evaluate_approx with r=%s, eps=%s" % (r,eps),
+        # verbose("       enter _evaluate_approx with r=%s, eps=%s" % (r,eps),
         #        level=5)
         cdef:
             llong N = self._N_E
@@ -3347,7 +3347,7 @@ cdef class ModularSymbolNumerical:
         if 2*y > m:
             y -= m
         x = (1-y*a) // m
-        #verbose("     smallest xgcd is "
+        # verbose("     smallest xgcd is "
         #        + " %s = %s * %s + %s * %s" % (a.gcd(m),a,y,x,m),
         #        level=4)
         # make the cusp -x/y unitary if possible.
@@ -3409,7 +3409,7 @@ cdef class ModularSymbolNumerical:
             sage: M._symbol_non_unitary_approx(5/38,0.1)  # abs tol 1e-11
             0.725215164486092 - 1.19349741385624*I
          """
-        #verbose("       enter _symbol_nonunitary_approx with r=%s,"
+        # verbose("       enter _symbol_nonunitary_approx with r=%s,"
         #        " eps=%s" % (r,eps), level=5)
         cdef:
             llong m, B, N_ell, aell, u, N = self._N_E
@@ -3480,7 +3480,7 @@ cdef class ModularSymbolNumerical:
         """
         cdef Integer D, Da, a, s, precd
         cdef RealNumber res, t
-        #verbose("       enter _twisted approx with ra=%s,
+        # verbose("       enter _twisted approx with ra=%s,
         #        eps=%s" % (ra,eps),
         #        level=5)
 

--- a/src/sage/schemes/elliptic_curves/period_lattice_region.pyx
+++ b/src/sage/schemes/elliptic_curves/period_lattice_region.pyx
@@ -275,17 +275,17 @@ cdef class PeriodicRegion:
         new_data = np.zeros((m+2, n+2), self.data.dtype)
         for i in range(m):
             for j in range(n):
-                if framed[i,j]:
-                    new_data[i  , j  ] = True
-                    new_data[i-1, j  ] = True
-                    new_data[i+1, j  ] = True
-                    new_data[i  , j-1] = True
-                    new_data[i  , j+1] = True
+                if framed[i, j]:
+                    new_data[i, j] = True
+                    new_data[i - 1, j] = True
+                    new_data[i + 1, j] = True
+                    new_data[i, j - 1] = True
+                    new_data[i, j + 1] = True
                     if corners:
-                        new_data[i-1, j-1] = True
-                        new_data[i+1, j-1] = True
-                        new_data[i+1, j+1] = True
-                        new_data[i-1, j+1] = True
+                        new_data[i - 1, j - 1] = True
+                        new_data[i + 1, j - 1] = True
+                        new_data[i + 1, j + 1] = True
+                        new_data[i - 1, j + 1] = True
         return PeriodicRegion(self.w1, self.w2, unframe_data(new_data, self.full), self.full)
 
     def contract(self, corners=True):
@@ -661,7 +661,7 @@ cdef class PeriodicRegion:
             kwds['rgbcolor'] = 'red'
         for i, j, dir in self.border():
             ii, jj = i+dir, j+(1-dir)
-            L.append(line([tuple(i*dw1 + j*dw2), tuple(ii*dw1 + jj*dw2 )], **kwds))
+            L.append(line([tuple(i*dw1 + j*dw2), tuple(ii*dw1 + jj*dw2)], **kwds))
         return sum(L, F)
 
 
@@ -691,7 +691,7 @@ cdef frame_data(data, bint full=True):
         framed[:-2,-1] = data[::-1, 0]
         framed[:-2,-2] = data[::-1,-1]
     # left and right
-    framed[-2,:] = framed[ 0,:]
+    framed[-2,:] = framed[0,:]
     framed[-1,:] = framed[-3,:]
     return framed
 
@@ -701,7 +701,7 @@ cdef unframe_data(framed, bint full=True):
     borders together using the "or" operator.
     """
     framed = framed.copy()
-    framed[ 0,:] |= framed[-2,:]
+    framed[0,:] |= framed[-2,:]
     framed[-3,:] |= framed[-1,:]
     if full:
         framed[:-2,-3] |= framed[:-2,-1]

--- a/src/sage/schemes/hyperelliptic_curves/hypellfrob.pyx
+++ b/src/sage/schemes/hyperelliptic_curves/hypellfrob.pyx
@@ -124,7 +124,7 @@ def interval_products(M0, M1, target):
     cdef vector[ZZ_c] targ
     cdef ntl_ZZ_pContext_class c = \
         (<ntl_ZZ_pContext_factory>ZZ_pContext_factory).make_c(
-        ntl_ZZ(M0.base_ring().characteristic()))
+            ntl_ZZ(M0.base_ring().characteristic()))
     cdef long dim = M0.nrows()
     sig_on()
     c.restore_c()


### PR DESCRIPTION
fixing a few more cython-lint suggestions in schemes

```cython-lint --ignore=E501,E231,E265 src/sage/schemes/```

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.