### PR TITLE
Fix typo in SAGE_PARI_MINVER

### DIFF
--- a/build/pkgs/pari/spkg-configure.m4
+++ b/build/pkgs/pari/spkg-configure.m4
@@ -1,6 +1,6 @@
 SAGE_SPKG_CONFIGURE([pari], [
   dnl See gp_version below on how the version is computed from MAJV.MINV.PATCHV
-  m4_pushdef([SAGE_PARI_MINVER],["135245"])dnl this version and higher allowed
+  m4_pushdef([SAGE_PARI_MINVER],["135425"])dnl this version and higher allowed
   m4_pushdef([SAGE_PARI_MAXVER],["999999"])dnl this version and higher not allowed
   SAGE_SPKG_DEPCHECK([gmp readline], [
     AC_PATH_PROG([GP], [gp])


### PR DESCRIPTION
2.17.0 is broken and shouldn't be accepted

Amends https://github.com/sagemath/sage/pull/38749