### PR TITLE
Fixed _positive_roots_reflections for index_set different from {1, 2, …, n}

### DIFF
--- a/src/sage/groups/matrix_gps/coxeter_group.py
+++ b/src/sage/groups/matrix_gps/coxeter_group.py
@@ -546,6 +546,18 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
             [-1  1]  [ 0 -1]  [ 1  0]
             [ 0  1], [-1  0], [ 1 -1]
             ]
+
+        TESTS::
+
+            sage: W = CoxeterGroup(CoxeterType(['A', 2]).relabel({1: 'r', 2: 's'}))
+            sage: F = W._positive_roots_reflections()
+            sage: F.keys()
+            [(1, 0), (1, 1), (0, 1)]
+            sage: list(F)
+            [
+            [-1  1]  [ 0 -1]  [ 1  0]
+            [ 0  1], [-1  0], [ 1 -1]
+            ]
         """
         if not self.is_finite():
             raise NotImplementedError('not available for infinite groups')

--- a/src/sage/groups/matrix_gps/coxeter_group.py
+++ b/src/sage/groups/matrix_gps/coxeter_group.py
@@ -557,13 +557,14 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
         simple_roots = FreeModule(self.base_ring(), self.ngens()).gens()
 
         refls = self.simple_reflections()
+        refls_index = dict((refl_i[1], refl_i[0]) for refl_i in enumerate(refls.keys()))
         resu = []
         d = {}
         for i in range(1, N + 1):
             segment = word[:i]
             last = segment.pop()
             ref = refls[last]
-            rt = simple_roots[last - 1]
+            rt = simple_roots[refls_index[last]]
             while segment:
                 last = segment.pop()
                 cr = refls[last]

--- a/src/sage/groups/matrix_gps/coxeter_group.py
+++ b/src/sage/groups/matrix_gps/coxeter_group.py
@@ -569,7 +569,7 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
         simple_roots = FreeModule(self.base_ring(), self.ngens()).gens()
 
         refls = self.simple_reflections()
-        refls_index = {refl_i[1]: refl_i[0] for refl_i in enumerate(refls)}
+        refls_index = {refl_i[1]: refl_i[0] for refl_i in enumerate(refls.keys())}
         resu = []
         d = {}
         for i in range(1, N + 1):

--- a/src/sage/groups/matrix_gps/coxeter_group.py
+++ b/src/sage/groups/matrix_gps/coxeter_group.py
@@ -557,7 +557,7 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
         simple_roots = FreeModule(self.base_ring(), self.ngens()).gens()
 
         refls = self.simple_reflections()
-        refls_index = dict((refl_i[1], refl_i[0]) for refl_i in enumerate(refls.keys()))
+        refls_index = {refl_i[1]: refl_i[0] for refl_i in enumerate(refls)}
         resu = []
         d = {}
         for i in range(1, N + 1):


### PR DESCRIPTION
The method _positive_roots_reflections() of CoxeterMatrixGroup, required by the method positive_roots(), assumes that the index_set of the group, represented by the keys of self.simple_reflections(), is of the type {1, 2, ..., n}.

This is not always the case, for example the following code fails:
`CoxeterGroup(CoxeterType("A3").relabel({1: "r", 2: "s", 3: "t"})).positive_roots()`

This PR fixes this issue by allowing other type of keys.