### PR TITLE
add "# long time" to slow-ish composite isogeny doctest

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -190,7 +190,7 @@ def _compute_factored_isogeny_prime_power(P, l, n, split=.8, velu_sqrt_bound=Non
         sage: P, = E.gens()
         sage: (l,n), = P.order().factor()
         sage: phis = hom_composite._compute_factored_isogeny_prime_power(P,l,n)
-        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0)
+        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0)  # long time -- about 10s
         True
         sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.1)
         True


### PR DESCRIPTION
...to silence the new(?) warning about tests that take a long time.