### PR TITLE
faster comparison of elliptic-curve morphisms

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -270,6 +270,13 @@ class EllipticCurveHom(Morphism):
         if lx != rx:
             return richcmp_not_equal(lx, rx, op)
 
+        # Check the Weierstraß scaling factor, too (should be fast)
+
+        if op == op_EQ or op == op_NE:
+            lx, rx = self.scaling_factor(), other.scaling_factor()
+            if lx != rx:
+                return richcmp_not_equal(lx, rx, op)
+
         # Do self or other have specialized comparison methods?
 
         ret = self._comparison_impl(self, other, op)
@@ -1176,6 +1183,12 @@ def compare_via_evaluation(left, right):
     F = E.base_ring()
 
     if isinstance(F, finite_field_base.FiniteField):
+        # check at a random rational point first
+        P = E.random_point()
+        if left(P) != right(P):
+            return False
+
+        # then extend to a field with enough points to conclude
         q = F.cardinality()
         d = left.degree()
         e = integer_floor(1 + 2 * (2*d.sqrt() + 1).log(q))  # from Hasse bound
@@ -1183,6 +1196,7 @@ def compare_via_evaluation(left, right):
         EE = E.base_extend(F.extension(e, 'U'))  # named extension is faster
         Ps = EE.gens()
         return all(left._eval(P) == right._eval(P) for P in Ps)
+
     elif isinstance(F, number_field_base.NumberField):
         for _ in range(100):
             P = E.lift_x(F.random_element(), extend=True)
@@ -1190,6 +1204,7 @@ def compare_via_evaluation(left, right):
                 return left._eval(P) == right._eval(P)
         else:
             assert False, "couldn't find a point of infinite order"
+
     else:
         raise NotImplementedError('not implemented for this base field')
 


### PR DESCRIPTION
Here we add two fast checks to the generic comparison method for elliptic-curve morphisms that will quickly detect some pairs of unequal morphisms. In the context of #35949, this speeds up the following example from 5.9 seconds to 1.8 seconds:
```sage
sage: E = EllipticCurve(GF((5, 2)), [0,1])
sage: %time _ = list(E.isogenies_degree(27))
```