### PR TITLE
fix: log as method gives symbolic output for non positive base

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -2851,16 +2851,24 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             sage: ZZ(8).log(int(2))
             3
 
+        Check that negative bases yield complex logarithms (:issue:`39959`)::
+
+            sage: 8.log(-2)
+            3*log(2)/(I*pi + log(2))
+
+        Check that zero base  yield complex logarithms (:issue:`39959`)::
+
+            sage: 8.log(0)
+            0
+
         TESTS::
 
             sage: (-2).log(3)                                                           # needs sage.symbolic
             (I*pi + log(2))/log(3)
         """
         cdef int self_sgn
-        if m is not None and m <= 0:
-            raise ValueError("log base must be positive")
         self_sgn = mpz_sgn(self.value)
-        if self_sgn < 0 and prec is None:
+        if self_sgn < 0 or (m is not None and m<=0) and prec is None:
             from sage.symbolic.ring import SR
             return SR(self).log(m)
         if prec:

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -2855,6 +2855,8 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
             sage: 8.log(-2)
             3*log(2)/(I*pi + log(2))
+            sage: (-10).log(prec=53)
+            2.30258509299405 + 3.14159265358979*I
 
         Check that zero base  yield complex logarithms (:issue:`39959`)::
 
@@ -2868,7 +2870,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         """
         cdef int self_sgn
         self_sgn = mpz_sgn(self.value)
-        if self_sgn < 0 or (m is not None and m<=0) and prec is None:
+        if (self_sgn < 0 or m is not None and m<=0) and prec is None:
             from sage.symbolic.ring import SR
             return SR(self).log(m)
         if prec:


### PR DESCRIPTION
This pull request updates the behaviour of the `log` method in the `Integer` class to handle cases where the base is non-positive to give symbolic output and added tests for the same. This solves the issue [#39959](https://github.com/sagemath/sage/issues/39959)
like this
```
sage: 8.log(-2)
3*log(2)/(I*pi + log(2))
```
 <!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


