### PR TITLE
src/sage/features/giac.py: add new feature for the giac program

### DIFF
--- a/src/sage/features/giac.py
+++ b/src/sage/features/giac.py
@@ -1,0 +1,30 @@
+# sage_setup: distribution = sagemath-environment
+r"""
+Feature for testing the presence of ``giac``
+"""
+
+from . import Executable, FeatureTestResult
+
+class Giac(Executable):
+    r"""
+    A :class:`~sage.features.Feature` describing the presence of :ref:`giac <spkg_giac>`.
+
+    EXAMPLES::
+
+        sage: from sage.features.giac import Giac
+        sage: Giac().is_present()  # needs giac
+        FeatureTestResult('giac', True)
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.giac import Giac
+            sage: isinstance(Giac(), Giac)
+            True
+        """
+        Executable.__init__(self, 'giac', executable='giac',
+                            spkg='giac', type='standard')
+
+def all_features():
+    return [Giac()]


### PR DESCRIPTION
In preparation for adding a `--disable-giac` option, we add a new feature that detects the presence of the "giac" executable. We already have a feature for `sage.libs.giac`, but that only guards the libgiac interface; we still have code that runs "giac" behind pexpect. This will allow us to skip those tests when giac is not installed.


