### PR TITLE
Fix bipartite graph constructor for reduced adjacency matrix with `immutable=True`

### DIFF
--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -482,26 +482,26 @@ class BipartiteGraph(Graph):
             self.left = set(range(ncols))
             self.right = set(range(ncols, nrows + ncols))
 
-            edges = []
-            if kwds.get("multiedges", False):
-                for ii in range(ncols):
-                    for jj in range(nrows):
-                        if data[jj, ii]:
-                            edges.extend([(ii, jj + ncols)] * data[jj, ii])
-            elif kwds.get("weighted", False):
-                for ii in range(ncols):
-                    for jj in range(nrows):
-                        if data[jj, ii]:
-                            edges.append((ii, jj + ncols, data[jj, ii]))
-            else:
-                for ii in range(ncols):
-                    for jj in range(nrows):
-                        if data[jj, ii]:
-                            edges.append((ii, jj + ncols))
+            def edges():
+                if kwds.get("multiedges", False):
+                    for ii in range(ncols):
+                        for jj in range(nrows):
+                            for _ in range(data[jj, ii]):
+                                yield (ii, jj + ncols)
+                elif kwds.get("weighted", False):
+                    for ii in range(ncols):
+                        for jj in range(nrows):
+                            if data[jj, ii]:
+                                yield (ii, jj + ncols, data[jj, ii])
+                else:
+                    for ii in range(ncols):
+                        for jj in range(nrows):
+                            if data[jj, ii]:
+                                yield (ii, jj + ncols)
 
             # ensure that construction works
             # when immutable=True (issue #39295)
-            Graph.__init__(self, data=[range(nrows + ncols), edges], format='vertices_and_edges', *args, **kwds)
+            Graph.__init__(self, data=[range(nrows + ncols), edges()], format='vertices_and_edges', *args, **kwds)
         else:
             if partition is not None:
                 left, right = set(partition[0]), set(partition[1])

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -391,6 +391,16 @@ class BipartiteGraph(Graph):
             Traceback (most recent call last):
             ...
             LookupError: vertex (7) is not a vertex of the graph
+
+        Check that :issue:`39295` is fixed::
+
+            sage: B = BipartiteGraph(matrix([[1, 1], [1, 1]]), immutable=True)
+            sage: print(B.vertices(), B.edges())
+            [0, 1, 2, 3] [(0, 2, None), (0, 3, None), (1, 2, None), (1, 3, None)]
+            sage: B.add_vertices([4], left=True)
+            Traceback (most recent call last):
+            ...
+            ValueError: graph is immutable; please change a copy instead (use function copy())
         """
         if kwds is None:
             kwds = {'loops': False}
@@ -472,9 +482,6 @@ class BipartiteGraph(Graph):
             self.left = set(range(ncols))
             self.right = set(range(ncols, nrows + ncols))
 
-            # ensure that the vertices exist even if there
-            # are no associated edges (trac #10356)
-            vertices = list(self.left) + list(self.right)
             edges = []
             if kwds.get("multiedges", False):
                 for ii in range(ncols):
@@ -494,7 +501,7 @@ class BipartiteGraph(Graph):
 
             # ensure that construction works
             # when immutable=True (trac #39295)
-            Graph.__init__(self, data=[vertices, edges], format='vertices_and_edges')
+            Graph.__init__(self, data=[range(nrows + ncols), edges], format='vertices_and_edges', *args, **kwds)
         else:
             if partition is not None:
                 left, right = set(partition[0]), set(partition[1])

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -500,7 +500,7 @@ class BipartiteGraph(Graph):
                             edges.append((ii, jj + ncols))
 
             # ensure that construction works
-            # when immutable=True (trac #39295)
+            # when immutable=True (issue #39295)
             Graph.__init__(self, data=[range(nrows + ncols), edges], format='vertices_and_edges', *args, **kwds)
         else:
             if partition is not None:


### PR DESCRIPTION
Related to issue `#39295` 

Previously, when a reduced adjacency matrix was provided and `immutable=True` was set, the graph construction failed. This fix ensures that the graph is correctly constructed and behaves as expected.

This issue occurred because the parent class `Graph` constructor was called with `immutable=True` and then attempted to add vertices and edges after construction, which is not allowed.

The fix prepares the vertex list and edge list before calling the parent class constructor with the precomputed vertices and edges.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



