### PR TITLE
Add missing long time tag to a failing doctest

### DIFF
--- a/src/sage/parallel/map_reduce.py
+++ b/src/sage/parallel/map_reduce.py
@@ -1145,7 +1145,7 @@ class RESetMapReduce:
 
         Cleanup::
 
-            sage: S.finish()
+            sage: S.finish()   # long time
         """
         if self._nprocess == 0:
             raise ValueError("No process connected")


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

To fix
```sage
sage -t --warn-long 5.0 --random-seed=279311403945742486210819617974441498089 src/sage/parallel/map_reduce.py
**********************************************************************
File "src/sage/parallel/map_reduce.py", line 1145, in sage.parallel.map_reduce.RESetMapReduce.start_workers
Failed example:
    S.finish()
Exception raised:
    Traceback (most recent call last):
      File "/Users/kwankyu/GitHub/sage-dev/src/sage/doctest/forker.py", line 715, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/Users/kwankyu/GitHub/sage-dev/src/sage/doctest/forker.py", line 1136, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.parallel.map_reduce.RESetMapReduce.start_workers[4]>", line 1, in <module>
        S.finish()
      File "/Users/kwankyu/GitHub/sage-dev/src/sage/parallel/map_reduce.py", line 1239, in finish
        worker.join()
      File "/usr/local/Cellar/python@3.12/3.12.7/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/process.py", line 148, in join
        assert self._popen is not None, 'can only join a started process'
               ^^^^^^^^^^^^^^^^^^^^^^^
    AssertionError: can only join a started process
**********************************************************************
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


