### PR TITLE
`sage.geometry.hyperbolic_space`: Add `# needs`

### DIFF
--- a/src/sage/geometry/hyperbolic_space/hyperbolic_coercion.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_coercion.py
@@ -649,7 +649,7 @@ def SL2R_to_SO21(A):
         sage: from sage.geometry.hyperbolic_space.hyperbolic_coercion import SL2R_to_SO21
         sage: A = SL2R_to_SO21(identity_matrix(2))
         sage: J = matrix([[1,0,0],[0,1,0],[0,0,-1]]) #Lorentzian Gram matrix
-        sage: norm(A.transpose()*J*A - J) < 10**-4
+        sage: norm(A.transpose()*J*A - J) < 10**-4                                      # needs scipy
         True
     """
     a, b, c, d = (A/A.det().sqrt()).list()
@@ -689,7 +689,7 @@ def SO21_to_SL2R(M):
     EXAMPLES::
 
         sage: from sage.geometry.hyperbolic_space.hyperbolic_coercion import SO21_to_SL2R
-        sage: (SO21_to_SL2R(identity_matrix(3)) - identity_matrix(2)).norm() < 10**-4
+        sage: (SO21_to_SL2R(identity_matrix(3)) - identity_matrix(2)).norm() < 10**-4   # needs scipy
         True
     """
     ####################################################################

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_geodesic.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_geodesic.py
@@ -794,7 +794,7 @@ class HyperbolicGeodesic(SageObject):
             sage: g = HM.get_geodesic((0,0,1), (1,0, n(sqrt(2))))
             sage: A = g.reflection_involution()
             sage: B = diagonal_matrix([1, -1, 1])
-            sage: bool((B - A.matrix()).norm() < 10**-9)
+            sage: bool((B - A.matrix()).norm() < 10**-9)                                # needs scipy
             True
 
         The above tests go through the Upper Half Plane.  It remains to
@@ -1602,7 +1602,7 @@ class HyperbolicGeodesicUHP(HyperbolicGeodesic):
             ....:     return bool(x.dist(m) < 1e-9)
             sage: c, d, e = CC(1, 1), CC(2, 1), CC(2, 0.5)
             sage: pairs = [(c, d), (d, c), (c, e), (e, c), (d, e), (e, d)]
-            sage: all(bisector_gets_midpoint(a, b) for a, b in pairs)
+            sage: all(bisector_gets_midpoint(a, b) for a, b in pairs)                   # needs scipy
             True
         """
         if self.length() == infinity:
@@ -2379,7 +2379,7 @@ class HyperbolicGeodesicHM(HyperbolicGeodesic):
             sage: p1 = HM.get_point((4, -4, sqrt(33)))
             sage: p2 = HM.get_point((-3,-3,sqrt(19)))
             sage: g = HM.get_geodesic(p1, p2)
-            sage: g._plot_vertices(5)
+            sage: g._plot_vertices(5)                                                   # needs sage.plot
             [(4.0, -4.0, 5.744562...),
              (1.363213..., -1.637073..., 2.353372...),
              (0.138568..., -0.969980..., 1.400022...),

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_isometry.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_isometry.py
@@ -1,3 +1,4 @@
+# sage.doctest: needs scipy
 r"""
 Hyperbolic Isometries
 

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_model.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_model.py
@@ -488,13 +488,13 @@ class HyperbolicModel(Parent, UniqueRepresentation, BindableClass):
             [1 0]
             [0 1]
 
-            sage: HyperbolicPlane().KM().get_isometry(identity_matrix(3))
+            sage: HyperbolicPlane().KM().get_isometry(identity_matrix(3))               # needs scipy
             Isometry in KM
             [1 0 0]
             [0 1 0]
             [0 0 1]
 
-            sage: HyperbolicPlane().HM().get_isometry(identity_matrix(3))
+            sage: HyperbolicPlane().HM().get_isometry(identity_matrix(3))               # needs scipy
             Isometry in HM
             [1 0 0]
             [0 1 0]
@@ -586,6 +586,7 @@ class HyperbolicModel(Parent, UniqueRepresentation, BindableClass):
 
         EXAMPLES::
 
+            sage: # needs scipy
             sage: A = HyperbolicPlane().PD().random_isometry()
             sage: A.preserves_orientation()
             True
