### PR TITLE
Implement preimage computation for Homomorphism from Quotient Ring to Finite Field of the same characteristic

### DIFF
--- a/src/sage/combinat/abstract_tree.py
+++ b/src/sage/combinat/abstract_tree.py
@@ -1478,7 +1478,7 @@ class AbstractTree:
         while l_repr:
             tr = l_repr.pop(0)
             acc += UnicodeArt([" "]) + tr
-            if not len(l_repr):
+            if not l_repr:
                 lf_sep += "─" * (tr._root) + "╮"
                 ls_sep += " " * (tr._root) + "│"
             else:

--- a/src/sage/graphs/generators/smallgraphs.py
+++ b/src/sage/graphs/generators/smallgraphs.py
@@ -3337,7 +3337,7 @@ def HoffmanSingletonGraph():
             D.append(p)
         vv = 'q%s' % (int(p[1]) + 1)
         v = [v[-1] for v in H.neighbors(p) if v[:2] == vv]
-        if len(v):
+        if v:
             s = int(v[0])
         l += 1
     map = H.relabel(range(50), return_map=True)

--- a/src/sage/interfaces/axiom.py
+++ b/src/sage/interfaces/axiom.py
@@ -843,7 +843,7 @@ class PanAxiomElement(ExpectElement, sage.interfaces.abc.AxiomElement):
             return ZZ(repr(self))
         elif type.startswith('Polynomial'):
             from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-            base_ring = P(type.lstrip('Polynomial '))._sage_domain()
+            base_ring = P(type.removeprefix('Polynomial '))._sage_domain()
             vars = str(self.variables())[1:-1]
             R = PolynomialRing(base_ring, vars)
             return R(self.unparsed_input_form())

--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -1108,11 +1108,26 @@ cdef class RingHomomorphism(RingMap):
             sage: psi = A.hom([v*u, w*u, t], B)
             sage: psi.inverse_image(t^2) == z^2
             True
+
+        Check that the case in which the domain is a quotient ring
+        and codomain a finite field of same characteristic is handled correctly::
+
+            sage: F8.<a> = GF(2^3)
+            sage: PR.<y> = PolynomialRing(F8)
+            sage: IP = y^4 + a*y^3 + (a^2 + 1)*y + a^2 + 1
+            sage: assert IP.is_irreducible()
+            sage: Q.<w> = PR.quotient(IP)
+            sage: SF.<z> = IP.splitting_field()
+            sage: r = z^9 + z^7 + z^3 + z + 1
+            sage: assert IP.change_ring(SF)(r) == 0
+            sage: f = Q.hom([r,], SF)
+            sage: f.inverse_image(z)                # indirect doctest
+            w^3 + (a^2 + a + 1)*w^2 + (a^2 + 1)*w + a^2 + 1
         """
         from sage.rings.finite_rings.finite_field_base import FiniteField
         from sage.rings.quotient_ring import QuotientRing_nc
         if isinstance(self.domain(), QuotientRing_nc) and isinstance(self.codomain(), FiniteField):
-            if self.domain().base_ring().prime_subfield() == self.codomain().prime_subfield():
+            if self.domain().characteristic() == self.codomain().characteristic():
                 return self._preimage_from_linear_dependence(b)
         graph, from_B, to_A = self._graph_ideal()
         gens_A = graph.ring().gens()[-self.domain().ngens():]
@@ -1121,6 +1136,7 @@ cdef class RingHomomorphism(RingMap):
             raise ValueError(f"element {b} does not have preimage")
         return to_A(a)
 
+    @cached_method
     def _preimage_from_linear_dependence(self, b):
         r"""
         Return an element `a` in self's domain such that ``self(a) = b``.
@@ -1137,32 +1153,6 @@ cdef class RingHomomorphism(RingMap):
 
         EXAMPLES::
 
