### PR TITLE
Fix configure script generated by pkgconf-2.3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,7 +222,7 @@ dnl Exit autoconf with exit code 16 in this case. This will be
 dnl caught by the bootstrap script.
 m4_exit(16)])
 
-PKG_PROG_PKG_CONFIG([0.29])
+PKG_PROG_PKG_CONFIG([0.29], [PKG_CONFIG=false])
 
 AC_CHECK_PROG(found_ranlib, ranlib, yes, no)
 if test x$found_ranlib != xyes


### PR DESCRIPTION
Pkgconf 2.3.0 changes the PKG_PROG_PKG_CONFIG macro to error out instead of marking it as not found. Arguably this is the correct default for most but not for us, since we support building on macos where Apple, in their infinite wisdom, decided not to ship their dev tools with it.

See also: https://github.com/pkgconf/pkgconf/blob/master/NEWS

    dnl PKG_PROG_PKG_CONFIG([MIN-VERSION], [ACTION-IF-NOT-FOUND])
    dnl ---------------------------------------------------------
    dnl Since: 0.16
    dnl
    dnl Search for the pkg-config tool and set the PKG_CONFIG variable to
    dnl first found in the path. Checks that the version of pkg-config found
    dnl is at least MIN-VERSION. If MIN-VERSION is not specified, 0.9.0 is
    dnl used since that's the first version where most current features of
    dnl pkg-config existed.
    dnl
    dnl If pkg-config is not found or older than specified, it will result
    dnl in an empty PKG_CONFIG variable. To avoid widespread issues with
    dnl scripts not checking it, ACTION-IF-NOT-FOUND defaults to aborting.
    dnl You can specify [PKG_CONFIG=false] as an action instead, which would
    dnl result in pkg-config tests failing, but no bogus error messages.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


