### PR TITLE
Fix broken docker/Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -230,7 +230,8 @@ FROM run-time-dependencies as sagemath
 ARG HOME=/home/sage
 ARG SAGE_ROOT=/home/sage/sage
 COPY --chown=sage:sage --from=make-release $SAGE_ROOT/ $SAGE_ROOT/
-# set path to start gap, gp, maxima, ... bashrc
+# set path in bashrc to start gap, gp, maxima, ... this does not
+# affect Sage (see https://github.com/sagemath/sage/pull/38049)
 RUN echo "export PATH=$SAGE_ROOT/local/bin:$PATH" >> ~/.bashrc
 
 COPY ./docker/entrypoint.sh /usr/local/bin/sage-entrypoint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -230,8 +230,9 @@ FROM run-time-dependencies as sagemath
 ARG HOME=/home/sage
 ARG SAGE_ROOT=/home/sage/sage
 COPY --chown=sage:sage --from=make-release $SAGE_ROOT/ $SAGE_ROOT/
-# Put scripts to start gap, gp, maxima, ... in /usr/bin
-RUN sudo $SAGE_ROOT/sage --nodotsage -c "install_scripts('/usr/bin')"
+# set path to start gap, gp, maxima, ... bashrc
+RUN echo "export PATH=$SAGE_ROOT/local/bin:$PATH" >> ~/.bashrc
+
 COPY ./docker/entrypoint.sh /usr/local/bin/sage-entrypoint
 WORKDIR $HOME
 ENTRYPOINT ["/usr/local/bin/sage-entrypoint"]


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

As mentioned in https://github.com/sagemath/sage/pull/37856#issuecomment-2108157341 the `Dockerfile`  is broken by https://github.com/sagemath/sage/pull/37856. This will be fixed in this PR.

More precisely we replace `install_scripts` by appending `$SAGE_ROOT/local/bin` to the `bash` path variable. This does not affect Sage but ensures easy access to `gap`,  `maxima`, ... in a `bash` session (see https://github.com/sagemath/sage/pull/37856#issuecomment-2123031214 ff).


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


