### PR TITLE
allow gcc-15 from the system

### DIFF
--- a/build/pkgs/ecl/spkg-install.in
+++ b/build/pkgs/ecl/spkg-install.in
@@ -1,6 +1,6 @@
 cd src
 
-export CFLAGS
+export CFLAGS="-std=gnu17 $CFLAGS"
 export CXXFLAGS
 export LDFLAGS
 

--- a/build/pkgs/gcc/spkg-configure.m4
+++ b/build/pkgs/gcc/spkg-configure.m4
@@ -165,8 +165,8 @@ SAGE_SPKG_CONFIGURE_BASE([gcc], [
                     # Install our own GCC if the system-provided one is older than gcc 8.4
                     SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_VERSION, which is quite old])
                 ],
-                [1[[5-9]].*], [
-                    # Install our own GCC if the system-provided one is newer than 14.x.
+                [1[[6-9]].*], [
+                    # Install our own GCC if the system-provided one is newer than 15.x.
                     # See https://github.com/sagemath/sage/issues/29456
                     SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_VERSION, which is too recent for this version of Sage])
                 ])

--- a/build/pkgs/gfortran/spkg-configure.m4
+++ b/build/pkgs/gfortran/spkg-configure.m4
@@ -86,8 +86,8 @@ SAGE_SPKG_CONFIGURE([gfortran], [
                         # Install our own gfortran if the system-provided one is older than gcc-4.8.
                         SAGE_SHOULD_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is quite old])
                     ],
-                    [1[[5-9]].*], [
-                        # Install our own gfortran if the system-provided one is newer than 14.x.
+                    [1[[6-9]].*], [
+                        # Install our own gfortran if the system-provided one is newer than 15.x.
                         # See https://github.com/sagemath/sage/issues/29456, https://github.com/sagemath/sage/issues/31838
                         SAGE_MUST_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is too recent for this version of Sage])
                     ])


### PR DESCRIPTION
Fedora 42 comes with gcc-15 by default, so it should be allowed, as asked on [sage-release](https://groups.google.com/g/sage-release/c/iBMmwCCKJuM/m/h4EXk5nUDAAJ)


## :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

- #39985 : linbox patches
- #39936 : givaro 4.2.1

