### PR TITLE
Fix MPoly functors for single variable

### DIFF
--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -1055,9 +1055,18 @@ class MultiPolynomialFunctor(ConstructionFunctor):
             Multivariate Polynomial Ring in x, y, z over Integer Ring
             sage: F(RR)          # indirect doctest                                     # needs sage.rings.real_mpfr
             Multivariate Polynomial Ring in x, y, z over Real Field with 53 bits of precision
+
+        Verify that single-variable multivariate polynomial rings are created
+        correctly (:issue:`38089`)::
+
+            sage: R = PolynomialRing(ZZ, 1, "z")
+            sage: F = R.construction()[0]; F
+            MPoly[z]
+            sage: F(ZZ) == R
+            True
         """
         from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-        return PolynomialRing(R, self.vars)
+        return PolynomialRing(R, len(self.vars), self.vars)
 
     def __eq__(self, other):
         """

--- a/src/sage/matroids/minorfix.h
+++ b/src/sage/matroids/minorfix.h
@@ -1,7 +1,3 @@
 // On some systems, macros "minor()" and "major()" are defined in system header files. This will undefine those:
-#ifdef major
-    #undef major
-#endif
-#ifdef minor
-    #undef minor
-#endif
+#undef major
+#undef minor

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -754,9 +754,11 @@ class EllipticCurveHom_composite(EllipticCurveHom):
 
         TESTS::
 
-            sage: f = phi.codomain().defining_polynomial()                              # needs sage.rings.finite_rings
-            sage: g = E.defining_polynomial().subs({2:1})                               # needs sage.rings.finite_rings
-            sage: f(*phi.rational_maps(), 1) % g                                        # needs sage.rings.finite_rings
+            sage: # needs sage.rings.finite_rings
+            sage: f = phi.codomain().defining_polynomial()
+            sage: g = E.defining_polynomial().subs({2:1})
+            sage: h = f(*phi.rational_maps(), 1)
+            sage: h.numerator() % h.numerator().parent()(g)
             0
 
         ::


### PR DESCRIPTION
Fixes #38089. The issue comes from that the construction tower of functors for multivariate polynomial rings behaves incorrectly, since the `_apply_functor` method is incorrect. This PR fixes that.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.

