### PR TITLE
build/pkgs/sagetex/dependencies: add $(PYTHON_TOOLCHAIN)

### DIFF
--- a/build/pkgs/sagetex/dependencies
+++ b/build/pkgs/sagetex/dependencies
@@ -1,4 +1,4 @@
- maxima scipy matplotlib pillow tachyon pyparsing | $(PYTHON)
+ maxima scipy matplotlib pillow tachyon pyparsing | $(PYTHON_TOOLCHAIN) $(PYTHON)
 
 To build SageTeX, you just need Python and pyparsing, but to test (SAGE_CHECK=yes)
 SageTeX, you actually need to run Sage, produce plots,...


### PR DESCRIPTION
Our sagetex package needs python_build, included as part of `$(PYTHON_TOOLCHAIN)`, to build.

Closes: https://github.com/sagemath/sage/issues/38657
