### PR TITLE
use StructureDescription() in gap/element.pyx tests

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2437,31 +2437,22 @@ cdef class GapElement_Function(GapElement):
             <Gap function "NormalSubgroups">
             sage: b
             Sym( [ 1 .. 4 ] )
-            sage: sorted(a(b))
-            [Group(()),
-             Sym( [ 1 .. 4 ] ),
-             Alt( [ 1 .. 4 ] ),
-             Group([ (1,4)(2,3), (1,2)(3,4) ])]
+            sage: [x.StructureDescription() for x in sorted(b.NormalSubgroups())
+            ["1", "S4", "A4", "C2 x C2"]
 
             sage: libgap.eval("a := NormalSubgroups")
             <Gap function "NormalSubgroups">
             sage: libgap.eval("b := SymmetricGroup(4)")
             Sym( [ 1 .. 4 ] )
             sage: libgap.collect()
-            sage: sorted(libgap.eval('a') (libgap.eval('b')))
-            [Group(()),
-             Sym( [ 1 .. 4 ] ),
-             Alt( [ 1 .. 4 ] ),
-             Group([ (1,4)(2,3), (1,2)(3,4) ])]
+            sage: [x.StructureDescription() for x in sorted(libgap.eval('a') (libgap.eval('b')))]
+            ["1", "S4", "A4", "C2 x C2"]
 
             sage: a = libgap.eval('a')
             sage: b = libgap.eval('b')
             sage: libgap.collect()
-            sage: sorted(a(b))
-            [Group(()),
-             Sym( [ 1 .. 4 ] ),
-             Alt( [ 1 .. 4 ] ),
-             Group([ (1,4)(2,3), (1,2)(3,4) ])]
+            sage: [x.StructureDescription() for x in sorted(b.NormalSubgroups())
+            ["1", "S4", "A4", "C2 x C2"]
 
         Not every ``GapElement`` is callable::
 

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2451,7 +2451,7 @@ cdef class GapElement_Function(GapElement):
             sage: a = libgap.eval('a')
             sage: b = libgap.eval('b')
             sage: libgap.collect()
-            sage: [x.StructureDescription() for x in sorted(b.NormalSubgroups())]
+            sage: [x.StructureDescription() for x in sorted(a(b))]
             ["1", "S4", "A4", "C2 x C2"]
 
         Not every ``GapElement`` is callable::

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2437,7 +2437,7 @@ cdef class GapElement_Function(GapElement):
             <Gap function "NormalSubgroups">
             sage: b
             Sym( [ 1 .. 4 ] )
-            sage: [x.StructureDescription() for x in sorted(b.NormalSubgroups())
+            sage: [x.StructureDescription() for x in sorted(b.NormalSubgroups())]
             ["1", "S4", "A4", "C2 x C2"]
 
             sage: libgap.eval("a := NormalSubgroups")
@@ -2451,7 +2451,7 @@ cdef class GapElement_Function(GapElement):
             sage: a = libgap.eval('a')
             sage: b = libgap.eval('b')
             sage: libgap.collect()
-            sage: [x.StructureDescription() for x in sorted(b.NormalSubgroups())
+            sage: [x.StructureDescription() for x in sorted(b.NormalSubgroups())]
             ["1", "S4", "A4", "C2 x C2"]
 
         Not every ``GapElement`` is callable::

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2437,7 +2437,7 @@ cdef class GapElement_Function(GapElement):
             <Gap function "NormalSubgroups">
             sage: b
             Sym( [ 1 .. 4 ] )
-            sage: [x.StructureDescription() for x in sorted(b.NormalSubgroups())]
+            sage: [x.StructureDescription() for x in sorted(a(b))]
             ["1", "S4", "A4", "C2 x C2"]
 
             sage: libgap.eval("a := NormalSubgroups")


### PR DESCRIPTION
This will fix #38760

The output of these tests is too verbose, and this unstable. We fix it here

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



