### PR TITLE
Fix loss of precision from singular in multivariable polynomial rings

### DIFF
--- a/src/sage/rings/polynomial/polynomial_singular_interface.py
+++ b/src/sage/rings/polynomial/polynomial_singular_interface.py
@@ -68,6 +68,14 @@ def _do_singular_init_(singular, base_ring, char, _vars, order):
          //                  : names    X
          //        block   2 : ordering C,
          None)
+
+    Verify that :issue:`39640` is fixed::
+
+        sage: R.<x,y>=RR[]
+        sage: I=R.ideal(x)
+        sage: Q=R.quotient(I)
+        sage: Q(1/3)
+        0.333333333333333
     """
     make_ring = lambda s: singular.ring(s, _vars, order=order)
 
@@ -82,7 +90,7 @@ def _do_singular_init_(singular, base_ring, char, _vars, order):
         #  size_t bits = 1 + (size_t) ((float)digits * 3.5);
         precision = base_ring.precision()
         digits = (2*precision + 4) // 7
-        return make_ring(f"(real,{digits},0)"), None
+        return make_ring(f"(real,{digits},10)"), None
 
     elif isinstance(base_ring, sage.rings.abc.ComplexField):
         # singular converts to bits from base_10 in mpr_complex.cc by:
@@ -94,7 +102,7 @@ def _do_singular_init_(singular, base_ring, char, _vars, order):
     elif isinstance(base_ring, sage.rings.abc.RealDoubleField):
         # singular converts to bits from base_10 in mpr_complex.cc by:
         #  size_t bits = 1 + (size_t) ((float)digits * 3.5);
-        return make_ring("(real,15,0)"), None
+        return make_ring("(real,15,10)"), None
 
     elif isinstance(base_ring, sage.rings.abc.ComplexDoubleField):
         # singular converts to bits from base_10 in mpr_complex.cc by:
@@ -205,7 +213,7 @@ class PolynomialRing_singular_repr:
             sage: R.<x,y> = PolynomialRing(RealField(100))                              # needs sage.rings.real_mpfr
             sage: singular(R)                                                           # needs sage.libs.singular sage.rings.real_mpfr
             polynomial ring, over a field, global ordering
-            // coefficients: Float()...
+            // coefficients: Float(...)...
             // number of vars : 2
             //        block   1 : ordering dp
             //                  : names    x y


### PR DESCRIPTION
As pointed out in #39640, there can be a drastic loss of precision when a polynomial over an inexact real field is processed by `singular`, and the cause seems to be an insufficient number of "stability bits" in the `singular` base field. So this PR changes the number of stability bits from 0 to 10 in the singular interface.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


