### PR TITLE
Period lattice: fix documentation error

### DIFF
--- a/src/sage/schemes/elliptic_curves/period_lattice.py
+++ b/src/sage/schemes/elliptic_curves/period_lattice.py
@@ -413,7 +413,7 @@ class PeriodLattice_ell(PeriodLattice):
         (tuple of Complex) `(\omega_1,\omega_2)` where the lattice is
         `\ZZ\omega_1 + \ZZ\omega_2`.  If the lattice is real then
         `\omega_1` is real and positive, `\Im(\omega_2)>0` and
-        `\Re(\omega_1/\omega_2)` is either `0` (for rectangular
+        `\Re(\omega_2/\omega_1)` is either `0` (for rectangular
         lattices) or `\frac{1}{2}` (for non-rectangular lattices).
         Otherwise, `\omega_1/\omega_2` is in the fundamental region of
         the upper half-plane.  If the latter normalisation is required
@@ -498,7 +498,7 @@ class PeriodLattice_ell(PeriodLattice):
         (tuple of Complex) `(\omega_1,\omega_2)` where the lattice is
         `\ZZ\omega_1 + \ZZ\omega_2`.  If the lattice is real then
         `\omega_1` is real and positive, `\Im(\omega_2)>0` and
-        `\Re(\omega_1/\omega_2)` is either `0` (for rectangular
+        `\Re(\omega_2/\omega_1)` is either `0` (for rectangular
         lattices) or `\frac{1}{2}` (for non-rectangular lattices).
         Otherwise, `\omega_1/\omega_2` is in the fundamental region of
         the upper half-plane.  If the latter normalisation is required
@@ -650,7 +650,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         (tuple of Complex) `(\omega_1,\omega_2)` where the lattice has
         the form `\ZZ\omega_1 + \ZZ\omega_2`, `\omega_1` is real and
-        `\omega_1/\omega_2` has real part either `0` or `frac{1}{2}`.
+        `\omega_2/\omega_1` has real part either `0` or `frac{1}{2}`.
 
         EXAMPLES::
 


### PR DESCRIPTION
That's what the code appear to be doing.

The existing example in `_compute_periods_real` also show it:

```sage
sage:             sage: # needs sage.rings.number_field
....:             sage: x = polygen(ZZ, 'x')
....:             sage: K.<a> = NumberField(x^3 - 2)
....:             sage: E = EllipticCurve([0,1,0,a,a])
....:             sage: embs = K.embeddings(CC)
....:             sage: Ls = [E.period_lattice(e) for e in embs]
....:             sage: [L.is_real() for L in Ls]
....: 
[False, False, True]
sage:             sage: Ls[2]._compute_periods_real(100)
....: 
(3.8145297721785450936365098936,
 1.9072648860892725468182549468 + 1.3404778596244020196600112394*I)

```
Then do
```sage
sage: ω1, ω2 = _
sage: ω2/ω1
0.50000000000000000000000000000 + 0.35141365769412556448697319411*I
sage: ω1/ω2
1.3387183410189190672591156778 - 0.94088781767934015952275257142*I
```



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


