### PR TITLE
Upgrade database_knotinfo to version 2024.10.1

### DIFF
--- a/src/sage/databases/knotinfo_db.py
+++ b/src/sage/databases/knotinfo_db.py
@@ -838,6 +838,8 @@ column_demo_sample = {
     'fibered':              ['Fibered',              KnotInfoColumnTypes.OnlyKnots],
     'unoriented':           ['Unoriented',           KnotInfoColumnTypes.OnlyLinks],
     'symmetry_type':        ['Symmetry Type',        KnotInfoColumnTypes.OnlyKnots],
+    'geometric_type':       ['Geometric Type',       KnotInfoColumnTypes.OnlyKnots],
+    'cosmetic_crossing':    ['Cosmetic Crossing',    KnotInfoColumnTypes.OnlyKnots],
     'width':                ['Width',                KnotInfoColumnTypes.OnlyKnots],
     'arc_notation':         ['Arc Notation',         KnotInfoColumnTypes.OnlyLinks],
     'dt_code':              ['DT code',              KnotInfoColumnTypes.OnlyLinks]
@@ -1019,6 +1021,18 @@ data_demo_sample = {
         'reversible',
         'reversible'
         ],
+    dc.geometric_type: [
+        '',
+        'torus knot T(2,3)',
+        'hyperbolic',
+        'torus knot T(2,5)',
+        'hyperbolic',
+        'hyperbolic',
+        'hyperbolic',
+        'hyperbolic',
+        'torus knot T(2,7)',
+        'hyperbolic'],
+    dc.cosmetic_crossing: ['', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N'],
     dc.homfly_polynomial: [
         '',
         '(2*v^2-v^4)+v^2*z^2',

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -1356,7 +1356,7 @@ class KnotInfoBase(Enum):
         verified = not knotinfo_bool(cosmetic_crossing)
         if not knotinfo_bool(cosmetic_crossing):
             return True
-        raise AssertionError('This seems to be a negative example to the conjecture')
+        raise AssertionError(f'{self} is a counterexample to the cosmetic crossing conjecture')
 
     @cached_method
     def homfly_polynomial(self, var1='v', var2='z', original=False):

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -1354,8 +1354,9 @@ class KnotInfoBase(Enum):
         if not cosmetic_crossing or cosmetic_crossing == 'Unknown':
             return False
         verified = not knotinfo_bool(cosmetic_crossing)
-        assert verified
-        return verified
+        if not knotinfo_bool(cosmetic_crossing):
+            return True
+        raise AssertionError('This seems to be a negative example to the conjecture')
 
     @cached_method
     def homfly_polynomial(self, var1='v', var2='z', original=False):

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -790,7 +790,7 @@ class KnotInfoBase(Enum):
             return (1, )
 
         braid_notation = eval_knotinfo(braid_notation)
-        if type(braid_notation) is list:
+        if type(braid_notation) in (list, tuple):
             # in some cases there are a pair of braid representations
             # in the database. If this is the case we select the
             # corresponding to the braid index.
@@ -1184,6 +1184,23 @@ class KnotInfoBase(Enum):
         return None
 
     @cached_method
+    def is_hyperbolic(self):
+        r"""
+        Return whether ``self`` is hyperbolic.
+
+        EXAMPLES::
+
+            sage: KnotInfo.K3_1.is_hyperbolic()
+            False
+            sage: KnotInfo.K5_2.is_hyperbolic()
+            True
+        """
+        geometric_type = self[self.items.geometric_type]
+        if (geometric_type == 'hyperbolic'):
+            return True
+        return False
+
+    @cached_method
     def is_alternating(self):
         r"""
         Return whether ``self`` is alternating.
@@ -1308,6 +1325,27 @@ class KnotInfoBase(Enum):
             True
         """
         return not knotinfo_bool(self[self.items.unoriented])
+
+    @cached_method
+    def cosmetic_crossing_conjecture_verified(self):
+        r"""
+        Return whether the Cosmetic Crossing Conjecture has been verified
+        for ``self``.
+
+        EXAMPLES::
+
+            sage: knots = [K for K in KnotInfo if K.is_knot() and K.crossing_number() < 10]
+            sage: all(K.cosmetic_crossing_conjecture_verified() for K in knots)
+            True
+        """
+        cosmetic_crossing = self[self.items.cosmetic_crossing]
+        if self.crossing_number() == 0:
+            return True
+        if (not cosmetic_crossing or cosmetic_crossing == 'Unknown'):
+            return False
+        verified = not knotinfo_bool(cosmetic_crossing)
+        assert(verified)
+        return verified
 
     @cached_method
     def homfly_polynomial(self, var1='v', var2='z', original=False):

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -1332,6 +1332,16 @@ class KnotInfoBase(Enum):
         Return whether the Cosmetic Crossing Conjecture has been verified
         for ``self``.
 
+        From the KnotInfo `description page <https://knotinfo.math.indiana.edu/descriptions/cosmetic_crossing.html>`__:
+
+            A crossing change in a diagram of a knot ``K`` is called cosmetic if
+            the resulting diagram also represents ``K``. The cosmetic crossing
+            conjecture posits that for any knot ``K``, the only cosmetic crossing
+            changes are nugatory, i.e. there exists an embedded 2-sphere in
+            ``S3`` which intersects K only at the two points of the relevant
+            crossing. Conversely, it is not hard to see that any nugatory
+            crossing change is cosmetic.
+
         EXAMPLES::
 
             sage: knots = [K for K in KnotInfo if K.is_knot() and K.crossing_number() < 10]

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -1196,7 +1196,7 @@ class KnotInfoBase(Enum):
             True
         """
         geometric_type = self[self.items.geometric_type]
-        if (geometric_type == 'hyperbolic'):
+        if geometric_type == 'hyperbolic':
             return True
         return False
 
@@ -1351,7 +1351,7 @@ class KnotInfoBase(Enum):
         cosmetic_crossing = self[self.items.cosmetic_crossing]
         if self.crossing_number() == 0:
             return True
-        if (not cosmetic_crossing or cosmetic_crossing == 'Unknown'):
+        if not cosmetic_crossing or cosmetic_crossing == 'Unknown':
             return False
         verified = not knotinfo_bool(cosmetic_crossing)
         assert verified

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -1344,7 +1344,7 @@ class KnotInfoBase(Enum):
         if (not cosmetic_crossing or cosmetic_crossing == 'Unknown'):
             return False
         verified = not knotinfo_bool(cosmetic_crossing)
-        assert(verified)
+        assert verified
         return verified
 
     @cached_method


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The current `database_knotinfo` version 2024.10.1 is no longer compatible with Sage because the syntax for 16 knots for which two braid notations are recorded has changed (see the corresponding [Release Notes](https://github.com/soehms/database_knotinfo/releases/tag/2024.10.1)).

This is fixed by this PR. In addition, two new fields (`geometric_type` and `cosmetic_crossing`) added in this version are used to implement corresponding methods (`is_hyperbolic` and `cosmetic_crossing_conjecture_verified`) of the interface.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


