### PR TITLE
Restore CI Linux made useful

### DIFF
--- a/.ci/retrofit-worktree.sh
+++ b/.ci/retrofit-worktree.sh
@@ -20,21 +20,18 @@ git config --global user.email "$GIT_AUTHOR_EMAIL"
 
 set -x
 
-# If actions/checkout downloaded our source tree using the GitHub REST API
-# instead of with git (because do not have git installed in our image),
-# we first make the source tree a repo.
+# If actions/checkout downloaded our source tree (in current directory) using the
+# GitHub REST API instead of with git, we first make the source tree a repo.
 if [ ! -d .git ]; then git init; fi
 
-# Commit and tag this state of the source tree "new". This is what we want to build and test.
+# Commit and tag this state of the source tree "new". The current directory
+# contains "new" source files with which we want to build and test.
 git add -A && git commit --quiet --allow-empty -m "new"
 git tag -f new
 
 # Our container image contains a source tree in $WORKTREE_DIRECTORY with a full build of Sage.
 # But $WORKTREE_DIRECTORY is not a git repository.
 # We make $WORKTREE_DIRECTORY a worktree whose index is at tag "new".
-# We then commit the current sources and set the tag "old". (This keeps all mtimes unchanged.)
-# Then we update worktree and index with "git checkout new".
-# (This keeps mtimes of unchanged files unchanged and mtimes of changed files newer than unchanged files.)
 if [ -L $WORKTREE_NAME ]; then
     rm -f $WORKTREE_NAME
 fi
@@ -42,5 +39,11 @@ git worktree prune --verbose
 git worktree add --detach $WORKTREE_NAME
 rm -rf $WORKTREE_DIRECTORY/.git && mv $WORKTREE_NAME/.git $WORKTREE_DIRECTORY/
 rm -rf $WORKTREE_NAME && ln -s $WORKTREE_DIRECTORY $WORKTREE_NAME
+
+# Copy "new" .gitignore (in current directory) to the worktree if there is not one already.
 if [ ! -f $WORKTREE_NAME/.gitignore ]; then cp .gitignore $WORKTREE_NAME/; fi
-(cd $WORKTREE_NAME && git add -A && git commit --quiet --allow-empty -m "old" -a && git tag -f old && git checkout -f new && git clean -fd && git status)
+# We then commit the worktree and set the tag "old". (This keeps all modification times unchanged.)
+(cd $WORKTREE_NAME && git add -A && git commit --quiet --allow-empty -m "old" && git tag -f old)
+# Then we update the worktree and index with "git checkout new". (This keeps modification times of "old" files
+# and makes modification times of "new" files newer, which triggers incremental build.)
+(cd $WORKTREE_NAME && git checkout -f new)

--- a/.github/workflows/changelog_trigger.yml
+++ b/.github/workflows/changelog_trigger.yml
@@ -1,4 +1,4 @@
-name: Trigger Changelog Generation
+name: Trigger changelog generation
 
 on:
   release:

--- a/.github/workflows/ci-linux-incremental.yml
+++ b/.github/workflows/ci-linux-incremental.yml
@@ -81,7 +81,86 @@ jobs:
             sage-package metrics :all:
           fi
 
-  test:
+  standard:
+    needs: [changed_files]
+    uses: ./.github/workflows/docker.yml
+    with:
+      tox_system_factors: >-
+        ["ubuntu-focal",
+         "ubuntu-noble",
+         "debian-bullseye",
+         "debian-bookworm",
+         "fedora-30",
+         "fedora-40",
+         "archlinux-latest",
+         "gentoo-python3.11",
+         "debian-bullseye-i386"]
+      tox_packages_factors: >-
+          ["standard"]
+      incremental: true
+      free_disk_space: true
+      from_docker_repository: ghcr.io/sagemath/sage/
+      from_docker_target: "with-targets"
+      from_docker_tag: "dev"
+      docker_targets: "with-targets"
+      targets: "${{needs.changed_files.outputs.build_targets}} ci-build-with-fallback doc-html ptest-nodoc"
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+      max_parallel: 8
+
+  minimal:
+    needs: [changed_files]
+    uses: ./.github/workflows/docker.yml
+    with:
+      tox_system_factors: >-
+        ["ubuntu-focal",
+         "ubuntu-noble",
+         "debian-bullseye",
+         "debian-bookworm",
+         "fedora-30",
+         "fedora-40",
+         "archlinux-latest",
+         "gentoo-python3.11",
+         "debian-bullseye-i386"]
+      tox_packages_factors: >-
+          ["minimal"]
+      incremental: true
+      free_disk_space: true
+      from_docker_repository: ghcr.io/sagemath/sage/
+      from_docker_target: "with-targets"
+      from_docker_tag: "dev"
+      docker_targets: "with-targets"
+      targets: "${{needs.changed_files.outputs.build_targets}} ci-build-with-fallback doc-html ptest-nodoc"
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+      max_parallel: 8
+
+  standard-constraints_pkgs:
+    # Turned off until fixed
+    if: false
+    needs: [changed_files]
+    uses: ./.github/workflows/docker.yml
+    with:
+      # Build incrementally from published Docker image
+      incremental: true
+      free_disk_space: true
+      from_docker_repository: ghcr.io/sagemath/sage/
+      from_docker_target: "with-targets-pre"
+      from_docker_tag: "dev"
+      docker_targets: "with-targets-pre"
+      targets_pre: "${{needs.changed_files.outputs.build_targets}} all-sage-local python3-ensure tox-ensure sagelib-tox-sagepython-constraints_pkgs-norequirements"
+      tox_system_factors: >-
+        ["ubuntu-focal",
+         "ubuntu-noble",
+         "debian-bookworm",
+         "fedora-40",
+         "debian-bullseye-i386"]
+      tox_packages_factors: >-
+          ["standard"]
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+      max_parallel: 16
+
+  standard-sitepackages:
+    # Turned off until fixed
+    if: false
     needs: [changed_files]
     uses: ./.github/workflows/docker.yml
     with:
@@ -92,16 +171,13 @@ jobs:
       from_docker_target: "with-targets"
       from_docker_tag: "dev"
       docker_targets: "with-targets"
-      targets: "${{needs.changed_files.outputs.build_targets}} ci-build-with-fallback doc-html ptest-nodoc"
+      targets: "${{needs.changed_files.outputs.build_targets}} doc-html ptest-nodoc"
+      # Only test systems with a usable system python (>= 3.9)
+      # with only a small number of test failures as of 10.2.rc0
       tox_system_factors: >-
-        ["ubuntu-focal",
-         "ubuntu-noble",
-         "debian-bullseye",
-         "debian-bookworm",
-         "fedora-30",
-         "fedora-40",]
+        ["gentoo-python3.11",
+         "archlinux-latest",
+         "fedora-40"]
       tox_packages_factors: >-
-          ["standard",
-           "minimal"]
+          ["standard-sitepackages"]
       docker_push_repository: ghcr.io/${{ github.repository }}/
-      max_parallel: 8

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,63 +1,174 @@
 name: CI Linux
 
-## This GitHub Actions workflow runs SAGE_ROOT/tox.ini with selected environments,
-## whenever a tag is pushed.
-##
-## It builds and checks some sage spkgs as defined in TARGETS.
-##
-## A job succeeds if there is no error.
-##
-## The build is run with "make V=0", so the build logs of individual packages are suppressed.
-##
-## At the end, all package build logs that contain an error are printed out.
-##
-## After all jobs have finished (or are canceled) and a short delay,
-## tar files of all logs are made available as "build artifacts".
-
-#on: [push, pull_request]
+# This GitHub Actions workflow runs SAGE_ROOT/tox.ini with select environments,
+# whenever a GitHub pull request is opened or synchronized in a repository
+# where GitHub Actions are enabled.
+#
+# It builds and checks some sage spkgs as defined in TARGETS.
+#
+# A job succeeds if there is no error.
+#
+# The build is run with "make V=0", so the build logs of individual packages are suppressed.
+#
+# At the end, all package build logs that contain an error are printed out.
+#
+# After all jobs have finished (or are canceled) and a short delay,
+# tar files of all logs are made available as "build artifacts".
 
 on:
   push:
     tags:
       - '*'
-  workflow_dispatch:
-    # Allow to run manually
+  workflow_dispatch: # allow to run manually
 
-env:
-  TARGETS_PRE: all-sage-local
-  TARGETS: build doc-html
-  TARGETS_OPTIONAL: ptest
+# A job may specify inputs to docker.yml such as
+#
+# targets_pre
+# targets
+# targets_optional
+# tox_system_factors
+# tox_packages_factors
+# ...
+#
+# consult docker.yml for descriptions and defaults for all possible inputs.
+#
+# For the meaning of docker_targets, see also tox.ini
 
 permissions:
   packages: write
 
 jobs:
+
+  # This duplicates the "standard" job (see below) for the default platform.
+  # The reason is to provide the default docker image as fast as possible
+  # for other workflows like build.yml.
+  default:
+    uses: ./.github/workflows/docker.yml
+    with:
+      tox_system_factors: >-
+        ["ubuntu-jammy"]
+      tox_packages_factors: >-
+        ["standard"]
+      free_disk_space: true
+      incremental: false
+      docker_targets: "with-system-packages configured with-targets-pre with-targets"
+      targets_pre: all-sage-local
+      targets: build doc-html
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+      logs_artifact_postfix: "-default"
+
+  # The following jobs run for all supported platforms. See the default list
+  # for tox_system_factors in docker.yml.
+
+  standard:
+    if: ${{ success() || failure() }}
+    uses: ./.github/workflows/docker.yml
+    with:
+      tox_packages_factors: >-
+          ["standard"]
+      free_disk_space: true
+      incremental: false
+      docker_targets: "with-system-packages configured with-targets-pre with-targets with-targets-optional"
+      targets_pre: all-sage-local
+      targets: build doc-html
+      targets_optional: ptest
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+      # Make sure that all "standard" jobs can start simultaneously,
+      # so that runners are available by the time that "default" starts.
+      max_parallel: 50
+
+  standard-sitepackages:
+    # Turned off until fixed
+    if: false
+    needs: [standard]
+    uses: ./.github/workflows/docker.yml
+    with:
+      tox_packages_factors: >-
+        ["standard-sitepackages"]
+      free_disk_space: true
+      incremental: true
+      from_docker_repository: ghcr.io/${{ github.repository }}/
+      from_docker_target: "with-targets-pre"
+      docker_targets: "with-targets with-targets-optional"
+      targets_optional: ptest
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+      logs_artifact_postfix: "-sitepackages"
+      max_parallel: 8
+
+  standard-constraints_pkgs:
+    # Turned off until fixed
+    needs: [standard-sitepackages]
+    uses: ./.github/workflows/docker.yml
+    with:
+      tox_packages_factors: >-
+          ["standard"]
+      free_disk_space: true
+      incremental: true
+      from_docker_repository: ghcr.io/${{ github.repository }}/
+      from_docker_target: "with-targets-pre"
+      docker_targets: "with-targets-pre"
+      targets_pre: all-sage-local python3-ensure tox-ensure sagelib-tox-sagepython-constraints_pkgs-norequirements
+      logs_artifact_postfix: "-constraints_pkgs"
+      max_parallel: 15
+
   minimal:
     if: ${{ success() || failure() }}
     uses: ./.github/workflows/docker.yml
     with:
-      # Build from scratch
-      free_disk_space: true
-      docker_targets: "with-system-packages configured with-targets-pre with-targets with-targets-optional"
-      # FIXME: duplicated from env.TARGETS
-      targets_pre: all-sage-local
-      targets: build doc-html
-      targets_optional: ptest
-      tox_system_factors: >-
-          ["ubuntu-jammy"]
       tox_packages_factors: >-
           ["minimal"]
-      docker_push_repository: ghcr.io/${{ github.repository }}/
-
-  standard:
-    uses: ./.github/workflows/docker.yml
-    with:
       free_disk_space: true
-      # Build from scratch
+      incremental: false
       docker_targets: "with-system-packages configured with-targets-pre with-targets with-targets-optional"
       targets_pre: all-sage-local
       targets: build doc-html
       targets_optional: ptest
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+      # Calibrated for clogging the job pipeline until the "default" job has finished.
+      max_parallel: 24
+
+  maximal:
+    if: ${{ success() || failure() }}
+    needs: [minimal]
+    uses: ./.github/workflows/docker.yml
+    with:
+      tox_packages_factors: >-
+          ["maximal"]
+      free_disk_space: true
+      incremental: false
+      docker_targets: "with-system-packages configured with-targets-pre with-targets with-targets-optional"
+      targets_pre: all-sage-local
+      targets: build doc-html
+      targets_optional: ptest
+      docker_push_repository: ghcr.io/${{ github.repository }}/
+
+  optional:
+    if: ${{ success() || failure() }}
+    needs: [standard]
+    uses: ./.github/workflows/docker.yml
+    with:
       tox_packages_factors: >-
           ["standard"]
-      docker_push_repository: ghcr.io/${{ github.repository }}/
+      incremental: true
+      free_disk_space: true
+      from_docker_repository: ghcr.io/${{ github.repository }}/
+      from_docker_target: "with-targets"
+      docker_targets: "with-targets-optional"
+      # We remove packages starting with _, in particular package _develop
+      targets_optional: '$(echo $(export PATH=build/bin:$PATH && sage-package list :optional: --has-file "spkg-install.in|spkg-install|requirements.txt" --no-file "huge|has_nonfree_dependencies" | grep -v sagemath_doc | grep -v ^_)) ptest'
+      logs_artifact_postfix: "-optional"
+
+  experimental:
+    if: ${{ success() || failure() }}
+    needs: [optional]
+    uses: ./.github/workflows/docker.yml
+    with:
+      tox_packages_factors: >-
+          ["standard"]
+      incremental: true
+      free_disk_space: true
+      from_docker_repository: ghcr.io/${{ github.repository }}/
+      from_docker_target: "with-targets"
+      docker_targets: "with-targets-optional"
+      targets_optional: '$(echo $(export PATH=build/bin:$PATH && sage-package list :experimental: --has-file "spkg-install.in|spkg-install|requirements.txt" --no-file "huge|has_nonfree_dependencies" | grep -v sagemath_doc))'
+      logs_artifact_postfix: "-experimental"

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,4 +1,4 @@
-name: Prepare source distributions and wheels
+name: Deploy release assets
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,16 @@
-name: Reusable workflow for Docker-based portability CI
+name: Workflow for Linux portability CI
 
 on:
   workflow_call:
     inputs:
       targets_pre:
-        default: build/make/Makefile
+        default: all-sage-local
         type: string
       targets:
-        default: build/make/Makefile
+        default: build
         type: string
       targets_optional:
-        default: build/make/Makefile
+        default: ptest
         type: string
       tox_system_factors:
         description: 'Stringified JSON object listing tox system factors'
