### PR TITLE
Steinhaus-Johnson-Trotter algorithm for permutations

### DIFF
--- a/src/sage/combinat/SJT.py
+++ b/src/sage/combinat/SJT.py
@@ -1,0 +1,137 @@
+r"""
+Steinhaus-Johnson-Trotter algorithm.
+
+The Steinhaus-Johnson-Trotter algorithm generates permutations in a specific
+order by transposing only two elements from the list at each operation. The
+algorithm stores an internal state for every element in the permutated list
+which corresponds to their direction. To know which elements to move, the
+internal state table is accessed and the transposition of two elements is then
+done.
+
+It is important to notice that the permutations are generated in a different
+order than the default lexicographic algorithm.
+
+The class defined here is meant to be used in the ``Permutation`` class when
+called with the parameter ``algorithm='sjt'``.
+
+AUTHORS:
+
+- Martin Grenouilloux (2024-05-22): initial version
+"""
+
+# ****************************************************************************
+#       Copyright (C) 2024 Martin Grenouilloux <martin.grenouilloux@uib.no>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************s
+class SJT:
+    def __init__(self, l, directions=None) -> None:
+        r"""
+        Transpose two elements at positions ``a`` and ``b`` in ``perm`` and
+        their corresponding directions as well following the
+        Steinhaus-Johnson-Trotter algorithm.
+
+        INPUT:
+
+        - ``l`` -- list: a list of ``int`` variables.
+
+        - ``directions`` -- list: a list of directions for each element in the
+          permuted list. There are three possible values:
+            - negative -> element tranposes to the left
+            - positive -> element transposes to the right
+            - null     -> element does not move
+          Used when constructing permutations from a pre-defined intern state.
+        """
+        # The permuted list.
+        self.__perm = l
+
+        # The length of the permuted list.
+        self.__n = len(l)
+
+        if directions is None:
+            if not all(l[i] <= l[i+1] for i in range(len(l) - 1)):
+                raise ValueError("No internal state directions were given for "
+                "non-identity starting permutation for "
+                "Steinhaus-Johnson-Trotter algorithm. Expected identity "
+                "permutation.")
+            self.__directions = [-1] * self.__n
+
+            # The first element has null direction.
+            self.__directions[0] = 0
+        else:
+            self.__directions = directions
+
+    def __idx_largest_element_non_zero_direction(self, perm, directions):
+        r"""
+        Find the largest element in ``perm`` with a non null direction.
+        """
+        largest = 0
+        index = None
+        for i in range(self.__n):
+            if directions[i] != 0:
+                e = perm[i]
+                if e > largest:
+                    index = i
+                    largest = e
+
+        return index
+
+    def next(self):
+        r"""
+        Produce the next permutation following the Steinhaus-Johnson-Trotter
+        algorithm.
+
+        OUTPUT: the list of the next permutation.
+        """
+        # Copying lists of permutation and directions to avoid changing internal
+        # state of the algorithm if ``next()`` is called without reassigning.
+        perm = self.__perm[:]
+        directions = self.__directions[:]
+
+        # Assume that the element to move is n (which will be in most cases).
+        selected_elt = self.__n
+        xi = perm.index(selected_elt)
+        direction = directions[xi]
+
+        # If this element has null direction, find the largest whose is
+        # non-null.
+        if direction == 0:
+            xi = self.__idx_largest_element_non_zero_direction(perm, directions)
+            if xi is None:
+                # We have created every permutation. Detected when all elements
+                # have null direction.
+                return False, None
+            direction = directions[xi]
+            selected_elt = perm[xi]
+
+        new_pos = xi + direction
+
+        # Proceed to transpose elements and corresponding directions.
+        perm[xi], perm[new_pos] = perm[new_pos], perm[xi]
+        directions[xi], directions[new_pos] = \
+            directions[new_pos], directions[xi]
+
+        # If the transposition results in the largest element being on one edge
+        # or if the following element in its direction is greater than it, then
+        # then set its direction to 0
+        if new_pos == 0 or new_pos == self.__n - 1 or \
+            perm[new_pos + direction] > selected_elt:
+            directions[new_pos] = 0
+
+        # After each permutation, update each element's direction. If one
+        # element is greater than selected element, change its direction towards
+        # the selected element. This loops has no reason to be if selected
+        # element is n and this will be the case most of the time.
+        if selected_elt != self.__n:
+            for i in range(self.__n):
+                if perm[i] > selected_elt:
+                    if i < new_pos:
+                        directions[i] = 1
+                    if i > new_pos:
+                        directions[i] = -1
+
+        return perm, directions

