### PR TITLE
pari/NTL conversions

### DIFF
--- a/src/sage/libs/ntl/ntl_ZZ_pE.pyx
+++ b/src/sage/libs/ntl/ntl_ZZ_pE.pyx
@@ -121,6 +121,7 @@ cdef class ntl_ZZ_pE():
             elif isinstance(v, Integer):
                 mpz_to_ZZ(&temp, (<Integer>v).value)
                 self.x = ZZ_to_ZZ_pE(temp)
+
             else:
                 str_v = str(v)  # can cause modulus to change; Issue #25790
                 self.c.restore_c()

--- a/src/sage/libs/pari/convert_ntl.pxd
+++ b/src/sage/libs/pari/convert_ntl.pxd
@@ -1,0 +1,73 @@
+"""
+Convert PARI objects to/from NTL objects
+
+AUTHORS:
+
+- Vincent Delecroix (2024)
+"""
+#*****************************************************************************
+#       Copyright (C) 2024 Vincent Delecroix <20100.delecroix@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+#*****************************************************************************
+
+from cysignals.signals cimport sig_on
+
+from cypari2.types cimport GEN
+from cypari2.gen cimport Gen
+from cypari2.paridecl cimport *
+from cypari2.stack cimport new_gen
+
+from .convert_gmp cimport _new_GEN_from_mpz_t
+
+from sage.libs.gmp.types cimport mpz_t
+from sage.libs.gmp.mpz cimport mpz_init, mpz_clear
+from sage.libs.pari.convert_gmp cimport INT_to_mpz
+from sage.libs.ntl.types cimport *
+from sage.libs.ntl.convert cimport mpz_to_ZZ, ZZ_to_mpz
+
+
+cdef Gen new_gen_from_ZZ(ZZ_c * x)
+
+
+cdef inline void INT_to_ZZ(ZZ_c * x, GEN g):
+    r"""
+    Set ``x`` to the value of the pari INT ``g``
+    """
+    # TODO: we should not go through mpz here but implement a direct conversion
+    cdef mpz_t tmp
+    mpz_init(tmp)
+    INT_to_mpz(tmp, g)
+    mpz_to_ZZ(x, tmp)
+    mpz_clear(tmp)
+
+
+cdef inline GEN _new_GEN_from_ZZ(ZZ_c * x):
+    r"""
+    Create a new PARI ``t_INT`` from a NTL `ZZ``
+    """
+    # TODO: we should not go through mpz here but implement a direct conversion
+    cdef mpz_t tmp
+    mpz_init(tmp)
+    ZZ_to_mpz(tmp, x)
+    cdef GEN g = _new_GEN_from_mpz_t(tmp)
+    mpz_clear(tmp)
+    return g
+
+# TODO
+# cdef inline void FFp_to_ZZ_p(ZZ_p x, ZZ_pContext_c * p_context, GEN g):
+#     r"""
+#     Set ``x`` to the value of the pari Fp element ``g`` given the NTL context ``p_context``
+#    """
+#    pass
+
+# TODO
+# cdef inline void FFELT_to_ZZ_pE(ZZ_pE_c x, ZZ_pEContext_c * p_context, ZZ_pEContext_c * pE_context, GEN g):
+#     r"""
+#     Set ``x`` to the value of the pari FFELT ``g`` given the NTL contexts ``p_context`` and ``pE_context``.
+#     """
+#     pass

--- a/src/sage/libs/pari/convert_ntl.pyx
+++ b/src/sage/libs/pari/convert_ntl.pyx
@@ -1,0 +1,23 @@
+"""
+Convert PARI objects to/from NTL objects
+
+AUTHORS:
+
+- Vincent Delecroix (2024)
+"""
+#*****************************************************************************
+#       Copyright (C) 2024 Vincent Delecroix <20100.delecroix@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+#*****************************************************************************
+
+
+cdef Gen new_gen_from_ZZ(ZZ_c * x):
+    sig_on()
+    return new_gen(_new_GEN_from_ZZ(x))
+
+

--- a/src/sage/libs/pari/meson.build
+++ b/src/sage/libs/pari/meson.build
@@ -3,6 +3,7 @@ py.install_sources(
   'all.py',
   'convert_flint.pxd',
   'convert_gmp.pxd',
+  'convert_ntl.pxd',
   'convert_sage.pxd',
   'convert_sage_complex_double.pxd',
   'convert_sage_real_double.pxd',
@@ -21,6 +22,7 @@ extension_data = {
   'convert_sage_real_double' : files('convert_sage_real_double.pyx'),
   'convert_sage_real_mpfr' : files('convert_sage_real_mpfr.pyx'),
   'misc' : files('misc.pyx'),
+  'convert_ntl' : files('convert_ntl.pyx'),
 }
 
 foreach name, pyx : extension_data


### PR DESCRIPTION
We implement C conversions between pari and NTL for
- integers
- finite fields
- univariate polynomials over the above
 
One of the goal is to make faster the coercion from the base ring with polynomials with coefficients in `GF(p^e)`
```
sage: p = random_prime(2**256)
sage: F.<i> = GF(p^2)
sage: R.<x> = PolynomialRing(F)
sage: a = F.random_element()
sage: %timeit R(a)
14.7 μs ± 727 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

### :memo: Checklist

- [ ] I have linked a relevant issue or discussion.
- [ ] I have updated the documentation and checked the documentation preview.