### PR TITLE
Fix typo in quaternion algebra docstring

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -121,7 +121,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
       number field or `\QQ`, ``primes`` is a list of prime ideals of `K`
       and ``inv_archimedean`` is a list of local invariants (`0` or
       `\frac{1}{2}`) specifying the ramification at the (infinite) real
-      places of `K`. This constructs a quaternion algebra ramified exacly
+      places of `K`. This constructs a quaternion algebra ramified exactly
       at the places given by ``primes`` and those (algebraic) real
       embeddings of `K` indexed in ``K.embeddings(AA)`` by ``l`` with
       ``inv_archimedean[l] = 1/2``.


### PR DESCRIPTION
Fix typo in quaternion algebra docstring

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


