### PR TITLE
Fixed issue the caused random element in for Tuples to stall by adding unrank method.

### DIFF
--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -432,7 +432,7 @@ class EnumeratedSets(CategoryWithAxiom):
                 sage: P[-1]
                 Traceback (most recent call last):
                 ...
-                NotImplementedError: cannot list an infinite set
+                ValueError: infinite list
 
             ::
 

--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -463,6 +463,8 @@ class EnumeratedSets(CategoryWithAxiom):
                 return self.unrank_range(i.start, i.stop, i.step)
             if i < 0:
                 i += self.cardinality()
+            if i < 0:
+                raise IndexError("index out of range")
             if i is Infinity:
                 return self.list()[i]
             return self.unrank(i)

--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -464,7 +464,7 @@ class EnumeratedSets(CategoryWithAxiom):
             if i < 0:
                 i += self.cardinality()
             if i is Infinity:
-                return self.list()[i]
+                raise ValueError("infinite list")
             return self.unrank(i)
 
         def __len__(self):

--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -470,10 +470,9 @@ class EnumeratedSets(CategoryWithAxiom):
                 to an integer
             """
             from sage.rings.infinity import Infinity
-            from sage.rings.integer_ring import ZZ
             if isinstance(i, slice):
                 return self.unrank_range(i.start, i.stop, i.step)
-            i = ZZ(i)
+            i = Integer(i)
             if i < 0:
                 i += self.cardinality()
             if i < 0:

--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -457,10 +457,23 @@ class EnumeratedSets(CategoryWithAxiom):
                 [1]
                 sage: F[1::2]
                 [2]
+
+            TESTS:
+
+            Verify that an infinite index raises an error::
+
+                sage: F = FiniteEnumeratedSet([1,2,3,4,5])
+                sage: F[oo]
+                Traceback (most recent call last):
+                ...
+                TypeError: unable to coerce <class 'sage.rings.infinity.PlusInfinity'>
+                to an integer
             """
             from sage.rings.infinity import Infinity
+            from sage.rings.integer_ring import ZZ
             if isinstance(i, slice):
                 return self.unrank_range(i.start, i.stop, i.step)
+            i = ZZ(i)
             if i < 0:
                 i += self.cardinality()
             if i < 0:

--- a/src/sage/categories/enumerated_sets.py
+++ b/src/sage/categories/enumerated_sets.py
@@ -458,9 +458,12 @@ class EnumeratedSets(CategoryWithAxiom):
                 sage: F[1::2]
                 [2]
             """
+            from sage.rings.infinity import Infinity
             if isinstance(i, slice):
                 return self.unrank_range(i.start, i.stop, i.step)
             if i < 0:
+                i += self.cardinality()
+            if i is Infinity:
                 return self.list()[i]
             return self.unrank(i)
 

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -90,6 +90,78 @@ class Tuples(Parent, UniqueRepresentation):
         """
         return "Tuples of %s of length %s" % (self.S, self.k)
 
