### PR TITLE
fix all pep E302 in manifolds and geometry

### DIFF
--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -72,6 +72,7 @@ individual functions and the references therein.
 # the top-level non-underscore functions defined in this module.
 #
 
+
 def _preprocess_args(ambient_dim, lattice):
     r"""
     Preprocess arguments for cone-constructing functions.

--- a/src/sage/geometry/cone_critical_angles.py
+++ b/src/sage/geometry/cone_critical_angles.py
@@ -40,6 +40,7 @@ from sage.rings.rational_field import QQ
 from sage.rings.real_double import RDF
 from sage.symbolic.constants import pi
 
+
 def _normalize_gevp_solution(gevp_solution):
     r"""
     Normalize the results of :func:`solve_gevp_nonzero` and

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_coercion.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_coercion.py
@@ -29,6 +29,7 @@ from sage.misc.functional import sqrt
 from sage.misc.lazy_import import lazy_import
 lazy_import('sage.misc.call', 'attrcall')
 
+
 class HyperbolicModelCoercion(Morphism):
     """
     Abstract base class for morphisms between the hyperbolic models.
@@ -148,6 +149,7 @@ class HyperbolicModelCoercion(Morphism):
 # From UHP #
 ############
 
+
 class CoercionUHPtoPD(HyperbolicModelCoercion):
     """
     Coercion from the UHP to PD model.
@@ -188,6 +190,7 @@ class CoercionUHPtoPD(HyperbolicModelCoercion):
             return matrix([[1,-I],[-I,1]]) * x * matrix([[1,I],[I,1]]).conjugate()/Integer(2)
         return matrix([[1,-I],[-I,1]]) * x * matrix([[1,I],[I,1]])/Integer(2)
 
+
 class CoercionUHPtoKM(HyperbolicModelCoercion):
     """
     Coercion from the UHP to KM model.
@@ -226,6 +229,7 @@ class CoercionUHPtoKM(HyperbolicModelCoercion):
             [0 0 1]
         """
         return SL2R_to_SO21(x)
+
 
 class CoercionUHPtoHM(HyperbolicModelCoercion):
     """
@@ -268,6 +272,7 @@ class CoercionUHPtoHM(HyperbolicModelCoercion):
 ###########
 # From PD #
 ###########
+
 
 class CoercionPDtoUHP(HyperbolicModelCoercion):
     """
@@ -317,6 +322,7 @@ class CoercionPDtoUHP(HyperbolicModelCoercion):
         if not HyperbolicIsometryPD._orientation_preserving(x):
             return matrix([[1,I],[I,1]]) * x * matrix([[1,-I],[-I,1]]).conjugate() / Integer(2)
         return matrix([[1,I],[I,1]]) * x * matrix([[1,-I],[-I,1]]) / Integer(2)
+
 
 class CoercionPDtoKM(HyperbolicModelCoercion):
     """
@@ -444,6 +450,7 @@ class CoercionKMtoUHP(HyperbolicModelCoercion):
         """
         return SO21_to_SL2R(x)
 
+
 class CoercionKMtoPD(HyperbolicModelCoercion):
     """
     Coercion from the KM to PD model.
@@ -481,6 +488,7 @@ class CoercionKMtoPD(HyperbolicModelCoercion):
         """
         return (matrix(2,[1,-I,-I,1]) * SO21_to_SL2R(x) *
                 matrix(2,[1,I,I,1])/Integer(2))
+
 
 class CoercionKMtoHM(HyperbolicModelCoercion):
     """
@@ -524,6 +532,7 @@ class CoercionKMtoHM(HyperbolicModelCoercion):
 # From HM #
 ###########
 
+
 class CoercionHMtoUHP(HyperbolicModelCoercion):
     """
     Coercion from the HM to UHP model.
@@ -560,6 +569,7 @@ class CoercionHMtoUHP(HyperbolicModelCoercion):
         """
         return SO21_to_SL2R(x)
 
+
 class CoercionHMtoPD(HyperbolicModelCoercion):
     """
     Coercion from the HM to PD model.
@@ -595,6 +605,7 @@ class CoercionHMtoPD(HyperbolicModelCoercion):
         """
         return (matrix(2,[1,-I,-I,1]) * SO21_to_SL2R(x) *
                 matrix(2,[1,I,I,1])/Integer(2))
+
 
 class CoercionHMtoKM(HyperbolicModelCoercion):
     """
@@ -634,6 +645,7 @@ class CoercionHMtoKM(HyperbolicModelCoercion):
 
 #####################################################################
 ## Helper functions
+
 
 def SL2R_to_SO21(A):
     r"""

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_isometry.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_isometry.py
@@ -620,6 +620,7 @@ class HyperbolicIsometry(Morphism):
         fp = self._cached_isometry.attracting_fixed_point()
         return self.domain().get_point(fp)
 
+
 class HyperbolicIsometryUHP(HyperbolicIsometry):
     r"""
     Create a hyperbolic isometry in the UHP model.
@@ -881,6 +882,7 @@ class HyperbolicIsometryUHP(HyperbolicIsometry):
             return self.domain().get_point(infinity)
         return self.domain().get_point(v[0] / v[1])
 
