### PR TITLE
Add method tikz (or latex_standalone) within combinat.crystals module

### DIFF
--- a/src/sage/categories/crystals.py
+++ b/src/sage/categories/crystals.py
@@ -987,7 +987,7 @@ class Crystals(Category_singleton):
                 sage: _ = t.pdf(view=False)         # long time (1s), optional - latex dot2tex graphviz
             """
             from sage.misc.latex_standalone import TikzPicture
-            if not 'standalone_config' in kwds:
+            if 'standalone_config' not in kwds:
                 kwds['standalone_config'] = ["border=1pt"]
             return TikzPicture(self._latex_(), **kwds)
 

--- a/src/sage/categories/crystals.py
+++ b/src/sage/categories/crystals.py
@@ -976,6 +976,21 @@ class Crystals(Category_singleton):
 
         latex = _latex_
 
+        def tikz(self, **kwds):
+            r"""
+            Return TikzPicture illustrating ``self``.
+
+            EXAMPLES::
+
+                sage: T = crystals.Tableaux(['A',2],shape=[1])
+                sage: t = T.tikz()
+                sage: _ = t.pdf(view=False)         # long time (1s), optional - latex dot2tex graphviz
+            """
+            from sage.misc.latex_standalone import TikzPicture
+            if not 'standalone_config' in kwds:
+                kwds['standalone_config'] = ["border=1pt"]
+            return TikzPicture(self._latex_(), **kwds)
+
         def metapost(self, filename, thicklines=False, labels=True, scaling_factor=1.0, tallness=1.0):
             r"""
             Export a file, suitable for MetaPost, to ``filename``.

--- a/src/sage/combinat/crystals/generalized_young_walls.py
+++ b/src/sage/combinat/crystals/generalized_young_walls.py
@@ -537,6 +537,34 @@ class GeneralizedYoungWall(CombinatorialElement):
             s += "{\\foreach \\y [count=\\t from 0] in \\x {  \\node[font=\\tiny] at (-\\t,\\s) {$\\y$}; \n \\draw (-\\t+.5,\\s+.5) to (-\\t-.5,\\s+.5); \n \\draw (-\\t+.5,\\s-.5) to (-\\t-.5,\\s-.5); \n \\draw (-\\t-.5,\\s-.5) to (-\\t-.5,\\s+.5);  } \n \\draw[-] (.5,\\s+1) to (.5,-.5) to (-\\t-1,-.5); } \n \\end{tikzpicture} \n"
         return s
 
+    def tikz(self, latex_large=False, **kwds):
+        r"""
+        Return TikzPicture illustrating ``self``.
+
+        INPUT:
+
+        - ``latex_large`` -- bool (default:``False``), whether to use the
+          output of ``latex_large`` method instead of ``_latex_`` method.
+
+        EXAMPLES::
+
+            sage: x = crystals.infinity.GeneralizedYoungWalls(3)([[],[1,0,3,2],[2,1],[3,2,1,0,3,2],[],[],[2]])
+            sage: t = x.tikz()
+            sage: _ = t.pdf(view=False)         # known bug
+
+        ::
+
+            sage: t = x.tikz(latex_large=True)
+            sage: _ = t.pdf(view=False)         # known bug
+
+        """
+        from sage.misc.latex_standalone import TikzPicture
+        if latex_large:
+            s = self.latex_large()
+        else:
+            s = self._latex_()
+        return TikzPicture(s, **kwds)
+
     def weight(self, root_lattice=False):
         r"""
         Return the weight of ``self``.

--- a/src/sage/combinat/crystals/generalized_young_walls.py
+++ b/src/sage/combinat/crystals/generalized_young_walls.py
@@ -562,7 +562,7 @@ class GeneralizedYoungWall(CombinatorialElement):
 
         """
         from sage.misc.latex_standalone import TikzPicture
-        if not 'standalone_config' in kwds:
+        if 'standalone_config' not in kwds:
             kwds['standalone_config'] = ["border=1pt"]
         if latex_large:
             s = self.latex_large()

