### PR TITLE
fix: added check for FriCAS version

### DIFF
--- a/build/pkgs/fricas/spkg-configure.m4
+++ b/build/pkgs/fricas/spkg-configure.m4
@@ -1,8 +1,8 @@
 SAGE_SPKG_CONFIGURE(
-dnl
-dnl make sure that the minimal version is also set in src/sage/feature/fricas.py
-dnl
     [fricas], [
+        dnl
+        dnl make sure that the minimal version is also set in src/sage/feature/fricas.py
+        dnl
         AC_CACHE_CHECK([for FriCAS >= 1.3.8], [ac_cv_path_FRICAS], [
         AC_PATH_PROGS_FEATURE_CHECK([FRICAS], [fricas], [
             fricas_version=`echo ")quit" | $ac_path_FRICAS -nox -noclef | grep Version | tail -1 2>&1 \

--- a/build/pkgs/fricas/spkg-configure.m4
+++ b/build/pkgs/fricas/spkg-configure.m4
@@ -1,4 +1,7 @@
 SAGE_SPKG_CONFIGURE(
+dnl
+dnl make sure that the minimal version is also set in src/sage/feature/fricas.py
+dnl
     [fricas], [
         AC_CACHE_CHECK([for FriCAS >= 1.3.8], [ac_cv_path_FRICAS], [
         AC_PATH_PROGS_FEATURE_CHECK([FRICAS], [fricas], [

--- a/src/sage/features/fricas.py
+++ b/src/sage/features/fricas.py
@@ -48,7 +48,7 @@ class FriCAS(Executable):
         EXAMPLES::
             sage: from sage.features.fricas import FriCAS
             sage: FriCAS().get_version() # optional - fricas
-            '1.3.8'
+            '1.3...'
         """
         try:
             output = subprocess.check_output(['fricas', '--version'], stderr=subprocess.STDOUT)

--- a/src/sage/features/fricas.py
+++ b/src/sage/features/fricas.py
@@ -14,6 +14,7 @@ Features for testing the presence of ``fricas``
 
 import subprocess
 from . import Executable, FeatureTestResult
+from packaging.version import Version
 
 
 class FriCAS(Executable):
@@ -26,6 +27,8 @@ class FriCAS(Executable):
         sage: FriCAS().is_present()  # optional - fricas
         FeatureTestResult('fricas', True)
     """
+    MINIMUM_VERSION = "1.3.8"
+
     def __init__(self):
         r"""
         TESTS::
@@ -37,6 +40,23 @@ class FriCAS(Executable):
         Executable.__init__(self, name='fricas', spkg='fricas',
                             executable='fricas',
                             url='https://fricas.github.io')
+
+    def get_version(self):
+        r"""
+        Retrieve the installed FriCAS version
+
+        EXAMPLES::
+            sage: from sage.features.fricas import FriCAS
+            sage: FriCAS().get_version() # optional - fricas
+            '1.3.8'
+        """
+        try:
+            output = subprocess.check_output(['fricas', '--version'], stderr=subprocess.STDOUT)
+            version_line = output.decode('utf-8').strip()
+            version = version_line.split()[1]
+            return version
+        except subprocess.CalledProcessError:
+            return None
 
     def is_functional(self):
         r"""
@@ -53,14 +73,24 @@ class FriCAS(Executable):
             lines = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError as e:
             return FeatureTestResult(self, False,
-                    reason="Call `{command}` failed with exit code {e.returncode}".format(command=" ".join(command), e=e))
+                                     reason="Call `{command}` failed with exit code {e.returncode}".format(command=" ".join(command), e=e))
 
         expected = b"FriCAS"
         if lines.find(expected) == -1:
             return FeatureTestResult(self, False,
-                    reason="Call `{command}` did not produce output which contains `{expected}`".format(command=" ".join(command), expected=expected))
+                                     reason="Call `{command}` did not produce output which contains `{expected}`".format(command=" ".join(command),
+                                                                                                                         expected=expected))
+        version = self.get_version()
+        if version is None:
+            return FeatureTestResult(self, False,
+                                     reason="Could not determine FriCAS version")
 
-        return FeatureTestResult(self, True)
+        try:
+            if Version(version) < Version(self.MINIMUM_VERSION):
+                return FeatureTestResult(self, False, reason=f"FriCAS version {version} is too old; minimum required is {self.MINIMUM_VERSION}")
+            return FeatureTestResult(self, True)
+        except ValueError:
+            return FeatureTestResult(self, False, reason="Invalid Version Format")
 
 
 def all_features():


### PR DESCRIPTION
This pull request includes several updates to the `FriCAS` class in the `src/sage/features/fricas.py` file. The changes introduce a minimum version requirement, add a method to retrieve the installed FriCAS version, and enhance the `is_functional` method to check the version.This is an attempt to fix the issue [39784](https://github.com/sagemath/sage/issues/39784)

Enhancements to version handling and functionality checks:

* [`src/sage/features/fricas.py`](diffhunk://#diff-a2c0d819d857ba2338e0d58e1a4875c88b600b174c8fb4371183ecc3f0e5b72eR29-R30): Added a `MINIMUM_VERSION` attribute to specify the minimum required version of FriCAS.
* [`src/sage/features/fricas.py`](diffhunk://#diff-a2c0d819d857ba2338e0d58e1a4875c88b600b174c8fb4371183ecc3f0e5b72eR43-R54): Introduced a `get_version` method to retrieve the installed FriCAS version.
* [`src/sage/features/fricas.py`](diffhunk://#diff-a2c0d819d857ba2338e0d58e1a4875c88b600b174c8fb4371183ecc3f0e5b72eL61-R85): Updated the `is_functional` method to call `get_version` and check if the installed version meets the minimum requirement. If the version is not retrievable or is too old, appropriate error messages are returned.
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


