### PR TITLE
Replace division by zero with +-inf

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7755,9 +7755,9 @@ cdef double mpz_get_d_nearest(mpz_t x) except? -648555075988944.5:
     # Check for overflow
     if sx > 1024:
         if resultsign < 0:
-            return -1.0/0.0
+            return float('-inf')
         else:
-            return 1.0/0.0
+            return float('inf')
 
     # General case
 

--- a/src/sage/rings/rational.pyx
+++ b/src/sage/rings/rational.pyx
@@ -3993,9 +3993,9 @@ cdef double mpq_get_d_nearest(mpq_t x) except? -648555075988944.5:
             return 0.0
     elif shift >= 971:  # |d| > 2^1024
         if resultsign < 0:
-            return -1.0/0.0
+            return float('-inf')
         else:
-            return 1.0/0.0
+            return float('inf')
 
     sig_on()
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

With some compilers you get
```
src/sage/rings/integer.cp311-win_amd64.pyd.p/src/sage/rings/integer.pyx.c(62495): error C2124: divide or mod by zero
```
This is fixed by using `float(+- inf)`.

Extracted from https://github.com/sagemath/sage/pull/38872

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


