### PR TITLE
added as_tuples as an optional argument to Combinations to facilitate hashing in Combination objects

### DIFF
--- a/src/sage/combinat/combination.py
+++ b/src/sage/combinat/combination.py
@@ -44,8 +44,8 @@ def Combinations(mset, k=None, *, as_tuples=False):
     objects of `M`, where every object can appear at most as many
     times as it appears in `M`.
 
-    The boolean keyword ``as_tuples`` determines whether each combination
-    is represented as a tuple or as a list.
+    The boolean keyword ``as_tuples`` (default: ``False``) determines whether
+    each combination is represented as a tuple or as a list.
 
     The combinatorial classes correctly handle the cases where ``mset`` has
     duplicate elements.
@@ -480,8 +480,7 @@ class Combinations_setk(Combinations_msetk):
             [(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
         """
         if self.as_tuples:
-            for combination in itertools.combinations(items, n):
-                yield combination
+            yield from itertools.combinations(items, n)
         else:
             for combination in itertools.combinations(items, n):
                 yield list(combination)

--- a/src/sage/combinat/combination.py
+++ b/src/sage/combinat/combination.py
@@ -34,7 +34,7 @@ from sage.structure.parent import Parent
 from sage.misc.persist import register_unpickle_override
 
 
-def Combinations(mset, k=None):
+def Combinations(mset, k=None, *, as_tuples=False):
     """
     Return the combinatorial class of combinations of the multiset
     ``mset``. If ``k`` is specified, then it returns the combinatorial
@@ -43,6 +43,9 @@ def Combinations(mset, k=None):
     A *combination* of a multiset `M` is an unordered selection of `k`
     objects of `M`, where every object can appear at most as many
     times as it appears in `M`.
+
+    The boolean keyword ``as_tuples`` determines whether each combination
+    is represented as a tuple or as a list.
 
     The combinatorial classes correctly handle the cases where ``mset`` has
     duplicate elements.
@@ -78,6 +81,16 @@ def Combinations(mset, k=None):
         sage: C2.list()
         [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]]
         sage: C2.cardinality()
+        6
+
+    ::
+
+        sage: C3 = Combinations(range(4),2,as_tuples=True)
+        sage: C3
+        Combinations of [0, 1, 2, 3] of length 2
+        sage: C3.list()
+        [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+        sage: C3.cardinality()
         6
 
     ::
@@ -183,18 +196,18 @@ def Combinations(mset, k=None):
 
     if is_unique:
         if k is None:
-            return Combinations_set(mset)
+            return Combinations_set(mset, as_tuples=as_tuples)
         else:
-            return Combinations_setk(mset, k)
+            return Combinations_setk(mset, k, as_tuples=as_tuples)
     else:
         if k is None:
-            return Combinations_mset(mset)
+            return Combinations_mset(mset, as_tuples=as_tuples)
         else:
-            return Combinations_msetk(mset, k)
+            return Combinations_msetk(mset, k, as_tuples=as_tuples)
 
 
 class Combinations_mset(Parent):
-    def __init__(self, mset):
+    def __init__(self, mset, as_tuples=False):
         """
         TESTS::
 
@@ -203,6 +216,7 @@ class Combinations_mset(Parent):
             True
         """
         self.mset = mset
+        self.as_tuples = as_tuples
         Parent.__init__(self, category=FiniteEnumeratedSets())
 
     def __contains__(self, x) -> bool:
@@ -265,9 +279,11 @@ class Combinations_mset(Parent):
 
             sage: Combinations(['a','a','b']).list() #indirect doctest
             [[], ['a'], ['b'], ['a', 'a'], ['a', 'b'], ['a', 'a', 'b']]
+            sage: Combinations(['a','a','b'],as_tuples=True).list()
+            [(), ('a',), ('b',), ('a', 'a'), ('a', 'b'), ('a', 'a', 'b')]
         """
         for k in range(len(self.mset) + 1):
-            yield from Combinations_msetk(self.mset, k)
+            yield from Combinations_msetk(self.mset, k, as_tuples=self.as_tuples)
 
     def cardinality(self) -> Integer:
         """
@@ -289,9 +305,11 @@ class Combinations_set(Combinations_mset):
 
             sage: Combinations([1,2,3]).list() #indirect doctest
             [[], [1], [2], [3], [1, 2], [1, 3], [2, 3], [1, 2, 3]]
+            sage: Combinations([1,2,3],as_tuples=True).list()
+            [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]
         """
         for k in range(len(self.mset) + 1):
-            yield from Combinations_setk(self.mset, k)
+            yield from Combinations_setk(self.mset, k, as_tuples=self.as_tuples)
 
     def unrank(self, r):
         """
@@ -309,7 +327,8 @@ class Combinations_set(Combinations_mset):
             k += 1
             b = binomial(n, k)
 
-        return [self.mset[i] for i in from_rank(r, n, k)]
+        result = [self.mset[i] for i in from_rank(r, n, k)]
+        return tuple(result) if self.as_tuples else result
 
     def rank(self, x):
         """
@@ -340,7 +359,7 @@ class Combinations_set(Combinations_mset):
 
 
 class Combinations_msetk(Parent):
-    def __init__(self, mset, k):
+    def __init__(self, mset, k, as_tuples=False):
         """
         TESTS::
 
@@ -350,6 +369,7 @@ class Combinations_msetk(Parent):
         """
         self.mset = mset
         self.k = k
+        self.as_tuples = as_tuples
         Parent.__init__(self, category=FiniteEnumeratedSets())
 
     def __contains__(self, x) -> bool:
@@ -423,8 +443,9 @@ class Combinations_msetk(Parent):
         for i in items:
             counts[indices.index(i)] += 1
         for iv in IntegerVectors(self.k, len(indices), outer=counts):
-            yield sum([[self.mset[indices[i]]] * iv[i]
-                       for i in range(len(indices))], [])
+            result = sum([[self.mset[indices[i]]] * iv[i]
+                          for i in range(len(indices))], [])
+            yield tuple(result) if self.as_tuples else result
 
     def cardinality(self) -> Integer:
         """
@@ -454,21 +475,31 @@ class Combinations_setk(Combinations_msetk):
             sage: it = Combinations([1,2,3,4],3)._iterator([1,2,3,4],3)
             sage: list(it)
             [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
+            sage: it = Combinations([1,2,3,4],3,as_tuples=True)._iterator([1,2,3,4],3)
+            sage: list(it)
+            [(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]
         """
-        for combination in itertools.combinations(items, n):
-            yield list(combination)
+        if self.as_tuples:
+            for combination in itertools.combinations(items, n):
+                yield combination
+        else:
+            for combination in itertools.combinations(items, n):
+                yield list(combination)
 
     def _iterator_zero(self):
         """
-        An iterator which just returns the empty list.
+        An iterator which just returns the empty list or tuple.
 
         EXAMPLES::
 
             sage: it = Combinations([1,2,3,4,5],3)._iterator_zero()
             sage: list(it)
             [[]]
+            sage: it = Combinations([1,2,3,4,5],3,as_tuples=True)._iterator_zero()
+            sage: list(it)
+            [()]
         """
-        yield []
+        yield () if self.as_tuples else []
 
     def __iter__(self):
         r"""
@@ -488,6 +519,17 @@ class Combinations_setk(Combinations_msetk):
              [2, 3, 5],
              [2, 4, 5],
              [3, 4, 5]]
+             sage: Combinations([1,2,3,4,5],3,as_tuples=True).list()
+             [(1, 2, 3),
+             (1, 2, 4),
+             (1, 2, 5),
+             (1, 3, 4),
+             (1, 3, 5),
+             (1, 4, 5),
+             (2, 3, 4),
+             (2, 3, 5),
+             (2, 4, 5),
+             (3, 4, 5)]
         """
         if self.k == 0:
             return self._iterator_zero()
@@ -520,7 +562,8 @@ class Combinations_setk(Combinations_msetk):
             sage: c.list() == list(map(c.unrank, range(c.cardinality())))
             True
         """
-        return [self.mset[i] for i in from_rank(r, len(self.mset), self.k)]
+        result = [self.mset[i] for i in from_rank(r, len(self.mset), self.k)]
+        return tuple(result) if self.as_tuples else result
 
     def rank(self, x):
         """


### PR DESCRIPTION
The as_tuples argument helps in achieving hashing of Combinations objects by producing elements of type tuple
This refers to issue [39455](https://github.com/sagemath/sage/issues/39455)

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


