### PR TITLE
partial pep8 cleanup in Lie conformal algebras

### DIFF
--- a/src/sage/algebras/lie_conformal_algebras/abelian_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/abelian_lie_conformal_algebra.py
@@ -89,16 +89,17 @@ class AbelianLieConformalAlgebra(GradedLieConformalAlgebra):
             names = 'a'
             self._latex_names = tuple(r'a_{%d}' % i for i in range(ngens))
 
-        names,index_set = standardize_names_index_set(names=names,
-                                                      index_set=index_set,
-                                                      ngens=ngens)
+        names, index_set = standardize_names_index_set(names=names,
+                                                       index_set=index_set,
+                                                       ngens=ngens)
         abeliandict = {}
 
         GradedLieConformalAlgebra.__init__(self, R, abeliandict, names=names,
-                                           index_set=index_set, weights=weights,
+                                           index_set=index_set,
+                                           weights=weights,
                                            parity=parity)
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         String representation.
 

--- a/src/sage/algebras/lie_conformal_algebras/affine_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/affine_lie_conformal_algebra.py
@@ -142,7 +142,7 @@ class AffineLieConformalAlgebra(GradedLieConformalAlgebra):
         """
         return self._ct
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         The name of this Lie conformal algebra.
 
@@ -152,4 +152,4 @@ class AffineLieConformalAlgebra(GradedLieConformalAlgebra):
             The affine Lie conformal algebra of type ['A', 1] over Rational Field
         """
         return "The affine Lie conformal algebra of type {} over {}".format(
-                                                    self._ct,self.base_ring())
+                                                    self._ct, self.base_ring())

--- a/src/sage/algebras/lie_conformal_algebras/bosonic_ghosts_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/bosonic_ghosts_lie_conformal_algebra.py
@@ -120,7 +120,7 @@ class BosonicGhostsLieConformalAlgebra(GradedLieConformalAlgebra):
                          weights=weights,
                          central_elements=('K',))
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         String representation.
 
@@ -130,4 +130,4 @@ class BosonicGhostsLieConformalAlgebra(GradedLieConformalAlgebra):
             The Bosonic ghosts Lie conformal algebra with generators (beta, gamma, K) over Algebraic Field
         """
         return "The Bosonic ghosts Lie conformal algebra with generators {} "\
-               "over {}".format(self.gens(),self.base_ring())
+            "over {}".format(self.gens(), self.base_ring())

--- a/src/sage/algebras/lie_conformal_algebras/fermionic_ghosts_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/fermionic_ghosts_lie_conformal_algebra.py
@@ -117,7 +117,7 @@ class FermionicGhostsLieConformalAlgebra(GradedLieConformalAlgebra):
                          parity=parity,
                          central_elements=('K',))
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         String representation.
 
@@ -127,4 +127,4 @@ class FermionicGhostsLieConformalAlgebra(GradedLieConformalAlgebra):
             The Fermionic ghosts Lie conformal algebra with generators (b, c, K) over Rational Field
         """
         return "The Fermionic ghosts Lie conformal algebra with generators {} "\
-               "over {}".format(self.gens(),self.base_ring())
+            "over {}".format(self.gens(), self.base_ring())

--- a/src/sage/algebras/lie_conformal_algebras/free_bosons_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/free_bosons_lie_conformal_algebra.py
@@ -114,37 +114,39 @@ class FreeBosonsLieConformalAlgebra(GradedLieConformalAlgebra):
             if ngens is None:
                 ngens = gram_matrix.dimensions()[0]
             try:
-                assert (gram_matrix in MatrixSpace(R,ngens,ngens))
+                assert (gram_matrix in MatrixSpace(R, ngens, ngens))
             except AssertionError:
                 raise ValueError("the gram_matrix should be a symmetric " +
-                    "{0} x {0} matrix, got {1}".format(ngens,gram_matrix))
+                    "{0} x {0} matrix, got {1}".format(ngens, gram_matrix))
             if not gram_matrix.is_symmetric():
                 raise ValueError("the gram_matrix should be a symmetric " +
-                    "{0} x {0} matrix, got {1}".format(ngens,gram_matrix))
+                    "{0} x {0} matrix, got {1}".format(ngens, gram_matrix))
         else:
             if ngens is None:
                 ngens = 1
             gram_matrix = identity_matrix(R, ngens, ngens)
 
         latex_names = None
-        if (names is None) and (index_set is None):
+        if names is None and index_set is None:
             names = 'alpha'
             latex_names = tuple(r'\alpha_{%d}' % i
                                 for i in range(ngens)) + ('K',)
-        names,index_set = standardize_names_index_set(names=names,
-                                                      index_set=index_set,
-                                                      ngens=ngens)
-        bosondict = {(i,j): {1: {('K',0): gram_matrix[index_set.rank(i),
-                    index_set.rank(j)]}} for i in index_set for j in index_set}
+        names, index_set = standardize_names_index_set(names=names,
+                                                       index_set=index_set,
+                                                       ngens=ngens)
+        bosondict = {(i, j): {1: {('K', 0): gram_matrix[index_set.rank(i),
+                                                        index_set.rank(j)]}}
+                     for i in index_set for j in index_set}
 
-        GradedLieConformalAlgebra.__init__(self,R,bosondict,names=names,
+        GradedLieConformalAlgebra.__init__(self, R, bosondict,
+                                           names=names,
                                            latex_names=latex_names,
                                            index_set=index_set,
                                            central_elements=('K',))
 
         self._gram_matrix = gram_matrix
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         String representation.
 
@@ -154,7 +156,7 @@ class FreeBosonsLieConformalAlgebra(GradedLieConformalAlgebra):
             The free Bosons Lie conformal algebra with generators (alpha, K) over Algebraic Real Field
         """
         return "The free Bosons Lie conformal algebra with generators {}"\
-                " over {}".format(self.gens(),self.base_ring())
+            " over {}".format(self.gens(), self.base_ring())
 
     def gram_matrix(self):
         r"""

--- a/src/sage/algebras/lie_conformal_algebras/free_fermions_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/free_fermions_lie_conformal_algebra.py
@@ -94,17 +94,17 @@ class FreeFermionsLieConformalAlgebra(GradedLieConformalAlgebra):
         """
         from sage.matrix.matrix_space import MatrixSpace
         from sage.matrix.special import identity_matrix
-        if (gram_matrix is not None):
+        if gram_matrix is not None:
             if ngens is None:
                 ngens = gram_matrix.dimensions()[0]
             try:
-                assert (gram_matrix in MatrixSpace(R,ngens,ngens))
+                assert (gram_matrix in MatrixSpace(R, ngens, ngens))
             except AssertionError:
                 raise ValueError("The gram_matrix should be a symmetric " +
-                    "{0} x {0} matrix, got {1}".format(ngens,gram_matrix))
+                    "{0} x {0} matrix, got {1}".format(ngens, gram_matrix))
             if not gram_matrix.is_symmetric():
                 raise ValueError("The gram_matrix should be a symmetric " +
-                    "{0} x {0} matrix, got {1}".format(ngens,gram_matrix))
+                    "{0} x {0} matrix, got {1}".format(ngens, gram_matrix))
         else:
             if ngens is None:
                 ngens = 1
@@ -112,34 +112,33 @@ class FreeFermionsLieConformalAlgebra(GradedLieConformalAlgebra):
 
         latex_names = None
 
-        if (names is None) and (index_set is None):
-            if ngens == 1:
-                names = 'psi'
-            else:
-                names = 'psi_'
+        if names is None and index_set is None:
+            names = 'psi' if ngens == 1 else 'psi_'
             latex_names = tuple(r"\psi_{%d}" % i
                                 for i in range(ngens)) + ('K',)
 
         from sage.structure.indexed_generators import \
-                                                standardize_names_index_set
-        names,index_set = standardize_names_index_set(names=names,
-                                                      index_set=index_set,
-                                                      ngens=ngens)
-        fermiondict = {(i,j): {0: {('K', 0): gram_matrix[index_set.rank(i),
-                    index_set.rank(j)]}} for i in index_set for j in index_set}
+            standardize_names_index_set
+        names, index_set = standardize_names_index_set(names=names,
+                                                       index_set=index_set,
+                                                       ngens=ngens)
+        fermiondict = {(i, j): {0: {('K', 0): gram_matrix[index_set.rank(i),
+                                                          index_set.rank(j)]}}
+                       for i in index_set for j in index_set}
 
         from sage.rings.rational_field import QQ
-        weights = (QQ(1/2),)*ngens
-        parity = (1,)*ngens
-        GradedLieConformalAlgebra.__init__(self,R,fermiondict,names=names,
+        weights = (QQ((1, 2)),) * ngens
+        parity = (1,) * ngens
+        GradedLieConformalAlgebra.__init__(self, R, fermiondict, names=names,
                                            latex_names=latex_names,
-                                           index_set=index_set,weights=weights,
+                                           index_set=index_set,
+                                           weights=weights,
                                            parity=parity,
                                            central_elements=('K',))
 
         self._gram_matrix = gram_matrix
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         String representation.
 
@@ -149,8 +148,8 @@ class FreeFermionsLieConformalAlgebra(GradedLieConformalAlgebra):
             The free Fermions super Lie conformal algebra with generators (psi, K) over Rational Field
         """
         return "The free Fermions super Lie conformal algebra "\
-                    "with generators {} over {}".format(self.gens(),
-                                                         self.base_ring())
+            "with generators {} over {}".format(self.gens(),
+                                                self.base_ring())
 
     def gram_matrix(self):
         r"""

--- a/src/sage/algebras/lie_conformal_algebras/freely_generated_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/freely_generated_lie_conformal_algebra.py
@@ -81,8 +81,8 @@ class FreelyGeneratedLieConformalAlgebra(LieConformalAlgebraWithBasis):
             (B[alpha[1]], B[alphacheck[1]], B[-alpha[1]], B['K'])
         """
         F = Family(self._generators,
-                      lambda i: self.monomial((i,Integer(0))),
-                      name="generator map")
+                   lambda i: self.monomial((i, Integer(0))),
+                   name="generator map")
         from sage.categories.sets_cat import Sets
         if F in Sets().Finite():
             return tuple(F)

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra.py
@@ -331,7 +331,7 @@ class LieConformalAlgebra(UniqueRepresentation, Parent):
             if key not in known_keywords:
                 raise ValueError("got an unexpected keyword argument '%s'" % key)
 
