### PR TITLE
Update gperftools integration for python3/musl

### DIFF
--- a/src/sage/misc/gperftools.py
+++ b/src/sage/misc/gperftools.py
@@ -100,28 +100,6 @@ class Profiler(SageObject):
         """
         return 'Profiler logging to {0}'.format(self.filename())
 
-    def _libc(self):
-        """
-        Return libc.
-
-        OUTPUT: a ctypes shared library handle
-
-        EXAMPLES::
-
-            sage: from sage.misc.gperftools import Profiler
-            sage: Profiler()._libc()
-            <CDLL '...', handle ... at ...>
-        """
-        global libc
-        if libc is not None:
-            return libc
-        name = find_library('c')
-        if name:
-            libc = ctypes.CDLL(name)
-            return libc
-        else:
-            raise ImportError('failed to open libc')
-
     def _libprofiler(self):
         """
         Return libprofiler.
@@ -159,7 +137,8 @@ class Profiler(SageObject):
             PROFILE: interrupts/evictions/bytes = ...
         """
         from signal import SIGPROF, SIG_DFL
-        self._previous_sigprof_handler = self._libc().signal(SIGPROF, SIG_DFL)
+        from cysignals.pysignals import setossignal
+        self._previous_sigprof_handler = setossignal(SIGPROF, SIG_DFL)
         profiler = self._libprofiler()
         self._t_start = time.time()
         rc = profiler.ProfilerStart(str.encode(self.filename()))

--- a/src/sage/misc/gperftools.py
+++ b/src/sage/misc/gperftools.py
@@ -162,7 +162,7 @@ class Profiler(SageObject):
         self._previous_sigprof_handler = self._libc().signal(SIGPROF, SIG_DFL)
         profiler = self._libprofiler()
         self._t_start = time.time()
-        rc = profiler.ProfilerStart(self.filename())
+        rc = profiler.ProfilerStart(str.encode(self.filename()))
         if rc < 0:
             raise ValueError('profiler failed to start')
 


### PR DESCRIPTION
Update this module for python3, and then fix https://github.com/sagemath/sage/issues/33047 by using cysignals instead of trying to guess the name of my libc.