### PR TITLE
Added example in documentation of set_legend_options

### DIFF
--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -434,7 +434,7 @@ class Graphics(WithEqualityById, SageObject):
         The parameters ``loc`` and ``borderaxespad`` can be altered in order to place the legend below the x-axis label or to the left of the y-axis label.
         The following example sets ``loc=3`` and ``borderaxespad = ``-7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label.
         
-            sage: p = line([(0, 0), (1, 1)], legend_label='test', axes_labels=('X LABEL', 'Y LABEL'))
+            sage: p = line([(0, 0), (1, 1)], legend_label='test')
             sage: p.axes_labels(['X-Label', 'Y-Label'])                                  # adding labels for axes
             sage: p.set_legend_options(loc=8, borderaxespad=-7.5-0.01*p.fontsize())
             sage: print(p)

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -435,7 +435,7 @@ class Graphics(WithEqualityById, SageObject):
         The following example sets ``loc=3`` and ``borderaxespad = ``-7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label.
         
             sage: p = line([(0, 0), (1, 1)], legend_label='test', axes_labels=('X LABEL', 'Y LABEL'))
-            sage: p.axes_labels(['X-Label', 'Y-Label'])
+            sage: p.axes_labels(['X-Label', 'Y-Label'])                                  # adding labels for axes
             sage: p.set_legend_options(loc=8, borderaxespad=-7.5-0.01*p.fontsize())
             sage: print(p)
             Graphics object consisting of 1 graphics primitive

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -310,7 +310,7 @@ class Graphics(WithEqualityById, SageObject):
             False
             sage: P.legend(True)
             sage: P  # show with the legend
-            Graphics object consisting of 1 graphics primitive   
+            Graphics object consisting of 1 graphics primitive
         """
         if show is None:
             return self._show_legend

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -432,7 +432,7 @@ class Graphics(WithEqualityById, SageObject):
             Graphics object consisting of 1 graphics primitive
 
         The parameters ``loc`` and ``borderaxespad`` can be altered in order to place the legend below the x-axis label or to the left of the y-axis label.
-        The following example sets ``loc=3`` and ``borderaxespad = -7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label.
+        The following example sets ``loc=3`` and ``borderaxespad = -7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label::
 
             sage: p = line([(0, 0), (1, 1)], legend_label='test')
             sage: p.axes_labels(['X-Label', 'Y-Label'])                                  # adding labels for axes

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -310,7 +310,7 @@ class Graphics(WithEqualityById, SageObject):
             False
             sage: P.legend(True)
             sage: P  #  show with the legend
-            Graphics object consisting of 1 graphics primitive
+            Graphics object consisting of 1 graphics primitive    
         """
         if show is None:
             return self._show_legend
@@ -429,6 +429,19 @@ class Graphics(WithEqualityById, SageObject):
         ::
 
             sage: p.set_legend_options(loc=(0.5,0.5)); p  # aligns the bottom of the box to the center                  # needs sage.symbolic
+            Graphics object consisting of 1 graphics primitive
+    
+        The dictionary ``_extra_kwds`` stores the keywords for graphics. This can be used to adjust vertical or
+        horizonal displacements from the x-axis or y-axis respectively::
+        
+            sage: p = line([(0, 0), (1, 1)], legend_label='test', axes_labels=('X LABEL', 'Y LABEL'))
+            sage: labels = p._extra_kwds.get('axes_labels')
+            sage: if labels and labels[0]:
+            ....:   displace = -.14 - .005 * p.fontsize()
+            ....: else:
+            ....:   displace = -.14
+            ....: p.set_legend_options(bbox_to_anchor=(0., displace, 1., .102), loc=3, mode="expand", borderaxespad=0.)
+            sage: print(p)
             Graphics object consisting of 1 graphics primitive
         """
         if len(kwds) == 0:

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -310,7 +310,7 @@ class Graphics(WithEqualityById, SageObject):
             False
             sage: P.legend(True)
             sage: P  # show with the legend
-            Graphics object consisting of 1 graphics primitive    
+            Graphics object consisting of 1 graphics primitive   
         """
         if show is None:
             return self._show_legend
@@ -430,10 +430,10 @@ class Graphics(WithEqualityById, SageObject):
 
             sage: p.set_legend_options(loc=(0.5,0.5)); p  # aligns the bottom of the box to the center                # needs sage.symbolic
             Graphics object consisting of 1 graphics primitive
-    
+
         The parameters ``loc`` and ``borderaxespad`` can be altered in order to place the legend below the x-axis label or to the left of the y-axis label.
         The following example sets ``loc=3`` and ``borderaxespad = -7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label.
