### PR TITLE
Update Pypi.io domain (301 permanent redirect)

### DIFF
--- a/build/pkgs/alabaster/checksums.ini
+++ b/build/pkgs/alabaster/checksums.ini
@@ -1,4 +1,4 @@
 tarball=alabaster-VERSION-py3-none-any.whl
 sha1=6c86446396c69236a1542e09771e8d7b8487dcfa
 sha256=b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92
-upstream_url=https://pypi.io/packages/py3/a/alabaster/alabaster-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/a/alabaster/alabaster-VERSION-py3-none-any.whl

--- a/build/pkgs/anyio/checksums.ini
+++ b/build/pkgs/anyio/checksums.ini
@@ -1,4 +1,4 @@
 tarball=anyio-VERSION-py3-none-any.whl
 sha1=f5bd548b3a14c9c93622bf04f7c6464e3f44966a
 sha256=c1b2d8f46a8a812513012e1107cb0e68c17159a7a594208005a57dc776e1bdc7
-upstream_url=https://pypi.io/packages/py3/a/anyio/anyio-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/a/anyio/anyio-VERSION-py3-none-any.whl

--- a/build/pkgs/appdirs/checksums.ini
+++ b/build/pkgs/appdirs/checksums.ini
@@ -1,4 +1,4 @@
 tarball=appdirs-VERSION-py2.py3-none-any.whl
 sha1=fc74022712122436427f8282a47bfa430ec2db56
 sha256=a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
-upstream_url=https://pypi.io/packages/py2.py3/a/appdirs/appdirs-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/a/appdirs/appdirs-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/appnope/checksums.ini
+++ b/build/pkgs/appnope/checksums.ini
@@ -1,4 +1,4 @@
 tarball=appnope-VERSION.tar.gz
 sha1=4dcd80020b345a184d6da6063a69e25b1d353323
 sha256=1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee
-upstream_url=https://pypi.io/packages/source/a/appnope/appnope-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/a/appnope/appnope-VERSION.tar.gz

--- a/build/pkgs/argon2_cffi/checksums.ini
+++ b/build/pkgs/argon2_cffi/checksums.ini
@@ -1,4 +1,4 @@
 tarball=argon2-cffi-VERSION.tar.gz
 sha1=c16c1506de0211bdfa23d4d51e780fb4aaff5222
 sha256=d384164d944190a7dd7ef22c6aa3ff197da12962bd04b17f64d4e93d934dba5b
-upstream_url=https://pypi.io/packages/source/a/argon2_cffi/argon2-cffi-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/a/argon2_cffi/argon2-cffi-VERSION.tar.gz

--- a/build/pkgs/argon2_cffi_bindings/checksums.ini
+++ b/build/pkgs/argon2_cffi_bindings/checksums.ini
@@ -1,4 +1,4 @@
 tarball=argon2-cffi-bindings-VERSION.tar.gz
 sha1=5a9b8906d9ca73c53c2bf0a2f0a8127fda69e965
 sha256=bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3
-upstream_url=https://pypi.io/packages/source/a/argon2_cffi_bindings/argon2-cffi-bindings-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/a/argon2_cffi_bindings/argon2-cffi-bindings-VERSION.tar.gz

--- a/build/pkgs/arrow/checksums.ini
+++ b/build/pkgs/arrow/checksums.ini
@@ -1,4 +1,4 @@
 tarball=arrow-VERSION-py3-none-any.whl
 sha1=fd9376ef4788dc2b1c981e6b5beb9048e046c556
 sha256=c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80
-upstream_url=https://pypi.io/packages/py3/a/arrow/arrow-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/a/arrow/arrow-VERSION-py3-none-any.whl

--- a/build/pkgs/asttokens/checksums.ini
+++ b/build/pkgs/asttokens/checksums.ini
@@ -1,4 +1,4 @@
 tarball=asttokens-VERSION-py2.py3-none-any.whl
 sha1=69a9448cd7fad3007a66f464f9daa35dd28183a6
 sha256=051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24
-upstream_url=https://pypi.io/packages/py2.py3/a/asttokens/asttokens-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/a/asttokens/asttokens-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/async_lru/checksums.ini
+++ b/build/pkgs/async_lru/checksums.ini
@@ -1,4 +1,4 @@
 tarball=async_lru-VERSION-py3-none-any.whl
 sha1=99b2ea5d551cbad28e08e45f0d0b00827f9ff73d
 sha256=ff02944ce3c288c5be660c42dbcca0742b32c3b279d6dceda655190240b99224
-upstream_url=https://pypi.io/packages/py3/a/async_lru/async_lru-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/a/async_lru/async_lru-VERSION-py3-none-any.whl

--- a/build/pkgs/attrs/checksums.ini
+++ b/build/pkgs/attrs/checksums.ini
@@ -1,4 +1,4 @@
 tarball=attrs-VERSION-py3-none-any.whl
 sha1=563b272af703f8960b76f6637d009fa5fc5864d3
 sha256=99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
-upstream_url=https://pypi.io/packages/py3/a/attrs/attrs-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/a/attrs/attrs-VERSION-py3-none-any.whl

--- a/build/pkgs/babel/checksums.ini
+++ b/build/pkgs/babel/checksums.ini
@@ -1,4 +1,4 @@
 tarball=Babel-VERSION-py3-none-any.whl
 sha1=7f8671a725d0bbf28618841c441af8bd7709d527
 sha256=efb1a25b7118e67ce3a259bed20545c29cb68be8ad2c784c83689981b7a57287
-upstream_url=https://pypi.io/packages/py3/b/babel/Babel-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/b/babel/Babel-VERSION-py3-none-any.whl

--- a/build/pkgs/beautifulsoup4/checksums.ini
+++ b/build/pkgs/beautifulsoup4/checksums.ini
@@ -1,4 +1,4 @@
 tarball=beautifulsoup4-VERSION.tar.gz
 sha1=d9cd72f81e7710692b8ff0a42e69bf93375b5fd3
 sha256=492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da
-upstream_url=https://pypi.io/packages/source/b/beautifulsoup4/beautifulsoup4-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/b/beautifulsoup4/beautifulsoup4-VERSION.tar.gz

--- a/build/pkgs/beniget/checksums.ini
+++ b/build/pkgs/beniget/checksums.ini
@@ -1,4 +1,4 @@
 tarball=beniget-VERSION.tar.gz
 sha1=0167f16d17fbd61b91e620bca07e4ec7054ce51d
 sha256=75554b3b8ad0553ce2f607627dad3d95c60c441189875b98e097528f8e23ac0c
-upstream_url=https://pypi.io/packages/source/b/beniget/beniget-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/b/beniget/beniget-VERSION.tar.gz

--- a/build/pkgs/bleach/checksums.ini
+++ b/build/pkgs/bleach/checksums.ini
@@ -1,4 +1,4 @@
 tarball=bleach-VERSION-py3-none-any.whl
 sha1=7ba81a446171fb840d3083afadd0c87f0b599305
 sha256=3225f354cfc436b9789c66c4ee030194bee0568fbf9cbdad3bc8b5c26c5f12b6
-upstream_url=https://pypi.io/packages/py3/b/bleach/bleach-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/b/bleach/bleach-VERSION-py3-none-any.whl

--- a/build/pkgs/cachetools/checksums.ini
+++ b/build/pkgs/cachetools/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cachetools-VERSION-py3-none-any.whl
 sha1=4210b349f838f75d64da22fbef7e5dc8e494c5f6
 sha256=0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945
-upstream_url=https://pypi.io/packages/py3/c/cachetools/cachetools-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/c/cachetools/cachetools-VERSION-py3-none-any.whl

--- a/build/pkgs/calver/checksums.ini
+++ b/build/pkgs/calver/checksums.ini
@@ -1,4 +1,4 @@
 tarball=calver-VERSION-py3-none-any.whl
 sha1=4553e3fbfc58908f3be2dd529e5991986f6a46b5
 sha256=a1d7fcdd67797afc52ee36ffb8c8adf6643173864306547bfd1380cbce6310a0
-upstream_url=https://pypi.io/packages/py3/c/calver/calver-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/c/calver/calver-VERSION-py3-none-any.whl

--- a/build/pkgs/certifi/checksums.ini
+++ b/build/pkgs/certifi/checksums.ini
@@ -1,4 +1,4 @@
 tarball=certifi-VERSION-py3-none-any.whl
 sha1=4acb42f49aed94aeb687b33d3dcb6b564ff36fac
 sha256=dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
-upstream_url=https://pypi.io/packages/py3/c/certifi/certifi-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/c/certifi/certifi-VERSION-py3-none-any.whl

--- a/build/pkgs/cffi/checksums.ini
+++ b/build/pkgs/cffi/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cffi-VERSION.tar.gz
 sha1=c42a46cd11f6153f299cf10e9c236e8b2a143c21
 sha256=d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
-upstream_url=https://pypi.io/packages/source/c/cffi/cffi-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/c/cffi/cffi-VERSION.tar.gz

--- a/build/pkgs/chardet/checksums.ini
+++ b/build/pkgs/chardet/checksums.ini
@@ -1,4 +1,4 @@
 tarball=chardet-VERSION-py3-none-any.whl
 sha1=2facc0387556aa8a2956ef682d49fc3eae56d30a
 sha256=e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970
-upstream_url=https://pypi.io/packages/py3/c/chardet/chardet-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/c/chardet/chardet-VERSION-py3-none-any.whl

--- a/build/pkgs/charset_normalizer/checksums.ini
+++ b/build/pkgs/charset_normalizer/checksums.ini
@@ -1,4 +1,4 @@
 tarball=charset_normalizer-VERSION-py3-none-any.whl
 sha1=1aa12424059bec1d95d9dda38b4ff6d062dededf
 sha256=3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc
-upstream_url=https://pypi.io/packages/py3/c/charset_normalizer/charset_normalizer-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/c/charset_normalizer/charset_normalizer-VERSION-py3-none-any.whl

--- a/build/pkgs/colorama/checksums.ini
+++ b/build/pkgs/colorama/checksums.ini
@@ -1,4 +1,4 @@
 tarball=colorama-VERSION-py2.py3-none-any.whl
 sha1=d6ab1608850fecfc0e1cf50bf93d743695c04027
 sha256=4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-upstream_url=https://pypi.io/packages/py2.py3/c/colorama/colorama-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/c/colorama/colorama-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/comm/checksums.ini
+++ b/build/pkgs/comm/checksums.ini
@@ -1,4 +1,4 @@
 tarball=comm-VERSION-py3-none-any.whl
 sha1=e7e20f9c1524a9fe059c0b6df90a68e1cd2115a9
 sha256=6d52794cba11b36ed9860999cd10fd02d6b2eac177068fdd585e1e2f8a96e67a
-upstream_url=https://pypi.io/packages/py3/c/comm/comm-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/c/comm/comm-VERSION-py3-none-any.whl

--- a/build/pkgs/contourpy/checksums.ini
+++ b/build/pkgs/contourpy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=contourpy-VERSION.tar.gz
 sha1=eb8520cb7172aa8b957d8ba2d09e8f6d9a068d2a
 sha256=96ba37c2e24b7212a77da85004c38e7c4d155d3e72a45eeaf22c1f03f607e8ab
-upstream_url=https://pypi.io/packages/source/c/contourpy/contourpy-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/c/contourpy/contourpy-VERSION.tar.gz

--- a/build/pkgs/conway_polynomials/checksums.ini
+++ b/build/pkgs/conway_polynomials/checksums.ini
@@ -1,4 +1,4 @@
 tarball=conway_polynomials-VERSION-py3-none-any.whl
 sha1=8d61cb30eb96dfce883a5761d08d45fcb035608a
 sha256=a354b4ac0a9985da75e2ac6ec6d7de2902396eff48913eeed86a962486171c28
-upstream_url=https://pypi.io/packages/py3/c/conway_polynomials/conway_polynomials-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/c/conway_polynomials/conway_polynomials-VERSION-py3-none-any.whl

--- a/build/pkgs/cppy/checksums.ini
+++ b/build/pkgs/cppy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cppy-VERSION-py3-none-any.whl
 sha1=57304a8ceaaf7cb34e4315aa9b8084b17fc0332c
 sha256=c5b5eac3d3f42593a07d35275b0bc27f447b76b9ad8f27c62e3cfa286dc1988a
-upstream_url=https://pypi.io/packages/py3/c/cppy/cppy-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/c/cppy/cppy-VERSION-py3-none-any.whl

--- a/build/pkgs/cvxopt/checksums.ini
+++ b/build/pkgs/cvxopt/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cvxopt-VERSION.tar.gz
 sha1=f9c3c3fb61e87d27f05b3b66bc10734d5e6284e6
 sha256=3461fa42c1b2240ba4da1d985ca73503914157fc4c77417327ed6d7d85acdbe6
-upstream_url=https://pypi.io/packages/source/c/cvxopt/cvxopt-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/c/cvxopt/cvxopt-VERSION.tar.gz

--- a/build/pkgs/cvxpy/checksums.ini
+++ b/build/pkgs/cvxpy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cvxpy-VERSION.tar.gz
 sha1=1ca24d9e2ee5add13b33724ab9a11e747fe4ed99
 sha256=7a9ef34e3c57ff8c844d86f0a3834fb5575af19233947639de0ba577c6122e3e
