### PR TITLE
PKG_CONFIG must be empty if not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,7 +222,7 @@ dnl Exit autoconf with exit code 16 in this case. This will be
 dnl caught by the bootstrap script.
 m4_exit(16)])
 
-PKG_PROG_PKG_CONFIG([0.29], [PKG_CONFIG=false])
+PKG_PROG_PKG_CONFIG([0.29], [PKG_CONFIG=])
 
 AC_CHECK_PROG(found_ranlib, ranlib, yes, no)
 if test x$found_ranlib != xyes


### PR DESCRIPTION
Followup to https://github.com/sagemath/sage/pull/38954, where I followed the pkgconf documentation to set `PKG_CONFIG=false` if it is not found. But Sage uses `"test -z $PKG_CONFIG"`, so it must instead be set to empty.

This causes pkgconf not to be built if pkgconf/pkg-config is not found. Which is basically only macOS.

