### PR TITLE
Fix some typo

### DIFF
--- a/src/sage/rings/padics/factory.py
+++ b/src/sage/rings/padics/factory.py
@@ -1643,7 +1643,7 @@ class Zp_class(UniqueFactory):
         1 + 2*5^2 + 5^3
 
     The floating point case is similar to the fixed modulus type
-    in that elements do not trac their own precision.  However, relative
+    in that elements do not track their own precision.  However, relative
     precision is truncated with each operation rather than absolute precision.
 
     On the contrary, the lattice type tracks precision using lattices
@@ -2196,7 +2196,7 @@ def Zq(q, prec=None, type='capped-rel', modulus=None, names=None,
         2*3^2 + (2*a + 2)*3^3
 
     The floating point case is similar to the fixed modulus type
-    in that elements do not trac their own precision.  However, relative
+    in that elements do not track their own precision.  However, relative
     precision is truncated with each operation rather than absolute precision.
 
     MODULUS:

--- a/src/sage/rings/polynomial/binary_form_reduce.py
+++ b/src/sage/rings/polynomial/binary_form_reduce.py
@@ -192,7 +192,7 @@ def covariant_z0(F, z0_cov=False, prec=53, emb=None, error_limit=0.000001):
         FM = f  # for Julia's invariant
     else:
         # solve the minimization problem for 'true' covariant
-        CF = ComplexIntervalField(prec=prec)  # keeps trac of our precision error
+        CF = ComplexIntervalField(prec=prec)  # keeps track of our precision error
         z = CF(z)
         FM = F(list(mat * vector(R.gens()))).subs({R.gen(1): 1}).univariate_polynomial()
         from sage.rings.polynomial.complex_roots import complex_roots


### PR DESCRIPTION
Just some trivial typo.

The remaining occurrences of `trac` should be changed to `issue` instead, but that's the topic for another pull request.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


