### PR TITLE
Fix diagonal matrix construction from base ring elements that have `_matrix_` methods

### DIFF
--- a/src/sage/matrix/args.pyx
+++ b/src/sage/matrix/args.pyx
@@ -1500,6 +1500,21 @@ cdef class MatrixArgs:
             Traceback (most recent call last):
             ...
             NameError: name 'a' is not defined
+
+        Check that :issue:`38221` is fixed::
+
+            sage: # needs sage.groups
+            sage: G = CyclicPermutationGroup(7)
+            sage: R = GF(2)
+            sage: A = G.algebra(R)
+            sage: matrix(A, 3, 3, A.zero())
+            [0 0 0]
+            [0 0 0]
+            [0 0 0]
+            sage: matrix(A, 3, 3, A.one())
+            [()  0  0]
+            [ 0 ()  0]
+            [ 0  0 ()]
         """
         # Check basic Python types. This is very fast, so it doesn't
         # hurt to do these first.
@@ -1524,6 +1539,8 @@ cdef class MatrixArgs:
         cdef bint is_elt = isinstance(self.entries, Element)
         if is_elt and isinstance(self.entries, Matrix):
             return MA_ENTRIES_MATRIX
+        if is_elt and self.base is not None and self.entries.parent() == self.base:
+            return MA_ENTRIES_SCALAR
         t = type(self.entries)
         try:
             f = t._matrix_

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -2170,9 +2170,20 @@ class MatrixSpace(UniqueRepresentation, Parent):
             False
             sage: MM.zero().is_mutable()
             False
+
+        Check that :issue:`38221` is fixed::
+
+            sage: # needs sage.groups
+            sage: G = CyclicPermutationGroup(7)
+            sage: R = GF(2)
+            sage: A = G.algebra(R)
+            sage: S = MatrixSpace(A, 3, 3)
+            sage: S.zero_matrix()
+            [0 0 0]
+            [0 0 0]
+            [0 0 0]
         """
-        zero = self.base_ring().zero()
-        res = self.element_class(self, zero, False, False)
+        res = self.element_class(self, None, False, False)
         res.set_immutable()
         return res
 

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -1000,11 +1000,23 @@ def zero_matrix(ring, nrows=None, ncols=None, sparse=False):
         [0 0 0 0 0]
         [0 0 0 0 0]
 
+    TESTS:
+
+    Check that :issue:`38221` is fixed::
+
+        sage: # needs sage.groups
+        sage: G = CyclicPermutationGroup(7)
+        sage: R = GF(2)
+        sage: A = G.algebra(R)
+        sage: zero_matrix(A, 3, 3)
+        [0 0 0]
+        [0 0 0]
+        [0 0 0]
     """
     if isinstance(ring, (Integer, int)):
         nrows, ncols = (ring, nrows)
         ring = ZZ
-    return matrix_space.MatrixSpace(ring, nrows, ncols, sparse)(0)
+    return matrix_space.MatrixSpace(ring, nrows, ncols, sparse).matrix(None)
 
 
 @matrix_method


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The matrix constructors are designed to accept a scalar as the `entries` and then construct a diagonal matrix; special case: constructing the zero matrix from 0.

However, when the scalar is a base ring element that happens to have a `_matrix_` method, that is tried first, leading to the errors reported in #38221.
Here we change it so that if the base ring (or matrix space) has been specified already and a scalar from that base ring is passed, that takes precedence over using a `_matrix_` method. (Coercion is not attempted.)

For the special case of `zero_matrix` and `MatrixSpace.zero_matrix`, we now use `entries=None`, which is the fastest and most robust path in `MatrixArgs.entries_type` to designate a zero matrix.

Fixes #38221 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


