### PR TITLE
Add deformation cones and checking for regularity for Point Configurations and normal fans of Polyhedra

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -104,6 +104,10 @@ REFERENCES:
              graphs and isoperimetric inequalities*, The Annals of Probability
              32 (2004), no.  3A, 1727-1745.
 
+.. [ACEP2020] Federico Ardila, Federico Castillo, Christopher Eur, Alexander Postnikov,
+         *Coxeter submodular functions and deformations of Coxeter permutahedra*,
+         Advances in Mathematics, Volume 365, 13 May 2020.
+
 .. [ALL2002] P. Auger, G. Labelle and P. Leroux, *Combinatorial
              addition formulas and applications*, Advances in Applied
              Mathematics 28 (2002) 302-342.

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -2444,7 +2444,7 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         Check if ``self`` is regular.
 
         A rational polyhedral fan is *regular* if it is the normal fan of a
-    polytope.
+        polytope.
 
         OUTPUT: ``True`` if ``self`` is complete and ``False`` otherwise
 
@@ -2478,14 +2478,15 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         from sage.geometry.triangulation.point_configuration import PointConfiguration
         from sage.geometry.polyhedron.constructor import Polyhedron
         pc = PointConfiguration(self.rays())
-        v_pc = [vector(pc.point(i)) for i in range(pc.n_points())]
-        v_r = [vector(list(r)) for r in self.rays()]
-        cone_indices = [_.ambient_ray_indices() for _ in self.generating_cones()]
-        translator = [v_pc.index(v_r[i]) for i in range(pc.n_points())]
+        v_pc = [tuple(p) for p in pc]
+        pc_to_indices = {tuple(p):i for (i,p) in enumerate(pc)}
+        indices_to_vr = [tuple(r) for r in self.rays()]
+        cone_indices = [cone.ambient_ray_indices() for cone in self.generating_cones()]
+        translator = [pc_to_indices[t] for t in indices_to_vr]
         translated_cone_indices = [[translator[i] for i in ci] for ci in cone_indices]
         dc_pc = pc.deformation_cone(translated_cone_indices)
         lift = dc_pc.an_element()
-        ieqs = [[lift[i]] + list(v_pc[i]) for i in range(self.nrays())]
+        ieqs = [(lift_i,) + v for (lift_i, v) in zip(lift, v_pc)]
         poly = Polyhedron(ieqs=ieqs)
         return self.is_equivalent(poly.normal_fan())
 

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -2472,6 +2472,15 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
             sage: mother(epsilon).is_polytopal()
             True
 
+        TESTS::
+
+            sage: cone = Cone([(1,1), (2,1)])
+            sage: F = Fan([cone])
+            sage: F.is_polytopal()
+            Traceback (most recent call last):
+            ...
+            ValueError: to be polytopal, the fan should be complete
+
         .. SEEALSO::
 
             :meth:`is_projective`.

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -2439,7 +2439,7 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         m = m.augment(matrix(ZZ, m.nrows(), 1, [1] * m.nrows()))
         return matrix(ZZ, m.integer_kernel().matrix())
 
-    def is_polytopal(self):
+    def is_polytopal(self) -> bool:
         r"""
         Check if ``self`` is the normal fan of a polytope.
 
@@ -2491,9 +2491,9 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         from sage.geometry.polyhedron.constructor import Polyhedron
         pc = PointConfiguration(self.rays())
         v_pc = [tuple(p) for p in pc]
-        pc_to_indices = {tuple(p):i for (i,p) in enumerate(pc)}
-        indices_to_vr = [tuple(r) for r in self.rays()]
-        cone_indices = [cone.ambient_ray_indices() for cone in self.generating_cones()]
+        pc_to_indices = {tuple(p):i for i, p in enumerate(pc)}
+        indices_to_vr = (tuple(r) for r in self.rays())
+        cone_indices = (cone.ambient_ray_indices() for cone in self.generating_cones())
         translator = [pc_to_indices[t] for t in indices_to_vr]
         translated_cone_indices = [[translator[i] for i in ci] for ci in cone_indices]
         dc_pc = pc.deformation_cone(translated_cone_indices)

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -2477,7 +2477,7 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
             :meth:`is_projective`.
         """
         if not self.is_complete():
