### PR TITLE
fix memory leak in is_planar

### DIFF
--- a/src/sage/graphs/planarity.pyx
+++ b/src/sage/graphs/planarity.pyx
@@ -135,6 +135,7 @@ def is_planar(g, kuratowski=False, set_pos=False, set_embedding=False):
         elif status == NONEMBEDDABLE:
             # We now know that the graph is nonplanar.
             if not kuratowski:
+                gp_Free(&theGraph)
                 return False
             # With just the current edges, we have a nonplanar graph,
             # so to isolate a kuratowski subgraph, just keep going.
@@ -150,6 +151,7 @@ def is_planar(g, kuratowski=False, set_pos=False, set_embedding=False):
     if status == NONEMBEDDABLE:
         # Kuratowski subgraph isolator
         if not kuratowski:
+            gp_Free(&theGraph)
             return False
         g_dict = {}
         for i in range(1, theGraph.N + 1):


### PR DESCRIPTION
Fixes the memory leak in `is_planar` reported at https://ask.sagemath.org/question/78467/memory-leak-in-is_planar/

We now ensure that memory is released before returning the answer.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


