### PR TITLE
Use format strints via flynt

### DIFF
--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
@@ -156,7 +156,7 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
         f, h = self._hyperelliptic_polynomials
         y = self._printing_ring.variable_name()
         x = self._printing_ring.base_ring().variable_name()
-        return HyperellipticCurve(f.change_ring(R), h.change_ring(R), "%s,%s" % (x,y))
+        return HyperellipticCurve(f.change_ring(R), h.change_ring(R), f"{x},{y}")
 
     base_extend = change_ring
 
@@ -181,8 +181,8 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
         y = self._printing_ring.gen()
         x = self._printing_ring.base_ring().gen()
         if h.is_zero():
-            return "Hyperelliptic Curve over %s defined by %s = %s" % (R, y**2, f(x))
-        return "Hyperelliptic Curve over %s defined by %s + %s = %s" % (R, y**2, h(x)*y, f(x))
+            return f"Hyperelliptic Curve over {R} defined by {y ** 2} = {f(x)}"
+        return f"Hyperelliptic Curve over {R} defined by {y ** 2} + {h(x) * y} = {f(x)}"
 
     def _latex_(self):
         r"""
@@ -675,7 +675,7 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
             defined by y^2 + x^10*y = x^3 + x + 2
         """
         f, h = self._hyperelliptic_polynomials
-        return 'HyperellipticCurve(%s, %s)' % (f._magma_init_(magma), h._magma_init_(magma))
+        return f'HyperellipticCurve({f._magma_init_(magma)}, {h._magma_init_(magma)})'
 
     def monsky_washnitzer_gens(self):
         import sage.schemes.hyperelliptic_curves.monsky_washnitzer as monsky_washnitzer
@@ -739,7 +739,7 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
         """
         d = P[1]
         if d == 0:
-            raise TypeError("P = %s is a Weierstrass point. Use local_coordinates_at_weierstrass instead!" % P)
+            raise TypeError(f"P = {P} is a Weierstrass point. Use local_coordinates_at_weierstrass instead!")
         pol = self.hyperelliptic_polynomials()[0]
         L = PowerSeriesRing(self.base_ring(), name, default_prec=prec)
         t = L.gen()
@@ -791,7 +791,7 @@ class HyperellipticCurve_generic(plane_curve.ProjectivePlaneCurve):
             - Francis Clarke (2012-08-26)
         """
         if P[1] != 0:
-            raise TypeError("P = %s is not a finite Weierstrass point. Use local_coordinates_at_nonweierstrass instead!" % P)
+            raise TypeError(f"P = {P} is not a finite Weierstrass point. Use local_coordinates_at_nonweierstrass instead!")
         L = PowerSeriesRing(self.base_ring(), name)
         t = L.gen()
         pol = self.hyperelliptic_polynomials()[0]

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_padic_field.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_padic_field.py
@@ -124,7 +124,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
         """
         prec = self.base_ring().precision_cap()
         if not self.is_same_disc(P,Q):
-            raise ValueError("%s and %s are not in the same residue disc" % (P,Q))
+            raise ValueError(f"{P} and {Q} are not in the same residue disc")
         disc = self.residue_disc(P)
         t = PowerSeriesRing(self.base_ring(), 't', prec).gen(0)
         if disc == self.change_ring(self.base_ring().residue_field())(0,1,0): # Infinite disc
@@ -256,7 +256,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
         - Jennifer Balakrishnan
         """
         if not self.is_in_weierstrass_disc(Q):
-            raise ValueError("%s is not in a Weierstrass disc" % Q)
+            raise ValueError(f"{Q} is not in a Weierstrass disc")
         points = self.weierstrass_points()
         for P in points:
             if self.is_same_disc(P,Q):
@@ -630,7 +630,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
         prof("eval f")
         R = forms[0].base_ring()
         try:
-            prof("eval f %s" % R)
+            prof(f"eval f {R}")
             if PP is None:
                 L = [-ff(R(QQ[0]), R(QQ[1])) for ff in forms]  ##changed
             elif QQ is None:
