### PR TITLE
Fix doctest when the optional benzene is installed

### DIFF
--- a/src/sage/features/__init__.py
+++ b/src/sage/features/__init__.py
@@ -382,6 +382,7 @@ class Feature(TrivialUniqueRepresentation):
 
             sage: Benzene().unhide()            # optional - benzene, needs sage.graphs
             sage: len(list(graphs.fusenes(2)))  # optional - benzene, needs sage.graphs
+            1
         """
         self._hidden = True
 


### PR DESCRIPTION
```
**********************************************************************
File "src/sage/features/__init__.py", line 384, in sage.features.Feature.hide
Failed example:
    len(list(graphs.fusenes(2)))  # optional - benzene, needs sage.graphs
Expected nothing
Got:
    1
**********************************************************************
1 item had failures:
   1 of   6 in sage.features.Feature.hide
    [146 tests, 1 failure, 3.74 s]
**********************************************************************
```

Comes from 1ade282122269d5369d53c07cdf069984f89bd8a