### PR TITLE
get rid of some sage-eval in gap3-related code

### DIFF
--- a/src/sage/combinat/root_system/reflection_group_complex.py
+++ b/src/sage/combinat/root_system/reflection_group_complex.py
@@ -971,7 +971,7 @@ class ComplexReflectionGroup(UniqueRepresentation, PermutationGroup_generic):
         """
         # This can be converted to usual GAP
         S = str(gap3('List(ConjugacyClasses(%s),Representative)' % self._gap_group._name))
-        return sage_eval(_gap_return(S), {'self': self})
+        return [self(w, check=False) for w in _gap_return(S)]
 
     def conjugacy_classes(self):
         r"""

--- a/src/sage/combinat/root_system/reflection_group_element.pyx
+++ b/src/sage/combinat/root_system/reflection_group_element.pyx
@@ -21,6 +21,7 @@ AUTHORS:
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
+import re
 
 from sage.misc.lazy_attribute import lazy_attribute
 from sage.misc.misc_c import prod
@@ -30,6 +31,8 @@ from sage.rings.rational_field import QQ
 from sage.combinat.root_system.reflection_group_c import reduced_word_c, reduce_in_coset
 from sage.matrix.constructor import Matrix
 from sage.matrix.special import identity_matrix
+
+TUPLE = re.compile(r'(?:\([0-9,]*\))+')
 
 
 cdef class ComplexReflectionGroupElement(PermutationGroupElement):
@@ -1246,8 +1249,7 @@ def _gap_return(S, coerce_obj='self'):
 
         sage: from sage.combinat.root_system.reflection_group_complex import _gap_return
         sage: _gap_return("[ (), (1,4)(2,3)(5,6), (1,6,2)(3,5,4) ]")    # optional - gap3
-        "[self('()',check=False),self('(1,4)(2,3)(5,6)',check=False),self('(1,6,2)(3,5,4)',check=False)]"
+        ['()', '(1,4)(2,3)(5,6)', '(1,6,2)(3,5,4)']
     """
     S = S.replace(' ', '').replace('\n', '')
-    S = S.replace(',(', '\',check=False),%s(\'(' % coerce_obj).replace('[', '[%s(\'' % coerce_obj).replace(']', '\',check=False)]')
-    return S
+    return TUPLE.findall(S)

--- a/src/sage/combinat/root_system/reflection_group_real.py
+++ b/src/sage/combinat/root_system/reflection_group_real.py
@@ -695,7 +695,7 @@ class RealReflectionGroup(ComplexReflectionGroup):
         from sage.combinat.root_system.reflection_group_element import _gap_return
         J_inv = [self._index_set_inverse[j] + 1 for j in J]
         S = str(gap3('ReducedRightCosetRepresentatives(%s,ReflectionSubgroup(%s,%s))' % (self._gap_group._name, self._gap_group._name, J_inv)))
-        return [self(w) for w in _gap_return(S)]
+        return [self(w, check=False) for w in _gap_return(S)]
 
     def simple_root_index(self, i):
         r"""
@@ -820,7 +820,7 @@ class RealReflectionGroup(ComplexReflectionGroup):
                      if self.fix_space().is_subspace(T[i].fix_space())]
             S = str(gap3('ReducedRightCosetRepresentatives(%s,ReflectionSubgroup(%s,%s))' % (W._gap_group._name, W._gap_group._name, T_fix)))
             from sage.combinat.root_system.reflection_group_element import _gap_return
-            return [W(w) for w in _gap_return(S)]
+            return [W(w, check=False) for w in _gap_return(S)]
 
         def left_coset_representatives(self):
             r"""

--- a/src/sage/combinat/root_system/reflection_group_real.py
+++ b/src/sage/combinat/root_system/reflection_group_real.py
@@ -47,9 +47,9 @@ AUTHORS:
 
 from sage.misc.cachefunc import cached_function, cached_method, cached_in_parent_method
 from sage.combinat.root_system.cartan_type import CartanType, CartanType_abstract
+from sage.interfaces.gap3 import gap3
 from sage.rings.integer_ring import ZZ
 from sage.combinat.root_system.reflection_group_complex import ComplexReflectionGroup, IrreducibleComplexReflectionGroup
-from sage.misc.sage_eval import sage_eval
 from sage.combinat.root_system.reflection_group_element import RealReflectionGroupElement
 
 
@@ -695,7 +695,7 @@ class RealReflectionGroup(ComplexReflectionGroup):
         from sage.combinat.root_system.reflection_group_element import _gap_return
         J_inv = [self._index_set_inverse[j] + 1 for j in J]
         S = str(gap3('ReducedRightCosetRepresentatives(%s,ReflectionSubgroup(%s,%s))' % (self._gap_group._name, self._gap_group._name, J_inv)))
-        return sage_eval(_gap_return(S), locals={'self': self})
+        return [self(w) for w in _gap_return(S)]
 
     def simple_root_index(self, i):
         r"""
@@ -820,8 +820,7 @@ class RealReflectionGroup(ComplexReflectionGroup):
                      if self.fix_space().is_subspace(T[i].fix_space())]
             S = str(gap3('ReducedRightCosetRepresentatives(%s,ReflectionSubgroup(%s,%s))' % (W._gap_group._name, W._gap_group._name, T_fix)))
             from sage.combinat.root_system.reflection_group_element import _gap_return
-            return sage_eval(_gap_return(S, coerce_obj='W'),
-                             locals={'self': self, 'W': W})
+            return [W(w) for w in _gap_return(S)]
 
         def left_coset_representatives(self):
             r"""


### PR DESCRIPTION
this simplifies the gap3-parsing done in `_gap_return` and then get rid of ` sage_eval` used on top of that.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



