### PR TITLE
Fix docstring formatting to use raw string literals in multiple files

### DIFF
--- a/src/sage/algebras/free_algebra_quotient_element.py
+++ b/src/sage/algebras/free_algebra_quotient_element.py
@@ -142,7 +142,7 @@ class FreeAlgebraQuotientElement(AlgebraElement):
             return repr_lincomb(zip(mons, cffs), strip_one=True)
 
     def _latex_(self):
-        """
+        r"""
         EXAMPLES::
 
             sage: H, (i,j,k) = sage.algebras.free_algebra_quotient.hamilton_quatalg(QQ)

--- a/src/sage/algebras/lie_algebras/bgg_dual_module.py
+++ b/src/sage/algebras/lie_algebras/bgg_dual_module.py
@@ -172,7 +172,7 @@ class BGGDualModule(CombinatorialFreeModule):
         return self._module._repr_generator(m) + "^*"
 
     def _latex_generator(self, m):
-        """
+        r"""
         Return a latex representation of the generator indexed by ``m``.
 
         EXAMPLES::

--- a/src/sage/algebras/steenrod/steenrod_algebra_misc.py
+++ b/src/sage/algebras/steenrod/steenrod_algebra_misc.py
@@ -567,7 +567,7 @@ def normalize_profile(profile, precision=None, truncation_type='auto', p=2, gene
 
 
 def milnor_mono_to_string(mono, latex=False, generic=False):
-    """
+    r"""
     String representation of element of the Milnor basis.
 
     This is used by the _repr_ and _latex_ methods.
@@ -720,7 +720,7 @@ def serre_cartan_mono_to_string(mono, latex=False, generic=False):
 
 
 def wood_mono_to_string(mono, latex=False):
-    """
+    r"""
     String representation of element of Wood's Y and Z bases.
 
     This is used by the _repr_ and _latex_ methods.
@@ -806,7 +806,7 @@ def wall_mono_to_string(mono, latex=False):
 
 
 def wall_long_mono_to_string(mono, latex=False):
-    """
+    r"""
     Alternate string representation of element of Wall's basis.
 
     This is used by the _repr_ and _latex_ methods.
@@ -891,7 +891,7 @@ def arnonA_mono_to_string(mono, latex=False, p=2):
 
 
 def arnonA_long_mono_to_string(mono, latex=False, p=2):
-    """
+    r"""
     Alternate string representation of element of Arnon's A basis.
 
     This is used by the _repr_ and _latex_ methods.

--- a/src/sage/misc/inline_fortran.py
+++ b/src/sage/misc/inline_fortran.py
@@ -12,7 +12,7 @@ from sage.misc.temporary_file import tmp_dir
 
 
 def _import_module_from_path(name, path=None):
-    """
+    r"""
     Import the module named ``name`` by searching the given path entries (or
     `sys.path` by default).
 


### PR DESCRIPTION
Discovered via pytest, which follows stricter rules when parsing doctests.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


