### PR TITLE
fixing superfluous empty lines in libs folder

### DIFF
--- a/src/sage/libs/eclib/mwrank.pyx
+++ b/src/sage/libs/eclib/mwrank.pyx
@@ -174,6 +174,7 @@ def initprimes(filename, verb=False):
     filename = str_to_bytes(filename, FS_ENCODING, 'surrogateescape')
     mwrank_initprimes(filename, verb)
 
+
 ############# bigint ###########################################
 #
 # In mwrank (and eclib) bigint is synonymous with NTL's ZZ class.

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -1030,7 +1030,6 @@ cdef class GapElement(RingElement):
             GAP_Leave()
         return make_any_gap_element(self.parent(), result)
 
-
     cpdef _mul_(self, right):
         r"""
         Multiply two GapElement objects.
@@ -1623,9 +1622,8 @@ cdef class GapElement_Float(GapElement):
         return GAP_ValueMacFloat(self.value)
 
 
-
 ############################################################################
-### GapElement_IntegerMod #####################################################
+#  GapElement_IntegerMod  ##################################################
 ############################################################################
 
 cdef GapElement_IntegerMod make_GapElement_IntegerMod(parent, Obj obj):
@@ -1674,7 +1672,6 @@ cdef class GapElement_IntegerMod(GapElement):
             <class 'sage.libs.gap.element.GapElement_Integer'>
         """
         return self.Int()
-
 
     def sage(self, ring=None):
         r"""
@@ -1764,7 +1761,6 @@ cdef class GapElement_FiniteField(GapElement):
             return self.IntFFE()
         else:
             raise TypeError('not in prime subfield')
-
 
     def sage(self, ring=None, var='a'):
         r"""
@@ -2098,7 +2094,6 @@ cdef class GapElement_Ring(GapElement):
         characteristic = self.Characteristic().sage()
         return ZZ.quotient_ring(characteristic)
 
-
     def ring_finite_field(self, var='a'):
         """
         Construct an integer ring.
@@ -2111,7 +2106,6 @@ cdef class GapElement_Ring(GapElement):
         size = self.Size().sage()
         from sage.rings.finite_rings.finite_field_constructor import GF
         return GF(size, name=var)
-
 
     def ring_cyclotomic(self):
         """
@@ -2389,7 +2383,6 @@ cdef class GapElement_Function(GapElement):
         <class 'sage.libs.gap.element.GapElement_Function'>
     """
 
-
     def __repr__(self):
         r"""
         Return a string representation
@@ -2407,7 +2400,6 @@ cdef class GapElement_Function(GapElement):
         name = libgap.NameFunction(self)
         s = '<Gap function "'+name.sage()+'">'
         return s
-
 
     def __call__(self, *args):
         """
@@ -2539,8 +2531,6 @@ cdef class GapElement_Function(GapElement):
             return None
         return make_any_gap_element(self.parent(), result)
 
-
-
     def _instancedoc_(self):
         r"""
         Return the help string
@@ -2556,8 +2546,6 @@ cdef class GapElement_Function(GapElement):
         libgap = self.parent()
         from sage.interfaces.gap import gap
         return gap.help(libgap.NameFunction(self).sage(), pager=False)
-
-
 
 
 ############################################################################
@@ -2647,7 +2635,6 @@ cdef class GapElement_MethodProxy(GapElement_Function):
             return GapElement_Function.__call__(self, * ([self.first_argument] + list(args)))
         else:
             return GapElement_Function.__call__(self, self.first_argument)
-
 
 
 ############################################################################
@@ -2891,8 +2878,7 @@ cdef class GapElement_List(GapElement):
             sage: all( x in ZZ for x in _ )
             True
         """
-        return [ x.sage(**kwds) for x in self ]
-
+        return [x.sage(**kwds) for x in self]
 
     def matrix(self, ring=None):
         """