--- a/src/sage/combinat/SJT.py
+++ b/src/sage/combinat/SJT.py
@@ -63,9 +63,9 @@ class SJT(CombinatorialElement):
         sage: from sage.combinat.SJT import SJT
         sage: s = SJT([1, 2, 3, 4]); s
         [1, 2, 3, 4]
-        sage: s, d = s.next(); s, d
-        ([1, 2, 4, 3], [0, -1, -1, -1])
-        sage: p = Permutation(s, algorithm='sjt', directions=d)
+        sage: s = s.next(); s
+        [1, 2, 4, 3]
+        sage: p = Permutation(s._get_perm(), algorithm='sjt', sjt=s)
         sage: p
         [1, 2, 4, 3]
         sage: p.next()
@@ -77,11 +77,11 @@ class SJT(CombinatorialElement):
         [1, 2, 3, 4]
         sage: s = SJT([1]); s
         [1]
-        sage: s, _ = s.next(); s
+        sage: s = s.next(); s
         False
         sage: s = SJT([]); s
         []
-        sage: s, _ = s.next(); s
+        sage: s = s.next(); s
         False
     """
     def __init__(self, l, directions=None) -> None:
@@ -106,9 +106,9 @@ class SJT(CombinatorialElement):
             sage: from sage.combinat.SJT import SJT
             sage: s = SJT([1, 2, 3, 4]); s
             [1, 2, 3, 4]
-            sage: s, d = s.next(); s, d
-            ([1, 2, 4, 3], [0, -1, -1, -1])
-            sage: p = Permutation(s, algorithm='sjt', directions=d)
+            sage: s = s.next(); s
+            [1, 2, 4, 3]
+            sage: p = Permutation(s._get_perm(), algorithm='sjt', sjt=s)
             sage: p
             [1, 2, 4, 3]
             sage: p.next()
@@ -124,7 +124,7 @@ class SJT(CombinatorialElement):
             starting permutation for Steinhaus-Johnson-Trotter algorithm
             sage: s = SJT([]); s
             []
-            sage: s, _ = s.next(); s
+            sage: s = s.next(); s
             False
         """
         # The permuted list.
@@ -162,6 +162,12 @@ class SJT(CombinatorialElement):
 
         return index
 
+    def _get_perm(self):
+        r"""
+        Return the current permutation of ``self``.
+        """
+        return self._list
+
     def next(self):
         r"""
         Produce the next permutation of ``self`` following the
@@ -177,9 +183,9 @@ class SJT(CombinatorialElement):
 
             sage: from sage.combinat.SJT import SJT
             sage: s = SJT([1, 2, 3, 4])
-            sage: s, d = s.next()
-            sage: s = SJT(s, directions=d)
-            sage: s, _ = s.next(); s
+            sage: s = s.next(); s
+            [1, 2, 4, 3]
+            sage: s = s.next(); s
             [1, 4, 2, 3]
 
         TESTS::
@@ -187,15 +193,15 @@ class SJT(CombinatorialElement):
             sage: from sage.combinat.SJT import SJT
             sage: s = SJT([1, 2, 3])
             sage: s.next()
-            ([1, 3, 2], [0, -1, -1])
+            [1, 3, 2]
 
             sage: s = SJT([1])
             sage: s.next()
-            (False, None)
+            False
         """
         # Return on empty list.
         if self._n == 0:
-            return False, None
+            return False
 
         # Copying lists of permutation and directions to avoid changing internal
         # state of the algorithm if ``next()`` is called without reassigning.
@@ -214,7 +220,7 @@ class SJT(CombinatorialElement):
             if xi is None:
                 # We have created every permutation. Detected when all elements
                 # have null direction.
