### PR TITLE
Workaround to allow flint to be compiled with numpy 2

### DIFF
--- a/src/sage/libs/flint/flint_wrap.h
+++ b/src/sage/libs/flint/flint_wrap.h
@@ -26,6 +26,10 @@
 #pragma push_macro("ulong")
 #undef ulong
 
+/* Reserved in C99, needed for FLINT without https://github.com/flintlib/flint/pull/2027 */
+#pragma push_macro("I")
+#define I Iv
+
 #include <flint/flint.h>
 
 /* If flint was already previously included via another header (e.g.
@@ -169,6 +173,7 @@
 #undef mp_bitcnt_t
 
 #pragma pop_macro("ulong")
+#pragma pop_macro("I")
 
 /* CPU_SIZE_1 and SIZE_RED_FAILURE_THRESH are defined as macros in flint/fmpz_lll.h
  * and as variables in fplll/defs.h, which breaks build if linbox is compiled with fplll */

--- a/src/sage_setup/autogen/flint/templates/flint_wrap.h.template
+++ b/src/sage_setup/autogen/flint/templates/flint_wrap.h.template
@@ -26,6 +26,10 @@
 #pragma push_macro("ulong")
 #undef ulong
 
+/* Reserved in C99, needed for FLINT without https://github.com/flintlib/flint/pull/2027 */
+#pragma push_macro("I")
+#define I Iv
+
 #include <flint/flint.h>
 
 /* If flint was already previously included via another header (e.g.
@@ -43,6 +47,7 @@
 #undef mp_bitcnt_t
 
 #pragma pop_macro("ulong")
+#pragma pop_macro("I")
 
 /* CPU_SIZE_1 and SIZE_RED_FAILURE_THRESH are defined as macros in flint/fmpz_lll.h
  * and as variables in fplll/defs.h, which breaks build if linbox is compiled with fplll */


### PR DESCRIPTION
As discussed in https://github.com/sagemath/sage/pull/39241 .

Based on https://github.com/mkoeppe/sage/commit/6247975f786c85c35124a66a0d32df00260461c5 , but also change the template file.

Note that for tests to pass, https://github.com/sagemath/sage/pull/39242 is also needed.

