### PR TITLE
Update isometries.py

### DIFF
--- a/src/sage/groups/matrix_gps/isometries.py
+++ b/src/sage/groups/matrix_gps/isometries.py
@@ -256,7 +256,7 @@ class GroupOfIsometries(FinitelyGeneratedMatrixGroup_gap):
             TypeError: matrix must be orthogonal with respect to the invariant form
         """
         F = self.invariant_bilinear_form()
-        if x * F * x.transpose() != F:
+        if x.transpose() * F * x != F:
             raise TypeError('matrix must be orthogonal '
                 'with respect to the invariant form')
 


### PR DESCRIPTION
Proposed change so that the convention here agrees with usual matrix multiplication, acting on vectors from the left (as opposed to from the right.)

A small toy example that illustrates the current state of things:

```python
A2 = IntegralLattice("A2")
a1, a2 = A2.gens()
b = lambda x,y: x * A2.gram_matrix() * y

OA2 = A2.orthogonal_group()

[ b(a1, a1) == b(x.matrix()*a1, x.matrix()*a1) for x in OA2 ]
# [True, True, False, True, True, False, True, True, False, True, True, False]

[ b(a1, a1) == b(x.matrix().T*a1, x.matrix().T*a1) for x in OA2 ]
# [True, True, True, True, True, True, True, True, True, True, True, True]

[ b(a1, a1) == b(a1 * x.matrix(), a1 * x.matrix()) for x in OA2]
# [True, True, True, True, True, True, True, True, True, True, True, True]

```

