### PR TITLE
src/sage/misc/package.py: use gnulib instead of conway_polynomials in tests

### DIFF
--- a/src/sage/misc/package.py
+++ b/src/sage/misc/package.py
@@ -402,9 +402,9 @@ def installed_packages(exclude_pip=True):
         sage: # optional - sage_spkg
         sage: from sage.misc.package import installed_packages
         sage: sorted(installed_packages().keys())
-        [...'conway_polynomials', ...]
-        sage: installed_packages()['conway_polynomials']  # random
-        '0.5'
+        [...'gnulib', ...]
+        sage: installed_packages()['gnulib']  # random
+        'f9b39c4e337f1dc0dd07c4f3985c476fb875d799'
 
     .. SEEALSO::
 
@@ -439,7 +439,7 @@ def is_package_installed(package, exclude_pip=True):
     EXAMPLES::
 
         sage: from sage.misc.package import is_package_installed
-        sage: is_package_installed('conway_polynomials')  # optional - sage_spkg
+        sage: is_package_installed('gnulib')  # optional - sage_spkg
         True
 
     Giving just the beginning of the package name is not good enough::
@@ -537,8 +537,8 @@ def package_manifest(package):
 
         sage: # optional - sage_spkg
         sage: from sage.misc.package import package_manifest
-        sage: manifest = package_manifest('conway_polynomials')
-        sage: manifest['package_name'] == 'conway_polynomials'
+        sage: manifest = package_manifest('gnulib')
+        sage: manifest['package_name'] == 'gnulib'
         True
         sage: 'files' in manifest
         True


### PR DESCRIPTION
The conway_polynomials package now has an `spkg-configure.m4`, and may not be installed as an SPKG. In that case, several tests fail. For example,

```
File "src/sage/misc/package.py", line 404, in sage.misc.package.installed_packages
Failed example:
    sorted(installed_packages().keys())
Expected:
    [...'conway_polynomials', ...]
Got:
    ['combinatorial_designs',
     'elliptic_curves',
     'execnet',
     'gnulib',
     'gnumake_tokenpool',
     'graphs',
     'h11',
     'iniconfig',
     'jmol',
     'polytopes_db',
     'pyproject_hooks',
     'pytest_mock',
     'pytest_xdist',
     'python3_venv',
     'python_build',
     'sage_conf',
     'sage_setup',
     'sagelib',
     'threejs']
```

The gnulib package seems like a safe alternative.
