### PR TITLE
fix and activate E305 in pyx files

### DIFF
--- a/src/sage/misc/c3_controlled.pyx
+++ b/src/sage/misc/c3_controlled.pyx
@@ -582,6 +582,7 @@ cdef class CmpKeyNamed:
 
 _cmp_key_named = CmpKeyNamed()
 
+
 ##############################################################################
 
 def C3_merge(list lists):
@@ -659,6 +660,7 @@ def C3_merge(list lists):
             # No head is available
             raise ValueError("Cannot merge the items %s."%', '.join(repr(head) for head in heads))
     return out
+
 
 cpdef identity(x):
     r"""
@@ -1354,7 +1356,6 @@ class HierarchyElement(object, metaclass=ClasscallMetaclass):
         if not super_classes:
             super_classes = (object,)
         return dynamic_class("%s.cls"%self, super_classes)
-
 
     @cached_method
     def all_bases(self):

--- a/src/sage/misc/cachefunc.pyx
+++ b/src/sage/misc/cachefunc.pyx
@@ -457,6 +457,7 @@ cdef frozenset special_method_names = frozenset(['__abs__', '__add__',
             '__rtruediv__', '__rxor__', '__set__', '__setattr__', '__setitem__', '__setslice__', '__sizeof__',
             '__str__', '__sub__', '__subclasscheck__', '__truediv__', '__unicode__', '__xor__', 'next'])
 
+
 def _cached_function_unpickle(module, name, cache=None):
     """
     Unpickle the cache function ``name`` defined in ``module``.
@@ -504,6 +505,7 @@ def _cached_function_unpickle(module, name, cache=None):
     if cache is not None:
         ret.cache.update(cache)
     return ret
+
 
 cdef class NonpicklingDict(dict):
     r"""
@@ -1453,6 +1455,7 @@ cdef class WeakCachedFunction(CachedFunction):
 
 
 weak_cached_function = decorator_keywords(WeakCachedFunction)
+
 
 class CachedMethodPickle():
     """
@@ -3016,6 +3019,7 @@ cdef class CachedSpecialMethod(CachedMethod):
                 pass
             D[name] = Caller
         return Caller
+
 
 @decorator_keywords
 def cached_method(f, name=None, key=None, do_pickle=None):

--- a/src/sage/misc/fpickle.pyx
+++ b/src/sage/misc/fpickle.pyx
@@ -61,6 +61,7 @@ def reduce_code(co):
 
 copyreg.pickle(types.CodeType, reduce_code)
 
+
 def pickle_function(func):
     """
     Pickle the Python function func.  This is not a normal pickle; you

--- a/src/sage/misc/lazy_import.pyx
+++ b/src/sage/misc/lazy_import.pyx
@@ -1136,6 +1136,7 @@ def lazy_import(module, names, as_=None, *,
 
 star_imports = None
 
+
 def save_cache_file():
     """
     Used to save the cached * import names.
@@ -1157,6 +1158,7 @@ def save_cache_file():
     os.makedirs(cache_dir, exist_ok=True)
     with atomic_write(cache_file, binary=True) as f:
         pickle.dump(star_imports, f)
+
 
 def get_star_imports(module_name):
     """

--- a/src/sage/misc/lazy_string.pyx
+++ b/src/sage/misc/lazy_string.pyx
@@ -61,6 +61,7 @@ from cpython.object cimport PyObject_Call, PyObject_RichCompare
 
 import types
 
+
 def is_lazy_string(obj):
     """
     Checks if the given object is a lazy string.
@@ -75,6 +76,7 @@ def is_lazy_string(obj):
     """
     return isinstance(obj, _LazyString)
 
+
 def lazy_string(f, *args, **kwargs):
     """
     Creates a lazy string.
@@ -85,7 +87,6 @@ def lazy_string(f, *args, **kwargs):
     - positional arguments that are given to ``f``, either by calling or by
       applying it as a format string
     - named arguments, that are forwarded to ``f`` if it is not a string
-
 
     EXAMPLES::
 
@@ -130,6 +131,7 @@ def _make_lazy_string(ftype, fpickle, args, kwargs):
     else:
         f = fpickle
     return _LazyString(f, args, kwargs)
+
 
 cdef class _LazyString():
     """

--- a/src/sage/misc/misc_c.pyx
+++ b/src/sage/misc/misc_c.pyx
@@ -23,6 +23,7 @@ AUTHORS:
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+from copy import copy
 
 from cpython.sequence cimport *
 from cpython.list cimport *
@@ -305,8 +306,6 @@ class NonAssociative:
         """
         return NonAssociative(self, other)
 
-from copy import copy
-
 
 def balanced_sum(x, z=None, Py_ssize_t recursion_cutoff=5):
     """
@@ -397,6 +396,7 @@ def balanced_sum(x, z=None, Py_ssize_t recursion_cutoff=5):
         sum = z + sum
 
     return sum
+
 
 cdef balanced_list_sum(L, Py_ssize_t offset, Py_ssize_t count, Py_ssize_t cutoff):
     """

--- a/src/sage/misc/nested_class.pyx
+++ b/src/sage/misc/nested_class.pyx
@@ -345,6 +345,7 @@ class MainClass(object, metaclass=NestedClassMetaclass):
                 """
                 pass
 
+
 class SubClass(MainClass):
     r"""
     A simple class to test nested_pickle.
