### PR TITLE
Implement a bijection between Knutson-Tao puzzles and LR tableaux

### DIFF
--- a/src/sage/combinat/knutson_tao_puzzles.py
+++ b/src/sage/combinat/knutson_tao_puzzles.py
@@ -11,7 +11,7 @@ AUTHORS:
 
 - Franco Saliola, Allen Knutson, Avinash Dalal, Anne Schilling (2013): initial version at Sage Days 45, ICERM
 - Elizabeth Beazley, Ed Richmond (2013): testing
-- Álvaro Gutiérrez (2025-02-24): added ``to_littlewood_richarsdon_tableau``
+- Álvaro Gutiérrez (2025-02-24): added ``to_littlewood_richardson_tableau``
 - Julian Rüth (2025-02-24): clean up code
 
 .. TODO::
@@ -1487,7 +1487,7 @@ class PuzzleFilling:
 
         return s
 
-    def to_littlewood_richarsdon_tableau(self):
+    def to_littlewood_richardson_tableau(self):
         r"""
         Creates a skew Littlewood--Richardson tableau from a puzzle.
 
@@ -1513,7 +1513,7 @@ class PuzzleFilling:
             sage: from sage.combinat.knutson_tao_puzzles import KnutsonTaoPuzzleSolver
             sage: ps = KnutsonTaoPuzzleSolver("H")
             sage: solns = ps('010101','010101')
-            sage: [puzzle.to_littlewood_richarsdon_tableau() for puzzle in solns]
+            sage: [puzzle.to_littlewood_richardson_tableau() for puzzle in solns]
             [[[None, None, None], [1, 1], [2]],
              [[None, None, 1], [None, 1], [2]],
              [[None, None, 1], [None, 2], [1]],
@@ -1522,7 +1522,7 @@ class PuzzleFilling:
             ....: ps = KnutsonTaoPuzzleSolver('H')
             ....: solns = ps('00000010001000010100', '00000000100010010100')
             ....: puzzle = solns[168]
-            ....: tab = puzzle.to_littlewood_richarsdon_tableau(); tab.pp()
+            ....: tab = puzzle.to_littlewood_richardson_tableau(); tab.pp()
               .  .  .  .  .  .  .  .  .  .  1  1  1  1
               .  .  .  .  .  .  .  1  1  1  2  2  2
               .  .  .  .  .  1  1  2  2  3  3

--- a/src/sage/combinat/knutson_tao_puzzles.py
+++ b/src/sage/combinat/knutson_tao_puzzles.py
@@ -11,7 +11,7 @@ AUTHORS:
 
 - Franco Saliola, Allen Knutson, Avinash Dalal, Anne Schilling (2013): initial version at Sage Days 45, ICERM
 - Elizabeth Beazley, Ed Richmond (2013): testing
-- Álvaro Gutiérrez (2025-02-24): added ``.to_LRtableaux()``
+- Álvaro Gutiérrez (2025-02-24): added ``to_littlewood_richarsdon_tableau``
 - Julian Rüth (2025-02-24): clean up code
 
 .. TODO::
@@ -1487,7 +1487,7 @@ class PuzzleFilling:
 
         return s
 
-    def to_LRtableau(self):
+    def to_littlewood_richarsdon_tableau(self):
         r"""
         Creates a skew Littlewood--Richardson tableau from a puzzle.
 
@@ -1506,14 +1506,14 @@ class PuzzleFilling:
 
         OUTPUT:
 
-        - a LR skew tableau
+        - a Littlewood--Richardson skew tableau
 
         EXAMPLES::
 
             sage: from sage.combinat.knutson_tao_puzzles import KnutsonTaoPuzzleSolver
             sage: ps = KnutsonTaoPuzzleSolver("H")
             sage: solns = ps('010101','010101')
