### PR TITLE
Handle empty matrices over univariate polynomials

### DIFF
--- a/src/sage/matrix/matrix_polynomial_dense.pyx
+++ b/src/sage/matrix/matrix_polynomial_dense.pyx
@@ -1567,7 +1567,7 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             ([1, -1, 0], [3, -1, 0])
 
         The leading positions and pivot degrees of an empty matrix (`0\times n`
-        or `m\times 0`) is not defined::
+        or `m\times 0`) are taken by convention as follows::
 
             sage: M = matrix(pR, 0, 3)
             sage: M.leading_positions(return_degree=True)

--- a/src/sage/matrix/matrix_polynomial_dense.pyx
+++ b/src/sage/matrix/matrix_polynomial_dense.pyx
@@ -151,7 +151,7 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             sage: M.degree()
             3
 
-        A zero matrix (including zero matrices) has degree ``-1``::
+        A zero matrix (including empty matrices) has degree ``-1``::
 
             sage: M = matrix(pR, 2, 3)
             sage: M.degree()

--- a/src/sage/matrix/matrix_polynomial_dense.pyx
+++ b/src/sage/matrix/matrix_polynomial_dense.pyx
@@ -1232,7 +1232,7 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             sage: M.column_degrees(shifts=[-2,1])
             [4, -3, -2]
 
-        The columns degrees of a column-empty matrix `m\times 0` is an empty
+        The column degrees of a column-empty matrix `m\times 0` is an empty
         list, while those of a row-empty matrix `0\times n` is a list of `n`
         times `-1`::
 

--- a/src/sage/matrix/matrix_polynomial_dense.pyx
+++ b/src/sage/matrix/matrix_polynomial_dense.pyx
@@ -1483,7 +1483,7 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
         """
         self._check_shift_dimension(shifts,row_wise)
         if self.ncols() == 0 or self.nrows() == 0:
-            return self._is_empty_popov(row_wise,include_zero_vectors)
+            return self._is_empty_popov(row_wise, include_zero_vectors)
         if include_zero_vectors:
             number_generators =                                           \
                 [self[i,:] != 0 for i in range(self.nrows())].count(True) \
@@ -1722,7 +1722,7 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
         """
         self._check_shift_dimension(shifts,row_wise)
         if self.ncols() == 0 or self.nrows() == 0:
-            return self._is_empty_popov(row_wise)
+            return self._is_empty_popov(row_wise, include_zero_vectors)
         leading_positions = self.leading_positions(shifts, row_wise)
         # here, because of the below sorting and of the convention that zero
         # rows (resp. columns) are at the bottom (resp. right) of the matrix in
@@ -1859,7 +1859,7 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
         # the matrix should be in weak Popov form (ordered except if
         # up_to_permutation==True)
         if self.ncols() == 0 or self.nrows() == 0:
-            return self._is_empty_popov(row_wise)
+            return self._is_empty_popov(row_wise, include_zero_vectors)
         if not self.is_weak_popov(shifts,
                                   row_wise,
                                   not up_to_permutation,

--- a/src/sage/matrix/matrix_polynomial_dense.pyx
+++ b/src/sage/matrix/matrix_polynomial_dense.pyx
@@ -4757,7 +4757,7 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
         # must have maximum entry at most min(shifts)
         # [see Lemma 4.2, Neiger-Vu, Computing Canonical Bases of Modules of
         # Univariate Relations, Proc. ISSAC 2017]
-        min_shift = 0 if len(shifts) == 0 else min(shifts)
+        min_shift = min(shifts, default=0)
         if row_wise:
             extended_shifts = [s - min_shift for s in shifts] + [0]*n
         else:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
Fixes #39587

Adds handling of empty matrices over univariate polynomials, specifically in the following methods:

- degree() (returns -1)
- constant_matrix()
- inverse_series_trunc()
- solve_left_series_trunc()
- row_degrees() ([] if no rows, [-1, ..., -1] if no columns)
- column_degrees() (vice versa)
- is_hermite() (defaults to _is_empty_popov())
- weak_popov_form()
- right_quo_rem()
- _right_quo_rem_reduced()
- minimal_relation_basis()

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.