### PR TITLE
fix and activate E303 check in pyx files

### DIFF
--- a/src/sage/libs/coxeter3/decl.pxd
+++ b/src/sage/libs/coxeter3/decl.pxd
@@ -33,7 +33,6 @@ cdef extern from "coxeter/coxtypes.h" namespace "coxtypes":
     ctypedef unsigned short Length
     ctypedef Ulong StarOp             # for numbering star operations
 
-
     #################
     #    CoxWord    #
     #################

--- a/src/sage/libs/ecl.pxd
+++ b/src/sage/libs/ecl.pxd
@@ -147,7 +147,6 @@ cdef extern from "ecl/ecl.h":
     ecl_character ecl_char(cl_object s, cl_index i)
     ecl_character ecl_char_set(cl_object s, cl_index i, ecl_character c)
 
-
     # S-expr evaluation and function calls
 
     cl_object cl_safe_eval(cl_object form, cl_object env, cl_object value)

--- a/src/sage/libs/linbox/fflas.pxd
+++ b/src/sage/libs/linbox/fflas.pxd
@@ -28,7 +28,6 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFLAS":
         FflasNoTrans
         FflasTrans
 
-
     ctypedef enum FFLAS_SIDE:
         FflasRight
 

--- a/src/sage/libs/m4rie.pxd
+++ b/src/sage/libs/m4rie.pxd
@@ -173,7 +173,6 @@ cdef extern from "m4rie/m4rie.h":
 
     void mzd_slice_row_add(mzd_slice_t *A, size_t sourcerow, size_t destrow)
 
-
     void mzd_slice_row_clear_offset(mzd_slice_t *A, size_t row, size_t coloffset)
 
     void mzd_slice_print(mzd_slice_t *A)

--- a/src/sage/libs/meataxe.pxd
+++ b/src/sage/libs/meataxe.pxd
@@ -113,7 +113,6 @@ cdef extern from "meataxe.h":
     Matrix_t *MatLoad(char *fn) except? NULL
     int MatSave(Matrix_t *mat, char *fn) except -1
 
-
     ## Basic Arithmetic  ## general rule: dest is changed, src/mat are unchanged!
     Matrix_t *MatTransposed(Matrix_t *src) except NULL
     Matrix_t *MatAdd(Matrix_t *dest, Matrix_t *src) except NULL

--- a/src/sage/libs/ntl/GF2X.pxd
+++ b/src/sage/libs/ntl/GF2X.pxd
@@ -58,7 +58,6 @@ cdef extern from "ntlwrap.h":
     void GF2XModulus_build "build"(GF2XModulus_c F, GF2X_c f) # MUST be called before using the modulus
     long GF2XModulus_deg "deg"(GF2XModulus_c F)
 
-
     GF2X_c GF2XModulus_GF2X "GF2X" (GF2XModulus_c m)
 
     GF2X_c GF2X_IrredPolyMod "IrredPolyMod" (GF2X_c g, GF2XModulus_c F)
@@ -71,7 +70,6 @@ cdef extern from "ntlwrap.h":
     void GF2X_PowerXMod_long_pre "PowerXMod"(GF2X_c x, long e, GF2XModulus_c F)
     void GF2X_PowerXPlusAMod_pre "PowerXPlusAMod"(GF2X_c x, GF2_c a, GF2_c e, GF2XModulus_c F)
     void GF2X_PowerXPlusAMod_long_pre "PowerXPlusAMod"(GF2X_c x, GF2_c a, long e, GF2XModulus_c F)
-
 
     # x = g(h) mod f; deg(h) < n
     void GF2X_CompMod "CompMod"(GF2X_c x, GF2X_c g, GF2X_c h, GF2XModulus_c F)

--- a/src/sage/libs/singular/decl.pxd
+++ b/src/sage/libs/singular/decl.pxd
@@ -151,7 +151,6 @@ cdef extern from "singular/Singular/libsingular.h":
         void    (*cfWrite)(number* a, const n_Procs_s* r)
         void    (*cfNormalize)(number* a,  const n_Procs_s* r)
 
-
         bint (*cfDivBy)(number* a, number* b, const n_Procs_s* r)
         bint (*cfEqual)(number* a,number* b, const n_Procs_s* )
         bint (*cfIsZero)(number* a, const n_Procs_s* ) # algebraic number comparison with zero
@@ -159,7 +158,6 @@ cdef extern from "singular/Singular/libsingular.h":
         bint (*cfIsMOne)(number* a, const n_Procs_s* )
         bint (*cfGreaterZero)(number* a, const n_Procs_s* )
         void (*cfPower)(number* a, int i, number* * result,  const n_Procs_s* r) # algebraic number power
-
 
         ring *extRing
         int ch
