### PR TITLE
Improvement to flint_autogen reader

### DIFF
--- a/src/sage_setup/autogen/flint/reader.py
+++ b/src/sage_setup/autogen/flint/reader.py
@@ -176,11 +176,16 @@ class Extractor:
         line = self.lines[self.i]
         if line.startswith('.. function::'):
             self.add_declaration()
-            if line[13] != ' ':
+            line_rest = line.removeprefix('.. function::')
+            if not line_rest.startswith(' '):
                 print('Warning: no space {}'.format(line))
-            self.signatures.append(line[13:].strip())
             self.state = self.FUNCTION_DECLARATION
             self.i += 1
+            signature = line_rest.strip()
+            while signature.endswith('\\'):
+                signature = signature.removesuffix('\\').strip() + ' ' + self.lines[self.i].strip()
+                self.i += 1
+            self.signatures.append(signature)
         elif line.startswith('.. macro::'):
             self.add_declaration()
             if line[10] != ' ':

--- a/src/sage_setup/autogen/flint/templates/flint_sage.pyx.template
+++ b/src/sage_setup/autogen/flint/templates/flint_sage.pyx.template
@@ -12,7 +12,7 @@ Import this module::
 
     sage: import sage.libs.flint.flint_sage
 
-We verify that :trac:`6919` is correctly fixed::
+We verify that :issue:`6919` is correctly fixed::
 
     sage: R.<x> = PolynomialRing(ZZ)
     sage: A = 2^(2^17+2^15)

--- a/src/sage_setup/autogen/flint/templates/types.pxd.template
+++ b/src/sage_setup/autogen/flint/templates/types.pxd.template
@@ -24,6 +24,9 @@ ctypedef mp_limb_t ulong
 ctypedef mp_limb_signed_t slong
 ctypedef mp_limb_t flint_bitcnt_t
 
+# New in flint 3.2.0-rc1
+ctypedef mp_ptr nn_ptr
+ctypedef mp_srcptr nn_srcptr
 
 cdef extern from "flint_wrap.h":
     # flint/fmpz.h
@@ -269,6 +272,16 @@ cdef extern from "flint_wrap.h":
     ctypedef struct flint_rand_s:
         pass
     ctypedef flint_rand_s flint_rand_t[1]
+    ctypedef enum flint_err_t:
+        # flint_autogen.py does not support parsing .. enum:: yet
+        FLINT_ERROR
+        FLINT_OVERFLOW
+        FLINT_IMPINV
+        FLINT_DOMERR
+        FLINT_DIVZERO
+        FLINT_EXPOF
+        FLINT_INEXACT
+        FLINT_TEST_FAIL
 
     cdef long FLINT_BITS
     cdef long FLINT_D_BITS


### PR DESCRIPTION
See https://github.com/sagemath/sage/pull/39413#issuecomment-2660680579

In flint latest master, there's this thing

```
.. function:: void n_mulmod_and_precomp_shoup(ulong * ab, ulong * ab_precomp, \
                             ulong a, ulong b,                                \
                             ulong a_pr_quo, ulong a_pr_rem, ulong b_precomp, \
                             ulong n)
```

In order to parse this (trailing backslash), it is necessary to modify `flint_autogen.py`. Now I only handled it for function so far.

Also some minor unrelated changes.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview. (no change)

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


