### PR TITLE
Adding the methods polredbest/polredabs to a numberfield

### DIFF
--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -2659,13 +2659,13 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
         EXAMPLES::
 
             sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
-            sage: NumberField(f, 'a').polred(polredabs=True, isomorphism_map=True)
+            sage: NumberField(f, 'a')._polred(polredabs=True, isomorphism_map=True)
             (Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26,
              Ring morphism:
                From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
                To:   Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26
                Defn: a |--> 1/3*a^2 + 35/3)
-            sage: NumberField(f, 'a').polred(polredabs=False, isomorphism_map=True)
+            sage: NumberField(f, 'a')._polred(polredabs=False, isomorphism_map=True)
             (Number Field in a with defining polynomial x^3 - 46*x - 123,
              Ring morphism:
                From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -2642,7 +2642,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
     @cached_method
     def _polred(self, names=None, polredabs=False, isomorphism_map=False):
         r"""
-        Return ``self`` as an absolute number field defined by a polynomial with
+        Return ``self`` as an absolute number field defined by a monic polynomial with
         with reasonably small coefficients by calling PARI ``polredbest`` (or ``polredabs``)
         and optionally the isomorphism map
 
@@ -2684,7 +2684,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
 
     def polredbest(self, names=None, isomorphism_map=False):
         """
-        Return ``self`` as an absolute number field defined by a polynomial with
+        Return ``self`` as an absolute number field defined by a monic polynomial with
         with reasonably small coefficients, by calling PARI ``polredbest``,
         and optionally the isomorphism map
 
@@ -2711,7 +2711,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
 
     def polredabs(self, names=None, isomorphism_map=False):
         """
-        Returns ``self`` as an absolute number field defined by canonical polynomial,
+        Returns ``self`` as an absolute number field defined by canonical monic polynomial,
         such that the sum of the squares of the of the roots is minimal,
         by calling PARI ``polredabs``, and optionally the isomorphism map
 

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -8672,7 +8672,7 @@ class NumberField_absolute(NumberField_generic):
         return K, from_K
 
     @cached_method
-    def _polred(self, names=None, algorithm='polredbest', isomorphism_map=False):
+    def _polred(self, names=None, algorithm='polredbest', map=False):
         r"""
         Return ``self`` as an absolute number field defined by a monic polynomial
         with reasonably small coefficients, computed by PARI's ``polredbest`` or
@@ -8683,25 +8683,25 @@ class NumberField_absolute(NumberField_generic):
         - ``names`` -- string (default: ``self._names``); name of generator of the absolute field
         - ``algorithm`` -- one of ``'polredbest'`` (default) or ``'polredabs'``;
           the PARI function to use
-        - ``isomorphism_map`` -- boolean (default: ``False``); whether to also
+        - ``map`` -- boolean (default: ``False``); whether to also
           return the isomorphism from ``self`` to the new field
 
         OUTPUT:
 
         An absolute number field isomorphic to ``self`` defined by a reduced
-        polynomial. If ``isomorphism_map`` is ``True``, a tuple of this field
+        polynomial. If ``map`` is ``True``, a tuple of this field
         and the isomorphism from ``self`` to it is returned instead.
 
         EXAMPLES::
 
             sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
-            sage: NumberField(f, 'a')._polred(algorithm='polredabs', isomorphism_map=True)
+            sage: NumberField(f, 'a')._polred(algorithm='polredabs', map=True)
             (Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26,
              Ring morphism:
                From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
                To:   Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26
                Defn: a |--> 1/3*a^2 + 35/3)
-            sage: NumberField(f, 'a')._polred(algorithm='polredbest', isomorphism_map=True)
+            sage: NumberField(f, 'a')._polred(algorithm='polredbest', map=True)
             (Number Field in a with defining polynomial x^3 - 46*x - 123,
              Ring morphism:
                From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
@@ -8716,11 +8716,11 @@ class NumberField_absolute(NumberField_generic):
         t = f.polredabs(flag=1) if algorithm == 'polredabs' else f.polredbest(flag=1)
         R = self.polynomial_ring()
         K = NumberField(R(t[0]), names)
-        if not isomorphism_map:
+        if not map:
             return K
         return K, self.hom([K(t[1])], check=False)
 
-    def polredbest(self, names=None, isomorphism_map=False):
+    def polredbest(self, names=None, map=False):
         r"""
         Return ``self`` as an absolute number field defined by a monic polynomial
         with reasonably small coefficients, computed by PARI's ``polredbest``,
@@ -8729,13 +8729,13 @@ class NumberField_absolute(NumberField_generic):
         INPUT:
 
         - ``names`` -- string (default: ``self._names``); name of generator of the absolute field
-        - ``isomorphism_map`` -- boolean (default: ``False``); whether to also
+        - ``map`` -- boolean (default: ``False``); whether to also
           return the isomorphism from ``self`` to the new field
 
         OUTPUT:
 
         An absolute number field isomorphic to ``self`` with reduced defining
-        polynomial. If ``isomorphism_map`` is ``True``, a tuple of this field
+        polynomial. If ``map`` is ``True``, a tuple of this field
         and the isomorphism from ``self`` to it is returned instead.
 
         .. SEEALSO::
@@ -8747,16 +8747,16 @@ class NumberField_absolute(NumberField_generic):
             sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
             sage: NumberField(f, 'a').polredbest()
             Number Field in a with defining polynomial x^3 - 46*x - 123
-            sage: NumberField(f, 'a').polredbest(isomorphism_map=True)
+            sage: NumberField(f, 'a').polredbest(map=True)
             (Number Field in a with defining polynomial x^3 - 46*x - 123,
              Ring morphism:
                From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
                To:   Number Field in a with defining polynomial x^3 - 46*x - 123
                Defn: a |--> a + 4)
         """
-        return self._polred(names=names, algorithm='polredbest', isomorphism_map=isomorphism_map)
+        return self._polred(names=names, algorithm='polredbest', map=map)
 
-    def polredabs(self, names=None, isomorphism_map=False):
+    def polredabs(self, names=None, map=False):
         r"""
         Return ``self`` as an absolute number field defined by the canonical
         monic polynomial minimizing the sum of squares of the roots, computed
@@ -8765,13 +8765,13 @@ class NumberField_absolute(NumberField_generic):
         INPUT:
 
         - ``names`` -- string (default: ``self._names``); name of generator of the absolute field
-        - ``isomorphism_map`` -- boolean (default: ``False``); whether to also
+        - ``map`` -- boolean (default: ``False``); whether to also
           return the isomorphism from ``self`` to the new field
 
         OUTPUT:
 
         An absolute number field isomorphic to ``self`` defined by the
-        canonical reduced polynomial. If ``isomorphism_map`` is ``True``,
+        canonical reduced polynomial. If ``map`` is ``True``,
         a tuple of this field and the isomorphism from ``self`` to it is
         returned instead.
 
@@ -8784,7 +8784,7 @@ class NumberField_absolute(NumberField_generic):
             sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
             sage: NumberField(f, 'a').polredabs()
             Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26
-            sage: NumberField(f, 'a').polredabs(isomorphism_map=True)
+            sage: NumberField(f, 'a').polredabs(map=True)
             (Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26,
              Ring morphism:
                From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
@@ -8800,10 +8800,10 @@ class NumberField_absolute(NumberField_generic):
             sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
             sage: K.<a> = NumberField(f)
             sage: for alg in ('polredbest', 'polredabs'):
-            ....:     L, phi = K._polred(algorithm=alg, isomorphism_map=True)
+            ....:     L, phi = K._polred(algorithm=alg, map=True)
             ....:     assert K.defining_polynomial()(phi(a)) == 0
         """
-        return self._polred(names=names, algorithm='polredabs', isomorphism_map=isomorphism_map)
+        return self._polred(names=names, algorithm='polredabs', map=map)
 
     def optimized_subfields(self, degree=0, name=None, both_maps=True):
         """

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -8539,11 +8539,22 @@ class NumberField_absolute(NumberField_generic):
         """
         return self.gen()
 
-    def optimized_representation(self, name=None, both_maps=True):
+    def optimized_representation(self, name=None, both_maps=True, algorithm='polredbest'):
         r"""
         Return a field isomorphic to ``self`` with a better defining polynomial
         if possible, along with field isomorphisms from the new field to
         ``self`` and from ``self`` to the new field.
+
+        INPUT:
+
+        - ``name`` -- string (default: ``None``); name of generator of the new
+          field. If ``None``, uses the generator name of ``self`` with a ``1``
+          appended.
+        - ``both_maps`` -- boolean (default: ``True``); whether to return both
+          isomorphisms or only the map from the new field to ``self``
+        - ``algorithm`` -- one of ``'polredbest'`` (default) or ``'polredabs'``;
+          the PARI function used to reduce the defining polynomial. See
+          :meth:`polredbest` and :meth:`polredabs`.
 
         EXAMPLES: We construct a compositum of 3 quadratic fields, then
         find an optimized representation and transform elements back and
@@ -8570,6 +8581,14 @@ class NumberField_absolute(NumberField_generic):
             True
             sage: to_L(from_L(L.0)) == L.0
             True
+
+        Selecting the ``polredabs`` algorithm gives the canonical reduced
+        polynomial::
+
+            sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
+            sage: K.<a> = NumberField(f)
+            sage: K.optimized_representation(algorithm='polredabs', both_maps=False)[0]
+            Number Field in a1 with defining polynomial x^3 - x^2 + 35*x - 26
 
         Number fields defined by non-monic and non-integral
         polynomials are supported (:issue:`252`)::
@@ -8606,14 +8625,27 @@ class NumberField_absolute(NumberField_generic):
             True
             sage: M1(M2(a)) == a
             True
+
+        An invalid algorithm raises an error::
+
+            sage: K.<a> = NumberField(x^2 + 1)
+            sage: K.optimized_representation(algorithm='bogus')
+            Traceback (most recent call last):
+            ...
+            ValueError: algorithm must be 'polredbest' or 'polredabs'
         """
+        if algorithm not in ('polredbest', 'polredabs'):
+            raise ValueError("algorithm must be 'polredbest' or 'polredabs'")
         if name is None:
             name = self.variable_names()
         name = normalize_names(1, name)[0]
 
         f = self.absolute_polynomial().__pari__()
 
-        g, alpha = f.polredbest(flag=1)
+        if algorithm == 'polredabs':
+            g, alpha = f.polredabs(flag=1)
+        else:
+            g, alpha = f.polredbest(flag=1)
         beta = alpha.modreverse()
 
         b = self(QQ['x'](lift(beta)))
@@ -8638,6 +8670,140 @@ class NumberField_absolute(NumberField_generic):
             return K, from_K, to_K
 
         return K, from_K
+
+    @cached_method
+    def _polred(self, names=None, algorithm='polredbest', isomorphism_map=False):
+        r"""
+        Return ``self`` as an absolute number field defined by a monic polynomial
+        with reasonably small coefficients, computed by PARI's ``polredbest`` or
+        ``polredabs``, and optionally the isomorphism map.
+
+        INPUT:
+
+        - ``names`` -- string (default: ``self._names``); name of generator of the absolute field
+        - ``algorithm`` -- one of ``'polredbest'`` (default) or ``'polredabs'``;
+          the PARI function to use
+        - ``isomorphism_map`` -- boolean (default: ``False``); whether to also
+          return the isomorphism from ``self`` to the new field
+
+        OUTPUT:
+
+        An absolute number field isomorphic to ``self`` defined by a reduced
+        polynomial. If ``isomorphism_map`` is ``True``, a tuple of this field
+        and the isomorphism from ``self`` to it is returned instead.
+
+        EXAMPLES::
+
+            sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
+            sage: NumberField(f, 'a')._polred(algorithm='polredabs', isomorphism_map=True)
+            (Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26,
+             Ring morphism:
+               From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
+               To:   Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26
+               Defn: a |--> 1/3*a^2 + 35/3)
+            sage: NumberField(f, 'a')._polred(algorithm='polredbest', isomorphism_map=True)
+            (Number Field in a with defining polynomial x^3 - 46*x - 123,
+             Ring morphism:
+               From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
+               To:   Number Field in a with defining polynomial x^3 - 46*x - 123
+               Defn: a |--> a + 4)
+        """
+        if algorithm not in ('polredbest', 'polredabs'):
+            raise ValueError("algorithm must be 'polredbest' or 'polredabs'")
+        if names is None:
+            names = self._names
+        f = self.defining_polynomial()._pari_with_name()
+        t = f.polredabs(flag=1) if algorithm == 'polredabs' else f.polredbest(flag=1)
+        R = self.polynomial_ring()
+        K = NumberField(R(t[0]), names)
+        if not isomorphism_map:
+            return K
+        return K, self.hom([K(t[1])], check=False)
+
+    def polredbest(self, names=None, isomorphism_map=False):
+        r"""
+        Return ``self`` as an absolute number field defined by a monic polynomial
+        with reasonably small coefficients, computed by PARI's ``polredbest``,
+        and optionally the isomorphism map.
+
+        INPUT:
+
+        - ``names`` -- string (default: ``self._names``); name of generator of the absolute field
+        - ``isomorphism_map`` -- boolean (default: ``False``); whether to also
+          return the isomorphism from ``self`` to the new field
+
+        OUTPUT:
+
+        An absolute number field isomorphic to ``self`` with reduced defining
+        polynomial. If ``isomorphism_map`` is ``True``, a tuple of this field
+        and the isomorphism from ``self`` to it is returned instead.
+
+        .. SEEALSO::
+
+            :meth:`polredabs`, :meth:`optimized_representation`
+
+        EXAMPLES::
+
+            sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
+            sage: NumberField(f, 'a').polredbest()
+            Number Field in a with defining polynomial x^3 - 46*x - 123
+            sage: NumberField(f, 'a').polredbest(isomorphism_map=True)
+            (Number Field in a with defining polynomial x^3 - 46*x - 123,
+             Ring morphism:
+               From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
+               To:   Number Field in a with defining polynomial x^3 - 46*x - 123
+               Defn: a |--> a + 4)
+        """
+        return self._polred(names=names, algorithm='polredbest', isomorphism_map=isomorphism_map)
+
+    def polredabs(self, names=None, isomorphism_map=False):
+        r"""
+        Return ``self`` as an absolute number field defined by the canonical
+        monic polynomial minimizing the sum of squares of the roots, computed
+        by PARI's ``polredabs``, and optionally the isomorphism map.
+
+        INPUT:
+
+        - ``names`` -- string (default: ``self._names``); name of generator of the absolute field
+        - ``isomorphism_map`` -- boolean (default: ``False``); whether to also
+          return the isomorphism from ``self`` to the new field
+
+        OUTPUT:
+
+        An absolute number field isomorphic to ``self`` defined by the
+        canonical reduced polynomial. If ``isomorphism_map`` is ``True``,
+        a tuple of this field and the isomorphism from ``self`` to it is
+        returned instead.
+
+        .. SEEALSO::
+
+            :meth:`polredbest`, :meth:`optimized_representation`
+
+        EXAMPLES::
+
+            sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
+            sage: NumberField(f, 'a').polredabs()
+            Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26
+            sage: NumberField(f, 'a').polredabs(isomorphism_map=True)
+            (Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26,
+             Ring morphism:
+               From: Number Field in a with defining polynomial x^3 - 12*x^2 + 2*x - 3
+               To:   Number Field in a with defining polynomial x^3 - x^2 + 35*x - 26
+               Defn: a |--> 1/3*a^2 + 35/3)
+
+        TESTS:
+
+        The returned isomorphism is a valid ring homomorphism: the image
+        of the generator of ``self`` is a root of ``self``'s defining
+        polynomial in the new field (for both algorithms)::
+
+            sage: f = ZZ['x']('x^3 - 12*x^2 + 2*x - 3')
+            sage: K.<a> = NumberField(f)
+            sage: for alg in ('polredbest', 'polredabs'):
+            ....:     L, phi = K._polred(algorithm=alg, isomorphism_map=True)
+            ....:     assert K.defining_polynomial()(phi(a)) == 0
+        """
+        return self._polred(names=names, algorithm='polredabs', isomorphism_map=isomorphism_map)
 
     def optimized_subfields(self, degree=0, name=None, both_maps=True):
         """


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The PR adds polynomial reduction methods to number fields. Prior to PR #39920, `polredbest` was applied internally by default, but this approach proved suboptimal for large polynomials. This change gives users the ability to explicitly call `polredbest`/`polredabs` on number fields after creation.

`optimized_representation` now also accepts `algorithm='polredbest'` (default) or `algorithm='polredabs'`, so existing callers can opt into the canonical reduction without switching to the new methods.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