-upstream_url=https://pypi.io/packages/source/c/cvxpy/cvxpy-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/c/cvxpy/cvxpy-VERSION.tar.gz

--- a/build/pkgs/cylp/checksums.ini
+++ b/build/pkgs/cylp/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cylp-VERSION.tar.gz
 sha1=22398052ca88123b77e691a0045806a030c9b259
 sha256=a7ee226caa274e190338da3d24314647df7e06599ab38cdd26c005d8b8258b16
-upstream_url=https://pypi.io/packages/source/c/cylp/cylp-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/c/cylp/cylp-VERSION.tar.gz

--- a/build/pkgs/cypari/checksums.ini
+++ b/build/pkgs/cypari/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cypari2-VERSION.tar.gz
 sha1=4e9f14d218bc1cea29e03a2ceec9bf3dfbfd5eb3
 sha256=817606bf661b71d33e1d012421907a4f8fb09dd81b7d3e3ae179b3978020bbf1
-upstream_url=https://pypi.io/packages/source/c/cypari2/cypari2-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/c/cypari2/cypari2-VERSION.tar.gz

--- a/build/pkgs/cysignals/checksums.ini
+++ b/build/pkgs/cysignals/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cysignals-VERSION.tar.gz
 sha1=76db7aa59d55e867c83b329c017382555253af43
 sha256=0f1e321e55a07f901c86a36a1e4497f6ff9dfe700681d0130a38c36e4eb238c3
-upstream_url=https://pypi.io/packages/source/c/cysignals/cysignals-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/c/cysignals/cysignals-VERSION.tar.gz

--- a/build/pkgs/cython/checksums.ini
+++ b/build/pkgs/cython/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cython-VERSION.tar.gz
 sha1=f692b0c6f209b75b6bbd69bdbd57fac23785c23e
 sha256=7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff
-upstream_url=https://pypi.io/packages/source/c/cython/cython-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/c/cython/cython-VERSION.tar.gz

--- a/build/pkgs/database_cubic_hecke/checksums.ini
+++ b/build/pkgs/database_cubic_hecke/checksums.ini
@@ -1,4 +1,4 @@
 tarball=database_cubic_hecke-VERSION.tar.gz
 sha1=a99713c94e4108f917aa354f53edc26a60fd3808
 sha256=553654a4ce987a277fe956a9a450d738bd1f58b96c45499075e28f2bca927ae9
-upstream_url=https://pypi.io/packages/source/d/database_cubic_hecke/database_cubic_hecke-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/d/database_cubic_hecke/database_cubic_hecke-VERSION.tar.gz

--- a/build/pkgs/database_knotinfo/checksums.ini
+++ b/build/pkgs/database_knotinfo/checksums.ini
@@ -1,4 +1,4 @@
 tarball=database_knotinfo-VERSION.tar.gz
 sha1=8bc72e561c009cc6a7c15eceedee522281fbf763
 sha256=805868c8f3c30888e5866d833aec4f9ab07ad92b7b7caeb09bfec4634b28b0fd
-upstream_url=https://pypi.io/packages/source/d/database_knotinfo/database_knotinfo-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/d/database_knotinfo/database_knotinfo-VERSION.tar.gz

--- a/build/pkgs/dateutil/checksums.ini
+++ b/build/pkgs/dateutil/checksums.ini
@@ -1,4 +1,4 @@
 tarball=python_dateutil-VERSION-py2.py3-none-any.whl
 sha1=323a8e8de7e00a254fadae9c77b1264d56525178
 sha256=a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
-upstream_url=https://pypi.io/packages/py2.py3/p/python_dateutil/python_dateutil-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/p/python_dateutil/python_dateutil-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/debugpy/checksums.ini
+++ b/build/pkgs/debugpy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=debugpy-VERSION-py2.py3-none-any.whl
 sha1=cc85be805ef4f25e85bae65cf5b04badca032bb6
 sha256=28acbe2241222b87e255260c76741e1fbf04fdc3b6d094fcf57b6c6f75ce1242
-upstream_url=https://pypi.io/packages/py2.py3/d/debugpy/debugpy-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/d/debugpy/debugpy-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/decorator/checksums.ini
+++ b/build/pkgs/decorator/checksums.ini
@@ -1,4 +1,4 @@
 tarball=decorator-VERSION.tar.gz
 sha1=929f42916ac8a4aa973599d558768b8f1728db46
 sha256=637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330
-upstream_url=https://pypi.io/packages/source/d/decorator/decorator-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/d/decorator/decorator-VERSION.tar.gz

--- a/build/pkgs/defusedxml/checksums.ini
+++ b/build/pkgs/defusedxml/checksums.ini
@@ -1,4 +1,4 @@
 tarball=defusedxml-VERSION.tar.gz
 sha1=37667af1dc1357eb96b005c4f408ad5292d77b9f
 sha256=1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69
-upstream_url=https://pypi.io/packages/source/d/defusedxml/defusedxml-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/d/defusedxml/defusedxml-VERSION.tar.gz

--- a/build/pkgs/distlib/checksums.ini
+++ b/build/pkgs/distlib/checksums.ini
@@ -1,4 +1,4 @@
 tarball=distlib-VERSION-py2.py3-none-any.whl
 sha1=97ea3bb71040f0348eaea272ec17fefea5806e87
 sha256=034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784
-upstream_url=https://pypi.io/packages/py2.py3/d/distlib/distlib-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/d/distlib/distlib-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/docutils/checksums.ini
+++ b/build/pkgs/docutils/checksums.ini
@@ -1,4 +1,4 @@
 tarball=docutils-VERSION-py3-none-any.whl
 sha1=a2120453cdb1498128183696711261dd5f328068
 sha256=dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
-upstream_url=https://pypi.io/packages/py3/d/docutils/docutils-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/d/docutils/docutils-VERSION-py3-none-any.whl

--- a/build/pkgs/ecos_python/checksums.ini
+++ b/build/pkgs/ecos_python/checksums.ini
@@ -1,4 +1,4 @@
 tarball=ecos-VERSION.tar.gz
 sha1=7afce63aec44522052e05fa2e1c82e12fe20fd45
 sha256=f48816d73b87ae325556ea537b7c8743187311403c80e3832035224156337c4e
-upstream_url=https://pypi.io/packages/source/e/ecos/ecos-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/e/ecos/ecos-VERSION.tar.gz

--- a/build/pkgs/editables/checksums.ini
+++ b/build/pkgs/editables/checksums.ini
@@ -1,4 +1,4 @@
 tarball=editables-VERSION-py3-none-any.whl
 sha1=7aa90de86b05d6dc1a04c219b01ca7eab09de113
 sha256=61e5ffa82629e0d8bfe09bc44a07db3c1ab8ed1ce78a6980732870f19b5e7d4c
-upstream_url=https://pypi.io/packages/py3/e/editables/editables-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/e/editables/editables-VERSION-py3-none-any.whl

--- a/build/pkgs/entrypoints/checksums.ini
+++ b/build/pkgs/entrypoints/checksums.ini
@@ -1,4 +1,4 @@
 tarball=entrypoints-VERSION.tar.gz
 sha1=ca5c5976781db7ec6e8faece06af31ff32960529
 sha256=b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4
-upstream_url=https://pypi.io/packages/source/e/entrypoints/entrypoints-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/e/entrypoints/entrypoints-VERSION.tar.gz

--- a/build/pkgs/exceptiongroup/checksums.ini
+++ b/build/pkgs/exceptiongroup/checksums.ini
@@ -1,4 +1,4 @@
 tarball=exceptiongroup-VERSION-py3-none-any.whl
 sha1=fd04443cb88d35ee59387ba20f62761ea5546a7d
 sha256=3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b
-upstream_url=https://pypi.io/packages/py3/e/exceptiongroup/exceptiongroup-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/e/exceptiongroup/exceptiongroup-VERSION-py3-none-any.whl

--- a/build/pkgs/execnet/checksums.ini
+++ b/build/pkgs/execnet/checksums.ini
@@ -1,4 +1,4 @@
 tarball=execnet-VERSION-py3-none-any.whl
 sha1=3a3b88b478a03a9c9933a7bdaea3224a118cc121
 sha256=26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc
-upstream_url=https://pypi.io/packages/py3/e/execnet/execnet-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/e/execnet/execnet-VERSION-py3-none-any.whl

--- a/build/pkgs/executing/checksums.ini
+++ b/build/pkgs/executing/checksums.ini
@@ -1,4 +1,4 @@
 tarball=executing-VERSION-py2.py3-none-any.whl
 sha1=c32699ff6868bf3613d56795016880fdadde4fc6
 sha256=eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc
-upstream_url=https://pypi.io/packages/py2.py3/e/executing/executing-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/e/executing/executing-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/fastjsonschema/checksums.ini
+++ b/build/pkgs/fastjsonschema/checksums.ini
@@ -1,4 +1,4 @@
 tarball=fastjsonschema-VERSION.tar.gz
 sha1=eab76262783dd81303e2b1da0914a1d5a7f388aa
 sha256=e820349dd16f806e4bd1467a138dced9def4bc7d6213a34295272a6cac95b5bd
-upstream_url=https://pypi.io/packages/source/f/fastjsonschema/fastjsonschema-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/f/fastjsonschema/fastjsonschema-VERSION.tar.gz

--- a/build/pkgs/filelock/checksums.ini
+++ b/build/pkgs/filelock/checksums.ini
@@ -1,4 +1,4 @@
 tarball=filelock-VERSION-py3-none-any.whl
 sha1=475b56870663924527abcf2f91b7d8dd7a7ab0ee
 sha256=43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f
-upstream_url=https://pypi.io/packages/py3/f/filelock/filelock-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/f/filelock/filelock-VERSION-py3-none-any.whl

--- a/build/pkgs/flit_core/checksums.ini
+++ b/build/pkgs/flit_core/checksums.ini
@@ -1,4 +1,4 @@
 tarball=flit_core-VERSION-py3-none-any.whl
 sha1=cf044db53e986d0735ad708cce9eba0b71684168
 sha256=7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301
-upstream_url=https://pypi.io/packages/py3/f/flit_core/flit_core-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/f/flit_core/flit_core-VERSION-py3-none-any.whl

--- a/build/pkgs/fonttools/checksums.ini
+++ b/build/pkgs/fonttools/checksums.ini
@@ -1,4 +1,4 @@
 tarball=fonttools-VERSION.tar.gz
 sha1=5432f0273040b044e8d6465947e3a4c00097bdbf
 sha256=c391cd5af88aacaf41dd7cfb96eeedfad297b5899a39e12f4c2c3706d0a3329d
-upstream_url=https://pypi.io/packages/source/f/fonttools/fonttools-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/f/fonttools/fonttools-VERSION.tar.gz

--- a/build/pkgs/fpylll/checksums.ini
+++ b/build/pkgs/fpylll/checksums.ini
@@ -1,4 +1,4 @@
 tarball=fpylll-VERSION.tar.gz
 sha1=c0bcf8c5583ebf614da9b26710a2c835d498bf34
 sha256=dfd9529a26c50993a2a716177debd7994312219070574cad31b35b4f0c040a19
-upstream_url=https://pypi.io/packages/source/f/fpylll/fpylll-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/f/fpylll/fpylll-VERSION.tar.gz

--- a/build/pkgs/fqdn/checksums.ini
+++ b/build/pkgs/fqdn/checksums.ini
@@ -1,4 +1,4 @@
 tarball=fqdn-VERSION-py3-none-any.whl
 sha1=85a7ac7d7f45d2e0b64c4b7653ab277ceec91ecf
 sha256=3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014
-upstream_url=https://pypi.io/packages/py3/f/fqdn/fqdn-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/f/fqdn/fqdn-VERSION-py3-none-any.whl

--- a/build/pkgs/furo/checksums.ini
+++ b/build/pkgs/furo/checksums.ini
@@ -1,4 +1,4 @@
 tarball=furo-VERSION-py3-none-any.whl
 sha1=de4aa7aff48696580d62abed717bf1c309af10f5
 sha256=b192c7c1f59805494c8ed606d9375fdac6e6ba8178e747e72bc116745fb7e13f
-upstream_url=https://pypi.io/packages/py3/f/furo/furo-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/f/furo/furo-VERSION-py3-none-any.whl

--- a/build/pkgs/gast/checksums.ini
+++ b/build/pkgs/gast/checksums.ini
@@ -1,4 +1,4 @@
 tarball=gast-VERSION.tar.gz
 sha1=6c113cf8d33cc654d33210335103485ab41d3dbb
 sha256=9c270fe5f4b130969b54174de7db4e764b09b4f7f67ccfc32480e29f78348d97
-upstream_url=https://pypi.io/packages/source/g/gast/gast-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/g/gast/gast-VERSION.tar.gz

--- a/build/pkgs/gmpy2/checksums.ini
+++ b/build/pkgs/gmpy2/checksums.ini
@@ -1,4 +1,4 @@
 tarball=gmpy2-VERSION.tar.gz
 sha1=700ef438964acd286d52e973a833cd57ae9a7ad7
 sha256=3b8acc939a40411a8ad5541ed178ff866dd1759e667ee26fe34c9291b6b350c3
