### PR TITLE
Improve error messages for missing Jupyter and JupyterLab installations

### DIFF
--- a/src/bin/sage-notebook
+++ b/src/bin/sage-notebook
@@ -37,11 +37,9 @@ class NotebookJupyter():
                 # notebook 7
                 from notebook.app import main
         except ImportError:
-            import traceback
-            traceback.print_exc()
             print("The Jupyter notebook is not installed (at least not in this Sage installation).")
-            print("You can install it by running")
-            print("  sage -i notebook")
+            print("You can install it by running the following command:")
+            print("  sage -pip install notebook")
             print("Alternatively, you can follow the instructions at")
             print("  " + _system_jupyter_url)
             print("to use Sage with an existing Jupyter notebook installation.")
@@ -61,11 +59,9 @@ class NotebookJupyterlab():
         try:
             from jupyterlab.labapp import main
         except ImportError:
-            import traceback
-            traceback.print_exc()
             print("Jupyterlab is not installed (at least not in this Sage installation).")
-            print("You can install it by running")
-            print("  sage -i jupyterlab")
+            print("You can install it by running the following command")
+            print("  sage -pip install jupyterlab")
             print("Alternatively, you can follow the instructions at")
             print("  " + _system_jupyter_url)
             print("to use Sage with an existing Jupyterlab installation.")


### PR DESCRIPTION
This PR fixes #39772 
- Removed stack trace outputs for clearer messaging.
- Updated installation instructions to use `sage -pip install notebook` and `sage -pip install jupyterlab`.
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


