### PR TITLE
[DOC] src/doc/fr/tutorial/conf.py: remove obsolete latex work-around

### DIFF
--- a/src/doc/fr/a_tour_of_sage/conf.py
+++ b/src/doc/fr/a_tour_of_sage/conf.py
@@ -49,7 +49,3 @@ latex_documents = [
   ('index', name + '.tex', 'A Tour Of Sage',
    'The Sage Development Team', 'manual'),
 ]
-
-# the definition of \\at in the standard preamble of the sphinx doc
-# conflicts with that in babel/french[b]
-latex_elements['preamble'] += '\\let\\at\\undefined'

--- a/src/doc/fr/tutorial/conf.py
+++ b/src/doc/fr/tutorial/conf.py
@@ -49,7 +49,3 @@ latex_documents = [
   ('index', name + '.tex', project,
    'The Sage Group', 'manual'),
 ]
-
-# the definition of \\at in the standard preamble of the sphinx doc
-# conflicts with that in babel/french[b]
-latex_elements['preamble'] += '\\let\\at\\undefined'


### PR DESCRIPTION
This work-around was needed with Pygments<1.0 hence has been obsolete for more than fifteen years.

Here is the [relevant commit](https://github.com/pygments/pygments/commit/14b9433c05086beb67aca7436a96d1e685787d93) from Pygments:
```text
commit 14b9433c05086beb67aca7436a96d1e685787d93
Author: Georg Brandl <georg@python.org>
Date:   Fri Sep 12 00:28:08 2008 +0200

    Don't define \at, \lb, \rb as escapes, but prepend commandprefix here too.
```

Update: it is possible early-history Sphinx had some hardcoded things nowadays imported dynamically from Pygments such as  the contents of the file `sphinxhighlight.sty` one finds in the latex build directory (which does currently `\def\PYGZat{@}`).  Indeed I also found a [similar commit at Sphinx](https://github.com/sphinx-doc/sphinx/commit/46544e4986fd2dbdf11d79897c18ef6623956db6), 
```text
commit 46544e4986fd2dbdf11d79897c18ef6623956db6
Author: Georg Brandl <georg@python.org>
Date:   Thu Sep 11 22:29:35 2008 +0000

    Use a prefix to \at, \lb and \rb since they are probably often used command names.

```
which was part of [Sphinx 0.5 release](https://github.com/sphinx-doc/sphinx/releases/tag/v0.5) from November 2008. It is  not fully clear to me why #8183 was raised in February 2010, but anyway I am very confident the issue does not exist at all if producing the PDF docs with a reasonable version of Sphinx.

There is another conf.py with this work-around but #39325 already handles it.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