-            sage: [puzzle.to_LRtableau() for puzzle in solns]
+            sage: [puzzle.to_littlewood_richarsdon_tableau() for puzzle in solns]
             [[[None, None, None], [1, 1], [2]],
              [[None, None, 1], [None, 1], [2]],
              [[None, None, 1], [None, 2], [1]],
@@ -1522,7 +1522,7 @@ class PuzzleFilling:
             ....: ps = KnutsonTaoPuzzleSolver('H')
             ....: solns = ps('00000010001000010100', '00000000100010010100')
             ....: puzzle = solns[168]
-            ....: tab = puzzle.to_LRtableau(); tab.pp()
+            ....: tab = puzzle.to_littlewood_richarsdon_tableau(); tab.pp()
               .  .  .  .  .  .  .  .  .  .  1  1  1  1
               .  .  .  .  .  .  .  1  1  1  2  2  2
               .  .  .  .  .  1  1  2  2  3  3
@@ -1547,7 +1547,7 @@ class PuzzleFilling:
 
     def _ne_to_south_path(self, coord):
         r"""
-        Returns the content row of the LR skew tableau corresponding to ``coord``.
+        Return the content row of the Littlewood--Richardson skew tableau corresponding to ``coord``.
 
         This method traces out a path from ``coord`` to its "mirror" coordinate.
         If ``coord`` specifies the `i`-th 1 from the top on the north-east border
@@ -1569,7 +1569,7 @@ class PuzzleFilling:
 
         OUTPUT:
 
-        - a list of numbers giving the content of one row in the LR tableau
+        - a list of numbers giving the content of one row in the Littlewood--Richardson tableau
 
         TESTS::
 

--- a/src/sage/combinat/knutson_tao_puzzles.py
+++ b/src/sage/combinat/knutson_tao_puzzles.py
@@ -2137,7 +2137,7 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
                     raise ValueError("max_letter needs to be specified")
         return super().__classcall__(cls, puzzle_pieces)
 
-    def __call__(self, lamda, mu, algorithm='strips'):
+    def __call__(self, lam, mu, algorithm='strips'):
         r"""
         TESTS::
 
@@ -2166,11 +2166,11 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
               (3, 4): 0/\0  1\/10,
               (4, 4): 10/0\1}]
         """
-        lamda, mu = tuple(lamda), tuple(mu)
+        lam, mu = tuple(lam), tuple(mu)
         if algorithm == 'pieces':
-            return list(self._fill_puzzle_by_pieces(lamda, mu))
+            return list(self._fill_puzzle_by_pieces(lam, mu))
         elif algorithm == 'strips':
-            return list(self._fill_puzzle_by_strips(lamda, mu))
+            return list(self._fill_puzzle_by_strips(lam, mu))
 
     solutions = __call__
 
@@ -2272,7 +2272,7 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
                     output.append(partial_filling + [piece])
         return output
 
-    def _fill_puzzle_by_pieces(self, lamda, mu):
+    def _fill_puzzle_by_pieces(self, lam, mu):
         r"""
         Fill puzzle pieces for given outer labels ``lambda`` and ``mu``.
 
@@ -2283,7 +2283,7 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
             sage: list(ps._fill_puzzle_by_pieces('0', '0'))
             [{(1, 1): 0/0\0}]
         """
-        queue = [PuzzleFilling(lamda, mu)]
+        queue = [PuzzleFilling(lam, mu)]
         while queue:
             PP = queue.pop()
             ne_label = PP.north_east_label_of_kink()
@@ -2300,7 +2300,7 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
                 else:
                     queue.append(PPcopy)
 
-    def _fill_puzzle_by_strips(self, lamda, mu):
+    def _fill_puzzle_by_strips(self, lam, mu):
         r"""
         Fill puzzle pieces by strips for given outer labels ``lambda`` and ``mu``.
 
@@ -2313,7 +2313,7 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
             sage: list(ps._fill_puzzle_by_strips('01', '01'))
             [{(1, 1): 0/0\0, (1, 2): 1/\0  0\/1, (2, 2): 1/1\1}]
         """
-        queue = [PuzzleFilling(lamda, mu)]
+        queue = [PuzzleFilling(lam, mu)]
         while queue:
             PP = queue.pop()
             i, _ = PP.kink_coordinates()
@@ -2323,7 +2323,7 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
                 nw_labels = PP._nw_labels
             else:
                 nw_labels = tuple(PP._squares[i - 1, k]['south_east']
-                                  for k in range(i, len(lamda) + 1))
+                                  for k in range(i, len(lam) + 1))
 
             # grab ne labels
             ne_label = PP._ne_labels[i - 1]
@@ -2357,7 +2357,7 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
         m = len([gg.axes(False) for gg in g])
         return graphics_array(g, (m + 3) / 4, 4)
 
-    def structure_constants(self, lamda, mu, nu=None):
+    def structure_constants(self, lam, mu, nu=None):
         r"""
         Compute cohomology structure coefficients from puzzles.
 
