### PR TITLE
Fix `sage_bootstrap.flock` for Python 3.13 (fedora-41)

### DIFF
--- a/build/sage_bootstrap/compat/__init__.py
+++ b/build/sage_bootstrap/compat/__init__.py
@@ -28,3 +28,11 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
+
+
+try:
+    # Python >= 3.3
+    from shlex import quote
+except ImportError:
+    # Python < 3.13
+    from pipes import quote

--- a/build/sage_bootstrap/compat/__init__.py
+++ b/build/sage_bootstrap/compat/__init__.py
@@ -31,8 +31,8 @@ except ImportError:
 
 
 try:
-    # Python >= 3.3
+    # Use this for Python 3.  This function is available for Python >= 3.3
     from shlex import quote
 except ImportError:
-    # Python < 3.13
+    # Use this for Python 2.  This function is available for Python < 3.13
     from pipes import quote

--- a/build/sage_bootstrap/flock.py
+++ b/build/sage_bootstrap/flock.py
@@ -12,7 +12,7 @@ command on some systems).
 
 import fcntl
 import os
-import pipes
+import shlex
 import sys
 import argparse
 
@@ -105,7 +105,7 @@ def run(argv=None):
             kind = "exclusive"
 
         sys.stderr.write("Waiting for {0} lock to run {1} ... ".format(
-            kind, ' '.join(pipes.quote(arg) for arg in command)))
+            kind, ' '.join(shlex.quote(arg) for arg in command)))
         fcntl.flock(lock, locktype)
         sys.stderr.write("ok\n")
 

--- a/build/sage_bootstrap/flock.py
+++ b/build/sage_bootstrap/flock.py
@@ -12,9 +12,10 @@ command on some systems).
 
 import fcntl
 import os
-import shlex
 import sys
 import argparse
+
+from sage_bootstrap.compat import quote
 
 
 class FileType(argparse.FileType):
@@ -105,7 +106,7 @@ def run(argv=None):
             kind = "exclusive"
 
         sys.stderr.write("Waiting for {0} lock to run {1} ... ".format(
-            kind, ' '.join(shlex.quote(arg) for arg in command)))
+            kind, ' '.join(quote(arg) for arg in command)))
         fcntl.flock(lock, locktype)
         sys.stderr.write("ok\n")
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Seen on Fedora 41, which already ships Python 3.13:

https://github.com/mkoeppe/sage/actions/runs/10426436105/job/28893965205#step:11:10930
```
#28 943.2   [pip-24.0]   [spkg-pipinst]   File "/sage/build/bin/../sage_bootstrap/flock.py", line 15, in <module>
#28 943.2   [pip-24.0]   [spkg-pipinst]     import pipes
#28 943.2   [pip-24.0]   [spkg-pipinst] ModuleNotFoundError: No module named 'pipes'
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


