### PR TITLE
Fix missing WARNING blocks in documentation (5 files)

### DIFF
--- a/src/sage/algebras/cluster_algebra.py
+++ b/src/sage/algebras/cluster_algebra.py
@@ -1763,7 +1763,7 @@ class ClusterAlgebra(Parent, UniqueRepresentation):
 
             This method implements the piecewise-linear map `\\nu_c` introduced in Section 9.1 of [ReSt2020]_.
 
-        .. WARNING:
+        .. WARNING:: # added colon
 
             This implementation works only when the initial exchange matrix is acyclic.
 
@@ -1789,7 +1789,7 @@ class ClusterAlgebra(Parent, UniqueRepresentation):
 
             This method implements the inverse of the piecewise-linear map `\\nu_c` introduced in Section 9.1 of [ReSt2020]_.
 
-        .. WARNING:
+        .. WARNING:: # added colon
 
             This implementation works only when the initial exchange matrix is acyclic.
 

--- a/src/sage/algebras/cluster_algebra.py
+++ b/src/sage/algebras/cluster_algebra.py
@@ -1763,7 +1763,7 @@ class ClusterAlgebra(Parent, UniqueRepresentation):
 
             This method implements the piecewise-linear map `\\nu_c` introduced in Section 9.1 of [ReSt2020]_.
 
-        .. WARNING:: # added colon
+        .. WARNING::
 
             This implementation works only when the initial exchange matrix is acyclic.
 
@@ -1789,7 +1789,7 @@ class ClusterAlgebra(Parent, UniqueRepresentation):
 
             This method implements the inverse of the piecewise-linear map `\\nu_c` introduced in Section 9.1 of [ReSt2020]_.
 
-        .. WARNING:: # added colon
+        .. WARNING::
 
             This implementation works only when the initial exchange matrix is acyclic.
 

--- a/src/sage/combinat/bijectionist.py
+++ b/src/sage/combinat/bijectionist.py
@@ -2113,7 +2113,7 @@ class Bijectionist(SageObject):
         Suppose that `p_1`, `p_2` are blocks of `P`, and `a_1, a'_1
         \in p_1` and `a_2, a'_2\in p_2`.  Then,
 
-        .. MATH:
+        .. MATH::
 
             s(\pi(a_1, a_2))
             = \rho(s(a_1), s(a_2))

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -6492,7 +6492,7 @@ class SymmetricFunctionsFunctor(ConstructionFunctor):
         - ``name`` -- the name of the basis
         - ``args`` -- any further arguments necessary to initialize the basis
 
-        .. WARNING:: # added colon
+        .. WARNING::
 
             Strictly speaking, this is not necessarily a functor on
             :class:`CommutativeRings`, but rather a functor on
@@ -6632,7 +6632,7 @@ class SymmetricFunctionsFamilyFunctor(SymmetricFunctionsFunctor):
 
         - ``basis`` -- the basis of the symmetric function algebra
 
-        .. WARNING:: # added colon
+        .. WARNING::
 
             Strictly speaking, this is not necessarily a functor on
             :class:`CommutativeRings`, but rather a functor on

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -6492,7 +6492,7 @@ class SymmetricFunctionsFunctor(ConstructionFunctor):
         - ``name`` -- the name of the basis
         - ``args`` -- any further arguments necessary to initialize the basis
 
-        .. WARNING:
+        .. WARNING:: # added colon
 
             Strictly speaking, this is not necessarily a functor on
             :class:`CommutativeRings`, but rather a functor on
@@ -6632,7 +6632,7 @@ class SymmetricFunctionsFamilyFunctor(SymmetricFunctionsFunctor):
 
         - ``basis`` -- the basis of the symmetric function algebra
 
-        .. WARNING:
+        .. WARNING:: # added colon
 
             Strictly speaking, this is not necessarily a functor on
             :class:`CommutativeRings`, but rather a functor on

--- a/src/sage/graphs/graph_decompositions/tree_decomposition.pyx
+++ b/src/sage/graphs/graph_decompositions/tree_decomposition.pyx
@@ -83,7 +83,7 @@ The treewidth of a clique is `n-1` and its treelength is 1::
     :meth:`length_of_tree_decomposition` | Return the length of the tree decomposition `T` of `G`.
 
 
