### PR TITLE
get rid of one sage_eval in modular

### DIFF
--- a/src/sage/modular/buzzard.py
+++ b/src/sage/modular/buzzard.py
@@ -18,30 +18,12 @@ AUTHORS:
 #
 #                  https://www.gnu.org/licenses/
 #############################################################################
+from pathlib import Path
 
-from sage.interfaces.gp import Gp
-from sage.misc.sage_eval import sage_eval
+from sage.env import SAGE_EXTCODE
+from sage.libs.pari import pari
 
-_gp = None
-
-
-def gp():
-    r"""
-    Return a copy of the GP interpreter with the appropriate files loaded.
-
-    EXAMPLES::
-
-        sage: import sage.modular.buzzard
-        sage: sage.modular.buzzard.gp()
-        PARI/GP interpreter
-    """
-    global _gp
-    if _gp is None:
-        _gp = Gp(script_subdirectory='buzzard')
-        _gp.read("DimensionSk.g")
-        _gp.read("genusn.g")
-        _gp.read("Tpprog.g")
-    return _gp
+buzzard_dir = Path(SAGE_EXTCODE) / "pari" / "buzzard"
 
 # def buzzard_dimension_cusp_forms(eps, k):
 #     r"""
@@ -86,6 +68,7 @@ def buzzard_tpslopes(p, N, kmax):
 
         sage: from sage.modular.buzzard import buzzard_tpslopes
         sage: c = buzzard_tpslopes(2,1,50)
+        ...
         sage: c[50]
         [4, 8, 13]
 
@@ -107,7 +90,10 @@ def buzzard_tpslopes(p, N, kmax):
 
     - William Stein (2006-03-17): small Sage wrapper of Buzzard's scripts
     """
-    v = gp().eval('tpslopes(%s, %s, %s)' % (p, N, kmax))
-    v = sage_eval(v)
-    v.insert(0, [])   # so v[k] = info about weight k (since python is 0-based)
+    pari.read(buzzard_dir / "DimensionSk.g")
+    pari.read(buzzard_dir / "genusn.g")
+    pari.read(buzzard_dir / "Tpprog.g")
+    # v = pari.tpslopes(p, N, kmax).sage()
+    v = pari('tpslopes(%s, %s, %s)' % (p, N, kmax)).sage()
+    v.insert(0, [])   # so that v[k] = info about weight k
     return v


### PR DESCRIPTION
and also using the pari library directly

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



