### PR TITLE
pkgconf to dependencies of libsemigroups

### DIFF
--- a/build/pkgs/libsemigroups/dependencies
+++ b/build/pkgs/libsemigroups/dependencies
@@ -1,4 +1,3 @@
-# no dependencies
-
+pkgconf
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
without it, libsemigroups will be useless for GAP's semigroups package

see [sage-release](https://groups.google.com/g/sage-release/c/tXlIIJ0HX_Y/m/ITFAkQv0BAAJ) for a discussion


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [x ] The description explains in detail what this PR is about.
- [x ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


