### PR TITLE
Fix `DiGraph.dig6_string` when the digraph has loops

### DIFF
--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -873,7 +873,7 @@ class DiGraph(GenericGraph):
         r"""
         Return the ``dig6`` representation of the digraph as an ASCII string.
 
-        This is only valid for single (no multiple edges) digraphs on at most
+        This is only valid for simple (no multiple edges) digraphs on at most
         `2^{18} - 1 = 262143` vertices.
 
         .. NOTE::
@@ -893,6 +893,9 @@ class DiGraph(GenericGraph):
             sage: D = DiGraph({0: [1, 2], 1: [2], 2: [3], 3: [0]})
             sage: D.dig6_string()
             'CW`_'
+            sage: L = DiGraph({0: [1, 2], 1: [2], 2: [3], 3: [3]})
+            sage: L.dig6_string()
+            'CW`C'
 
         TESTS::
 

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -831,8 +831,11 @@ class GenericGraph(GenericGraph_pyx):
 
     def _bit_vector(self):
         """
-        Return a string representing the edges of the (simple) graph for
-        ``graph6`` and ``dig6`` strings.
+        Return a string representing the edges of the graph for ``graph6``
+        and ``dig6`` strings.
+
+        The graph must be simple; loops are allowed only if the graph is
+        directed, and multiple edges are never allowed.
 
         EXAMPLES::
 
@@ -862,7 +865,7 @@ class GenericGraph(GenericGraph_pyx):
             sage: P.canonical_label(algorithm='sage')._bit_vector()
             '001100001111000000011010100110100011'
         """
-        self._scream_if_not_simple()
+        self._scream_if_not_simple(allow_loops=self._directed)
         n = self.order()
         if self._directed:
             total_length = n * n

--- a/src/sage/graphs/graph_input.py
+++ b/src/sage/graphs/graph_input.py
@@ -145,7 +145,7 @@ def from_dig6(G, dig6_string):
         sage: g.is_isomorphic(digraphs.Circuit(10))
         True
 
-    The string may represent a graph with loops::
+    The string may represent a directed graph with loops::
 
         sage: L = DiGraph(loops=True)
         sage: from_dig6(L, 'CW`C')

--- a/src/sage/graphs/graph_input.py
+++ b/src/sage/graphs/graph_input.py
@@ -144,6 +144,13 @@ def from_dig6(G, dig6_string):
         sage: from_dig6(g, digraphs.Circuit(10).dig6_string())
         sage: g.is_isomorphic(digraphs.Circuit(10))
         True
+
+    The string may represent a graph with loops::
+
+        sage: L = DiGraph(loops=True)
+        sage: from_dig6(L, 'CW`C')
+        sage: L.edges(labels=False, sort=True)
+        [(0, 1), (0, 2), (1, 2), (2, 3), (3, 3)]
     """
     from .generic_graph_pyx import length_and_string_from_graph6, binary_string_from_dig6
     if isinstance(dig6_string, bytes):


### PR DESCRIPTION
The [`digraph6` format](https://users.cecs.anu.edu.au/~bdm/data/formats.txt) works perfectly well when a directed graph has loops, so don't raise an exception in that case.

- Fixes https://github.com/sagemath/sage/issues/38552

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.