### PR TITLE
Grammar fixes to documentation: an to a euclidean

### DIFF
--- a/src/doc/en/thematic_tutorials/lie/lie_basics.rst
+++ b/src/doc/en/thematic_tutorials/lie/lie_basics.rst
@@ -789,7 +789,7 @@ and for describing the affine Weyl group.
 In particular, the hyperplane for the reflection `r_0`, used in generating
 the affine Weyl group, is translated off the origin (so it becomes an affine
 hyperplane). Now the root system is not described as linear transformations
-on an Euclidean space, but instead by *affine* transformations. Thus the
+on a Euclidean space, but instead by *affine* transformations. Thus the
 dominant chamber has finite volume and tiles the Eucledian space. Moreover,
 each such tile corresponds to a unique element in the affine Weyl group.
 

--- a/src/doc/en/thematic_tutorials/lie/lie_basics.rst
+++ b/src/doc/en/thematic_tutorials/lie/lie_basics.rst
@@ -848,7 +848,7 @@ the twisting procedure defined in [Kac]_. It has the following properties:
 Further Generalizations
 -----------------------
 
-If a root system (on an Euclidean space) has only the angles
+If a root system (on a Euclidean space) has only the angles
 `\pi/2, 2\pi/3, 3\pi/4, 5\pi/6` between its roots, then we call the
 root system *crystallographic* (on :wikipedia:`Root_system`, this
 condition is called integrality since for any two roots we have

--- a/src/sage/categories/euclidean_domains.py
+++ b/src/sage/categories/euclidean_domains.py
@@ -130,7 +130,7 @@ class EuclideanDomains(Category_singleton):
 
         def _test_euclidean_degree(self, **options):
             r"""
-            Test that the assumptions on an Euclidean degree are met.
+            Test that the assumptions on a Euclidean degree are met.
 
             EXAMPLES::
 
@@ -195,7 +195,7 @@ class EuclideanDomains(Category_singleton):
         @abstract_method
         def euclidean_degree(self):
             r"""
-            Return the degree of this element as an element of an Euclidean
+            Return the degree of this element as an element of a Euclidean
             domain, i.e., for elements `a`, `b` the euclidean degree `f`
             satisfies the usual properties:
 

--- a/src/sage/categories/fields.py
+++ b/src/sage/categories/fields.py
@@ -550,7 +550,7 @@ class Fields(CategoryWithAxiom):
     class ElementMethods:
         def euclidean_degree(self):
             r"""
-            Return the degree of this element as an element of an Euclidean
+            Return the degree of this element as an element of a Euclidean
             domain.
 
             In a field, this returns 0 for all but the zero element (for

--- a/src/sage/coding/grs_code.py
+++ b/src/sage/coding/grs_code.py
@@ -1531,7 +1531,7 @@ class GRSGaoDecoder(Decoder):
 
     def _partial_xgcd(self, a, b, PolRing):
         r"""
-        Perform an Euclidean algorithm on ``a`` and ``b`` until a remainder
+        Perform a Euclidean algorithm on ``a`` and ``b`` until a remainder
         has degree less than `\frac{n+k}{2}`, `n` being the dimension of the
         code, `k` its dimension, and returns `(r, s)` such that in the step
         just before termination, `r = a s + b t`.

--- a/src/sage/combinat/root_system/cartan_type.py
+++ b/src/sage/combinat/root_system/cartan_type.py
@@ -438,7 +438,7 @@ Type specific data
 
 The data essentially consists of a description of the Dynkin/Coxeter
 diagram and, when relevant, of the natural embedding of the root
-system in an Euclidean space. Everything else is reconstructed from
+system in a Euclidean space. Everything else is reconstructed from
 this data.
 
 - :ref:`sage.combinat.root_system.type_A`

--- a/src/sage/manifolds/differentiable/examples/euclidean.py
+++ b/src/sage/manifolds/differentiable/examples/euclidean.py
@@ -1,10 +1,10 @@
 r"""
 Euclidean Spaces
 
-An *Euclidean space of dimension* `n` is an affine space `E`, whose associated
+A *Euclidean space of dimension* `n` is an affine space `E`, whose associated
 vector space is a `n`-dimensional vector space over `\RR` and is equipped with
 a positive definite symmetric bilinear form, called the *scalar product* or
-*dot product* [Ber1987]_. An Euclidean space of dimension `n` can also be
+*dot product* [Ber1987]_. A Euclidean space of dimension `n` can also be
 viewed as a Riemannian manifold that is diffeomorphic to `\RR^n` and that
 has a flat metric `g`. The Euclidean scalar product is then that defined
 by the Riemannian metric `g`.
@@ -423,7 +423,7 @@ class EuclideanSpace(PseudoRiemannianManifold):
     r"""
     Euclidean space.
 
-    An *Euclidean space of dimension* `n` is an affine space `E`, whose
+    A *Euclidean space of dimension* `n` is an affine space `E`, whose
     associated vector space is a `n`-dimensional vector space over `\RR` and
     is equipped with a positive definite symmetric bilinear form, called
     the *scalar product* or *dot product*.
@@ -506,7 +506,7 @@ class EuclideanSpace(PseudoRiemannianManifold):
         sage: latex(F)
         \mathcal{F}
 
-    By default, an Euclidean space is created with a single coordinate chart:
+    By default, a Euclidean space is created with a single coordinate chart:
     that of Cartesian coordinates::
 
         sage: E.atlas()
@@ -556,7 +556,7 @@ class EuclideanSpace(PseudoRiemannianManifold):
         sage: latex(xi+ze)
         {\xi} + {\zeta}
 
-    Thanks to the argument ``coordinates``, an Euclidean space can be
+    Thanks to the argument ``coordinates``, a Euclidean space can be
     constructed with curvilinear coordinates initialized instead of the
     Cartesian ones::
 
@@ -729,14 +729,14 @@ class EuclideanSpace(PseudoRiemannianManifold):
                  category=None, init_coord_methods=None,
                  unique_tag=None):
         r"""
-        Construct an Euclidean space.
+        Construct a Euclidean space.
 
         INPUT:
 
         This class also takes the following input:
 
         - ``base_manifold`` -- (default: ``None``) if not ``None``, must be
-          an Euclidean space; the created object is then an open subset
+          a Euclidean space; the created object is then an open subset
           of ``base_manifold``
         - ``category`` -- (default: ``None``) to specify the category;
           if ``None``,
@@ -1045,14 +1045,14 @@ class EuclideanPlane(EuclideanSpace):
     r"""
     Euclidean plane.
 
