### PR TITLE
clang-19 build fix: workaround narrowing-const-reference error

### DIFF
--- a/src/sage/graphs/base/boost_interface.cpp
+++ b/src/sage/graphs/base/boost_interface.cpp
@@ -116,7 +116,8 @@ public:
         std::vector<std::pair<v_index, std::pair<v_index, double>>> to_return;
         typename boost::graph_traits<adjacency_list>::edge_iterator ei, ei_end;
         for (boost::tie(ei, ei_end) = boost::edges(graph); ei != ei_end; ++ei) {
-            to_return.push_back({index[boost::source(*ei, graph)],
+            v_index sidx = index[boost::source(*ei, graph)];
+            to_return.push_back({sidx,
                                  {index[boost::target(*ei, graph)],
                                   get(boost::edge_weight, graph, *ei)}});
         }


### PR DESCRIPTION
while building sage 10.5 with clang-19 with nixpkgs on macOS the build fails with the following error:

```
In file included from build/cythonized/sage/graphs/base/boost_graph.cpp:1278:
build/cythonized/sage/graphs/base/boost_interface.cpp:119:34: error: non-constant-expression cannot be narrowed from type 'value_type' (aka 'unsigned long') to 'int' in initializer list [-Wc++11-narrowing-const-reference]
  119 | to_return.push_back({index[boost::source(*ei, graph)],
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
build/cythonized/sage/graphs/base/boost_graph.cpp:17503:29: note: in instantiation of member function 'BoostGraph<boost::vecS, boost::vecS, boost::directedS, boost::vecS, boost::property<boost::edge_weight_t, double>>::edge_list' requested here
 17503 |   __pyx_v_edges = __pyx_v_g.edge_list();
                                     ^
```

https://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-narrowing-const-reference

To silence the error assign to a v_index outside of the initializer list.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


