### PR TITLE
Remove deprecated PseudoQuaternionicProjectivePlane alias

### DIFF
--- a/src/sage/topology/simplicial_complex_examples.py
+++ b/src/sage/topology/simplicial_complex_examples.py
@@ -63,15 +63,6 @@ EXAMPLES::
     {0: 0, 1: C4, 2: 0}
     sage: simplicial_complexes.MatchingComplex(6).homology()                            # needs sage.modules
     {0: 0, 1: Z^16, 2: 0}
-
-TESTS::
-
-    sage: from sage.topology.simplicial_complex_examples import PseudoQuaternionicProjectivePlane
-    sage: H = PseudoQuaternionicProjectivePlane()                                       # needs sage.groups
-    doctest:warning...:
-    DeprecationWarning: PseudoQuaternionicProjectivePlane is deprecated.
-    Please use sage.topology.simplicial_complex_examples.QuaternionicProjectivePlane instead.
-    See https://github.com/sagemath/sage/issues/34568 for details.
 """
 
 from .simplicial_complex import SimplicialComplex
@@ -617,9 +608,6 @@ def QuaternionicProjectivePlane():
     return UniqueSimplicialComplex([[g(index) for index in tup]
                                     for tup in start_list
                                     for g in PermutationGroup([P, S])])
-
-
-PseudoQuaternionicProjectivePlane = deprecated_function_alias(34568, QuaternionicProjectivePlane)
 
 
 def PoincareHomologyThreeSphere():


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Eliminate the deprecated alias for PseudoQuaternionicProjectivePlane and its associated warning.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


