### PR TITLE
Fix import duplication in `sage.rings.all`

### DIFF
--- a/src/sage/rings/all.py
+++ b/src/sage/rings/all.py
@@ -12,8 +12,6 @@ Rings
 # ****************************************************************************
 from sage.misc.lazy_import import lazy_import
 
-from sage.rings.all__sagemath_categories import *
-
 # Ring base classes
 from sage.rings.ring import (Ring, Field, CommutativeRing, IntegralDomain,
                              PrincipalIdealDomain)

--- a/src/sage/rings/all__sagemath_categories.py
+++ b/src/sage/rings/all__sagemath_categories.py
@@ -1,7 +1,0 @@
-# sage_setup: distribution = sagemath-categories
-# Ring base classes
-from sage.rings.ring import Ring
-# Ideals
-from sage.rings.ideal import Ideal
-
-ideal = Ideal

--- a/src/sage/rings/meson.build
+++ b/src/sage/rings/meson.build
@@ -3,7 +3,6 @@ py.install_sources(
   'abc.pxd',
   'algebraic_closure_finite_field.py',
   'all.py',
-  'all__sagemath_categories.py',
   'all__sagemath_objects.py',
   'big_oh.py',
   'cc.py',


### PR DESCRIPTION
The import of the `all_sagemath_categories` module triggered exactly the same imports that were already in the `rings.all` file. We thus delete this obsolete file.

More cleanup of this sort will be done in a follow-up.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