-            raise ValueError('To be polytopal, the fan should be complete.')
+            raise ValueError('to be polytopal, the fan should be complete')
         from sage.geometry.triangulation.point_configuration import PointConfiguration
         from sage.geometry.polyhedron.constructor import Polyhedron
         pc = PointConfiguration(self.rays())

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -2439,14 +2439,15 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         m = m.augment(matrix(ZZ, m.nrows(), 1, [1] * m.nrows()))
         return matrix(ZZ, m.integer_kernel().matrix())
 
-    def is_regular(self):
+    def is_polytopal(self):
         r"""
-        Check if ``self`` is regular.
+        Check if ``self`` is the normal fan of a polytope.
 
-        A rational polyhedral fan is *regular* if it is the normal fan of a
-        polytope.
+        A rational polyhedral fan is *polytopal* if it is the normal fan of a
+        polytope. This is also called *regular*, or provide a *coherent*
+        subdivision or leads to a *projective* toric variety.
 
-        OUTPUT: ``True`` if ``self`` is complete and ``False`` otherwise
+        OUTPUT: ``True`` if ``self`` is polytopal and ``False`` otherwise
 
         EXAMPLES:
 
@@ -2459,16 +2460,16 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
             ....:     S1 = [Cone([rays[i] for i in indices]) for indices in L]
             ....:     return Fan(S1)
 
-        When epsilon=0, it is not regular::
+        When epsilon=0, it is not polytopal::
 
             sage: epsilon = 0
-            sage: mother(epsilon).is_regular()
+            sage: mother(epsilon).is_polytopal()
             False
 
-        Doing a slight perturbation makes the same subdivision regular::
+        Doing a slight perturbation makes the same subdivision polytopal::
 
             sage: epsilon = 1/2
-            sage: mother(epsilon).is_regular()
+            sage: mother(epsilon).is_polytopal()
             True
 
         .. SEEALSO::
@@ -2476,7 +2477,7 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
             :meth:`is_projective`.
         """
         if not self.is_complete():
-            raise ValueError('the fan is not complete')
+            raise ValueError('To be polytopal, the fan should be complete.')
         from sage.geometry.triangulation.point_configuration import PointConfiguration
         from sage.geometry.polyhedron.constructor import Polyhedron
         pc = PointConfiguration(self.rays())
@@ -2491,8 +2492,6 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         ieqs = [(lift_i,) + v for (lift_i, v) in zip(lift, v_pc)]
         poly = Polyhedron(ieqs=ieqs)
         return self.is_equivalent(poly.normal_fan())
-
-    is_projective = is_regular
 
     def generating_cone(self, n):
         r"""

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -2444,7 +2444,7 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         Check if ``self`` is the normal fan of a polytope.
 
         A rational polyhedral fan is *polytopal* if it is the normal fan of a
-        polytope. This is also called *regular*, or provide a *coherent*
+        polytope. This is also called *regular*, or provides a *coherent*
         subdivision or leads to a *projective* toric variety.
 
         OUTPUT: ``True`` if ``self`` is polytopal and ``False`` otherwise

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -2450,23 +2450,25 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
 
         EXAMPLES:
 
-        This is the mother of all examples, which is not regular (see Section
-        7.1.1 in [DLRS2010]_)::
+        This is the mother of all examples (see Section 7.1.1 in
+        [DLRS2010]_)::
+
+            sage: def mother(epsilon=0):
+            ....:     rays = [(4-epsilon,epsilon,0),(0,4-epsilon,epsilon),(epsilon,0,4-epsilon),(2,1,1),(1,2,1),(1,1,2),(-1,-1,-1)]
+            ....:     L = [(0,1,4),(0,3,4),(1,2,5),(1,4,5),(0,2,3),(2,3,5),(3,4,5),(6,0,1),(6,1,2),(6,2,0)]
+            ....:     S1 = [Cone([rays[i] for i in indices]) for indices in L]
+            ....:     return Fan(S1)
+
+        When epsilon=0, it is not regular::
 
             sage: epsilon = 0
-            sage: rays = [(4-epsilon,epsilon,0),(0,4-epsilon,epsilon),(epsilon,0,4-epsilon),(2,1,1),(1,2,1),(1,1,2),(-1,-1,-1)]
-            sage: S1 = [Cone([rays[i] for i in indices]) for indices in [(0,1,4),(0,3,4),(1,2,5),(1,4,5),(0,2,3),(2,3,5),(3,4,5),(6,0,1),(6,1,2),(6,2,0)]]
-            sage: mother = Fan(S1)
-            sage: mother.is_regular()
+            sage: mother(epsilon).is_regular()
             False
 
         Doing a slight perturbation makes the same subdivision regular::
 
             sage: epsilon = 1/2
-            sage: rays = [(4-epsilon,epsilon,0),(0,4-epsilon,epsilon),(epsilon,0,4-epsilon),(2,1,1),(1,2,1),(1,1,2),(-1,-1,-1)]
-            sage: S1 = [Cone([rays[i] for i in indices]) for indices in [(0,1,4),(0,3,4),(1,2,5),(1,4,5),(0,2,3),(2,3,5),(3,4,5),(6,0,1),(6,1,2),(6,2,0)]]
-            sage: mother = Fan(S1)
-            sage: mother.is_regular()
+            sage: mother(epsilon).is_regular()
             True
 
         .. SEEALSO::

--- a/src/sage/geometry/polyhedron/base5.py
+++ b/src/sage/geometry/polyhedron/base5.py
@@ -711,19 +711,19 @@ class Polyhedron_base5(Polyhedron_base4):
             2.2 of [ACEP2020].
         """
         from .constructor import Polyhedron
