### PR TITLE
Fix test if SAGE_ROOT is not defined

### DIFF
--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -11,7 +11,7 @@ environment variables, and has the same ``SAGE_ROOT`` and ``SAGE_LOCAL``
     sage: module_name = "sage.all"   # hide .all import from the linter
     sage: cmd  = f"from {module_name} import SAGE_ROOT, SAGE_LOCAL;"
     sage: cmd +=  "from os.path import samefile;"
-    sage: cmd += f"s1 = samefile(SAGE_ROOT, '{SAGE_ROOT}');"
+    sage: cmd += f"s1 = samefile(SAGE_ROOT, '{SAGE_ROOT}') if SAGE_ROOT else True;"
     sage: cmd += f"s2 = samefile(SAGE_LOCAL, '{SAGE_LOCAL}');"
     sage: cmd += "print(s1 and s2);"
     sage: out = check_output([sys.executable, "-c", cmd], env=env).decode().strip()   # long time


### PR DESCRIPTION
`SAGE_ROOT` is not defined in distro builds, make the test pass in that case