@@ -2984,7 +2970,6 @@ cdef class GapElement_List(GapElement):
         return vector(ring, n, self.sage(ring=ring))
 
     _vector_ = vector
-
 
 
 ############################################################################
@@ -3253,7 +3238,6 @@ cdef class GapElement_RecordIterator():
         """
         self.rec = rec
         self.i = 1
-
 
     def __next__(self):
         r"""

--- a/src/sage/libs/giac/giac.pyx
+++ b/src/sage/libs/giac/giac.pyx
@@ -1306,7 +1306,7 @@ cdef class Pygen(GiacMethods_base):
     #        url='file:'+url
     #        wwwbrowseropen(url)
 
-1    def _help(self):
+    def _help(self):
         return self.findhelp().__str__()
 
     def _sage_doc_(self):

--- a/src/sage/libs/giac/giac.pyx
+++ b/src/sage/libs/giac/giac.pyx
@@ -176,6 +176,7 @@ def decstring23(s):
 def encstring23(s):
     return bytes(s, 'UTF-8')
 
+
 listrange = list, range
 # End of Python3 compatibility #####################
 
@@ -647,7 +648,6 @@ cdef class GiacSetting(Pygen):
         def __get__(self):
             return (self.cas_setup()[6])._val
 
-
         def __set__(self,value):
             l = Pygen('cas_setup()').eval()
             pl = [ i for i in l ]
@@ -660,7 +660,6 @@ cdef class GiacSetting(Pygen):
         """
         def __get__(self):
             return (self.cas_setup()[9])._val == 1
-
 
         def __set__(self,value):
             l = Pygen('cas_setup()').eval()
@@ -921,8 +920,7 @@ cdef class Pygen(GiacMethods_base):
             #GIAC_size return a gen. we take the int: val
             return rep
 
-
-    def __getitem__(self,i):  #TODO?: add gen support for indexes
+    def __getitem__(self, i):  #TODO?: add gen support for indexes
         """
         Lists of 10^6 integers should be translated to giac easily
 
@@ -994,8 +992,7 @@ cdef class Pygen(GiacMethods_base):
                 raise TypeError("Error executing code in Giac\nCODE:\n\t%s\nGiac ERROR:\n\t%s"%(cmd, ans))
             return ans
 
-
-    def __setitem__(self,key,value):
+    def __setitem__(self, key, value):
         """
         Set the value of a coefficient of a giac vector or matrix or list.
            Warning: It is an in place affectation.
@@ -1045,8 +1042,6 @@ cdef class Pygen(GiacMethods_base):
         sig_off()
         return
 
-
-
     def __iter__(self):
         """
         Pygen lists of 10^6 elements should be yield
@@ -1068,14 +1063,12 @@ cdef class Pygen(GiacMethods_base):
         for i in range(len(self)):
             yield self[i]
 
-
     def eval(self):
         cdef gen result
         sig_on()
         result=GIAC_protecteval(self.gptr[0],giacsettings.eval_level,context_ptr)
         sig_off()
         return _wrap_gen(result)
-
 
     def __add__(self, right):
         cdef gen result
@@ -1089,7 +1082,6 @@ cdef class Pygen(GiacMethods_base):
         result= (<Pygen>self).gptr[0] + (<Pygen>right).gptr[0]
         sig_off()
         return _wrap_gen(result)
-
 
     def __call__(self, *args):
         cdef gen result
@@ -1129,7 +1121,6 @@ cdef class Pygen(GiacMethods_base):
         finally:
             sig_off()
         return _wrap_gen(result)
-
 
     def __sub__(self, right):
         cdef gen result
@@ -1198,7 +1189,6 @@ cdef class Pygen(GiacMethods_base):
         sig_off()
         return _wrap_gen(result)
 
-
     def __pow__(self, right ,ignored):
         cdef gen result
         if not isinstance(right, Pygen):
