### PR TITLE
Fix testing of installed rst files

### DIFF
--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -282,13 +282,14 @@ def skipfile(filename, tested_optional_tags=False, *,
         sage: skipfile(filename, True)
         False
     """
-    if filename.endswith('.rst.txt'):
-        ext = '.rst.txt'
     if filename.endswith('__main__.py'):
         if log:
             log(f"Skipping '{filename}' because it is a __main__.py file")
         return True
-    _ , ext = os.path.splitext(filename)
+    if filename.endswith('.rst.txt'):
+        ext = '.rst.txt'
+    else:
+        _ , ext = os.path.splitext(filename)
     # .rst.txt appear in the installed documentation in subdirectories named "_sources"
     if ext not in ('.py', '.pyx', '.pxd', '.pxi', '.sage', '.spyx', '.rst', '.tex', '.rst.txt'):
         if log:


### PR DESCRIPTION
Fix a regression from https://github.com/sagemath/sage/pull/36524 where `sage -t` skips doctesting installed `rst` files (which get installed as `rst.txt`)