### PR TITLE
Error when both arguments and keywords present

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -160,9 +160,10 @@ class MPolynomial_element(MPolynomial):
             sage: R.<a,b> = PolynomialRing(ZZ)
             sage: f = a + b
             sage: f(1, 2, a=3, b=4)
+
             Traceback (most recent call last):
             ...
-            TypeError: Cannot mix both arguments and keywords
+            TypeError: Cannot mix both arguments and keywords.
 
         AUTHORS:
 

--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -169,13 +169,10 @@ class MPolynomial_element(MPolynomial):
         - David Kohel (2005-09-27)
         """
         if len(kwds) > 0 and len(x) > 0:
-            raise TypeError("Cannot mix both arguments and keywords")
+            raise TypeError("Cannot mix both arguments and keywords.")
         if len(kwds) > 0:
             f = self.subs(**kwds)
-            if len(x) > 0:
-                return f(*x)
-            else:
-                return f
+            return f
         if len(x) == 1 and isinstance(x[0], (list, tuple)):
             x = x[0]
         n = self.parent().ngens()

--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -154,11 +154,22 @@ class MPolynomial_element(MPolynomial):
             sage: a = P(1)
             sage: a(()).parent()
             Rational Field
+        
+        Check :issue:`39081`::
+            
+            sage: R.<a,b> = PolynomialRing(ZZ)
+            sage: f = a + b
+            sage: f(1, 2, a=3, b=4)
+            Traceback (most recent call last):
+            ...
+            TypeError: Cannot mix both arguments and keywords
 
         AUTHORS:
 
         - David Kohel (2005-09-27)
         """
+        if len(kwds) > 0 and len(x) > 0:
+            raise TypeError("Cannot mix both arguments and keywords")
         if len(kwds) > 0:
             f = self.subs(**kwds)
             if len(x) > 0:

--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -155,15 +155,6 @@ class MPolynomial_element(MPolynomial):
             sage: a(()).parent()
             Rational Field
         
-        Check :issue:`39081`::
-            
-            sage: R.<a,b> = PolynomialRing(ZZ)
-            sage: f = a + b
-            sage: f(1, 2, a=3, b=4)
-
-            Traceback (most recent call last):
-            ...
-            TypeError: Cannot mix both arguments and keywords.
 
         AUTHORS:
 

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -2066,6 +2066,9 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         """
         cdef Element sage_res
 
+        if len(x) > 0 and len(kwds) > 0:
+            raise TypeError("Cannot mix both arguments and keywords.")
+
         if len(kwds) > 0:
             f = self.subs(**kwds)
             if len(x) > 0:


### PR DESCRIPTION


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
Added a condition so that it returns an error when both arguments and keywords are present in multivariate polynomial.
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". --> "Fixes #39081"



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


