### PR TITLE
Simplify quadratic_twist implementation

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -189,13 +189,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                         while (x**2 + x + D).roots():
                             D *= a
                 else:
-                    # We could take a multiplicative generator but
-                    # that might be expensive to compute; otherwise
-                    # half the elements will do, and testing squares
-                    # is very fast.
-                    D = K.random_element()
-                    while D.is_square():
-                        D = K.random_element()
+                    D = K.quadratic_nonresidue()
             else:
                 raise ValueError("twisting parameter D must be specified over infinite fields.")
         else:


### PR DESCRIPTION
Just a code simplification.

Note that there's a slight behavioral change: now the result is fixed instead of randomized — but I don't think anyone relies on this.

Thoughts? (Maybe we could make `quadratic_nonresidue` optionally-randomized too if that behavior is desirable?)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion. (don't know one)
- [x] I have created tests covering the changes. (no behavioral change)
- [x] I have updated the documentation and checked the documentation preview. (no user-facing change)
