### PR TITLE
Fix hypellfrob.pyx calling Python inside sig_on

### DIFF
--- a/src/sage/schemes/hyperelliptic_curves/hypellfrob.pyx
+++ b/src/sage/schemes/hyperelliptic_curves/hypellfrob.pyx
@@ -127,8 +127,10 @@ def interval_products(M0, M1, target):
     cdef long dim = M0.nrows()
     sig_on()
     c.restore_c()
+    sig_off()
     set_ntl_matrix_modn_dense(mm0, c, M0)
     set_ntl_matrix_modn_dense(mm1, c, M1)
+    sig_on()
     for t in target:
         targ.push_back(ntl_ZZ(t).x)
     numintervals = len(target)/2


### PR DESCRIPTION
set_ntl_matrix_modn_dense uses isinstance so there is a chance for Python garbage collection to run. Presumably you get the

    SystemError: calling remove_from_pari_stack() inside sig_on()

if that happens.

Fixes #33304
