### PR TITLE
Freetype fails to find freetype on macos

### DIFF
--- a/build/pkgs/zlib/spkg-configure.m4
+++ b/build/pkgs/zlib/spkg-configure.m4
@@ -1,7 +1,8 @@
 SAGE_SPKG_CONFIGURE([zlib], [
+    PKG_CHECK_MODULES([zlib], [zlib >= 1.2.11], [zlib_cv_pc=yes], [zlib_cv_pc=no])
     AC_CHECK_LIB([z], [inflateEnd], [zlib_cv_libz=yes], [zlib_cv_libz=no])
     AC_CHECK_HEADER([zlib.h], [zlib_cv_zlib_h=yes], [zlib_cv_zlib_h=no])
-    if test "$zlib_cv_libz" = "yes" && test "$zlib_cv_zlib_h" = "yes"; then
+    if test "$zlib_cv_pc" = "yes" && test "$zlib_cv_libz" = "yes" && test "$zlib_cv_zlib_h" = "yes"; then
         PKG_CHECK_MODULES([LIBPNG], [libpng >= 1.2], [], [
             dnl inflateValidate is needed for Sage's libpng, newer than 1.2; this ensures
             dnl we have the minimum required for building zlib version


### PR DESCRIPTION
Freetype fails to find freetype on macos (Mac mini M2 with only XCode installed):

    src/checkdep_freetype2.c:8:10: fatal error: 'ft2build.h' file not found
    #include <ft2build.h>
             ^~~~~~~~~~~~
    2 errors generated.
    error: command '/usr/bin/gcc' failed with exit code 1

Sage skips installing zlib on macos because it is installed as part of XCode. The freetype configuration uses freetype-config which ends up using pkg-config to find zlib. In their infinite wisdom, Apple does not ship the .pc file:

    vbraun@Mini-M2 local % ./bin/freetype-config
    Package zlib was not found in the pkg-config search path.
    Perhaps you should add the directory containing `zlib.pc'
    to the PKG_CONFIG_PATH environment variable
    Package 'zlib', required by 'libpng', not found
    Package zlib was not found in the pkg-config search path.
    Perhaps you should add the directory containing `zlib.pc'
    to the PKG_CONFIG_PATH environment variable
    Package 'zlib', required by 'libpng', not found

Solution is to require a zlib.pc file via PKG_CHECK_MODULES([zlib], ...

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


