### PR TITLE
use pkg-config to find msolve, otherwise try to run it

### DIFF
--- a/build/pkgs/msolve/spkg-configure.m4
+++ b/build/pkgs/msolve/spkg-configure.m4
@@ -1,0 +1,23 @@
+SAGE_SPKG_CONFIGURE([msolve], [
+    PKG_CHECK_MODULES([msolve], [msolve >= 0.6.5], [], [
+       AC_CACHE_CHECK([for msolve], [ac_cv_path_MSOLVE],
+         [AC_PATH_PROGS_FEATURE_CHECK([MSOLVE], [msolve],
+           [msolvin=$(mktemp)
+            msolvout=$(mktemp)
+            msolvchk=$(mktemp)
+            echo -e 'x,y\n0\nx-y,\nx*y-1' >$msolvin
+	    changequote(<<, >>)dnl
+            echo -e '[0, [1,\n[[[-1, -1], [-1, -1]], [[1, 1], [1, 1]]]\n]]:' >$msolvchk
+	    changequote([, ])dnl
+            $ac_path_MSOLVE -f $msolvin -o $msolvout
+            AS_IF([test x$(diff $msolvout $msolvchk) = x],
+                  [ac_cv_path_MSOLVE=$ac_path_MSOLVE
+                   ac_path_MSOLVE_found=:],
+                  [sage_spkg_install_msolve=yes
+                   AC_MSG_RESULT([could not find working msolve])
+            ])
+            ], [sage_spkg_install_msolve=yes
+                AC_MSG_RESULT([could not find working msolve])
+	    ])])
+        ])
+])


### PR DESCRIPTION
spkg-config.m4 for msolve

This will fix #38315

So far, it's not possible to find msolve's version by running it, but it should be fixed in the future by https://github.com/algebraic-solving/msolve/pull/147




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ x] The title is concise and informative.
- [ x] The description explains in detail what this PR is about.
- [ x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



