### PR TITLE
Replace uses of `setup.py bdist_wheel` and direct uses of `python3 -m build`

### DIFF
--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -215,8 +215,7 @@ sdh_setup_bdist_wheel() {
          "$@" || sdh_die "Error building a wheel for $PKG_NAME"
 }
 
-sdh_pip_install() {
-    echo "Installing $PKG_NAME"
+sdh_build_wheel() {
     mkdir -p dist
     rm -f dist/*.whl
     export PIP_NO_INDEX=1
@@ -282,6 +281,16 @@ sdh_pip_install() {
     unset PIP_FIND_LINKS
     unset PIP_NO_BINARY
     unset PIP_NO_INDEX
+}
+
+sdh_build_and_store_wheel() {
+    sdh_build_wheel "$@"
+    sdh_store_wheel .
+}
+
+sdh_pip_install() {
+    echo "Installing $PKG_NAME"
+    sdh_build_wheel "$@"
     sdh_store_and_pip_install_wheel $install_options .
 }
 

--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -223,6 +223,8 @@ sdh_build_wheel() {
     build_options=""
     # pip has --no-build-isolation but no flag that turns the default back on...
     build_isolation_option=""
+    # build has --wheel but no flag that turns the default (build sdist and then wheel) back on
+    dist_option="--wheel"
     export PIP_FIND_LINKS="$SAGE_SPKG_WHEELS"
     unset PIP_NO_BINARY
     while [ $# -gt 0 ]; do
@@ -242,6 +244,9 @@ sdh_build_wheel() {
                 export PIP_NO_BINARY=:all:
                 build_isolation_option="--no-isolation --skip-dependency-check"
                 ;;
+            --sdist-then-wheel)
+                dist_option=""
+                ;;
             --no-deps)
                 install_options="$install_options $1"
                 ;;
@@ -257,7 +262,7 @@ sdh_build_wheel() {
         esac
         shift
     done
-    if python3 -m build --wheel --outdir=dist $build_isolation_option $build_options "$@"; then
+    if python3 -m build $dist_option --outdir=dist $build_isolation_option $build_options "$@"; then
         : # successful
     else
         case $build_isolation_option in
@@ -265,12 +270,12 @@ sdh_build_wheel() {
                 sdh_die "Error building a wheel for $PKG_NAME"
                 ;;
             *)
-                echo >&2 "Warning: building with \"python3 -m build --wheel --outdir=dist $build_isolation_option $build_options $@\" failed."
+                echo >&2 "Warning: building with \"python3 -m build $dist_option --outdir=dist $build_isolation_option $build_options $@\" failed."
                 unset PIP_FIND_LINKS
                 export PIP_NO_BINARY=:all:
                 build_isolation_option="--no-isolation --skip-dependency-check"
-                echo >&2 "Retrying with \"python3 -m build --wheel --outdir=dist $build_isolation_option $build_options $@\"."
-                if python3 -m build --wheel --outdir=dist $build_isolation_option $build_options "$@"; then
+                echo >&2 "Retrying with \"python3 -m build $dist_option --outdir=dist $build_isolation_option $build_options $@\"."
+                if python3 -m build $dist_option --outdir=dist $build_isolation_option $build_options "$@"; then
                     echo >&2 "Warning: Wheel building needed to use \"$build_isolation_option\" to succeed. This means that a dependencies file in build/pkgs/ needs to be updated. Please report this to sage-devel@googlegroups.com, including the build log of this package."
                 else
                     sdh_die "Error building a wheel for $PKG_NAME"

--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -205,16 +205,6 @@ sdh_make_install() {
         sdh_die "Error installing $PKG_NAME"
 }
 
-sdh_setup_bdist_wheel() {
-    # Issue #32046: Most uses of this function can be replaced by sdh_pip_install
-    mkdir -p dist
-    rm -f dist/*.whl
-    BDIST_DIR="$(mktemp -d)"
-    python3 setup.py --no-user-cfg \
-         bdist_wheel --bdist-dir "$BDIST_DIR" \
-         "$@" || sdh_die "Error building a wheel for $PKG_NAME"
-}
-
 sdh_build_wheel() {
     mkdir -p dist
     rm -f dist/*.whl

--- a/build/pkgs/sage_conf/spkg-install.in
+++ b/build/pkgs/sage_conf/spkg-install.in
@@ -1,9 +1,1 @@
-cd src
-if [ "$SAGE_EDITABLE" = yes ]; then
-    sdh_pip_editable_install .
-    if [ "$SAGE_WHEELS" = yes ]; then
-        sdh_setup_bdist_wheel && sdh_store_wheel .
-    fi
-else
-    sdh_pip_install .
-fi
+../sage_setup/spkg-install.in

--- a/build/pkgs/sage_docbuild/spkg-install.in
+++ b/build/pkgs/sage_docbuild/spkg-install.in
@@ -1,9 +1,1 @@
-cd src
-if [ "$SAGE_EDITABLE" = yes ]; then
-    sdh_pip_editable_install .
-    if [ "$SAGE_WHEELS" = yes ]; then
-        sdh_setup_bdist_wheel && sdh_store_wheel .
-    fi
-else
-    sdh_pip_install .
-fi
+../sage_setup/spkg-install.in

--- a/build/pkgs/sage_setup/spkg-install.in
+++ b/build/pkgs/sage_setup/spkg-install.in
@@ -2,7 +2,7 @@ cd src
 if [ "$SAGE_EDITABLE" = yes ]; then
     sdh_pip_editable_install .
     if [ "$SAGE_WHEELS" = yes ]; then
-        sdh_setup_bdist_wheel && sdh_store_wheel .
+        sdh_build_and_store_wheel --no-isolation .
     fi
 else
     sdh_pip_install .

--- a/build/pkgs/sage_sws2rst/spkg-install.in
+++ b/build/pkgs/sage_sws2rst/spkg-install.in
@@ -1,9 +1,1 @@
-cd src
-if [ "$SAGE_EDITABLE" = yes ]; then
-    sdh_pip_editable_install .
-    if [ "$SAGE_WHEELS" = yes ]; then
-        sdh_setup_bdist_wheel && sdh_store_wheel .
-    fi
-else
-    sdh_pip_install .
-fi
+../sage_setup/spkg-install.in

--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -53,7 +53,7 @@ if [ "$SAGE_EDITABLE" = yes ]; then
 
     if [ "$SAGE_WHEELS" = yes ]; then
         # Additionally build a wheel (for use in other venvs)
-        cd $SAGE_PKGS/sagelib/src && time sdh_setup_bdist_wheel && sdh_store_wheel .
+        cd $SAGE_PKGS/sagelib/src && time sdh_build_and_store_wheel --no-build-isolation .
     fi
 else
     # Now implied: "$SAGE_WHEELS" = yes

--- a/build/pkgs/sagemath_objects/spkg-install.in
+++ b/build/pkgs/sagemath_objects/spkg-install.in
@@ -7,8 +7,4 @@ export PIP_FIND_LINKS="file://$SAGE_SPKG_WHEELS"
 # https://pypa-build.readthedocs.io/en/latest/#python--m-build
 # (Important because sagemath-objects uses MANIFEST.in for filtering.)
 # Do not install the wheel.
-DIST_DIR="$(mktemp -d)"
-python3 -m build --outdir "$DIST_DIR"/dist . || sdh_die "Failure building sdist and wheel"
-
-wheel=$(cd "$DIST_DIR" && sdh_store_wheel . >&2 && echo $wheel)
-ls -l "$wheel"
+sdh_build_and_store_wheel --sdist-then-wheel .

--- a/src/doc/en/developer/packaging.rst
+++ b/src/doc/en/developer/packaging.rst
@@ -444,10 +444,6 @@ begin with ``sdh_``, which stands for "Sage-distribution helper".
   arguments. If ``$SAGE_DESTDIR`` is not set then the command is run
   with ``$SAGE_SUDO``, if set.
 
-- ``sdh_setup_bdist_wheel [...]``: Runs ``setup.py bdist_wheel`` with
-  the given arguments, as well as additional default arguments used for
-  installing packages into Sage.
-
 - ``sdh_pip_install [...]``: The equivalent of running ``pip install``
   with the given arguments, as well as additional default arguments used for
   installing packages into Sage with pip. The last argument must be
@@ -608,10 +604,6 @@ case the ``spkg-install.in`` script template might just consist of
 Where ``sdh_pip_install`` is a function provided by ``sage-dist-helpers`` that
 points to the correct ``pip`` for the Python used by Sage, and includes some
 default flags needed for correct installation into Sage.
-
-If ``pip`` will not work for a package but a command like ``python3 setup.py install``
-will, you may use ``sdh_setup_bdist_wheel``, followed by
-``sdh_store_and_pip_install_wheel .``.
 
 For ``spkg-check.in`` script templates, use ``python3`` rather
 than just ``python``.  The paths are set by the Sage build system


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This is the next step in the modernization of our use of build front ends for Python SPKGs, after #35618.

- New `sage-dist-helper` functions `sdh_build_wheel`, `sdh_build_and_store_wheel` (split out from #36730)
- New option `--sdist-then-wheel` for `sdh_pip_install` (and the new `sdh_build*wheel` functions)

By switching the packages `sagemath_environment` etc. from direct use of `python3 -m build` to the `sdh_build_and_store_wheel` script, it now falls back to `--no-build-isolation` when building with build isolation fails.
- This fixes #38190 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


