### PR TITLE
Declare `del_edge` as `cpdef`

### DIFF
--- a/src/sage/graphs/base/static_sparse_backend.pyx
+++ b/src/sage/graphs/base/static_sparse_backend.pyx
@@ -674,7 +674,7 @@ cdef class StaticSparseBackend(CGraphBackend):
         """
         raise ValueError("graph is immutable; please change a copy instead (use function copy())")
 
-    def del_edge(self, object u, object v, object l, bint directed):
+    cpdef del_edge(self, object u, object v, object l, bint directed):
         r"""
         Delete an edge of the graph. No way.
 


### PR DESCRIPTION
Consistent with its parent class; a build warning gets resolved:
```
warning: /home/runner/work/sage/sage/src/sage/graphs/base/static_sparse_backend.pyx:677:4: Overriding cdef method with def method.
```
