### PR TITLE
Dokchitser: Pass internal parameter over properly

### DIFF
--- a/src/sage/lfunctions/dokchitser.py
+++ b/src/sage/lfunctions/dokchitser.py
@@ -486,6 +486,10 @@ class Dokchitser(SageObject):
 
         - ``s`` -- complex number
 
+        - ``c`` -- internal parameter, call with `c>1` to get the same value
+          with a different cutoff point (`c` close to `1`); should return the
+          same answer, good to check if everything works with right precision
+
         .. NOTE::
 
            Evaluation of the function takes a long time, so each
@@ -509,7 +513,10 @@ class Dokchitser(SageObject):
             self.__values = {}
         except KeyError:
             pass
-        z = self._gp_call_inst('L', s)
+        if c is None:
+            z = self._gp_call_inst('L', s)
+        else:
+            z = self._gp_call_inst('L', s, c)
         CC = self.__CC
         if 'pole' in z:
             print(z)

--- a/src/sage/lfunctions/dokchitser.py
+++ b/src/sage/lfunctions/dokchitser.py
@@ -504,11 +504,20 @@ class Dokchitser(SageObject):
             0.00000000000000000000000000000
             sage: L(1+I)
             -1.3085436607849493358323930438 + 0.81298000036784359634835412129*I
+            sage: L(1+I, 1.2)
+            -1.3085436607849493358323930438 + 0.81298000036784359634835412129*I
+
+        TESTS::
+
+            sage: L(1+I, 0)
+            Traceback (most recent call last):
+            ...
+            RuntimeError
         """
         self.__check_init()
         s = self.__CC(s)
         try:
-            return self.__values[s]
+            return self.__values[s, c]
         except AttributeError:
             self.__values = {}
         except KeyError:
@@ -529,10 +538,10 @@ class Dokchitser(SageObject):
             msg = z[:i].replace('digits', 'decimal digits')
             verbose(msg, level=-1)
             ans = CC(z[i + 1:])
-            self.__values[s] = ans
+            self.__values[s, c] = ans
             return ans
         ans = CC(z)
-        self.__values[s] = ans
+        self.__values[s, c] = ans
         return ans
 
     def derivative(self, s, k=1):

--- a/src/sage/modular/modform/l_series_gross_zagier.py
+++ b/src/sage/modular/modform/l_series_gross_zagier.py
@@ -73,7 +73,7 @@ class GrossZagierLseries(SageObject):
 
         - ``s`` -- complex number
 
-        - ``der`` -- (default: 0)
+        - ``der`` -- order of derivative (default: 0)
 
         EXAMPLES::
 
@@ -84,8 +84,10 @@ class GrossZagierLseries(SageObject):
             sage: G = GrossZagierLseries(e, A)
             sage: G(3)
             -0.272946890617590
+            sage: G(3, 1)
+            0.212442670030741
         """
-        return self._dokchister(s, der)
+        return self._dokchister.derivative(s, der)
 
     def taylor_series(self, s=1, series_prec=6, var='z'):
         r"""


### PR DESCRIPTION
Previously the `c` parameter was completely unused. I assume this is what it should be used for.

The documentation is copied from the PARI code.

I don't think there's a way to actually test it, but there is already code in the docstring that tries to pass $c ≠ 1$.

The documentation update is invisible because of https://github.com/sagemath/sage/issues/38480 .

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion. (not aware of one)
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
