### PR TITLE
Remove `register` macro in Ginac

### DIFF
--- a/src/sage/symbolic/ginac/constant.cpp
+++ b/src/sage/symbolic/ginac/constant.cpp
@@ -20,7 +20,6 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#define register
 #include <Python.h>
 #include "py_funcs.h"
 #include "constant.h"

--- a/src/sage/symbolic/ginac/ex.cpp
+++ b/src/sage/symbolic/ginac/ex.cpp
@@ -20,7 +20,6 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#define register
 #include <Python.h>
 #include "ex.h"
 #include "ex_utils.h"

--- a/src/sage/symbolic/ginac/fderivative.cpp
+++ b/src/sage/symbolic/ginac/fderivative.cpp
@@ -20,7 +20,6 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#define register
 #include <Python.h>
 #include "py_funcs.h"
 #include "fderivative.h"

--- a/src/sage/symbolic/ginac/function.cpp
+++ b/src/sage/symbolic/ginac/function.cpp
@@ -20,7 +20,6 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#define register
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "py_funcs.h"

--- a/src/sage/symbolic/ginac/inifcns_hyperg.cpp
+++ b/src/sage/symbolic/ginac/inifcns_hyperg.cpp
@@ -23,7 +23,6 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#define register
 #include <Python.h>
 #include "py_funcs.h"
 #include "inifcns.h"

--- a/src/sage/symbolic/ginac/numeric.cpp
+++ b/src/sage/symbolic/ginac/numeric.cpp
@@ -49,7 +49,6 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#define register
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "flint/fmpz.h"


### PR DESCRIPTION
Fixes
```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\include\xkeycheck.h(341): warning C4005: 'register': macro redefinition
../src/sage/symbolic/ginac/constant.cpp(23): note: see previous definition of 'register'
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\include\xkeycheck.h(343): fatal error C1189: #error:  The C++ Standard Library forbids macroizing the keyword "register". Enable warning C4005 to find the forbidden define.
```

Not sure why `register` was declared there in the first place.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


