### PR TITLE
Refactor import statements to use absolute paths for PyPolyBoRi

### DIFF
--- a/src/sage/rings/polynomial/pbori/PyPolyBoRi.py
+++ b/src/sage/rings/polynomial/pbori/PyPolyBoRi.py
@@ -99,6 +99,7 @@ BoolePolynomialVector = BooleanPolynomialVector
 def WeakRingRef(ring):
     return weakref.weakref(ring)
 
+
 _add_up_polynomials = add_up_polynomials
 
 

--- a/src/sage/rings/polynomial/pbori/PyPolyBoRi.py
+++ b/src/sage/rings/polynomial/pbori/PyPolyBoRi.py
@@ -75,10 +75,10 @@ from sage.rings.polynomial.pbori.pbori import (
 )
 
 # The following imports are necessary to make these objects available for backward compatibility
-from sage.rings.polynomial.pbori.pbori import Monomial as Monomial
-from sage.rings.polynomial.pbori.pbori import OrderCode as OrderCode
-from sage.rings.polynomial.pbori.pbori import Polynomial as Polynomial
-from sage.rings.polynomial.pbori.pbori import Variable as Variable
+from sage.rings.polynomial.pbori.pbori import Monomial as Monomial  # noqa: PLC0414
+from sage.rings.polynomial.pbori.pbori import OrderCode as OrderCode  # noqa: PLC0414
+from sage.rings.polynomial.pbori.pbori import Polynomial as Polynomial  # noqa: PLC0414
+from sage.rings.polynomial.pbori.pbori import Variable as Variable  # noqa: PLC0414
 from sage.rings.polynomial.pbori.pbori import gauss_on_polys as _gauss_on_polys
 
 

--- a/src/sage/rings/polynomial/pbori/PyPolyBoRi.py
+++ b/src/sage/rings/polynomial/pbori/PyPolyBoRi.py
@@ -65,15 +65,21 @@ AUTHOR:
         [a, b, c, d, e, y2]
 """
 
-from .pbori import (order_dict, TermOrder_from_pb_order, BooleanPolynomialRing,
-                    BooleanPolynomialVector, MonomialFactory,
-                    PolynomialFactory, VariableFactory, add_up_polynomials)
-from .pbori import gauss_on_polys as _gauss_on_polys
-
 import weakref
 
+from sage.rings.polynomial.pbori.pbori import (
+    BooleanPolynomialRing,
+    BooleanPolynomialVector,
+    TermOrder_from_pb_order,
+    add_up_polynomials,
+)
 
-OrderCode = type('OrderCode', (object,), order_dict)
+# The following imports are necessary to make these objects available for backward compatibility
+from sage.rings.polynomial.pbori.pbori import Monomial as Monomial
+from sage.rings.polynomial.pbori.pbori import OrderCode as OrderCode
+from sage.rings.polynomial.pbori.pbori import Polynomial as Polynomial
+from sage.rings.polynomial.pbori.pbori import Variable as Variable
+from sage.rings.polynomial.pbori.pbori import gauss_on_polys as _gauss_on_polys
 
 
 def Ring(n, order='lp', names=None, blocks=None):
@@ -92,12 +98,6 @@ BoolePolynomialVector = BooleanPolynomialVector
 # todo: PolyBoRi's original interface uses its WeakRingPtr here
 def WeakRingRef(ring):
     return weakref.weakref(ring)
-
-
-Monomial = MonomialFactory()
-Polynomial = PolynomialFactory()
-Variable = VariableFactory()
-
 
 _add_up_polynomials = add_up_polynomials
 

--- a/src/sage/rings/polynomial/pbori/__init__.py
+++ b/src/sage/rings/polynomial/pbori/__init__.py
@@ -29,3 +29,15 @@ M. Brickenstein, A. Dreyer, PolyBoRi:
 Electronic Proceedings of the MEGA 2007 - Effective Methods in Algebraic Geometry, Strobl, Austria, June 2007.
 http://www.ricam.oeaw.ac.at/mega2007/electronic/electronic.html
 """
+from sage.misc.lazy_import import lazy_import
+from .PyPolyBoRi import Ring, Polynomial, Monomial, Variable
+
+# Get all-inclusive groebner routine
+from .gbcore import groebner_basis
+from .nf import normal_form
+
+# Import some high-level modelling functionality
+from .blocks import declare_ring
+from .blocks import HigherOrderBlock, AlternatingBlock, Block
+from .gbrefs import load_file
+from .specialsets import all_monomials_of_degree_d, power_set

