### PR TITLE
Add warning filter for DeprecationWarning while doc build

### DIFF
--- a/src/sage_docbuild/sphinxbuild.py
+++ b/src/sage_docbuild/sphinxbuild.py
@@ -307,6 +307,11 @@ def runsphinx():
     saved_stdout = sys.stdout
     saved_stderr = sys.stderr
 
+    if not sys.warnoptions:
+        import warnings
+        original_filters = warnings.filters[:]
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module='sphinx.util.inspect')
+
     try:
         sys.stdout = SageSphinxLogger(sys.stdout, os.path.basename(output_dir))
         sys.stderr = SageSphinxLogger(sys.stderr, os.path.basename(output_dir))
@@ -323,3 +328,6 @@ def runsphinx():
         sys.stderr = saved_stderr
         sys.stdout.flush()
         sys.stderr.flush()
+
+    if not sys.warnoptions:
+        warnings.filters = original_filters[:]


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes #37664.

from the log of the doc build workflow of this PR,
```
  [sagemath_doc_html-none] [spkg-install] sage --docbuild --no-pdf-links reference/cryptography inventory 
  [sagemath_doc_html-none] [spkg-install] [cryptogra] Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
  [sagemath_doc_html-none] [spkg-install] [cryptogra] building [inventory]: targets for 25 source files that are out of date
  [sagemath_doc_html-none] [spkg-install] [cryptogra] updating environment: [new config] 25 added, 0 changed, 0 removed
  [sagemath_doc_html-none] [spkg-install] [cryptogra] The inventory file is in ../../local/share/doc/sage/inventory/en/reference/cryptography.
  [sagemath_doc_html-none] [spkg-install] sage --docbuild --no-pdf-links reference/curves inventory 
```

This PR is based on #38580 and replaces it. Thank @thecaligarmo for allowing this arrangement.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


