### PR TITLE
prevent crash in order_from_multiple() due to rounding error

### DIFF
--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -1257,6 +1257,17 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
         sage: K.<a> = GF(3^60)
         sage: order_from_multiple(a, 3^60 - 1, operation='*', check=False)
         42391158275216203514294433200
+
+    TESTS:
+
+    Check that :issue:`38489` is fixed::
+
+        sage: from sage.groups.generic import order_from_multiple
+        sage: plist = [43, 257, 547, 881]
+        sage: m = prod(plist[:-1])
+        sage: elt = Zmod(m)(plist[-1])
+        sage: order_from_multiple(elt, m, plist=plist)
+        6044897
     """
     Z = integer_ring.ZZ
 
@@ -1325,6 +1336,8 @@ def order_from_multiple(P, m, plist=None, factorization=None, check=True,
                 if abs(sum_left + v - (S / 2)) > abs(sum_left - (S / 2)):
                     break
                 sum_left += v
+            if not 0 < k < l:
+                k = l // 2
             L1 = L[:k]
             L2 = L[k:]
             # recursive calls


### PR DESCRIPTION
Due to what appears to be rounding errors, the value of `k` here can be zero, which results in the list `L` being split as `L1 == []` and `L2 == L`. This causes an error in the next recursive call.

Simple workaround: If either `L1` or `L2` would end up being empty, we split the lists in the middle instead.

Resolves #38489.