### PR TITLE
Delay LaTeX feature tests as long as possible

### DIFF
--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -505,10 +505,10 @@ def default_engine():
 @cached_function
 def _default_engine():
     r"""
-    Return the default latex engine and the official name of the engine.
+    Return the name of the default latex engine.
 
-    This is determined by availability of the popular engines on the user's
-    system. It is assumed that at least latex is available.
+    This is determined by availability of the popular engines on the
+    user's system. It is assumed that at least "latex" is available.
 
     EXAMPLES::
 

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -474,7 +474,7 @@ def has_latex_attr(x) -> bool:
 
 
 @cached_function
-def default_engine():
+def _default_engine():
     r"""
     Return the default latex engine and the official name of the engine.
 
@@ -483,8 +483,8 @@ def default_engine():
 
     EXAMPLES::
 
-        sage: from sage.misc.latex import default_engine
-        sage: default_engine()  # random
+        sage: from sage.misc.latex import _default_engine
+        sage: _default_engine()  # random
         'lualatex'
 
     TESTS:
@@ -494,16 +494,16 @@ def default_engine():
     options dict for the delimiters)::
 
         sage: import sage.misc.latex
-        sage: real_de = sage.misc.latex.default_engine
+        sage: real_de = sage.misc.latex._default_engine
         sage: def crash():
         ....:     raise ValueError
-        sage: sage.misc.latex.default_engine = crash
+        sage: sage.misc.latex._default_engine = crash
         sage: latex(matrix.identity(QQ, 2))
         \left(\begin{array}{rr}
         1 & 0 \\
         0 & 1
         \end{array}\right)
