### PR TITLE
Implement more algorithms for computing eigenvalues

### DIFF
--- a/src/doc/en/prep/Quickstarts/Linear-Algebra.rst
+++ b/src/doc/en/prep/Quickstarts/Linear-Algebra.rst
@@ -313,12 +313,8 @@ eigenvectors.
 ::
 
     sage: D,P=H.eigenmatrix_right()
-    sage: P*D-H*P
-    [0 0 0 0 0]
-    [0 0 0 0 0]
-    [0 0 0 0 0]
-    [0 0 0 0 0]
-    [0 0 0 0 0]
+    sage: P*D-H*P == matrix.zero(5)
+    True
 
 Matrix Solving
 ---------------

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -2132,6 +2132,22 @@ cdef class mpf(mpf_base):
         """
         return binop(OP_RICHCMP+op, self, other, global_opts)
 
+    def _mpfr_(self, RR):
+        """
+        Returns a Sage ``RealNumber``::
+
+            sage: from mpmath import mpf
+            sage: mpf(3)._mpfr_(RealField(53))
+            3.00000000000000
+            sage: RR(mpf(3))  # indirect doctest
+            3.00000000000000
+        """
+        signbit, man, exp, bc = self._mpf_
+        result = RR(man) << exp
+        if signbit:
+            result = -result
+        return result
+
 
 cdef class constant(mpf_base):
     """
@@ -2570,6 +2586,19 @@ cdef class mpc(mpnumber):
             True
         """
         return binop(OP_RICHCMP+op, self, other, global_opts)
+
+    def _complex_mpfr_field_(self, CC):
+        """
+        Return a Sage complex number::
+
+            sage: from mpmath import mpc
+            sage: CC(mpc(1,2))  # indirect doctest
+            1.00000000000000 + 2.00000000000000*I
+            sage: mpc(1,2)._complex_mpfr_field_(CC)
+            1.00000000000000 + 2.00000000000000*I
+        """
+        RR = CC._real_field()
+        return CC((self.real._mpfr_(RR), self.imag._mpfr_(RR)))
 
 
 def hypsum_internal(int p, int q, param_types, str ztype, coeffs, z,

--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -2134,7 +2134,9 @@ cdef class mpf(mpf_base):
 
     def _mpfr_(self, RR):
         """
-        Returns a Sage ``RealNumber``::
+        Return a Sage ``RealNumber``.
+
+        EXAMPLES::
 
             sage: from mpmath import mpf
             sage: mpf(3)._mpfr_(RealField(53))
@@ -2589,7 +2591,9 @@ cdef class mpc(mpnumber):
 
     def _complex_mpfr_field_(self, CC):
         """
-        Return a Sage complex number::
+        Return a Sage complex number.
+
+        EXAMPLES::
 
             sage: from mpmath import mpc
             sage: CC(mpc(1,2))  # indirect doctest

--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -738,6 +738,33 @@ cdef class Matrix(Matrix0):
         A = numpy.matrix(self.list(), dtype=dtype, copy=copy)
         return numpy.resize(A,(self.nrows(), self.ncols()))
 
+    def _mpmath_(self, prec=None, rounding=None):
+        """
+        Return a ``mpmath`` matrix.
+
+        INPUT: See :meth:`sage.structure.element.Element._mpmath_`.
+
+        EXAMPLES::
+
+            sage: # needs mpmath
+            sage: m = matrix(SR, 2, 2, [1, 2, 3, pi])
+            sage: from mpmath import mp
+            sage: mp.dps = 30
+            sage: mp.matrix(m)  # not tested (doesn't work yet)
+            sage: m._mpmath_(mp.prec)
+            matrix(
+            [['1.0', '2.0'],
+             ['3.0', '3.14159265358979323846264338328']])
+        """
+        if prec is None:
+            R = self.base_ring()
+            try:
+                prec = R.precision()
+            except AttributeError:
+                prec = 53
+        from mpmath import mp
+        return mp.matrix([[item._mpmath_(prec, rounding) for item in row] for row in self])
+
     # Define the magic "__array__" function so that numpy.array(m) can convert
     # a matrix m to a numpy array.
     # See http://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html#converting-an-arbitrary-sequence-object

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -7208,7 +7208,7 @@ cdef class Matrix(Matrix1):
 
     def _fix_eigenvectors_extend(self, result: list, extend: bool) -> list:
         """
