### PR TITLE
remove final empty lines in pxd/pxi files

### DIFF
--- a/src/sage/coding/binary_code.pxd
+++ b/src/sage/coding/binary_code.pxd
@@ -115,4 +115,3 @@ cdef class BinaryCodeClassifier:
 
     cdef void record_automorphism(self, int *, int) noexcept
     cdef void aut_gp_and_can_label(self, BinaryCode, int) noexcept
-

--- a/src/sage/combinat/permutation_cython.pxd
+++ b/src/sage/combinat/permutation_cython.pxd
@@ -8,4 +8,3 @@ cpdef list left_action_same_n(list l, list r)
 cpdef list right_action_same_n(list l, list r)
 cpdef list left_action_product(list l, list r)
 cpdef list right_action_product(list l, list r)
-

--- a/src/sage/combinat/rigged_configurations/rigged_partition.pxd
+++ b/src/sage/combinat/rigged_configurations/rigged_partition.pxd
@@ -12,4 +12,3 @@ cdef class RiggedPartition(SageObject):
 
 cdef class RiggedPartitionTypeB(RiggedPartition):
     pass
-

--- a/src/sage/data_structures/bitset.pxd
+++ b/src/sage/data_structures/bitset.pxd
@@ -37,4 +37,3 @@ cdef class Bitset(FrozenBitset):
     cpdef discard(self, unsigned long n)
     cpdef pop(self)
     cpdef clear(self)
-

--- a/src/sage/groups/group.pxd
+++ b/src/sage/groups/group.pxd
@@ -11,4 +11,3 @@ cdef class FiniteGroup(Group):
 
 cdef class AlgebraicGroup(Group):
     pass
-

--- a/src/sage/groups/old.pxd
+++ b/src/sage/groups/old.pxd
@@ -11,4 +11,3 @@ cdef class FiniteGroup(Group):
 
 cdef class AlgebraicGroup(Group):
     pass
-

--- a/src/sage/groups/perm_gps/partn_ref/canonical_augmentation.pxd
+++ b/src/sage/groups/perm_gps/partn_ref/canonical_augmentation.pxd
@@ -82,4 +82,3 @@ cdef iterator *setup_canonical_generator(int degree,
     iterator *cangen_prealloc) except NULL
 
 cdef iterator *start_canonical_generator(StabilizerChain *, void *, int, iterator *) except NULL
-

--- a/src/sage/groups/perm_gps/partn_ref/refinement_matrices.pxd
+++ b/src/sage/groups/perm_gps/partn_ref/refinement_matrices.pxd
@@ -28,4 +28,3 @@ cdef class MatrixStruct:
 cdef int refine_matrix(PartitionStack *, void *, int *, int) noexcept
 cdef int compare_matrices(int *, int *, void *, void *, int) noexcept
 cdef bint all_matrix_children_are_equivalent(PartitionStack *, void *) noexcept
-

--- a/src/sage/libs/gmp/mpq.pxd
+++ b/src/sage/libs/gmp/mpq.pxd
@@ -55,4 +55,3 @@ cdef extern from "gmp.h":
     # Input and Output Functions
     # size_t mpq_out_str (file *stream, int base, mpq_t op)
     # size_t mpq_inp_str (mpq_t rop, file *stream, int base)
-

--- a/src/sage/libs/m4ri.pxd
+++ b/src/sage/libs/m4ri.pxd
@@ -192,4 +192,3 @@ cdef extern from "m4ri/m4ri.h":
     ##################################
 
     cdef void mzd_clear_bits(mzd_t *m, int x, int y, int n)
-

--- a/src/sage/libs/ntl/ZZ_pX.pxd
+++ b/src/sage/libs/ntl/ZZ_pX.pxd
@@ -119,4 +119,3 @@ cdef extern from "ntlwrap_impl.h":
     void ZZ_pX_right_pshift(ZZ_pX_c x, ZZ_pX_c a, ZZ_c pn, ZZ_pContext_c c)
     void ZZ_pX_InvMod_newton_unram(ZZ_pX_c x, ZZ_pX_c a, ZZ_pX_Modulus_c F, ZZ_pContext_c cpn, ZZ_pContext_c cp)
     void ZZ_pX_InvMod_newton_ram(ZZ_pX_c x, ZZ_pX_c a, ZZ_pX_Modulus_c F, ZZ_pContext_c cpn)