@@ -2428,9 +2428,9 @@ class KnutsonTaoPuzzleSolver(UniqueRepresentation):
              (('2', '1', '1', '0', '2'), 1)]
         """
         from collections import defaultdict
-        R = PolynomialRing(Integers(), 'y', len(lamda) + 1)
+        R = PolynomialRing(Integers(), 'y', len(lam) + 1)
         z = defaultdict(R.zero)
-        for p in self(lamda, mu):
+        for p in self(lam, mu):
             z[p.south_labels()] += p.contribution()
         if nu is None:
             return dict(z)

--- a/src/sage/combinat/knutson_tao_puzzles.py
+++ b/src/sage/combinat/knutson_tao_puzzles.py
@@ -6,14 +6,12 @@ instance of this class will be callable: the arguments are the labels of
 north-east and north-west sides of the puzzle boundary; the output is the list
 of the fillings of the puzzle with the specified pieces.
 
-Acknowledgements
-----------------
 
-The initial version of this code was written during Sage Days 45 at ICERM.
+AUTHORS:
 
-- Franco Saliola, Allen Knutson, Avinash Dalal, Anne Schilling (Initial version, 2013)
-- Elizabeth Beazley, Ed Richmond (Testing, 2013)
-- Álvaro Gutiérrez (added .to_LRtableaux(), 2025)
+- Franco Saliola, Allen Knutson, Avinash Dalal, Anne Schilling (2013): initial version at Sage Days 45, ICERM
+- Elizabeth Beazley, Ed Richmond (2013): testing
+- Álvaro Gutiérrez (2025-02-24): added ``.to_LRtableaux()``
 
 .. TODO::
 
@@ -34,9 +32,13 @@ The initial version of this code was written during Sage Days 45 at ICERM.
 #                     2013 Ed Richmond,
 #                     2025 Álvaro Gutiérrez <gutierrez.caceres@outlook.com>
 #
-#  Distributed under the terms of the GNU General Public License (GPL)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+
 from __future__ import annotations
 
 from sage.misc.lazy_import import lazy_import

--- a/src/sage/combinat/knutson_tao_puzzles.py
+++ b/src/sage/combinat/knutson_tao_puzzles.py
@@ -1584,7 +1584,6 @@ class PuzzleFilling:
             Traceback (most recent call last):
             ...
             AssertionError: the coordinate needs to be a coordinate of a 1 on the north-east boundary
-
         """
         assert self._ne_labels[coord-1] == '1', "the coordinate needs to be a coordinate of a 1 on the north-east boundary"
 

--- a/src/sage/combinat/knutson_tao_puzzles.py
+++ b/src/sage/combinat/knutson_tao_puzzles.py
@@ -1489,7 +1489,7 @@ class PuzzleFilling:
 
     def to_littlewood_richardson_tableau(self):
         r"""
-        Creates a skew Littlewood--Richardson tableau from a puzzle.
+        Create a skew Littlewood--Richardson tableau from a puzzle.
 
         We follow the bijection given in [Purbhoo07]_. A similar but different
         bijection is given in [Vakil03]_.

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -278,7 +278,10 @@ We use the lexicographic ordering::
 #       Copyright (C) 2007 Mike Hansen <mhansen@gmail.com>,
 #                     2025 Álvaro Gutiérrez <gutierrez.caceres@outlook.com>
 #
-#  Distributed under the terms of the GNU General Public License (GPL)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -5817,7 +5817,7 @@ class Partition(CombinatorialElement):
 
     def to_abacus(self, size=0, ones=0):
         r"""
-        Return an abacus from a partition.
+        Return an abacus.
 
         This is the inverse to :func:`.abacus_to_partition`.
 
@@ -5832,9 +5832,10 @@ class Partition(CombinatorialElement):
         convention. For each vertical step, record a 1; for each horizontal
         step record a 0. The resulting word is the corresponding abacus.
 
-        Additionally, if ``size`` is given, the abacus will be of length at least
-        ``size`` (by padding with 0s on the right). The number of 1s in the abacus
-        will be at least ``ones``.
+        The abacus will be of length at least ``size``, by padding with 
+        0s on the right if necessary. The number of 1s in
+        the abacus will be at least ``ones``, by padding with 1s on the
+        left if necessary.
 
         INPUT:
 

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -62,6 +62,8 @@ AUTHORS:
 
 - Matthew Lancellotti (2018-09-14): Added a bunch of "k" methods to Partition.
 
+- Álvaro Gutiérrez (2025-02-24): added functionality to translate to and from abaci
+
 EXAMPLES:
 
 There are `5` partitions of the integer `4`::
