### PR TITLE
Improve sage_getfile by looking at __init__

### DIFF
--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -1328,6 +1328,16 @@ def sage_getfile(obj):
         if isinstance(obj, functools.partial):
             return sage_getfile(obj.func)
         return sage_getfile(obj.__class__)  # inspect.getabsfile(obj.__class__)
+    else:
+        try:
+            objinit = obj.__init__
+        except AttributeError:
+            pass
+        else:
+            pos = _extract_embedded_position(_sage_getdoc_unformatted(objinit))
+            if pos is not None:
+                (_, filename, _) = pos
+                return filename
 
     # No go? fall back to inspect.
     try:
@@ -1336,6 +1346,10 @@ def sage_getfile(obj):
         return ''
     for suffix in import_machinery.EXTENSION_SUFFIXES:
         if sourcefile.endswith(suffix):
+            # TODO: the following is incorrect in meson editable install
+            # but as long as either the class or its __init__ method has a
+            # docstring, _sage_getdoc_unformatted should return correct result
+            # see https://github.com/mesonbuild/meson-python/issues/723
             return sourcefile.removesuffix(suffix)+os.path.extsep+'pyx'
     return sourcefile
 

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -1329,12 +1329,8 @@ def sage_getfile(obj):
             return sage_getfile(obj.func)
         return sage_getfile(obj.__class__)  # inspect.getabsfile(obj.__class__)
     else:
-        try:
-            objinit = obj.__init__
-        except AttributeError:
-            pass
-        else:
-            pos = _extract_embedded_position(_sage_getdoc_unformatted(objinit))
+        if hasattr(obj, '__init__'):
+            pos = _extract_embedded_position(_sage_getdoc_unformatted(obj.__init__))
             if pos is not None:
                 (_, filename, _) = pos
                 return filename
@@ -1347,6 +1343,7 @@ def sage_getfile(obj):
     for suffix in import_machinery.EXTENSION_SUFFIXES:
         if sourcefile.endswith(suffix):
             # TODO: the following is incorrect in meson editable install
+            # because the build is out-of-tree,
             # but as long as either the class or its __init__ method has a
             # docstring, _sage_getdoc_unformatted should return correct result
             # see https://github.com/mesonbuild/meson-python/issues/723
@@ -2370,12 +2367,8 @@ def sage_getsourcelines(obj):
         try:
             return inspect.getsourcelines(obj)
         except (OSError, TypeError) as err:
-            try:
-                objinit = obj.__init__
-            except AttributeError:
-                pass
-            else:
-                d = _sage_getdoc_unformatted(objinit)
+            if hasattr(obj, '__init__'):
+                d = _sage_getdoc_unformatted(obj.__init__)
                 pos = _extract_embedded_position(d)
                 if pos is None:
                     if inspect.isclass(obj):


### PR DESCRIPTION
Otherwise it will fail with meson editable install on objects like `x` of type `Expression`, where the class does not have a docstring but `__init__` method have.

The strategy is similar to `sage_getsourcelines` where `__init__` method is looked in.

I choose to implement this instead of the more complex workaround (see the comment below).

This fixes the test that fails in meson editable mode:

```
2025-02-11T20:13:36.4801998Z **********************************************************************
2025-02-11T20:13:36.4803076Z File "src/sage/misc/sageinspect.py", line 1363, in sage.misc.sageinspect.sage_getfile_relative
2025-02-11T20:13:36.4804104Z Failed example:
2025-02-11T20:13:36.4804750Z     sage_getfile_relative(x)                                                  # needs sage.symbolic
2025-02-11T20:13:36.4808395Z Expected:
2025-02-11T20:13:36.4813350Z     'sage/symbolic/expression.pyx'
2025-02-11T20:13:36.4814244Z Got:
2025-02-11T20:13:36.4815714Z     '/home/runner/work/sage/sage/builddir/src/sage/symbolic/expression.pyx'
2025-02-11T20:13:44.3128543Z **********************************************************************
```

This may still fail in another case where neither class nor `__init__` method has a docstring (in that case `?` will fail to get the file in meson editable mode), but that's not in scope I guess. (I left a comment there to explain)

See also https://github.com/sagemath/sage/pull/39369

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview. (change should be invisible to users not using meson editable so…)

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