@@ -1240,7 +1230,6 @@ cdef class Pygen(GiacMethods_base):
     # To be able to use the eval function before the GiacMethods initialisation
     def cas_setup(self,*args):
         return Pygen('cas_setup')(self,*args)
-
 
     def savegen(self, str filename):
         """
@@ -1297,7 +1286,6 @@ cdef class Pygen(GiacMethods_base):
         else:
             raise TypeError("self is not a giac List")
 
-
     # def htmlhelp(self, str lang='en'):
     #     """
     #     Open the giac  html  detailled help about self in an external  browser
@@ -1318,17 +1306,11 @@ cdef class Pygen(GiacMethods_base):
     #        url='file:'+url
     #        wwwbrowseropen(url)
 
-
-
-    def _help(self):
+1    def _help(self):
         return self.findhelp().__str__()
-
-#     def help(self):
-#        return self._help()
 
     def _sage_doc_(self):
         return self._help()
-
 
     def __doc__(self):
         return self._help()
@@ -1360,7 +1342,6 @@ cdef class Pygen(GiacMethods_base):
         result=decstring23(GIAC_gen2tex(self.gptr[0], context_ptr).c_str()) #python3
         sig_off()
         return result
-
 
     def _integer_(self,Z=None):
         """
@@ -1411,8 +1392,7 @@ cdef class Pygen(GiacMethods_base):
         else:
             raise TypeError("cannot convert non giac integers to Integer")
 
-
-    def _rational_(self,Z=None):
+    def _rational_(self, Z=None):
         """
         Convert giac rationals to sage rationals
 
@@ -1435,7 +1415,6 @@ cdef class Pygen(GiacMethods_base):
             return ZZ(self.numer()) / ZZ(self.denom())
         else:
             raise TypeError("cannot convert non giac _FRAC_ to QQ")
-
 
     def sage(self):
         r"""
@@ -1531,7 +1510,6 @@ cdef class Pygen(GiacMethods_base):
             sig_off()
             return result
 
-
     def _symbolic_(self, R):
         r"""
         Convert self object to the ring R via a basic string evaluation. (slow)
@@ -1578,8 +1556,6 @@ cdef class Pygen(GiacMethods_base):
 
             except Exception:
                 raise NotImplementedError("Unable to parse Giac output: %s" % self.__repr__())
-
-
 
     def _matrix_(self, R=ZZ):
         r"""
@@ -1647,7 +1623,6 @@ cdef class Pygen(GiacMethods_base):
 
     # # # # # # # # # # # # # # #
 
-
     def mplot(self):
         """
         Basic export of some 2D plots to sage. Only generic plots are supported.
@@ -1668,14 +1643,12 @@ cdef class Pygen(GiacMethods_base):
                 for g in G:
                     xyscat=xyscat+[[(g.real())._double,(g.im())._double]]
 
-
             else:
                 if G[1].type()=='DOM_LIST':
                     l=G[1].op()
                 else:
                     l=G[1][2].op()
                 xyplot=[[(u.real())._double,(u.im())._double] for u in l]
-
 
         if xyscat:
             result = scatter_plot(xyscat)
@@ -1715,7 +1688,6 @@ cdef class Pygen(GiacMethods_base):
             result = self.gptr.type
             sig_off()
             return result
-
 
     property _subtype:
         def __get__(self):
@@ -1813,8 +1785,6 @@ cdef inline _wrap_gen(gen  g)except +:
 #    else:
 #      raise MemoryError("empty gen")
 
-
-
 ################################################################
 #    A wrapper from a python list to a vector of gen           #
 ################################################################
@@ -1856,9 +1826,6 @@ cdef  vecteur _getgiacslice(Pygen L,slice sl) except +:
         return V[0]
     else:
         raise TypeError("argument must be a Pygen list and a slice")
-
-
-
 
 
 cdef  gen pylongtogen(a) except +:
