### PR TITLE
Fix a bug in version selector of documentation

### DIFF
--- a/src/doc/common/static/jupyter-sphinx-furo.js
+++ b/src/doc/common/static/jupyter-sphinx-furo.js
@@ -109,12 +109,12 @@ function changeVersion() {
     if (selected_url) {
         if (window.location.protocol == 'file:') {
             let pathname = window.location.pathname;
-            let cutoff_point = pathname.indexOf('doc/sage');
+            let cutoff_point = pathname.indexOf('/html');
             if (cutoff_point !== -1) {
-                pathname = pathname.substring(cutoff_point + 8);
+                pathname = pathname.substring(cutoff_point);
                 window.location.href = selected_url + pathname;
             } else {
-                window.location.href = selected_url + 'html/en/index.html';
+                window.location.href = selected_url + '/index.html';
             }
         } else {
             window.location.href = selected_url + window.location.pathname;


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The version selector should work for

1. documentation in online sites
2. documentation in local sage install
3. standalone tree of the documentation (such as github action artifact doc.zip)

The version selector javascript code works fine with the cases (1) and (2), but currently it fails with (3). 

Tested with doc.zip in https://github.com/sagemath/sage/actions/runs/10032161715

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


