### PR TITLE
Fix bug in covering map of simplicial set with degenerate faces.

### DIFF
--- a/src/sage/categories/simplicial_sets.py
+++ b/src/sage/categories/simplicial_sets.py
@@ -484,7 +484,7 @@ class SimplicialSets(Category_singleton):
                         char[s] = G.one()
 
                 for d in range(1, self.dimension() + 1):
-                    for s in self.n_cells(d):
+                    for s in self.all_n_simplices(d):
                         if s not in char.keys():
                             if d == 1 and s.is_degenerate():
                                 char[s] = G.one()
@@ -575,6 +575,16 @@ class SimplicialSets(Category_singleton):
                      (f * f * f, e): ((f * f, 1), s_0 (f, e), s_1 (f, e), (f * f, e))}
                     sage: C.fundamental_group()
                     Finitely presented group <  |  >
+
+                TESTS::
+
+                    sage: RP2 = simplicial_sets.RealProjectiveSpace(2)
+                    sage: S3 = simplicial_sets.Sphere(3)
+                    sage: X = S3.wedge(RP2)
+                    sage: XU = X.universal_cover()
+                    sage: [XU.homology(i) for i in range(5)]
+                    [0, 0, Z, Z x Z, 0]
+
                 """
                 return self.universal_cover_map().domain()
 


### PR DESCRIPTION
There is a bug in the method to compute universal covers of simplicial sets. It is triggered when a nondegenerate cell
has degenerate faces:

```
sage: RP2 = simplicial_sets.RealProjectiveSpace(2)
sage: S3 = simplicial_sets.Sphere(3)
sage: X = S3.wedge(RP2)
sage: XU = X.universal_cover()
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[5], line 1
----> 1 X.universal_cover()

File /usr/local/sage97/src/sage/categories/simplicial_sets.py:581, in SimplicialSets.Pointed.ParentMethods.universal_cover(self)
    557 def universal_cover(self):
    558     r"""
    559     Return the universal cover of the simplicial set.
    560     The fundamental group must be finite in order to ensure that the
   (...)
    579         Finitely presented group <  |  >
    580     """
--> 581     return self.universal_cover_map().domain()

File /usr/local/sage97/src/sage/categories/simplicial_sets.py:429, in SimplicialSets.Pointed.ParentMethods.universal_cover_map(self)
    427     return self.identity()
    428 G, char = self._universal_cover_dict()
--> 429 return self.covering_map(char)

File /usr/local/sage97/src/sage/categories/simplicial_sets.py:499, in SimplicialSets.Pointed.ParentMethods.covering_map(self, character)
    497             char[s] = char[s.nondegenerate()]
    498     else:
--> 499         char[s] = char[self.face(s, d)]
    500 if s.is_nondegenerate():
    501     for g in G:

KeyError: s_1 s_0 *
```


This PR fixes this.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