-        sage: sage.misc.latex.default_engine = real_de
+        sage: sage.misc.latex._default_engine = real_de
 
     """
     from sage.features.latex import pdflatex, xelatex, lualatex
@@ -539,7 +539,7 @@ class _Latex_prefs_object(SageObject):
         self.__option["macros"] = ""
         self.__option["preamble"] = ""
 
-        # If None, the default_engine() will be used.
+        # If None, the _default_engine() will be used.
         self.__option["engine"] = None
 
     @lazy_attribute
@@ -670,7 +670,7 @@ def _run_latex_(filename, debug=False, density=150, engine=None, png=False, do_i
     if engine is None:
         engine = _Latex_prefs._option["engine"]
         if engine is None:
-            engine = default_engine()
+            engine = _default_engine()
 
     if not engine or engine == "latex":
         from sage.features.latex import latex
@@ -1088,7 +1088,7 @@ class Latex(LatexCall):
                 if engine is None:
                     engine = _Latex_prefs._option["engine"]
                     if engine is None:
-                        engine = default_engine()
+                        engine = _default_engine()
 
             e = _run_latex_(os.path.join(base, filename + ".tex"),
                             debug=debug,
@@ -1557,7 +1557,7 @@ Warning: `{}` is not part of this computer's TeX installation.""".format(file_na
         if e is None:
             e = _Latex_prefs._option["engine"]
             if e is None:
-                return default_engine()
+                return _default_engine()
             else:
                 return e
 
@@ -1865,7 +1865,7 @@ def view(objects, title='Sage', debug=False, sep='', tiny=False,
     if engine is None:
         engine = _Latex_prefs._option["engine"]
         if engine is None:
-            engine = default_engine()
+            engine = _default_engine()
 
     if viewer == "pdf" and engine == "latex":
         engine = "pdflatex"
@@ -1969,7 +1969,7 @@ def pdf(x, filename, tiny=False, tightpage=True, margin=None, engine=None, debug
     if engine is None:
         engine = _Latex_prefs._option["engine"]
         if engine is None:
-            engine = default_engine()
+            engine = _default_engine()
 
     # path name for permanent pdf output
     abs_path_to_pdf = os.path.abspath(filename)
@@ -2032,7 +2032,7 @@ def png(x, filename, density=150, debug=False,
     if engine is None:
         engine = _Latex_prefs._option["engine"]
         if engine is None:
-            engine = default_engine()
+            engine = _default_engine()
 
     # path name for permanent png output
     abs_path_to_png = os.path.abspath(filename)

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -519,6 +519,8 @@ class _Latex_prefs_object(SageObject):
         self.__option["matrix_column_alignment"] = matrix_column_alignment
         self.__option["macros"] = ""
         self.__option["preamble"] = ""
+
+        # If None, the default_engine() will be used.
         self.__option["engine"] = None
 
     @lazy_attribute
@@ -648,6 +650,8 @@ def _run_latex_(filename, debug=False, density=150, engine=None, png=False, do_i
     """
     if engine is None:
         engine = _Latex_prefs._option["engine"]
+        if engine is None:
+            engine = default_engine()
 
     if not engine or engine == "latex":
         from sage.features.latex import latex
@@ -1061,10 +1065,12 @@ class Latex(LatexCall):
 
             O.close()
             if engine is None:
-                if self.__engine is None:
+                engine = self.__engine
+                if engine is None:
                     engine = _Latex_prefs._option["engine"]
-                else:
-                    engine = self.__engine
+                    if engine is None:
+                        engine = default_engine()
+
             e = _run_latex_(os.path.join(base, filename + ".tex"),
                             debug=debug,
                             density=density,
@@ -1530,18 +1536,16 @@ Warning: `{}` is not part of this computer's TeX installation.""".format(file_na
             'pdflatex'
         """
         if e is None:
-            return _Latex_prefs._option["engine"]
+            e = _Latex_prefs._option["engine"]
+            if e is None:
+                return default_engine()
+            else:
+                return e
 
-        if e == "latex":
-            _Latex_prefs._option["engine"] = "latex"
-        elif e == "pdflatex":
-            _Latex_prefs._option["engine"] = "pdflatex"
-        elif e == "xelatex":
-            _Latex_prefs._option["engine"] = e
-        elif e == "lualatex":
-            _Latex_prefs._option["engine"] = e
-        else:
+        if e not in ["latex", "pdflatex", "xelatex", "luatex"]:
             raise ValueError("%s is not a supported LaTeX engine. Use latex, pdflatex, xelatex, or lualatex" % e)
+
+        _Latex_prefs._option["engine"] = e
 
 
 # Note: latex used to be a separate function, which by default was
@@ -1841,6 +1845,9 @@ def view(objects, title='Sage', debug=False, sep='', tiny=False,
     s = _latex_file_(objects, title=title, sep=sep, tiny=tiny, debug=debug, **latex_options)
     if engine is None:
         engine = _Latex_prefs._option["engine"]
+        if engine is None:
+            engine = default_engine()
+
     if viewer == "pdf" and engine == "latex":
         engine = "pdflatex"
     # command line or notebook with viewer
@@ -1942,6 +1949,9 @@ def pdf(x, filename, tiny=False, tightpage=True, margin=None, engine=None, debug
     s = _latex_file_([x], title='', tiny=tiny, debug=debug, **latex_options)
     if engine is None:
         engine = _Latex_prefs._option["engine"]
+        if engine is None:
+            engine = default_engine()
+
     # path name for permanent pdf output
     abs_path_to_pdf = os.path.abspath(filename)
     # temporary directory to store stuff
@@ -2002,6 +2012,9 @@ def png(x, filename, density=150, debug=False,
                      extra_preamble='\\textheight=2\\textheight')
     if engine is None:
         engine = _Latex_prefs._option["engine"]
+        if engine is None:
+            engine = default_engine()
+
     # path name for permanent png output
     abs_path_to_png = os.path.abspath(filename)
     # temporary directory to store stuff

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -474,6 +474,35 @@ def has_latex_attr(x) -> bool:
 
 
 @cached_function
+def default_engine():
+    """
+    Return the default latex engine and the official name of the engine.
+    This is determined by availability of the popular engines on the user's
+    system. It is assumed that at least latex is available.
+
+    This function is deprecated as part of the public API. There is
+    instead an internal counterpart :func:`_default_engine`, but no
+    stability promises are made with regards to its interface.
+
+    EXAMPLES::
+
+        sage: from sage.misc.latex import default_engine
+        sage: default_engine()  # random
+        ('lualatex', 'LuaLaTeX')
+    """
+    from sage.misc.superseded import deprecation
+    deprecation(39351, "default_engine is being removed from the public API and replaced with the internal function _default_engine")
+
+    from sage.features.latex import pdflatex, xelatex, lualatex
+    if lualatex().is_present():
+        return 'lualatex', 'LuaLaTeX'
+    if xelatex().is_present():
+        return 'xelatex', 'XeLaTeX'
+    if pdflatex().is_present():
+        return 'pdflatex', 'pdfLaTeX'
+    return 'latex', 'LaTeX'
+
+@cached_function
 def _default_engine():
     r"""
     Return the default latex engine and the official name of the engine.

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -519,6 +519,7 @@ class _Latex_prefs_object(SageObject):
         self.__option["matrix_column_alignment"] = matrix_column_alignment
         self.__option["macros"] = ""
         self.__option["preamble"] = ""
+        self.__option["engine"] = None
 
     @lazy_attribute
     def _option(self):
@@ -528,16 +529,16 @@ class _Latex_prefs_object(SageObject):
         EXAMPLES::
 
             sage: from sage.misc.latex import _Latex_prefs_object
-            sage: _Latex_prefs_object()._option  # random
-            {'blackboard_bold': False,
-             'matrix_delimiters': ['(', ')'],
-             'vector_delimiters': ['(', ')'],
-             'matrix_column_alignment': 'r',
-             'macros': '',
-             'preamble': '',
-             'engine': 'lualatex'}
+            sage: sorted(_Latex_prefs_object()._option.items())
+            [('blackboard_bold', False),
+             ('engine', None),
+             ('macros', ''),
+             ('matrix_column_alignment', 'r'),
+             ('matrix_delimiters', ['(', ')']),
+             ('preamble', ''),
+             ('vector_delimiters', ['(', ')'])]
+
         """
-        self.__option["engine"] = default_engine()
         return self.__option
 
 

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -475,7 +475,7 @@ def has_latex_attr(x) -> bool:
 
 @cached_function
 def default_engine():
-    """
+    r"""
     Return the default latex engine and the official name of the engine.
 
     This is determined by availability of the popular engines on the user's
@@ -486,6 +486,25 @@ def default_engine():
         sage: from sage.misc.latex import default_engine
         sage: default_engine()  # random
         'lualatex'
+
+    TESTS:
+
+    Ensure that this (expensive) function is not necessary to obtain
+    the latex representation of a matrix (doing so probes the latex
+    options dict for the delimiters)::
+
+        sage: import sage.misc.latex
+        sage: real_de = sage.misc.latex.default_engine
+        sage: def crash():
+        ....:     raise ValueError
+        sage: sage.misc.latex.default_engine = crash
+        sage: latex(matrix.identity(QQ, 2))
+        \left(\begin{array}{rr}
+        1 & 0 \\
+        0 & 1
+        \end{array}\right)
+        sage: sage.misc.latex.default_engine = real_de
+
     """
     from sage.features.latex import pdflatex, xelatex, lualatex
     if lualatex().is_present():

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -502,6 +502,7 @@ def default_engine():
         return 'pdflatex', 'pdfLaTeX'
     return 'latex', 'LaTeX'
 
+
 @cached_function
 def _default_engine():
     r"""
@@ -533,7 +534,6 @@ def _default_engine():
         0 & 1
         \end{array}\right)
         sage: sage.misc.latex._default_engine = real_de
-
     """
     from sage.features.latex import pdflatex, xelatex, lualatex
     if lualatex().is_present():

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -485,16 +485,16 @@ def default_engine():
 
         sage: from sage.misc.latex import default_engine
         sage: default_engine()  # random
-        ('lualatex', 'LuaLaTeX')
+        'lualatex'
     """
     from sage.features.latex import pdflatex, xelatex, lualatex
     if lualatex().is_present():
-        return 'lualatex', 'LuaLaTeX'
+        return 'lualatex'
     if xelatex().is_present():
-        return 'xelatex', 'XeLaTeX'
+        return 'xelatex'
     if pdflatex().is_present():
-        return 'pdflatex', 'pdfLaTeX'
-    return 'latex', 'LaTeX'
+        return 'pdflatex'
+    return 'latex'
 
 
 class _Latex_prefs_object(SageObject):
@@ -535,11 +535,9 @@ class _Latex_prefs_object(SageObject):
              'matrix_column_alignment': 'r',
              'macros': '',
              'preamble': '',
-             'engine': 'lualatex',
-             'engine_name': 'LuaLaTeX'}
+             'engine': 'lualatex'}
         """
-        self.__option["engine"] = default_engine()[0]
-        self.__option["engine_name"] = default_engine()[1]
+        self.__option["engine"] = default_engine()
         return self.__option
 
 
@@ -1535,16 +1533,12 @@ Warning: `{}` is not part of this computer's TeX installation.""".format(file_na
 
         if e == "latex":
             _Latex_prefs._option["engine"] = "latex"
-            _Latex_prefs._option["engine_name"] = "LaTeX"
         elif e == "pdflatex":
             _Latex_prefs._option["engine"] = "pdflatex"
-            _Latex_prefs._option["engine_name"] = "PDFLaTeX"
         elif e == "xelatex":
             _Latex_prefs._option["engine"] = e
-            _Latex_prefs._option["engine_name"] = "XeLaTeX"
         elif e == "lualatex":
             _Latex_prefs._option["engine"] = e
-            _Latex_prefs._option["engine_name"] = "LuaLaTeX"
         else:
             raise ValueError("%s is not a supported LaTeX engine. Use latex, pdflatex, xelatex, or lualatex" % e)
 


### PR DESCRIPTION
We shouldn't need a functional LaTeX engine to turn the matrix `[1]` into `\left(\begin{array}{r}1\end{array}\right)`. We used to try; now we don't. (This avoids compiling a test document in a temporary directory.)

There's some other cleanup at the same time, but the basic idea is to avoid putting the result `default_engine()` in the preferences dict when the preferences dict is constructed. Instead, we now leave the "engine" option set to `None` by default. Inside the functions where latex is actually used, we check...

1. Did the user pass `engine=whatever` to this function?
2. If not, is the "engine" option set in the preferences dict?
3. If not, use the default engine.

So `foo(engine=bar)` overrides the preferences dict, and the preferences dict overrides `default_engine()`.

Closes:

* https://github.com/sagemath/sage/issues/39351
