### PR TITLE
Meson: find more dependencies via pkg-config

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -56,9 +56,10 @@ print(cypari2.__file__.replace('__init__.py', ''))
   check: true,
 ).stdout().strip()
 cypari2 = declare_dependency(include_directories: inc_cypari2)
+# Cannot be found via pkg-config
 pari = cc.find_library('pari')
 
-mpfr = cc.find_library('mpfr')
+mpfr = dependency('mpfr')
 
 flint = dependency('flint', version: '>=3.0.0')
 if flint.version().version_compare('<3.1')
@@ -78,35 +79,47 @@ endif
 # that too to make the fallback detection with CMake work
 blas_order += ['cblas', 'openblas', 'OpenBLAS', 'flexiblas', 'blis', 'blas']
 blas = dependency(blas_order)
-gsl = dependency('gsl', version: '>=2.5', required: true)
-gd = cc.find_library('gd')
+gsl = dependency('gsl', version: '>=2.5')
+gd = dependency('gdlib', required: false, version: '>=2.1')
+if not gd.found()
+  gd = cc.find_library('gd', required: true)
+endif
 # Only some platforms have a standalone math library (https://mesonbuild.com/howtox.html#add-math-library-lm-portably)
 m = cc.find_library('m', required: false)
-m4ri = cc.find_library('m4ri')
-m4rie = cc.find_library('m4rie')
-mtx = cc.find_library('mtx', required: false, disabler: true)
-png = cc.find_library('png', required: false)
-if not png.found()
-  png = cc.find_library('png16')
+m4ri = dependency('m4ri', version: '>=20140914')
+m4rie = dependency('m4rie', required: false)
+if not m4rie.found()
+  # For some reason, m4rie is not found via pkg-config on some systems (eg Conda)
+  m4rie = cc.find_library('m4rie')
 endif
-zlib = cc.find_library('z')
 # Cannot be found via pkg-config
-ec = cc.find_library('ec')
+mtx = cc.find_library('mtx', required: false, disabler: true)
+png = dependency(['libpng', 'png', 'png16'], version: '>=1.2')
+zlib = dependency('zlib', version: '>=1.2.11')
+# We actually want >= 20231212, but the version number is not updated in the pkgconfig
+# https://github.com/conda-forge/eclib-feedstock/issues/48
+ec = dependency('eclib', version: '>=20231211')
+# Cannot be found via pkg-config
 ecm = cc.find_library('ecm')
+# Cannot be found via pkg-config
 ppl = cc.find_library('ppl')
-gmpxx = cc.find_library('gmpxx')
-fflas = dependency('fflas-ffpack')
+gmpxx = dependency('gmpxx')
+fflas = dependency('fflas-ffpack', version: '>=2.5.0')
 fplll = dependency('fplll')
-givaro = cc.find_library('givaro')
-linbox = dependency('linbox', required: false)
+givaro = dependency('givaro', version: '>=4.2.0')
+linbox = dependency('linbox', required: false, version: '>=1.7.0')
 if not linbox.found()
   linbox = cc.find_library('linbox')
 endif
 mpc = cc.find_library('mpc')
 mpfi = cc.find_library('mpfi')
-# Cannot be found via pkg-config (pkg-config file will be added in 4.13)
-# Test for common.h header that was added in 4.12 as a indirect version check
-gap = cc.find_library('gap', has_headers: ['gap/common.h'])
+
+gap = dependency('libgap', version: '>=4.13.0', required: false)
+if not gap.found()
+  # Fallback in case pkg-config info is not available
+  # Test for common.h header that was added in 4.12 as a indirect version check
+  gap = cc.find_library('gap', has_headers: ['gap/common.h'])
+endif
 singular = dependency('Singular')
 maxima = find_program('maxima', required: true)
 # Cannot be found via pkg-config

--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -1,8 +1,12 @@
 sirocco = cc.find_library('sirocco', required: false, disabler: true)
 # cannot be found via pkg-config
 ecl = cc.find_library('ecl')
-braiding = cc.find_library('braiding')
-gc = cc.find_library('gc')
+braiding = dependency('libbraiding', required: false)
+if not braiding.found()
+  # Fallback since pkg-config support was only added in v1.3.1
+  braiding = cc.find_library('braiding')
+endif
+gc = dependency(['bdw-gc-threaded', 'bdw-gc'], version: '>=7.6.4')
 homfly = cc.find_library('homfly', has_headers: ['homfly.h'])
 
 py.install_sources(


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Use pkg-config to find more dependencies, and add version constraints (mostly) as specified in the `spkg-configure` scripts.

Now only the packages without pkg-config info use `find_library` (refs https://github.com/sagemath/sage/issues/39064)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

- #37447 for the updated conda lock files

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


