### PR TITLE
Add cython.binding(True) to occurrences of sage_wraps

### DIFF
--- a/src/sage/misc/decorators.py
+++ b/src/sage/misc/decorators.py
@@ -51,6 +51,18 @@ def sage_wraps(wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES):
     the special attribute ``_sage_argspec_`` of the wrapping function (for an
     example, see e.g. ``@options`` decorator in this module).
 
+    Note that in ``.pyx`` files which is compiled by Cython, because Sage uses
+    ``binding=False`` compiler directive by default, you need to explicitly
+    specify ``binding=True`` for all functions decorated with ``sage_wraps``::
+
+        sage: import cython
+        sage: def square(f):
+        ....:     @sage_wraps(f)
+        ....:     @cython.binding(True)
+        ....:     def new_f(x):
+        ....:         return f(x)*f(x)
+        ....:     return new_f
+
     EXAMPLES:
 
     Demonstrate that documentation string and source are retained from the

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -4737,6 +4737,7 @@ def coerce_binop(method):
         TypeError: algorithm 1 not supported
     """
     @sage_wraps(method)
+    @cython.binding(True)
     def new_method(self, other, *args, **kwargs):
         if have_same_parent(self, other):
             return method(self, other, *args, **kwargs)

--- a/src/sage/structure/mutability.pyx
+++ b/src/sage/structure/mutability.pyx
@@ -12,6 +12,7 @@ Mutability Cython Implementation
 #                  https://www.gnu.org/licenses/
 ##########################################################################
 
+cimport cython
 from sage.misc.decorators import sage_wraps
 
 cdef class Mutability:
@@ -286,6 +287,7 @@ def require_mutable(f):
     - Simon King <simon.king@uni-jena.de>
     """
     @sage_wraps(f)
+    @cython.binding(True)
     def new_f(self, *args, **kwds):
         if getattr(self, '_is_immutable', False):
             raise ValueError("{} instance is immutable, {} must not be called".format(type(self), repr(f)))
@@ -338,6 +340,7 @@ def require_immutable(f):
     - Simon King <simon.king@uni-jena.de>
     """
     @sage_wraps(f)
+    @cython.binding(True)
     def new_f(self, *args, **kwds):
         if not getattr(self,'_is_immutable',False):
             raise ValueError("{} instance is mutable, {} must not be called".format(type(self), repr(f)))

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -372,6 +372,7 @@ More sanity tests::
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
+cimport cython
 from cysignals.signals cimport sig_on, sig_off
 from sage.ext.cplusplus cimport ccrepr, ccreadstr
 
@@ -13574,6 +13575,7 @@ def _eval_on_operands(f):
         Some documentation.
     """
     @sage_wraps(f)
+    @cython.binding(True)
     def new_f(ex, *args, **kwds):
         new_args = list(ex._unpack_operands())
         new_args.extend(args)


### PR DESCRIPTION
This is needed for the code to work in future Cython versions.

Looks like Cython considers this a feature, not a bug: https://github.com/cython/cython/issues/6555


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.  (existing tests should catch it)
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


