### PR TITLE
Added the rank method under ModulesWithBasis.ParentMethod.

### DIFF
--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -1308,11 +1308,11 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (AttributeError, TypeError):
                 from sage.rings.integer_ring import ZZ
                 return ZZ(len(self.basis()))
-        
+
         def rank(self):
             """
             Return the rank of ``self``.
-            
+
             Since there is a (distinguished) basis, the rank of ``self``
             is equal to the cardinality of the basis (which equals
             the :meth:`dimension` of ``self``).
@@ -1332,7 +1332,7 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 3
             """
             return self.dimension()
-            
+
         def _from_dict(self, d, coerce=True, remove_zeros=True):
             """
             Construct an element of ``self`` from the dictionary ``d``.

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -1312,8 +1312,10 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
         def rank(self):
             """
             Return the rank of ``self``.
-            Note the rank of ``self`` should equal dimension of ``self``,
-            assuming infinite rank is defined in the context.
+            
+            Since there is a (distinguished) basis, the rank of ``self``
+            is equal to the cardinality of the basis (which equals
+            the :meth:`dimension` of ``self``).
 
             EXAMPLES::
 

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -1308,7 +1308,29 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
             except (AttributeError, TypeError):
                 from sage.rings.integer_ring import ZZ
                 return ZZ(len(self.basis()))
+        
+        def rank(self):
+            """
+            Return the rank of ``self``.
+            Note the rank of ``self`` should equal dimension of ``self``,
+            assuming infinite rank is defined in the context.
 
+            EXAMPLES::
+
+                sage: A.<x,y> = algebras.DifferentialWeyl(QQ)                           # needs sage.modules
+                sage: A.rank()                                                          # needs sage.modules
+                +Infinity
+
+                sage: R.<x,y> = QQ[]
+                sage: R.rank()
+                +Infinity
+
+                sage: F = CombinatorialFreeModule(QQ, ['a','b','c'])
+                sage: F.rank()
+                3
+            """
+            return self.dimension()
+            
         def _from_dict(self, d, coerce=True, remove_zeros=True):
             """
             Construct an element of ``self`` from the dictionary ``d``.


### PR DESCRIPTION
#34445
It is based on the understanding that dimension is equal rank under the context, assuming rank defined for infinite dimensional space.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


