### PR TITLE
Fix sagelib install with `configure --disable-editable`

### DIFF
--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -26,9 +26,9 @@ export SAGE_SRC_ROOT=/doesnotexist
 export SAGE_DOC_SRC=/doesnotexist
 export SAGE_BUILD_DIR=/doesnotexist
 
-# We also poison all directories below SAGE_LOCAL.
+# We also poison all directories below SAGE_LOCAL
+# except for SAGE_SPKG_SCRIPTS, which is needed by sage-dist-helpers
 export SAGE_PKGCONFIG=/doesnotexist
-export SAGE_SPKG_SCRIPTS=/doesnotexist
 export SAGE_SHARE=/doesnotexist
 
 # However, we only unset SAGE_LOCAL and SAGE_PKG_CONFIG_PATH.

--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -24,7 +24,6 @@ export SAGE_ROOT=/doesnotexist
 export SAGE_SRC=/doesnotexist
 export SAGE_SRC_ROOT=/doesnotexist
 export SAGE_DOC_SRC=/doesnotexist
-export SAGE_BUILD_DIR=/doesnotexist
 
 # We also poison all directories below SAGE_LOCAL
 # except for SAGE_SPKG_SCRIPTS, which is needed by sage-dist-helpers


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

As reported by @culler, when Sage is configured with `./configure --disable-editable` silently fails to install the Sage library in the venv (including scripts such as `sage-ipython`).

`./sage -pip list | grep sage ` will show no `sagemath-standard`

The build log shows these messages:
```
[spkg-install] Successfully built sagemath_standard-10.4rc1-cp312-cp312-macosx_14_0_x86_64.whl
[spkg-install] Staged wheel file, staged /doesnotexist/sagelib/spkg-requirements.txt
[spkg-install] /Users/mkoeppe/s/sage/sage-rebasing/worktree-pristine/build/bin/sage-dist-helpers: line 367: /doesnotexist/sagelib/spkg-pipinst: No such file or directory
[spkg-install] /Users/mkoeppe/s/sage/sage-rebasing/worktree-pristine/build/bin/sage-dist-helpers: line 387: /doesnotexist/sagelib/spkg-piprm: No such file or directory
Moving package files from temporary location /Users/mkoeppe/s/sage/sage-rebasing/worktree-pristine/venv-wheels/var/tmp/sage/build/sagelib-10.4.rc1/inst to /Users/mkoeppe/s/sage/sage-rebasing/worktree-pristine/venv-wheels
Deleting build directory /Users/mkoeppe/s/sage/sage-rebasing/worktree-pristine/venv-wheels/var/tmp/sage/build/sagelib-10.4.rc1
Finished installing sagelib-10.4.rc1
```

Fixed here in this PR.

- Also fixes #38293.
- Also fixes #38253.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