--- a/src/sage/combinat/crystals/generalized_young_walls.py
+++ b/src/sage/combinat/crystals/generalized_young_walls.py
@@ -559,6 +559,8 @@ class GeneralizedYoungWall(CombinatorialElement):
 
         """
         from sage.misc.latex_standalone import TikzPicture
+        if not 'standalone_config' in kwds:
+            kwds['standalone_config'] = ["border=1pt"]
         if latex_large:
             s = self.latex_large()
         else:

--- a/src/sage/combinat/crystals/generalized_young_walls.py
+++ b/src/sage/combinat/crystals/generalized_young_walls.py
@@ -553,12 +553,12 @@ class GeneralizedYoungWall(CombinatorialElement):
 
             sage: x = crystals.infinity.GeneralizedYoungWalls(3)([[],[1,0,3,2],[2,1],[3,2,1,0,3,2],[],[],[2]])
             sage: t = x.tikz()
-            sage: _ = t.pdf(view=False)
+            sage: _ = t.pdf(view=False)         # long time (2s), optional - latex
 
         ::
 
             sage: t = x.tikz(latex_large=True)
-            sage: _ = t.pdf(view=False)
+            sage: _ = t.pdf(view=False)         # long time (2s), optional - latex
 
         """
         from sage.misc.latex_standalone import TikzPicture

--- a/src/sage/combinat/crystals/generalized_young_walls.py
+++ b/src/sage/combinat/crystals/generalized_young_walls.py
@@ -553,12 +553,12 @@ class GeneralizedYoungWall(CombinatorialElement):
 
             sage: x = crystals.infinity.GeneralizedYoungWalls(3)([[],[1,0,3,2],[2,1],[3,2,1,0,3,2],[],[],[2]])
             sage: t = x.tikz()
-            sage: _ = t.pdf(view=False)         # known bug
+            sage: _ = t.pdf(view=False)
 
         ::
 
             sage: t = x.tikz(latex_large=True)
-            sage: _ = t.pdf(view=False)         # known bug
+            sage: _ = t.pdf(view=False)
 
         """
         from sage.misc.latex_standalone import TikzPicture

--- a/src/sage/combinat/crystals/mv_polytopes.py
+++ b/src/sage/combinat/crystals/mv_polytopes.py
@@ -146,6 +146,8 @@ class MVPolytope(PBWCrystalElement):
 
         """
         from sage.misc.latex_standalone import TikzPicture
+        if not 'standalone_config' in kwds:
+            kwds['standalone_config'] = ["border=1pt"]
         return TikzPicture(self._latex_(), **kwds)
 
     def _polytope_vertices(self, P):

--- a/src/sage/combinat/crystals/mv_polytopes.py
+++ b/src/sage/combinat/crystals/mv_polytopes.py
@@ -146,7 +146,7 @@ class MVPolytope(PBWCrystalElement):
 
         """
         from sage.misc.latex_standalone import TikzPicture
-        if not 'standalone_config' in kwds:
+        if 'standalone_config' not in kwds:
             kwds['standalone_config'] = ["border=1pt"]
         return TikzPicture(self._latex_(), **kwds)
 

--- a/src/sage/combinat/crystals/mv_polytopes.py
+++ b/src/sage/combinat/crystals/mv_polytopes.py
@@ -133,6 +133,21 @@ class MVPolytope(PBWCrystalElement):
         ret += "\\end{tikzpicture}"
         return ret
 
+    def tikz(self, **kwds):
+        r"""
+        Return TikzPicture illustrating ``self``.
+
+        EXAMPLES::
+
+            sage: MV = crystals.infinity.MVPolytopes(['C', 2])
+            sage: b = MV.module_generators[0].f_string([1,2,1,2])
+            sage: t = b.tikz()
+            sage: _ = t.pdf(view=False)         # long time (2s), optional - latex
+
+        """
+        from sage.misc.latex_standalone import TikzPicture
+        return TikzPicture(self._latex_(), **kwds)
+
     def _polytope_vertices(self, P):
         """
         Return a list of the vertices of ``self`` in ``P``.

--- a/src/sage/combinat/crystals/spins.pyx
+++ b/src/sage/combinat/crystals/spins.pyx
@@ -524,7 +524,7 @@ cdef class Spin(Element):
 
         """
         from sage.misc.latex_standalone import Standalone
-        if not 'standalone_config' in kwds:
+        if 'standalone_config' not in kwds:
             kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 

--- a/src/sage/combinat/crystals/spins.pyx
+++ b/src/sage/combinat/crystals/spins.pyx
@@ -511,6 +511,21 @@ cdef class Spin(Element):
         """
         return Tableau([[i] for i in reversed(self.signature())])._latex_()
 
+    def latex_standalone(self, **kwds):
+        r"""
+        Return Standalone picture illustrating ``self``.
+
+        EXAMPLES::
+
+            sage: C = crystals.Spins(['B',3])
+            sage: b = C([1,1,-1])
+            sage: s = b.latex_standalone()
+            sage: _ = s.pdf(view=False)           # long time (2s), optional - latex
+
+        """
+        from sage.misc.latex_standalone import Standalone
+        return Standalone(self._latex_(), **kwds)
+
     def weight(self):
         """
         Return the weight of ``self``.

--- a/src/sage/combinat/crystals/spins.pyx
+++ b/src/sage/combinat/crystals/spins.pyx
@@ -524,6 +524,8 @@ cdef class Spin(Element):
 
         """
         from sage.misc.latex_standalone import Standalone
