### PR TITLE
Dropping support for power with Finite Field Polynomial Element

### DIFF
--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -784,7 +784,7 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
             sage: 2 ^ a
             Traceback (most recent call last):
             ...
-            TypeError: unsupported operand parent(s) for ^: 'Finite Field in a of size 2^63' and 'Finite Field in a of size 2^63'
+            TypeError: Unable to raise power using finite field polynomial element
             sage: a ^ "exp"
             Traceback (most recent call last):
             ...

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -491,20 +491,24 @@ class FiniteFieldFactory(UniqueFactory):
 
     Check that :issue:`32287` has been fixed::
 
-        sage: def print_error(impl=None):
-        ....:     try:
-        ....:         x = 123**GF(64, impl=impl)(5)
-        ....:     except TypeError as e:
-        ....:         print(e)
-        ....:
-        sage: print_error('givaro')
-        Unable to raise power with finite field polynomial element
-        sage: print_error('ntl')
-        Unable to raise power with finite field polynomial element
-        sage: print_error('pari_ffelt')
-        Unable to raise power with finite field polynomial element
+        sage: x = 12.3**GF(64, impl='givaro')(5)
+        Traceback (most recent call last):
+        ...
+        TypeError: Unable to raise power using finite field polynomial element
+
+        sage: x = 12.3**GF(64, impl='ntl')(5)
+        Traceback (most recent call last):
+        ...
+        TypeError: Unable to raise power using finite field polynomial element
+
+        sage: x = 12.3**GF(64, impl='pari_ffelt')(5)
+        Traceback (most recent call last):
+        ...
+        TypeError: Unable to raise power using finite field polynomial element
+
         sage: x = 123**GF(61)(5); x
         28153056843
+
         sage: x = 12.3**GF(61)(5); x
         281530.568430000
     """

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -488,6 +488,29 @@ class FiniteFieldFactory(UniqueFactory):
         sage: q=2**152
         sage: GF(q,'a',modulus='primitive') == GF(q,'a',modulus='primitive')
         True
+    
+    Check that :issue:`32287` has been fixed::
+    
+        sage: x = 123**GF(64, impl='givaro')(5)
+        Traceback (most recent call last)
+        ...
+        TypeError: Unable to raise power with finite field polynomial element
+        
+        sage: x = 12.3**GF(64, impl='ntl')(5)
+        Traceback (most recent call last)
+        ...
+        TypeError: Unable to raise power with finite field polynomial element
+        
+        sage: x = 12.3**GF(64, impl='pari_ffelt')(5)
+        Traceback (most recent call last)
+        ...
+        TypeError: Unable to raise power with finite field polynomial element
+        
+        sage: x = 123**GF(61)(5); x
+        28153056843
+
+        sage: x = 12.3**GF(61)(5); x
+        281530.568430000
     """
     def __init__(self, *args, **kwds):
         """

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -488,27 +488,23 @@ class FiniteFieldFactory(UniqueFactory):
         sage: q=2**152
         sage: GF(q,'a',modulus='primitive') == GF(q,'a',modulus='primitive')
         True
-    
+
     Check that :issue:`32287` has been fixed::
-    
-        sage: x = 123**GF(64, impl='givaro')(5)
-        Traceback (most recent call last)
-        ...
-        TypeError: Unable to raise power with finite field polynomial element
 
-        sage: x = 12.3**GF(64, impl='ntl')(5)
-        Traceback (most recent call last)
-        ...
-        TypeError: Unable to raise power with finite field polynomial element
-
-        sage: x = 12.3**GF(64, impl='pari_ffelt')(5)
-        Traceback (most recent call last)
-        ...
-        TypeError: Unable to raise power with finite field polynomial element
-
+        sage: def print_error(impl=None):
+        ....:     try:
+        ....:         x = 123**GF(64, impl=impl)(5)
+        ....:     except TypeError as e:
+        ....:         print(e)
+        ....:
+        sage: print_error('givaro')
+        Unable to raise power with finite field polynomial element
+        sage: print_error('ntl')
+        Unable to raise power with finite field polynomial element
+        sage: print_error('pari_ffelt')
+        Unable to raise power with finite field polynomial element
         sage: x = 123**GF(61)(5); x
         28153056843
-
         sage: x = 12.3**GF(61)(5); x
         281530.568430000
     """

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -495,17 +495,17 @@ class FiniteFieldFactory(UniqueFactory):
         Traceback (most recent call last)
         ...
         TypeError: Unable to raise power with finite field polynomial element
-        
+
         sage: x = 12.3**GF(64, impl='ntl')(5)
         Traceback (most recent call last)
         ...
         TypeError: Unable to raise power with finite field polynomial element
-        
+
         sage: x = 12.3**GF(64, impl='pari_ffelt')(5)
         Traceback (most recent call last)
         ...
         TypeError: Unable to raise power with finite field polynomial element
-        
+
         sage: x = 123**GF(61)(5); x
         28153056843
 

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -2733,6 +2733,7 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
             S_is_int = parent_is_integers(S)
             if not S_is_int:
                 from sage.rings.abc import IntegerModRing
+                from sage.rings.finite_rings.finite_field_base import FiniteField
                 if isinstance(S, IntegerModRing):
                     # We allow powering by an IntegerMod by treating it
                     # as an integer.
@@ -2741,10 +2742,7 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
                     # to support. But in general this should not be
                     # allowed. See Issue #15709
                     S_is_int = True
-                from sage.rings.finite_rings.finite_field_pari_ffelt import FiniteField_pari_ffelt
-                from sage.rings.finite_rings.finite_field_ntl_gf2e import FiniteField_ntl_gf2e
-                from sage.rings.finite_rings.finite_field_givaro import FiniteField_givaro
-                if isinstance(S, (FiniteField_pari_ffelt, FiniteField_ntl_gf2e, FiniteField_givaro)):
+                elif isinstance(S, FiniteField):
                     # See Issue : #32287
                     # Disallowing Finite Field Polynomial Element
                     # to be used to raise power

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -2741,6 +2741,14 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
                     # to support. But in general this should not be
                     # allowed. See Issue #15709
                     S_is_int = True
+                from sage.rings.finite_rings.finite_field_pari_ffelt import FiniteField_pari_ffelt
+                from sage.rings.finite_rings.finite_field_ntl_gf2e import FiniteField_ntl_gf2e
+                from sage.rings.finite_rings.finite_field_givaro import FiniteField_givaro
+                if isinstance(S, (FiniteField_pari_ffelt, FiniteField_ntl_gf2e, FiniteField_givaro)):
+                    # See Issue : #32287
+                    # Disallowing Finite Field Polynomial Element
+                    # to be used to raise power
+                    raise TypeError('Unable to raise power using finite field polynomial element')
             if S_is_int:
                 from sage.structure.coerce_actions import IntegerPowAction
                 try:


### PR DESCRIPTION
Fixes issue : #32287
`Reference : pow ( Int, Finite Field)`
It was noticed that raising power with ModN field numbers and Gravio/NTL was not consistent.

- Finite Field = ModN : Coerced the FF element to Integer then performed Powering
- Finite Field = Gravio/NTL: Coerced the output to Gravio/NTL rather than Integer because it could only interpret non prime order field elements to be polynomials.

Change:
Removed support for Gravio/NTL/Pari_ffelt in powering scenario.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