-        A = matrix([_.A() for _ in self.Hrepresentation()])
-        A = A.transpose()
-        A_ker = A.right_kernel_matrix(basis='computed')
-        gale = tuple(A_ker.columns())
+        m = matrix([_.A() for _ in self.Hrepresentation()])
+        m = m.transpose()
+        m_ker = m.right_kernel_matrix(basis='computed')
+        gale = tuple(m_ker.columns())
         collection = [f.ambient_H_indices() for f in self.faces(0)]
         n = len(gale)
-        K = None
+        c = None
         for cone_indices in collection:
             dual_cone = Polyhedron(rays=[gale[i] for i in range(n) if i not in
                                          cone_indices])
-            K = K.intersection(dual_cone) if K is not None else dual_cone
-        preimages = [A_ker.solve_right(r.vector()) for r in K.rays()]
-        return Polyhedron(lines=A.rows(), rays=preimages)
+            c = c.intersection(dual_cone) if c is not None else dual_cone
+        preimages = [A_ker.solve_right(r.vector()) for r in c.rays()]
+        return Polyhedron(lines=m.rows(), rays=preimages)
 
     ###########################################################
     # Binary operations.

--- a/src/sage/geometry/polyhedron/base5.py
+++ b/src/sage/geometry/polyhedron/base5.py
@@ -694,7 +694,7 @@ class Polyhedron_base5(Polyhedron_base4):
             sage: py = Polyhedron([(0, -1, -1), (0, -1, 1), (0, 1, -1), (0, 1, 1), (1, 0, 0)])
             sage: dc_py = py.deformation_cone(); dc_py
             A 4-dimensional polyhedron in QQ^5 defined as the convex hull of 1 vertex, 1 ray, 3 lines
-            sage: [_.b() for _ in py.Hrepresentation()]
+            sage: [ineq.b() for ineq in py.Hrepresentation()]
             [0, 1, 1, 1, 1]
             sage: r = dc_py.rays()[0]
             sage: l1,l2,l3 = dc_py.lines()
