### PR TITLE
deprecate the class "Algebra"

### DIFF
--- a/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra.py
+++ b/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra.py
@@ -1,7 +1,7 @@
 """
 Finite-Dimensional Algebras
 """
-#*****************************************************************************
+# ***************************************************************************
 #  Copyright (C) 2011 Johan Bosman <johan.g.bosman@gmail.com>
 #  Copyright (C) 2011, 2013 Peter Bruin <peter.bruin@math.uzh.ch>
 #  Copyright (C) 2011 Michiel Kosters <kosters@gmail.com>
@@ -9,8 +9,8 @@ Finite-Dimensional Algebras
 #  Distributed under the terms of the GNU General Public License (GPL)
 #  as published by the Free Software Foundation; either version 2 of
 #  the License, or (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  http:s//www.gnu.org/licenses/
+# ***************************************************************************
 
 from .finite_dimensional_algebra_element import FiniteDimensionalAlgebraElement
 from .finite_dimensional_algebra_ideal import FiniteDimensionalAlgebraIdeal
@@ -20,15 +20,15 @@ from sage.rings.integer_ring import ZZ
 from sage.categories.magmatic_algebras import MagmaticAlgebras
 from sage.matrix.constructor import matrix
 from sage.structure.element import Matrix
-from sage.rings.ring import Algebra
 from sage.structure.category_object import normalize_names
+from sage.structure.parent import Parent
 from sage.structure.unique_representation import UniqueRepresentation
 
 from sage.misc.cachefunc import cached_method
 from functools import reduce
 
 
-class FiniteDimensionalAlgebra(UniqueRepresentation, Algebra):
+class FiniteDimensionalAlgebra(UniqueRepresentation, Parent):
     r"""
     Create a finite-dimensional `k`-algebra from a multiplication table.
 
@@ -187,7 +187,7 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Algebra):
         self._table = table
         self._assume_associative = "Associative" in category.axioms()
         # No further validity checks necessary!
-        Algebra.__init__(self, base_ring=k, names=names, category=category)
+        Parent.__init__(self, base=k, names=names, category=category)
 
     def _repr_(self):
         """
@@ -303,10 +303,10 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Algebra):
             sage: A = FiniteDimensionalAlgebra(GF(3), [Matrix([[1, 0], [0, 1]]),
             ....:                                      Matrix([[0, 1], [0, 0]])])
             sage: A.basis()
-            Family (e0, e1)
+            Finite family {0: e0, 1: e1}
         """
         from sage.sets.family import Family
-        return Family(self.gens())
+        return Family({i: self.gen(i) for i in range(self.ngens())})
 
     def __iter__(self):
         """

--- a/src/sage/categories/category_with_axiom.py
+++ b/src/sage/categories/category_with_axiom.py
@@ -1908,7 +1908,7 @@ class CategoryWithAxiom(Category):
             sage: CommutativeRings()._base_category_class_and_axiom
             (<class 'sage.categories.rings.Rings'>, 'Commutative')
             sage: CommutativeRings()._base_category_class_and_axiom_origin
-            'deduced by base_category_class_and_axiom'
+            'set by __classget__'
 
         ``Sets.Infinite`` is a nested class, so the attribute is set
         by :meth:`CategoryWithAxiom.__classget__` the first time

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -93,7 +93,7 @@ This is to test a deprecation::
     sage: F = Nichts(QQ, QQ)
     ...:
     DeprecationWarning: use the category Algebras
-    See https://github.com/sagemath/sage/issues/38000 for details.
+    See https://github.com/sagemath/sage/issues/38502 for details.
     sage: F.category()
     Category of rings
 
@@ -1488,7 +1488,7 @@ cdef class Algebra(Ring):
     _default_category = _Rings
 
     def __init__(self, base_ring, *args, **kwds):
-        deprecation(38000, "use the category Algebras")
+        deprecation(38502, "use the category Algebras")
         super().__init__(*args, **kwds)
 
 

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -18,7 +18,7 @@ The class inheritance hierarchy is:
 
 - :class:`Ring` (to be deprecated)
 
-  - :class:`Algebra` (to be deprecated)
+  - :class:`Algebra` (deprecated and essentially removed)
   - :class:`CommutativeRing`
 
     - :class:`NoetherianRing` (deprecated)
@@ -86,6 +86,17 @@ This is to test a deprecation::
     See https://github.com/sagemath/sage/issues/37719 for details.
     sage: F.category()
     Category of principal ideal domains
+
+    sage: from sage.rings.ring import Algebra
+    sage: class Nichts(Algebra):
+    ....:     pass
+    sage: F = Nichts(QQ, QQ)
+    ...:
+    DeprecationWarning: use the category Algebras
+    See https://github.com/sagemath/sage/issues/38000 for details.
+    sage: F.category()
+    Category of rings
+
 """
 
 # ****************************************************************************
@@ -1474,24 +1485,11 @@ cdef class Field(CommutativeRing):
 
 
 cdef class Algebra(Ring):
-    """
-    Generic algebra
-    """
-    def __init__(self, base_ring, names=None, normalize=True, category=None):
-        """
-        Initialize ``self``.
+    _default_category = _Rings
 
