### PR TITLE
Fix test failures due to global mpmath state

### DIFF
--- a/src/sage/functions/orthogonal_polys.py
+++ b/src/sage/functions/orthogonal_polys.py
@@ -2343,10 +2343,10 @@ class Func_ultraspherical(GinacFunction):
         sage: # needs mpmath
         sage: from mpmath import gegenbauer as gegenbauer_mp
         sage: from mpmath import mp
-        sage: mp.pretty = True; mp.dps=25
-        sage: gegenbauer_mp(-7,0.5,0.3)
+        sage: print(gegenbauer_mp(-7,0.5,0.3))
         0.1291811875
-        sage: gegenbauer_mp(2+3j, -0.75, -1000j)
+        sage: with mp.workdps(25):
+        ....:     print(gegenbauer_mp(2+3j, -0.75, -1000j))
         (-5038991.358609026523401901 + 9414549.285447104177860806j)
 
     TESTS:

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -983,7 +983,6 @@ cdef class Context:
         TESTS::
 
             sage: from mpmath import mp
-            sage: mp.pretty = True
             sage: (x, T) = mp._convert_param(3)
             sage: (x, type(x).__name__, T)
             (3, 'int', 'Z')
@@ -991,11 +990,11 @@ cdef class Context:
             sage: (x, type(x).__name__, T)
             (mpq(5,2), 'mpq', 'Q')
             sage: (x, T) = mp._convert_param(2.3)
-            sage: (x, type(x).__name__, T)
-            (2.3, 'mpf', 'R')
+            sage: (str(x), type(x).__name__, T)
+            ('2.3', 'mpf', 'R')
             sage: (x, T) = mp._convert_param(2+3j)
             sage: (x, type(x).__name__, T)
-            ((2.0 + 3.0j), 'mpc', 'C')
+            (mpc(real='2.0', imag='3.0'), 'mpc', 'C')
             sage: mp.pretty = False
         """
         cdef MPF v

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -1056,7 +1056,6 @@ cdef class Context:
         TESTS::
 
             sage: from mpmath import *
-            sage: mp.pretty = True
             sage: mag(10), mag(10.0), mag(mpf(10)), int(ceil(log(10,2)))
             (4, 4, 4, 4)
             sage: mag(10j), mag(10+10j)
@@ -1064,7 +1063,7 @@ cdef class Context:
             sage: mag(0.01), int(ceil(log(0.01,2)))
             (-6, -6)
             sage: mag(0), mag(inf), mag(-inf), mag(nan)
-            (-inf, +inf, +inf, nan)
+            (mpf('-inf'), mpf('+inf'), mpf('+inf'), mpf('nan'))
 
     ::
 

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -2201,12 +2201,13 @@ cdef class constant(mpf_base):
         Represent ``self`` as a string. With mp.pretty=False, the
         representation differs from that of an ordinary mpf::
 
-            sage: from mpmath import mp, pi
-            sage: mp.pretty = True
-            sage: repr(pi)
+            sage: from mpmath import mp
+            sage: mp2 = mp.clone()
+            sage: mp2.pretty = True
+            sage: repr(mp2.pi)
             '3.14159265358979'
-            sage: mp.pretty = False
-            sage: repr(pi)
+            sage: mp2.pretty = False
+            sage: repr(mp2.pi)
             '<pi: 3.14159~>'
         """
         if global_context.pretty:
@@ -2372,11 +2373,12 @@ cdef class mpc(mpnumber):
         TESTS::
 
             sage: from mpmath import mp
-            sage: mp.pretty = True
-            sage: repr(mp.mpc(2,3))
+            sage: mp2 = mp.clone()
+            sage: mp2.pretty = True
+            sage: repr(mp2.mpc(2,3))
             '(2.0 + 3.0j)'
-            sage: mp.pretty = False
-            sage: repr(mp.mpc(2,3))
+            sage: mp2.pretty = False
+            sage: repr(mp2.mpc(2,3))
             "mpc(real='2.0', imag='3.0')"
         """
         if global_context.pretty:


### PR DESCRIPTION
mpmath has a global `mp.pretty` variable that affects how its numbers are printed. On my machine, it's not reliable. For example:

```
Failed example:
    repr(mp.mpc(2,3))
Expected:
    '(2.0 + 3.0j)'
Got:
    "mpc(real='2.0', imag='3.0')"
```

I've only fixed the tests that are failing for me, since mpmath-1.4 is on the TODO list. A few different strategies are used:

* `print()` will use the pretty format if all we're doing is displaying an answer.
* `with workdps` can be used to change the precision only locally.
* In TESTS blocks, the ugly output is acceptable.
* When actually testing `mp.pretty`, we can first clone the `mp` object with `mp2 = mp.clone()`, and then work on the new one.