@@ -711,7 +711,7 @@ class Polyhedron_base5(Polyhedron_base4):
             2.2 of [ACEP2020].
         """
         from .constructor import Polyhedron
-        m = matrix([_.A() for _ in self.Hrepresentation()])
+        m = matrix([ineq.A() for ineq in self.Hrepresentation()])
         m = m.transpose()
         m_ker = m.right_kernel_matrix(basis='computed')
         gale = tuple(m_ker.columns())
@@ -722,7 +722,7 @@ class Polyhedron_base5(Polyhedron_base4):
             dual_cone = Polyhedron(rays=[gale[i] for i in range(n) if i not in
                                          cone_indices])
             c = c.intersection(dual_cone) if c is not None else dual_cone
-        preimages = [A_ker.solve_right(r.vector()) for r in c.rays()]
+        preimages = [m_ker.solve_right(r.vector()) for r in c.rays()]
         return Polyhedron(lines=m.rows(), rays=preimages)
 
     ###########################################################

--- a/src/sage/geometry/polyhedron/base5.py
+++ b/src/sage/geometry/polyhedron/base5.py
@@ -664,7 +664,7 @@ class Polyhedron_base5(Polyhedron_base4):
         Return the deformation cone of ``self``.
 
         Let `P` be a `d`-polytope in `\RR^r` with `n` facets. The deformation
-        cone is a polyhedron in `\RR^n` who points are the right-hand side `b`
+        cone is a polyhedron in `\RR^n` whose points are the right-hand side `b`
         in `Ax\leq b` where `A` is the matrix of facet normals of ``self``, so
         that the resulting polytope has a normal fan which is a coarsening of
         the normal fan of ``self``.
@@ -707,15 +707,15 @@ class Polyhedron_base5(Polyhedron_base4):
 
         REFERENCES:
 
-            For more information, see Section 5.4 of [DLRS2010]_ and Section
-            2.2 of [ACEP2020].
+        For more information, see Section 5.4 of [DLRS2010]_ and Section
+        2.2 of [ACEP2020].
         """
         from .constructor import Polyhedron
         m = matrix([ineq.A() for ineq in self.Hrepresentation()])
         m = m.transpose()
         m_ker = m.right_kernel_matrix(basis='computed')
         gale = tuple(m_ker.columns())
-        collection = [f.ambient_H_indices() for f in self.faces(0)]
+        collection = (f.ambient_H_indices() for f in self.faces(0))
         n = len(gale)
         c = None
         for cone_indices in collection:

--- a/src/sage/geometry/polyhedron/base5.py
+++ b/src/sage/geometry/polyhedron/base5.py
@@ -669,7 +669,10 @@ class Polyhedron_base5(Polyhedron_base4):
         that the resulting polytope has a normal fan which is a coarsening of
         the normal fan of ``self``.
 
-        EXAMPLES::
+        EXAMPLES:
+
+        Let's examine the deformation cone of the square with one truncated
+        vertex::
 
             sage: tc = Polyhedron([(1, -1), (1/3, 1), (1, 1/3), (-1, 1), (-1, -1)])
             sage: dc = tc.deformation_cone()
@@ -685,6 +688,19 @@ class Polyhedron_base5(Polyhedron_base4):
              A ray in the direction (0, 1, 1),
              A ray in the direction (1, 0, 2))
 
+        Now, let's compute the deformation cone of the pyramid over a square
+        and verify that it is not full dimensional::
+
+            sage: py = Polyhedron([(0, -1, -1), (0, -1, 1), (0, 1, -1), (0, 1, 1), (1, 0, 0)])
+            sage: dc_py = py.deformation_cone(); dc_py
+            A 4-dimensional polyhedron in QQ^5 defined as the convex hull of 1 vertex, 1 ray, 3 lines
+            sage: [_.b() for _ in py.Hrepresentation()]
+            [0, 1, 1, 1, 1]
+            sage: r = dc_py.rays()[0]
+            sage: l1,l2,l3 = dc_py.lines()
+            sage: r.vector()-l1.vector()/2-l2.vector()-l3.vector()/2
+            (0, 1, 1, 1, 1)
+
         .. SEEALSO::
 
             :meth:`~sage.schemes.toric.variety.Kaehler_cone`
@@ -699,7 +715,7 @@ class Polyhedron_base5(Polyhedron_base4):
         A = A.transpose()
         A_ker = A.right_kernel_matrix(basis='computed')
         gale = tuple(A_ker.columns())
-        collection = [_.ambient_H_indices() for _ in self.faces(0)]
+        collection = [f.ambient_H_indices() for f in self.faces(0)]
         n = len(gale)
         K = None
         for cone_indices in collection:

--- a/src/sage/geometry/triangulation/point_configuration.py
+++ b/src/sage/geometry/triangulation/point_configuration.py
@@ -2121,7 +2121,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
             except TypeError:
                 pass
         if homogenize:
-            m = matrix([ (1,) + p.affine() for p in points])
+            m = matrix([(1,) + p.affine() for p in points])
         else:
             m = matrix([p.affine() for p in points])
         return m.left_kernel().matrix()
