### PR TITLE
rpy2 (standard) cannot depend on r (optional)

### DIFF
--- a/build/pkgs/rpy2/dependencies
+++ b/build/pkgs/rpy2/dependencies
@@ -1,4 +1,4 @@
- r cffi tzlocal pytz jinja2 | $(PYTHON_TOOLCHAIN) pycparser $(PYTHON)
+ cffi tzlocal pytz jinja2 | $(PYTHON_TOOLCHAIN) pycparser $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
"make download-for-sdist" tries to download all standard sources and fails if we depend on a dummy package. Presumably fine since the r dummy package should only used at configure time.

Fixes #38773 