### PR TITLE
move spkg tarballs from user.ox.ac.uk

### DIFF
--- a/build/pkgs/cunningham_tables/checksums.ini
+++ b/build/pkgs/cunningham_tables/checksums.ini
@@ -1,4 +1,4 @@
 tarball=cunningham_tables-VERSION.tar.gz
 sha1=8bea1a113d85bb9c37d8f213dd19525d9d026f22
 sha256=ef39ab25bef5b1813071c9bd96abe3a9e683d5595c9654a3ffde5b07b7fe52b0
-upstream_url=http://users.ox.ac.uk/~coml0531/sage/cunningham_tables-VERSION.tar.gz
+upstream_url=https://github.com/sagemath/sage-package/releases/download/tars/cunningham_tables-VERSION.tar.gz

--- a/build/pkgs/graphs/checksums.ini
+++ b/build/pkgs/graphs/checksums.ini
@@ -1,4 +1,4 @@
 tarball=graphs-VERSION.tar.bz2
 sha1=c3b9fcbc92482efd6b7f6f3a33df5a78e1256aa1
 sha256=07237c0d9853611505c389fd7bb92500c8743f5631babb4d0f45dfd8332f3741
-upstream_url=http://users.ox.ac.uk/~coml0531/sage/graphs-VERSION.tar.bz2
+upstream_url=https://github.com/sagemath/sage-package/releases/download/tars/graphs-VERSION.tar.bz2

--- a/build/pkgs/planarity/checksums.ini
+++ b/build/pkgs/planarity/checksums.ini
@@ -1,4 +1,4 @@
 tarball=planarity-VERSION.tar.gz
 sha1=8407bccf33c07bf0dae22d79b5e6ac7d89c62ea3
 sha256=63e979d37e7160e4e72a286a8dd7ba74e4795f63742f417c8ba1cea2b2a51280
-upstream_url=http://users.ox.ac.uk/~coml0531/sage/planarity-VERSION.tar.gz
+upstream_url=https://github.com/sagemath/sage-package/releases/download/tars/planarity-VERSION.tar.gz

--- a/build/pkgs/rubiks/checksums.ini
+++ b/build/pkgs/rubiks/checksums.ini
@@ -1,4 +1,4 @@
 tarball=rubiks-VERSION-unix.tar.bz2
 sha1=c12069ed1eb0fc19f80a474b1c4bad2d845f5e40
 sha256=aae4c88c0f1cf84718c1a6e31e027a2886e9eaea65051385339fd98be8693e07
-upstream_url=https://users.ox.ac.uk/~coml0531/tmp/rubiks-VERSION-unix.tar.bz2
+upstream_url=https://github.com/sagemath/sage-package/releases/download/tars/rubiks-VERSION-unix.tar.bz2

--- a/build/pkgs/symmetrica/checksums.ini
+++ b/build/pkgs/symmetrica/checksums.ini
@@ -1,4 +1,4 @@
 tarball=symmetrica-VERSION.tar.xz
 sha1=0044cc087ff04267c246e730c6570d89f6e593af
 sha256=05ae107ec41f38cada19c26b6d7884970cbafae6e3b55ec3964896230358b456
-upstream_url=http://users.ox.ac.uk/~coml0531/sage/symmetrica-VERSION.tar.xz
+upstream_url=https://github.com/sagemath/sage-package/releases/download/tars/symmetrica-VERSION.tar.xz

--- a/build/pkgs/tachyon/checksums.ini
+++ b/build/pkgs/tachyon/checksums.ini
@@ -1,4 +1,4 @@
 tarball=tachyon-VERSION.tar.gz
 sha1=28ac9dc28ba90b47ab7e03c81bb2170ddbb1c248
 sha256=09203c102311149f5df5cc367409f96c725742666d19c24db5ba994d5a81a6f5
-upstream_url=https://users.ox.ac.uk/~coml0531/tmp/tachyon-VERSION.tar.gz
+upstream_url=https://github.com/sagemath/sage-package/releases/download/tars/tachyon-VERSION.tar.gz

--- a/build/pkgs/topcom/checksums.ini
+++ b/build/pkgs/topcom/checksums.ini
@@ -1,4 +1,4 @@
 tarball=TOPCOM-1_1_2.tgz
 sha1=65db8c00309f3bf8467ee5ba9da109c196db3461
 sha256=4fb10754ee5b76056441fea98f2c8dee5db6f2984d8c14283b49239ad4378ab6
-upstream_url=https://users.ox.ac.uk/~coml0531/tmp/TOPCOM-1_1_2.tgz
+upstream_url=https://github.com/sagemath/sage-package/releases/download/tars/TOPCOM-1_1_2.tgz


### PR DESCRIPTION
These tarballs are now hosted at a release of sagemath/sage-package as "assets", as `user.ox.ac.uk/~coml0531` is to be removed




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [x ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


