### PR TITLE
Remove outdated note from docstring of `cliques_maximal`

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -5825,12 +5825,6 @@ class Graph(GenericGraph):
 
         .. NOTE::
 
-            This method sorts its output before returning it. If you prefer to
-            save the extra time, you can call
-            :class:`sage.graphs.independent_sets.IndependentSets` directly.
-
-        .. NOTE::
-
             Sage's implementation of the enumeration of *maximal* independent
             sets is not much faster than NetworkX' (expect a 2x speedup), which
             is surprising as it is written in Cython. This being said, the


### PR DESCRIPTION
Sage no longer sorts the output of [cliques_maximal](https://doc-develop--sagemath.netlify.app/html/en/reference/graphs/sage/graphs/graph.html#sage.graphs.graph.Graph.cliques_maximal) since commit 5b0c7b45f06ebee0b4a06bbe158.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.