### PR TITLE
Add doctest that integral of 0 function is 0

### DIFF
--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -776,6 +776,13 @@ def integral(x, *args, **kwds):
         ...
         sage: result                                                                    # needs sage.symbolic
         -1/4
+
+    Verify that :issue:`33034` is fixed::
+
+        sage: f(x) = (x + sin(3*x)) * exp(-3*x*I)
+        sage: h(x) = f(x) - f(x).expand()
+        sage: integral(h(x), (x, 0, 2*pi))
+        0
     """
     if hasattr(x, 'integral'):
         return x.integral(*args, **kwds)


### PR DESCRIPTION
Fixes #33034.

Issue #33034 pointed out that integrating a function that is identically zero can produce a nonzero value. However, this was a maxima bug that was fixed in sage 10.1.  So we just add a doctest.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