+
 class HyperbolicIsometryPD(HyperbolicIsometry):
     r"""
     Create a hyperbolic isometry in the PD model.
@@ -981,6 +983,7 @@ class HyperbolicIsometryPD(HyperbolicIsometry):
         """
         return bool(A[1][0] == A[0][1].conjugate() and A[1][1] == A[0][0].conjugate()
                     and abs(A[0][0]) - abs(A[0][1]) != 0)
+
 
 class HyperbolicIsometryKM(HyperbolicIsometry):
     r"""

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_point.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_point.py
@@ -74,6 +74,7 @@ from sage.functions.other import real, imag
 
 from sage.geometry.hyperbolic_space.hyperbolic_isometry import HyperbolicIsometry
 
+
 class HyperbolicPoint(Element):
     r"""
     Abstract base class for hyperbolic points.  This class should never

--- a/src/sage/geometry/hyperplane_arrangement/check_freeness.py
+++ b/src/sage/geometry/hyperplane_arrangement/check_freeness.py
@@ -26,6 +26,7 @@ for details.
 from sage.matrix.constructor import matrix
 import sage.libs.singular.function_factory as fun_fact
 
+
 def less_generators(X):
     """
     Reduce the generator matrix of the module defined by ``X``.
@@ -62,6 +63,7 @@ def less_generators(X):
             return X
         Kd = set(range(X.nrows())).difference(K)
         X = X.matrix_from_rows(sorted(Kd))
+
 
 def construct_free_chain(A):
     """

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -415,6 +415,7 @@ def ReflexivePolytope(dim, n):
 # Sequences of reflexive polytopes
 _rp = [None] * 4
 
+
 def ReflexivePolytopes(dim):
     r"""
     Return the sequence of all 2- or 3-dimensional reflexive polytopes.
@@ -493,6 +494,7 @@ def is_LatticePolytope(x):
     from sage.misc.superseded import deprecation
     deprecation(34307, "is_LatticePolytope is deprecated, use isinstance instead")
     return isinstance(x, LatticePolytopeClass)
+
 
 @richcmp_method
 class LatticePolytopeClass(ConvexSet_compact, Hashable, sage.geometry.abc.LatticePolytope):
@@ -4981,6 +4983,7 @@ class NefPartition(SageObject, Hashable):
 
 
 _palp_dimension = None
+
 
 def _palp(command, polytopes, reduce_dimension=False):
     r"""

--- a/src/sage/geometry/polyhedron/backend_polymake.py
+++ b/src/sage/geometry/polyhedron/backend_polymake.py
@@ -724,6 +724,8 @@ class Polyhedron_polymake(Polyhedron_base):
         tester.assertEqual(P.AFFINE_HULL, P1.AFFINE_HULL)
 
 #########################################################################
+
+
 class Polyhedron_QQ_polymake(Polyhedron_polymake, Polyhedron_QQ):
     r"""
     Polyhedra over `\QQ` with polymake.

--- a/src/sage/geometry/polyhedron/base0.py
+++ b/src/sage/geometry/polyhedron/base0.py
@@ -35,6 +35,7 @@ from sage.misc.abstract_method import abstract_method
 from sage.structure.element import Element
 import sage.geometry.abc
 
+
 class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
     """
     Initialization and basic access for polyhedra.

--- a/src/sage/geometry/polyhedron/base2.py
+++ b/src/sage/geometry/polyhedron/base2.py
@@ -37,6 +37,7 @@ from sage.rings.integer_ring import ZZ
 from sage.modules.free_module_element import vector
 from .base1 import Polyhedron_base1
 
+
 class Polyhedron_base2(Polyhedron_base1):
     """
     Methods related to lattice points.

--- a/src/sage/geometry/polyhedron/base3.py
+++ b/src/sage/geometry/polyhedron/base3.py
@@ -38,6 +38,7 @@ from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from .base2 import Polyhedron_base2
 
+
 class Polyhedron_base3(Polyhedron_base2):
     """
     Methods related to the combinatorics of a polyhedron.

--- a/src/sage/geometry/polyhedron/base4.py
+++ b/src/sage/geometry/polyhedron/base4.py
@@ -36,6 +36,7 @@ Define methods relying on :mod:`sage.graphs`.
 from sage.misc.cachefunc import cached_method
 from .base3 import Polyhedron_base3
 
+
 class Polyhedron_base4(Polyhedron_base3):
     """
     Methods relying on :mod:`sage.graphs`.

--- a/src/sage/geometry/polyhedron/base5.py
+++ b/src/sage/geometry/polyhedron/base5.py
@@ -42,6 +42,7 @@ from sage.modules.free_module_element import vector
 
 from .base4 import Polyhedron_base4
 
+
 class Polyhedron_base5(Polyhedron_base4):
     """
     Methods constructing new polyhedra

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -37,6 +37,7 @@ from sage.modules.free_module_element import vector
 from sage.geometry.convex_set import AffineHullProjectionData
 from .base5 import Polyhedron_base5
 
+
 class Polyhedron_base6(Polyhedron_base5):
     r"""
     Methods related to plotting including affine hull projection.

--- a/src/sage/geometry/polyhedron/base7.py
+++ b/src/sage/geometry/polyhedron/base7.py
@@ -37,6 +37,7 @@ from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from .base6 import Polyhedron_base6
 
+
 class Polyhedron_base7(Polyhedron_base6):
     r"""
     Methods related to triangulation and volume.

