### PR TITLE
Replace deprecated/removed mem_fun_ref

### DIFF
--- a/src/sage/symbolic/ginac/archive.cpp
+++ b/src/sage/symbolic/ginac/archive.cpp
@@ -581,7 +581,7 @@ void archive::clear()
 /** Delete cached unarchived expressions in all archive_nodes (mainly for debugging). */
 void archive::forget()
 {
-	for_each(nodes.begin(), nodes.end(), std::mem_fun_ref(&archive_node::forget));
+	std::for_each(nodes.begin(), nodes.end(), [](archive_node &node) { node.forget(); });
 }
 
 /** Delete cached unarchived expressions from node (for debugging). */


### PR DESCRIPTION
Fixes 
```
../src/sage/symbolic/ginac/archive.cpp(584): error C2039: 'mem_fun_ref': is not a member of 'std'
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\include\sstream(19): note: see declaration of 'std'
../src/sage/symbolic/ginac/archive.cpp(584): error C3861: 'mem_fun_ref': identifier not found
../src/sage/symbolic/ginac/archive.cpp(584): error C2672: 'for_each': no matching overloaded function found
```
with  C++17.

Extracted from https://github.com/sagemath/sage/pull/38872.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


