### PR TITLE
Fix exactify caching when interrupted

### DIFF
--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -7098,11 +7098,25 @@ class AlgebraicPolynomialTracker(SageObject):
             sage: cp.exactify()
             sage: cp._exact
             True
+
+        TESTS:
+
+        Check that interrupting ``exactify()`` does not lead to incoherent state::
+
+            sage: x = polygen(AA)
+            sage: p = AA(2)^(1/100) * x + AA(3)^(1/100)
+            sage: cp = AA.common_polynomial(p)
+            sage: alarm(0.5); cp.generator()
+            Traceback (most recent call last):
+            ...
+            AlarmInterrupt
+            sage: alarm(0.5); cp.generator()
+            Traceback (most recent call last):
+            ...
+            AlarmInterrupt
         """
         if self._exact:
             return
-
-        self._exact = True
 
         if self._poly.base_ring() is QQ:
             self._factors = [fac_exp[0] for fac_exp in self._poly.factor()]
@@ -7127,6 +7141,8 @@ class AlgebraicPolynomialTracker(SageObject):
                 fp = fld_poly(coeffs)
 
                 self._factors = [fac_exp[0] for fac_exp in fp.factor()]
+
+        self._exact = True
 
     def factors(self):
         r"""


### PR DESCRIPTION
Fix a certain `AttributeError` — if you run the newly added test under previous version of SageMath then it will give an `AttributeError` in the last line instead.

(ideally you'd want some polynomial where `exactify()` takes exactly 1 second, use `alarm(0.5)` in first case and no `alarm()` in the second case to get the correct result — but finding such a polynomial is not easy, and timing result varies over machines/versions anyway)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion. (not aware of one)
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


