### PR TITLE
build/pkgs/planarity/spkg-configure.m4: update header check

### DIFF
--- a/build/pkgs/planarity/spkg-configure.m4
+++ b/build/pkgs/planarity/spkg-configure.m4
@@ -1,6 +1,6 @@
 SAGE_SPKG_CONFIGURE([planarity], [
      AC_LANG_PUSH([C])
-     AC_CHECK_HEADER([planarity/planarity.h], [
+     AC_CHECK_HEADER([planarity/graph.h], [
         AC_CHECK_LIB([planarity], [gp_InitGraph], [
          AC_MSG_CHECKING([for planarity version 3.0 or later])
          AC_COMPILE_IFELSE(


### PR DESCRIPTION
In the `./configure` test for libplanarity, we should be testing for `planarity/graph.h` instead of `planarity/planarity.h`:

  1. `graph.h` is what we actually use in `src/sage/graphs/planarity.pyx`,
  2. `planarity.h` is going away in a future version.

cf. https://github.com/graph-algorithms/edge-addition-planarity-suite/pull/125