@@ -2166,6 +2166,55 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
              A ray in the direction (0, -1, 2),
              A ray in the direction (0, 1, 0),
              A ray in the direction (1, 0, -1))
+
+        Let's verify the mother of all examples explained in Section 7.1.1 of
+        [DLRS2010]_::
+
+            sage: epsilon = 0
+            sage: mother = PointConfiguration([(4-epsilon,epsilon,0),(0,4-epsilon,epsilon),(epsilon,0,4-epsilon),(2,1,1),(1,2,1),(1,1,2)])
+            sage: mother.points()
+            (P(4, 0, 0), P(0, 4, 0), P(0, 0, 4), P(2, 1, 1), P(1, 2, 1), P(1, 1, 2))
+            sage: S1 = [(0,1,4),(0,3,4),(1,2,5),(1,4,5),(0,2,3),(2,3,5)]
+            sage: S2 = [(0,1,3),(1,3,4),(1,2,4),(2,4,5),(0,2,5),(0,3,5)]
+
+        Both subdivisions `S1` and `S2` are not regular::
+
+            sage: mother_dc1 = mother.deformation_cone(S1)
+            sage: mother_dc1
+            A 4-dimensional polyhedron in QQ^6 defined as the convex hull of 1 vertex, 1 ray, 3 lines
+            sage: mother_dc2 = mother.deformation_cone(S2)
+            sage: mother_dc2
+            A 4-dimensional polyhedron in QQ^6 defined as the convex hull of 1 vertex, 1 ray, 3 lines
+
+        Notice that they have a ray which provides a degenerate lifting which
+        only provides a coarsening of the subdivision from the lower hull (it
+        has 5 facets, and should have 8)::
+
+            sage: result = Polyhedron([vector(list(mother.points()[_])+[mother_dc1.rays()[0][_]]) for _ in range(len(mother.points()))])
+            sage: result.f_vector()
+            (1, 6, 9, 5, 1)
+
+        But if we use epsilon to perturb the configuration, suddenly
+        `S1` becomes regular::
+
+            sage: epsilon = 1/2
+            sage: mother = PointConfiguration([(4-epsilon,epsilon,0), 
+                                               (0,4-epsilon,epsilon),
+                                               (epsilon,0,4-epsilon),
+                                               (2,1,1),
+                                               (1,2,1),
+                                               (1,1,2)])
+            sage: mother.points()
+            (P(7/2, 1/2, 0),
+             P(0, 7/2, 1/2),
+             P(1/2, 0, 7/2),
+             P(2, 1, 1),
+             P(1, 2, 1),
+             P(1, 1, 2))
+            sage: mother_dc1 = mother.deformation_cone(S1);mother_dc1
+            A 6-dimensional polyhedron in QQ^6 defined as the convex hull of 1 vertex, 3 rays, 3 lines
+            sage: mother_dc2 = mother.deformation_cone(S2);mother_dc2
+            A 3-dimensional polyhedron in QQ^6 defined as the convex hull of 1 vertex and 3 lines
 
         .. SEEALSO::                                                                                                                                                                                        
                    

--- a/src/sage/geometry/triangulation/point_configuration.py
+++ b/src/sage/geometry/triangulation/point_configuration.py
@@ -2073,20 +2073,20 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
 
             sage: pc2 = PointConfiguration([[0,0],[3,0],[0,3],[3,3],[1,1]])
             sage: pc2.Gale_transform(homogenize=False)
-            [-1  0  0  0  0]
-            [ 0  1  1 -1  0]
+            [ 1  0  0  0  0]
             [ 0  1  1  0 -3]
+            [ 0  0  0  1 -3]
             sage: pc2.Gale_transform(homogenize=True)
             [ 1  1  1  0 -3]
             [ 0  2  2 -1 -3]
 
-        It might not affect the dimension of the result::
+        It might not affect the result (when acyclic)::
 
             sage: PC = PointConfiguration([[4,0,0],[0,4,0],[0,0,4],[2,1,1],[1,2,1],[1,1,2]])
             sage: GT = PC.Gale_transform(homogenize=False);GT
