### PR TITLE
Use TemporaryFile for test code compilation

### DIFF
--- a/src/sage/repl/load.py
+++ b/src/sage/repl/load.py
@@ -119,42 +119,44 @@ def load(filename, globals, attach=False):
 
     Note that ``.py`` files are *not* preparsed::
 
-        sage: t = tmp_filename(ext='.py')
-        sage: with open(t, 'w') as f:
-        ....:     _ = f.write("print(('hi', 2^3)); z = -2^7")
-        sage: z = 1
-        sage: sage.repl.load.load(t, globals())
-        ('hi', 1)
-        sage: z
+        sage: from tempfile import NamedTemporaryFile
+        sage: context = { "z": 1}
+        sage: with NamedTemporaryFile(mode='w', suffix='.py') as file:
+        ....:     _ = file.write("print(('hi', 2^3, z)); z = -2^7")
+        ....:     _ = file.seek(0)
+        ....:     sage.repl.load.load(file.name, context)
+        ('hi', 1, 1)
+        sage: context["z"]
         -7
 
     A ``.sage`` file *is* preparsed::
 
-        sage: t = tmp_filename(ext='.sage')
-        sage: with open(t, 'w') as f:
-        ....:     _ = f.write("print(('hi', 2^3)); z = -2^7")
-        sage: z = 1
-        sage: sage.repl.load.load(t, globals())
-        ('hi', 8)
-        sage: z
+        sage: context = { "z": 1, "Integer": Integer }
+        sage: with NamedTemporaryFile(mode='w', suffix='.sage') as file:
+        ....:     _ = file.write("print(('hi', 2^3, z)); z = -2^7")
+        ....:     _ = file.seek(0)
+        ....:     sage.repl.load.load(file.name, context)
+        ('hi', 8, 1)
+        sage: context["z"]
         -128
 
     Cython files are *not* preparsed::
 
-        sage: t = tmp_filename(ext='.pyx')
-        sage: with open(t, 'w') as f:
-        ....:     _ = f.write("print(('hi', 2^3)); z = -2^7")
-        sage: z = 1
-        sage: sage.repl.load.load(t, globals())                                         # needs sage.misc.cython
+        sage: context = { "z": 1 }
+        sage: with NamedTemporaryFile(mode='w', suffix='.pyx') as file:
+        ....:     _ = file.write("print(('hi', 2^3)); z = -2^7")
+        ....:     _ = file.seek(0)
+        ....:     sage.repl.load.load(file.name, context)                                         # needs sage.misc.cython
         Compiling ...
         ('hi', 1)
-        sage: z
+        sage: context["z"]
         -7
 
     If the file is not a Cython, Python, or Sage file, a :exc:`ValueError`
     is raised::
 
-        sage: sage.repl.load.load(tmp_filename(ext='.foo'), globals())
+        sage: with NamedTemporaryFile(mode='w', suffix='.foo') as file:
+        ....:     sage.repl.load.load(file.name, {})
         Traceback (most recent call last):
         ...
         ValueError: unknown file extension '.foo' for load or attach (supported extensions: .py, .pyx, .sage, .spyx, .f, .f90, .m)
@@ -172,12 +174,12 @@ def load(filename, globals, attach=False):
     We attach a file (note that :func:`~sage.repl.attach.attach`
     is equivalent, but available at the global scope by default)::
 
-        sage: t = tmp_filename(ext='.py')
-        sage: with open(t, 'w') as f:
-        ....:     _ = f.write("print('hello world')")
-        sage: sage.repl.load.load(t, globals(), attach=True)
+        sage: with NamedTemporaryFile(mode='w', suffix='.py') as file:
+        ....:     _ = file.write("print('hello world')")
+        ....:     _ = file.seek(0)
+        ....:     sage.repl.load.load(file.name, {}, attach=True)
         hello world
-        sage: t in attached_files()
+        sage: file.name in attached_files()
         True
 
     You cannot attach remote URLs (yet)::


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Use `tempfile.TemporaryFile` instead of Sage's own temporary file handler for the compilation of the test cython file.

This fixes errors during test collection with pytest:
```
conftest.py:129: in collect
    for test in finder.find(module, module.__name__):
../../../miniconda3/envs/sage-dev/lib/python3.12/doctest.py:948: in find
    self._find(tests, obj, name, module, source_lines, globs, {})
conftest.py:82: in _find
    super()._find(  # type:ignore[misc]
../../../miniconda3/envs/sage-dev/lib/python3.12/doctest.py:1022: in _find
    self._find(tests, val, valname, module, source_lines,
conftest.py:82: in _find
    super()._find(  # type:ignore[misc]
../../../miniconda3/envs/sage-dev/lib/python3.12/doctest.py:1010: in _find
    test = self._get_test(obj, name, module, globs, source_lines)
../../../miniconda3/envs/sage-dev/lib/python3.12/doctest.py:1092: in _get_test
    return self._parser.get_doctest(docstring, globs, name,
../../../miniconda3/envs/sage-dev/lib/python3.12/doctest.py:684: in get_doctest
    return DocTest(self.get_examples(string, name), globs,
../../../miniconda3/envs/sage-dev/lib/python3.12/doctest.py:698: in get_examples
    return [x for x in self.parse(string, name)
../../../miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/parsing.py:1111: in parse
    elif tag not in available_software:
../../../miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/external.py:489: in __contains__
    elif feature.is_present():
../../../miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/features/__init__.py:211: in is_present
    res = self._is_present()
../../../miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/features/__init__.py:924: in _is_present
    with open(tmp_filename(ext='.pyx'), 'w') as pyx:
../../../miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/misc/temporary_file.py:126: in tmp_filename
    handle, tmp = tempfile.mkstemp(prefix=name,
../../../miniconda3/envs/sage-dev/lib/python3.12/tempfile.py:357: in mkstemp
    return _mkstemp_inner(dir, prefix, suffix, flags, output_type)
../../../miniconda3/envs/sage-dev/lib/python3.12/tempfile.py:256: in _mkstemp_inner
    fd = _os.open(file, flags, 0o600)
E   FileNotFoundError: [Errno 2] No such file or directory: '/tmp/sage__ig56pe8/tmp_tjklyklm.pyx'
```
https://github.com/sagemath/sage/actions/runs/13718450041/job/38368348037?pr=39641#step:13:2369

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


