### PR TITLE
add parameter immutable to GraphQuery `src/sage/graphs/graph_database.py`

### DIFF
--- a/src/sage/graphs/graph_database.py
+++ b/src/sage/graphs/graph_database.py
@@ -320,8 +320,9 @@ class GenericGraphQuery(SQLQuery):
 
 class GraphQuery(GenericGraphQuery):
 
-    def __init__(self, graph_db=None, query_dict=None, display_cols=None, **kwds):
-        """
+    def __init__(self, graph_db=None, query_dict=None, display_cols=None,
+                 immutable=False, **kwds):
+        r"""
         A query for an instance of :class:`~GraphDatabase`.
 
         This class nicely wraps the :class:`sage.databases.sql_db.SQLQuery`
@@ -351,6 +352,9 @@ class GraphQuery(GenericGraphQuery):
         - ``display_cols`` -- list of strings (default: ``None``); a list of
           column names (strings) to display in the result when running or
           showing a query
+
+        - ``immutable`` -- boolean (default: ``False``); whether to return
+          immutable or mutable graphs
 
         - ``kwds`` -- the columns of the database are all keywords. For a
           database table/column structure dictionary, call
@@ -413,7 +417,17 @@ class GraphQuery(GenericGraphQuery):
             F_?@w                7                    [1, 1, 1, 1, 1, 1, 4]
             F_?Hg                7                    [1, 1, 1, 1, 1, 2, 3]
             F_?XO                7                    [1, 1, 1, 1, 2, 2, 2]
+
+        Check the behavior of parameter ``immutable``::
+
+            sage: Q = GraphQuery(display_cols=['graph6'], num_vertices=3)
+            sage: any(g.is_immutable() for g in Q)
+            False
+            sage: Q = GraphQuery(display_cols=['graph6'], num_vertices=3, immutable=True)
+            sage: all(g.is_immutable() for g in Q)
+            True
         """
+        self._immutable = immutable
         if graph_db is None:
             graph_db = GraphDatabase()
         if query_dict is not None:
@@ -534,9 +548,15 @@ class GraphQuery(GenericGraphQuery):
                                                self.__query_string__)
                 self.__query_string__ += ' ORDER BY graph_data.graph6'
 
-    def query_iterator(self):
+    def query_iterator(self, immutable=None):
         """
         Return an iterator over the results list of the :class:`~GraphQuery`.
+
+        INPUT:
+
+        - ``immutable`` -- boolean (default: ``None``); whether to create
+          mutable/immutable graphs. By default (``immutable=None``), follow the
+          behavior of ``self``.
 
         EXAMPLES::
 
@@ -566,8 +586,27 @@ class GraphQuery(GenericGraphQuery):
             FEOhW
             FGC{o
             FIAHo
+
+        Check the behavior of parameter ``immutable``::
+
+            sage: Q = GraphQuery(display_cols=['graph6'], num_vertices=3)
+            sage: any(g.is_immutable() for g in Q.query_iterator())
+            False
+            sage: all(g.is_immutable() for g in Q.query_iterator(immutable=True))
+            True
+            sage: Q = GraphQuery(display_cols=['graph6'], num_vertices=3, immutable=True)
+            sage: all(g.is_immutable() for g in Q.query_iterator())
+            True
+            sage: any(g.is_immutable() for g in Q.query_iterator(immutable=False))
+            False
         """
-        return iter(self.get_graphs_list())
+        if immutable is None:
+            immutable = self._immutable
+        s = self.__query_string__
+        re.sub('SELECT.*FROM ', 'SELECT graph6 FROM ', s)
+        q = GenericGraphQuery(s, self.__database__, self.__param_tuple__)
+        for g in q.query_results():
+            yield Graph(str(g[0]), immutable=immutable)
 
     __iter__ = query_iterator
 
@@ -687,9 +726,15 @@ class GraphQuery(GenericGraphQuery):
                           format_cols=format_cols, relabel_cols=relabel,
                           id_col='graph6')
 
-    def get_graphs_list(self):
+    def get_graphs_list(self, immutable=None):
         """
         Return a list of Sage Graph objects that satisfy the query.
+
+        INPUT:
+
+        - ``immutable`` -- boolean (default: ``None``); whether to create
+          mutable/immutable graphs. By default (``immutable=None``), follow the
+          behavior of ``self``.
 
         EXAMPLES::
 
@@ -699,12 +744,23 @@ class GraphQuery(GenericGraphQuery):
             Graph on 2 vertices
             sage: len(L)
             35
+
+        Check the behavior of parameter ``immutable``::
+
+            sage: Q = GraphQuery(display_cols=['graph6'], num_vertices=3)
+            sage: any(g.is_immutable() for g in Q.get_graphs_list())
+            False
+            sage: all(g.is_immutable() for g in Q.get_graphs_list(immutable=True))
+            True
+            sage: Q = GraphQuery(display_cols=['graph6'], num_vertices=3, immutable=True)
+            sage: all(g.is_immutable() for g in Q.get_graphs_list())
+            True
+            sage: any(g.is_immutable() for g in Q.get_graphs_list(immutable=False))
+            False
         """
-        s = self.__query_string__
-        re.sub('SELECT.*FROM ', 'SELECT graph6 FROM ', s)
-        q = GenericGraphQuery(s, self.__database__, self.__param_tuple__)
-        graph6_list = q.query_results()
-        return [Graph(str(g[0])) for g in graph6_list]
+        if immutable is None:
+            immutable = self._immutable
+        return list(self.query_iterator(immutable=immutable))
 
     def number_of(self):
         """


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs when querying the graph database.

We also exchange some code between methods `query_iterator` and `get_graphs_list` to avoid the creation of a list when we only want to iterate over the answers.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


