### PR TITLE
Deprecate global imports: `GroupExp_Class`, `GroupExpElement`, `GroupSemidirectProductElement`

### DIFF
--- a/src/sage/groups/all.py
+++ b/src/sage/groups/all.py
@@ -32,6 +32,7 @@ lazy_import('sage.groups', 'groups_catalog', 'groups')
 
 lazy_import('sage.groups.semimonomial_transformations.semimonomial_transformation_group', 'SemimonomialTransformationGroup')
 
-lazy_import('sage.groups.group_exp', ['GroupExp', 'GroupExp_Class', 'GroupExpElement'])
+lazy_import('sage.groups.group_exp', ['GroupExp'])
+lazy_import('sage.groups.group_exp', ['GroupExp_Class', 'GroupExpElement'], deprecation=99999)
 
 lazy_import('sage.groups.group_semidirect_product', ['GroupSemidirectProduct', 'GroupSemidirectProductElement'])

--- a/src/sage/groups/all.py
+++ b/src/sage/groups/all.py
@@ -32,7 +32,10 @@ lazy_import('sage.groups', 'groups_catalog', 'groups')
 
 lazy_import('sage.groups.semimonomial_transformations.semimonomial_transformation_group', 'SemimonomialTransformationGroup')
 
-lazy_import('sage.groups.group_exp', ['GroupExp'])
-lazy_import('sage.groups.group_exp', ['GroupExp_Class', 'GroupExpElement'], deprecation=99999)
+lazy_import('sage.groups.group_exp', 'GroupExp')
+lazy_import('sage.groups.group_exp', ['GroupExp_Class', 'GroupExpElement'],
+            deprecation=38238)
 
-lazy_import('sage.groups.group_semidirect_product', ['GroupSemidirectProduct', 'GroupSemidirectProductElement'])
+lazy_import('sage.groups.group_semidirect_product', 'GroupSemidirectProduct')
+lazy_import('sage.groups.group_semidirect_product', 'GroupSemidirectProductElement',
+            deprecation=38238)

--- a/src/sage/groups/group_exp.py
+++ b/src/sage/groups/group_exp.py
@@ -14,15 +14,16 @@ AUTHORS:
 # (at your option) any later version.
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
+
 from sage.categories.commutative_additive_groups import CommutativeAdditiveGroups
-from sage.categories.groups import Groups
-from sage.structure.element import MultiplicativeGroupElement
-from sage.structure.unique_representation import UniqueRepresentation
-from sage.structure.parent import Parent
-from sage.categories.morphism import SetMorphism
 from sage.categories.functor import Functor
+from sage.categories.groups import Groups
 from sage.categories.homset import Hom
+from sage.categories.morphism import SetMorphism
+from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.element_wrapper import ElementWrapper
+from sage.structure.parent import Parent
+from sage.structure.unique_representation import UniqueRepresentation
 
 
 class GroupExp(Functor):
@@ -59,7 +60,7 @@ class GroupExp(Functor):
         -3
         sage: x.parent()
         Multiplicative form of Integer Ring
-        sage: EZ(-1)*EZ(6) == EZ(5)
+        sage: EZ(-1) * EZ(6) == EZ(5)
         True
         sage: EZ(3)^(-1)
         -3
@@ -77,9 +78,10 @@ class GroupExp(Functor):
         ....:     return s2.action(mu)
         sage: from sage.categories.morphism import SetMorphism
         sage: from sage.categories.homset import Hom
-        sage: f = SetMorphism(Hom(L,L,CommutativeAdditiveGroups()), my_action)
+        sage: f = SetMorphism(Hom(L, L, CommutativeAdditiveGroups()), my_action)
         sage: F = E(f); F
-        Generic endomorphism of Multiplicative form of Ambient space of the Root system of type ['A', 2]
+        Generic endomorphism of
+         Multiplicative form of Ambient space of the Root system of type ['A', 2]
         sage: v = L.an_element(); v
         (2, 2, 3)
         sage: y = F(EL(v)); y
@@ -114,8 +116,8 @@ class GroupExp(Functor):
         OUTPUT: an isomorphic group whose operation is multiplication rather
         than addition
 
-        In the following example, ``self`` is the functor `GroupExp()`,
-        `x` is the additive group `QQ^2`, and the output group is stored as `EQ2`.
+        In the following example, ``self`` is the functor ``GroupExp()``,
+        ``x`` is the additive group ``QQ^2``, and the output group is stored as ``EQ2``.
 
         EXAMPLES::
 
