### PR TITLE
Fix docstring format for `EllipticCurve_with_prime_order`

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2962,7 +2962,7 @@ def EllipticCurve_with_prime_order(N):
     a suitable `D` *incrementally*, by enlarging the table `S` by `log(N)`-size
     interval of primes `p` and testing all products of distinct primes `p` (or
     rather `p^*`). We find this difficult to implement without testing
-    duplicate `D`s, so we instead enlarge the table one prime at a time
+    duplicate `D`\s, so we instead enlarge the table one prime at a time
     (effectively replacing `[r\log(N), (r + 1)\log(N)]` in the paper by `[r,
     r]`). To compensate for the speed loss, we begin the algorithm by
     prefilling `S` with the primes below `1000` (satisfying quadratic
@@ -2970,14 +2970,14 @@ def EllipticCurve_with_prime_order(N):
     to be fast for many purposes, and for most `N` we tested we are able to
     find a suitable small `D` without increasing the size of `S`.
 
-    The paper also doesn't specify how to enumerate such `D`s, which recall
+    The paper also doesn't specify how to enumerate such `D`\s, which recall
     should be product of distinct values in the table `S`. We implement this
     with a priority queue (min heap), which also allows us to search for the
-    suitable `D`s in increasing (absolute value) order. This is suitable for
+    suitable `D`\s in increasing (absolute value) order. This is suitable for
     the algorithm because smaller `D` means the Hilbert class polynomial is
     computed quicker.
 
-    Finally, to avoid repeatedly testing the same `D`s, we require the latest
+    Finally, to avoid repeatedly testing the same `D`\s, we require the latest
     prime to be added to the table to be included as a factor of `D` (see code
     for more explanation). As we need to find integers `x, y` such that `x^2 +
     (-D)y^2 = 4N` with `D < 0` and `N` prime, we actually need `|D| \leq 4N`,
@@ -3022,7 +3022,7 @@ def EllipticCurve_with_prime_order(N):
         sage: E.has_order(N)
         True
 
-    ::
+    Another example for large primes::
 
         sage: N = next_prime(2^256)
         sage: E = next(EllipticCurve_with_prime_order(N)); E                            # random


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The docstring for `EllipticCurve_with_prime_order` function failed to format for the html version. More precisely, some latex math inclusion failed due to a letter appended right after the closing backtick.

It now formats properly and as originally intented.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


