### PR TITLE
Fixed FFT setting function that assumed that values were uninitialized

### DIFF
--- a/src/sage/calculus/transforms/fft.pyx
+++ b/src/sage/calculus/transforms/fft.pyx
@@ -166,7 +166,7 @@ cdef class FastFourierTransform_complex(FastFourierTransform_base):
 
         TESTS:
 
-        Verify that :issue:10758 is fixed. ::
+        Verify that :issue:`10758` is fixed. ::
 
             sage: F = FFT(1)
             sage: F[0] = (1,1)

--- a/src/sage/calculus/transforms/fft.pyx
+++ b/src/sage/calculus/transforms/fft.pyx
@@ -163,6 +163,16 @@ cdef class FastFourierTransform_complex(FastFourierTransform_base):
             Traceback (most recent call last):
             ...
             TypeError: unable to convert 1.0*I to float; use abs() or real_part() as desired
+
+        TESTS:
+
+        Assigning a value to a pair no longer assumes that the values are uninitialized. ::
+
+            sage: F = FFT(1)
+            sage: F[0] = (1,1)
+            sage: F[0] = 1
+            sage: F[0]
+            (1.0, 0.0)
         """
         # just set real for now
         if i < 0 or i >= self.n:
@@ -172,6 +182,7 @@ cdef class FastFourierTransform_complex(FastFourierTransform_base):
             self.data[2*i+1] = xy[1]
         else:
             self.data[2*i] = xy
+            self.data[2*i+1] = 0
 
     def __getitem__(self, i):
         """

--- a/src/sage/calculus/transforms/fft.pyx
+++ b/src/sage/calculus/transforms/fft.pyx
@@ -166,7 +166,7 @@ cdef class FastFourierTransform_complex(FastFourierTransform_base):
 
         TESTS:
 
-        Assigning a value to a pair no longer assumes that the values are uninitialized. ::
+        Verify that :issue:10758 is fixed. ::
 
             sage: F = FFT(1)
             sage: F[0] = (1,1)


### PR DESCRIPTION
Fixes #10758. Fixed error in the FFT.__setitem__ function of fft.pyx. The function was assuming that the pair of values was uninitialized when assigning values to it. Added the one line of code self.data[2\*i+1] = 0 below the line  self.data[2\*i] = xy as suggested by boothby. Then added a doctest based on the example also given by boothby.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies