### PR TITLE
Remove unnecessary dummy lines in doctests

### DIFF
--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -75,8 +75,7 @@ Check that Cython source code appears in tracebacks::
 
     sage: from sage.repl.interpreter import get_test_shell
     sage: shell = get_test_shell()
-    sage: print("dummy line"); shell.run_cell('1/0') # known bug (meson doesn't include the Cython source code) # see #25320 for the reason of the `...` and the dummy line in this test
-    dummy line
+    sage: shell.run_cell('1/0') # known bug (meson doesn't include the Cython source code)
     ...
     ZeroDivisionError...Traceback (most recent call last)
     ...

--- a/src/sage/repl/ipython_extension.py
+++ b/src/sage/repl/ipython_extension.py
@@ -395,14 +395,13 @@ class SageMagics(Magics):
             ....: ''')
             UsageError: unrecognized arguments: --help
 
-        Test invalid quotes (see :mod:`sage.repl.interpreter` for explanation of the dummy line)::
+        Test invalid quotes::
 
             sage: # needs sage.misc.cython
-            sage: print("dummy line"); shell.run_cell('''
+            sage: shell.run_cell('''
             ....: %%cython --a='
             ....: print(1)
             ....: ''')
-            dummy line
             ...
             ValueError...Traceback (most recent call last)
             ...


### PR DESCRIPTION
I didn't know the dummy line is unnecessary while working on https://github.com/sagemath/sage/pull/38945 . Better removing it so that future developers won't stumble upon it in the future.

Side note: ideally instead of `known bug (meson ...)` we could just do `optional - !meson`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


