### PR TITLE
graph: modular decomposition of a single vertex should be a single tree node

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -8209,7 +8209,7 @@ class Graph(GenericGraph):
         if not self.order():
             D = None
         elif self.order() == 1:
-            D = create_normal_node(self.vertices(sort=False)[0])
+            D = create_normal_node(next(self.vertex_iterator()))
         else:
             D = habib_maurer_algorithm(self)
 

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -8159,9 +8159,9 @@ class Graph(GenericGraph):
         Singleton Vertex::
 
             sage: Graph(1).modular_decomposition()
-            (PRIME, [0])
+            0
             sage: Graph(1).modular_decomposition(style='tree')
-            PRIME[0[]]
+            0[]
 
         Vertices may be arbitrary --- check that :issue:`24898` is fixed::
 
@@ -8209,8 +8209,7 @@ class Graph(GenericGraph):
         if not self.order():
             D = None
         elif self.order() == 1:
-            D = create_prime_node()
-            D.children.append(create_normal_node(self.vertices(sort=False)[0]))
+            D = create_normal_node(self.vertices(sort=False)[0])
         else:
             D = habib_maurer_algorithm(self)
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The modular decomposition tree computed by Sage for a graph with a single vertex is wrong (tested in Sage from 9.8-10.4.rc0)

```py
sage: Graph(1).modular_decomposition()
(PRIME, [0])
```

Sage returns a tree with a `PRIME` root with a single child representing the vertex `0`, but according to the recursive definition of a modular decomposition tree, it should be a single node tree ([see Wikipedia for example](https://en.wikipedia.org/wiki/Modular_decomposition#:~:text=As%20a%20base%20case%2C%20if,is%20a%20single%20tree%20node.))

This PR fixes this issue. It is an easy fix, as the case of single vertex graphs was treated separately in the `modular_decomposition` method of `Graph`.
Two doctests were modified to reflect this changes.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