+    def unrank(self, i):
+        """
+        Return the `i`-th element of the set of Tuples.
+
+        INPUT:
+
+        - ``i`` -- integer between `0` and `n-1` where `n` is the cardinality
+          of this set.
+
+        EXAMPLES::
+
+            sage: T = Tuples(range(7), 6)
+            sage: T[73451]
+            (0, 0, 1, 4, 2, 4)
+
+        TESTS::
+
+        Verify that `unrank` is giving the correct result. ::
+
+            sage: T = Tuples(range(4), 5)
+            sage: all(T[i] == x for i,x in enumerate(T))
+            True
+
+        Verify that `unrank` is fast for large inputs. ::
+
+            sage: Tuples(range(3), 30)[10^12]
+            (1, 0, 0, 1, 1, 1, 2, 0, 1, 2, 0, 1, 1, 0, 2, 1, 1, 0, 1, 2, 1, 2,
+            1, 1, 0, 1, 0, 0, 0, 0)
+
+        Verify that `unrank` normalizes ``i``. ::
+
+            sage: T = Tuples(range(3), 2)
+            sage: T[QQ(4/2)]
+            (2, 0)
+            sage: T[QQ(1/2)]
+            Traceback (most recent call last):
+            ...
+            TypeError: no conversion of this rational to integer
+
+        Verify that `unrank` throws an error when ``i`` is out of bounds. ::
+
+            sage: T = Tuples(range(3), 3)
+            sage: T[27]
+            Traceback (most recent call last):
+            ...
+            IndexError: index i (=27) is greater than or equal to the cardinality
+
+        Verify that `unrank` works correctly for Tuples where `k = 1`. ::
+
+            sage: T = Tuples(range(6), 1)
+            sage: T[5]
+            (5,)
+
+        Verify that :issue:`39534` has been fixed. ::
+
+            sage: Tuples(range(3), 30).random_element() #random
+            (0, 2, 2, 1, 2, 1, 0, 2, 0, 2, 1, 0, 0, 2, 1, 1, 2, 0, 2, 1, 1, 0,
+            2, 2, 0, 0, 0, 2, 1, 1)
+        """
+        r = ZZ(i)
+        if r < 0:
+            raise IndexError("i (={}) must be a nonnegative integer")
+        ts = len(self.S)
+        elt = []
+        for _ in range(0, self.k):
+            elt.append(self.S[r % ts])
+            r //= ts
+        if r > 0:
+            raise IndexError("index i (={}) is greater than or equal to the cardinality"
+                             .format(i))
+        return tuple(elt)
+
     def __iter__(self):
         """
         EXAMPLES::

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -139,7 +139,7 @@ class Tuples(Parent, UniqueRepresentation):
             sage: T[-28]
             Traceback (most recent call last):
             ...
-            IndexError: i (=-1) must be a nonnegative integer
+            IndexError: index out of range
 
         Verify that `unrank` works correctly for Tuples where `k = 1`. ::
 
@@ -161,7 +161,7 @@ class Tuples(Parent, UniqueRepresentation):
         """
         r = ZZ(i)
         if r < 0:
-            raise IndexError("i (={}) must be a nonnegative integer".format(i))
+            raise IndexError("index out of range")
         ts = len(self.S)
         elt = []
         for _ in range(0, self.k):

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -107,7 +107,7 @@ class Tuples(Parent, UniqueRepresentation):
 
         TESTS:
 
-        Verify that `unrank` is giving the correct result. ::
+        Verify that :meth:`unrank` is giving the correct result::
 
             sage: T = Tuples(range(4), 5)
             sage: all(T[i] == x for i,x in enumerate(T))

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -155,9 +155,11 @@ class Tuples(Parent, UniqueRepresentation):
 
         Verify that :issue:`39534` has been fixed. ::
 
-            sage: Tuples(range(3), 30).random_element() #random
-            (0, 2, 2, 1, 2, 1, 0, 2, 0, 2, 1, 0, 0, 2, 1, 1, 2, 0, 2, 1, 1, 0,
-            2, 2, 0, 0, 0, 2, 1, 1)
+            sage: T = Tuples(range(3), 30).random_element()
+            sage: all(v in range(3) for v in T)
+            True
+            sage: len(T)
+            30
         """
         r = ZZ(i)
         if r < 0:

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -182,6 +182,18 @@ class Tuples(Parent, UniqueRepresentation):
             sage: T[0]
             (1, 1, 1, 1, 1)
 
+        Verify that :meth:`unrank` gives the correct answer when `k = 0`::
+
+            sage: T = Tuples(range(6), 0)
+            sage: list(T)
+            [()]
+            sage: T[0]
+            ()
+            sage: T[1]
+            Traceback (most recent call last):
+            ...
+            IndexError: index i (=1) is greater than or equal to the cardinality
+
         Verify that :issue:`39534` has been fixed::
 
             sage: T = Tuples(range(3), 30).random_element()

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -136,12 +136,22 @@ class Tuples(Parent, UniqueRepresentation):
             Traceback (most recent call last):
             ...
             IndexError: index i (=27) is greater than or equal to the cardinality
+            sage: T[-28]
+            Traceback (most recent call last):
+            ...
+            IndexError: i (=-1) must be a nonnegative integer
 
         Verify that `unrank` works correctly for Tuples where `k = 1`. ::
 
             sage: T = Tuples(range(6), 1)
             sage: T[5]
             (5,)
+
+        Verify that `unrank` works when called directly. ::
+
+            sage: T = Tuples(range(4), 3)
+            sage: T.unrank(19)
+            (3, 0, 1)
 
         Verify that :issue:`39534` has been fixed. ::
 
@@ -151,7 +161,7 @@ class Tuples(Parent, UniqueRepresentation):
         """
         r = ZZ(i)
         if r < 0:
