### PR TITLE
Raise exception when factoring zero polynomial

### DIFF
--- a/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
@@ -762,7 +762,19 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
             sage: P.<x> = GF(7)[]
             sage: (6*x+3).squarefree_decomposition()
             (6) * (x + 4)
+
+        Test zero polynomial::
+
+            sage: R.<x> = PolynomialRing(GF(65537), implementation="FLINT")
+            sage: R.zero().squarefree_decomposition()
+            Traceback (most recent call last):
+            ...
+            ArithmeticError: square-free decomposition of 0 is not defined
         """
+        if self.is_zero():
+            raise ArithmeticError(
+                "square-free decomposition of 0 is not defined"
+            )
         if not self.base_ring().is_field():
             raise NotImplementedError("square free factorization of polynomials over rings with composite characteristic is not implemented")
 
@@ -803,9 +815,20 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
             Traceback (most recent call last):
             ...
             AlarmInterrupt
-        """
-        R = self.base_ring()
 
+        Test zero polynomial::
+
+            sage: R.<x> = PolynomialRing(GF(65537), implementation="FLINT")
+            sage: R.zero().factor()
+            Traceback (most recent call last):
+            ...
+            ArithmeticError: factorization of 0 is not defined
+
+        """
+        if self.is_zero():
+            raise ArithmeticError("factorization of 0 is not defined")
+
+        R = self.base_ring()
         if not R.is_field():
             p,e = R.characteristic().is_prime_power(get_data=True)
             if not e:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The zero polynomial doesn't have a factorization or square-free factorization, so
```
PolynomialRing(GF(7), 'x').zero().factor()
PolynomialRing(GF(7), 'x').zero().squarefree_decomposition()
```
should raise errors instead of returning zero. This patch fixes this behavior.
