### PR TITLE
Define __iter__ method in iterator types

### DIFF
--- a/src/sage/matroids/extension.pyx
+++ b/src/sage/matroids/extension.pyx
@@ -211,6 +211,9 @@ cdef class LinearSubclassesIter:
 
         self._nodes = [first_cut]
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
         """
         Return the next linear subclass.

--- a/src/sage/matroids/set_system.pyx
+++ b/src/sage/matroids/set_system.pyx
@@ -772,6 +772,9 @@ cdef class SetSystemIterator:
         self._pointer = -1
         self._len = len(H)
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
         """
         Return the next subset of a SetSystem.


### PR DESCRIPTION
This is required for iterator types and seems to be enforced in Python 3.13

https://docs.python.org/3/library/stdtypes.html#iterator-types

