### PR TITLE
fix issue #38832 about `canonical_label` in bipartite graphs

### DIFF
--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -2641,13 +2641,14 @@ class BipartiteGraph(Graph):
             sage: C = B.canonical_label()
             sage: C.left, C.right
             ({0, 1}, {2, 3})
-            sage: B.canonical_label(certificate=True)
-            (Bipartite graph on 4 vertices, {0: 0, 1: 1, 2: 2, 3: 3})
+            sage: C, certificate = B.canonical_label(certificate=True)
+            sage: C.left, C.right
+            ({0, 1}, {2, 3})
             sage: C = B.canonical_label(edge_labels=True)
             sage: C.left, C.right
             ({0, 1}, {2, 3})
             sage: B.allow_multiple_edges(True)
-            sage: B.add_edges(G.edges())
+            sage: B.add_edges(B.edges())
             sage: C = B.canonical_label()
             sage: C.left, C.right
             ({0, 1}, {2, 3})

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -2633,11 +2633,29 @@ class BipartiteGraph(Graph):
             sage: C.right
             {4, 5, 6}
 
+        TESTS:
+
+        Check that :issue:`38832` is fixed::
+
+            sage: B = BipartiteGraph(matrix([[1, 1], [1, 1]]))
+            sage: C = B.canonical_label()
+            sage: C.left, C.right
+            ({0, 1}, {2, 3})
+            sage: B.canonical_label(certificate=True)
+            (Bipartite graph on 4 vertices, {0: 0, 1: 1, 2: 2, 3: 3})
+            sage: C = B.canonical_label(edge_labels=True)
+            sage: C.left, C.right
+            ({0, 1}, {2, 3})
+            sage: B.allow_multiple_edges(True)
+            sage: B.add_edges(G.edges())
+            sage: C = B.canonical_label()
+            sage: C.left, C.right
+            ({0, 1}, {2, 3})
+
         .. SEEALSO::
 
             :meth:`~sage.graphs.generic_graph.GenericGraph.canonical_label()`
         """
-
         if certificate:
             C, cert = GenericGraph.canonical_label(self, partition=partition,
                                                    certificate=certificate,
@@ -2669,6 +2687,8 @@ class BipartiteGraph(Graph):
                 cert = {v: c[G_to[relabeling[v]]] for v in self}
 
             else:
+                if partition is None:
+                    partition = self.bipartition()
                 G_vertices = list(chain(*partition))
                 G_to = {u: i for i, u in enumerate(G_vertices)}
                 H = Graph(len(G_vertices))

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -2638,20 +2638,16 @@ class BipartiteGraph(Graph):
         Check that :issue:`38832` is fixed::
 
             sage: B = BipartiteGraph(matrix([[1, 1], [1, 1]]))
-            sage: C = B.canonical_label()
-            sage: C.left, C.right
-            ({0, 1}, {2, 3})
-            sage: C, certificate = B.canonical_label(certificate=True)
-            sage: C.left, C.right
-            ({0, 1}, {2, 3})
-            sage: C = B.canonical_label(edge_labels=True)
-            sage: C.left, C.right
-            ({0, 1}, {2, 3})
+            sage: B.canonical_label()
+            Bipartite graph on 4 vertices
+            sage: B.canonical_label(certificate=True)[0]
+            Bipartite graph on 4 vertices
+            sage: B.canonical_label(edge_labels=True)
+            Bipartite graph on 4 vertices
             sage: B.allow_multiple_edges(True)
             sage: B.add_edges(B.edges())
-            sage: C = B.canonical_label()
-            sage: C.left, C.right
-            ({0, 1}, {2, 3})
+            sage: B.canonical_label()
+            Bipartite multi-graph on 4 vertices
 
         .. SEEALSO::
 


### PR DESCRIPTION
Fixes #38832.

We fix call to `canonical_label` on `BipartiteGraph` when parameter `partition` is `None`.
```py
sage: G = BipartiteGraph(matrix([[1, 1], [1, 1]]))
sage: C = G.canonical_label()
sage: C.left, C.right
({0, 1}, {2, 3})
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


