### PR TITLE
adding the check for pycodestyle E222 in pyx files

### DIFF
--- a/src/tox.ini
+++ b/src/tox.ini
@@ -181,7 +181,7 @@ description =
     # See https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 deps = pycodestyle
 commands = pycodestyle --select E111,E115,E21,E221,E222,E225,E227,E228,E25,E271,E272,E275,E302,E303,E305,E306,E401,E502,E701,E702,E703,E71,E72,W291,W293,W391,W605 {posargs:{toxinidir}/sage/}
-       pycodestyle --select E111,E271,E301,E302,E303,E305,E306,E401,E502,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
+       pycodestyle --select E111,E222,E271,E301,E302,E303,E305,E306,E401,E502,E703,E712,E713,E714,E72,W29,W391,W605, --filename *.pyx {posargs:{toxinidir}/sage/}
 
 [pycodestyle]
 max-line-length = 160


### PR DESCRIPTION
as this is already passing

about E222 multiple spaces after operator

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.

