### PR TITLE
number_field_elements_from_algebraics: Fix CyclotomicField embedding when embedding=False

### DIFF
--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -2830,62 +2830,62 @@ def number_field_elements_from_algebraics(numbers, minimal=False,
 
     Test ``embedded`` for quadratic and cyclotomic fields::
 
-        sage: number_field_elements_from_algebraics([QQbar((-1)^(2/3))], embedded=False, minimal=True)
+        sage: v = number_field_elements_from_algebraics([QQbar((-1)^(2/3))], embedded=False, minimal=True); v
         (Number Field in zeta6 with defining polynomial x^2 - x + 1,
          [zeta6 - 1],
          Ring morphism:
            From: Number Field in zeta6 with defining polynomial x^2 - x + 1
            To:   Algebraic Field
            Defn: zeta6 |--> 0.500000000000000? + 0.866025403784439?*I)
-        sage: _[0].coerce_embedding()
-        sage: number_field_elements_from_algebraics([QQbar((-1)^(2/3))], embedded=True, minimal=True)
+        sage: v[0].coerce_embedding()
+        sage: v = number_field_elements_from_algebraics([QQbar((-1)^(2/3))], embedded=True, minimal=True); v
         (Cyclotomic Field of order 6 and degree 2,
          [zeta6 - 1],
          Ring morphism:
            From: Cyclotomic Field of order 6 and degree 2
            To:   Algebraic Field
            Defn: zeta6 |--> 0.500000000000000? + 0.866025403784439?*I)
-        sage: _[0].coerce_embedding()
+        sage: v[0].coerce_embedding()
         Generic morphism:
           From: Cyclotomic Field of order 6 and degree 2
           To:   Complex Lazy Field
           Defn: zeta6 -> 0.500000000000000? + 0.866025403784439?*I
-        sage: number_field_elements_from_algebraics([QQbar((-1)^(1/2))], embedded=False, minimal=True)
+        sage: v = number_field_elements_from_algebraics([QQbar((-1)^(1/2))], embedded=False, minimal=True); v
         (Number Field in I with defining polynomial x^2 + 1,
          [I],
          Ring morphism:
            From: Number Field in I with defining polynomial x^2 + 1
            To:   Algebraic Field
            Defn: I |--> 1*I)
-        sage: _[0].coerce_embedding()
-        sage: number_field_elements_from_algebraics([QQbar((-1)^(1/2))], embedded=True, minimal=True)
+        sage: v[0].coerce_embedding()
+        sage: v = number_field_elements_from_algebraics([QQbar((-1)^(1/2))], embedded=True, minimal=True); v
         (Number Field in I with defining polynomial x^2 + 1 with I = 1*I,
          [I],
          Ring morphism:
            From: Number Field in I with defining polynomial x^2 + 1 with I = 1*I
            To:   Algebraic Field
            Defn: I |--> 1*I)
-        sage: _[0].coerce_embedding()
+        sage: v[0].coerce_embedding()
         Generic morphism:
           From: Number Field in I with defining polynomial x^2 + 1 with I = 1*I
           To:   Complex Lazy Field
           Defn: I -> 1*I
-        sage: number_field_elements_from_algebraics([QQbar((-1)^(1/5))], embedded=False, minimal=True)
+        sage: v = number_field_elements_from_algebraics([QQbar((-1)^(1/5))], embedded=False, minimal=True); v
         (Number Field in zeta10 with defining polynomial x^4 - x^3 + x^2 - x + 1,
          [zeta10],
          Ring morphism:
            From: Number Field in zeta10 with defining polynomial x^4 - x^3 + x^2 - x + 1
            To:   Algebraic Field
            Defn: zeta10 |--> 0.8090169943749474? + 0.5877852522924731?*I)
-        sage: _[0].coerce_embedding()
-        sage: number_field_elements_from_algebraics([QQbar((-1)^(1/5))], embedded=True, minimal=True)
+        sage: v[0].coerce_embedding()
+        sage: v = number_field_elements_from_algebraics([QQbar((-1)^(1/5))], embedded=True, minimal=True); v
         (Cyclotomic Field of order 10 and degree 4,
          [zeta10],
          Ring morphism:
            From: Cyclotomic Field of order 10 and degree 4
            To:   Algebraic Field
            Defn: zeta10 |--> 0.8090169943749474? + 0.5877852522924731?*I)
-        sage: _[0].coerce_embedding()
+        sage: v[0].coerce_embedding()
         Generic morphism:
           From: Cyclotomic Field of order 10 and degree 4
           To:   Complex Lazy Field

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -2911,10 +2911,10 @@ def number_field_elements_from_algebraics(numbers, minimal=False,
         sage: AA((-1)^(2/3))
         1
         sage: number_field_elements_from_algebraics([(-1)^(2/3)])
-        (Cyclotomic Field of order 6 and degree 2,
+        (Number Field in zeta6 with defining polynomial x^2 - x + 1,
          [zeta6 - 1],
          Ring morphism:
-           From: Cyclotomic Field of order 6 and degree 2
+           From: Number Field in zeta6 with defining polynomial x^2 - x + 1
            To:   Algebraic Field
            Defn: zeta6 |--> 0.500000000000000? + 0.866025403784439?*I)
     """

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -2969,10 +2969,8 @@ def number_field_elements_from_algebraics(numbers, minimal=False,
     exact_generator = gen.root_as_algebraic()
     hom = fld.hom([exact_generator])
 
-    if fld is QQ:
-        # ignore embedded parameter
-        pass
-    else:
+    if fld is not QQ:
+        # ignore the embedded parameter for QQ
         # cyclotomic fields are embedded by default
         # number fields are not embedded by default
         # if the default embedding is different from what is expected then modify the field


### PR DESCRIPTION
Fixes #38440.

Uses `.coerce_embedding()` to determine the existence of the embedding and modify the field accordingly, instead of doing what the code does currently (assume the field is unembedded by default).

Note that there's a behavior change --- now when `embedding=False` it will return a `NumberField` instead of `CyclotomicField` (even though it is technically possible to create a `CyclotomicField(5, embedding=None)`). I don't think this matters.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview. (only part that change is https://doc-pr-38441--sagemath.netlify.app/html/en/reference/number_fields/sage/rings/qqbar.html#sage.rings.qqbar.number_field_elements_from_algebraics )
