### PR TITLE
CI: Remove broken Linux Mint and openSUSE runs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,12 +23,6 @@ on:
            "ubuntu-jammy",
            "debian-bullseye",
            "debian-bookworm",
-           "linuxmint-20.2",
-           "linuxmint-20.3",
-           "linuxmint-21",
-           "linuxmint-21.1",
-           "linuxmint-21.2",
-           "linuxmint-21.3",
            "fedora-40",
            "fedora-41",
            "centos-stream-9",
@@ -36,7 +30,6 @@ on:
            "almalinux-9-python3.11",
            "archlinux-latest",
            "opensuse-15.5-gcc_11-python3.11",
-           "opensuse-tumbleweed-python3.10",
            "opensuse-tumbleweed",
           ]
         # 'tox -e update_docker_platforms' updates above


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Remove the following broken CI runs (https://github.com/sagemath/sage/actions/runs/13750937379):
- Linux Mint: fails due to an error in the retrofit script
   ```
   touch: cannot touch 'build/make/Makefile': No such file or directory
   rm: cannot remove '/new/.git': Directory not empty
   ```
- openSUSE with python 3.10 fails with `checking ... whether /usr/bin/python3.10 is good... no, Python 3.10.16 is too old`
   can probably be removed compltely; at least sage-lib no longer supports 3.10, not sure about sage-the-distro.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


