### PR TITLE
Meson: automatically install into venv if activated

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   ['c', 'cpp', 'cython'],
   version: files('src/VERSION.txt'),
   license: 'GPL v3',
-  default_options: ['c_std=c17', 'cpp_std=c++17'],
+  default_options: ['c_std=c17', 'cpp_std=c++17', 'python.install_env=auto'],
 )
 
 # Python module

--- a/src/doc/en/installation/meson.rst
+++ b/src/doc/en/installation/meson.rst
@@ -85,11 +85,9 @@ To configure the project, we need to run the following command:
 
 .. CODE-BLOCK:: shell-session
 
-    $ meson setup builddir --prefix=$PWD/build-install
+    $ meson setup builddir
 
 This will create a build directory ``builddir`` that will hold the build artifacts.
-The ``--prefix`` option specifies the directory where the Sage will be installed,
-and can be omitted when ``pip`` is used to install as explained below.
 
 If pip is used as above with ``--editable``, ``builddir`` is set to be
 ``build/cp[Python major version][Python minor version]``, such as ``build/cp311``.
@@ -106,18 +104,27 @@ Installing is done with the following command:
 
     $ meson install -C builddir
 
-This will then install in the directory specified by ``--prefix``, e.g.
-``build-install/lib/python3.11/site-packages/sage``.
-Usually, this directory is not on your Python path, so you have to use:
-
-.. CODE-BLOCK:: shell-session
-
-    $ PYTHONPATH=build-install/lib/python3.11/site-packages ./sage
-
+This will install the project to currently active Python environment, 
+or to the system Python environment if no environment is active.
 When editable install is used, it is not necessary to reinstall after each compilation.
 
-Alternatively, we can still use pip to install (which does not require specifying
-``--prefix`` in advance and automatically works with conda environment):
+.. NOTE::
+
+    If you want to install the project to a different directory, you can specify
+    the ``--prefix`` option when running the ``meson setup`` command:
+
+    .. CODE-BLOCK:: shell-session
+
+        $ meson setup builddir --prefix=/desired/install/path -Dpython.install_env=prefix
+
+    This will then install in the directory specified by ``--prefix``.
+    Usually, this directory is not on your Python path, so you have to use:
+
+    .. CODE-BLOCK:: shell-session
+
+        $ PYTHONPATH=/desired/install/path ./sage
+
+Alternatively, we can still use pip to install:
 
 .. CODE-BLOCK:: shell-session
 

--- a/src/doc/en/installation/meson.rst
+++ b/src/doc/en/installation/meson.rst
@@ -117,7 +117,9 @@ When editable install is used, it is not necessary to reinstall after each compi
 
         $ meson setup builddir --prefix=/desired/install/path -Dpython.install_env=prefix
 
-    This will then install in the directory specified by ``--prefix``.
+    This will then install in the directory specified by ``--prefix``,
+    in particular the root folder will be be installed to
+    ``/desired/install/path/lib/python3.11/site-packages/sage``.
     Usually, this directory is not on your Python path, so you have to use:
 
     .. CODE-BLOCK:: shell-session


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Makes the meson experience a bit smoother by no longer requiring that a manual prefix is specified (it still can be specified if wanted). So `meson install` will just install into the current venv, the same as `pip install .`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


