### PR TITLE
fix linter warnings in sage_setup and sage_docbuild

### DIFF
--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -670,6 +670,7 @@ for macro in sage_latex_macros():
     # used when building html version
     pngmath_latex_preamble += macro + '\n'
 
+
 # ------------------------------------------
 # add custom context variables for templates
 # ------------------------------------------
@@ -712,9 +713,11 @@ def add_page_context(app, pagename, templatename, context, doctree):
 
 dangling_debug = False
 
+
 def debug_inf(app, message):
     if dangling_debug:
         app.info(message)
+
 
 def call_intersphinx(app, env, node, contnode):
     r"""
@@ -748,6 +751,7 @@ def call_intersphinx(app, env, node, contnode):
     else:
         debug_inf(app, "---- Intersphinx: %s not Found" % node['reftarget'])
     return res
+
 
 def find_sage_dangling_links(app, env, node, contnode):
     r"""
@@ -859,6 +863,7 @@ skip_picklability_check_modules = [
     '__builtin__',
 ]
 
+
 def check_nested_class_picklability(app, what, name, obj, skip, options):
     """
     Print a warning if pickling is broken for nested classes.
@@ -878,6 +883,7 @@ def check_nested_class_picklability(app, what, name, obj, skip, options):
                          'Please set the metaclass of the parent class to '
                          'sage.misc.nested_class.NestedClassMetaclass.' % (
                         v.__module__ + '.' + name + '.' + nm))
+
 
 def skip_member(app, what, name, obj, skip, options):
     """

--- a/src/sage_docbuild/ext/sage_autodoc.py
+++ b/src/sage_docbuild/ext/sage_autodoc.py
@@ -81,8 +81,12 @@ from sage.misc.sageinspect import (sage_getdoc_original,
                                    is_function_or_cython_function)
 
 _getdoc = getdoc
+
+
 def getdoc(obj, *args, **kwargs):
     return sage_getdoc_original(obj)
+
+
 # ------------------------------------------------------------------
 
 if TYPE_CHECKING:
@@ -1616,7 +1620,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         try:
             result_bool = isinstance(member, type) or (
                 isattr and isinstance(member, NewType | TypeVar))
-        except:
+        except Exception:
             result_bool = isinstance(member, type) or (
                 isattr and (inspect.isNewType(member) or isinstance(member, TypeVar)))
         return result_bool
@@ -1695,7 +1699,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             # support both sphinx 8 and py3.9/older sphinx
             try:
                 test_bool = isinstance(self.object, NewType | TypeVar)
-            except:
+            except Exception:
                 test_bool = inspect.isNewType(self.object) or isinstance(self.object, TypeVar)
             if test_bool:
                 modname = getattr(self.object, '__module__', self.modname)
@@ -1709,7 +1713,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         # support both sphinx 8 and py3.9/older sphinx
         try:
             test_bool = isinstance(self.object, NewType | TypeVar)
-        except:
+        except Exception:
             test_bool = inspect.isNewType(self.object) or isinstance(self.object, TypeVar)
         if test_bool:
             # Suppress signature
@@ -1899,7 +1903,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         # support both sphinx 8 and py3.9/older sphinx
         try:
             test_bool = isinstance(self.object, NewType | TypeVar)
-        except:
+        except Exception:
             test_bool = inspect.isNewType(self.object) or isinstance(self.object, TypeVar)
         if test_bool:
             return
@@ -1911,7 +1915,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         # support both sphinx 8 and py3.9/older sphinx
         try:
             newtype_test = isinstance(self.object, NewType)
-        except:
+        except Exception:
             newtype_test = inspect.isNewType(self.object)
         if (not self.doc_as_attr and not newtype_test
                 and canonical_fullname and self.fullname != canonical_fullname):
@@ -2053,7 +2057,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         # support both sphinx 8 and py3.9/older sphinx
         try:
             newtype_test = isinstance(self.object, NewType)
-        except:
+        except Exception:
             newtype_test = inspect.isNewType(self.object)
         if newtype_test:
             if self.config.autodoc_typehints_format == "short":

--- a/src/sage_setup/autogen/interpreters/internal/instructions.py
+++ b/src/sage_setup/autogen/interpreters/internal/instructions.py
@@ -385,6 +385,7 @@ def instr_funcall_1arg_mpfr(name, io, op):
     """
     return InstrSpec(name, io, code='%s(o0, i0, MPFR_RNDN);' % op)
 
+
 def instr_funcall_2args_mpc(name, io, op):
     r"""
     A helper function for creating MPC instructions with two inputs
@@ -399,6 +400,7 @@ def instr_funcall_2args_mpc(name, io, op):
         add: SS->S = 'mpc_add(o0, i0, i1, MPC_RNDNN);'
     """
     return InstrSpec(name, io, code='%s(o0, i0, i1, MPC_RNDNN);' % op)
+
 
 def instr_funcall_1arg_mpc(name, io, op):
     r"""

