### PR TITLE
GH Actions: Create a GitHub release also for beta and rc

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          prerelease: contains(github.ref, 'beta') || contains(github.ref, 'rc')
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
           files: |
             dist/*
             upstream/*

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -80,7 +80,7 @@ jobs:
 
     needs: release_dist
     runs-on: ubuntu-latest
-    if: (success() || failure()) && github.repository == 'sagemath/sage' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')
+    if: (success() || failure()) && github.repository == 'sagemath/sage' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -88,6 +88,7 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: contains(github.ref, 'beta') || contains(github.ref, 'rc')
           files: |
             dist/*
             upstream/*


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

We have only created GitHub releases for stable releases. 
It's common practice to create GitHub releases also for development versions and release candidates.
See for example https://github.com/numpy/numpy/releases/tag/v2.1.0rc1

- Test run: https://github.com/mkoeppe/sage/actions/runs/10425205605/job/28875873350
- Test release created: https://github.com/mkoeppe/sage/releases/tag/10.5.beta008

Follow-up:
- Use the release assets from beta/rc

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


