### PR TITLE
`crypto/sbox.pyx`: remove unreachable code

### DIFF
--- a/src/sage/crypto/sbox.pyx
+++ b/src/sage/crypto/sbox.pyx
@@ -445,7 +445,6 @@ cdef class SBox(SageObject):
                     return K(self._S_list[<Integer> X])
                 except TypeError:
                     raise TypeError("cannot apply SBox to %s" % (X,))
-                raise TypeError("the characteristic of the base field must be 2")
             V = None
             try:
                 V = K.vector_space(map=False)


### PR DESCRIPTION
Remove unreachable line 448 from `crypto/sbox.pyx`.