### PR TITLE
CI / `tox docker-incremental`: Fix incremental build from a different Sage version

### DIFF
--- a/.ci/write-dockerfile.sh
+++ b/.ci/write-dockerfile.sh
@@ -283,8 +283,8 @@ $ADD .upstream.d /new/.upstream.d
 ADD .ci /.ci
 RUN if [ -d /sage ]; then                                               \
         echo "### Incremental build from \$(cat /sage/VERSION.txt)" &&  \
-        printf '/src\n!/src/doc/bootstrap\n!/src/bin\n!/src/*.m4\n!/src/*.toml\n!/src/VERSION.txt\n' >> /sage/.gitignore && \
-        printf '/src\n!/src/doc/bootstrap\n!/src/bin\n!/src/*.m4\n!/src/*.toml\n!/src/VERSION.txt\n' >> /new/.gitignore && \
+        printf '/src/*\n!/src/doc/bootstrap\n!/src/bin\n!/src/*.m4\n!/src/*.toml\n!/src/VERSION.txt\n' >> /sage/.gitignore && \
+        printf '/src/*\n!/src/doc/bootstrap\n!/src/bin\n!/src/*.m4\n!/src/*.toml\n!/src/VERSION.txt\n' >> /new/.gitignore && \
         if ! (cd /new && /.ci/retrofit-worktree.sh worktree-image /sage); then \
             echo "retrofit-worktree.sh failed, falling back to replacing /sage"; \
             for a in local logs; do                                     \


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

As reported in https://groups.google.com/g/sage-devel/c/H6SHSpLF87E @kwankyu 

Reproducer: 
`DOCKER_TARGETS=bootstrapped FROM_DOCKER_TAG=10.5.beta1 tox -e docker-ubuntu-jammy-incremental-standard`; then in the built container, `cat src/VERSION.txt` should give 10.5.beta2, but it gives 10.5.beta1.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