--- a/src/sage/rings/polynomial/pbori/__init__.py
+++ b/src/sage/rings/polynomial/pbori/__init__.py
@@ -29,15 +29,3 @@ M. Brickenstein, A. Dreyer, PolyBoRi:
 Electronic Proceedings of the MEGA 2007 - Effective Methods in Algebraic Geometry, Strobl, Austria, June 2007.
 http://www.ricam.oeaw.ac.at/mega2007/electronic/electronic.html
 """
-from sage.misc.lazy_import import lazy_import
-from .PyPolyBoRi import Ring, Polynomial, Monomial, Variable
-
-# Get all-inclusive groebner routine
-from .gbcore import groebner_basis
-from .nf import normal_form
-
-# Import some high-level modelling functionality
-from .blocks import declare_ring
-from .blocks import HigherOrderBlock, AlternatingBlock, Block
-from .gbrefs import load_file
-from .specialsets import all_monomials_of_degree_d, power_set

--- a/src/sage/rings/polynomial/pbori/blocks.py
+++ b/src/sage/rings/polynomial/pbori/blocks.py
@@ -1,8 +1,13 @@
 import sys
 from itertools import chain, islice
 
-from .pbori import VariableBlock
-from .PyPolyBoRi import (Ring, Polynomial, VariableFactory, Variable)
+from sage.rings.polynomial.pbori.pbori import (
+    Polynomial,
+    Variable,
+    VariableBlock,
+    VariableFactory,
+)
+from sage.rings.polynomial.pbori.PyPolyBoRi import Ring
 
 
 class Block:

--- a/src/sage/rings/polynomial/pbori/cnf.py
+++ b/src/sage/rings/polynomial/pbori/cnf.py
@@ -1,7 +1,8 @@
 from random import Random
+
 from sage.rings.polynomial.pbori.pbori import if_then_else as ite
-from .PyPolyBoRi import Polynomial
-from .statistics import used_vars_set
+from sage.rings.polynomial.pbori.PyPolyBoRi import Polynomial
+from sage.rings.polynomial.pbori.statistics import used_vars_set
 
 
 class CNFEncoder:

--- a/src/sage/rings/polynomial/pbori/easy_polynomials.py
+++ b/src/sage/rings/polynomial/pbori/easy_polynomials.py
@@ -1,5 +1,8 @@
-from .interpolate import variety_lex_leading_terms, nf_lex_points
-from .pbori import easy_linear_factors
+from sage.rings.polynomial.pbori.interpolate import (
+    nf_lex_points,
+    variety_lex_leading_terms,
+)
+from sage.rings.polynomial.pbori.pbori import easy_linear_factors
 
 
 def easy_linear_polynomials(p):

--- a/src/sage/rings/polynomial/pbori/fglm.py
+++ b/src/sage/rings/polynomial/pbori/fglm.py
@@ -1,5 +1,5 @@
-from .pbori import BooleSet, FGLMStrategy
-from .PyPolyBoRi import BoolePolynomialVector, Polynomial
+from sage.rings.polynomial.pbori.pbori import BooleSet, FGLMStrategy
+from sage.rings.polynomial.pbori.PyPolyBoRi import BoolePolynomialVector, Polynomial
 
 
 def _fglm(I, from_ring, to_ring):

--- a/src/sage/rings/polynomial/pbori/frontend.py
+++ b/src/sage/rings/polynomial/pbori/frontend.py
@@ -31,9 +31,10 @@ EXAMPLES::
 """
 
 
-from .PyPolyBoRi import Ring
-from .pbori import VariableFactory
-from .blocks import declare_ring as orig_declare_ring
+from sage.features import FeatureNotPresentError
+from sage.rings.polynomial.pbori.blocks import declare_ring as orig_declare_ring
+from sage.rings.polynomial.pbori.pbori import VariableFactory
+from sage.rings.polynomial.pbori.PyPolyBoRi import Ring
 
 
 def block_scheme_names(blocks):

--- a/src/sage/rings/polynomial/pbori/gbcore.py
+++ b/src/sage/rings/polynomial/pbori/gbcore.py
@@ -1,18 +1,28 @@
 import contextlib
 from copy import copy
-from itertools import chain
 from inspect import getfullargspec as getargspec
+from itertools import chain
 