-                return False, None
+                return False
             direction = directions[xi]
             selected_elt = perm[xi]
 
@@ -244,6 +250,6 @@ class SJT(CombinatorialElement):
                     if i > new_pos:
                         directions[i] = -1
 
-        return perm, directions
+        return SJT(perm, directions)
 
     __next__ = next

--- a/src/sage/combinat/SJT.py
+++ b/src/sage/combinat/SJT.py
@@ -27,7 +27,7 @@ AUTHORS:
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
-# ****************************************************************************s
+# ****************************************************************************
 class SJT:
     def __init__(self, l, directions=None) -> None:
         r"""

--- a/src/sage/combinat/SJT.py
+++ b/src/sage/combinat/SJT.py
@@ -65,13 +65,14 @@ class SJT(CombinatorialElement):
         [1, 2, 3, 4]
         sage: s = s.next(); s
         [1, 2, 4, 3]
-        sage: p = Permutation(s._get_perm(), algorithm='sjt', sjt=s)
+        sage: p = Permutation(s._list, algorithm='sjt', sjt=s)
         sage: p
         [1, 2, 4, 3]
         sage: p.next()
         [1, 4, 2, 3]
 
     TESTS::
+
         sage: from sage.combinat.SJT import SJT
         sage: s = SJT([1, 2, 3, 4]); s
         [1, 2, 3, 4]
@@ -97,7 +98,7 @@ class SJT(CombinatorialElement):
 
         - ``l`` -- list; a list of ordered ``int``.
 
-        - ``directions`` -- list (default: ``None`` ); a list of directions for
+        - ``directions`` -- list (default: ``None``); a list of directions for
           each element in the permuted list. Used when constructing permutations
           from a pre-defined internal state.
 
@@ -108,7 +109,7 @@ class SJT(CombinatorialElement):
             [1, 2, 3, 4]
             sage: s = s.next(); s
             [1, 2, 4, 3]
-            sage: p = Permutation(s._get_perm(), algorithm='sjt', sjt=s)
+            sage: p = Permutation(s._list, algorithm='sjt', sjt=s)
             sage: p
             [1, 2, 4, 3]
             sage: p.next()
@@ -162,22 +163,12 @@ class SJT(CombinatorialElement):
 
         return index
 
-    def _get_perm(self):
-        r"""
-        Return the current permutation of ``self``.
-        """
-        return self._list
-
     def next(self):
         r"""
         Produce the next permutation of ``self`` following the
         Steinhaus-Johnson-Trotter algorithm.
 
-        OUTPUT: a tuple of
-
-        - the list of the next permutation
-
-        - the list of associated directions
+        OUTPUT: the list of the next permutation
 
         EXAMPLES::
 

--- a/src/sage/combinat/SJT.py
+++ b/src/sage/combinat/SJT.py
@@ -37,14 +37,18 @@ class SJT:
 
         INPUT:
 
-        - ``l`` -- list: a list of ``int`` variables.
+        - ``l`` -- list: a list of ordered ``int``.
 
-        - ``directions`` -- list: a list of directions for each element in the
-          permuted list. There are three possible values:
-            - negative -> element tranposes to the left
-            - positive -> element transposes to the right
-            - null     -> element does not move
-          Used when constructing permutations from a pre-defined intern state.
+        - ``directions`` -- list (default: ``None`` ): a list of directions for
+          each element in the permuted list. Used when constructing permutations
+          from a pre-defined internal state. There are three possible values:
+
+          - ``-1`` -> element tranposes to the left
+
+          - ``1``  -> element transposes to the right
+
+          - ``0``  -> element does not move
+
         """
         # The permuted list.
         self.__perm = l

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -597,7 +597,6 @@ class Permutation(CombinatorialElement):
             raise ValueError("unsupported algorithm %s; expected 'lex' or 'sjt'"
                              % self._algorithm)
 
-
         if check and len(l) > 0:
             # Make a copy to sort later
             lst = list(l)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -404,7 +404,6 @@ class Permutation(CombinatorialElement):
         sage: p = Permutation([1, 2, 3], algorithm='sjt')
         sage: for _ in range(6):
         ....:     p = p.next()
-        ....:
         sage: p
         False
 
@@ -477,8 +476,7 @@ class Permutation(CombinatorialElement):
     """
     @staticmethod
     @rename_keyword(deprecation=35233, check_input='check')
