### PR TITLE
bump prompt_toolkit/version_requirements.txt, more spkg-configures

### DIFF
--- a/build/pkgs/httpcore/spkg-configure.m4
+++ b/build/pkgs/httpcore/spkg-configure.m4
@@ -1,0 +1,3 @@
+SAGE_SPKG_CONFIGURE([httpcore], [
+  SAGE_PYTHON_PACKAGE_CHECK([httpcore])
+])

--- a/build/pkgs/httpx/spkg-configure.m4
+++ b/build/pkgs/httpx/spkg-configure.m4
@@ -1,0 +1,3 @@
+SAGE_SPKG_CONFIGURE([httpx], [
+  SAGE_PYTHON_PACKAGE_CHECK([httpx])
+])

--- a/build/pkgs/prompt_toolkit/version_requirements.txt
+++ b/build/pkgs/prompt_toolkit/version_requirements.txt
@@ -1,1 +1,1 @@
-prompt_toolkit >=3.0.38
+prompt_toolkit >=3.0.43


### PR DESCRIPTION
in particular the bump is needed to prevent
 `DeprecationWarning: There is no current event loop loop = asyncio.get_event_loop()`
as in https://github.com/sagemath/sage/issues/37539

On Fedora 40 using old prompt_toolkit from the system not only produces warnings, it hangs `make test`

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [x ] The description explains in detail what this PR is about.
- [x ] I have linked a relevant issue or discussion.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


