### PR TITLE
Add sphinx-copybutton to dependency of sage-docbuild

### DIFF
--- a/pkgs/sage-docbuild/pyproject.toml
+++ b/pkgs/sage-docbuild/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {Homepage = "https://www.sagemath.org"}
-dependencies = ["sphinx"]
+dependencies = ["sphinx", "sphinx-copybutton"]
 dynamic = ["version"]
 
 [project.readme]


### PR DESCRIPTION
Reason: the package doesn't run correctly without the dependency. It is listed as a dependency in the sage spkg too (`build/pkgs/sagemath_doc_html/dependencies`)

First noticed while working on https://github.com/sagemath/sage/pull/39279 .

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