--- a/src/sage/geometry/polyhedron/cdd_file_format.py
+++ b/src/sage/geometry/polyhedron/cdd_file_format.py
@@ -14,6 +14,8 @@ Generate cdd ``.ext`` / ``.ine`` file format
 from .misc import _set_to_None_if_empty, _common_length_of, _to_space_separated_string
 
 #########################################################################
+
+
 def cdd_Vrepresentation(cdd_type, vertices, rays, lines, file_output=None):
     r"""
     Return a string containing the V-representation in cddlib's ext format.
@@ -92,6 +94,8 @@ def cdd_Vrepresentation(cdd_type, vertices, rays, lines, file_output=None):
         return s
 
 #########################################################################
+
+
 def cdd_Hrepresentation(cdd_type, ieqs, eqns, file_output=None):
     r"""
     Return a string containing the H-representation in cddlib's ine format.

--- a/src/sage/geometry/polyhedron/double_description.py
+++ b/src/sage/geometry/polyhedron/double_description.py
@@ -704,6 +704,7 @@ class StandardDoubleDescriptionPair(DoubleDescriptionPair):
         self.R = R_pos + R_nul + R_new
         self.A.append(a)
 
+
 class StandardAlgorithm(Problem):
     """
     Standard implementation of the double description algorithm.

--- a/src/sage/geometry/polyhedron/face.py
+++ b/src/sage/geometry/polyhedron/face.py
@@ -991,6 +991,7 @@ class PolyhedronFace(ConvexSet_closed):
 
         return parent.element_class(parent, None, [locus_ieqs, locus_eqns])
 
+
 def combinatorial_face_to_polyhedral_face(polyhedron, combinatorial_face):
     r"""
     Convert a combinatorial face to a face of a polyhedron.

--- a/src/sage/geometry/polyhedron/library.py
+++ b/src/sage/geometry/polyhedron/library.py
@@ -91,6 +91,7 @@ lazy_import('sage.graphs.digraph', 'DiGraph')
 lazy_import('sage.graphs.graph', 'Graph')
 lazy_import('sage.combinat.root_system.associahedron', 'Associahedron')
 
+
 def zero_sum_projection(d, base_ring=None):
     r"""
     Return a matrix corresponding to the projection on the orthogonal of
@@ -318,6 +319,7 @@ def gale_transform_to_polytope(vectors, base_ring=None, backend=None):
         raise ValueError("the gale transform does not correspond to a polytope")
 
     return P
+
 
 def gale_transform_to_primal(vectors, base_ring=None, backend=None):
     r"""

--- a/src/sage/geometry/ribbon_graph.py
+++ b/src/sage/geometry/ribbon_graph.py
@@ -32,6 +32,7 @@ from copy import deepcopy
 
 #Auxiliary functions that will be used in the classes.
 
+
 def _find(l, k):
     r"""
     Return the two coordinates of the element ``k`` in the list of
@@ -1078,6 +1079,7 @@ class RibbonGraph(SageObject, UniqueRepresentation):
                         PermutationConstructor([tuple(x) for x in aux_rho])
                         )
 
+
 def make_ribbon(g, r):
     r"""
     Return a ribbon graph whose thickening has genus ``g`` and ``r``
@@ -1150,6 +1152,7 @@ def make_ribbon(g, r):
 
     return RibbonGraph(PermutationConstructor([tuple(x) for x in repr_sigma]),
                        PermutationConstructor([tuple(x) for x in repr_rho]))
+
 
 def bipartite_ribbon_graph(p, q):
     r"""

--- a/src/sage/manifolds/catalog.py
+++ b/src/sage/manifolds/catalog.py
@@ -93,6 +93,7 @@ def Minkowski(positive_spacelike=True, names=None):
     g[1,1], g[2,2], g[3,3] = sgn, sgn, sgn
     return M
 
+
 def Kerr(m=1, a=0, coordinates='BL', names=None):
     """
     Generate a Kerr spacetime.
@@ -216,6 +217,7 @@ def Kerr(m=1, a=0, coordinates='BL', names=None):
 
     raise NotImplementedError("coordinates system not implemented, see help"
                               " for details")
+
 
 def Torus(R=2, r=1, names=None):
     """

--- a/src/sage/manifolds/chart.py
+++ b/src/sage/manifolds/chart.py
@@ -3270,6 +3270,7 @@ class RealChart(Chart):
 
 # *****************************************************************************
 
+
 class CoordChange(SageObject):
     r"""
     Transition map between two charts of a topological manifold.

--- a/src/sage/manifolds/chart_func.py
+++ b/src/sage/manifolds/chart_func.py
@@ -2613,6 +2613,7 @@ class ChartFunction(AlgebraElement, ModuleElementWithMutability):
         self._del_derived()
         return self
 
+
 class ChartFunctionRing(Parent, UniqueRepresentation):
     """
     Ring of all chart functions on a chart.

--- a/src/sage/manifolds/continuous_map.py
+++ b/src/sage/manifolds/continuous_map.py
@@ -34,6 +34,7 @@ REFERENCES:
 from sage.categories.homset import Hom
 from sage.categories.morphism import Morphism
 
+
 class ContinuousMap(Morphism):
     r"""
     Continuous map between two topological manifolds.

