### PR TITLE
Add announcement banner for push to develop

### DIFF
--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -447,10 +447,11 @@ if github_ref:
     match = re.search(r'refs/pull/(\d+)/merge', github_ref)
     if match:
         pr_number = match.group(1)
-is_develop_version = not version.split('.')[-1].isnumeric()
+is_for_develop = github_ref.startswith('refs/heads/develop')
 is_for_github_pr = github_ref and match and pr_number
+is_stable_release = version.split('.')[-1].isnumeric()
 
-if is_develop_version or is_for_github_pr:  # condition for announcement banner
+if is_for_develop or is_for_github_pr or not is_stable_release:  # condition for announcement banner
     # This URL is hardcoded in the file .github/workflows/doc-publish.yml.
     # See NETLIFY_ALIAS of the "Deploy to Netlify" step.
     ver = f'<a href="https://doc-develop--sagemath.netlify.app/html/en/index.html">{version}</a>'


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

motivated by spurious diffs seen in https://doc-pr-38402--sagemath.netlify.app/changes

These diffs can be avoided by adding announcement banner for any push to develop, regardless of stable or unstable releases.

Tested in: https://doc-develop--sagemath-test.netlify.app/html/en/

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