@@ -18,16 +18,30 @@ on:
         # 'tox -e update_docker_platforms' updates below
         default: >-
           [
-           "ubuntu-xenial-toolchain-gcc_9",
            "ubuntu-focal",
            "ubuntu-jammy",
+           "ubuntu-noble",
            "debian-bullseye",
            "debian-bookworm",
+           "linuxmint-21",
+           "linuxmint-21.1",
+           "linuxmint-21.2",
+           "linuxmint-21.3",
+           "linuxmint-22",
+           "linuxmint-22.1",
+           "fedora-36",
+           "fedora-37",
+           "fedora-38",
+           "fedora-39",
            "fedora-40",
            "fedora-41",
            "centos-stream-9",
            "centos-stream-9-python3.12",
-           "almalinux-9-python3.11",
+           "almalinux-8",
+           "almalinux-9",
+           "almalinux-9.5",
+           "gentoo-python3.11",
+           "gentoo-python3.12",
            "archlinux-latest",
            "opensuse-15.5-gcc_11-python3.11",
            "opensuse-tumbleweed",
@@ -54,9 +68,10 @@ on:
         description: 'Elapsed time (seconds) at which to kill the build'
         default: 20000
         type: number
-      logs_artifact:
-        default: true
-        type: boolean
+      logs_artifact_postfix:
+        description: 'Postfix (default: none) for logs artifact name'
+        default: ""
+        type: string
       #
       # Publishing to GitHub Packages
       #
@@ -70,6 +85,7 @@ on:
         default: "with-system-packages configured with-targets-pre with-targets with-targets-optional"
         type: string
       incremental:
+        description: 'Whether to build Sage from scratch or from prebuilt Sage'
         default: false
         type: boolean
       from_docker_repository:
@@ -101,19 +117,58 @@ on:
         required: false
         type: string
 
+  workflow_dispatch:
+    inputs:
+      tox_system_factors:
+        default: >-
+          [ "ubuntu-jammy"]
+        type: string
+      tox_packages_factors:
+        type: string
+        default: >-
+          ["standard"]
+      targets_pre:
+        default: "all-sage-local"
+        type: string
+      targets:
+        default: "build"
+        type: string
+      targets_optional:
+        default: "ptest"
+        type: string
+      docker_targets:
+        default: "with-targets"
+        type: string
+      incremental:
+        default: true
+        type: boolean
+      from_docker_repository:
+        default: "ghcr.io/sagemath/sage/"
+        type: string
+      from_docker_target:
+        default: "with-targets-pre"
+        type: string
+      from_docker_tag:
+        default: "dev"
+        type: string
+
+
 jobs:
   linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.max_parallel }}
+      max-parallel: ${{ inputs.max_parallel || 10 }}
       matrix:
         tox_system_factor:   ${{ fromJson(inputs.tox_system_factors) }}
         tox_packages_factor: ${{ fromJson(inputs.tox_packages_factors) }}
     env:
+      # See tox.ini to see how these environment variables define the
+      # Dockerfile used to build the docker image, written by the
+      # .ci/write-dockerfile.sh
       TOX_ENV:            "docker-${{ matrix.tox_system_factor }}-${{ matrix.tox_packages_factor }}${{ inputs.incremental && '-incremental' || '' }}"
-      LOGS_ARTIFACT_NAME: logs-commit-${{ github.sha }}-tox-docker-${{ matrix.tox_system_factor }}-${{ matrix.tox_packages_factor }}
-      DOCKER_TARGETS:     ${{ inputs.docker_targets }}
+      LOGS_ARTIFACT_NAME: logs-commit-${{ github.sha }}-tox-docker-${{ matrix.tox_system_factor }}-${{ matrix.tox_packages_factor }}${{ inputs.logs_artifact_postfix }}
+      DOCKER_TARGETS:     ${{ inputs.docker_targets || github.event.inputs.docker_targets }}
       TARGETS_PRE:        ${{ inputs.targets_pre }}
       TARGETS:            ${{ inputs.targets }}
       TARGETS_OPTIONAL:   ${{ inputs.targets_optional }}
@@ -135,63 +190,80 @@ jobs:
           remove-docker-images: true
         continue-on-error: true
         if: inputs.free_disk_space
+
       - name: Check out SageMath
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.sage_repo }}
           ref: ${{ inputs.sage_ref }}
           fetch-depth: 10000
+
       - name: Download upstream artifact
         uses: actions/download-artifact@v4
         with:
           path: upstream
           name: ${{ inputs.upstream_artifact }}
         if: inputs.upstream_artifact
+
       - name: Install test prerequisites
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install tox
           sudo apt-get clean
           df -h
+
       - name: Update Sage packages from upstream artifact
-        # Handle both the old and new location of write-dockerfile.sh,
-        # because docker.yml is a reusable workflow.
         run: |
-          (export PATH=$(pwd)/build/bin:$PATH; (cd upstream && bash -x update-pkgs.sh) && sed -i.bak '/upstream/d' .dockerignore; for a in build/bin/write-dockerfile.sh .ci/write-dockerfile.sh; do if [ -r $a ]; then echo "/:toolchain:/i ADD upstream upstream" | sed -i.bak -f - $a; fi; done; git diff)
+          export PATH=$(pwd)/build/bin:$PATH
+          # The sed command removes any lines containing 'upstream' from .dockerignore
+          (cd upstream && bash -x update-pkgs.sh) && sed -i.bak '/upstream/d' .dockerignore
+          if [ -r .ci/write-dockerfile.sh ]; then
+            # Add 'ADD upstream upstream' before the line containing ':toolchain:' in the script
+            echo "/:toolchain:/i ADD upstream upstream" | sed -i.bak -f - .ci/write-dockerfile.sh
+          fi
+          # Show the changes made to the repository for review
+          git diff
         if: inputs.upstream_artifact
 
       - name: Try to login to ghcr.io
-        if: inputs.docker_push_repository != ''
+        if: (inputs.docker_push_repository == null || inputs.docker_push_repository != '')
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
         run: |
-            TOKEN="${{ secrets.DOCKER_PKG_GITHUB_TOKEN }}"
-            if [ -z "$TOKEN" ]; then
-              TOKEN="${{ secrets.GITHUB_TOKEN }}"
-            fi
-            if echo "$TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin; then
+          TOKEN="${{ secrets.DOCKER_PKG_GITHUB_TOKEN }}"
+          if [ -z "$TOKEN" ]; then
+            TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          fi
+          if echo "$TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin; then
+            if [ -z "${{ inputs.docker_push_repository }}" ]; then
+              echo "DOCKER_PUSH_REPOSITORY=ghcr.io/${{ github.repository }}/" >> $GITHUB_ENV
+            else
               echo "DOCKER_PUSH_REPOSITORY=$(echo ${{ inputs.docker_push_repository }} | tr "[:upper:]" "[:lower:]")" >> $GITHUB_ENV
-              echo "DOCKER_CONFIG_FILE=$HOME/.docker/config.json" >> $GITHUB_ENV
             fi
+            echo "DOCKER_CONFIG_FILE=$HOME/.docker/config.json" >> $GITHUB_ENV
+          fi
 
       - name: Determine Docker tags to use
         run: |
-            # This line needs to be run before the step "Merge CI fixes from sagemath/sage".
-            DOCKER_TAG="$(git describe --dirty --always)"
-            echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
-            # From the docker documentation via .ci/update-env.sh:
-            # "A tag name must be valid ASCII and may
-            # contain lowercase and uppercase letters, digits, underscores, periods and
-            # dashes. A tag name may not start with a period or a dash and may contain a
-            # maximum of 128 characters."
-            EXTRA_DOCKER_TAGS=`echo $GITHUB_REF_NAME | tr -d '[:space:]' | tr -c '[:alnum:]_.-' '-' | sed 's/^[-.]*//' | cut -c1-128`
-            shopt -s extglob
-            case "$GITHUB_REF_NAME" in
-              +([0-9]).+([0-9])?(.+([0-9])) )
-                EXTRA_DOCKER_TAGS="latest dev $EXTRA_DOCKER_TAGS";;
-              +([0-9]).+([0-9])?(.+([0-9]))?(.)@(a|alpha|b|beta|rc)+([0-9]) )
-                EXTRA_DOCKER_TAGS="dev $EXTRA_DOCKER_TAGS";;
-            esac
-            echo "EXTRA_DOCKER_TAGS=$EXTRA_DOCKER_TAGS" >> $GITHUB_ENV
+          # This line needs to be run before the step "Merge CI fixes from sagemath/sage".
+          #
+          DOCKER_TAG="$(git describe --dirty --always)"
+          echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
+          #
+          # From the docker documentation via .ci/update-env.sh:
+          # "A tag name must be valid ASCII and may
+          # contain lowercase and uppercase letters, digits, underscores, periods and
+          # dashes. A tag name may not start with a period or a dash and may contain a
+          # maximum of 128 characters."
+          #
+          EXTRA_DOCKER_TAGS=`echo $GITHUB_REF_NAME | tr -d '[:space:]' | tr -c '[:alnum:]_.-' '-' | sed 's/^[-.]*//' | cut -c1-128`
+          shopt -s extglob
+          case "$GITHUB_REF_NAME" in
+            +([0-9]).+([0-9])?(.+([0-9])) )
+              EXTRA_DOCKER_TAGS="latest dev $EXTRA_DOCKER_TAGS";;
+            +([0-9]).+([0-9])?(.+([0-9]))?(.)@(a|alpha|b|beta|rc)+([0-9]) )
+              EXTRA_DOCKER_TAGS="dev $EXTRA_DOCKER_TAGS";;
+          esac
+          echo "EXTRA_DOCKER_TAGS=$EXTRA_DOCKER_TAGS" >> $GITHUB_ENV
 
       - name: Merge CI fixes from sagemath/sage
         # This step needs to happen after the commit sha is put in DOCKER_TAG
@@ -206,43 +278,69 @@ jobs:
         run: |
           df -h
         if: inputs.free_disk_space
+
       - name: Configure and build Sage distribution within a Docker container
-        # The first command below is a self-destruct sequence,
-        # which preempts the GitHub Actions 6-hour job cancellation.
-        #
-        # Using "docker exec", we enter the temporary containers used by
-        # "docker build" and kill the "make" processes of the Sage distribution.
-        #
-        # The arcane "find" command is a replacement for "pkill make",
-        # which we use because pkill is not installed in the "minimal" package
-        # configuration on many platforms.
-        #
-        # The "sed" command strips away timestamps from "docker build" (buildkit)
-        # such as "#25 1211.0" at the beginning of each line. The timestamps are
-        # redundant because GH Actions provides timestamps for each line already.
-        # Stripping the timestamps from the beginnings of lines also allows
-        # GitHub Actions to recognize workflow commands such as ::error etc.
-        #
         run: |
