### PR TITLE
Don't (mis)use `prec_words_to_bits()`

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -142,7 +142,6 @@ lazy_import('sage.schemes.generic.morphism', 'SchemeMorphism')
 
 try:
     from sage.libs.pari.all import pari, PariError
-    from cypari2.pari_instance import prec_words_to_bits
 except ImportError:
     PariError = ()
 
@@ -3712,7 +3711,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
         E_pari = E_work.pari_curve()
         log_pari = E_pari.ellpointtoz(pt_pari, precision=working_prec)
 
-        while prec_words_to_bits(log_pari.precision()) < precision:
+        while log_pari.bitprecision() < precision:
             # result is not precise enough, re-compute with double
             # precision. if the base field is not QQ, this
             # requires modifying the precision of the embedding,


### PR DESCRIPTION
We need to remove this function from cypari2, because pari 2.17 has
changed precision from words to bits which would cause confusion.

Besides, the current usage is incorrect, since `log_pari.precision()`
will give the precision in *decimal digits* not in words.

See: #38749

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
