### PR TITLE
Add --quiet and --simple-prompt command line arguments

### DIFF
--- a/src/sage/cli/__init__.py
+++ b/src/sage/cli/__init__.py
@@ -24,6 +24,19 @@ def main() -> int:
         default=False,
         help="print additional information",
     )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="do not display the banner",
+    )
+    parser.add_argument(
+        "--simple-prompt",
+        action="store_true",
+        default=False,
+        help="use simple prompt IPython mode",
+    )
 
     VersionCmd.extend_parser(parser)
     JupyterNotebookCmd.extend_parser(parser)

--- a/src/sage/cli/interactive_shell_cmd.py
+++ b/src/sage/cli/interactive_shell_cmd.py
@@ -14,12 +14,15 @@ class InteractiveShellCmd:
         """
         # Display startup banner. Do this before anything else to give the user
         # early feedback that Sage is starting.
-        from sage.misc.banner import banner
-
-        banner()
+        if not self.options.quiet:
+            from sage.misc.banner import banner
+            banner()
 
         from sage.repl.interpreter import SageTerminalApp
 
         app = SageTerminalApp.instance()
+        if self.options.simple_prompt:
+            app.config['InteractiveShell']['simple_prompt'] = True
+            app.config['InteractiveShell']['colors'] = 'nocolor'
         app.initialize([])
         return app.start()  # type: ignore

--- a/src/sage/cli/options.py
+++ b/src/sage/cli/options.py
@@ -10,6 +10,12 @@ class CliOptions:
     """Indicates whether verbose output is enabled."""
     verbose: bool = False
 
+    """Indicates whether the banner should be displayed."""
+    quiet: bool = False
+
+    """Indicates whether the IPython simple prompt should be used."""
+    simple_prompt: bool = False
+
     """The notebook type to start."""
     notebook: str = "jupyter"
 


### PR DESCRIPTION
These are required by some third-party UIs, such as:

- emacs sage-mode https://github.com/sagemath/sage-shell-mode/blob/4291700e981a2105d55fa56382ba25046d3d268d/sage-shell-mode.el#L204
- KDE cantor https://invent.kde.org/education/cantor/-/blob/v25.04.0/src/backends/sage/sagesession.cpp?ref_type=tags#L118


