### PR TITLE
src/sage/env.py: don't pass if mismatched SAGE_ROOT is None

### DIFF
--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -2,16 +2,21 @@
 r"""
 Sage Runtime Environment
 
-Verify that importing ``sage.all`` works in Sage's Python without any ``SAGE_``
-environment variables, and has the same ``SAGE_ROOT`` and ``SAGE_LOCAL``
-(see also :issue:`29446`)::
+Verify that importing ``sage.all`` works in Sage's Python without any
+``SAGE_`` environment variables, and has the same ``SAGE_ROOT`` and
+``SAGE_LOCAL`` (see also :issue:`29446`). If ``SAGE_ROOT`` is a path,
+we normalize it, but keep in mind that ``SAGE_ROOT`` may also be
+``None``::
 
     sage: env = {k:v for (k,v) in os.environ.items() if not k.startswith("SAGE_")}
     sage: from subprocess import check_output
     sage: module_name = "sage.all"   # hide .all import from the linter
     sage: cmd  = f"from {module_name} import SAGE_ROOT, SAGE_LOCAL;"
     sage: cmd +=  "from os.path import samefile;"
-    sage: cmd += f"s1 = samefile(SAGE_ROOT, '{SAGE_ROOT}') if SAGE_ROOT else True;"
+    sage: if SAGE_ROOT is None:
+    ....:     cmd +=  "s1 = SAGE_ROOT is None;"
+    ....: else:
+    ....:     cmd += f"s1 = samefile(SAGE_ROOT, '{SAGE_ROOT}');"
     sage: cmd += f"s2 = samefile(SAGE_LOCAL, '{SAGE_LOCAL}');"
     sage: cmd += "print(s1 and s2);"
     sage: out = check_output([sys.executable, "-c", cmd], env=env).decode().strip()   # long time


### PR DESCRIPTION
In this file we test that `SAGE_ROOT` in a subprocess is the same as `SAGE_ROOT` in the parent. There is a special case for when `SAGE_ROOT is None`, but that special case can pass if only one of the `SAGE_ROOT` variables is `None` and the other is not -- contrary to the intent of the test.

Here we extend the special case to ensure that both `SAGE_ROOT` variables are `None` if one of them is.

Thanks to Gonzalo Tornaría for the suggestion.
