### PR TITLE
OS X: do not use -ld_classic

### DIFF
--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -373,32 +373,6 @@ if [ -n "$SAGE_LOCAL" ]; then
     # Construct and export LDFLAGS
     if [ "$UNAME" = "Darwin" ]; then
        LDFLAGS="-L$SAGE_LOCAL/lib $LDFLAGS"
-       # On OS X, use the old linker if it is available.
-       # if "ld-classic" is present in the selected XCode
-       # toolchain, add "-Wl,-ld_classic" to LDFLAGS (see #36599) unless
-       # LD is already set, as it will be with conda on macOS.  When the
-       # selected toolchain is in the Xcode app the output of "xcode-select -p"
-       # is "/Applications/Xcode.app/Contents/Developer", but "ld-classic" is
-       # not in the subdirectory "usr/bin/" but rather in the subdirectory
-       # "Toolchains/XcodeDefault.xctoolchain/usr/bin/".  (See #37237.)
-       if [ -z "$LD" ]; then
-	   # Running xcode-select on a system with no toolchain writes an
-	   # error message to stderr, so redirect stderr to /dev/null. 
-	   XCODE_PATH=$(/usr/bin/xcode-select -p 2> /dev/null)
-	   if [ -n $XCODE_PATH ]; then
-               if [ -x "$XCODE_PATH/usr/bin/ld-classic" -o \
-		       -x "$XCODE_PATH/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic" ]; then
-		   LDFLAGS="$LDFLAGS -Wl,-ld_classic"
-               fi
-           else
-               # On a macOS system with no toolchain we don't want this script
-               # to call gcc because that will also print an error message to
-               # stderr.  We can avoid this by setting AS and LD to their
-               # default values.
-               AS=as
-               LD=ld
-	   fi
-       fi
     fi
     if [ "$UNAME" = "Linux" ]; then
 	LDFLAGS="-L$SAGE_LOCAL/lib -Wl,-rpath,$SAGE_LOCAL/lib $LDFLAGS"

--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -373,6 +373,35 @@ if [ -n "$SAGE_LOCAL" ]; then
     # Construct and export LDFLAGS
     if [ "$UNAME" = "Darwin" ]; then
        LDFLAGS="-L$SAGE_LOCAL/lib $LDFLAGS"
+       # On OS X, use the old linker if it is available.
+       # if "ld-classic" is present in the selected XCode
+       # toolchain, add "-Wl,-ld_classic" to LDFLAGS (see #36599) unless
+       # LD is already set, as it will be with conda on macOS.  When the
+       # selected toolchain is in the Xcode app the output of "xcode-select -p"
+       # is "/Applications/Xcode.app/Contents/Developer", but "ld-classic" is
+       # not in the subdirectory "usr/bin/" but rather in the subdirectory
+       # "Toolchains/XcodeDefault.xctoolchain/usr/bin/".  (See #37237.)
+       if [ -z "$LD" ]; then
+	   # Running xcode-select on a system with no toolchain writes an
+	   # error message to stderr, so redirect stderr to /dev/null.
+	   XCODE_PATH=$(/usr/bin/xcode-select -p 2> /dev/null)
+	   if [ -n $XCODE_PATH ]; then
+               if [ -x "$XCODE_PATH/usr/bin/ld-classic" -o \
+		       -x "$XCODE_PATH/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld-classic" ]; then
+                   # Add -ld_classic only if -ld_classic is not deprecated.
+                   if [ -z "$(ld -ld_classic 2>&1 | grep 'ld_classic is deprecated')" ]; then
+		       LDFLAGS="$LDFLAGS -Wl,-ld_classic"
+                   fi
+               fi
+           else
+               # On a macOS system with no toolchain we don't want this script
+               # to call gcc because that will also print an error message to
+               # stderr.  We can avoid this by setting AS and LD to their
+               # default values.
+               AS=as
+               LD=ld
+	   fi
+       fi
     fi
     if [ "$UNAME" = "Linux" ]; then
 	LDFLAGS="-L$SAGE_LOCAL/lib -Wl,-rpath,$SAGE_LOCAL/lib $LDFLAGS"

--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -1516,6 +1516,21 @@ class SageOutputChecker(doctest.OutputChecker):
             pythran_numpy_warning_regex = re.compile(r'WARNING: Overriding pythran description with argspec information for: numpy\.random\.[a-z_]+')
             got = pythran_numpy_warning_regex.sub('', got)
             did_fixup = True
+
+        if "ld_classic is deprecated" in got:
+            # New warnings as of Oct '24, Xcode 16.
+            ld_warn_regex = re.compile("ld: warning: -ld_classic is deprecated and will be removed in a future release")
+            got = ld_warn_regex.sub('', got)
+            did_fixup = True
+
+        if "duplicate libraries" in got:
+            # New warnings as of Sept '23, OS X 13.6, new command-line
+            # tools. In particular, these seem to come from ld in
+            # Xcode 15.
+            dup_lib_regex = re.compile("ld: warning: ignoring duplicate libraries: .*")
+            got = dup_lib_regex.sub('', got)
+            did_fixup = True
+
         return did_fixup, want, got
 
     def output_difference(self, example, got, optionflags):

--- a/src/sage/tests/cmdline.py
+++ b/src/sage/tests/cmdline.py
@@ -776,4 +776,13 @@ def test_executable(args, input='', timeout=100.0, pydebug_ignore_warnings=False
                 p.stderr.close()
             err.append(s)
 
-    return (''.join(out), ''.join(err), p.wait())
+    # In case out or err contains a quoted string, force the use of
+    # double quotes so that the output is enclosed in single
+    # quotes. This avoids some doctest failures with some versions of
+    # OS X and Xcode.
+    out = ''.join(out)
+    out = out.replace("'", '"')
+    err = ''.join(err)
+    err = err.replace("'", '"')
+
+    return (out, err, p.wait())


### PR DESCRIPTION
Recent versions of Xcode have deprecated `-ld_classic`, so (a) we stop using it, (b) we filter warnings about it when doctesting, and (c) we filter some other warnings related to ld in Xcode.

Without these changes, when building with the latest Xcode, I get many doctest failures because of the new warning
```
ld: warning: -ld_classic is deprecated and will be removed in a future release
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


