### PR TITLE
Require weaker Sphinx dependency for sagelib

### DIFF
--- a/src/setup.cfg.m4
+++ b/src/setup.cfg.m4
@@ -33,7 +33,7 @@ dnl From Makefile.in: SAGERUNTIME
     SPKG_INSTALL_REQUIRES_ipython
     SPKG_INSTALL_REQUIRES_pexpect
 dnl From Makefile.in: DOC_DEPENDENCIES
-    SPKG_INSTALL_REQUIRES_sphinx
+    sphinx >=5.2, <9
     SPKG_INSTALL_REQUIRES_networkx
     SPKG_INSTALL_REQUIRES_scipy
     SPKG_INSTALL_REQUIRES_sympy


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The version constraint added in https://github.com/sagemath/sage/pull/38549 broke the conda ci workflow and added an unnecessarily strict version constraint for sphinx as a dependency of sagelib (as opposed to sage-the-docs).

This is fixed by providing the old version constraint for sphinx in `setup.cfg`, but with `v8` now allowed.

Alternatively, the stricter version constraint should only be added to the sage-the-docs package.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