--- a/src/sage/manifolds/continuous_map_image.py
+++ b/src/sage/manifolds/continuous_map_image.py
@@ -19,6 +19,7 @@ subset of `N`.
 
 from sage.manifolds.subset import ManifoldSubset
 
+
 class ImageManifoldSubset(ManifoldSubset):
     r"""
     Subset of a topological manifold that is a continuous image of a manifold subset.

--- a/src/sage/manifolds/differentiable/affine_connection.py
+++ b/src/sage/manifolds/differentiable/affine_connection.py
@@ -35,6 +35,7 @@ from sage.manifolds.differentiable.manifold import DifferentiableManifold
 from sage.parallel.decorate import parallel
 from sage.parallel.parallelism import Parallelism
 
+
 class AffineConnection(SageObject):
     r"""
     Affine connection on a smooth manifold.

--- a/src/sage/manifolds/differentiable/automorphismfield.py
+++ b/src/sage/manifolds/differentiable/automorphismfield.py
@@ -28,6 +28,7 @@ from sage.tensor.modules.free_module_automorphism import FreeModuleAutomorphism
 from sage.manifolds.differentiable.tensorfield import TensorField
 from sage.manifolds.differentiable.tensorfield_paral import TensorFieldParal
 
+
 class AutomorphismField(TensorField):
     r"""
     Field of automorphisms of tangent spaces to a generic (a priori

--- a/src/sage/manifolds/differentiable/automorphismfield_group.py
+++ b/src/sage/manifolds/differentiable/automorphismfield_group.py
@@ -48,6 +48,7 @@ from sage.manifolds.differentiable.vectorfield_module import (VectorFieldModule,
 from sage.manifolds.differentiable.automorphismfield import (AutomorphismField,
                                                              AutomorphismFieldParal)
 
+
 class AutomorphismFieldGroup(UniqueRepresentation, Parent):
     r"""
     General linear group of the module of vector fields along a differentiable

--- a/src/sage/manifolds/differentiable/chart.py
+++ b/src/sage/manifolds/differentiable/chart.py
@@ -1069,6 +1069,7 @@ class RealDiffChart(DiffChart, RealChart):
 
 #******************************************************************************
 
+
 class DiffCoordChange(CoordChange):
     r"""
     Transition map between two charts of a differentiable manifold.

--- a/src/sage/manifolds/differentiable/curve.py
+++ b/src/sage/manifolds/differentiable/curve.py
@@ -37,6 +37,7 @@ from sage.misc.decorators import options
 from sage.manifolds.point import ManifoldPoint
 from sage.manifolds.differentiable.diff_map import DiffMap
 
+
 class DifferentiableCurve(DiffMap):
     r"""
     Curve in a differentiable manifold.

--- a/src/sage/manifolds/differentiable/de_rham_cohomology.py
+++ b/src/sage/manifolds/differentiable/de_rham_cohomology.py
@@ -53,6 +53,7 @@ from sage.categories.algebras import Algebras
 from .characteristic_cohomology_class import (CharacteristicCohomologyClassRing,
                                               CharacteristicCohomologyClassRingElement)
 
+
 class DeRhamCohomologyClass(AlgebraElement):
     r"""
     Define a cohomology class in the de Rham cohomology ring.
@@ -297,6 +298,7 @@ class DeRhamCohomologyClass(AlgebraElement):
             if self.representative() == other.representative():
                 return True
         raise NotImplementedError('comparison via exact forms is currently not supported')
+
 
 class DeRhamCohomologyRing(Parent, UniqueRepresentation):
     r"""

--- a/src/sage/manifolds/differentiable/degenerate.py
+++ b/src/sage/manifolds/differentiable/degenerate.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 ###############################################################################
 
+
 class DegenerateManifold(DifferentiableManifold):
     r"""
 
@@ -369,6 +370,7 @@ class DegenerateManifold(DifferentiableManifold):
 
 from sage.manifolds.differentiable.tensorfield_paral import TensorFieldParal
 from sage.manifolds.differentiable.tensorfield import TensorField
+
 
 class TangentTensor(TensorFieldParal):
     r"""

--- a/src/sage/manifolds/differentiable/degenerate_submanifold.py
+++ b/src/sage/manifolds/differentiable/degenerate_submanifold.py
@@ -172,6 +172,7 @@ from sage.symbolic.expression import Expression
 if TYPE_CHECKING:
     from sage.manifolds.differentiable.metric import DegenerateMetric
 
+
 class DegenerateSubmanifold(DegenerateManifold, DifferentiableSubmanifold):
     r"""
     Degenerate submanifolds.

--- a/src/sage/manifolds/differentiable/diff_form_module.py
+++ b/src/sage/manifolds/differentiable/diff_form_module.py
@@ -570,6 +570,7 @@ class DiffFormModule(UniqueRepresentation, Parent):
 
 # *****************************************************************************
 
+
 class DiffFormFreeModule(ExtPowerDualFreeModule):
     r"""
     Free module of differential forms of a given degree `p` (`p`-forms) along

--- a/src/sage/manifolds/differentiable/diff_map.py
+++ b/src/sage/manifolds/differentiable/diff_map.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from sage.manifolds.point import ManifoldPoint
     from sage.tensor.modules.free_module_morphism import FiniteRankFreeModuleMorphism
 
