### PR TITLE
Implement EllipticCurve_with_prime_order() constructor

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -1326,6 +1326,9 @@ REFERENCES:
             no. 1 (2003): 97-111,
             http://www.moi.math.bas.bg/moiuser/~iliya/pdf_site/gf5srev.pdf.
 
+.. [BS2007] \R. Bröker and P. Stevenhagen. *Constructing elliptic curves of
+            prime order*. [math.NT] (2007), :arXiv:`0712.2022`.
+
 .. [BS2010] \P. Baseilhac and K. Shigechi. *A new current algebra and the
             reflection equation*. Lett. Math. Phys. **92** (2010),
             pp. 47-65. :arxiv:`0906.1482`.

--- a/src/sage/schemes/elliptic_curves/all.py
+++ b/src/sage/schemes/elliptic_curves/all.py
@@ -27,10 +27,10 @@ from sage.misc.lazy_import import lazy_import
 lazy_import('sage.schemes.elliptic_curves.jacobian', 'Jacobian')
 
 lazy_import('sage.schemes.elliptic_curves.ell_finite_field', 'special_supersingular_curve')
-lazy_import('sage.schemes.elliptic_curves.ell_finite_field', 'EllipticCurve_with_prime_order')
 lazy_import('sage.schemes.elliptic_curves.ell_rational_field',
             ['cremona_curves', 'cremona_optimal_curves'])
 