-

--- a/src/sage/libs/ntl/ntl_GF2E.pxd
+++ b/src/sage/libs/ntl/ntl_GF2E.pxd
@@ -5,4 +5,3 @@ cdef class ntl_GF2E():
     cdef GF2E_c x
     cdef ntl_GF2EContext_class c
     cdef ntl_GF2E _new(self)
-

--- a/src/sage/matrix/matrix_cyclo_dense.pxd
+++ b/src/sage/matrix/matrix_cyclo_dense.pxd
@@ -13,4 +13,3 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
 
     cdef _randomize_rational_column_unsafe(Matrix_cyclo_dense self,
         Py_ssize_t col, mpz_t nump1, mpz_t denp1, distribution=?)
-

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -3241,4 +3241,3 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             [0 1]
         """
         return self._entries[j+i*self._ncols] == 0
-

--- a/src/sage/modules/free_module_element.pxd
+++ b/src/sage/modules/free_module_element.pxd
@@ -19,4 +19,3 @@ cdef class FreeModuleElement_generic_sparse(FreeModuleElement):
 
     # cdef'd methods
     cdef _new_c(self, object v)
-

--- a/src/sage/rings/finite_rings/element_base.pxd
+++ b/src/sage/rings/finite_rings/element_base.pxd
@@ -9,4 +9,3 @@ cdef class FinitePolyExtElement(FiniteRingElement):
 
 cdef class Cache_base(SageObject):
     cpdef FinitePolyExtElement fetch_int(self, number)
-

--- a/src/sage/rings/finite_rings/stdint.pxd
+++ b/src/sage/rings/finite_rings/stdint.pxd
@@ -16,4 +16,3 @@ from libc.stdint cimport int_fast32_t, int_fast64_t
 cdef extern from "integer_mod_limits.h":
     int_fast32_t INTEGER_MOD_INT32_LIMIT
     int_fast64_t INTEGER_MOD_INT64_LIMIT
-

--- a/src/sage/rings/laurent_series_ring_element.pxd
+++ b/src/sage/rings/laurent_series_ring_element.pxd
@@ -7,4 +7,3 @@ cdef class LaurentSeries(AlgebraElement):
     cdef _normalize(self)
     cpdef _add_(self, other)
     cpdef _mul_(self, other)
-

--- a/src/sage/rings/number_field/number_field_element_quadratic.pxd
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pxd
@@ -31,4 +31,3 @@ cdef class OrderElement_quadratic(NumberFieldElement_quadratic):
     pass
 
 cpdef bint is_sqrt_disc(Rational ad, Rational bd) noexcept
-

--- a/src/sage/rings/number_field/totallyreal_data.pxd
+++ b/src/sage/rings/number_field/totallyreal_data.pxd
@@ -23,4 +23,3 @@ cdef class tr_data:
     cdef int *df
 
     cdef void incr(self, int *f_out, int verbose, int haltk, int phc) noexcept
-

--- a/src/sage/rings/polynomial/polynomial_element.pxd
+++ b/src/sage/rings/polynomial/polynomial_element.pxd
@@ -61,4 +61,3 @@ cpdef Polynomial generic_power_trunc(Polynomial p, Integer n, long prec)
 cpdef list _dict_to_list(dict x, zero)
 
 cpdef bint polynomial_is_variable(x) noexcept
-

--- a/src/sage/rings/polynomial/polynomial_gf2x.pxd
+++ b/src/sage/rings/polynomial/polynomial_gf2x.pxd
@@ -7,4 +7,3 @@ include "polynomial_template_header.pxi"
 
 cdef class Polynomial_GF2X(Polynomial_template):
     pass
-

--- a/src/sage/rings/polynomial/polynomial_rational_flint.pxd
+++ b/src/sage/rings/polynomial/polynomial_rational_flint.pxd
@@ -17,4 +17,3 @@ cdef class Polynomial_rational_flint(Polynomial):
     cpdef _mod_(self, right)
     cpdef _unsafe_mutate(self, unsigned long n, value)
     cpdef Polynomial truncate(self, long n)
-

--- a/src/sage/rings/polynomial/skew_polynomial_finite_order.pxd
+++ b/src/sage/rings/polynomial/skew_polynomial_finite_order.pxd
@@ -7,4 +7,3 @@ cdef class SkewPolynomial_finite_order_dense (SkewPolynomial_generic_dense):
 
     cdef _matphir_c(self)
     cdef _matmul_c(self)
-

--- a/src/sage/rings/power_series_poly.pxd
+++ b/src/sage/rings/power_series_poly.pxd
@@ -7,4 +7,3 @@ cdef class PowerSeries_poly(PowerSeries):
 
 cdef class BaseRingFloorDivAction(Action):
     pass
-

--- a/src/sage/rings/real_lazy.pxd
+++ b/src/sage/rings/real_lazy.pxd
@@ -27,4 +27,3 @@ cdef class LazyUnop(LazyFieldElement):
 
 cdef class LazyNamedUnop(LazyUnop):
     cdef readonly _extra_args
-

--- a/src/sage/rings/ring_extension_conversion.pxd
+++ b/src/sage/rings/ring_extension_conversion.pxd
@@ -13,5 +13,3 @@ cpdef from_backend_morphism(f, RingExtension_generic E)
 
 cpdef to_backend(arg)
 cpdef from_backend(arg, E)
-
-

--- a/src/sage/rings/ring_extension_element.pxd
+++ b/src/sage/rings/ring_extension_element.pxd
@@ -18,5 +18,3 @@ cdef class RingExtensionWithBasisElement(RingExtensionElement):
     cdef _trace(self, Parent base)
     cdef _norm(self, Parent base)
     cpdef minpoly(self, base=*, var=*)
-
-

--- a/src/sage/rings/tate_algebra_element.pxd
+++ b/src/sage/rings/tate_algebra_element.pxd
@@ -46,4 +46,3 @@ cdef class TateAlgebraElement(CommutativeAlgebraElement):
     cdef _quo_rem_c(self, list divisors, bint quo, bint rem, bint integral)
     cdef _quo_rem_check(self, divisors, bint quo, bint rem)
     cdef TateAlgebraElement _Spoly_c(self, TateAlgebraElement other)
-

--- a/src/sage/stats/hmm/hmm.pxd
+++ b/src/sage/stats/hmm/hmm.pxd
@@ -14,4 +14,3 @@ cdef class HiddenMarkovModel:
     cdef TimeSeries A, pi
 
     cdef TimeSeries _baum_welch_gamma(self, TimeSeries alpha, TimeSeries beta)
-

--- a/src/sage/stats/hmm/util.pxd
+++ b/src/sage/stats/hmm/util.pxd
@@ -4,4 +4,3 @@ cdef class HMM_Util:
     cpdef normalize_probability_TimeSeries(self, TimeSeries T, Py_ssize_t i, Py_ssize_t j)
     cpdef TimeSeries initial_probs_to_TimeSeries(self, pi, bint normalize)
     cpdef TimeSeries state_matrix_to_TimeSeries(self, A, int N, bint normalize)
-

--- a/src/sage/structure/element_wrapper.pxd
+++ b/src/sage/structure/element_wrapper.pxd
@@ -10,4 +10,3 @@ cdef class ElementWrapper(Element):
 
 cdef class ElementWrapperCheckWrappedClass(ElementWrapper):
     pass
-


### PR DESCRIPTION
remove the final empty lines 

`W391 blank line at end of file`

in some pxd and pxi files

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about. 


