### PR TITLE
Make sure truncate_neg works correctly

### DIFF
--- a/src/sage/rings/laurent_series_ring_element.pxd
+++ b/src/sage/rings/laurent_series_ring_element.pxd
@@ -1,7 +1,8 @@
-from sage.structure.element cimport AlgebraElement, ModuleElement
+from sage.structure.element cimport AlgebraElement
+from sage.rings.power_series_ring_element cimport PowerSeries
 
 cdef class LaurentSeries(AlgebraElement):
-    cdef ModuleElement __u
+    cdef PowerSeries __u
     cdef long __n
 
     cdef _normalize(self)

--- a/src/sage/rings/laurent_series_ring_element.pyx
+++ b/src/sage/rings/laurent_series_ring_element.pyx
@@ -161,18 +161,18 @@ cdef class LaurentSeries(AlgebraElement):
                 self.__u = parent._power_series_ring.zero()
             else:
                 self.__n = n
-                self.__u = f
+                self.__u = parent._power_series_ring(f)
         else:
             val = f.valuation()
             if val is infinity:
                 self.__n = 0
-                self.__u = f
+                self.__u = parent._power_series_ring(f)
             elif val == 0:
                 self.__n = n    # power of the variable
-                self.__u = f    # unit part
+                self.__u = parent._power_series_ring(f)    # unit part
             else:
                 self.__n = n + val
-                self.__u = f >> val
+                self.__u = parent._power_series_ring(f >> val)
 
     def __reduce__(self):
         return self._parent, (self.__u, self.__n)
@@ -1090,6 +1090,14 @@ cdef class LaurentSeries(AlgebraElement):
             t + t^2
             sage: (t+t^2).truncate_neg(-2)
             t + t^2
+
+        Check that :issue:`39842` is fixed::
+
+            sage: f = LaurentSeriesRing(QQ, "t")(LaurentPolynomialRing(QQ, "t")([1, 2, 3]))
+            sage: f
+            1 + 2*t + 3*t^2
+            sage: f.truncate_neg(1)
+            2*t + 3*t^2
         """
         return type(self)(self._parent, self.__u >> (n - self.__n), n)
 


### PR DESCRIPTION
Previous behavior:

```
sage: f = LaurentSeriesRing(QQ, "t")([1, 2, 3])
sage: f
1 + 2*t + 3*t^2
sage: f.truncate_neg(1)
2*t + 3*t^2
sage: f = LaurentSeriesRing(QQ, "t")(LaurentPolynomialRing(QQ, "t")([1, 2, 3]))
....: f
1 + 2*t + 3*t^2
sage: f.truncate_neg(1)
1 + 2*t + 3*t^2
```

Last line is obviously wrong.

This pull request fixes it.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