-            [ 2  1  1 -4  0  0]
-            [ 1  2  1  0 -4  0]
-            [-2 -2 -1  3  3 -1]
+            [ 1  0  0 -3  1  1]
+            [ 0  1  0  1 -3  1]
+            [ 0  0  1  1  1 -3]
             sage: GT = PC.Gale_transform(homogenize=True);GT
             [ 1  0  0 -3  1  1]
             [ 0  1  0  1 -3  1]
@@ -2103,10 +2103,10 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
             [ 0  1  0 -1  1 -1  0]
             [ 0  0  1 -1  0 -1  1]
             sage: g_inhom = pc3.Gale_transform(homogenize=False);g_inhom
-            [-1  1  1  1  0  0  0]
-            [ 0  1  0  0  1  0  0]
-            [ 1 -1 -1  0  0  1  0]
-            [ 0  0  1  0  0  0  1]
+            [1 0 0 0 1 1 1]
+            [0 1 0 0 1 0 0]
+            [0 0 1 0 0 0 1]
+            [0 0 0 1 0 1 0]
             sage: Polyhedron(rays=g_hom.columns())
             A 3-dimensional polyhedron in ZZ^3 defined as the convex hull of 1 vertex and 3 lines
             sage: Polyhedron(rays=g_inhom.columns())
@@ -2175,7 +2175,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
 
             sage: epsilon = 0
             sage: m = mother(0)
-            sage: mother.points()
+            sage: m.points()
             (P(4, 0, 0), P(0, 4, 0), P(0, 0, 4), P(2, 1, 1), P(1, 2, 1), P(1, 1, 2))
             sage: S1 = [(0,1,4),(0,3,4),(1,2,5),(1,4,5),(0,2,3),(2,3,5)]
             sage: S2 = [(0,1,3),(1,3,4),(1,2,4),(2,4,5),(0,2,5),(0,3,5)]

--- a/src/sage/geometry/triangulation/point_configuration.py
+++ b/src/sage/geometry/triangulation/point_configuration.py
@@ -61,7 +61,7 @@ A triangulation of it::
     (2, 3, 4)
     sage: list(t)
     [(1, 3, 4), (2, 3, 4)]
-    sage: t.plot(axes=False)                                                            # needs sage.plot
+    sage: t.plot(axes=False)                                                       # needs sage.plot
     Graphics object consisting of 12 graphics primitives
 
 .. PLOT::
@@ -91,7 +91,7 @@ A 3-dimensional point configuration::
     sage: p = [[0,-1,-1], [0,0,1], [0,1,0], [1,-1,-1], [1,0,1], [1,1,0]]
     sage: points = PointConfiguration(p)
     sage: triang = points.triangulate()
-    sage: triang.plot(axes=False)                                                       # needs sage.plot
+    sage: triang.plot(axes=False)                                                 # needs sage.plot
     Graphics3d Object
 
 .. PLOT::
@@ -116,7 +116,7 @@ The standard example of a non-regular triangulation (requires TOPCOM)::
     16
     sage: len(nonregular)
     2
-    sage: nonregular[0].plot(aspect_ratio=1, axes=False)                                # needs sage.plot
+    sage: nonregular[0].plot(aspect_ratio=1, axes=False)                          # needs sage.plot
     Graphics object consisting of 25 graphics primitives
     sage: PointConfiguration.set_engine('internal')   # to make doctests independent of TOPCOM
 
@@ -1131,10 +1131,10 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
 
             sage: pyramid = PointConfiguration([[1,0,0], [0,1,1], [0,1,-1],
             ....:                               [0,-1,-1], [0,-1,1]])
-            sage: G = pyramid.restricted_automorphism_group()                           # needs sage.graphs sage.groups
-            sage: G == PermutationGroup([[(3,5)], [(2,3),(4,5)], [(2,4)]])              # needs sage.graphs sage.groups
+            sage: G = pyramid.restricted_automorphism_group()                      # needs sage.graphs sage.groups
+            sage: G == PermutationGroup([[(3,5)], [(2,3),(4,5)], [(2,4)]])         # needs sage.graphs sage.groups
             True
-            sage: DihedralGroup(4).is_isomorphic(G)                                     # needs sage.graphs sage.groups
+            sage: DihedralGroup(4).is_isomorphic(G)                                # needs sage.graphs sage.groups
             True
 
         The square with an off-center point in the middle. Note that
