### PR TITLE
Implement im_gens in the class fraction_field_FpT

### DIFF
--- a/src/sage/rings/fraction_field_FpT.pyx
+++ b/src/sage/rings/fraction_field_FpT.pyx
@@ -575,22 +575,21 @@ cdef class FpTElement(FieldElement):
     def _im_gens_(self, codomain, im_gens, base_map=None):
         r"""
         Return the image of this element in ``codomain`` under the
-        map that sends the images of the generators of the parent
-        to the tuple of elements of ``im_gens``.
+        map that sends the image of the generator of the parent to
+        the element in ``im_gens``.
 
         INPUT:
 
         - ``codomain`` -- a ring; where the image is computed
 
-        - ``im_gens`` -- a list; the images of the generators
-          of the parent
+        - ``im_gens`` -- a list containing the image of the
+          generator of the parent as unique element
 
         - ``base_map`` -- a morphism (default: ``None``);
           the action on the underlying base ring
 
         EXAMPLES::
 
-            sage: Fq = GF(5)
             sage: A.<T> = GF(5)[]
             sage: K.<T> = Frac(A)
             sage: f = K.hom([T^2])

--- a/src/sage/rings/fraction_field_FpT.pyx
+++ b/src/sage/rings/fraction_field_FpT.pyx
@@ -572,6 +572,36 @@ cdef class FpTElement(FieldElement):
         normalize(x._numer, x._denom, self.p)
         return x
 
+    def _im_gens_(self, codomain, im_gens, base_map=None):
+        r"""
+        Return the image of this element in ``codomain`` under the
+        map that sends the images of the generators of the parent
+        to the tuple of elements of ``im_gens``.
+
+        INPUT:
+
+        - ``codomain`` -- a ring; where the image is computed
+
+        - ``im_gens`` -- a list; the images of the generators
+          of the parent
+
+        - ``base_map`` -- a morphism (default: ``None``);
+          the action on the underlying base ring
+
+        EXAMPLES::
+
+            sage: Fq = GF(5)
+            sage: A.<T> = GF(5)[]
+            sage: K.<T> = Frac(A)
+            sage: f = K.hom([T^2])
+            sage: f(1/T)
+            1/T^2
+        """
+        nden = self.denom()._im_gens_(codomain, im_gens, base_map=base_map)
+        invden = nden.inverse_of_unit()
+        nnum = self.numer()._im_gens_(codomain, im_gens, base_map=base_map)
+        return nnum * invden
+
     cpdef FpTElement next(self):
         """
         Iterate through all polynomials, returning the "next" polynomial after this one.


### PR DESCRIPTION
We implement the method `_im_gens_` in the class `sage.rings.fraction_field_FpT.FpTElement`.
This allows the following code to work:

```
sage: Fq = GF(5)
sage: A.<T> = GF(5)[]
sage: K.<T> = Frac(A)
sage: f = K.hom([T^2])
sage: f(T)
T^2
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
