### PR TITLE
Fix `is_homogeneous` weight bug

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -1285,8 +1285,17 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
             False
             sage: (x^2*y + y^2*x).is_homogeneous()
             True
+
+        The weight of the parent ring is respected::
+
+            sage: term_order = TermOrder("wdegrevlex", [1, 3])
+            sage: R.<x, y> = PolynomialRing(Qp(5), order=term_order)
+            sage: (x + y).is_homogeneous()
+            False
+            sage: (x^3 + y).is_homogeneous()
+            True
         """
-        return self.element().is_homogeneous()
+        return self.element().is_homogeneous(self.parent().term_order().weights())
 
     def _homogenize(self, var):
         r"""

--- a/src/sage/rings/polynomial/polydict.pyx
+++ b/src/sage/rings/polynomial/polydict.pyx
@@ -672,7 +672,7 @@ cdef class PolyDict:
                 ans[ETuple(t)] = self.__repn[S]
         return self._new(ans)
 
-    def is_homogeneous(self):
+    def is_homogeneous(self, tuple w=None):
         r"""
         Return whether this polynomial is homogeneous.
 
@@ -688,12 +688,20 @@ cdef class PolyDict:
         """
         if not self.__repn:
             return True
+        cdef size_t s
         it = iter(self.__repn)
-        cdef size_t s = (<ETuple> next(it)).unweighted_degree()
-        for elt in it:
-            if (<ETuple> elt).unweighted_degree() != s:
-                return False
-        return True
+        if w is None:
+            s = (<ETuple> next(it)).unweighted_degree()
+            for elt in it:
+                if (<ETuple> elt).unweighted_degree() != s:
+                    return False
+            return True
+        else:
+            s = (<ETuple> next(it)).weighted_degree(w)
+            for elt in it:
+                if (<ETuple> elt).weighted_degree(w) != s:
+                    return False
+            return True
 
     def is_constant(self):
         """


### PR DESCRIPTION
PoC:

```sage
term_order = TermOrder("wdegrevlex", [1, 3])
R.<x, y> = PolynomialRing(Qp(5), order=term_order)
assert not (x + y).is_homogeneous()
assert (x^3 + y).is_homogeneous()
```