### PR TITLE
Fix conda environments after `build` was removed from conda-forge in favor of `python-build`

### DIFF
--- a/build/pkgs/python_build/distros/conda.txt
+++ b/build/pkgs/python_build/distros/conda.txt
@@ -1,1 +1,1 @@
-build
+python-build

--- a/src/environment-3.10-linux-aarch64.yml
+++ b/src/environment-3.10-linux-aarch64.yml
@@ -38,7 +38,6 @@ dependencies:
   - brotli=1.1.0=h31becfc_1
   - brotli-bin=1.1.0=h31becfc_1
   - brotli-python=1.1.0=py310hbb3657e_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h8af1aa0_1
   - bzip2=1.0.8=h31becfc_5
   - c-ares=1.28.1=h31becfc_0
@@ -320,6 +319,7 @@ dependencies:
   - pyrsistent=0.20.0=py310h7c1f4a2_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.10.14=hbbe8eec_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.10-linux.yml
+++ b/src/environment-3.10-linux.yml
@@ -39,7 +39,6 @@ dependencies:
   - brotli=1.1.0=hd590300_1
   - brotli-bin=1.1.0=hd590300_1
   - brotli-python=1.1.0=py310hc6cd4ac_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=ha770c72_1
   - bzip2=1.0.8=hd590300_5
   - c-ares=1.28.1=hd590300_0
@@ -358,6 +357,7 @@ dependencies:
   - pyrsistent=0.20.0=py310h2372a71_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.10.14=hd12c33a_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.10-macos-x86_64.yml
+++ b/src/environment-3.10-macos-x86_64.yml
@@ -32,7 +32,6 @@ dependencies:
   - brotli=1.1.0=h0dc2134_1
   - brotli-bin=1.1.0=h0dc2134_1
   - brotli-python=1.1.0=py310h9e9d8ca_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h694c41f_1
   - bzip2=1.0.8=h10d778d_5
   - c-ares=1.28.1=h10d778d_0
@@ -324,6 +323,7 @@ dependencies:
   - pyrsistent=0.20.0=py310hb372a2b_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.10.14=h00d2728_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.10-macos.yml
+++ b/src/environment-3.10-macos.yml
@@ -32,7 +32,6 @@ dependencies:
   - brotli=1.1.0=hb547adb_1
   - brotli-bin=1.1.0=hb547adb_1
   - brotli-python=1.1.0=py310h1253130_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=hce30654_1
   - bzip2=1.0.8=h93a5062_5
   - c-ares=1.28.1=h93a5062_0
@@ -324,6 +323,7 @@ dependencies:
   - pyrsistent=0.20.0=py310hd125d64_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.10.14=h2469fbe_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.11-linux-aarch64.yml
+++ b/src/environment-3.11-linux-aarch64.yml
@@ -38,7 +38,6 @@ dependencies:
   - brotli=1.1.0=h31becfc_1
   - brotli-bin=1.1.0=h31becfc_1
   - brotli-python=1.1.0=py311h8715677_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h8af1aa0_1
   - bzip2=1.0.8=h31becfc_5
   - c-ares=1.28.1=h31becfc_0
@@ -320,6 +319,7 @@ dependencies:
   - pyrsistent=0.20.0=py311hc8f2f60_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.11.9=hddfb980_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.11-linux.yml
+++ b/src/environment-3.11-linux.yml
@@ -39,7 +39,6 @@ dependencies:
   - brotli=1.1.0=hd590300_1
   - brotli-bin=1.1.0=hd590300_1
   - brotli-python=1.1.0=py311hb755f60_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=ha770c72_1
   - bzip2=1.0.8=hd590300_5
   - c-ares=1.28.1=hd590300_0
@@ -358,6 +357,7 @@ dependencies:
   - pyrsistent=0.20.0=py311h459d7ec_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.11.9=hb806964_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.11-macos-x86_64.yml
+++ b/src/environment-3.11-macos-x86_64.yml
@@ -32,7 +32,6 @@ dependencies:
   - brotli=1.1.0=h0dc2134_1
   - brotli-bin=1.1.0=h0dc2134_1
   - brotli-python=1.1.0=py311hdf8f085_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h694c41f_1
   - bzip2=1.0.8=h10d778d_5
   - c-ares=1.28.1=h10d778d_0
@@ -324,6 +323,7 @@ dependencies:
   - pyrsistent=0.20.0=py311he705e18_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.11.9=h657bba9_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.11-macos.yml
