### PR TITLE
removing some unused imports in pyx files

### DIFF
--- a/src/sage/categories/category_singleton.pyx
+++ b/src/sage/categories/category_singleton.pyx
@@ -9,16 +9,13 @@ Singleton categories
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
+from cpython.type cimport PyType_IsSubtype
 
 from sage.misc.constant_function import ConstantFunction
 from sage.misc.lazy_attribute import lazy_class_attribute
 from sage.categories.category import Category
 from sage.structure.category_object cimport CategoryObject
 from sage.structure.dynamic_class import DynamicMetaclass
-
-# I have no idea why this is necessary, but otherwise the type import fails (maybe because its shadowed by sage's cpython module?)
-from cpython.method cimport PyMethod_Check
-from cpython.type cimport PyType_IsSubtype
 
 # This helper class is used to implement Category_singleton.__contains__
 # In particular, the docstring is what appears upon C.__contains__?

--- a/src/sage/coding/binary_code.pyx
+++ b/src/sage/coding/binary_code.pyx
@@ -30,20 +30,20 @@ AUTHOR:
 * canonical generation function
 """
 
-#*****************************************************************************
+# ***************************************************************************
 #       Copyright (C) 2007 Robert L. Miller <rlmillster@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ***************************************************************************
 
 from libc.string cimport memcpy
 from cpython.mem cimport *
 from cpython.object cimport PyObject_RichCompare
-from cysignals.memory cimport sig_malloc, sig_realloc, sig_free
+from cysignals.memory cimport sig_malloc, sig_free
 
 from sage.structure.element cimport Matrix
 from sage.misc.timing import cputime

--- a/src/sage/graphs/traversals.pyx
+++ b/src/sage/graphs/traversals.pyx
@@ -61,7 +61,6 @@ Methods
 
 from collections import deque
 
-from libc.string cimport memset
 from libc.stdint cimport uint32_t
 from libcpp.vector cimport vector
 from cysignals.signals cimport sig_on, sig_off
@@ -73,7 +72,6 @@ from sage.graphs.base.static_sparse_backend cimport StaticSparseCGraph
 from sage.graphs.base.static_sparse_backend cimport StaticSparseBackend
 from sage.graphs.base.static_sparse_graph cimport init_short_digraph
 from sage.graphs.base.static_sparse_graph cimport free_short_digraph
-from sage.graphs.base.static_sparse_graph cimport out_degree
 from sage.graphs.graph_decompositions.slice_decomposition cimport \
         extended_lex_BFS
 

--- a/src/sage/libs/singular/ring.pyx
+++ b/src/sage/libs/singular/ring.pyx
@@ -33,7 +33,6 @@ from sage.libs.singular.decl cimport rDefault, GFInfo, ZnmInfo, nInitChar, AlgEx
 
 from sage.rings.integer cimport Integer
 from sage.rings.integer_ring cimport IntegerRing_class
-from sage.rings.integer_ring import ZZ
 import sage.rings.abc
 from sage.rings.number_field.number_field_base cimport NumberField
 from sage.rings.rational_field import RationalField

--- a/src/sage/matrix/matrix_dense.pyx
+++ b/src/sage/matrix/matrix_dense.pyx
@@ -11,7 +11,6 @@ TESTS::
 cimport sage.matrix.matrix as matrix
 
 from sage.structure.richcmp cimport richcmp_item, rich_to_bool
-from sage.calculus.functional import derivative
 import sage.matrix.matrix_space
 import sage.structure.sequence
 
@@ -211,7 +210,7 @@ cdef class Matrix_dense(matrix.Matrix):
                 e2 = self.get_unsafe(nrows - i - 1, ncols - j - 1)
                 self.set_unsafe(i, j, e2)
                 self.set_unsafe(nrows - i - 1, ncols - j - 1, e1)
-        if nrows % 2 == 1:
+        if nrows % 2:
             i = nrows // 2
             for j in range(ncols // 2):
                 e1 = self.get_unsafe(i, j)

--- a/src/sage/matrix/matrix_sparse.pyx
+++ b/src/sage/matrix/matrix_sparse.pyx
@@ -16,7 +16,6 @@ from cysignals.signals cimport sig_check
 cimport sage.matrix.matrix as matrix
 cimport sage.matrix.matrix0 as matrix0
 from sage.categories.rings import Rings
-from sage.calculus.functional import derivative
 from sage.structure.element cimport Element, Vector
 from sage.structure.richcmp cimport richcmp_item, rich_to_bool
 

--- a/src/sage/matroids/transversal_matroid.pyx
+++ b/src/sage/matroids/transversal_matroid.pyx
@@ -47,13 +47,13 @@ REFERENCES:
 from collections import Counter
 from copy import copy
 from cpython.object cimport Py_EQ, Py_NE
-from sage.graphs.graph import Graph
+import networkx as nx
+
 from sage.graphs.digraph import DiGraph
 from sage.graphs.bipartite_graph import BipartiteGraph
 from sage.matroids.basis_exchange_matroid cimport BasisExchangeMatroid
 from sage.matroids.minor_matroid import MinorMatroid
 from sage.matroids.utilities import newlabel
-import networkx as nx
 
 
 cdef class TransversalMatroid(BasisExchangeMatroid):

--- a/src/sage/misc/fpickle.pyx
+++ b/src/sage/misc/fpickle.pyx
@@ -7,7 +7,6 @@ REFERENCE: The python cookbook.
 """
 import copyreg
 import pickle
-import sys
 import types
 
 

--- a/src/sage/numerical/linear_tensor_element.pyx
+++ b/src/sage/numerical/linear_tensor_element.pyx
@@ -23,14 +23,14 @@ from cpython.object cimport *
 
 from sage.misc.fast_methods cimport hash_by_id
 from sage.structure.element cimport ModuleElement, Element
-from sage.numerical.linear_functions cimport LinearFunction, is_LinearFunction
+from sage.numerical.linear_functions cimport LinearFunction
 
 
-#*****************************************************************************
+# ***************************************************************************
 #
 # Elements of linear functions tensored with a free module
 #
-#*****************************************************************************
+# ***************************************************************************
 
 cdef class LinearTensor(ModuleElement):
     r"""


### PR DESCRIPTION
found using
`
cython-lint --ignore=E501,E741,E231,E265 src/sage/ | grep imported
`
### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.