### PR TITLE
src/sage/parallel/map_reduce.py: fixup start_workers() test case

### DIFF
--- a/src/sage/parallel/map_reduce.py
+++ b/src/sage/parallel/map_reduce.py
@@ -1133,18 +1133,16 @@ class RESetMapReduce:
 
         TESTS::
 
+            sage: # long time
             sage: from sage.parallel.map_reduce import RESetMapReduce
             sage: def children(x):
             ....:     print(f"Starting: {x}", flush=True)
             ....:     return []
             sage: S = RESetMapReduce(roots=[1, 2], children=children)
             sage: S.setup_workers(2)
-            sage: S.start_workers(); sleep(float(5))  # long time
+            sage: S.start_workers(); sleep(float(5))
             Starting: ...
             Starting: ...
-
-        Cleanup::
-
             sage: S.finish()
         """
         if self._nprocess == 0:


### PR DESCRIPTION
In commit a1818838 I made this test wait a bit longer (to be more robust under load) and added a "long time" to the corresponding start_workers() line. But, further down, there's another test that calls finish(), which needs the workers to be started.  Without a "long time" on the finish(), it can fail sans --long.

To fix it, we combine the two tests that call start_workers() and finish(), and then mark the whole thing "long time". The finish() is supposed to delete the workers created in setup_workers() as well, so there's not much point in trying to make the "long time" more fine-grained than that.