-            raise IndexError("i (={}) must be a nonnegative integer")
+            raise IndexError("i (={}) must be a nonnegative integer".format(i))
         ts = len(self.S)
         elt = []
         for _ in range(0, self.k):

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -105,7 +105,7 @@ class Tuples(Parent, UniqueRepresentation):
             sage: T[73451]
             (0, 0, 1, 4, 2, 4)
 
-        TESTS::
+        TESTS:
 
         Verify that `unrank` is giving the correct result. ::
 

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -113,13 +113,13 @@ class Tuples(Parent, UniqueRepresentation):
             sage: all(T[i] == x for i,x in enumerate(T))
             True
 
-        Verify that `unrank` is fast for large inputs. ::
+        Verify that :meth:`unrank` is fast for large inputs::
 
             sage: Tuples(range(3), 30)[10^12]
             (1, 0, 0, 1, 1, 1, 2, 0, 1, 2, 0, 1, 1, 0, 2, 1, 1, 0, 1, 2, 1, 2,
             1, 1, 0, 1, 0, 0, 0, 0)
 
-        Verify that `unrank` normalizes ``i``. ::
+        Verify that :meth:`unrank` normalizes ``i``::
 
             sage: T = Tuples(range(3), 2)
             sage: T[QQ(4/2)]
@@ -129,7 +129,7 @@ class Tuples(Parent, UniqueRepresentation):
             ...
             TypeError: no conversion of this rational to integer
 
-        Verify that `unrank` throws an error when ``i`` is out of bounds. ::
+        Verify that :meth:`unrank` throws an error when ``i`` is out of bounds::
 
             sage: T = Tuples(range(3), 3)
             sage: T[27]
@@ -141,19 +141,19 @@ class Tuples(Parent, UniqueRepresentation):
             ...
             IndexError: index out of range
 
-        Verify that `unrank` works correctly for Tuples where `k = 1`. ::
+        Verify that :meth:`unrank` works correctly for Tuples where `k = 1`::
 
             sage: T = Tuples(range(6), 1)
             sage: T[5]
             (5,)
 
-        Verify that `unrank` works when called directly. ::
+        Verify that :meth:`unrank` works when called directly::
 
             sage: T = Tuples(range(4), 3)
             sage: T.unrank(19)
             (3, 0, 1)
 
-        Verify that :issue:`39534` has been fixed. ::
+        Verify that :issue:`39534` has been fixed::
 
             sage: T = Tuples(range(3), 30).random_element()
             sage: all(v in range(3) for v in T)

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -164,7 +164,7 @@ class Tuples(Parent, UniqueRepresentation):
             raise IndexError("i (={}) must be a nonnegative integer".format(i))
         ts = len(self.S)
         elt = []
-        for _ in range(0, self.k):
+        for _ in range(self.k):
             elt.append(self.S[r % ts])
             r //= ts
         if r > 0:

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -152,6 +152,10 @@ class Tuples(Parent, UniqueRepresentation):
             sage: T = Tuples(range(4), 3)
             sage: T.unrank(19)
             (3, 0, 1)
+            sage: T.unrank(-1)
+            Traceback (most recent call last):
+            ...
+            IndexError: index out of range
 
         Verify that :issue:`39534` has been fixed::
 

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -96,8 +96,8 @@ class Tuples(Parent, UniqueRepresentation):
 
         INPUT:
 
