### PR TITLE
fix issue 38527 with `spqr_tree_to_graph`

### DIFF
--- a/src/sage/graphs/connectivity.pyx
+++ b/src/sage/graphs/connectivity.pyx
@@ -2634,10 +2634,27 @@ def spqr_tree_to_graph(T):
         sage: H.is_isomorphic(G)
         True
 
-    TESTS::
+    TESTS:
+
+    Check that the method is working for the empty SPQR tree::
 
         sage: H = spqr_tree_to_graph(Graph())
         sage: H.is_isomorphic(Graph())
+        True
+
+    Check that :issue:`38527` is fixed::
+
+        sage: from sage.graphs.connectivity import spqr_tree, spqr_tree_to_graph
+        sage: G = Graph('LlCG{O@?GBoMw?')
+        sage: T1 = spqr_tree(G, algorithm="Hopcroft_Tarjan")
+        sage: T2 = spqr_tree(G, algorithm="cleave")
+        sage: T1.is_isomorphic(T2)
+        True
+        sage: G1 = spqr_tree_to_graph(T1)
+        sage: G2 = spqr_tree_to_graph(T2)
+        sage: G.is_isomorphic(G1)
+        True
+        sage: G.is_isomorphic(G2)
         True
     """
     from sage.graphs.graph import Graph
@@ -2645,11 +2662,23 @@ def spqr_tree_to_graph(T):
 
     count_G = Counter()
     count_P = Counter()
+    vertex_to_int = dict()
     for t, g in T:
+        for u in g:
+            if u not in vertex_to_int:
+                vertex_to_int[u] = len(vertex_to_int)
         if t in ['P', 'Q']:
-            count_P.update(g.edge_iterator())
+            for u, v, label in g.edge_iterator():
+                if vertex_to_int[u] < vertex_to_int[v]:
+                    count_P[u, v, label] += 1
+                else:
+                    count_P[v, u, label] += 1
         else:
-            count_G.update(g.edge_iterator())
+            for u, v, label in g.edge_iterator():
+                if vertex_to_int[u] < vertex_to_int[v]:
+                    count_G[u, v, label] += 1
+                else:
+                    count_G[v, u, label] += 1
 
     G = Graph(multiedges=True)
     for e, num in count_G.items():


### PR DESCRIPTION
Fixes #38527. 

This PR makes the comparison of edges more robust in `spqr_tree_to_graph`, so that edges `(u, v, label)` and `(v, u, label)` are no longer considered as distinct edges.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