+
 class DiffMap(ContinuousMap):
     r"""
     Differentiable map between two differentiable manifolds.

--- a/src/sage/manifolds/differentiable/examples/euclidean.py
+++ b/src/sage/manifolds/differentiable/examples/euclidean.py
@@ -419,6 +419,7 @@ from sage.manifolds.differentiable.pseudo_riemannian import \
 
 ###############################################################################
 
+
 class EuclideanSpace(PseudoRiemannianManifold):
     r"""
     Euclidean space.
@@ -1040,6 +1041,7 @@ class EuclideanSpace(PseudoRiemannianManifold):
                       coordinates=coordinates, names=names)
 
 ###############################################################################
+
 
 class EuclideanPlane(EuclideanSpace):
     r"""

--- a/src/sage/manifolds/differentiable/examples/real_line.py
+++ b/src/sage/manifolds/differentiable/examples/real_line.py
@@ -33,6 +33,7 @@ from sage.manifolds.differentiable.manifold import DifferentiableManifold
 from sage.manifolds.structure import RealDifferentialStructure
 from sage.categories.manifolds import Manifolds
 
+
 class OpenInterval(DifferentiableManifold):
     r"""
     Open interval as a 1-dimensional differentiable manifold over `\RR`.

--- a/src/sage/manifolds/differentiable/examples/sphere.py
+++ b/src/sage/manifolds/differentiable/examples/sphere.py
@@ -173,6 +173,7 @@ from sage.categories.topological_spaces import TopologicalSpaces
 from sage.rings.real_mpfr import RR
 from sage.manifolds.differentiable.examples.euclidean import EuclideanSpace
 
+
 class Sphere(PseudoRiemannianSubmanifold):
     r"""
     Sphere smoothly embedded in Euclidean Space.

--- a/src/sage/manifolds/differentiable/integrated_curve.py
+++ b/src/sage/manifolds/differentiable/integrated_curve.py
@@ -2864,6 +2864,7 @@ class IntegratedCurve(DifferentiableCurve):
                              aspect_ratio=aspect_ratio, color=color,
                              style=style, label_axes=label_axes)
 
+
 class IntegratedAutoparallelCurve(IntegratedCurve):
     r"""
     Autoparallel curve on the manifold with respect to a given
@@ -3647,6 +3648,7 @@ class IntegratedAutoparallelCurve(IntegratedCurve):
             print(description)
 
         return [self._equations_rhs, v0, chart]
+
 
 class IntegratedGeodesic(IntegratedAutoparallelCurve):
     r"""

--- a/src/sage/manifolds/differentiable/levi_civita_connection.py
+++ b/src/sage/manifolds/differentiable/levi_civita_connection.py
@@ -34,6 +34,7 @@ from sage.parallel.parallelism import Parallelism
 from sage.manifolds.differentiable.affine_connection import AffineConnection
 from sage.manifolds.differentiable.vectorframe import CoordFrame
 
+
 class LeviCivitaConnection(AffineConnection):
     r"""
     Levi-Civita connection on a pseudo-Riemannian manifold.

--- a/src/sage/manifolds/differentiable/manifold_homset.py
+++ b/src/sage/manifolds/differentiable/manifold_homset.py
@@ -49,6 +49,7 @@ from sage.manifolds.differentiable.integrated_curve import IntegratedCurve
 from sage.manifolds.differentiable.integrated_curve import IntegratedAutoparallelCurve
 from sage.manifolds.differentiable.integrated_curve import IntegratedGeodesic
 
+
 class DifferentiableManifoldHomset(TopologicalManifoldHomset):
     r"""
     Set of differentiable maps between two differentiable manifolds.
@@ -508,6 +509,7 @@ class DifferentiableCurveSet(DifferentiableManifoldHomset):
 
 #******************************************************************************
 
+
 class IntegratedCurveSet(DifferentiableCurveSet):
     r"""
     Set of integrated curves in a differentiable manifold.
@@ -962,6 +964,7 @@ class IntegratedCurveSet(DifferentiableCurveSet):
 
 #******************************************************************************
 
+
 class IntegratedAutoparallelCurveSet(IntegratedCurveSet):
     r"""
     Set of integrated autoparallel curves in a differentiable manifold.
@@ -1414,6 +1417,7 @@ class IntegratedAutoparallelCurveSet(IntegratedCurveSet):
         # value above
 
 #******************************************************************************
+
 
 class IntegratedGeodesicSet(IntegratedAutoparallelCurveSet):
     r"""

--- a/src/sage/manifolds/differentiable/mixed_form_algebra.py
+++ b/src/sage/manifolds/differentiable/mixed_form_algebra.py
@@ -37,6 +37,7 @@ from sage.structure.unique_representation import UniqueRepresentation
 from sage.symbolic.ring import SR
 from sage.manifolds.differentiable.mixed_form import MixedForm
 
