### PR TITLE
CI Build&Test: Split test-long into multiple jobs, repair Coverage.py upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,7 +371,7 @@ jobs:
           ln -s $(pwd)/.coverage /sage/
           cd /sage
           ./sage -python -m pip install coverage
-          ./sage -python -m coverage run --rcfile=src/tox.ini src/bin/sage-runtests --long -p4 --format github --random-seed=286735480429121101562228604801325644303 ${{ matrix.tests }}
+          ./sage -python -m coverage run --rcfile=src/tox.ini src/bin/sage-runtests --force-lib --long -p4 --format github --random-seed=286735480429121101562228604801325644303 ${{ matrix.tests }}
         shell: sh .ci/docker-exec-script.sh BUILD . {0}
 
       - name: Combine coverage results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -483,13 +483,14 @@ jobs:
           pattern: coverage-*
 
       - name: Coverage report
+        # Using --omit to avoid "CoverageWarning: Couldn't parse '/tmp/tmp06qizzie/tmp_ldpu46ob.py': No source for code"
         run: |
           rm -rf /sage/.coverage
           ln -s $(pwd)/.coverage /sage/
           cd /sage
           ./sage -python -m pip install coverage
           ./sage -python -m coverage combine --rcfile=src/tox.ini .coverage/coverage-*/.coverage
-          ./sage -python -m coverage xml --rcfile=src/tox.ini
+          ./sage -python -m coverage xml --rcfile=src/tox.ini --omit="/tmp/*"
           mkdir -p .coverage/coverage-report
           mv coverage.xml .coverage/coverage-report/
         shell: sh .ci/docker-exec-script.sh BUILD . {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,8 +287,8 @@ jobs:
       fail-fast: false
       matrix:
         tests:
-          - "src/sage/[a-g]*"
-          - "src/sage/[h-o]*"
+          - "src/sage/[a-f]*"
+          - "src/sage/[g-o]*"
           - "src/sage/[p-z]*"
           - "src/doc src/sage_docbuild src/sage_setup"
     steps:
@@ -373,6 +373,12 @@ jobs:
           ./sage -python -m pip install coverage
           ./sage -python -m coverage run --rcfile=src/tox.ini src/bin/sage-runtests --long -p4 --format github --random-seed=286735480429121101562228604801325644303 ${{ matrix.tests }}
         shell: sh .ci/docker-exec-script.sh BUILD . {0}
+
+      - name: Combine coverage results
+        if: (success() || failure()) && steps.container.outcome == 'success'
+        run: |
+          ./sage -python -m coverage combine --rcfile=src/tox.ini
+        shell: sh .ci/docker-exec-script.sh BUILD /sage {0}
 
       - name: Prepare upload
         id: copy-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -488,7 +488,7 @@ jobs:
           ln -s $(pwd)/.coverage /sage/
           cd /sage
           ./sage -python -m pip install coverage
-          ./sage -python -m coverage combine --rcfile=src/tox.ini .coverage/coverage-*
+          ./sage -python -m coverage combine --rcfile=src/tox.ini .coverage/coverage-*/.coverage
           ./sage -python -m coverage xml --rcfile=src/tox.ini
           mkdir -p .coverage/coverage-report
           mv coverage.xml .coverage/coverage-report/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,6 +283,14 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          - "src/sage/[a-g]*"
+          - "src/sage/[h-o]*"
+          - "src/sage/[p-z]*"
+          - "src/doc src/sage_docbuild src/sage_setup"
     steps:
       - name: Maximize build disk space
         uses: easimon/maximize-build-space@v10
@@ -356,23 +364,131 @@ jobs:
 
       # Testing
 
-      - name: Test all files (sage -t --all --long)
+      - name: Test all files (sage -t --long ${{ matrix.tests }})
         run: |
+          mkdir .coverage
+          rm -rf /sage/.coverage
+          ln -s $(pwd)/.coverage /sage/
+          cd /sage
           ./sage -python -m pip install coverage
-          ./sage -python -m coverage run --rcfile=src/tox.ini src/bin/sage-runtests --all --long -p4 --format github --random-seed=286735480429121101562228604801325644303
-        shell: sh .ci/docker-exec-script.sh BUILD /sage {0}
+          ./sage -python -m coverage run --rcfile=src/tox.ini src/bin/sage-runtests --long -p4 --format github --random-seed=286735480429121101562228604801325644303 ${{ matrix.tests }}
+        shell: sh .ci/docker-exec-script.sh BUILD . {0}
 
-      - name: Copy coverage results
+      - name: Prepare upload
+        id: copy-coverage
         if: (success() || failure()) && steps.container.outcome == 'success'
         run: |
-          ./sage -python -m coverage combine --rcfile=src/tox.ini
+          echo tests_id=$(echo "${{ matrix.tests }}" | sed -E 's, +,--,g;s,/,_,g;s/[^-_A-Za-z]//g;') >> "$GITHUB_OUTPUT"
+
+      - name: Upload coverage results
+        if: (success() || failure()) && steps.container.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ steps.copy-coverage.outputs.tests_id }}
+          path: .coverage
+
+  coverage-report:
+    runs-on: ubuntu-latest
+    needs: [test-long]
+    if: (success() || failure())
+    services:
+      # https://docs.docker.com/build/ci/github-actions/local-registry/
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - name: Maximize build disk space
+        uses: easimon/maximize-build-space@v10
+        with:
+          # need space in /var for Docker images
+          root-reserve-mb:      30000
+          remove-dotnet:        true
+          remove-android:       true
+          remove-haskell:       true
+          remove-codeql:        true
+          remove-docker-images: true
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+      - name: Install test prerequisites
+        # From docker.yml
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install tox
+          sudo apt-get clean
+          df -h
+      - name: Merge CI fixes from sagemath/sage
+        # From docker.yml
+        # This step needs to happen after the commit sha is put in DOCKER_TAG
+        # so that multi-stage builds can work correctly.
+        run: |
+          .ci/merge-fixes.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # Building
+
+      - name: Generate Dockerfile
+        # From docker.yml
+        run: |
+          tox -e ${{ env.TOX_ENV }}
+          cp .tox/${{ env.TOX_ENV }}/Dockerfile .
+        env:
+          # Only generate the Dockerfile, do not run 'docker build' here
+          DOCKER_TARGETS: ""
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Build Docker image
+        id: image
+        uses: docker/build-push-action@v5
+        with:
+          push:       true
+          load:       false
+          context:    .
+          tags:       ${{ env.BUILD_IMAGE }}
+          target:     with-targets
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
+          build-args: |
+            NUMPROC=6
+            USE_MAKEFLAGS=-k V=0 SAGE_NUM_THREADS=4 --output-sync=recurse
+            TARGETS_PRE=build/make/Makefile
+            TARGETS=ci-build-with-fallback
+
+      - name: Start container
+        id: container
+        run: |
+          docker run --name BUILD -dit \
+                     --mount type=bind,src=$(pwd),dst=$(pwd) \
+                     --workdir $(pwd) \
+                     ${{ env.BUILD_IMAGE }} /bin/sh
+
+      # Combining
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .coverage
+          pattern: coverage-*
+
+      - name: Coverage report
+        run: |
+          rm -rf /sage/.coverage
+          ln -s $(pwd)/.coverage /sage/
+          cd /sage
+          ./sage -python -m pip install coverage
+          ./sage -python -m coverage combine --rcfile=src/tox.ini .coverage/coverage-*
           ./sage -python -m coverage xml --rcfile=src/tox.ini
