### PR TITLE
Tweak a few tests to pass when giac is not installed

### DIFF
--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -407,7 +407,7 @@ To check that :issue:`14821` is fixed::
     0.6321205588285577
     sage: result = integral(exp(-300.0/(-0.064*x+14.0)),x,0.0,120.0)
     ...
-    sage: result
+    sage: result  # abs tol 1e-10
     4.62770039817000e-9
 
 To check that :issue:`27092` is fixed::

--- a/src/sage/functions/piecewise.py
+++ b/src/sage/functions/piecewise.py
@@ -828,9 +828,9 @@ class PiecewiseFunction(BuiltinFunction):
             Check that the algorithm keyword can be used::
 
                 sage: ex = piecewise([([0, 1], 1), ((1, oo), 1/x**2)])
-                sage: integral(ex, x, 0, 100, algorithm='giac')
+                sage: integral(ex, x, 0, 100, algorithm='sympy')
                 199/100
-                sage: integral(ex, x, algorithm='giac')
+                sage: integral(ex, x, algorithm='sympy')
                 piecewise(x|-->x on [0, 1], x|-->-1/x + 2 on (1, +oo); x)
             """
             if a is not None and b is not None:

--- a/src/sage/symbolic/integration/integral.py
+++ b/src/sage/symbolic/integration/integral.py
@@ -71,12 +71,13 @@ class IndefiniteIntegral(BuiltinFunction):
             sage: (f*f).integrate(x, algorithm='mathematica_free') # optional -- internet
             -b*log(e^(a/b) + e^(x/b)) + x + b/(e^(-(a - x)/b) + 1)
 
-        Check for :issue:`25119`::
+        After :issue:`25119` we can integrate the following function,
+        although giac and sympy give different-looking answers::
 
             sage: result = integrate(sqrt(x^2)/x,x)
             ...
-            sage: result
-            x*sgn(x)
+            sage: result in [x*sgn(x), sqrt(x^2)]
+            True
         """
         # The automatic evaluation routine will try these integrators
         # in the given order. This is an attribute of the class instead of


### PR DESCRIPTION
This is one of the prerequisites to make it possible to install sage without giac (https://github.com/sagemath/sage/issues/38668). These few tests can be made to work easily without a `# needs giac`, so let's do that.