### PR TITLE
cli: Add -V alias for --version

### DIFF
--- a/src/sage/cli/version_cmd.py
+++ b/src/sage/cli/version_cmd.py
@@ -18,6 +18,7 @@ class VersionCmd:
         - the extended parser.
         """
         parser.add_argument(
+            "-V",
             "--version",
             action="version",
             version=version,


### PR DESCRIPTION
This is quite common in Python world:

```
$> python -V
Python 3.13.2
$> ipython -V
9.0.2
$> cython -V
Cython version 3.0.12
```