### PR TITLE
Make test deterministic to fix CI

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -2354,12 +2354,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: set(E.gens()) <= set([P,-P])
             True
 
-        Check that :issue:`38813` has been fixed:
+        Check that :issue:`38813` has been fixed::
 
-            sage: set_random_seed(91390048253425197917505296851335255685)
+            sage: # long time
             sage: E = EllipticCurve([-127^2,0])
-            sage: E.gens(use_database=False, algorithm='pari', pari_effort=4)   # long time
+            sage: l = E.gens(use_database=False, algorithm='pari', pari_effort=4); l   # random
             [(611429153205013185025/9492121848205441 : 15118836457596902442737698070880/924793900700594415341761 : 1)]
+            sage: a = E(611429153205013185025/9492121848205441, 15118836457596902442737698070880/924793900700594415341761)
+            sage: assert len(l) == 1 and ((l[0] - a).is_finite_order() or (l[0] + a).is_finite_order())
         """
         if proof is None:
             from sage.structure.proof.proof import get_flag


### PR DESCRIPTION
Apparently the test is introduced in https://github.com/sagemath/sage/pull/38824 and  it's basically copied from another test below that is marked `random`

```
            sage: E = EllipticCurve([-127^2,0])
            sage: E.gens(use_database=False, algorithm='pari', pari_effort=4)   # long time, random
            [(611429153205013185025/9492121848205441 : 15118836457596902442737698070880/924793900700594415341761 : 1)]
```

I don't know why this one isn't marked `# random` but I choose to keep checking the output but does it more carefully. Basically it has rank 1 so the generator is determined up to `± 1` and modulo torsion, so we just need to check `l[0] - a` or `l[0] + a` is in torsion.

It's not clear why the test starts failing now. Maybe it's just random after all.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