@@ -210,7 +208,6 @@ cdef extern from "singular/Singular/libsingular.h":
 
         int pCompIndex # index of components
         unsigned long bitmask # mask for getting single exponents
-
 
         n_Procs_s*    cf # coefficient field/ring
         int ref
@@ -793,7 +790,6 @@ cdef extern from "singular/Singular/libsingular.h":
 
     number *nlCopy(number *)
 
-
     # number to integer handle
 
     long SR_TO_INT(number *)
@@ -812,7 +808,6 @@ cdef extern from "singular/Singular/libsingular.h":
     # ideal destructor
 
     void id_Delete(ideal **, ring *)
-
 
     # lifting
 

--- a/src/sage/libs/symmetrica/sb.pxi
+++ b/src/sage/libs/symmetrica/sb.pxi
@@ -51,7 +51,6 @@ def mult_schubert_schubert_symmetrica(a, b):
         freeall(cres)
         raise err
 
-
     sig_on()
     mult_schubert_schubert(ca, cb, cres)
     sig_off()

--- a/src/sage/libs/symmetrica/schur.pxi
+++ b/src/sage/libs/symmetrica/schur.pxi
@@ -28,7 +28,6 @@ cdef extern from 'symmetrica/def.h':
     INT t_HOMSYM_MONOMIAL(OP a, OP b)
     INT t_HOMSYM_ELMSYM(OP a, OP b)
 
-
     INT t_POWSYM_SCHUR(OP a, OP b)
     INT t_SCHUR_POWSYM(OP a, OP b)
     INT t_POWSYM_HOMSYM(OP a, OP b)

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -854,7 +854,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             A.subdivide(*self.subdivisions())
         return A
 
-
     cpdef _add_(self, right):
         r"""
         Add two dense matrices over `\Z/n\Z`.
@@ -897,7 +896,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             M._entries[i] = k - (k >= p) * p
         sig_off()
         return M
-
 
     cpdef _sub_(self, right):
         r"""
@@ -1403,7 +1401,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         self.cache(cache_key, g)
         return g
-
 
     def minpoly(self, var='x', algorithm='linbox', proof=None):
         """

--- a/src/sage/rings/finite_rings/hom_finite_field.pyx
+++ b/src/sage/rings/finite_rings/hom_finite_field.pyx
@@ -150,7 +150,6 @@ cdef class SectionFiniteFieldHomomorphism_generic(Section):
                 return root
         raise ValueError("%s is not in the image of %s" % (x, self._inverse))
 
-
     def _repr_(self):
         """
         Return a string representation of this section.
@@ -166,7 +165,6 @@ cdef class SectionFiniteFieldHomomorphism_generic(Section):
             'Section of Ring morphism:\n  From: Finite Field in t of size 3^7\n  To:   Finite Field in T of size 3^21\n  Defn: t |--> T^20 + 2*T^18 + T^16 + 2*T^13 + T^9 + 2*T^8 + T^7 + T^6 + T^5 + T^3 + 2*T^2 + T'
         """
         return "Section of %s" % self._inverse
-
 
     def _latex_(self):
         r"""
@@ -321,7 +319,6 @@ cdef class FiniteFieldHomomorphism_generic(RingHomomorphism_im_gens):
             f = f.map_coefficients(bm)
         return f(self.im_gens()[0])
 
-
     def is_injective(self):
         """
         Return ``True`` since a embedding between finite fields is
@@ -337,7 +334,6 @@ cdef class FiniteFieldHomomorphism_generic(RingHomomorphism_im_gens):
             True
         """
         return True
-
 
     def is_surjective(self):
         """
@@ -357,7 +353,6 @@ cdef class FiniteFieldHomomorphism_generic(RingHomomorphism_im_gens):
             True
         """
         return self.domain().cardinality() == self.codomain().cardinality()
-
 
     @cached_method
     def section(self):
@@ -544,7 +539,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
         self._q = domain.characteristic() ** self._power
         RingHomomorphism.__init__(self, Hom(domain, domain))
 
-
     def _repr_(self):
         """
         Return a string representation of this endomorphism.
@@ -568,7 +562,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
         s += " %s" % self.domain()
         return s
 
-
     def _repr_short(self):
         """
         Return a short string representation of this endomorphism.
@@ -590,7 +583,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
         else:
             s = "%s |--> %s^(%s^%s)" % (name, name, self.domain().characteristic(), self._power)
         return s
-
 
     def _latex_(self):
         r"""
@@ -615,7 +607,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
             s = "%s \\mapsto %s^{%s^{%s}}" % (name, name, self.domain().characteristic(), self._power)
         return s
 
-
     cpdef Element _call_(self, x):
         """
         TESTS::
@@ -631,7 +622,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
             return x
         else:
             return x.pth_power(self._power)
