### PR TITLE
Fix test failure on 32-bit where a different element is picked

### DIFF
--- a/src/sage/geometry/polyhedral_complex.py
+++ b/src/sage/geometry/polyhedral_complex.py
@@ -932,8 +932,11 @@ class PolyhedralComplex(GenericCellComplex):
             sage: pc = PolyhedralComplex([
             ....:         Polyhedron(vertices=[(1/3, 1/3), (0, 0), (1, 2)]),
             ....:         Polyhedron(vertices=[(1, 2), (0, 0), (0, 1/2)])])
-            sage: pc._an_element_().vertices_list()
+            sage: element = pc._an_element_().vertices_list()
+            sage: element   # random output (one of the two maximal cells)
             [[0, 0], [0, 1/2], [1, 2]]
+            sage: element in ([[0, 0], [0, 1/2], [1, 2]], [[0, 0], [1/3, 1/3], [1, 2]])
+            True
         """
         try:
             return next(self.maximal_cell_iterator(increasing=False))


### PR DESCRIPTION
On Debian 12 32-bit I get:
```
**********************************************************************
File "src/sage/geometry/polyhedral_complex.py", line 935, in sage.geometry.polyhedral_complex.PolyhedralComplex._an_element_
Failed example:
    pc._an_element_().vertices_list()
Expected:
    [[0, 0], [0, 1/2], [1, 2]]
Got:
    [[0, 0], [1/3, 1/3], [1, 2]]
**********************************************************************
1 item had failures:
   1 of   4 in sage.geometry.polyhedral_complex.PolyhedralComplex._an_element_
    [469 tests, 1 failure, 17.41 s]
----------------------------------------------------------------------
sage -t --long --random-seed=0 src/sage/geometry/polyhedral_complex.py  # 1 doctest failed
----------------------------------------------------------------------
```
Just accept either of the two maximal cells