### PR TITLE
Let `AsymptoticRing` respect custom choice of key for underlying `MutablePoset` data structure

### DIFF
--- a/src/sage/rings/asymptotic/asymptotic_ring.py
+++ b/src/sage/rings/asymptotic/asymptotic_ring.py
@@ -1438,7 +1438,7 @@ class AsymptoticExpansion(CommutativeAlgebraElement):
         exact_terms = self.summands.copy()
         for term in self.summands.elements_topological():
             if not term.is_exact():
-                exact_terms.remove(term.growth)
+                exact_terms.remove(exact_terms.get_key(term))
 
         return self.parent(exact_terms)
 
@@ -2143,7 +2143,7 @@ class AsymptoticExpansion(CommutativeAlgebraElement):
         for term in self.summands.elements_topological():
             if not term.is_little_o_of_one():
                 large_terms.append(term)
-                expr_o.remove(term.growth)
+                expr_o.remove(expr_o.get_key(term))
 
         expr_o = P(expr_o)
 

--- a/src/sage/rings/asymptotic/asymptotic_ring.py
+++ b/src/sage/rings/asymptotic/asymptotic_ring.py
@@ -1434,7 +1434,7 @@ class AsymptoticExpansion(CommutativeAlgebraElement):
             x + y
             sage: O(x).exact_part()
             0
-        
+
         Check that the exact part of an expansion can also be determined for
         rings with custom element keys::
 

--- a/src/sage/rings/asymptotic/asymptotic_ring.py
+++ b/src/sage/rings/asymptotic/asymptotic_ring.py
@@ -1434,6 +1434,25 @@ class AsymptoticExpansion(CommutativeAlgebraElement):
             x + y
             sage: O(x).exact_part()
             0
+        
+        Check that the exact part of an expansion can also be determined for
+        rings with custom element keys::
+
+            sage: from sage.data_structures.mutable_poset import MutablePoset
+            sage: from sage.rings.asymptotic.term_monoid import can_absorb, absorption
+            sage: from sage.rings.asymptotic.asymptotic_ring import AsymptoticRing
+            sage: class CustomAsymptoticRing(AsymptoticRing):
+            ....:     @staticmethod
+            ....:     def _create_empty_summands_():
+            ....:         return MutablePoset(key=lambda element: element.growth**2,
+            ....:             can_merge=can_absorb, merge=absorption)
+            sage: AR = CustomAsymptoticRing(growth_group='n^QQ', coefficient_ring=QQ)
+            sage: n = AR.gen()
+            sage: expr = n^5 + n^3 + O(n^(-2))
+            sage: expr.exact_part()
+            n^5 + n^3
+            sage: list(expr.summands.keys())
+            [n^10, n^6, n^(-4)]
         """
         exact_terms = self.summands.copy()
         for term in self.summands.elements_topological():

--- a/src/sage/rings/asymptotic/asymptotic_ring.py
+++ b/src/sage/rings/asymptotic/asymptotic_ring.py
@@ -3981,13 +3981,13 @@ class AsymptoticRing(Parent, UniqueRepresentation, WithLocals):
                 raise TypeError('Not all list entries of %s '
                                 'are asymptotic terms, so cannot create an '
                                 'asymptotic expansion in %s.' % (data, self))
-            summands = AsymptoticRing._create_empty_summands_()
+            summands = self._create_empty_summands_()
             summands.union_update(data)
             return self.element_class(self, summands,
                                       simplify=simplify, convert=convert)
 
         if not data:
-            summands = AsymptoticRing._create_empty_summands_()
+            summands = self._create_empty_summands_()
             return self.element_class(self, summands,
                                       simplify=simplify, convert=False)
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The default `AsymptoticRing` uses a data structure in which individual terms are stored based on their growth (`key=lambda term: term.growth`). In custom `AsymptoticRing`s , it may happen that this is overridden. To make sure this works as intended, we need to use the data structure's `get_key` method instead of directly passing `term.summand`. This PR fixes two such cases and adds a corresponding doctest.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.


*(Contributed from Sage Days 127)*

