### PR TITLE
Give deprecation warning when raising negative AlgebraicReal to fractional odd power

### DIFF
--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -879,8 +879,8 @@ class sage__rings__number_field(JoinFeature):
     should be marked likewise::
 
         sage: # needs sage.rings.number_field
-        sage: AA(-1)^(1/3)
-        -1
+        sage: AA(2)^(1/2)
+        1.414213562373095?
         sage: QQbar(-1)^(1/3)
         0.500000000000000? + 0.866025403784439?*I
 

--- a/src/sage/symbolic/expression_conversion_algebraic.py
+++ b/src/sage/symbolic/expression_conversion_algebraic.py
@@ -26,6 +26,7 @@ from sage.functions.all import exp
 from sage.symbolic.expression_conversions import Converter
 from sage.symbolic.operators import add_vararg, mul_vararg
 from sage.symbolic.ring import SR
+from sage.rings.qqbar import AlgebraicRealField
 
 
 #############
@@ -73,6 +74,15 @@ class AlgebraicConverter(Converter):
             sage: a = AlgebraicConverter(QQbar)
             sage: a.arithmetic(f, f.operator())
             1.414213562373095?
+
+        Note that converting an expression where an odd root is taken will take the real root
+        if the target is ``AA``, but this behavior will change in the future::
+
+            sage: AA((-1)^(2/3))
+            doctest:warning...
+            DeprecationWarning: Taking the root of an algebraic real number will yield the principal root in the future.
+            See https://github.com/sagemath/sage/issues/38362 for details.
+            1
 
         TESTS::
 


### PR DESCRIPTION
Previously, the behavior of `AA` is inconsistent with most other cases:

```sage
sage: AA(-8)^(1/3)
-2
sage: QQbar(-8)^(1/3)
1.000000000000000? + 1.732050807568878?*I
```

This will give a deprecation warning when the user attempt to rely on that behavior.

------

### Previous description

Intended to fix​ https://github.com/sagemath/sage/issues/36735 , but now it doesn't.

This fix tries to be more conservative in how to converts symbolic expression of the form `a^b`: it still first convert `a` to `self.field` then raise the result to power of `b`, but it checks if `a<0` and `b` is a fraction then raise an error (I think the previously computed result in this case is never expected).

It does not fix​ https://github.com/sagemath/sage/issues/12745 though (an alternative, as mentioned in https://github.com/sagemath/sage/pull/36942 , is to convert to QQbar first then convert it to AA, then this code wouldn't be necessary. What do you think of that alternative approach?)

### :memo: Checklist


- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
