### PR TITLE
correct the index type in Boost interface

### DIFF
--- a/src/sage/graphs/base/boost_interface.cpp
+++ b/src/sage/graphs/base/boost_interface.cpp
@@ -116,7 +116,7 @@ public:
         std::vector<std::pair<v_index, std::pair<v_index, double>>> to_return;
         typename boost::graph_traits<adjacency_list>::edge_iterator ei, ei_end;
         for (boost::tie(ei, ei_end) = boost::edges(graph); ei != ei_end; ++ei) {
-            to_return.push_back({index[boost::source(*ei, graph)],
+            to_return.push_back({static_cast<int>(index[boost::source(*ei, graph)]),
                                  {index[boost::target(*ei, graph)],
                                   get(boost::edge_weight, graph, *ei)}});
         }


### PR DESCRIPTION
without this fix, conda build of Sage 10.6 is failing; 
this is with clang 18.1.8

This was reported on https://groups.google.com/g/sage-devel/c/YSiaVdsLKQg/m/13mZHNErCAAJ,
but the cause wasn't identified correctly.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


