### PR TITLE
configure.ac: add --disable-sagetex option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -463,6 +463,12 @@ AC_ARG_ENABLE([r],
     done
   ])
 
+AC_ARG_ENABLE([sagetex],
+  AS_HELP_STRING([--disable-sagetex],
+                 [don't build SageTeX]), [
+    AS_VAR_SET([SAGE_ENABLE_sagetex], [$enableval])
+  ])
+
 AC_ARG_ENABLE([doc],
   AS_HELP_STRING([--disable-doc],
                  [disable build of the Sage documentation and packages depending on it]), [


### PR DESCRIPTION
SageTeX is a standard package, but it isn't used anywhere else in the sage library or even in the sage distribution. If you know you don't need it, the new `--disable-sagetex` option lets you avoid downloading and installing it.

(inspired by https://github.com/sagemath/sage/issues/38657, but I should have done this a long time ago)