### PR TITLE
adding method has_solution to dancing_links

### DIFF
--- a/src/sage/combinat/matrices/dancing_links.pyx
+++ b/src/sage/combinat/matrices/dancing_links.pyx
@@ -565,6 +565,45 @@ cdef class dancing_linksWrapper:
         while self.search():
             yield self.get_solution()
 
+    def has_solution(self):
+        r"""
+        Return whether the problem as a solution.
+
+        EXAMPLES::
+
+            sage: from sage.combinat.matrices.dancing_links import dlx_solver
+            sage: rows = [[0,1,2], [3,4,5], [0,1], [2,3,4,5], [0], [1,2,3,4,5]]
+            sage: d = dlx_solver(rows)
+            sage: d.has_solution()
+            True
+
+        ::
+
+            sage: rows = [[0,2], [3,4,5], [0,4], [2,3,4,5], [3], [1,2,3,4,5]]
+            sage: d = dlx_solver(rows)
+            sage: d.has_solution()
+            False
+
+        TESTS:
+
+        We check that reinitialization works ok::
+
+            sage: rows = [[0,1,2],[0,2],[1],[3]]
+            sage: d = dlx_solver(rows)
+            sage: d.number_of_solutions(ncpus=1)
+            2
+            sage: d.has_solution()
+            True
+            sage: d.has_solution()
+            True
+            sage: d.has_solution()
+            True
+
+        """
+        if self._x.search_is_started():
+            self.reinitialize()
+        return self.search() == 1
+
     def one_solution(self, ncpus=None, column=None):
         r"""
         Return the first solution found.


### PR DESCRIPTION
While answering https://ask.sagemath.org/question/81610/test-if-a-graph-has-a-claw-decomposition/, I realized a method `has_solution` was missing to the dancing links class.

This PR adds such a method.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
