### PR TITLE
Doctest for defining multivariate polynomial ring over InfinityRing

### DIFF
--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -622,7 +622,7 @@ def PolynomialRing(base_ring, *args, **kwds):
         sage: R.<x,y> = PolynomialRing(RIF,2)
         sage: TestSuite(R).run(skip=['_test_elements', '_test_elements_eq_transitive'])
 
-    We verify that multivariate polynomial rings over InfinityRing from
+    We verify that multivariate polynomial rings over ``InfinityRing`` from
     :issue:`34675` are fixed::
 
         sage: PolynomialRing(InfinityRing, 2, 'x')

--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -621,6 +621,12 @@ def PolynomialRing(base_ring, *args, **kwds):
         ....:                        '_test_distributivity', '_test_prod'])
         sage: R.<x,y> = PolynomialRing(RIF,2)
         sage: TestSuite(R).run(skip=['_test_elements', '_test_elements_eq_transitive'])
+
+    We verify that multivariate polynomial rings over InfinityRing from
+    :issue:`34675` are fixed::
+
+        sage: PolynomialRing(InfinityRing, 2, 'x')
+        Multivariate Polynomial Ring in x0, x1 over The Infinity Ring
     """
     from sage.rings.semirings.tropical_semiring import TropicalSemiring
     if base_ring not in Rings() and not isinstance(base_ring, TropicalSemiring):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes #34675

Previously, defining a multivariate polynomial ring over InfinityRing would incorrectly result in an error. As mentioned in the comments under the linked issue, this behaviour was fixed in version 10.3 but a doctest was still needed.

This pull request adds the required doctest, verifying that the statement `PolynomialRing(InfinityRing,2,'x')` correctly generates a ring instead of throwing an error.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


