### PR TITLE
Fix documentation of integral_points

### DIFF
--- a/src/sage/geometry/integral_points.py
+++ b/src/sage/geometry/integral_points.py
@@ -1,3 +1,7 @@
+r"""
+Cython helper methods to compute integral points in polyhedra
+"""
+
 try:
     from .integral_points_integer_dense import (
         parallelotope_points,

--- a/src/sage/geometry/integral_points.py
+++ b/src/sage/geometry/integral_points.py
@@ -26,3 +26,9 @@ except ImportError:
         Inequality_int,
         InequalityCollection,
     )
+
+
+# __all__ is needed to generate Sphinx documentation
+__all__ = ['InequalityCollection', 'Inequality_generic', 'Inequality_int',
+           'loop_over_parallelotope_points', 'parallelotope_points', 'print_cache',
+           'ray_matrix_normal_form', 'rectangular_box_points', 'simplex_points']


### PR DESCRIPTION
Fixes https://github.com/sagemath/sage/issues/39395

Replacement for https://github.com/sagemath/sage/pull/39414 

Check https://doc-pr-39468--sagemath.netlify.app/html/en/reference/discrete_geometry/ and https://doc-pr-39468--sagemath.netlify.app/html/en/reference/discrete_geometry/sage/geometry/integral_points to see it is fixed.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


