### PR TITLE
adding a few more links to python standard errors in doc

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2129,7 +2129,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         characteristic, and is an element of the field which is zero
         if and only if the curve is supersingular.  Over a field of
         characteristic zero, where the Hasse invariant is undefined,
-        a ``ValueError`` is raised.
+        a :class:`ValueError` is raised.
 
         EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -444,7 +444,7 @@ class EllipticCurve_finite_field(EllipticCurve_field):
 
           - ``'all'`` -- compute cardinality with both ``'pari'`` and
             ``'bsgs'``; return result if they agree or raise a
-            ``AssertionError`` if they do not
+            :class:`AssertionError` if they do not
 
         - ``extension_degree`` -- an integer `d` (default: 1): if the
           base field is `\GF{q}`, return the cardinality of ``self``
@@ -1612,7 +1612,7 @@ class EllipticCurve_finite_field(EllipticCurve_field):
 
         (integer) The discriminant of the endomorphism ring `\text{End}(E)`, if
         this has class number ``h``.  If `\text{End}(E)` does not have class
-        number ``h``, a ``ValueError`` is raised.
+        number ``h``, a :class:`ValueError` is raised.
 
         ALGORITHM:
 
@@ -1622,7 +1622,7 @@ class EllipticCurve_finite_field(EllipticCurve_field):
         must be a multiple of `h_0`, compute the possible conductors,
         using :meth:`height_above_floor` for each prime `\ell`
         dividing the quotient `h/h_0`.  If exactly one conductor `f`
-        remains, return `f^2D_0`, otherwise raise a ``ValueError``;
+        remains, return `f^2D_0`, otherwise raise a :class:`ValueError`;
         this can onlyhappen when the input value of `h` was incorrect.
 
         .. NOTE::

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -2701,8 +2701,8 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         .. NOTE::
 
-            If the curves in question are not isomorphic, a ``ValueError``
-            is raised.
+            If the curves in question are not isomorphic,
+            a :class:`ValueError` is raised.
 
         EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -1628,7 +1628,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: Emin.non_minimal_primes()
             []
 
-        If the model is not globally integral, a ``ValueError`` is
+        If the model is not globally integral, a :class:`ValueError` is
         raised::
 
             sage: E = EllipticCurve([0, 0, 0, 1/2, 1/3])

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -694,7 +694,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
     def database_curve(self):
         r"""
         Return the curve in the elliptic curve database isomorphic to this
-        curve, if possible. Otherwise raise a ``LookupError`` exception.
+        curve, if possible.
+
+        Otherwise this raises a :class:`LookupError` exception.
 
         Since :issue:`11474`, this returns exactly the same curve as
         :meth:`minimal_model`; the only difference is the additional
@@ -1515,7 +1517,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         TESTS:
 
         When the input is horrendous, some of the algorithms just bomb
-        out with a ``RuntimeError``::
+        out with a :class:`RuntimeError`::
 
             sage: EllipticCurve([1234567,89101112]).analytic_rank(algorithm='rubinstein')
             Traceback (most recent call last):
@@ -4100,7 +4102,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
     def cremona_label(self, space=False):
         r"""
         Return the Cremona label associated to (the minimal model) of this
-        curve, if it is known. If not, raise a ``LookupError`` exception.
+        curve, if it is known.
+
+        If not, this raises a :class:`LookupError` exception.
 
         EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
@@ -840,7 +840,7 @@ def _semistable_reducible_primes(E, verbose=False):
     A list of primes, which contains all primes `l` unramified in
     `K/\mathbb{QQ}`, such that `E` is semistable at all primes lying
     over `l`, and the Galois image at `l` is reducible. If `E` has CM
-    defined over its ground field, a ``ValueError`` is raised.
+    defined over its ground field, a :class:`ValueError` is raised.
 
     EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -566,6 +566,7 @@ class RingClassField(SageObject):
     def is_subfield(self, M):
         """
         Return ``True`` if this ring class field is a subfield of the ring class field `M`.
+
         If `M` is not a ring class field, then a :class:`TypeError` is raised.
 
         EXAMPLES::
@@ -706,7 +707,7 @@ class GaloisGroup(SageObject):
 
         - `x` -- automorphism or quadratic field element
 
-        OUTPUT: An automorphism (or ``TypeError``)
+        OUTPUT: An automorphism (or :class:`TypeError`)
 
         EXAMPLES::
 

--- a/src/sage/schemes/elliptic_curves/lseries_ell.py
+++ b/src/sage/schemes/elliptic_curves/lseries_ell.py
@@ -17,8 +17,8 @@ AUTHORS:
 #  Distributed under the terms of the GNU General Public License (GPL)
 #  as published by the Free Software Foundation; either version 2 of
 #  the License, or (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from sage.structure.sage_object import SageObject
 from sage.rings.real_mpfr import RealField
@@ -143,7 +143,7 @@ class Lseries_ell(SageObject):
 
         If the curve has too large a conductor, it is not possible to
         compute with the `L`-series using this command.  Instead a
-        ``RuntimeError`` is raised::
+        :class:`RuntimeError` is raised::
 
             sage: e = EllipticCurve([1,1,0,-63900,-1964465932632])
             sage: L = e.lseries().dokchitser(15, algorithm='gp')

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -1252,7 +1252,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_add_`` calls the
         Python method ``self._add_`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -1364,7 +1364,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_sub_`` calls the
         Python method ``self._sub_`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -1418,7 +1418,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_neg_`` calls the
         Python method ``self._neg_`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -1532,7 +1532,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_mul_`` calls the
         Python method ``self._mul_`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -1645,7 +1645,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_matmul_`` calls the
         Python method ``self._matmul_`` if it exists. This method may
         be defined in the ``ElementMethods`` of the category of the
-        parent. If the method is not found, a ``TypeError`` is raised
+        parent. If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -1748,7 +1748,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_div_`` calls the
         Python method ``self._div_`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -1848,7 +1848,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_floordiv_`` calls the
         Python method ``self._floordiv_`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -1948,7 +1948,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_mod_`` calls the
         Python method ``self._mod_`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -2075,7 +2075,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_pow_`` calls the
         Python method ``self._pow_`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -2105,7 +2105,7 @@ cdef class Element(SageObject):
         This default Cython implementation of ``_pow_int`` calls the
         Python method ``self._pow_int`` if it exists. This method may be
         defined in the ``ElementMethods`` of the category of the parent.
-        If the method is not found, a ``TypeError`` is raised
+        If the method is not found, a :class:`TypeError` is raised
         indicating that the operation is not supported.
 
         See :ref:`element_arithmetic`.
@@ -2847,8 +2847,9 @@ cdef class RingElement(ModuleElement):
 
     def multiplicative_order(self):
         r"""
