### PR TITLE
improve graph traversal methods

### DIFF
--- a/src/sage/graphs/traversals.pyx
+++ b/src/sage/graphs/traversals.pyx
@@ -1422,6 +1422,17 @@ def maximum_cardinality_search(G, reverse=False, tree=False, initial_vertex=None
         Traceback (most recent call last):
         ...
         ValueError: vertex (17) is not a vertex of the graph
+
+    Immutable graphs;:
+
+        sage: G = graphs.RandomGNP(10, .7)
+        sage: G._backend
+        <sage.graphs.base.sparse_graph.SparseGraphBackend ...>
+        sage: H = Graph(G, immutable=True)
+        sage: H._backend
+        <sage.graphs.base.static_sparse_backend.StaticSparseBackend ...>
+        sage: G.maximum_cardinality_search() == H.maximum_cardinality_search()
+        True
     """
     if tree:
         from sage.graphs.digraph import DiGraph


### PR DESCRIPTION
Similarly to #39216, we avoid the conversion to `short_digraph` when the input graph is an instance of `StaticSparseBackend`. 

Furthermore, we use the new `PairingHeap_of_n_integers` data structure (#39046) instead of a `priority_queue` to emulate a max-heap. This is slightly faster this way and cleaner.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