-    def __classcall_private__(cls, l, algorithm='lex', sjt=None,
-                              check=True):
+    def __classcall_private__(cls, l, algorithm='lex', sjt=None, check=True):
         """
         Return a permutation in the general permutations parent.
 
@@ -867,7 +865,6 @@ class Permutation(CombinatorialElement):
             sage: for _ in range(factorial(len(l))):
             ....:     s.add(p)
             ....:     p = p.next()
-            ....:
             sage: p
             False
             sage: assert(len(s)) == factorial(len(l))
@@ -878,7 +875,7 @@ class Permutation(CombinatorialElement):
             sjt = self._sjt.next()
             if sjt is False:
                 return False
-            return Permutations()(sjt._get_perm(), algorithm='sjt', sjt=sjt)
+            return Permutations()(sjt._list, algorithm='sjt', sjt=sjt)
 
         p = self[:]
         n = len(self)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -396,11 +396,15 @@ class Permutation(CombinatorialElement):
         False
 
         sage: Permutation([1, 2, 3, 4], algorithm='blah')
-        ValueError: Unsupported algorithm 'blah'; expected 'lex' or 'sjt'
+        Traceback (most recent call last):
+        ...
+        ValueError: Unsupported algorithm blah; expected 'lex' or 'sjt'
 
         sage: Permutation([1, 3, 2, 4], algorithm='sjt')
-        ValueError: No internal state directions were given for non-identity \
-        starting permutation for Steinhaus-Johnson-Trotter algorithm. Expected \
+        Traceback (most recent call last):
+        ...
+        ValueError: No internal state directions were given for non-identity
+        starting permutation for Steinhaus-Johnson-Trotter algorithm. Expected
         identity permutation.
 
     Construction from a string in cycle notation::

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -565,6 +565,8 @@ class Permutation(CombinatorialElement):
             is something wrong with its length.
         """
         l = list(l)
+        # Default initialisation to ``None`` to declare the variable.
+        self.__sjt = None
 
         if check and len(l) > 0:
             # Make a copy to sort later
@@ -602,7 +604,8 @@ class Permutation(CombinatorialElement):
                 raise ValueError("unsupported algorithm %s; expected 'lex' or"
                 "'sjt'." % algorithm)
 
-            self.__sjt = SJT(l, directions=directions) if algorithm == "sjt" else None
+            if algorithm == "sjt":
+                self.__sjt = SJT(l, directions=directions)
 
         CombinatorialElement.__init__(self, parent, l)
 
@@ -793,7 +796,10 @@ class Permutation(CombinatorialElement):
         r"""
         Return the permutation that follows ``self`` in lexicographic order on
         the symmetric group containing ``self``. If ``self`` is the last
-        permutation, then ``next`` returns ``False``.
+        permutation, then ``next`` returns ``False``. If the algorithm parameter
+        is specified, the permutations will be generated according to it.
+        Allowed algorithms: lexicographic or "lex" and Steinhaus-Johnson-Trotter
+        or "sjt".
 
         EXAMPLES::
 
@@ -872,13 +878,20 @@ class Permutation(CombinatorialElement):
             sage: p.prev()
             False
 
+            sage: p = Permutation([1,2,3], algorithm='sjt')
+            sage: p.prev()
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: Previous permutation for SJT algorithm is not
+            yet implemented
+
         Check that :issue:`16913` is fixed::
 
             sage: Permutation([1,4,3,2]).prev()
             [1, 4, 2, 3]
         """
         if self.__sjt is not None:
-            raise NotImplementedError
+            raise NotImplementedError("Previous permutation for SJT algorithm is not yet implemented")
 
         p = self[:]
         n = len(self)

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -548,11 +548,11 @@ class Permutation(CombinatorialElement):
           generate the permutations. Supported algorithms are:
 
           - ``lex``: lexicographic order generation, this is the default