@@ -1996,6 +1963,7 @@ class GiacFunctionNoEV(Pygen):
         a
     """
 
+
 #############################################################
 # Some convenient settings
 ############################################################
@@ -2028,7 +1996,6 @@ for i in mostkeywords+moremethods:
 __all__=['Pygen','giacsettings','libgiac','loadgiacgen','GiacFunction','GiacMethods','GiacMethods_base']
 
 
-
 def loadgiacgen(str filename):
     """
       Open a file in giac compressed format to create a Pygen element.
@@ -2059,7 +2026,6 @@ def loadgiacgen(str filename):
     return _wrap_gen(result)
 
 
-
 class GiacInstance:
     """
     This class is used to create the giac interpreter object.
@@ -2082,14 +2048,11 @@ class GiacInstance:
     def __init__(self):
         self.__dict__.update(GiacMethods)
 
-
     def __call__(self,s):
         return _giac(s)
 
-
     def _sage_doc_(self):
         return _giac.__doc__
-
 
     def eval(self, code, strip=True, **kwds):
 
@@ -2097,12 +2060,10 @@ class GiacInstance:
             code = code.replace("\n","").strip()
         return self(code)
 
-
     __doc__ = _giac.__doc__
 
 
-
-libgiac=GiacInstance()
+libgiac = GiacInstance()
 
 # Issue #23976 (bound threads with SAGE_NUM_THREADS)
 import os

--- a/src/sage/libs/lcalc/lcalc_Lfunction.pyx
+++ b/src/sage/libs/lcalc/lcalc_Lfunction.pyx
@@ -226,7 +226,6 @@ cdef class Lfunction:
         cdef c_Complex result = self._hardy_z_function(z)
         return CCC(result.real(),result.imag())
 
-
     def compute_rank(self):
         """
         Computes the analytic rank (the order of vanishing at the center) of
@@ -647,7 +646,6 @@ cdef class Lfunction_D(Lfunction):
     cdef inline c_Complex _value(self,c_Complex s,int derivative) noexcept:
         return (<c_Lfunction_D *>(self.thisptr)).value(s, derivative, "pure")
 
-
     cdef inline c_Complex _hardy_z_function(self,c_Complex s) noexcept:
         return (<c_Lfunction_D *>(self.thisptr)).value(s, 0, "rotated pure")
 
@@ -791,13 +789,11 @@ cdef class Lfunction_C:
     cdef inline c_Complex _value(self,c_Complex s,int derivative) noexcept:
         return (<c_Lfunction_C *>(self.thisptr)).value(s, derivative, "pure")
 
-
     cdef inline c_Complex _hardy_z_function(self,c_Complex s) noexcept:
         return (<c_Lfunction_C *>(self.thisptr)).value(s, 0,"rotated pure")
 
     cdef inline int _compute_rank(self) noexcept:
         return (<c_Lfunction_C *>(self.thisptr)).compute_rank()
-
 
     cdef void _find_zeros_v(self, double T1, double T2, double stepsize, doublevec *result) noexcept:
         (<c_Lfunction_C *>self.thisptr).find_zeros_v(T1,T2,stepsize,result[0])
@@ -876,13 +872,11 @@ cdef class Lfunction_Zeta(Lfunction):
     cdef inline c_Complex _value(self,c_Complex s,int derivative) noexcept:
         return (<c_Lfunction_Zeta *>(self.thisptr)).value(s, derivative, "pure")
 
-
     cdef inline c_Complex _hardy_z_function(self,c_Complex s) noexcept:
         return (<c_Lfunction_Zeta *>(self.thisptr)).value(s, 0, "rotated pure")
 
     cdef inline int _compute_rank(self) noexcept:
         return (<c_Lfunction_Zeta *>(self.thisptr)).compute_rank()
-
 
     cdef void _find_zeros_v(self, double T1, double T2, double stepsize, doublevec *result) noexcept:
         (<c_Lfunction_Zeta *>self.thisptr).find_zeros_v(T1,T2,stepsize,result[0])