-          mkdir -p coverage-report
-          mv coverage.xml coverage-report/
-        shell: sh .ci/docker-exec-script.sh BUILD /sage {0}
+          mkdir -p .coverage/coverage-report
+          mv coverage.xml .coverage/coverage-report/
+        shell: sh .ci/docker-exec-script.sh BUILD . {0}
 
       - name: Upload coverage to codecov
-        if: (success() || failure()) && steps.container.outcome == 'success'
         uses: codecov/codecov-action@v4
         with:
-          directory: ./coverage-report
+          directory: .coverage/coverage-report

--- a/src/sage/ext_data/nbconvert/postprocess.py
+++ b/src/sage/ext_data/nbconvert/postprocess.py
@@ -11,35 +11,38 @@ AUTHORS:
 
 - Thierry Monteil (2018): initial version.
 """
-import sys
-import re
 
-file_name = sys.argv[1]
+if __name__ == '__main__':
 
-with open(file_name, 'r') as f:
-        lines = f.readlines()
+    import sys
+    import re
 
-# states of the parser
-wrong_math_def_started = False
-wrong_math_fixed = False
-wrong_title_fixed = False
+    file_name = sys.argv[1]
 
-# processing
-new_file = ''
-for i, line in enumerate(lines):
-    if line.startswith(' # ') and not wrong_title_fixed:
-        new_file += re.sub('^ # ', '', line)
-        new_file += '=' * (len(line) - 4) + '\n'
-        wrong_title_fixed = True
-    elif line.startswith('.. math::') and not wrong_math_fixed:
-        pass
-    elif line.startswith('   \\def') and not wrong_math_fixed:
-        wrong_math_def_started = True
-    elif wrong_math_def_started and not wrong_math_fixed:
-        wrong_math_fixed = True
-    else:
-        new_file += re.sub(':math:', '', line)
+    with open(file_name, 'r') as f:
+            lines = f.readlines()
 
-# write new file
-with open(file_name, 'w') as f:
-    f.write(new_file)
+    # states of the parser
+    wrong_math_def_started = False
+    wrong_math_fixed = False
+    wrong_title_fixed = False
+
+    # processing
+    new_file = ''
+    for i, line in enumerate(lines):
+        if line.startswith(' # ') and not wrong_title_fixed:
+            new_file += re.sub('^ # ', '', line)
+            new_file += '=' * (len(line) - 4) + '\n'
+            wrong_title_fixed = True
+        elif line.startswith('.. math::') and not wrong_math_fixed:
+            pass
+        elif line.startswith('   \\def') and not wrong_math_fixed:
+            wrong_math_def_started = True
+        elif wrong_math_def_started and not wrong_math_fixed:
+            wrong_math_fixed = True
+        else:
+            new_file += re.sub(':math:', '', line)
+
+    # write new file
+    with open(file_name, 'w') as f:
+        f.write(new_file)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

test-long (90 minutes) runs after a successful test-new (10 minutes). This is the critical path (100 minutes), longer than build-docs-pdf (85 minutes). We split it into multiple parallel jobs (33 minutes), merging the coverage files in a job afterwards (6 minutes). 

This also repairs the Coverage.py upload, which apparently got broken.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