-from .nf import GeneratorLimitExceeded, symmGB_F2_C, symmGB_F2_python
-from .pbori import GroebnerStrategy, ll_red_nf_redsb
-from .PyPolyBoRi import (Monomial, Polynomial,
-                         OrderCode)
-from .ll import eliminate, ll_encode
-from .statistics import used_vars_set
-from .heuristics import dense_system, gauss_on_linear
-from .easy_polynomials import easy_linear_polynomials
-from .interpolate import lex_groebner_basis_for_polynomial_via_variety
-from .fglm import _fglm
+from sage.rings.polynomial.pbori.easy_polynomials import easy_linear_polynomials
+from sage.rings.polynomial.pbori.fglm import _fglm
+from sage.rings.polynomial.pbori.heuristics import dense_system, gauss_on_linear
+from sage.rings.polynomial.pbori.interpolate import (
+    lex_groebner_basis_for_polynomial_via_variety,
+)
+from sage.rings.polynomial.pbori.ll import eliminate, ll_encode
+from sage.rings.polynomial.pbori.nf import (
+    GeneratorLimitExceeded,
+    symmGB_F2_C,
+    symmGB_F2_python,
+)
+from sage.rings.polynomial.pbori.pbori import (
+    GroebnerStrategy,
+    Monomial,
+    OrderCode,
+    Polynomial,
+    ll_red_nf_redsb,
+)
+from sage.rings.polynomial.pbori.statistics import used_vars_set
 
 
 def get_options_from_function(f):

--- a/src/sage/rings/polynomial/pbori/gbrefs.py
+++ b/src/sage/rings/polynomial/pbori/gbrefs.py
@@ -1,9 +1,11 @@
-import gzip
-from io import StringIO
 import base64 as uu
+import gzip
 import re
+from io import StringIO
 from types import ModuleType
-from .PyPolyBoRi import Polynomial
+
+from sage.rings.polynomial.pbori.PyPolyBoRi import Polynomial
+
 AUTO = "auto"
 SINGLE = "single"
 

--- a/src/sage/rings/polynomial/pbori/heuristics.py
+++ b/src/sage/rings/polynomial/pbori/heuristics.py
@@ -1,4 +1,4 @@
-from .PyPolyBoRi import Polynomial, gauss_on_polys
+from sage.rings.polynomial.pbori.PyPolyBoRi import Polynomial, gauss_on_polys
 
 
 def dense_system(I):

--- a/src/sage/rings/polynomial/pbori/interpolate.py
+++ b/src/sage/rings/polynomial/pbori/interpolate.py
@@ -1,14 +1,21 @@
 # Copyright (c) 2005-2007 by The PolyBoRi Team
-from time import process_time as clock
 from random import Random
+from time import process_time as clock
 
-from .PyPolyBoRi import (Polynomial, Variable, Monomial,
-                         BoolePolynomialVector)
-from .randompoly import gen_random_poly
-from .pbori import (BooleSet, add_up_polynomials, interpolate_smallest_lex,
-                    interpolate)
-from .blocks import Block, declare_ring
-
+from sage.rings.polynomial.pbori.blocks import Block, declare_ring
+from sage.rings.polynomial.pbori.pbori import (
+    BooleSet,
+    Monomial,
+    Polynomial,
+    Variable,
+    add_up_polynomials,
+    interpolate,
+    interpolate_smallest_lex,
+)
+from sage.rings.polynomial.pbori.PyPolyBoRi import (
+    BoolePolynomialVector,
+)
+from sage.rings.polynomial.pbori.randompoly import gen_random_poly
 
 generator = Random()
 

--- a/src/sage/rings/polynomial/pbori/interred.py
+++ b/src/sage/rings/polynomial/pbori/interred.py
@@ -1,5 +1,4 @@
-from .pbori import ReductionStrategy
-from .PyPolyBoRi import Polynomial
+from sage.rings.polynomial.pbori.pbori import Polynomial, ReductionStrategy
 
 
 def interred(l, completely=False):