+++ b/src/environment-3.11-macos.yml
@@ -32,7 +32,6 @@ dependencies:
   - brotli=1.1.0=hb547adb_1
   - brotli-bin=1.1.0=hb547adb_1
   - brotli-python=1.1.0=py311ha891d26_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=hce30654_1
   - bzip2=1.0.8=h93a5062_5
   - c-ares=1.28.1=h93a5062_0
@@ -324,6 +323,7 @@ dependencies:
   - pyrsistent=0.20.0=py311h05b510d_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.11.9=h932a869_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.9-linux-aarch64.yml
+++ b/src/environment-3.9-linux-aarch64.yml
@@ -38,7 +38,6 @@ dependencies:
   - brotli=1.1.0=h31becfc_1
   - brotli-bin=1.1.0=h31becfc_1
   - brotli-python=1.1.0=py39h387a81e_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h8af1aa0_1
   - bzip2=1.0.8=h31becfc_5
   - c-ares=1.28.1=h31becfc_0
@@ -320,6 +319,7 @@ dependencies:
   - pyrsistent=0.20.0=py39h7cc1d5f_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.9.19=h4ac3b42_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.9-linux.yml
+++ b/src/environment-3.9-linux.yml
@@ -39,7 +39,6 @@ dependencies:
   - brotli=1.1.0=hd590300_1
   - brotli-bin=1.1.0=hd590300_1
   - brotli-python=1.1.0=py39h3d6467e_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=ha770c72_1
   - bzip2=1.0.8=hd590300_5
   - c-ares=1.28.1=hd590300_0
@@ -358,6 +357,7 @@ dependencies:
   - pyrsistent=0.20.0=py39hd1e30aa_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.9.19=h0755675_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.9-macos-x86_64.yml
+++ b/src/environment-3.9-macos-x86_64.yml
@@ -32,7 +32,6 @@ dependencies:
   - brotli=1.1.0=h0dc2134_1
   - brotli-bin=1.1.0=h0dc2134_1
   - brotli-python=1.1.0=py39h840bb9f_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h694c41f_1
   - bzip2=1.0.8=h10d778d_5
   - c-ares=1.28.1=h10d778d_0
@@ -324,6 +323,7 @@ dependencies:
   - pyrsistent=0.20.0=py39ha09f3b3_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.9.19=h7a9c478_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-3.9-macos.yml
+++ b/src/environment-3.9-macos.yml
@@ -32,7 +32,6 @@ dependencies:
   - brotli=1.1.0=hb547adb_1
   - brotli-bin=1.1.0=hb547adb_1
   - brotli-python=1.1.0=py39hb198ff7_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=hce30654_1
   - bzip2=1.0.8=h93a5062_5
   - c-ares=1.28.1=h93a5062_0
@@ -324,6 +323,7 @@ dependencies:
   - pyrsistent=0.20.0=py39h17cfd9d_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.9.19=hd7ebdb9_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.10-linux-aarch64.yml
+++ b/src/environment-dev-3.10-linux-aarch64.yml
@@ -42,7 +42,6 @@ dependencies:
   - brotli=1.1.0=h31becfc_1
   - brotli-bin=1.1.0=h31becfc_1
   - brotli-python=1.1.0=py310hbb3657e_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h8af1aa0_1
   - bzip2=1.0.8=h31becfc_5
   - c-ares=1.28.1=h31becfc_0
@@ -367,6 +366,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.10.14=hbbe8eec_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.10-linux.yml
+++ b/src/environment-dev-3.10-linux.yml
@@ -42,7 +42,6 @@ dependencies:
   - brotli=1.1.0=hd590300_1
   - brotli-bin=1.1.0=hd590300_1
   - brotli-python=1.1.0=py310hc6cd4ac_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=ha770c72_1
   - bzip2=1.0.8=hd590300_5
   - c-ares=1.28.1=hd590300_0
@@ -402,6 +401,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.10.14=hd12c33a_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.10-macos-x86_64.yml
+++ b/src/environment-dev-3.10-macos-x86_64.yml
@@ -35,7 +35,6 @@ dependencies:
   - brotli=1.1.0=h0dc2134_1
   - brotli-bin=1.1.0=h0dc2134_1
   - brotli-python=1.1.0=py310h9e9d8ca_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h694c41f_1
   - bzip2=1.0.8=h10d778d_5
   - c-ares=1.28.1=h10d778d_0
@@ -365,6 +364,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.10.14=h00d2728_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.10-macos.yml
+++ b/src/environment-dev-3.10-macos.yml
@@ -35,7 +35,6 @@ dependencies:
   - brotli=1.1.0=hb547adb_1
   - brotli-bin=1.1.0=hb547adb_1
   - brotli-python=1.1.0=py310h1253130_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=hce30654_1
   - bzip2=1.0.8=h93a5062_5
   - c-ares=1.28.1=h93a5062_0
