### PR TITLE
Fix error in exception handling code of gap interface

### DIFF
--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -670,6 +670,15 @@ class Gap_generic(ExtraTabCompletion, Expect):
             Restarting Gap and trying again
             sage: a
             3
+
+        Checks for :issue:`39906`::
+
+            sage: gap("a"*200)
+            Traceback (most recent call last):
+            ...
+            TypeError: Gap terminated unexpectedly while reading in a large line:
+            Gap produced error output
+            Error, Variable: 'aaaa...aaaa' must have a value executing Read("...");
         """
         expect_eof = self._quit_string() in line
 
@@ -728,7 +737,7 @@ class Gap_generic(ExtraTabCompletion, Expect):
                 else:
                     return ''
             else:
-                raise RuntimeError(exc)
+                raise exc
 
         except KeyboardInterrupt:
             self._keyboard_interrupt()


### PR DESCRIPTION
Previously the (newly-added) test would raise

```
    TypeError: argument of type 'RuntimeError' is not iterable
```

instead, because `RuntimeError(exc)` will create an object that is `RuntimeError(RuntimeError('Gap produced error output...'))` instead, and later there is a check that is `if "Input/output error" in msg.args[0]:` which would fail if `msg.args[0]` is not a string.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