-upstream_url=https://pypi.io/packages/source/g/gmpy2/gmpy2-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/g/gmpy2/gmpy2-VERSION.tar.gz

--- a/build/pkgs/gnumake_tokenpool/checksums.ini
+++ b/build/pkgs/gnumake_tokenpool/checksums.ini
@@ -1,4 +1,4 @@
 tarball=gnumake_tokenpool-VERSION-py3-none-any.whl
 sha1=882c694dc3c0a935275a8d2acd9e766399719754
 sha256=0c49578df1a76b6ff7724b99053d96f1583bd3e52fe9547587cfb6ffdb0d1fcd
-upstream_url=https://pypi.io/packages/py3/g/gnumake_tokenpool/gnumake_tokenpool-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/g/gnumake_tokenpool/gnumake_tokenpool-VERSION-py3-none-any.whl

--- a/build/pkgs/h11/checksums.ini
+++ b/build/pkgs/h11/checksums.ini
@@ -1,4 +1,4 @@
 tarball=h11-VERSION-py3-none-any.whl
 sha1=c502d56dc3288212142a398704a5109749331dd8
 sha256=e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
-upstream_url=https://pypi.io/packages/py3/h/h11/h11-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/h/h11/h11-VERSION-py3-none-any.whl

--- a/build/pkgs/hatchling/checksums.ini
+++ b/build/pkgs/hatchling/checksums.ini
@@ -1,4 +1,4 @@
 tarball=hatchling-VERSION-py3-none-any.whl
 sha1=cae79d374a238c7674687fb4fff0b15cf1af9be4
 sha256=b47948e45d4d973034584dd4cb39c14b6a70227cf287ab7ec0ad7983408a882c
-upstream_url=https://pypi.io/packages/py3/h/hatchling/hatchling-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/h/hatchling/hatchling-VERSION-py3-none-any.whl

--- a/build/pkgs/httpcore/checksums.ini
+++ b/build/pkgs/httpcore/checksums.ini
@@ -1,4 +1,4 @@
 tarball=httpcore-VERSION-py3-none-any.whl
 sha1=52c8337dcf474d63f5b053e0f65cf79714ae69fe
 sha256=421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5
-upstream_url=https://pypi.io/packages/py3/h/httpcore/httpcore-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/h/httpcore/httpcore-VERSION-py3-none-any.whl

--- a/build/pkgs/httpx/checksums.ini
+++ b/build/pkgs/httpx/checksums.ini
@@ -1,4 +1,4 @@
 tarball=httpx-VERSION-py3-none-any.whl
 sha1=01f2a657e43842cb7c8dda30d38860fa741acb7e
 sha256=71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5
-upstream_url=https://pypi.io/packages/py3/h/httpx/httpx-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/h/httpx/httpx-VERSION-py3-none-any.whl

--- a/build/pkgs/idna/checksums.ini
+++ b/build/pkgs/idna/checksums.ini
@@ -1,4 +1,4 @@
 tarball=idna-VERSION-py3-none-any.whl
 sha1=ccb2491074ec1b6ffda6e6c11c1c668f885ed20a
 sha256=82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
-upstream_url=https://pypi.io/packages/py3/i/idna/idna-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/i/idna/idna-VERSION-py3-none-any.whl

--- a/build/pkgs/imagesize/checksums.ini
+++ b/build/pkgs/imagesize/checksums.ini
@@ -1,4 +1,4 @@
 tarball=imagesize-VERSION-py2.py3-none-any.whl
 sha1=6054e528ed40a9979df9952437a20c3e5773d972
 sha256=0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b
-upstream_url=https://pypi.io/packages/py2.py3/i/imagesize/imagesize-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/i/imagesize/imagesize-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/importlib_metadata/checksums.ini
+++ b/build/pkgs/importlib_metadata/checksums.ini
@@ -1,4 +1,4 @@
 tarball=importlib_metadata-VERSION-py3-none-any.whl
 sha1=82c9e2e6cfbb2d5a14558085efa65e75a95bd12f
 sha256=4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e
-upstream_url=https://pypi.io/packages/py3/i/importlib_metadata/importlib_metadata-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/i/importlib_metadata/importlib_metadata-VERSION-py3-none-any.whl

--- a/build/pkgs/importlib_resources/checksums.ini
+++ b/build/pkgs/importlib_resources/checksums.ini
@@ -1,4 +1,4 @@
 tarball=importlib_resources-VERSION-py3-none-any.whl
 sha1=5caa4e8a9ee93123a5c3badb6edbc009b5d8494a
 sha256=e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6
-upstream_url=https://pypi.io/packages/py3/i/importlib_resources/importlib_resources-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/i/importlib_resources/importlib_resources-VERSION-py3-none-any.whl

--- a/build/pkgs/iniconfig/checksums.ini
+++ b/build/pkgs/iniconfig/checksums.ini
@@ -1,4 +1,4 @@
 tarball=iniconfig-VERSION-py3-none-any.whl
 sha1=ec7addd8337eee38e86554d2f0f114f8a1c74b20
 sha256=b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
-upstream_url=https://pypi.io/packages/py3/i/iniconfig/iniconfig-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/i/iniconfig/iniconfig-VERSION-py3-none-any.whl

--- a/build/pkgs/ipykernel/checksums.ini
+++ b/build/pkgs/ipykernel/checksums.ini
@@ -1,4 +1,4 @@
 tarball=ipykernel-VERSION.tar.gz
 sha1=3465b4aa523705e930f295b5c549924e376a02e2
 sha256=7d5d594b6690654b4d299edba5e872dc17bb7396a8d0609c97cb7b8a1c605de6
-upstream_url=https://pypi.io/packages/source/i/ipykernel/ipykernel-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/i/ipykernel/ipykernel-VERSION.tar.gz

--- a/build/pkgs/ipympl/checksums.ini
+++ b/build/pkgs/ipympl/checksums.ini
@@ -1,4 +1,4 @@
 tarball=ipympl-VERSION-py2.py3-none-any.whl
 sha1=9848409026669d9edd83074730d7e2456ae8a187
 sha256=d113cd55891bafe9b27ef99b6dd111a87beb6bb2ae550c404292272103be8013
-upstream_url=https://pypi.io/packages/py2.py3/i/ipympl/ipympl-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/i/ipympl/ipympl-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/ipython/checksums.ini
+++ b/build/pkgs/ipython/checksums.ini
@@ -1,4 +1,4 @@
 tarball=ipython-VERSION.tar.gz
 sha1=4b5ab06a1b5e1a3285ac91d7dac9a22d18898a31
 sha256=ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27
-upstream_url=https://pypi.io/packages/source/i/ipython/ipython-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/i/ipython/ipython-VERSION.tar.gz

--- a/build/pkgs/ipywidgets/checksums.ini
+++ b/build/pkgs/ipywidgets/checksums.ini
@@ -1,4 +1,4 @@
 tarball=ipywidgets-VERSION.tar.gz
 sha1=95f7ec13e8ce75e2da40c1789b4af291946a6d99
 sha256=40211efb556adec6fa450ccc2a77d59ca44a060f4f9f136833df59c9f538e6e8
-upstream_url=https://pypi.io/packages/source/i/ipywidgets/ipywidgets-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/i/ipywidgets/ipywidgets-VERSION.tar.gz

--- a/build/pkgs/isoduration/checksums.ini
+++ b/build/pkgs/isoduration/checksums.ini
@@ -1,4 +1,4 @@
 tarball=isoduration-VERSION-py3-none-any.whl
 sha1=a113878d368fee6881efcfd12421b12f8e6ae11c
 sha256=b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042
-upstream_url=https://pypi.io/packages/py3/i/isoduration/isoduration-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/i/isoduration/isoduration-VERSION-py3-none-any.whl

--- a/build/pkgs/jedi/checksums.ini
+++ b/build/pkgs/jedi/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jedi-VERSION.tar.gz
 sha1=07d1e04c24cecf1b7f38f8905ce81c006f76cc20
 sha256=cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd
-upstream_url=https://pypi.io/packages/source/j/jedi/jedi-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/j/jedi/jedi-VERSION.tar.gz

--- a/build/pkgs/jinja2/checksums.ini
+++ b/build/pkgs/jinja2/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jinja2-VERSION-py3-none-any.whl
 sha1=57760ed83d9ad15fcdf63ad1ffa14941333ef655
 sha256=bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
-upstream_url=https://pypi.io/packages/py3/j/jinja2/jinja2-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jinja2/jinja2-VERSION-py3-none-any.whl

--- a/build/pkgs/json5/checksums.ini
+++ b/build/pkgs/json5/checksums.ini
@@ -1,4 +1,4 @@
 tarball=json5-VERSION-py2.py3-none-any.whl
 sha1=54bf91b9c2812e82ccd212cefca5bc5607a538b4
 sha256=740c7f1b9e584a468dbb2939d8d458db3427f2c93ae2139d05f47e453eae964f
-upstream_url=https://pypi.io/packages/py2.py3/j/json5/json5-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/j/json5/json5-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/jsonpointer/checksums.ini
+++ b/build/pkgs/jsonpointer/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jsonpointer-VERSION-py2.py3-none-any.whl
 sha1=de1b07c2d014f5b8e672cf0fb1225b2232d0b414
 sha256=15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a
-upstream_url=https://pypi.io/packages/py2.py3/j/jsonpointer/jsonpointer-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/j/jsonpointer/jsonpointer-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/jsonschema/checksums.ini
+++ b/build/pkgs/jsonschema/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jsonschema-VERSION-py3-none-any.whl
 sha1=189537b18c91e60be991a3dba704577d19f8e48d
 sha256=a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6
-upstream_url=https://pypi.io/packages/py3/j/jsonschema/jsonschema-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jsonschema/jsonschema-VERSION-py3-none-any.whl

--- a/build/pkgs/jsonschema_specifications/checksums.ini
+++ b/build/pkgs/jsonschema_specifications/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jsonschema_specifications-VERSION-py3-none-any.whl
 sha1=4132bed31478bc96960099e58ae4c083c514c551
 sha256=764a2b9325c225208121948b15f2b2d16fddbe223fdfc096b45c70c1f7f7b8c1
-upstream_url=https://pypi.io/packages/py3/j/jsonschema_specifications/jsonschema_specifications-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jsonschema_specifications/jsonschema_specifications-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyter_client/checksums.ini
+++ b/build/pkgs/jupyter_client/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyter_client-VERSION-py3-none-any.whl
 sha1=341f822626b55b53f03a21a44d78dc203472406b
 sha256=5eb9f55eb0650e81de6b7e34308d8b92d04fe4ec41cd8193a913979e33d8e1a5
-upstream_url=https://pypi.io/packages/py3/j/jupyter_client/jupyter_client-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyter_client/jupyter_client-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyter_core/checksums.ini
+++ b/build/pkgs/jupyter_core/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyter_core-VERSION.tar.gz
 sha1=0fe33e3247e595cdb83e2220f02c566ea9397e6a
 sha256=0c28db6cbe2c37b5b398e1a1a5b22f84fd64cd10afc1f6c05b02fb09481ba45f
-upstream_url=https://pypi.io/packages/source/j/jupyter_core/jupyter_core-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/j/jupyter_core/jupyter_core-VERSION.tar.gz

--- a/build/pkgs/jupyter_events/checksums.ini
+++ b/build/pkgs/jupyter_events/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyter_events-VERSION-py3-none-any.whl
 sha1=1b3fd8c003ea9e51b0f2d38daa89fded161767f7
 sha256=57a2749f87ba387cd1bfd9b22a0875b889237dbf2edc2121ebb22bde47036c17
-upstream_url=https://pypi.io/packages/py3/j/jupyter_events/jupyter_events-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyter_events/jupyter_events-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyter_jsmol/checksums.ini
+++ b/build/pkgs/jupyter_jsmol/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyter_jsmol-VERSION-py2.py3-none-any.whl
 sha1=b00f1ca76aaa906c7c0a43e36baf608183f3d552
 sha256=dca3a232f98aa92739de8b7905765d22f325a2ba5d7a3a2f5b2374e88cc80471
-upstream_url=https://pypi.io/packages/py2.py3/j/jupyter_jsmol/jupyter_jsmol-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/j/jupyter_jsmol/jupyter_jsmol-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/jupyter_lsp/checksums.ini
+++ b/build/pkgs/jupyter_lsp/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyter_lsp-VERSION-py3-none-any.whl
 sha1=0f7a63d99c5cf624315583099f00eafc4b996b59
 sha256=9e06b8b4f7dd50300b70dd1a78c0c3b0c3d8fa68e0f2d8a5d1fbab62072aca3f
-upstream_url=https://pypi.io/packages/py3/j/jupyter_lsp/jupyter_lsp-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyter_lsp/jupyter_lsp-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyter_server/checksums.ini
+++ b/build/pkgs/jupyter_server/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyter_server-VERSION-py3-none-any.whl
 sha1=a54aa7f6f1657a55cae9ecc4a6654b6e3ca5fb73
 sha256=8e4b90380b59d7a1e31086c4692231f2a2ea4cb269f5516e60aba72ce8317fc9
