### PR TITLE
 `permgroup_element.pyx`: add some `const`s

### DIFF
--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -596,8 +596,8 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
             ...
             ValueError: invalid data to initialize a permutation
         """
-        cdef UInt2* p2
-        cdef UInt4* p4
+        cdef const UInt2* p2
+        cdef const UInt4* p4
         cdef int i
         cdef UInt d
 


### PR DESCRIPTION
Done to avoid the following warnings:
```
warning: sage/groups/perm_gps/permgroup_element.pyx:611:33: Assigning to 'UInt2 *' from 'const UInt2 *' discards const qualifier
warning: sage/groups/perm_gps/permgroup_element.pyx:621:33: Assigning to 'UInt4 *' from 'const UInt4 *' discards const qualifier
```