### PR TITLE
Some improvements to findstat._submit

### DIFF
--- a/src/sage/databases/findstat.py
+++ b/src/sage/databases/findstat.py
@@ -213,6 +213,7 @@ from sage.databases.oeis import FancyTuple
 
 from ast import literal_eval
 from copy import deepcopy
+from pathlib import Path
 import re
 import webbrowser
 import tempfile
@@ -491,8 +492,9 @@ def _submit(args, url):
         ....:         "CurrentEmail": ""}
         sage: _submit(args, url)                                                # optional -- webbrowser
     """
-    f = tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False)
+    f = tempfile.NamedTemporaryFile(mode='w', suffix='.html', encoding='utf-8', delete=False)
     verbose("Created temporary file %s" % f.name, caller_name='FindStat')
+    f.write('<!doctype html>\n<html lang="en">\n<meta charset="utf-8">\n')
     f.write(FINDSTAT_POST_HEADER)
     f.write(url)
     for key, value in args.items():
@@ -506,7 +508,7 @@ def _submit(args, url):
     f.write(FINDSTAT_FORM_FOOTER)
     f.close()
     verbose("Opening file with webbrowser", caller_name='FindStat')
-    webbrowser.open(f.name)
+    webbrowser.open(Path(f.name).as_uri())
 
 
 def _data_to_str(data, domain, codomain=None):


### PR DESCRIPTION
* for some reason the proper header is needed to open the HTML file on my machine.
* It's reported that `webbrowser.open()` doesn't work when called on a file path, rather an URI is needed (https://github.com/sagemath/sage/pull/38946)


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview. (not needed)

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


