### PR TITLE
Remove dead mailing lists.

### DIFF
--- a/build/pkgs/ipython/SPKG.rst
+++ b/build/pkgs/ipython/SPKG.rst
@@ -33,7 +33,3 @@ Upstream Contact
 ----------------
 
 http://ipython.org
-
-ipython-dev@scipy.org
-
-ipython-user@scipy.org


### PR DESCRIPTION
AFAICT, the `@scipy.org` mailing lists are dead
since 2018 technically ipython-dev was migrated to `@python.org`, but had no messages since 2023 and
-user was never migrated.
