### PR TITLE
Set explicit install name path on macOS suitesparse

### DIFF
--- a/build/pkgs/suitesparse/spkg-install.in
+++ b/build/pkgs/suitesparse/spkg-install.in
@@ -9,7 +9,10 @@ echo "Configuring suitesparse"
 # gcc and gfortran version are not matching.
 # * SUITESPARSE_ENABLE_PROJECTS semi column separated list of the desired packages. Default is
 # all the packages in the suitesparse tarball.
+# On macOS ARM cvxopt does not start if suitesparse uses @rpath, set explicit install name dir instead
 sdh_cmake -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DCMAKE_INSTALL_NAME_DIR="$SAGE_LOCAL/lib" \
+          -DCMAKE_MACOSX_RPATH=OFF \
           -DNSTATIC=ON \
           -DSUITESPARSE_USE_FORTRAN=OFF \
           -DSUITESPARSE_INCLUDEDIR_POSTFIX="" \


### PR DESCRIPTION
Without this cvxopt fails to start
 
Fixes https://github.com/sagemath/sage/issues/38771