### PR TITLE
is_circumscribable: support other MIP solvers

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -8400,8 +8400,9 @@ class Graph(GenericGraph):
         try:
             solution = M.solve(log=verbose)
         except MIPSolverException as msg:
-            if str(msg) == "PPL : There is no feasible solution":
+            if str(msg).endswith("no feasible solution"):
                 return False
+            raise msg
         return solution > 0
 
     @doc_index("Graph properties")


### PR DESCRIPTION
The graph methods [`is_circumscribable`](https://doc.sagemath.org/html/en/reference/graphs/sage/graphs/graph.html#sage.graphs.graph.Graph.is_circumscribable) and [`is_inscribable`](https://doc.sagemath.org/html/en/reference/graphs/sage/graphs/graph.html#sage.graphs.graph.Graph.is_inscribable) currently only work when the optional argument `solver` is kept unchanged at `PPL`. For example,

```sage
Graph("JIQCC?ZJ`i?").is_inscribable(solver="GLPK")
````

fails with `UnboundLocalError: cannot access local variable 'solution' where it is not associated with a value` while it should evaluate to `False` (at least that's what you get with `solver="PPL"`).

I fixed this in a quick-and-dirty way. It is unfortunate that we need to do a string comparison on the MIPSolverException since the solver can also fail for reasons like "unknown error during call to GLPK" (although in [other places](https://github.com/sagemath/sage/blob/b9e396a7444167fb334b12a5b41db9af0cfa8ef0/src/sage/graphs/matching.py#L157) a MIPSolverException is assumed to mean "unsolvable").