### PR TITLE
Fix bootstrap-conda script

### DIFF
--- a/bootstrap-conda
+++ b/bootstrap-conda
@@ -96,9 +96,6 @@ echo >&2 $0:$LINENO: generate conda environment files
         for pkg in $BOOTSTRAP_SYSTEM_PACKAGES; do
             echo "  - $pkg"
         done
-    ) > environment-template.yml
-    (
-        sed 's/name: sage-build/name: sage/' environment-template.yml
         echo "  - meson"
         echo "  - meson-python"
         echo "  - pytest"


### PR DESCRIPTION
The issue was pointed out at https://github.com/user202729/sage/pull/new/fix-conda . looks like it breaks all the conda builds.

[**edit**] wait… it's not the issue. `https://github.com/sagemath/sage/pull/37447` should makes bootstrap-conda irrelevant anyway.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