-        EXAMPLES::
-
-            sage: A = Algebra(ZZ); A                                                    # needs sage.modules
-            <sage.rings.ring.Algebra object at ...>
-        """
-        # This is a low-level class. For performance, we trust that the category
-        # is fine, if it is provided. If it isn't, we use the category of Algebras(base_ring).
-        if category is None:
-            category = check_default_category(Algebras(base_ring), category)
-        Ring.__init__(self,base_ring, names=names, normalize=normalize,
-                      category=category)
+    def __init__(self, base_ring, *args, **kwds):
+        deprecation(38000, "use the category Algebras")
+        super().__init__(*args, **kwds)
 
 
 cdef class CommutativeAlgebra(CommutativeRing):

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -70,7 +70,7 @@ This is to test a deprecation::
     sage: from sage.rings.ring import CommutativeAlgebra
     sage: class Nein(CommutativeAlgebra):
     ....:     pass
-    sage: F = Nein(QQ, QQ)
+    sage: F = Nein(QQ)
     ...:
     DeprecationWarning: use the category CommutativeAlgebras
     See https://github.com/sagemath/sage/issues/37999 for details.
@@ -90,7 +90,7 @@ This is to test a deprecation::
     sage: from sage.rings.ring import Algebra
     sage: class Nichts(Algebra):
     ....:     pass
-    sage: F = Nichts(QQ, QQ)
+    sage: F = Nichts(QQ)
     ...:
     DeprecationWarning: use the category Algebras
     See https://github.com/sagemath/sage/issues/38502 for details.

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -75,7 +75,7 @@ This is to test a deprecation::
     DeprecationWarning: use the category CommutativeAlgebras
     See https://github.com/sagemath/sage/issues/37999 for details.
     sage: F.category()
-    Category of commutative rings
+    Category of commutative algebras over Rational Field
 
     sage: from sage.rings.ring import PrincipalIdealDomain
     sage: class Non(PrincipalIdealDomain):
@@ -95,7 +95,7 @@ This is to test a deprecation::
     DeprecationWarning: use the category Algebras
     See https://github.com/sagemath/sage/issues/38502 for details.
     sage: F.category()
-    Category of rings
+    Category of algebras over Rational Field
 
 """
 
@@ -1488,14 +1488,15 @@ cdef class Field(CommutativeRing):
 
 cdef class Algebra(Ring):
     def __init__(self, base_ring, *args, **kwds):
-        self.__default_category = Algebras(base_ring)
+        if 'category' not in kwds:
+            kwds['category'] = Algebras(base_ring)
         deprecation(38502, "use the category Algebras")
         super().__init__(base_ring, *args, **kwds)
 
 
 cdef class CommutativeAlgebra(CommutativeRing):
     def __init__(self, base_ring, *args, **kwds):
-        self.__default_category = CommutativeAlgebras(base_ring)
+        self._default_category = CommutativeAlgebras(base_ring)
         deprecation(37999, "use the category CommutativeAlgebras")
         super().__init__(base_ring, *args, **kwds)
 

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -116,6 +116,8 @@ from sage.structure.parent cimport Parent
 from sage.structure.category_object cimport check_default_category
 from sage.misc.prandom import randint
 from sage.categories.rings import Rings
+from sage.categories.algebras import Algebras
+from sage.categories.commutative_algebras import CommutativeAlgebras
 from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.integral_domains import IntegralDomains
 from sage.categories.dedekind_domains import DedekindDomains
@@ -1485,17 +1487,15 @@ cdef class Field(CommutativeRing):
 
 
 cdef class Algebra(Ring):
-    _default_category = _Rings
-
     def __init__(self, base_ring, *args, **kwds):
+        self.__default_category = Algebras(base_ring)
         deprecation(38502, "use the category Algebras")
         super().__init__(base_ring, *args, **kwds)
 
 
 cdef class CommutativeAlgebra(CommutativeRing):
-    __default_category = _CommutativeRings
-
     def __init__(self, base_ring, *args, **kwds):
+        self.__default_category = CommutativeAlgebras(base_ring)
         deprecation(37999, "use the category CommutativeAlgebras")
         super().__init__(base_ring, *args, **kwds)
 

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -1489,7 +1489,7 @@ cdef class Algebra(Ring):
 
     def __init__(self, base_ring, *args, **kwds):
         deprecation(38502, "use the category Algebras")
-        super().__init__(*args, **kwds)
+        super().__init__(base_ring, *args, **kwds)
 
 
 cdef class CommutativeAlgebra(CommutativeRing):
@@ -1497,7 +1497,7 @@ cdef class CommutativeAlgebra(CommutativeRing):
 
     def __init__(self, base_ring, *args, **kwds):
         deprecation(37999, "use the category CommutativeAlgebras")
-        super().__init__(*args, **kwds)
+        super().__init__(base_ring, *args, **kwds)
 
 
 def is_Ring(x):


### PR DESCRIPTION
deprecate the auld-style "Algebra" class, and replace its last use in sage codebase by `Parent`

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.