-    An *Euclidean plane* is an affine space `E`, whose associated vector space
+    A *Euclidean plane* is an affine space `E`, whose associated vector space
     is a 2-dimensional vector space over `\RR` and is equipped with a
     positive definite symmetric bilinear form, called the *scalar product* or
     *dot product*.
 
     The class :class:`EuclideanPlane` inherits from
     :class:`~sage.manifolds.differentiable.pseudo_riemannian.PseudoRiemannianManifold`
-    (via :class:`EuclideanSpace`) since an Euclidean plane can be viewed
+    (via :class:`EuclideanSpace`) since a Euclidean plane can be viewed
     as a Riemannian manifold that is diffeomorphic to `\RR^2` and that has a
     flat metric `g`. The Euclidean scalar product is the one defined by the
     Riemannian metric `g`.
@@ -1109,7 +1109,7 @@ class EuclideanPlane(EuclideanSpace):
 
     EXAMPLES:
 
-    One creates an Euclidean plane ``E`` with::
+    One creates a Euclidean plane ``E`` with::
 
         sage: E.<x,y> = EuclideanSpace(); E
         Euclidean plane E^2
@@ -1165,7 +1165,7 @@ class EuclideanPlane(EuclideanSpace):
                  symbols=None, metric_name='g', metric_latex_name=None,
                  start_index=1, base_manifold=None, category=None, unique_tag=None):
         r"""
-        Construct an Euclidean plane.
+        Construct a Euclidean plane.
 
         TESTS::
 
@@ -1598,7 +1598,7 @@ class Euclidean3dimSpace(EuclideanSpace):
     - ``start_index`` -- (default: 1) integer; lower value of the range of
       indices used for "indexed objects" in the Euclidean 3-space, e.g.
       coordinates of a chart
-    - ``base_manifold`` -- (default: ``None``) if not ``None``, must be an
+    - ``base_manifold`` -- (default: ``None``) if not ``None``, must be a
       Euclidean 3-space; the created object is then an open subset of
       ``base_manifold``
     - ``category`` -- (default: ``None``) to specify the category; if ``None``,

--- a/src/sage/manifolds/differentiable/examples/euclidean.py
+++ b/src/sage/manifolds/differentiable/examples/euclidean.py
@@ -1686,7 +1686,7 @@ class Euclidean3dimSpace(EuclideanSpace):
                  symbols=None, metric_name='g', metric_latex_name=None,
                  start_index=1, base_manifold=None, category=None, unique_tag=None):
         r"""
