### PR TITLE
use decomposition into biconnected components in Gomory-Hu tree

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -7852,6 +7852,26 @@ class Graph(GenericGraph):
             sage: g.edge_connectivity() == min(t.edge_labels()) or not g.is_connected()
             True
 
+        If the graph has an edge whose removal increases the number of connected
+        components, the flow between the parts separated by this edge is one::
+
+            sage: g = Graph()
+            sage: g.add_clique([1, 2, 3, 4])
+            sage: g.add_clique([5, 6, 7, 8])
+            sage: g.add_edge(1, 5)
+            sage: t = g.gomory_hu_tree()
+            sage: t.edge_label(1, 5)
+            1
+            sage: g.flow(randint(1, 4), randint(5, 8)) == t.edge_label(1, 5)
+            True
+            sage: for u, v in g.edge_iterator(labels=False):
+            ....:     g.set_edge_label(u, v, 3)
+            sage: t = g.gomory_hu_tree()
+            sage: t.edge_label(1, 5)
+            3
+            sage: g.flow(randint(1, 4), randint(5, 8)) == t.edge_label(1, 5)
+            True
+
         TESTS:
 
         :issue:`16475`::
@@ -7883,11 +7903,22 @@ class Graph(GenericGraph):
 
         # We use a stack to avoid recursion. An element of the stack contains
         # the graph to be processed and the corresponding set of "real" vertices
-        # (as opposed to the fakes one introduced during the computations.
-        if self.is_connected():
+        # (as opposed to the fakes one introduced during the computations).
+        blocks = self.blocks_and_cut_vertices()[0]
+        if len(blocks) == 1 and len(blocks[0]) == self.order():
+            # The graph is biconnected
             stack = [(self, frozenset(self))]
         else:
-            stack = [(cc, frozenset(cc)) for cc in self.connected_components_subgraphs()]
+            stack = []
+            for block in blocks:
+                if len(block) == 2:
+                    # This block is a cut-edge. It corresponds to an edge of the
+                    # tree with capacity 1 if the label is None
+                    u, v = block
+                    label = self.edge_label(u, v)
+                    T.add_edge(u, v, 1 if label is None else label)
+                else:
+                    stack.append((self.subgraph(block), frozenset(block)))
 
         # We now iteratively decompose the graph to build the tree
         while stack:


### PR DESCRIPTION
We use method `blocks_and_cut_vertices` to decompose the graph into biconnected components.
- isolated vertices can be ignored
- a block of size 2 is a cut-edge. It suffices to add an edge of capacity 1 to the tree.
- it remains to compute the Gomory-Hu trees of the remaining biconnected components.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


