### PR TITLE
let the categories handle "is_commutative" for rings

### DIFF
--- a/src/doc/en/thematic_tutorials/coercion_and_categories.rst
+++ b/src/doc/en/thematic_tutorials/coercion_and_categories.rst
@@ -130,7 +130,6 @@ This base class provides a lot more methods than a general parent::
      'gen',
      'gens',
      'integral_closure',
-     'is_commutative',
      'is_field',
      'krull_dimension',
      'ngens',

--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -844,7 +844,7 @@ class CliffordAlgebra(CombinatorialFreeModule):
         """
         return FrozenBitset()
 
-    def is_commutative(self):
+    def is_commutative(self) -> bool:
         """
         Check if ``self`` is a commutative algebra.
 

--- a/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra.py
+++ b/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra.py
@@ -497,7 +497,7 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Parent):
         return True
 
     @cached_method
-    def is_commutative(self):
+    def is_commutative(self) -> bool:
         """
         Return ``True`` if ``self`` is commutative.
 

--- a/src/sage/algebras/iwahori_hecke_algebra.py
+++ b/src/sage/algebras/iwahori_hecke_algebra.py
@@ -766,7 +766,7 @@ class IwahoriHeckeAlgebra(Parent, UniqueRepresentation):
                 """
                 return False
 
-            def is_commutative(self):
+            def is_commutative(self) -> bool:
                 """
                 Return whether this Iwahori-Hecke algebra is commutative.
 

--- a/src/sage/algebras/steenrod/steenrod_algebra.py
+++ b/src/sage/algebras/steenrod/steenrod_algebra.py
@@ -2827,10 +2827,12 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             tot += 1
         return test
 
-    def is_commutative(self):
+    def is_commutative(self) -> bool:
         r"""
         Return ``True`` if ``self`` is graded commutative, as determined by the
-        profile function.  In particular, a sub-Hopf algebra of the
+        profile function.
+
+        In particular, a sub-Hopf algebra of the
         mod 2 Steenrod algebra is commutative if and only if there is
         an integer `n>0` so that its profile function `e` satisfies
 

--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -46,6 +46,17 @@ class CommutativeRings(CategoryWithAxiom):
 
         sage: GroupAlgebra(CyclicPermutationGroup(3), QQ) in CommutativeRings()     # not implemented, needs sage.groups sage.modules
         True
+
+    Some tests for the method ``is_commutative``::
+
+        sage: QQ.is_commutative()
+        True
+        sage: ZpCA(7).is_commutative()                                              # needs sage.rings.padics
+        True
+        sage: A = QuaternionAlgebra(QQ, -1, -3, names=('i','j','k')); A             # needs sage.combinat sage.modules
+        Quaternion Algebra (-1, -3) with base ring Rational Field
+        sage: A.is_commutative()                                                    # needs sage.combinat sage.modules
+        False
     """
     class ParentMethods:
         def is_commutative(self) -> bool:

--- a/src/sage/categories/finite_dimensional_algebras_with_basis.py
+++ b/src/sage/categories/finite_dimensional_algebras_with_basis.py
@@ -1143,7 +1143,7 @@ class FiniteDimensionalAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                                                   for f in l[:i]))
 
         @cached_method
-        def is_commutative(self):
+        def is_commutative(self) -> bool:
             """
             Return whether ``self`` is a commutative algebra.
 
@@ -1158,7 +1158,7 @@ class FiniteDimensionalAlgebrasWithBasis(CategoryWithAxiom_over_base_ring):
                 True
             """
             B = list(self.basis())
-            try: # See if 1 is a basis element, if so, remove it
+            try:  # See if 1 is a basis element, if so, remove it
                 B.remove(self.one())
             except ValueError:
                 pass

--- a/src/sage/categories/lie_algebras.py
+++ b/src/sage/categories/lie_algebras.py
@@ -589,10 +589,11 @@ class LieAlgebras(Category_over_base_ring):
             zero = self.zero()
             return all(x._bracket_(y) == zero for x in G for y in G)
 
-        def is_commutative(self):
+        def is_commutative(self) -> bool:
             """
-            Return if ``self`` is commutative. This is equivalent to ``self``
-            being abelian.
+            Return if ``self`` is commutative.
+
+            This is equivalent to ``self`` being abelian.
 
             EXAMPLES::
 

--- a/src/sage/categories/magmas.py
+++ b/src/sage/categories/magmas.py
@@ -398,7 +398,7 @@ class Magmas(Category_singleton):
     class Commutative(CategoryWithAxiom):
 
         class ParentMethods:
-            def is_commutative(self):
+            def is_commutative(self) -> bool:
                 """
                 Return ``True``, since commutative magmas are commutative.
 

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -589,7 +589,7 @@ class QuotientRing_nc(ring.Ring, sage.structure.parent_gens.ParentWithGens):
         """
         return "%s/%s" % (latex.latex(self.cover_ring()), latex.latex(self.defining_ideal()))
 
-    def is_commutative(self):
+    def is_commutative(self) -> bool:
         """
         Tell whether this quotient ring is commutative.
 

--- a/src/sage/rings/real_double.pyx
+++ b/src/sage/rings/real_double.pyx
@@ -132,7 +132,8 @@ cdef class RealDoubleField_class(sage.rings.abc.RealDoubleField):
             sage: TestSuite(R).run()
         """
         from sage.categories.fields import Fields
-        Field.__init__(self, self, category=Fields().Infinite().Metric().Complete())
+        Field.__init__(self, self,
+                       category=Fields().Infinite().Metric().Complete())
         self._populate_coercion_lists_(init_no_parent=True,
                                        convert_method_name='_real_double_')
 

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -761,11 +761,9 @@ cdef class CommutativeRing(Ring):
             sage: Integers(389)['x,y']
             Multivariate Polynomial Ring in x, y over Ring of integers modulo 389
         """
-        try:
-            if not base_ring.is_commutative():
-                raise TypeError("base ring %s is no commutative ring" % base_ring)
-        except AttributeError:
+        if base_ring is not self and base_ring not in _CommutativeRings:
             raise TypeError("base ring %s is no commutative ring" % base_ring)
+
         # This is a low-level class. For performance, we trust that
         # the category is fine, if it is provided. If it isn't, we use
         # the category of commutative rings.
@@ -829,23 +827,6 @@ cdef class CommutativeRing(Ring):
             return self.fraction_field()
         except (NotImplementedError,TypeError):
             return coercion_model.division_parent(self)
-
-    def is_commutative(self):
-        """
-        Return ``True``, since this ring is commutative.
-
-        EXAMPLES::
-
-            sage: QQ.is_commutative()
-            True
-            sage: ZpCA(7).is_commutative()                                              # needs sage.rings.padics
-            True
-            sage: A = QuaternionAlgebra(QQ, -1, -3, names=('i','j','k')); A             # needs sage.combinat sage.modules
-            Quaternion Algebra (-1, -3) with base ring Rational Field
-            sage: A.is_commutative()                                                    # needs sage.combinat sage.modules
-            False
-        """
-        return True
 
     def krull_dimension(self):
         """


### PR DESCRIPTION
This makes sure that the method `is_commutative` for rings is handled by the category framework and not by the auld `Ring` class.

Also adding annotations on some `is_commutative` methods

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



