### PR TITLE
add PLW0211 and PLW0642 to ignore list for ruff

### DIFF
--- a/src/tox.ini
+++ b/src/tox.ini
@@ -272,50 +272,54 @@ deps = ruff
 passenv = RUFF_OUTPUT_FORMAT
 # Output of currently failing, from "./sage -tox -e ruff -- --statistics":
 #
-#   3579        PLR2004 [ ] Magic value used in comparison, consider replacing `- 0.5` with a constant variable
-#   3498        I001    [*] Import block is un-sorted or un-formatted
-#   2146        F401    [*] `.PyPolyBoRi.Monomial` imported but unused
-#   1964        E741    [ ] Ambiguous variable name: `I`
-#   1676        F821    [ ] Undefined name `AA`
-#   1513        PLR0912 [ ] Too many branches (102 > 12)
-#   1159        PLR0913 [ ] Too many arguments in function definition (10 > 5)
-#    815        E402    [ ] Module level import not at top of file
-#    671        PLR0915 [ ] Too many statements (100 > 50)
-#    483        PLW2901 [ ] Outer `for` loop variable `ext` overwritten by inner `for` loop target
-#    433        PLR5501 [*] Use `elif` instead of `else` then `if`, to reduce indentation
-#    428        PLR0911 [ ] Too many return statements (10 > 6)
-#    404        E731    [*] Do not assign a `lambda` expression, use a `def`
-#    351        F405    [ ] `ComplexField` may be undefined, or defined from star imports
-#    306        PLR1714 [*] Consider merging multiple comparisons. Use a `set` if the elements are hashable.
-#    236        F403    [ ] `from .abelian_gps.all import *` used; unable to detect undefined names
-#    116        PLR0402 [*] Use `from matplotlib import cm` in lieu of alias
-#    111        PLW0603 [ ] Using the global statement to update `AA_0` is discouraged
-#     78        F841    [*] Local variable `B` is assigned to but never used
-#     64        E713    [*] Test for membership should be `not in`
-#     48        PLW0602 [ ] Using global for `D` but no assignment is done
-#     33        PLR1711 [*] Useless `return` statement at end of function
-#     24        E714    [*] Test for object identity should be `is not`
-#     20        PLR1701 [*] Merge `isinstance` calls
-#     17        PLW3301 [ ] Nested `max` calls can be flattened
-#     16        PLW1510 [*] `subprocess.run` without explicit `check` argument
-#     14        E721    [ ] Do not compare types, use `isinstance()`
-#     14        PLW0120 [*] `else` clause on loop without a `break` statement; remove the `else` and dedent its contents
-#     12        F811    [*] Redefinition of unused `CompleteDiscreteValuationRings` from line 49
-#      8        PLC0414 [*] Import alias does not rename original package
-#      7        E743    [ ] Ambiguous function name: `I`
-#      7        PLE0101 [ ] Explicit return in `__init__`
-#      7        PLR0124 [ ] Name compared with itself, consider replacing `a == a`
-#      5        PLW0127 [ ] Self-assignment of variable `a`
-#      4        F541    [*] f-string without any placeholders
-#      4        PLW1508 [ ] Invalid type for environment variable default; expected `str` or `None`
-#      3        PLC3002 [ ] Lambda expression called directly. Execute the expression inline instead.
-#      2        E742    [ ] Ambiguous class name: `I`
-#      2        PLE0302 [ ] The special method `__len__` expects 1 parameter, 3 were given
-#      2        PLW0129 [ ] Asserting on a non-empty string literal will always pass
-#      1        F402    [ ] Import `factor` from line 259 shadowed by loop variable
-#      1        PLC0208 [*] Use a sequence type instead of a `set` when iterating over values
+# 3602	PLR2004	[ ] magic-value-comparison
+# 3339	I001   	[*] unsorted-imports
+# 2295	F821   	[ ] undefined-name
+# 2046	F401   	[ ] unused-import
+# 1959	E741   	[ ] ambiguous-variable-name
+# 1414	PLR0912	[ ] too-many-branches
+# 793	E402   	[ ] module-import-not-at-top-of-file
+# 785	PLR0913	[ ] too-many-arguments
+# 671	PLR0915	[ ] too-many-statements
+# 479	PLW0211	[ ] bad-staticmethod-argument
+# 455	PLW2901	[ ] redefined-loop-name
+# 433	PLR5501	[*] collapsible-else-if
+# 430	PLR0911	[ ] too-many-return-statements
+# 396	E731   	[*] lambda-assignment
+# 304	PLR1714	[*] repeated-equality-comparison
+# 149	F405   	[ ] undefined-local-with-import-star-usage
+# 145	F403   	[ ] undefined-local-with-import-star
+# 112	PLR0402	[*] manual-from-import
+# 105	PLW0603	[ ] global-statement
+#  84	F841   	[*] unused-variable
+#  69	PLR1730	[ ] if-stmt-min-max
+#  63	PLW0642	[ ] self-or-cls-assignment
+#  62	E713   	[*] not-in-test
+#  57	PLR1704	[ ] redefined-argument-from-local
+#  44	PLW0602	[ ] global-variable-not-assigned
+#  32	PLR1711	[*] useless-return
+#  21	E714   	[*] not-is-test
+#  17	PLW3301	[ ] nested-min-max
+#  14	PLW0120	[*] useless-else-on-loop
+#  14	PLW1510	[*] subprocess-run-without-check
+#   8	F811   	[ ] redefined-while-unused
+#   7	E743   	[ ] ambiguous-function-name
+#   7	PLC0414	[*] useless-import-alias
+#   7	PLE0101	[ ] return-in-init
+#   7	PLR0124	[ ] comparison-with-itself
+#   5	E721   	[ ] type-comparison
+#   5	F541   	[*] f-string-missing-placeholders
+#   5	PLC2401	[ ] non-ascii-name
+#   5	PLW0127	[ ] self-assigning-variable
+#   4	PLW1508	[ ] invalid-envvar-default
+#   3	PLC3002	[ ] unnecessary-direct-lambda-call
+#   2	E742   	[ ] ambiguous-class-name
+#   2	PLE0302	[ ] unexpected-special-method-signature
+#   2	PLW0129	[ ] assert-on-string-literal
+#   1	F402   	[ ] import-shadowed-by-loop-var
+#   1	PLR1736	[*] unnecessary-list-index-lookup
 #
-commands = ruff check --ignore PLR2004,I001,F401,E741,F821,PLR0912,PLR0913,E402,PLR0915,PLW2901,PLR5501,PLR0911,E731,F405,PLR1714,PLR1736,F403,PLR0402,PLW0603,F841,E713,PLW0602,PLR1711,E714,PLR1701,PLR1704,PLW3301,PLW1510,E721,PLW0120,F811,PLC2401,PLC0414,E743,PLE0101,PLR0124,PLW0127,F541,PLW1508,PLC3002,E742,PLE0302,PLW0129,F402,PLC0208 {posargs:{toxinidir}/sage/}
+commands = ruff check --ignore PLR2004,I001,F401,E741,F821,PLR0912,PLR0913,E402,PLR0915,PLW2901,PLR5501,PLR0911,E731,F405,PLR1714,PLR1736,F403,PLR0402,PLW0603,F841,E713,PLW0602,PLR1711,E714,PLR1701,PLR1704,PLW3301,PLW1510,E721,PLW0120,F811,PLC2401,PLC0414,E743,PLE0101,PLR0124,PLW0127,F541,PLW1508,PLC3002,E742,PLE0302,PLW0129,F402,PLC0208,PLW0211,PLW0642 {posargs:{toxinidir}/sage/}
 
 [flake8]
 rst-roles =


### PR DESCRIPTION
The majority of the failures in the lint is due to PLW0211 and PLW0642 which we should ignore until we're ready to perform the refactor to fix this.

With #38540 this should fix the three appearing issues in the ruff lint check

```
Jack: sage % ruff check --ignore PLR2004,I001,F401,E741,F821,PLR0912,PLR0913,E402,PLR0915,PLW2901,PLR5501,PLR0911,E731,F405,PLR1714,PLR1736,F403,PLR0402,PLW0603,F841,E713,PLW0602,PLR1711,E714,PLR1701,PLR1704,PLW3301,PLW1510,E721,PLW0120,F811,PLC2401,PLC0414,E743,PLE0101,PLR0124,PLW0127,F541,PLW1508,PLC3002,E742,PLE0302,PLW0129,F402,PLC0208 ./src/sage/ --statistics
warning: `PLR1701` has been remapped to `SIM101`.
479 PLW0211 bad-staticmethod-argument
 69 PLR1730 if-stmt-min-max
 63 PLW0642 self-or-cls-assignment
```