### PR TITLE
fixing doctests failures in misc/latex*.py

### DIFF
--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -1025,7 +1025,6 @@ class Latex(LatexCall):
             ''
             sage: latex.eval(r"\ThisIsAnInvalidCommand", {}) # optional -- latex ImageMagick
             An error occurred...
-            No pages of output...
         """
         MACROS = latex_extra_preamble()
 

--- a/src/sage/misc/latex_standalone.py
+++ b/src/sage/misc/latex_standalone.py
@@ -676,7 +676,7 @@ class Standalone(SageObject):
             Traceback (most recent call last):
             ...
             CalledProcessError: Command '['...latex', '-interaction=nonstopmode',
-            'tikz_...tex']' returned nonzero exit status 1.
+            'tikz_...tex']' returned non-zero exit status 1.
         """
         from sage.features.latex import lualatex, pdflatex
 
@@ -797,7 +797,7 @@ class Standalone(SageObject):
             Traceback (most recent call last):
             ...
             CalledProcessError: Command '['latex', '-interaction=nonstopmode',
-            'tikz_...tex']' returned nonzero exit status 1.
+            'tikz_...tex']' returned non-zero exit status 1.
 
         We test the behavior when a wrong value is provided::
 


### PR DESCRIPTION
On 10.5.beta6, the command

`sage -t --long --optional=sage,latex src/sage/misc/latex.py src/sage/misc/latex_standalone.py`

gives

```
sage -t --long src/sage/misc/latex.py  # 1 doctest failed
sage -t --long src/sage/misc/latex_standalone.py  # 2 doctests failed
```

This PR fixes this.