### PR TITLE
Remove jupyter_execute directory after doc build finishes

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -154,6 +154,7 @@ jobs:
           git config --global user.email "ci-sage@example.com"
           git config --global user.name "Build documentation workflow"
           unzip doc.zip
+          rm doc.zip
           PR_NUMBER=""
           if [[ "$GITHUB_REF" =~ refs/pull/([0-9]+)/merge ]]; then
             PR_NUMBER="${BASH_REMATCH[1]}"

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -202,6 +202,10 @@ jobs:
         if: steps.docbuild.outcome == 'success'
         run: |
           set -ex
+          # Remove any existing html directory before copying a new one
+          if [ -d "doc/html" ]; then
+              rm -rf doc/html
+          fi
           # Simpler "docker cp --follow-link ... doc" does not work
           mkdir -p doc
           mkdir -p temp
@@ -217,7 +221,7 @@ jobs:
           fi
           # If so, then create CHANGES.html
           if [[ -n "$PR_NUMBER" ]]; then
-            (cd doc && git commit -a -m 'new')
+            (cd doc && git add -A && git commit --quiet -m 'new')
             # Wipe out chronic diffs of new doc against old doc before creating CHANGES.html
             (cd doc && \
              find . -name "*.html" | xargs sed -i -e '/This is documentation/ s/ built with GitHub PR .* for development/ for development/' \
@@ -229,7 +233,7 @@ jobs:
             # Since HEAD is at commit 'wipe-out', HEAD~1 is commit 'new' (new doc), HEAD~2 is commit 'old' (old doc)
             (cd doc && git diff $(git rev-parse HEAD~2) -- "*.html") > diff.txt
             # Restore the new doc dropping changes by "wipe out"
-            (cd doc && git checkout -q -f HEAD~1)
+            (cd doc && git checkout --quiet -f HEAD~1)
             .ci/create-changes-html.sh diff.txt doc
             # Sometimes rm -rf .git errors out because of some diehard hidden files
             # So we simply move it out of the doc directory

--- a/src/doc/Makefile
+++ b/src/doc/Makefile
@@ -66,6 +66,8 @@ doc-html-other: doc-html-reference
 	$(MAKE) $(foreach doc, $(wordlist 2, 100, $(DOCS)), doc-html--$(subst /,-,$(doc)))
 
 doc-html: doc-html-reference doc-html-other
+	SAGE_DOC=$$(sage --python -c "from sage.env import SAGE_DOC; print(SAGE_DOC)")
+	find $${SAGE_DOC}/html -type d -path "*/jupyter_execute" -exec rm -rf {} +
 
 # Matches doc-pdf--developer, doc-pdf--reference-manifolds etc.
 doc-pdf--%:
@@ -88,7 +90,8 @@ doc-pdf-other: doc-pdf-reference
 	$(MAKE) SAGE_DOCBUILD_OPTS="$(SAGE_DOCBUILD_OPTS) --no-prune-empty-dirs" $(foreach doc, $(wordlist 2, 100, $(DOCS)), doc-pdf--$(subst /,-,$(doc)))
 
 doc-pdf: doc-pdf-reference doc-pdf-other
-
+	SAGE_DOC=$$(sage --python -c "from sage.env import SAGE_DOC; print(SAGE_DOC)")
+	find $${SAGE_DOC}/latex -type d -path "*/jupyter_execute" -exec rm -rf {} +
 
 .PHONY: all clean \
 	doc-src \


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

as discussed in https://groups.google.com/g/sage-devel/c/YbaVbz_y_xY

Along the way, a bug in the doc-build workflow is fixed.

Test: https://doc-pr-38895--sagemath.netlify.app/html/en/jupyter_execute/latex.py (should not exist)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


