### PR TITLE
Python3 build does not find openssl without pkgconf

### DIFF
--- a/build/pkgs/python3/dependencies
+++ b/build/pkgs/python3/dependencies
@@ -1,4 +1,4 @@
-zlib readline sqlite libpng bzip2 liblzma libffi openssl | xz
+zlib readline sqlite libpng bzip2 liblzma libffi openssl | xz pkgconf
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
Building the python3 package fails with 
```
Using cached file /Users/buildbot-sage/worker/sage_git/build/upstream/Python-3.12.5.tar.xz
[...]
[spkg-build] checking for pkg-config... no
[...]
[spkg-build] checking for include/openssl/ssl.h in /usr/local/ssl... no
[spkg-build] checking for include/openssl/ssl.h in /usr/lib/ssl... no
[spkg-build] checking for include/openssl/ssl.h in /usr/ssl... no
[spkg-build] checking for include/openssl/ssl.h in /usr/pkg... no
[spkg-build] checking for include/openssl/ssl.h in /usr/local... no
[spkg-build] checking for include/openssl/ssl.h in /usr... no
[spkg-build] checking whether compiling and linking against OpenSSL works... no
[spkg-build] checking for --with-openssl-rpath... 
[spkg-build] checking whether OpenSSL provides required ssl module APIs... no
[spkg-build] checking whether OpenSSL provides required hashlib module APIs... no
[spkg-build] checking for --with-ssl-default-suites... python
[...]
[spkg-build] ModuleNotFoundError: No module named '_ssl'
[spkg-build] ssl module failed to import
[spkg-build] _scproxy module imported OK
[spkg-build] Error: One or more modules failed to import.
************************************************************************
Error building package python3-3.12.5
************************************************************************
```
(see http://build.sagemath.org/#/builders/62/builds/3/steps/11/logs/python3)
