### PR TITLE
Replace Python 2 'long' with Python 3 'int'

### DIFF
--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -580,8 +580,7 @@ cdef class Context:
             s = (<mpc>x).re.special
             t = (<mpc>x).im.special
             return s == S_NAN or t == S_NAN
-        if isinstance(x, (int, Integer)) \
-            or isinstance(x, rationallib.mpq):
+        if isinstance(x, (int, Integer, rationallib.mpq)):
             return False
         typ = MPF_set_any(&tmp_opx_re, &tmp_opx_im, x, global_opts, 0)
         if typ == 1:
@@ -622,8 +621,7 @@ cdef class Context:
             s = (<mpc>x).re.special
             t = (<mpc>x).im.special
             return s == S_INF or s == S_NINF or t == S_INF or t == S_NINF
-        if isinstance(x, (int, Integer)) \
-            or isinstance(x, rationallib.mpq):
+        if isinstance(x, (int, Integer, rationallib.mpq)):
             return False
         typ = MPF_set_any(&tmp_opx_re, &tmp_opx_im, x, global_opts, 0)
         if typ == 1:
@@ -671,8 +669,7 @@ cdef class Context:
             if re == libmp.fzero: return im_normal
             if im == libmp.fzero: return re_normal
             return re_normal and im_normal
-        if isinstance(x, (int, Integer)) \
-            or isinstance(x, rationallib.mpq):
+        if isinstance(x, (int, Integer, rationallib.mpq)):
             return bool(x)
         x = ctx.convert(x)
         if hasattr(x, '_mpf_') or hasattr(x, '_mpc_'):

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -580,7 +580,7 @@ cdef class Context:
             s = (<mpc>x).re.special
             t = (<mpc>x).im.special
             return s == S_NAN or t == S_NAN
-        if type(x) is int or type(x) is long or isinstance(x, Integer) \
+        if isinstance(x, (int, Integer)) \
             or isinstance(x, rationallib.mpq):
             return False
         typ = MPF_set_any(&tmp_opx_re, &tmp_opx_im, x, global_opts, 0)
@@ -622,7 +622,7 @@ cdef class Context:
             s = (<mpc>x).re.special
             t = (<mpc>x).im.special
             return s == S_INF or s == S_NINF or t == S_INF or t == S_NINF
-        if type(x) is int or type(x) is long or isinstance(x, Integer) \
+        if isinstance(x, (int, Integer)) \
             or isinstance(x, rationallib.mpq):
             return False
         typ = MPF_set_any(&tmp_opx_re, &tmp_opx_im, x, global_opts, 0)
@@ -671,7 +671,7 @@ cdef class Context:
             if re == libmp.fzero: return im_normal
             if im == libmp.fzero: return re_normal
             return re_normal and im_normal
-        if type(x) is int or type(x) is long or isinstance(x, Integer) \
+        if isinstance(x, (int, Integer)) \
             or isinstance(x, rationallib.mpq):
             return bool(x)
         x = ctx.convert(x)
@@ -708,7 +708,7 @@ cdef class Context:
         cdef MPF v
         cdef MPF w
         cdef int typ
-        if type(x) is int or type(x) is long or isinstance(x, Integer):
+        if isinstance(x, (int, Integer)):
             return True
         if isinstance(x, mpf):
             v = (<mpf>x).value

--- a/src/sage/libs/singular/singular.pyx
+++ b/src/sage/libs/singular/singular.pyx
@@ -1535,7 +1535,7 @@ cdef inline number *sa2si_ZZmod(IntegerMod_abstract d, ring *_ring) noexcept:
     cdef nMapFunc nMapFuncPtr = NULL
 
     if _ring.cf.type == n_Z2m:
-        _d = long(d)
+        _d = d
         return nr2mMapZp(<number *>_d, currRing.cf, _ring.cf)
     elif _ring.cf.type == n_Zn or _ring.cf.type == n_Znm:
         lift = d.lift()

--- a/src/sage/misc/randstate.pyx
+++ b/src/sage/misc/randstate.pyx
@@ -529,11 +529,11 @@ cdef class randstate:
 
         if seed is None:
             if use_urandom:
-                seed = long(binascii.hexlify(os.urandom(16)), 16)
+                seed = int(binascii.hexlify(os.urandom(16)), 16)
             else:
