### PR TITLE
Fix detection of tdlib and mcqd with meson

### DIFF
--- a/src/sage/graphs/graph_decompositions/meson.build
+++ b/src/sage/graphs/graph_decompositions/meson.build
@@ -1,4 +1,9 @@
-tdlib = cc.find_library('tdlib', required: false, disabler: true)
+# tdlib is a header-only library
+if cc.has_header('treedec/combinations.hpp')
+  tdlib = declare_dependency()
+else
+  tdlib = disabler()
+endif
 # Cannot be found via pkg-config
 rw = cc.find_library('rw')
 

--- a/src/sage/graphs/meson.build
+++ b/src/sage/graphs/meson.build
@@ -1,5 +1,10 @@
 bliss = cc.find_library('bliss', required: false, disabler: true)
-mcqd = cc.find_library('mcqd', required: false, disabler: true)
+# mcqd is a header-only library
+if cc.has_header('mcqd.h')
+  mcqd = declare_dependency()
+else
+  mcqd = disabler()
+endif
 cliquer = cc.find_library('cliquer')
 
 # Cannot be found via pkg-config


### PR DESCRIPTION
These are header-only libraries, so find_library doesn't work with them
