### PR TITLE
Implemented an Explicit Dimension Formula for the Newspace with character

### DIFF
--- a/src/sage/modular/arithgroup/congroup_gamma1.py
+++ b/src/sage/modular/arithgroup/congroup_gamma1.py
@@ -645,8 +645,10 @@ class Gamma1_class(GammaH_class):
             return Gamma0(N).dimension_new_cusp_forms(k, p)
 
         if algorithm == "Ross":
-            if p != 0: raise ValueError("Algorithm 'Ross' not defined for p-new subspace")
-            if k < 2:  raise ValueError("Algorithm 'Ross' only defined for k >= 2")
+            if p != 0:
+                raise ValueError("Algorithm 'Ross' not defined for p-new subspace")
+            if k < 2:
+                raise ValueError("Algorithm 'Ross' only defined for k >= 2")
             return _dimension_new_cusp_forms_Ross(N, k, eps)
 
         from .congroup_gammaH import mumu
@@ -659,86 +661,75 @@ class Gamma1_class(GammaH_class):
         return self.dimension_cusp_forms(k, eps, algorithm) - 2*old
 
 
-def _dimension_new_cusp_forms_Ross(N,k,chi):
+def _dimension_new_cusp_forms_Ross(N, k, chi):
     r"""
     Compute the dimension formula given in Theorem 1.4 of :arxiv:`2407.08881`.
-    
+
     For more tests, see :meth:`sage.modular.arithgroup.tests.Test.test_dim_formula_Ross()`.
-    
+
     TESTS::
 
         sage: chi = DirichletGroup(60)[5]
         sage: sage.modular.arithgroup.congroup_gamma1._dimension_new_cusp_forms_Ross(60,12,chi)
         66
     """
-    
+
     # First term of explicit dimension formula
-    def psi_local(p,r):
-        assert r >= 1
-        return (p+1)*p**(r-1)
-    
-    def psi(n):
-        ret = 1
-        for p,r in factor(n):
-            ret *= psi_local(p,r)
-        return ret
-    
-    def beta_psi_f_local(p,r,alpha):
-        assert r >= 1
-        if alpha == 0:
-            if r == 1:
-                return p-1
-            elif r==2:
-                return p**2-p-1
-            else:
-                return (p**3-p**2-p+1) * p**(r-3)
-        else:
-            if r==1:
-                return p-2
-            else:
-                return (p**2-2*p+1) * p**(r-2)
-            
-    def beta_psi_f(n, f):
-        ret = 1
-        for p,r in factor(n):
-            ret *= beta_psi_f_local(p,r,f.valuation(p))
+    def psi(n_fact):
+        ret = ZZ(1)
+        for p,r in n_fact:
+            ret *= (p+1) * p**(r-1)
         return ret
 
+    def beta_psi_f(n_fact, f):
+        ret = ZZ(1)
+        for p,r in n_fact:
+            alpha = f.valuation(p)
+            if alpha == 0:
+                if r == 1:
+                    ret *= p-1
+                elif r == 2:
+                    ret *= p**2-p-1
+                else:
+                    ret *= (p**3-p**2-p+1) * p**(r-3)
+            else:
+                if r == 1:
+                    ret *= p-2
+                else:
+                    ret *= (p**2-2*p+1) * p**(r-2)
+        return ret
 
     # Second term of explicit dimension formula