--- a/src/sage/rings/polynomial/pbori/ll.py
+++ b/src/sage/rings/polynomial/pbori/ll.py
@@ -1,10 +1,20 @@
-from .pbori import (top_index, if_then_else,
-                    substitute_variables, BooleSet,
-                    ll_red_nf_redsb, ll_red_nf_noredsb,
-                    ll_red_nf_noredsb_single_recursive_call)
-from .PyPolyBoRi import (Polynomial, Monomial, Ring, BoolePolynomialVector)
-from .statistics import used_vars_set
-from .rank import rank
+from sage.rings.polynomial.pbori.pbori import (
+    BooleSet,
+    Monomial,
+    Polynomial,
+    if_then_else,
+    ll_red_nf_noredsb,
+    ll_red_nf_noredsb_single_recursive_call,
+    ll_red_nf_redsb,
+    substitute_variables,
+    top_index,
+)
+from sage.rings.polynomial.pbori.PyPolyBoRi import (
+    BoolePolynomialVector,
+    Ring,
+)
+from sage.rings.polynomial.pbori.rank import rank
+from sage.rings.polynomial.pbori.statistics import used_vars_set
 
 lead_index = top_index
 

--- a/src/sage/rings/polynomial/pbori/nf.py
+++ b/src/sage/rings/polynomial/pbori/nf.py
@@ -1,14 +1,24 @@
 from pathlib import Path
 from warnings import warn
 
-from sage.rings.polynomial.pbori.pbori import mod_mon_set
-from .pbori import (BooleSet, GroebnerStrategy, ReductionStrategy,
-                    parallel_reduce, easy_linear_factors)
-from .PyPolyBoRi import (Monomial, Polynomial, Variable,
-                         BoolePolynomialVector)
-from .easy_polynomials import (easy_linear_polynomials as
-                               easy_linear_polynomials_func)
-from .statistics import used_vars_set
+from sage.rings.polynomial.pbori.easy_polynomials import (
+    easy_linear_polynomials as easy_linear_polynomials_func,
+)
+from sage.rings.polynomial.pbori.pbori import (
+    BooleSet,
+    GroebnerStrategy,
+    Monomial,
+    Polynomial,
+    ReductionStrategy,
+    Variable,
+    easy_linear_factors,
+    mod_mon_set,
+    parallel_reduce,
+)
+from sage.rings.polynomial.pbori.PyPolyBoRi import (
+    BoolePolynomialVector,
+)
+from sage.rings.polynomial.pbori.statistics import used_vars_set
 
 
 class GeneratorLimitExceeded(Exception):

