### PR TITLE
Implement apply_map method in ModulesWithBasis category

### DIFF
--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -2215,6 +2215,52 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 3*x*y^2
             """
             return self.parent().term(*self.trailing_item(*args, **kwds))
+        
+        def apply_map(self, phi):
+            """
+            Return a function that applies ``phi`` to its argument.
+
+            EXAMPLES::
+
+                sage: from sage.modules.vector_symbolic_dense import apply_map
+                sage: v = vector([1,2,3])
+                sage: f = apply_map(lambda x: x+1)
+                sage: f(v)
+                (2, 3, 4)
+            """
+            def apply(self, *args, **kwds):
+                """
+                Generic function used to implement common symbolic operations
+                elementwise as methods of a vector.
+
+                EXAMPLES::
+
+                    sage: var('x,y')
+                    (x, y)
+                    sage: v = vector([sin(x)^2 + cos(x)^2, log(x*y), sin(x/(x^2 + x)), factorial(x+1)/factorial(x)])
+                    sage: v.simplify_trig()
+                    (1, log(x*y), sin(1/(x + 1)), factorial(x + 1)/factorial(x))
+                    sage: v.canonicalize_radical()
+                    (cos(x)^2 + sin(x)^2, log(x) + log(y), sin(1/(x + 1)), factorial(x + 1)/factorial(x))
+                    sage: v.simplify_rational()
+                    (cos(x)^2 + sin(x)^2, log(x*y), sin(1/(x + 1)), factorial(x + 1)/factorial(x))
+                    sage: v.simplify_factorial()
+                    (cos(x)^2 + sin(x)^2, log(x*y), sin(x/(x^2 + x)), x + 1)
+                    sage: v.simplify_full()
+                    (1, log(x*y), sin(1/(x + 1)), x + 1)
+
+                    sage: v = vector([sin(2*x), sin(3*x)])
+                    sage: v.simplify_trig()
+                    (2*cos(x)*sin(x), (4*cos(x)^2 - 1)*sin(x))
+                    sage: v.simplify_trig(False)
+                    (sin(2*x), sin(3*x))
+                    sage: v.simplify_trig(expand=False)
+                    (sin(2*x), sin(3*x))
+                """
+                return self.apply_map(lambda x: phi(x, *args, **kwds))
+
+            apply.__doc__ += "\nSee Expression." + phi.__name__ + "() for optional arguments."
+            return apply
 
         def map_coefficients(self, f, new_base_ring=None):
             """


### PR DESCRIPTION
This PR fixes issue #39751 
This PR introduces the `apply_map` method to the `ModulesWithBasis` category. This method allows applying a function element-wise to the elements of a finite-dimensional module with a basis, enhancing its functionality and performance.
## Changes Made

- Added `apply_map` method to `ElementMethods` class in `ModulesWithBasis`.
- The new method allows passing a function `phi` that will be applied to each element of the module.


## Motivation
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