-          (sleep ${{ inputs.timeout }}; for id in $(docker ps -q); do docker exec $id find /proc -maxdepth 2 -name cmdline -exec bash -c "grep -l [m][a][k][e] {} | cut -d/ -f3 | xargs --no-run-if-empty kill" \;; done) &
-          set -o pipefail; EXTRA_DOCKER_BUILD_ARGS="--build-arg NUMPROC=9 --build-arg USE_MAKEFLAGS=\"-k V=0 SAGE_NUM_THREADS=5\"" tox -e $TOX_ENV -- $TARGETS 2>&1 | sed -E --unbuffered "s/^#[0-9]+ [0-9]+[.][0-9]+ //;/^configure: notice:/s|^|::warning file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;/^configure: warning:/s|^|::warning file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;/^configure: error:/s|^|::error file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|;"
+          # The first command below is a self-destruct sequence,
+          # which preempts the GitHub Actions 6-hour job cancellation.
+          #
+          # Using "docker exec", we enter the temporary containers used by
+          # "docker build" and kill the "make" processes of the Sage distribution.
+          (
+            sleep ${{ inputs.timeout || 20000 }}
+            for container_id in $(docker ps -q); do
+              #
+              # The arcane "find" command is a replacement for "pkill make",
+              # which we use because pkill is not installed in the "minimal" package
+              # configuration on many platforms.
+              #
+              docker exec "$container_id" find /proc -maxdepth 2 -name cmdline \
+                -exec bash -c 'grep -l "[m][a][k][e]" {} | cut -d/ -f3 | xargs --no-run-if-empty kill' \;
+            done
+          ) &
+          # Set pipeline to fail if any command fails
+          set -o pipefail
+          #
+          EXTRA_DOCKER_BUILD_ARGS="--build-arg NUMPROC=9 --build-arg USE_MAKEFLAGS=\"-k V=0 SAGE_NUM_THREADS=5\""
+          #
+          # The tox command starts to build and test Sage within a Docker container.
+          #
+          # After the build, the sed command strips away timestamps from
+          # "docker build" (buildkit) such as "#25 1211.0" at the beginning of
+          # each line. The timestamps are redundant because GH Actions provides
+          # timestamps for each line already. Stripping the timestamps from
+          # the beginnings of lines also allows GitHub Actions to recognize
+          # workflow commands such as ::error etc. The other sed commands
+          # annotate configuration notices/warnings/errors as GitHub
+          # ::warning/::warning/::error respectively.
+          #
+          tox -e $TOX_ENV -- $TARGETS 2>&1 | sed -E --unbuffered "
+            s/^#[0-9]+ [0-9]+[.][0-9]+ //
+            /^configure: notice:/s|^|::warning file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|
+            /^configure: warning:/s|^|::warning file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|
+            /^configure: error:/s|^|::error file=artifacts/$LOGS_ARTIFACT_NAME/config.log::|
+          "
+
       - name: Copy logs from the Docker image or build container
         run: |
           mkdir -p "artifacts/$LOGS_ARTIFACT_NAME"
           cp -r .tox/$TOX_ENV/* "artifacts/$LOGS_ARTIFACT_NAME"
           rm -rf "artifacts/$LOGS_ARTIFACT_NAME"/{bin,lib,pyvenv.cfg}
         if: always()
+
       - name: Upload logs artifact
         uses: actions/upload-artifact@v4
         with:
           path: artifacts
           name: ${{ env.LOGS_ARTIFACT_NAME }}
-        if: always() && inputs.logs_artifact
+        if: always()
+
       - name: Print out logs for immediate inspection
         # and markup the output with GitHub Actions logging commands
         run: |
           .github/workflows/scan-logs.sh "artifacts/$LOGS_ARTIFACT_NAME"
         if: always()
+
       - name: List Docker images
         run: |
           if [ -n "$DOCKER_PUSH_REPOSITORY" -a -f .tox/$TOX_ENV/Dockertags.pushed ]; then
@@ -285,4 +383,4 @@ jobs:
           else
              echo "No Docker images created."
           fi
-        if: always() && ${{ inputs.docker_push_repository }}
+        if: ${{ always() && inputs.docker_push_repository }}

--- a/.github/workflows/docker_hub.yml
+++ b/.github/workflows/docker_hub.yml
@@ -1,4 +1,4 @@
-name: Reusable workflow for Docker Hub images
+name: Workflow for Docker Hub images
 
 on:
   workflow_call:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: Reusable workflow for macOS portability CI
+name: Workflow for macOS portability CI
 
 on:
   workflow_call:

--- a/.github/workflows/push_to_docker_hub.yml
+++ b/.github/workflows/push_to_docker_hub.yml
@@ -1,4 +1,4 @@
-name: Build Docker images and push to DockerHub
+name: Publish Docker images to DockerHub
 
 on:
   workflow_dispatch:

--- a/build/make/Makefile.in
+++ b/build/make/Makefile.in
@@ -111,12 +111,15 @@ GCC_DEP = @SAGE_GCC_DEP@
 OPTIONAL_INSTALLED_PACKAGES = @SAGE_OPTIONAL_INSTALLED_PACKAGES@
 INSTALLED_PACKAGES = $(OPTIONAL_INSTALLED_PACKAGES)
 INSTALLED_PACKAGE_INSTS = \
-    $(foreach pkgname,$(INSTALLED_PACKAGES),$(inst_$(pkgname)))
+    $(foreach pkgname,$(INSTALLED_PACKAGES),inst_$(pkgname))
 
 # All previously installed standard/optional/experimental packages that are to be uninstalled
 OPTIONAL_UNINSTALLED_PACKAGES = @SAGE_OPTIONAL_UNINSTALLED_PACKAGES@
 UNINSTALLED_PACKAGES = $(OPTIONAL_UNINSTALLED_PACKAGES)
-UNINSTALLED_PACKAGES_UNINSTALLS = $(UNINSTALLED_PACKAGES:%=%-uninstall)
+UNINSTALLED_PACKAGE_UNINSTALLS = \
+    $(foreach pkgname,$(UNINSTALLED_PACKAGES),$(pkgname)-uninstall)
+
+.PHONY: $(INSTALLED_PACKAGE_INSTS) $(UNINSTALLED_PACKAGE_UNINSTALLS)
 
 # All packages which should be downloaded
 SDIST_PACKAGES = @SAGE_SDIST_PACKAGES@
@@ -187,20 +190,29 @@ $(foreach pkgname,$(PIP_PACKAGES),\
 $(SAGE_LOCAL)/$(SPKG_INST_RELDIR)/.dummy:
 	touch $@
 
-
-# Filtered by installation tree
+# Define variables
+#
+# SAGE_LOCAL_INSTALLED_PACKAGE_INSTS
+# SAGE_VENV_INSTALLED_PACKAGE_INSTS
+# SAGE_DOCS_INSTALLED_PACKAGE_INSTS
+#
+# SAGE_LOCAL_UNINSTALLED_PACKAGE_UNINSTALLS
+# SAGE_VENV_UNINSTALLED_PACKAGE_UNINSTALLS
+# SAGE_DOCS_UNINSTALLED_PACKAGE_UNINSTALLS
+#
+# that list targets for packages to be installed/uninstalled into installation
+# tree SAGE_LOCAL/SAGE_VENV/SAGE_DOCS
 $(foreach tree,SAGE_LOCAL SAGE_VENV SAGE_DOCS, \
     $(eval $(tree)_INSTALLED_PACKAGE_INSTS = \
                $(foreach pkgname,$(INSTALLED_PACKAGES), \
                          $(if $(findstring $(tree),$(trees_$(pkgname))), \
                               $(inst_$(pkgname))))) \
     $(eval $(tree)_UNINSTALLED_PACKAGE_UNINSTALLS = \
-               $(foreach pkgname,$(INSTALLED_PACKAGES), \
+               $(foreach pkgname,$(UNINSTALLED_PACKAGES), \
                          $(if $(findstring $(tree),$(trees_$(pkgname))), \
-                              $(inst_$(pkgname))))))
+                              $(pkgname)-uninstall))))
 
-
-###############################################################################
+# ==============================================================================
 
 # Silent rules
 # https://www.gnu.org/software/automake/manual/html_node/Automake-Silent-Rules.html
@@ -277,8 +289,8 @@ base-toolchain: _clean-broken-gcc base
 
 # All targets except for the base packages and except the documentation
 all-sage: \
-		$(SAGE_LOCAL_INSTALLED_PACKAGE_INSTS) $(SAGE_LOCAL_UNINSTALLED_PACKAGES_UNINSTALLS) \
-		$(SAGE_VENV_INSTALLED_PACKAGE_INSTS)  $(SAGE_VENV_UNINSTALLED_PACKAGES_UNINSTALLS)
+	$(SAGE_LOCAL_INSTALLED_PACKAGE_INSTS) $(SAGE_LOCAL_UNINSTALLED_PACKAGE_UNINSTALLS) \
+	$(SAGE_VENV_INSTALLED_PACKAGE_INSTS) $(SAGE_VENV_UNINSTALLED_PACKAGE_UNINSTALLS)
 
 # Same but filtered by installation trees:
 all-build-local: toolchain-deps
@@ -289,12 +301,12 @@ all-sage-local: $(SAGE_LOCAL_INSTALLED_PACKAGE_INSTS) $(SAGE_LOCAL_UNINSTALLED_P
 all-build-venv: toolchain-deps
 	+$(MAKE_REC) all-sage-venv
 
-all-sage-venv:  $(SAGE_VENV_INSTALLED_PACKAGE_INSTS)  $(SAGE_VENV_UNINSTALLED_PACKAGES_UNINSTALLS)
+all-sage-venv: $(SAGE_VENV_INSTALLED_PACKAGE_INSTS) $(SAGE_VENV_UNINSTALLED_PACKAGES_UNINSTALLS)
 
 all-build-docs: toolchain-deps
 	+$(MAKE_REC) all-sage-docs
 
-all-sage-docs:  $(SAGE_DOCS_INSTALLED_PACKAGE_INSTS) $(SAGE_DOCS_UNINSTALLED_PACKAGES_UNINSTALLS)
+all-sage-docs: $(SAGE_DOCS_INSTALLED_PACKAGE_INSTS) $(SAGE_DOCS_UNINSTALLED_PACKAGES_UNINSTALLS)
 
 # Download all packages which should be inside an sdist tarball (the -B
 # option to make forces all targets to be built unconditionally)
@@ -343,17 +355,15 @@ SAGERUNTIME = sagelib $(inst_ipython) $(inst_pexpect)
 all-sageruntime: toolchain-deps
 	+$(MAKE_REC) $(SAGERUNTIME)
 
-
-###############################################################################
+# ==============================================================================
 # Building the base system
 #
 # This consists of packages which are required for the Sage build system.
-###############################################################################
+# ==============================================================================
 base: $(inst_patch) $(inst_pkgconf)
 
-###############################################################################
+# ==============================================================================
 # Building the documentation
-###############################################################################
 
 # You can choose to have the built HTML version of the documentation link to
 # the PDF version. To do so, you need to build both the HTML and PDF versions.
@@ -365,7 +375,7 @@ base: $(inst_patch) $(inst_pkgconf)
 # For more information on the docbuild utility, do
 #
 # $ ./sage --docbuild -H
-
+# ==============================================================================
 doc: doc-html
 
 # All doc-building is delegated to the script packages
@@ -481,9 +491,9 @@ wheels:
 
 pypi-wheels-check: $(PYPI_WHEEL_PACKAGES:%=%-check)
 
-#==============================================================================
+# ==============================================================================
 # Setting SAGE_CHECK... variables
-#==============================================================================
+# ==============================================================================
 ifeq "$(origin SAGE_CHECK)" "undefined"
 SAGE_CHECK := no
 endif
@@ -525,10 +535,9 @@ $(foreach clause, $(SAGE_CHECK_PACKAGES_sep),					\
 debug-check:
 	@echo $(foreach pkgname, $(NORMAL_PACKAGES) $(SCRIPT_PACKAGES), SAGE_CHECK_$(pkgname) = $(SAGE_CHECK_$(pkgname)))
 
-
-#==============================================================================
+# ==============================================================================
 # Rules generated from pkgs/<package>/dependencies files
-#==============================================================================
+# ==============================================================================
 
 # Define a function for generating the list of a package's dependencies
 # as $(inst_<pkgname>) variables.  For example, takes:
@@ -595,7 +604,7 @@ pkg_deps = \
 # sage-spkg, and --keep-files to sage-spkg-uninstall since those packages can
 # have a recursive self-dependency, and should not be deleted while upgrading.
 # See Issue #25857
-
+#
 # Positional arguments:
 #     $(1): package name
 #     $(2): package version
@@ -657,7 +666,7 @@ $(foreach pkgname, $(NORMAL_PACKAGES),\
 	                                   $(call pkg_deps,$(pkgname)),$(tree)))))
 endif
 
-# ================================ pip packages ===============================
+# ================================ pip packages ====================================
 # Generate build rules for 'pip' packages; this template is used to generate
 # two rules in the form:
 #
@@ -666,10 +675,11 @@ endif
 #
 # <pkgname>-uninstall:
 #     -sage --pip uninstall -y ...
-
+#
 # Positional arguments:
 #     $(1): package name
 #     $(2): package dependencies
+
 define PIP_PACKAGE_templ
 $(1)-build-deps: $(2)
 
@@ -719,7 +729,7 @@ endif
 #         . '$SAGE_ROOT/build/bin/sage-build-env-config' && \\
 #         . '$SAGE_ROOT/build/bin/sage-build-env' && \\
 #         '$SAGE_ROOT/build/pkgs/$PKG_NAME/spkg-uninstall'
-
+#
 # Positional arguments:
 #     $(1): package name
 #     $(2): package version

--- a/build/pkgs/_develop/dependencies
+++ b/build/pkgs/_develop/dependencies
@@ -1,1 +1,1 @@
-_bootstrap git pytest pytest_xdist github_cli
+git pytest pytest_xdist github_cli

--- a/build/pkgs/_prereq/distros/debian.txt
+++ b/build/pkgs/_prereq/distros/debian.txt
@@ -19,10 +19,11 @@ python3
 tar
 bc
 gcc
-# On debian buster, need C++ even to survive 'configure'. Otherwise:
-# checking how to run the C++ preprocessor... /lib/cpp
-# configure: error: in `/sage':
-# configure: error: C++ preprocessor "/lib/cpp" fails sanity check
+# On debian bullseye, need C++ even to survive 'configure'. Otherwise:
+#
+#  checking how to run the C++ preprocessor... /lib/cpp
+#  Error: configure: error: in `/sage':
+#  Error: configure: error: C++ preprocessor "/lib/cpp" fails sanity check
 g++
-# Needed if we download some packages from a https upstream URL
+# needed if we download some packages from a https upstream URL
 ca-certificates

--- a/build/pkgs/git/SPKG.rst
+++ b/build/pkgs/git/SPKG.rst
@@ -4,12 +4,9 @@ git: Version control system
 Description
 -----------
 
-   Git is a fast, scalable, distributed revision control system with an
-   unusually rich command set that provides both high-operations and
-   full access to internals.
-
--  ``man git``
-
+Git is a fast, scalable, distributed revision control system with an
+unusually rich command set that provides both high-operations and
+full access to internals.
 
 Upstream Contact
 ----------------

--- a/src/doc/en/developer/portability_platform_table.rst
+++ b/src/doc/en/developer/portability_platform_table.rst
@@ -1,111 +1,3 @@
-.. |image-ubuntu-xenial-toolchain-gcc_9-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-with-system-packages
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-configured
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets-pre
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets-optional
-
-.. |codespace-ubuntu-xenial-toolchain-gcc_9-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-xenial-toolchain-gcc_9-minimal%2Fdevcontainer.json
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-with-system-packages
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-configured
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-with-targets-pre
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-with-targets
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-standard-with-targets-optional
-
-.. |codespace-ubuntu-xenial-toolchain-gcc_9-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-xenial-toolchain-gcc_9-standard%2Fdevcontainer.json
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-with-system-packages
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-configured
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets-pre
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets
-
-.. |image-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets-optional
-
-.. |codespace-ubuntu-xenial-toolchain-gcc_9-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-xenial-toolchain-gcc_9-maximal%2Fdevcontainer.json
-
-.. |image-ubuntu-bionic-gcc_8-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-with-system-packages
-
-.. |image-ubuntu-bionic-gcc_8-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-configured
-
-.. |image-ubuntu-bionic-gcc_8-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-with-targets-pre
-
-.. |image-ubuntu-bionic-gcc_8-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-with-targets
-
-.. |image-ubuntu-bionic-gcc_8-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-minimal-with-targets-optional
-
-.. |codespace-ubuntu-bionic-gcc_8-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-bionic-gcc_8-minimal%2Fdevcontainer.json
-
-.. |image-ubuntu-bionic-gcc_8-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-with-system-packages
-
-.. |image-ubuntu-bionic-gcc_8-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-configured
-
-.. |image-ubuntu-bionic-gcc_8-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-with-targets-pre
-
-.. |image-ubuntu-bionic-gcc_8-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-with-targets
-
-.. |image-ubuntu-bionic-gcc_8-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-standard-with-targets-optional
-
-.. |codespace-ubuntu-bionic-gcc_8-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-bionic-gcc_8-standard%2Fdevcontainer.json
-
-.. |image-ubuntu-bionic-gcc_8-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-with-system-packages
-
-.. |image-ubuntu-bionic-gcc_8-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-configured
-
-.. |image-ubuntu-bionic-gcc_8-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-with-targets-pre
-
-.. |image-ubuntu-bionic-gcc_8-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-with-targets
-
-.. |image-ubuntu-bionic-gcc_8-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-maximal-with-targets-optional
-
-.. |codespace-ubuntu-bionic-gcc_8-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-bionic-gcc_8-maximal%2Fdevcontainer.json
-
 .. |image-ubuntu-focal-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-focal-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
    :target: https://ghcr.io/sagemath/sage/sage-ubuntu-focal-minimal-with-system-packages
 
@@ -213,114 +105,6 @@
 
 .. |codespace-ubuntu-jammy-maximal| image:: https://github.com/codespaces/badge.svg
    :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-jammy-maximal%2Fdevcontainer.json
-
-.. |image-ubuntu-lunar-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-minimal-with-system-packages
-
-.. |image-ubuntu-lunar-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-minimal-configured
-
-.. |image-ubuntu-lunar-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-minimal-with-targets-pre
-
-.. |image-ubuntu-lunar-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-minimal-with-targets
-
-.. |image-ubuntu-lunar-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-minimal-with-targets-optional
-
-.. |codespace-ubuntu-lunar-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-lunar-minimal%2Fdevcontainer.json
-
-.. |image-ubuntu-lunar-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-standard-with-system-packages
-
-.. |image-ubuntu-lunar-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-standard-configured
-
-.. |image-ubuntu-lunar-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-standard-with-targets-pre
-
-.. |image-ubuntu-lunar-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-standard-with-targets
-
-.. |image-ubuntu-lunar-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-standard-with-targets-optional
-
-.. |codespace-ubuntu-lunar-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-lunar-standard%2Fdevcontainer.json
-
-.. |image-ubuntu-lunar-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-maximal-with-system-packages
-
-.. |image-ubuntu-lunar-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-maximal-configured
-
-.. |image-ubuntu-lunar-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-maximal-with-targets-pre
-
-.. |image-ubuntu-lunar-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-maximal-with-targets
-
-.. |image-ubuntu-lunar-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-lunar-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-lunar-maximal-with-targets-optional
-
-.. |codespace-ubuntu-lunar-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-lunar-maximal%2Fdevcontainer.json
-
-.. |image-ubuntu-mantic-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-minimal-with-system-packages
-
-.. |image-ubuntu-mantic-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-minimal-configured
-
-.. |image-ubuntu-mantic-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-minimal-with-targets-pre
-
-.. |image-ubuntu-mantic-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-minimal-with-targets
-
-.. |image-ubuntu-mantic-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-minimal-with-targets-optional
-
-.. |codespace-ubuntu-mantic-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-mantic-minimal%2Fdevcontainer.json
-
-.. |image-ubuntu-mantic-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-standard-with-system-packages
-
-.. |image-ubuntu-mantic-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-standard-configured
-
-.. |image-ubuntu-mantic-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-standard-with-targets-pre
-
-.. |image-ubuntu-mantic-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-standard-with-targets
-
-.. |image-ubuntu-mantic-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-standard-with-targets-optional
-
-.. |codespace-ubuntu-mantic-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-mantic-standard%2Fdevcontainer.json
-
-.. |image-ubuntu-mantic-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-maximal-with-system-packages
-
-.. |image-ubuntu-mantic-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-maximal-configured
-
-.. |image-ubuntu-mantic-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-maximal-with-targets-pre
-
-.. |image-ubuntu-mantic-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-maximal-with-targets
-
-.. |image-ubuntu-mantic-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-mantic-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-mantic-maximal-with-targets-optional
-
-.. |codespace-ubuntu-mantic-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-mantic-maximal%2Fdevcontainer.json
 
 .. |image-ubuntu-noble-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-noble-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
    :target: https://ghcr.io/sagemath/sage/sage-ubuntu-noble-minimal-with-system-packages
@@ -483,276 +267,6 @@
 
 .. |codespace-debian-bookworm-maximal| image:: https://github.com/codespaces/badge.svg
    :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-bookworm-maximal%2Fdevcontainer.json
-
-.. |image-debian-trixie-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-minimal-with-system-packages
-
-.. |image-debian-trixie-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-minimal-configured
-
-.. |image-debian-trixie-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-minimal-with-targets-pre
-
-.. |image-debian-trixie-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-minimal-with-targets
-
-.. |image-debian-trixie-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-minimal-with-targets-optional
-
-.. |codespace-debian-trixie-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-trixie-minimal%2Fdevcontainer.json
-
-.. |image-debian-trixie-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-standard-with-system-packages
-
-.. |image-debian-trixie-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-standard-configured
-
-.. |image-debian-trixie-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-standard-with-targets-pre
-
-.. |image-debian-trixie-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-standard-with-targets
-
-.. |image-debian-trixie-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-standard-with-targets-optional
-
-.. |codespace-debian-trixie-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-trixie-standard%2Fdevcontainer.json
-
-.. |image-debian-trixie-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-maximal-with-system-packages
-
-.. |image-debian-trixie-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-maximal-configured
-
-.. |image-debian-trixie-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-maximal-with-targets-pre
-
-.. |image-debian-trixie-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-maximal-with-targets
-
-.. |image-debian-trixie-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-trixie-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-debian-trixie-maximal-with-targets-optional
-
-.. |codespace-debian-trixie-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-trixie-maximal%2Fdevcontainer.json
-
-.. |image-debian-sid-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-minimal-with-system-packages
-
-.. |image-debian-sid-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-minimal-configured
-
-.. |image-debian-sid-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-minimal-with-targets-pre
-
-.. |image-debian-sid-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-minimal-with-targets
-
-.. |image-debian-sid-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-minimal-with-targets-optional
-
-.. |codespace-debian-sid-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-sid-minimal%2Fdevcontainer.json
-
-.. |image-debian-sid-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-standard-with-system-packages
-
-.. |image-debian-sid-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-standard-configured
-
-.. |image-debian-sid-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-standard-with-targets-pre
-
-.. |image-debian-sid-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-standard-with-targets
-
-.. |image-debian-sid-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-standard-with-targets-optional
-
-.. |codespace-debian-sid-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-sid-standard%2Fdevcontainer.json
-
-.. |image-debian-sid-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-maximal-with-system-packages
-
-.. |image-debian-sid-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-maximal-configured
-
-.. |image-debian-sid-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-maximal-with-targets-pre
-
-.. |image-debian-sid-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-maximal-with-targets
-
-.. |image-debian-sid-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-sid-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-debian-sid-maximal-with-targets-optional
-
-.. |codespace-debian-sid-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-sid-maximal%2Fdevcontainer.json
-
-.. |image-linuxmint-20.1-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-minimal-with-system-packages
-
-.. |image-linuxmint-20.1-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-minimal-configured
-
-.. |image-linuxmint-20.1-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-minimal-with-targets-pre
-
-.. |image-linuxmint-20.1-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-minimal-with-targets
-
-.. |image-linuxmint-20.1-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-minimal-with-targets-optional
-
-.. |codespace-linuxmint-20.1-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.1-minimal%2Fdevcontainer.json
-
-.. |image-linuxmint-20.1-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-standard-with-system-packages
-
-.. |image-linuxmint-20.1-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-standard-configured
-
-.. |image-linuxmint-20.1-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-standard-with-targets-pre
-
-.. |image-linuxmint-20.1-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-standard-with-targets
-
-.. |image-linuxmint-20.1-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-standard-with-targets-optional
-
-.. |codespace-linuxmint-20.1-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.1-standard%2Fdevcontainer.json
-
-.. |image-linuxmint-20.1-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-maximal-with-system-packages
-
-.. |image-linuxmint-20.1-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-maximal-configured
-
-.. |image-linuxmint-20.1-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-maximal-with-targets-pre
-
-.. |image-linuxmint-20.1-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-maximal-with-targets
-
-.. |image-linuxmint-20.1-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.1-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.1-maximal-with-targets-optional
-
-.. |codespace-linuxmint-20.1-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.1-maximal%2Fdevcontainer.json
-
-.. |image-linuxmint-20.2-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-minimal-with-system-packages
-
-.. |image-linuxmint-20.2-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-minimal-configured
-
-.. |image-linuxmint-20.2-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-minimal-with-targets-pre
-
-.. |image-linuxmint-20.2-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-minimal-with-targets
-
-.. |image-linuxmint-20.2-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-minimal-with-targets-optional
-
-.. |codespace-linuxmint-20.2-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.2-minimal%2Fdevcontainer.json
-
-.. |image-linuxmint-20.2-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-standard-with-system-packages
-
-.. |image-linuxmint-20.2-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-standard-configured
-
-.. |image-linuxmint-20.2-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-standard-with-targets-pre
-
-.. |image-linuxmint-20.2-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-standard-with-targets
-
-.. |image-linuxmint-20.2-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-standard-with-targets-optional
-
-.. |codespace-linuxmint-20.2-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.2-standard%2Fdevcontainer.json
-
-.. |image-linuxmint-20.2-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-maximal-with-system-packages
-
-.. |image-linuxmint-20.2-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-maximal-configured
-
-.. |image-linuxmint-20.2-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-maximal-with-targets-pre
-
-.. |image-linuxmint-20.2-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-maximal-with-targets
-
-.. |image-linuxmint-20.2-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.2-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.2-maximal-with-targets-optional
-
-.. |codespace-linuxmint-20.2-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.2-maximal%2Fdevcontainer.json
-
-.. |image-linuxmint-20.3-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-minimal-with-system-packages
-
-.. |image-linuxmint-20.3-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-minimal-configured
-
-.. |image-linuxmint-20.3-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-minimal-with-targets-pre
-
-.. |image-linuxmint-20.3-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-minimal-with-targets
-
-.. |image-linuxmint-20.3-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-minimal-with-targets-optional
-
-.. |codespace-linuxmint-20.3-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.3-minimal%2Fdevcontainer.json
-
-.. |image-linuxmint-20.3-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-standard-with-system-packages
-
-.. |image-linuxmint-20.3-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-standard-configured
-
-.. |image-linuxmint-20.3-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-standard-with-targets-pre
-
-.. |image-linuxmint-20.3-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-standard-with-targets
-
-.. |image-linuxmint-20.3-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-standard-with-targets-optional
-
-.. |codespace-linuxmint-20.3-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.3-standard%2Fdevcontainer.json
-
-.. |image-linuxmint-20.3-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-maximal-with-system-packages
-
-.. |image-linuxmint-20.3-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-maximal-configured
-
-.. |image-linuxmint-20.3-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-maximal-with-targets-pre
-
-.. |image-linuxmint-20.3-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-maximal-with-targets
-
-.. |image-linuxmint-20.3-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-20.3-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-20.3-maximal-with-targets-optional
-
-.. |codespace-linuxmint-20.3-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-20.3-maximal%2Fdevcontainer.json
 
 .. |image-linuxmint-21-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-21-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
    :target: https://ghcr.io/sagemath/sage/sage-linuxmint-21-minimal-with-system-packages
@@ -970,329 +484,113 @@
 .. |codespace-linuxmint-21.3-maximal| image:: https://github.com/codespaces/badge.svg
    :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-21.3-maximal%2Fdevcontainer.json
 
-.. |image-fedora-30-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-minimal-with-system-packages
+.. |image-linuxmint-22-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-minimal-with-system-packages
 
-.. |image-fedora-30-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-minimal-configured
+.. |image-linuxmint-22-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-minimal-configured
 
-.. |image-fedora-30-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-minimal-with-targets-pre
+.. |image-linuxmint-22-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-minimal-with-targets-pre
 
-.. |image-fedora-30-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-minimal-with-targets
+.. |image-linuxmint-22-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-minimal-with-targets
 
-.. |image-fedora-30-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-minimal-with-targets-optional
+.. |image-linuxmint-22-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-minimal-with-targets-optional
 
-.. |codespace-fedora-30-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-30-minimal%2Fdevcontainer.json
+.. |codespace-linuxmint-22-minimal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-22-minimal%2Fdevcontainer.json
 
-.. |image-fedora-30-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-standard-with-system-packages
+.. |image-linuxmint-22-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-standard-with-system-packages
 
-.. |image-fedora-30-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-standard-configured
+.. |image-linuxmint-22-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-standard-configured
 
-.. |image-fedora-30-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-standard-with-targets-pre
+.. |image-linuxmint-22-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-standard-with-targets-pre
 
-.. |image-fedora-30-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-standard-with-targets
+.. |image-linuxmint-22-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-standard-with-targets
 
-.. |image-fedora-30-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-standard-with-targets-optional
+.. |image-linuxmint-22-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-standard-with-targets-optional
 
-.. |codespace-fedora-30-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-30-standard%2Fdevcontainer.json
+.. |codespace-linuxmint-22-standard| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-22-standard%2Fdevcontainer.json
 
-.. |image-fedora-30-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-maximal-with-system-packages
+.. |image-linuxmint-22-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-maximal-with-system-packages
 
-.. |image-fedora-30-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-maximal-configured
+.. |image-linuxmint-22-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-maximal-configured
 
-.. |image-fedora-30-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-maximal-with-targets-pre
+.. |image-linuxmint-22-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-maximal-with-targets-pre
 
-.. |image-fedora-30-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-maximal-with-targets
+.. |image-linuxmint-22-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-maximal-with-targets
 
-.. |image-fedora-30-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-30-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-30-maximal-with-targets-optional
+.. |image-linuxmint-22-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22-maximal-with-targets-optional
 
-.. |codespace-fedora-30-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-30-maximal%2Fdevcontainer.json
+.. |codespace-linuxmint-22-maximal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-22-maximal%2Fdevcontainer.json
 
-.. |image-fedora-31-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-minimal-with-system-packages
+.. |image-linuxmint-22.1-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-minimal-with-system-packages
 
-.. |image-fedora-31-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-minimal-configured
+.. |image-linuxmint-22.1-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-minimal-configured
 
-.. |image-fedora-31-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-minimal-with-targets-pre
+.. |image-linuxmint-22.1-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-minimal-with-targets-pre
 
-.. |image-fedora-31-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-minimal-with-targets
+.. |image-linuxmint-22.1-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-minimal-with-targets
 
-.. |image-fedora-31-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-minimal-with-targets-optional
+.. |image-linuxmint-22.1-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-minimal-with-targets-optional
 
-.. |codespace-fedora-31-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-31-minimal%2Fdevcontainer.json
+.. |codespace-linuxmint-22.1-minimal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-22.1-minimal%2Fdevcontainer.json
 
-.. |image-fedora-31-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-standard-with-system-packages
+.. |image-linuxmint-22.1-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-standard-with-system-packages
 
-.. |image-fedora-31-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-standard-configured
+.. |image-linuxmint-22.1-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-standard-configured
 
-.. |image-fedora-31-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-standard-with-targets-pre
+.. |image-linuxmint-22.1-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-standard-with-targets-pre
 
-.. |image-fedora-31-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-standard-with-targets
+.. |image-linuxmint-22.1-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-standard-with-targets
 
-.. |image-fedora-31-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-standard-with-targets-optional
+.. |image-linuxmint-22.1-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-standard-with-targets-optional
 
-.. |codespace-fedora-31-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-31-standard%2Fdevcontainer.json
+.. |codespace-linuxmint-22.1-standard| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-22.1-standard%2Fdevcontainer.json
 
-.. |image-fedora-31-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-maximal-with-system-packages
+.. |image-linuxmint-22.1-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-maximal-with-system-packages
 
-.. |image-fedora-31-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-maximal-configured
+.. |image-linuxmint-22.1-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-maximal-configured
 
-.. |image-fedora-31-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-maximal-with-targets-pre
+.. |image-linuxmint-22.1-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-maximal-with-targets-pre
 
-.. |image-fedora-31-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-maximal-with-targets
+.. |image-linuxmint-22.1-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-maximal-with-targets
 
-.. |image-fedora-31-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-31-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-31-maximal-with-targets-optional
+.. |image-linuxmint-22.1-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-linuxmint-22.1-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
+   :target: https://ghcr.io/sagemath/sage/sage-linuxmint-22.1-maximal-with-targets-optional
 
-.. |codespace-fedora-31-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-31-maximal%2Fdevcontainer.json
-
-.. |image-fedora-32-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-minimal-with-system-packages
-
-.. |image-fedora-32-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-minimal-configured
-
-.. |image-fedora-32-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-minimal-with-targets-pre
-
-.. |image-fedora-32-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-minimal-with-targets
-
-.. |image-fedora-32-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-minimal-with-targets-optional
-
-.. |codespace-fedora-32-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-32-minimal%2Fdevcontainer.json
-
-.. |image-fedora-32-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-standard-with-system-packages
-
-.. |image-fedora-32-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-standard-configured
-
-.. |image-fedora-32-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-standard-with-targets-pre
-
-.. |image-fedora-32-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-standard-with-targets
-
-.. |image-fedora-32-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-standard-with-targets-optional
-
-.. |codespace-fedora-32-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-32-standard%2Fdevcontainer.json
-
-.. |image-fedora-32-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-maximal-with-system-packages
-
-.. |image-fedora-32-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-maximal-configured
-
-.. |image-fedora-32-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-maximal-with-targets-pre
-
-.. |image-fedora-32-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-maximal-with-targets
-
-.. |image-fedora-32-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-32-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-32-maximal-with-targets-optional
-
-.. |codespace-fedora-32-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-32-maximal%2Fdevcontainer.json
-
-.. |image-fedora-33-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-minimal-with-system-packages
-
-.. |image-fedora-33-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-minimal-configured
-
-.. |image-fedora-33-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-minimal-with-targets-pre
-
-.. |image-fedora-33-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-minimal-with-targets
-
-.. |image-fedora-33-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-minimal-with-targets-optional
-
-.. |codespace-fedora-33-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-33-minimal%2Fdevcontainer.json
-
-.. |image-fedora-33-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-standard-with-system-packages
-
-.. |image-fedora-33-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-standard-configured
-
-.. |image-fedora-33-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-standard-with-targets-pre
-
-.. |image-fedora-33-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-standard-with-targets
-
-.. |image-fedora-33-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-standard-with-targets-optional
-
-.. |codespace-fedora-33-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-33-standard%2Fdevcontainer.json
-
-.. |image-fedora-33-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-maximal-with-system-packages
-
-.. |image-fedora-33-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-maximal-configured
-
-.. |image-fedora-33-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-maximal-with-targets-pre
-
-.. |image-fedora-33-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-maximal-with-targets
-
-.. |image-fedora-33-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-33-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-33-maximal-with-targets-optional
-
-.. |codespace-fedora-33-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-33-maximal%2Fdevcontainer.json
-
-.. |image-fedora-34-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-minimal-with-system-packages
-
-.. |image-fedora-34-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-minimal-configured
-
-.. |image-fedora-34-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-minimal-with-targets-pre
-
-.. |image-fedora-34-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-minimal-with-targets
-
-.. |image-fedora-34-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-minimal-with-targets-optional
-
-.. |codespace-fedora-34-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-34-minimal%2Fdevcontainer.json
-
-.. |image-fedora-34-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-standard-with-system-packages
-
-.. |image-fedora-34-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-standard-configured
-
-.. |image-fedora-34-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-standard-with-targets-pre
-
-.. |image-fedora-34-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-standard-with-targets
-
-.. |image-fedora-34-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-standard-with-targets-optional
-
-.. |codespace-fedora-34-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-34-standard%2Fdevcontainer.json
-
-.. |image-fedora-34-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-maximal-with-system-packages
-
-.. |image-fedora-34-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-maximal-configured
-
-.. |image-fedora-34-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-maximal-with-targets-pre
-
-.. |image-fedora-34-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-maximal-with-targets
-
-.. |image-fedora-34-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-34-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-34-maximal-with-targets-optional
-
-.. |codespace-fedora-34-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-34-maximal%2Fdevcontainer.json
-
-.. |image-fedora-35-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-minimal-with-system-packages
-
-.. |image-fedora-35-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-minimal-configured
-
-.. |image-fedora-35-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-minimal-with-targets-pre
-
-.. |image-fedora-35-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-minimal-with-targets
-
-.. |image-fedora-35-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-minimal-with-targets-optional
-
-.. |codespace-fedora-35-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-35-minimal%2Fdevcontainer.json
-
-.. |image-fedora-35-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-standard-with-system-packages
-
-.. |image-fedora-35-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-standard-configured
-
-.. |image-fedora-35-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-standard-with-targets-pre
-
-.. |image-fedora-35-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-standard-with-targets
-
-.. |image-fedora-35-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-standard-with-targets-optional
-
-.. |codespace-fedora-35-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-35-standard%2Fdevcontainer.json
-
-.. |image-fedora-35-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-maximal-with-system-packages
-
-.. |image-fedora-35-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-maximal-configured
-
-.. |image-fedora-35-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-maximal-with-targets-pre
-
-.. |image-fedora-35-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-maximal-with-targets
-
-.. |image-fedora-35-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-35-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-fedora-35-maximal-with-targets-optional
-
-.. |codespace-fedora-35-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-fedora-35-maximal%2Fdevcontainer.json
+.. |codespace-linuxmint-22.1-maximal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-linuxmint-22.1-maximal%2Fdevcontainer.json
 
 .. |image-fedora-36-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-fedora-36-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
    :target: https://ghcr.io/sagemath/sage/sage-fedora-36-minimal-with-system-packages
@@ -1726,167 +1024,167 @@
 .. |codespace-centos-stream-9-python3.12-maximal| image:: https://github.com/codespaces/badge.svg
    :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-centos-stream-9-python3.12-maximal%2Fdevcontainer.json
 
-.. |image-almalinux-8-python3.9-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-minimal-with-system-packages
+.. |image-almalinux-8-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-minimal-with-system-packages
 
-.. |image-almalinux-8-python3.9-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-minimal-configured
+.. |image-almalinux-8-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-minimal-configured
 
-.. |image-almalinux-8-python3.9-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-minimal-with-targets-pre
+.. |image-almalinux-8-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-minimal-with-targets-pre
 
-.. |image-almalinux-8-python3.9-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-minimal-with-targets
+.. |image-almalinux-8-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-minimal-with-targets
 
-.. |image-almalinux-8-python3.9-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-minimal-with-targets-optional
+.. |image-almalinux-8-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-minimal-with-targets-optional
 
-.. |codespace-almalinux-8-python3.9-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-8-python3.9-minimal%2Fdevcontainer.json
+.. |codespace-almalinux-8-minimal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-8-minimal%2Fdevcontainer.json
 
-.. |image-almalinux-8-python3.9-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-standard-with-system-packages
+.. |image-almalinux-8-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-standard-with-system-packages
 
-.. |image-almalinux-8-python3.9-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-standard-configured
+.. |image-almalinux-8-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-standard-configured
 
-.. |image-almalinux-8-python3.9-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-standard-with-targets-pre
+.. |image-almalinux-8-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-standard-with-targets-pre
 
-.. |image-almalinux-8-python3.9-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-standard-with-targets
+.. |image-almalinux-8-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-standard-with-targets
 
-.. |image-almalinux-8-python3.9-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-standard-with-targets-optional
+.. |image-almalinux-8-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-standard-with-targets-optional
 
-.. |codespace-almalinux-8-python3.9-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-8-python3.9-standard%2Fdevcontainer.json
+.. |codespace-almalinux-8-standard| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-8-standard%2Fdevcontainer.json
 
-.. |image-almalinux-8-python3.9-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-maximal-with-system-packages
+.. |image-almalinux-8-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-maximal-with-system-packages
 
-.. |image-almalinux-8-python3.9-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-maximal-configured
+.. |image-almalinux-8-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-maximal-configured
 
-.. |image-almalinux-8-python3.9-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-maximal-with-targets-pre
+.. |image-almalinux-8-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-maximal-with-targets-pre
 
-.. |image-almalinux-8-python3.9-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-maximal-with-targets
+.. |image-almalinux-8-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-maximal-with-targets
 
-.. |image-almalinux-8-python3.9-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-python3.9-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-python3.9-maximal-with-targets-optional
+.. |image-almalinux-8-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-8-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-8-maximal-with-targets-optional
 
-.. |codespace-almalinux-8-python3.9-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-8-python3.9-maximal%2Fdevcontainer.json
+.. |codespace-almalinux-8-maximal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-8-maximal%2Fdevcontainer.json
 
-.. |image-almalinux-9-python3.11-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-minimal-with-system-packages
+.. |image-almalinux-9-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-minimal-with-system-packages
 
-.. |image-almalinux-9-python3.11-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-minimal-configured
+.. |image-almalinux-9-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-minimal-configured
 
-.. |image-almalinux-9-python3.11-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-minimal-with-targets-pre
+.. |image-almalinux-9-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-minimal-with-targets-pre
 
-.. |image-almalinux-9-python3.11-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-minimal-with-targets
+.. |image-almalinux-9-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-minimal-with-targets
 
-.. |image-almalinux-9-python3.11-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-minimal-with-targets-optional
+.. |image-almalinux-9-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-minimal-with-targets-optional
 
-.. |codespace-almalinux-9-python3.11-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9-python3.11-minimal%2Fdevcontainer.json
+.. |codespace-almalinux-9-minimal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9-minimal%2Fdevcontainer.json
 
-.. |image-almalinux-9-python3.11-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-standard-with-system-packages
+.. |image-almalinux-9-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-standard-with-system-packages
 
-.. |image-almalinux-9-python3.11-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-standard-configured
+.. |image-almalinux-9-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-standard-configured
 
-.. |image-almalinux-9-python3.11-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-standard-with-targets-pre
+.. |image-almalinux-9-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-standard-with-targets-pre
 
-.. |image-almalinux-9-python3.11-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-standard-with-targets
+.. |image-almalinux-9-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-standard-with-targets
 
-.. |image-almalinux-9-python3.11-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-standard-with-targets-optional
+.. |image-almalinux-9-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-standard-with-targets-optional
 
-.. |codespace-almalinux-9-python3.11-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9-python3.11-standard%2Fdevcontainer.json
+.. |codespace-almalinux-9-standard| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9-standard%2Fdevcontainer.json
 
-.. |image-almalinux-9-python3.11-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-maximal-with-system-packages
+.. |image-almalinux-9-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-maximal-with-system-packages
 
-.. |image-almalinux-9-python3.11-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-maximal-configured
+.. |image-almalinux-9-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-maximal-configured
 
-.. |image-almalinux-9-python3.11-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-maximal-with-targets-pre
+.. |image-almalinux-9-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-maximal-with-targets-pre
 
-.. |image-almalinux-9-python3.11-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-maximal-with-targets
+.. |image-almalinux-9-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-maximal-with-targets
 
-.. |image-almalinux-9-python3.11-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-python3.11-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-python3.11-maximal-with-targets-optional
+.. |image-almalinux-9-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9-maximal-with-targets-optional
 
-.. |codespace-almalinux-9-python3.11-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9-python3.11-maximal%2Fdevcontainer.json
+.. |codespace-almalinux-9-maximal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9-maximal%2Fdevcontainer.json
 
-.. |image-gentoo-python3.10-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-minimal-with-system-packages
+.. |image-almalinux-9.5-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-minimal-with-system-packages
 
-.. |image-gentoo-python3.10-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-minimal-configured
+.. |image-almalinux-9.5-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-minimal-configured
 
-.. |image-gentoo-python3.10-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-minimal-with-targets-pre
+.. |image-almalinux-9.5-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-minimal-with-targets-pre
 
-.. |image-gentoo-python3.10-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-minimal-with-targets
+.. |image-almalinux-9.5-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-minimal-with-targets
 
-.. |image-gentoo-python3.10-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-minimal-with-targets-optional
+.. |image-almalinux-9.5-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-minimal-with-targets-optional
 
-.. |codespace-gentoo-python3.10-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-gentoo-python3.10-minimal%2Fdevcontainer.json
+.. |codespace-almalinux-9.5-minimal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9.5-minimal%2Fdevcontainer.json
 
-.. |image-gentoo-python3.10-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-standard-with-system-packages
+.. |image-almalinux-9.5-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-standard-with-system-packages
 
-.. |image-gentoo-python3.10-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-standard-configured
+.. |image-almalinux-9.5-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-standard-configured
 
-.. |image-gentoo-python3.10-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-standard-with-targets-pre
+.. |image-almalinux-9.5-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-standard-with-targets-pre
 
-.. |image-gentoo-python3.10-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-standard-with-targets
+.. |image-almalinux-9.5-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-standard-with-targets
 
-.. |image-gentoo-python3.10-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-standard-with-targets-optional
+.. |image-almalinux-9.5-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-standard-with-targets-optional
 
-.. |codespace-gentoo-python3.10-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-gentoo-python3.10-standard%2Fdevcontainer.json
+.. |codespace-almalinux-9.5-standard| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9.5-standard%2Fdevcontainer.json
 
-.. |image-gentoo-python3.10-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-maximal-with-system-packages
+.. |image-almalinux-9.5-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-maximal-with-system-packages
 
-.. |image-gentoo-python3.10-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-maximal-configured
+.. |image-almalinux-9.5-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-maximal-configured
 
-.. |image-gentoo-python3.10-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-maximal-with-targets-pre
+.. |image-almalinux-9.5-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-maximal-with-targets-pre
 
-.. |image-gentoo-python3.10-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-maximal-with-targets
+.. |image-almalinux-9.5-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-maximal-with-targets
 
-.. |image-gentoo-python3.10-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.10-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.10-maximal-with-targets-optional
+.. |image-almalinux-9.5-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-almalinux-9.5-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
+   :target: https://ghcr.io/sagemath/sage/sage-almalinux-9.5-maximal-with-targets-optional
 
-.. |codespace-gentoo-python3.10-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-gentoo-python3.10-maximal%2Fdevcontainer.json
+.. |codespace-almalinux-9.5-maximal| image:: https://github.com/codespaces/badge.svg
+   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-almalinux-9.5-maximal%2Fdevcontainer.json
 
 .. |image-gentoo-python3.11-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-gentoo-python3.11-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
    :target: https://ghcr.io/sagemath/sage/sage-gentoo-python3.11-minimal-with-system-packages
@@ -2104,60 +1402,6 @@
 .. |codespace-opensuse-15.5-gcc_11-python3.11-maximal| image:: https://github.com/codespaces/badge.svg
    :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-opensuse-15.5-gcc_11-python3.11-maximal%2Fdevcontainer.json
 
-.. |image-opensuse-tumbleweed-python3.10-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-with-system-packages
-
-.. |image-opensuse-tumbleweed-python3.10-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-configured
-
-.. |image-opensuse-tumbleweed-python3.10-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-with-targets-pre
-
-.. |image-opensuse-tumbleweed-python3.10-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-with-targets
-
-.. |image-opensuse-tumbleweed-python3.10-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-minimal-with-targets-optional
-
-.. |codespace-opensuse-tumbleweed-python3.10-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-opensuse-tumbleweed-python3.10-minimal%2Fdevcontainer.json
-
-.. |image-opensuse-tumbleweed-python3.10-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-with-system-packages
-
-.. |image-opensuse-tumbleweed-python3.10-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-configured
-
-.. |image-opensuse-tumbleweed-python3.10-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-with-targets-pre
-
-.. |image-opensuse-tumbleweed-python3.10-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-with-targets
-
-.. |image-opensuse-tumbleweed-python3.10-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-standard-with-targets-optional
-
-.. |codespace-opensuse-tumbleweed-python3.10-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-opensuse-tumbleweed-python3.10-standard%2Fdevcontainer.json
-
-.. |image-opensuse-tumbleweed-python3.10-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-with-system-packages
-
-.. |image-opensuse-tumbleweed-python3.10-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-configured
-
-.. |image-opensuse-tumbleweed-python3.10-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-with-targets-pre
-
-.. |image-opensuse-tumbleweed-python3.10-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-with-targets
-
-.. |image-opensuse-tumbleweed-python3.10-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-python3.10-maximal-with-targets-optional
-
-.. |codespace-opensuse-tumbleweed-python3.10-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-opensuse-tumbleweed-python3.10-maximal%2Fdevcontainer.json
-
 .. |image-opensuse-tumbleweed-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-opensuse-tumbleweed-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
    :target: https://ghcr.io/sagemath/sage/sage-opensuse-tumbleweed-minimal-with-system-packages
 
@@ -2212,168 +1456,6 @@
 .. |codespace-opensuse-tumbleweed-maximal| image:: https://github.com/codespaces/badge.svg
    :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-opensuse-tumbleweed-maximal%2Fdevcontainer.json
 
-.. |image-conda-forge-python3.11-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-minimal-with-system-packages
-
-.. |image-conda-forge-python3.11-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-minimal-configured
-
-.. |image-conda-forge-python3.11-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-minimal-with-targets-pre
-
-.. |image-conda-forge-python3.11-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-minimal-with-targets
-
-.. |image-conda-forge-python3.11-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-minimal-with-targets-optional
-
-.. |codespace-conda-forge-python3.11-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-conda-forge-python3.11-minimal%2Fdevcontainer.json
-
-.. |image-conda-forge-python3.11-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-standard-with-system-packages
-
-.. |image-conda-forge-python3.11-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-standard-configured
-
-.. |image-conda-forge-python3.11-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-standard-with-targets-pre
-
-.. |image-conda-forge-python3.11-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-standard-with-targets
-
-.. |image-conda-forge-python3.11-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-standard-with-targets-optional
-
-.. |codespace-conda-forge-python3.11-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-conda-forge-python3.11-standard%2Fdevcontainer.json
-
-.. |image-conda-forge-python3.11-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-maximal-with-system-packages
-
-.. |image-conda-forge-python3.11-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-maximal-configured
-
-.. |image-conda-forge-python3.11-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-maximal-with-targets-pre
-
-.. |image-conda-forge-python3.11-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-maximal-with-targets
-
-.. |image-conda-forge-python3.11-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-conda-forge-python3.11-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-conda-forge-python3.11-maximal-with-targets-optional
-
-.. |codespace-conda-forge-python3.11-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-conda-forge-python3.11-maximal%2Fdevcontainer.json
-
-.. |image-ubuntu-bionic-gcc_8-i386-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-with-system-packages
-
-.. |image-ubuntu-bionic-gcc_8-i386-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-configured
-
-.. |image-ubuntu-bionic-gcc_8-i386-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-with-targets-pre
-
-.. |image-ubuntu-bionic-gcc_8-i386-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-with-targets
-
-.. |image-ubuntu-bionic-gcc_8-i386-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-minimal-with-targets-optional
-
-.. |codespace-ubuntu-bionic-gcc_8-i386-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-bionic-gcc_8-i386-minimal%2Fdevcontainer.json
-
-.. |image-ubuntu-bionic-gcc_8-i386-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-with-system-packages
-
-.. |image-ubuntu-bionic-gcc_8-i386-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-configured
-
-.. |image-ubuntu-bionic-gcc_8-i386-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-with-targets-pre
-
-.. |image-ubuntu-bionic-gcc_8-i386-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-with-targets
-
-.. |image-ubuntu-bionic-gcc_8-i386-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-standard-with-targets-optional
-
-.. |codespace-ubuntu-bionic-gcc_8-i386-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-bionic-gcc_8-i386-standard%2Fdevcontainer.json
-
-.. |image-ubuntu-bionic-gcc_8-i386-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-with-system-packages
-
-.. |image-ubuntu-bionic-gcc_8-i386-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-configured
-
-.. |image-ubuntu-bionic-gcc_8-i386-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-with-targets-pre
-
-.. |image-ubuntu-bionic-gcc_8-i386-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-with-targets
-
-.. |image-ubuntu-bionic-gcc_8-i386-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-ubuntu-bionic-gcc_8-i386-maximal-with-targets-optional
-
-.. |codespace-ubuntu-bionic-gcc_8-i386-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-ubuntu-bionic-gcc_8-i386-maximal%2Fdevcontainer.json
-
-.. |image-debian-bullseye-i386-minimal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-minimal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-minimal-with-system-packages
-
-.. |image-debian-bullseye-i386-minimal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-minimal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-minimal-configured
-
-.. |image-debian-bullseye-i386-minimal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-minimal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%23677895
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-minimal-with-targets-pre
-
-.. |image-debian-bullseye-i386-minimal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-minimal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%236686c1
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-minimal-with-targets
-
-.. |image-debian-bullseye-i386-minimal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-minimal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%236495ed
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-minimal-with-targets-optional
-
-.. |codespace-debian-bullseye-i386-minimal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-bullseye-i386-minimal%2Fdevcontainer.json
-
-.. |image-debian-bullseye-i386-standard-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-standard-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-standard-with-system-packages
-
-.. |image-debian-bullseye-i386-standard-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-standard-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-standard-configured
-
-.. |image-debian-bullseye-i386-standard-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-standard-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%235d8a4c
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-standard-with-targets-pre
-
-.. |image-debian-bullseye-i386-standard-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-standard-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%2350ab2e
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-standard-with-targets
-
-.. |image-debian-bullseye-i386-standard-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-standard-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%2344cc11
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-standard-with-targets-optional
-
-.. |codespace-debian-bullseye-i386-standard| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-bullseye-i386-standard%2Fdevcontainer.json
-
-.. |image-debian-bullseye-i386-maximal-with-system-packages| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-maximal-with-system-packages/size?tag=dev&label=with-system-packages&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-maximal-with-system-packages
-
-.. |image-debian-bullseye-i386-maximal-configured| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-maximal-configured/latest_tag?ignore=latest,dev,*-failed&label=configured&color=%23696969
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-maximal-configured
-
-.. |image-debian-bullseye-i386-maximal-with-targets-pre| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-maximal-with-targets-pre/latest_tag?ignore=latest,dev,*-failed&label=with-targets-pre&color=%238f6b8d
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-maximal-with-targets-pre
-
-.. |image-debian-bullseye-i386-maximal-with-targets| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-maximal-with-targets/latest_tag?ignore=latest,dev,*-failed&label=with-targets&color=%23b46eb2
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-maximal-with-targets
-
-.. |image-debian-bullseye-i386-maximal-with-targets-optional| image:: https://ghcr-badge.egpl.dev/sagemath/sage/sage-debian-bullseye-i386-maximal-with-targets-optional/latest_tag?ignore=latest,dev,*-failed&label=with-targets-optional&color=%23da70d6
-   :target: https://ghcr.io/sagemath/sage/sage-debian-bullseye-i386-maximal-with-targets-optional
-
-.. |codespace-debian-bullseye-i386-maximal| image:: https://github.com/codespaces/badge.svg
-   :target: https://codespaces.new/sagemath/sage?devcontainer_path=.devcontainer%2Fportability-debian-bullseye-i386-maximal%2Fdevcontainer.json
-
 .. list-table::
    :widths: 50 50 40
    :header-rows: 1
@@ -2382,28 +1464,6 @@
    * - Platform
      - Images
      - 
-   * - **ubuntu**-xenial-toolchain-gcc_9 
-       
-          ‑*minimal*
-     - |image-ubuntu-xenial-toolchain-gcc_9-minimal-with-system-packages| |image-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets-pre| |image-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets| |image-ubuntu-xenial-toolchain-gcc_9-minimal-with-targets-optional|
-     - |codespace-ubuntu-xenial-toolchain-gcc_9-minimal|
-   * -    ‑*standard*
-     - |image-ubuntu-xenial-toolchain-gcc_9-standard-with-system-packages| |image-ubuntu-xenial-toolchain-gcc_9-standard-with-targets-pre| |image-ubuntu-xenial-toolchain-gcc_9-standard-with-targets| |image-ubuntu-xenial-toolchain-gcc_9-standard-with-targets-optional|
-     - |codespace-ubuntu-xenial-toolchain-gcc_9-standard|
-   * -    ‑*maximal*
-     - |image-ubuntu-xenial-toolchain-gcc_9-maximal-with-system-packages| |image-ubuntu-xenial-toolchain-gcc_9-maximal-with-targets-pre|
-     -
-   * - **ubuntu**-bionic-gcc_8 
-       
-          ‑*minimal*
-     - |image-ubuntu-bionic-gcc_8-minimal-with-system-packages| |image-ubuntu-bionic-gcc_8-minimal-with-targets-pre| |image-ubuntu-bionic-gcc_8-minimal-with-targets| |image-ubuntu-bionic-gcc_8-minimal-with-targets-optional|
-     - |codespace-ubuntu-bionic-gcc_8-minimal|
-   * -    ‑*standard*
-     - |image-ubuntu-bionic-gcc_8-standard-with-system-packages| |image-ubuntu-bionic-gcc_8-standard-with-targets-pre| |image-ubuntu-bionic-gcc_8-standard-with-targets| |image-ubuntu-bionic-gcc_8-standard-with-targets-optional|
-     - |codespace-ubuntu-bionic-gcc_8-standard|
-   * -    ‑*maximal*
-     - |image-ubuntu-bionic-gcc_8-maximal-with-system-packages| |image-ubuntu-bionic-gcc_8-maximal-with-targets-pre|
-     -
    * - **ubuntu**-focal 
        
           ‑*minimal*
@@ -2425,28 +1485,6 @@
      - |codespace-ubuntu-jammy-standard|
    * -    ‑*maximal*
      - |image-ubuntu-jammy-maximal-with-system-packages| |image-ubuntu-jammy-maximal-with-targets-pre|
-     -
-   * - **ubuntu**-lunar 
-       
-          ‑*minimal*
-     - |image-ubuntu-lunar-minimal-with-system-packages| |image-ubuntu-lunar-minimal-with-targets-pre| |image-ubuntu-lunar-minimal-with-targets| |image-ubuntu-lunar-minimal-with-targets-optional|
-     - |codespace-ubuntu-lunar-minimal|
-   * -    ‑*standard*
-     - |image-ubuntu-lunar-standard-with-system-packages| |image-ubuntu-lunar-standard-with-targets-pre| |image-ubuntu-lunar-standard-with-targets| |image-ubuntu-lunar-standard-with-targets-optional|
-     - |codespace-ubuntu-lunar-standard|
-   * -    ‑*maximal*
-     - |image-ubuntu-lunar-maximal-with-system-packages| |image-ubuntu-lunar-maximal-with-targets-pre|
-     -
-   * - **ubuntu**-mantic 
-       
-          ‑*minimal*
-     - |image-ubuntu-mantic-minimal-with-system-packages| |image-ubuntu-mantic-minimal-with-targets-pre| |image-ubuntu-mantic-minimal-with-targets| |image-ubuntu-mantic-minimal-with-targets-optional|
-     - |codespace-ubuntu-mantic-minimal|
-   * -    ‑*standard*
-     - |image-ubuntu-mantic-standard-with-system-packages| |image-ubuntu-mantic-standard-with-targets-pre| |image-ubuntu-mantic-standard-with-targets| |image-ubuntu-mantic-standard-with-targets-optional|
-     - |codespace-ubuntu-mantic-standard|
-   * -    ‑*maximal*
-     - |image-ubuntu-mantic-maximal-with-system-packages| |image-ubuntu-mantic-maximal-with-targets-pre|
      -
    * - **ubuntu**-noble 
        
@@ -2480,61 +1518,6 @@
      - |codespace-debian-bookworm-standard|
    * -    ‑*maximal*
      - |image-debian-bookworm-maximal-with-system-packages| |image-debian-bookworm-maximal-with-targets-pre|
-     -
-   * - **debian**-trixie 
-       
-          ‑*minimal*
-     - |image-debian-trixie-minimal-with-system-packages| |image-debian-trixie-minimal-with-targets-pre| |image-debian-trixie-minimal-with-targets| |image-debian-trixie-minimal-with-targets-optional|
-     - |codespace-debian-trixie-minimal|
-   * -    ‑*standard*
-     - |image-debian-trixie-standard-with-system-packages| |image-debian-trixie-standard-with-targets-pre| |image-debian-trixie-standard-with-targets| |image-debian-trixie-standard-with-targets-optional|
-     - |codespace-debian-trixie-standard|
-   * -    ‑*maximal*
-     - |image-debian-trixie-maximal-with-system-packages| |image-debian-trixie-maximal-with-targets-pre|
-     -
-   * - **debian**-sid 
-       
-          ‑*minimal*
-     - |image-debian-sid-minimal-with-system-packages| |image-debian-sid-minimal-with-targets-pre| |image-debian-sid-minimal-with-targets| |image-debian-sid-minimal-with-targets-optional|
-     - |codespace-debian-sid-minimal|
-   * -    ‑*standard*
-     - |image-debian-sid-standard-with-system-packages| |image-debian-sid-standard-with-targets-pre| |image-debian-sid-standard-with-targets| |image-debian-sid-standard-with-targets-optional|
-     - |codespace-debian-sid-standard|
-   * -    ‑*maximal*
-     - |image-debian-sid-maximal-with-system-packages| |image-debian-sid-maximal-with-targets-pre|
-     -
-   * - **linuxmint**-20.1 
-       
-          ‑*minimal*
-     - |image-linuxmint-20.1-minimal-with-system-packages| |image-linuxmint-20.1-minimal-with-targets-pre| |image-linuxmint-20.1-minimal-with-targets| |image-linuxmint-20.1-minimal-with-targets-optional|
-     - |codespace-linuxmint-20.1-minimal|
-   * -    ‑*standard*
-     - |image-linuxmint-20.1-standard-with-system-packages| |image-linuxmint-20.1-standard-with-targets-pre| |image-linuxmint-20.1-standard-with-targets| |image-linuxmint-20.1-standard-with-targets-optional|
-     - |codespace-linuxmint-20.1-standard|
-   * -    ‑*maximal*
-     - |image-linuxmint-20.1-maximal-with-system-packages| |image-linuxmint-20.1-maximal-with-targets-pre|
-     -
-   * - **linuxmint**-20.2 
-       
-          ‑*minimal*
-     - |image-linuxmint-20.2-minimal-with-system-packages| |image-linuxmint-20.2-minimal-with-targets-pre| |image-linuxmint-20.2-minimal-with-targets| |image-linuxmint-20.2-minimal-with-targets-optional|
-     - |codespace-linuxmint-20.2-minimal|
-   * -    ‑*standard*
-     - |image-linuxmint-20.2-standard-with-system-packages| |image-linuxmint-20.2-standard-with-targets-pre| |image-linuxmint-20.2-standard-with-targets| |image-linuxmint-20.2-standard-with-targets-optional|
-     - |codespace-linuxmint-20.2-standard|
-   * -    ‑*maximal*
-     - |image-linuxmint-20.2-maximal-with-system-packages| |image-linuxmint-20.2-maximal-with-targets-pre|
-     -
-   * - **linuxmint**-20.3 
-       
-          ‑*minimal*
-     - |image-linuxmint-20.3-minimal-with-system-packages| |image-linuxmint-20.3-minimal-with-targets-pre| |image-linuxmint-20.3-minimal-with-targets| |image-linuxmint-20.3-minimal-with-targets-optional|
-     - |codespace-linuxmint-20.3-minimal|
-   * -    ‑*standard*
-     - |image-linuxmint-20.3-standard-with-system-packages| |image-linuxmint-20.3-standard-with-targets-pre| |image-linuxmint-20.3-standard-with-targets| |image-linuxmint-20.3-standard-with-targets-optional|
-     - |codespace-linuxmint-20.3-standard|
-   * -    ‑*maximal*
-     - |image-linuxmint-20.3-maximal-with-system-packages| |image-linuxmint-20.3-maximal-with-targets-pre|
      -
    * - **linuxmint**-21 
        
@@ -2580,71 +1563,27 @@
    * -    ‑*maximal*
      - |image-linuxmint-21.3-maximal-with-system-packages| |image-linuxmint-21.3-maximal-with-targets-pre|
      -
-   * - **fedora**-30 
+   * - **linuxmint**-22 
        
           ‑*minimal*
-     - |image-fedora-30-minimal-with-system-packages| |image-fedora-30-minimal-with-targets-pre| |image-fedora-30-minimal-with-targets| |image-fedora-30-minimal-with-targets-optional|
-     - |codespace-fedora-30-minimal|
+     - |image-linuxmint-22-minimal-with-system-packages| |image-linuxmint-22-minimal-with-targets-pre| |image-linuxmint-22-minimal-with-targets| |image-linuxmint-22-minimal-with-targets-optional|
+     - |codespace-linuxmint-22-minimal|
    * -    ‑*standard*
-     - |image-fedora-30-standard-with-system-packages| |image-fedora-30-standard-with-targets-pre| |image-fedora-30-standard-with-targets| |image-fedora-30-standard-with-targets-optional|
-     - |codespace-fedora-30-standard|
+     - |image-linuxmint-22-standard-with-system-packages| |image-linuxmint-22-standard-with-targets-pre| |image-linuxmint-22-standard-with-targets| |image-linuxmint-22-standard-with-targets-optional|
+     - |codespace-linuxmint-22-standard|
    * -    ‑*maximal*
-     - |image-fedora-30-maximal-with-system-packages| |image-fedora-30-maximal-with-targets-pre|
+     - |image-linuxmint-22-maximal-with-system-packages| |image-linuxmint-22-maximal-with-targets-pre|
      -
-   * - **fedora**-31 
+   * - **linuxmint**-22.1 
        
           ‑*minimal*
-     - |image-fedora-31-minimal-with-system-packages| |image-fedora-31-minimal-with-targets-pre| |image-fedora-31-minimal-with-targets| |image-fedora-31-minimal-with-targets-optional|
-     - |codespace-fedora-31-minimal|
+     - |image-linuxmint-22.1-minimal-with-system-packages| |image-linuxmint-22.1-minimal-with-targets-pre| |image-linuxmint-22.1-minimal-with-targets| |image-linuxmint-22.1-minimal-with-targets-optional|
+     - |codespace-linuxmint-22.1-minimal|
    * -    ‑*standard*
-     - |image-fedora-31-standard-with-system-packages| |image-fedora-31-standard-with-targets-pre| |image-fedora-31-standard-with-targets| |image-fedora-31-standard-with-targets-optional|
-     - |codespace-fedora-31-standard|
+     - |image-linuxmint-22.1-standard-with-system-packages| |image-linuxmint-22.1-standard-with-targets-pre| |image-linuxmint-22.1-standard-with-targets| |image-linuxmint-22.1-standard-with-targets-optional|
+     - |codespace-linuxmint-22.1-standard|
    * -    ‑*maximal*
-     - |image-fedora-31-maximal-with-system-packages| |image-fedora-31-maximal-with-targets-pre|
-     -
-   * - **fedora**-32 
-       
-          ‑*minimal*
-     - |image-fedora-32-minimal-with-system-packages| |image-fedora-32-minimal-with-targets-pre| |image-fedora-32-minimal-with-targets| |image-fedora-32-minimal-with-targets-optional|
-     - |codespace-fedora-32-minimal|
-   * -    ‑*standard*
-     - |image-fedora-32-standard-with-system-packages| |image-fedora-32-standard-with-targets-pre| |image-fedora-32-standard-with-targets| |image-fedora-32-standard-with-targets-optional|
-     - |codespace-fedora-32-standard|
-   * -    ‑*maximal*
-     - |image-fedora-32-maximal-with-system-packages| |image-fedora-32-maximal-with-targets-pre|
-     -
-   * - **fedora**-33 
-       
-          ‑*minimal*
-     - |image-fedora-33-minimal-with-system-packages| |image-fedora-33-minimal-with-targets-pre| |image-fedora-33-minimal-with-targets| |image-fedora-33-minimal-with-targets-optional|
-     - |codespace-fedora-33-minimal|
-   * -    ‑*standard*
-     - |image-fedora-33-standard-with-system-packages| |image-fedora-33-standard-with-targets-pre| |image-fedora-33-standard-with-targets| |image-fedora-33-standard-with-targets-optional|
-     - |codespace-fedora-33-standard|
-   * -    ‑*maximal*
-     - |image-fedora-33-maximal-with-system-packages| |image-fedora-33-maximal-with-targets-pre|
-     -
-   * - **fedora**-34 
-       
-          ‑*minimal*
-     - |image-fedora-34-minimal-with-system-packages| |image-fedora-34-minimal-with-targets-pre| |image-fedora-34-minimal-with-targets| |image-fedora-34-minimal-with-targets-optional|
-     - |codespace-fedora-34-minimal|
-   * -    ‑*standard*
-     - |image-fedora-34-standard-with-system-packages| |image-fedora-34-standard-with-targets-pre| |image-fedora-34-standard-with-targets| |image-fedora-34-standard-with-targets-optional|
-     - |codespace-fedora-34-standard|
-   * -    ‑*maximal*
-     - |image-fedora-34-maximal-with-system-packages| |image-fedora-34-maximal-with-targets-pre|
-     -
-   * - **fedora**-35 
-       
-          ‑*minimal*
-     - |image-fedora-35-minimal-with-system-packages| |image-fedora-35-minimal-with-targets-pre| |image-fedora-35-minimal-with-targets| |image-fedora-35-minimal-with-targets-optional|
-     - |codespace-fedora-35-minimal|
-   * -    ‑*standard*
-     - |image-fedora-35-standard-with-system-packages| |image-fedora-35-standard-with-targets-pre| |image-fedora-35-standard-with-targets| |image-fedora-35-standard-with-targets-optional|
-     - |codespace-fedora-35-standard|
-   * -    ‑*maximal*
-     - |image-fedora-35-maximal-with-system-packages| |image-fedora-35-maximal-with-targets-pre|
+     - |image-linuxmint-22.1-maximal-with-system-packages| |image-linuxmint-22.1-maximal-with-targets-pre|
      -
    * - **fedora**-36 
        
@@ -2734,38 +1673,38 @@
    * -    ‑*maximal*
      - |image-centos-stream-9-python3.12-maximal-with-system-packages| |image-centos-stream-9-python3.12-maximal-with-targets-pre|
      -
-   * - **almalinux**-8-python3.9 
+   * - **almalinux**-8 
        
           ‑*minimal*
-     - |image-almalinux-8-python3.9-minimal-with-system-packages| |image-almalinux-8-python3.9-minimal-with-targets-pre| |image-almalinux-8-python3.9-minimal-with-targets| |image-almalinux-8-python3.9-minimal-with-targets-optional|
-     - |codespace-almalinux-8-python3.9-minimal|
+     - |image-almalinux-8-minimal-with-system-packages| |image-almalinux-8-minimal-with-targets-pre| |image-almalinux-8-minimal-with-targets| |image-almalinux-8-minimal-with-targets-optional|
+     - |codespace-almalinux-8-minimal|
    * -    ‑*standard*
-     - |image-almalinux-8-python3.9-standard-with-system-packages| |image-almalinux-8-python3.9-standard-with-targets-pre| |image-almalinux-8-python3.9-standard-with-targets| |image-almalinux-8-python3.9-standard-with-targets-optional|
-     - |codespace-almalinux-8-python3.9-standard|
+     - |image-almalinux-8-standard-with-system-packages| |image-almalinux-8-standard-with-targets-pre| |image-almalinux-8-standard-with-targets| |image-almalinux-8-standard-with-targets-optional|
+     - |codespace-almalinux-8-standard|
    * -    ‑*maximal*
-     - |image-almalinux-8-python3.9-maximal-with-system-packages| |image-almalinux-8-python3.9-maximal-with-targets-pre|
+     - |image-almalinux-8-maximal-with-system-packages| |image-almalinux-8-maximal-with-targets-pre|
      -
-   * - **almalinux**-9-python3.11 
+   * - **almalinux**-9 
        
           ‑*minimal*
-     - |image-almalinux-9-python3.11-minimal-with-system-packages| |image-almalinux-9-python3.11-minimal-with-targets-pre| |image-almalinux-9-python3.11-minimal-with-targets| |image-almalinux-9-python3.11-minimal-with-targets-optional|
-     - |codespace-almalinux-9-python3.11-minimal|
+     - |image-almalinux-9-minimal-with-system-packages| |image-almalinux-9-minimal-with-targets-pre| |image-almalinux-9-minimal-with-targets| |image-almalinux-9-minimal-with-targets-optional|
+     - |codespace-almalinux-9-minimal|
    * -    ‑*standard*
-     - |image-almalinux-9-python3.11-standard-with-system-packages| |image-almalinux-9-python3.11-standard-with-targets-pre| |image-almalinux-9-python3.11-standard-with-targets| |image-almalinux-9-python3.11-standard-with-targets-optional|
-     - |codespace-almalinux-9-python3.11-standard|
+     - |image-almalinux-9-standard-with-system-packages| |image-almalinux-9-standard-with-targets-pre| |image-almalinux-9-standard-with-targets| |image-almalinux-9-standard-with-targets-optional|
+     - |codespace-almalinux-9-standard|
    * -    ‑*maximal*
-     - |image-almalinux-9-python3.11-maximal-with-system-packages| |image-almalinux-9-python3.11-maximal-with-targets-pre|
+     - |image-almalinux-9-maximal-with-system-packages| |image-almalinux-9-maximal-with-targets-pre|
      -
-   * - **gentoo**-python3.10 
+   * - **almalinux**-9.5 
        
           ‑*minimal*
-     - |image-gentoo-python3.10-minimal-with-system-packages| |image-gentoo-python3.10-minimal-with-targets-pre| |image-gentoo-python3.10-minimal-with-targets| |image-gentoo-python3.10-minimal-with-targets-optional|
-     - |codespace-gentoo-python3.10-minimal|
+     - |image-almalinux-9.5-minimal-with-system-packages| |image-almalinux-9.5-minimal-with-targets-pre| |image-almalinux-9.5-minimal-with-targets| |image-almalinux-9.5-minimal-with-targets-optional|
+     - |codespace-almalinux-9.5-minimal|
    * -    ‑*standard*
-     - |image-gentoo-python3.10-standard-with-system-packages| |image-gentoo-python3.10-standard-with-targets-pre| |image-gentoo-python3.10-standard-with-targets| |image-gentoo-python3.10-standard-with-targets-optional|
-     - |codespace-gentoo-python3.10-standard|
+     - |image-almalinux-9.5-standard-with-system-packages| |image-almalinux-9.5-standard-with-targets-pre| |image-almalinux-9.5-standard-with-targets| |image-almalinux-9.5-standard-with-targets-optional|
+     - |codespace-almalinux-9.5-standard|
    * -    ‑*maximal*
-     - |image-gentoo-python3.10-maximal-with-system-packages| |image-gentoo-python3.10-maximal-with-targets-pre|
+     - |image-almalinux-9.5-maximal-with-system-packages| |image-almalinux-9.5-maximal-with-targets-pre|
      -
    * - **gentoo**-python3.11 
        
@@ -2811,17 +1750,6 @@
    * -    ‑*maximal*
      - |image-opensuse-15.5-gcc_11-python3.11-maximal-with-system-packages| |image-opensuse-15.5-gcc_11-python3.11-maximal-with-targets-pre|
      -
-   * - **opensuse**-tumbleweed-python3.10 
-       
-          ‑*minimal*
-     - |image-opensuse-tumbleweed-python3.10-minimal-with-system-packages| |image-opensuse-tumbleweed-python3.10-minimal-with-targets-pre| |image-opensuse-tumbleweed-python3.10-minimal-with-targets| |image-opensuse-tumbleweed-python3.10-minimal-with-targets-optional|
-     - |codespace-opensuse-tumbleweed-python3.10-minimal|
-   * -    ‑*standard*
-     - |image-opensuse-tumbleweed-python3.10-standard-with-system-packages| |image-opensuse-tumbleweed-python3.10-standard-with-targets-pre| |image-opensuse-tumbleweed-python3.10-standard-with-targets| |image-opensuse-tumbleweed-python3.10-standard-with-targets-optional|
-     - |codespace-opensuse-tumbleweed-python3.10-standard|
-   * -    ‑*maximal*
-     - |image-opensuse-tumbleweed-python3.10-maximal-with-system-packages| |image-opensuse-tumbleweed-python3.10-maximal-with-targets-pre|
-     -
    * - **opensuse**-tumbleweed 
        
           ‑*minimal*
@@ -2832,34 +1760,4 @@
      - |codespace-opensuse-tumbleweed-standard|
    * -    ‑*maximal*
      - |image-opensuse-tumbleweed-maximal-with-system-packages| |image-opensuse-tumbleweed-maximal-with-targets-pre|
-     -
-   * - **conda**-forge-python3.11 
-       
-          ‑*standard*
-     - |image-conda-forge-python3.11-standard-with-system-packages| |image-conda-forge-python3.11-standard-with-targets-pre| |image-conda-forge-python3.11-standard-with-targets| |image-conda-forge-python3.11-standard-with-targets-optional|
-     - |codespace-conda-forge-python3.11-standard|
-   * -    ‑*maximal*
-     - |image-conda-forge-python3.11-maximal-with-system-packages| |image-conda-forge-python3.11-maximal-with-targets-pre|
-     -
-   * - **ubuntu**-bionic-gcc_8-i386 
-       
-          ‑*minimal*
-     - |image-ubuntu-bionic-gcc_8-i386-minimal-with-system-packages| |image-ubuntu-bionic-gcc_8-i386-minimal-with-targets-pre| |image-ubuntu-bionic-gcc_8-i386-minimal-with-targets| |image-ubuntu-bionic-gcc_8-i386-minimal-with-targets-optional|
-     - |codespace-ubuntu-bionic-gcc_8-i386-minimal|
-   * -    ‑*standard*
-     - |image-ubuntu-bionic-gcc_8-i386-standard-with-system-packages| |image-ubuntu-bionic-gcc_8-i386-standard-with-targets-pre| |image-ubuntu-bionic-gcc_8-i386-standard-with-targets| |image-ubuntu-bionic-gcc_8-i386-standard-with-targets-optional|
-     - |codespace-ubuntu-bionic-gcc_8-i386-standard|
-   * -    ‑*maximal*
-     - |image-ubuntu-bionic-gcc_8-i386-maximal-with-system-packages| |image-ubuntu-bionic-gcc_8-i386-maximal-with-targets-pre|
-     -
-   * - **debian**-bullseye-i386 
-       
-          ‑*minimal*
-     - |image-debian-bullseye-i386-minimal-with-system-packages| |image-debian-bullseye-i386-minimal-with-targets-pre| |image-debian-bullseye-i386-minimal-with-targets| |image-debian-bullseye-i386-minimal-with-targets-optional|
-     - |codespace-debian-bullseye-i386-minimal|
-   * -    ‑*standard*
-     - |image-debian-bullseye-i386-standard-with-system-packages| |image-debian-bullseye-i386-standard-with-targets-pre| |image-debian-bullseye-i386-standard-with-targets| |image-debian-bullseye-i386-standard-with-targets-optional|
-     - |codespace-debian-bullseye-i386-standard|
-   * -    ‑*maximal*
-     - |image-debian-bullseye-i386-maximal-with-system-packages| |image-debian-bullseye-i386-maximal-with-targets-pre|
      -

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 # SAGE_ROOT/tox.ini: Environments for testing the Sage distribution
 #
-
 # To run a specific environment:
 #
 #   $ tox -e docker-fedora-31-standard
@@ -55,12 +54,14 @@ envlist =
     ### - standard  # Install all known system packages equivalent to standard packages that have spkg-configure.m4
     ### - maximal   # Install all known system packages equivalent to standard/optional packages that have spkg-configure.m4
 
-    docker-ubuntu-trusty-toolchain-gcc_9-minimal,
-    docker-debian-bullseye-standard,
-    docker-fedora-34-standard,
-    docker-archlinux-latest-maximal,
-    docker-manylinux-2_24-i686-standard,
-    docker-conda-forge-standard,
+    ### Example "docker" environments:
+    ###
+    ### docker-ubuntu-trusty-toolchain-gcc_9-minimal
+    ### docker-debian-bullseye-standard
+    ### docker-fedora-34-standard
+    ### docker-archlinux-latest-maximal
+    ### docker-manylinux-2_24-i686-standard
+    ### docker-conda-forge-standard
 
     ### "local" targets should be run from a source tree that is freshly checked out
     ### (for example, by 'git worktree add ...') or has been cleaned by 'make bdist-clean' --
@@ -110,10 +111,16 @@ envlist =
     #
     #   $ tox -e local-direct -- openblas
 
+    ###
+    ### Delegation to src/tox.ini
+    ###
+    ### This works through build/make/Makefile(.in). Find "recursive tox invocation" there.
+    #
+    #   $ tox -e sagelib-tox-sagepython-constraints_pkgs-norequirements
+    #
+    # Recursively, this runs tox -e sagepython-constraints_pkgs-norequirements in build/pkgs/sagelib/src/
+    # with build/pkgs/sagelib/src/tox.ini
 
-    #####
-    ##### Delegation to src/tox.ini
-    #####
 
     # included with (cd src && tox -p auto):
     #
@@ -190,14 +197,15 @@ setenv =
     # For -maximal environments, the default is 'yes' but later we override it for rolling distributions
     # (but not for unstable distributions that often have intermittent issues).
                                                IGNORE_MISSING_SYSTEM_PACKAGES=no
-    maximal:                                   IGNORE_MISSING_SYSTEM_PACKAGES=yes
-    # What system packages should be installed. Default: All standard packages with spkg-configure.
+    # What system packages should be installed.
+                           # Default: all standard packages with spkg-configure
                            SAGE_PACKAGE_LIST_ARGS=--has-file=spkg-configure.m4 :standard:
     recommended:             EXTRA_SAGE_PACKAGES_3=_recommended $(head -n 1 build/pkgs/_recommended/dependencies)
-    incremental:             EXTRA_SAGE_PACKAGES_4=git
     develop:                 EXTRA_SAGE_PACKAGES_4=_develop $(head -n 1 build/pkgs/_develop/dependencies)
-    minimal:               SAGE_PACKAGE_LIST_ARGS=_prereq
-    maximal:               SAGE_PACKAGE_LIST_ARGS=:standard: :optional:
+    minimal:               SAGE_PACKAGE_LIST_ARGS=--has-file=spkg-configure.m4 _prereq
+    standard:              SAGE_PACKAGE_LIST_ARGS=--has-file=spkg-configure.m4 _prereq :standard:
+    maximal:               SAGE_PACKAGE_LIST_ARGS=--has-file=spkg-configure.m4 _prereq :standard: :optional:
+    maximal:                                   IGNORE_MISSING_SYSTEM_PACKAGES=yes
     sitepackages:              ENABLE_SYSTEM_SITE_PACKAGES=yes
     sitepackages:                CONFIG_CONFIGURE_ARGS_SITEPACKAGES=--enable-system-site-packages
     conda-environment:     SAGE_PACKAGE_LIST_ARGS=_prereq
@@ -213,6 +221,7 @@ setenv =
     # default tag is "latest"
     #
     docker:           BASE_TAG=latest
+    docker:                 EXTRA_SAGE_PACKAGES_4=git
     #
     # https://hub.docker.com/_/ubuntu?tab=description
     # as of 2024-02, latest=jammy=22.04, rolling=mantic=23.10, devel=noble=24.04
@@ -235,8 +244,6 @@ setenv =
     ubuntu-focal:     BASE_TAG=focal
     ubuntu-focal:                              IGNORE_MISSING_SYSTEM_PACKAGES=yes
     ubuntu-jammy:     BASE_TAG=jammy
-    ubuntu-lunar:     BASE_TAG=lunar
-    ubuntu-mantic:    BASE_TAG=mantic
     ubuntu-noble:     BASE_TAG=noble
     ubuntu-noble:                              IGNORE_MISSING_SYSTEM_PACKAGES=yes
     #
@@ -264,12 +271,6 @@ setenv =
     #
     linuxmint:      SYSTEM=debian
     linuxmint:                                 IGNORE_MISSING_SYSTEM_PACKAGES=yes
-    linuxmint-17:   BASE_IMAGE=linuxmintd/mint17
-    linuxmint-18:   BASE_IMAGE=linuxmintd/mint18
-    linuxmint-19:   BASE_IMAGE=linuxmintd/mint19
-    linuxmint-19.1: BASE_IMAGE=linuxmintd/mint19.1
-    linuxmint-19.2: BASE_IMAGE=linuxmintd/mint19.2
-    linuxmint-19.3: BASE_IMAGE=linuxmintd/mint19.3
     linuxmint-20:   BASE_IMAGE=linuxmintd/mint20
     linuxmint-20.1: BASE_IMAGE=linuxmintd/mint20.1
     linuxmint-20.2: BASE_IMAGE=linuxmintd/mint20.2
@@ -278,6 +279,8 @@ setenv =
     linuxmint-21.1: BASE_IMAGE=linuxmintd/mint21.1
     linuxmint-21.2: BASE_IMAGE=linuxmintd/mint21.2
     linuxmint-21.3: BASE_IMAGE=linuxmintd/mint21.3
+    linuxmint-22:   BASE_IMAGE=linuxmintd/mint22
+    linuxmint-22.1: BASE_IMAGE=linuxmintd/mint22.1
     #
     # https://hub.docker.com/_/fedora
     # as of 2024-08, latest=40, rawhide=41
@@ -303,11 +306,11 @@ setenv =
     #
     # https://hub.docker.com/r/scientificlinux/sl
     #
-    scientificlinux:        SYSTEM=fedora
-    scientificlinux:        BASE_IMAGE=scientificlinux/sl
+    scientificlinux: SYSTEM=fedora
+    scientificlinux: BASE_IMAGE=scientificlinux/sl
     scientificlinux:                           IGNORE_MISSING_SYSTEM_PACKAGES=yes
-    scientificlinux-6:        BASE_TAG=6
-    scientificlinux-7:        BASE_TAG=7
+    scientificlinux-6: BASE_TAG=6
+    scientificlinux-7: BASE_TAG=7
     #
     # https://hub.docker.com/_/centos
     # https://quay.io/repository/centos/centos?tab=tags
@@ -329,6 +332,7 @@ setenv =
     almalinux:                                 IGNORE_MISSING_SYSTEM_PACKAGES=yes
     almalinux-8:      BASE_TAG=8
     almalinux-9:      BASE_TAG=9
+    almalinux-9.5:    BASE_TAG=9.5
     #
     # https://hub.docker.com/r/sheerluck/sage-on-gentoo-stage4/tags
     #
@@ -345,6 +349,7 @@ setenv =
     archlinux:      SYSTEM=arch
     archlinux:      BASE_IMAGE=archlinux
     archlinux:                                 IGNORE_MISSING_SYSTEM_PACKAGES=yes
+    archlinux-latest: BASE_TAG=latest
     #
     # https://hub.docker.com/r/vbatts/slackware
     #
@@ -506,7 +511,7 @@ setenv =
     docker-incremental-{develop,recommended,maximal}:   SKIP_SYSTEM_PKG_INSTALL=yes
     docker-incremental-sitepackages:                    SKIP_SYSTEM_PKG_INSTALL=no
     #
-    docker-nobootstrap: BOOTSTRAP=./bootstrap -D
+    docker-nobootstrap:       BOOTSTRAP=./bootstrap -D
     docker:           CONFIG_CONFIGURE_ARGS_ROOT=--enable-build-as-root
     ###
     ### "local" envs
@@ -514,7 +519,7 @@ setenv =
     local:            SHARED_CACHE_DIR={toxworkdir}/Caches
     local:            SETENV=:
     local:            SETENV_CONFIGURE=:
-    local-nobootstrap: BOOTSTRAP=:
+    local-nobootstrap:        BOOTSTRAP=:
     local-!direct:    PATH=/usr/bin:/bin:/usr/sbin:/sbin
     local-sudo:       __SUDO=--sudo
     local-root:       CONFIG_CONFIGURE_ARGS_ROOT=--enable-build-as-root
@@ -579,31 +584,28 @@ setenv =
     # so that the configured python3 can be accepted by configure.
                                                                  PYTHON_MAJOR=3
                                                                    PYTHON_MINOR=10
-    python3.9:                                                     PYTHON_MINOR=9
     python3.10:                                                    PYTHON_MINOR=10
     python3.11:                                                    PYTHON_MINOR=11
     python3.12:                                                    PYTHON_MINOR=12
+    python3.13:                                                    PYTHON_MINOR=13
                                                                      CONFIG_CONFIGURE_ARGS_1=--with-system-python3=yes
     python3_spkg:                                                    CONFIG_CONFIGURE_ARGS_1=--without-system-python3
-    python3.9,python3.10,python3.11,python3.12:                      CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python=python{env:PYTHON_MAJOR}.{env:PYTHON_MINOR}
-    # As of 2023-9, Xcode 15.0.0, this is Python 3.9.6.
+    python3.10,python3.11,python3.12:                      CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python=python{env:PYTHON_MAJOR}.{env:PYTHON_MINOR}
     macos-python3_xcode:                                             CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python=/usr/bin/python3
-    macos-{python3_xcode,nohomebrew}-{python3.9}:                    CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python=/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/{env:PYTHON_MAJOR}.{env:PYTHON_MINOR}/bin/python3
     # Homebrew keg installs
-    homebrew-{python3.9,python3.10,python3.11,python3.12}:           CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python={env:HOMEBREW}/opt/python@{env:PYTHON_MAJOR}.{env:PYTHON_MINOR}/bin/python3
+    homebrew-{python3.10,python3.11,python3.12}:           CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python={env:HOMEBREW}/opt/python@{env:PYTHON_MAJOR}.{env:PYTHON_MINOR}/bin/python3
     # Installers from https://www.python.org/downloads/macos/ (must manually download and install)
     macos-python3_pythonorg:                                         CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python=/Library/Frameworks/Python.framework/Versions/{env:PYTHON_MAJOR}.{env:PYTHON_MINOR}/bin/python3
     # MacPorts
-    macports-{python3.8,python3.9,python3.10,python3.11,python3.12}: CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python={env:MP_PREFIX}/bin/python{env:PYTHON_MAJOR}.{env:PYTHON_MINOR}
+    macports-{python3.10,python3.11,python3.12}: CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python={env:MP_PREFIX}/bin/python{env:PYTHON_MAJOR}.{env:PYTHON_MINOR}
     # https://github.com/pypa/manylinux
     manylinux-standard:                                              CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python=/opt/python/cp{env:PYTHON_MAJOR}{env:PYTHON_MINOR}-cp{env:PYTHON_MAJOR}{env:PYTHON_MINOR}/bin/python3
     conda:                                                           CONFIG_CONFIGURE_ARGS_1=--with-system-python3=force --with-python=python3
     conda:                                                             EXTRA_SAGE_PACKAGES_5=_bootstrap liblzma bzip2 libffi libpng zlib
-    python3.9,python3.10,python3.11,python3.12:                        EXTRA_SAGE_PACKAGES_5=_python{env:PYTHON_MAJOR}.{env:PYTHON_MINOR} _bootstrap liblzma bzip2 libffi libpng zlib
-    manylinux-{python3.9,python3.10,python3.11,python3.12}:            EXTRA_SAGE_PACKAGES_5=_bootstrap liblzma bzip2 libffi libpng
+    python3.10,python3.11,python3.12:                        EXTRA_SAGE_PACKAGES_5=_python{env:PYTHON_MAJOR}.{env:PYTHON_MINOR} _bootstrap liblzma bzip2 libffi libpng zlib
+    manylinux-{python3.10,python3.11,python3.12}:            EXTRA_SAGE_PACKAGES_5=_bootstrap liblzma bzip2 libffi libpng
     macos-python3_pythonorg:                                           EXTRA_SAGE_PACKAGES_5=_bootstrap liblzma bzip2 libffi libpng zlib
     macos-python3_xcode:                                               EXTRA_SAGE_PACKAGES_5=_bootstrap liblzma bzip2 libffi libpng zlib
-    {centos-stream,almalinux}-8-python3.9:                             EXTRA_SYSTEM_PACKAGES=python39 python39-devel
     #
     #  - toolchain
     #
@@ -708,7 +710,8 @@ allowlist_externals =
     docker:        docker
     homebrew:      brew
 
-#commands_pre =
+# commands_pre =
+
 commands =
 
     #
@@ -758,7 +761,9 @@ commands =
     # Install a symbolic link "prefix" in SAGE_ROOT for convenient inspection; it is not used in the build.
     local:         bash -c 'if [ ! -d prefix -o -L prefix ]; then rm -f prefix; ln -sf {env:PREFIX:{envdir}/local} prefix; fi'
 
-##commands =
+    #
+    # docker
+    #
     docker:        bash -c 'BUILD_TAG={env:DOCKER_TAG:$(git describe --dirty --always)} .ci/write-dockerfile.sh {env:SYSTEM} "{env:SAGE_PACKAGE_LIST_ARGS:}" {env:WITH_SYSTEM_SPKG} {env:IGNORE_MISSING_SYSTEM_PACKAGES} "{env:ALL_EXTRA_SAGE_PACKAGES}" > {envdir}/Dockerfile'
     # From https://hub.docker.com/r/multiarch/ubuntu-core/
     # configure binfmt-support on the Docker host (works locally or remotely, i.e: using boot2docker)
@@ -770,13 +775,15 @@ commands =
     docker:            BUILD_TAG={env:DOCKER_TAG:$(git describe --dirty --always)}; \
     docker:            TAG_ARGS=$(for tag in $BUILD_TAG {env:EXTRA_DOCKER_TAGS:}; do echo --tag $BUILD_IMAGE:$tag; done); \
     docker:            DOCKER_BUILDKIT={env:DOCKER_BUILDKIT:1}; \
-    docker:            docker build . -f {envdir}/Dockerfile \
+    docker:            git worktree add source-tree; \
+    docker:            docker build source-tree -f {envdir}/Dockerfile \
     docker:              --target $docker_target \
     docker:              $TAG_ARGS \
     docker:              --build-arg TARGETS_PRE="$(if test -n "$TARGETS_PRE"; then echo $TARGETS_PRE; else echo {posargs:all-sage-local}; fi)" \
     docker:              --build-arg TARGETS="{posargs:build}" \
     docker:              --build-arg TARGETS_OPTIONAL="{env:TARGETS_OPTIONAL:ptest}" \
     docker:              {env:EXTRA_DOCKER_BUILD_ARGS:}; status=$?; \
+    docker:            git worktree remove source-tree; \
     docker:            unset CONTAINER; \
     docker:            if [ $status != 0 ]; then \
     docker:              if [ $DOCKER_BUILDKIT = 0 ]; then \
@@ -852,20 +859,20 @@ setenv =
     #
     # Master list of platforms tested in CI Linux
     #
+    # if you modify this list, be sure to run "tox -e update_docker_platforms"
+    # and commit the changes using Git
+    #
     DEFAULT_SYSTEM_FACTORS=\
-                     ubuntu-{xenial-toolchain-gcc_9,bionic-gcc_8,focal,jammy,lunar,mantic,noble} \
-                     debian-{bullseye,bookworm,trixie,sid} \
-                     linuxmint-{20.1,20.2,20.3,21,21.1,21.2,21.3} \
-                     fedora-{30,31,32,33,34,35,36,37,38,39,40,41} \
+                     ubuntu-{focal,jammy,noble} \
+                     debian-{bullseye,bookworm} \
+                     linuxmint-{21,21.1,21.2,21.3,22,22.1} \
+                     fedora-{36,37,38,39,40,41} \
                      centos-stream-{9,9-python3.12} \
-                     almalinux-{8-python3.9,9-python3.11} \
-                     gentoo-python{3.10,3.11,3.12} \
+                     almalinux-{8,9,9.5} \
+                     gentoo-python{3.11,3.12} \
                      archlinux-latest \
                      opensuse-15.5-gcc_11-python3.11 \
-                     opensuse-tumbleweed{-python3.10,} \
-                     conda-forge-python3.11 \
-                     ubuntu-bionic-gcc_8-i386 \
-                     debian-bullseye-i386
+                     opensuse-tumbleweed
     #
     # Container badges for the developer guide
     #


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR is the closed PR #39009 rebased on the current develop branch. 

**Test CI run (as of 10.7.beta0)**: https://github.com/kwankyu/sage/actions/runs/14437849808
**compare with the status quo**: https://github.com/sagemath/sage/actions/runs/14229865306

To improve the situation with the CI infrastructure, this PR:

- Restore jobs removed by #39467 (and its sequel #39670), which made CI Linux useless.

- Added comments untangling obscure code in CI-related files, for those poor guys who ever attempt to read the files for whatever reasons.

- While doing the cosmetic changes, a bug (about `-uninstall` targets) was found `build/make/Makefile.in`, which is fixed here.

  To test, do
  ```
  $ ./configure --enable-dot2tex | grep dot2tex
  $ make build | grep dot2tex
  $ ./configure --disable-dot2tex | grep dot2tex
  $ make build | grep dot2tex
  ```

- Fixed some jobs in the CI-linux workflow that fail because of duplicate artifact names.

- Reduced supported platforms under testing. This is how to properly modify the list:
   - first edit `tox.ini` (find DEFAULT_SYSTEM_FACTORS)
   - run `tox -e update_docker_platforms`
   - commit the changes

- "optional" and "experimental" jobs now run upon "standard" docker images, instead of "maximal" ones, to avoid "out of runner space" error.

- Renamed "Reusable workflow for Docker-based portability CI" to "Workflow for Linux portability CI" for short name and made it runnable through github interface to facilitate testing specific platform by adding "workflow-dispatch" calling `docker.yml`.

   Test: https://github.com/kwankyu/sage/actions/workflows/docker.yml

- Added helpful comments and updated the developer doc

- Reimplemented `.ci/write-dockerfile.sh` so that simplified Dockerfile is generated for present and future stability

- Turned off failing jobs in "CI Linux incremental"

- Removed seemingly useless `subprojects/factory` directory to eliminate certain git warnings. 

- Turned off "standard-sitepackegs" and "standard-constraints_pkgs-norequirements" jobs as they fail on (almost) all platforms.

Test CI with a PR: to be prepared.

The main objective of this PR is to solve issues with the workflow "CI Linux" such that a failure on a platform reveals solely some problem of sage built on the platform, but not a problem of the CI infrastructure. After this PR, hopefully, each of failing platforms should be tackled individually. If a platform fails, perhaps we should

1. decide first whether to support the platform or not. 
2. if the platform is supported, open a github issue for it.
3. if the platform is not supported, then remove it from the "master list of supported linux platforms" in tox.ini.
4. if a supported platform constantly fails but no PR for the issue is present, then we may turn it off (by commenting it out) until fixed.

I suggest discontinuing support (at least in CI) for Linux releases that have been past their EOL (end of life or end of support by the distributor) for more than 2 years.

Only decent platforms according to the CI results should be listed in https://github.com/sagemath/sage/wiki/Sage-10.6-Release-Tour#availability-and-installation-help.

The following diagram shows how packages are installed for each of CI jobs:
```
                _prereq | standard package | optional package | experimental package | "ptest" runs
-----------------------------------------------------------------------------------------------
"minimal"        SSSSSS | ---------------- |                  |                      | yes
"standard"       SSSSSS | SSSSSSSSSSS----- |                  |                      | yes
"maximal"        SSSSSS | SSSSSSSSSSS----- | SSSS             |                      | yes 
"optional"       SSSSSS | SSSSSSSSSSS----- | ------------     |                      | yes
"experimental"   SSSSSS | SSSSSSSSSSS----- |                  | ----                 | no
```
where "S" represents system package and dash "-" represents Sage package. Hence

- In the test results of  "minimal" job, we can examine how well standard **sage packages** behave with sage.
- In the test results of  "standard" job, we can examine how well standard **system packages** behave with sage.
- In the test results of  "maximal" job, we can examine how well optional **system packages** behave with sage.
- In the test results of  "optional" job, we can examine how well optional **sage packages** behave with sage. 
- In the test results of  "experimental" job, we can examine how well experimental **sage packages** behave with sage. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->