### PR TITLE
Run long test in test-new

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -123,7 +123,7 @@ jobs:
           # If editable then deleting the directory will cause sage to detect rebuild, which will cause ninja to fail
           # so we don't delete the directory in this case
           ${{ matrix.editable && 'true' || 'rm -R ./src/sage_setup/' }}
-          ./sage -t --${{ matrix.tests }} -p4 --format github
+          ./sage -t ${{ matrix.tests == 'all' && '--all' || '--new --long' }} -p4 --format github
 
       - name: Check that all modules can be imported
         shell: bash -l {0}


### PR DESCRIPTION
https://github.com/sagemath/sage/pull/39641 introduced an issue that long new tests are not ran in test-new.

This is an issue because then the author is only notified by the failure when test-long finishes. (e.g. happened to me in https://github.com/sagemath/sage/pull/39733/ .)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


