### PR TITLE
Update ncsf.py documentation

### DIFF
--- a/src/sage/combinat/ncsf_qsym/ncsf.py
+++ b/src/sage/combinat/ncsf_qsym/ncsf.py
@@ -182,8 +182,11 @@ class NonCommutativeSymmetricFunctions(UniqueRepresentation, Parent):
     bialgebra structure, which cooperates with the grading to form a
     connected graded bialgebra. Thus, as any connected graded bialgebra,
     ``Psi`` is a Hopf algebra. Over ``QQ`` (or any other `\QQ`-algebra),
-    this Hopf algebra ``Psi`` is isomorphic to the tensor algebra of
-    its space of primitive elements.
+    this Hopf algebra ``Psi`` is isomorphic to the universal enveloping 
+    algebra of its space of primitive elements. Here, the primitives 
+    form a countably generated free Lie algebra, so ``Psi`` is isomorphic 
+    to the tensor algebra on a countably infinite dimensional vector 
+    space.
 
     The antipode is an anti-algebra morphism; in the ``Psi`` basis, it
     sends the generators to their opposites and changes their sign if

--- a/src/sage/combinat/ncsf_qsym/ncsf.py
+++ b/src/sage/combinat/ncsf_qsym/ncsf.py
@@ -182,10 +182,10 @@ class NonCommutativeSymmetricFunctions(UniqueRepresentation, Parent):
     bialgebra structure, which cooperates with the grading to form a
     connected graded bialgebra. Thus, as any connected graded bialgebra,
     ``Psi`` is a Hopf algebra. Over ``QQ`` (or any other `\QQ`-algebra),
-    this Hopf algebra ``Psi`` is isomorphic to the universal enveloping 
-    algebra of its space of primitive elements. Here, the primitives 
-    form a countably generated free Lie algebra, so ``Psi`` is isomorphic 
-    to the tensor algebra on a countably infinite dimensional vector 
+    this Hopf algebra ``Psi`` is isomorphic to the universal enveloping
+    algebra of its space of primitive elements. Here, the primitives
+    form a countably generated free Lie algebra, so ``Psi`` is isomorphic
+    to the tensor algebra on a countably infinite dimensional vector
     space.
 
     The antipode is an anti-algebra morphism; in the ``Psi`` basis, it


### PR DESCRIPTION
Correction lines 184-189: Psi is not the tensor algebra on the primitives but on the generators of this free Lie algebra.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Correction lines 184-189: Psi is not the tensor algebra on the primitives but on the generators of this free Lie algebra.

Fixes #38370

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


