### PR TITLE
CI Fix: Do not upload logs artifact for the default job in CI Linux

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -50,6 +50,7 @@ jobs:
       tox_packages_factors: >-
         ["standard"]
       docker_push_repository: ghcr.io/${{ github.repository }}/
+      logs_artifact: false
 
   # All platforms. This duplicates the default platform, but why not,
   # it makes it more robust regarding random timeouts.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,9 @@ on:
         description: 'Elapsed time (seconds) at which to kill the build'
         default: 20000
         type: number
+      logs_artifact:
+        default: true
+        type: boolean
       #
       # Publishing to GitHub Packages
       #
@@ -260,11 +263,12 @@ jobs:
           cp -r .tox/$TOX_ENV/* "artifacts/$LOGS_ARTIFACT_NAME"
           rm -rf "artifacts/$LOGS_ARTIFACT_NAME"/{bin,lib,pyvenv.cfg}
         if: always()
-      - uses: actions/upload-artifact@v4
+      - name: Upload logs artifact
+        uses: actions/upload-artifact@v4
         with:
           path: artifacts
           name: ${{ env.LOGS_ARTIFACT_NAME }}
-        if: always()
+        if: always() && inputs.logs_artifact
       - name: Print out logs for immediate inspection
         # and markup the output with GitHub Actions logging commands
         run: |


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

fixes the failure seen in https://github.com/sagemath/sage/actions/runs/11869791506/job/33080484685

The cause is duplicate uploading of artifacts of the same name.

Test: https://github.com/kwankyu/sage/actions/runs/11906298470/job/33178163324

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