@@ -359,10 +360,13 @@ class SubClass(MainClass):
     """
     pass
 
+
 nested_pickle(SubClass)
+
 
 def _provide_SubClass():
     return SubClass
+
 
 class CopiedClass():
     r"""
@@ -380,7 +384,9 @@ class CopiedClass():
     NestedSubClass = MainClass.NestedClass.NestedSubClass
     SubClass = _provide_SubClass()
 
+
 nested_pickle(CopiedClass)
+
 
 # Further classes for recursive tests
 

--- a/src/sage/misc/parser.pyx
+++ b/src/sage/misc/parser.pyx
@@ -37,6 +37,7 @@ def foo(*args, **kwds):
     """
     return args, kwds
 
+
 function_map = {
   'foo': foo,
   'sqrt': math.sqrt,
@@ -44,6 +45,7 @@ function_map = {
   'cos': math.cos,
   'tan': math.tan,
 }
+
 
 cdef enum token_types:
     # leave room for ASCII character tokens such as '+'

--- a/src/sage/misc/persist.pyx
+++ b/src/sage/misc/persist.pyx
@@ -341,6 +341,7 @@ def dumps(obj, compress=True):
 # This is used below, and also by explain_pickle.py
 unpickle_override = {}
 
+
 def register_unpickle_override(module, name, callable, call_name=None):
     r"""
     Python pickles include the module and class name of classes.
@@ -999,6 +1000,7 @@ def loads(s, compress=True, **kwargs):
 
 
 cdef bint make_pickle_jar = 'SAGE_PICKLE_JAR' in os.environ
+
 
 def picklejar(obj, dir=None):
     """

--- a/src/sage/misc/pickle_old.pyx
+++ b/src/sage/misc/pickle_old.pyx
@@ -2,6 +2,7 @@
 from sage.misc.superseded import deprecation_cython as deprecation
 import sage.rings.fraction_field_element
 
+
 def make_element_old(_class, _dict, parent):
     """
     Used for unpickling old pickles of Element objects (and subclasses).

--- a/src/sage/misc/randstate.pyx
+++ b/src/sage/misc/randstate.pyx
@@ -753,7 +753,6 @@ cdef class randstate:
         except KeyError:
             prev = None
 
-
         if prev is not self:
             if self._gp_saved_seeds is not None and gp in self._gp_saved_seeds:
                 seed = self._gp_saved_seeds[gp]
@@ -969,6 +968,7 @@ cpdef int random() noexcept:
     """
     return gmp_urandomb_ui(_current_randstate.gmp_state, 31)
 
+
 def initial_seed():
     r"""
     Returns the initial seed used to create the current :class:`randstate`.
@@ -990,6 +990,7 @@ def initial_seed():
     """
     return _current_randstate._seed
 
+
 def benchmark_libc():
     r"""
     This function was used to test whether moving from libc to GMP's
@@ -1008,6 +1009,7 @@ def benchmark_libc():
     for i from 0 <= i < 100000:
         c_libc_random()
 
+
 def benchmark_mt():
     r"""
     This function was used to test whether moving from libc to GMP's
@@ -1025,6 +1027,7 @@ def benchmark_mt():
     cdef randstate rstate = _current_randstate
     for i from 0 <= i < 100000:
         gmp_urandomb_ui(rstate.gmp_state, 32)
+
 
 cpdef int _doctest_libc_random() noexcept:
     r"""

--- a/src/sage/misc/stopgap.pyx
+++ b/src/sage/misc/stopgap.pyx
@@ -9,7 +9,7 @@ Stopgaps
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 #*****************************************************************************
 
 import warnings
@@ -17,6 +17,7 @@ import warnings
 
 from sage.doctest import DOCTEST_MODE
 cdef bint ENABLED = not DOCTEST_MODE
+
 
 def set_state(bint mode):
     """
@@ -41,6 +42,7 @@ def set_state(bint mode):
     global ENABLED
     ENABLED = mode
 
+
 class StopgapWarning(Warning):
     """
     This class is used to warn users of a known issue that may produce
@@ -48,9 +50,12 @@ class StopgapWarning(Warning):
     """
     pass
 
+
 warnings.filterwarnings('always', category=StopgapWarning)
 
-cdef set _stopgap_cache = set([])
+
+cdef set _stopgap_cache = set()
+
 
 def stopgap(message, int issue_no):
     r"""

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -183,7 +183,7 @@ description =
     # See https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 deps = pycodestyle
 commands = pycodestyle --select E111,E21,E221,E222,E225,E227,E228,E25,E271,E303,E305,E306,E401,E502,E701,E702,E703,E71,E72,W291,W293,W391,W605 {posargs:{toxinidir}/sage/}
-       pycodestyle --select E111,E271,E301,E306,E401,E502,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
+       pycodestyle --select E111,E271,E301,E305,E306,E401,E502,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
 
 [pycodestyle]
 max-line-length = 160

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -156,8 +156,6 @@ deps = pycodestyle
 commands = pycodestyle {posargs:{toxinidir}/sage/}
 
 [testenv:pycodestyle-minimal]
-## Note that the the pycodestyle linter provided by vscode checks against the
-## same minimal conventions as defined below, see the file SAGE_ROOT/.vscode/settings.json.
 description =
     check against Sage's minimal style conventions
     # Check for the following issues:


### PR DESCRIPTION
this is adding the pycodestyle E305 check to pycodestyle-minimal in pyx files


### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.