### PR TITLE
Correct method `is_sparse_paving`

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -3689,6 +3689,9 @@ REFERENCES:
 .. [Ja1971] \N. Jacobson. *Exceptional Lie Algebras*. Marcel Dekker,
             Inc. New York. 1971. IBSN No. 0-8247-1326-5.
 
+.. [Jer2006] Mark Jerrum. *Two remarks concerning balanced matroids*.
+             Combinatorica 26, no. 6 (2006): 733-742.
+
 .. [Jet2008] \D. Jetchev. Global divisibility of Heegner points and
              Tamagawa numbers. Compos. Math. 144 (2008), no. 4, 811--826.
 
@@ -4990,6 +4993,10 @@ REFERENCES:
 .. [MNO1994] Alexander Molev, Maxim Nazarov, and Grigori Olshanski.
              *Yangians and classical Lie algebras*. (1994)
              :arxiv:`hep-th/9409025`
+
+.. [MNWW2011] Dillon Mayhew, Mike Newman, Dominic Welsh, and Geoff Whittle.
+              *On the asymptotic proportion of connected matroids*.
+              European Journal of Combinatorics. 2011 Aug 1;32(6):882-90.
 
 .. [Mol2007] Alexander Ivanovich Molev.
              *Yangians and Classical Lie Algebras*.

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -6210,6 +6210,10 @@ cdef class Matroid(SageObject):
             sage: M = matroids.Theta(4)
             sage: M.is_paving()
             False
+
+        REFERENCES:
+
+        [Oxl2011]_, p. 24.
         """
         if self.rank() >= 2:
             for _ in self.dependent_sets_iterator(self.rank() - 1):
@@ -6239,12 +6243,17 @@ cdef class Matroid(SageObject):
             sage: M.is_sparse_paving()
             False
 
+        REFERENCES:
+
+        The definition of sparse-paving matroids can be found in [MNWW2011]_.
+        The algorithm uses an alternative characterization from [Jer2006]_.
+
         TESTS::
 
             sage: M = matroids.Uniform(4, 50)  # fast because we don't check M.dual().is_paving()
             sage: M.is_sparse_paving()
             True
-            sage: for M in matroids.AllMatroids(8):
+            sage: for M in matroids.AllMatroids(8):  # optional - matroid_database
             ....:    assert M.is_sparse_paving() == (M.is_paving() and M.dual().is_paving())
         """
         if not self.is_paving():

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -6212,33 +6212,45 @@ cdef class Matroid(SageObject):
             False
         """
         if self.rank() >= 2:
-            for X in combinations(self.groundset(), self.rank() - 1):
-                if not self._is_independent(frozenset(X)):
-                    return False
+            for _ in self.dependent_sets_iterator(self.rank() - 1):
+                return False
         return True
 
     cpdef bint is_sparse_paving(self) noexcept:
         """
         Return if ``self`` is sparse-paving.
 
-        A matroid is sparse-paving if the symmetric difference of every pair
-        of circuits is greater than 2.
+        A matroid is sparse-paving if it is paving and its dual is paving.
 
         OUTPUT: boolean
+
+        ALGORITHM:
+
+        First, check that the matroid is paving. Then, verify that the
+        symmetric difference of every pair of distinct `r`-circuits is greater
+        than 2.
 
         EXAMPLES::
 
             sage: M = matroids.catalog.Vamos()
             sage: M.is_sparse_paving()
+            True
+            sage: M = matroids.catalog.N1()
+            sage: M.is_sparse_paving()
             False
-            sage: M = matroids.catalog.Fano()
+
+        TESTS::
+
+            sage: M = matroids.Uniform(4, 50)  # fast because we don't check M.dual().is_paving()
             sage: M.is_sparse_paving()
             True
+            sage: for M in matroids.AllMatroids(8):
+            ....:    assert M.is_sparse_paving() == (M.is_paving() and M.dual().is_paving())
         """
         if not self.is_paving():
             return False
         from itertools import combinations
-        for (C1, C2) in combinations(self.circuits_iterator(), 2):
+        for (C1, C2) in combinations(self.nonbases_iterator(), 2):
             if len(C1 ^ C2) <= 2:
                 return False
         return True


### PR DESCRIPTION
It was brought to my attention that the method `is_sparse_paving` is incorrect. See https://github.com/sagemath/sage/pull/36962#issuecomment-2614537747.

The method should only check the symmetric differences of `r`-element circuits rather than all (`r`- and `r+1`-element) circuits.

The algorithm used is based on a somewhat unusual definition which can be found in https://arxiv.org/pdf/math/0404200.