-        Return the multiplicative order of ``self``, if ``self`` is a unit,
-        or raise ``ArithmeticError`` otherwise.
+        Return the multiplicative order of ``self``, if ``self`` is a unit.
+
+        This raise an :class:`ArithmeticError` otherwise.
         """
         if not self.is_unit():
             raise ArithmeticError("self (=%s) must be a unit to have a multiplicative order.")

--- a/src/sage/structure/list_clone.pyx
+++ b/src/sage/structure/list_clone.pyx
@@ -295,7 +295,7 @@ cdef class ClonableElement(Element):
         """
         Check that ``self`` is mutable.
 
-        Raise a ``ValueError`` if ``self`` is immutable.
+        This raises a :class:`ValueError` if ``self`` is immutable.
 
         TESTS::
 

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -1418,7 +1418,7 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
               To:   Finite Field of size 5
 
         There might not be a natural morphism, in which case a
-        ``TypeError`` is raised::
+        :class:`TypeError` is raised::
 
             sage: QQ.hom(ZZ)
             Traceback (most recent call last):

--- a/src/sage/symbolic/assumptions.py
+++ b/src/sage/symbolic/assumptions.py
@@ -461,11 +461,11 @@ def assume(*args):
     If everything goes as planned, there is no output.
 
     If you assume something that is not one of the two forms above, then
-    an ``AttributeError`` is raised as we try to call its ``assume``
+    an :class:`AttributeError` is raised as we try to call its ``assume``
     method.
 
     If you make inconsistent assumptions (for example, that ``x`` is
-    both even and odd), then a ``ValueError`` is raised.
+    both even and odd), then a :class:`ValueError` is raised.
 
     .. WARNING::
 
@@ -630,7 +630,7 @@ def assume(*args):
         True
         sage: forget()
 
-    Ensure that an ``AttributeError`` is raised if we are given junk::
+    Ensure that an :class:`AttributeError` is raised if we are given junk::
 
         sage: assume(3)
         Traceback (most recent call last):

--- a/src/sage/symbolic/comparison_impl.pxi
+++ b/src/sage/symbolic/comparison_impl.pxi
@@ -189,7 +189,7 @@ class _math_key():
 
         OUTPUT:
 
-        Boolean. A ``ValueError`` is raised if we do not know how to
+        Boolean. A :class:`ValueError` is raised if we do not know how to
         perform the comparison.
 
         EXAMPLES::
@@ -232,7 +232,7 @@ cpdef math_sorted(expressions):
 
     The list sorted by ascending (real) value. If an entry does not
     define a real value (or plus/minus infinity), or if the comparison
-    is not known, a ``ValueError`` is raised.
+    is not known, a :class:`ValueError` is raised.
 
     EXAMPLES::
 
@@ -341,7 +341,7 @@ class _mixed_key():
 
         OUTPUT:
 
-        Boolean. A ``ValueError`` is raised if we do not know how to
+        Boolean. A :class:`ValueError` is raised if we do not know how to
         perform the comparison.
 
         EXAMPLES::
@@ -424,7 +424,7 @@ cpdef mixed_sorted(expressions):
     and the expressions with variables according to print order.
     If an entry does not
     define a real value (or plus/minus infinity), or if the comparison
-    is not known, a ``ValueError`` is raised.
+    is not known, a :class:`ValueError` is raised.
 
     EXAMPLES::
 

--- a/src/sage/symbolic/pynac_function_impl.pxi
+++ b/src/sage/symbolic/pynac_function_impl.pxi
@@ -66,7 +66,7 @@ cpdef unsigned find_registered_function(name, int nargs) except -1:
     r"""
     Look up a function registered with Pynac (GiNaC).
 
-    Raise a ``ValueError`` if the function is not registered.
+    This raises a :class:`ValueError` if the function is not registered.
 
     OUTPUT:
 

--- a/src/sage/symbolic/random_tests.py
+++ b/src/sage/symbolic/random_tests.py
@@ -356,7 +356,7 @@ def assert_strict_weak_order(a, b, c, cmp_func):
 
     OUTPUT:
 
-    Does not return anything. Raises a ``ValueError`` if ``cmp_func``
+    Nothing. This raises a :class:`ValueError` if ``cmp_func``
     is not a strict weak order on the three given elements.
 
     REFERENCES:


### PR DESCRIPTION
in symbolics, schemes and structure folders

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.