### PR TITLE
Fix compile error when compiling boost graphs with recent clang

### DIFF
--- a/src/sage/graphs/base/boost_graph.pxd
+++ b/src/sage/graphs/base/boost_graph.pxd
@@ -61,7 +61,7 @@ cdef extern from "boost_interface.cpp":
         v_index num_verts()
         void add_edge(v_index u, v_index v)
         void add_edge(v_index u, v_index v, double w)
-        vector[pair[int, pair[int, double]]] edge_list()
+        vector[pair[v_index, pair[v_index, double]]] edge_list()
         e_index num_edges()
         result_ec edge_connectivity()
         double clustering_coeff(v_index v)

--- a/src/sage/graphs/base/boost_graph.pyx
+++ b/src/sage/graphs/base/boost_graph.pyx
@@ -1071,7 +1071,7 @@ cdef get_predecessors(BoostWeightedGraph g, result, int_to_v, directed, weight_t
         sage: johnson_shortest_paths(g, distances=False, predecessors=True) == expected
         True
     """
-    cdef vector[pair[int, pair[int, double]]] edges
+    cdef vector[pair[v_index, pair[v_index, double]]] edges
     sig_on()
     edges = g.edge_list()
     sig_off()

--- a/src/sage/graphs/base/boost_interface.cpp
+++ b/src/sage/graphs/base/boost_interface.cpp
@@ -22,8 +22,8 @@
 #include <iostream>
 #include <utility>
 
-typedef int v_index;
-typedef long e_index;
+typedef unsigned long v_index;
+typedef unsigned long e_index;
 
 // This struct is the output of the edge connectivity Boost algorithm.
 typedef struct {
@@ -84,11 +84,11 @@ private:
     // This map is a parameter/output for biconnected_components function
     typedef typename std::map<edge_descriptor, int, order_edges> edge_map;
 
-public:
     adjacency_list graph;
     std::vector<vertex_descriptor> vertices;
     vertex_to_int_map index;
 
+public:
     BoostGraph() {
     }
 


### PR DESCRIPTION
this fixes an underlying type confusion in our wrapper that has lead to warnings before but now produces an actual error, see https://github.com/sagemath/sage/pull/39249