-.. TODO:
+.. TODO::
 
     - Approximation of treelength based on :meth:`~sage.graphs.graph.Graph.lex_M`
     - Approximation of treelength based on BFS Layering

--- a/src/sage/groups/matrix_gps/finitely_generated_gap.py
+++ b/src/sage/groups/matrix_gps/finitely_generated_gap.py
@@ -606,14 +606,14 @@ class FinitelyGeneratedMatrixGroup_gap(MatrixGroup_gap):
 
         Let `K[x]` be a polynomial ring and `\chi` a linear character for `G`. Let
 
-        .. MATH:
+        .. MATH::
 
             K[x]^G_{\chi} = \{f \in K[x] | \pi f = \chi(\pi) f \forall \pi\in G\}
 
         be the ring of invariants of `G` relative to `\chi`. Then the Reynolds operator
         is a map `R` from `K[x]` into `K[x]^G_{\chi}` defined by
 
-        .. MATH:
+        .. MATH::
 
             f \mapsto \frac{1}{|G|} \sum_{ \pi \in G} \chi(\pi) f.
 

--- a/src/sage/modules/filtered_vector_space.py
+++ b/src/sage/modules/filtered_vector_space.py
@@ -768,7 +768,7 @@ class FilteredVectorSpace_class(FreeModule_ambient_field):
         """
         Return an abbreviated field name as string.
 
-        .. NOTE: This should rather be a method of fields and rings.
+        .. NOTE:: This should rather be a method of fields and rings.
 
         RAISES:
 

--- a/src/sage/modules/ore_module_morphism.py
+++ b/src/sage/modules/ore_module_morphism.py
@@ -77,7 +77,7 @@ define a morphism of Ore modules::
     ...
     ValueError: does not define a morphism of Ore modules
 
-.. RUBRIC: Kernels, images and related things
+.. RUBRIC:: Kernels, images and related things
 
 SageMath provides methods to compute kernels, cokernels,
 images and coimages. In order to illustrate this, we will
@@ -228,7 +228,7 @@ As a shortcut, we can use explicit conversions as follows::
     sage: h == h2
     True
 
-.. RUBRIC: Determinants and characteristic polynomials
+.. RUBRIC:: Determinants and characteristic polynomials
 
 For endomorphisms, one can compute classical invariants as
 determinants and characteristic polynomials.

--- a/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
@@ -296,19 +296,19 @@ class DrinfeldModule_finite(DrinfeldModule):
 
         .. NOTE::
 
-            Available algorithms are:
+                Available algorithms are:
 
-                - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
-                central simple algebra (CSA) over `\mathbb
-                F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
-                - ``'crystalline'`` -- it uses the action of the Frobenius
-                on the crystalline cohomology (see [MS2023]_).
-                - ``'gekeler'`` -- it tries to identify coefficients by
-                writing that the characteristic polynomial annihilates the
-                Frobenius endomorphism; this algorithm may fail is some
-                cases (see [Gek2008]_).
-                - ``'motive'`` -- it uses the action of the Frobenius on the
-                Anderson motive (see Chapter 2 of [CL2023]_).
+                    - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
+                    central simple algebra (CSA) over `\mathbb
+                    F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
+                    - ``'crystalline'`` -- it uses the action of the Frobenius
+                    on the crystalline cohomology (see [MS2023]_).
+                    - ``'gekeler'`` -- it tries to identify coefficients by
+                    writing that the characteristic polynomial annihilates the
+                    Frobenius endomorphism; this algorithm may fail is some
+                    cases (see [Gek2008]_).
+                    - ``'motive'`` -- it uses the action of the Frobenius on the
+                    Anderson motive (see Chapter 2 of [CL2023]_).
 
         The method raises an exception if the user asks for an
         unimplemented algorithm, even if the characteristic polynomial
@@ -774,13 +774,13 @@ class DrinfeldModule_finite(DrinfeldModule):
 
         .. NOTE::
 
-            Available algorithms are:
+                Available algorithms are:
 
-                - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
-                central simple algebra (CSA) over `\mathbb
-                F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
-                - ``'crystalline'`` -- it uses the action of the Frobenius
-                on the crystalline cohomology (see [MS2023]_).
+                    - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
+                    central simple algebra (CSA) over `\mathbb
+                    F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
+                    - ``'crystalline'`` -- it uses the action of the Frobenius
+                    on the crystalline cohomology (see [MS2023]_).
 
         The method raises an exception if the user asks for an
         unimplemented algorithm, even if the characteristic has already

--- a/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
@@ -571,7 +571,7 @@ class DrinfeldModule_finite(DrinfeldModule):
         Instead, use :meth:`frobenius_charpoly` with the option
         `algorithm='gekeler'`.
 
-        .. WARNING:: # added colon
+        .. WARNING::
 
             This algorithm only works in the generic case when the
             corresponding linear system is invertible. Notable cases

--- a/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
@@ -571,7 +571,7 @@ class DrinfeldModule_finite(DrinfeldModule):
         Instead, use :meth:`frobenius_charpoly` with the option
         `algorithm='gekeler'`.
 
-        .. WARNING:
+        .. WARNING:: # added colon
 
             This algorithm only works in the generic case when the
             corresponding linear system is invertible. Notable cases

--- a/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
@@ -296,19 +296,19 @@ class DrinfeldModule_finite(DrinfeldModule):
 
         .. NOTE::
 
-                Available algorithms are:
+           Available algorithms are:
 
-                    - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
-                    central simple algebra (CSA) over `\mathbb
-                    F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
-                    - ``'crystalline'`` -- it uses the action of the Frobenius
-                    on the crystalline cohomology (see [MS2023]_).
-                    - ``'gekeler'`` -- it tries to identify coefficients by
+                - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
+                   central simple algebra (CSA) over `\mathbb
+                   F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
+                - ``'crystalline'`` -- it uses the action of the Frobenius
+                   on the crystalline cohomology (see [MS2023]_).
+                - ``'gekeler'`` -- it tries to identify coefficients by
                     writing that the characteristic polynomial annihilates the
                     Frobenius endomorphism; this algorithm may fail is some
                     cases (see [Gek2008]_).
-                    - ``'motive'`` -- it uses the action of the Frobenius on the
-                    Anderson motive (see Chapter 2 of [CL2023]_).
+                - ``'motive'`` -- it uses the action of the Frobenius on the
+                   Anderson motive (see Chapter 2 of [CL2023]_).
 
         The method raises an exception if the user asks for an
         unimplemented algorithm, even if the characteristic polynomial
@@ -777,10 +777,10 @@ class DrinfeldModule_finite(DrinfeldModule):
                 Available algorithms are:
 
                     - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
-                    central simple algebra (CSA) over `\mathbb
-                    F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
+                       central simple algebra (CSA) over `\mathbb
+                       F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
                     - ``'crystalline'`` -- it uses the action of the Frobenius
-                    on the crystalline cohomology (see [MS2023]_).
+                       on the crystalline cohomology (see [MS2023]_).
 
         The method raises an exception if the user asks for an
         unimplemented algorithm, even if the characteristic has already

--- a/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
@@ -294,21 +294,21 @@ class DrinfeldModule_finite(DrinfeldModule):
         - ``algorithm`` (default: ``None``) -- the algorithm
           used to compute the characteristic polynomial
 
-        .. NOTE:
+        .. NOTE::
 
-        Available algorithms are:
+            Available algorithms are:
 
-            - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
-              central simple algebra (CSA) over `\mathbb
-              F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
-            - ``'crystalline'`` -- it uses the action of the Frobenius
-              on the crystalline cohomology (see [MS2023]_).
-            - ``'gekeler'`` -- it tries to identify coefficients by
-              writing that the characteristic polynomial annihilates the
-              Frobenius endomorphism; this algorithm may fail is some
-              cases (see [Gek2008]_).
-            - ``'motive'`` -- it uses the action of the Frobenius on the
-              Anderson motive (see Chapter 2 of [CL2023]_).
+                - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
+                central simple algebra (CSA) over `\mathbb
+                F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
+                - ``'crystalline'`` -- it uses the action of the Frobenius
+                on the crystalline cohomology (see [MS2023]_).
+                - ``'gekeler'`` -- it tries to identify coefficients by
+                writing that the characteristic polynomial annihilates the
+                Frobenius endomorphism; this algorithm may fail is some
+                cases (see [Gek2008]_).
+                - ``'motive'`` -- it uses the action of the Frobenius on the
+                Anderson motive (see Chapter 2 of [CL2023]_).
 
         The method raises an exception if the user asks for an
         unimplemented algorithm, even if the characteristic polynomial
@@ -772,15 +772,15 @@ class DrinfeldModule_finite(DrinfeldModule):
         - ``algorithm`` (default: ``None``) -- the algorithm
           used to compute the characteristic polynomial
 
-        .. NOTE:
+        .. NOTE::
 
-        Available algorithms are:
+            Available algorithms are:
 
-            - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
-              central simple algebra (CSA) over `\mathbb
-              F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
-            - ``'crystalline'`` -- it uses the action of the Frobenius
-              on the crystalline cohomology (see [MS2023]_).
+                - ``'CSA'`` -- it exploits the fact that `K\{\tau\}` is a
+                central simple algebra (CSA) over `\mathbb
+                F_q[\text{Frob}_\phi]` (see Chapter 4 of [CL2023]_).
+                - ``'crystalline'`` -- it uses the action of the Frobenius
+                on the crystalline cohomology (see [MS2023]_).
 
         The method raises an exception if the user asks for an
         unimplemented algorithm, even if the characteristic has already

--- a/src/sage/rings/number_field/number_field_rel.py
+++ b/src/sage/rings/number_field/number_field_rel.py
@@ -38,7 +38,7 @@ We do some arithmetic in a tower of relative number fields::
     sage: a.parent()
     Number Field in sqrt2 with defining polynomial x^2 - 2 over its base field
 
-.. WARNING:
+.. WARNING:: # added colon
 
     Doing arithmetic in towers of relative fields that depends on canonical
     coercions is currently VERY SLOW.  It is much better to explicitly coerce

--- a/src/sage/rings/number_field/number_field_rel.py
+++ b/src/sage/rings/number_field/number_field_rel.py
@@ -38,7 +38,7 @@ We do some arithmetic in a tower of relative number fields::
     sage: a.parent()
     Number Field in sqrt2 with defining polynomial x^2 - 2 over its base field
 
-.. WARNING:: # added colon
+.. WARNING::
 
     Doing arithmetic in towers of relative fields that depends on canonical
     coercions is currently VERY SLOW.  It is much better to explicitly coerce

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py
@@ -62,7 +62,7 @@ the LMFDB label of the curve is 169.a.169.1::
     sage: A.geometric_endomorphism_algebra_is_field()
     False
 
-.. WARNING:
+.. WARNING:: # added colon
 
     There is a very small chance that the algorithms return ``False`` for the
     two methods described above when in fact one or both of them are ``True``.

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py
@@ -62,7 +62,7 @@ the LMFDB label of the curve is 169.a.169.1::
     sage: A.geometric_endomorphism_algebra_is_field()
     False
 
-.. WARNING:: # added colon
+.. WARNING::
 
     There is a very small chance that the algorithms return ``False`` for the
     two methods described above when in fact one or both of them are ``True``.


### PR DESCRIPTION
### Fix missing WARNING blocks in documentation
This pull request addresses the issue where the documentation was missing WARNING blocks due to the use of a single colon instead of a double colon (::). These warning blocks are crucial for properly displaying warnings in the documentation, and this change corrects that formatting oversight.

Files modified:

src/sage/algebras/cluster_algebra.py
src/sage/combinat/sf/sfa.py
src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
src/sage/rings/number_field/number_field_rel.py
src/sage/schemes/hyperelliptic_curves/jacobian_endomorphism_utils.py

The change ensures that the warnings are properly rendered in the documentation.

Fixes #39786 



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies
No dependencies.
