### PR TITLE
Fixed randomly failing test in bigraphical hyperplane function

### DIFF
--- a/src/sage/geometry/hyperplane_arrangement/library.py
+++ b/src/sage/geometry/hyperplane_arrangement/library.py
@@ -142,7 +142,10 @@ class HyperplaneArrangementLibrary:
 
         TESTS:
 
-        We try::
+        One of the above examples was marked "# random" because the output is
+        not always the same. However, the answer is "65" more than 99.9% of the
+        time, so we can make a doctest by running it repeatedly
+        (see :issue:39167). ::
 
             sage: G = graphs.CycleGraph(4)
             sage: any(hyperplane_arrangements.bigraphical(G,

--- a/src/sage/geometry/hyperplane_arrangement/library.py
+++ b/src/sage/geometry/hyperplane_arrangement/library.py
@@ -145,7 +145,7 @@ class HyperplaneArrangementLibrary:
         One of the above examples was marked "# random" because the output is
         not always the same. However, the answer is "65" more than 99.9% of the
         time, so we can make a doctest by running it repeatedly
-        (see :issue:39167). ::
+        (see :issue:`39167`). ::
 
             sage: G = graphs.CycleGraph(4)
             sage: any(hyperplane_arrangements.bigraphical(G,

--- a/src/sage/geometry/hyperplane_arrangement/library.py
+++ b/src/sage/geometry/hyperplane_arrangement/library.py
@@ -130,7 +130,8 @@ class HyperplaneArrangementLibrary:
             sage: HA = hyperplane_arrangements.bigraphical(G, A)
             sage: HA.n_regions()
             63
-            sage: hyperplane_arrangements.bigraphical(G, 'generic').n_regions()
+            sage: hyperplane_arrangements.bigraphical(G, # random
+            ....:   'generic').n_regions()
             65
             sage: hyperplane_arrangements.bigraphical(G).n_regions()
             59
@@ -138,6 +139,15 @@ class HyperplaneArrangementLibrary:
         REFERENCES:
 
         - [HP2016]_
+
+        TESTS:
+
+        We try::
+
+            sage: G = graphs.CycleGraph(4)
+            sage: any(hyperplane_arrangements.bigraphical(G,
+            ....:   'generic').n_regions() == 65 for _ in range(5))
+            True
         """
         n = G.num_verts()
         if A is None:  # default to G-semiorder arrangement


### PR DESCRIPTION
Fixes #39167. Fixed a doctest in the bigraphical function for hyperplanes that had a test failing every 1 in 1000 times. Made example have # random so it can fail and made a separate test in the test block that runs the original test 5 times.
### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies