### PR TITLE
GH Actions: Fix upload of macOS wheels to PyPI

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -240,6 +240,20 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.arch }}-wheels
           path: ./wheelhouse/*.whl
 
+  upload_wheels:
+    # This needs to be a separate job because pypa/gh-action-pypi-publish cannot run on macOS
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    env:
+      CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' }}
+    steps:
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*-*-wheels"
+          path: wheelhouse
+          merge-multiple: true
+
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The change made in #37099 to accommodate the new design of actions/{up,down}load-artifact@v4 broke the upload of macOS wheels to PyPI (see https://github.com/sagemath/sage/actions/runs/9234698750/job/25408786962#step:8:23); this was masked so far because the build of macOS wheels was broken until #36525.

Here we revert to using a separate job that uploads all platform wheels. This uses the new keywords `pattern` and `merge-multiple` of actions/download-artifact@v4

Example run: https://github.com/mkoeppe/sage/actions/runs/9291646178/job/25572343853 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


