### PR TITLE
use specialized 2-dimensional .log() method in .matrix_on_subgroup()

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -1118,10 +1118,8 @@ class EllipticCurveHom(Morphism):
         imP = self._eval(P)
         imQ = self._eval(Q)
 
-        from sage.groups.additive_abelian.additive_abelian_wrapper import AdditiveAbelianGroupWrapper
-        H = AdditiveAbelianGroupWrapper(R.parent(), [R,S], [n,n])
-        vecP = H.discrete_log(imP)
-        vecQ = H.discrete_log(imQ)
+        vecP = imP.log([R, S])
+        vecQ = imQ.log([R, S])
 
         from sage.matrix.constructor import matrix
         from sage.rings.finite_rings.integer_mod_ring import Zmod


### PR DESCRIPTION
This should be equivalent but faster (see #38347).

```sage
sage: E = EllipticCurve(GF((2^77-33, 2)), [1,0])
....: P, Q = E.gens()
....: pi = E.automorphisms()[-1]
....: %time pi.matrix_on_subgroup([P, Q])
```

Sage 10.5.beta7:
```
CPU times: user 13.8 s, sys: 32.5 ms, total: 13.8 s
```

This branch:
```
CPU times: user 48.1 ms, sys: 64 µs, total: 48.2 ms
```