### PR TITLE
Use meson as backend for numpy.f2py

### DIFF
--- a/src/sage/misc/inline_fortran.py
+++ b/src/sage/misc/inline_fortran.py
@@ -162,9 +162,7 @@ class InlineFortran:
 
             # What follows are the arguments to f2py itself (appended later
             # just for logical separation)
-            cmd += ['-c', '-m', name, fortran_file, '--quiet',
-                    '--f77exec=sage-inline-fortran',
-                    '--f90exec=sage-inline-fortran'] + s_lib_path + s_lib
+            cmd += ['-c', '-m', name, fortran_file, '--quiet', '--backend', 'meson'] + s_lib_path + s_lib
 
             try:
                 out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Newer versions of numpy use meson instead of the old distutils. Needed for #37447.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


