### PR TITLE
 Changed single colon to double colon after WARNING in relevant files

### DIFF
--- a/src/sage/algebras/cluster_algebra.py
+++ b/src/sage/algebras/cluster_algebra.py
@@ -1763,7 +1763,7 @@ class ClusterAlgebra(Parent, UniqueRepresentation):
 
             This method implements the piecewise-linear map `\\nu_c` introduced in Section 9.1 of [ReSt2020]_.
 
-        .. WARNING:
+        .. WARNING::
 
             This implementation works only when the initial exchange matrix is acyclic.
 
@@ -1789,7 +1789,7 @@ class ClusterAlgebra(Parent, UniqueRepresentation):
 
             This method implements the inverse of the piecewise-linear map `\\nu_c` introduced in Section 9.1 of [ReSt2020]_.
 
-        .. WARNING:
+        .. WARNING::
 
             This implementation works only when the initial exchange matrix is acyclic.
 

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -6492,7 +6492,7 @@ class SymmetricFunctionsFunctor(ConstructionFunctor):
         - ``name`` -- the name of the basis
         - ``args`` -- any further arguments necessary to initialize the basis
 
-        .. WARNING:
+        .. WARNING::
 
             Strictly speaking, this is not necessarily a functor on
             :class:`CommutativeRings`, but rather a functor on
@@ -6632,7 +6632,7 @@ class SymmetricFunctionsFamilyFunctor(SymmetricFunctionsFunctor):
 
         - ``basis`` -- the basis of the symmetric function algebra
 
-        .. WARNING:
+        .. WARNING::
 
             Strictly speaking, this is not necessarily a functor on
             :class:`CommutativeRings`, but rather a functor on

--- a/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
@@ -571,7 +571,7 @@ class DrinfeldModule_finite(DrinfeldModule):
         Instead, use :meth:`frobenius_charpoly` with the option
         `algorithm='gekeler'`.
 
-        .. WARNING:
+        .. WARNING::
 
             This algorithm only works in the generic case when the
             corresponding linear system is invertible. Notable cases

--- a/src/sage/rings/number_field/number_field_rel.py
+++ b/src/sage/rings/number_field/number_field_rel.py
@@ -38,7 +38,7 @@ We do some arithmetic in a tower of relative number fields::
     sage: a.parent()
     Number Field in sqrt2 with defining polynomial x^2 - 2 over its base field
 
-.. WARNING:
+.. WARNING::
 
     Doing arithmetic in towers of relative fields that depends on canonical
     coercions is currently VERY SLOW.  It is much better to explicitly coerce

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py
@@ -62,7 +62,7 @@ the LMFDB label of the curve is 169.a.169.1::
     sage: A.geometric_endomorphism_algebra_is_field()
     False
 
-.. WARNING:
+.. WARNING::
 
     There is a very small chance that the algorithms return ``False`` for the
     two methods described above when in fact one or both of them are ``True``.


### PR DESCRIPTION
this PR fixes #39786 
corrected the formatting of WARNING directives in the documentation. The source code mistakenly used a single colon after WARNING instead of a double colon.
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


