### PR TITLE
remove attempt to coerce scalar to basering for truediv

### DIFF
--- a/src/sage/rings/polynomial/padics/polynomial_padic_capped_relative_dense.py
+++ b/src/sage/rings/polynomial/padics/polynomial_padic_capped_relative_dense.py
@@ -573,7 +573,7 @@ class Polynomial_padic_capped_relative_dense(Polynomial_generic_cdv, Polynomial_
             sage: K(13,7) * a
             (13 + O(13^7))*t^4 + (13^2 + O(13^6))*t^2 + 13^2 + O(13^8)
         """
-        return None
+        # return None #commented this out to see how broken this is
         # The code below has never been tested and is somehow subtly broken.
 
         if self._valaddeds is None:

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -2767,15 +2767,6 @@ cdef class Polynomial(CommutativePolynomial):
         if have_same_parent(left, right):
             return (<Element>left)._div_(right)
 
-        # Try division of polynomial by a scalar
-        if isinstance(left, Polynomial):
-            R = (<Polynomial>left)._parent._base
-            try:
-                x = R.coerce(right)
-                return left * ~x
-            except TypeError:
-                pass
-
         # Delegate to coercion model. The line below is basically
         # RingElement.__truediv__(left, right), except that it also
         # works if left is not of type RingElement.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

As was observed in #39318, presently division of general univariate polynomials first tries to convert the dividing element into the base ring and invert it there. That's a problem with something like `QQ['x']['y']` and computing `y/1`: the scalar `1` gets coerced into `QQ['x']` and computing its inverse there yields an element in the field of fractions of `QQ['x']`. The parent of the result is therefore the polynomial ring in `y` over that. 

The coercion framework is capable of finding an action of `QQ` on `QQ['x']['y']`, so if we just leave it to the coercion framework, we end up with a tighter parent for the result. Preliminary timings indicate that there is no significant performance regression, but more detailed timing might be warranted.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