-          algorithm.
+            algorithm.
 
           - ``sjt``: Steinhaus-Johnson-Trotter algorithm to generate
-          permutations using only transposition of two elements in the list.
-          It is highly recommended to set ``check=True`` (default value).
+            permutations using only transposition of two elements in the list.
+            It is highly recommended to set ``check=True`` (default value).
 
         - ``sjt`` -- SJT (default: ``None``); the ``SJT`` object holding the
           permutation internal state. This should only be specified when

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -542,11 +542,11 @@ class Permutation(CombinatorialElement):
 
         - ``l`` -- a list of ``int`` variables
 
-        - ``check`` boolean (default: ``True``); -- whether to check that input
+        - ``check`` -- boolean (default: ``True``); whether to check that input
           is correct. Slows the function down, but ensures that nothing bad
           happens.
 
-        - ``algorithm`` string (default: ``lex``); -- the algorithm used to
+        - ``algorithm`` -- string (default: ``lex``); the algorithm used to
           generate the permutations. Supported algorithms are:
 
           - ``lex``: lexicographic order generation, this is the default

--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -309,11 +309,11 @@ class Permutation(CombinatorialElement):
         the permutation obtained from the pair using the inverse of the
         Robinson-Schensted algorithm.
 
-    - ``check`` boolean (default: ``True``) -- whether to check that input is
-      correct. Slows the function down, but ensures that nothing bad happens. This
-      is set to ``True`` by default.
+    - ``check`` boolean (default: ``True``); -- whether to check that input is
+      correct. Slows the function down, but ensures that nothing bad happens.
+      This is set to ``True`` by default.
 
-    - ``algorithm`` string (default: ``lex``) -- the algorithm used to generate
+    - ``algorithm`` string (default: ``lex``); -- the algorithm used to generate
       the permutations. Supported algorithms are:
 
       - ``lex``: lexicographic order generation, this is the default algorithm.
@@ -322,10 +322,9 @@ class Permutation(CombinatorialElement):
         using only transposition of two elements in the list. It is highly
         recommended to set ``check=True`` (default value).
 
-    - ``directions`` list (default: ``None``) -- the list of directions to be
+    - ``directions`` list (default: ``None``); -- the list of directions to be
       used with ``sjt`` algorithm when initializing the ``Permutation`` object
-      with non-identity permutation. Mainly used to handle internal states, best
-      to leave it by default.
+      with non-identity permutation.
 
     .. WARNING::
 
@@ -412,9 +411,8 @@ class Permutation(CombinatorialElement):
         sage: Permutation([1, 3, 2, 4], algorithm='sjt')
         Traceback (most recent call last):
         ...
-        ValueError: No internal state directions were given for non-identity
-        starting permutation for Steinhaus-Johnson-Trotter algorithm. Expected
-        identity permutation.
+        ValueError: no internal state directions were given for non-identity
+        starting permutation for Steinhaus-Johnson-Trotter algorithm
 
     Construction from a string in cycle notation::
 
@@ -468,7 +466,7 @@ class Permutation(CombinatorialElement):
         sage: Permutation([1, 2, 3, 4], algorithm='blah')
         Traceback (most recent call last):
         ...
-        ValueError: Unsupported algorithm blah; expected 'lex' or 'sjt'
+        ValueError: unsupported algorithm blah; expected 'lex' or 'sjt'
 
     From a pair of empty tableaux ::
 
@@ -479,7 +477,8 @@ class Permutation(CombinatorialElement):
     """
     @staticmethod
     @rename_keyword(deprecation=35233, check_input='check')
-    def __classcall_private__(cls, l, algorithm='lex', directions=None, check=True):
+    def __classcall_private__(cls, l, algorithm='lex', directions=None,
+                              check=True):
         """
         Return a permutation in the general permutations parent.
 
@@ -529,11 +528,8 @@ class Permutation(CombinatorialElement):
             else:
                 raise ValueError("cannot convert l (= %s) to a Permutation" % l)
 
