### PR TITLE
fix and activate check E702 in pyx files

### DIFF
--- a/src/tox.ini
+++ b/src/tox.ini
@@ -181,7 +181,7 @@ description =
     # See https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 deps = pycodestyle
 commands = pycodestyle --select E111,E21,E221,E222,E225,E227,E228,E25,E271,E303,E305,E306,E401,E502,E701,E702,E703,E71,E72,W291,W293,W391,W605 {posargs:{toxinidir}/sage/}
-       pycodestyle --select E111,E271,E301,E302,E303,E305,E306,E401,E502,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
+       pycodestyle --select E111,E271,E301,E302,E303,E305,E306,E401,E502,E702,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
 
 [pycodestyle]
 max-line-length = 160


### PR DESCRIPTION
fix the last 6 warnings in pyx files about

E702 multiple statements on one line (semicolon)

and activate the check for E702 in pyx files in our linter

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



