### PR TITLE
Deprecate construction of rings with same free variable names

### DIFF
--- a/src/sage/misc/superseded.py
+++ b/src/sage/misc/superseded.py
@@ -122,14 +122,14 @@ def deprecation_cython(issue_number, message, stacklevel=3):
         ....:     deprecation(100, "boo")
         sage: if True:  # Execute the three "with" blocks as one doctest
         ....:     with warnings.catch_warnings(record=True) as w1:
-        ....:        warnings.simplefilter("always")
-        ....:        foo1()
+        ....:         warnings.simplefilter("always")
+        ....:         foo1()
         ....:     with warnings.catch_warnings(record=True) as w2:
-        ....:        warnings.simplefilter("always")
-        ....:        foo2()
+        ....:         warnings.simplefilter("always")
+        ....:         foo2()
         ....:     with warnings.catch_warnings(record=True) as w3:
-        ....:        warnings.simplefilter("always")
-        ....:        foo3()
+        ....:         warnings.simplefilter("always")
+        ....:         foo3()
         sage: w1[0].filename == w3[0].filename
         True
         sage: w2[0].filename == w3[0].filename


### PR DESCRIPTION
As explained in https://github.com/sagemath/sage/issues/39126 , this is necessary to ensure "reasonable" coercion maps are commutative. Otherwise there's no way to make `Q[a] → Q[a,b][c] → Q[a,b][a,c]` and `Q[a] → Q[b][a,c]` → `Q[a,b][a,c]` commutative.

An alternative is to disable coercion maps whenever such a ring appear.

On the other hand, the following cases remain safe:

```
sage: QQ[I]["I"]
Univariate Polynomial Ring in I over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
sage: R.<x> = QQ[]
sage: S.<x> = R.quotient(x^2+1)
sage: S
Univariate Quotient Polynomial Ring in x over Rational Field with modulus x^2 + 1
sage: R.<x> = QQ[]
sage: S.<xbar> = R.quotient(x^2+1)
sage: S["xbar"]
Univariate Polynomial Ring in xbar over Univariate Quotient Polynomial Ring in xbar over Rational Field with modulus x^2 + 1
```

Thoughts?

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