-upstream_url=https://pypi.io/packages/py3/j/jupyter_server/jupyter_server-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyter_server/jupyter_server-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyter_server_terminals/checksums.ini
+++ b/build/pkgs/jupyter_server_terminals/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyter_server_terminals-VERSION-py3-none-any.whl
 sha1=fd1201e9f0064b2a5a05ed7346dfe52546f13b0b
 sha256=75779164661cec02a8758a5311e18bb8eb70c4e86c6b699403100f1585a12a36
-upstream_url=https://pypi.io/packages/py3/j/jupyter_server_terminals/jupyter_server_terminals-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyter_server_terminals/jupyter_server_terminals-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyter_sphinx/checksums.ini
+++ b/build/pkgs/jupyter_sphinx/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyter_sphinx-VERSION.tar.gz
 sha1=85e6e1665488fac3131da2e3ab9648037c0d1da9
 sha256=2e23699a3a1cf5db31b10981da5aa32606ee730f6b73a844d1e76d800756af56
-upstream_url=https://pypi.io/packages/source/j/jupyter_sphinx/jupyter_sphinx-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/j/jupyter_sphinx/jupyter_sphinx-VERSION.tar.gz

--- a/build/pkgs/jupyterlab/checksums.ini
+++ b/build/pkgs/jupyterlab/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyterlab-VERSION-py3-none-any.whl
 sha1=4efdd879660e719fd49be6ec169272f32a16593e
 sha256=67dbec7057c6ad46f08a3667a80bdb890df9453822c93b5ddfd5e8313a718ef9
-upstream_url=https://pypi.io/packages/py3/j/jupyterlab/jupyterlab-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyterlab/jupyterlab-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyterlab_mathjax2/checksums.ini
+++ b/build/pkgs/jupyterlab_mathjax2/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyterlab_mathjax2-VERSION-py3-none-any.whl
 sha1=4e2bb182594a6c4f5d4edfb4f6e33597f09de402
 sha256=c65c401ee5638e7cbf1223ba95aceed8b26a2a3e48fd1d585a10dd95b9327a8f
-upstream_url=https://pypi.io/packages/py3/j/jupyterlab_mathjax2/jupyterlab_mathjax2-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyterlab_mathjax2/jupyterlab_mathjax2-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyterlab_pygments/checksums.ini
+++ b/build/pkgs/jupyterlab_pygments/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyterlab_pygments-VERSION-py2.py3-none-any.whl
 sha1=601f547767fa867494ff0764891807904b8ebbd2
 sha256=2405800db07c9f770863bcf8049a529c3dd4d3e28536638bd7c1c01d2748309f
-upstream_url=https://pypi.io/packages/py2.py3/j/jupyterlab_pygments/jupyterlab_pygments-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/j/jupyterlab_pygments/jupyterlab_pygments-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/jupyterlab_server/checksums.ini
+++ b/build/pkgs/jupyterlab_server/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyterlab_server-VERSION-py3-none-any.whl
 sha1=1fff8c8bc4c81b006cb83d4524dc8a6f3364e57c
 sha256=5f077e142bb8dc9b843d960f940c513581bceca3793a0d80f9c67d9522c4e876
-upstream_url=https://pypi.io/packages/py3/j/jupyterlab_server/jupyterlab_server-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyterlab_server/jupyterlab_server-VERSION-py3-none-any.whl

--- a/build/pkgs/jupyterlab_widgets/checksums.ini
+++ b/build/pkgs/jupyterlab_widgets/checksums.ini
@@ -1,4 +1,4 @@
 tarball=jupyterlab_widgets-VERSION-py3-none-any.whl
 sha1=b10775bb3966af627bb44fbda4efb553b24a5b93
 sha256=3cf5bdf5b897bf3bccf1c11873aa4afd776d7430200f765e0686bd352487b58d
-upstream_url=https://pypi.io/packages/py3/j/jupyterlab_widgets/jupyterlab_widgets-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/j/jupyterlab_widgets/jupyterlab_widgets-VERSION-py3-none-any.whl

--- a/build/pkgs/lrcalc_python/checksums.ini
+++ b/build/pkgs/lrcalc_python/checksums.ini
@@ -1,4 +1,4 @@
 tarball=lrcalc-VERSION.tar.gz
 sha1=3e9366d9e8b8beccec70b07d174b8f6683c01574
 sha256=e3a0509aeda487b412b391a52e817ca36b5c063a8305e09fd54d53259dd6aaa9
-upstream_url=https://pypi.io/packages/source/l/lrcalc/lrcalc-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/l/lrcalc/lrcalc-VERSION.tar.gz

--- a/build/pkgs/markupsafe/checksums.ini
+++ b/build/pkgs/markupsafe/checksums.ini
@@ -1,4 +1,4 @@
 tarball=MarkupSafe-VERSION.tar.gz
 sha1=08593f9490b9be070aa2337e7311a392d33944dd
 sha256=d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b
-upstream_url=https://pypi.io/packages/source/m/markupsafe/MarkupSafe-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/m/markupsafe/MarkupSafe-VERSION.tar.gz

--- a/build/pkgs/matplotlib/checksums.ini
+++ b/build/pkgs/matplotlib/checksums.ini
@@ -1,4 +1,4 @@
 tarball=matplotlib-VERSION.tar.gz
 sha1=b3391b48ab0bf91778064ce5b2226ff2a2658d7c
 sha256=df8505e1c19d5c2c26aff3497a7cbd3ccfc2e97043d1e4db3e76afa399164b69
-upstream_url=https://pypi.io/packages/source/m/matplotlib/matplotlib-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/m/matplotlib/matplotlib-VERSION.tar.gz

--- a/build/pkgs/matplotlib_inline/checksums.ini
+++ b/build/pkgs/matplotlib_inline/checksums.ini
@@ -1,4 +1,4 @@
 tarball=matplotlib-inline-VERSION.tar.gz
 sha1=a09347e3f2eaa6f9453c773132bf4bd9d38e2163
 sha256=f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304
-upstream_url=https://pypi.io/packages/source/m/matplotlib_inline/matplotlib-inline-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/m/matplotlib_inline/matplotlib-inline-VERSION.tar.gz

--- a/build/pkgs/matroid_database/checksums.ini
+++ b/build/pkgs/matroid_database/checksums.ini
@@ -1,4 +1,4 @@
 tarball=matroid_database-VERSION-py3-none-any.whl
 sha1=f6539d37c9a03e14a8b100555525d3b54feb602b
 sha256=85d0304575784ceb4797014fb5a761443d2a0bbf01aafc38ef293d2c64a1b5ce
-upstream_url=https://pypi.io/packages/py3/m/matroid_database/matroid_database-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/m/matroid_database/matroid_database-VERSION-py3-none-any.whl

--- a/build/pkgs/memory_allocator/checksums.ini
+++ b/build/pkgs/memory_allocator/checksums.ini
@@ -1,4 +1,4 @@
 tarball=memory_allocator-VERSION.tar.gz
 sha1=21661580dd3f41aac0f2090033d8804e6ff495d9
 sha256=d609216b03031967e2b45a804b12ff9029578f4ec019fde42cf6aed6ca09efe4
-upstream_url=https://pypi.io/packages/source/m/memory_allocator/memory_allocator-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/m/memory_allocator/memory_allocator-VERSION.tar.gz

--- a/build/pkgs/meson/checksums.ini
+++ b/build/pkgs/meson/checksums.ini
@@ -1,4 +1,4 @@
 tarball=meson-VERSION-py3-none-any.whl
 sha1=baf5b9bc9ca97f18c7dc87cfaf0e1dc4d617a4cf
 sha256=d5223ecca9564d735d36daaba2571abc6c032c8c3a7ffa0674e803ef0c7e0219
-upstream_url=https://pypi.io/packages/py3/m/meson/meson-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/m/meson/meson-VERSION-py3-none-any.whl

--- a/build/pkgs/meson_python/checksums.ini
+++ b/build/pkgs/meson_python/checksums.ini
@@ -1,4 +1,4 @@
 tarball=meson_python-VERSION.tar.gz
 sha1=71bf382c2f2e76aada2f511a84bd59a99a6b1238
 sha256=fddb73eecd49e89c1c41c87937cd89c2d0b65a1c63ba28238681d4bd9484d26f
-upstream_url=https://pypi.io/packages/source/m/meson_python/meson_python-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/m/meson_python/meson_python-VERSION.tar.gz

--- a/build/pkgs/mistune/checksums.ini
+++ b/build/pkgs/mistune/checksums.ini
@@ -1,4 +1,4 @@
 tarball=mistune-VERSION.tar.gz
 sha1=c15d02c98d04a3e615c3c1932d1b9a3b1759067a
 sha256=9ee0a66053e2267aba772c71e06891fa8f1af6d4b01d5e84e267b4570d4d9808
-upstream_url=https://pypi.io/packages/source/m/mistune/mistune-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/m/mistune/mistune-VERSION.tar.gz

--- a/build/pkgs/nbclient/checksums.ini
+++ b/build/pkgs/nbclient/checksums.ini
@@ -1,4 +1,4 @@
 tarball=nbclient-VERSION-py3-none-any.whl
 sha1=fcb4ad9b3ea1bea4d305076c0a7640a483bd11f3
 sha256=25e861299e5303a0477568557c4045eccc7a34c17fc08e7959558707b9ebe548
-upstream_url=https://pypi.io/packages/py3/n/nbclient/nbclient-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/n/nbclient/nbclient-VERSION-py3-none-any.whl

--- a/build/pkgs/nbconvert/checksums.ini
+++ b/build/pkgs/nbconvert/checksums.ini
@@ -1,4 +1,4 @@
 tarball=nbconvert-VERSION-py3-none-any.whl
 sha1=5317fa68bbd7f66fc3fcc5b0e6b0d6e2df967ba0
 sha256=39fe4b8bdd1b0104fdd86fc8a43a9077ba64c720bda4c6132690d917a0a154ee
-upstream_url=https://pypi.io/packages/py3/n/nbconvert/nbconvert-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/n/nbconvert/nbconvert-VERSION-py3-none-any.whl

--- a/build/pkgs/nbformat/checksums.ini
+++ b/build/pkgs/nbformat/checksums.ini
@@ -1,4 +1,4 @@
 tarball=nbformat-VERSION-py3-none-any.whl
 sha1=e38af74817e9d81101583363d9ffe349f0038eb9
 sha256=1c5172d786a41b82bcfd0c23f9e6b6f072e8fb49c39250219e4acfff1efe89e9
-upstream_url=https://pypi.io/packages/py3/n/nbformat/nbformat-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/n/nbformat/nbformat-VERSION-py3-none-any.whl

--- a/build/pkgs/nest_asyncio/checksums.ini
+++ b/build/pkgs/nest_asyncio/checksums.ini
@@ -1,4 +1,4 @@
 tarball=nest_asyncio-VERSION-py3-none-any.whl
 sha1=675b145491553e6a725884081244860a635552cd
 sha256=87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c
-upstream_url=https://pypi.io/packages/py3/n/nest_asyncio/nest_asyncio-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/n/nest_asyncio/nest_asyncio-VERSION-py3-none-any.whl

--- a/build/pkgs/networkx/checksums.ini
+++ b/build/pkgs/networkx/checksums.ini
@@ -1,4 +1,4 @@
 tarball=networkx-VERSION.tar.gz
 sha1=b12cf95ed8bc3fe568e3c8e023473a3767c43f8d
 sha256=9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6
-upstream_url=https://pypi.io/packages/source/n/networkx/networkx-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/n/networkx/networkx-VERSION.tar.gz

--- a/build/pkgs/notebook/checksums.ini
+++ b/build/pkgs/notebook/checksums.ini
@@ -1,4 +1,4 @@
 tarball=notebook-VERSION-py3-none-any.whl
 sha1=90ec65091058ac541a55cc2417de83c1bcb24985
 sha256=197d8e0595acabf4005851c8716e952a81b405f7aefb648067a761fbde267ce7
-upstream_url=https://pypi.io/packages/py3/n/notebook/notebook-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/n/notebook/notebook-VERSION-py3-none-any.whl

--- a/build/pkgs/notebook_shim/checksums.ini
+++ b/build/pkgs/notebook_shim/checksums.ini
@@ -1,4 +1,4 @@
 tarball=notebook_shim-VERSION-py3-none-any.whl
 sha1=9bb3dce360ce69aec99f873d8e80c1e9fdf92fde
 sha256=a83496a43341c1674b093bfcebf0fe8e74cbe7eda5fd2bbc56f8e39e1486c0c7
-upstream_url=https://pypi.io/packages/py3/n/notebook_shim/notebook_shim-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/n/notebook_shim/notebook_shim-VERSION-py3-none-any.whl

--- a/build/pkgs/numpy/checksums.ini
+++ b/build/pkgs/numpy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=numpy-VERSION.tar.gz
 sha1=915414f1efabd7c183583154cf1a709bd2745828
 sha256=697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4
-upstream_url=https://pypi.io/packages/source/n/numpy/numpy-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/n/numpy/numpy-VERSION.tar.gz

