### PR TITLE
`categories/morphism.pyx`: remove some `noexcept`s

### DIFF
--- a/src/sage/categories/morphism.pyx
+++ b/src/sage/categories/morphism.pyx
@@ -798,7 +798,7 @@ cdef class SetIsomorphism(SetMorphism):
             raise RuntimeError('inverse morphism has not been set')
         return self._inverse
 
-    cdef dict _extra_slots(self) noexcept:
+    cdef dict _extra_slots(self):
         """
         Extend the dictionary with extra slots for this class.
 
@@ -823,7 +823,7 @@ cdef class SetIsomorphism(SetMorphism):
         slots['_inverse'] = self._inverse
         return slots
 
-    cdef _update_slots(self, dict _slots) noexcept:
+    cdef _update_slots(self, dict _slots):
         """
         Update the slots of ``self`` from the data in the dictionary.
 


### PR DESCRIPTION
Remove ignored `noexcept`s for functions with `Python` return types.

```
[sagelib-10.5.beta3] [spkg-install]     warning: sage/categories/morphism.pyx:801:26: noexcept clause is ignored for function returning Python object
[sagelib-10.5.beta3] [spkg-install]     warning: sage/categories/morphism.pyx:826:22: noexcept clause is ignored for function returning Python object
```
