### PR TITLE
Fix more doctests in meson_editable install

### DIFF
--- a/src/sage/doctest/external.py
+++ b/src/sage/doctest/external.py
@@ -366,6 +366,10 @@ def external_features():
     r"""
     Generate the features that are only to be tested if ``--optional=external`` is used.
 
+    .. SEEALSO::
+
+        :func:`sage.features.all.all_features`
+
     EXAMPLES::
 
         sage: from sage.doctest.external import external_features

--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -87,7 +87,17 @@ def get_basename(path):
         sage: import os
         sage: get_basename(sage.doctest.sources.__file__)
         'sage.doctest.sources'
+
+    ::
+
+        sage: # optional - !meson_editable
         sage: get_basename(os.path.join(sage.structure.__path__[0], 'element.pxd'))
+        'sage.structure.element.pxd'
+
+    TESTS::
+
+        sage: # optional - meson_editable
+        sage: get_basename(os.path.join(os.path.dirname(sage.structure.__file__), 'element.pxd'))
         'sage.structure.element.pxd'
     """
     if path is None:

--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -319,6 +319,10 @@ def sage_include_directories(use_sources=False):
         sage: dirs = sage.env.sage_include_directories(use_sources=True)
         sage: any(os.path.isfile(os.path.join(d, file)) for d in dirs)
         True
+
+    ::
+
+        sage: # optional - !meson_editable (no need, see :issue:`39275`)
         sage: dirs = sage.env.sage_include_directories(use_sources=False)
         sage: any(os.path.isfile(os.path.join(d, file)) for d in dirs)
         True

--- a/src/sage/features/meson_editable.py
+++ b/src/sage/features/meson_editable.py
@@ -1,0 +1,45 @@
+r"""
+Feature for testing if Meson editable install is used.
+"""
+
+import sys
+from . import Feature, FeatureTestResult
+
+
+class MesonEditable(Feature):
+    r"""
+    A :class:`~sage.features.Feature` describing if Meson editable install is used.
+
+    EXAMPLES::
+
+        sage: from sage.features.meson_editable import MesonEditable
+        sage: MesonEditable()
+        Feature('meson_editable')
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.meson_editable import MesonEditable
+            sage: MesonEditable() is MesonEditable()
+            True
+        """
+        Feature.__init__(self, 'meson_editable')
+
+    def _is_present(self):
+        r"""
+        Test whether Meson editable install is used.
+
+        EXAMPLES::
+
+            sage: from sage.features.meson_editable import MesonEditable
+            sage: MesonEditable()._is_present()  # random
+            FeatureTestResult('meson_editable', True)
+        """
+        import sage
+        result = type(sage.__loader__).__module__ == '_sagemath_editable_loader'
+        return FeatureTestResult(self, result)
+
+
+def all_features():
+    return [MesonEditable()]

--- a/src/sage/misc/package_dir.py
+++ b/src/sage/misc/package_dir.py
@@ -274,7 +274,7 @@ def is_package_or_sage_namespace_package_dir(path, *, distribution_filter=None):
         sage: # optional - !meson_editable
         sage: directory = os.path.join(sage.libs.__path__[0], 'mpfr'); directory
         '.../sage/libs/mpfr'
-        sage: is_package_or_sage_namespace_package_dir(directory)
+        sage: is_package_or_sage_namespace_package_dir(directory)       # known bug (seen in build.yml)
         True
 
     :mod:`sage` is designated to become an implicit namespace package::

--- a/src/sage/misc/package_dir.py
+++ b/src/sage/misc/package_dir.py
@@ -261,6 +261,7 @@ def is_package_or_sage_namespace_package_dir(path, *, distribution_filter=None):
 
     :mod:`sage.cpython` is an ordinary package::
 
+        sage: # optional - !meson_editable
         sage: from sage.misc.package_dir import is_package_or_sage_namespace_package_dir
         sage: directory = sage.cpython.__path__[0]; directory
         '.../sage/cpython'
@@ -270,23 +271,47 @@ def is_package_or_sage_namespace_package_dir(path, *, distribution_filter=None):
     :mod:`sage.libs.mpfr` only has an ``__init__.pxd`` file, but we consider
     it a package directory for consistency with Cython::
 
+        sage: # optional - !meson_editable
         sage: directory = os.path.join(sage.libs.__path__[0], 'mpfr'); directory
         '.../sage/libs/mpfr'
-        sage: is_package_or_sage_namespace_package_dir(directory)       # known bug (seen in build.yml)
+        sage: is_package_or_sage_namespace_package_dir(directory)
         True
 
     :mod:`sage` is designated to become an implicit namespace package::
 
+        sage: # optional - !meson_editable
         sage: directory = sage.__path__[0]; directory
         '.../sage'
-        sage: is_package_or_sage_namespace_package_dir(directory)       # known bug (seen in build.yml)
+        sage: is_package_or_sage_namespace_package_dir(directory)
         True
 
     Not a package::
 
+        sage: # optional - !meson_editable
         sage: directory = os.path.join(sage.symbolic.__path__[0], 'ginac'); directory   # needs sage.symbolic
         '.../sage/symbolic/ginac'
         sage: is_package_or_sage_namespace_package_dir(directory)                       # needs sage.symbolic
+        False
+
+    TESTS::
+
+        sage: # optional - meson_editable
+        sage: from sage.misc.package_dir import is_package_or_sage_namespace_package_dir
+        sage: directory = os.path.dirname(sage.cpython.__file__); directory
+        '.../sage/cpython'
+        sage: is_package_or_sage_namespace_package_dir(directory)
+        True
+
+        sage: # optional - meson_editable
+        sage: directory = os.path.join(os.path.dirname(sage.libs.__file__), 'mpfr'); directory
+        '.../sage/libs/mpfr'
+        sage: is_package_or_sage_namespace_package_dir(directory)
+        True
+
+        sage: # optional - meson_editable, sage.symbolic
+        sage: directory = os.path.join(os.path.dirname(sage.symbolic.__file__), 'ginac'); directory
+        '.../sage/symbolic/ginac'
+        sage: is_package_or_sage_namespace_package_dir(directory)
         False
     """
     if os.path.exists(os.path.join(path, '__init__.py')):                # ordinary package
@@ -345,8 +370,15 @@ def walk_packages(path=None, prefix='', onerror=None):
 
     EXAMPLES::
 
+        sage: # optional - !meson_editable
         sage: sorted(sage.misc.package_dir.walk_packages(sage.misc.__path__))  # a namespace package
         [..., ModuleInfo(module_finder=FileFinder('.../sage/misc'), name='package_dir', ispkg=False), ...]
+
+    TESTS::
+
+        sage: # optional - meson_editable
+        sage: sorted(sage.misc.package_dir.walk_packages(sage.misc.__path__))
+        [..., ModuleInfo(module_finder=<...MesonpyPathFinder object...>, name='package_dir', ispkg=False), ...]
     """
     # Adapted from https://github.com/python/cpython/blob/3.11/Lib/pkgutil.py
 


### PR DESCRIPTION
Fix more bugs uncovered by https://github.com/sagemath/sage/pull/39369 .

Add a feature flag `meson_editable`, and put doctests behind this flag accordingly.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