+from sage.schemes.elliptic_curves.ell_finite_field import EllipticCurve_with_prime_order
 from sage.schemes.elliptic_curves.cm import (cm_orders,
                                              cm_j_invariants,
                                              cm_j_invariants_and_orders,

--- a/src/sage/schemes/elliptic_curves/all.py
+++ b/src/sage/schemes/elliptic_curves/all.py
@@ -27,7 +27,7 @@ from sage.misc.lazy_import import lazy_import
 lazy_import('sage.schemes.elliptic_curves.jacobian', 'Jacobian')
 
 lazy_import('sage.schemes.elliptic_curves.ell_finite_field', 'special_supersingular_curve')
-
+lazy_import('sage.schemes.elliptic_curves.ell_finite_field', 'EllipticCurve_with_prime_order')
 lazy_import('sage.schemes.elliptic_curves.ell_rational_field',
             ['cremona_curves', 'cremona_optimal_curves'])
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2863,6 +2863,8 @@ def EllipticCurve_with_order(m, *, D=None):
                         continue
                     # This tests whether the curve has given order
                     if Et.has_order(m_val):
+                        # TODO: remove after 38617
+                        Et.set_order(m_val, check=False)
                         seen.add(Et)
                         yield Et
 
@@ -3167,8 +3169,10 @@ def EllipticCurve_with_prime_order(N):
                         E = EllipticCurve(K, j=j0)
                         # `E.twists()` also contains E.
                         for Et in E.twists():
-                            # `num_checks=1` is sufficient for prime order.
+                            # `num_checks=1` is sufficient for prime order
                             if Et.has_order(N, num_checks=1):
+                                # TODO: remove after 38617
+                                Et.set_order(N, check=False)
                                 yield Et
 
         if p != 1:

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1353,7 +1353,9 @@ class EllipticCurve_finite_field(EllipticCurve_field):
 
         - ``num_checks``-- integer (default: `8`); the number of times to check
           whether ``value`` times a random point on this curve equals the
-          identity
+          identity. If ``value`` is a prime and the curve is over a field of
+          order at least `5`, it is sufficient to pass in ``num_checks=1`` -
+          see the examples below.
 
         .. NOTE::
 
@@ -1403,14 +1405,20 @@ class EllipticCurve_finite_field(EllipticCurve_field):
             sage: E.has_order(N^2 + N)
             True
 
+        Due to the nature of the algorithm (testing multiple of points) and the Hasse-Weil bound, we see that for testing prime orders, ``num_checks=1`` is sufficient::
+
+            sage: p = random_prime(1000)
+            sage: E = EllipticCurve(GF(p), j=randrange(p))
+            sage: q = random_prime(p + 20, lbound=p - 20)
+            sage: E.has_order(q, num_checks=20) == E.has_order(q, num_checks=1)
+            True
+
         AUTHORS:
 
          - Mariah Lenox (2011-02-16): Initial implementation
 
          - Gareth Ma (2024-01-21): Fix bug for small curves
         """
-        # This method does *not* use the cached value of `_order` even when
-        # available.
         q = self.base_field().order()
         a, b = Hasse_bounds(q, 1)
         if not a <= value <= b:
@@ -2980,7 +2988,7 @@ def EllipticCurve_with_prime_order(N):
          Elliptic Curve defined by y^2 = x^3 + 20*x + 20 over Finite Field of size 23,
          Elliptic Curve defined by y^2 = x^3 + 10*x + 16 over Finite Field of size 23]
         sage: import itertools
-        sage: # These are the only primes, by the Weil-Hasse bound
+        sage: # These are the only primes, by the Hasse-Weil bound
         sage: for q in prime_range(17, 35):
         ....:     K = GF(q)
         ....:     for u in itertools.product(range(q), repeat=2):

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2753,7 +2753,7 @@ def EllipticCurve_with_order(m, *, D=None):
     Return an iterator for elliptic curves over finite fields with the given order. The curves are
     computed using the Complex Multiplication (CM) method.
 
-    A :sage:`~sage.structure.factorization.Factorization` can be passed for ``m``, in which case
+    A :class:`~sage.structure.factorization.Factorization` can be passed for ``m``, in which case
     the algorithm is more efficient.
 
     If ``D`` is specified, it is used as the discriminant.

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2800,60 +2800,71 @@ def EllipticCurve_with_prime_order(N):
     - ``N`` -- integer; the order for which we seek an elliptic curve. Must be a
       prime number.
 
-    OUTPUT: an elliptic curve `E/\mathbb F_p` of order ``N``
+    OUTPUT: an iterator of elliptic curves `E/\mathbb F_p` of order ``N``
 
     EXAMPLES::
 
         sage: N = next_prime(int(b'sagemath'.hex(), 16))
-        sage: E = EllipticCurve_with_prime_order(N)
+        sage: E = next(EllipticCurve_with_prime_order(N))
         sage: E
         Elliptic Curve defined by y^2 = x^3 + 4757897140353078952*x +
         1841350074072114366 over Finite Field of size 8314040074357871443
         sage: E.order() == N
         True
 
+    You can directly iterate over the function call; here only on the first 10
+    curves::
+
+        sage: N = 54675917
+        sage: for _, E in zip(range(10), EllipticCurve_with_prime_order(N)):
+        ....:     assert E.order() == N
+
     It works for large primes::
 
         sage: N = 0x6cbc824032974516623e732462f4b74b56c4ffbd984380d9
-        sage: E = EllipticCurve_with_prime_order(N)
+        sage: E = next(EllipticCurve_with_prime_order(N))
         sage: E.order() == N
         True
 
     But the execution time largely depends on the input::
 
         sage: N = 200396817641911230625970463749415493753
-        sage: E = EllipticCurve_with_prime_order(N)
+        sage: E = next(EllipticCurve_with_prime_order(N))
         sage: E.order() == N
         True
 
     TESTS::
 
         sage: for N in prime_range(3, 100):
-        ....:     E = EllipticCurve_with_prime_order(N)
+        ....:     E = next(EllipticCurve_with_prime_order(N))
+        ....:     assert E.order() == N
+
+        sage: N = 113
+        sage: for _, E in zip(range(30), EllipticCurve_with_prime_order(N)):
         ....:     assert E.order() == N
 
         sage: N = 15175980689839334471
-        sage: E = EllipticCurve_with_prime_order(N)
+        sage: E = next(EllipticCurve_with_prime_order(N))
         sage: E.order() == N
         True
 
         sage: N = next_prime(123456789)
-        sage: E = EllipticCurve_with_prime_order(N)
+        sage: E = next(EllipticCurve_with_prime_order(N))
         sage: E.order() == N
         True
 
         sage: N = 123456789
-        sage: E = EllipticCurve_with_prime_order(N)
+        sage: E = next(EllipticCurve_with_prime_order(N))
         Traceback (most recent call last):
         ...
         ValueError: input order is not prime
 
-        sage: E = EllipticCurve_with_prime_order(0)
+        sage: E = next(EllipticCurve_with_prime_order(0))
         Traceback (most recent call last):
         ...
         ValueError: input order is not prime
 
-        sage: E = EllipticCurve_with_prime_order(-7)
+        sage: E = next(EllipticCurve_with_prime_order(-7))
         Traceback (most recent call last):
         ...
         ValueError: input order is not prime
@@ -2901,7 +2912,7 @@ def EllipticCurve_with_prime_order(N):
         # done multiple times.
         for e in powerset(S):
             D = product(e)
-            if D % 8 != 5 or D >= 0 or D >= prime_start^2:
+            if D % 8 != 5 or D >= 0:
                 continue
 
             Q = BinaryQF([1, 0, -D])
@@ -2918,7 +2929,7 @@ def EllipticCurve_with_prime_order(N):
                         # `E.twists()` also contains E.
                         for Et in E.twists():
                             if Et.order() == N:
-                                return Et
+                                yield Et
 
         # At this point, no discriminant has been found, moving to next round
         # and extending the prime list.

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -3003,32 +3003,32 @@ def EllipticCurve_with_prime_order(N):
         sage: for _, E in zip(range(3), EllipticCurve_with_prime_order(10^9 + 7)):
         ....:     print(E)
         Elliptic Curve defined by y^2 = x^3 + 265977778*x + 120868502 over Finite Field of size 1000041437
-        Elliptic Curve defined by y^2 = x^3 + 665393686*x + 948152000 over Finite Field of size 999969307
-        Elliptic Curve defined by y^2 = x^3 + 572311614*x + 178583984 over Finite Field of size 999969307
+        Elliptic Curve defined by y^2 = x^3 + 689795416*x + 188156157 over Finite Field of size 999969307
+        Elliptic Curve defined by y^2 = x^3 + 999178436*x + 900579394 over Finite Field of size 999969307
         sage: set_verbose(2)
         sage: set_random_seed(1337)
         sage: for _, E in zip(range(3), EllipticCurve_with_prime_order(10^9 + 7)):
         ....:     print(E)
-        verbose 2 (2865: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-163
+        verbose 2 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-163
         Elliptic Curve defined by y^2 = x^3 + 265977778*x + 120868502 over Finite Field of size 1000041437
-        verbose 2 (2865: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-667
-        Elliptic Curve defined by y^2 = x^3 + 665393686*x + 948152000 over Finite Field of size 999969307
-        Elliptic Curve defined by y^2 = x^3 + 572311614*x + 178583984 over Finite Field of size 999969307
+        verbose 2 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-667
+        Elliptic Curve defined by y^2 = x^3 + 689795416*x + 188156157 over Finite Field of size 999969307
+        Elliptic Curve defined by y^2 = x^3 + 999178436*x + 900579394 over Finite Field of size 999969307
         sage: set_verbose(4)
         sage: set_random_seed(1337)
         sage: for _, E in zip(range(3), EllipticCurve_with_prime_order(10^9 + 7)):
         ....:     print(E)
-        verbose 4 (2865: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-19
+        verbose 4 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-19
         ...
-        verbose 4 (2865: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-163
-        verbose 2 (2865: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-163
+        verbose 4 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-163
+        verbose 2 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-163
         Elliptic Curve defined by y^2 = x^3 + 265977778*x + 120868502 over Finite Field of size 1000041437
-        verbose 4 (2865: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-179
+        verbose 4 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-179
         ...
-        verbose 4 (2865: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-667
-        verbose 2 (2865: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-667
-        Elliptic Curve defined by y^2 = x^3 + 665393686*x + 948152000 over Finite Field of size 999969307
-        Elliptic Curve defined by y^2 = x^3 + 572311614*x + 178583984 over Finite Field of size 999969307
+        verbose 4 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-667
+        verbose 2 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-667
+        Elliptic Curve defined by y^2 = x^3 + 689795416*x + 188156157 over Finite Field of size 999969307
+        Elliptic Curve defined by y^2 = x^3 + 999178436*x + 900579394 over Finite Field of size 999969307
 
     TESTS::
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2725,8 +2725,8 @@ def EllipticCurve_with_order(m, *, D=None):
         sage: all(E.order() == 21 for E in Es)
         True
 
-    Indeed, we can verify that this is correct. Hasse's bounds tell us that $p \leq 50$
-    (approximately), and the rest can be checked via bruteforce::
+    Indeed, we can verify that this is correct. Hasse's bounds tell us that
+    `p \leq 50` (approximately), and the rest can be checked via bruteforce::
 
         sage: for p in prime_range(50):
         ....:     for j in range(p):

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -3084,7 +3084,7 @@ def EllipticCurve_with_prime_order(N):
     for p in itertools.chain([1], Primes()):
         # We add p = 1 to process the small primes
         if p != 1:
-            if p < 1000:
+            if p < S[-1]:
                 continue
 
             if legendre_symbol(N, p) != 1:
@@ -3098,7 +3098,7 @@ def EllipticCurve_with_prime_order(N):
             verbose(f"Considering {len(S) + 1}th valid prime {p}", level=3)
 
         # Equivalent to p* = (-1)^((p - 1) / 2) * p in [BS2007]_ page 5.
-        p_star = -p if p >> 1 & 1 else p
+        p_star = -p if p % 4 == 3 else p
 
         for e in recur(4 * N // p):
             D = p_star * e

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2864,7 +2864,7 @@ def EllipticCurve_with_prime_order(N):
     from sage.arith.misc import is_prime
     from sage.combinat.subset import powerset
     from sage.functions.other import ceil
-    from sage.misc.functional import symbolic_prod as product
+    from sage.misc.functional import symbolic_prod as product, log
     from sage.quadratic_forms.binary_qf import BinaryQF
     from sage.rings.fast_arith import prime_range
     from sage.schemes.elliptic_curves.cm import hilbert_class_polynomial
@@ -2878,7 +2878,7 @@ def EllipticCurve_with_prime_order(N):
     # loglog N.
     r = 0
     prime_start = 3
-    prime_end = ceil((r + 1) * N.log())
+    prime_end = ceil((r + 1) * log(N))
     S = []
 
     while True:
@@ -2919,4 +2919,4 @@ def EllipticCurve_with_prime_order(N):
         r += 1
 
         prime_start = prime_end
-        prime_end = ceil((r + 1) * N.log())
+        prime_end = ceil((r + 1) * log(N))

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -3061,6 +3061,8 @@ def EllipticCurve_with_prime_order(N):
     # prime factor. We expect this algorithm to terminate after a number of
     # rounds that is polynomial in loglog N.
     # We start with small primes directly to accelerate the search
+    # Note: 1000 is a magic constant, it's just fast enough to compute without
+    # sacrificing much speed
     S = [(-p if p >> 1 & 1 else p) for p in prime_range(3, min(1000, 4 * N))
          if legendre_symbol(N, p) == 1]
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2877,10 +2877,13 @@ def EllipticCurve_with_prime_order(N):
     # algorithm to terminate after a number of rounds that is polynomial in
     # loglog N.
     r = 0
+    prime_start = 3
+    prime_end = ceil((r + 1) * N.log())
+    S = []
 
     while True:
         # Iterating over the odd primes by chunks of size log(`N`).
-        S = prime_range(3, ceil((r + 1) * N.log()))
+        S.extend(prime_range(prime_start, prime_end))
 
         # Every possible products of distinct elements of `S`.
         # There probably is a more optimal way to compute all possible products
@@ -2914,3 +2917,6 @@ def EllipticCurve_with_prime_order(N):
         # At this point, no discriminant has been found, moving to next round
         # and extending the prime list.
         r += 1
+
+        prime_start = prime_end
+        prime_end = ceil((r + 1) * N.log())

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2853,7 +2853,11 @@ def EllipticCurve_with_prime_order(N):
 
     .. NOTE::
 
-        Depending on the input, this function may run forever.
+        Depending on the input, this function may run for a *very* long time.
+        This algorithm consists of multiple "search rounds" for a suitable
+        discriminant `D`. We expect this algorithm to terminate after a number
+        of rounds that is polynomial in `loglog N`. In practice (cf. Section 5),
+        this number is usually 1.
 
     ALGORITHM: [BS2007]_, Algorithm 2.2
     """

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2812,10 +2812,17 @@ def EllipticCurve_with_prime_order(N):
         sage: E.order() == N
         True
 
-    The execution time largely depends on the input::
+    It works for large primes::
 
-        sage: N = 125577861263605878504082476745517446213
-        sage: E = EllipticCurve_with_prime_order(N) # Takes ~1 second.
+        sage: N = 0x6cbc824032974516623e732462f4b74b56c4ffbd984380d9
+        sage: E = EllipticCurve_with_prime_order(N)
+        sage: E.order() == N
+        True
+
+    But the execution time largely depends on the input::
+
+        sage: N = 200396817641911230625970463749415493753
+        sage: E = EllipticCurve_with_prime_order(N)
         sage: E.order() == N
         True
 
@@ -2861,7 +2868,7 @@ def EllipticCurve_with_prime_order(N):
 
     ALGORITHM: [BS2007]_, Algorithm 2.2
     """
-    from sage.arith.misc import is_prime
+    from sage.arith.misc import is_prime, kronecker
     from sage.combinat.subset import powerset
     from sage.functions.other import ceil
     from sage.misc.functional import symbolic_prod as product, log
@@ -2883,7 +2890,8 @@ def EllipticCurve_with_prime_order(N):
 
     while True:
         # Iterating over the odd primes by chunks of size log(`N`).
-        S.extend(prime_range(prime_start, prime_end))
+        S.extend(p for p in prime_range(prime_start, prime_end)
+                 if kronecker(N, p) == 1)
 
         # Every possible products of distinct elements of `S`.
         # There probably is a more optimal way to compute all possible products

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1399,6 +1399,7 @@ class EllipticCurve_finite_field(EllipticCurve_field):
             True
             sage: E.has_order(N^2)
             True
+            sage: del E._order
             sage: E.has_order(N^2 + N)
             True
 
@@ -1419,7 +1420,7 @@ class EllipticCurve_finite_field(EllipticCurve_field):
         # orders So we go with computing directly instead.
         # In #38341, the bound has been increased to a large value (2^64), but
         # it should be decreased (to ~100) after bug #38617 is fixed.
-        if q <= 2**64:
+        if q <= 2**64 or hasattr(self, "_order"):
             return self.order() == value
 
         # This might be slow
@@ -3008,24 +3009,24 @@ def EllipticCurve_with_prime_order(N):
         sage: set_random_seed(1337)
         sage: for _, E in zip(range(3), EllipticCurve_with_prime_order(10^9 + 7)):
         ....:     print(E)
-        verbose 2 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-163
+        verbose 2 (...: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-163
         Elliptic Curve defined by y^2 = x^3 + 265977778*x + 120868502 over Finite Field of size 1000041437
-        verbose 2 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-667
+        verbose 2 (...: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-667
         Elliptic Curve defined by y^2 = x^3 + 689795416*x + 188156157 over Finite Field of size 999969307
         Elliptic Curve defined by y^2 = x^3 + 999178436*x + 900579394 over Finite Field of size 999969307
         sage: set_verbose(4)
         sage: set_random_seed(1337)
         sage: for _, E in zip(range(3), EllipticCurve_with_prime_order(10^9 + 7)):
         ....:     print(E)
-        verbose 4 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-19
+        verbose 4 (...: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-19
         ...
-        verbose 4 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-163
-        verbose 2 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-163
+        verbose 4 (...: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-163
+        verbose 2 (...: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-163
         Elliptic Curve defined by y^2 = x^3 + 265977778*x + 120868502 over Finite Field of size 1000041437
-        verbose 4 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-179
+        verbose 4 (...: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-179
         ...
-        verbose 4 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-667
-        verbose 2 (2866: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-667
+        verbose 4 (...: ell_finite_field.py, EllipticCurve_with_prime_order) Testing D=-667
+        verbose 2 (...: ell_finite_field.py, EllipticCurve_with_prime_order) Computing the Hilbert class polynomial H_-667
         Elliptic Curve defined by y^2 = x^3 + 689795416*x + 188156157 over Finite Field of size 999969307
         Elliptic Curve defined by y^2 = x^3 + 999178436*x + 900579394 over Finite Field of size 999969307
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1436,6 +1436,7 @@ class EllipticCurve_finite_field(EllipticCurve_field):
             if not (value * G).is_zero():
                 return False
 
+        self._order = value
         return True
 
     def set_order(self, value, *, check=True, num_checks=8):
@@ -2859,7 +2860,6 @@ def EllipticCurve_with_order(m, *, D=None):
                         continue
                     # This tests whether the curve has given order
                     if Et.has_order(m_val):
-                        Et.set_order(m_val, check=False)
                         seen.add(Et)
                         yield Et
 
@@ -2891,7 +2891,6 @@ def EllipticCurve_with_prime_order(N):
     to be fast for many purposes, and for most `N` we tested we are able to
     find a suitable small `D` without increasing the size of `S`.
 
-<<<<<<< HEAD
     The paper also doesn't specify how to enumerate such `D`s, which recall
     should be product of distinct values in the table `S`. We implement this
     with a priority queue (min heap), which also allows us to search for the
@@ -2905,7 +2904,7 @@ def EllipticCurve_with_prime_order(N):
     (-D)y^2 = 4N` with `D < 0` and `N` prime, we actually need `|D| \leq 4N`,
     so we terminate the algorithm when the primes in the table are larger than
     that bound. This makes the iterator return all curves it can find in finite
-    time :)
+    time.
 
     ALGORITHM: Based on [BS2007]_, Algorithm 2.2
 
@@ -3167,7 +3166,6 @@ def EllipticCurve_with_prime_order(N):
                         for Et in E.twists():
                             # `num_checks=1` is sufficient for prime order.
                             if Et.has_order(N, num_checks=1):
-                                Et.set_order(N, check=False)
                                 yield Et
 
         if p != 1:

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2856,8 +2856,8 @@ def EllipticCurve_with_prime_order(N):
         Depending on the input, this function may run for a *very* long time.
         This algorithm consists of multiple "search rounds" for a suitable
         discriminant `D`. We expect this algorithm to terminate after a number
-        of rounds that is polynomial in `loglog N`. In practice (cf. Section 5),
-        this number is usually 1.
+        of rounds that is polynomial in `\log\log N`. In practice (cf. Section
+        5), this number is usually 1.
 
     ALGORITHM: [BS2007]_, Algorithm 2.2
     """

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1437,7 +1437,9 @@ class EllipticCurve_finite_field(EllipticCurve_field):
             if not (value * G).is_zero():
                 return False
 
-        self._order = value
+        # TODO: uncomment this and remove the line in `set_order` after 38617 is fixed.
+        # self._order = value
+
         return True
 
     def set_order(self, value, *, check=True, num_checks=8):

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1405,14 +1405,15 @@ class EllipticCurve_finite_field(EllipticCurve_field):
 
          - Gareth Ma (2024-01-21): Fix bug for small curves
         """
-        # This method does *not* use the cached value of `_order` even when available
+        # This method does *not* use the cached value of `_order` even when
+        # available.
         q = self.base_field().order()
         a, b = Hasse_bounds(q, 1)
         if not a <= value <= b:
             return False
 
-        # For really small values, the random tests are too weak to detect wrong orders
-        # So we go with computing directly instead.
+        # For really small values, the random tests are too weak to detect wrong
+        # orders So we go with computing directly instead.
         if q <= 100:
             return self.order() == value
 
@@ -1498,10 +1499,9 @@ class EllipticCurve_finite_field(EllipticCurve_field):
             ...
             ValueError: Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field of size 7 does not have order 1000
 
-        It is also very likely an error to pass a value which is not
-        the actual order of this curve. How unlikely is determined by
-        ``num_checks``, the factorization of the actual order, and the
-        actual group structure::
+        It is also very likely an error to pass a value which is not the actual
+        order of this curve. How unlikely is determined by ``num_checks``, the
+        factorization of the actual order, and the actual group structure::
 
             sage: E = EllipticCurve(GF(1009), [0, 1]) # This curve has order 948
             sage: E.set_order(947)
@@ -1509,8 +1509,8 @@ class EllipticCurve_finite_field(EllipticCurve_field):
             ...
             ValueError: Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field of size 1009 does not have order 947
 
-        For curves over small finite fields, the order is cheap to compute, so it is computed
-        directly and compared::
+        For curves over small finite fields, the order is cheap to compute, so
+        it is computed directly and compared::
 
             sage: E = EllipticCurve(GF(7), [0, 1]) # This curve has order 12
             sage: E.set_order(11)
@@ -1520,8 +1520,8 @@ class EllipticCurve_finite_field(EllipticCurve_field):
 
         TESTS:
 
-        The previous version's random tests are not strong enough. In particular, the following used
-        to work::
+        The previous version's random tests are not strong enough. In particular,
+        the following used to work::
 
             sage: E = EllipticCurve(GF(2), [0, 0, 1, 1, 1]) # This curve has order 1
             sage: E.set_order(3)
@@ -1539,8 +1539,8 @@ class EllipticCurve_finite_field(EllipticCurve_field):
             sage: E.order()
             12
 
-        .. TODO:: Add provable correctness check by computing the abelian group structure and
-            comparing.
+        .. TODO:: Add provable correctness check by computing the abelian group
+            structure and comparing.
 
         AUTHORS:
 
@@ -2896,10 +2896,10 @@ def EllipticCurve_with_prime_order(N):
         True
 
     The returned curves are sometimes random because
-    :meth:`~sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.twists` is
-    not deterministic. However, it's always isomorphic::
+    :meth:`~sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.twists`
+    is not deterministic. However, it's always isomorphic::
 
-        sage: E = next(EllipticCurve_with_prime_order(23)); E                           # random
+        sage: E = next(EllipticCurve_with_prime_order(23)); E # random
         Elliptic Curve defined by y^2 = x^3 + 12*x + 6 over Finite Field of size 17
         sage: E.is_isomorphic(EllipticCurve(GF(17), [3, 5]))
         True
@@ -2939,7 +2939,8 @@ def EllipticCurve_with_prime_order(N):
         sage: EllipticCurve(GF(7), [0, 5]).order()
         7
 
-    However, experimentally it returns many of them. Here it returns all of them::
+    However, experimentally it returns many of them. Here it returns all of
+    them::
 
         sage: N = 23
         sage: set_random_seed(1337)  # as the function returns random twists of curves
@@ -2960,12 +2961,12 @@ def EllipticCurve_with_prime_order(N):
         ....:         if E.has_order(N):
         ....:             assert any(E.is_isomorphic(E_) for E_ in curves)
 
-    The algorithm is efficient for small ``N`` due to the low number of
-    suitable discriminants (see the ``recur`` internal function of the code for
-    details). The following runs in less than a second::
+    The algorithm is efficient for small ``N`` due to the low number of suitable
+    discriminants (see the ``abs_products_under`` internal function of the code
+    for details). The following runs in less than a second::
 
         sage: len(list(EllipticCurve_with_prime_order(next_prime(5000))))
-        534
+        945
 
     There is different verbose data for level `2` to `4`, though level `3`
     rarely logs anything (it logs when a new prime `p` is added to the
@@ -3024,21 +3025,26 @@ def EllipticCurve_with_prime_order(N):
         sage: E.has_order(N)
         True
 
+        sage: E = next(EllipticCurve_with_prime_order(2))
+        Traceback (most recent call last):
+        ...
+        ValueError: input order is not an odd prime
+
         sage: N = 123456789
         sage: E = next(EllipticCurve_with_prime_order(N))
         Traceback (most recent call last):
         ...
-        ValueError: input order is not prime
+        ValueError: input order is not an odd prime
 
         sage: E = next(EllipticCurve_with_prime_order(0))
         Traceback (most recent call last):
         ...
-        ValueError: input order is not prime
+        ValueError: input order is not an odd prime
 
         sage: E = next(EllipticCurve_with_prime_order(-7))
         Traceback (most recent call last):
         ...
-        ValueError: input order is not prime
+        ValueError: input order is not an odd prime
     """
     import itertools
     from sage.arith.misc import is_prime, legendre_symbol
@@ -3048,29 +3054,23 @@ def EllipticCurve_with_prime_order(N):
     from sage.schemes.elliptic_curves.cm import hilbert_class_polynomial
     from sage.sets.primes import Primes
 
-    if not is_prime(N):
-        raise ValueError("input order is not prime")
-
-    # if N < 1000:
-    #     # Log how long this algorithm will take
-    #     from sage.rings.fast_arith import prime_range
-    #     num = sum(1 for p in prime_range(3, 4 * N) if legendre_symbol(N, p) == 1)
-    #     verbose(f"Total work to enumerate curves with order {N}: 2^{num}", level=2)
+    if not is_prime(N) or N < 3:
+        raise ValueError("input order is not an odd prime")
 
     # The algorithm considers smooth discriminants `D`, sorted by their largest
     # prime factor. We expect this algorithm to terminate after a number of
     # rounds that is polynomial in loglog N.
-    # We start with small primes directly to accelerate the search
+    # We start with small primes directly to accelerate the search.
     # Note: 1000 is a magic constant, it's just fast enough to compute without
-    # sacrificing much speed
+    # sacrificing much speed.
     S = [(-p if p >> 1 & 1 else p) for p in prime_range(3, min(1000, 4 * N))
          if legendre_symbol(N, p) == 1]
 
-    def recur(bound):
+    def abs_products_under(bound):
         """
-        This function returns an iterator of all numbers with absolute value
-        not exceeding ``bound`` expressable as product of distinct elements in
-        ``S`` in ascending order.
+        This function returns an iterator of all numbers with absolute value not
+        exceeding ``bound`` expressable as product of distinct elements in ``S``
+        in ascending order.
         """
         import heapq
         hq = [(1, 1, -1)]
@@ -3083,8 +3083,9 @@ def EllipticCurve_with_prime_order(N):
                 else:
                     break
 
+    # We add p = 1 to process the small primes.
     for p in itertools.chain([1], Primes()):
-        # We add p = 1 to process the small primes
+        if p == 2: continue
         if p != 1:
             if p < S[-1]:
                 continue
@@ -3092,17 +3093,18 @@ def EllipticCurve_with_prime_order(N):
             if legendre_symbol(N, p) != 1:
                 continue
 
-            # later we need x^2 + (-D)y^2 = 4N, and since y = 0 has no solution, we need
-            # p = |p_star| <= |-D| <= 4N
+            # Later we need x^2 + (-D)y^2 = 4N, and since y = 0 has no solution,
+            # we need p = |p_star| <= |-D| <= 4N. This is a stopping condition
+            # for the algorithm.
             if p > 4 * N:
                 break
 
             verbose(f"Considering {len(S) + 1}th valid prime {p}", level=3)
 
-        # Equivalent to p* = (-1)^((p - 1) / 2) * p in [BS2007]_ page 5.
-        p_star = -p if p % 4 == 3 else p
+        # Equivalent to p_star = (-1)^((p - 1) / 2) * p in [BS2007]_ page 5.
+        p_star = -p if p >> 1 & 1 else p
 
-        for e in recur(4 * N // p):
+        for e in abs_products_under(4 * N // p):
             D = p_star * e
             assert abs(D) <= 4 * N
 
@@ -3119,15 +3121,17 @@ def EllipticCurve_with_prime_order(N):
             x, _ = sol
             for p_i in [N + 1 - x, N + 1 + x]:
                 if is_prime(p_i):
-                    verbose(f"Computing the Hilbert class polynomial H_{D}", level=2)
+                    verbose(f"Computing the Hilbert class polynomial H_{D}",
+                            level=2)
                     H = hilbert_class_polynomial(D)
                     K = GF(p_i)
                     for j0 in H.roots(ring=K, multiplicities=False):
                         E = EllipticCurve(K, j=j0)
                         # `E.twists()` also contains E.
                         for Et in E.twists():
-                            # num_checks=1 is sufficient for prime order
+                            # `num_checks=1` is sufficient for prime order.
                             if Et.has_order(N, num_checks=1):
                                 yield Et
 
+        # Extending our prime list and continuing onto the next round.
         S.append(p_star)

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2873,7 +2873,7 @@ def EllipticCurve_with_prime_order(N):
     - ``N`` -- integer; the order for which we seek an elliptic curve. Must be a
       prime number.
 
-    OUTPUT: an iterator of elliptic curves `E/\mathbb F_p` of order ``N``
+    OUTPUT: an iterator of (some) elliptic curves `E/\mathbb F_p` of order ``N``
 
     .. NOTE::
 
@@ -2883,11 +2883,11 @@ def EllipticCurve_with_prime_order(N):
         of rounds that is polynomial in `\log\log N`. In practice (cf. Section
         5), this number is usually 1.
 
-    ALGORITHM: [BS2007]_, Algorithm 2.2
+    ALGORITHM: Based on [BS2007]_, Algorithm 2.2
 
     EXAMPLES::
 
-        sage: N = next_prime(int.from_bytes(b'sagemath', 'big'))
+        sage: N = 8314040072427107567
         sage: E = next(EllipticCurve_with_prime_order(N))
         sage: E
         Elliptic Curve defined by y^2 = x^3 + 4757897140353078952*x + 1841350074072114366
@@ -2913,7 +2913,7 @@ def EllipticCurve_with_prime_order(N):
 
     It works for large primes::
 
-        sage: N = 0x6cbc824032974516623e732462f4b74b56c4ffbd984380d9
+        sage: N = 2666207849820848272386538889527600954292544013630953455833
         sage: E = next(EllipticCurve_with_prime_order(N)); E
         Elliptic Curve defined by y^2 = x^3 + 2666207849820848272386538889427721639173508298483739490459*x
          + 77986137112576 over Finite Field of size 2666207849820848272386538889427721639173508298487130585243

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2841,7 +2841,7 @@ def EllipticCurve_with_prime_order(N):
         ...
         ValueError: input order is not prime
 
-    ..NOTE::
+    .. NOTE::
 
         Depending on the input, this function may run forever.
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Me and @grhkm21 suggest this diff against develop that implements the `EllipticCurve_with_prime_order(N)` constructor. Using the prime order `N` in input, this method finds another prime `p` and constructs an elliptic curve `E/Fp` with `#E(Fp) = N`.

It follows Algorithm 2.2 of the paper [Constructing Elliptic Curves of prime order](https://arxiv.org/abs/0712.2022) by Bröker and Stevenhagen. The running time is quite random depending on the input parameter but can turn out to be fast for some larger values (≃ 256 bits primes). It's also worth noticing that some values will make this function run for a **very** long time.

There had been a [PR](https://github.com/sagemath/sage/pull/37119) by @grhkm21 and @GiacomoPope that implements the `EllipticCurve_with_order()` method. This PR would intuitively fit nice into their work but I felt uncomfortable with it returning an iterator. I felt like returning a single curve was more handy so I implemented this method in a separate function that does so but I'm open to suggestions if this is of any interest to the community.

Fixes https://github.com/sagemath/sage/issues/38342

### :memo: Checklist
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