--- a/src/sage/rings/polynomial/pbori/parallel.py
+++ b/src/sage/rings/polynomial/pbori/parallel.py
@@ -5,12 +5,22 @@ PolyBoRi
 Created by Michael Brickenstein on 2008-10-31.
 Copyright 2008 The PolyBoRi Team
 """
-from zlib import compress, decompress
 import copyreg
+from zlib import compress, decompress
 
-from .pbori import if_then_else, BooleSet, CCuddNavigator
-from .PyPolyBoRi import (Polynomial, Ring, WeakRingRef, Monomial, Variable)
-from .gbcore import groebner_basis
+from sage.rings.polynomial.pbori.gbcore import groebner_basis
+from sage.rings.polynomial.pbori.pbori import (
+    BooleSet,
+    CCuddNavigator,
+    Monomial,
+    Polynomial,
+    Variable,
+    if_then_else,
+)
+from sage.rings.polynomial.pbori.PyPolyBoRi import (
+    Ring,
+    WeakRingRef,
+)
 
 
 def to_fast_pickable(l):

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -191,7 +191,7 @@ import sage.misc.weak_dict
 from sage.rings.integer import Integer
 from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF
 
-from sage.rings.polynomial.polynomial_element cimport Polynomial
+from sage.rings.polynomial.polynomial_element cimport Polynomial as Polynomial_generic
 from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
 from sage.rings.polynomial.term_order import TermOrder
 from sage.rings.polynomial.polynomial_ring import PolynomialRing_generic
@@ -853,7 +853,7 @@ cdef class BooleanPolynomialRing(BooleanPolynomialRing_base):
                     new_monom *= var_mapping[i]
                 p += new_monom
             return p
-        elif isinstance(other, (MPolynomial, Polynomial)) and \
+        elif isinstance(other, (MPolynomial, Polynomial_generic)) and \
                 self.base_ring().has_coerce_map_from(other.base_ring()) and \
                 (other.parent().ngens() <= self._pbring.nVariables()):
             try:
@@ -966,7 +966,7 @@ cdef class BooleanPolynomialRing(BooleanPolynomialRing_base):
                     new_monom *= var_mapping[i]
                 p += new_monom
             return p
-        elif (isinstance(other, (MPolynomial, Polynomial))) and \
+        elif (isinstance(other, (MPolynomial, Polynomial_generic))) and \
                 self.base_ring().has_coerce_map_from(other.base_ring()):
             try:
                 var_mapping = get_var_mapping(self, other)
@@ -975,7 +975,7 @@ cdef class BooleanPolynomialRing(BooleanPolynomialRing_base):
             p = self._zero_element
             exponents = other.exponents()
             coefs = other.coefficients()
-            if isinstance(other, Polynomial):
+            if isinstance(other, Polynomial_generic):
                 # we have a univariate polynomial.
                 # That case had only been implemented
                 # in github issue #9138:

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -8100,6 +8100,6 @@ cdef class PolynomialFactory:
             raise TypeError("cannot convert %s to BooleanPolynomial" %
                             type(arg))
 
-cdef MonomialFactory Monomial = MonomialFactory()
-cdef PolynomialFactory Polynomial = PolynomialFactory()
-cdef VariableFactory Variable = VariableFactory()
+Monomial = MonomialFactory()
+Polynomial = PolynomialFactory()
+Variable = VariableFactory()

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -223,6 +223,7 @@ order_dict = {"lp": pblp,
               "block_dp_asc": pbblock_dp_asc,
               "block_dp": pbblock_dp}
 
+OrderCode = type('OrderCode', (object,), order_dict)
 
 inv_order_dict = {pblp: "lex",
                   pbdlex: "deglex",
@@ -8098,3 +8099,7 @@ cdef class PolynomialFactory:
 
             raise TypeError("cannot convert %s to BooleanPolynomial" %
                             type(arg))
+
+Monomial = MonomialFactory()
+Polynomial = PolynomialFactory()
+Variable = VariableFactory()

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -8100,6 +8100,6 @@ cdef class PolynomialFactory:
             raise TypeError("cannot convert %s to BooleanPolynomial" %
                             type(arg))
 
-Monomial = MonomialFactory()
-Polynomial = PolynomialFactory()
-Variable = VariableFactory()
+cdef MonomialFactory Monomial = MonomialFactory()
+cdef PolynomialFactory Polynomial = PolynomialFactory()
+cdef VariableFactory Variable = VariableFactory()

--- a/src/sage/rings/polynomial/pbori/randompoly.py
+++ b/src/sage/rings/polynomial/pbori/randompoly.py
@@ -1,10 +1,16 @@
-from random import Random
 from pprint import pformat
+from random import Random
 
-from .PyPolyBoRi import (Monomial, Polynomial, Variable)
-from .pbori import random_set, set_random_seed, ll_red_nf_redsb
-from .ll import ll_encode
-from .blocks import declare_ring
+from sage.rings.polynomial.pbori.blocks import declare_ring
+from sage.rings.polynomial.pbori.ll import ll_encode
+from sage.rings.polynomial.pbori.pbori import (
+    Monomial,
+    Polynomial,
+    Variable,
+    ll_red_nf_redsb,
+    random_set,
+    set_random_seed,
+)
 
 
 def gen_random_poly(ring, l, deg, vars_set, seed=123):

--- a/src/sage/rings/polynomial/pbori/specialsets.py
+++ b/src/sage/rings/polynomial/pbori/specialsets.py
@@ -1,6 +1,13 @@
-from .pbori import (top_index, if_then_else,
-                    mod_mon_set, BooleSet, BooleConstant)
-from .PyPolyBoRi import (Polynomial, Monomial, Variable)
+from sage.rings.polynomial.pbori.pbori import (
+    BooleConstant,
+    BooleSet,
+    Monomial,
+    Polynomial,
+    Variable,
+    if_then_else,
+    mod_mon_set,
+    top_index,
+)
 
 
 def all_monomials_of_degree_d_old(d, variables):

--- a/src/sage/rings/polynomial/pbori/statistics.py
+++ b/src/sage/rings/polynomial/pbori/statistics.py
@@ -1,5 +1,9 @@
-from .pbori import top_index, BooleConstant
-from .PyPolyBoRi import Monomial, Polynomial
+from sage.rings.polynomial.pbori.pbori import (
+    BooleConstant,
+    Monomial,
+    Polynomial,
+    top_index,
+)
 
 
 def used_vars(l, bound=None):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Also move the creation of the objects `Monomial`, `Polynomial` and `Variable` to `pbori.pyx`, which makes it easier to handle the case when brial is not available and thus the cython module is not compiled (with meson).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