-        if isinstance(arg0,dict) and arg0:
+        if isinstance(arg0, dict) and arg0:
             graded = kwds.pop("graded", False)
             if weights is not None or graded:
                 from .graded_lie_conformal_algebra import \

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
@@ -148,7 +148,7 @@ class LieConformalAlgebraWithStructureCoefficients(
         index_to_parity = dict(zip(index_set, parity))
         sc = {}
         # mypair has a pair of generators
-        for mypair in s_coeff.keys():
+        for mypair, v in s_coeff.items():
             # e.g.  v = { 0: { (L,2):3, (G,3):1}, 1:{(L,1),2} }
             v = s_coeff[mypair]
             key = tuple(mypair)
@@ -186,7 +186,7 @@ class LieConformalAlgebraWithStructureCoefficients(
                                 kth_product[(i[0], i[1] + j)] = \
                                     kth_product.get((i[0], i[1] + j), 0)
                                 kth_product[(i[0], i[1] + j)] += parsgn *\
-                                    v[k+j][i]*(-1)**(k+j+1)*binomial(i[1]+j,j)
+                                    v[k+j][i]*(-1)**(k+j+1)*binomial(i[1]+j, j)
                 kth_product = {k: v for k, v in kth_product.items() if v}
                 if kth_product:
                     vals[k] = kth_product
@@ -212,7 +212,7 @@ class LieConformalAlgebraWithStructureCoefficients(
             sage: V = lie_conformal_algebras.NeveuSchwarz(QQ)
             sage: TestSuite(V).run()
         """
-        names, index_set = standardize_names_index_set(names,index_set)
+        names, index_set = standardize_names_index_set(names, index_set)
         if central_elements is None:
             central_elements = ()
 
@@ -220,13 +220,14 @@ class LieConformalAlgebraWithStructureCoefficients(
             names2 = names + tuple(central_elements)
             index_set2 = DisjointUnionEnumeratedSets((index_set,
                 Family(tuple(central_elements))))
-            d = {x:index_set2[i] for i,x in enumerate(names2)}
+            d = {x: index_set2[i] for i, x in enumerate(names2)}
             try:
-                #If we are given a dictionary with names as keys,
-                #convert to index_set as keys
-                s_coeff = {(d[k[0]],d[k[1]]):{a:{(d[x[1]],x[2]):
-                    s_coeff[k][a][x] for x in
-                    s_coeff[k][a]} for a in s_coeff[k]} for k in s_coeff.keys()}
+                # If we are given a dictionary with names as keys,
+                # convert to index_set as keys
+                s_coeff = {(d[k[0]], d[k[1]]):
+                           {a: {(d[x[1]], x[2]): sck[a][x] for x in sck[a]}
+                            for a in s_coeff[k]}
+                           for k, sck in s_coeff.items()}
 
             except KeyError:
                 # We assume the dictionary was given with keys in the
@@ -274,9 +275,12 @@ class LieConformalAlgebraWithStructureCoefficients(
             prefix=prefix, names=names, latex_names=latex_names, **kwds)
 
         s_coeff = dict(s_coeff)
-        self._s_coeff = Family({k: tuple((j, sum(c*self.monomial(i)
-                for i,c in v)) for j,v in s_coeff[k]) for k in s_coeff})
-        self._parity = dict(zip(self.gens(),parity+(0,)*len(central_elements)))
+        self._s_coeff = Family({k:
+                                tuple((j, sum(c * self.monomial(i)
+                                              for i, c in v)) for j, v in sck)
+                                for k, sck in s_coeff.items()})
+        self._parity = dict(zip(self.gens(),
+                                parity + (0,) * len(central_elements)))
 
     def structure_coefficients(self):
         """
@@ -293,7 +297,7 @@ class LieConformalAlgebraWithStructureCoefficients(
         """
         return self._s_coeff
 
-    def _repr_generator(self, x):
+    def _repr_generator(self, x) -> str:
         """
         String representation of the generator ``x``.
 
@@ -316,4 +320,4 @@ class LieConformalAlgebraWithStructureCoefficients(
         """
         if x in self:
             return repr(x)
-        return IndexedGenerators._repr_generator(self,x)
+        return IndexedGenerators._repr_generator(self, x)

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
@@ -87,9 +87,11 @@ class LieConformalAlgebraWithStructureCoefficients(
       `\lambda`-brackets of the generators::
 
         sage: betagamma_dict = {('b','a'):{0:{('K',0):1}}}
-        sage: V = LieConformalAlgebra(QQ, betagamma_dict, names=('a','b'), weights=(1,0), central_elements=('K',))
+        sage: V = LieConformalAlgebra(QQ, betagamma_dict, names=('a','b'),
+        ....:         weights=(1,0), central_elements=('K',))
         sage: V.category()
-        Category of H-graded finitely generated Lie conformal algebras with basis over Rational Field
+        Category of H-graded finitely generated Lie conformal algebras
+        with basis over Rational Field
         sage: V.inject_variables()
         Defining a, b, K
         sage: a.bracket(b)
@@ -150,7 +152,6 @@ class LieConformalAlgebraWithStructureCoefficients(
         # mypair has a pair of generators
         for mypair, v in s_coeff.items():
             # e.g.  v = { 0: { (L,2):3, (G,3):1}, 1:{(L,1),2} }
-            v = s_coeff[mypair]
             key = tuple(mypair)
             vals = {}
             for l in v:
@@ -293,7 +294,10 @@ class LieConformalAlgebraWithStructureCoefficients(
             Finite family {('L', 'L'): ((0, TL), (1, 2*L), (3, 1/2*C))}
 
             sage: lie_conformal_algebras.NeveuSchwarz(QQ).structure_coefficients()
-            Finite family {('G', 'G'): ((0, 2*L), (2, 2/3*C)),  ('G', 'L'): ((0, 1/2*TG), (1, 3/2*G)),  ('L', 'G'): ((0, TG), (1, 3/2*G)),  ('L', 'L'): ((0, TL), (1, 2*L), (3, 1/2*C))}
+            Finite family {('G', 'G'): ((0, 2*L), (2, 2/3*C)),
+            ('G', 'L'): ((0, 1/2*TG), (1, 3/2*G)),
+            ('L', 'G'): ((0, TG), (1, 3/2*G)),
+            ('L', 'L'): ((0, TL), (1, 2*L), (3, 1/2*C))}
         """
         return self._s_coeff
 


### PR DESCRIPTION
just adding spaces after comma, mostly

alos using `.items()` in several places

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