-        We compute the preimage of an element under the homomorphism f: `\mathbb{F}_{2^2}[y] / (y^3+y+1) \rightarrow \mathbb{F}_{2^6}`. Fixes (:issue:`39690`)::
-
-            sage: F4.<a> = GF(2^2, modulus=[1,1,1])
-            sage: PR.<y> = PolynomialRing(F4)
-            sage: IP = y^3+y+1
-            sage: assert IP.is_irreducible()
-            sage: Q.<w> = PR.quotient(IP)
-            sage: Q
-            Univariate Quotient Polynomial Ring in w over Finite Field in a of size 2^2 with modulus y^3 + y + 1
-            sage: SF.<z> = IP.splitting_field()
-            sage: r = IP.change_ring(SF).roots(multiplicities=False)[0]
-            sage: r
-            z^4 + z^2 + z + 1
-            sage: SF
-            Finite Field in z of size 2^6
-            sage: f = Q.hom([r,], SF)
-            sage: f
-            Ring morphism:
-                From: Univariate Quotient Polynomial Ring in w over Finite Field in a of size 2^2 with modulus y^3 + y + 1
-                To:   Finite Field in z of size 2^6
-                Defn: w |--> z^4 + z^2 + z + 1
-            sage: f._preimage_from_linear_dependence(z)
-            (a + 1)*w^2 + a*w + 1
-            sage: f((a + 1)*w^2 + a*w + 1) == z
-            True
-
         This example illustrates the error message we get if the domain and codomain have different cardinality.
         In that case, we certainly know the morphism is not an isomorphism::
 
@@ -1177,24 +1167,23 @@ cdef class RingHomomorphism(RingMap):
             sage: f._preimage_from_linear_dependence(z)
             Traceback (most recent call last):
             ...
-            ValueError: The cardinalities of the domain (=1024) and codomain (=64) should be equal.
+            ValueError: the cardinalities of the domain (=1024) and codomain (=64) should be equal
         """
         D = self.domain()
         C = self.codomain()
+        if D.characteristic() != C.characteristic():
+            raise ValueError("the domain's and codomain's characteristic should be equal")
         if (d_card := D.cardinality()) != (c_card := C.cardinality()):
-            raise ValueError(f"The cardinalities of the domain (={d_card}) and codomain (={c_card}) should be equal.")
+            raise ValueError(f"the cardinalities of the domain (={d_card}) and codomain (={c_card}) should be equal")
         if C != b.parent():
             raise TypeError(f"{b} fails to convert into the morphism's codomain {C}")
         F1 = D.base_ring()
-        if F1.prime_subfield() != C.prime_subfield():
-            raise NotImplementedError("The domain's base ring and codomain's prime subfields should match.")
         im_gen = self.im_gens()[0]
         target = im_gen.parent().gen()
         g = F1.gen()
-        DD = D.degree()
         ncoeffs = F1.degree()
         from sage.modules.free_module_element import vector
-        A = [vector(g**j * im_gen**i) for i in range(DD) for j in range(ncoeffs)]
+        A = [vector(g**j * im_gen**i) for i in range(D.degree()) for j in range(ncoeffs)]
         from sage.matrix.constructor import Matrix
         M = Matrix(A).T
         T = vector(target)
@@ -1675,6 +1664,30 @@ cdef class RingHomomorphism(RingMap):
             True
             sage: f._graph_ideal()[0].groebner_basis.is_in_cache()                      # needs sage.libs.singular
             True
+
+        Check case where domain is quotient ring and codomain a finite field of same characteristic. Fixes (:issue:`39690`)::
+
+            sage: F4.<a> = GF(2^2, modulus=[1,1,1])
+            sage: PR.<y> = PolynomialRing(F4)
+            sage: IP = y^3 + y + 1
+            sage: assert IP.is_irreducible()
+            sage: Q.<w> = PR.quotient(IP)
+            sage: SF.<z> = IP.splitting_field()
+            sage: SF
+            Finite Field in z of size 2^6
+            sage: r = z^4 + z^2 + z + 1
+            sage: assert IP.change_ring(SF)(r) == 0
+            sage: f = Q.hom([r,], SF)
+            sage: f
+            Ring morphism:
+                From: Univariate Quotient Polynomial Ring in w over Finite Field in a of size 2^2 with modulus y^3 + y + 1
+                To:   Finite Field in z of size 2^6
+                Defn: w |--> z^4 + z^2 + z + 1
+            sage: f.inverse()                   # indirect doctest
+            Ring morphism:
+              From: Finite Field in z of size 2^6
+              To:   Univariate Quotient Polynomial Ring in w over Finite Field in a of size 2^2 with modulus y^3 + y + 1
+              Defn: z |--> (a + 1)*w^2 + a*w + 1
         """
         if not self.is_injective():
             raise ZeroDivisionError("ring homomorphism not injective")

--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -1145,6 +1145,8 @@ cdef class RingHomomorphism(RingMap):
         in the common prime subfield. This yields the unique
         element in the domain that maps to ``b`` in the codomain.
 
+        An error is raised when the domain and codomain are not isomorphic.
+
         INPUT:
 
         - ``b`` -- an element in the codomain of this morphism

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -3179,7 +3179,7 @@ def EllipticCurve_with_prime_order(N):
         """
         import heapq
         hq = [(1, 1, -1)]
-        while len(hq):
+        while hq:
             abs_n, n, idx = heapq.heappop(hq)
             yield n
             for nxt in range(idx + 1, len(S)):

--- a/src/sage/schemes/riemann_surfaces/riemann_surface.py
+++ b/src/sage/schemes/riemann_surfaces/riemann_surface.py
@@ -3869,8 +3869,8 @@ class RiemannSurface:
                 ys = []
                 for gi in gis:
                     # This test is a bit clunky, it surely can be made more efficient.
-                    if len(ys):
-                        ers = min([gi(y, r).abs() for y in ys])
+                    if ys:
+                        ers = min(gi(y, r).abs() for y in ys)
                     else:
                         ers = 1
 

--- a/src/sage/topology/cubical_complex.py
+++ b/src/sage/topology/cubical_complex.py
@@ -1270,11 +1270,11 @@ class CubicalComplex(GenericCellComplex):
                 # nonzero via a dictionary.
                 matrix_data = {}
                 col = 0
-                if len(old) and len(current):
+                if old and current:
                     for cube in current:
                         faces = cube.faces_as_pairs()
                         sign = 1
-                        for (upper, lower) in faces:
+                        for upper, lower in faces:
                             # trac 32203: use two "try/except" loops
                             # in case lower is in old but upper is not.
                             try:


### PR DESCRIPTION
## Technical Details

This PR introduces a new function into the file `src/sage/rings/morphism.pyx`, named `_preimage_from_linear_dependence`.
More specifically, it computes the preimage of an element for a homomorphism $f$ from a univariate polynomial quotient ring to a finite extension field extension. When the codomain's field degree is the same as the domain's base ring degree, and the domain is constructed from an irreducible polynomial, $f$ is guaranteed to have a preimage for any element and `_preimage_from_linear_dependence` returns this preimage.

Fixes #39690.

The way this function is currently used, it fixes the `NotImplementedError` raised by:

- `f.inverse`
- `f.inverse_image` and
- `f._inverse_image_element`

## How it was fixed?

Internally, `_inverse_image_element` calls `_graph_ideal` which is the cause of the NotImplementedError due to the check `A.base_ring() != B.base_ring()`. Now, before calling `_graph_ideal`, the new method `_preimage_from_linear_dependence` is conditionally called and returns early, thereby avoiding the error.

I have not included any documentation because it's supposed to be used as an internal function. Let me know if it is needed.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

- #39699 : Probably due to a recent version change in the ruff linter, the ruff linting check failed. This PR fixes these errors so I cherry-picked the author's commit.