### PR TITLE
Fix documentation of integral_points

### DIFF
--- a/src/doc/en/reference/discrete_geometry/index.rst
+++ b/src/doc/en/reference/discrete_geometry/index.rst
@@ -157,7 +157,11 @@ Helper functions
 
    sage/geometry/fan_isomorphism
    sage/geometry/hasse_diagram
-   sage/geometry/integral_points
+   sage/geometry/integral_points_generic_dense
    sage/geometry/hyperplane_arrangement/check_freeness
+
+..
+   The integral_points_generic_dense entry above should be sage/geometry/integral_points
+   but Sphinx does not handle the Python file containing only import very well
 
 .. include:: ../footer.txt

--- a/src/sage/geometry/integral_points_generic_dense.pyx
+++ b/src/sage/geometry/integral_points_generic_dense.pyx
@@ -1,4 +1,13 @@
 # cython: wraparound=False, boundscheck=False
+r"""
+Cython helper methods to compute integral points in polyhedra
+
+Note that while the URL of this documentation page ends with
+``integral_points_generic_dense``, this is merely to allow Sphinx to generate
+the documentation automatically. Imports should be from
+:mod:`sage.geometry.integral_points`, as can be seen in the examples below.
+Furthermore, not all functions are exported to the public interface.
+"""
 
 from sage.modules.vector_integer_dense cimport Vector_integer_dense as VectorClass
 from sage.matrix.matrix_dense cimport Matrix_dense as MatrixClass


### PR DESCRIPTION
Fixes https://github.com/sagemath/sage/issues/39395

Check https://doc-pr-39414--sagemath.netlify.app/html/en/reference/discrete_geometry/ and https://doc-pr-39414--sagemath.netlify.app/html/en/reference/discrete_geometry/sage/geometry/integral_points_generic_dense to confirm the issue is fixed.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


