### PR TITLE
Faster conversion from numpy array to matrix mod 2

### DIFF
--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -108,7 +108,7 @@ from cysignals.memory cimport check_malloc, sig_free
 from cysignals.signals cimport sig_on, sig_str, sig_off
 
 cimport sage.matrix.matrix_dense as matrix_dense
-from sage.matrix.args cimport SparseEntry, MatrixArgs_init
+from sage.matrix.args cimport SparseEntry, MatrixArgs_init, MA_ENTRIES_NDARRAY
 from libc.stdio cimport *
 from sage.structure.element cimport (Matrix, Vector)
 from sage.modules.free_module_element cimport FreeModuleElement
@@ -257,8 +257,25 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             []
             sage: Matrix(GF(2),0,2)
             []
+
+        Make sure construction from numpy array is reasonably fast::
+
+            sage: # needs numpy
+            sage: import numpy as np
+            sage: n = 5000
+            sage: M = matrix(GF(2), np.random.randint(0, 2, (n, n)))  # around 700ms
+
+        Unsupported numpy data types (slower but still works)::
+
+            sage: # needs numpy
+            sage: n = 100
+            sage: M = matrix(GF(2), np.random.randint(0, 2, (n, n)).astype(np.float32))
         """
         ma = MatrixArgs_init(parent, entries)
+        if ma.get_type() == MA_ENTRIES_NDARRAY:
+            from ..modules.numpy_util import set_matrix_mod2_from_numpy
+            if set_matrix_mod2_from_numpy(self, ma.entries):
+                return
         for t in ma.iter(coerce, True):
             se = <SparseEntry>t
             mzd_write_bit(self._entries, se.i, se.j, se.entry)

--- a/src/sage/modules/numpy_util.pxd
+++ b/src/sage/modules/numpy_util.pxd
@@ -1,5 +1,8 @@
 from libc.stdint cimport uintptr_t
 from sage.libs.m4ri cimport *
+from sage.matrix.matrix_mod2_dense cimport Matrix_mod2_dense
+
+cpdef int set_matrix_mod2_from_numpy(Matrix_mod2_dense a, b) except -1
 
 cpdef int set_mzd_from_numpy(uintptr_t entries_addr, Py_ssize_t degree, x) except -1
 # Note: we don't actually need ``cimport`` to work, which means this header file is not used in practice

--- a/src/sage/modules/numpy_util.pyx
+++ b/src/sage/modules/numpy_util.pyx
@@ -69,6 +69,22 @@ cpdef int set_mzd_from_numpy(uintptr_t entries_addr, Py_ssize_t degree, x) excep
 cpdef int _set_matrix_mod2_from_numpy_helper(Matrix_mod2_dense a, np.ndarray[numpy_integral, ndim=2] b) except -1:
     """
     Internal function, helper for :func:`set_matrix_mod2_from_numpy`.
+
+    TESTS::
+
+        sage: from sage.modules.numpy_util import _set_matrix_mod2_from_numpy_helper
+        sage: import numpy as np
+        sage: a = matrix(GF(2), 2, 3)
+        sage: b = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8)
+        sage: _set_matrix_mod2_from_numpy_helper(a, b)
+        1
+        sage: a
+        [1 0 1]
+        [0 1 0]
+        sage: _set_matrix_mod2_from_numpy_helper(a, np.array([[1, 0], [0, 1]], dtype=np.int8))
+        Traceback (most recent call last):
+        ...
+        ValueError: shape mismatch
     """
     if not (a.nrows() == b.shape[0] and a.ncols() == b.shape[1]):
         raise ValueError("shape mismatch")
@@ -87,7 +103,31 @@ cpdef int set_matrix_mod2_from_numpy(Matrix_mod2_dense a, b) except -1:
     - ``a`` -- the destination matrix
     - ``b`` -- a numpy array, must have dimension 2 and the same shape as ``a``
 
-    OUTPUT: ``True`` if successful, ``False`` otherwise. May throw ``ValueError``.
+    OUTPUT: ``True`` (when used as bool) if successful, ``False`` otherwise. May throw ``ValueError``.
+
+    The exact type of the return value is not guaranteed, in the actual current implementation
+    it is ``1`` for success and ``0`` for failure.
+
+    TESTS::
+
+        sage: from sage.modules.numpy_util import set_matrix_mod2_from_numpy
+        sage: import numpy as np
+        sage: a = matrix(GF(2), 2, 3)
+        sage: b = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int8)
+        sage: set_matrix_mod2_from_numpy(a, b)
+        1
+        sage: a
+        [1 0 1]
+        [0 1 0]
+        sage: set_matrix_mod2_from_numpy(a, np.array([[1, 0], [0, 1]], dtype=np.int8))
+        Traceback (most recent call last):
+        ...
+        ValueError: shape mismatch
+        sage: # unsupported type (may be supported in the future)
+        sage: set_matrix_mod2_from_numpy(a, np.array([[1, 1, 0], [0, 1, 0]], dtype=np.float64))
+        0
+        sage: set_matrix_mod2_from_numpy(a, np.array([1, 0, 0], dtype=np.int8))  # wrong number of dimensions
+        0
     """
     try:
         return (<object>_set_matrix_mod2_from_numpy_helper)(a, b)  # https://github.com/cython/cython/issues/6588


### PR DESCRIPTION
As in the title. Estimated 50× speedup.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

(Reuses the `numpy_util` module from #38834 for the utility function)


Reverse direction: https://github.com/sagemath/sage/pull/39152 