### PR TITLE
Implement conjugate method for RealBall

### DIFF
--- a/src/sage/rings/real_arb.pyx
+++ b/src/sage/rings/real_arb.pyx
@@ -3106,6 +3106,17 @@ cdef class RealBall(RingElement):
             raise TypeError("unsupported operand type(s) for >>: '{}' and '{}'"
                             .format(type(val).__name__, type(shift).__name__))
 
+    def conjugate(self):
+        r"""
+        Return the conjugate of this ball.
+
+        EXAMPLES::
+
+            sage: RBF(1).conjugate()
+            1.000000000000000
+        """
+        return self
+
     # Elementary functions
 
     def log(self, base=None):


### PR DESCRIPTION
While not particularly useful, this allows some generic method to work e.g. matrix `.H`.
Also `RR` etc. all have this.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


