### PR TITLE
Fix test failure with giac 1.9.0.998

### DIFF
--- a/src/sage/libs/giac/giac.pyx
+++ b/src/sage/libs/giac/giac.pyx
@@ -382,13 +382,8 @@ def _giac(s):
         sage: (1+2*sin(3*x)).solve(x).simplify()
         ...list[-pi/18,7*pi/18]
 
-        sage: libgiac.solve('sin(3*x)>2*sin(x)',x)
-        Traceback (most recent call last):
-        ...
-        RuntimeError: Unable to find numeric values solving equation. For
-        trigonometric equations this may be solved using assumptions, e.g.
-        assume(x>-pi && x<pi) Error: Bad Argument Value
-
+        sage: libgiac.solve('x^3-x>x',x)
+        list[((x>(-sqrt(2))) and (x<0)),x>(sqrt(2))]
 
     You can also add some hypothesis to a giac symbol::
 


### PR DESCRIPTION
The previous test `libgiac.solve('sin(3*x)>2*sin(x)',x)` no longer throws an error in 1.9.0.998, it throws a warning and automatically adds constraints instead. Replace it with a different test that gives the same result in all giac versions, since we are only testing proper quoting of expressions here.