@@ -145,8 +147,6 @@ class GroupExp(Functor):
         OUTPUT: the above homomorphism, but between the corresponding
         multiplicative groups
 
-        - The above homomorphism, but between the corresponding multiplicative groups.
-
         In the following example, ``self`` is the functor :class:`GroupExp` and `f`
         is an endomorphism of the additive group of integers.
 
@@ -156,7 +156,7 @@ class GroupExp(Functor):
             ....:     return x + x
             sage: from sage.categories.morphism import SetMorphism
             sage: from sage.categories.homset import Hom
-            sage: f = SetMorphism(Hom(ZZ,ZZ,CommutativeAdditiveGroups()),double)
+            sage: f = SetMorphism(Hom(ZZ, ZZ, CommutativeAdditiveGroups()), double)
             sage: E = GroupExp()
             sage: EZ = E._apply_functor(ZZ)
             sage: F = E._apply_functor_to_morphism(f)
@@ -164,13 +164,14 @@ class GroupExp(Functor):
             True
             sage: F.codomain() == EZ
             True
-            sage: F(EZ(3)) == EZ(3)*EZ(3)
+            sage: F(EZ(3)) == EZ(3) * EZ(3)
             True
         """
         new_domain = self._apply_functor(f.domain())
         new_codomain = self._apply_functor(f.codomain())
         new_f = lambda a: new_codomain(f(a.value))
         return SetMorphism(Hom(new_domain, new_codomain, Groups()), new_f)
+
 
 class GroupExpElement(ElementWrapper, MultiplicativeGroupElement):
     r"""
@@ -184,13 +185,14 @@ class GroupExpElement(ElementWrapper, MultiplicativeGroupElement):
 
     EXAMPLES::
 
+        sage: from sage.groups.group_exp import GroupExpElement
         sage: G = QQ^2
         sage: EG = GroupExp()(G)
-        sage: z = GroupExpElement(EG, vector(QQ, (1,-3))); z
+        sage: z = GroupExpElement(EG, vector(QQ, (1, -3))); z
         (1, -3)
         sage: z.parent()
         Multiplicative form of Vector space of dimension 2 over Rational Field
-        sage: EG(vector(QQ,(1,-3)))==z
+        sage: EG(vector(QQ, (1, -3))) == z
         True
 
     """
@@ -202,7 +204,7 @@ class GroupExpElement(ElementWrapper, MultiplicativeGroupElement):
             sage: EG = GroupExp()(G)
             sage: x = EG.an_element(); x
             (1, 0)
-            sage: TestSuite(x).run(skip = "_test_category")
+            sage: TestSuite(x).run(skip="_test_category")
 
         See the documentation of :meth:`sage.structure.element_wrapper.ElementWrapper.__init__`
         for the reason behind skipping the category test.
@@ -233,7 +235,7 @@ class GroupExpElement(ElementWrapper, MultiplicativeGroupElement):
             sage: x = G(2)
             sage: x.__mul__(G(3))
             5
-            sage: G.product(G(2),G(3))
+            sage: G.product(G(2), G(3))
             5
         """
         return GroupExpElement(self.parent(), self.value + x.value)
@@ -245,7 +247,7 @@ class GroupExp_Class(UniqueRepresentation, Parent):
 
     INPUT:
 
-    - `G` -- a commutative additive group
+    - ``G`` -- a commutative additive group
 
     OUTPUT: the multiplicative form of `G`
 
@@ -260,7 +262,7 @@ class GroupExp_Class(UniqueRepresentation, Parent):
         EXAMPLES::
 
             sage: EG = GroupExp()(QQ^2)
-            sage: TestSuite(EG).run(skip = "_test_elements")
+            sage: TestSuite(EG).run(skip="_test_elements")
         """
         if G not in CommutativeAdditiveGroups():
             raise TypeError("%s must be a commutative additive group" % G)
@@ -286,7 +288,7 @@ class GroupExp_Class(UniqueRepresentation, Parent):
         EXAMPLES::
 
             sage: G = GroupExp()(ZZ)
-            sage: G(4) # indirect doctest
+            sage: G(4)  # indirect doctest
             4
         """
         return GroupExpElement(self, x)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

`GroupExp_Class` as discussed in:
- https://github.com/sagemath/sage/issues/38211#issuecomment-2176904086 @saraedum 

Part of:
- https://github.com/sagemath/sage/issues/25383

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


