### PR TITLE
Eliminate division by 0 in 1.0^x

### DIFF
--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -4375,6 +4375,11 @@ cdef class Expression(Expression_abc):
             sage: complex(1,3)^(sqrt(2))
             (1+3j)^sqrt(2)
 
+        Check that :issue:`39035` is fixed::
+
+            sage: 1.0^x
+            1.00000000000000^x
+
         Test complex numeric powers::
 
             sage: symI = SR(I)

--- a/src/sage/symbolic/ginac/power.cpp
+++ b/src/sage/symbolic/ginac/power.cpp
@@ -651,7 +651,7 @@ ex power::eval(int level) const
 
 
 	// Reduce x^(c/log(x)) to exp(c) if x is positive
-	if (ebasis.is_positive()) {
+	if (ebasis.is_positive() && (log(ebasis) != 0)) {
 		if (eexponent.is_equal(1/log(ebasis)))
 			return exp(log(basis)*exponent);
 		if (is_exactly_a<mul>(eexponent) and


### PR DESCRIPTION
Fixes #39035.

Calculating `1.0^x` results in `ValueError: power::eval(): division by zero`. This comes from the following snippet of `src/sage/symbolic/ginac/power.cpp` (lines 653-656):

```
// Reduce x^(c/log(x)) to exp(c) if x is positive
if (ebasis.is_positive()) {
	if (eexponent.is_equal(1/log(ebasis)))
		return exp(log(basis)*exponent);
```
To eliminate the bug we add `&& (log(ebasis) != 0)` to the test `ebasis.is_positive()`, thereby making sure the denominator of `1/log(ebasis)` is not 0.

The PR also adds a doctest for the issue.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


