### PR TITLE
Fix find_replacements with Python 3.13

### DIFF
--- a/src/sage/misc/replace_dot_all.py
+++ b/src/sage/misc/replace_dot_all.py
@@ -63,7 +63,6 @@ to find the correct ``import`` statement.
 from sage.misc.dev_tools import import_statements
 import os
 import re
-import sys
 import argparse
 
 # We import this using __import__ so that "tox -e relint" does not complain about this source file.
@@ -195,21 +194,15 @@ def find_replacements(location, package_regex=None, verbose=False):
                     to_exec = to_exec.replace("'", '').replace('"', '')
                     if (to_exec[-1] == ','):
                         to_exec = to_exec[:-1]
-                    if sys.version_info.minor < 13:
-                        exec(to_exec)
-                    else:
-                        loc = locals()
-                        exec(to_exec, locals=loc)
+                    glob = globals()
+                    exec(to_exec, glob)
                 except ModuleNotFoundError as err:
                     print(f'ModuleNotFoundError: {err} found when trying to execute {to_exec}')
                 except ImportError as err:
                     print(f'ImportError: {err} found when trying to execute {to_exec}')
 
                 try:  # try to evaluate the list of module names to get a list of the modules themselves which we can call import_statements on
-                    if sys.version_info.minor < 13:
-                        modules = eval(to_eval)
-                    else:
-                        modules = eval(to_eval, locals=loc)
+                    modules = eval(to_eval, glob)
                 except NameError as err:
                     print(f'NameError: {err} found when trying to evaluate {to_eval} at {location}:{row_index + 1}')
                 except SyntaxError as err:

--- a/src/sage/misc/replace_dot_all.py
+++ b/src/sage/misc/replace_dot_all.py
@@ -194,7 +194,7 @@ def find_replacements(location, package_regex=None, verbose=False):
                     to_exec = to_exec.replace("'", '').replace('"', '')
                     if (to_exec[-1] == ','):
                         to_exec = to_exec[:-1]
-                    glob = globals()
+                    glob = dict()
                     exec(to_exec, glob)
                 except ModuleNotFoundError as err:
                     print(f'ModuleNotFoundError: {err} found when trying to execute {to_exec}')

--- a/src/sage/misc/replace_dot_all.py
+++ b/src/sage/misc/replace_dot_all.py
@@ -63,6 +63,7 @@ to find the correct ``import`` statement.
 from sage.misc.dev_tools import import_statements
 import os
 import re
+import sys
 import argparse
 
 # We import this using __import__ so that "tox -e relint" does not complain about this source file.
@@ -194,14 +195,21 @@ def find_replacements(location, package_regex=None, verbose=False):
                     to_exec = to_exec.replace("'", '').replace('"', '')
                     if (to_exec[-1] == ','):
                         to_exec = to_exec[:-1]
-                    exec(to_exec)
+                    if sys.version_info.minor < 13:
+                        exec(to_exec)
+                    else:
+                        loc = locals()
+                        exec(to_exec, locals=loc)
                 except ModuleNotFoundError as err:
                     print(f'ModuleNotFoundError: {err} found when trying to execute {to_exec}')
                 except ImportError as err:
                     print(f'ImportError: {err} found when trying to execute {to_exec}')
 
                 try:  # try to evaluate the list of module names to get a list of the modules themselves which we can call import_statements on
-                    modules = eval(to_eval)
+                    if sys.version_info.minor < 13:
+                        modules = eval(to_eval)
+                    else:
+                        modules = eval(to_eval, locals=loc)
                 except NameError as err:
                     print(f'NameError: {err} found when trying to evaluate {to_eval} at {location}:{row_index + 1}')
                 except SyntaxError as err:


### PR DESCRIPTION
After PEP 667 implementation [1] `globals()` changes within an `exec` call are not propagated outside the call

[1] https://github.com/python/cpython/commit/b034f14a4b6e9197d3926046721b8b4b4b4f5b3d
