### PR TITLE
Fix crash when specify invalid base for RR and RIF construction

### DIFF
--- a/src/sage/rings/convert/mpfi.pyx
+++ b/src/sage/rings/convert/mpfi.pyx
@@ -72,6 +72,33 @@ cdef int mpfi_set_sage(mpfi_ptr re, mpfi_ptr im, x, field, int base) except -1:
       imaginary component is 0.
 
     - in all other cases: raise an exception.
+
+    TESTS::
+
+        sage: RIF('0xabc')
+        Traceback (most recent call last):
+        ...
+        TypeError: unable to convert '0xabc' to real interval
+        sage: RIF("0x123.e1", base=0)  # rel tol 1e-12
+        291.87890625000000?
+        sage: RIF("0x123.@1", base=0)  # rel tol 1e-12
+        4656
+        sage: RIF("1Xx", base=36)  # rel tol 1e-12
+        2517
+        sage: RIF("-1Xx@-10", base=62)  # rel tol 1e-12
+        -7.088054920481391?e-15
+        sage: RIF("1", base=1)
+        Traceback (most recent call last):
+        ...
+        ValueError: base (=1) must be 0 or between 2 and 62
+        sage: RIF("1", base=-1)
+        Traceback (most recent call last):
+        ...
+        ValueError: base (=-1) must be 0 or between 2 and 62
+        sage: RIF("1", base=63)
+        Traceback (most recent call last):
+        ...
+        ValueError: base (=63) must be 0 or between 2 and 62
     """
     cdef RealIntervalFieldElement ri
     cdef ComplexIntervalFieldElement zi
@@ -79,6 +106,8 @@ cdef int mpfi_set_sage(mpfi_ptr re, mpfi_ptr im, x, field, int base) except -1:
     cdef ComplexDoubleElement zd
     cdef bytes s
 
+    if base != 0 and (base < 2 or base > 62):
+        raise ValueError(f"base (={base}) must be 0 or between 2 and 62")
     if im is not NULL and isinstance(x, tuple):
         # For complex numbers, interpret tuples as real/imag parts
         if len(x) != 2:

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -1437,6 +1437,33 @@ cdef class RealNumber(sage.structure.element.RingElement):
 
             sage: RealNumber('1_3.1e-32_45')
             1.31000000000000e-3244
+
+        Test conversion from base different from `10`::
+
+            sage: RR('0xabc')
+            Traceback (most recent call last):
+            ...
+            TypeError: unable to convert '0xabc' to a real number
+            sage: RR("0x123.e1", base=0)  # rel tol 1e-12
+            291.878906250000
+            sage: RR("0x123.@1", base=0)  # rel tol 1e-12
+            4656.00000000000
+            sage: RR("1Xx", base=36)  # rel tol 1e-12
+            2517.00000000000
+            sage: RR("-1Xx@-10", base=62)  # rel tol 1e-12
+            -7.08805492048139e-15
+            sage: RR("1", base=1)
+            Traceback (most recent call last):
+            ...
+            ValueError: base (=1) must be 0 or between 2 and 62
+            sage: RR("1", base=-1)
+            Traceback (most recent call last):
+            ...
+            ValueError: base (=-1) must be 0 or between 2 and 62
+            sage: RR("1", base=63)
+            Traceback (most recent call last):
+            ...
+            ValueError: base (=63) must be 0 or between 2 and 62
         """
         if x is not None:
             self._set(x, base)
@@ -1485,6 +1512,8 @@ cdef class RealNumber(sage.structure.element.RingElement):
         # Real Numbers are supposed to be immutable.
         cdef RealField_class parent
         parent = self._parent
+        if base != 0 and (base < 2 or base > 62):
+            raise ValueError(f"base (={base}) must be 0 or between 2 and 62")
         if isinstance(x, RealNumber):
             if isinstance(x, RealLiteral):
                 s = (<RealLiteral>x).literal


### PR DESCRIPTION
As in the title.

Note that currently `ZZ(str, base=int)` only support 2 to 36. Should this be changed for consistency?



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview. (There's no change in documentation.)

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


------

The test on Conda (Mac) fails with

```
2024-11-19T04:02:36.0696760Z ./bootstrap: line 142: aclocal: command not found
2024-11-19T04:02:36.0697900Z Bootstrap failed. Either install autotools; or run bootstrap with
2024-11-19T04:02:36.0698610Z the -d option to download the auto-generated files instead.
```

Looks unrelated.

Another one (Ubuntu 3.9) is

```
2024-11-19T04:26:04.0471925Z **********************************************************************
2024-11-19T04:26:04.0591101Z File "src/sage/plot/plot.py", line 1857, in sage.plot.plot.plot
2024-11-19T04:26:04.0591946Z Failed example:
2024-11-19T04:26:04.0592761Z     plot(f, (x, -3.5, 3.5), detect_poles='show', exclude=[-3..3],
2024-11-19T04:26:04.0593588Z          ymin=-5, ymax=5)
2024-11-19T04:26:04.0594061Z Expected:
2024-11-19T04:26:04.0649808Z     Graphics object consisting of 12 graphics primitives
2024-11-19T04:26:04.0650471Z Got:
2024-11-19T04:26:04.1009273Z     Graphics object consisting of 13 graphics primitives
2024-11-19T04:26:26.6704957Z **********************************************************************
```

Also looks unrelated. Reported in #39002.