### PR TITLE
Fix typo "sage.ring" in docstrings

### DIFF
--- a/src/sage/modular/pollack_stevens/padic_lseries.py
+++ b/src/sage/modular/pollack_stevens/padic_lseries.py
@@ -1,4 +1,4 @@
-# sage.doctest: needs sage.ring.padics
+# sage.doctest: needs sage.rings.padics
 r"""
 `p`-adic `L`-series attached to overconvergent eigensymbols
 
@@ -174,7 +174,7 @@ class pAdicLseries(SageObject):
 
             sage: E = EllipticCurve('11a')
             sage: L = E.padic_lseries(11,implementation="pollackstevens",precision=6) # long time
-            sage: L == loads(dumps(L)) # indirect doctest long time
+            sage: L == loads(dumps(L)) # indirect doctest, long time
             True
         """
         if not isinstance(other, pAdicLseries):

--- a/src/sage/rings/polynomial/padics/polynomial_padic.py
+++ b/src/sage/rings/polynomial/padics/polynomial_padic.py
@@ -274,7 +274,7 @@ class Polynomial_padic(Polynomial):
 
         * ``check_irreducible`` -- check whether the polynomial is irreducible
 
-        * ``kwds`` -- see :meth:`sage.ring.padics.padic_generic.pAdicGeneric.extension`
+        * ``kwds`` -- see :meth:`sage.rings.padics.padic_generic.pAdicGeneric.extension`
 
         EXAMPLES::
 

--- a/src/sage/structure/factory.pyx
+++ b/src/sage/structure/factory.pyx
@@ -520,7 +520,7 @@ cdef class UniqueFactory(SageObject):
         The ``GF`` factory used to have a custom :meth:`other_keys`
         method, but this was removed in :issue:`16934`::
 
-            sage: # needs sage.libs.linbox sage.ring.finite_rings
+            sage: # needs sage.libs.linbox sage.rings.finite_rings
             sage: key, _ = GF.create_key_and_extra_args(27, 'k'); key
             (27, ('k',), x^3 + 2*x + 1, 'givaro', 3, 3, True, None, 'poly', True, True, True)
             sage: K = GF.create_object(0, key); K


### PR DESCRIPTION
The correct module path is "sage.rings" instead of "sage.ring".
In sage/modular/pollack_stevens/padic_lseries.py and in sage/structure/factory.pyx the typo prevents doctests from being run because the "needs" requirement canot be fulfilled.
In sage/rings/polynomial/padics/polynomial_padic.py the typo is merely cosmetic.

See brief [discussion in Sage Support Group](https://groups.google.com/g/sage-support/c/Msx0QJF7rpA)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
/

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


