### PR TITLE
Fix Ginac cast error

### DIFF
--- a/src/sage/symbolic/ginac/upoly-ginac.cpp
+++ b/src/sage/symbolic/ginac/upoly-ginac.cpp
@@ -216,12 +216,12 @@ std::pair<ex,ex> quo_rem(const ex &a, const ex &b, const ex &x, bool check_args)
         }
         for (size_t i=0; i<qvec.size(); ++i)
                 if (not qvec[i].is_zero())
-                        qvec[i] = qvec[i] * power(x, numeric(i));
+                        qvec[i] = qvec[i] * power(x, numeric(static_cast<int>(i)));
         if (avec.size() > bdeg)
                 avec.resize(bdeg);
         for (size_t i=0; i<bdeg; ++i)
                 if (not avec[i].is_zero())
-                        avec[i] = avec[i] * power(x, numeric(i));
+                        avec[i] = avec[i] * power(x, numeric(static_cast<int>(i)));
         return std::make_pair(add(qvec), add(avec));
 }
 
@@ -565,7 +565,7 @@ ex parfrac(const ex & a, const ex & x)
                                         return a;
                                 size_t expo = ex_to<numeric>(ee).to_int();
                                 for (size_t j=1; j<=expo; ++j) {
-                                        ex eee = power(e.op(0), numeric(j));
+                                        ex eee = power(e.op(0), numeric(static_cast<int>(j)));
                                         factor.push_back(eee);
                                         cofac.push_back((facmul/eee).expand());
                                 }
@@ -582,7 +582,7 @@ ex parfrac(const ex & a, const ex & x)
                         return a;
                 size_t expo = ex_to<numeric>(facmul.op(1)).to_int();
                 for (size_t j=1; j<=expo; ++j) {
-                        ex ee = power(facmul.op(0), numeric(j));
+                        ex ee = power(facmul.op(0), numeric(static_cast<int>(j)));
                         factor.push_back(ee);
                         cofac.push_back((facmul/ee).expand());
                 }


### PR DESCRIPTION
Fixes
```
../src/sage/symbolic/ginac/upoly-ginac.cpp(219): error C2440: '<function-style-cast>': cannot convert from 'size_t' to 'GiNaC::numeric'
../src/sage/symbolic/ginac/upoly-ginac.cpp(219): note: 'GiNaC::numeric::numeric': ambiguous call to overloaded function
```
by static casting.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


