### PR TITLE
Remove imports from `gsl.all`

### DIFF
--- a/src/sage/calculus/integration.pyx
+++ b/src/sage/calculus/integration.pyx
@@ -31,7 +31,10 @@ from cysignals.signals cimport sig_on, sig_off
 from memory_allocator cimport MemoryAllocator
 
 from sage.rings.real_double import RDF
-from sage.libs.gsl.all cimport *
+from sage.libs.gsl.errno cimport gsl_set_error_handler_off
+from sage.libs.gsl.integration cimport *
+from sage.libs.gsl.monte cimport *
+from sage.libs.gsl.rng cimport *
 from sage.misc.sageinspect import sage_getargspec
 from sage.ext.interpreters.wrapper_rdf cimport Wrapper_rdf
 from sage.ext.fast_callable import fast_callable

--- a/src/sage/calculus/ode.pyx
+++ b/src/sage/calculus/ode.pyx
@@ -22,7 +22,8 @@ from cysignals.memory cimport sig_malloc, sig_free
 from cysignals.signals cimport sig_on, sig_off
 
 from sage.misc.sageinspect import sage_getargspec
-from sage.libs.gsl.all cimport *
+from sage.libs.gsl.types cimport *
+from sage.libs.gsl.odeiv cimport *
 import sage.calculus.interpolation
 
 

--- a/src/sage/probability/probability_distribution.pyx
+++ b/src/sage/probability/probability_distribution.pyx
@@ -40,7 +40,8 @@ REFERENCES:
 # ****************************************************************************
 from cysignals.memory cimport sig_malloc, sig_free
 
-from sage.libs.gsl.all cimport *
+from sage.libs.gsl.rng cimport * 
+from sage.libs.gsl.random cimport *
 import sage.misc.prandom as random
 import sage.rings.real_double
 from sage.modules.free_module_element import vector

--- a/src/sage/probability/probability_distribution.pyx
+++ b/src/sage/probability/probability_distribution.pyx
@@ -40,7 +40,7 @@ REFERENCES:
 # ****************************************************************************
 from cysignals.memory cimport sig_malloc, sig_free
 
-from sage.libs.gsl.rng cimport * 
+from sage.libs.gsl.rng cimport *
 from sage.libs.gsl.random cimport *
 import sage.misc.prandom as random
 import sage.rings.real_double

--- a/src/sage/rings/complex_mpfr.pyx
+++ b/src/sage/rings/complex_mpfr.pyx
@@ -48,7 +48,6 @@ from sage.rings.integer cimport Integer
 
 from sage.rings.complex_double cimport ComplexDoubleElement
 from sage.rings.real_mpfr cimport RealNumber
-from sage.libs.gsl.complex cimport *
 
 from sage.libs.mpmath.utils cimport mpfr_to_mpfval
 from sage.rings.integer_ring import ZZ

--- a/src/sage/rings/number_field/number_field_morphisms.pyx
+++ b/src/sage/rings/number_field/number_field_morphisms.pyx
@@ -20,15 +20,13 @@ fields (generally `\RR` or `\CC`).
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-import sage.rings.complex_double
-
 from sage.structure.element cimport Element
 from sage.categories.morphism cimport Morphism
 from sage.categories.map cimport Map
 from sage.categories.pushout import pushout
 
+from sage.rings.complex_double import CDF
 from sage.rings.real_lazy import RLF, CLF, LazyField, LazyAlgebraic
-
 
 cdef class NumberFieldEmbedding(Morphism):
 
@@ -254,7 +252,7 @@ cdef class EmbeddedNumberFieldMorphism(NumberFieldEmbedding):
                 candidate_ambient_fields.append(ambient_field.algebraic_closure())
             except NotImplementedError:
                 pass
-            candidate_ambient_fields.append(sage.rings.complex_double.CDF)
+            candidate_ambient_fields.append(CDF)
         else:
             candidate_ambient_fields = [ambient_field]
 

--- a/src/sage/rings/real_double_element_gsl.pyx
+++ b/src/sage/rings/real_double_element_gsl.pyx
@@ -8,7 +8,16 @@ from cysignals.signals cimport sig_on, sig_off
 
 from sage.arith.constants cimport *
 
-from sage.libs.gsl.all cimport *
+from sage.libs.gsl.errno cimport gsl_set_error_handler_off
+from sage.libs.gsl.math cimport *
+from sage.libs.gsl.exp cimport *
+from sage.libs.gsl.log cimport gsl_sf_log
+from sage.libs.gsl.trig cimport *
+from sage.libs.gsl.dilog cimport gsl_sf_dilog
+from sage.libs.gsl.gamma cimport gsl_sf_fact, gsl_sf_gamma
+from sage.libs.gsl.zeta cimport gsl_sf_zeta
+from sage.libs.gsl.erf cimport gsl_sf_erf
+
 
 gsl_set_error_handler_off()
 

--- a/src/sage/symbolic/pynac_impl.pxi
+++ b/src/sage/symbolic/pynac_impl.pxi
@@ -40,7 +40,6 @@ from sage.arith.functions import lcm
 from sage.cpython.string cimport str_to_bytes, char_to_str
 from sage.ext.stdsage cimport PY_NEW
 from sage.libs.gmp.all cimport *
-from sage.libs.gsl.types cimport *
 from sage.libs.gsl.complex cimport *
 from sage.libs.gsl.gamma cimport gsl_sf_lngamma_complex_e
 from sage.libs.mpmath import utils as mpmath_utils


### PR DESCRIPTION
I had troubles with importing `gsl` (on Windows) and tried to fix it by changing imports from `gsl.all` to more specific imports. Turns out the real problem was actually wrong `pkg-config` entry; but I thought these more specific imports might be helpful anyway and should (slightly) reduce the size of the built library.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


