### PR TITLE
tox.ini: Reject broken filelock 3.15.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,14 +28,12 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         SAGE_CI_FIXES_FROM_REPOSITORIES: ${{ vars.SAGE_CI_FIXES_FROM_REPOSITORIES }}
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-
-    - name: Install dependencies
+    - name: Install test prerequisites
       id: deps
-      run: pip install tox
+      # From docker.yml
+      run: |
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install tox
 
     - name: Code style check with ruff-minimal
       if: (success() || failure()) && steps.deps.outcome == 'success'

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -30,6 +30,7 @@ requires =
     # Because of https://github.com/tox-dev/tox/issues/3238, need <4.14.1
     tox>=3.18
     tox<4.14.1
+    filelock!=3.15.0
 
 [sagedirect]
 # Base for tox environments that bypass the virtual environment set up by tox,

--- a/tox.ini
+++ b/tox.ini
@@ -133,6 +133,7 @@ requires =
     # Because of https://github.com/tox-dev/tox/issues/3238, need <4.14.1
     tox>=4.2.7
     tox<4.14.1
+    filelock!=3.15.0
 
 skipsdist = true
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The release of https://pypi.org/project/filelock/ 3.15.0, released 2024-06-12, broke our use of `tox` in the CI.
For example https://github.com/sagemath/sage/actions/runs/9487516102/job/26144331163?pr=37430#step:11:17

Here we reject this version when auto-provisioning tox.

Unfortunately this cannot fix the breakage in the Lint workflow via the "CI Fix" mechanism, so this will only take after the PR is merged.

Update: The broken filelock 3.15.0 release was yanked 1 hour later

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


