### PR TITLE
src/sage/env.py: canonicalize paths in a test

### DIFF
--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -8,10 +8,14 @@ environment variables, and has the same ``SAGE_ROOT`` and ``SAGE_LOCAL``
 
     sage: env = {k:v for (k,v) in os.environ.items() if not k.startswith("SAGE_")}
     sage: from subprocess import check_output
-    sage: environment = "sage.all"
-    sage: cmd = f"from {environment} import SAGE_ROOT, SAGE_LOCAL; print((SAGE_ROOT, SAGE_LOCAL))"
+    sage: module_name = "sage.all"   # hide .all import from the linter
+    sage: cmd  = f"from {module_name} import SAGE_ROOT, SAGE_LOCAL;"
+    sage: cmd +=  "from os.path import samefile;"
+    sage: cmd += f"s1 = samefile(SAGE_ROOT, '{SAGE_ROOT}');"
+    sage: cmd += f"s2 = samefile(SAGE_LOCAL, '{SAGE_LOCAL}');"
+    sage: cmd += "print(s1 and s2);"
     sage: out = check_output([sys.executable, "-c", cmd], env=env).decode().strip()   # long time
-    sage: out == repr((SAGE_ROOT, SAGE_LOCAL))                                        # long time
+    sage: out == "True"                                                               # long time
     True
 
 AUTHORS:


### PR DESCRIPTION
A test in sage.env is running sage in a subprocess to compare the values of `SAGE_ROOT` and `SAGE_LOCAL`. It does the comparison as strings, however, and can fail:

```
File "src/sage/env.py", line 14, in sage.env
Failed example:
    out == repr((SAGE_ROOT, SAGE_LOCAL))   # long time
Expected:
    True
Got:
    False
```

This despite the fact that both values are equivalent:

```
sage: out
"('/home/mjo/src/sage.git/src/sage/../..', '/usr')"
sage: repr((SAGE_ROOT, SAGE_LOCAL))
"('/home/mjo/src/sage.git', '/usr')"
```

We update the test to canonicalize the paths within the subprocess, and output only "True" or "False" instead.
