### PR TITLE
Correctly passing kwargs in short_vectors

### DIFF
--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -1518,12 +1518,13 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
             [[(0, 0)], [], [(1, 1), (0, 1), (1, 0)]]
 
         TESTS::
-        
-            sage: A2 = IntegralLattice(IntegralLattice('A2').gram_matrix())             # needs sage.graphs
-            sage: A2.short_vectors(3)                                                   # needs sage.graphs sage.libs.pari
+
+        Check that keyword arguments are passed to :meth:`sage.quadratic_forms.short_vector_list_up_to_length`
+        (:issue:`39848`)::
+
+            sage: A2 = IntegralLattice('A2')                                            # needs sage.graphs
+            sage: A2.short_vectors(3, up_to_sign_flag=False)                            # needs sage.graphs sage.libs.pari
             [[(0, 0)], [], [(1, 1), (-1, -1), (0, 1), (0, -1), (1, 0), (-1, 0)]]
-            sage: A2.short_vectors(3, up_to_sign_flag=True)                             # needs sage.graphs sage.libs.pari
-            [[(0, 0)], [], [(1, 1), (0, 1), (1, 0)]]  
         """
         p, m = self.signature_pair()
         if p * m != 0:

--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -1516,6 +1516,14 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
             [[(0, 0)], [], [(1, 1), (-1, -1), (0, 1), (0, -1), (1, 0), (-1, 0)]]
             sage: A2.short_vectors(3, up_to_sign_flag=True)                             # needs sage.graphs sage.libs.pari
             [[(0, 0)], [], [(1, 1), (0, 1), (1, 0)]]
+
+        TESTS::
+        
+            sage: A2 = IntegralLattice(IntegralLattice('A2').gram_matrix())             # needs sage.graphs
+            sage: A2.short_vectors(3)                                                   # needs sage.graphs sage.libs.pari
+            [[(0, 0)], [], [(1, 1), (-1, -1), (0, 1), (0, -1), (1, 0), (-1, 0)]]
+            sage: A2.short_vectors(3, up_to_sign_flag=True)                             # needs sage.graphs sage.libs.pari
+            [[(0, 0)], [], [(1, 1), (0, 1), (1, 0)]]  
         """
         p, m = self.signature_pair()
         if p * m != 0:
@@ -1525,7 +1533,7 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
             e = -2
         from sage.quadratic_forms.quadratic_form import QuadraticForm
         q = QuadraticForm(e * self.gram_matrix())
-        short = q.short_vector_list_up_to_length(n, *kwargs)
+        short = q.short_vector_list_up_to_length(n, **kwargs)
         return [[self(v * self.basis_matrix()) for v in L] for L in short]
 
     def _fplll_enumerate(self, target=None):

--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -1517,7 +1517,7 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
             sage: A2.short_vectors(3, up_to_sign_flag=True)                             # needs sage.graphs sage.libs.pari
             [[(0, 0)], [], [(1, 1), (0, 1), (1, 0)]]
 
-        TESTS::
+        TESTS:
 
         Check that keyword arguments are passed to :meth:`sage.quadratic_forms.short_vector_list_up_to_length`
         (:issue:`39848`)::


### PR DESCRIPTION
This fixes the bug in that I tested for.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.



