### PR TITLE
Allow optional elliptic curve data from database_cremona_ellcurve

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -203,6 +203,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             self.__regulator = (kwds.pop('regulator'), True)
         if 'torsion_order' in kwds:
             self._set_torsion_order(kwds.pop('torsion_order'))
+        if 'db_extra' in kwds:
+            # optional data provided by database_cremona_ellcurve
+            self.db_extra = kwds.pop('db_extra')
         if kwds:
             raise TypeError(f"unexpected keyword arguments: {kwds}")
 


### PR DESCRIPTION
If the optional db in istalled, then extra data is passed to the elliptic curve constructor. Recently unexpected keyword arguments were changed to an exception, without taking the optional package into account.

Caused by https://github.com/sagemath/sage/pull/38361

Without the patch tests fail with
```
$ sage -i database_cremona_ellcurve
$ sage -t src/sage/schemes/elliptic_curves/period_lattice.py
[...]
**********************************************************************
File "src/sage/schemes/elliptic_curves/period_lattice.py", line 77, in sage.schemes.elliptic_curves.period_lattice
Failed example:
    E = EllipticCurve('37a')
Exception raised:
    Traceback (most recent call last):
      File "/var/lib/buildbot/worker/sage_git/build/src/sage/doctest/forker.py", line 715, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/var/lib/buildbot/worker/sage_git/build/src/sage/doctest/forker.py", line 1136, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.schemes.elliptic_curves.period_lattice[14]>", line 1, in <module>
        E = EllipticCurve('37a')
            ^^^^^^^^^^^^^^^^^^^^
      File "sage/structure/factory.pyx", line 373, in sage.structure.factory.UniqueFactory.__call__
        return self.get_object(version, key, kwds)
      File "sage/structure/factory.pyx", line 416, in sage.structure.factory.UniqueFactory.get_object
        obj = self.create_object(version, key, **extra_args)
      File "/var/lib/buildbot/worker/sage_git/build/src/sage/schemes/elliptic_curves/constructor.py", line 508, in create_object
        return EllipticCurve_rational_field(x, **kwds)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/var/lib/buildbot/worker/sage_git/build/src/sage/schemes/elliptic_curves/ell_rational_field.py", line 207, in __init__
        raise TypeError(f"unexpected keyword arguments: {kwds}")
    TypeError: unexpected keyword arguments: {'db_extra': [1, 5.98691729246392, 0.305999773834052, 0.0511114082399688, 1.0]}
**********************************************************************
```