-        Construct an Euclidean 3-space.
+        Construct a Euclidean 3-space.
 
         TESTS::
 
@@ -2439,7 +2439,7 @@ class Euclidean3dimSpace(EuclideanSpace):
         Return the scalar triple product operator, as a 3-form.
 
         The *scalar triple product* (also called *mixed product*) of three
-        vector fields `u`, `v` and `w` defined on an Euclidean space `E`
+        vector fields `u`, `v` and `w` defined on a Euclidean space `E`
         is the scalar field
 
         .. MATH::

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -16342,7 +16342,7 @@ cdef class Matrix(Matrix1):
         Transform the matrix in place to hermite normal form and optionally
         return the transformation matrix.
 
-        The matrix is assumed to be over an Euclidean domain. In particular,
+        The matrix is assumed to be over a Euclidean domain. In particular,
         ``xgcd()`` method should be available for the elements of the domain.
 
         INPUT:

--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -85,7 +85,7 @@ def IntegralLattice(data, basis=None):
     - ``data`` -- can be one of the following:
 
       * a symmetric matrix over the rationals -- the inner product matrix
-      * an integer -- the dimension for an Euclidean lattice
+      * an integer -- the dimension for a Euclidean lattice
       * a symmetric Cartan type or anything recognized by
         :class:`CartanMatrix` (see also
         :mod:`Cartan types <sage.combinat.root_system.cartan_type>`)
@@ -120,7 +120,7 @@ def IntegralLattice(data, basis=None):
         [ 2  1]
         [ 1 -2]
 
-    We can define an Euclidean lattice just by its dimension::
+    We can define a Euclidean lattice just by its dimension::
 
         sage: IntegralLattice(3)
         Lattice of degree 3 and rank 3 over Integer Ring

--- a/src/sage/plot/plot3d/point_c.pxi
+++ b/src/sage/plot/plot3d/point_c.pxi
@@ -110,7 +110,7 @@ cdef inline void point_c_middle(point_c* res, point_c P, point_c Q, double a) no
 
 cdef inline void point_c_transform(point_c* res, double* M, point_c P) noexcept:
     """
-    M is a flattened 4x4 matrix, row major, representing an Euclidean Transformation.
+    M is a flattened 4x4 matrix, row major, representing a Euclidean Transformation.
     Operate on P as a point.
     """
     res.x = M[0]*P.x + M[1]*P.y + M[2]*P.z + M[3]
@@ -119,7 +119,7 @@ cdef inline void point_c_transform(point_c* res, double* M, point_c P) noexcept:
 
 cdef inline void point_c_stretch(point_c* res, double* M, point_c P) noexcept:
     """
-    M is a flattened 4x4 matrix, row major, representing an Euclidean Transformation.
+    M is a flattened 4x4 matrix, row major, representing a Euclidean Transformation.
     Operate on P as a vector (i.e. ignore the translation component)
     """
     res.x = M[0]*P.x + M[1]*P.y + M[2]*P.z

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -3278,7 +3278,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
     def euclidean_degree(self):
         r"""
-        Return the degree of this element as an element of an Euclidean domain.
+        Return the degree of this element as an element of a Euclidean domain.
 
         If this is an element in the ring of integers, this is simply its
         absolute value.

--- a/src/sage/rings/padics/local_generic_element.pyx
+++ b/src/sage/rings/padics/local_generic_element.pyx
@@ -870,7 +870,7 @@ cdef class LocalGenericElement(CommutativeRingElement):
 
     def euclidean_degree(self):
         r"""
-        Return the degree of this element as an element of an Euclidean domain.
+        Return the degree of this element as an element of a Euclidean domain.
 
         EXAMPLES:
 

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -3948,7 +3948,7 @@ cdef class Polynomial(CommutativePolynomial):
 
     def euclidean_degree(self):
         r"""
-        Return the degree of this element as an element of an Euclidean domain.
+        Return the degree of this element as an element of a Euclidean domain.
 
         If this polynomial is defined over a field, this is simply its :meth:`degree`.
 


### PR DESCRIPTION
Fix grammar in documentation. Changing the article preceding the word "Euclidean" from "an" to "a" should help things read more smoothly.  

### :memo: Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have updated the documentation and checked the documentation preview.