--- a/build/pkgs/osqp_python/checksums.ini
+++ b/build/pkgs/osqp_python/checksums.ini
@@ -1,4 +1,4 @@
 tarball=osqp-VERSION.tar.gz
 sha1=3358e48aa6d81496665a8b0ee157465ce6cd329a
 sha256=03e460e683ec2ce0f839353ddfa3c4c8ffa509ab8cf6a2b2afbb586fa453e180
-upstream_url=https://pypi.io/packages/source/o/osqp/osqp-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/o/osqp/osqp-VERSION.tar.gz

--- a/build/pkgs/overrides/checksums.ini
+++ b/build/pkgs/overrides/checksums.ini
@@ -1,4 +1,4 @@
 tarball=overrides-VERSION-py3-none-any.whl
 sha1=740e9e607a9e4f78dea7a1b82bcb27f285bc5f48
 sha256=3ad24583f86d6d7a49049695efe9933e67ba62f0c7625d53c59fa832ce4b8b7d
-upstream_url=https://pypi.io/packages/py3/o/overrides/overrides-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/o/overrides/overrides-VERSION-py3-none-any.whl

--- a/build/pkgs/packaging/checksums.ini
+++ b/build/pkgs/packaging/checksums.ini
@@ -1,4 +1,4 @@
 tarball=packaging-VERSION-py3-none-any.whl
 sha1=a050029d1e0c1b95b3ddcd566be4ad352cd42666
 sha256=5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
-upstream_url=https://pypi.io/packages/py3/p/packaging/packaging-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/packaging/packaging-VERSION-py3-none-any.whl

--- a/build/pkgs/pandocfilters/checksums.ini
+++ b/build/pkgs/pandocfilters/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pandocfilters-VERSION.tar.gz
 sha1=bdee4f81063c02168b421640f3e18917011153df
 sha256=0b679503337d233b4339a817bfc8c50064e2eff681314376a47cb582305a7a38
-upstream_url=https://pypi.io/packages/source/p/pandocfilters/pandocfilters-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pandocfilters/pandocfilters-VERSION.tar.gz

--- a/build/pkgs/pari_jupyter/checksums.ini
+++ b/build/pkgs/pari_jupyter/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pari-jupyter-VERSION.tar.gz
 sha1=b410ee0352cd58f5f140246540b71b5ff83ddf73
 sha256=7cd9291d05b92b8303c6ae8cf25622e5ecbab1ac2bcf13911f900ea987471b9d
-upstream_url=https://pypi.io/packages/source/p/pari_jupyter/pari-jupyter-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pari_jupyter/pari-jupyter-VERSION.tar.gz

--- a/build/pkgs/parso/checksums.ini
+++ b/build/pkgs/parso/checksums.ini
@@ -1,4 +1,4 @@
 tarball=parso-VERSION-py2.py3-none-any.whl
 sha1=091d37e09a601d854e18f4d42aeb478392bb7e63
 sha256=a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18
-upstream_url=https://pypi.io/packages/py2.py3/p/parso/parso-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/p/parso/parso-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/pathspec/checksums.ini
+++ b/build/pkgs/pathspec/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pathspec-VERSION-py3-none-any.whl
 sha1=e31b7b2b1a59ab192eb2e92ac283211a11039769
 sha256=a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08
-upstream_url=https://pypi.io/packages/py3/p/pathspec/pathspec-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pathspec/pathspec-VERSION-py3-none-any.whl

--- a/build/pkgs/pexpect/checksums.ini
+++ b/build/pkgs/pexpect/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pexpect-VERSION.tar.gz
 sha1=5bff9230c419eecbf701059f104e74a3f3a1b208
 sha256=ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f
-upstream_url=https://pypi.io/packages/source/p/pexpect/pexpect-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pexpect/pexpect-VERSION.tar.gz

--- a/build/pkgs/pillow/checksums.ini
+++ b/build/pkgs/pillow/checksums.ini
@@ -1,4 +1,4 @@
 tarball=Pillow-VERSION.tar.gz
 sha1=be2dc6aeee145894f3ccbc2358a37f7849e710aa
 sha256=e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38
-upstream_url=https://pypi.io/packages/source/p/pillow/Pillow-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pillow/Pillow-VERSION.tar.gz

--- a/build/pkgs/pip/checksums.ini
+++ b/build/pkgs/pip/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pip-VERSION-py3-none-any.whl
 sha1=044a04440eef697c8ec9e03544117345c57aa683
 sha256=2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2
-upstream_url=https://pypi.io/packages/py3/p/pip/pip-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pip/pip-VERSION-py3-none-any.whl

--- a/build/pkgs/pkgconfig/checksums.ini
+++ b/build/pkgs/pkgconfig/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pkgconfig-VERSION-py3-none-any.whl
 sha1=bca14b2806a8e8afb0bd04f8e3675550b286dda8
 sha256=d20023bbeb42ee6d428a0fac6e0904631f545985a10cdd71a20aa58bc47a4209
-upstream_url=https://pypi.io/packages/py3/p/pkgconfig/pkgconfig-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pkgconfig/pkgconfig-VERSION-py3-none-any.whl

--- a/build/pkgs/platformdirs/checksums.ini
+++ b/build/pkgs/platformdirs/checksums.ini
@@ -1,4 +1,4 @@
 tarball=platformdirs-VERSION-py3-none-any.whl
 sha1=81890edbdf2f709f83001cb5bcfd71c3978225ce
 sha256=2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee
-upstream_url=https://pypi.io/packages/py3/p/platformdirs/platformdirs-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/platformdirs/platformdirs-VERSION-py3-none-any.whl

--- a/build/pkgs/pluggy/checksums.ini
+++ b/build/pkgs/pluggy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pluggy-VERSION-py3-none-any.whl
 sha1=ccb7a74c114522f26e2c3b1884468343f54098d3
 sha256=44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
-upstream_url=https://pypi.io/packages/py3/p/pluggy/pluggy-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pluggy/pluggy-VERSION-py3-none-any.whl

--- a/build/pkgs/ply/checksums.ini
+++ b/build/pkgs/ply/checksums.ini
@@ -1,4 +1,4 @@
 tarball=ply-VERSION.tar.gz
 sha1=10a555a32095991fbc7f7ed10c677a14e21fad1d
 sha256=00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3
-upstream_url=https://pypi.io/packages/source/p/ply/ply-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/ply/ply-VERSION.tar.gz

--- a/build/pkgs/pplpy/checksums.ini
+++ b/build/pkgs/pplpy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pplpy-VERSION.tar.gz
 sha1=dc9e8a7a867ee1c066bdbecf22b6a59dc2052711
 sha256=db7a3b571d6ef053f75137975e947c3a1c1e45a30bab90eaf215b4e5cc15797e
-upstream_url=https://pypi.io/packages/source/p/pplpy/pplpy-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pplpy/pplpy-VERSION.tar.gz

--- a/build/pkgs/primecountpy/checksums.ini
+++ b/build/pkgs/primecountpy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=primecountpy-VERSION.tar.gz
 sha1=3526784adad04d67a15f05fb1367d12ec50a59dc
 sha256=78fe7cc32115f0669a45d7c90faaf39f7ce3939e39e2e7e5f14c17fe4bff0676
-upstream_url=https://pypi.io/packages/source/p/primecountpy/primecountpy-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/primecountpy/primecountpy-VERSION.tar.gz

--- a/build/pkgs/prometheus_client/checksums.ini
+++ b/build/pkgs/prometheus_client/checksums.ini
@@ -1,4 +1,4 @@
 tarball=prometheus_client-VERSION.tar.gz
 sha1=dabd66e652ea8275b4980e337cefcea68cc0b560
 sha256=5459c427624961076277fdc6dc50540e2bacb98eebde99886e59ec55ed92093a
-upstream_url=https://pypi.io/packages/source/p/prometheus-client/prometheus_client-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/prometheus-client/prometheus_client-VERSION.tar.gz

--- a/build/pkgs/prompt_toolkit/checksums.ini
+++ b/build/pkgs/prompt_toolkit/checksums.ini
@@ -1,4 +1,4 @@
 tarball=prompt_toolkit-VERSION.tar.gz
 sha1=b5ada8cb45c11f9184c990bd33a98d3d690e6edc
 sha256=3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d
-upstream_url=https://pypi.io/packages/source/p/prompt_toolkit/prompt_toolkit-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/prompt_toolkit/prompt_toolkit-VERSION.tar.gz

--- a/build/pkgs/psutil/checksums.ini
+++ b/build/pkgs/psutil/checksums.ini
@@ -1,4 +1,4 @@
 tarball=psutil-VERSION.tar.gz
 sha1=24c493ef33d4df44e76a1801e480b4185bd911c5
 sha256=e4b92ddcd7dd4cdd3f900180ea1e104932c7bce234fb88976e2a3b296441225a
-upstream_url=https://pypi.io/packages/source/p/psutil/psutil-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/psutil/psutil-VERSION.tar.gz

--- a/build/pkgs/ptyprocess/checksums.ini
+++ b/build/pkgs/ptyprocess/checksums.ini
@@ -1,4 +1,4 @@
 tarball=ptyprocess-VERSION.tar.gz
 sha1=2d8830d1025c8e33149c7723c2f283122f9488c1
 sha256=5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
-upstream_url=https://pypi.io/packages/source/p/ptyprocess/ptyprocess-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/ptyprocess/ptyprocess-VERSION.tar.gz

--- a/build/pkgs/pure_eval/checksums.ini
+++ b/build/pkgs/pure_eval/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pure_eval-VERSION-py3-none-any.whl
 sha1=dbd5eaa9eb5a4910cff5ccd42b570f866f581da4
 sha256=01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350
-upstream_url=https://pypi.io/packages/py3/p/pure_eval/pure_eval-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pure_eval/pure_eval-VERSION-py3-none-any.whl

--- a/build/pkgs/py/checksums.ini
+++ b/build/pkgs/py/checksums.ini
@@ -1,4 +1,4 @@
 tarball=py-VERSION-py2.py3-none-any.whl
 sha1=44002baec8d2184d218bd2fa6049967cd9b4dbb5
 sha256=607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-upstream_url=https://pypi.io/packages/py2.py3/p/py/py-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/p/py/py-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/pybind11/checksums.ini
+++ b/build/pkgs/pybind11/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pybind11-VERSION.tar.gz
 sha1=3c75333a9056f0be18eb612803cd46a2bb0c87fc
 sha256=00cd59116a6e8155aecd9174f37ba299d1d397ed4a6b86ac1dfe01b3e40f2cc4
-upstream_url=https://pypi.io/packages/source/p/pybind11/pybind11-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pybind11/pybind11-VERSION.tar.gz

--- a/build/pkgs/pycparser/checksums.ini
+++ b/build/pkgs/pycparser/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pycparser-VERSION-py3-none-any.whl
 sha1=34702512290f3bfd4850bcc95dfaf1ae972a8929
 sha256=c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
-upstream_url=https://pypi.io/packages/py3/p/pycparser/pycparser-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pycparser/pycparser-VERSION-py3-none-any.whl

--- a/build/pkgs/pygments/checksums.ini
+++ b/build/pkgs/pygments/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pygments-VERSION-py3-none-any.whl
 sha1=edb9fdfbc4cf53d356a02beee8822dd8e9529f35
 sha256=b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
-upstream_url=https://pypi.io/packages/py3/p/pygments/pygments-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pygments/pygments-VERSION-py3-none-any.whl

--- a/build/pkgs/pynormaliz/checksums.ini
+++ b/build/pkgs/pynormaliz/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pynormaliz-VERSION.tar.gz
 sha1=4ce4fef4db61a0408bc84747294922fc49afc090
 sha256=95d29fff9380ea2948166fd2b4c730985e0881043fa41f3e44ff9f402b97f0b4
-upstream_url=https://pypi.io/packages/source/p/pynormaliz/pynormaliz-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pynormaliz/pynormaliz-VERSION.tar.gz

--- a/build/pkgs/pyparsing/checksums.ini
+++ b/build/pkgs/pyparsing/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pyparsing-VERSION-py3-none-any.whl
 sha1=bf1ab91fb997ccee2793e1e7f22a56a25f5e3a93
 sha256=f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742
-upstream_url=https://pypi.io/packages/py3/p/pyparsing/pyparsing-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pyparsing/pyparsing-VERSION-py3-none-any.whl

--- a/build/pkgs/pyproject_api/checksums.ini
+++ b/build/pkgs/pyproject_api/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pyproject_api-VERSION-py3-none-any.whl
 sha1=3723eb52bd6844f30f30f6f5b3723ce0f57a3cbf
 sha256=2dc1654062c2b27733d8fd4cdda672b22fe8741ef1dde8e3a998a9547b071eeb
-upstream_url=https://pypi.io/packages/py3/p/pyproject_api/pyproject_api-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pyproject_api/pyproject_api-VERSION-py3-none-any.whl

--- a/build/pkgs/pyproject_hooks/checksums.ini
+++ b/build/pkgs/pyproject_hooks/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pyproject_hooks-VERSION-py3-none-any.whl
 sha1=f8c16752e1deea6a3e9a261c6725c1af408d04e7
 sha256=7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2