@@ -1142,9 +1142,9 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         `D_4` of the convex hull::
 
             sage: square = PointConfiguration([(3/4,3/4), (1,1), (1,-1), (-1,-1), (-1,1)])
-            sage: square.restricted_automorphism_group()                                # needs sage.graphs sage.groups
+            sage: square.restricted_automorphism_group()                           # needs sage.graphs sage.groups
             Permutation Group with generators [(3,5)]
-            sage: DihedralGroup(1).is_isomorphic(_)                                     # needs sage.graphs sage.groups
+            sage: DihedralGroup(1).is_isomorphic(_)                                # needs sage.graphs sage.groups
             True
         """
         v_list = [ vector(p.projective()) for p in self ]
@@ -1532,9 +1532,9 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
             sage: pc.bistellar_flips()
             (((<0,1,3>, <0,2,3>), (<0,1,2>, <1,2,3>)),)
             sage: Tpos, Tneg = pc.bistellar_flips()[0]
-            sage: Tpos.plot(axes=False)                                                 # needs sage.plot
+            sage: Tpos.plot(axes=False)                                            # needs sage.plot
             Graphics object consisting of 11 graphics primitives
-            sage: Tneg.plot(axes=False)                                                 # needs sage.plot
+            sage: Tneg.plot(axes=False)                                            # needs sage.plot
             Graphics object consisting of 11 graphics primitives
 
         The 3d analog::
@@ -1549,7 +1549,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
             sage: pc.bistellar_flips()
             (((<0,1,3>, <0,2,3>), (<0,1,2>, <1,2,3>)),)
             sage: Tpos, Tneg = pc.bistellar_flips()[0]
-            sage: Tpos.plot(axes=False)                                                 # needs sage.plot
+            sage: Tpos.plot(axes=False)                                            # needs sage.plot
             Graphics3d Object
         """
         flips = []
@@ -2080,7 +2080,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
             [ 1  1  1  0 -3]
             [ 0  2  2 -1 -3]
 
-        It might not affect the dimension of the result:: 
+        It might not affect the dimension of the result::
 
             sage: PC = PointConfiguration([[4,0,0],[0,4,0],[0,0,4],[2,1,1],[1,2,1],[1,1,2]])
             sage: GT = PC.Gale_transform(homogenize=False);GT
@@ -2136,9 +2136,9 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         - ``collection`` -- a collection of subconfigurations of ``self``.
           Subconfigurations are given as indices
 
-        OUTPUT: a polyhedron. It contains the liftings of the point configuration 
-        making the collection a regular (or coherent, or projective)
-        subdivision.
+        OUTPUT: a polyhedron. It contains the liftings of the point configuration
+        making the collection a regular (or coherent, or projective, or
+        polytopal) subdivision.
 
         EXAMPLES::
 
@@ -2170,8 +2170,11 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         Let's verify the mother of all examples explained in Section 7.1.1 of
         [DLRS2010]_::
 
+            sage: def mother(epsilon=0):
+            ....:     return PointConfiguration([(4-epsilon,epsilon,0),(0,4-epsilon,epsilon),(epsilon,0,4-epsilon),(2,1,1),(1,2,1),(1,1,2)])
+
             sage: epsilon = 0
-            sage: mother = PointConfiguration([(4-epsilon,epsilon,0),(0,4-epsilon,epsilon),(epsilon,0,4-epsilon),(2,1,1),(1,2,1),(1,1,2)])
+            sage: m = mother(0)
             sage: mother.points()
             (P(4, 0, 0), P(0, 4, 0), P(0, 0, 4), P(2, 1, 1), P(1, 2, 1), P(1, 1, 2))
             sage: S1 = [(0,1,4),(0,3,4),(1,2,5),(1,4,5),(0,2,3),(2,3,5)]
@@ -2179,10 +2182,10 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
 
         Both subdivisions `S1` and `S2` are not regular::
 
-            sage: mother_dc1 = mother.deformation_cone(S1)
+            sage: mother_dc1 = m.deformation_cone(S1)
             sage: mother_dc1
             A 4-dimensional polyhedron in QQ^6 defined as the convex hull of 1 vertex, 1 ray, 3 lines
