### PR TITLE
get rid of sage_eval in grobner_fan

### DIFF
--- a/src/sage/rings/polynomial/groebner_fan.py
+++ b/src/sage/rings/polynomial/groebner_fan.py
@@ -58,10 +58,9 @@ REFERENCES:
 """
 
 import string
+import re
 import pexpect
 from subprocess import PIPE, Popen
-
-from sage.misc.sage_eval import sage_eval
 
 from sage.structure.sage_object import SageObject
 from sage.interfaces.gfan import gfan
@@ -983,8 +982,9 @@ class GroebnerFan(SageObject):
                                stdin=PIPE, stdout=PIPE, stderr=PIPE)
         ans, err = gfan_processes.communicate(input=str_to_bytes(self.gfan()))
         ans = bytes_to_str(ans)
-        ans = sage_eval(ans.replace('{', '').replace('}', '').replace('\n', ''))
-        return [vector(QQ, x) for x in ans]
+        vect = re.compile(r"\([0-9,/\s]*\)")
+        ans = (tup[1:-1].split(',') for tup in vect.findall(ans))
+        return [vector(QQ, [QQ(y) for y in x]) for x in ans]
 
     def ring(self):
         """


### PR DESCRIPTION
parsing the input by hand instead of using the big hammer `sage_eval`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