-
 
     def order(self):
         """
@@ -672,7 +662,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
             1
         """
         return self._power
-
 
     def __pow__(self, n, modulus):
         """
@@ -735,7 +724,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
         else:
             return RingHomomorphism._composition(self, right)
 
-
     def fixed_field(self):
         """
         Return the fixed field of ``self``.
@@ -780,7 +768,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
             f = FiniteFieldHomomorphism_generic(Hom(k, self.domain()))
         return k, f
 
-
     def is_injective(self):
         """
         Return ``True`` since any power of the Frobenius endomorphism
@@ -795,7 +782,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
         """
         return True
 
-
     def is_surjective(self):
         """
         Return ``True`` since any power of the Frobenius endomorphism
@@ -809,7 +795,6 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
             True
         """
         return True
-
 
     def is_identity(self):
         """

--- a/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
@@ -102,7 +102,6 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
         """
         fmpz_poly_init(self._poly)
 
-
     def __dealloc__(self):
         r"""
         Call the underlying FLINT fmpz_poly destructor
@@ -652,7 +651,6 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
         sig_off()
         return x
 
-
     cpdef _sub_(self, right):
         r"""
         Return ``self`` minus ``right``.
@@ -671,7 +669,6 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
                 (<Polynomial_integer_dense_flint>right)._poly)
         sig_off()
         return x
-
 
     cpdef _neg_(self):
         r"""
@@ -834,7 +831,6 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
         sig_off()
         return x
 
-
     @coerce_binop
     def lcm(self, right):
         """
@@ -954,7 +950,6 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
             return R(d*g), R(d*u), R(d*v)
         else:
             return self._parent(rr), ss, tt
-
 
     cpdef _mul_(self, right):
         r"""
@@ -1360,11 +1355,10 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
 
         return real_roots(self)
 
-##     def __copy__(self):
-##         f = Polynomial_integer_dense(self.parent())
-##         f._poly = self._poly.copy()
-##         return f
-
+    #     def __copy__(self):
+    #         f = Polynomial_integer_dense(self.parent())
+    #         f._poly = self._poly.copy()
+    #         return f
 
     def degree(self, gen=None):
         """
@@ -1484,7 +1478,6 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
         if variable is None:
             variable = self.parent().variable_name()
         return pari(self.list()).Polrev(variable)
-
 
     def squarefree_decomposition(Polynomial_integer_dense_flint self):
         """
@@ -1742,7 +1735,6 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
             []
         """
         return [self.get_unsafe(i) for i in range(self.degree()+1)]
-
 
     @coerce_binop
     def resultant(self, other, proof=True):

--- a/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
@@ -69,6 +69,7 @@ from sage.libs.ntl.ZZX cimport *
 
 from sage.rings.polynomial.evaluation_ntl cimport ZZX_evaluation_mpfr, ZZX_evaluation_mpfi
 
+
 cdef class Polynomial_integer_dense_ntl(Polynomial):
     r"""
     A dense polynomial over the integers, implemented via NTL.
@@ -82,7 +83,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
         x._parent = self._parent
         x._is_gen = 0
         return x
-
 
     def __init__(self, parent, x=None, check=True, is_gen=False, construct=False):
         r"""
@@ -235,7 +235,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
                     a = ZZ(a)
                 mpz_to_ZZ(&y, (<Integer>a).value)
                 ZZX_SetCoeff(self._poly, i, y)
-
 
     def content(self):
         r"""
@@ -445,7 +444,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
                 (<Polynomial_integer_dense_ntl>right)._poly)
         return x
 
-
     cpdef _sub_(self, right):
         r"""
         Return ``self`` minus ``right``.
@@ -463,7 +461,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
                 (<Polynomial_integer_dense_ntl>right)._poly)
         return x
 
-
     cpdef _neg_(self):
         r"""
         Return negative of ``self``.
@@ -478,7 +475,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
         cdef Polynomial_integer_dense_ntl x = self._new()
         ZZX_negate(x._poly, self._poly)
         return x
-
 
     @coerce_binop
     def quo_rem(self, right):
@@ -565,7 +561,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
 
         return qq, rr
 
-
     @coerce_binop
     def gcd(self, right):
         r"""
@@ -586,7 +581,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
         x._poly = temp[0]
         del temp
         return x
-
 
     @coerce_binop
     def lcm(self, right):
@@ -677,7 +671,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
             S = self.parent()
             return S(rr), ss, tt
 
-
     cpdef _mul_(self, right):
         r"""
         Return ``self`` multiplied by ``right``.
@@ -733,7 +726,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
         ZZX_mul_ZZ(x._poly, self._poly, _right)
         return x
 
-
     def __floordiv__(self, right):
         """
         EXAMPLES::
@@ -785,7 +777,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
         mpz_to_ZZ(&y, (<Integer>value).value)
         ZZX_SetCoeff(self._poly, n, y)
 