-        Fix the eigenvectors if the extend option is set to False.
+        Fix the eigenvectors if the extend option is set to ``False``.
 
         INPUT:
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -7311,14 +7311,14 @@ cdef class Matrix(Matrix1):
         TESTS::
 
             sage: m = matrix(RR, [[0, 1], [-2, 0]])
-            sage: l = m.eigenvectors_left(algorithm="pari"); l
+            sage: l = m.eigenvectors_left(algorithm="pari"); l  # abs tol 1e-14
             [(-1.4142135623730950487637880730318329370*I,
               [(0.707106781186547524*I, 1.00000000000000000)],
               1),
              (1.4142135623730950487637880730318329370*I,
               [(-0.707106781186547524*I, 1.00000000000000000)],
               1)]
-            sage: m._fix_eigenvectors_extend(l, extend=True)
+            sage: m._fix_eigenvectors_extend(l, extend=True)  # abs tol 1e-14
             [(-1.4142135623730950487637880730318329370*I,
               [(0.707106781186547524*I, 1.00000000000000000)],
               1),
@@ -7412,7 +7412,7 @@ cdef class Matrix(Matrix1):
         Only works for matrices over ``RealField`` or ``ComplexField``.
 
             sage: m = matrix(RR, [[0, 1], [-2, 0]])
-            sage: m.eigenvectors_left(algorithm="pari")
+            sage: m.eigenvectors_left(algorithm="pari")  # abs tol 1e-14
             [(-1.4142135623730950487637880730318329370*I,
               [(0.707106781186547524*I, 1.00000000000000000)],
               1),

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -6837,7 +6837,7 @@ cdef class Matrix(Matrix1):
 
     right_eigenspaces = eigenspaces_right
 
-    def eigenvalues(self, extend=True, algorithm=None):
+    def eigenvalues(self, extend=True, algorithm=None) -> Sequence:
         r"""
         Return a sequence of the eigenvalues of a matrix, with
         multiplicity. If the eigenvalues are roots of polynomials in ``QQ``,
@@ -6971,6 +6971,8 @@ cdef class Matrix(Matrix1):
             [-1.41421356237309505*I, 1.41421356237309505*I]
             sage: m.eigenvalues()
             [-1.41421356237309505*I, 1.41421356237309505*I]
+            sage: type(m.eigenvalues())
+            <class 'sage.structure.sequence.Sequence_generic'>
         """
         if algorithm is None:
             from sage.rings.abc import RealField, ComplexField
@@ -6983,7 +6985,7 @@ cdef class Matrix(Matrix1):
             return self._eigenvalues_sage(extend=extend)
         elif algorithm == "pari_charpoly":
             from sage.libs.pari import pari
-            return pari(self).charpoly().polroots().sage()
+            return Sequence(pari(self).charpoly().polroots().sage())
         else:
             return self._eigenvectors_result_to_eigenvalues(
                     self._eigenvectors_left(
@@ -7013,7 +7015,7 @@ cdef class Matrix(Matrix1):
         """
         return Sequence([e for e, _, _ in eigenvectors])
 
-    def _eigenvalues_sage(self, extend=True):
+    def _eigenvalues_sage(self, extend=True) -> Sequence:
         """
         Compute the eigenvalues of a matrix using algorithm implemented in Sage.
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -6848,7 +6848,9 @@ cdef class Matrix(Matrix1):
 
         - ``extend`` -- (default: ``True``); see below
         - ``algorithm`` -- (default: ``None``); algorithm to use,
-          see :meth:`eigenvectors_left`
+          supported values are ``'sage'``, ``'flint'``, ``'mpmath'``, ``'pari'``
+          (passed to :meth:`eigenvectors_left`), or ``'pari_charpoly'``; if ``None``,
+          the algorithm is chosen automatically
 
         If the option ``extend`` is set to ``False``, only eigenvalues in the base
         ring are considered.
@@ -6965,28 +6967,23 @@ cdef class Matrix(Matrix1):
             sage: m.eigenvalues(algorithm="pari")  # abs tol 1e-14
             [-1.4142135623730950487637880730318329370*I,
              1.4142135623730950487637880730318329370*I]
-
-        The following currently uses ``algorithm="flint"`` under the hood,
-        but ``FutureWarning`` must not be raised. This is because the internal
-        implementation may change in the future to keep the external interface.
-
-        ::
-
+            sage: m.eigenvalues(algorithm="pari_charpoly")  # abs tol 1e-14
+            [-1.41421356237309505*I, 1.41421356237309505*I]
             sage: m.eigenvalues()
-            [-1.41421356237309*I, 1.41421356237310*I]
+            [-1.41421356237309505*I, 1.41421356237309505*I]
         """
         if algorithm is None:
             from sage.rings.abc import RealField, ComplexField
             R = self.base_ring()
             if isinstance(R, (RealField, ComplexField)):
-                return self._eigenvectors_result_to_eigenvalues(
-                        self._eigenvectors_left(
-                            extend=extend, algorithm="flint",
-                            suppress_future_warning=True))
+                algorithm = "pari_charpoly"
             else:
                 algorithm = "sage"
         if algorithm == "sage":
             return self._eigenvalues_sage(extend=extend)
+        elif algorithm == "pari_charpoly":
+            from sage.libs.pari import pari
+            return pari(self).charpoly().polroots().sage()
         else:
             return self._eigenvectors_result_to_eigenvalues(
                     self._eigenvectors_left(

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -7089,8 +7089,8 @@ cdef class Matrix(Matrix1):
           * ``'flint'``
           * ``'mpmath'``
           * ``'pari'``
-          * ``'scipy'`` - only supported for matrices over :class:`RDF <.RealDoubleField_class>`
-            and :class:`CDF <.ComplexDoubleField_class>`
+          * ``'scipy'`` - only supported for matrices over :class:`RDF <sage.rings.real_double.RealDoubleField_class>`
+            and :class:`CDF <sage.rings.complex_double.ComplexDoubleField_class>`
 
         OUTPUT:
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -7082,9 +7082,14 @@ cdef class Matrix(Matrix1):
 
         - ``extend`` -- boolean (default: ``True``)
 
-        - ``algorithm`` -- string (default: ``None``); the algorithm, options are
-          ``'sage'``, ``'flint'``, ``'mpmath'``, ``'pari'``, ``'scipy'``; if ``None``, the
-          algorithm is chosen automatically (``'scipy'`` is only supported for matrices over ``RDF`` or ``CDF``)
+        - ``algorithm`` -- string (default: ``None``); if ``None``, then it is
+          chosen automatically; options are:
+
+          * ``'sage'``
+          * ``'flint'``
+          * ``'mpmath'``
+          * ``'pari'``
+          * ``'scipy'`` - only supported for matrices over :class:`RDF` and :class:`CDF`
 
         OUTPUT:
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -7089,7 +7089,8 @@ cdef class Matrix(Matrix1):
           * ``'flint'``
           * ``'mpmath'``
           * ``'pari'``
-          * ``'scipy'`` - only supported for matrices over :class:`RDF` and :class:`CDF`
+          * ``'scipy'`` - only supported for matrices over :class:`RDF <.RealDoubleField_class>`
+            and :class:`CDF <.ComplexDoubleField_class>`
 
         OUTPUT:
 

--- a/src/sage/matrix/matrix_double_dense.pyx
+++ b/src/sage/matrix/matrix_double_dense.pyx
@@ -1387,7 +1387,7 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
                     ev_group[location][2] = ev_group[location][0]/ev_group[location][1]
             return [(return_class(avg), m) for _, m, avg in ev_group]
 
-    def left_eigenvectors(self, other=None, *, homogeneous=False):
+    def eigenvectors_left(self, other=None, *, algorithm=None, homogeneous=False):
         r"""
         Compute the ordinary or generalized left eigenvectors of a matrix of
         double precision real or complex numbers (i.e. ``RDF`` or ``CDF``).
@@ -1397,6 +1397,10 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         - ``other`` -- a square matrix `B` (default: ``None``) in a generalized
           eigenvalue problem; if ``None``, an ordinary eigenvalue problem is
           solved
+
+        - ``algorithm`` (default: ``None``); for compatibility with
+          :meth:`sage.matrix.matrix2.Matrix.eigenvectors_left`, supported options
+          are ``None`` (select automatically) or ``'scipy'``
 
         - ``homogeneous`` -- boolean (default: ``False``); if ``True``, use
           homogeneous coordinates for the eigenvalues in the output
@@ -1514,6 +1518,8 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             sage: spectrum
             [(1.0*I, [(1.0, 0.0)], 1), (1.0, [(0.0, 1.0)], 1)]
         """
+        if algorithm not in (None, "scipy"):
+            raise NotImplementedError(f"algorithm {algorithm} not implemented for matrix over {self.base_ring()}")
         if not self.is_square():
             raise ArithmeticError("self must be a square matrix")
         if other is not None and not other.is_square():
@@ -1542,9 +1548,9 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             v = [CDF(e) for e in v]
         return [(v[i], [eig[i].conjugate()], 1) for i in range(len(v))]
 
-    eigenvectors_left = left_eigenvectors
+    left_eigenvectors = eigenvectors_left
 
-    def right_eigenvectors(self, other=None, *, homogeneous=False):
+    def eigenvectors_right(self, other=None, *, homogeneous=False):
         r"""
         Compute the ordinary or generalized right eigenvectors of a matrix of
         double precision real or complex numbers (i.e. ``RDF`` or ``CDF``).
@@ -1694,7 +1700,7 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             v = [CDF(e) for e in v]
         return [(v[i], [eig[i]], 1) for i in range(len(v))]
 
-    eigenvectors_right = right_eigenvectors
+    right_eigenvectors = eigenvectors_right
 
     def _solve_right_nonsingular_square(self, B, check_rank=False):
         """

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -2657,7 +2657,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
         return x
 
     # Bit shifting
-    def _lshift_(RealNumber self, n):
+    def _lshift_(RealNumber self, Integer n):
         """
         Return ``self * (2^n)`` for an integer ``n``.
 
@@ -2668,6 +2668,8 @@ cdef class RealNumber(sage.structure.element.RingElement):
             sage: RR(1.5)._lshift_(2)
             6.00000000000000
         """
+        if n < 0:
+            return self._rshift_(-n)
         cdef RealNumber x
         if n > sys.maxsize:
             raise OverflowError("n (=%s) must be <= %s" % (n, sys.maxsize))
@@ -2687,6 +2689,15 @@ cdef class RealNumber(sage.structure.element.RingElement):
             Traceback (most recent call last):
             ...
             TypeError: unsupported operands for <<
+
+        TESTS::
+
+            sage: 32r << 2.5
+            Traceback (most recent call last):
+            ...
+            TypeError: unsupported operands for <<
+            sage: 1.5 << -2
+            0.375000000000000
         """
         if not isinstance(x, RealNumber):
             raise TypeError("unsupported operands for <<")
@@ -2695,7 +2706,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
         except TypeError:
             raise TypeError("unsupported operands for <<")
 
-    def _rshift_(RealNumber self, n):
+    def _rshift_(RealNumber self, Integer n):
         """
         Return ``self / (2^n)`` for an integer ``n``.
 
@@ -2706,6 +2717,8 @@ cdef class RealNumber(sage.structure.element.RingElement):
             sage: RR(1.5)._rshift_(2)
             0.375000000000000
         """
+        if n < 0:
+            return self._lshift_(-n)
         if n > sys.maxsize:
             raise OverflowError("n (=%s) must be <= %s" % (n, sys.maxsize))
         cdef RealNumber x = self._new()
@@ -2724,6 +2737,11 @@ cdef class RealNumber(sage.structure.element.RingElement):
             Traceback (most recent call last):
             ...
             TypeError: unsupported operands for >>
+
+        TESTS::
+
+            sage: 1.5 >> -2
+            6.00000000000000
         """
         if not isinstance(x, RealNumber):
             raise TypeError("unsupported operands for >>")

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -927,7 +927,13 @@ cdef class Element(SageObject):
             sage: (1 + pi)._mpmath_(mp.prec)                                            # needs sage.symbolic
             mpf('4.14159265358979323846264338327933')
         """
-        return self.n(prec)._mpmath_(prec=prec)
+        t = self.n(prec)
+        from sage.rings.real_mpfr import RealNumber
+        from sage.rings.complex_mpfr import ComplexNumber
+        if not isinstance(t, (RealNumber, ComplexNumber)):
+            # avoid infinite recursion
+            raise NotImplementedError("mpmath conversion not implemented for %s" % type(self))
+        return t._mpmath_(prec=prec)
 
     cpdef _act_on_(self, x, bint self_on_left):
         """


### PR DESCRIPTION
Now `eigenvalues()` and `eigenvectors_left()` takes `algorithm` parameter.

Partially handles https://github.com/sagemath/sage/issues/39762

Also changes the default algorithm of `eigenvalues()` to `pari_charpoly` when the base field is `RR` or `CC`.

Additional changes required:

* implement conversion from mpmath object to RR or CC
* implement shifting elements of RR by a negative value
* detect error of conversion to mpmath object
* change a hard error to a warning

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