-        
+
             sage: p = line([(0, 0), (1, 1)], legend_label='test')
             sage: p.axes_labels(['X-Label', 'Y-Label'])                                  # adding labels for axes
             sage: p.set_legend_options(loc=8, borderaxespad=-7.5-0.01*p.fontsize())

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -431,13 +431,14 @@ class Graphics(WithEqualityById, SageObject):
             sage: p.set_legend_options(loc=(0.5,0.5)); p  # aligns the bottom of the box to the center                # needs sage.symbolic
             Graphics object consisting of 1 graphics primitive
 
-        The parameters ``loc`` and ``borderaxespad`` can be altered in order to place the legend below the x-axis label or to the left of the y-axis label.
-        The following example sets ``loc=3`` and ``borderaxespad = -7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label::
+        The parameters ``loc`` and ``borderaxespad`` can be altered
+        in order to place the legend below the x-axis label or to
+        the left of the y-axis label::
 
             sage: p = line([(0, 0), (1, 1)], legend_label='test')
-            sage: p.axes_labels(['X-Label', 'Y-Label'])                                  # adding labels for axes
+            sage: p.axes_labels(['X-Label', 'Y-Label'])  # adding labels for axes
             sage: p.set_legend_options(loc=8, borderaxespad=-7.5-0.01*p.fontsize())
-            sage: print(p)
+            sage: p
             Graphics object consisting of 1 graphics primitive
         """
         if len(kwds) == 0:

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -432,7 +432,7 @@ class Graphics(WithEqualityById, SageObject):
             Graphics object consisting of 1 graphics primitive
 
         The parameters ``loc`` and ``borderaxespad`` can be altered in order to place the legend below the x-axis label or to the left of the y-axis label.
-        The following example sets ``loc=3`` and ``borderaxespad = -7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label::
+        The following example sets ``loc=3`` and ``borderaxespad = -7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label.
 
             sage: p = line([(0, 0), (1, 1)], legend_label='test')
             sage: p.axes_labels(['X-Label', 'Y-Label'])                                  # adding labels for axes

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -309,7 +309,7 @@ class Graphics(WithEqualityById, SageObject):
             sage: P.legend()
             False
             sage: P.legend(True)
-            sage: P  #  show with the legend
+            sage: P  # show with the legend
             Graphics object consisting of 1 graphics primitive    
         """
         if show is None:
@@ -428,11 +428,11 @@ class Graphics(WithEqualityById, SageObject):
 
         ::
 
-            sage: p.set_legend_options(loc=(0.5,0.5)); p  # aligns the bottom of the box to the center                  # needs sage.symbolic
+            sage: p.set_legend_options(loc=(0.5,0.5)); p  # aligns the bottom of the box to the center                # needs sage.symbolic
             Graphics object consisting of 1 graphics primitive
     
         The parameters ``loc`` and ``borderaxespad`` can be altered in order to place the legend below the x-axis label or to the left of the y-axis label.
-        The following example sets ``loc=3`` and ``borderaxespad = ``-7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label.
+        The following example sets ``loc=3`` and ``borderaxespad = -7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label.
         
             sage: p = line([(0, 0), (1, 1)], legend_label='test')
             sage: p.axes_labels(['X-Label', 'Y-Label'])                                  # adding labels for axes

--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -431,16 +431,12 @@ class Graphics(WithEqualityById, SageObject):
             sage: p.set_legend_options(loc=(0.5,0.5)); p  # aligns the bottom of the box to the center                  # needs sage.symbolic
             Graphics object consisting of 1 graphics primitive
     
-        The dictionary ``_extra_kwds`` stores the keywords for graphics. This can be used to adjust vertical or
-        horizonal displacements from the x-axis or y-axis respectively::
+        The parameters ``loc`` and ``borderaxespad`` can be altered in order to place the legend below the x-axis label or to the left of the y-axis label.
+        The following example sets ``loc=3`` and ``borderaxespad = ``-7.5-0.01*p.fontsize()`` so as to obtain the legend below the x-axis label.
         
             sage: p = line([(0, 0), (1, 1)], legend_label='test', axes_labels=('X LABEL', 'Y LABEL'))
-            sage: labels = p._extra_kwds.get('axes_labels')
-            sage: if labels and labels[0]:
-            ....:   displace = -.14 - .005 * p.fontsize()
-            ....: else:
-            ....:   displace = -.14
-            ....: p.set_legend_options(bbox_to_anchor=(0., displace, 1., .102), loc=3, mode="expand", borderaxespad=0.)
+            sage: p.axes_labels(['X-Label', 'Y-Label'])
+            sage: p.set_legend_options(loc=8, borderaxespad=-7.5-0.01*p.fontsize())
             sage: print(p)
             Graphics object consisting of 1 graphics primitive
         """


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR introduces a new example in the documentation of `set_legend_options` method that explains how you can have vertical and horizontal displacements below x-axis and beside y-axis respectively. It fixes [this issue.](https://github.com/sagemath/sage/issues/33556). @tscrim 


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


