### PR TITLE
small improvement in `classically_highest_weight_vectors`

### DIFF
--- a/src/sage/categories/loop_crystals.py
+++ b/src/sage/categories/loop_crystals.py
@@ -773,16 +773,17 @@ class KirillovReshetikhinCrystals(Category_singleton):
                     except StopIteration:
                         it.pop()
                         if path:
-                            path.pop(0)
+                            path.pop()
                         continue
 
-                    b = self.element_class(self, [x] + path)
+                    path.append(x)
+                    b = self.element_class(self, reversed(path))
                     if not b.is_highest_weight(index_set=I0):
+                        path.pop()
                         continue
-                    path.insert(0, x)
                     if len(path) == n:
                         ret.append(b)
-                        path.pop(0)
+                        path.pop()
                     else:
                         it.append(iter(self.crystals[-len(path) - 1]))
                 return tuple(ret)


### PR DESCRIPTION
The change is to avoid insertions and removals at the beginning of a list as these operations require linear time in the length of the list. We instead build the reverse path (append and pop at the end of the list in constant time) and use method `reversed` when needed.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