-upstream_url=https://pypi.io/packages/py3/p/pyproject_hooks/pyproject_hooks-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pyproject_hooks/pyproject_hooks-VERSION-py3-none-any.whl

--- a/build/pkgs/pyproject_metadata/checksums.ini
+++ b/build/pkgs/pyproject_metadata/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pyproject_metadata-VERSION-py3-none-any.whl
 sha1=59998bbcd31cc63f3e95f3ad8120ff71326595a0
 sha256=ad858d448e1d3a1fb408ac5bac9ea7743e7a8bbb472f2693aaa334d2db42f526
-upstream_url=https://pypi.io/packages/py3/p/pyproject_metadata/pyproject_metadata-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pyproject_metadata/pyproject_metadata-VERSION-py3-none-any.whl

--- a/build/pkgs/pyrsistent/checksums.ini
+++ b/build/pkgs/pyrsistent/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pyrsistent-VERSION.tar.gz
 sha1=79980873658f7634ae25758b9710088b62e0612a
 sha256=1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440
-upstream_url=https://pypi.io/packages/source/p/pyrsistent/pyrsistent-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pyrsistent/pyrsistent-VERSION.tar.gz

--- a/build/pkgs/pyscipopt/checksums.ini
+++ b/build/pkgs/pyscipopt/checksums.ini
@@ -1,4 +1,4 @@
 tarball=PySCIPOpt-VERSION.tar.gz
 sha1=713e32cc0ff112500c4f43487614094ece4a8bbf
 sha256=f9c36c941e1373406b00c030f2511578c3fb02a95a2cf5559772deb846a0af47
-upstream_url=https://pypi.io/packages/source/p/pyscipopt/PySCIPOpt-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pyscipopt/PySCIPOpt-VERSION.tar.gz

--- a/build/pkgs/pysingular/checksums.ini
+++ b/build/pkgs/pysingular/checksums.ini
@@ -1,4 +1,4 @@
 tarball=PySingular-VERSION.tar.gz
 sha1=c8d4bbe4552490aac37afe6d87a2cd3a7b445a7e
 sha256=ca03d1d7538fc61f4350acff42708c6c443e0232712a2dc42ce72140831ef60c
-upstream_url=https://pypi.io/packages/source/p/pysingular/PySingular-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pysingular/PySingular-VERSION.tar.gz

--- a/build/pkgs/pytest/checksums.ini
+++ b/build/pkgs/pytest/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pytest-VERSION-py3-none-any.whl
 sha1=985b136db51e6729983433c6632564dc557f5fb6
 sha256=4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5
-upstream_url=https://pypi.io/packages/py3/p/pytest/pytest-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pytest/pytest-VERSION-py3-none-any.whl

--- a/build/pkgs/pytest_mock/checksums.ini
+++ b/build/pkgs/pytest_mock/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pytest_mock-VERSION-py3-none-any.whl
 sha1=7fcd316f0d08a7c961bec3ca0d756429ccb6b840
 sha256=0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f
-upstream_url=https://pypi.io/packages/py3/p/pytest_mock/pytest_mock-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pytest_mock/pytest_mock-VERSION-py3-none-any.whl

--- a/build/pkgs/pytest_xdist/checksums.ini
+++ b/build/pkgs/pytest_xdist/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pytest_xdist-VERSION-py3-none-any.whl
 sha1=de5b68f355cb51478ba9d5104da67a6359dee9e0
 sha256=9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7
-upstream_url=https://pypi.io/packages/py3/p/pytest_xdist/pytest_xdist-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/pytest_xdist/pytest_xdist-VERSION-py3-none-any.whl

--- a/build/pkgs/python_build/checksums.ini
+++ b/build/pkgs/python_build/checksums.ini
@@ -1,4 +1,4 @@
 tarball=build-VERSION-py3-none-any.whl
 sha1=950bf228726af5041adbe2bb04a7ca74e27bce60
 sha256=75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4
-upstream_url=https://pypi.io/packages/py3/b/build/build-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/b/build/build-VERSION-py3-none-any.whl

--- a/build/pkgs/python_flint/checksums.ini
+++ b/build/pkgs/python_flint/checksums.ini
@@ -1,4 +1,4 @@
 tarball=python-flint-VERSION.tar.gz
 sha1=c7d5b3b8db47c903eea9e752bd7732e34d6c5945
 sha256=f829e00774534891b38de41bc511cf6c7d6d216544a6a84b92d9e1f159de0878
-upstream_url=https://pypi.io/packages/source/p/python_flint/python-flint-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/python_flint/python-flint-VERSION.tar.gz

--- a/build/pkgs/python_igraph/checksums.ini
+++ b/build/pkgs/python_igraph/checksums.ini
@@ -1,4 +1,4 @@
 tarball=python-igraph-VERSION.tar.gz
 sha1=da963213ab22c60938d4e77ffab811875ee43a8a
 sha256=2d71d645a4c3344c5910543fabbae10d3163f46a3e824ba7753c14b9036b8233
-upstream_url=https://pypi.io/packages/source/i/igraph/igraph-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/i/igraph/igraph-VERSION.tar.gz

--- a/build/pkgs/python_json_logger/checksums.ini
+++ b/build/pkgs/python_json_logger/checksums.ini
@@ -1,4 +1,4 @@
 tarball=python_json_logger-VERSION-py3-none-any.whl
 sha1=c1176f521d95b5452b6169943b2b9b259e024b39
 sha256=f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd
-upstream_url=https://pypi.io/packages/py3/p/python_json_logger/python_json_logger-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/p/python_json_logger/python_json_logger-VERSION-py3-none-any.whl

--- a/build/pkgs/pythran/checksums.ini
+++ b/build/pkgs/pythran/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pythran-VERSION.tar.gz
 sha1=dc8a6035c0c46d36630085003160a3aba4444add
 sha256=f9bc61bcb96df2cd4b578abc5a62dfb3fbb0b0ef02c264513dfb615c5f87871c
-upstream_url=https://pypi.io/packages/source/p/pythran/pythran-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pythran/pythran-VERSION.tar.gz

--- a/build/pkgs/pytz/checksums.ini
+++ b/build/pkgs/pytz/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pytz-VERSION.tar.gz
 sha1=be3f14bc0d6b89b8c579d8ae4e0fcb4478ff92e6
 sha256=7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b
-upstream_url=https://pypi.io/packages/source/p/pytz/pytz-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pytz/pytz-VERSION.tar.gz

--- a/build/pkgs/pytz_deprecation_shim/checksums.ini
+++ b/build/pkgs/pytz_deprecation_shim/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pytz_deprecation_shim-VERSION.tar.gz
 sha1=d7900c309c26d48f6499fbda955eb80bd0b437dd
 sha256=af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d
-upstream_url=https://pypi.io/packages/source/p/pytz_deprecation_shim/pytz_deprecation_shim-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pytz_deprecation_shim/pytz_deprecation_shim-VERSION.tar.gz

--- a/build/pkgs/pyyaml/checksums.ini
+++ b/build/pkgs/pyyaml/checksums.ini
@@ -1,4 +1,4 @@
 tarball=PyYAML-VERSION.tar.gz
 sha1=a80d802ad8f693bed34c8fb5ee168a1872663c9a
 sha256=bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43
-upstream_url=https://pypi.io/packages/source/p/pyyaml/PyYAML-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pyyaml/PyYAML-VERSION.tar.gz

--- a/build/pkgs/pyzmq/checksums.ini
+++ b/build/pkgs/pyzmq/checksums.ini
@@ -1,4 +1,4 @@
 tarball=pyzmq-VERSION.tar.gz
 sha1=f750e59a3d5fcca64d0a1a6723c1bc72173e976f
 sha256=259c22485b71abacdfa8bf79720cd7bcf4b9d128b30ea554f01ae71fdbfdaa23
-upstream_url=https://pypi.io/packages/source/p/pyzmq/pyzmq-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/p/pyzmq/pyzmq-VERSION.tar.gz

--- a/build/pkgs/qdldl_python/checksums.ini
+++ b/build/pkgs/qdldl_python/checksums.ini
@@ -1,4 +1,4 @@
 tarball=qdldl-VERSION.tar.gz
 sha1=af76c57ca1787f5e44e42f6c9f916b84ae599f1f
 sha256=69c092f6e1fc23fb779a80a62e6fcdfe2eba05c925860248c4d6754f4736938f
-upstream_url=https://pypi.io/packages/source/q/qdldl/qdldl-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/q/qdldl/qdldl-VERSION.tar.gz

--- a/build/pkgs/referencing/checksums.ini
+++ b/build/pkgs/referencing/checksums.ini
@@ -1,4 +1,4 @@
 tarball=referencing-VERSION-py3-none-any.whl
 sha1=9d710ba3a604d24ffded218a3813b5fd1fe2e495
 sha256=160f24a7d2411dc82b1efd96dfb083ee9e5cc9bc8e492d323e0dd853989d37b3
-upstream_url=https://pypi.io/packages/py3/r/referencing/referencing-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/r/referencing/referencing-VERSION-py3-none-any.whl

--- a/build/pkgs/requests/checksums.ini
+++ b/build/pkgs/requests/checksums.ini
@@ -1,4 +1,4 @@
 tarball=requests-VERSION-py3-none-any.whl
 sha1=e82ece8f17ba4237cc5a4fd641349e45e1d3ddfd
 sha256=fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c
-upstream_url=https://pypi.io/packages/py3/r/requests/requests-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/r/requests/requests-VERSION-py3-none-any.whl

--- a/build/pkgs/rfc3339_validator/checksums.ini
+++ b/build/pkgs/rfc3339_validator/checksums.ini
@@ -1,4 +1,4 @@
 tarball=rfc3339_validator-VERSION-py2.py3-none-any.whl
 sha1=daa86cb641dfd6ebfef4ece6dea1be8fd63dec00
 sha256=24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
-upstream_url=https://pypi.io/packages/py2.py3/r/rfc3339_validator/rfc3339_validator-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/r/rfc3339_validator/rfc3339_validator-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/rfc3986_validator/checksums.ini
+++ b/build/pkgs/rfc3986_validator/checksums.ini
@@ -1,4 +1,4 @@
 tarball=rfc3986_validator-VERSION-py2.py3-none-any.whl
 sha1=c0fabd5c0568cc516f9258f3e5846a04a059dc31
 sha256=2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9
-upstream_url=https://pypi.io/packages/py2.py3/r/rfc3986_validator/rfc3986_validator-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/r/rfc3986_validator/rfc3986_validator-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/rpy2/checksums.ini
+++ b/build/pkgs/rpy2/checksums.ini
@@ -1,4 +1,4 @@
 tarball=rpy2-VERSION.tar.gz
 sha1=7d236c0c6982333b20b6a126f0c17a5481fea64b
 sha256=5d31a5ea43f5a59f6dec30faca87edb01fc9b8affa0beae96a99be923bd7dab3
-upstream_url=https://pypi.io/packages/source/r/rpy2/rpy2-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/r/rpy2/rpy2-VERSION.tar.gz

--- a/build/pkgs/rst2ipynb/checksums.ini
+++ b/build/pkgs/rst2ipynb/checksums.ini
@@ -1,4 +1,4 @@
 tarball=rst2ipynb-VERSION.tar.gz
 sha1=98926df9a8336c8974f446a2a858458495b5aec4
 sha256=30d70b0e96f1c37baad9c8dbe904fc2567354eec02c52b94e7c7287b6268eaa3
-upstream_url=https://pypi.io/packages/source/r/rst2ipynb/rst2ipynb-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/r/rst2ipynb/rst2ipynb-VERSION.tar.gz

--- a/build/pkgs/sage_numerical_backends_coin/checksums.ini
+++ b/build/pkgs/sage_numerical_backends_coin/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sage_numerical_backends_coin-VERSION.tar.gz
 sha1=2033e1ba209315366a6dbfe249d5de5f7a1bc1b0
 sha256=6e34d48632d070e97dc37b724098c0f050026b166b328af78929b1ea079fa9e7
-upstream_url=https://pypi.io/packages/source/s/sage_numerical_backends_coin/sage_numerical_backends_coin-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/s/sage_numerical_backends_coin/sage_numerical_backends_coin-VERSION.tar.gz

--- a/build/pkgs/sage_numerical_backends_cplex/checksums.ini
+++ b/build/pkgs/sage_numerical_backends_cplex/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sage_numerical_backends_cplex-VERSION.tar.gz
 sha1=b7085bfdeecb55a43c799493672a228687c30eaf
 sha256=367480d7a291e0ac4e3df529fbc2a17f78f3770ce7dc2cf78d765f72b7bd938e
-upstream_url=https://pypi.io/packages/source/s/sage_numerical_backends_cplex/sage_numerical_backends_cplex-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/s/sage_numerical_backends_cplex/sage_numerical_backends_cplex-VERSION.tar.gz

--- a/build/pkgs/sage_numerical_backends_gurobi/checksums.ini
+++ b/build/pkgs/sage_numerical_backends_gurobi/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sage_numerical_backends_gurobi-VERSION.tar.gz
 sha1=6891c154bd035932759152dba6a8bd77e8811f22
 sha256=3c3b51d6577f651d10cb7f6fc37ca4bb27c6fe2716d6515d1d23eeed1f34e32a
