### PR TITLE
Revert cysignals build constraint

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     # version constraint for macOS Big Sur support (see https://github.com/sagemath/sage/issues/31050)
     'wheel >=0.36.2',
     'cypari2 >=2.1.1',
-    'cysignals >=1.11.4',
+    'cysignals >=1.10.2',
     # Exclude 3.0.3 because of https://github.com/cython/cython/issues/5748
     'cython >=3.0, != 3.0.3, <4.0',
     'gmpy2 ~=2.1.b999',


### PR DESCRIPTION
Reverts https://github.com/sagemath/sage/commit/95428a1c31939d8159fbce8fb0384fa26f0470fe which broke the conda ci.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


