### PR TITLE
Fix CI documentation diff

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -173,8 +173,10 @@ jobs:
                                                   -e 's;'"$mathjax_path_from"';'"$mathjax_path_to"';' \
                                                   -e '\;<script type="application/vnd\.jupyter\.widget-state+json">;,\;</script>; d' \
                                                   -e 's;#L[0-9]*";";' \
-                                                  -e 's;tab-set--[0-9]*-;tab-set-;' \
+                                                  -e 's;tab-set--[0-9]*-;tab-set-;g' \
+                                                  -e 's;"tab-set--[0-9]*";"tab-set";' \
              && true)
+            # If the regex list above is changed, the sed command in "Copy doc" step should also be changed
             # Create git repo from old doc
             (cd doc && \
              git init && \
@@ -229,9 +231,10 @@ jobs:
                                                   -e 's;?v=[0-9a-f]*";";' \
                                                   -e '\;<script type="application/vnd\.jupyter\.widget-state+json">;,\;</script>; d' \
                                                   -e 's;#L[0-9]*";";' \
-                                                  -e 's;tab-set--[0-9]*-;tab-set-;' \
+                                                  -e 's;tab-set--[0-9]*-;tab-set-;g' \
                                                   -e 's;"tab-set--[0-9]*";"tab-set";' \
              && git commit -a -m 'wipe-out')
+            # If the regex list above is changed, the sed command in "Store old doc" step should also be changed
             # Since HEAD is at commit 'wipe-out', HEAD~1 is commit 'new' (new doc), HEAD~2 is commit 'old' (old doc)
             (cd doc && git diff $(git rev-parse HEAD~2) -- "*.html") > diff.txt
             # Restore the new doc dropping changes by "wipe out"

--- a/tools/update-conda.py
+++ b/tools/update-conda.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-# Requirements: pip install https://github.com/conda/grayskull conda-lock
-# Usage: python tools/update-conda.py .
+# See README.md for more details
 
 import argparse
 import subprocess

--- a/tools/update-meson.py
+++ b/tools/update-meson.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# See README.md for more details
 
 import argparse
 import os


### PR DESCRIPTION
As discussed in https://github.com/sagemath/sage/pull/39542 . Without this, the "Changes is ready!" feature will be broken.

Also remove some outdated documentation (the requirement list in update-conda was wrong (toml missing), I just refer to README.md which contains the correct list)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


