### PR TITLE
Added example in digits function to showcase that the sum of digits can be computed

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -1421,6 +1421,19 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: (-12).digits(2)
             [0, 0, -1, -1]
 
+        We can sum the digits of an integer in any base::
+
+            sage: sum(14.digits())
+            5
+            sage: sum(14.digits(base=2))
+            3
+            sage: sum(13408967.digits())
+            38
+            sage: sum(13408967.digits(base=7))
+            29
+            sage: sum(13408967.digits(base=1111))
+            1277
+
         We support large bases.
 
         ::

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -1425,14 +1425,14 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
             sage: sum(14.digits())
             5
-            sage: sum(14.digits(base=2))
-            3
+            sage: 14.digits(base=2), sum(14.digits(base=2))
+            ([0, 1, 1, 1], 3)
             sage: sum(13408967.digits())
             38
-            sage: sum(13408967.digits(base=7))
-            29
-            sage: sum(13408967.digits(base=1111))
-            1277
+            sage: 13408967.digits(base=7), sum(13408967.digits(base=7))
+            ([5, 2, 1, 5, 5, 6, 1, 2, 2], 29)
+            sage: 13408967.digits(base=1111), sum(13408967.digits(base=1111))
+            ([308, 959, 10], 1277)
 
         We support large bases.
 


### PR DESCRIPTION
Fixes #28100. Fixes the issue of not having a dedicated function to sum digits by showcasing through examples how it can be done using python code.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies