### PR TITLE
Automatic `CI Manager` labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 # This action automatically labels Pull-Requests
 # based on files edited and no of lines changed.
-name: Size Labeler/Checker
+name: Automatic Labeler / Checker
 on:
   pull_request_target:
     types:
@@ -12,7 +12,7 @@ on:
       - edited
 jobs:
   label-changes:
-    if: vars.SMALL_THRESHOLD && vars.MODERATE_THRESHOLD && vars.LARGE_THRESHOLD && github.event.pull_request.draft == false
+    if: vars.SMALL_THRESHOLD && vars.MODERATE_THRESHOLD && vars.LARGE_THRESHOLD && vars.CI_PATH && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -22,11 +22,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Add labels based on size
+      - name: Add labels based on size and directory of file changed
         run: |
           git fetch origin $BASE_SHA
-          chmod a+x .github/workflows/set_labels_by_changes.sh
-          .github/workflows/set_labels_by_changes.sh
+          chmod a+x .github/workflows/set_labels.sh
+          .github/workflows/set_labels.sh
         env:
           BASE_SHA: ${{ github.base_ref }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -37,3 +37,4 @@ jobs:
           SMALL_THRESHOLD: ${{ vars.SMALL_THRESHOLD }}
           MODERATE_THRESHOLD: ${{ vars.MODERATE_THRESHOLD }}
           LARGE_THRESHOLD: ${{ vars.LARGE_THRESHOLD }}
+          CI_PATH: ${{ vars.CI_PATH }}

--- a/.github/workflows/set_labels.sh
+++ b/.github/workflows/set_labels.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+echo 'set_labels_by_changes.sh called with environment:'
+echo "BASE SHA: $PR_BASE_SHA" 
+echo "HEAD SHA: $PR_HEAD_SHA" 
+echo "SMALL THRESHOLD: $SMALL_THRESHOLD"
+echo "MODERATE THERESHOLD: $MODERATE_THRESHOLD"
+echo "LARGE THRESHOLD: $LARGE_THRESHOLD"
+
+# get all the changes made and changed files
+CHANGES=$(git diff --ignore-all-space $PR_BASE_SHA $PR_HEAD_SHA)
+
+# ignore blank lines
+CHANGES=$(echo "$CHANGES" | grep -vE '^[\+\-]\s*$')
+
+# ignore non necessary lines from git diff
+CHANGES=$(echo "$CHANGES" | grep -E '^[+\-]' | grep -vE '^\+\+\+|^\-\-\-')
+
+# count total no of lines
+CHANGES=$(echo "$CHANGES" | wc -l)
+
+echo "CHANGES MADE: $CHANGES"
+
+AUTH_HEADER="Authorization: Bearer $GITHUB_TOKEN"
+
+MINIMAL="v: minimal"
+SMALL="v: small"
+MODERATE="v: moderate"
+LARGE="v: large"
+CI_MANAGER="p: CI Manager"
+
+DELETE_LABELS=("$MINIMAL" "$SMALL" "$MODERATE" "$LARGE")
+
+if [ "$CHANGES" -gt "$LARGE_THRESHOLD" ]; then
+    LABELS="$LARGE"
+elif [ "$CHANGES" -gt "$MODERATE_THRESHOLD" ]; then
+    LABELS="$MODERATE"
+elif [ "$CHANGES" -gt "$SMALL_THRESHOLD" ]; then
+    LABELS="$SMALL"
+else
+    LABELS="$MINIMAL"
+fi
+
+DELETE_LABELS=("${DELETE_LABELS[@]//${LABELS}/}")
+
+# API for adding labels on the Pull Request 
+API_URL="https://api.github.com/repos/$REPOSITORY/issues/$PR_NUMBER/labels"
+
+# 'CI Manager' label
+CHANGED_PATH=$(git diff --name-only $PR_BASE_SHA $PR_HEAD_SHA)
+CI_PATH=($CI_PATH)
+ci_label="false"
+for item in "${CI_PATH[@]}"; do
+    [[ "$CHANGED_PATH" == "${item}"* ]] && ci_label="true" && break
+done
+if $ci_label; then
+    echo "Changes made in the CI Managed directory: $CHANGED_PATH"
+    LABELS+=($CI_MANAGER)
+else
+    DELETE_LABELS=("${DELETE_LABELS[@]//${CI_MANAGER}/}")
+fi
+
+echo "Adding label: ${LABELS[@]}"
+for LABEL in "${LABELS[@]}"; do
+    curl -X POST \
+        -H "$AUTH_HEADER" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -d "{\"labels\":[\"$LABEL\"]}" \
+        "$API_URL" >/dev/null
+done
+
+echo "Deleting Labels:"
+
+for DELETE_LABEL in "${DELETE_LABELS[@]}"; do
+    ENCODED_LABEL=$(echo "$DELETE_LABEL" | sed 's/ /%20/g')
+    curl -X DELETE \
+        -H "Accept: application/vnd.github+json" \
+        -H "$AUTH_HEADER" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "$API_URL/$ENCODED_LABEL" >/dev/null
+done

--- a/.github/workflows/set_labels.sh
+++ b/.github/workflows/set_labels.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+echo 'set_labels_by_changes.sh called with environment:'
+echo "BASE SHA: $PR_BASE_SHA" 
+echo "HEAD SHA: $PR_HEAD_SHA" 
+echo "SMALL THRESHOLD: $SMALL_THRESHOLD"
+echo "MODERATE THERESHOLD: $MODERATE_THRESHOLD"
+echo "LARGE THRESHOLD: $LARGE_THRESHOLD"
+
+# get all the changes made and changed files
+CHANGES=$(git diff --ignore-all-space $PR_BASE_SHA $PR_HEAD_SHA)
+
+# ignore blank lines
+CHANGES=$(echo "$CHANGES" | grep -vE '^[\+\-]\s*$')
+
+# ignore non necessary lines from git diff
+CHANGES=$(echo "$CHANGES" | grep -E '^[+\-]' | grep -vE '^\+\+\+|^\-\-\-')
+
+# count total no of lines
+CHANGES=$(echo "$CHANGES" | wc -l)
+
+echo "CHANGES MADE: $CHANGES"
+
+AUTH_HEADER="Authorization: Bearer $GITHUB_TOKEN"
+
+MINIMAL="v: minimal"
+SMALL="v: small"
+MODERATE="v: moderate"
+LARGE="v: large"
+CI_MANAGER="p: CI Manager"
+
+DELETE_LABELS=("$MINIMAL" "$SMALL" "$MODERATE" "$LARGE")
+
+if [ "$CHANGES" -gt "$LARGE_THRESHOLD" ]; then
+    LABELS="$LARGE"
+elif [ "$CHANGES" -gt "$MODERATE_THRESHOLD" ]; then
+    LABELS="$MODERATE"
+elif [ "$CHANGES" -gt "$SMALL_THRESHOLD" ]; then
+    LABELS="$SMALL"
+else
+    LABELS="$MINIMAL"
+fi
+
+DELETE_LABELS=("${DELETE_LABELS[@]//${LABELS}/}")
+
+# API for adding labels on the Pull Request 
+API_URL="https://api.github.com/repos/$REPOSITORY/issues/$PR_NUMBER/labels"
+
+# 'CI Manager' label
+CHANGED_PATH=$(git diff --name-only $PR_BASE_SHA $PR_HEAD_SHA)
+CI_PATH=($CI_PATH)
+ci_label="false"
+for item in "${CI_PATH[@]}"; do
+    [[ "$CHANGED_PATH" == "${item}"* ]] && ci_label="true" && break
+done
+if $ci_label; then
+    echo "Changes made in the CI Managed directory: $CHANGED_PATH"
+    LABELS+=("$CI_MANAGER")
+else
+    DELETE_LABELS+=("$CI_MANAGER")
+fi
+
+echo "Adding label: ${LABELS[@]}"
+for LABEL in "${LABELS[@]}"; do
+    curl -X POST \
+        -H "$AUTH_HEADER" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -d "{\"labels\":[\"$LABEL\"]}" \
+        "$API_URL" >/dev/null
+done
+
+echo "Deleting Labels:"
+
+for DELETE_LABEL in "${DELETE_LABELS[@]}"; do
+    ENCODED_LABEL=$(echo "$DELETE_LABEL" | sed 's/ /%20/g')
+    curl -X DELETE \
+        -H "Accept: application/vnd.github+json" \
+        -H "$AUTH_HEADER" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "$API_URL/$ENCODED_LABEL" >/dev/null
+done


### PR DESCRIPTION
The label `p: CI Manager` will automatically be added for changes made in certain files defined in the repo variable `CI_PATH`.
multiple files can be defined with space in between.

Fixes #37971

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
