### PR TITLE
Allow powers of SignGroup elements to live in other parents

### DIFF
--- a/src/sage/groups/misc_gps/argument_groups.py
+++ b/src/sage/groups/misc_gps/argument_groups.py
@@ -1474,10 +1474,9 @@ class Sign(AbstractArgument):
         result = self._element_ ** exponent
         P = self.parent()
         try:
-            result = P.element_class(P, self._element_ ** exponent)
+            return P.element_class(P, result)
         except (ValueError, TypeError):
-            pass
-        return result
+            return result
 
     def __invert__(self):
         r"""

--- a/src/sage/groups/misc_gps/argument_groups.py
+++ b/src/sage/groups/misc_gps/argument_groups.py
@@ -1461,6 +1461,15 @@ class Sign(AbstractArgument):
             1
             sage: S(-1)^3  # indirect doctest
             -1
+
+        Check that the results may live in other parents too::
+
+            sage: x = SR.var('x')
+            sage: elem = S(-1)^x; elem  # indirect doctest
+            (-1)^x
+            sage: elem.parent()
+            Symbolic Ring
+
         """
         result = self._element_ ** exponent
         P = self.parent()

--- a/src/sage/groups/misc_gps/argument_groups.py
+++ b/src/sage/groups/misc_gps/argument_groups.py
@@ -1462,8 +1462,13 @@ class Sign(AbstractArgument):
             sage: S(-1)^3  # indirect doctest
             -1
         """
+        result = self._element_ ** exponent
         P = self.parent()
-        return P.element_class(P, self._element_ ** exponent)
+        try:
+            result = P.element_class(P, self._element_ ** exponent)
+        except (ValueError, TypeError):
+            pass
+        return result
 
     def __invert__(self):
         r"""

--- a/src/sage/rings/asymptotic/asymptotic_ring.py
+++ b/src/sage/rings/asymptotic/asymptotic_ring.py
@@ -4415,6 +4415,16 @@ class AsymptoticRing(Parent, UniqueRepresentation, WithLocals):
             ....:    'n', precision=5))
             True
 
+        Positive and negative singularities::
+
+            sage: def permutations_odd_cycles(z):
+            ....:     return sqrt((1+z) / (1-z))
+            sage: ex = B.coefficients_of_generating_function(
+            ....:     permutations_odd_cycles, (1, -1,), precision=2,
+            ....: ); ex
+            sqrt(2)/sqrt(pi)*n^(-1/2) - 1/2*sqrt(1/2)/sqrt(pi)*n^(-3/2)*(-1)^n
+            + O(n^(-5/2))
+
         .. WARNING::
 
             Once singular expansions around points other than infinity


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

A `SignGroup` is used as an auxiliary construct in the context of [asymptotic expansions](https://doc.sagemath.org/html/en/reference/asymptotic/sage/rings/asymptotic/asymptotic_ring.html) to split the growth of terms like `(-2)^n * n^42` into, essentially, `2^n * n^42 * (-1)^n` that lives in a cartesian product `QQ^n * n^QQ  * Signs^n`.

In the current implementation of `Sign.__pow__`, the power is computed using the raw data (essentially, `int ** whatever`) and then an attempt is made to push the result back into `SignGroup`. This changes this behavior to still attempt the conversion -- but if it fails while the raw operation itself was successful, the result living in some other parent not coercing back to `SignGroup` is returned.

Simple example:

```py
sage: from sage.groups.misc_gps.argument_groups import SignGroup
sage: S = SignGroup()
sage: x = SR.var('x')
sage: S(-1)^x  # this fails on develop
(-1)^x
sage: _.parent()
Symbolic Ring
```

For asymptotic expansions, this fixes an issue preventing substitutions in expansions with terms that involve, e.g., `(-1)^n`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



