### PR TITLE
Fix dual_code Method to Return Cyclic Code Object for BCH Codes

### DIFF
--- a/src/sage/coding/bch_code.py
+++ b/src/sage/coding/bch_code.py
@@ -139,6 +139,44 @@ class BCHCode(CyclicCode):
         self._offset = offset
         self._designed_distance = designed_distance
 
+    def dual_code(self):
+        r"""
+        Return the dual code of this BCH code as a cyclic code.
+
+        The dual of a BCH code is a cyclic code, so we compute its
+        generator polynomial and return it as a CyclicCode object.
+
+        EXAMPLES::
+
+            sage: P.<x> = PolynomialRing(GF(2))
+            sage: f = x^6 + x^4 + x^3 + x + 1
+            sage: F.<a> = GF(2^6, modulus=f)
+            sage: n = 63
+            sage: C = codes.BCHCode(GF(2), n, 9, a)
+            sage: C
+            [63, 39] BCH Code over GF(2) with designed distance 9
+            sage: C_dual = C.dual_code()
+            sage: C_dual
+            [63, 24] Cyclic Code over GF(2)
+            sage: C_dual.generator_polynomial()
+            x^39 + x^36 + x^35 + ... + 1
+        """
+        # Get parameters
+        n = self.length()  # Code length
+        k = self.dimension()  # Code dimension
+        g = self.generator_polynomial()  # Generator polynomial
+
+        # Compute parity-check polynomial h(x)
+        P = g.parent()  # Polynomial ring
+        h = (P.gen()**n - 1) // g
+
+        # Compute generator polynomial for dual cyclic code
+        h0 = h[0]  # Constant term of h(x)
+        g_dual = P(h0**-1 * P.gen()**k * h(1 / P.gen()))
+
+        # Return dual as a cyclic code
+        return CyclicCode(generator_pol=g_dual, length=n)
+    
     def __eq__(self, other):
         r"""
         Test equality between BCH Code objects.


### PR DESCRIPTION
This PR fixes #39750 
This pull request addresses the issue where the dual of a BCH code is not returned as a CyclicCode object. The dual code of a BCH code should be a cyclic code, allowing users to call methods like generator_polynomial() on it. This fix overrides the dual_code method in the BCHCode class to ensure it returns a CyclicCode object.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


