### PR TITLE
fix mistake in category of fraction fields

### DIFF
--- a/src/sage/rings/fraction_field.py
+++ b/src/sage/rings/fraction_field.py
@@ -187,14 +187,20 @@ class FractionField_generic(ring.Field):
             sage: Frac(QQ['x,y']).variable_names()
             ('x', 'y')
             sage: category(Frac(QQ['x']))
-            Category of quotient fields
+            Category of infinite quotient fields
+
+        TESTS::
+
+            sage: F = FractionField(QQ['x'])
+            sage: F.cardinality()
+            +Infinity
         """
         self._R = R
         self._element_class = element_class
         cat = category
-        if self in Rings().Infinite():
+        if R in Rings().Infinite():
             cat = cat.Infinite()
-        elif self in Rings().Finite():
+        elif R in Rings().Finite():
             cat = cat.Finite()
         Parent.__init__(self, base=R, names=R._names, category=cat)
 


### PR DESCRIPTION
This is fixing wrong code used to determine the category of fraction fields.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



