### PR TITLE
Drinfeld Modules: Default to zero endomorphism in `.hom` and avoid inversion of zero endomorphism

### DIFF
--- a/src/sage/rings/function_field/drinfeld_modules/drinfeld_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/drinfeld_module.py
@@ -1855,7 +1855,7 @@ class DrinfeldModule(Parent, UniqueRepresentation):
 
     def velu(self, isog):
         r"""
-        Return a new Drinfeld module such that input is an
+        Return a new Drinfeld module such that ``isog`` defines an
         isogeny to this module with domain ``self``; if no such isogeny
         exists, raise an exception.
 
@@ -2018,11 +2018,19 @@ class DrinfeldModule(Parent, UniqueRepresentation):
             Traceback (most recent call last):
             ...
             ValueError: Ore polynomial does not define a morphism
+
+        Check that x = 0 (without specified codomain) gives the zero endomorphism::
+
+            sage: phi.hom(K.zero())
+            Endomorphism of Drinfeld module defined by ...
+              Defn: 0
         """
         # When `x` is in the function ring (or something that coerces to it):
         if self.function_ring().has_coerce_map_from(x.parent()):
             return self.Hom(self)(x)
         if codomain is None:
+            if x.is_zero():
+                return self.Hom(self)(0)
             try:
                 codomain = self.velu(x)
             except TypeError:

--- a/src/sage/rings/function_field/drinfeld_modules/morphism.py
+++ b/src/sage/rings/function_field/drinfeld_modules/morphism.py
@@ -536,9 +536,11 @@ class DrinfeldModuleMorphism(Morphism, UniqueRepresentation,
             sage: K.<z> = Fq.extension(3)
             sage: coeffs = [z] + [K.random_element() for _ in range(10)]
             sage: phi = DrinfeldModule(A, coeffs)
-            sage: f = phi.hom(K.random_element())
+            sage: a = K.random_element()
+            sage: while a.is_zero():
+            ....:     a = K.random_element()
+            sage: f = phi.hom(a)
             sage: g = ~f
-
             sage: (f*g).is_identity()
             True
             sage: (g*f).is_identity()


### PR DESCRIPTION
This PR fixes #38953 and is inspired by the error raised in the issue: 
- The main fix is to avoid sampling the zero element of the base field in the test of `__invert__`, so that `phi.hom(a)` actually returns an invertible morphism.
- However, the error raised in the issue named above was slightly confusing, as the call of `phi.hom(K.zero())` does not return any homomorphism: Since the codomain is not specified, it tries to find a codomain via the `.velu`-method, but this only works if the given element defines an isogeny, which `K.zero()` does not. Instead of raising an error for this special case in `.hom`, it seems more robust to default to the zero endomorphism of `self` instead.
- Also added the mention of `isog` in the `.velu`-method.