### PR TITLE
Use equality '==' instead of 'is' for strings comparison

### DIFF
--- a/src/sage/graphs/distances_all_pairs.pyx
+++ b/src/sage/graphs/distances_all_pairs.pyx
@@ -2351,7 +2351,7 @@ def szeged_index(G, algorithm=None):
     if G.is_directed() and not G.is_strongly_connected():
         raise ValueError("the Szeged index is defined for "
                          "strongly connected digraphs only")
-    if G.is_directed() and algorithm is "low":
+    if G.is_directed() and algorithm == "low":
         raise ValueError("the 'low' algorithm cannot be used on digraphs")
 
     if algorithm is None:
@@ -2360,7 +2360,7 @@ def szeged_index(G, algorithm=None):
     elif algorithm not in ["low", "high"]:
         raise ValueError(f"unknown algorithm '{algorithm}'")
 
-    if algorithm is "low" and (G.has_loops() or G.has_multiple_edges()):
+    if algorithm == "low" and (G.has_loops() or G.has_multiple_edges()):
         raise ValueError("the 'low' algorithm is for simple connected "
                          "undirected graphs only")
 
@@ -2370,7 +2370,7 @@ def szeged_index(G, algorithm=None):
     cdef short_digraph sd
     cdef uint64_t s
 
-    if algorithm is "low":
+    if algorithm == "low":
         init_short_digraph(sd, G, edge_labelled=False, vertex_list=list(G), sort_neighbors=True)
         s = c_szeged_index_low_memory(sd)
     else:

--- a/src/sage/graphs/traversals.pyx
+++ b/src/sage/graphs/traversals.pyx
@@ -444,7 +444,7 @@ def lex_BFS(G, reverse=False, tree=False, initial_vertex=None, algorithm="fast")
     cdef int now, v, vi, int_neighbor
 
     # Perform Lex BFS
-    if algorithm is "fast":
+    if algorithm == "fast":
         lex_BFS_fast_short_digraph(sd, sigma_int, pred)
         sigma = [int_to_v[sigma_int[i]] for i in range(n)]
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

In a very few cases, comparison between a variable and a constant string was done using the is operator.
Strings must be compared using == as two equal strings (even small ones) are not guaranteed to be the same object.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