@@ -934,7 +935,7 @@ class HyperbolicModelUHP(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: hp = HyperbolicPlane().UHP().get_background_graphic()
+            sage: hp = HyperbolicPlane().UHP().get_background_graphic()                 # needs sage.plot
         """
         from sage.plot.line import line
         bd_min = bdry_options.get('bd_min', -5)
@@ -1104,9 +1105,9 @@ class HyperbolicModelUHP(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: A = HyperbolicPlane().UHP().random_isometry()
-            sage: B = HyperbolicPlane().UHP().random_isometry(preserve_orientation=False)
-            sage: B.preserves_orientation()
+            sage: A = HyperbolicPlane().UHP().random_isometry()                         # needs scipy
+            sage: B = HyperbolicPlane().UHP().random_isometry(preserve_orientation=False)           # needs scipy
+            sage: B.preserves_orientation()                                             # needs scipy
             False
         """
         [a, b, c, d] = [RR.random_element() for k in range(4)]
@@ -1272,7 +1273,7 @@ class HyperbolicModelPD(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: circ = HyperbolicPlane().PD().get_background_graphic()
+            sage: circ = HyperbolicPlane().PD().get_background_graphic()                # needs sage.plot
         """
         from sage.plot.circle import circle
         return circle((0, 0), 1, axes=False, color='black')
@@ -1380,7 +1381,7 @@ class HyperbolicModelKM(HyperbolicModel):
         EXAMPLES::
 
             sage: A = matrix(3, [[1, 0, 0], [0, 17/8, 15/8], [0, 15/8, 17/8]])
-            sage: HyperbolicPlane().KM().isometry_in_model(A)
+            sage: HyperbolicPlane().KM().isometry_in_model(A)                           # needs scipy
             True
         """
         if isinstance(A, HyperbolicIsometry):
@@ -1396,7 +1397,7 @@ class HyperbolicModelKM(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: circ = HyperbolicPlane().KM().get_background_graphic()
+            sage: circ = HyperbolicPlane().KM().get_background_graphic()                # needs sage.plot
         """
         from sage.plot.circle import circle
         return circle((0, 0), 1, axes=False, color='black')
@@ -1490,7 +1491,7 @@ class HyperbolicModelHM(HyperbolicModel):
         EXAMPLES::
 
            sage: A = diagonal_matrix([1,1,-1])
-           sage: HyperbolicPlane().HM().isometry_in_model(A)
+           sage: HyperbolicPlane().HM().isometry_in_model(A)                            # needs scipy
            True
         """
         if isinstance(A, HyperbolicIsometry):
@@ -1505,7 +1506,7 @@ class HyperbolicModelHM(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: H = HyperbolicPlane().HM().get_background_graphic()
+            sage: H = HyperbolicPlane().HM().get_background_graphic()                   # needs sage.plot
         """
         from sage.plot.plot3d.all import plot3d
         from sage.symbolic.ring import SR

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_point.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_point.py
@@ -318,7 +318,7 @@ class HyperbolicPoint(Element):
         We also lift matrices into isometries::
 
             sage: B = diagonal_matrix([-1, -1, 1])
-            sage: B = HyperbolicPlane().HM().get_isometry(B)
+            sage: B = HyperbolicPlane().HM().get_isometry(B)                            # needs scipy
             sage: B * HyperbolicPlane().HM().get_point((0, 1, sqrt(2)))
             Point in HM (0, -1, sqrt(2))
         """
@@ -491,7 +491,7 @@ class HyperbolicPoint(Element):
             sage: A.preserves_orientation()
             True
 
-            sage: A*A == HyperbolicPlane().UHP().get_isometry(identity_matrix(2))
+            sage: A*A == HyperbolicPlane().UHP().get_isometry(identity_matrix(2))       # needs scipy
             True
         """
         R = self.parent().realization_of().a_realization()
@@ -508,11 +508,11 @@ class HyperbolicPoint(Element):
 
         EXAMPLES::
 
-            sage: HyperbolicPlane().PD().get_point(0).show()
+            sage: HyperbolicPlane().PD().get_point(0).show()                            # needs sage.plot
             Graphics object consisting of 2 graphics primitives
-            sage: HyperbolicPlane().KM().get_point((0,0)).show()
+            sage: HyperbolicPlane().KM().get_point((0,0)).show()                        # needs sage.plot
             Graphics object consisting of 2 graphics primitives
-            sage: HyperbolicPlane().HM().get_point((0,0,1)).show()
+            sage: HyperbolicPlane().HM().get_point((0,0,1)).show()                      # needs sage.plot
             Graphics3d Object
         """
         p = self.coordinates()
@@ -587,7 +587,7 @@ class HyperbolicPointUHP(HyperbolicPoint):
 
             sage: HyperbolicPlane().UHP().get_point(I).show()
             Graphics object consisting of 2 graphics primitives
-            sage: HyperbolicPlane().UHP().get_point(0).show()
+            sage: HyperbolicPlane().UHP().get_point(0).show()                           # needs sage.plot
             Graphics object consisting of 2 graphics primitives
             sage: HyperbolicPlane().UHP().get_point(infinity).show()
             Traceback (most recent call last):

--- a/src/sage/modules/free_module_integer.py
+++ b/src/sage/modules/free_module_integer.py
@@ -384,7 +384,10 @@ class FreeModule_submodule_with_basis_integer(FreeModule_submodule_with_basis_pi
         basis = matrix(ZZ, len(basis), len(basis[0]), basis)
         basis.set_immutable()
 
-        if self.reduced_basis[0].norm() > basis[0].norm():
+        b0 = basis[0]
+        rb0 = self.reduced_basis[0]
+
+        if rb0.dot_product(rb0) > b0.dot_product(b0):
             self._reduced_basis = basis
         return basis
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Some of these are from the use of a matrix norm, which `# needs scipy`.

Also a norm-related change in `sage.modules.free_module_integer` - avoiding use of `norm`, which send us into symbolics land, in favor of just comparing norm squares

- Cherry-picked from #35095.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