-    def beta_sigma_f_local(p,r,alpha):
-        assert r>=1
-        if alpha == 0:
-            if r % 2 == 1:
-                return 0
-            elif r == 2:
-                return p-2
+    def beta_sigma_f(n_fact, f):
+        ret = ZZ(1)
+        for p,r in n_fact:
+            alpha = f.valuation(p)
+            if alpha == 0:
+                if r % 2 == 1:
+                    ret *= 0
+                elif r == 2:
+                    ret *= p-2
+                else:
+                    ret *= (p**2-2*p+1) * p**(r//2-2)
+            elif r == 1:
+                if alpha == 1:
+                    ret *= (p-3)/2
+                else:
+                    ret *= p-2
             else:
-                return (p**2-2*p+1) * p**(r//2-2)
-        elif r == 1:
-            if alpha == 1:
-                return (p-3)/2
-            else:
-                return p-2
-        else:
-            if r >= alpha+1 and (r+alpha)%2==1:
-                return 0
-            elif r >= alpha+2 and (r+alpha)%2==0:
-                return ZZ(1)/2 * (p**2-2*p+1) * p**((r+alpha)/2-2) 
-            elif r == alpha:
-                return ZZ(1)/2 * (p**2-3*p+2) * p**(r-2)
-            else:
-                return (p**2-2*p+1) * p**(r-2) 
-
-    def beta_sigma_f(n,f):
-        ret = 1
-        for p,r in factor(n):
-            ret *= beta_sigma_f_local(p,r,f.valuation(p))
+                if r >= alpha+1 and (r+alpha) % 2 == 1:
+                    ret *= 0
+                elif r >= alpha+2 and (r+alpha) % 2 == 0:
+                    ret *= ZZ(1)/2 * (p**2-2*p+1) * p**((r+alpha)/2-2)
+                elif r == alpha:
+                    ret *= ZZ(1)/2 * (p**2-3*p+2) * p**(r-2)
+                else:
+                    ret *= (p**2-2*p+1) * p**(r-2)
         return ret
 
-    
     # Third term of explicit dimension formula
-    def get_chi_p_alpha(f_fact, chi, p, x):
+    def get_chi_p_alpha(f, chi, p, x):
+        f_fact = factor(f)
         rems = [(int(x) if q == p else 1) for (q,alpha) in f_fact]
         mods = [p**alpha for (p,alpha) in f_fact]
         assert rems.count(1) == len(rems) - 1
@@ -746,164 +737,123 @@ def _dimension_new_cusp_forms_Ross(N,k,chi):
         chi_prim = chi.primitive_character()
         return chi_prim(x_hat)
 
-    def rho_local(p,r,alpha,chi,f_fact):
-        assert r >= alpha
-        assert r >= 1
-        if p == 2:
-            return 0
-        elif p == 3:
+    def rho(n_fact,chi,f):
+        ret = 1
+        for p,r in n_fact:
+            if p == 2:
+                ret *= 0
+            elif p == 3:
+                if r == 1:
+                    ret *= 1
+                else:
+                    ret *= 0
+            elif kronecker(-3,p) == -1:
+                ret *= 0
+            else:
+                u = Zmod(p**r)(-3).sqrt(extend=False)
+                chi_x = get_chi_p_alpha(f, chi, p, (-1+u)/2)
+                assert chi_x**3 == 1
+                if chi_x == 1:
+                    ret *= 2
+                else:
+                    ret *= -1
+        return ret
+
+    def beta_rho_f(n_fact, f):
+        ret = 1
+        for p,r in n_fact:
+            alpha = f.valuation(p)
             if r == 1:
-                return 1
+                if p == 3 and alpha == 0:
+                    ret *= -1
+                elif p != 3 and alpha >= 1:
+                    ret *= -1
+                elif p != 2 and p != 3 and alpha == 0 and kronecker(-3,p) == 1:
+                    ret *= 0
+                else:
+                    ret *= -2
+            elif r == 2:
+                if p == 3 and alpha == 0:
+                    ret *= -1
+                elif p != 3 and alpha >= 1:
+                    ret *= 0
+                elif p != 2 and p != 3 and alpha == 0 and kronecker(-3,p) == 1:
+                    ret *= -1
+                else:
+                    ret *= 1
             else:
-                return 0
-        elif kronecker(-3,p) == -1:
-            return 0
-        else:
-            u = Zmod(p**r)(-3).sqrt(extend=False)
-            chi_x = get_chi_p_alpha(f_fact, chi, p, (-1+u)/2)
-            assert chi_x**3 == 1
-            if chi_x == 1:
-                return 2
-            else:
-                return -1
-    
-    def rho(n,chi,f):
-        f_fact = factor(f)
-        ret = 1
-        for p,r in factor(n):
-            ret *= rho_local(p,r,f.valuation(p),chi,f_fact)
+                if p == 3 and r == 3 and alpha == 0:
+                    ret *= 1
+                else:
+                    ret *= 0
         return ret
-
-    def beta_rho_f_local(p,r,alpha):
-        assert r >= 1
-        if r == 1:
-            if p == 3 and alpha == 0:
-                return -1
-            elif p != 3 and alpha >= 1:
-                return -1
-            elif p != 2 and p != 3 and alpha == 0 and kronecker(-3,p)==1:
-                return 0
-            else:
-                return -2
-        elif r == 2:
-            if p == 3 and alpha == 0:
-                return -1
-            elif p != 3 and alpha >= 1:
-                return 0
-            elif p != 2 and p != 3 and alpha == 0 and kronecker(-3,p)==1:
-                return -1
-            else:
-                return 1
-        else:
-            if p == 3 and r == 3 and alpha == 0:
-                return 1
-            else:
-                return 0
-
-    def beta_rho_f(n,f):
-        ret = 1
-        for p,r in factor(n):
-            ret *= beta_rho_f_local(p,r,f.valuation(p))
-        return ret
-
 
     # Fourth term of explicit dimension formula
-    def rhopm_local(p,r,alpha,chi,f_fact):
-        assert r >= alpha
-        assert r >= 1
+    def rhopm(n_fact,chi,f):
+        ret = 1
+        for p,r in n_fact:
+            if p == 2:
+                if r == 1:
+                    ret *= 1
+                else:
+                    ret *= 0
+            elif kronecker(-1,p) == -1:
+                ret *= 0
+            else:
+                upm = Zmod(p**r)(-1).sqrt(extend=False)
+                chi_x = get_chi_p_alpha(f, chi, p, upm)
+                assert chi_x**4 == 1
+                if chi_x == 1:
+                    ret *= 2
+                elif chi_x == -1:
+                    ret *= -2
+                else:
+                    ret *= 0
+        return ret
 
-        if p == 2:
+    def beta_rhopm_f(n_fact, f):
+        ret = 1
+        for p,r in n_fact:
+            alpha = f.valuation(p)
             if r == 1:
-                return 1
+                if p == 2 and alpha == 0:
+                    ret *= -1
+                elif p != 2 and alpha >= 1:
+                    ret *= -1
+                elif p != 2 and alpha == 0 and kronecker(-1,p) == 1:
+                    ret *= 0
+                else:
+                    ret *= -2
+            elif r == 2:
+                if p == 2 and alpha == 0:
+                    ret *= -1
+                elif p != 2 and alpha >= 1:
+                    ret *= 0
+                elif p != 2 and alpha == 0 and kronecker(-1,p) == 1:
+                    ret *= -1
+                else:
+                    ret *= 1
             else:
-                return 0
-        elif kronecker(-1,p) == -1:
-            return 0
-        else:
-            upm = Zmod(p**r)(-1).sqrt(extend=False)
-            chi_x = get_chi_p_alpha(f_fact, chi, p, upm)
-            assert chi_x**4 == 1
-            if chi_x == 1:
-                return 2
-            elif chi_x == -1:
-                return -2
-            else:
-                return 0
-
-    def rhopm(n,chi,f):
-        f_fact = factor(f)
-        ret = 1
-        for p,r in factor(n):
-            ret *= rhopm_local(p,r,f.valuation(p),chi,f_fact)
+                if p == 2 and r == 3 and alpha == 0:
+                    ret *= 1
+                else:
+                    ret *= 0
         return ret
-
-    def beta_rhopm_f_local(p,r,alpha):
-        assert r >= 1
-        if r == 1:
-            if p == 2 and alpha == 0:
-                return -1
-            elif p != 2 and alpha >= 1:
-                return -1
-            elif p != 2 and alpha == 0 and kronecker(-1,p)==1:
-                return 0
-            else:
-                return -2
-        elif r == 2:
-            if p == 2 and alpha == 0:
-                return -1
-            elif p != 2 and alpha >= 1:
-                return 0
-            elif p != 2 and alpha == 0 and kronecker(-1,p)==1:
-                return -1
-            else:
-                return 1
-        else:
-            if p == 2 and r == 3 and alpha == 0:
-                return 1
-            else:
-                return 0
-
-    def beta_rhopm_f(n,f):
-        ret = 1
-        for p,r in factor(n):
-            ret *= beta_rhopm_f_local(p,r,f.valuation(p))
-        return ret
-
-
-
-    # Constant factors for each term of the explicit dimension formula
-    def c3(k):
-        return (k-1)/3 - k//3
-
-    def c4(k):
-        return (k-1)/4 - k//4
-
-    def c0(k,f):
-        if k == 2 and f == 1:
-            return 1
-        else:
-            return 0
-
-    def omega(n):
-        return len(factor(n))
-
 
     # Finally, compute the actual dimension formula
     k = ZZ(k)
     N = ZZ(N)
     assert k >= 2
     if chi(-1) != (-1)**k:
-        return 0
+        return ZZ(0)
     f = chi.conductor()
-    ret = 0
-    ret += (k-1)/12 * psi(f) * beta_psi_f(N//f, f)
-    ret += -1 * c3(k) * rho(f, chi, f) * beta_rho_f(N//f, f)
-    ret += -1 * c4(k) * rhopm(f, chi, f) * beta_rhopm_f(N//f, f)
-    ret += ZZ(-1)/2 * 2**omega(f) * beta_sigma_f(N//f, f) 
-    ret += c0(k,f) * moebius(N//f)
+    f_fact = factor(f)
+    Nf_fact = factor(N//f)
+    ret = ZZ(0)
+    ret += (k-1)/12 * psi(f_fact) * beta_psi_f(Nf_fact, f)
+    ret -= ((k-1)/3 - k//3) * rho(f_fact, chi, f) * beta_rho_f(Nf_fact, f)
+    ret -= ((k-1)/4 - k//4) * rhopm(f_fact, chi, f) * beta_rhopm_f(Nf_fact, f)
+    ret -= ZZ(1)/2 * 2**len(f_fact) * beta_sigma_f(Nf_fact, f)
+    ret += (1 if k == 2 and f == 1 else 0) * moebius(N//f)
     assert ret.is_integral()
     return ZZ(ret)
-
-
-
-

--- a/src/sage/modular/arithgroup/congroup_gamma1.py
+++ b/src/sage/modular/arithgroup/congroup_gamma1.py
@@ -659,7 +659,6 @@ class Gamma1_class(GammaH_class):
         return self.dimension_cusp_forms(k, eps, algorithm) - 2*old
 
 
-
 def _dimension_new_cusp_forms_Ross(N,k,chi):
     r"""
     Compute the dimension formula given in Theorem 1.4 of :arxiv:`2407.08881`.

--- a/src/sage/modular/arithgroup/congroup_gamma1.py
+++ b/src/sage/modular/arithgroup/congroup_gamma1.py
@@ -661,9 +661,10 @@ class Gamma1_class(GammaH_class):
 
 
 def _dimension_new_cusp_forms_Ross(N,k,chi):
-    r"""An internal function to implement the explicit dimension formula
-        given in Theorem 1.4 of https://arxiv.org/abs/2407.08881. For tests, 
-        see test_dim_formula_Ross() in sage/modular/arithgroup/tests.py  
+    r"""
+    Compute the dimension formula given in Theorem 1.4 of :arxiv:`2407.08881`.
+    
+    For more tests, see :meth:`sage.modular.arithgroup.tests.Test.test_dim_formula_Ross()`.
     """
     # First term of explicit dimension formula
     def psi_local(p,r):

--- a/src/sage/modular/arithgroup/congroup_gamma1.py
+++ b/src/sage/modular/arithgroup/congroup_gamma1.py
@@ -17,7 +17,8 @@ from sage.misc.cachefunc import cached_method
 from sage.misc.misc_c import prod
 from .congroup_gammaH import GammaH_class, is_GammaH, GammaH_constructor
 from sage.rings.integer_ring import ZZ
-from sage.arith.misc import euler_phi as phi, moebius, divisors
+from sage.rings.finite_rings.integer_mod_ring import Zmod
+from sage.arith.misc import euler_phi as phi, moebius, divisors, kronecker, CRT, factor
 from sage.modular.dirichlet import DirichletGroup
 
 
@@ -589,11 +590,12 @@ class Gamma1_class(GammaH_class):
 
         -  ``p`` -- a prime (default: 0); just the `p`-new subspace if given
 
-        - ``algorithm`` -- either "CohenOesterle" (the default) or "Quer". This
-          specifies the method to use in the case of nontrivial character:
-          either the Cohen--Oesterle formula as described in Stein's book, or
+        - ``algorithm`` -- either "CohenOesterle" (the default), "Quer", or "Ross".
+          This specifies the method to use in the case of nontrivial character:
+          either the Cohen--Oesterle formula as described in Stein's book,
           by Möbius inversion using the subgroups GammaH (a method due to
-          Jordi Quer).
+          Jordi Quer), or by an explicit formula (due to Erick Ross).
+
 
         EXAMPLES::
 
@@ -642,6 +644,11 @@ class Gamma1_class(GammaH_class):
             from .all import Gamma0
             return Gamma0(N).dimension_new_cusp_forms(k, p)
 
+        if algorithm == "Ross":
+            if p != 0: raise ValueError("Algorithm 'Ross' not defined for p-new subspace")
+            if k < 2:  raise ValueError("Algorithm 'Ross' only defined for k >= 2")
+            return _dimension_new_cusp_forms_Ross(N, k, eps)
+
         from .congroup_gammaH import mumu
 
         if p == 0 or N % p != 0 or eps.conductor().valuation(p) == N.valuation(p):
@@ -650,3 +657,246 @@ class Gamma1_class(GammaH_class):
         eps_p = eps.restrict(N//p)
         old = Gamma1_constructor(N//p).dimension_cusp_forms(k, eps_p, algorithm)
         return self.dimension_cusp_forms(k, eps, algorithm) - 2*old
+
+
+
+def _dimension_new_cusp_forms_Ross(N,k,chi):
+    r"""An internal function to implement the explicit dimension formula
+        given in Theorem 1.4 of https://arxiv.org/abs/2407.08881. For tests, 
+        see test_dim_formula_Ross() in sage/modular/arithgroup/tests.py  
+    """
+    # First term of explicit dimension formula
+    def psi_local(p,r):
+        assert r >= 1
+        return (p+1)*p**(r-1)
+    
+    def psi(n):
+        ret = 1
+        for p,r in factor(n):
+            ret *= psi_local(p,r)
+        return ret
+    
+    def beta_psi_f_local(p,r,alpha):
+        assert r >= 1
+        if alpha == 0:
+            if r == 1:
+                return p-1
+            elif r==2:
+                return p**2-p-1
+            else:
+                return (p**3-p**2-p+1) * p**(r-3)
+        else:
+            if r==1:
+                return p-2
+            else:
+                return (p**2-2*p+1) * p**(r-2)
+            
+    def beta_psi_f(n, f):
+        ret = 1
+        for p,r in factor(n):
+            ret *= beta_psi_f_local(p,r,f.valuation(p))
+        return ret
+
+
+    # Second term of explicit dimension formula
+    def beta_sigma_f_local(p,r,alpha):
+        assert r>=1
+        if alpha == 0:
+            if r % 2 == 1:
+                return 0
+            elif r == 2:
+                return p-2
+            else:
+                return (p**2-2*p+1) * p**(r//2-2)
+        elif r == 1:
+            if alpha == 1:
+                return (p-3)/2
+            else:
+                return p-2
+        else:
+            if r >= alpha+1 and (r+alpha)%2==1:
+                return 0
+            elif r >= alpha+2 and (r+alpha)%2==0:
+                return ZZ(1)/2 * (p**2-2*p+1) * p**((r+alpha)/2-2) 
+            elif r == alpha:
+                return ZZ(1)/2 * (p**2-3*p+2) * p**(r-2)
+            else:
+                return (p**2-2*p+1) * p**(r-2) 
+
+    def beta_sigma_f(n,f):
+        ret = 1
+        for p,r in factor(n):
+            ret *= beta_sigma_f_local(p,r,f.valuation(p))
+        return ret
+
+    
+    # Third term of explicit dimension formula
+    def get_chi_p_alpha(f_fact, chi, p, x):
+        rems = [(int(x) if q == p else 1) for (q,alpha) in f_fact]
+        mods = [p**alpha for (p,alpha) in f_fact]
+        assert rems.count(1) == len(rems) - 1
+        x_hat = CRT(rems, mods)
+        chi_prim = chi.primitive_character()
+        return chi_prim(x_hat)
+
+    def rho_local(p,r,alpha,chi,f_fact):
+        assert r >= alpha
+        assert r >= 1
+        if p == 2:
+            return 0
+        elif p == 3:
+            if r == 1:
+                return 1
+            else:
+                return 0
+        elif kronecker(-3,p) == -1:
+            return 0
+        else:
+            u = Zmod(p**r)(-3).sqrt(extend=False)
+            chi_x = get_chi_p_alpha(f_fact, chi, p, (-1+u)/2)
+            assert chi_x**3 == 1
+            if chi_x == 1:
+                return 2
+            else:
+                return -1
+    
+    def rho(n,chi,f):
+        f_fact = factor(f)
+        ret = 1
+        for p,r in factor(n):
+            ret *= rho_local(p,r,f.valuation(p),chi,f_fact)
+        return ret
+
+    def beta_rho_f_local(p,r,alpha):
+        assert r >= 1
+        if r == 1:
+            if p == 3 and alpha == 0:
+                return -1
+            elif p != 3 and alpha >= 1:
+                return -1
+            elif p != 2 and p != 3 and alpha == 0 and kronecker(-3,p)==1:
+                return 0
+            else:
+                return -2
+        elif r == 2:
+            if p == 3 and alpha == 0:
+                return -1
+            elif p != 3 and alpha >= 1:
+                return 0
+            elif p != 2 and p != 3 and alpha == 0 and kronecker(-3,p)==1:
+                return -1
+            else:
+                return 1
+        else:
+            if p == 3 and r == 3 and alpha == 0:
+                return 1
+            else:
+                return 0
+
+    def beta_rho_f(n,f):
+        ret = 1
+        for p,r in factor(n):
+            ret *= beta_rho_f_local(p,r,f.valuation(p))
+        return ret
+
+
+    # Fourth term of explicit dimension formula
+    def rhopm_local(p,r,alpha,chi,f_fact):
+        assert r >= alpha
+        assert r >= 1
+
+        if p == 2:
+            if r == 1:
+                return 1
+            else:
+                return 0
+        elif kronecker(-1,p) == -1:
+            return 0
+        else:
+            upm = Zmod(p**r)(-1).sqrt(extend=False)
+            chi_x = get_chi_p_alpha(f_fact, chi, p, upm)
+            assert chi_x**4 == 1
+            if chi_x == 1:
+                return 2
+            elif chi_x == -1:
+                return -2
+            else:
+                return 0
+
+    def rhopm(n,chi,f):
+        f_fact = factor(f)
+        ret = 1
+        for p,r in factor(n):
+            ret *= rhopm_local(p,r,f.valuation(p),chi,f_fact)
+        return ret
+
+    def beta_rhopm_f_local(p,r,alpha):
+        assert r >= 1
+        if r == 1:
+            if p == 2 and alpha == 0:
+                return -1
+            elif p != 2 and alpha >= 1:
+                return -1
+            elif p != 2 and alpha == 0 and kronecker(-1,p)==1:
+                return 0
+            else:
+                return -2
+        elif r == 2:
+            if p == 2 and alpha == 0:
+                return -1
+            elif p != 2 and alpha >= 1:
+                return 0
+            elif p != 2 and alpha == 0 and kronecker(-1,p)==1:
+                return -1
+            else:
+                return 1
+        else:
+            if p == 2 and r == 3 and alpha == 0:
+                return 1
+            else:
+                return 0
+
+    def beta_rhopm_f(n,f):
+        ret = 1
+        for p,r in factor(n):
+            ret *= beta_rhopm_f_local(p,r,f.valuation(p))
+        return ret
+
+
+
+    # Constant factors for each term of the explicit dimension formula
+    def c3(k):
+        return (k-1)/3 - k//3
+
+    def c4(k):
+        return (k-1)/4 - k//4
+
+    def c0(k,f):
+        if k == 2 and f == 1:
+            return 1
+        else:
+            return 0
+
+    def omega(n):
+        return len(factor(n))
+
+
+    # Finally, compute the actual dimension formula
+    k = ZZ(k)
+    N = ZZ(N)
+    assert k >= 2
+    if chi(-1) != (-1)**k:
+        return 0
+    f = chi.conductor()
+    ret = 0
+    ret += (k-1)/12 * psi(f) * beta_psi_f(N//f, f)
+    ret += -1 * c3(k) * rho(f, chi, f) * beta_rho_f(N//f, f)
+    ret += -1 * c4(k) * rhopm(f, chi, f) * beta_rhopm_f(N//f, f)
+    ret += ZZ(-1)/2 * 2**omega(f) * beta_sigma_f(N//f, f) 
+    ret += c0(k,f) * moebius(N//f)
+    assert ret.is_integral()
+    return ZZ(ret)
+
+
+
+

--- a/src/sage/modular/arithgroup/congroup_gamma1.py
+++ b/src/sage/modular/arithgroup/congroup_gamma1.py
@@ -664,7 +664,14 @@ def _dimension_new_cusp_forms_Ross(N,k,chi):
     Compute the dimension formula given in Theorem 1.4 of :arxiv:`2407.08881`.
     
     For more tests, see :meth:`sage.modular.arithgroup.tests.Test.test_dim_formula_Ross()`.
+    
+    TESTS::
+
+        sage: chi = DirichletGroup(60)[5]
+        sage: sage.modular.arithgroup.congroup_gamma1._dimension_new_cusp_forms_Ross(60,12,chi)
+        66
     """
+    
     # First term of explicit dimension formula
     def psi_local(p,r):
         assert r >= 1

--- a/src/sage/modular/arithgroup/tests.py
+++ b/src/sage/modular/arithgroup/tests.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 from .arithgroup_perm import ArithmeticSubgroup_Permutation, EvenArithmeticSubgroup_Permutation, OddArithmeticSubgroup_Permutation
 from sage.modular.arithgroup.all import Gamma, Gamma0, Gamma1, GammaH
 from sage.rings.finite_rings.integer_mod_ring import Zmod
-from sage.modular.dirichlet import DirichletGroup
-from sage.rings.integer_ring import ZZ
 
 import sage.misc.prandom as prandom
 from sage.misc.timing import cputime

--- a/src/sage/modular/arithgroup/tests.py
+++ b/src/sage/modular/arithgroup/tests.py
@@ -434,6 +434,5 @@ class Test:
             for eps in DirichletGroup(N):
                 for k in range(2,k_ub+1):
                     Ross_dim = Gamma1_N.dimension_new_cusp_forms(k,eps,algorithm="Ross")
-                    CO_dim   = Gamma1_N.dimension_new_cusp_forms(k,eps,algorithm="CohenOesterle")
+                    CO_dim = Gamma1_N.dimension_new_cusp_forms(k,eps,algorithm="CohenOesterle")
                     assert Ross_dim == CO_dim
-

--- a/src/sage/modular/arithgroup/tests.py
+++ b/src/sage/modular/arithgroup/tests.py
@@ -430,6 +430,7 @@ class Test:
             sage: from sage.modular.arithgroup.tests import Test
             sage: Test().test_dim_formula_Ross(100,16)
         """
+        from sage.modular.dirichlet import DirichletGroup
         for N in range(3,N_ub+1):
             Gamma1_N = Gamma1(N)
             for eps in DirichletGroup(N):

--- a/src/sage/modular/arithgroup/tests.py
+++ b/src/sage/modular/arithgroup/tests.py
@@ -422,8 +422,8 @@ class Test:
 
     def test_dim_formula_Ross(self, N_ub=50, k_ub=10):
         r"""
-        Test the explicit dimension formula implemented in 
-        Gamma1._dimension_new_cusp_forms_Ross()
+        Test the dimension formula given in Theorem 1.4
+        of :arxiv:`2407.08881`
 
         EXAMPLES::
 

--- a/src/sage/modular/arithgroup/tests.py
+++ b/src/sage/modular/arithgroup/tests.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 from .arithgroup_perm import ArithmeticSubgroup_Permutation, EvenArithmeticSubgroup_Permutation, OddArithmeticSubgroup_Permutation
 from sage.modular.arithgroup.all import Gamma, Gamma0, Gamma1, GammaH
 from sage.rings.finite_rings.integer_mod_ring import Zmod
+from sage.modular.dirichlet import DirichletGroup
+from sage.rings.integer_ring import ZZ
 
 import sage.misc.prandom as prandom
 from sage.misc.timing import cputime
@@ -196,6 +198,9 @@ class Test:
             ...
             sage: T.test('todd_coxeter',seconds=1)
             test_todd_coxeter
+            ...
+            sage: T.test('dim_formula_Ross',seconds=3)
+            test_dim_formula_Ross
             ...
         """
         seconds = float(seconds)
@@ -415,3 +420,23 @@ class Test:
             for j in range(i + 1, len(reps)):
                 assert reps[i] * ~reps[j] not in G
                 assert reps[j] * ~reps[i] not in G
+
+
+    def test_dim_formula_Ross(self, N_ub=50, k_ub=10):
+        r"""
+        Test the explicit dimension formula implemented in 
+        Gamma1._dimension_new_cusp_forms_Ross()
+
+        EXAMPLES::
+
+            sage: from sage.modular.arithgroup.tests import Test
+            sage: Test().test_dim_formula_Ross(100,16)
+        """
+        for N in range(3,N_ub+1):
+            Gamma1_N = Gamma1(N)
+            for eps in DirichletGroup(N):
+                for k in range(2,k_ub+1):
+                    Ross_dim = Gamma1_N.dimension_new_cusp_forms(k,eps,algorithm="Ross")
+                    CO_dim   = Gamma1_N.dimension_new_cusp_forms(k,eps,algorithm="CohenOesterle")
+                    assert Ross_dim == CO_dim
+

--- a/src/sage/modular/arithgroup/tests.py
+++ b/src/sage/modular/arithgroup/tests.py
@@ -418,8 +418,6 @@ class Test:
             for j in range(i + 1, len(reps)):
                 assert reps[i] * ~reps[j] not in G
                 assert reps[j] * ~reps[i] not in G
-
-
     def test_dim_formula_Ross(self, N_ub=50, k_ub=10):
         r"""
         Test the dimension formula given in Theorem 1.4


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR implements a [recently computed](https://arxiv.org/abs/2407.08881) explicit dimension formula for newspaces of modular forms with character.
This completes Issue #38384  
The tests verify this formula against the current dimension computation in Sage.

I added some additional documentation underneath `dimension_new_cusp_forms()` for this change. But I can't view the documentation preview, because for some reason, I can't get the docs to build on my machine. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