--- a/src/sage_setup/autogen/interpreters/internal/memory.py
+++ b/src/sage_setup/autogen/interpreters/internal/memory.py
@@ -36,7 +36,7 @@ def string_of_addr(a):
     """
     if isinstance(a, int):
         return str(a)
-    assert(isinstance(a, MemoryChunk))
+    assert isinstance(a, MemoryChunk)
     return '*%s++' % a.name
 
 

--- a/src/sage_setup/autogen/interpreters/internal/specs/cc.py
+++ b/src/sage_setup/autogen/interpreters/internal/specs/cc.py
@@ -101,6 +101,7 @@ class MemoryChunkCCRetval(MemoryChunk):
         """
         return "result"
 
+
 class CCInterpreter(StackInterpreter):
     r"""
     A subclass of StackInterpreter, specifying an interpreter over

--- a/src/sage_setup/autogen/interpreters/internal/storage.py
+++ b/src/sage_setup/autogen/interpreters/internal/storage.py
@@ -852,6 +852,7 @@ class StorageTypeMPFR(StorageTypeAutoReference):
 
 ty_mpfr = StorageTypeMPFR()
 
+
 class StorageTypeMPC(StorageTypeAutoReference):
     r"""
     StorageTypeMPC is a subtype of StorageTypeAutoReference that deals

--- a/src/sage_setup/command/sage_build_cython.py
+++ b/src/sage_setup/command/sage_build_cython.py
@@ -49,6 +49,7 @@ DEVEL = False
 if DEVEL:
     extra_compile_args.append('-ggdb')
 
+
 class sage_build_cython(Command):
     name = 'build_cython'
     description = "compile Cython extensions into C/C++ extensions"

--- a/src/sage_setup/command/sage_build_ext.py
+++ b/src/sage_setup/command/sage_build_ext.py
@@ -15,6 +15,7 @@ except ImportError:
     from distutils.errors import DistutilsSetupError
 from sage_setup.run_parallel import execute_list_of_commands
 
+
 class sage_build_ext(build_ext):
     def finalize_options(self):
         build_ext.finalize_options(self)

--- a/src/sage_setup/excepthook.py
+++ b/src/sage_setup/excepthook.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+
 def excepthook(*exc):
     """
     When an error occurs, display an error message similar to the error

--- a/src/sage_setup/find.py
+++ b/src/sage_setup/find.py
@@ -172,6 +172,7 @@ def find_python_sources(src_dir, modules=['sage'], distributions=None,
         os.chdir(cwd)
     return python_packages, python_modules, cython_modules
 
+
 def filter_cython_sources(src_dir, distributions, exclude_distributions=None):
     """
     Find all Cython modules in the given source directory that belong to the
@@ -220,6 +221,7 @@ def filter_cython_sources(src_dir, distributions, exclude_distributions=None):
                 files.append(filepath)
 
     return files
+
 
 def _cythonized_dir(src_dir=None, editable_install=None):
     """
@@ -342,6 +344,7 @@ def find_extra_files(src_dir, modules, cythonized_dir, special_filenames=[], *,
         os.chdir(cwd)
 
     return data_files
+
 
 def installed_files_by_module(site_packages, modules=('sage',)):
     """

--- a/src/sage_setup/run_parallel.py
+++ b/src/sage_setup/run_parallel.py
@@ -22,6 +22,7 @@ import time
 
 keep_going = False
 
+
 def run_command(cmd):
     """
     INPUT:
@@ -34,6 +35,7 @@ def run_command(cmd):
     print(cmd)
     sys.stdout.flush()
     return os.system(cmd)
+
 
 def apply_func_progress(p):
     """
@@ -48,6 +50,7 @@ def apply_func_progress(p):
     sys.stdout.write(p[2])
     sys.stdout.flush()
     return p[0](p[1])
+
 
 def execute_list_of_commands_in_parallel(command_list, nthreads):
     """
@@ -83,6 +86,7 @@ def execute_list_of_commands_in_parallel(command_list, nthreads):
     pool.join()
     process_command_results(result)
 
+
 def process_command_results(result_values):
     error = None
     for r in result_values:
@@ -93,6 +97,7 @@ def process_command_results(result_values):
             error = r
     if error:
         sys.exit(1)
+
 
 def execute_list_of_commands(command_list):
     """
@@ -124,10 +129,10 @@ def execute_list_of_commands(command_list):
     nthreads = min(len(command_list), nthreads)
     nthreads = max(1, nthreads)
 
-    def plural(n,noun):
+    def plural(n, noun):
         if n == 1:
             return "1 %s" % noun
-        return "%i %ss" % (n,noun)
+        return "%i %ss" % (n, noun)
 
     print("Executing %s (using %s)" % (plural(len(command_list),"command"), plural(nthreads,"thread")))
     execute_list_of_commands_in_parallel(command_list, nthreads)

--- a/src/sage_setup/setenv.py
+++ b/src/sage_setup/setenv.py
@@ -4,12 +4,14 @@ import os
 import platform
 from pathlib import Path
 
+
 def _environ_prepend(var, value, separator=':'):
     if value:
         if var in os.environ:
             os.environ[var] = value + separator + os.environ[var]
         else:
             os.environ[var] = value
+
 
 def setenv():
     from sage.env import SAGE_LOCAL, SAGE_VENV, SAGE_ARCHFLAGS, SAGE_PKG_CONFIG_PATH


### PR DESCRIPTION
this is fixing some pycodestyle warnings that have appeared during #39134

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.