-            sage: mother_dc2 = mother.deformation_cone(S2)
+            sage: mother_dc2 = m.deformation_cone(S2)
             sage: mother_dc2
             A 4-dimensional polyhedron in QQ^6 defined as the convex hull of 1 vertex, 1 ray, 3 lines
 
@@ -2190,7 +2193,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         only provides a coarsening of the subdivision from the lower hull (it
         has 5 facets, and should have 8)::
 
-            sage: result = Polyhedron([vector(list(mother.points()[_])+[mother_dc1.rays()[0][_]]) for _ in range(len(mother.points()))])
+            sage: result = Polyhedron([vector(list(m.points()[_])+[mother_dc1.rays()[0][_]]) for _ in range(len(m.points()))])
             sage: result.f_vector()
             (1, 6, 9, 5, 1)
 
@@ -2198,30 +2201,25 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         `S1` becomes regular::
 
             sage: epsilon = 1/2
-            sage: mother = PointConfiguration([(4-epsilon,epsilon,0), 
-                                               (0,4-epsilon,epsilon),
-                                               (epsilon,0,4-epsilon),
-                                               (2,1,1),
-                                               (1,2,1),
-                                               (1,1,2)])
-            sage: mother.points()
+            sage: mp = mother(epsilon)
+            sage: mp.points()
             (P(7/2, 1/2, 0),
              P(0, 7/2, 1/2),
              P(1/2, 0, 7/2),
              P(2, 1, 1),
              P(1, 2, 1),
              P(1, 1, 2))
-            sage: mother_dc1 = mother.deformation_cone(S1);mother_dc1
+            sage: mother_dc1 = mp.deformation_cone(S1);mother_dc1
             A 6-dimensional polyhedron in QQ^6 defined as the convex hull of 1 vertex, 3 rays, 3 lines
-            sage: mother_dc2 = mother.deformation_cone(S2);mother_dc2
+            sage: mother_dc2 = mp.deformation_cone(S2);mother_dc2
             A 3-dimensional polyhedron in QQ^6 defined as the convex hull of 1 vertex and 3 lines
 
-        .. SEEALSO::                                                                                                                                                                                        
-                   
+        .. SEEALSO::
+
             :meth:`~sage.schemes.toric.variety.Kaehler_cone`
-                   
+
         REFERENCES:
-                   
+
             For more information, see Section 5.4 of [DLRS2010]_ and Section
             2.2 of [ACEP2020].
         """


### PR DESCRIPTION
In this pull request, we add the method `deformation_cone` (to point configurations and polyhedron) and `is_polytopal` (to fans).

This is related to the Kahler cone of Toric Varieties, but has some subtle differences to make it work as it should in the discrete geometry context. Therefore, it has a separate implementation. 

TODO: In the future, perhaps it could be fusioned.

```sage
sage: tc = Polyhedron([(1, -1), (1/3, 1), (1, 1/3), (-1, 1), (-1, -1)])
sage: dc = tc.deformation_cone()
sage: dc.an_element()
(2, 1, 1, 0, 0)
sage: [_.A() for _ in tc.Hrepresentation()]
[(1, 0), (0, 1), (0, -1), (-3, -3), (-1, 0)]
sage: P = Polyhedron(rays=[(1, 0, 2), (0, 1, 1), (0, -1, 1), (-3, -3, 0), (-1, 0, 0)])
sage: P.rays()
(A ray in the direction (-1, -1, 0),
 A ray in the direction (-1, 0, 0),
 A ray in the direction (0, -1, 1),
 A ray in the direction (0, 1, 1),
 A ray in the direction (1, 0, 2))

sage: py = Polyhedron([(0, -1, -1), (0, -1, 1), (0, 1, -1), (0, 1, 1), (1, 0, 0)])
sage: dc_py = py.deformation_cone(); dc_py
A 4-dimensional polyhedron in QQ^5 defined as the convex hull of 1 vertex, 1 ray, 3 lines
sage: [ineq.b() for ineq in py.Hrepresentation()]
[0, 1, 1, 1, 1]
sage: r = dc_py.rays()[0]
sage: l1,l2,l3 = dc_py.lines()
sage: r.vector()-l1.vector()/2-l2.vector()-l3.vector()/2
(0, 1, 1, 1, 1)
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
