### PR TITLE
Add warning in LazyPowerSeriesRing.taylor() documentation

### DIFF
--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -3038,15 +3038,15 @@ class LazyPowerSeriesRing(LazySeriesRing):
 
         .. WARNING::
             
-            For inputs with precision greater than the default, this does not check
-            that the function is well-defined in the base ring::
+            :issue:`39838` For inputs with precision greater than the default, 
+            this does not check that the function is well-defined in the base ring::
 
                 sage: LazyPowerSeriesRing(QQ, "x").taylor(sqrt(2)*x^100)
                 O(x^7)
                 sage: LazyPowerSeriesRing(QQ, "x").taylor(sqrt(2)*x^100).add_bigoh(101)
                 Traceback (most recent call last)
                 ...
-                TypeError: unable to convert sqrt(2) to a rational
+                TypeError: self must be a numeric expression
 
         EXAMPLES::
 

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -3038,8 +3038,8 @@ class LazyPowerSeriesRing(LazySeriesRing):
 
         .. WARNING::
             
-            :issue:`39838` For inputs with precision greater than the default, 
-            this does not check that the function is well-defined in the base ring::
+            For inputs with precision greater than the default, 
+            this does not check that the function is well-defined in the base ring (:issue:`39838`)::
 
                 sage: LazyPowerSeriesRing(QQ, "x").taylor(sqrt(2)*x^100)
                 O(x^7)

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -3036,6 +3036,18 @@ class LazyPowerSeriesRing(LazySeriesRing):
             For inputs as symbolic functions/expressions, this does not check
             that the function does not have poles at `0`.
 
+        .. WARNING::
+            
+            For inputs with precision greater than the default, this does not check
+            that the function is well-defined in the base ring::
+
+                sage: LazyPowerSeriesRing(QQ, "x").taylor(sqrt(2)*x^100)
+                O(x^7)
+                sage: LazyPowerSeriesRing(QQ, "x").taylor(sqrt(2)*x^100).add_bigoh(101)
+                Traceback (most recent call last)
+                ...
+                TypeError: unable to convert sqrt(2) to a rational
+
         EXAMPLES::
 
             sage: L.<z> = LazyPowerSeriesRing(QQ)

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -3044,9 +3044,9 @@ class LazyPowerSeriesRing(LazySeriesRing):
                 sage: LazyPowerSeriesRing(QQ, "x").taylor(sqrt(2)*x^100)
                 O(x^7)
                 sage: LazyPowerSeriesRing(QQ, "x").taylor(sqrt(2)*x^100).add_bigoh(101)
-                Traceback (most recent call last)
+                Traceback (most recent call last):
                 ...
-                TypeError: self must be a numeric expression
+                TypeError: unable to convert sqrt(2) to a rational
 
         EXAMPLES::
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
part 1 of #39838 
As the title says, adds another warning in the LazyPowerSeriesRing.taylor() documentation

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


