### PR TITLE
Remove redundant modulo operation in vector_modn_dense

### DIFF
--- a/src/sage/modules/vector_modn_dense.pyx
+++ b/src/sage/modules/vector_modn_dense.pyx
@@ -171,13 +171,15 @@ cdef class Vector_modn_dense(free_module_element.FreeModuleElement):
         """
         Create an element.
 
+        TESTS:
+
         Note that ``coerce=False`` is dangerous::
 
             sage: V = VectorSpace(GF(7), 3)
             sage: v = V([2, 9, -5], coerce=False)
             sage: v[0] == v[1]
             False
-            sage: v[0]+1 == v[1]+1
+            sage: v[0] + 1 == v[1] + 1
             True
             sage: v[0] == v[2]
             False

--- a/src/sage/modules/vector_modn_dense.pyx
+++ b/src/sage/modules/vector_modn_dense.pyx
@@ -184,7 +184,7 @@ cdef class Vector_modn_dense(free_module_element.FreeModuleElement):
         """
         cdef Py_ssize_t i
         cdef mod_int a
-        if isinstance(x, xrange):
+        if isinstance(x, range):
             x = tuple(x)
         if isinstance(x, (list, tuple)):
             if len(x) != self._degree:

--- a/src/sage/modules/vector_modn_dense.pyx
+++ b/src/sage/modules/vector_modn_dense.pyx
@@ -168,8 +168,22 @@ cdef class Vector_modn_dense(free_module_element.FreeModuleElement):
             self._init(parent.degree(), parent, parent.base_ring().order())
 
     def __init__(self, parent, x, coerce=True, copy=True):
+        """
+        Create an element.
+
+        Note that ``coerce=False`` is dangerous::
+
+            sage: V = VectorSpace(GF(7), 3)
+            sage: v = V([2, 9, -5], coerce=False)
+            sage: v[0] == v[1]
+            False
+            sage: v[0]+1 == v[1]+1
+            True
+            sage: v[0] == v[2]
+            False
+        """
         cdef Py_ssize_t i
-        cdef mod_int a, p
+        cdef mod_int a
         if isinstance(x, xrange):
             x = tuple(x)
         if isinstance(x, (list, tuple)):
@@ -177,10 +191,9 @@ cdef class Vector_modn_dense(free_module_element.FreeModuleElement):
                 raise TypeError("x must be a list of the right length")
             if coerce:
                 R = parent.base_ring()
-                p = R.order()
                 for i from 0 <= i < self._degree:
                     a = int(R(x[i]))
-                    self._entries[i] = a % p
+                    self._entries[i] = a
             else:
                 for i from 0 <= i < self._degree:
                     self._entries[i] = x[i]


### PR DESCRIPTION
Just a tiny change. There's no user-visible behavior seen.

(The output of `int(…)` is already reduced modulo `p` anyway.)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