@@ -274,6 +276,7 @@ We use the lexicographic ordering::
 """
 # ****************************************************************************
 #       Copyright (C) 2007 Mike Hansen <mhansen@gmail.com>,
+#                     2025 Álvaro Gutiérrez <gutierrez.caceres@outlook.com>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
@@ -5809,6 +5812,62 @@ class Partition(CombinatorialElement):
         R = SymmetricGroupAlgebra(base_ring, sum(self))
         return TabloidModule(R, self)
 
+    def to_abacus(self, size=0, ones=0):
+        r"""
+        Return an abacus from a partition.
+
+        This is the inverse to :func:`.abacus_to_partition`.
+
+        An abacus is a function `w : \mathbb{Z} \to \{0,1\}` such that
+        `w(n) = 0` for `n \ll 0` and `w(n) = 1` for `n \gg 0`. It is usually
+        represented with an infinite tuple, e.g. `(...,0,0,0,1,0,0,1,0,1,1,...)`.
+        Here, we use finite tuples, and assume everything to the left is a 0
+        and everything to the right is a 1.
+
+        A partition determines an abacus via the following interpretation:
+        read the outline of the Young diagram of the partition, with English
+        convention. For each vertical step, record a 1; for each horizontal
+        step record a 0. The resulting word is the corresponding abacus.
+
+        Additionally, if ``size`` is given, the abacus will be of length at least
+        ``size`` (by padding with 0s on the right). The number of 1s in the abacus
+        will be at least ``ones``.
+
+        INPUT:
+
+        - ``size``, ``ones`` -- Integer (optional. Default: 0)
+
+        OUTPUT:
+
+        - a string of 0s and 1s.
+
+        EXAMPLES::
+
+            sage: Partition([3,2,1]).to_abacus()
+            '010101'
+            sage: Partition([3,2,1]).to_abacus(size=10)
+            '0101010000'
+            sage: Partition([3,3]).to_abacus()
+            '00011'
+            sage: Partition([]).to_abacus(size=6)
+            '000000'
+            sage: Partition([]).to_abacus(ones=2)
+            '11'
+            sage: Partition([2,2]).to_abacus(size=4)
+            '0011'
+            sage: Partition([2,2]).to_abacus(size=5)
+            '00110'
+            sage: Partition([2,2]).to_abacus(size=5, ones=3)
+            '10011'
+
+        """
+        L = max(ones,len(self))
+        lam = list(self)+[0]*(L+1-len(self))
+        abacus = [1] * L
+        for i in range(L):
+            abacus = abacus[:(L-i-1)] + [0]*(lam[i]-lam[i+1]) + abacus[(L-i-1):]
+        return ''.join(map(str, abacus + [0]*(size-len(abacus))))
+
 
 ##############
 # Partitions #
@@ -9664,6 +9723,59 @@ class RestrictedPartitions_n(RestrictedPartitions_generic, Partitions_n):
             [1]
         """
         return self.element_class(self, Partitions_n._an_element_(self).conjugate())
+
+##################################################################
+
+
+def abacus_to_partition(abacus):
+    r"""
+    Returns a partition from an abacus.
+
+    An abacus is a function `w : \mathbb{Z} \to \{0,1\}` such that
+    `w(n) = 0` for `n \ll 0` and `w(n) = 1` for `n \gg 0`. It is usually
+    represented with an infinite tuple, e.g. `(...,0,0,0,1,0,0,1,0,1,1,...)`.
+    Here, we use finite tuples, and assume everything to the left is a 0
+    and everything to the right is a 1.
+
+    An abacus determines a partition, via the following interpretation:
+    a 1 in the abacus encodes a vertical line, and a 0 encodes a
+    horizontal one. Reading from left to right, the abacus spells the
+    outline of the Young diagram.
+
+    This is the inverse to :meth:`Partition.to_abacus`.
+
+    INPUT:
+
+    - ``abacus`` -- a tuple, a list or a string of 1's and 0's
+
+    OUTPUT:
+
+    - a Partition
+
+    EXAMPLES::
+
+        sage: from sage.combinat.partition import abacus_to_partition
+        sage: abacus_to_partition('010101')
+        [3, 2, 1]
+        sage: abacus_to_partition([1,1,0,0,0])
+        []
+        sage: abacus_to_partition((0,0,0,1,1))
+        [3, 3]
+        sage: abacus_to_partition(('1','1','1','0','0','0'))
+        []
+        sage: abacus_to_partition(['0','0','0','1','1','1'])
+        [3, 3, 3]
+    """
+    part = []
+    n = len(abacus)
+    k = 0
+    for i in range(0,n):
+        if abacus[i] == '1' or abacus[i] == 1:
+            k += 1
+            part.insert(0, i+1-k)
+        elif abacus[i] != '0' and abacus[i] != 0:
+            raise ValueError('an abacus should be a tuple, list or string of 0s and 1s')
+    return Partition(part)
 
 
 #########################################################################

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -9732,7 +9732,7 @@ class RestrictedPartitions_n(RestrictedPartitions_generic, Partitions_n):
 
 def abacus_to_partition(abacus):
     r"""
-    Returns a partition from an abacus.
+    Return a partition from an abacus.
 
     An abacus is a function `w : \mathbb{Z} \to \{0,1\}` such that
     `w(n) = 0` for `n \ll 0` and `w(n) = 1` for `n \gg 0`. It is usually

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -5832,7 +5832,7 @@ class Partition(CombinatorialElement):
         convention. For each vertical step, record a 1; for each horizontal
         step record a 0. The resulting word is the corresponding abacus.
 
-        The abacus will be of length at least ``size``, by padding with 
+        The abacus will be of length at least ``size``, by padding with
         0s on the right if necessary. The number of 1s in
         the abacus will be at least ``ones``, by padding with 1s on the
         left if necessary.

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -5824,7 +5824,7 @@ class Partition(CombinatorialElement):
         An abacus is a function `w : \mathbb{Z} \to \{0,1\}` such that
         `w(n) = 0` for `n \ll 0` and `w(n) = 1` for `n \gg 0`. It is usually
         represented with an infinite tuple, e.g. `(...,0,0,0,1,0,0,1,0,1,1,...)`.
-        Here, we use finite tuples, and assume everything to the left is a 0
+        Here we use finite tuples and assume everything to the left is a 0
         and everything to the right is a 1.
 
         A partition determines an abacus via the following interpretation:
@@ -5833,9 +5833,8 @@ class Partition(CombinatorialElement):
         step record a 0. The resulting word is the corresponding abacus.
 
         The abacus will be of length at least ``size``, by padding with
-        0s on the right if necessary. The number of 1s in
-        the abacus will be at least ``ones``, by padding with 1s on the
-        left if necessary.
+        0s on the right if necessary. The number of 1s in the abacus will
+        be at least ``ones``, by padding with 1s on the left if necessary.
 
         INPUT:
 
@@ -9769,11 +9768,15 @@ def abacus_to_partition(abacus):
         []
         sage: abacus_to_partition(['0','0','0','1','1','1'])
         [3, 3, 3]
+        sage: abacus_to_partition('--*-**')
+        Traceback (most recent call last):
+        ...
+        ValueError: an abacus should be a tuple, list or string of 0s and 1s
     """
     part = []
     n = len(abacus)
     k = 0
