### PR TITLE
Improve Matrix_mod2_dense solve_right performance

### DIFF
--- a/src/sage/libs/m4ri.pxd
+++ b/src/sage/libs/m4ri.pxd
@@ -179,6 +179,9 @@ cdef extern from "m4ri/m4ri.h":
     # reduced row echelon form using PLUQ factorization
     cdef mzd_t *mzd_kernel_left_pluq(mzd_t *A, int cutoff)
 
+    # system solving
+    cdef int mzd_solve_left(mzd_t *A, mzd_t *B, int cutoff, int inconsistency_check)
+
     ########################
     # Bit operations
     ########################

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1958,9 +1958,13 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             sage: A * A.solve_right(B) == B
             True
         """
-        cdef Matrix_mod2_dense X  # the solution
-
         cdef mzd_t *B_entries = (<Matrix_mod2_dense>B)._entries
+
+        cdef Matrix_mod2_dense X  # the solution
+        X = self.new_matrix(nrows=self._entries.ncols, ncols=B_entries.ncols)
+        if self._entries.nrows == 0 or self._entries.ncols == 0:
+            # special case: empty matrix
+            return X
         cdef rci_t rows = self._entries.nrows
         if self._entries.nrows < self._entries.ncols:
             rows = self._entries.ncols  # mzd_solve_left requires ncols <= nrows
@@ -1979,7 +1983,6 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
 
             if ret == 0:
                 # solution is placed in rhs
-                X = self.new_matrix(nrows=self._entries.ncols, ncols=B_entries.ncols)
                 rhs.nrows = self._entries.ncols
                 mzd_copy(X._entries, rhs)
                 return X

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1962,7 +1962,7 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
 
         cdef Matrix_mod2_dense X  # the solution
         X = self.new_matrix(nrows=self._entries.ncols, ncols=B_entries.ncols)
-        if self._entries.nrows == 0 or self._entries.ncols == 0:
+        if self._entries.ncols == 0 or B_entries.ncols == 0:
             # special case: empty matrix
             return X
         cdef rci_t rows = self._entries.nrows

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1964,6 +1964,8 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         X = self.new_matrix(nrows=self._entries.ncols, ncols=B_entries.ncols)
         if self._entries.ncols == 0 or B_entries.ncols == 0:
             # special case: empty matrix
+            if B != 0:
+                raise ValueError("matrix equation has no solutions")
             return X
         cdef rci_t rows = self._entries.nrows
         if self._entries.nrows < self._entries.ncols:

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1918,7 +1918,7 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         mzd_free(A)
         self.cache('rank', r)
         return r
-    
+
     def _solve_right_general(self, B, check=True):
         """
         Solve the matrix equation AX = B for X using the M4RI library.
@@ -1938,7 +1938,7 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             Traceback (most recent call last):
             ...
             ValueError: matrix equation has no solutions
-        
+
         TESTS::
 
             sage: n = 128
@@ -1986,7 +1986,6 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         else:
             mzd_free(rhs)
             raise ValueError("matrix equation has no solutions")
-
 
     def _right_kernel_matrix(self, **kwds):
         r"""

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1967,6 +1967,18 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             True
             sage: matrix(GF(2), 2, 2).solve_right(matrix(GF(2), 2, 0)) == matrix(GF(2), 2, 0)
             True
+
+        Check that it can be interrupted::
+
+            sage: set_random_seed(12345)
+            sage: n, m = 20000, 19968
+            sage: A = random_matrix(GF(2), n, m)
+            sage: x = random_vector(GF(2), m)
+            sage: B = A*x
+            sage: alarm(0.5); sol = A.solve_right(B)
+            Traceback (most recent call last):
+            ...
+            AlarmInterrupt
         """
         cdef mzd_t *B_entries = (<Matrix_mod2_dense>B)._entries
 

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1957,6 +1957,16 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             sage: B = A * random_vector(GF(2), m)
             sage: A * A.solve_right(B) == B
             True
+            sage: matrix(GF(2), 2, 0).solve_right(matrix(GF(2), 2, 2)) == matrix(GF(2), 0, 2)
+            True
+            sage: matrix(GF(2), 2, 0).solve_right(matrix(GF(2), 2, 2) + 1)
+            Traceback (most recent call last):
+            ...
+            ValueError: matrix equation has no solutions
+            sage: matrix(GF(2), 2, 0).solve_right(matrix(GF(2), 2, 2) + 1, check=False) == matrix(GF(2), 0, 2)
+            True
+            sage: matrix(GF(2), 2, 2).solve_right(matrix(GF(2), 2, 0)) == matrix(GF(2), 2, 0)
+            True
         """
         cdef mzd_t *B_entries = (<Matrix_mod2_dense>B)._entries
 
@@ -1964,7 +1974,7 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         X = self.new_matrix(nrows=self._entries.ncols, ncols=B_entries.ncols)
         if self._entries.ncols == 0 or B_entries.ncols == 0:
             # special case: empty matrix
-            if B != 0:
+            if check and B != 0:
                 raise ValueError("matrix equation has no solutions")
             return X
         cdef rci_t rows = self._entries.nrows


### PR DESCRIPTION
Use M4RI builtin `mzd_solve_left` function to solve equation.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Currently, using `solve_right` on large `GF(2)` matrix is pretty slow because it use a generic solving function in matrix2.pyx, but M4RI provides a `mzd_solve_left` function that does the same thing.

For example, try running this in sage's IPython REPL:

```python
set_random_seed(12345)
n, m = 20000, 19968
A = random_matrix(GF(2), n, m)
x = random_vector(GF(2), m)
B = A*x
%time sol = A.solve_right(B)
assert A * sol == B
```

without this PR, it took

```
CPU times: user 1min 2s, sys: 190 ms, total: 1min 2s
Wall time: 15.2 s
```

with this PR, it becomes

```
CPU times: user 12.5 s, sys: 40.8 ms, total: 12.6 s
Wall time: 1.09 s
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


