### PR TITLE
Meson: build groups even without gap

### DIFF
--- a/src/sage/groups/meson.build
+++ b/src/sage/groups/meson.build
@@ -38,13 +38,17 @@ extension_data = {
 }
 
 foreach name, pyx : extension_data
+  deps = [py_dep, gmp]
+  if name == 'libgap_wrapper'
+    deps += [gap]
+  endif
   py.extension_module(
     name,
     sources: pyx,
     subdir: 'sage/groups',
     install: true,
     include_directories: [inc_cpython],
-    dependencies: [py_dep, gmp, gap],
+    dependencies: deps,
   )
 endforeach
 


### PR DESCRIPTION
`group.pyx` compiles fine also without gap installed.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


