### PR TITLE
Fix `spyx_tmp()` cleanup.

### DIFF
--- a/src/sage/misc/temporary_file.py
+++ b/src/sage/misc/temporary_file.py
@@ -32,7 +32,9 @@ from typing import IO
 # as the parent for all temporary files & directories created by them.
 # This lets us clean up after those two functions when sage exits normally
 # using an atexit hook
-TMP_DIR_FILENAME_BASE = tempfile.TemporaryDirectory()
+# Note that `TemporaryDirectory()` will cleanup on program exit;
+# we keep the atexit hook to be redundant, in case that fails.
+TMP_DIR_FILENAME_BASE = tempfile.TemporaryDirectory(prefix='sage_')
 atexit.register(lambda: TMP_DIR_FILENAME_BASE.cleanup())
 
 

--- a/src/sage/misc/temporary_file.py
+++ b/src/sage/misc/temporary_file.py
@@ -542,7 +542,9 @@ def spyx_tmp() -> str:
         return _spyx_tmp
 
     # We don't use `tempfile.TemporaryDirectory()` here because it
-    # will be cleaned up on child exit (e.g. for parallel testing)
+    # is not clear when it will or will not be cleaned. Sometimes it
+    # might not be cleaned up at all, and starting in python 3.13 it
+    # might be cleaned up on child exit, breaking parallel testing.
     # For some reason this doesn't affect the `TemporaryDirectory`
     # stored in the global `TMP_DIR_FILENAME_BASE`.
     _spyx_tmp = tmp_dir(name='spyx_')

--- a/src/sage/misc/temporary_file.py
+++ b/src/sage/misc/temporary_file.py
@@ -533,14 +533,15 @@ def spyx_tmp() -> str:
     We cache the result of this function "by hand" so that the same
     temporary directory will always be returned. A function is used to
     delay creating a directory until (if) it is needed. The temporary
-    directory is removed when sage terminates by way of an atexit
-    hook.
+    directory is automatically removed when sage terminates.
     """
     global _spyx_tmp
     if _spyx_tmp:
         return _spyx_tmp
 
-    d = tempfile.TemporaryDirectory()
-    _spyx_tmp = os.path.join(d.name, 'spyx')
-    atexit.register(lambda: d.cleanup())
+    # We don't use `tempfile.TemporaryDirectory()` here because it
+    # will be cleaned up on child exit (e.g. for parallel testing)
+    # For some reason this doesn't affect the `TemporaryDirectory`
+    # stored in the global `TMP_DIR_FILENAME_BASE`.
+    _spyx_tmp = tmp_dir(name='spyx_')
     return _spyx_tmp


### PR DESCRIPTION
For some reason, a new behaviour of python 3.13 [0] causes the
`TemporaryDirectory()` in `sage.misc.temporary_file.spyx_tmp()`
to be deleted on child exit, which causes trouble with parallel
doctesting [1].

We rewrite `spyx_tmp()` using `tmp_dir()`, which doesn't have this
problem, see [2].

[0] https://github.com/python/cpython/pull/114279
[1] https://github.com/sagemath/sage/pull/39188#issuecomment-2559925083
[2] https://github.com/sagemath/sage/pull/39188#issuecomment-2561459269

In addition, use `sage_` prefix for the main temporary directory.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
