### PR TITLE
fix issue 39864 in `src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx`

### DIFF
--- a/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
+++ b/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
@@ -978,6 +978,8 @@ cdef int everywhere_locally_soluble(mpz_t a, mpz_t b, mpz_t c, mpz_t d, mpz_t e)
 
     # Odd finite primes
     Delta = f.discriminant()
+    if not Delta:
+        raise ValueError("the curve is singular, Delta is zero")
     for p in prime_divisors(Delta):
         if p == 2:
             continue
@@ -1002,6 +1004,15 @@ def test_els(a, b, c, d, e):
         ....:                 print("This never happened", a, b, c, d, e)
         ....:         except ValueError:
         ....:             continue
+
+    TESTS:
+
+    Check that :issue:`39864` is fixed::
+
+        sage: test_els(194, 617, 846, 617, 194)
+        Traceback (most recent call last):
+        ...
+        ValueError: the curve is singular, Delta is zero
     """
     cdef Integer A, B, C, D, E
     A = Integer(a)


### PR DESCRIPTION
Fixes #39864.

As suggested in https://github.com/sagemath/sage/issues/39864#issuecomment-2779072090, we add a test in method `everywhere_locally_soluble` to raise a ValueError when needed.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


