### PR TITLE
Do not allow order of AbelianGroup generator to be negative

### DIFF
--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -365,6 +365,13 @@ def _normalize(n, gens_orders=None, names='f'):
         Traceback (most recent call last):
         ...
         TypeError: unable to convert 's' to an integer
+
+    Verify that :issue:`38967` is fixed::
+
+        sage: AbelianGroup([-4])
+        Traceback (most recent call last):
+        ...
+        ValueError: orders of generators cannot be negative but they are (-4,)
     """
     if gens_orders is None:
         if isinstance(n, (list, tuple)):
@@ -376,6 +383,8 @@ def _normalize(n, gens_orders=None, names='f'):
     if len(gens_orders) < n:
         gens_orders = [0] * (n - len(gens_orders)) + list(gens_orders)
     gens_orders = tuple(ZZ(i) for i in gens_orders)
+    if any(i < 0 for i in gens_orders):
+        raise ValueError(f'orders of generators cannot be negative but they are {gens_orders}')
     if len(gens_orders) > n:
         raise ValueError('gens_orders (='+str(gens_orders)+') must have length n (='+str(n)+')')
     if isinstance(names, list):


### PR DESCRIPTION
Fixes #38967.

Revised the `_normalize` method of Multiplicative Abelian Groups to raise an error if any of the generators are specified to have negative order. Also added a doctest.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
