### PR TITLE
Update sageinspect.getargspec to handle keyword only arguments

### DIFF
--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -1600,6 +1600,19 @@ def sage_getargspec(obj):
         sage: shell.run_cell('f = Foo()')
         sage: shell.run_cell('f??')
         ...the source code string...
+    
+    Test that :issue:`39627` is fixed:
+        sage: from sage.misc.sageinspect import sage_formatargspec
+        sage: def afunc(a, b=1, *, x=2, y, z=3):
+        ....:     return
+        ....: 
+        sage: sage_getargspec(afunc)
+        FullArgSpec(args=['a', 'b'], varargs=None, varkw=None, defaults=(1,), kwonlyargs=['x', 'y', 'z'], kwonlydefaults={'x': 2, 'z': 3}, annotations={})
+        sage: sage_formatargspec(*sage_getargspec(afunc))
+        '(a, b=1, *, x=2, y, z=3)'
+        sage: sage_getargspec(sage.categories.enumerated_sets.EnumeratedSets.ParentMethods.map)
+        FullArgSpec(args=['self', 'f', 'name'], varargs=None, varkw=None, defaults=(None,), kwonlyargs=['is_injective'], kwonlydefaults={'is_injective': True}, annotations={})
+         
     """
     from sage.misc.lazy_attribute import lazy_attribute
     from sage.misc.abstract_method import AbstractMethod

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -1626,9 +1626,7 @@ def sage_getargspec(obj):
     if hasattr(obj, '__code__'):
         # Note that this may give a wrong result for the constants!
         try:
-            args, varargs, varkw = inspect.getargs(obj.__code__)
-            return inspect.FullArgSpec(args, varargs, varkw, obj.__defaults__,
-                                       kwonlyargs=[], kwonlydefaults=None, annotations={})
+            return inspect.getfullargspec(obj)
         except (TypeError, AttributeError):
             pass
     if isclassinstance(obj):


### PR DESCRIPTION
Fixes #39627

Keyword-only arguments were added in Python 3 and are not being handled properly by sageinspect, causing documentation to have incorrect signatures, including incorrect default arguments.

This PR replaces a usage of the deprecated inspect.getargs and inspect.FullArgSpec with inspect.getfullargspec.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies


