### PR TITLE
Add is_integral method to algebraic numbers

### DIFF
--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -4487,7 +4487,7 @@ class AlgebraicNumber_base(sage.structure.element.FieldElement):
 
     def is_integral(self):
         r"""
-        Determine if a number is an algebraic integer.
+        Check if this number is an algebraic integer.
 
         EXAMPLES::
 

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -4485,6 +4485,26 @@ class AlgebraicNumber_base(sage.structure.element.FieldElement):
         """
         return number_field_elements_from_algebraics(self, minimal=minimal, embedded=embedded, prec=prec)
 
+    def is_integral(self):
+        r"""
+        Determine if a number is an algebraic integer.
+
+        EXAMPLES::
+
+            sage: QQbar(sqrt(-23)).is_integral()
+            True
+            sage: AA(sqrt(23/2)).is_integral()
+            False
+
+        TESTS:
+
+        Method should return the same value as :meth:`NumberFieldElement.is_integral`::
+
+             sage: for a in [QQbar(2^(1/3)), AA(2^(1/3)), QQbar(sqrt(1/2)), AA(1/2), AA(2), QQbar(1/2)]:
+             ....:    assert a.as_number_field_element()[1].is_integral() == a.is_integral()
+        """
+        return all(a in ZZ for a in self.minpoly())
+
     def exactify(self):
         """
         Compute an exact representation for this number.


### PR DESCRIPTION
For symmetry with existing methods e.g. `QQ(1).is_integral` or such method on elements of number fields.

Implementation pretty much copied from `NumberFieldElement`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
