### PR TITLE
make algdep always an alias for algebraic_dependency

### DIFF
--- a/src/sage/arith/all.py
+++ b/src/sage/arith/all.py
@@ -1,6 +1,7 @@
 from sage.misc.lazy_import import lazy_import
 
-from sage.arith.misc import (algdep, bernoulli, is_prime, is_prime_power,
+from sage.arith.misc import (algdep, algebraic_dependency,
+                             bernoulli, is_prime, is_prime_power,
                              is_pseudoprime, is_pseudoprime_power,
                              prime_powers, primes_first_n, eratosthenes, primes,
                              next_prime_power, next_probable_prime, next_prime,

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -40,8 +40,9 @@ from sage.arith.functions import LCM_list
 ##################################################################
 
 
-def algdep(z, degree, known_bits=None, use_bits=None, known_digits=None,
-           use_digits=None, height_bound=None, proof=False):
+def algebraic_dependency(z, degree, known_bits=None,
+                         use_bits=None, known_digits=None,
+                         use_digits=None, height_bound=None, proof=False):
     """
     Return an irreducible polynomial of degree at most `degree` which
     is approximately satisfied by the number `z`.
@@ -62,9 +63,9 @@ def algdep(z, degree, known_bits=None, use_bits=None, known_digits=None,
     indicating that higher precision is required.
 
     ALGORITHM: Uses LLL for real/complex inputs, PARI C-library
-    ``algdep`` command otherwise.
+    :pari:`algdep` command otherwise.
 
-    Note that ``algebraic_dependency`` is a synonym for ``algdep``.
+    Note that ``algdep`` is a synonym for ``algebraic_dependency``.
 
     INPUT:
 
@@ -79,7 +80,7 @@ def algdep(z, degree, known_bits=None, use_bits=None, known_digits=None,
 
     EXAMPLES::
 
-        sage: algdep(1.888888888888888, 1)                                              # needs sage.libs.pari
+        sage: algebraic_dependency(1.888888888888888, 1)                                # needs sage.libs.pari
         9*x - 17
         sage: algdep(0.12121212121212, 1)                                               # needs sage.libs.pari
         33*x - 4
@@ -266,15 +267,14 @@ def algdep(z, degree, known_bits=None, use_bits=None, known_digits=None,
 
     else:
         from sage.libs.pari import pari
-        y = pari(z)
-        f = y.algdep(degree)
+        f = pari(z).algdep(degree)
 
     # f might be reducible. Find the best fitting irreducible factor
-    factors = [p for p, e in R(f).factor()]
+    factors = (p for p, _ in R(f).factor())
     return min(factors, key=lambda f: abs(f(z)))
 
 
-algebraic_dependency = algdep
+alg_dep = algebraic_dependency
 
 
 def bernoulli(n, algorithm='default', num_threads=1):

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -274,7 +274,7 @@ def algebraic_dependency(z, degree, known_bits=None,
     return min(factors, key=lambda f: abs(f(z)))
 
 
-alg_dep = algebraic_dependency
+algdep = algebraic_dependency
 
 
 def bernoulli(n, algorithm='default', num_threads=1):

--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -419,7 +419,7 @@ To check that :issue:`27092` is fixed::
 """
 
 import re
-from sage.arith.misc import algdep
+from sage.arith.misc import algebraic_dependency
 from sage.rings.integer import Integer
 from sage.rings.rational_field import QQ
 from sage.rings.real_double import RealDoubleElement
@@ -1117,7 +1117,7 @@ def minpoly(ex, var='x', algorithm=None, bits=None, degree=None, epsilon=0):
 
             for degree in degree_list:
 
-                f = QQ[var](algdep(a, degree))  # TODO: use the known_bits parameter?
+                f = QQ[var](algebraic_dependency(a, degree))  # TODO: use the known_bits parameter?
                 # If indeed we have found a minimal polynomial,
                 # it should be accurate to a much higher precision.
                 error = abs(f(aa))

--- a/src/sage/rings/complex_double.pyx
+++ b/src/sage/rings/complex_double.pyx
@@ -2439,34 +2439,38 @@ cdef class ComplexDoubleElement(FieldElement):
             from sage.libs.pari.convert_sage_complex_double import complex_double_element_zeta
         return complex_double_element_zeta(self)
 
-    def algdep(self, long n):
+    def algebraic_dependency(self, long n):
         """
         Return a polynomial of degree at most `n` which is
-        approximately satisfied by this complex number. Note that the
-        returned polynomial need not be irreducible, and indeed usually
-        won't be if `z` is a good approximation to an algebraic
-        number of degree less than `n`.
+        approximately satisfied by this complex number.
 
-        ALGORITHM: Uses the PARI C-library algdep command.
+        Note that the returned polynomial need not be irreducible, and
+        indeed usually will not be if `z` is a good approximation to an
+        algebraic number of degree less than `n`.
+
+        ALGORITHM: Uses the PARI C-library :pari:`algdep` command.
 
         EXAMPLES::
 
             sage: z = (1/2)*(1 + RDF(sqrt(3)) * CDF.0); z   # abs tol 1e-16             # needs sage.symbolic
             0.5 + 0.8660254037844387*I
-            sage: p = z.algdep(5); p                                                    # needs sage.libs.pari sage.symbolic
+            sage: p = z.algebraic_dependency(5); p                                      # needs sage.libs.pari sage.symbolic
             x^2 - x + 1
             sage: abs(z^2 - z + 1) < 1e-14                                              # needs sage.symbolic
             True
 
         ::
 
-            sage: CDF(0,2).algdep(10)                                                   # needs sage.libs.pari
+            sage: CDF(0,2).algebraic_dependency(10)                                     # needs sage.libs.pari
             x^2 + 4
-            sage: CDF(1,5).algdep(2)                                                    # needs sage.libs.pari
+            sage: CDF(1,5).algebraic_dependency(2)                                      # needs sage.libs.pari
             x^2 - 2*x + 26
         """
-        from sage.arith.misc import algdep
-        return algdep(self, n)
+        from sage.arith.misc import algebraic_dependency
+        return algebraic_dependency(self, n)
+
+    algdep = algebraic_dependency
+
 
 cdef class FloatToCDF(Morphism):
     """

--- a/src/sage/rings/complex_mpc.pyx
+++ b/src/sage/rings/complex_mpc.pyx
@@ -1365,8 +1365,10 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
 
         ALGORITHM: Uses the PARI C-library :pari:`algdep` command.
 
-        INPUT: Type ``algdep?`` at the top level prompt. All additional
-        parameters are passed onto the top-level algdep command.
+        INPUT: Type ``algebraic_dependency?`` at the top level prompt.
+
+        All additional parameters are passed onto the top-level
+        ``algebraic_dependency`` command.
 
         EXAMPLES::
 
@@ -1379,8 +1381,10 @@ cdef class MPComplexNumber(sage.structure.element.FieldElement):
             sage: p(z)
             1.11022302462516e-16
         """
-        from sage.arith.misc import algdep
-        return algdep(self, n, **kwds)
+        from sage.arith.misc import algebraic_dependency
+        return algebraic_dependency(self, n, **kwds)
+
+    algdep = algebraic_dependency
 
     ################################
     # Basic Arithmetic

--- a/src/sage/rings/complex_mpfr.pyx
+++ b/src/sage/rings/complex_mpfr.pyx
@@ -3257,21 +3257,23 @@ cdef class ComplexNumber(sage.structure.element.FieldElement):
 
         ALGORITHM: Uses the PARI C-library :pari:`algdep` command.
 
-        INPUT: Type ``algdep?`` at the top level prompt. All additional
-        parameters are passed onto the top-level :func:`algdep` command.
+        INPUT: Type ``algebraic_dependency?`` at the top level prompt.
+
+        All additional parameters are passed onto the top-level
+        :func:`algebraic_dependency` command.
 
         EXAMPLES::
 
             sage: C = ComplexField()
             sage: z = (1/2)*(1 + sqrt(3.0) *C.0); z
             0.500000000000000 + 0.866025403784439*I
-            sage: p = z.algdep(5); p
+            sage: p = z.algebraic_dependency(5); p
             x^2 - x + 1
             sage: p(z)
             1.11022302462516e-16
         """
-        from sage.arith.misc import algdep
-        return algdep(self, n, **kwds)
+        from sage.arith.misc import algebraic_dependency
+        return algebraic_dependency(self, n, **kwds)
 
     # Alias
     algdep = algebraic_dependency

--- a/src/sage/rings/padics/padic_ZZ_pX_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_element.pyx
@@ -513,7 +513,7 @@ cdef class pAdicZZpXElement(pAdicExtElement):
         Return a rational approximation of ``self``.
 
         This does not try to optimize which rational is picked: see
-        ``algdep`` for another option.
+        ``algebraic_dependency`` for another option.
 
         EXAMPLES::
 

--- a/src/sage/rings/padics/padic_generic_element.pyx
+++ b/src/sage/rings/padics/padic_generic_element.pyx
@@ -1117,57 +1117,13 @@ cdef class pAdicGenericElement(LocalGenericElement):
         extdeg = parent.absolute_degree() // (base.absolute_degree() * polydeg)
         return -extdeg * poly[polydeg-1]
 
-    def algdep(self, n):
-        """
-        Return a polynomial of degree at most `n` which is approximately
-        satisfied by this number. Note that the returned polynomial need not be
-        irreducible, and indeed usually won't be if this number is a good
-        approximation to an algebraic number of degree less than `n`.
-
-        ALGORITHM: Uses the PARI C-library :pari:`algdep` command.
-
-        INPUT:
-
-        - ``self`` -- a `p`-adic element
-        - ``n`` -- integer
-
-        OUTPUT: polynomial; degree `n` polynomial approximately satisfied by ``self``
-
-        EXAMPLES::
-
-            sage: K = Qp(3,20,'capped-rel','series'); R = Zp(3,20,'capped-rel','series')
-            sage: a = K(7/19); a
-            1 + 2*3 + 3^2 + 3^3 + 2*3^4 + 2*3^5 + 3^8 + 2*3^9 + 3^11 + 3^12
-              + 2*3^15 + 2*3^16 + 3^17 + 2*3^19 + O(3^20)
-            sage: a.algdep(1)
-            19*x - 7
-            sage: K2 = Qp(7,20,'capped-rel')
-            sage: b = K2.zeta(); b.algdep(2)
-            x^2 - x + 1
-            sage: K2 = Qp(11,20,'capped-rel')
-            sage: b = K2.zeta(); b.algdep(4)
-            x^4 - x^3 + x^2 - x + 1
-            sage: a = R(7/19); a
-            1 + 2*3 + 3^2 + 3^3 + 2*3^4 + 2*3^5 + 3^8 + 2*3^9 + 3^11 + 3^12
-              + 2*3^15 + 2*3^16 + 3^17 + 2*3^19 + O(3^20)
-            sage: a.algdep(1)
-            19*x - 7
-            sage: R2 = Zp(7,20,'capped-rel')
-            sage: b = R2.zeta(); b.algdep(2)
-            x^2 - x + 1
-            sage: R2 = Zp(11,20,'capped-rel')
-            sage: b = R2.zeta(); b.algdep(4)
-            x^4 - x^3 + x^2 - x + 1
-        """
-        # TODO: figure out if this works for extension rings.  If not, move this to padic_base_generic_element.
-        from sage.arith.misc import algdep
-        return algdep(self, n)
-
     def algebraic_dependency(self, n):
         """
         Return a polynomial of degree at most `n` which is approximately
-        satisfied by this number.  Note that the returned polynomial need not
-        be irreducible, and indeed usually won't be if this number is a good
+        satisfied by this number.
+
+        Note that the returned polynomial need not be irreducible, and
+        indeed usually will not be if this number is a good
         approximation to an algebraic number of degree less than `n`.
 
         ALGORITHM: Uses the PARI C-library :pari:`algdep` command.
@@ -1177,7 +1133,9 @@ cdef class pAdicGenericElement(LocalGenericElement):
         - ``self`` -- a `p`-adic element
         - ``n`` -- integer
 
-        OUTPUT: polynomial; degree `n` polynomial approximately satisfied by ``self``
+        OUTPUT:
+
+        polynomial; degree `n` polynomial approximately satisfied by ``self``
 
         EXAMPLES::
 
@@ -1205,7 +1163,12 @@ cdef class pAdicGenericElement(LocalGenericElement):
             sage: b = R2.zeta(); b.algebraic_dependency(4)
             x^4 - x^3 + x^2 - x + 1
         """
-        return self.algdep(n)
+        # TODO: figure out if this works for extension rings.
+        # If not, move this to padic_base_generic_element.
+        from sage.arith.misc import algebraic_dependency
+        return algebraic_dependency(self, n)
+
+    algdep = algebraic_dependency
 
     #def exp_artin_hasse(self):
     #    """

--- a/src/sage/rings/real_double.pyx
+++ b/src/sage/rings/real_double.pyx
@@ -1955,7 +1955,7 @@ cdef class RealDoubleElement(FieldElement):
             sage: r.algebraic_dependency(5)                                             # needs sage.libs.pari
             x^2 - 2
         """
-        return sage.arith.misc.algdep(self, n)
+        return sage.arith.misc.algebraic_dependency(self, n)
 
     algdep = algebraic_dependency
 

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -4996,7 +4996,7 @@ cdef class RealIntervalFieldElement(RingElement):
         """
         return (~self).arctanh()
 
-    def algdep(self, n):
+    def algebraic_dependency(self, n):
         r"""
         Return a polynomial of degree at most `n` which is
         approximately satisfied by ``self``.
@@ -5012,13 +5012,13 @@ cdef class RealIntervalFieldElement(RingElement):
 
         ALGORITHM:
 
-        Uses the PARI C-library ``algdep`` command.
+        This uses the PARI C-library :pari:`algdep` command.
 
         EXAMPLES::
 
             sage: r = sqrt(RIF(2)); r
             1.414213562373095?
-            sage: r.algdep(5)
+            sage: r.algebraic_dependency(5)
             x^2 - 2
 
         If we compute a wrong, but precise, interval, we get a wrong
@@ -5026,7 +5026,7 @@ cdef class RealIntervalFieldElement(RingElement):
 
             sage: r = sqrt(RealIntervalField(200)(2)) + (1/2)^40; r
             1.414213562374004543503461652447613117632171875376948073176680?
-            sage: r.algdep(5)
+            sage: r.algebraic_dependency(5)
             7266488*x^5 + 22441629*x^4 - 90470501*x^3 + 23297703*x^2 + 45778664*x + 13681026
 
         But if we compute an interval that includes the number we mean,
@@ -5034,13 +5034,13 @@ cdef class RealIntervalFieldElement(RingElement):
         interval is very imprecise::
 
             sage: r = r.union(sqrt(2.0))
-            sage: r.algdep(5)
+            sage: r.algebraic_dependency(5)
             x^2 - 2
 
         Even on this extremely imprecise interval we get an answer which is
         technically correct::
 
-            sage: RIF(-1, 1).algdep(5)
+            sage: RIF(-1, 1).algebraic_dependency(5)
             x
         """
         # If 0 is in the interval, then we have no known bits!  But
@@ -5053,7 +5053,10 @@ cdef class RealIntervalFieldElement(RingElement):
 
         known_bits = -self.relative_diameter().log2()
 
-        return sage.arith.misc.algdep(self.center(), n, known_bits=known_bits)
+        return sage.arith.misc.algebraic_dependency(self.center(),
+                                                    n, known_bits=known_bits)
+
+    algdep = algebraic_dependency
 
     def factorial(self):
         """

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -5397,7 +5397,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
             sage: r.algebraic_dependency(5)
             x^2 - 2
         """
-        return sage.arith.misc.algdep(self, n)
+        return sage.arith.misc.algebraic_dependency(self, n)
 
     algdep = algebraic_dependency
 

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -3355,7 +3355,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         the discriminant below is strong confirmation -- but not proof
         -- that this polynomial is correct::
 
-            sage: f = P.numerical_approx(70)[0].algdep(6); f
+            sage: f = P.numerical_approx(70)[0].algebraic_dependency(6); f
             1225*x^6 + 1750*x^5 - 21675*x^4 - 380*x^3 + 110180*x^2 - 129720*x + 48771
             sage: f.discriminant().factor()
             2^6 * 3^2 * 5^11 * 7^4 * 13^2 * 19^6 * 199^2 * 719^2 * 26161^2
@@ -3460,7 +3460,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         if algorithm == 'lll':
             P = self.numerical_approx(prec)
-            f = P[0].algdep(n)
+            f = P[0].algebraic_dependency(n)
             if f.is_irreducible() and self._check_poly_discriminant(f):
                 return f.monic()
             else:
@@ -3543,7 +3543,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             sage: z = P.point_exact(200, optimize=True)
             sage: z[1].charpoly()
             x^12 + 6*x^11 + 90089/1715*x^10 + 71224/343*x^9 + 52563964/588245*x^8 - 483814934/588245*x^7 - 156744579/16807*x^6 - 2041518032/84035*x^5 + 1259355443184/14706125*x^4 + 3094420220918/14706125*x^3 + 123060442043827/367653125*x^2 + 82963044474852/367653125*x + 211679465261391/1838265625
-            sage: f = P.numerical_approx(500)[1].algdep(12); f / f.leading_coefficient()
+            sage: f = P.numerical_approx(500)[1].algebraic_dependency(12); f / f.leading_coefficient()
             x^12 + 6*x^11 + 90089/1715*x^10 + 71224/343*x^9 + 52563964/588245*x^8 - 483814934/588245*x^7 - 156744579/16807*x^6 - 2041518032/84035*x^5 + 1259355443184/14706125*x^4 + 3094420220918/14706125*x^3 + 123060442043827/367653125*x^2 + 82963044474852/367653125*x + 211679465261391/1838265625
 
             sage: E = EllipticCurve('5077a')
@@ -4223,13 +4223,14 @@ class KolyvaginPoint(HeegnerPoint):
             if E.root_number() == -1:
                 return self._recognize_point_over_QQ(P, 2*self.index())
             else:
-                # root number +1.  We use algdep to recognize the x
+                # root number +1.  We use algebraic_dependency
+                # to recognize the x
                 # coordinate, stick it in the appropriate quadratic
                 # field, then make sure that we got the right
                 # embedding, and if not fix things so we do.
                 x = P[0]
                 C = x.parent()
-                f = x.algdep(2)
+                f = x.algebraic_dependency(2)
                 K = self.quadratic_field()
                 roots = [r[0] for r in f.roots(K)]
                 if not roots:
@@ -6414,7 +6415,7 @@ def ell_heegner_point(self, D, c=ZZ(1), f=None, check=True):
     Working out the details manually::
 
         sage: P = E.heegner_point(-47).numerical_approx(prec=200)
-        sage: f = algdep(P[0], 5); f
+        sage: f = algebraic_dependency(P[0], 5); f
         x^5 - x^4 + x^3 + x^2 - 2*x + 1
         sage: f.discriminant().factor()
         47^2

--- a/src/sage/schemes/riemann_surfaces/riemann_surface.py
+++ b/src/sage/schemes/riemann_surfaces/riemann_surface.py
@@ -114,7 +114,7 @@ The initial version of this code was developed alongside [BSZ2019]_.
 
 from scipy.spatial import Voronoi
 from sage.arith.functions import lcm
-from sage.arith.misc import GCD, algdep
+from sage.arith.misc import GCD, algebraic_dependency
 from sage.ext.fast_callable import fast_callable
 from sage.graphs.graph import Graph
 from sage.groups.matrix_gps.finitely_generated import MatrixGroup
@@ -617,7 +617,7 @@ class RiemannSurface:
         sage: f = Y^2+X*Y+phi*Y-(X^3-X^2-2*phi*X+phi)
         sage: S = RiemannSurface(f,prec=prec, differentials=[1])
         sage: tau = S.riemann_matrix()[0, 0]
-        sage: tau.algdep(6).degree() == 2
+        sage: tau.algebraic_dependency(6).degree() == 2
         True
     """
 
@@ -2292,7 +2292,7 @@ class RiemannSurface:
             sage: m = S.matrix_of_integral_values(B)
             sage: parent(m)
             Full MatrixSpace of 1 by 2 dense matrices over Complex Field with 53 bits of precision
-            sage: (m[0,0]/m[0,1]).algdep(3).degree() # curve is CM, so the period is quadratic
+            sage: (m[0,0]/m[0,1]).algebraic_dependency(3).degree() # curve is CM, so the period is quadratic
             2
 
         .. NOTE::
@@ -2412,7 +2412,7 @@ class RiemannSurface:
 
             sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^2 - x + 2)
-            sage: all(len(m.algdep(6).roots(K)) > 0 for m in M.list())
+            sage: all(len(m.algebraic_dependency(6).roots(K)) > 0 for m in M.list())
             True
         """
         PeriodMatrix = self.period_matrix()
@@ -2689,7 +2689,7 @@ class RiemannSurface:
             d = 1
             while True:
                 d += 1
-                dep = algdep(alpha, d, height_bound=10**d)
+                dep = algebraic_dependency(alpha, d, height_bound=10**d)
                 if dep and dep(alpha) < epscomp:
                     return dep
 


### PR DESCRIPTION
for the sake of uniformity, make sure that `algdep` only ever appears as an alias of `algebraic_dependency` both as method and as function in `arith.misc`.

We keep both `algdep` and `algebraic_dependency` in the global namespace.

also fixes #17302

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