+
 class MixedFormAlgebra(Parent, UniqueRepresentation):
     r"""
     An instance of this class represents the graded algebra of mixed forms.

--- a/src/sage/manifolds/differentiable/multivector_module.py
+++ b/src/sage/manifolds/differentiable/multivector_module.py
@@ -489,6 +489,7 @@ class MultivectorModule(UniqueRepresentation, Parent):
 
 #***********************************************************************
 
+
 class MultivectorFreeModule(ExtPowerFreeModule):
     r"""
     Free module of multivector fields of a given degree `p` (`p`-vector

--- a/src/sage/manifolds/differentiable/multivectorfield.py
+++ b/src/sage/manifolds/differentiable/multivectorfield.py
@@ -40,6 +40,7 @@ from sage.tensor.modules.alternating_contr_tensor import AlternatingContrTensor
 from sage.manifolds.differentiable.tensorfield import TensorField
 from sage.manifolds.differentiable.tensorfield_paral import TensorFieldParal
 
+
 class MultivectorField(TensorField):
     r"""
     Multivector field with values on a generic (i.e. a priori not

--- a/src/sage/manifolds/differentiable/pseudo_riemannian.py
+++ b/src/sage/manifolds/differentiable/pseudo_riemannian.py
@@ -274,6 +274,7 @@ from sage.manifolds.differentiable.manifold import DifferentiableManifold
 
 ###############################################################################
 
+
 class PseudoRiemannianManifold(DifferentiableManifold):
     r"""
     PseudoRiemannian manifold.

--- a/src/sage/manifolds/differentiable/scalarfield_algebra.py
+++ b/src/sage/manifolds/differentiable/scalarfield_algebra.py
@@ -35,6 +35,7 @@ from sage.symbolic.ring import SymbolicRing
 from sage.manifolds.scalarfield_algebra import ScalarFieldAlgebra
 from sage.manifolds.differentiable.scalarfield import DiffScalarField
 
+
 class DiffScalarFieldAlgebra(ScalarFieldAlgebra):
     r"""
     Commutative algebra of differentiable scalar fields on a differentiable

--- a/src/sage/manifolds/differentiable/symplectic_form_test.py
+++ b/src/sage/manifolds/differentiable/symplectic_form_test.py
@@ -158,6 +158,7 @@ class TestCoherenceOfFormulas:
         b = M.one_form(3,4)
         assert omega.on_forms(a, b) == omega(a.up(omega), b.up(omega))
 
+
 def generic_scalar_field(M: DifferentiableManifold, name: str) -> DiffScalarField:
     chart_functions = {chart: function(name)(*chart[:]) for chart in M.atlas()}
     return M.scalar_field(chart_functions, name=name)

--- a/src/sage/manifolds/differentiable/tangent_space.py
+++ b/src/sage/manifolds/differentiable/tangent_space.py
@@ -34,6 +34,7 @@ from sage.tensor.modules.finite_rank_free_module import FiniteRankFreeModule
 if TYPE_CHECKING:
     from sage.manifolds.point import ManifoldPoint
 
+
 class TangentSpace(FiniteRankFreeModule):
     r"""
     Tangent space to a differentiable manifold at a given point.

--- a/src/sage/manifolds/differentiable/tensorfield_module.py
+++ b/src/sage/manifolds/differentiable/tensorfield_module.py
@@ -587,6 +587,7 @@ class TensorFieldModule(UniqueRepresentation, ReflexiveModule_tensor):
 
 #***********************************************************************
 
+
 class TensorFieldFreeModule(TensorFreeModule):
     r"""
     Free module of tensor fields of a given type `(k,l)` along a

--- a/src/sage/manifolds/differentiable/vector_bundle.py
+++ b/src/sage/manifolds/differentiable/vector_bundle.py
@@ -37,6 +37,7 @@ from sage.rings.infinity import infinity
 from sage.misc.superseded import deprecated_function_alias
 from sage.rings.rational_field import QQ
 
+
 class DifferentiableVectorBundle(TopologicalVectorBundle):
     r"""
     An instance of this class represents a differentiable vector bundle
@@ -332,6 +333,7 @@ class DifferentiableVectorBundle(TopologicalVectorBundle):
         return self._total_space
 
 # *****************************************************************************
+
 
 class TensorBundle(DifferentiableVectorBundle):
     r"""

--- a/src/sage/manifolds/differentiable/vectorfield.py
+++ b/src/sage/manifolds/differentiable/vectorfield.py
@@ -1376,6 +1376,7 @@ class VectorField(MultivectorField):
 
 #******************************************************************************
 
+
 class VectorFieldParal(FiniteRankFreeModuleElement, MultivectorFieldParal,
                        VectorField):
     r"""

--- a/src/sage/manifolds/differentiable/vectorframe.py
+++ b/src/sage/manifolds/differentiable/vectorframe.py
@@ -1554,6 +1554,7 @@ class VectorFrame(FreeModuleBasis):
 
 #******************************************************************************
 
+
 class CoordCoFrame(CoFrame):
     r"""
     Coordinate coframe on a differentiable manifold.
@@ -1666,6 +1667,7 @@ class CoordCoFrame(CoFrame):
         return "Coordinate coframe " + self._name
 
 #******************************************************************************
+
 
 class CoordFrame(VectorFrame):
     r"""

--- a/src/sage/manifolds/family.py
+++ b/src/sage/manifolds/family.py
@@ -28,6 +28,7 @@ AUTHORS:
 from functools import total_ordering
 from sage.sets.family import FiniteFamily
 
+
 @total_ordering
 class ManifoldObjectFiniteFamily(FiniteFamily):
 
@@ -180,6 +181,7 @@ class ManifoldObjectFiniteFamily(FiniteFamily):
             '\\{A, B\\}'
         """
         return self._latex_name
+
 
 class ManifoldSubsetFiniteFamily(ManifoldObjectFiniteFamily):
 

--- a/src/sage/manifolds/local_frame.py
+++ b/src/sage/manifolds/local_frame.py
@@ -408,6 +408,7 @@ class LocalCoFrame(FreeModuleCoBasis):
 
 #******************************************************************************
 
+
 class LocalFrame(FreeModuleBasis):
     r"""
     Local frame on a vector bundle.
@@ -1232,6 +1233,7 @@ class LocalFrame(FreeModuleBasis):
 
 #******************************************************************************
 
+
 class TrivializationCoFrame(LocalCoFrame):
     r"""
     Trivialization coframe on a vector bundle.
@@ -1363,6 +1365,7 @@ class TrivializationCoFrame(LocalCoFrame):
         return "Trivialization coframe " + self._name
 
 #******************************************************************************
+
 
 class TrivializationFrame(LocalFrame):
     r"""

--- a/src/sage/manifolds/manifold_homset.py
+++ b/src/sage/manifolds/manifold_homset.py
@@ -33,6 +33,7 @@ from sage.structure.unique_representation import UniqueRepresentation
 from sage.manifolds.continuous_map import ContinuousMap
 from sage.misc.cachefunc import cached_method
 
+
 class TopologicalManifoldHomset(UniqueRepresentation, Homset):
     r"""
     Set of continuous maps between two topological manifolds.

--- a/src/sage/manifolds/operators.py
+++ b/src/sage/manifolds/operators.py
@@ -43,6 +43,7 @@ AUTHORS:
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
+
 def grad(scalar):
     r"""
     Gradient operator.
@@ -93,6 +94,7 @@ def grad(scalar):
     more details and examples.
     """
     return scalar.gradient()
+
 
 def div(tensor):
     r"""
@@ -167,6 +169,7 @@ def div(tensor):
     """
     return tensor.divergence()
 
+
 def curl(vector):
     r"""
     Curl operator.
@@ -234,6 +237,7 @@ def curl(vector):
     """
     return vector.curl()
 
+
 def laplacian(field):
     r"""
     Laplace-Beltrami operator.
@@ -293,6 +297,7 @@ def laplacian(field):
     more details and examples.
     """
     return field.laplacian()
+
 
 def dalembertian(field):
     r"""

--- a/src/sage/manifolds/point.py
+++ b/src/sage/manifolds/point.py
@@ -92,6 +92,7 @@ from sage.misc.decorators import options
 from sage.symbolic.expression import Expression
 from sage.rings.integer_ring import ZZ
 
+
 class ManifoldPoint(Element):
     r"""
     Point of a topological manifold.

--- a/src/sage/manifolds/scalarfield_algebra.py
+++ b/src/sage/manifolds/scalarfield_algebra.py
@@ -38,6 +38,7 @@ from sage.categories.topological_spaces import TopologicalSpaces
 from sage.symbolic.ring import SymbolicRing, SR
 from sage.manifolds.scalarfield import ScalarField
 
+
 class ScalarFieldAlgebra(UniqueRepresentation, Parent):
     r"""
     Commutative algebra of scalar fields on a topological manifold.

--- a/src/sage/manifolds/section.py
+++ b/src/sage/manifolds/section.py
@@ -25,6 +25,7 @@ from sage.tensor.modules.tensor_with_indices import TensorWithIndices
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 
+
 class Section(ModuleElementWithMutability):
     r"""
     Section in a vector bundle.
@@ -2249,6 +2250,7 @@ class Section(ModuleElementWithMutability):
         super().set_immutable()
 
 #******************************************************************************
+
 
 class TrivialSection(FiniteRankFreeModuleElement, Section):
     r"""

--- a/src/sage/manifolds/section_module.py
+++ b/src/sage/manifolds/section_module.py
@@ -34,6 +34,7 @@ from sage.categories.modules import Modules
 from sage.tensor.modules.finite_rank_free_module import FiniteRankFreeModule
 from sage.manifolds.section import Section, TrivialSection
 
+
 class SectionModule(UniqueRepresentation, Parent):
     r"""
     Module of sections over a vector bundle `E \to M` of class `C^k` on a domain
@@ -475,6 +476,7 @@ class SectionModule(UniqueRepresentation, Parent):
         self._def_frame = basis
 
 #******************************************************************************
+
 
 class SectionFreeModule(FiniteRankFreeModule):
     r"""

--- a/src/sage/manifolds/structure.py
+++ b/src/sage/manifolds/structure.py
@@ -35,6 +35,8 @@ from sage.manifolds.differentiable.manifold_homset import \
 
 # This is a slight abuse by making this a Singleton, but there is no
 #    need to have different copies of this object.
+
+
 class TopologicalStructure(Singleton):
     """
     The structure of a topological manifold over a general topological field.
@@ -81,6 +83,7 @@ class RealTopologicalStructure(Singleton):
             Category of manifolds over Real Field with 53 bits of precision
         """
         return cat
+
 
 class DifferentialStructure(Singleton):
     """
@@ -130,6 +133,7 @@ class RealDifferentialStructure(Singleton):
         """
         return cat
 
+
 class PseudoRiemannianStructure(Singleton):
     """
     The structure of a pseudo-Riemannian manifold.
@@ -152,6 +156,7 @@ class PseudoRiemannianStructure(Singleton):
             Category of manifolds over Real Field with 53 bits of precision
         """
         return cat
+
 
 class RiemannianStructure(Singleton):
     """
@@ -176,6 +181,7 @@ class RiemannianStructure(Singleton):
         """
         return cat
 
+
 class LorentzianStructure(Singleton):
     """
     The structure of a Lorentzian manifold.
@@ -198,6 +204,7 @@ class LorentzianStructure(Singleton):
             Category of manifolds over Real Field with 53 bits of precision
         """
         return cat
+
 
 class DegenerateStructure(Singleton):
     """

--- a/src/sage/manifolds/subset.py
+++ b/src/sage/manifolds/subset.py
@@ -75,6 +75,7 @@ from sage.categories.sets_cat import Sets
 from sage.manifolds.family import ManifoldObjectFiniteFamily, ManifoldSubsetFiniteFamily
 from sage.manifolds.point import ManifoldPoint
 
+
 class ManifoldSubset(UniqueRepresentation, Parent):
     r"""
     Subset of a topological manifold.

--- a/src/sage/manifolds/subsets/closure.py
+++ b/src/sage/manifolds/subsets/closure.py
@@ -17,6 +17,7 @@ of a manifold subset in the topology of the manifold.
 
 from sage.manifolds.subset import ManifoldSubset
 
+
 class ManifoldSubsetClosure(ManifoldSubset):
 
     r"""

--- a/src/sage/manifolds/trivialization.py
+++ b/src/sage/manifolds/trivialization.py
@@ -24,6 +24,7 @@ from sage.structure.sage_object import SageObject
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.manifolds.local_frame import TrivializationFrame
 
+
 class Trivialization(UniqueRepresentation, SageObject):
     r"""
     A local trivialization of a given vector bundle.
@@ -301,6 +302,7 @@ class Trivialization(UniqueRepresentation, SageObject):
         return self._frame._coframe
 
 # *****************************************************************************
+
 
 class TransitionMap(SageObject):
     r"""

--- a/src/sage/manifolds/utilities.py
+++ b/src/sage/manifolds/utilities.py
@@ -672,6 +672,7 @@ def simplify_chain_generic(expr):
     expr = expr.expand_sum()
     return expr
 
+
 def simplify_chain_generic_sympy(expr):
     r"""
     Apply a chain of simplifications to a sympy expression.
@@ -730,6 +731,7 @@ def simplify_chain_generic_sympy(expr):
     expr = expr.expand()
     expr = expr.simplify()
     return expr
+
 
 def simplify_chain_real_sympy(expr):
     r"""
@@ -803,6 +805,7 @@ def simplify_chain_real_sympy(expr):
     return expr
 
 #******************************************************************************
+
 
 class ExpressionNice(Expression):
     r"""
@@ -1229,6 +1232,7 @@ def _list_functions(ex, list_f):
 
 #******************************************************************************
 
+
 def set_axes_labels(graph, xlabel, ylabel, zlabel, **kwds):
     r"""
     Set axes labels for a 3D graphics object ``graph``.
@@ -1277,6 +1281,7 @@ def set_axes_labels(graph, xlabel, ylabel, zlabel, **kwds):
     graph += text3d('  ' + ylabel, (xmin1, y1, zmin1), **kwds)
     graph += text3d('  ' + zlabel, (xmin1, ymin1, z1), **kwds)
     return graph
+
 
 def exterior_derivative(form):
     r"""

--- a/src/sage/manifolds/vector_bundle.py
+++ b/src/sage/manifolds/vector_bundle.py
@@ -41,6 +41,7 @@ from sage.rings.real_mpfr import RR
 from sage.rings.integer import Integer
 from sage.manifolds.vector_bundle_fiber import VectorBundleFiber
 
+
 class TopologicalVectorBundle(CategoryObject, UniqueRepresentation):
     r"""
     An instance of this class is a topological vector bundle `E \to B` over a

--- a/src/sage/manifolds/vector_bundle_fiber.py
+++ b/src/sage/manifolds/vector_bundle_fiber.py
@@ -21,6 +21,7 @@ from sage.symbolic.ring import SR
 from sage.tensor.modules.finite_rank_free_module import FiniteRankFreeModule
 from sage.manifolds.vector_bundle_fiber_element import VectorBundleFiberElement
 
+
 class VectorBundleFiber(FiniteRankFreeModule):
     r"""
     Fiber of a given vector bundle at a given point.

--- a/src/sage/manifolds/vector_bundle_fiber_element.py
+++ b/src/sage/manifolds/vector_bundle_fiber_element.py
@@ -20,6 +20,7 @@ AUTHORS:
 
 from sage.tensor.modules.free_module_element import FiniteRankFreeModuleElement
 
+
 class VectorBundleFiberElement(FiniteRankFreeModuleElement):
     r"""
     Vector in a fiber of a vector bundle at the given point.


### PR DESCRIPTION
this is about fixing the warning

E302 expected 2 blank lines, found 1

in the `manifolds` and `geometry` folders.

Purely scripted using `autopep8`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.


