### PR TITLE
some care for pep E272 (spurious white spaces)

### DIFF
--- a/src/sage/categories/bimodules.py
+++ b/src/sage/categories/bimodules.py
@@ -102,7 +102,7 @@ class Bimodules(CategoryWithParameters):
             sage: Bimodules(Fields(), Rings())._make_named_class_key('element_class')
             (Category of fields, Category of rings)
         """
-        return (self._left_base_ring  if isinstance(self._left_base_ring,  Category) else self._left_base_ring.category(),
+        return (self._left_base_ring if isinstance(self._left_base_ring,  Category) else self._left_base_ring.category(),
                 self._right_base_ring if isinstance(self._right_base_ring, Category) else self._right_base_ring.category())
 
     @classmethod

--- a/src/sage/categories/finite_enumerated_sets.py
+++ b/src/sage/categories/finite_enumerated_sets.py
@@ -13,7 +13,7 @@ from sage.categories.category_with_axiom import CategoryWithAxiom
 from sage.categories.enumerated_sets import EnumeratedSets
 from sage.categories.sets_cat import Sets
 from sage.categories.cartesian_product import CartesianProductsCategory
-from sage.categories.isomorphic_objects   import IsomorphicObjectsCategory
+from sage.categories.isomorphic_objects import IsomorphicObjectsCategory
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_import import lazy_import
 from sage.cpython.getattr import raw_getattr

--- a/src/sage/categories/group_algebras.py
+++ b/src/sage/categories/group_algebras.py
@@ -209,7 +209,7 @@ class GroupAlgebras(AlgebrasCategory):
                 - :meth:`Groups.Algebras.ElementMethods.central_form`
                 - :meth:`Monoids.Algebras.ElementMethods.is_central`
             """