@@ -365,6 +364,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.10.14=h2469fbe_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.11-linux-aarch64.yml
+++ b/src/environment-dev-3.11-linux-aarch64.yml
@@ -42,7 +42,6 @@ dependencies:
   - brotli=1.1.0=h31becfc_1
   - brotli-bin=1.1.0=h31becfc_1
   - brotli-python=1.1.0=py311h8715677_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h8af1aa0_1
   - bzip2=1.0.8=h31becfc_5
   - c-ares=1.28.1=h31becfc_0
@@ -367,6 +366,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.11.9=hddfb980_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.11-linux.yml
+++ b/src/environment-dev-3.11-linux.yml
@@ -42,7 +42,6 @@ dependencies:
   - brotli=1.1.0=hd590300_1
   - brotli-bin=1.1.0=hd590300_1
   - brotli-python=1.1.0=py311hb755f60_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=ha770c72_1
   - bzip2=1.0.8=hd590300_5
   - c-ares=1.28.1=hd590300_0
@@ -402,6 +401,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.11.9=hb806964_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.11-macos-x86_64.yml
+++ b/src/environment-dev-3.11-macos-x86_64.yml
@@ -35,7 +35,6 @@ dependencies:
   - brotli=1.1.0=h0dc2134_1
   - brotli-bin=1.1.0=h0dc2134_1
   - brotli-python=1.1.0=py311hdf8f085_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h694c41f_1
   - bzip2=1.0.8=h10d778d_5
   - c-ares=1.28.1=h10d778d_0
@@ -365,6 +364,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.11.9=h657bba9_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.11-macos.yml
+++ b/src/environment-dev-3.11-macos.yml
@@ -35,7 +35,6 @@ dependencies:
   - brotli=1.1.0=hb547adb_1
   - brotli-bin=1.1.0=hb547adb_1
   - brotli-python=1.1.0=py311ha891d26_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=hce30654_1
   - bzip2=1.0.8=h93a5062_5
   - c-ares=1.28.1=h93a5062_0
@@ -365,6 +364,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.11.9=h932a869_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.9-linux-aarch64.yml
+++ b/src/environment-dev-3.9-linux-aarch64.yml
@@ -42,7 +42,6 @@ dependencies:
   - brotli=1.1.0=h31becfc_1
   - brotli-bin=1.1.0=h31becfc_1
   - brotli-python=1.1.0=py39h387a81e_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h8af1aa0_1
   - bzip2=1.0.8=h31becfc_5
   - c-ares=1.28.1=h31becfc_0
@@ -367,6 +366,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.9.19=h4ac3b42_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.9-linux.yml
+++ b/src/environment-dev-3.9-linux.yml
@@ -42,7 +42,6 @@ dependencies:
   - brotli=1.1.0=hd590300_1
   - brotli-bin=1.1.0=hd590300_1
   - brotli-python=1.1.0=py39h3d6467e_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=ha770c72_1
   - bzip2=1.0.8=hd590300_5
   - c-ares=1.28.1=hd590300_0
@@ -402,6 +401,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.9.19=h0755675_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.9-macos-x86_64.yml
+++ b/src/environment-dev-3.9-macos-x86_64.yml
@@ -35,7 +35,6 @@ dependencies:
   - brotli=1.1.0=h0dc2134_1
   - brotli-bin=1.1.0=h0dc2134_1
   - brotli-python=1.1.0=py39h840bb9f_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=h694c41f_1
   - bzip2=1.0.8=h10d778d_5
   - c-ares=1.28.1=h10d778d_0
@@ -365,6 +364,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.9.19=h7a9c478_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0

--- a/src/environment-dev-3.9-macos.yml
+++ b/src/environment-dev-3.9-macos.yml
@@ -35,7 +35,6 @@ dependencies:
   - brotli=1.1.0=hb547adb_1
   - brotli-bin=1.1.0=hb547adb_1
   - brotli-python=1.1.0=py39hb198ff7_1
-  - build=0.7.0=pyhd8ed1ab_0
   - bwidget=1.9.14=hce30654_1
   - bzip2=1.0.8=h93a5062_5
   - c-ares=1.28.1=h93a5062_0
@@ -365,6 +364,7 @@ dependencies:
   - pytest=8.2.2=pyhd8ed1ab_0
   - pytest-xdist=3.6.1=pyhd8ed1ab_0
   - python=3.9.19=hd7ebdb9_0_cpython
+  - python-build=1.2.1=pyhd8ed1ab_0
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0


### PR DESCRIPTION
- Fixes https://github.com/sagemath/sage/issues/38550

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.
