### PR TITLE
Homogenise `.log()` api across implementations of finite field elements

### DIFF
--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1411,10 +1411,17 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
         """
         return Integer(self._cache.log_to_int(self.element))
 
-    def log(FiniteField_givaroElement self, base):
+    def log(FiniteField_givaroElement self, base, order=None, *, check=False):
         """
         Return the log to the base `b` of ``self``, i.e., an integer `n`
         such that `b^n =` ``self``.
+
+        INPUT:
+
+        - ``base`` -- non-zero field element
+        - ``order`` -- integer (optional), multiple of order of ``base``
+        - ``check`` -- boolean (default: ``False``): If set,
+          test whether the given ``order`` is correct.
 
         .. WARNING::
 
@@ -1429,9 +1436,22 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: a = b^7
             sage: a.log(b)
             7
+        
+        TESTS:
+
+        An example for ``check=True``::
+
+            sage: F.<t> = GF(3^5, impl='givaro')
+            sage: t.log(t, 3^4, check=True)
+            Traceback (most recent call last):
+            ...
+            ValueError: 81 is not a multiple of the order of the base
         """
         b = self.parent()(base)
-        return sage.groups.generic.discrete_log(self, b)
+        if (order is not None) and check and not (b**order).is_one():
+            raise ValueError(f"{order} is not a multiple of the order of the base")
+
+        return sage.groups.generic.discrete_log(self, b, ord=order)
 
     def _int_repr(FiniteField_givaroElement self):
         r"""

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1436,7 +1436,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: a = b^7
             sage: a.log(b)
             7
-        
+
         TESTS:
 
         An example for ``check=True``::

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -1281,7 +1281,7 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
             Traceback (most recent call last):
             ...
             ValueError: no logarithm of z50 exists to base z50^49 + z50^46 + z50^45 + z50^44 + z50^41 + z50^34 + z50^33 + z50^32 + z50^27 + z50^25 + z50^24 + z50^21 + z50^18 + z50^17 + z50^16 + z50^15 + z50^12 + z50^11 + z50^10 + z50^8 + z50^7 + z50^3 + z50^2
-        
+
         An example for ``check=True``::
 
             sage: F.<t> = GF(2^5, impl='ntl')

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -1281,6 +1281,14 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
             Traceback (most recent call last):
             ...
             ValueError: no logarithm of z50 exists to base z50^49 + z50^46 + z50^45 + z50^44 + z50^41 + z50^34 + z50^33 + z50^32 + z50^27 + z50^25 + z50^24 + z50^21 + z50^18 + z50^17 + z50^16 + z50^15 + z50^12 + z50^11 + z50^10 + z50^8 + z50^7 + z50^3 + z50^2
+        
+        An example for ``check=True``::
+
+            sage: F.<t> = GF(2^5, impl='ntl')
+            sage: t.log(t, 3^4, check=True)
+            Traceback (most recent call last):
+            ...
+            ValueError: base does not have the provided order
 
         AUTHORS:
 

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -767,6 +767,15 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             sage: R(1).factor()
             1
 
+        An example for ``check=True``::
+
+            sage: F = GF(127, impl='modn')
+            sage: t = F.primitive_element()
+            sage: t.log(t, 57, check=True)
+            Traceback (most recent call last):
+            ...
+            ValueError: base does not have the provided order
+
         AUTHORS:
 
         - David Joyner and William Stein (2005-11)
@@ -791,7 +800,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         if check:
             from sage.groups.generic import has_order
             if not has_order(b, order, '*'):
-                raise ValueError('b does not have the provided order')
+                raise ValueError('base does not have the provided order')
 
         cdef Integer n = Integer()
         cdef Integer m = one_Z

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -638,7 +638,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         else:
             return sib(self.parent())(v)
 
-    def log(self, b=None):
+    def log(self, b=None, order=None):
         r"""
         Compute the discrete logarithm of this element to base `b`,
         that is,
@@ -653,6 +653,10 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         -  ``b`` -- a unit modulo `n`. If ``b`` is not given,
            ``R.multiplicative_generator()`` is used, where
            ``R`` is the parent of ``self``.
+        
+        -  ``order`` -- integer (unused), the order of ``b``.
+           This argument is unused, only there for coherence of
+           api with finite field elements.
 
 
         OUTPUT:

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -638,7 +638,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         else:
             return sib(self.parent())(v)
 
-    def log(self, b=None, order=None):
+    def log(self, b=None, order=None, check=False):
         r"""
         Compute the discrete logarithm of this element to base `b`,
         that is,
@@ -655,8 +655,11 @@ cdef class IntegerMod_abstract(FiniteRingElement):
            ``R`` is the parent of ``self``.
         
         -  ``order`` -- integer (unused), the order of ``b``.
-           This argument is unused, only there for coherence of
-           api with finite field elements.
+           This argument is normally unused, only there for
+           coherence of apis with finite field elements.
+        
+        - ``check`` -- boolean (default: ``False``). If set,
+           test whether the given ``order`` is correct.
 
 
         OUTPUT:
@@ -784,6 +787,11 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             b = self._parent(b)
             if not b.is_unit():
                 raise ValueError(f"logarithm with base {b} is not defined since it is not a unit modulo {b.modulus()}")
+
+        if check:
+            from sage.groups.generic import has_order
+            if not has_order(b, order, '*'):
+                raise ValueError('b does not have the provided order')
 
         cdef Integer n = Integer()
         cdef Integer m = one_Z

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -653,11 +653,11 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         -  ``b`` -- a unit modulo `n`. If ``b`` is not given,
            ``R.multiplicative_generator()`` is used, where
            ``R`` is the parent of ``self``.
-        
+
         -  ``order`` -- integer (unused), the order of ``b``.
            This argument is normally unused, only there for
            coherence of apis with finite field elements.
-        
+
         - ``check`` -- boolean (default: ``False``). If set,
            test whether the given ``order`` is correct.
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes #38350 by adding `order=` and `check=` arguments to the `.log()` method of finite field elements, under all implementations.
- `element_pari_ffelt.pyx`: done by @yyyyx4 in #37329.
- `element_ntl_gf2e.pyx`: if provided, does not compute `base_order`.
- `element_givaro.pyx`: if provided, passes `order` to the underlying `discrete_log` call.
- `integer_mod.pyx`: the argument is discarded (unless `check=True`, in which case the order is checked).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


