### PR TITLE
Deprecate `arguments`, `args`, `number_of_arguments` for non-callable Expression

### DIFF
--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -6248,6 +6248,11 @@ cdef class Expression(Expression_abc):
 
     def arguments(self):
         """
+        Return sorted tuple of arguments of this callable symbolic expression.
+
+        For ordinary symbolic expressions, this is a deprecated alias of
+        :meth:`variables`.
+
         EXAMPLES::
 
             sage: x,y = var('x,y')
@@ -6263,12 +6268,23 @@ cdef class Expression(Expression_abc):
         try:
             return self._parent.arguments()
         except AttributeError:
+            from sage.misc.superseded import deprecation
+            deprecation(14270,
+                        "methods 'args', 'arguments', 'number_of_arguments' "
+                        "for expressions that are not callable is deprecated; "
+                        "use 'variables' or 'free_variables', or use a "
+                        "callable symbolic expression instead")
             return self.variables()
 
     args = arguments
 
     def number_of_arguments(self):
         """
+        Return the number of arguments of ``self`` as a callable symbolic expression.
+
+        For ordinary symbolic expressions, this is deprecated and returns the length
+        of :meth:`variables`.
+
         EXAMPLES::
 
             sage: x,y = var('x,y')


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

- Rebased from #32227. 

Fixes #32227.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