--- a/src/sage/libs/mpmath/ext_impl.pyx
+++ b/src/sage/libs/mpmath/ext_impl.pyx
@@ -1488,6 +1488,7 @@ def cos_sin_fixed(Integer x, int prec, pi2=None):
     mpfr_clear(sf)
     return cv, sv
 
+
 DEF MAX_LOG_INT_CACHE = 2000
 
 cdef mpz_t log_int_cache[MAX_LOG_INT_CACHE+1]
@@ -1976,7 +1977,6 @@ cdef mpz_t ACRE[MAX_PARAMS]
 cdef mpz_t ACIM[MAX_PARAMS]
 cdef mpz_t BCRE[MAX_PARAMS]
 cdef mpz_t BCIM[MAX_PARAMS]
-
 
 
 cdef MPF_hypsum(MPF *a, MPF *b, int p, int q, param_types, str ztype, coeffs, z,

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -287,7 +287,6 @@ cdef binop(int op, x, y, MPopts opts):
                 MPF_add(&rc.im, &rc.im, &tmp1, opts)
             return rc
 
-
     elif op == OP_DIV:
         if typx == 1 and typy == 1:
             # Real result
@@ -1487,7 +1486,6 @@ cdef class wrapped_libmp_function:
         raise NotImplementedError("%s of a %s" % (self.name, type(x)))
 
 
-
 cdef class wrapped_specfun:
     cdef public f, name, __name__, __doc__
 
@@ -2150,7 +2148,6 @@ cdef class mpf(mpf_base):
             False
         """
         return binop(OP_RICHCMP+op, self, other, global_opts)
-
 
 
 cdef class constant(mpf_base):

--- a/src/sage/libs/ntl/ntl_GF2E.pyx
+++ b/src/sage/libs/ntl/ntl_GF2E.pyx
@@ -71,6 +71,7 @@ def ntl_GF2E_random(ntl_GF2EContext_class ctx):
     r.x = GF2E_random()
     return r
 
+
 cdef class ntl_GF2E():
     r"""
     The :class:`GF2E` represents a finite extension field over GF(2)

--- a/src/sage/libs/ntl/ntl_GF2EContext.pyx
+++ b/src/sage/libs/ntl/ntl_GF2EContext.pyx
@@ -91,7 +91,6 @@ cdef class ntl_GF2EContext_class():
         """
         return self.m
 
-
     def restore(self):
         """
         EXAMPLES::

--- a/src/sage/libs/ntl/ntl_ZZ.pyx
+++ b/src/sage/libs/ntl/ntl_ZZ.pyx
@@ -473,6 +473,7 @@ def ntl_setSeed(x=None):
     ZZ_SetSeed(seed.x)
     sig_off()
 
+
 ntl_setSeed()
 
 

--- a/src/sage/libs/ntl/ntl_ZZ_p.pyx
+++ b/src/sage/libs/ntl/ntl_ZZ_p.pyx
@@ -68,7 +68,6 @@ def ntl_ZZ_p_random_element(v):
     return y
 
 
-
 ##############################################################################
 #
 # ZZ_p_c: integers modulo p

--- a/src/sage/libs/ntl/ntl_ZZ_pE.pyx
+++ b/src/sage/libs/ntl/ntl_ZZ_pE.pyx
@@ -267,7 +267,6 @@ cdef class ntl_ZZ_pE():
         sig_off()
         return r
 
-
     cdef ntl_ZZ_pX get_as_ZZ_pX(ntl_ZZ_pE self):
         r"""
         Returns value as ntl_ZZ_pX.

--- a/src/sage/libs/ntl/ntl_lzz_pX.pyx
+++ b/src/sage/libs/ntl/ntl_lzz_pX.pyx
@@ -750,7 +750,6 @@ cdef class ntl_zz_pX():
             sig_off()
         return y
 
-
     def is_zero(self):
         """
         Return True exactly if this polynomial is 0.

--- a/src/sage/libs/ntl/ntl_mat_ZZ.pyx
+++ b/src/sage/libs/ntl/ntl_mat_ZZ.pyx
@@ -106,7 +106,6 @@ cdef class ntl_mat_ZZ():
                     tmp = ntl_ZZ(v[i*ncols+j])
                     mat_ZZ_setitem(&self.x, i, j, &tmp.x)
 
-
     def __reduce__(self):
         """
         EXAMPLES::

--- a/src/sage/libs/singular/function.pyx
+++ b/src/sage/libs/singular/function.pyx
@@ -394,6 +394,7 @@ def is_sage_wrapper_for_singular_ring(ring):
         return True
     return False
 
+
 cdef new_sage_polynomial(ring,  poly *p):
     if isinstance(ring, MPolynomialRing_libsingular):
         return new_MP(ring, p)
@@ -1159,8 +1160,6 @@ cdef class SingularFunction(SageObject):
     The base class for Singular functions either from the kernel or
     from the library.
     """
-
-
     def __init__(self, name):
         """
         INPUT:
@@ -1462,7 +1461,6 @@ cdef inline call_function(SingularFunction self, tuple args, object R, bint sign
     global currentVoice
     global myynest
     global error_messages
-
 
     cdef ring *si_ring
     if isinstance(R, MPolynomialRing_libsingular):
@@ -1856,6 +1854,7 @@ def list_of_functions(packages=False):
                     ph = IDNEXT(ph)
         h = IDNEXT(h)
     return l
+
 
 cdef inline RingWrap new_RingWrap(ring* r):
     cdef RingWrap ring_wrap_result = RingWrap.__new__(RingWrap)

--- a/src/sage/libs/singular/option.pyx
+++ b/src/sage/libs/singular/option.pyx
@@ -467,7 +467,6 @@ cdef class LibSingularOptions(LibSingularOptions_abstract):
         self.load(_saved_options)
 
 
-
 #############
 
 cdef class LibSingularVerboseOptions(LibSingularOptions_abstract):

--- a/src/sage/libs/singular/ring.pyx
+++ b/src/sage/libs/singular/ring.pyx
@@ -51,10 +51,6 @@ from cpython.object cimport Py_EQ, Py_NE
 from collections import defaultdict
 
 
-
-
-
-
 # mapping str --> SINGULAR representation
 order_dict = {
     "dp": ringorder_dp,
@@ -319,7 +315,6 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
 
         _cf = nInitChar(n_transExt, <void *>&trextParam)
 
-
         if (_cf is NULL):
             raise RuntimeError("Failed to allocate _cf ring.")
 
@@ -346,12 +341,10 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
 
         _cf = nInitChar(n_transExt, <void *>&trextParam)
 
-
         if (_cf is NULL):
             raise RuntimeError("Failed to allocate _cf ring.")
 
         _ring = rDefault (_cf ,nvars, _names, nblcks, _order, _block0, _block1, _wvhdl)
-
 
     elif isinstance(base_ring, NumberField) and base_ring.is_absolute():
         characteristic = 1

--- a/src/sage/libs/singular/singular.pyx
+++ b/src/sage/libs/singular/singular.pyx
@@ -476,8 +476,6 @@ cdef object si2sa_transext_FF(number *n, ring *_ring, object base):
 
     while numer:
 
-
-
         c = p_GetCoeff(numer, cfRing)
         coeff = base(cfRing.cf.cfInt(c, cfRing.cf))
         numer.coef = c
@@ -1779,7 +1777,6 @@ cdef init_libsingular():
     global error_messages
 
     cdef void *handle = NULL
-
 
     # This is a workaround for https://github.com/Singular/Singular/issues/1113
     # and can be removed once that fix makes it into release of Singular that


### PR DESCRIPTION
this is removing empty lines in the `libs` folder in `.pyx` files, for compliance with pep8 E302 and E305

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.