-            return tuple([self.sum_of_monomials(conj) for conj  in
+            return tuple([self.sum_of_monomials(conj) for conj in
                           self.basis().keys().conjugacy_classes()])
 
         # Hopf algebra structure

--- a/src/sage/categories/poor_man_map.py
+++ b/src/sage/categories/poor_man_map.py
@@ -91,15 +91,14 @@ class PoorManMap(sage.structure.sage_object.SageObject):
             A map from (1, 2, 3)
             sage: PoorManMap(lambda x: x+2, codomain=(3,4,5))
             A map to (3, 4, 5)
-
         """
         return ((self._name if self._name is not None else "A map") +
-                (" from %s" % (self._domain,) if self._domain is not None else ""     ) +
-                (" to %s" % (self._codomain,) if self._codomain is not None else ""     ))
+                (" from %s" % (self._domain,) if self._domain is not None else "") +
+                (" to %s" % (self._codomain,) if self._codomain is not None else ""))
 
     def domain(self):
         """
-        Returns the domain of ``self``
+        Return the domain of ``self``.
 
         EXAMPLES::
 

--- a/src/sage/categories/poor_man_map.py
+++ b/src/sage/categories/poor_man_map.py
@@ -94,7 +94,7 @@ class PoorManMap(sage.structure.sage_object.SageObject):
 
         """
         return ((self._name if self._name is not None else "A map") +
-                (" from %s" % (self._domain,) if self._domain   is not None else ""     ) +
+                (" from %s" % (self._domain,) if self._domain is not None else ""     ) +
                 (" to %s" % (self._codomain,) if self._codomain is not None else ""     ))
 
     def domain(self):

--- a/src/sage/categories/semigroups.py
+++ b/src/sage/categories/semigroups.py
@@ -344,7 +344,7 @@ class Semigroups(CategoryWithAxiom):
                     generators = self.semigroup_generators()
             if isinstance(generators, (list, tuple)):
                 generators = {self(g): self(g) for g in generators}
-            left = (side == "left"  or side == "twosided")
+            left = (side == "left" or side == "twosided")
             right = (side == "right" or side == "twosided")
 
             def add_edge(source, target, label, side_label):

--- a/src/sage/crypto/mq/sr.py
+++ b/src/sage/crypto/mq/sr.py
@@ -2478,7 +2478,7 @@ class SR_gf2n(SR_generic):
             l = r*c
 
         _vars = self.vars(name, i, l, e)
-        return [_vars[e*j+k]**2 - _vars[e*j+(k+1) % e]   for j in range(l)  for k in range(e)]
+        return [_vars[e*j+k]**2 - _vars[e*j+(k+1) % e] for j in range(l) for k in range(e)]
 
 class SR_gf2(SR_generic):
     def __init__(self, n=1, r=1, c=1, e=4, star=False, **kwargs):
@@ -3200,7 +3200,7 @@ class SR_gf2(SR_generic):
         if self._polybori:
             return []
         _vars = self.vars(name, i, l, e)
-        return [_vars[e*j+k]**2 - _vars[e*j+k]   for j in range(l)  for k in range(e)]
+        return [_vars[e*j+k]**2 - _vars[e*j+k] for j in range(l) for k in range(e)]
 
 class SR_gf2_2(SR_gf2):
     """

--- a/src/sage/geometry/ribbon_graph.py
+++ b/src/sage/geometry/ribbon_graph.py
@@ -1210,10 +1210,10 @@ def bipartite_ribbon_graph(p, q):
     sigma = []
     rho = []
     for i in range(p):
-        aux_tuple = [i*q + j + 1  for j in range(q)]
+        aux_tuple = [i*q + j + 1 for j in range(q)]
         sigma += [aux_tuple]
     for i in range(q):
-        aux_tuple = [p*q + i*p + j + 1  for j in range(p)]
+        aux_tuple = [p*q + i*p + j + 1 for j in range(p)]
         sigma += [aux_tuple]
     for i in range(p*q):
         if (i+1) % q == 0:

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -19586,8 +19586,8 @@ class GenericGraph(GenericGraph_pyx):
             raise TypeError('both arguments must be of the same class')
 
         multiedges = self.allows_multiple_edges() or other.allows_multiple_edges()
-        loops = self.allows_loops()          or other.allows_loops()
-        weighted = self.weighted()              and other.weighted()
+        loops = self.allows_loops() or other.allows_loops()
+        weighted = self.weighted() and other.weighted()
 
         if self._directed:
             from sage.graphs.digraph import DiGraph

--- a/src/sage/groups/cubic_braid.py
+++ b/src/sage/groups/cubic_braid.py
@@ -995,7 +995,7 @@ class CubicBraidGroup(FinitelyPresentedGroup):
             matrix_grpF4 = self.as_matrix_group(root_bur=r64)
             self._internal_test_attached_group(matrix_grpF4, tester)
 
-        if self.strands() < 5  or self._cbg_type == CubicBraidGroup.type.Coxeter:
+        if self.strands() < 5 or self._cbg_type == CubicBraidGroup.type.Coxeter:
             matrix_grpF5 = self.as_matrix_group(characteristic=5)
             self._internal_test_attached_group(matrix_grpF5, tester)
 
@@ -1180,7 +1180,7 @@ class CubicBraidGroup(FinitelyPresentedGroup):
             # to the invariant bilinear form.
             # -----------------------------------------------------------
             xbas = [bas[mhalf - i - 1] for i in range(mhalf)]
-            ybas = [bas[mhalf + i]    for i in range(mhalf)]
+            ybas = [bas[mhalf + i] for i in range(mhalf)]
 
             # -----------------------------------------------------------
             # computing the List of transvection vectors according to

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -4396,7 +4396,7 @@ class Link(SageObject):
             if all(i is SymmetryMutant.mirror_image for i in sym_mut):
                 # all matching links are mirrored to self
                 return S, SymmetryMutant.mirror_image
-            if all(i is SymmetryMutant.itself  for i in sym_mut):
+            if all(i is SymmetryMutant.itself for i in sym_mut):
                 # all matching links are self itself
                 return S, SymmetryMutant.itself
             if any(i is SymmetryMutant.unknown for i in sym_mut):

--- a/src/sage/matrix/symplectic_basis.py
+++ b/src/sage/matrix/symplectic_basis.py
@@ -533,8 +533,8 @@ def symplectic_basis_over_ZZ(M):
             pivot += 2
 
     ps.sort()
-    es = [ p[1]   for p in ps ]
-    fs = [ p[1]+1 for p in ps ]
+    es = [p[1] for p in ps]
+    fs = [p[1] + 1 for p in ps]
     C = B.matrix_from_rows(es + fs + zeroes)
     F = C * M * C.transpose()
     return F, C

--- a/src/sage/modular/abvar/cuspidal_subgroup.py
+++ b/src/sage/modular/abvar/cuspidal_subgroup.py
@@ -69,14 +69,14 @@ TESTS::
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.matrix.constructor        import matrix
-from sage.modular.arithgroup.all    import Gamma0_class
-from sage.modular.cusps             import Cusp
-from sage.rings.infinity            import infinity
-from sage.rings.integer_ring        import ZZ
-from sage.rings.rational_field      import QQ
+from sage.matrix.constructor import matrix
+from sage.modular.arithgroup.all import Gamma0_class
+from sage.modular.cusps import Cusp
+from sage.rings.infinity import infinity
+from sage.rings.integer_ring import ZZ
+from sage.rings.rational_field import QQ
 
-from .finite_subgroup               import FiniteSubgroup
+from .finite_subgroup import FiniteSubgroup
 
 
 class CuspidalSubgroup_generic(FiniteSubgroup):

--- a/src/sage/modular/local_comp/local_comp.py
+++ b/src/sage/modular/local_comp/local_comp.py
@@ -20,22 +20,22 @@ AUTHORS:
 - Jared Weinstein
 """
 
-from sage.structure.sage_object     import SageObject
-from sage.rings.integer_ring        import ZZ
+from sage.structure.sage_object import SageObject
+from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.polynomial_ring import polygen
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.misc.abstract_method      import abstract_method
-from sage.misc.cachefunc            import cached_method
-from sage.misc.lazy_import          import lazy_import
-from sage.misc.verbose              import verbose
-from sage.misc.flatten              import flatten
-from sage.modular.modform.element   import Newform
-from sage.structure.sequence        import Sequence
+from sage.misc.abstract_method import abstract_method
+from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_import import lazy_import
+from sage.misc.verbose import verbose
+from sage.misc.flatten import flatten
+from sage.modular.modform.element import Newform
+from sage.structure.sequence import Sequence
 
 lazy_import('sage.rings.qqbar', 'QQbar')
 
-from .type_space                    import TypeSpace
-from .smoothchar                    import SmoothCharacterGroupQp, SmoothCharacterGroupUnramifiedQuadratic, SmoothCharacterGroupRamifiedQuadratic
+from .type_space import TypeSpace
+from .smoothchar import SmoothCharacterGroupQp, SmoothCharacterGroupUnramifiedQuadratic, SmoothCharacterGroupRamifiedQuadratic
 
 def LocalComponent(f, p, twist_factor=None):
     r"""

--- a/src/sage/modular/modform/cuspidal_submodule.py
+++ b/src/sage/modular/modform/cuspidal_submodule.py
@@ -43,7 +43,7 @@ from sage.matrix.constructor import Matrix
 from sage.matrix.special import identity_matrix
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_import import lazy_import
-from sage.misc.verbose  import verbose
+from sage.misc.verbose import verbose
 from sage.rings.integer import Integer
 from sage.rings.rational_field import QQ
 

--- a/src/sage/modular/modform/numerical.py
+++ b/src/sage/modular/modform/numerical.py
@@ -13,20 +13,20 @@ Numerical computation of newforms
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.rings.fast_arith       import prime_range
-from sage.matrix.constructor     import matrix
-from sage.misc.verbose           import verbose
-from sage.misc.cachefunc         import cached_method
-from sage.misc.prandom           import randint
+from sage.rings.fast_arith import prime_range
+from sage.matrix.constructor import matrix
+from sage.misc.verbose import verbose
+from sage.misc.cachefunc import cached_method
+from sage.misc.prandom import randint
 from sage.modular.arithgroup.all import Gamma0
-from sage.modular.modsym.all     import ModularSymbols
+from sage.modular.modsym.all import ModularSymbols
 from sage.modules.free_module_element import free_module_element as vector
-from sage.rings.complex_double   import CDF
-from sage.rings.integer          import Integer
-from sage.rings.rational_field   import QQ
-from sage.structure.richcmp      import richcmp_method, richcmp
-from sage.structure.sage_object  import SageObject
-from sage.structure.sequence     import Sequence
+from sage.rings.complex_double import CDF
+from sage.rings.integer import Integer
+from sage.rings.rational_field import QQ
+from sage.structure.richcmp import richcmp_method, richcmp
+from sage.structure.sage_object import SageObject
+from sage.structure.sequence import Sequence
 
 # This variable controls importing the SciPy library sparingly
 scipy = None

--- a/src/sage/numerical/optimize.py
+++ b/src/sage/numerical/optimize.py
@@ -400,7 +400,9 @@ def minimize(func, x0, gradient=None, hessian=None, algorithm="default",
         fast_f = fast_callable(func, vars=var_names, domain=float)
         f = lambda p: fast_f(*p)
         gradient_list = func.gradient()
-        fast_gradient_functions = [fast_callable(gradient_list[i], vars=var_names, domain=float)  for i in range(len(gradient_list))]
+        fast_gradient_functions = [fast_callable(gradient_list[i],
+                                                 vars=var_names, domain=float)
+                                   for i in range(len(gradient_list))]
         gradient = lambda p: numpy.array([ a(*p) for a in fast_gradient_functions])
     else:
         f = func

--- a/src/sage/schemes/elliptic_curves/mod_poly.py
+++ b/src/sage/schemes/elliptic_curves/mod_poly.py
@@ -136,7 +136,7 @@ def classical_modular_polynomial(l, j=None):
 
     # If the generic polynomial is in the cache or the database, evaluating
     # it directly should always be faster than recomputing it from scratch.
-    if l  in _cache:
+    if l in _cache:
         return _cache[l](j, Y)
     try:
         Phi = _db[l]

--- a/src/sage/tensor/modules/comp.py
+++ b/src/sage/tensor/modules/comp.py
@@ -1895,8 +1895,8 @@ class Components(SageObject):
         if nproc != 1:
             # Parallel computation
             lol = lambda lst, sz: [lst[i:i+sz] for i in range(0, len(lst), sz)]
-            ind_list = [ind for ind  in self._comp]
-            ind_step = max(1, int(len(ind_list)/nproc))
+            ind_list = list(self._comp)
+            ind_step = max(1, int(len(ind_list) / nproc))
             local_list = lol(ind_list, ind_step)
             # list of input parameters:
             listParalInput = [(self, other, ind_part) for ind_part in local_list]

--- a/src/sage/tensor/modules/comp.py
+++ b/src/sage/tensor/modules/comp.py
@@ -1896,7 +1896,7 @@ class Components(SageObject):
             # Parallel computation
             lol = lambda lst, sz: [lst[i:i+sz] for i in range(0, len(lst), sz)]
             ind_list = list(self._comp)
-            ind_step = max(1, int(len(ind_list) / nproc))
+            ind_step = max(1, len(ind_list) // nproc)
             local_list = lol(ind_list, ind_step)
             # list of input parameters:
             listParalInput = [(self, other, ind_part) for ind_part in local_list]


### PR DESCRIPTION
This is fixing some pycodestyle E272 warnings.

There remains some in `combinat/designs` and in our main `all.py`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.