-    for i in range(0,n):
+    for i in range(n):
         if abacus[i] == '1' or abacus[i] == 1:
             k += 1
             part.insert(0, i+1-k)

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -1844,7 +1844,7 @@ class SkewTableau(ClonableList,
 
     def is_littlewood_richardson(self):
         r"""
-        Checks whether ``self`` is a Littlewood--Richardson tableau.
+        Check whether ``self`` is a Littlewood--Richardson tableau.
 
         A Littlewood--Richardson tableau is a semistandard skew tableau whose
         (row reading) word is Yamanouchi.
@@ -1863,7 +1863,7 @@ class SkewTableau(ClonableList,
 
     def to_knutson_tao_puzzle(self, size=None):
         r"""
-        Takes a Littlewood--Richardson tableau and returns a Knutson--Tao puzzle.
+        Take a Littlewood--Richardson tableau and return a Knutson--Tao puzzle.
 
 
         INPUT:

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -8,22 +8,18 @@ AUTHORS:
   Factored out ``CombinatorialClass``
 - Trevor K. Karn (2022-08-03): added ``backward_slide``
 - Álvaro Gutiérrez (2025-02-24): added ``to_KTpuzzle``
+
 """
 # ****************************************************************************
 #       Copyright (C) 2007 Mike Hansen <mhansen@gmail.com>,
-#       Copyright (C) 2013 Travis Scrimshaw <tcscrims at gmail.com>
-#       Copyright (C) 2013 Arthur Lubovsky
-#       Copyright (C) 2025 Álvaro Gutiérrez <gutierrez.caceres@outlook.com>
+#                     2013 Travis Scrimshaw <tcscrims at gmail.com>
+#                     2013 Arthur Lubovsky
+#                     2025 Álvaro Gutiérrez <gutierrez.caceres@outlook.com>
 #
-#  Distributed under the terms of the GNU General Public License (GPL)
-#
-#    This code is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-#    General Public License for more details.
-#
-#  The full text of the GPL is available at:
-#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -1868,8 +1868,6 @@ class SkewTableau(ClonableList,
 
         INPUT:
 
-        - ``tableau`` -- a Littlewood--Richardson SkewTableau
-
         - ``size`` -- the size of the output Knutson--Tao puzzle (optional)
 
         TESTS::
@@ -1907,18 +1905,15 @@ class SkewTableau(ClonableList,
         tab_w = self.weight()
         tab_out = self.outer_shape()
         tab_inn = self.inner_shape()
-        L = len(self)
 
         if size is None:
-            size = max(tab_w[0] + L, tab_out[0] + L)
-        assert size >= max(tab_w[0] + L, tab_out[0] + L), "the puzzle size inputted is too small"
+            size = max(tab_w[0] + len(self), tab_out[0] + len(self))
+        assert size >= max(tab_w[0] + len(self), tab_out[0] + len(self)), "the puzzle size inputted is too small"
 
-        n = size
-
-        lam = Partition(tab_w).to_abacus(size=size, ones=L)[::-1]
-        mu = [(n - L) - r for r in tab_out][::-1]
-        mu = Partition(mu).to_abacus(size=size, ones=L)[::-1]
-        nu = Partition(tab_inn).to_abacus(size=size, ones=L)
+        lam = Partition(tab_w).to_abacus(size=size, ones=len(self))[::-1]
+        mu = [(size - len(self)) - r for r in tab_out][::-1]
+        mu = Partition(mu).to_abacus(size=size, ones=len(self))[::-1]
+        nu = Partition(tab_inn).to_abacus(size=size, ones=len(self))
 
         # Initialize puzzle
 
@@ -1926,11 +1921,11 @@ class SkewTableau(ClonableList,
 
         # Find the locations of 1-triangles (blue by default in the plot)
 
-        chosenCols = [i+1 for i in range(n) if nu[i] == '1']
-        chosenRows = [i+1 for i in range(n) if lam[i] == '1']
+        chosenCols = [i+1 for i in range(size) if nu[i] == '1']
+        chosenRows = [i+1 for i in range(size) if lam[i] == '1']
         delta_blue_positions = []
         nabla_blue_positions = []
-        for col in range(L):
+        for col in range(len(self)):
             propagationRow = []
             propagationCol = []
             for row in range(col+1):
@@ -1939,7 +1934,7 @@ class SkewTableau(ClonableList,
 
                 delta_blue_positions.append((j, i))
 
-                k = self[L-col+row-1].count(row+1)
+                k = self[len(self)-col+row-1].count(row+1)
                 nabla_blue_positions.append((j+k, i+k+1))
 
                 propagationCol.insert(0, j+k)
@@ -1950,7 +1945,7 @@ class SkewTableau(ClonableList,
         # Create a dictionary of boundaries
         # (not all boundaries are in the dictionary)
 
-        D = {(i,j) : {} for i in range(1,n+1) for j in range(i,n+1)}
+        D = {(i,j) : {} for i in range(1,size+1) for j in range(i,size+1)}
         for (i,j) in delta_blue_positions:
             D[(i,j)]['north_west'] = '1'
             D[(i,j)]['north_east'] = '1'
@@ -1978,10 +1973,10 @@ class SkewTableau(ClonableList,
                 D[(a,b)]['south_west'] = '1'
                 D[(a+1,b)]['north_east'] = '1'
                 D[(a+1,b)]['north_west'] = '10'
-        for i in range(n):
+        for i in range(size):
             D[(1,i+1)]['north_west'] = lam[i]
             D[(i+1,i+1)]['south'] = nu[i]
-            D[(i+1,n)]['north_east'] = mu[i]
+            D[(i+1,size)]['north_east'] = mu[i]
 
         # Now fill piece by piece
         # (like KnutsonTaoPuzzleSolver._fill_puzzle_by_pieces

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -1857,14 +1857,12 @@ class SkewTableau(ClonableList,
             False
             sage: SkewTableau([[None,1],[2,2]]).is_littlewood_richardson()
             False
-
         """
         return self.is_semistandard() and self.to_word().is_yamanouchi()
 
     def to_knutson_tao_puzzle(self, size=None):
         r"""
         Return a Knutson--Tao puzzle.
-
 
         INPUT:
 
@@ -1893,7 +1891,7 @@ class SkewTableau(ClonableList,
             1/\0  0\/1
             sage: ''.join(puzzle.south_labels())
             '01000010001001000000'
-            sage: # puzzle.plot() # not tested
+            sage: puzzle.plot() # not tested
         """
         assert self.is_littlewood_richardson(), "this method only applies to Littlewood-Richardson tableaux"
 
@@ -1946,26 +1944,26 @@ class SkewTableau(ClonableList,
         # (not all boundaries are in the dictionary)
 
         D = {(i,j) : {} for i in range(1,size+1) for j in range(i,size+1)}
-        for (i,j) in delta_blue_positions:
+        for i,j in delta_blue_positions:
             D[(i,j)]['north_west'] = '1'
             D[(i,j)]['north_east'] = '1'
-            (a, b) = (i, j)
+            a, b = (i, j)
             while ((a-1, b) not in nabla_blue_positions and a > 1):
                 a -= 1
                 D[(a,b)]['north_east'] = '0'
                 D[(a,b)]['north_west'] = '1'
                 D[(a,b)]['south_east'] = '1'
                 D[(a,b)]['south_west'] = '0'
-            (a, b) = (i, j)
+            a, b = (i, j)
             while ((a, b) not in nabla_blue_positions and b > a):
                 b -= 1
                 D[(a,b)]['north_west'] = '0'
                 D[(a,b)]['north_east'] = '10'
-        for (i,j) in nabla_blue_positions:
+        for i,j in nabla_blue_positions:
             if (i,j) in D.keys():
                 D[(i,j)]['south_west'] = '1'
                 D[(i,j)]['south_east'] = '1'
-            (a, b) = (i, j)
+            a, b = (i, j)
             while ((a, b-1) not in delta_blue_positions and a > 0):
                 a -= 1
                 b -= 1
@@ -1990,7 +1988,7 @@ class SkewTableau(ClonableList,
         dirs = ('north_east', 'north_west', 'south')
         triangles = sorted(all_pieces.delta_pieces(), key=lambda p : ''.join(p[dir] for dir in dirs))
 
-        for (i,j) in D.keys():
+        for i,j in D:
             candidates = []
             if i == j:
                 pieces = triangles
@@ -2000,7 +1998,7 @@ class SkewTableau(ClonableList,
                 dirs = ('north_east', 'north_west', 'south_east', 'south_west')
             # Check what pieces have the desired boundaries
             for piece in pieces:
-                if all(piece[dir] == D[(i,j)][dir] for dir in dirs if dir in D[(i,j)].keys()):
+                if all(piece[dir] == D[(i,j)][dir] for dir in dirs if dir in D[(i,j)]):
                     candidates.append(piece)
             # Place the smallest possible piece (the one with most 0s)
             puzzle._squares[(i,j)] = candidates[0]

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -7,7 +7,7 @@ AUTHORS:
 - Travis Scrimshaw, Arthur Lubovsky (2013-02-11):
   Factored out ``CombinatorialClass``
 - Trevor K. Karn (2022-08-03): added ``backward_slide``
-- Álvaro Gutiérrez (2025-02-24): added ``to_KTpuzzle``
+- Álvaro Gutiérrez (2025-02-24): added ``to_knutson_tao_puzzle``
 
 """
 # ****************************************************************************
@@ -1842,26 +1842,26 @@ class SkewTableau(ClonableList,
         return all(kshapes[i + 1].contains(kshapes[i])
                    for i in range(len(shapes) - 1))
 
-    def is_LR(self):
+    def is_littlewood_richarsdon(self):
         r"""
         Checks whether ``self`` is a Littlewood--Richardson tableau.
 
-        A Littlewood--Richardson tableau (LR tableau) is a semistandard skew tableau whose
+        A Littlewood--Richardson tableau is a semistandard skew tableau whose
         (row reading) word is Yamanouchi.
 
         EXAMPLES::
 
-            sage: SkewTableau([[None,1],[1,2]]).is_LR()
+            sage: SkewTableau([[None,1],[1,2]]).is_littlewood_richarsdon()
             True
-            sage: SkewTableau([[None,1],[2,1]]).is_LR()
+            sage: SkewTableau([[None,1],[2,1]]).is_littlewood_richarsdon()
             False
-            sage: SkewTableau([[None,1],[2,2]]).is_LR()
+            sage: SkewTableau([[None,1],[2,2]]).is_littlewood_richarsdon()
             False
 
         """
         return self.is_semistandard() and self.to_word().is_yamanouchi()
 
-    def to_KTpuzzle(self, size=None):
+    def to_knutson_tao_puzzle(self, size=None):
         r"""
         Takes a Littlewood--Richardson tableau and returns a Knutson--Tao puzzle.
 
@@ -1869,6 +1869,16 @@ class SkewTableau(ClonableList,
         INPUT:
 
         - ``size`` -- the size of the output Knutson--Tao puzzle (optional)
+
+        EXAMPLES::
+
+            sage: ps = KnutsonTaoPuzzleSolver("H")
+            sage: puzzle = ps('01010','01001')[0]
+            sage: tab = puzzle.to_littlewood_richarsdon_tableau(); tab
+            [[None, 1, 1], [2]]
+            sage: puzzle2 = tab.to_knutson_tao_puzzle()
+            sage: puzzle == puzzle2
+            True
 
         TESTS::
 
@@ -1878,24 +1888,14 @@ class SkewTableau(ClonableList,
             ....: [None]*8 + [1]*2 + [2]*3,
             ....: [None]*5 + [1]*2 + [2]*2 + [3]*2,
             ....: [None] + [1]*2 + [2]*2 + [3] + [4]*2])
-            sage: puzzle = tab.to_KTpuzzle(20)
+            sage: puzzle = tab.to_knutson_tao_puzzle(20)
             sage: puzzle[(5,10)]
             1/\0  0\/1
             sage: ''.join(puzzle.south_labels())
             '01000010001001000000'
             sage: # puzzle.plot() # not tested
-
-        EXAMPLES::
-
-            sage: ps = KnutsonTaoPuzzleSolver("H")
-            sage: puzzle = ps('01010','01001')[0]
-            sage: tab = puzzle.to_LRtableau(); tab
-            [[None, 1, 1], [2]]
-            sage: puzzle2 = tab.to_KTpuzzle()
-            sage: puzzle == puzzle2
-            True
         """
-        assert self.is_LR(), "this method only applies to Littlewood-Richardson tableaux"
+        assert self.is_littlewood_richarsdon(), "this method only applies to Littlewood-Richardson tableaux"
 
         from sage.combinat.partition import abacus_to_partition
         from sage.combinat.knutson_tao_puzzles import H_grassmannian_pieces, KnutsonTaoPuzzleSolver, PuzzleFilling

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -1842,7 +1842,7 @@ class SkewTableau(ClonableList,
         return all(kshapes[i + 1].contains(kshapes[i])
                    for i in range(len(shapes) - 1))
 
-    def is_littlewood_richarsdon(self):
+    def is_littlewood_richardson(self):
         r"""
         Checks whether ``self`` is a Littlewood--Richardson tableau.
 
@@ -1851,11 +1851,11 @@ class SkewTableau(ClonableList,
 
         EXAMPLES::
 
-            sage: SkewTableau([[None,1],[1,2]]).is_littlewood_richarsdon()
+            sage: SkewTableau([[None,1],[1,2]]).is_littlewood_richardson()
             True
-            sage: SkewTableau([[None,1],[2,1]]).is_littlewood_richarsdon()
+            sage: SkewTableau([[None,1],[2,1]]).is_littlewood_richardson()
             False
-            sage: SkewTableau([[None,1],[2,2]]).is_littlewood_richarsdon()
+            sage: SkewTableau([[None,1],[2,2]]).is_littlewood_richardson()
             False
 
         """
@@ -1874,7 +1874,7 @@ class SkewTableau(ClonableList,
 
             sage: ps = KnutsonTaoPuzzleSolver("H")
             sage: puzzle = ps('01010','01001')[0]
-            sage: tab = puzzle.to_littlewood_richarsdon_tableau(); tab
+            sage: tab = puzzle.to_littlewood_richardson_tableau(); tab
             [[None, 1, 1], [2]]
             sage: puzzle2 = tab.to_knutson_tao_puzzle()
             sage: puzzle == puzzle2
@@ -1895,7 +1895,7 @@ class SkewTableau(ClonableList,
             '01000010001001000000'
             sage: # puzzle.plot() # not tested
         """
-        assert self.is_littlewood_richarsdon(), "this method only applies to Littlewood-Richardson tableaux"
+        assert self.is_littlewood_richardson(), "this method only applies to Littlewood-Richardson tableaux"
 
         from sage.combinat.partition import abacus_to_partition
         from sage.combinat.knutson_tao_puzzles import H_grassmannian_pieces, KnutsonTaoPuzzleSolver, PuzzleFilling

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -1863,7 +1863,7 @@ class SkewTableau(ClonableList,
 
     def to_knutson_tao_puzzle(self, size=None):
         r"""
-        Take a Littlewood--Richardson tableau and return a Knutson--Tao puzzle.
+        Return a Knutson--Tao puzzle.
 
 
         INPUT:

--- a/src/sage/combinat/skew_tableau.py
+++ b/src/sage/combinat/skew_tableau.py
@@ -1947,23 +1947,23 @@ class SkewTableau(ClonableList,
         for i,j in delta_blue_positions:
             D[(i,j)]['north_west'] = '1'
             D[(i,j)]['north_east'] = '1'
-            a, b = (i, j)
+            a, b = i, j
             while ((a-1, b) not in nabla_blue_positions and a > 1):
                 a -= 1
                 D[(a,b)]['north_east'] = '0'
                 D[(a,b)]['north_west'] = '1'
                 D[(a,b)]['south_east'] = '1'
                 D[(a,b)]['south_west'] = '0'
-            a, b = (i, j)
+            a, b = i, j
             while ((a, b) not in nabla_blue_positions and b > a):
                 b -= 1
                 D[(a,b)]['north_west'] = '0'
                 D[(a,b)]['north_east'] = '10'
-        for i,j in nabla_blue_positions:
-            if (i,j) in D.keys():
+        for i, j in nabla_blue_positions:
+            if (i,j) in D:
                 D[(i,j)]['south_west'] = '1'
                 D[(i,j)]['south_east'] = '1'
-            a, b = (i, j)
+            a, b = i, j
             while ((a, b-1) not in delta_blue_positions and a > 0):
                 a -= 1
                 b -= 1
@@ -1988,7 +1988,7 @@ class SkewTableau(ClonableList,
         dirs = ('north_east', 'north_west', 'south')
         triangles = sorted(all_pieces.delta_pieces(), key=lambda p : ''.join(p[dir] for dir in dirs))
 
-        for i,j in D:
+        for i, j in D:
             candidates = []
             if i == j:
                 pieces = triangles


### PR DESCRIPTION
The bijection from Knutson-Tao puzzles to Littlewood-Richardson tableaux was implemented in the initial version of ```sage.combinat.knutson_tao_puzzles``` but it was removed during revision. See https://github.com/sagemath/sage/issues/14141#issuecomment-1417508031 and https://github.com/sagemath/sage/issues/14141#issuecomment-1417508056
This is a new independent implementation.

Changes to ```sage.combinat.knutso_tao_puzzles```:
- A new public method ```PuzzleFilling.to_littlewood_richardson_tableau``` that takes a puzzle filling and returns its corresponding Littlewood-Richardson tableau. 
- A new private method ```PuzzleFilling._ne_to_south_path``` that does one step of the above bijection.
- Refactoring of all code to make output consistent.

Changes to ```sage.combinat.skew_tableau```:
- A new method ```SkewTableau.is_littlewood_richardson``` that checks if a tableau is Littlewood-Richardson
- A new method ```SkewTableau.to_knutson_tao_puzzle``` that sends a Littlewood-Richardson tableau to a Knutson-Tao puzzle. This is the inverse of ```PuzzleFilling.to_littlewood_richardson_tableau```. 

Changes to ```sage.combinat.partition```:
- A new public method ```Partition.to_abacus``` that converts a partition to a string of 0s and 1s representing its abacus.
- A new public function ```abacus_to_partition``` which is the inverse of the above.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies



