### PR TITLE
fix overflow in Matrix_modn_dense

### DIFF
--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -451,7 +451,13 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
         else:
             self._entries = <celement *> check_allocarray(self._nrows * self._ncols, sizeof(celement))
 
+        # TODO: it is a bit of a waste to allocate _matrix when ncols=0. Though some
+        # of the code expects self._matrix[i] to be valid, even though it points to
+        # an empty vector.
         self._matrix = <celement **> check_allocarray(self._nrows, sizeof(celement*))
+        if self._nrows == 0:
+            return
+
         cdef Py_ssize_t i
         self._matrix[0] = self._entries
         for i in range(self._nrows - 1):

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -447,17 +447,15 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             raise OverflowError("p (=%s) must be < %s."%(p, MAX_MODULUS))
 
         if zeroed_alloc:
-            self._entries = <celement *>check_calloc(self._nrows * self._ncols, sizeof(celement))
+            self._entries = <celement *> check_calloc(self._nrows * self._ncols, sizeof(celement))
         else:
-            self._entries = <celement *>check_allocarray(self._nrows * self._ncols, sizeof(celement))
+            self._entries = <celement *> check_allocarray(self._nrows * self._ncols, sizeof(celement))
 
-        self._matrix = <celement **>check_allocarray(self._nrows, sizeof(celement*))
-        cdef unsigned int k
+        self._matrix = <celement **> check_allocarray(self._nrows, sizeof(celement*))
         cdef Py_ssize_t i
-        k = 0
-        for i in range(self._nrows):
-            self._matrix[i] = self._entries + k
-            k = k + self._ncols
+        self._matrix[0] = self._entries
+        for i in range(self._nrows - 1):
+            self._matrix[i + 1] = self._matrix[i] + self._ncols
 
     def __dealloc__(self):
         """


### PR DESCRIPTION
Replace use of `unsigned int` in matrix indices in favor of `Py_ssize_t` to avoid overflow.

Fixes #35885