### PR TITLE
bump python to at least 3.11 in spkg-configure.m4

### DIFF
--- a/build/pkgs/python3/spkg-configure.m4
+++ b/build/pkgs/python3/spkg-configure.m4
@@ -1,6 +1,6 @@
 SAGE_SPKG_CONFIGURE([python3], [
-   m4_pushdef([MIN_VERSION],               [3.9.0])
-   m4_pushdef([MIN_NONDEPRECATED_VERSION], [3.9.0])
+   m4_pushdef([MIN_VERSION],               [3.11.0])
+   m4_pushdef([MIN_NONDEPRECATED_VERSION], [3.11.0])
    m4_pushdef([LT_STABLE_VERSION],         [3.14.0])
    m4_pushdef([LT_VERSION],                [3.14.0])
    AC_ARG_WITH([python],


### PR DESCRIPTION
this 2-line fix was  missing on #39251

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


