### PR TITLE
Remove nitpick_patch_config function

### DIFF
--- a/src/sage_docbuild/__main__.py
+++ b/src/sage_docbuild/__main__.py
@@ -12,14 +12,14 @@ given, it returns information about ``DOCUMENT``.
 Run ``sage --docbuild`` to get detailed explanations about
 arguments and options.
 
-positional arguments::
+Positional arguments::
 
   DOCUMENT              name of the document to build. It can be either one of
                         the documents listed by -D or 'file=/path/to/FILE' to
                         build documentation for this specific file.
   FORMAT or COMMAND     document output format (or command)
 
-Standard::
+Standard options::
 
   -h, --help            show a help message and exit
   -H, --help-all        show an extended help message and exit
@@ -57,7 +57,7 @@ Standard::
   -o DIR, --output DIR  if DOCUMENT is a single file ('file=...'), write output
                         to this directory
 
-Advanced::
+Advanced options::
 
   Use these options with care.
 

--- a/src/sage_docbuild/__main__.py
+++ b/src/sage_docbuild/__main__.py
@@ -12,49 +12,64 @@ given, it returns information about ``DOCUMENT``.
 Run ``sage --docbuild`` to get detailed explanations about
 arguments and options.
 
-Positional arguments::
+positional arguments::
 
-  DOCUMENT                  name of the document to build. It can be either one
-                            of the documents listed by -D or 'file=/path/to/FILE' to build documentation
-                            for this specific file.
-  FORMAT or COMMAND         document output format (or command)
+  DOCUMENT              name of the document to build. It can be either one of
+                        the documents listed by -D or 'file=/path/to/FILE' to
+                        build documentation for this specific file.
+  FORMAT or COMMAND     document output format (or command)
 
-Standard options::
+Standard::
 
-  -h, --help                show a help message and exit
-  -H, --help-all            show an extended help message and exit
-  -D, --documents           list all available DOCUMENTs
-  -F, --formats             list all output FORMATs
-  -C DOC, --commands DOC    list all COMMANDs for DOCUMENT DOC; use 'all' to list all
-  -i, --inherited           include inherited members in reference manual; may be slow, may fail for PDF output
-  -u, --underscore          include variables prefixed with '_' in reference
-                            manual; may be slow, may fail for PDF output
-  -j, --mathjax, --jsmath   ignored for backwards compatibility
-  --no-plot                 do not include graphics auto-generated using the '.. plot' markup
-  --include-tests-blocks    include TESTS blocks in the reference manual
-  --no-pdf-links            do not include PDF links in DOCUMENT 'website';
-                            FORMATs: html, json, pickle, web
-  --warn-links              issue a warning whenever a link is not properly
-                            resolved; equivalent to '--sphinx-opts -n' (sphinx option: nitpicky)
-  --check-nested            check picklability of nested classes in DOCUMENT 'reference'
-  --no-prune-empty-dirs     do not prune empty directories in the documentation sources
-  -N, --no-colors           do not color output; does not affect children
-  -q, --quiet               work quietly; same as --verbose=0
-  -v LEVEL, --verbose LEVEL report progress at LEVEL=0 (quiet), 1 (normal), 2
-                            (info), or 3 (debug); does not affect children
-  -o DIR, --output DIR      if DOCUMENT is a single file ('file=...'), write output to this directory
+  -h, --help            show a help message and exit
+  -H, --help-all        show an extended help message and exit
+  -D, --documents       list all available DOCUMENTs
+  -F, --formats         list all output FORMATs
+  -C DOC, --commands DOC
+                        list all COMMANDs for DOCUMENT DOC; use 'all' to list all
+  -i, --inherited       include inherited members in reference manual; may be
+                        slow, may fail for PDF output
+  -u, --underscore      include variables prefixed with '_' in reference
+                        manual; may be slow, may fail for PDF output
+  -j, --mathjax, --jsmath
+                        ignored for backwards compatibility
+  --no-plot             do not include graphics auto-generated using the '.. plot' markup
+  --no-preparsed-examples
+                        do not show preparsed versions of EXAMPLES blocks
+  --include-tests-blocks
+                        include TESTS blocks in the reference manual
+  --no-pdf-links        do not include PDF links in DOCUMENT 'website';
+                        FORMATs: html, json, pickle, web
+  --live-doc            make Sage code blocks live for html FORMAT
+  --warn-links          issue a warning whenever a link is not properly
+                        resolved; equivalent to '--sphinx-opts -n' (sphinx
+                        option: nitpicky)
+  --check-nested        check picklability of nested classes in DOCUMENT 'reference'
+  --no-prune-empty-dirs
+                        do not prune empty directories in the documentation sources
+  --use-cdns            assume internet connection and use CDNs; in particular,
+                        use MathJax CDN
+  -N, --no-colors       do not color output; does not affect children
+  -q, --quiet           work quietly; same as --verbose=0
+  -v LEVEL, --verbose LEVEL
+                        report progress at LEVEL=0 (quiet), 1 (normal), 2
+                        (info), or 3 (debug); does not affect children
+  -o DIR, --output DIR  if DOCUMENT is a single file ('file=...'), write output
+                        to this directory
 
-Advanced options::
+Advanced::
 
-  -S OPTS, --sphinx-opts OPTS pass comma-separated OPTS to sphinx-build; must
-                              precede OPTS with '=', as in '-S=-q,-aE' or '-S="-q,-aE"'
-  -U, --update-mtimes         before building reference manual, update
-                              modification times for auto-generated reST files
-  -k, --keep-going            do not abort on errors but continue as much as
-                              possible after an error
-  --all-documents ARG         if ARG is 'reference', list all subdocuments of
-                              en/reference. If ARG is 'all', list all main documents
+  Use these options with care.
 
