### PR TITLE
Show test failures of ci-meson as annotations

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           # We don't install sage_setup, so don't try to test it
           rm -R ./src/sage_setup/
-          ./sage -t --all -p4
+          ./sage -t --all -p4 --format github
 
       - name: Upload log
         uses: actions/upload-artifact@v4.5.0


### PR DESCRIPTION
Follow-up to https://github.com/sagemath/sage/pull/36938 and https://github.com/sagemath/sage/pull/37738 , this PR shows the test failures of ci-meson.yml workflow as GitHub annotations, which has the advantage that you don't need to scroll through the whole log to view the failed tests.

(actually I just search for `Failed examples`, but this is not foolproof)

Previously only build.yml got this feature.

There's a disadvantage, then the file and line numbers are no longer shown in the downloaded log file, instead only `[error]` is shown (but this is trivially fixable by printing the format in both old and new ways when `--format github` is passed). I think if everyone views the annotations instead of reading the raw log anyway, it shouldn't matter too much.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes. (no functionality change)
- [ ] I have updated the documentation and checked the documentation preview. (no documentation change)

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


