### PR TITLE
Fix a minor typo

### DIFF
--- a/src/sage/schemes/elliptic_curves/period_lattice.py
+++ b/src/sage/schemes/elliptic_curves/period_lattice.py
@@ -2041,7 +2041,7 @@ def extended_agm_iteration(a, b, c):
 
     OUTPUT:
 
-    (3-tuple) `(a_0,b_0,c_0)`, the limit of the iteration `(a,b,c) \mapsto ((a+b)/2,\sqrt{ab},(c+\sqrt(c^2+b^2-a^2))/2)`.
+    (3-tuple) `(a_0,b_0,c_0)`, the limit of the iteration `(a,b,c) \mapsto ((a+b)/2,\sqrt{ab},(c+\sqrt{c^2+b^2-a^2})/2)`.
 
     EXAMPLES::
 


### PR DESCRIPTION
Just a minor typo. Previously the math doesn't render on the website correctly. https://doc.sagemath.org/html/en/reference/arithmetic_curves/sage/schemes/elliptic_curves/period_lattice.html#sage.schemes.elliptic_curves.period_lattice.extended_agm_iteration

Fixed version in documentation preview: https://doc-pr-38352--sagemath.netlify.app/html/en/reference/arithmetic_curves/sage/schemes/elliptic_curves/period_lattice.html#sage.schemes.elliptic_curves.period_lattice.extended_agm_iteration

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
