### PR TITLE
introduce limit(expr, v, a) syntax

### DIFF
--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -1155,7 +1155,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 ###################################################################
 # limits
 ###################################################################
-def limit(ex, dir=None, taylor=False, algorithm='maxima', **argv):
+def limit(ex, v=None, a=None, dir=None, taylor=False, algorithm='maxima', **argv):
     r"""
     Return the limit as the variable `v` approaches `a`
     from the given direction.
@@ -1413,8 +1413,12 @@ def limit(ex, dir=None, taylor=False, algorithm='maxima', **argv):
     if not isinstance(ex, Expression):
         ex = SR(ex)
 
-    if len(argv) != 1:
-        raise ValueError("call the limit function like this, e.g. limit(expr, x=2).")
+    if  (v is not None or a is not None):
+        if len(argv) != 0:
+            raise ValueError("if you call limit as limit(expr, x, 2) you cannot specify 'x=0'")
+        v = var(v)
+    elif len(argv) != 1:
+        raise ValueError("call the limit function like this, e.g. limit(expr, x=2), or as limit(expr, x, 2).")
     else:
         k, = argv.keys()
         v = var(k)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

following up on discussion https://groups.google.com/g/sage-support/c/o3r9bObqz3s, we introduce the notation
```
limit(expr, v, a)
```
here to get a more direct interface with the internals. The current syntax only accepts `limit(expr, v=a)` which is cute, but it requires the variable to be denoted by a string. This can be problematic when, for instance, you want to take a limit with respect to `X[0]` where `X=var('x',n=3)`, in which case the string description of the variable is not directly available.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