-upstream_url=https://pypi.io/packages/source/s/sage_numerical_backends_gurobi/sage_numerical_backends_gurobi-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/s/sage_numerical_backends_gurobi/sage_numerical_backends_gurobi-VERSION.tar.gz

--- a/build/pkgs/sagetex/checksums.ini
+++ b/build/pkgs/sagetex/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sagetex-VERSION.tar.gz
 sha1=821c8a6ab11ee651d0dcc599c5582fefb6706775
 sha256=03162ec62cb86da13a747f982241af3e4f4cdd4d29fcba8fbb6c6982a9e906d9
-upstream_url=https://pypi.io/packages/source/s/sagetex/sagetex-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/s/sagetex/sagetex-VERSION.tar.gz

--- a/build/pkgs/scipy/checksums.ini
+++ b/build/pkgs/scipy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=scipy-VERSION.tar.gz
 sha1=0fd6e14972d8dd9b4a656686a40aed00ad0f1396
 sha256=4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3
-upstream_url=https://pypi.io/packages/source/s/scipy/scipy-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/s/scipy/scipy-VERSION.tar.gz

--- a/build/pkgs/scs/checksums.ini
+++ b/build/pkgs/scs/checksums.ini
@@ -1,4 +1,4 @@
 tarball=scs-VERSION.tar.gz
 sha1=92e4ff21b450c9659f610064eb79e804de9167b4
 sha256=e3bd779e7e977e3ae5a2f2035aa4c2a309e29082d59a722d5d6592edc4bdb4b3
-upstream_url=https://pypi.io/packages/source/s/scs/scs-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/s/scs/scs-VERSION.tar.gz

--- a/build/pkgs/send2trash/checksums.ini
+++ b/build/pkgs/send2trash/checksums.ini
@@ -1,4 +1,4 @@
 tarball=Send2Trash-VERSION-py3-none-any.whl
 sha1=e24d3494febe78a4a1c8ecbfde78ed52e78cf299
 sha256=0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9
-upstream_url=https://pypi.io/packages/py3/s/send2trash/Send2Trash-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/send2trash/Send2Trash-VERSION-py3-none-any.whl

--- a/build/pkgs/setuptools/checksums.ini
+++ b/build/pkgs/setuptools/checksums.ini
@@ -1,4 +1,4 @@
 tarball=setuptools-VERSION-py3-none-any.whl
 sha1=3756539d45341ca5cec9e2dfe11539faa066f5cd
 sha256=b208925fcb9f7af924ed2dc04708ea89791e24bde0d3020b27df0e116088b34e
-upstream_url=https://pypi.io/packages/py3/s/setuptools/setuptools-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-VERSION-py3-none-any.whl

--- a/build/pkgs/setuptools_scm/checksums.ini
+++ b/build/pkgs/setuptools_scm/checksums.ini
@@ -1,4 +1,4 @@
 tarball=setuptools_scm-VERSION-py3-none-any.whl
 sha1=be606b6acb67714b96e9e1e9a9944feaca504e44
 sha256=897a3226a6fd4a6eb2f068745e49733261a21f70b1bb28fce0339feb978d9af3
-upstream_url=https://pypi.io/packages/py3/s/setuptools_scm/setuptools_scm-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/setuptools_scm/setuptools_scm-VERSION-py3-none-any.whl

--- a/build/pkgs/six/checksums.ini
+++ b/build/pkgs/six/checksums.ini
@@ -1,4 +1,4 @@
 tarball=six-VERSION-py2.py3-none-any.whl
 sha1=79e6f2e4f9e24898f1896df379871b9c9922f147
 sha256=8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-upstream_url=https://pypi.io/packages/py2.py3/s/six/six-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/s/six/six-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/sniffio/checksums.ini
+++ b/build/pkgs/sniffio/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sniffio-VERSION-py3-none-any.whl
 sha1=bd8d1ec2b285eed542c53ca22232e6e9e468c389
 sha256=2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2
-upstream_url=https://pypi.io/packages/py3/s/sniffio/sniffio-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sniffio/sniffio-VERSION-py3-none-any.whl

--- a/build/pkgs/snowballstemmer/checksums.ini
+++ b/build/pkgs/snowballstemmer/checksums.ini
@@ -1,4 +1,4 @@
 tarball=snowballstemmer-VERSION.tar.gz
 sha1=aaf1b0e3b58d25e2e297ea3dbef59d8534ef8d92
 sha256=09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1
-upstream_url=https://pypi.io/packages/source/s/snowballstemmer/snowballstemmer-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/s/snowballstemmer/snowballstemmer-VERSION.tar.gz

--- a/build/pkgs/soupsieve/checksums.ini
+++ b/build/pkgs/soupsieve/checksums.ini
@@ -1,4 +1,4 @@
 tarball=soupsieve-VERSION-py3-none-any.whl
 sha1=a155a6208211aa90bbc3bcfc9cab194a05000e59
 sha256=eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7
-upstream_url=https://pypi.io/packages/py3/s/soupsieve/soupsieve-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/soupsieve/soupsieve-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinx/checksums.ini
+++ b/build/pkgs/sphinx/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinx-VERSION-py3-none-any.whl
 sha1=f9af5608fbb188f12e38d3c09cdefeef40255365
 sha256=c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239
-upstream_url=https://pypi.io/packages/py3/s/sphinx/sphinx-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinx/sphinx-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinx_basic_ng/checksums.ini
+++ b/build/pkgs/sphinx_basic_ng/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinx_basic_ng-VERSION-py3-none-any.whl
 sha1=abcd9bda6ae61bb20c52bf46c17fb1bbdfdab4ea
 sha256=eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b
-upstream_url=https://pypi.io/packages/py3/s/sphinx_basic_ng/sphinx_basic_ng-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinx_basic_ng/sphinx_basic_ng-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinx_copybutton/checksums.ini
+++ b/build/pkgs/sphinx_copybutton/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinx_copybutton-VERSION-py3-none-any.whl
 sha1=a15e038b665225b13f7bd3eae6a2a64c8bd4b582
 sha256=fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e
-upstream_url=https://pypi.io/packages/py3/s/sphinx_copybutton/sphinx_copybutton-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinx_copybutton/sphinx_copybutton-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinx_inline_tabs/checksums.ini
+++ b/build/pkgs/sphinx_inline_tabs/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinx_inline_tabs-VERSION-py3-none-any.whl
 sha1=1404e320d0533280355e7e1e71cffd9937015027
 sha256=06809ac613f7c48ddd6e2fa588413e3fe92cff2397b56e2ccf0b0218f9ef6a78
-upstream_url=https://pypi.io/packages/py3/s/sphinx_inline_tabs/sphinx_inline_tabs-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinx_inline_tabs/sphinx_inline_tabs-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinxcontrib_applehelp/checksums.ini
+++ b/build/pkgs/sphinxcontrib_applehelp/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinxcontrib_applehelp-VERSION-py3-none-any.whl
 sha1=e426527562da2c5c520b27c58210cd1d44a1185b
 sha256=cb61eb0ec1b61f349e5cc36b2028e9e7ca765be05e49641c97241274753067b4
-upstream_url=https://pypi.io/packages/py3/s/sphinxcontrib_applehelp/sphinxcontrib_applehelp-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinxcontrib_applehelp/sphinxcontrib_applehelp-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinxcontrib_devhelp/checksums.ini
+++ b/build/pkgs/sphinxcontrib_devhelp/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinxcontrib_devhelp-VERSION-py3-none-any.whl
 sha1=c1c774393d267d97eaf07f0e5c740f82af24d628
 sha256=6485d09629944511c893fa11355bda18b742b83a2b181f9a009f7e500595c90f
-upstream_url=https://pypi.io/packages/py3/s/sphinxcontrib_devhelp/sphinxcontrib_devhelp-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinxcontrib_devhelp/sphinxcontrib_devhelp-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinxcontrib_htmlhelp/checksums.ini
+++ b/build/pkgs/sphinxcontrib_htmlhelp/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinxcontrib_htmlhelp-VERSION-py3-none-any.whl
 sha1=6b60c617a0fe98a663ca146edc03867581da5e07
 sha256=393f04f112b4d2f53d93448d4bce35842f62b307ccdc549ec1585e950bc35e04
-upstream_url=https://pypi.io/packages/py3/s/sphinxcontrib_htmlhelp/sphinxcontrib_htmlhelp-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinxcontrib_htmlhelp/sphinxcontrib_htmlhelp-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinxcontrib_jsmath/checksums.ini
+++ b/build/pkgs/sphinxcontrib_jsmath/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinxcontrib_jsmath-VERSION-py2.py3-none-any.whl
 sha1=beff4fc35d13a5f2883bc129f28ac031046195c5
 sha256=2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178
-upstream_url=https://pypi.io/packages/py2.py3/s/sphinxcontrib_jsmath/sphinxcontrib_jsmath-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/s/sphinxcontrib_jsmath/sphinxcontrib_jsmath-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/sphinxcontrib_qthelp/checksums.ini
+++ b/build/pkgs/sphinxcontrib_qthelp/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinxcontrib_qthelp-VERSION-py3-none-any.whl
 sha1=8f593bd6ca46487ed25ee0fca50f0d88b18e5f9e
 sha256=e2ae3b5c492d58fcbd73281fbd27e34b8393ec34a073c792642cd8e529288182
-upstream_url=https://pypi.io/packages/py3/s/sphinxcontrib_qthelp/sphinxcontrib_qthelp-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinxcontrib_qthelp/sphinxcontrib_qthelp-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinxcontrib_serializinghtml/checksums.ini
+++ b/build/pkgs/sphinxcontrib_serializinghtml/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinxcontrib_serializinghtml-VERSION-py3-none-any.whl
 sha1=a5198a72d1668e97fdda39a559586bcf57cb7278
 sha256=326369b8df80a7d2d8d7f99aa5ac577f51ea51556ed974e7716cfd4fca3f6cb7
-upstream_url=https://pypi.io/packages/py3/s/sphinxcontrib_serializinghtml/sphinxcontrib_serializinghtml-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinxcontrib_serializinghtml/sphinxcontrib_serializinghtml-VERSION-py3-none-any.whl

--- a/build/pkgs/sphinxcontrib_websupport/checksums.ini
+++ b/build/pkgs/sphinxcontrib_websupport/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sphinxcontrib_websupport-VERSION-py3-none-any.whl
 sha1=649d1447a4773b665588060efda66344cb9b99a5
 sha256=2dc179d7f821ebd54f31f93c894ca52435ebc5364e4e4dfb0da834ac119d51fd
-upstream_url=https://pypi.io/packages/py3/s/sphinxcontrib_websupport/sphinxcontrib_websupport-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sphinxcontrib_websupport/sphinxcontrib_websupport-VERSION-py3-none-any.whl

--- a/build/pkgs/stack_data/checksums.ini
+++ b/build/pkgs/stack_data/checksums.ini
@@ -1,4 +1,4 @@
 tarball=stack_data-VERSION-py3-none-any.whl
 sha1=96814b10bdc464e8ef00f4a07c60dd17a3dc9668
 sha256=d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
-upstream_url=https://pypi.io/packages/py3/s/stack_data/stack_data-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/stack_data/stack_data-VERSION-py3-none-any.whl

--- a/build/pkgs/symengine_py/checksums.ini
+++ b/build/pkgs/symengine_py/checksums.ini
@@ -1,4 +1,4 @@
 tarball=symengine.py-VERSION.tar.gz
 sha1=4a8da0d0a057c8709c5b28543dbb3d26a060f013
 sha256=0dd30d29b804ebb7251bddec29c38c3b1fc15ea6953a2c57ee758d5f6fcba458
-upstream_url=https://pypi.io/packages/source/s/symengine/symengine-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/s/symengine/symengine-VERSION.tar.gz

--- a/build/pkgs/sympy/checksums.ini
+++ b/build/pkgs/sympy/checksums.ini
@@ -1,4 +1,4 @@
 tarball=sympy-VERSION-py3-none-any.whl
 sha1=e34c28a2aa2b677efe2f1b7cefe275e20d2e652c
 sha256=c51d75517712f1aed280d4ce58506a4a88d635d6b5dd48b39102a7ae1f3fcfe9
-upstream_url=https://pypi.io/packages/py3/s/sympy/sympy-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/s/sympy/sympy-VERSION-py3-none-any.whl

--- a/build/pkgs/terminado/checksums.ini
+++ b/build/pkgs/terminado/checksums.ini
@@ -1,4 +1,4 @@
 tarball=terminado-VERSION.tar.gz
 sha1=608fcc44b845e1fb783e361d59e79fba83126e14
 sha256=6ccbbcd3a4f8a25a5ec04991f39a0b8db52dfcd487ea0e578d977e6752380333
-upstream_url=https://pypi.io/packages/source/t/terminado/terminado-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/t/terminado/terminado-VERSION.tar.gz

--- a/build/pkgs/texttable/checksums.ini
+++ b/build/pkgs/texttable/checksums.ini
@@ -1,4 +1,4 @@
 tarball=texttable-VERSION.tar.gz
 sha1=0fa175fa6e0fefea31434746641bedc8cbb60248
 sha256=2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638
