### PR TITLE
override _le_ of UnivariateProduct (in the asymptotic ring) for better performance

### DIFF
--- a/src/sage/rings/asymptotic/growth_group_cartesian.py
+++ b/src/sage/rings/asymptotic/growth_group_cartesian.py
@@ -1366,6 +1366,39 @@ class UnivariateProduct(GenericProduct):
 
     CartesianProduct = CartesianProductGrowthGroups
 
+    class Element(GenericProduct.Element):
+
+        def _le_(self, other):
+            r"""
+            Return if this element is less or equal to ``other``.
+
+            INPUT:
+
+            - ``other`` -- an element of :class:`UnivariateProduct`
+
+            OUTPUT: boolean
+
+            .. NOTE::
+
+                This override method produces exactly the same output
+                as the overridden method (in the base class), but it
+                is faster.
+
+            TESTS::
+
+                sage: A.<n> = AsymptoticRing('n^ZZ * log(n)^ZZ', QQ)
+
+            The following line is intended to test the gain in performance.
+            With this override of `_le_`, the test completes with about
+            10 percent time less.
+
+            ::
+
+                sage: sum(n^k for k in range(6)).log()  # long time
+                5*log(n) + n^(-1) + ...
+            """
+            return self.value <= other.value
+
 
 class MultivariateProduct(GenericProduct):
     r"""


### PR DESCRIPTION
We override `_le_` in sage.rings.asymptotic_ring.cartesian_product to provide a faster comparison. The patch gains already 10% in small examples. In the existing method, there seems to be too much overhead (and this cannot be fixed easily).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


