### PR TITLE
Disjoint direct product decomposition of a permutation group

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -1658,6 +1658,11 @@ REFERENCES:
 .. [CIA] CIA Factbook 09
          https://www.cia.gov/library/publications/the-world-factbook/
 
+.. [CJ2022] \M. Chang, C. Jefferson, *Disjoint direct product decomposition
+            of permutation groups*, Journal of Symbolic Computation (2022),
+            Volume 108, pages 1-16. :doi:`10.1016/j.jsc.2021.04.003`.
+            Preprint: :arxiv:`2004.11618v3`.
+
 .. [CK1986] \R. Calderbank, W.M. Kantor,
             *The geometry of two-weight codes*,
             Bull. London Math. Soc. 18(1986) 97-122.

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1612,9 +1612,9 @@ class PermutationGroup_generic(FiniteGroup):
             sage: PermutationGroup(PermutationGroup(gap_group=B).gens(),domain=list(S[0])).disjoint_direct_product_decomposition()
             {{1, 2, 3}}
 
-        Counting the number of connected subgroups::
+        Counting the number of "connected" permutation groups of degree `n`::
 
-            sage: seq = [sum(1 for G in SymmetricGroup(n).conjugacy_classes_subgroups() if len(G.disjoint_direct_product_decomposition()) == 1) for n in range(1,8)];seq
+            sage: seq = [sum(1 for G in SymmetricGroup(n).conjugacy_classes_subgroups() if len(G.disjoint_direct_product_decomposition()) == 1) for n in range(1,8)]; seq
             [1, 1, 2, 6, 6, 27, 20]
             sage: oeis(seq) # optional -- internet
             0: A005226: Number of atomic species of degree n; also number of connected permutation groups of degree n.

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1590,10 +1590,12 @@ class PermutationGroup_generic(FiniteGroup):
         of ``self``.
 
         The algorithm is from [CJ2022]_, which runs in time polynomial in
-        `n \cdot |G|`, where `n` is the degree of the group and `|G|` is
+        `n \cdot |X|`, where `n` is the degree of the group and `|X|` is
         the size of a generating set, see Theorem 4.5.
 
         EXAMPLES::
+
+        The example from the original paper::
 
             sage: H = PermutationGroup([[(1,2,3),(7,9,8),(10,12,11)],[(4,5,6),(7,8,9),(10,11,12)],[(5,6),(8,9),(11,12)],[(7,8,9),(10,11,12)]])
             sage: S = H.disjoint_direct_product_decomposition();S
@@ -1609,6 +1611,14 @@ class PermutationGroup_generic(FiniteGroup):
             {{4, 5, 6, 7, 8, 9, 10, 11, 12}}
             sage: PermutationGroup(PermutationGroup(gap_group=B).gens(),domain=list(S[0])).disjoint_direct_product_decomposition()
             {{1, 2, 3}}
+
+        Counting the number of connected subgroups::
+
+            sage: # optional -- internet
+            sage: seq = [sum(1 for G in SymmetricGroup(n).conjugacy_classes_subgroups() if len(G.disjoint_direct_product_decomposition()) == 1) for n in range(1,8)];seq
+            [1, 1, 2, 6, 6, 27, 20]
+            sage: oeis(seq)
+            0: A005226: Number of atomic species of degree n; also number of connected permutation groups of degree n.
         """
         from sage.combinat.set_partition import SetPartition
         from sage.sets.disjoint_set import DisjointSet

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1584,12 +1584,17 @@ class PermutationGroup_generic(FiniteGroup):
     @cached_method
     def disjoint_direct_product_decomposition(self):
         r"""
-        Returns the finest partition of `self.domain()` such that `self`
-        is isomorphic to the direct product of the projections of `self`
+        Returns the finest partition of the underlying set such that ``self``
+        is isomorphic to the direct product of the projections of ``self``
         onto each part of the partition. Each part is a union of orbits
-        of `self`.
+        of ``self``.
+
+        The algorithm is from [CJ2022]_, which runs in time polynomial in
+        `n \cdot |G|`, where `n` is the degree of the group and `|G|` is
+        the size of a generating set, see Theorem 4.5.
 
         EXAMPLES::
+
             sage: H = PermutationGroup([[(1,2,3),(7,9,8),(10,12,11)],[(4,5,6),(7,8,9),(10,11,12)],[(5,6),(8,9),(11,12)],[(7,8,9),(10,11,12)]])
             sage: S = H.disjoint_direct_product_decomposition();S
             {{1, 2, 3}, {4, 5, 6, 7, 8, 9, 10, 11, 12}}
@@ -1598,7 +1603,7 @@ class PermutationGroup_generic(FiniteGroup):
             sage: B = libgap.Stabilizer(H, list(S[1]), libgap.OnTuples);B
             Group([ (1,2,3) ])
             sage: T = PermutationGroup(gap_group=libgap.DirectProduct(A,B))
-            sage T.is_isomorphic(H)
+            sage: T.is_isomorphic(H)
             True
         """
         from sage.combinat.set_partition import SetPartition
@@ -1613,40 +1618,40 @@ class PermutationGroup_generic(FiniteGroup):
         OrbitMapping = dict()
         for i in range(k):
             for x in O[i]:
-                OrbitMapping[x]=i
-        C = libgap.StabChain(H,libgap.Concatenation(O))
+                OrbitMapping[x] = i
+        C = libgap.StabChain(H, libgap.Concatenation(O))
         X = libgap.StrongGeneratorsStabChain(C)
         P = DisjointSet(k)
         R = libgap.List([])
         identity = libgap.Identity(H)
         for i in range(k-1):
-            libgap.Append(R,O[i])
+            libgap.Append(R, O[i])
             Xp = libgap.List([])
             while True:
                 try:
-                    if libgap.IsSubset(O[i],C['orbit']):
+                    if libgap.IsSubset(O[i], C['orbit']):
                         C = C['stabilizer']
                     else:
                         break
                 except ValueError:  #this should catch a GAPError but I don't know how to make it work
                     break
             for x in X:
-                xs = libgap.SiftedPermutation(C,x)
+                xs = libgap.SiftedPermutation(C, x)
                 if xs != identity:
-                    cj = OrbitMapping[libgap.SmallestMovedPoint(libgap.RestrictedPerm(x,R))]
-                    libgap.Add(Xp,xs)
-                    if libgap.RestrictedPerm(xs,O[i+1]) != identity:
-                        P.union(i+1,cj)
+                    cj = OrbitMapping[libgap.SmallestMovedPoint(libgap.RestrictedPerm(x, R))]
+                    libgap.Add(Xp, xs)
+                    if libgap.RestrictedPerm(xs, O[i+1]) != identity:
+                        P.union(i+1, cj)
                 else:
-                    libgap.Add(Xp,x)
+                    libgap.Add(Xp, x)
             X = Xp
         final_partition = DisjointSet(self.domain())
         for part in P:
             grp = [self._domain_from_gap[Integer(x)]
                    for i in part
                    for x in O[i]]
-            for i in range(1,len(grp)):
-                final_partition.union(grp[0],grp[i])
+            for i in range(1, len(grp)):
+                final_partition.union(grp[0], grp[i])
         return SetPartition(final_partition)
 
     def representative_action(self, x, y):

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1593,16 +1593,16 @@ class PermutationGroup_generic(FiniteGroup):
         `n \cdot |X|`, where `n` is the degree of the group and `|X|` is
         the size of a generating set, see Theorem 4.5.
 
-        EXAMPLES::
+        EXAMPLES:
 
         The example from the original paper::
 
             sage: H = PermutationGroup([[(1,2,3),(7,9,8),(10,12,11)],[(4,5,6),(7,8,9),(10,11,12)],[(5,6),(8,9),(11,12)],[(7,8,9),(10,11,12)]])
-            sage: S = H.disjoint_direct_product_decomposition();S
+            sage: S = H.disjoint_direct_product_decomposition(); S
             {{1, 2, 3}, {4, 5, 6, 7, 8, 9, 10, 11, 12}}
-            sage: A = libgap.Stabilizer(H, list(S[0]), libgap.OnTuples);A
+            sage: A = libgap.Stabilizer(H, list(S[0]), libgap.OnTuples); A
             Group([ (7,8,9)(10,11,12), (5,6)(8,9)(11,12), (4,5,6)(7,8,9)(10,11,12) ])
-            sage: B = libgap.Stabilizer(H, list(S[1]), libgap.OnTuples);B
+            sage: B = libgap.Stabilizer(H, list(S[1]), libgap.OnTuples); B
             Group([ (1,2,3) ])
             sage: T = PermutationGroup(gap_group=libgap.DirectProduct(A,B))
             sage: T.is_isomorphic(H)
@@ -1614,10 +1614,9 @@ class PermutationGroup_generic(FiniteGroup):
 
         Counting the number of connected subgroups::
 
-            sage: # optional -- internet
             sage: seq = [sum(1 for G in SymmetricGroup(n).conjugacy_classes_subgroups() if len(G.disjoint_direct_product_decomposition()) == 1) for n in range(1,8)];seq
             [1, 1, 2, 6, 6, 27, 20]
-            sage: oeis(seq)
+            sage: oeis(seq) # optional -- internet
             0: A005226: Number of atomic species of degree n; also number of connected permutation groups of degree n.
         """
         from sage.combinat.set_partition import SetPartition
@@ -1659,14 +1658,11 @@ class PermutationGroup_generic(FiniteGroup):
                 else:
                     libgap.Add(Xp, x)
             X = Xp
-        final_partition = DisjointSet(self.domain())
-        for part in P:
-            grp = [self._domain_from_gap[Integer(x)]
-                   for i in part
-                   for x in O[i]]
-            for i in range(1, len(grp)):
-                final_partition.union(grp[0], grp[i])
-        return SetPartition(final_partition)
+        return SetPartition([
+            [self._domain_from_gap[Integer(x)]
+             for i in part
+             for x in O[i]] for part in P] +
+             [[x] for x in self.fixed_points()])
 
     def representative_action(self, x, y):
         r"""

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1605,6 +1605,10 @@ class PermutationGroup_generic(FiniteGroup):
             sage: T = PermutationGroup(gap_group=libgap.DirectProduct(A,B))
             sage: T.is_isomorphic(H)
             True
+            sage: PermutationGroup(PermutationGroup(gap_group=A).gens(),domain=list(S[1])).disjoint_direct_product_decomposition()
+            {{4, 5, 6, 7, 8, 9, 10, 11, 12}}
+            sage: PermutationGroup(PermutationGroup(gap_group=B).gens(),domain=list(S[0])).disjoint_direct_product_decomposition()
+            {{1, 2, 3}}
         """
         from sage.combinat.set_partition import SetPartition
         from sage.sets.disjoint_set import DisjointSet

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -1584,7 +1584,7 @@ class PermutationGroup_generic(FiniteGroup):
     @cached_method
     def disjoint_direct_product_decomposition(self):
         r"""
-        Returns the finest partition of the underlying set such that ``self``
+        Return the finest partition of the underlying set such that ``self``
         is isomorphic to the direct product of the projections of ``self``
         onto each part of the partition. Each part is a union of orbits
         of ``self``.
@@ -1612,6 +1612,13 @@ class PermutationGroup_generic(FiniteGroup):
             sage: PermutationGroup(PermutationGroup(gap_group=B).gens(),domain=list(S[0])).disjoint_direct_product_decomposition()
             {{1, 2, 3}}
 
+        An example with a different domain::
+
+            sage: PermutationGroup([[('a','c','d'),('b','e')]]).disjoint_direct_product_decomposition()
+            {{'a', 'c', 'd'}, {'b', 'e'}}
+            sage: PermutationGroup([[('a','c','d','b','e')]]).disjoint_direct_product_decomposition()
+            {{'a', 'b', 'c', 'd', 'e'}}
+
         Counting the number of "connected" permutation groups of degree `n`::
 
             sage: seq = [sum(1 for G in SymmetricGroup(n).conjugacy_classes_subgroups() if len(G.disjoint_direct_product_decomposition()) == 1) for n in range(1,8)]; seq
@@ -1622,22 +1629,22 @@ class PermutationGroup_generic(FiniteGroup):
         from sage.combinat.set_partition import SetPartition
         from sage.sets.disjoint_set import DisjointSet
         H = self._libgap_()
-        if self.is_trivial():
-            return SetPartition(DisjointSet(self.domain()))
-        if libgap.NrMovedPoints(H) == self.degree() and libgap.IsTransitive(H):
-            return SetPartition([self.domain()])
-        O = libgap.Orbits(H)
-        k = len(O)
+        # sort each orbit and order list by smallest element of each orbit
+        O = libgap.List([libgap.ShallowCopy(orbit) for orbit in libgap.Orbits(H)])
+        for orbit in O:
+            libgap.Sort(orbit)
+        O.Sort()
+        num_orbits = len(O)
         OrbitMapping = dict()
-        for i in range(k):
+        for i in range(num_orbits):
             for x in O[i]:
                 OrbitMapping[x] = i
         C = libgap.StabChain(H, libgap.Concatenation(O))
         X = libgap.StrongGeneratorsStabChain(C)
-        P = DisjointSet(k)
+        P = DisjointSet(num_orbits)
         R = libgap.List([])
         identity = libgap.Identity(H)
-        for i in range(k-1):
+        for i in range(num_orbits-1):
             libgap.Append(R, O[i])
             Xp = libgap.List([])
             while True:
@@ -1646,14 +1653,14 @@ class PermutationGroup_generic(FiniteGroup):
                         C = C['stabilizer']
                     else:
                         break
-                except ValueError:  #this should catch a GAPError but I don't know how to make it work
+                except ValueError:
                     break
             for x in X:
                 xs = libgap.SiftedPermutation(C, x)
                 if xs != identity:
-                    cj = OrbitMapping[libgap.SmallestMovedPoint(libgap.RestrictedPerm(x, R))]
                     libgap.Add(Xp, xs)
                     if libgap.RestrictedPerm(xs, O[i+1]) != identity:
+                        cj = OrbitMapping[libgap.SmallestMovedPoint(libgap.RestrictedPerm(x, R))]
                         P.union(i+1, cj)
                 else:
                     libgap.Add(Xp, x)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR implements the disjoint direct decomposition of a permutation group, which is a partition of its domain such that the group is isomorphic to the direct product of its projection onto each part of the partition. Each part is a union of orbits.

The algorithm used is an adaptation of [https://arxiv.org/abs/2004.11618v3](https://arxiv.org/abs/2004.11618v3). Additionally, the output of this algorithm is guaranteed to be the _finest_ such partition, that is the groups formed from each part are themselves d.d.p indecomposable.

An implementation of the algorithm in the paper by the authors is available at [https://github.com/peal/DisjointDirectProdDecomposition](https://github.com/peal/DisjointDirectProdDecomposition).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
