### PR TITLE
less use of ParentWithGens

### DIFF
--- a/src/sage/rings/fraction_field_element.pyx
+++ b/src/sage/rings/fraction_field_element.pyx
@@ -348,9 +348,9 @@ cdef class FractionFieldElement(FieldElement):
         This function hashes in a special way to ensure that generators of
         a ring `R` and generators of a fraction field of `R` have the same
         hash. This enables them to be used as keys interchangeably in a
-        dictionary (since ``==`` will claim them equal). This is particularly
-        useful for methods like ``subs`` on ``ParentWithGens`` if you are
-        passing a dictionary of substitutions.
+        dictionary (since ``==`` will claim them equal).
+
+        This is useful for substitution using dicts.
 
         EXAMPLES::
 

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -90,14 +90,11 @@ cdef class MPolynomialRing_base(CommutativeRing):
         self._term_order = order
         self._has_singular = False  # cannot convert to Singular by default
         self._magma_cache = {}
-        # Ring.__init__ already does assign the names.
-        # It would be a mistake to call ParentWithGens.__init__
-        # as well, assigning the names twice.
-        # ParentWithGens.__init__(self, base_ring, names)
         if base_ring.is_zero():
             category = categories.rings.Rings().Finite()
         else:
             category = polynomial_default_category(base_ring.category(), n)
+        # Ring.__init__ assigns the names.
         Ring.__init__(self, base_ring, names, category=category)
         from sage.combinat.integer_vector import IntegerVectors
         self._indices = IntegerVectors(self._ngens)

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -383,7 +383,7 @@ from sage.structure.category_object import check_default_category
 
 
 @richcmp_method
-class QuotientRing_nc(ring.Ring, sage.structure.parent_gens.ParentWithGens):
+class QuotientRing_nc(ring.Ring):
     """
     The quotient ring of `R` by a twosided ideal `I`.
 
@@ -495,8 +495,7 @@ class QuotientRing_nc(ring.Ring, sage.structure.parent_gens.ParentWithGens):
             raise TypeError("The second argument must be an ideal of the given ring, but %s is not" % I)
         self.__R = R
         self.__I = I
-        #sage.structure.parent_gens.ParentWithGens.__init__(self, R.base_ring(), names)
-        ##
+
         # Unfortunately, computing the join of categories, which is done in
         # check_default_category, is very expensive.
         # However, we don't just want to use the given category without mixing in

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -253,8 +253,6 @@ cdef class Ring(ParentWithGens):
         # yield an infinite recursion. But when we call it from here, it works.
         # This is done in order to ensure that __init_extra__ is called.
         #
-        # ParentWithGens.__init__(self, base, names=names, normalize=normalize)
-        #
         # This is a low-level class. For performance, we trust that the category
         # is fine, if it is provided. If it isn't, we use the category of rings.
         if category is None:

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -817,9 +817,9 @@ cdef class Element(SageObject):
             ngens = parent.ngens()
         except (AttributeError, NotImplementedError, TypeError):
             return self
-        variables=[]
-        # use "gen" instead of "gens" as a ParentWithGens is not
-        # required to have the latter
+        variables = []
+
+        # using gen instead of gens
         for i in range(ngens):
             gen = parent.gen(i)
             if str(gen) in kwds:


### PR DESCRIPTION
only one important change : the quotient ring class no longer inherits from `ParentWithGens`

indeed, the auld class `Ring` itself inherits from `ParentWithGens` ....


### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
