### PR TITLE
src/sage/symbolic/integration: make libgiac integration optional

### DIFF
--- a/src/sage/symbolic/integration/external.py
+++ b/src/sage/symbolic/integration/external.py
@@ -285,7 +285,15 @@ def libgiac_integrator(expression, v, a=None, b=None):
         sage: (F.derivative(x) - f).simplify_trig()
         0
     """
-    from sage.libs.giac import libgiac
+    try:
+        from sage.libs.giac import libgiac
+    except ImportError:
+        # If libgiac isn't available, return a symbolic answer
+        # (without actually integrating anything). This is essentially
+        # the failure case of any integration: see below for what we
+        # do if libgiac is *available* but unable to do much.
+        return expression.integrate(v, a, b, hold=True)
+
     from sage.libs.giac.giac import Pygen
     # We call Pygen on first argument because otherwise some expressions
     # involving derivatives result in doctest failures in interfaces/sympy.py

--- a/src/sage/symbolic/integration/integral.py
+++ b/src/sage/symbolic/integration/integral.py
@@ -83,6 +83,10 @@ class IndefiniteIntegral(BuiltinFunction):
         # in the given order. This is an attribute of the class instead of
         # a global variable in this module to enable customization by
         # creating a subclasses which define a different set of integrators
+        #
+        # The libgiac integrator may immediately return a symbolic
+        # (unevaluated) answer if libgiac is unavailable. This essentially
+        # causes it to be skipped.
         self.integrators = [external.maxima_integrator,
                             external.libgiac_integrator,
                             external.sympy_integrator]


### PR DESCRIPTION
We turn the libgiac integrator into a no-op if libgiac isn't available. That way, in the default integration routines, it is essentially skipped. If it were tried last, we could literally skip it; but currently it lives between maxima and sympy and cannot be rearanged without messing up some doctests.
