### PR TITLE
implement is_functional for LattE executable

### DIFF
--- a/src/sage/features/latte.py
+++ b/src/sage/features/latte.py
@@ -16,14 +16,41 @@ Features for testing the presence of ``latte_int``
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from . import Executable
+import subprocess
+from . import Executable, FeatureTestResult
 from .join_feature import JoinFeature
 
 
 LATTE_URL = "https://www.math.ucdavis.edu/~latte/software.php"
 
 
-class Latte_count(Executable):
+class Latte_executable(Executable):
+    def is_functional(self):
+        r"""
+        Check whether this LattE executable works on trivial input.
+
+        EXAMPLES::
+
+            sage: from sage.features.latte import Latte_count, Latte_integrate
+
+            sage: Latte_count().is_functional() # optional - latte_int
+            FeatureTestResult('count', True)
+            sage: Latte_integrate().is_functional() # optional - latte_int
+            FeatureTestResult('integrate', True)
+        """
+        try:
+            lines = subprocess.check_output(self.executable, stderr=subprocess.STDOUT, shell=True)
+        except subprocess.CalledProcessError as e:
+            return FeatureTestResult(self, False,
+                    reason="Call `{command}` failed with exit code {e.returncode}".format(command=self.executable, e=e))
+        if 'LattE' not in lines:
+            return FeatureTestResult(self, False,
+                    reason="Call `{command}` did not produce output which contains `{expected}`".format(command=self.executable, expected='LattE'))
+
+        return FeatureTestResult(self, True)
+
+
+class Latte_count(Latte_executable):
     r"""
     Feature for the executable ``count`` from :ref:`LattE integrale <spkg_latte_int>`.
     """
@@ -40,7 +67,7 @@ class Latte_count(Executable):
                             url=LATTE_URL)
 
 
-class Latte_integrate(Executable):
+class Latte_integrate(Latte_executable):
     r"""
     Feature for the executable ``integrate`` from :ref:`LattE integrale <spkg_latte_int>`.
     """

--- a/src/sage/interfaces/latte.py
+++ b/src/sage/interfaces/latte.py
@@ -121,6 +121,8 @@ def count(arg, ehrhart_polynomial=False, multivariate_generating_function=False,
         ...
         The polyhedron is unbounded.
     """
+    Latte_count().require()
+
     arg = str_to_bytes(arg)
 
     args = [Latte_count().absolute_filename()]
@@ -336,6 +338,8 @@ def integrate(arg, polynomial=None, algorithm='triangulate', raw_output=False, v
         ...
         determinant: nonsquare matrix
     """
+    Latte_integrate().require()
+
     arg = str_to_bytes(arg)
 
     from sage.rings.rational import Rational


### PR DESCRIPTION
Implement the method `is_functional` for the two LattE features `count` and `integrate` so that at least the problem from #38651 raises a meaningful error.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

