### PR TITLE
magma interface: fix typo in a comment

### DIFF
--- a/src/sage/interfaces/magma.py
+++ b/src/sage/interfaces/magma.py
@@ -361,7 +361,7 @@ class Magma(ExtraTabCompletion, Expect):
         self.__ref = 0
         self.__available_var = []
         self.__cache = {}
-        self._preparse_colon_equals = False  # if set to try, all "=" become ":=" (some users really appreciate this)
+        self._preparse_colon_equals = False  # if set to True, all "=" become ":=" (some users really appreciate this)
         self._seed = seed
 
     def set_seed(self, seed=None):


### PR DESCRIPTION
 Fix a typo in a comment.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


