### PR TITLE
fix random doctest error in `src/sage/data_structures/bitset.pyx`

### DIFF
--- a/src/sage/data_structures/bitset.pyx
+++ b/src/sage/data_structures/bitset.pyx
@@ -164,7 +164,7 @@ cdef class FrozenBitset:
 
     Try a random bitset::
 
-        sage: a = Bitset(randint(0, 1) for n in range(1, randint(1, 10^4)))
+        sage: a = Bitset(randint(0, 1) for n in range(randint(1, 10^4)))
         sage: b = FrozenBitset(a); c = FrozenBitset(b)
         sage: bitcmp(a, b, c)
         True
@@ -239,7 +239,7 @@ cdef class FrozenBitset:
 
     A random iterable, with all duplicate elements removed::
 
-        sage: L = [randint(0, 100) for n in range(1, randint(1, 10^4))]
+        sage: L = [randint(0, 100) for n in range(randint(1, 10^4))]
         sage: FrozenBitset(L) == FrozenBitset(list(set(L)))
         True
         sage: FrozenBitset(tuple(L)) == FrozenBitset(tuple(set(L)))


### PR DESCRIPTION
Fixes #39826.

Bitset cannot be build from an empty list. We change the doctest to pass lists with at least 1 element.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


