### PR TITLE
Added immutable keyword argument to canonical_form function

### DIFF
--- a/src/sage/graphs/bliss.pyx
+++ b/src/sage/graphs/bliss.pyx
@@ -377,7 +377,7 @@ cdef canonical_form_from_edge_list(int Vnr, list Vout, list Vin, int Lnr=1, list
     return new_edges
 
 
-cpdef canonical_form(G, partition=None, return_graph=False, use_edge_labels=True, certificate=False) noexcept:
+cpdef canonical_form(G, partition=None, return_graph=False, use_edge_labels=True, certificate=False, immutable=False) noexcept:
     r"""
     Return a canonical label for the given (di)graph.
 
@@ -403,6 +403,9 @@ cpdef canonical_form(G, partition=None, return_graph=False, use_edge_labels=True
 
     - ``certificate`` -- boolean (default: ``False``); when set to ``True``,
       returns the labeling of G into a canonical graph
+
+    - ``immutable`` -- boolean (default: ``False``); when set to ``True``,
+      returns an immutable canonical label of the graph
 
     TESTS::
 
@@ -503,6 +506,13 @@ cpdef canonical_form(G, partition=None, return_graph=False, use_edge_labels=True
         Traceback (most recent call last):
         ...
         ValueError: some vertices of the graph are not in the partition
+
+    Check that parameter ``immutable`` can be used::
+
+        sage: g = Graph({1: [2]})
+        sage: g_ = canonical_form(g, return_graph=True, immutable=True)   # optional - bliss
+        sage: g_.is_immutable()                                           # optional - bliss
+        True
     """
     # We need this to convert the numbers from <unsigned int> to <long>.
     # This assertion should be true simply for memory reasons.
@@ -588,6 +598,9 @@ cpdef canonical_form(G, partition=None, return_graph=False, use_edge_labels=True
 
         H.add_vertices(range(G.order()))
         return (H, relabel) if certificate else H
+
+    if immutable:
+        H = H.copy(immutable=True)
 
     # Warning: this may break badly in Python 3 if the graph is not simple
     return (sorted(new_edges), relabel) if certificate else sorted(new_edges)


### PR DESCRIPTION
### Description
-Fixes #39177. Avoiding extra code block for declaring an immutable graph while generating it. 
-Added immutable keyword argument to canonical_form function to directly return an immutable canonical label of a given graph.
-Updated the function to handle the immutable argument and return an immutable graph if specified.
-Added tests to verify the functionality of the immutable argument.

### :memo: Checklist

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
