### PR TITLE
`src/sage/algebras/steenrod/all.py`: Use lazy_import, remove deprecated global import

### DIFF
--- a/src/sage/algebras/steenrod/all.py
+++ b/src/sage/algebras/steenrod/all.py
@@ -4,7 +4,4 @@ The Steenrod algebra
 """
 from sage.misc.lazy_import import lazy_import
 lazy_import('sage.algebras.steenrod.steenrod_algebra', ['SteenrodAlgebra', 'Sq'])
-lazy_import('sage.algebras.steenrod.steenrod_algebra_bases',
-            'steenrod_algebra_basis',
-            deprecation=(32647, 'removed from namespace'))
 del lazy_import

--- a/src/sage/algebras/steenrod/all.py
+++ b/src/sage/algebras/steenrod/all.py
@@ -1,8 +1,10 @@
+# sage_setup: distribution = sagemath-combinat
 """
 The Steenrod algebra
 """
-from sage.algebras.steenrod.steenrod_algebra import SteenrodAlgebra, Sq
 from sage.misc.lazy_import import lazy_import
+lazy_import('sage.algebras.steenrod.steenrod_algebra', ['SteenrodAlgebra', 'Sq'])
 lazy_import('sage.algebras.steenrod.steenrod_algebra_bases',
             'steenrod_algebra_basis',
             deprecation=(32647, 'removed from namespace'))
+del lazy_import

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -1280,6 +1280,7 @@ def sage_getfile(obj):
         sage: from sage.misc.sageinspect import sage_getfile
         sage: sage_getfile(sage.rings.rational)
         '...sage/rings/rational.pyx'
+        sage: from sage.algebras.steenrod.steenrod_algebra import Sq                    # needs sage.combinat sage.modules
         sage: sage_getfile(Sq)                                                          # needs sage.combinat sage.modules
         '...sage/algebras/steenrod/steenrod_algebra.py'
         sage: sage_getfile(x)                                                           # needs sage.symbolic
@@ -1358,6 +1359,7 @@ def sage_getfile_relative(obj):
         sage: from sage.misc.sageinspect import sage_getfile_relative
         sage: sage_getfile_relative(sage.rings.rational)
         'sage/rings/rational.pyx'
+        sage: from sage.algebras.steenrod.steenrod_algebra import Sq                    # needs sage.combinat sage.modules
         sage: sage_getfile_relative(Sq)                                                 # needs sage.combinat sage.modules
         'sage/algebras/steenrod/steenrod_algebra.py'
         sage: sage_getfile_relative(x)                                                  # needs sage.symbolic


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

- The change to use `lazy_import` was cherry-picked from #37900
- The global import was deprecated in #32647 (2021)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