-                seed = long(time.time() * 256)
+                seed = int(time.time() * 256)
         else:
-            seed = long(seed)
+            seed = int(seed)
 
         # If seed==0, leave it at the default seed used by
         # gmp_randinit_default()
@@ -605,9 +605,9 @@ cdef class randstate:
         from sage.rings.integer_ring import ZZ
         rand = cls()
         if seed is None:
-            rand.seed(long(ZZ.random_element(long(1)<<128)))
+            rand.seed(int(ZZ.random_element(1<<128)))
         else:
-            rand.seed(long(seed))
+            rand.seed(int(seed))
         self._python_random = rand
         return rand
 
@@ -624,7 +624,7 @@ cdef class randstate:
             48314508034782595865062786044921182484
         """
         from sage.rings.integer_ring import ZZ
-        return ZZ.random_element(long(1)<<128)
+        return ZZ.random_element(1<<128)
 
     cpdef long_seed(self):
         r"""
@@ -638,7 +638,7 @@ cdef class randstate:
             256056279774514099508607350947089272595
         """
         from sage.rings.integer_ring import ZZ
-        return long(ZZ.random_element(long(1)<<128))
+        return int(ZZ.random_element(1<<128))
 
     cpdef set_seed_libc(self, bint force):
         r"""
@@ -688,7 +688,7 @@ cdef class randstate:
         if force or _ntl_seed_randstate is not self:
             import sage.libs.ntl.ntl_ZZ as ntl_ZZ
             from sage.rings.integer_ring import ZZ
-            ntl_ZZ.ntl_setSeed(ZZ.random_element(long(1)<<128))
+            ntl_ZZ.ntl_setSeed(ZZ.random_element(1<<128))
             _ntl_seed_randstate = self
 
     def set_seed_gap(self):
@@ -715,7 +715,7 @@ cdef class randstate:
                 mersenne_seed, classic_seed = self._gap_saved_seed
             else:
                 from sage.rings.integer_ring import ZZ
-                seed = ZZ.random_element(long(1)<<128)
+                seed = ZZ.random_element(1<<128)
                 classic_seed = seed
                 mersenne_seed = seed
 

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -1358,7 +1358,7 @@ cdef class FiniteField(Field):
             False
         """
         from sage.rings.integer_ring import ZZ
-        if R in int or R is ZZ:
+        if R is int or R is ZZ:
             return True
         if isinstance(R, sage.rings.abc.IntegerModRing) and self.characteristic().divides(R.characteristic()):
             return R.hom((self.one(),), check=False)

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -1358,7 +1358,7 @@ cdef class FiniteField(Field):
             False
         """
         from sage.rings.integer_ring import ZZ
-        if R is int or R is long or R is ZZ:
+        if R in int or R is ZZ:
             return True
         if isinstance(R, sage.rings.abc.IntegerModRing) and self.characteristic().divides(R.characteristic()):
             return R.hom((self.one(),), check=False)

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -2039,8 +2039,12 @@ cdef class IntegerMod_gmp(IntegerMod_abstract):
             sage: e = Mod(19, 10^10)
             sage: e << 102
             9443608576
+            sage: e << (2^200)
+            Traceback (most recent call last):
+            ...
+            OverflowError: Python int too large to convert to C long
         """
-        return self.shift(long(k))
+        return self.shift(k)
 
     def __rshift__(IntegerMod_gmp self, k):
         r"""
@@ -2053,8 +2057,12 @@ cdef class IntegerMod_gmp(IntegerMod_abstract):
             sage: e = Mod(19, 10^10)
             sage: e >> 1
             9
+            sage: e << (2^200)
+            Traceback (most recent call last):
+            ...
+            OverflowError: Python int too large to convert to C long
         """
-        return self.shift(-long(k))
+        return self.shift(-k)
 
     cdef shift(IntegerMod_gmp self, long k):
         r"""

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -645,7 +645,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
                 mpz_set_pylong(self.value, x)
 
             elif isinstance(x, float):
-                n = long(x)
+                n = int(x)
                 if n == x:
                     mpz_set_pylong(self.value, n)
                 else:
@@ -7434,7 +7434,7 @@ cdef class int_to_Z(Morphism):
     def __init__(self):
         import sage.categories.homset
         from sage.sets.pythonclass import Set_PythonType
