### PR TITLE
Simplify __invert__ for polynomial quotient ring element

### DIFF
--- a/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
@@ -618,7 +618,7 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
         since they need not exist.  Instead, over the integers, we
         first multiply `g` by a divisor of the resultant of `a/g` and
         `b/g`, up to sign, and return ``g, u, v`` such that
-        ``g = s*self + s*right``.  But note that this `g` may be a
+        ``g = u*self + v*right``.  But note that this `g` may be a
         multiple of the gcd.
 
         If ``self`` and ``right`` are coprime as polynomials over the

--- a/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
@@ -386,10 +386,6 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
         """
         Return the inverse of this element.
 
-        .. WARNING::
-
-            Only implemented when the base ring is a field.
-
         EXAMPLES::
 
             sage: R.<x> = QQ[]
@@ -414,35 +410,21 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
             sage: (2*y)^(-1)
             Traceback (most recent call last):
             ...
-            NotImplementedError: The base ring (=Ring of integers modulo 16) is not a field
+            NotImplementedError
 
         Check that :issue:`29469` is fixed::
 
             sage: ~S(3)
             11
         """
-        if self._polynomial.is_zero():
-            raise ZeroDivisionError("element %s of quotient polynomial ring not invertible" % self)
-        if self._polynomial.is_one():
-            return self
-
-        parent = self.parent()
-
+        P = self.parent()
         try:
-            if self._polynomial.is_unit():
-                inv_pol = self._polynomial.inverse_of_unit()
-                return parent(inv_pol)
-        except (TypeError, NotImplementedError):
-            pass
-
-        base = parent.base_ring()
-        if not base.is_field():
-            raise NotImplementedError("The base ring (=%s) is not a field" % base)
-        g, _, a = parent.modulus().xgcd(self._polynomial)
-        if g.degree() != 0:
-            raise ZeroDivisionError("element %s of quotient polynomial ring not invertible" % self)
-        c = g[0]
-        return self.__class__(self.parent(), (~c)*a, check=False)
+            return type(self)(P, self._polynomial.inverse_mod(P.modulus()), check=False)
+        except ValueError as e:
+            if e.args[0] == "Impossible inverse modulo":
+                raise ZeroDivisionError(f"element {self} of quotient polynomial ring not invertible")
+            else:
+                raise NotImplementedError
 
     def field_extension(self, names):
         r"""

--- a/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
@@ -411,6 +411,12 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
             Traceback (most recent call last):
             ...
             NotImplementedError
+            sage: (2*y+1)^(-1)  # this cannot raise ValueError because...
+            Traceback (most recent call last):
+            ...
+            NotImplementedError
+            sage: (2*y+1) * (10*y+5)  # the element is in fact invertible
+            1
 
         Check that :issue:`29469` is fixed::
 


### PR DESCRIPTION
Previously `__invert__` uses `xgcd`, while the method `inverse_mod` already exists, it's duplication of code. Besides, while simplifying this some missing features in `inverse_mod` is uncovered.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


