### PR TITLE
Fix Derangements(0) to return 1 and yield the empty permutation

### DIFF
--- a/src/sage/combinat/derangements.py
+++ b/src/sage/combinat/derangements.py
@@ -281,6 +281,9 @@ class Derangements(UniqueRepresentation, Parent):
             sage: D = Derangements([1,1,2,2,2])
             sage: D.list()
             []
+            sage: D = Derangements(0)
+            sage: D.list()
+            [[]]
         """
         if self.__multi:
             for p in Permutations(self._set):
@@ -309,7 +312,10 @@ class Derangements(UniqueRepresentation, Parent):
              [3, 4, 1, 2],
              [2, 1, 4, 3]]
         """
-        if n <= 1:
+        if n == 0:
+            yield []
+            return 
+        elif n == 1:
             return
         elif n == 2:
             yield [2, 1]
@@ -359,7 +365,9 @@ class Derangements(UniqueRepresentation, Parent):
             sage: D._count_der(5)
             44
         """
-        if n <= 1:
+        if n == 0:
+            return Integer(1)
+        if n == 1:
             return Integer(0)
         if n == 2:
             return Integer(1)
@@ -415,6 +423,9 @@ class Derangements(UniqueRepresentation, Parent):
             sage: D = Derangements([1,1,2,2,2])
             sage: D.cardinality()
             0
+            sage: D = Derangements(0)
+            sage: D.cardinality()
+            1
         """
         if self.__multi:
             sL = set(self._set)


### PR DESCRIPTION
Fixes #39734

### What this does

This PR fixes the behavior of `Derangements(0)` in two ways:

- `Derangements(0).cardinality()` now correctly returns `1` instead of `0`, aligning with standard combinatorics conventions and OEIS [A000166](https://oeis.org/A000166).
- `Derangements(0).list()` now returns `[[]]`, representing the single (empty) derangement of the empty set, instead of an empty list.

These changes ensure consistency with mathematical definitions and fix an inconsistency between `Derangements(0)` and `Permutations(0)`.

### Why this matters

Returning `1` for `Derangements(0).cardinality()` is consistent with the recursive definition of derangements and is mathematically correct. Without this fix, Sage currently contradicts standard references and user expectations.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.