-        Morphism.__init__(self, sage.categories.homset.Hom(Set_PythonType(long), integer_ring.ZZ))
+        Morphism.__init__(self, sage.categories.homset.Hom(Set_PythonType(int), integer_ring.ZZ))
 
     cpdef Element _call_(self, a):
         cdef Integer r

--- a/src/sage/rings/padics/relaxed_template.pxi
+++ b/src/sage/rings/padics/relaxed_template.pxi
@@ -1659,7 +1659,7 @@ cdef class RelaxedElement(pAdicGenericElement):
             964*997^4 + 572*997^5 + 124*997^6 + ...
         """
         cdef long start
-        cdef long shift = long(s)
+        cdef long shift = s
         if shift:
             if (<RelaxedElement>self)._parent.is_field():
                 start = -maxordp

--- a/src/sage/rings/puiseux_series_ring_element.pyx
+++ b/src/sage/rings/puiseux_series_ring_element.pyx
@@ -201,7 +201,7 @@ cdef class PuiseuxSeries(AlgebraElement):
                 l = l.add_bigoh(prec / d)
 
         self._l = l
-        self._e = long(abs(e))
+        self._e = int(abs(e))
 
     def __reduce__(self):
         """

--- a/src/sage/rings/rational.pyx
+++ b/src/sage/rings/rational.pyx
@@ -3030,7 +3030,7 @@ cdef class Rational(sage.structure.element.FieldElement):
         Convert this rational to a Python ``int``.
 
         This truncates ``self`` if ``self`` has a denominator (which is
-        consistent with Python's ``long(floats)``).
+        consistent with Python's ``int(floats)``).
 
         EXAMPLES::
 
@@ -4243,7 +4243,7 @@ cdef class int_to_Q(Morphism):
         import sage.categories.homset
         from sage.sets.pythonclass import Set_PythonType
         Morphism.__init__(self, sage.categories.homset.Hom(
-            Set_PythonType(long), rational_field.QQ))
+            Set_PythonType(int), rational_field.QQ))
 
     cpdef Element _call_(self, a):
         """

--- a/src/sage/rings/real_lazy.pyx
+++ b/src/sage/rings/real_lazy.pyx
@@ -174,7 +174,7 @@ cdef class LazyField(Field):
             True
         """
         if isinstance(R, type):
-            if R in [int, long]:
+            if R is int:
                 from sage.sets.pythonclass import Set_PythonType
                 return LazyWrapperMorphism(Set_PythonType(R), self)
         elif R.is_exact():

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -816,9 +816,7 @@ cdef class RealIntervalField_class(sage.rings.abc.RealIntervalField):
         prec = self._prec
 
         # Direct and efficient conversions
-        if S is ZZ or S is QQ:
-            return True
-        if S is int:
+        if S is ZZ or S is QQ or S is int:
             return True
         if isinstance(S, RealIntervalField_class):
             return (<RealIntervalField_class>S)._prec >= prec

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -818,7 +818,7 @@ cdef class RealIntervalField_class(sage.rings.abc.RealIntervalField):
         # Direct and efficient conversions
         if S is ZZ or S is QQ:
             return True
-        if S is int or S is long:
+        if S is int:
             return True
         if isinstance(S, RealIntervalField_class):
             return (<RealIntervalField_class>S)._prec >= prec

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -753,8 +753,6 @@ cdef class RealField_class(sage.rings.abc.RealField):
             return QQtoRR(QQ, self)
         elif (S is RDF or S is float) and self._prec <= 53:
             return double_toRR(S, self)
-        elif S is long:
-            return int_toRR(long, self)
         elif S is int:
             return int_toRR(int, self)
         elif isinstance(S, RealField_class) and S.prec() >= self._prec:

--- a/src/sage/symbolic/ring.pyx
+++ b/src/sage/symbolic/ring.pyx
@@ -187,7 +187,7 @@ cdef class SymbolicRing(sage.rings.abc.SymbolicRing):
             True
         """
         if isinstance(R, type):
-            if R in [int, float, long, complex, bool]:
+            if R in (int, float, complex, bool):
                 return True
 
             if is_numpy_type(R):


### PR DESCRIPTION
After Cython commit https://github.com/cython/cython/commit/d0f53f40f8c18da747919449febc2344ebb43e5f , `long` is no longer valid in `.pyx` file.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


