### PR TITLE
fixes ruff PLC in categories

### DIFF
--- a/src/sage/categories/finite_complex_reflection_groups.py
+++ b/src/sage/categories/finite_complex_reflection_groups.py
@@ -1227,8 +1227,8 @@ class FiniteComplexReflectionGroups(CategoryWithAxiom):
                             to_test.extend((hp, j) for j in Ip)
                         cosets[Ip].append(frozenset(H))
                 verts = {}
-                for Ip in cosets:
-                    for C in cosets[Ip]:
+                for Ip, cosetsIp in cosets.items():
+                    for C in cosetsIp:
                         verts[C, Ip] = len(verts)
                 facets = [[verts[k] for k in verts if g in k[0]] for g in self]
                 from sage.topology.simplicial_complex import SimplicialComplex

--- a/src/sage/categories/loop_crystals.py
+++ b/src/sage/categories/loop_crystals.py
@@ -547,7 +547,7 @@ class KirillovReshetikhinCrystals(Category_singleton):
             from sage.rings.integer_ring import ZZ
             if ell is None:
                 if (self.cartan_type().dual().type() == 'BC'
-                    and self.cartan_type().rank() - 1 == self.r()):
+                        and self.cartan_type().rank() - 1 == self.r()):
                     return True
                 ell = self.s() / self.cartan_type().c()[self.r()]
                 if ell not in ZZ:
@@ -557,9 +557,9 @@ class KirillovReshetikhinCrystals(Category_singleton):
                 raise ValueError("perfectness not defined for non-integral levels")
 
             # [FOS2010]_ check
-            if self.cartan_type().classical().type() not in ['E','F','G']:
+            if self.cartan_type().classical().type() not in ['E', 'F', 'G']:
                 if (self.cartan_type().dual().type() == 'BC'
-                    and self.cartan_type().rank() - 1 == self.r()):
+                        and self.cartan_type().rank() - 1 == self.r()):
                     return ell == self.s()
                 return ell == self.s() / self.cartan_type().c()[self.r()]
 
@@ -580,9 +580,9 @@ class KirillovReshetikhinCrystals(Category_singleton):
             rank = len(I)
             La = self.weight_lattice_realization().basis()
             from sage.combinat.integer_vector import IntegerVectors
-            for n in range(1, ell+1):
+            for n in range(1, ell + 1):
                 for c in IntegerVectors(n, rank):
-                    w = sum(c[i]*La[i] for i in I)
+                    w = sum(c[i] * La[i] for i in I)
                     if w.level() == ell:
                         weights.append(w)
             return sorted(b.Phi() for b in MPhi) == sorted(weights)
@@ -629,7 +629,7 @@ class KirillovReshetikhinCrystals(Category_singleton):
             if not self.is_perfect():
                 raise ValueError("this crystal is not perfect")
             if (self.cartan_type().dual().type() == 'BC'
-                and self.cartan_type().rank() - 1 == self.r()):
+                    and self.cartan_type().rank() - 1 == self.r()):
                 return self.s()
             return self.s() / self.cartan_type().c()[self.r()]
 
@@ -764,7 +764,7 @@ class KirillovReshetikhinCrystals(Category_singleton):
                 """
                 n = len(self.crystals)
                 I0 = self.cartan_type().classical().index_set()
-                it = [ iter(self.crystals[-1].classically_highest_weight_vectors()) ]
+                it = [iter(self.crystals[-1].classically_highest_weight_vectors())]
                 path = []
                 ret = []
                 while it:
@@ -784,7 +784,7 @@ class KirillovReshetikhinCrystals(Category_singleton):
                         ret.append(b)
                         path.pop(0)
                     else:
-                        it.append( iter(self.crystals[-len(path)-1]) )
+                        it.append(iter(self.crystals[-len(path) - 1]))
                 return tuple(ret)
 
             # TODO: This is duplicated in KR crystals category
@@ -873,9 +873,10 @@ class KirillovReshetikhinCrystals(Category_singleton):
                 if group_components:
                     G = self.digraph(index_set=self.cartan_type().classical().index_set())
                     C = G.connected_components(sort=False)
-                    return B.sum(q**(c[0].energy_function())*B.sum(B(P0(b.weight())) for b in c)
+                    return B.sum(q**(c[0].energy_function()) * B.sum(B(P0(b.weight()))
+                                                                     for b in c)
                                  for c in C)
-                return B.sum(q**(b.energy_function())*B(P0(b.weight())) for b in self)
+                return B.sum(q**(b.energy_function()) * B(P0(b.weight())) for b in self)
 
         class ElementMethods:
             def energy_function(self, algorithm=None):
@@ -975,8 +976,8 @@ class KirillovReshetikhinCrystals(Category_singleton):
                 from sage.arith.misc import integer_ceil as ceil
 
                 C = self.parent().crystals[0]
-                ell = ceil(C.s()/C.cartan_type().c()[C.r()])
-                is_perfect = all(ell == K.s()/K.cartan_type().c()[K.r()]
+                ell = ceil(C.s() / C.cartan_type().c()[C.r()])
+                is_perfect = all(ell == K.s() / K.cartan_type().c()[K.r()]
                                  for K in self.parent().crystals)
                 if algorithm is None:
                     if is_perfect:
@@ -995,12 +996,12 @@ class KirillovReshetikhinCrystals(Category_singleton):
                     from sage.rings.integer_ring import ZZ
                     energy = ZZ.zero()
                     R_mats = [[K.R_matrix(Kp) for Kp in self.parent().crystals[i+1:]]
-                              for i,K in enumerate(self.parent().crystals)]
+                              for i, K in enumerate(self.parent().crystals)]
                     H_funcs = [[K.local_energy_function(Kp) for Kp in self.parent().crystals[i+1:]]
-                               for i,K in enumerate(self.parent().crystals)]
+                               for i, K in enumerate(self.parent().crystals)]
 
-                    for i,b in enumerate(self):
-                        for j,R in enumerate(R_mats[i]):
+                    for i, b in enumerate(self):
+                        for j, R in enumerate(R_mats[i]):
                             H = H_funcs[i][j]
                             bp = self[i+j+1]
                             T = R.domain()
@@ -1128,7 +1129,7 @@ class KirillovReshetikhinCrystals(Category_singleton):
 
 
 #####################################################################
-## Local energy function
+# Local energy function
 
 class LocalEnergyFunction(Map):
     r"""