-        - ``i`` -- integer between `0` and `n-1` where `n` is the cardinality
-          of this set.
+        - ``i`` -- integer between `0` and `n-1`, where `n` is the cardinality
+          of this set
 
         EXAMPLES::
 

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -194,6 +194,19 @@ class Tuples(Parent, UniqueRepresentation):
             ...
             IndexError: index i (=1) is greater than or equal to the cardinality
 
+        Verify that :meth:`unrank` gives the correct answer when `|S| < 1` and
+        `k = 0`::
+
+            sage: T = Tuples(range(0), 0)
+            sage: T[0]
+            ()
+            sage: T[-1]
+            ()
+            sage: T[1]
+            Traceback (most recent call last):
+            ...
+            IndexError: index i (=1) is greater than or equal to the cardinality
+
         Verify that :issue:`39534` has been fixed::
 
             sage: T = Tuples(range(3), 30).random_element()
@@ -209,7 +222,7 @@ class Tuples(Parent, UniqueRepresentation):
             raise IndexError("index i (={}) is greater than or equal to the cardinality"
                              .format(i))
         ts = len(self.S)
-        if ts == 1:
+        if ts <= 1:
             return tuple(self.S[0] for _ in range(self.k))
         return tuple(i.digits(ts, self.S, self.k))
 

--- a/src/sage/combinat/tuple.py
+++ b/src/sage/combinat/tuple.py
@@ -157,6 +157,31 @@ class Tuples(Parent, UniqueRepresentation):
             ...
             IndexError: index out of range
 
+        Verify that :meth:`unrank` works with non-integer sets::
+
+            sage: T = Tuples(['a', 'b', 'c'], 3)
+            sage: T[15]
+            ('a', 'c', 'b')
+            sage: T = Tuples([None, 1, ZZ, GF(2)], 5)
+            sage: T[30]
+            (Integer Ring, Finite Field of size 2, 1, None, None)
+
+        Verify that :meth:`unrank` gives the correct answer when `|S| < 1`::
+
+            sage: T = Tuples([],5)
+            sage: T[0]
+            Traceback (most recent call last):
+            ...
+            IndexError: index i (=0) is greater than or equal to the cardinality
+            sage: list(T)
+            []
+
+        Verify that :meth:`unrank` gives the correct answer when `|S| = 1`::
+
+            sage: T = Tuples([1],5)
+            sage: T[0]
+            (1, 1, 1, 1, 1)
+
         Verify that :issue:`39534` has been fixed::
 
             sage: T = Tuples(range(3), 30).random_element()
@@ -165,18 +190,16 @@ class Tuples(Parent, UniqueRepresentation):
             sage: len(T)
             30
         """
-        r = ZZ(i)
-        if r < 0:
+        i = ZZ(i)
+        if i < 0:
             raise IndexError("index out of range")
-        ts = len(self.S)
-        elt = []
-        for _ in range(self.k):
-            elt.append(self.S[r % ts])
-            r //= ts
-        if r > 0:
+        if i >= self.cardinality():
             raise IndexError("index i (={}) is greater than or equal to the cardinality"
                              .format(i))
-        return tuple(elt)
+        ts = len(self.S)
+        if ts == 1:
+            return tuple(self.S[0] for _ in range(self.k))
+        return tuple(i.digits(ts, self.S, self.k))
 
     def __iter__(self):
         """

--- a/src/sage/sets/finite_enumerated_set.py
+++ b/src/sage/sets/finite_enumerated_set.py
@@ -288,7 +288,7 @@ class FiniteEnumeratedSet(UniqueRepresentation, Parent):
             sage: S[-4]
             Traceback (most recent call last):
             ...
-            IndexError: list index out of range
+            IndexError: index out of range
         """
         return self._elements[i]
 


### PR DESCRIPTION
Fixes #39534. There was an issue in Tuples causing random element to stall. It was stalling because Tuples did not have an efficient method of getting the i-th element without iterating through the entire set. To fix this an unrank method was added to Tuples. This method was based on the unrank method found in src\sage\categories\finite_enumerated_sets.py. This unrank method creates each tuple in a similar way to how numbers in some base are created. Also added documentation, an example, and various tests to make sure the function is working correctly.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies