### PR TITLE
Replace conda with mamba for consistency

### DIFF
--- a/src/doc/en/installation/meson.rst
+++ b/src/doc/en/installation/meson.rst
@@ -11,11 +11,11 @@ Walkthrough
 
 Assume we're starting from a clean repo and a fully set up conda environment
 (modify ``-linux`` according to your operating system):
-        
+
 .. CODE-BLOCK:: shell-session
 
     $ mamba env create --file environment-3.11-linux.yml --name sage-dev
-    $ conda activate sage-dev
+    $ mamba activate sage-dev
 
 Alternatively, install all build requirements as described in section
 :ref:`section-prereqs`. In the likely case that you have to install some
@@ -31,29 +31,29 @@ to the installed libraries:
 .. NOTE::
 
     If you have previously build Sage in-place, you first have to delete the
-    already compiled files, e.g. with ``shopt -s globstar`` followed by 
+    already compiled files, e.g. with ``shopt -s globstar`` followed by
     ``rm src/**/*.so`` or ``for f in src/**/*.so ; do mv "$f" "$f.old"; done``.
     Moreover, remove the old generated files with
-    ``find src/sage/ext/interpreters -type f ! -name 'meson.build' -delete``. 
+    ``find src/sage/ext/interpreters -type f ! -name 'meson.build' -delete``.
     Also uninstall the 'old' sage packages with ``pip uninstall sage-conf sage-setup sagemath-standard``.
 
 To compile and install the project in editable install, just use:
-    
+
 .. CODE-BLOCK:: shell-session
 
     $ pip install --no-build-isolation --editable .
 
-This will install Sage in the current Python environment. 
-In a Conda environment, the ``--no-build-isolation`` flag is necessary to 
+This will install Sage in the current Python environment.
+In a Conda environment, the ``--no-build-isolation`` flag is necessary to
 allow the build system to reuse the already installed build dependencies.
 If you don't use Conda, you can omit this flag.
 
-You can then start Sage from the command line with ``./sage`` 
+You can then start Sage from the command line with ``./sage``
 or run the tests with ``./sage -t``.
 
 .. NOTE::
-    
-    By using ``pip install --editable`` in the above steps, the Sage library 
+
+    By using ``pip install --editable`` in the above steps, the Sage library
     is installed in editable mode. This means that when you only edit source
     files, there is no need to rebuild the library; it suffices to restart Sage.
     Note that this even works when you edit Cython files (they will be recompiled
@@ -63,7 +63,7 @@ or run the tests with ``./sage -t``.
 .. NOTE::
 
     Note that ``make`` is not used at all, nor is ``configure``.
-    This means that any Sage-the-distribution commands such as ``sage -i`` 
+    This means that any Sage-the-distribution commands such as ``sage -i``
     will not work.
 
 .. NOTE::
@@ -128,7 +128,7 @@ Alternatively, we can still use pip to install (which does not require specifyin
     Package maintainers may want to specify further build options or need
     to install to a different directory than the install prefix.
     Both are supported naturally by Meson:
-    
+
     .. CODE-BLOCK:: shell-session
 
         $ meson setup builddir --prefix=/usr --libdir=... -Dcpp_args=...


### PR DESCRIPTION
The command right above it uses `mamba`, so I think it's better if both of them uses the same thing. In fact I think conda and mamba stores their environments in different locations and there are certain difficulties using them together.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


