### PR TITLE
simplifications in some libgap calls

### DIFF
--- a/src/sage/algebras/quantum_groups/quantum_group_gap.py
+++ b/src/sage/algebras/quantum_groups/quantum_group_gap.py
@@ -838,7 +838,7 @@ class QuantumGroup(UniqueRepresentation, Parent):
                 constant = R(str(ext_rep.pop(2 * i)))  # Pop the coefficient
                 break
         # To reconstruct, we need the following
-        F = libgap.eval('ElementsFamily')(libgap.eval('FamilyObj')(self._libgap))
+        F = self._libgap.FamilyObj().ElementsFamily()
         elt = F.ObjByExtRep(ext_rep)
         co = self._libgap.CounitMap()
         return R(str(co(elt))) + constant
@@ -2330,7 +2330,7 @@ class LowerHalfQuantumGroup(Parent, UniqueRepresentation):
             sage: B._construct_monomial((3,0,1))
             F[a1]^(3)*F[a2]
         """
-        F = libgap.eval('ElementsFamily')(libgap.eval('FamilyObj')(self._libgap))
+        F = self._libgap.FamilyObj().ElementsFamily()
         one = self._libgap_base.One()
         data = []
         for i, val in enumerate(k):
@@ -2684,7 +2684,7 @@ def _unpickle_generic_element(parent, data):
         sage: loads(dumps(x)) == x  # indirect doctest
         True
     """
-    F = libgap.eval('ElementsFamily')(libgap.eval('FamilyObj')(parent._libgap))
+    F = parent._libgap.FamilyObj().ElementsFamily()
     ret = []
     # We need to multiply by this to get the right type in GAP
     one = parent._libgap_base.One()

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -2974,20 +2974,21 @@ class PermutationGroup_generic(FiniteGroup):
                 raise ValueError(msg)
 
         # create a parallel list of the automorphisms of N in GAP
-        libgap.eval('N := Group({})'.format(list(N.gens())))
-        gens_string = ",".join(str(x) for x in N.gens())
-        homomorphism_cmd = 'alpha := GroupHomomorphismByImages(N, N, [{0}],[{1}])'
-        libgap.eval('morphisms := []')
+        N_gap = libgap.eval(f'Group({list(N.gens())})')
+        morphisms = libgap.eval('[]')
+        libgap_gens = N_gap.GeneratorsOfGroup()
         for alpha in mapping[1]:
-            images_string = ",".join(str(alpha(n)) for n in N.gens())
-            libgap.eval(homomorphism_cmd.format(gens_string, images_string))
-            libgap.eval('Add(morphisms, alpha)')
+            images = [alpha(g) for g in N.gens()]
+            alpha_gap = N_gap.GroupHomomorphismByImages(N_gap,
+                                                        libgap_gens, images)
+            morphisms.Add(alpha_gap)
         # create the necessary homomorphism from self into the
         # automorphism group of N in GAP
-        libgap.eval('H := Group({0})'.format(mapping[0]))
-        libgap.eval('phi := GroupHomomorphismByImages(H, AutomorphismGroup(N),{},morphisms)'.format(mapping[0]))
-        libgap.eval('sdp := SemidirectProduct(H, phi, N)')
-        return PermutationGroup(gap_group='sdp')
+        H = libgap.eval(f'Group({mapping[0]})')
+        phi = H.GroupHomomorphismByImages(N_gap.AutomorphismGroup(),
+                                          H.GeneratorsOfGroup(), morphisms)
+        sdp = H.SemidirectProduct(phi, N_gap)
+        return PermutationGroup(gap_group=sdp)
 
     def holomorph(self):
         r"""
@@ -3047,11 +3048,11 @@ class PermutationGroup_generic(FiniteGroup):
 
         - Kevin Halasz (2012-08-14)
         """
-        libgap.eval('G := Group({})'.format(list(self.gens())))
-        libgap.eval('aut := AutomorphismGroup(G)')
-        libgap.eval('alpha := InverseGeneralMapping(NiceMonomorphism(aut))')
-        libgap.eval('product := SemidirectProduct(NiceObject(aut),alpha,G)')
-        return PermutationGroup(gap_group='product')
+        G = libgap.eval(f'Group({list(self.gens())})')
+        aut = G.AutomorphismGroup()
+        alpha = aut.NiceMonomorphism().InverseGeneralMapping()
+        product = aut.NiceObject().SemidirectProduct(alpha, G)
+        return PermutationGroup(gap_group=product)
 
     def subgroup(self, gens=None, gap_group=None, domain=None, category=None, canonicalize=True, check=True):
         """


### PR DESCRIPTION
by avoiding multiple calls of `libgap.eval`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
