### PR TITLE
standard package build fixes for conda environment

### DIFF
--- a/build/pkgs/contourpy/spkg-install.in
+++ b/build/pkgs/contourpy/spkg-install.in
@@ -1,5 +1,9 @@
 # https://github.com/scipy/scipy/issues/16536 - meson breaks when CXX="g++ -std=gnu++11"
 export CXX=$(echo "$CXX" | sed 's/-std=[a-z0-9+]*//g')
+# Ignore array and string bounds checking on pybind wrapper
+# (see https://github.com/sagemath/sage/issues/38406 and
+# https://github.com/contourpy/contourpy/issues/409)
+export CXXFLAGS="$CXXFLAGS -Wno-array-bounds -Wno-stringop-overread"
 
 cd src
 # --no-build-isolation because it has build dep on 'meson', which we don't have as a Python package

--- a/build/pkgs/cvxopt/spkg-install.in
+++ b/build/pkgs/cvxopt/spkg-install.in
@@ -65,9 +65,15 @@ export CVXOPT_BLAS_LIB="$(cvxopt_output l blas)"
 export CVXOPT_BLAS_LIB_DIR="$(pkg-config --variable=libdir blas)"
 export CVXOPT_LAPACK_LIB="$(cvxopt_output l lapack)"
 
+# Check for suitesparse lib dirs. In case of suitesparse SPKG built
+# as part of Sage, these should be automatically set by the build system.
+# Otherwise, query umfpack module dirs with pkg-config.
 if test "x$SAGE_SUITESPARSE_PREFIX" != "x"; then
    export CVXOPT_SUITESPARSE_LIB_DIR="${SAGE_SUITESPARSE_PREFIX}"
    export CVXOPT_SUITESPARSE_INC_DIR="${SAGE_SUITESPARSE_PREFIX}/include"
+else
+   export CVXOPT_SUITESPARSE_LIB_DIR="$(pkg-config --variable=libdir UMFPACK)"
+   export CVXOPT_SUITESPARSE_INC_DIR="$(pkg-config --variable=includedir UMFPACK)"
 fi
 
 export CVXOPT_BUILD_GLPK=1


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fix two standard SPKGs build errors when building in conda environment
(tested on Arch Linux with `miniconda3` with packages installed from
`environment-optional-3.11.yml`):

* contourpy (`-Werror=array-bounds` build error) in #38406
* cvxopt (cannot find `umfpack.h`) in #38419

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


