### PR TITLE
src/sage: revert "touch libgap consumers"

### DIFF
--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -96,8 +96,6 @@ Check that :issue:`13569` is fixed::
     (1,2), (1,3), (1,3), (2,3), (1,2), (1,2), (1,3), (2,3)]
 """
 
-# hi
-
 # ****************************************************************************
 #       Copyright (C) 2006 William Stein <wstein@gmail.com>
 #       Copyright (C) 2006 David Joyner

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -5,9 +5,6 @@ This document describes the individual wrappers for various GAP
 elements. For general information about GAP, you should read the
 :mod:`~sage.libs.gap.libgap` module documentation.
 """
-
-# hi
-
 # ****************************************************************************
 #       Copyright (C) 2012 Volker Braun <vbraun.name@gmail.com>
 #

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -176,8 +176,6 @@ AUTHORS:
     libgap API
 """
 
-# hi
-
 ###############################################################################
 #       Copyright (C) 2009, William Stein <wstein@gmail.com>
 #       Copyright (C) 2012, Volker Braun <vbraun.name@gmail.com>

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -2,8 +2,6 @@
 Utility functions for GAP
 """
 
-# hi
-
 #*****************************************************************************
 #       Copyright (C) 2012 Volker Braun <vbraun.name@gmail.com>
 #


### PR DESCRIPTION
This was a junk commit to trigger a rebuild of certain parts of sagelib after a GAP upgrade.