-        if algorithm != "lex" and algorithm != "sjt":
-            raise ValueError("Unsupported algorithm %s; expected 'lex' or 'sjt'"
-            % algorithm)
         # otherwise, it gets processed by CombinatorialElement's __init__.
-        return Permutations()(l, algorithm=algorithm, directions=directions, check=check)
+        return Permutations()(l, algorithm, directions, check)
 
     @rename_keyword(deprecation=35233, check_input='check')
     def __init__(self, parent, l, algorithm='lex', directions=None, check=True):
@@ -546,20 +542,21 @@ class Permutation(CombinatorialElement):
 
         - ``l`` -- a list of ``int`` variables
 
-        - ``check`` boolean (default: ``True``) -- whether to check that input
+        - ``check`` boolean (default: ``True``); -- whether to check that input
           is correct. Slows the function down, but ensures that nothing bad
           happens.
 
-        - ``algorithm`` string (default: ``lex``) -- the algorithm used to
+        - ``algorithm`` string (default: ``lex``); -- the algorithm used to
           generate the permutations. Supported algorithms are:
 
           - ``lex``: lexicographic order generation, this is the default
           algorithm.
-          - ``sjt``: Steinhaus-Johnson-Trotter algorithm to generate
-          permutations using only transposition of two elements in the list. It
-          is highly recommended to set ``check=True`` (default value).
 
-        - ``directions`` list (default: ``None``) -- the list of directions to
+          - ``sjt``: Steinhaus-Johnson-Trotter algorithm to generate
+          permutations using only transposition of two elements in the list.
+          It is highly recommended to set ``check=True`` (default value).
+
+        - ``directions`` list (default: ``None``); -- the list of directions to
           be used with ``sjt`` algorithm when initializing the ``Permutation``
           object with non-identity permutation.
 
@@ -578,23 +575,21 @@ class Permutation(CombinatorialElement):
             sage: Permutation([1,2,4,5])
             Traceback (most recent call last):
             ...
-            ValueError: The permutation has length 4 but its maximal element is
+            ValueError: the permutation has length 4 but its maximal element is
             5. Some element may be repeated, or an element is missing, but there
             is something wrong with its length.
 
             sage: Permutation([1, 3, 2], algorithm='sjt')
             Traceback (most recent call last):
             ...
-            ValueError: No internal state directions were given for non-identity
-            starting permutation for Steinhaus-Johnson-Trotter algorithm.
-            Expected identity permutation.
+            ValueError: no internal state directions were given for non-identity
+            starting permutation for Steinhaus-Johnson-Trotter algorithm
 
             sage: Permutation([1, 3, 2], algorithm='sjt', check=False)
             Traceback (most recent call last):
             ...
-            ValueError: No internal state directions were given for non-identity
-            starting permutation for Steinhaus-Johnson-Trotter algorithm.
-            Expected identity permutation.
+            ValueError: no internal state directions were given for non-identity
+            starting permutation for Steinhaus-Johnson-Trotter algorithm
         """
         l = list(l)
         # Default initialisation to ``None`` to declare the variable.
@@ -602,7 +597,7 @@ class Permutation(CombinatorialElement):
 
         if algorithm != "lex" and algorithm != "sjt":
             raise ValueError("unsupported algorithm %s; expected 'lex' or 'sjt'"
-                             "." % algorithm)
+                             % algorithm)
 
         if check and len(l) > 0:
             # Make a copy to sort later
@@ -615,18 +610,19 @@ class Permutation(CombinatorialElement):
                 except TypeError:
                     raise ValueError("the elements must be integer variables")
                 if i < 1:
-                    raise ValueError("the elements must be strictly positive integers")
+                    raise ValueError("the elements must be strictly positive "
+                                     "integers")
 
             lst.sort()
 
             # Is the maximum element of the permutation the length of input,
             # or is some integer missing ?
             if int(lst[-1]) != len(lst):
-                raise ValueError("The permutation has length "+str(len(lst)) +
+                raise ValueError("the permutation has length "+str(len(lst)) +
                                  " but its maximal element is " +
-                                 str(int(lst[-1]))+". Some element " +
-                                 "may be repeated, or an element is missing" +
-                                 ", but there is something wrong with its length.")
+                                 str(int(lst[-1])) + ". Some element may be " +
+                                 "repeated, or an element is missing, but " +
+                                 "there is something wrong with its length.")
 
             # Do the elements appear only once ?
             previous = lst[0]-1
@@ -826,11 +822,11 @@ class Permutation(CombinatorialElement):
 
     def __next__(self):
         r"""