-upstream_url=https://pypi.io/packages/source/t/texttable/texttable-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/t/texttable/texttable-VERSION.tar.gz

--- a/build/pkgs/tinycss2/checksums.ini
+++ b/build/pkgs/tinycss2/checksums.ini
@@ -1,4 +1,4 @@
 tarball=tinycss2-VERSION.tar.gz
 sha1=3871ffec30bde346d1a17f80a423dce488bad4f7
 sha256=8cff3a8f066c2ec677c06dbc7b45619804a6938478d9d73c284b29d14ecb0627
-upstream_url=https://pypi.io/packages/source/t/tinycss2/tinycss2-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/t/tinycss2/tinycss2-VERSION.tar.gz

--- a/build/pkgs/tomli/checksums.ini
+++ b/build/pkgs/tomli/checksums.ini
@@ -1,4 +1,4 @@
 tarball=tomli-VERSION-py3-none-any.whl
 sha1=5bfc83c14bc54e6193a0d50a50c16a88eda0c4fa
 sha256=939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc
-upstream_url=https://pypi.io/packages/py3/t/tomli/tomli-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/t/tomli/tomli-VERSION-py3-none-any.whl

--- a/build/pkgs/tornado/checksums.ini
+++ b/build/pkgs/tornado/checksums.ini
@@ -1,4 +1,4 @@
 tarball=tornado-VERSION.tar.gz
 sha1=5b4036313660a74034186ac63b10d244ca9444b8
 sha256=72291fa6e6bc84e626589f1c29d90a5a6d593ef5ae68052ee2ef000dfd273dee
-upstream_url=https://pypi.io/packages/source/t/tornado/tornado-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/t/tornado/tornado-VERSION.tar.gz

--- a/build/pkgs/tox/checksums.ini
+++ b/build/pkgs/tox/checksums.ini
@@ -1,4 +1,4 @@
 tarball=tox-VERSION-py3-none-any.whl
 sha1=d3312285c4988d3307d3b000a8a18cfcb16aea29
 sha256=da761b4a57ee2b92b5ce39f48ff723fc42d185bf2af508effb683214efa662ea
-upstream_url=https://pypi.io/packages/py3/t/tox/tox-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/t/tox/tox-VERSION-py3-none-any.whl

--- a/build/pkgs/traitlets/checksums.ini
+++ b/build/pkgs/traitlets/checksums.ini
@@ -1,4 +1,4 @@
 tarball=traitlets-VERSION-py3-none-any.whl
 sha1=a6c667ce2b3adf2ab3562f144067f02326383c25
 sha256=b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f
-upstream_url=https://pypi.io/packages/py3/t/traitlets/traitlets-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/t/traitlets/traitlets-VERSION-py3-none-any.whl

--- a/build/pkgs/trove_classifiers/checksums.ini
+++ b/build/pkgs/trove_classifiers/checksums.ini
@@ -1,4 +1,4 @@
 tarball=trove_classifiers-VERSION-py3-none-any.whl
 sha1=8219f839a8223a9dd0912cde22d579cfa75a516e
 sha256=ccc57a33717644df4daca018e7ec3ef57a835c48e96a1e71fc07eb7edac67af6
-upstream_url=https://pypi.io/packages/py3/t/trove_classifiers/trove_classifiers-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/t/trove_classifiers/trove_classifiers-VERSION-py3-none-any.whl

--- a/build/pkgs/types_python_dateutil/checksums.ini
+++ b/build/pkgs/types_python_dateutil/checksums.ini
@@ -1,4 +1,4 @@
 tarball=types_python_dateutil-VERSION-py3-none-any.whl
 sha1=fc0a6cbd54667dd8dadb95c448014efe66c9ae0a
 sha256=6b8cb66d960771ce5ff974e9dd45e38facb81718cc1e208b10b1baccbfdbee3b
-upstream_url=https://pypi.io/packages/py3/t/types_python_dateutil/types_python_dateutil-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/t/types_python_dateutil/types_python_dateutil-VERSION-py3-none-any.whl

--- a/build/pkgs/typing_extensions/checksums.ini
+++ b/build/pkgs/typing_extensions/checksums.ini
@@ -1,4 +1,4 @@
 tarball=typing_extensions-VERSION-py3-none-any.whl
 sha1=0fb5b2732cc421561b1348cac1334eb6a4e0bb7f
 sha256=04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d
-upstream_url=https://pypi.io/packages/py3/t/typing_extensions/typing_extensions-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/t/typing_extensions/typing_extensions-VERSION-py3-none-any.whl

--- a/build/pkgs/tzdata/checksums.ini
+++ b/build/pkgs/tzdata/checksums.ini
@@ -1,4 +1,4 @@
 tarball=tzdata-VERSION-py2.py3-none-any.whl
 sha1=4686c7c91a01d5af9075903937c343afa05c141b
 sha256=7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda
-upstream_url=https://pypi.io/packages/py2.py3/t/tzdata/tzdata-VERSION-py2.py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py2.py3/t/tzdata/tzdata-VERSION-py2.py3-none-any.whl

--- a/build/pkgs/tzlocal/checksums.ini
+++ b/build/pkgs/tzlocal/checksums.ini
@@ -1,4 +1,4 @@
 tarball=tzlocal-VERSION.tar.gz
 sha1=1d61e52edddf882c9af4f5f3f1be0db3788dd7b5
 sha256=46eb99ad4bdb71f3f72b7d24f4267753e240944ecfc16f25d2719ba89827a803
-upstream_url=https://pypi.io/packages/source/t/tzlocal/tzlocal-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/t/tzlocal/tzlocal-VERSION.tar.gz

--- a/build/pkgs/uri_template/checksums.ini
+++ b/build/pkgs/uri_template/checksums.ini
@@ -1,4 +1,4 @@
 tarball=uri_template-VERSION-py3-none-any.whl
 sha1=bbc8808bdb7e687f0c099c8120cd901dc90bce69
 sha256=a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363
-upstream_url=https://pypi.io/packages/py3/u/uri_template/uri_template-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/u/uri_template/uri_template-VERSION-py3-none-any.whl

--- a/build/pkgs/urllib3/checksums.ini
+++ b/build/pkgs/urllib3/checksums.ini
@@ -1,4 +1,4 @@
 tarball=urllib3-VERSION-py3-none-any.whl
 sha1=1e197082cd0d0f98bc97f2fbfd7d2a597e3ff3e4
 sha256=55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3
-upstream_url=https://pypi.io/packages/py3/u/urllib3/urllib3-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/u/urllib3/urllib3-VERSION-py3-none-any.whl

--- a/build/pkgs/virtualenv/checksums.ini
+++ b/build/pkgs/virtualenv/checksums.ini
@@ -1,4 +1,4 @@
 tarball=virtualenv-VERSION-py3-none-any.whl
 sha1=f18ea5b827ba66a1724769371c6912601ec4d647
 sha256=a624db5e94f01ad993d476b9ee5346fdf7b9de43ccaee0e0197012dc838a0e9b
-upstream_url=https://pypi.io/packages/py3/v/virtualenv/virtualenv-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/v/virtualenv/virtualenv-VERSION-py3-none-any.whl

--- a/build/pkgs/wcwidth/checksums.ini
+++ b/build/pkgs/wcwidth/checksums.ini
@@ -1,4 +1,4 @@
 tarball=wcwidth-VERSION.tar.gz
 sha1=49bdbcac346f31be8201c663082331b693264382
 sha256=f01c104efdf57971bcb756f054dd58ddec5204dd15fa31d6503ea57947d97c02
-upstream_url=https://pypi.io/packages/source/w/wcwidth/wcwidth-VERSION.tar.gz
+upstream_url=https://files.pythonhosted.org/packages/source/w/wcwidth/wcwidth-VERSION.tar.gz

--- a/build/pkgs/webcolors/checksums.ini
+++ b/build/pkgs/webcolors/checksums.ini
@@ -1,4 +1,4 @@
 tarball=webcolors-VERSION-py3-none-any.whl
 sha1=e13a9143964b824fc4972b60eddd8115f6839a26
 sha256=29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf
-upstream_url=https://pypi.io/packages/py3/w/webcolors/webcolors-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/w/webcolors/webcolors-VERSION-py3-none-any.whl

--- a/build/pkgs/websocket_client/checksums.ini
+++ b/build/pkgs/websocket_client/checksums.ini
@@ -1,4 +1,4 @@
 tarball=websocket_client-VERSION-py3-none-any.whl
 sha1=eb78bd39f1ae4d531cc965bd21d121ba3d156f84
 sha256=084072e0a7f5f347ef2ac3d8698a5e0b4ffbfcab607628cadabc650fc9a83a24
-upstream_url=https://pypi.io/packages/py3/w/websocket_client/websocket_client-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/w/websocket_client/websocket_client-VERSION-py3-none-any.whl

--- a/build/pkgs/wheel/checksums.ini
+++ b/build/pkgs/wheel/checksums.ini
@@ -1,4 +1,4 @@
 tarball=wheel-VERSION-py3-none-any.whl
 sha1=65ec55742da04152c8b06d6586fb36d779d7883e
 sha256=2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f
-upstream_url=https://pypi.io/packages/py3/w/wheel/wheel-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/w/wheel/wheel-VERSION-py3-none-any.whl

--- a/build/pkgs/widgetsnbextension/checksums.ini
+++ b/build/pkgs/widgetsnbextension/checksums.ini
@@ -1,4 +1,4 @@
 tarball=widgetsnbextension-VERSION-py3-none-any.whl
 sha1=067535b5d1738a4de0abb5f1219581a4a66d243c
 sha256=91452ca8445beb805792f206e560c1769284267a30ceb1cec9f5bcc887d15175
-upstream_url=https://pypi.io/packages/py3/w/widgetsnbextension/widgetsnbextension-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/w/widgetsnbextension/widgetsnbextension-VERSION-py3-none-any.whl

--- a/build/pkgs/zipp/checksums.ini
+++ b/build/pkgs/zipp/checksums.ini
@@ -1,4 +1,4 @@
 tarball=zipp-VERSION-py3-none-any.whl
 sha1=22cf149f293964ac7538ad41af8caa9aacf8fe1a
 sha256=96dc6ad62f1441bcaccef23b274ec471518daf4fbbc580341204936a5a3dddec
-upstream_url=https://pypi.io/packages/py3/z/zipp/zipp-VERSION-py3-none-any.whl
+upstream_url=https://files.pythonhosted.org/packages/py3/z/zipp/zipp-VERSION-py3-none-any.whl

--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -430,9 +430,9 @@ class Application(object):
                     tarball = pypi_version.tarball.replace(pypi_version.version, 'VERSION')
                 if not version:
                     version = pypi_version.version
-                # Use a URL from pypi.io instead of the specific URL received from the PyPI query
+                # Use a URL from files.pythonhosted.org instead of the specific URL received from the PyPI query
                 # because it follows a simple pattern.
-                upstream_url = 'https://pypi.io/packages/source/{0:1.1}/{0}/{1}'.format(package_name, tarball)
+                upstream_url = 'https://files.pythonhosted.org/packages/source/{0:1.1}/{0}/{1}'.format(package_name, tarball)
             elif source == 'wheel':
                 if not tarball:
                     tarball = pypi_version.tarball.replace(pypi_version.version, 'VERSION')
@@ -459,7 +459,7 @@ class Application(object):
                                 self.create(dep, pkg_type=pkg_type)
                                 dep = Package(dep).name
                             dependencies.append(dep)
-                upstream_url = 'https://pypi.io/packages/{2}/{0:1.1}/{0}/{1}'.format(package_name, tarball, pypi_version.python_version)
+                upstream_url = 'https://files.pythonhosted.org/packages/{2}/{0:1.1}/{0}/{1}'.format(package_name, tarball, pypi_version.python_version)
             if not description:
                 description = pypi_version.summary
             if not license:

--- a/src/doc/en/developer/packaging.rst
+++ b/src/doc/en/developer/packaging.rst
@@ -1010,11 +1010,11 @@ to refer to the dot-separated components of a version by ``VERSION_MAJOR``,
 ``VERSION_MINOR``, and ``VERSION_MICRO``.
 
 For Python packages available from PyPI, you should use an
-``upstream_url`` from ``pypi.io``, which follows the format
+``upstream_url`` from ``files.pythonhosted.org``, which follows the format
 
 .. CODE-BLOCK:: bash
 
-    upstream_url=https://pypi.io/packages/source/m/matplotlib/matplotlib-VERSION.tar.gz
+    upstream_url=https://files.pythonhosted.org/packages/source/m/matplotlib/matplotlib-VERSION.tar.gz
 
 Developers who wish to test a package update from a PR branch before
 the archive is available on a Sage mirror. Sage falls back to


### PR DESCRIPTION
Which itself redirect pypi.io/(*) to pypi.org/$1,
anything under /package/ redirect directly to files.pythonhosted.org.

Pypi.io is legacy/was temporary so it's a nice things to maybe one day let the pypa infra team to stop supporting it.
; the pypi.org -> files.pythonhosted.org just avoids an extra redirect,

(Note that one of the changed files is a Python file). 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


