### PR TITLE
Fix issue on matrix construction over integer mod ring for large coefficients

### DIFF
--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -514,6 +514,9 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             sage: Matrix(Integers(4618990), 2, 2, [-1, int(-2), GF(7)(-3), 1/7])        # needs sage.rings.finite_rings
             [4618989 4618988]
             [      4 2639423]
+
+            sage: Matrix(IntegerModRing(200), [[int(2**128+1), int(2**256+1), int(2**1024+1)]])        # needs sage.rings.finite_rings
+            [ 57 137  17]
         """
         ma = MatrixArgs_init(parent, entries)
         cdef long i, j

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -525,10 +525,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             se = <SparseEntry>t
             x = se.entry
             v = self._matrix[se.i]
-            if type(x) is int:
-                tmp = (<long>x) % p
-                v[se.j] = tmp + (tmp<0)*p
-            elif type(x) is IntegerMod_int and (<IntegerMod_int>x)._parent is R:
+            if type(x) is IntegerMod_int and (<IntegerMod_int>x)._parent is R:
                 v[se.j] = <celement>(<IntegerMod_int>x).ivalue
             elif type(x) is Integer:
                 if coerce:


### PR DESCRIPTION
Fixes #36104.

In previous versions of Python, `int` size was limited and therefore could be cast to `long`. With Python 3 this limit does not exists and the code breaks with large integers. We modify the construction of `Matrix_modn_dense_template`  from Python integers, directly using some existing cast from Sage.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.