@@ -641,7 +641,7 @@ class HyperellipticCurve_padic_field(hyperelliptic_generic.HyperellipticCurve_ge
         except ValueError:
             prof("changing rings")
             forms = [ff.change_ring(self.base_ring()) for ff in forms]
-            prof("eval f %s" % self.base_ring())
+            prof(f"eval f {self.base_ring()}")
             if PP is None:
                 L = [-ff(QQ[0], QQ[1]) for ff in forms]  ##changed
             elif QQ is None:

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_rational_field.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_rational_field.py
@@ -79,5 +79,5 @@ class HyperellipticCurve_rational_field(hyperelliptic_generic.HyperellipticCurve
         """
         from sage.lfunctions.pari import LFunction, lfun_genus2
         L = LFunction(lfun_genus2(self), prec=prec)
-        L.rename('PARI L-function associated to %s' % self)
+        L.rename(f'PARI L-function associated to {self}')
         return L

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_homset.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_homset.py
@@ -152,7 +152,7 @@ class JacobianHomset_divisor_classes(SchemeHomset_points):
                     return JacobianMorphism_divisor_class_field(self, tuple(P))
                 if isinstance(P1, SchemeMorphism) and isinstance(P2, SchemeMorphism):
                     return self(P1) - self(P2)
-            raise TypeError("argument P (= %s) must have length 2" % P)
+            raise TypeError(f"argument P (= {P}) must have length 2")
         elif isinstance(P, JacobianMorphism_divisor_class_field) and self == P.parent():
             return P
         elif isinstance(P, SchemeMorphism):
@@ -160,7 +160,7 @@ class JacobianHomset_divisor_classes(SchemeHomset_points):
             y0 = P[1]
             R, x = self.curve().hyperelliptic_polynomials()[0].parent().change_ring(self.value_ring()).objgen()
             return self((x - x0, R(y0)))
-        raise TypeError("argument P (= %s) does not determine a divisor class" % P)
+        raise TypeError(f"argument P (= {P}) does not determine a divisor class")
 
     def _morphism(self, *args, **kwds):
         return JacobianMorphism_divisor_class_field(*args, **kwds)

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_morphism.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_morphism.py
@@ -454,7 +454,7 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
         if self.is_zero():
             return "(1)"
         a, b = self._printing_polys()
-        return "(%s, %s)" % (a, b)
+        return f"({a}, {b})"
 
     def _latex_(self):
         r"""
@@ -484,7 +484,7 @@ class JacobianMorphism_divisor_class_field(AdditiveGroupElement, SchemeMorphism)
         if self.is_zero():
             return "\\left(1\\right)"
         a, b = self._printing_polys()
-        return "\\left(%s, %s\\right)" % (latex(a), latex(b))
+        return f"\\left({latex(a)}, {latex(b)}\\right)"
 
     def scheme(self):
         r"""

--- a/src/sage/schemes/hyperelliptic_curves/monsky_washnitzer.py
+++ b/src/sage/schemes/hyperelliptic_curves/monsky_washnitzer.py
@@ -512,10 +512,10 @@ class SpecialCubicQuotientRing(UniqueRepresentation, Parent):
             (=Ring of integers modulo 10) of Q
         """
         if not isinstance(Q, Polynomial):
-            raise TypeError("Q (=%s) must be a polynomial" % Q)
+            raise TypeError(f"Q (={Q}) must be a polynomial")
 
         if Q.degree() != 3 or not Q[2].is_zero():
-            raise ValueError("Q (=%s) must be of the form x^3 + ax + b" % Q)
+            raise ValueError(f"Q (={Q}) must be of the form x^3 + ax + b")
 
         base_ring = Q.parent().base_ring()
 
@@ -1616,7 +1616,7 @@ def matrix_of_frobenius(Q, p, M, trace=None, compute_exact_forms=False):
     """
     M = int(M)
     if M < 2:
-        raise ValueError("M (=%s) must be at least 2" % M)
+        raise ValueError(f"M (={M}) must be at least 2")
 
     base_ring = Q.base_ring()
 
@@ -2444,7 +2444,7 @@ class SpecialHyperellipticQuotientRing(UniqueRepresentation, Parent):
             SpecialHyperellipticQuotientRing K[x,y,y^-1] / (y^2 = x^5 - 3*x + 1) over Rational Field
         """
         y_inverse = ",y^-1" if isinstance(self._series_ring, (LaurentSeriesRing, LazyLaurentSeriesRing)) else ""
-        return "SpecialHyperellipticQuotientRing K[x,y%s] / (y^2 = %s) over %s" % (y_inverse, self._Q, self.base_ring())
+        return f"SpecialHyperellipticQuotientRing K[x,y{y_inverse}] / (y^2 = {self._Q}) over {self.base_ring()}"
 
     def base_extend(self, R):
         r"""
@@ -2992,7 +2992,7 @@ class MonskyWashnitzerDifferential(ModuleElement):
         """
         s = self._coeff._repr_()
         if s.find("+") != -1 or s.find("-") > 0:
-            s = "(%s)" % s
+            s = f"({s})"
         return s + " dx/2y"
 
     def _latex_(self):
@@ -3012,7 +3012,7 @@ class MonskyWashnitzerDifferential(ModuleElement):
         """
         s = self._coeff._latex_()
         if s.find("+") != -1 or s.find("-") > 0:
-            s = "\\left(%s\\right)" % s
+            s = f"\\left({s}\\right)"
         return s + " \\frac{dx}{2y}"
 
     def _richcmp_(self, other, op):


### PR DESCRIPTION
I am using https://github.com/ikamensh/flynt to convert old "%-formatted" and .format(...) strings into Python 3.6+'s "f-strings".
@fchapoton , do you have any opinions regarding this?

Using format strings is in many ways better, in particular, one avoids bugs like:

```python3
File /Applications/sage-stable/src/sage/schemes/hyperelliptic_curves/jacobian_homset.py:155, in JacobianHomset_divisor_classes.__call__(self, P)
    153         if isinstance(P1, SchemeMorphism) and isinstance(P2, SchemeMorphism):
    154             return self(P1) - self(P2)
--> 155     raise TypeError("argument P (= %s) must have length 2" % P)
    156 elif isinstance(P, JacobianMorphism_divisor_class_field) and self == P.parent():
    157     return P

TypeError: not all arguments converted during string formatting
sage: %debug
> /Applications/sage-stable/src/sage/schemes/hyperelliptic_curves/jacobian_homset.py(155)__call__()
    153                 if isinstance(P1, SchemeMorphism) and isinstance(P2, SchemeMorphism):
    154                     return self(P1) - self(P2)
--> 155             raise TypeError("argument P (= %s) must have length 2" % P)
    156         elif isinstance(P, JacobianMorphism_divisor_class_field) and self == P.parent():
    157             return P

ipdb> p P
(1, 2, 3)
```




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.


