### PR TITLE
avoid using isinstance IntegralDomain in modules

### DIFF
--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -172,7 +172,7 @@ AUTHORS:
 #
 #  The full text of the GPL is available at:
 #
-#                  http://www.gnu.org/licenses/
+#                  https://www.gnu.org/licenses/
 ###########################################################################
 
 import itertools
@@ -185,7 +185,6 @@ import sage.rings.infinity
 import sage.rings.integer
 import sage.rings.integer_ring
 import sage.rings.rational_field
-from sage.rings.ring import IntegralDomain
 from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.fields import Fields
 from sage.categories.infinite_enumerated_sets import InfiniteEnumeratedSets
@@ -296,7 +295,7 @@ class FreeModuleFactory(UniqueFactory):
                 and base_ring.is_maximal() and base_ring.class_number() == 1):
             return FreeModule_ambient_pid(base_ring, rank, sparse=sparse)
 
-        if isinstance(base_ring, IntegralDomain) or base_ring in IntegralDomains():
+        if base_ring in IntegralDomains():
             return FreeModule_ambient_domain(base_ring, rank, sparse=sparse)
 
         return FreeModule_ambient(base_ring, rank, sparse=sparse)

--- a/src/sage/modules/free_quadratic_module.py
+++ b/src/sage/modules/free_quadratic_module.py
@@ -69,8 +69,9 @@ import weakref
 
 from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.principal_ideal_domains import PrincipalIdealDomains
+from sage.categories.integral_domains import IntegralDomains
 from sage.modules import free_module
-from sage.rings.ring import Field, IntegralDomain
+from sage.rings.ring import Field
 import sage.matrix.matrix_space
 import sage.misc.latex as latex
 
@@ -175,7 +176,7 @@ def FreeQuadraticModule(base_ring, rank, inner_product_matrix,
         M = FreeQuadraticModule_ambient_pid(
             base_ring, rank, sparse=sparse, inner_product_matrix=inner_product_matrix)
 
-    elif isinstance(base_ring, IntegralDomain) or base_ring.is_integral_domain():
+    elif base_ring in IntegralDomains():
         M = FreeQuadraticModule_ambient_domain(
             base_ring, rank, sparse=sparse, inner_product_matrix=inner_product_matrix)
     else:


### PR DESCRIPTION
as a small step towards getting rid of the auld class `IntegralDomain`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.


