### PR TITLE
Fix two floating point bugs in the hyperbolic geometry code

### DIFF
--- a/src/sage/geometry/hyperbolic_space/hyperbolic_coercion.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_coercion.py
@@ -26,6 +26,7 @@ from sage.rings.integer import Integer
 from sage.rings.infinity import infinity
 from sage.functions.other import real, imag
 from sage.misc.functional import sqrt
+from sage.geometry.hyperbolic_space.hyperbolic_constants import EPSILON
 from sage.misc.lazy_import import lazy_import
 lazy_import('sage.misc.call', 'attrcall')
 
@@ -296,8 +297,19 @@ class CoercionPDtoUHP(HyperbolicModelCoercion):
             +Infinity
             sage: phi.image_coordinates(-I)
             0
+
+        TESTS::
+
+        Check that the second bug discussed in :issue:`32362` is fixed::
+
+            sage: PD = HyperbolicPlane().PD()
+            sage: UHP = HyperbolicPlane().UHP()
+            sage: r = exp((pi*I/2).n())
+            sage: p = PD.get_point(r)
+            sage: UHP(p)
+            Boundary point in UHP +Infinity
         """
-        if x == I:
+        if abs(x - I) < EPSILON:
             return infinity
         return (x + I)/(Integer(1) + I*x)
 

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_geodesic.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_geodesic.py
@@ -1212,6 +1212,17 @@ class HyperbolicGeodesicUHP(HyperbolicGeodesic):
             sage: UHP.get_geodesic(1 + I, 2 + 4*I).ideal_endpoints()
             [Boundary point in UHP -sqrt(65) + 9,
              Boundary point in UHP sqrt(65) + 9]
+
+        TESTS::
+
+        Check that :issue:`32362` is fixed::
+
+            sage: PD = HyperbolicPlane().PD()
+            sage: z0 = CC(-0.0571909584179366 + 0.666666666666667*I)
+            sage: z1 = CC(-1)
+            sage: pts = PD.get_geodesic(z0, z1).ideal_endpoints()
+            sage: pts[1]
+            Boundary point in PD I
         """
 
         start = self._start.coordinates()
@@ -1227,7 +1238,7 @@ class HyperbolicGeodesicUHP(HyperbolicGeodesic):
         if CC(end).is_infinity():
             return [M.get_point(x1), M.get_point(end)]
         # We could also have a vertical line with two interior points
-        if x1 == x2:
+        if abs(x1 - x2) < EPSILON:
             return [M.get_point(x1), M.get_point(infinity)]
         # Otherwise, we have a semicircular arc in the UHP
         c = ((x1+x2)*(x2-x1) + (y1+y2)*(y2-y1)) / (2*(x2-x1))


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

There are two places in the hyperbolic geometry code where comparing floating point values for equality causes issues. This PR should fix #32362.
﻿
See also this discussion on sage-devel: [hyperbolic_polygon bug](https://groups.google.com/g/sage-devel/c/Czt-2y6W4iw).
﻿
﻿

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


