### PR TITLE
Fix duplicate install of config.py in meson build

### DIFF
--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -86,7 +86,6 @@ foreach package : no_processing
 endforeach
 
 py.install_sources(
-  config_file,
   'all.py',
   'all__sagemath_bliss.py',
   'all__sagemath_categories.py',


### PR DESCRIPTION
The  `configure_file` command creating this `config.py` file already has `install: true` which makes it installed by default. Installing it again here creates a duplicate entry in wheel packages, which breaks installing them with some tools (eg. python-installer).