### PR TITLE
faster method `__mul__` for graphs

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -768,6 +768,17 @@ class GenericGraph(GenericGraph_pyx):
             [0, 1, 2, 3, 4, 5, 6, 7, 8]
             sage: H = G * 1; H
             Cycle graph: Graph on 3 vertices
+
+        TESTS::
+
+            sage: Graph(1) * -1
+            Traceback (most recent call last)
+            ...
+            TypeError: multiplication of a graph and a nonpositive integer is not defined
+            sage: Graph(1) * 2.5
+            Traceback (most recent call last)
+            ...
+            TypeError: multiplication of a graph and something other than an integer is not defined
         """
         if isinstance(n, (int, Integer)):
             if n < 1:

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -774,9 +774,17 @@ class GenericGraph(GenericGraph_pyx):
                 raise TypeError('multiplication of a graph and a nonpositive integer is not defined')
             if n == 1:
                 return copy(self)
-            return sum([self] * (n - 1), self)
-        else:
-            raise TypeError('multiplication of a graph and something other than an integer is not defined')
+            # Use a logarithmic number of additions to build the result
+            bits = Integer(n).bits()
+            parts = [self]
+            parts.extend(parts[-1] + parts[-1] for _ in range(1, len(bits)))
+            H, _ = parts.pop(), bits.pop()
+            while bits:
+                g, b = parts.pop(), bits.pop()
+                if b:
+                    H += g
+            return H
+        raise TypeError('multiplication of a graph and something other than an integer is not defined')
 
     def __ne__(self, other):
         """

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -772,11 +772,11 @@ class GenericGraph(GenericGraph_pyx):
         TESTS::
 
             sage: Graph(1) * -1
-            Traceback (most recent call last)
+            Traceback (most recent call last):
             ...
             TypeError: multiplication of a graph and a nonpositive integer is not defined
             sage: Graph(1) * 2.5
-            Traceback (most recent call last)
+            Traceback (most recent call last):
             ...
             TypeError: multiplication of a graph and something other than an integer is not defined
         """


### PR DESCRIPTION
Instead of $n-1$ additions of graphs, we use a logarithmic number of additions of graphs to compute $G * n$.

Before
```sage
sage: def test(G):
....:     for i in [1, 2, 3, 4, 5, 10, 15, 20, 50, 100]:
....:         t = walltime()
....:         for _ in range(10):
....:             H = G * i
....:         t = walltime() - t
....:         print(f"{i}\t {round(t/10, 5)}")
sage: test(Graph([(0, 1)]))
1	 3e-05
2	 0.00011
3	 0.00016
4	 0.00024
5	 0.00032
10	 0.00072
15	 0.00108
20	 0.00139
50	 0.00437
100	 0.01272
sage: test(graphs.PetersenGraph())
1	 5e-05
2	 0.00017
3	 0.00028
4	 0.00042
5	 0.00055
10	 0.00148
15	 0.0024
20	 0.00343
50	 0.01802
100	 0.07057
```

Now
 ```sage
sage: test(Graph([(0, 1)]))
1	 3e-05
2	 0.0001
3	 0.00018
4	 0.00018
5	 0.00025
10	 0.00035
15	 0.00053
20	 0.00043
50	 0.00083
100	 0.00118
sage: test(graphs.PetersenGraph())
1	 4e-05
2	 0.00015
3	 0.00028
4	 0.00026
5	 0.00041
10	 0.00066
15	 0.00117
20	 0.00094
50	 0.0024
100	 0.00448
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