@@ -1246,9 +1247,9 @@ class LocalEnergyFunction(Map):
             for i in self._I0:
                 b = cur.e(i)
                 if b is not None and b not in visited:
-                    visited[b] = visited[cur] # No change
+                    visited[b] = visited[cur]  # No change
                     return b
-            return None # is classically HW or all have been visited
+            return None  # is classically HW or all have been visited
 
         cur = x
         # Get the affine node (it might not be 0 if the type
@@ -1270,19 +1271,19 @@ class LocalEnergyFunction(Map):
 
                 bp = self._R_matrix(b)
                 cp = bp.e(i0)
-                if b[1] == c[1] and bp[1] == cp[1]: # LL case
+                if b[1] == c[1] and bp[1] == cp[1]:  # LL case
                     visited[c] = visited[b] + 1
-                elif b[0] == c[0] and bp[0] == cp[0]: # RR case
+                elif b[0] == c[0] and bp[0] == cp[0]:  # RR case
                     visited[c] = visited[b] - 1
                 else:
-                    visited[c] = visited[b] # Otherwise no change
+                    visited[c] = visited[b]  # Otherwise no change
                 b = c
 
             cur = b
             check0.append(b)
 
         baseline = self._known_values[cur] - visited[cur]
-        for y in visited:
-            self._known_values[y] = baseline + visited[y]
+        for y, vy in visited.items():
+            self._known_values[y] = baseline + vy
 
         return self._known_values[x]

--- a/src/sage/categories/simplicial_sets.py
+++ b/src/sage/categories/simplicial_sets.py
@@ -723,7 +723,7 @@ class SimplicialSets(Category_singleton):
                     if s in twop:
                         return twop[s]
                     if s.dimension() > 1:
-                        return twist(self.face(s,s.dimension()))
+                        return twist(self.face(s, s.dimension()))
                     return 1
                 base_ring = cm.common_parent(*twop.values())
 
@@ -815,9 +815,8 @@ class SimplicialSets(Category_singleton):
                         differentials[d] = matrix(base_ring, old_rank, rank, sparse=False)
 
                 if cochain:
-                    new_diffs = {}
-                    for d in differentials:
-                        new_diffs[d-1] = differentials[d].transpose()
+                    new_diffs = {d - 1: diff_d.transpose()
+                                 for d, diff_d in differentials.items()}
                     return ChainComplex(new_diffs, degree_of_differential=1,
                                         check=check)
                 return ChainComplex(differentials, degree_of_differential=-1,
@@ -961,7 +960,7 @@ class SimplicialSets(Category_singleton):
                     res = M
                     for g in GB:
                         res = res.stack(g*identity_matrix(M.ncols()))
-                    singres = matrix(singlift(res.T, S.T,ring=res.base_ring()))
+                    singres = matrix(singlift(res.T, S.T, ring=res.base_ring()))
                     return singres.submatrix(0, 0, M.nrows(), S.nrows())
 
                 def mgb(M):
@@ -973,7 +972,7 @@ class SimplicialSets(Category_singleton):
                     sres = matrix(singstd(res.T, ring=RP))
                     to_delete = [i for i, r in enumerate(sres.apply_map(reduce_laurent)) if not r]
                     return sres.delete_rows(to_delete)
-                    M2 = border_matrix(n+1)
+
                 if M1.nrows() == 0:
                     opt_verb.reset_default()
                     return (RP**0).quotient_module([])


### PR DESCRIPTION
this fixes all ruff PLC warnings in the categories folder, plus a few pep8 style warnings in the 3 modified files

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.