+        if not 'standalone_config' in kwds:
+            kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 
     def weight(self):

--- a/src/sage/combinat/crystals/tensor_product.py
+++ b/src/sage/combinat/crystals/tensor_product.py
@@ -1172,6 +1172,8 @@ class CrystalOfQueerTableaux(CrystalOfWords, QueerSuperCrystalsMixin):
 
             """
             from sage.misc.latex_standalone import Standalone
+            if not 'standalone_config' in kwds:
+                kwds['standalone_config'] = ["border=1pt"]
             return Standalone(self._latex_(), **kwds)
 
         def rows(self):

--- a/src/sage/combinat/crystals/tensor_product.py
+++ b/src/sage/combinat/crystals/tensor_product.py
@@ -1159,6 +1159,21 @@ class CrystalOfQueerTableaux(CrystalOfWords, QueerSuperCrystalsMixin):
             return tex_from_array([[None]*i + list(reversed(row))
                                   for i, row in enumerate(self.rows())])
 
+        def latex_standalone(self, **kwds):
+            r"""
+            Return Standalone picture illustrating ``self``.
+
+            EXAMPLES::
+
+                sage: B = crystals.Tableaux(['Q',3], shape=[3,2,1])
+                sage: t = B.an_element()
+                sage: s = t.latex_standalone()
+                sage: _ = s.pdf(view=False)         # long time (2s), optional - latex
+
+            """
+            from sage.misc.latex_standalone import Standalone
+            return Standalone(self._latex_(), **kwds)
+
         def rows(self):
             """
             Return the list of rows of ``self``.

--- a/src/sage/combinat/crystals/tensor_product.py
+++ b/src/sage/combinat/crystals/tensor_product.py
@@ -1170,7 +1170,7 @@ class CrystalOfQueerTableaux(CrystalOfWords, QueerSuperCrystalsMixin):
 
             """
             from sage.misc.latex_standalone import Standalone
-            if not 'standalone_config' in kwds:
+            if 'standalone_config' not in kwds:
                 kwds['standalone_config'] = ["border=1pt"]
             return Standalone(self._latex_(), **kwds)
 

--- a/src/sage/combinat/crystals/tensor_product_element.pyx
+++ b/src/sage/combinat/crystals/tensor_product_element.pyx
@@ -134,6 +134,25 @@ cdef class TensorProductOfCrystalsElement(ImmutableListWithParent):
             return r' \otimes '.join(latex(c) for c in reversed(self))
         return r' \otimes '.join(latex(c) for c in self)
 
+    def latex_standalone(self, **kwds):
+        r"""
+        Return Standalone picture illustrating ``self``.
+
+        EXAMPLES::
+
+            sage: C = crystals.Letters(["A",2])
+            sage: D = crystals.Tableaux(["A",2], shape=[2])
+            sage: E = crystals.TensorProduct(C,D)
+            sage: x = E.module_generators[0]
+            sage: s = x.latex_standalone()
+            sage: _ = s.pdf(view=False)       # long time (2s), optional - latex
+
+        """
+        from sage.misc.latex_standalone import Standalone
+        if not 'standalone_config' in kwds:
+            kwds['standalone_config'] = ["border=1pt"]
+        return Standalone(self._latex_(), **kwds)
+
     def _ascii_art_(self):
         """
         Return an ASCII art representation of ``self``.
@@ -893,6 +912,21 @@ cdef class CrystalOfTableauxElement(TensorProductOfRegularCrystalsElement):
         T = Tableau(tab).conjugate()
         return tex_from_array([[letter._latex_() for letter in row] for row in T])
 
+    def latex_standalone(self, **kwds):
+        r"""
+        Return Standalone picture illustrating ``self``.
+
+        EXAMPLES::
+
+            sage: T = crystals.Tableaux(['A',3], shape = [4,2])
+            sage: t = T(rows=[[1,1,2,3],[2,3]])
+            sage: s = t.latex_standalone()
+            sage: _ = s.pdf(view=False)        # long time (2s), optional - latex
+
+        """
+        from sage.misc.latex_standalone import Standalone
+        return Standalone(self._latex_(), **kwds)
+
     @cached_method
     def to_tableau(self):
         """
@@ -1378,6 +1412,21 @@ cdef class CrystalOfBKKTableauxElement(TensorProductOfSuperCrystalsElement):
         """
         return self.to_tableau()._latex_()
 
+    def latex_standalone(self, **kwds):
+        r"""
+        Return Standalone picture illustrating ``self``.
+
+        EXAMPLES::
+
+            sage: C = crystals.Tableaux(['A',[1,2]], shape=[1,1])
+            sage: c = C.an_element()
+            sage: s = c.latex_standalone()
+            sage: _ = s.pdf(view=False)        # long time (2s), optional - latex
+
+        """
+        from sage.misc.latex_standalone import Standalone
+        return Standalone(self._latex_(), **kwds)
+
     @cached_method
     def to_tableau(self):
         """
@@ -1719,6 +1768,21 @@ cdef class InfinityQueerCrystalOfTableauxElement(TensorProductOfQueerSuperCrysta
         from sage.combinat.output import tex_from_array
         return tex_from_array([[None]*i + list(reversed(row))
                               for i, row in enumerate(self.rows())])
+
+    def latex_standalone(self, **kwds):
+        r"""
+        Return Standalone picture illustrating ``self``.
+
+        EXAMPLES::
+
+            sage: B = crystals.infinity.Tableaux(['Q',4])
+            sage: t = B([[4,4,4,4,4,2,1],[3,3,3,3],[2,2,1],[1]])
+            sage: s = t.latex_standalone()
+            sage: _ = s.pdf(view=False)        # long time (2s), optional - latex
+
+        """
+        from sage.misc.latex_standalone import Standalone
+        return Standalone(self._latex_(), **kwds)
 
     def rows(self):
         """

--- a/src/sage/combinat/crystals/tensor_product_element.pyx
+++ b/src/sage/combinat/crystals/tensor_product_element.pyx
@@ -925,6 +925,8 @@ cdef class CrystalOfTableauxElement(TensorProductOfRegularCrystalsElement):
 
         """
         from sage.misc.latex_standalone import Standalone
+        if not 'standalone_config' in kwds:
+            kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 
     @cached_method
@@ -1425,6 +1427,8 @@ cdef class CrystalOfBKKTableauxElement(TensorProductOfSuperCrystalsElement):
 
         """
         from sage.misc.latex_standalone import Standalone
+        if not 'standalone_config' in kwds:
+            kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 
     @cached_method
@@ -1782,6 +1786,8 @@ cdef class InfinityQueerCrystalOfTableauxElement(TensorProductOfQueerSuperCrysta
 
         """
         from sage.misc.latex_standalone import Standalone
+        if not 'standalone_config' in kwds:
+            kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 
     def rows(self):

--- a/src/sage/combinat/crystals/tensor_product_element.pyx
+++ b/src/sage/combinat/crystals/tensor_product_element.pyx
@@ -149,7 +149,7 @@ cdef class TensorProductOfCrystalsElement(ImmutableListWithParent):
 
         """
         from sage.misc.latex_standalone import Standalone
-        if not 'standalone_config' in kwds:
+        if 'standalone_config' not in kwds:
             kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 
@@ -925,7 +925,7 @@ cdef class CrystalOfTableauxElement(TensorProductOfRegularCrystalsElement):
 
         """
         from sage.misc.latex_standalone import Standalone
-        if not 'standalone_config' in kwds:
+        if 'standalone_config' not in kwds:
             kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 
@@ -1426,7 +1426,7 @@ cdef class CrystalOfBKKTableauxElement(TensorProductOfSuperCrystalsElement):
 
         """
         from sage.misc.latex_standalone import Standalone
-        if not 'standalone_config' in kwds:
+        if 'standalone_config' not in kwds:
             kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 
@@ -1785,7 +1785,7 @@ cdef class InfinityQueerCrystalOfTableauxElement(TensorProductOfQueerSuperCrysta
 
         """
         from sage.misc.latex_standalone import Standalone
-        if not 'standalone_config' in kwds:
+        if 'standalone_config' not in kwds:
             kwds['standalone_config'] = ["border=1pt"]
         return Standalone(self._latex_(), **kwds)
 


### PR DESCRIPTION
We add a tikz (or latex_standalone) method within combinat.crystals module in every class where a _latex_ method is defined. When the string is a tikzpicture, we add a tikz method. When the string is a generic picture, we add a latex_standalone method.

Hopefully, it fixes #38745.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None. 

The branch was written on top of old SageMath version 10.4.beta9, Release Date: 2024-06-09

### Notes

While writing this branch, it made me realize that the latex code generated by the following two methods is broken:

```
x = crystals.infinity.GeneralizedYoungWalls(3)([[],[1,0,3,2],[2,1],[3,2,1,0,3,2],[],[],[2]])
x._latex_()
x.large_latex()
```

because the last draw command uses variable \t which is defined in the inner scope. I did not try to fix that issue here. This is why I added a "known bug" tag at two places.