### PR TITLE
no longer ignore errors in method `union` of `DisjointSet`

### DIFF
--- a/src/sage/sets/disjoint_set.pxd
+++ b/src/sage/sets/disjoint_set.pxd
@@ -29,7 +29,7 @@ cdef class DisjointSet_of_hashables(DisjointSet_class):
     cdef list _int_to_el
     cdef dict _el_to_int
     cpdef find(self, e)
-    cpdef void union(self, e, f) noexcept
+    cpdef void union(self, e, f) except *
     cpdef root_to_elements_dict(self)
     cpdef element_to_root_dict(self)
     cpdef to_digraph(self)

--- a/src/sage/sets/disjoint_set.pyx
+++ b/src/sage/sets/disjoint_set.pyx
@@ -833,7 +833,7 @@ cdef class DisjointSet_of_hashables(DisjointSet_class):
         cdef int r = <int> OP_find(self._nodes, i)
         return self._int_to_el[r]
 
-    cpdef void union(self, e, f) noexcept:
+    cpdef void union(self, e, f) except *:
         r"""
         Combine the set of ``e`` and the set of ``f`` into one.
 
@@ -861,8 +861,9 @@ cdef class DisjointSet_of_hashables(DisjointSet_class):
             sage: e
             {{'a', 'b', 'c', 'e'}, {'d'}}
             sage: e.union('a', 2**10)
-            KeyError: 1024
+            Traceback (most recent call last):
             ...
+            KeyError: 1024
         """
         cdef int i = <int> self._el_to_int[e]
         cdef int j = <int> self._el_to_int[f]


### PR DESCRIPTION
Fixes #38939.

This PR changes the declaration of method `union` from `noexcept` to `except *` to properly raise errors.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


