### PR TITLE
fix bijectionist.py doctest

### DIFF
--- a/src/sage/combinat/bijectionist.py
+++ b/src/sage/combinat/bijectionist.py
@@ -207,7 +207,8 @@ The output is in a form suitable for FindStat::
     sage: findmap(list(bij.minimal_subdistributions_iterator()))            # optional -- internet
     0: Mp00034 (quality [100])
     1: Mp00061oMp00023 (quality [100])
-    2: Mp00018oMp00140 (quality [100])
+    2: Mp00029oMp00327 (quality [100])
+    3: Mp00018oMp00140 (quality [100])
 
 TESTS::
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes #36480 

Fixed the bijectionist.py doctest that was failing on testing with 

```
--optional=4ti2,antic,build,cbc,ccache,cryptominisat,debian,dot2tex,e_antic,external,fricas,glucose,kissat,latte_int,lidia,normaliz,pip,sage,sage_numerical_backends_coin,sage_spkg
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
