### PR TITLE
Speed up binomial

### DIFF
--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -3959,7 +3959,7 @@ def binomial(x, m, **kwds):
     P = parent(x)
     x = py_scalar_to_element(x)
 
-    # case 1: native binomial implemented on x
+    # case 1: native binomial implemented on x (see also dont_call_method_on_arg)
     try:
         return P(x.binomial(m, **kwds))
     except (AttributeError, TypeError):

--- a/src/sage/functions/other.py
+++ b/src/sage/functions/other.py
@@ -1715,6 +1715,17 @@ class Function_binomial(GinacFunction):
         from sage.misc.misc_c import prod
         return prod(n - i for i in range(k)) / factorial(k)
 
+    def _method_arguments(self, n, k):
+        """
+        See :meth:`sage.symbolic.function.BuiltinFunction._method_arguments`.
+
+        TESTS::
+
+            sage: binomial._method_arguments(10, 5)
+            (10, 5)
+        """
+        return (n, k)
+
     def _eval_(self, n, k):
         """
         EXAMPLES::

--- a/src/sage/functions/transcendental.py
+++ b/src/sage/functions/transcendental.py
@@ -390,7 +390,7 @@ class Function_zetaderiv(GinacFunction):
         """
         return _mpmath_utils_call(_mpmath_zeta, x, 1, n, parent=parent)
 
-    def _method_arguments(self, k, x, **args):
+    def _method_arguments(self, k, x):
         r"""
         TESTS::
 

--- a/src/sage/symbolic/function.pxd
+++ b/src/sage/symbolic/function.pxd
@@ -12,7 +12,7 @@ cdef class Function(SageObject):
     cdef _register_function(self)
 
 cdef class BuiltinFunction(Function):
-    cdef object _preserved_arg
+    cdef int _preserved_arg  # 0 if none, otherwise in [1.._nargs], see function.pyx
     cdef _is_registered(self)
 
 cdef class GinacFunction(BuiltinFunction):

--- a/src/sage/symbolic/function.pxd
+++ b/src/sage/symbolic/function.pxd
@@ -3,9 +3,9 @@ from sage.structure.sage_object cimport SageObject
 cdef class Function(SageObject):
     cdef unsigned int _serial
     cdef int _nargs
-    cdef object _name
-    cdef object _alt_name
-    cdef object _latex_name
+    cdef str _name
+    cdef str _alt_name
+    cdef str _latex_name
     cdef object _conversions
     cdef object _evalf_params_first
     cdef _is_registered(self)
@@ -16,7 +16,7 @@ cdef class BuiltinFunction(Function):
     cdef _is_registered(self)
 
 cdef class GinacFunction(BuiltinFunction):
-    cdef object _ginac_name
+    cdef str _ginac_name
     cdef _is_registered(self)
     cdef _register_function(self)
 

--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -157,6 +157,7 @@ try:
 except ImportError:
     register_or_update_function = None
 
+cdef object SR = None, PolynomialRing_commutative = None, MPolynomialRing_polydict_domain = None
 
 # List of functions which ginac allows us to define custom behavior for.
 # Changing the order of this list could cause problems unpickling old pickles.
@@ -1057,11 +1058,15 @@ cdef class BuiltinFunction(Function):
             if (self._preserved_arg
                     and isinstance(args[self._preserved_arg-1], Element)):
                 arg_parent = parent(args[self._preserved_arg-1])
-                from sage.symbolic.ring import SR
+                global SR
+                if SR is None:
+                    from sage.symbolic.ring import SR
                 if arg_parent is SR:
                     return res
-                from sage.rings.polynomial.polynomial_ring import PolynomialRing_commutative
-                from sage.rings.polynomial.multi_polynomial_ring import MPolynomialRing_polydict_domain
+                global PolynomialRing_commutative, MPolynomialRing_polydict_domain
+                if PolynomialRing_commutative is None:
+                    from sage.rings.polynomial.polynomial_ring import PolynomialRing_commutative
+                    from sage.rings.polynomial.multi_polynomial_ring import MPolynomialRing_polydict_domain
                 if isinstance(arg_parent, (PolynomialRing_commutative,
                                            MPolynomialRing_polydict_domain)):
                     try:

--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -141,6 +141,7 @@ from sage.structure.sage_object cimport SageObject
 from sage.structure.element cimport Element, parent, Expression
 from sage.misc.lazy_attribute import lazy_attribute
 
+from sage.structure.parent cimport Parent
 from sage.structure.coerce cimport (coercion_model,
         py_scalar_to_element, is_numpy_type, is_mpmath_type)
 from sage.structure.richcmp cimport richcmp
@@ -1054,6 +1055,7 @@ cdef class BuiltinFunction(Function):
                 res = super().__call__(
                         *args, coerce=coerce, hold=hold)
 
+        cdef Parent arg_parent
         if any(isinstance(x, Element) for x in args):
             if (self._preserved_arg
                     and isinstance(args[self._preserved_arg-1], Element)):


### PR DESCRIPTION
As first observed in https://github.com/sagemath/sage/pull/39379, when `n` and `k` are small sage integers, `binomial(n, k)` are much slower than `n.binomial(k)`.

This pull request fixes it. Now `%timeit binomial(20, 10)` is only twice slower than `%timeit 20.binomial(10)` — previously it was **30** times slower.

There's also a minor patch where some code is skipped when all arguments are instances of `Element`. It is certainly a more common case for the input to be `Element` than otherwise, so we optimize for it.

Another minor patch involves storing imported modules as C global variables instead of re-import every time.

I think using not-overriding `_method_arguments` as an indicator of "don't call the method"
(then silently catch `TypeError` and throw it away) is rather bad design,
but this is not in scope here.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

