### PR TITLE
Fix AttributeError in PowerSeriesRing for division

### DIFF
--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -572,7 +572,7 @@ class CommutativeRings(CategoryWithAxiom):
             """
             try:
                 return self.fraction_field()
-            except (NotImplementedError,TypeError):
+            except (NotImplementedError, TypeError):
                 return coercion_model.division_parent(self)
 
     class ElementMethods:

--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -562,6 +562,7 @@ class CommutativeRings(CategoryWithAxiom):
                 Traceback (most recent call last):
                 ...
                 TypeError: self must be an integral domain.
+
             TESTS::
 
                 sage: R.<x> = QQ[[]]

--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -15,6 +15,7 @@ Commutative rings
 from sage.categories.category_with_axiom import CategoryWithAxiom
 from sage.categories.cartesian_product import CartesianProductsCategory
 from sage.structure.sequence import Sequence
+from sage.structure.element import coercion_model
 
 
 class CommutativeRings(CategoryWithAxiom):
@@ -538,6 +539,40 @@ class CommutativeRings(CategoryWithAxiom):
             else:
                 codomain = self
             return self.derivation_module(codomain, twist=twist)(arg)
+
+        def _pseudo_fraction_field(self):
+            r"""
+            This method is used by the coercion model to determine if `a / b`
+            should be treated as `a * (1/b)`, for example when dividing an element
+            of `\ZZ[x]` by an element of `\ZZ`.
+
+            The default is to return the same value as ``self.fraction_field()``,
+            but it may return some other domain in which division is usually
+            defined (for example, ``\ZZ/n\ZZ`` for possibly composite `n`).
+
+            EXAMPLES::
+
+                sage: ZZ._pseudo_fraction_field()
+                Rational Field
+                sage: ZZ['x']._pseudo_fraction_field()
+                Fraction Field of Univariate Polynomial Ring in x over Integer Ring
+                sage: Integers(15)._pseudo_fraction_field()
+                Ring of integers modulo 15
+                sage: Integers(15).fraction_field()
+                Traceback (most recent call last):
+                ...
+                TypeError: self must be an integral domain.
+            TESTS::
+
+                sage: R.<x> = QQ[[]]
+                sage: S.<y> = R[[]]
+                sage: parent(y/(1+x))
+                Power Series Ring in y over Laurent Series Ring in x over Rational Field
+            """
+            try:
+                return self.fraction_field()
+            except (NotImplementedError,TypeError):
+                return coercion_model.division_parent(self)
 
     class ElementMethods:
         pass

--- a/src/sage/categories/fields.py
+++ b/src/sage/categories/fields.py
@@ -527,7 +527,7 @@ class Fields(CategoryWithAxiom):
                 True
             """
             return self
-        
+
         def _pseudo_fraction_field(self):
             """
             The fraction field of ``self`` is always available as ``self``.

--- a/src/sage/categories/fields.py
+++ b/src/sage/categories/fields.py
@@ -527,6 +527,22 @@ class Fields(CategoryWithAxiom):
                 True
             """
             return self
+        
+        def _pseudo_fraction_field(self):
+            """
+            The fraction field of ``self`` is always available as ``self``.
+
+            EXAMPLES::
+
+                sage: QQ._pseudo_fraction_field()
+                Rational Field
+                sage: K = GF(5)
+                sage: K._pseudo_fraction_field()
+                Finite Field of size 5
+                sage: K._pseudo_fraction_field() is K
+                True
+            """
+            return self
 
         def ideal(self, *gens, **kwds):
             """


### PR DESCRIPTION
This PR resolves a bug where attempting to divide a power series element, like `x/(1-z)`, in `PowerSeriesRing_over_field_with_category` would result in an AttributeError due to the missing `_pseudo_fraction_field` attribute. The fix ensures that operations involving division within power series rings work as expected, similar to multiplication. 

Fixes: #39684 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


