### PR TITLE
Fix matrix coercion with numpy 2.1

### DIFF
--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -670,7 +670,7 @@ cdef class Matrix(Matrix0):
             entries = [[sib(v, 2) for v in row] for row in self.rows()]
             return sib.name('matrix')(self.base_ring(), entries)
 
-    def numpy(self, dtype=None, copy=None):
+    def numpy(self, dtype=None, copy=True):
         """
         Return the Numpy matrix associated to this matrix.
 

--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -670,7 +670,7 @@ cdef class Matrix(Matrix0):
             entries = [[sib(v, 2) for v in row] for row in self.rows()]
             return sib.name('matrix')(self.base_ring(), entries)
 
-    def numpy(self, dtype=None):
+    def numpy(self, dtype=None, copy=None):
         """
         Return the Numpy matrix associated to this matrix.
 
@@ -731,7 +731,7 @@ cdef class Matrix(Matrix0):
             (3, 4)
         """
         import numpy
-        A = numpy.matrix(self.list(), dtype=dtype)
+        A = numpy.matrix(self.list(), dtype=dtype, copy=copy)
         return numpy.resize(A,(self.nrows(), self.ncols()))
 
     # Define the magic "__array__" function so that numpy.array(m) can convert

--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -680,6 +680,10 @@ cdef class Matrix(Matrix0):
           then the type will be determined as the minimum type required
           to hold the objects in the sequence.
 
+        - ``copy`` -- if `self` is already an `ndarray`, then this flag
+          determines whether the data is copied (the default), or whether
+          a view is constructed.
+
         EXAMPLES::
 
             sage: # needs numpy


### PR DESCRIPTION
numpy 2.1 requires a `copy` argument for `numpy.array`. Fixes test failures with numpy 2.1:
```
**********************************************************************
File "/usr/lib/python3.12/site-packages/sage/matrix/matrix1.pyx", line 723, in sage.matrix.matrix1.Matrix.numpy
Failed example:
    b = numpy.array(a); b
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python3.12/site-packages/sage/doctest/forker.py", line 716, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/usr/lib/python3.12/site-packages/sage/doctest/forker.py", line 1146, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.matrix.matrix1.Matrix.numpy[9]>", line 1, in <module>
        b = numpy.array(a); b
            ^^^^^^^^^^^^^^
      File "sage/matrix/matrix1.pyx", line 673, in sage.matrix.matrix1.Matrix.numpy (build/cythonized/sage/matrix/matrix1.c:14076)
        def numpy(self, dtype=None):
    TypeError: numpy() got an unexpected keyword argument 'copy'
**********************************************************************
File "/usr/lib/python3.12/site-packages/sage/matrix/matrix1.pyx", line 727, in sage.matrix.matrix1.Matrix.numpy
Failed example:
    b.dtype
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python3.12/site-packages/sage/doctest/forker.py", line 716, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/usr/lib/python3.12/site-packages/sage/doctest/forker.py", line 1146, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.matrix.matrix1.Matrix.numpy[10]>", line 1, in <module>
        b.dtype
        ^
    NameError: name 'b' is not defined
**********************************************************************
File "/usr/lib/python3.12/site-packages/sage/matrix/matrix1.pyx", line 730, in sage.matrix.matrix1.Matrix.numpy
Failed example:
    b.shape
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python3.12/site-packages/sage/doctest/forker.py", line 716, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/usr/lib/python3.12/site-packages/sage/doctest/forker.py", line 1146, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.matrix.matrix1.Matrix.numpy[11]>", line 1, in <module>
        b.shape
        ^
    NameError: name 'b' is not defined
**********************************************************************
```


