### PR TITLE
cli: remove default from -n argument

### DIFF
--- a/src/sage/cli/notebook_cmd.py
+++ b/src/sage/cli/notebook_cmd.py
@@ -23,7 +23,6 @@ class JupyterNotebookCmd:
             nargs="?",
             const="jupyter",
             choices=["jupyter", "jupyterlab"],
-            default="jupyter",
             help="start the Jupyter notebook server (default: jupyter)",
         )
 


### PR DESCRIPTION
Without this, calling any command line argument (currently only `sage -v`) will launch the notebook, because `args.notebook` evaluates to `True` in https://github.com/sagemath/sage/blob/10.7.beta0/src/sage/cli/__init__.py#L42

The `const` option already takes care of providing a default value for `-n`. 

