### PR TITLE
move `conj_sqrt()` to method for finite fields

### DIFF
--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -2163,7 +2163,6 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             ...
             NotImplementedError: not implemented when p|n!; dimension of invariant forms may be greater than one
         """
-        from sage.matrix.special import diagonal_matrix
         F = self.base_ring()
         G = self.group()
 
@@ -2189,22 +2188,12 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             raise ValueError("the base ring must be a finite field of square order")
         if F.characteristic().divides(G.cardinality()):
             raise NotImplementedError("not implemented when p|n!; dimension of invariant forms may be greater than one")
-        q = F.order().sqrt()
-
-        def conj_square_root(u):
-            if not u:
-                return F.zero()
-            z = F.multiplicative_generator()
-            k = u.log(z)
-            if k % (q+1) != 0:
-                raise ValueError(f"unable to factor as {u} is not in base field GF({q})")
-            return z ** ((k//(q+1)) % (q-1))
 
         dft_matrix = self.dft()
         n = dft_matrix.nrows()
         for i in range(n):
             d = sum(dft_matrix[i, j] * dft_matrix[i, j].conjugate() for j in range(n))
-            dft_matrix[i] *= ~conj_square_root(d)
+            dft_matrix[i] *= ~d.conj_sqrt()
         return dft_matrix
 
     def _dft_seminormal(self, mult='l2r'):

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1091,15 +1091,15 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: k(0).conj_sqrt()
             0
             sage: z = k(2).conj_sqrt(); z
-            z2 + 4
+            a + 4
             sage: z*z.conjugate()
             2
             sage: z = k(3).conj_sqrt(); z
-            z2
+            a
             sage: z*z.conjugate()
             3
             sage: z = k(4).conj_sqrt(); z
-            2*z2 + 6
+            2*a + 6
             sage: z*z.conjugate()
             4
 

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1102,7 +1102,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             2*z2 + 6
             sage: z*z.conjugate()
             4
-            
+
         TESTS::
 
             sage: k.<a> = GF(7**3)

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1069,7 +1069,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             raise NotImplementedError  # TODO: fix this once we have nested embeddings of finite fields
         else:
             raise ValueError("must be a perfect square.")
-    
+
     def conj_sqrt(FiniteField_givaroElement self):
         r"""
         Return a conjugate square root of this finite field element in its

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1069,6 +1069,56 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             raise NotImplementedError  # TODO: fix this once we have nested embeddings of finite fields
         else:
             raise ValueError("must be a perfect square.")
+    
+    def conj_sqrt(FiniteField_givaroElement self):
+        r"""
+        Return a conjugate square root of this finite field element in its
+        parent, if there is one.  Otherwise, raise a :exc:`ValueError`.
+
+        ALGORITHM:
+
+        ``self`` is stored as `a^k` for some generator `a`.
+        Return `a^{k/(q+1)}` for `k` divisible by `q+1`.
+
+        .. WARNING::
+
+            This is only implemented for elements whose exponent
+            is divisible by `q+1` in fields of order `q**2`.
+
+        EXAMPLES::
+
+            sage: k.<a> = GF(7**2)
+            sage: k(0).conj_sqrt()
+            0
+            sage: z = k(2).conj_sqrt(); z
+            z2 + 4
+            sage: z*z.conjugate()
+            2
+            sage: z = k(3).conj_sqrt(); z
+            z2
+            sage: z*z.conjugate()
+            3
+            sage: z = k(4).conj_sqrt(); z
+            2*z2 + 6
+            sage: z*z.conjugate()
+            4
+            sage: k.<a> = GF(7**3)
+            sage: k(3).conj_sqrt()
+            Traceback (most recent call last):
+            ...
+            ValueError: exponent must be divisible by q+1
+        """
+        if not self.parent().order().is_square():
+            raise ValueError("the base ring must be a finite field of square order")
+        q = self.parent().order().sqrt()
+
+        if self == 0:
+            return 0
+        z = self.parent().multiplicative_generator()
+        k = self.log(z)  # Compute discrete log of u to the base z
+        if k % (q+1) != 0:
+            raise ValueError("exponent must be divisible by q+1")
+        return z ** (k//(q+1))
 
     cpdef _add_(self, right):
         """

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1102,11 +1102,19 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             2*z2 + 6
             sage: z*z.conjugate()
             4
+            
+        TESTS::
+
             sage: k.<a> = GF(7**3)
             sage: k(3).conj_sqrt()
             Traceback (most recent call last):
             ...
-            ValueError: exponent must be divisible by q+1
+            ValueError: the base ring must be a finite field of square order
+            sage: k.<a> = GF(7**2)
+            sage: k.multiplicative_generator().conj_sqrt()
+            Traceback (most recent call last):
+            ...
+            ValueError: element must be element of base field GF(7)
         """
         if not self.parent().order().is_square():
             raise ValueError("the base ring must be a finite field of square order")
@@ -1117,7 +1125,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
         z = self.parent().multiplicative_generator()
         k = self.log(z)  # Compute discrete log of u to the base z
         if k % (q+1) != 0:
-            raise ValueError("exponent must be divisible by q+1")
+            raise ValueError(f"element must be element of base field GF({q})")
         return z ** (k//(q+1))
 
     cpdef _add_(self, right):

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1111,7 +1111,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             ...
             ValueError: the base ring must be a finite field of square order
             sage: k.<a> = GF(7**2)
-            sage: k.multiplicative_generator().conj_sqrt()
+            sage: a.conj_sqrt()
             Traceback (most recent call last):
             ...
             ValueError: element must be element of base field GF(7)


### PR DESCRIPTION
`conj_sqrt` is a useful and common operation used for finite fields. it should be promoted to a standalone method. We should figure out an equivalence for the condition of the exponent being divisible by q+1. This is equivalent to being in the base field `GF(q)` of `GF(q**2)`.

For an element `u` in `GF(q**2)`, we compute `a` such that `u = a*a.conjugate()`. Note $aa^\ast = aa^q = a^{q+1}$, so we just need to find a $(q+1)^{th}$ root of $u = z^k$ for a multiplicative generator $z$. We can do this iff $q+1 | k$, so $a=z^{k/(q+1)}$.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

#[#39668](https://github.com/sagemath/sage/issues/39668)


