### PR TITLE
Fix time limitation in magma_free docstring

### DIFF
--- a/src/sage/interfaces/magma_free.py
+++ b/src/sage/interfaces/magma_free.py
@@ -29,7 +29,7 @@ def magma_free_eval(code, strip=True, columns=0):
     .. WARNING::
     
         The code must evaluate in at most 120 seconds
-    and there is a limitation on the amount of RAM.
+        and there is a limitation on the amount of RAM.
 
     EXAMPLES::
 

--- a/src/sage/interfaces/magma_free.py
+++ b/src/sage/interfaces/magma_free.py
@@ -26,7 +26,7 @@ def magma_free_eval(code, strip=True, columns=0):
     Use the free online MAGMA calculator to evaluate the given
     input code and return the answer as a string.
 
-    LIMITATIONS: The code must evaluate in at most 20 seconds
+    LIMITATIONS: The code must evaluate in at most 120 seconds
     and there is a limitation on the amount of RAM.
 
     EXAMPLES::

--- a/src/sage/interfaces/magma_free.py
+++ b/src/sage/interfaces/magma_free.py
@@ -27,7 +27,6 @@ def magma_free_eval(code, strip=True, columns=0):
     input code and return the answer as a string.
 
     .. WARNING::
-    
         The code must evaluate in at most 120 seconds
         and there is a limitation on the amount of RAM.
 

--- a/src/sage/interfaces/magma_free.py
+++ b/src/sage/interfaces/magma_free.py
@@ -26,7 +26,9 @@ def magma_free_eval(code, strip=True, columns=0):
     Use the free online MAGMA calculator to evaluate the given
     input code and return the answer as a string.
 
-    LIMITATIONS: The code must evaluate in at most 120 seconds
+    .. WARNING::
+    
+        The code must evaluate in at most 120 seconds
     and there is a limitation on the amount of RAM.
 
     EXAMPLES::

--- a/src/sage/interfaces/magma_free.py
+++ b/src/sage/interfaces/magma_free.py
@@ -27,6 +27,7 @@ def magma_free_eval(code, strip=True, columns=0):
     input code and return the answer as a string.
 
     .. WARNING::
+
         The code must evaluate in at most 120 seconds
         and there is a limitation on the amount of RAM.
 


### PR DESCRIPTION
<!-- v Describe your changes below in detail. -->
Change time limitation from 20 to 120 in the documentation of magma_free.
<!-- v Why is this change required? What problem does it solve? -->

> Calculations are restricted to 120 seconds.
http://magma.maths.usyd.edu.au/calc/

> <max_time>120</max_time>
http://magma.maths.usyd.edu.au/xml/calculator.xml?input=Factorization(15)


<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