+  -S OPTS, --sphinx-opts OPTS
+                        pass comma-separated OPTS to sphinx-build; must precede
+                        OPTS with '=', as in '-S=-q,-aE' or '-S="-q,-aE"'
+  -U, --update-mtimes   before building reference manual, update modification
+                        times for auto-generated reST files
+  -k, --keep-going      Do not abort on errors but continue as much as possible
+                        after an error
+  --all-documents ARG   if ARG is 'reference', list all subdocuments of
+                        en/reference. If ARG is 'all', list all main documents
 """
 
 import logging
@@ -68,6 +83,7 @@ from .builders import DocBuilder, ReferenceBuilder, get_builder, get_documents
 from . import build_options
 
 logger = logging.getLogger(__name__)
+
 
 def format_columns(lst, align='<', cols=None, indent=4, pad=3, width=80):
     """

--- a/src/sage_docbuild/builders.py
+++ b/src/sage_docbuild/builders.py
@@ -867,20 +867,10 @@ class ReferenceSubBuilder(DocBuilder):
         """
         Return the Sphinx environment for this project.
         """
-        class FakeConfig():
-            values = tuple()
-
-        class FakeApp():
-            def __init__(self, dir):
-                self.srcdir = dir
-                self.config = FakeConfig()
-
         env_pickle = os.path.join(self._doctrees_dir(), 'environment.pickle')
         try:
             with open(env_pickle, 'rb') as f:
                 env = pickle.load(f)
-                env.app = FakeApp(self.dir)
-                env.config.values = env.app.config.values
                 logger.debug("Opened Sphinx environment: %s", env_pickle)
                 return env
         except (OSError, EOFError) as err:
@@ -897,29 +887,14 @@ class ReferenceSubBuilder(DocBuilder):
             for doc in env.all_docs:
                 env.all_docs[doc] = time.time()
             logger.info("Updated %d reST file mtimes", len(env.all_docs))
+
             # This is the only place we need to save (as opposed to
             # load) Sphinx's pickle, so we do it right here.
-            env_pickle = os.path.join(self._doctrees_dir(),
-                                      'environment.pickle')
-
-            # When cloning a new branch (see
-            # SAGE_LOCAL/bin/sage-clone), we hard link the doc output.
-            # To avoid making unlinked, potentially inconsistent
-            # copies of the environment, we *don't* use
-            # env.topickle(env_pickle), which first writes a temporary
-            # file.  We adapt sphinx.environment's
-            # BuildEnvironment.topickle:
+            env_pickle = os.path.join(self._doctrees_dir(), 'environment.pickle')
 
             # remove unpicklable attributes
             env.set_warnfunc(None)
-            del env.config.values
             with open(env_pickle, 'wb') as picklefile:
-                # remove potentially pickling-problematic values from config
-                for key, val in vars(env.config).items():
-                    if key.startswith('_') or isinstance(val, (types.ModuleType,
-                                                               types.FunctionType,
-                                                               type)):
-                        del env.config[key]
                 pickle.dump(env, picklefile, pickle.HIGHEST_PROTOCOL)
 
             logger.debug("Saved Sphinx environment: %s", env_pickle)

--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -820,25 +820,14 @@ base_class_as_func = [
     'frozenset', 'int', 'list', 'long', 'object',
     'set', 'slice', 'str', 'tuple', 'type', 'unicode', 'xrange']
 
-# Nit picky option configuration: Put here broken links we want to ignore. For
+
+# nitpicky option configuration: Put here broken links we want to ignore. For
 # link to the Python documentation several links where broken because there
 # where class listed as functions. Expand the list 'base_class_as_func' above
 # instead of marking the link as broken.
 nitpick_ignore = [
     ('py:class', 'twisted.web2.resource.Resource'),
     ('py:class', 'twisted.web2.resource.PostableResource')]
-
-def nitpick_patch_config(app):
-    """
-    Patch the default config for nitpicky
-
-    Calling path_config ensure that nitpicky is not considered as a Sphinx
-    environment variable but rather as a Sage environment variable. As a
-    consequence, changing it doesn't force the recompilation of the entire
-    documentation.
-    """
-    app.config.values['nitpicky'] = (False, 'sage')
-    app.config.values['nitpick_ignore'] = ([], 'sage')
 
 
 skip_picklability_check_modules = [
@@ -1055,7 +1044,6 @@ def setup(app):
         # in find_sage_dangling_links.
         #   app.connect('missing-reference', missing_reference)
         app.connect('missing-reference', find_sage_dangling_links)
-        app.connect('builder-inited', nitpick_patch_config)
         app.connect('html-page-context', add_page_context)
 
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes #37996.

We remove this function 

```python
def nitpick_patch_config(app):
    """
    Patch the default config for nitpicky
    [...] ensure that nitpicky is not considered as a Sphinx
    environment variable but rather as a Sage environment variable. As a
    consequence, changing it doesn't force the recompilation of the entire
    documentation.
    """
    app.config.values['nitpicky'] = (False, 'sage')
    app.config.values['nitpick_ignore'] = ([], 'sage')
```
from `src/sage_docbuild/conf.py`.  

The original purpose of the function seems to change `"env"` to `"sage"` for `nitpicky` config variable. But the recent Sphinx is setting `""` (empty string) instead of `"env"` by default. See https://github.com/sphinx-doc/sphinx/blob/48cbb43e28efe82b198137042811e0ade3599ae7/sphinx/config.py#L250C1-L250C41

- Hence  the function is already no-op. But this old and obsolete function is the cause of #37996. Hence we simply remove it.

- To prepare for Sphinx 7.3.7, we also remove some code which seems to have become obsolete when `sage -clone` was removed long time ago.

- Made some docstring up-to-date, to test incremental doc build.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