-        Return the permutation that follows ``self`` in lexicographic order on
-        the symmetric group containing ``self``. If ``self`` is the last
-        permutation, then ``next`` returns ``False``. If the ``algorithm``
-        parameter is specified, the permutations will be generated according to
-        it. Supported algorithms are:
+        Return the permutation that follows ``self`` on the symmetric group
+        containing ``self``. If ``self`` is the last permutation, then ``next``
+        returns ``False``. If the ``algorithm`` parameter is specified, the
+        permutations will be generated according to it. Supported algorithms
+        are:
 
         - ``lex``: lexicographic order generation, this is the default
           algorithm.
@@ -848,17 +844,35 @@ class Permutation(CombinatorialElement):
             sage: next(p)
             False
             sage: p = Permutation([1, 2, 3], algorithm='sjt')
-            sage: next(p)
+            sage: p = next(p); p
             [1, 3, 2]
+            sage: p = next(p); p
+            [3, 1, 2]
 
         TESTS::
 
             sage: p = Permutation([])
             sage: next(p)
             False
+            sage: p = Permutation([], algorithm='sjt')
+            sage: next(p)
+            False
+            sage: p = Permutation([1], algorithm='sjt')
+            sage: next(p)
+            False
+            sage: l = [1, 2, 3, 4]
+            sage: s = set()
+            sage: p = Permutation(l, algorithm='sjt')
+            sage: for _ in range(factorial(len(l))):
+            ....:     s.add(p)
+            ....:     p = p.next()
+            ....:
+            sage: p
+            False
+            sage: assert(len(s)) == factorial(len(l))
         """
         if self.__sjt is not None:
-            # Ensure the same permutations is yielded when called multiple times
+            # Ensure the same permutation is yielded when called multiple times
             # without reassigning
             p, directions = self.__sjt.next()
             if p is False:
@@ -924,7 +938,7 @@ class Permutation(CombinatorialElement):
             sage: p.prev()
             Traceback (most recent call last):
             ...
-            NotImplementedError: Previous permutation for SJT algorithm is not
+            NotImplementedError: previous permutation for SJT algorithm is not
             yet implemented
 
         Check that :issue:`16913` is fixed::
@@ -938,7 +952,8 @@ class Permutation(CombinatorialElement):
             algorithm.
         """
         if self.__sjt is not None:
-            raise NotImplementedError("Previous permutation for SJT algorithm is not yet implemented")
+            raise NotImplementedError("previous permutation for SJT algorithm "
+                                      "is not yet implemented")
 
         p = self[:]
         n = len(self)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
I suggest this diff against develop to implement the Steinhaus-Johnson-Trotter algorithm that generates the permutations of a list using only transpositions of two elements of the list. The algorithm can be selected upon initialization with the parameter of the same name, defaults to "lex" which is the current algorithm.

Since the `Permutation` class is a bit weird and creates a new list and a new object on every iteration, I had to tweak a bit the parameters in input to the class `__init__` method adding
- `algorithm`: this one is fine, it allows to choose which algorithm to use to generate the permutations
- `directions`: this one is meant to keep track of the internal state specific to the SJT algorithm. To find the two elements to transpose for the next permutation, we need to find elements according to some conditions regarding each of their direction. Since the `Permutation` class creates a new object at each iteration, I tried to find the best way to pass on the internal state to the new object. Maybe the internal state can be directly computed from the list, I haven't checked. Because of this dependency on the internal state, only the identity permutation can be used when initializing a `Permutation` object with `algorithm='sjt'` (see examples from doc). I am aware that adding an extra optional parameter to the object construction might not be the best option thus I will gladly take your feedback and opinions.

I haven't implemented the `prev()` method. I think it should be done if this is accepted.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

 