-
     def real_root_intervals(self):
         """
         Return isolating intervals for the real roots of this polynomial.
@@ -803,11 +794,10 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
 
         return real_roots(self)
 
-##     def __copy__(self):
-##         f = Polynomial_integer_dense(self.parent())
-##         f._poly = self._poly.copy()
-##         return f
-
+    #     def __copy__(self):
+    #         f = Polynomial_integer_dense(self.parent())
+    #         f._poly = self._poly.copy()
+    #         return f
 
     def degree(self, gen=None):
         """
@@ -855,7 +845,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
         del temp
         return x
 
-
     def __pari__(self, variable=None):
         """
         EXAMPLES::
@@ -868,7 +857,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
         if variable is None:
             variable = self.parent().variable_name()
         return pari(self.list()).Polrev(variable)
-
 
     def squarefree_decomposition(self):
         """
@@ -1100,7 +1088,6 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
             []
         """
         return [self.get_unsafe(i) for i in range(self.degree()+1)]
-
 
     @coerce_binop
     def resultant(self, other, proof=True):

--- a/src/sage/rings/polynomial/polynomial_template.pxi
+++ b/src/sage/rings/polynomial/polynomial_template.pxi
@@ -588,7 +588,6 @@ cdef class Polynomial_template(Polynomial):
             return -2
         return result
 
-
     def __pow__(self, ee, modulus):
         """
         EXAMPLES::

--- a/src/sage/rings/polynomial/skew_polynomial_finite_field.pyx
+++ b/src/sage/rings/polynomial/skew_polynomial_finite_field.pyx
@@ -100,7 +100,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
         N = self._parent._working_center(self.reduced_norm(var=False))
         return N.is_irreducible()
 
-
     def type(self, N):
         r"""
         Return the `N`-type of this skew polynomial (see definition below).
@@ -209,7 +208,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
         self._types[N] = type
         return type
 
-
     # Finding divisors
     # ----------------
 
@@ -288,7 +286,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
                 continue
             return D
 
-
     def _reduced_norm_factor_uniform(self):
         r"""
         Return a factor of the reduced norm of this skew
@@ -356,7 +353,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
         for i in range(len(F)):
             if random < count[i]:
                 return F[i][0]
-
 
     def _irreducible_divisors(self, bint right):
         r"""
@@ -468,7 +464,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
                     d = gcd2(mul(f,Q1), P)
                     d, _ = quo_rem2(P, d)
                     yield d
-
 
     def right_irreducible_divisor(self, uniform=False):
         r"""
@@ -617,7 +612,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
             if LD.degree() == degN:
                 return LD
 
-
     def right_irreducible_divisors(self):
         r"""
         Return an iterator over all irreducible monic right divisors
@@ -686,7 +680,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
         """
         return self._irreducible_divisors(False)
 
-
     def count_irreducible_divisors(self):
         r"""
         Return the number of irreducible monic divisors of
@@ -743,7 +736,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
             cardL = cardcenter**degN
             count += (cardL**m - 1) // (cardL - 1)
         return count
-
 
     # Finding factorizations
     # ----------------------
@@ -926,7 +918,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
         factors.reverse()
         return Factorization(factors, sort=False, unit=unit)
 
-
     def factor(self, uniform=False):
         r"""
         Return a factorization of this skew polynomial.
@@ -993,7 +984,6 @@ cdef class SkewPolynomial_finite_field_dense(SkewPolynomial_finite_order_dense):
                 self._factorization = self._factor_c()
             F = self._factorization
         return F
-
 
     def count_factorizations(self):
         r"""

--- a/src/sage/rings/polynomial/skew_polynomial_finite_order.pyx
+++ b/src/sage/rings/polynomial/skew_polynomial_finite_order.pyx
@@ -518,7 +518,6 @@ cdef class SkewPolynomial_finite_order_dense(SkewPolynomial_generic_dense):
             return center(self._optbound)
         return self.reduced_norm()
 
-
     def optimal_bound(self):
         r"""
         Return the optimal bound of this skew polynomial (i.e.

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -181,7 +181,7 @@ description =
     # See https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 deps = pycodestyle
 commands = pycodestyle --select E111,E21,E221,E222,E225,E227,E228,E25,E271,E303,E305,E306,E401,E502,E701,E702,E703,E71,E72,W291,W293,W391,W605 {posargs:{toxinidir}/sage/}
-       pycodestyle --select E111,E271,E301,E302,E305,E306,E401,E502,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
+       pycodestyle --select E111,E271,E301,E302,E303,E305,E306,E401,E502,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
 
 [pycodestyle]
 max-line-length = 160


### PR DESCRIPTION
This is activating the fix for

E303 too many blank lines

in all pyx files.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


