### PR TITLE
Adding an implementation of the Abreu-Nigro symmetric functions

### DIFF
--- a/src/doc/en/reference/combinat/module_list.rst
+++ b/src/doc/en/reference/combinat/module_list.rst
@@ -309,6 +309,7 @@ Comprehensive Module List
     sage/combinat/set_partition
     sage/combinat/set_partition_iterator
     sage/combinat/set_partition_ordered
+    sage/combinat/sf/abreu_nigro
     sage/combinat/sf/all
     sage/combinat/sf/character
     sage/combinat/sf/classical

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -265,6 +265,18 @@ REFERENCES:
               Symposium, Volume 51, page 20.
               Australian Computer Society, Inc. 2006.
 
+.. [AN2021] Alex Abreu and Antonio Nigro. *Chromatic symmetric functions from
+            the modular law*. J. Combin. Theory Ser. A, **180** (2021), paper
+            no. 105407. :arxiv:`2006.00657`.
+
+.. [AN2021II] Alex Abreu and Antonio Nigro. *A symmetric function of increasing
+              forests*. Forum Math. Sigma, **9** No. 21 (2021), Id/No e35.
+              :arxiv:`2006.08418`.
+
+.. [AN2023] Alex Abreu and Antonio Nigro. *Splitting the cohomology of Hessenberg
+            varieties and e-positivity of chromatic symmetric functions*. 
+            Preprint (2023). :arxiv:`2304.10644`.
+
 .. [Ang1997] B. Anglès. 1997. *On some characteristic polynomials attached to
              finite Drinfeld modules.* manuscripta mathematica 93, 1 (01 Aug 1997),
              369–379. https://doi.org/10.1007/BF02677478

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -274,7 +274,7 @@ REFERENCES:
               :arxiv:`2006.08418`.
 
 .. [AN2023] Alex Abreu and Antonio Nigro. *Splitting the cohomology of Hessenberg
-            varieties and e-positivity of chromatic symmetric functions*. 
+            varieties and e-positivity of chromatic symmetric functions*.
             Preprint (2023). :arxiv:`2304.10644`.
 
 .. [Ang1997] B. Anglès. 1997. *On some characteristic polynomials attached to

--- a/src/sage/combinat/posets/poset_examples.py
+++ b/src/sage/combinat/posets/poset_examples.py
@@ -37,7 +37,7 @@ The infinite set of all posets can be used to find minimal examples::
     :meth:`~Posets.DoubleTailedDiamond` | Return the double tailed diamond poset on `2n + 2` elements.
     :meth:`~Posets.IntegerCompositions` | Return the poset of integer compositions of `n`.
     :meth:`~Posets.IntegerPartitions` | Return the poset of integer partitions of ``n``.
-    :meth:`~Posets.IntegerPartitionsDominanceOrder` | Return the lattice of integer partitions on the integer `n` ordered by dominance.
+    :meth:`~Posets.IntegerPartitionsDominanceOrder` | Return the lattice of integer partitions of the integer `n` ordered by dominance.
     :meth:`~Posets.MobilePoset` | Return the mobile poset formed by the `ribbon` with `hangers` below and an `anchor` above.
     :meth:`~Posets.NoncrossingPartitions` | Return the poset of noncrossing partitions of a finite Coxeter group ``W``.
     :meth:`~Posets.PentagonPoset` | Return the Pentagon poset.
@@ -467,8 +467,8 @@ class Posets(metaclass=ClasscallMetaclass):
         """
         Return the divisor lattice of an integer.
 
-        Elements of the lattice are divisors of `n` and `x < y` in the
-        lattice if `x` divides `y`.
+        Elements of the lattice are divisors of `n`, and we have
+        `x \leq y` in the lattice if `x` divides `y`.
 
         INPUT:
 
@@ -508,12 +508,13 @@ class Posets(metaclass=ClasscallMetaclass):
         A *Hessenberg function* (of length `n`) is a function `H: \{1,\ldots,n\}
         \to \{1,\ldots,n\}` such that `\max(i, H(i-1)) \leq H(i) \leq n` for all
         `i` (where `H(0) = 0` by convention). The corresponding poset is given
-        by `i < j` if and only if `H(i) < j`. These correspond to the natural
-        unit interval order posets.
+        by `i < j` (in the poset) if and only if `H(i) < j` (as integers).
+        These posets correspond to the natural unit interval order posets.
 
         INPUT:
 
-        - ``H`` -- list; the Hessenberg function values
+        - ``H`` -- list of the Hessenberg function values
+          (without `H(0)`)
 
         EXAMPLES::
 
@@ -528,9 +529,11 @@ class Posets(metaclass=ClasscallMetaclass):
             Traceback (most recent call last):
             ...
             ValueError: [2, 2, 6, 4, 5, 6] is not a Hessenberg function
+            sage: P = posets.HessenbergPoset([]); P
+            Finite poset containing 0 elements
         """
         n = len(H)
-        if not all(max(i+1, H[i-1]) <= H[i] for i in range(1, n)) or H[-1] > n:
+        if not all(max(i+1, H[i-1]) <= H[i] for i in range(1, n)) or 0 < n < H[-1]:
             raise ValueError(f"{H} is not a Hessenberg function")
         return Poset((tuple(range(1, n+1)), lambda i, j: H[i-1] < j))
 
@@ -541,9 +544,9 @@ class Posets(metaclass=ClasscallMetaclass):
 
         A composition of a positive integer `n` is a list of positive
         integers that sum to `n`. The order is reverse refinement:
-        `[p_1,p_2,...,p_l] < [q_1,q_2,...,q_m]` if `q` consists
-        of an integer composition of `p_1`, followed by an integer
-        composition of `p_2`, and so on.
+        `p = [p_1,p_2,...,p_l] \leq q = [q_1,q_2,...,q_m]` if `q`
+        consists of an integer composition of `p_1`, followed by an
+        integer composition of `p_2`, and so on.
 
         EXAMPLES::
 
@@ -560,7 +563,7 @@ class Posets(metaclass=ClasscallMetaclass):
     @staticmethod
     def IntegerPartitions(n):
         """
-        Return the poset of integer partitions on the integer ``n``.
+        Return the poset of integer partitions of the integer ``n``.
 
         A partition of a positive integer `n` is a non-increasing list
         of positive integers that sum to `n`. If `p` and `q` are
@@ -599,7 +602,7 @@ class Posets(metaclass=ClasscallMetaclass):
     @staticmethod
     def RestrictedIntegerPartitions(n):
         """
-        Return the poset of integer partitions on the integer `n`
+        Return the poset of integer partitions of the integer `n`
         ordered by restricted refinement.
 
         That is, if `p` and `q` are integer partitions of `n`, then
@@ -638,12 +641,12 @@ class Posets(metaclass=ClasscallMetaclass):
     @staticmethod
     def IntegerPartitionsDominanceOrder(n):
         r"""
-        Return the lattice of integer partitions on the integer `n`
+        Return the lattice of integer partitions of the integer `n`
         ordered by dominance.
 
         That is, if `p=(p_1,\ldots,p_i)` and `q=(q_1,\ldots,q_j)` are
-        integer partitions of `n`, then `p` is greater than `q` if and
-        only if `p_1+\cdots+p_k > q_1+\cdots+q_k` for all `k`.
+        integer partitions of `n`, then `p \geq q` if and
+        only if `p_1+\cdots+p_k \geq q_1+\cdots+q_k` for all `k`.
 
         INPUT:
 

--- a/src/sage/combinat/posets/poset_examples.py
+++ b/src/sage/combinat/posets/poset_examples.py
@@ -501,6 +501,40 @@ class Posets(metaclass=ClasscallMetaclass):
                                   category=FiniteLatticePosets())
 
     @staticmethod
+    def HessenbergPoset(H):
+        r"""
+        Return the poset associated to a Hessenberg function ``H``.
+
+        A *Hessenberg function* (of length `n`) is a function `H: \{1,\ldots,n\}
+        \to \{1,\ldots,n\}` such that `\max(i, H(i-1)) \leq H(i) \leq n` for all
+        `i` (where `H(0) = 0` by convention). The corresponding poset is given
+        by `i < j` if and only if `H(i) < j`. These correspond to the natural
+        unit interval order posets.
+
+        INPUT:
+
+        - ``H`` -- list; the Hessenberg function values
+
+        EXAMPLES::
+
+            sage: P = posets.HessenbergPoset([2, 3, 5, 5, 5]); P
+            Finite poset containing 5 elements
+            sage: P.cover_relations()
+            [[2, 4], [2, 5], [1, 3], [1, 4], [1, 5]]
+
+        TESTS::
+
+            sage: P = posets.HessenbergPoset([2, 2, 6, 4, 5, 6])
+            Traceback (most recent call last):
+            ...
+            ValueError: [2, 2, 6, 4, 5, 6] is not a Hessenberg function
+        """
+        n = len(H)
+        if not all(max(i+1, H[i-1]) <= H[i] for i in range(1, n)) or H[-1] > n:
+            raise ValueError(f"{H} is not a Hessenberg function")
+        return Poset((tuple(range(1, n+1)), lambda i, j: H[i-1] < j))
+
+    @staticmethod
     def IntegerCompositions(n):
         """
         Return the poset of integer compositions of the integer ``n``.

--- a/src/sage/combinat/sf/abreu_nigro.py
+++ b/src/sage/combinat/sf/abreu_nigro.py
@@ -1,0 +1,341 @@
+# sage.doctest: needs sage.combinat sage.modules
+"""
+Abreu-Nigro symmetric functions
+"""
+# ****************************************************************************
+#       Copyright (C) 2025 Travis Scrimshaw <tcscrims at gmail.com>
+#
+#  Distributed under the terms of the GNU General Public License (GPL)
+#
+#    This code is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    General Public License for more details.
+#
+#  The full text of the GPL is available at:
+#
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
+
+from . import multiplicative
+from sage.misc.cachefunc import cached_method
+
+
+class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebra_multiplicative):
+    r"""
+    The Abreu-Nigro (symmetric function) basis.
+
+    The Abreu-Nigro basis `\{\rho_{\lambda}(x; q)\}_{\lambda}` is the
+    multiplicative basis defined by
+
+    .. MATH::
+
+        [n]_q h_n(x) = \sum_{i=1}^n h_{n-i}(x) \rho_i(x; q),
+        \qquad\qquad
+        \rho_{\lambda}(x; q) = \rho_{\lambda_1}(x; q) \rho_{\lambda_2}(x; q)
+        \cdots \rho_{\lambda_{\ell}}(x; q).
+
+    Here `[n]_q = 1 + \cdots + q^{n-1}`. An alternative definition is given
+    by `\rho_n = q^{n-1} P_n(x; q^{-1})`, where `P_n(x; q)` is the
+    Hall-Littlewood `P` functions.
+
+    INPUT:
+
+    - ``Sym`` -- the ring of the symmetric functions
+    - ``q`` -- the parameter `q`
+
+    REFERENCES:
+
+    - [AN2021]_
+    - [AN2021II]_
+    - [AN2023]_
+
+    EXAMPLES:
+
+    We verify the change of basis formula for the first few `n`::
+
+        sage: q = ZZ['q'].fraction_field().gen()
+        sage: Sym = SymmetricFunctions(q.parent())
+        sage: an = Sym.abreu_nigro(q)
+        sage: h = Sym.h()
+        sage: from sage.combinat.q_analogues import q_int, q_factorial
+        sage: all(q_int(n, q) * h[n] == sum(h[n-i] * an[i] for i in range(1,n+1))
+        ....:     for n in range(1, 5))
+        True
+
+        sage: P = Sym.hall_littlewood(q).P()
+        sage: all(h(P[n]).map_coefficients(lambda c: q^(n-1) * c(q=~q)) == h(an[n])
+        ....:     for n in range(1, 6))
+        True
+
+    Next, we give the expansion in a few other bases::
+
+        sage: p = Sym.p()
+        sage: s = Sym.s()
+        sage: m = Sym.m()
+        sage: e = Sym.e()
+
+        sage: p(an([1]))
+        p[1]
+        sage: m(an([1]))
+        m[1]
+        sage: e(an([1]))
+        e[1]
+        sage: h(an([1]))
+        h[1]
+        sage: s(an([1]))
+        s[1]
+
+        sage: p(an([2]))
+        ((q-1)/2)*p[1, 1] + ((q+1)/2)*p[2]
+        sage: m(an([2]))
+        (q-1)*m[1, 1] + q*m[2]
+        sage: e(an([2]))
+        q*e[1, 1] + (-q-1)*e[2]
+        sage: h(an([2]))
+        -h[1, 1] + (q+1)*h[2]
+        sage: s(an([2]))
+        -s[1, 1] + q*s[2]
+
+        sage: p(an([3]))
+        ((q^2-2*q+1)/6)*p[1, 1, 1] + ((q^2-1)/2)*p[2, 1] + ((q^2+q+1)/3)*p[3]
+        sage: m(an([3]))
+        (q^2-2*q+1)*m[1, 1, 1] + (q^2-q)*m[2, 1] + q^2*m[3]
+        sage: e(an([3]))
+        q^2*e[1, 1, 1] + (-2*q^2-q)*e[2, 1] + (q^2+q+1)*e[3]
+        sage: h(an([3]))
+        h[1, 1, 1] + (-q-2)*h[2, 1] + (q^2+q+1)*h[3]
+        sage: s(an([3]))
+        s[1, 1, 1] - q*s[2, 1] + q^2*s[3]
+
+    Some examples of conversions the other way::
+
+        sage: q_int(3, q) * an(h[3])
+        (1/(q+1))*an[1, 1, 1] + ((q+2)/(q+1))*an[2, 1] + an[3]
+        sage: q_int(3, q) * an(e[3])
+        (q^3/(q+1))*an[1, 1, 1] + ((-2*q^2-q)/(q+1))*an[2, 1] + an[3]
+        sage: q_int(3, q) * an(m[2,1])
+        ((-2*q^3+q^2+q)/(q+1))*an[1, 1, 1] + ((5*q^2+2*q-1)/(q+1))*an[2, 1] - 3*an[3]
+        sage: q_int(3, q) * an(p[3])
+        (q^2-2*q+1)*an[1, 1, 1] + (-3*q+3)*an[2, 1] + 3*an[3]
+
+    We verify the determinant formulas of [AN2021II]_ Proposition 2.1, but
+    correcting a parity issue with (3)::
+
+        sage: def h_det(n):
+        ....:     ret = matrix.zero(an, n)
+        ....:     for i in range(n):
+        ....:         if i != 0:
+        ....:             ret[i,i-1] = -q_int(i)
+        ....:         for j in range(i, n):
+        ....:             ret[i,j] = an[j-i+1]
+        ....:     return ret.det()
+        sage: all(q_factorial(n, q) * h[n] == h(h_det(n)) for n in range(6))
+        True
+        sage: all(q_factorial(n, q) * an(h[n]) == h_det(n) for n in range(6))
+        True
+
+        sage: def rho_det(n):
+        ....:     ret = matrix.zero(h, n)
+        ....:     for i in range(n):
+        ....:         if i == 0:
+        ....:             for j in range(n):
+        ....:                 ret[0,j] = q_int(j+1, q) * h[j+1]
+        ....:         else:
+        ....:             for j in range(i-1, n):
+        ....:                 ret[i,j] = h[j-i+1]
+        ....:     return ret.det()
+        sage: all((-1)^(n+1) * an[n] == an(rho_det(n)) for n in range(1, 6))
+        True
+        sage: all((-1)^(n+1) * h(an[n]) == rho_det(n) for n in range(1, 6))
+        True
+
+    Antipodes::
+
+        sage: an([1]).antipode()
+        -an[1]
+        sage: an([2]).antipode()
+        (q-1)*an[1, 1] - an[2]
+        sage: an([3]).antipode()
+        (-q^2+2*q-1)*an[1, 1, 1] + (2*q-2)*an[2, 1] - an[3]
+    """
+    @staticmethod
+    def __classcall_private__(cls, Sym, q='q'):
+        """
+        Normalize input to enxure a unique representation.
+
+        EXAMPLES::
+
+            sage: q = ZZ['q'].fraction_field().gen()
+            sage: Sym = SymmetricFunctions(q.parent())
+            sage: Sym.abreu_nigro(q) is Sym.abreu_nigro('q')
+            True
+        """
+        q = Sym.base_ring()(q)
+        return super().__classcall__(cls, Sym, q)
+
+    def __init__(self, Sym, q):
+        r"""
+        Initialize ``self``.
+
+        TESTS::
+
+            sage: q = ZZ['q'].fraction_field().gen()
+            sage: Sym = SymmetricFunctions(q.parent())
+            sage: an = Sym.abreu_nigro(q)
+            sage: TestSuite(an).run(skip=['_test_associativity', '_test_distributivity', '_test_prod'])
+            sage: TestSuite(an).run(elements=[an[1,1]+an[2], an[1]+2*an[1,1]])
+        """
+        self._q = q
+        multiplicative.SymmetricFunctionAlgebra_multiplicative.__init__(self, Sym, "Abreu-Nigro", 'an')
+        self._print_options['latex_prefix'] = "\\rho"
+
+        self._h = Sym.h()
+        self.register_coercion(self._h._module_morphism(self._h_to_an_on_basis, codomain=self))
+        self._h.register_coercion(self._module_morphism(self._an_to_h_on_basis, codomain=self._h))
+
+    @cached_method
+    def _h_to_an_on_basis(self, lam):
+        r"""
+        Return the complete homogeneous symmetric function ``h[lam]``
+        expanded in the Abreu-Nigro basis.
+
+        INPUT:
+
+        - ``lam`` -- a partition
+
+        OUTPUT: the expansion of ``h[lam]`` in the Abreu-Nigro basis ``self``
+
+        EXAMPLES::
+
+            sage: q = ZZ['q'].fraction_field().gen()
+            sage: Sym = SymmetricFunctions(q.parent())
+            sage: an = Sym.abreu_nigro(q)
+            sage: h = Sym.homogeneous()
+            sage: an._h_to_an_on_basis(Partition([]))
+            an[]
+            sage: from sage.combinat.q_analogues import q_factorial as qfact
+            sage: qfact(4, q) * qfact(2, q) * an._h_to_an_on_basis(Partition([4,2,1]))
+            an[1, 1, 1, 1, 1, 1, 1] + (q^2+2*q+4)*an[2, 1, 1, 1, 1, 1]
+             + (2*q^2+3*q+4)*an[2, 2, 1, 1, 1] + (q^2+q+1)*an[2, 2, 2, 1]
+             + (q^3+2*q^2+3*q+2)*an[3, 1, 1, 1, 1] + (q^3+2*q^2+3*q+2)*an[3, 2, 1, 1]
+             + (q^3+2*q^2+2*q+1)*an[4, 1, 1, 1] + (q^3+2*q^2+2*q+1)*an[4, 2, 1]
+            sage: h(an._h_to_an_on_basis(Partition([3,1]))) == h[3,1]
+            True
+
+            sage: all(an(h(an[n])) == an[n] for n in range(10))
+            True
+        """
+        if not lam:
+            return self.one()
+        P = self._indices
+        if len(lam) == 1:
+            R = self.base_ring()
+            q = self._q
+            B = self.basis()
+            n = lam[0]
+            return (self.sum(self._h_to_an_on_basis(P([n-i])) * B[P([i])]
+                             for i in range(1, n+1)) / R.sum(q**k for k in range(n)))
+        # Multiply by the smallest part to minimize the number of products
+        return self._h_to_an_on_basis(P(lam[:-1])) * self._h_to_an_on_basis(P([lam[-1]]))
+
+    @cached_method
+    def _an_to_h_on_basis(self, lam):
+        r"""
+        Return the Abreu-Nigro symmetric function ``an[lam]``  expanded in the
+        complete homogeneous basis.
+
+        INPUT:
+
+        - ``lam`` -- a partition
+
+        OUTPUT:
+
+        the expansion of ``an[lam]`` in the complete homogeneous basis
+        of ``self.realization_of()``
+
+        EXAMPLES::
+
+            sage: q = ZZ['q'].fraction_field().gen()
+            sage: Sym = SymmetricFunctions(q.parent())
+            sage: an = Sym.abreu_nigro(q)
+            sage: h = Sym.homogeneous()
+            sage: an._an_to_h_on_basis(Partition([]))
+            h[]
+            sage: an._an_to_h_on_basis(Partition([4,2,1]))
+            h[1, 1, 1, 1, 1, 1, 1] + (-2*q-4)*h[2, 1, 1, 1, 1, 1]
+             + (q^2+5*q+4)*h[2, 2, 1, 1, 1] + (-q^2-2*q-1)*h[2, 2, 2, 1]
+             + (q^2+q+2)*h[3, 1, 1, 1, 1] + (-q^3-2*q^2-3*q-2)*h[3, 2, 1, 1]
+             + (-q^3-q^2-q-1)*h[4, 1, 1, 1] + (q^4+2*q^3+2*q^2+2*q+1)*h[4, 2, 1]
+            sage: an(an._an_to_h_on_basis(Partition([3,1]))) == an[3,1]
+            True
+
+            sage: all(h(an(h[n])) == h[n] for n in range(10))
+            True
+        """
+        if not lam:
+            return self._h.one()
+        P = self._indices
+        if len(lam) == 1:
+            R = self.base_ring()
+            q = self._q
+            B = self._h.basis()
+            n = lam[0]
+            return (R.sum(q**k for k in range(n)) * self._h[n]
+                    - self._h.sum(B[P([n-i])] * self._an_to_h_on_basis(P([i])) for i in range(1, n)))
+        # Multiply by the smallest part to minimize the number of products
+        return self._an_to_h_on_basis(P(lam[:-1])) * self._an_to_h_on_basis(P([lam[-1]]))
+
+    def coproduct_on_generators(self, n):
+        r"""
+        Return the coproduct on the ``n``-th generator of ``self``.
+
+        We have
+
+        .. MATH::
+
+            \Delta(\rho_n) = \rho_0 \otimes \rho_n
+            + (q-1) \sum_{k=1}^{n-1} \rho_k \otimes \rho_{n-k}
+            + \rho_n \otimes \rho_0.
+
+        INPUT:
+
+        - ``n`` -- a nonnegative integer
+
+        OUTPUT:
+
+        The coproduct acting on ``elt``; the result is an element of the
+        tensor squared of the basis ``self``.
+
+        EXAMPLES::
+
+            sage: q = ZZ['q'].fraction_field().gen()
+            sage: Sym = SymmetricFunctions(q.parent())
+            sage: h = Sym.h()
+            sage: an = Sym.abreu_nigro(q)
+            sage: an.coproduct_on_generators(2)
+            an[] # an[2] + (q-1)*an[1] # an[1] + an[2] # an[]
+            sage: an[2].coproduct()
+            an[] # an[2] + (q-1)*an[1] # an[1] + an[2] # an[]
+            sage: an.coproduct(an[2])
+            an[] # an[2] + (q-1)*an[1] # an[1] + an[2] # an[]
+            sage: an.tensor_square()(h(an[5]).coproduct()) == an[5].coproduct()
+            True
+            sage: an[2,1].coproduct()
+            an[] # an[2, 1] + (q-1)*an[1] # an[1, 1] + an[1] # an[2]
+             + (q-1)*an[1, 1] # an[1] + an[2] # an[1] + an[2, 1] # an[]
+            sage: an.tensor_square()(h(an[2,1]).coproduct())
+            an[] # an[2, 1] + (q-1)*an[1] # an[1, 1] + an[1] # an[2]
+             + (q-1)*an[1, 1] # an[1] + an[2] # an[1] + an[2, 1] # an[]
+        """
+        TS = self.tensor_square()
+        if not n:
+            return TS.one()
+        P = self._indices
+        one = self.base_ring().one()
+        d = {(P([n]), P([])): one, (P([]), P([n])): one}
+        coeff = self._q - one
+        if coeff:
+            for k in range(1, n):
+                d[P([k]), P([n-k])] = coeff
+        return TS.element_class(TS, d)

--- a/src/sage/combinat/sf/abreu_nigro.py
+++ b/src/sage/combinat/sf/abreu_nigro.py
@@ -160,14 +160,13 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
         sage: an([3]).antipode()
         (-q^2+2*q-1)*an[1, 1, 1] + (2*q-2)*an[2, 1] - an[3]
 
-    For length-1 partitions, the antipode is in fact given
-    by the formula `S(\rho_n(x; q)) = -P_n(x; q)`, where `P_n`
+    For single row partitions, the antipode is given by the formula
+    `S(\rho_n(x; q)) = -P_n(x; q)`, where `P_n`
     is the Hall-Littlewood P-function::
 
         sage: P = Sym.hall_littlewood(q).P()
         sage: all(P(an[n].antipode()) == -P[n] for n in range(1, 6))
         True
-
     """
     @staticmethod
     def __classcall_private__(cls, Sym, q='q'):
@@ -216,8 +215,6 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
 
         - ``lam`` -- a partition
 
-        OUTPUT: the expansion of ``h[lam]`` in the Abreu-Nigro basis ``self``
-
         EXAMPLES::
 
             sage: q = ZZ['q'].fraction_field().gen()
@@ -260,11 +257,6 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
         INPUT:
 
         - ``lam`` -- a partition
-
-        OUTPUT:
-
-        the expansion of ``an[lam]`` in the complete homogeneous basis
-        of ``self.realization_of()``
 
         EXAMPLES::
 
@@ -316,8 +308,7 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
 
         OUTPUT:
 
-        The coproduct applied to ``elt``; the result is an element of the
-        tensor squared of the basis ``self``.
+        an element of the tensor squared of the basis ``self``
 
         EXAMPLES::
 

--- a/src/sage/combinat/sf/abreu_nigro.py
+++ b/src/sage/combinat/sf/abreu_nigro.py
@@ -35,9 +35,10 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
         \rho_{\lambda}(x; q) = \rho_{\lambda_1}(x; q) \rho_{\lambda_2}(x; q)
         \cdots \rho_{\lambda_{\ell}}(x; q).
 
-    Here `[n]_q = 1 + \cdots + q^{n-1}`. An alternative definition is given
-    by `\rho_n = q^{n-1} P_n(x; q^{-1})`, where `P_n(x; q)` is the
-    Hall-Littlewood `P` functions.
+    Here `[n]_q = 1 + q + \cdots + q^{n-1}` is a `q`-integer.
+    An alternative definition is given by
+    `\rho_n = q^{n-1} P_n(x; q^{-1})`, where `P_n(x; q)` is the
+    Hall-Littlewood `P` function for the one-row partition `n`.
 
     INPUT:
 
@@ -158,11 +159,20 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
         (q-1)*an[1, 1] - an[2]
         sage: an([3]).antipode()
         (-q^2+2*q-1)*an[1, 1, 1] + (2*q-2)*an[2, 1] - an[3]
+
+    For length-1 partitions, the antipode is in fact given
+    by the formula `S(\rho_n(x; q)) = -P_n(x; q)`, where `P_n`
+    is the Hall-Littlewood P-function::
+
+        sage: P = Sym.hall_littlewood(q).P()
+        sage: all(P(an[n].antipode()) == -P[n] for n in range(1, 6))
+        True
+
     """
     @staticmethod
     def __classcall_private__(cls, Sym, q='q'):
         """
-        Normalize input to enxure a unique representation.
+        Normalize input to ensure a unique representation.
 
         EXAMPLES::
 
@@ -185,6 +195,8 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
             sage: an = Sym.abreu_nigro(q)
             sage: TestSuite(an).run(skip=['_test_associativity', '_test_distributivity', '_test_prod'])
             sage: TestSuite(an).run(elements=[an[1,1]+an[2], an[1]+2*an[1,1]])
+            sage: latex(an[2,1])
+            \rho_{2,1}
         """
         self._q = q
         multiplicative.SymmetricFunctionAlgebra_multiplicative.__init__(self, Sym, "Abreu-Nigro", 'an')
@@ -290,7 +302,7 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
         r"""
         Return the coproduct on the ``n``-th generator of ``self``.
 
-        We have
+        For any `n \geq 1`, we have
 
         .. MATH::
 
@@ -304,7 +316,7 @@ class SymmetricFunctionAlgebra_AbreuNigro(multiplicative.SymmetricFunctionAlgebr
 
         OUTPUT:
 
-        The coproduct acting on ``elt``; the result is an element of the
+        The coproduct applied to ``elt``; the result is an element of the
         tensor squared of the basis ``self``.
 
         EXAMPLES::

--- a/src/sage/combinat/sf/all.py
+++ b/src/sage/combinat/sf/all.py
@@ -27,6 +27,7 @@ Symmetric Functions
 - :ref:`sage.combinat.sf.macdonald`
 - :ref:`sage.combinat.sf.ns_macdonald`
 - :ref:`sage.combinat.sf.witt`
+- :ref:`sage.combinat.sf.abreu_nigro`
 """
 # install the docstring of this module to the containing package
 from sage.misc.namespace_package import install_doc

--- a/src/sage/combinat/sf/sf.py
+++ b/src/sage/combinat/sf/sf.py
@@ -1321,6 +1321,19 @@ class SymmetricFunctions(UniqueRepresentation, Parent):
         """
         return jack.Jack( self, t=t )
 
+    def abreu_nigro(self, q='q'):
+        """
+        The Abreu-Nigro basis of the Symmetric Functions.
+
+        EXAMPLES::
+
+            sage: q = ZZ['q'].fraction_field().gen()
+            sage: SymmetricFunctions(q.parent()).abreu_nigro()
+            Symmetric Functions over Fraction Field of Univariate Polynomial Ring in q over Integer Ring in the Abreu-Nigro basis
+        """
+        from sage.combinat.sf.abreu_nigro import SymmetricFunctionAlgebra_AbreuNigro
+        return SymmetricFunctionAlgebra_AbreuNigro(self, q)
+
     def zonal(self):
         """
         The zonal basis of the Symmetric Functions.

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -1519,8 +1519,9 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
 
         def abreu_nigro_g(self, H, k, q='q'):
             r"""
-            Return the Abreu-Nigro `g_H(x; q)` symmetric function
-            for the Hessenberg function ``H`` in the basis ``self``.
+            Return the Abreu-Nigro `g_{H,k}(x; q)` symmetric function
+            for the Hessenberg function ``H`` in the basis ``self``,
+            as defined in (2.2) of [HHKKO25]_.
 
             INPUT:
 
@@ -1539,18 +1540,28 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
                 (-1)^{|\tau_1|-n+k} q^{w_H(\sigma)} h_{|\tau_1|-n+k}(x)
                 \omega( \rho_{|\tau_2|,\ldots,|\tau_j|}(x; q) ),
 
-            where the sum is over all permutations `\sigma` such that
+            where the sum is over all permutations `\sigma \in S_n` such that
             `|\tau_1| \geq n - k` and `\sigma(i) \leq H(i)` for all `i`;
-            `\tau_1, \ldots, \tau_j` is the cycle decomposition of `\sigma`;
-            `\rho_{\lambda}` is the Abreu-Nigro basis [AN2021II]_; and
+            `\tau_1, \ldots, \tau_j` is the cycle decomposition of `\sigma`
+            (with cycles sorted by smallest elements, and with these
+            smallest elements placed at the beginning of each cycle);
+            `\rho_{\lambda}` is the Abreu-Nigro basis [AN2021II]_
+            (see :class:`SymmetricFunctions.abreu_nigro`); and
 
             .. MATH::
 
                 w_H(\sigma) = |\{(i, j) \mid i < j \leq H(i) \text{ and } j
-                                 \text{ preceeds } i \text{ in } \sigma^c \}|,
+                                 \text{ precedes } i \text{ in } \sigma^c \}|,
 
-            with `\sigma^c` being the permutations formed by removing the
-            parentheses in the cycle decomposition.
+            with `\sigma^c` being the permutation formed by removing the
+            parentheses in the cycle decomposition `\tau_1 \cdots \tau_j`.
+
+            REFERENCES:
+
+            .. [HHKKO25] \JiSun Huh, Byung-Hak Hwang, Donghyun Kim
+               Jang Soo Kim, Jaeseong Oh,
+               *Refinement of Hikita's e-positivity theorem via Abreu--Nigro's g-functions and restricted modular law*.
+               :arxiv:`2504.09123v1`.
 
             EXAMPLES:
 

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -1520,8 +1520,7 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
         def abreu_nigro_g(self, H, k, q='q'):
             r"""
             Return the Abreu-Nigro `g_{H,k}(x; q)` symmetric function
-            for the Hessenberg function ``H`` in the basis ``self``,
-            as defined in (2.2) of [HHKKO25]_.
+            for the Hessenberg function ``H`` in the basis ``self``.
 
             INPUT:
 
@@ -1532,7 +1531,8 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
             A *Hessenberg function* (of length `n`) is a function `H \colon
             \{1, \ldots, n\} \to \{1, \ldots, n\}` such that `\max(i, H(i-1))
             \leq H(i) \leq n` for all `i` (by convention `H(0) = 0`). The
-            *Abreu-Nigro* `g` *symmetric function* [AN2024]_ is defined by
+            *Abreu-Nigro* `g` *symmetric function* [AN2023]_ (Definition 1.3)
+            is defined by
 
             .. MATH::
 
@@ -1555,13 +1555,6 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
 
             with `\sigma^c` being the permutation formed by removing the
             parentheses in the cycle decomposition `\tau_1 \cdots \tau_j`.
-
-            REFERENCES:
-
-            .. [HHKKO25] \JiSun Huh, Byung-Hak Hwang, Donghyun Kim
-               Jang Soo Kim, Jaeseong Oh,
-               *Refinement of Hikita's e-positivity theorem via Abreu--Nigro's g-functions and restricted modular law*.
-               :arxiv:`2504.09123v1`.
 
             EXAMPLES:
 

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -1517,6 +1517,141 @@ class SymmetricFunctionsBases(Category_realization_of_parent):
                                distinct=True)
             return self(r)
 
+        def abreu_nigro_g(self, H, k, q='q'):
+            r"""
+            Return the Abreu-Nigro `g_H(x; q)` symmetric function
+            for the Hessenberg function ``H`` in the basis ``self``.
+
+            INPUT:
+
+            - ``H`` -- list; the Hessenberg function
+            - ``k`` -- integer; must satisfy ``0 <= k < len(H)``
+            - ``q`` -- (default: ``'q'``) base ring element for `q`
+
+            A *Hessenberg function* (of length `n`) is a function `H \colon
+            \{1, \ldots, n\} \to \{1, \ldots, n\}` such that `\max(i, H(i-1))
+            \leq H(i) \leq n` for all `i` (by convention `H(0) = 0`). The
+            *Abreu-Nigro* `g` *symmetric function* [AN2024]_ is defined by
+
+            .. MATH::
+
+                g_{H,k}(x; q) := \sum_{\sigma = \tau_1 \cdots \tau_j}
+                (-1)^{|\tau_1|-n+k} q^{w_H(\sigma)} h_{|\tau_1|-n+k}(x)
+                \omega( \rho_{|\tau_2|,\ldots,|\tau_j|}(x; q) ),
+
+            where the sum is over all permutations `\sigma` such that
+            `|\tau_1| \geq n - k` and `\sigma(i) \leq H(i)` for all `i`;
+            `\tau_1, \ldots, \tau_j` is the cycle decomposition of `\sigma`;
+            `\rho_{\lambda}` is the Abreu-Nigro basis [AN2021II]_; and
+
+            .. MATH::
+
+                w_H(\sigma) = |\{(i, j) \mid i < j \leq H(i) \text{ and } j
+                                 \text{ preceeds } i \text{ in } \sigma^c \}|,
+
+            with `\sigma^c` being the permutations formed by removing the
+            parentheses in the cycle decomposition.
+
+            EXAMPLES:
+
+            We verify the `e`-positivity of some examples::
+
+                sage: q = ZZ['q'].fraction_field().gen()
+                sage: Sym = SymmetricFunctions(q.parent())
+                sage: e = Sym.e()
+                sage: e.abreu_nigro_g([1,2], 0, q)
+                0
+                sage: e.abreu_nigro_g([1,2], 1, q)
+                e[1]
+                sage: e.abreu_nigro_g([2,2], 0, q)
+                e[]
+                sage: e.abreu_nigro_g([2,2], 1, q)
+                0
+                sage: H = [3, 3, 4, 5, 6, 7, 7]
+                sage: [e.abreu_nigro_g(H, k, q) for k in range(7)]
+                [(q+1)*e[],
+                 q*e[1],
+                 (q^2+q)*e[2],
+                 q^2*e[2, 1] + (q^3+2*q^2+q)*e[3],
+                 (q^3+q^2)*e[2, 2] + (q^3+q^2)*e[3, 1] + (q^4+2*q^3+2*q^2+q)*e[4],
+                 q^3*e[3, 2] + (q^4+q^3+q^2)*e[5],
+                 (q^4+q^3)*e[3, 3] + (q^4+q^3)*e[4, 2] + (q^5+q^4+q^3+q^2)*e[6]]
+
+            We reproduce Example 1.5 in [AN2023]_::
+
+                sage: H = [2, 4, 4, 5, 6, 6]
+                sage: [e.abreu_nigro_g(H, k, q) for k in range(6)]
+                [(q+1)*e[],
+                 q*e[1],
+                 (q^2+q)*e[2],
+                 q^2*e[3],
+                 (q^3+q^2)*e[4],
+                 (q^4+3*q^3+q^2)*e[3, 2] + (q^4+q^3+q^2)*e[4, 1]
+                  + (q^5+2*q^4+2*q^3+2*q^2+q)*e[5]]
+
+            We verify Theorem 1.7 in [AN2023]_ for an example::
+
+                sage: from sage.combinat.q_analogues import q_int
+                sage: H = [2, 4, 4, 4]
+                sage: G = posets.HessenbergPoset(H).incomparability_graph()
+                sage: cqf = G.chromatic_quasisymmetric_function(q, q.parent()); cqf
+                (q^4+6*q^3+10*q^2+6*q+1)*M[1, 1, 1, 1] + (q^3+2*q^2+q)*M[1, 1, 2]
+                 + (q^3+2*q^2+q)*M[1, 2, 1] + (q^3+2*q^2+q)*M[2, 1, 1]
+                sage: e(cqf.to_symmetric_function())
+                (q^3+2*q^2+q)*e[3, 1] + (q^4+2*q^3+2*q^2+2*q+1)*e[4]
+                sage: sum(q_int(k, q) * e[k] * e.abreu_nigro_g(H, len(H)-k, q)
+                ....:     for k in range(1, len(H)+1))
+                (q^3+2*q^2+q)*e[3, 1] + (q^4+2*q^3+2*q^2+2*q+1)*e[4]
+
+            TESTS::
+
+                sage: e = SymmetricFunctions(ZZ['q'].fraction_field()).e()
+                sage: e.abreu_nigro_g([3, 2, 3], 2, q)
+                Traceback (most recent call last):
+                ...
+                ValueError: [3, 2, 3] is not a Hessenberg function
+                sage: e.abreu_nigro_g([1, 4, 5], 2, q)
+                Traceback (most recent call last):
+                ...
+                ValueError: [1, 4, 5] is not a Hessenberg function
+                sage: e.abreu_nigro_g([1, 1, 3], 2, q)
+                Traceback (most recent call last):
+                ...
+                ValueError: [1, 1, 3] is not a Hessenberg function
+                sage: e.abreu_nigro_g([1, 3, 3], 5, q)
+                Traceback (most recent call last):
+                ...
+                ValueError: k must be between 0 and 3
+            """
+            if not H:
+                return self.one()
+            n = len(H)
+            if not all(max(i+1, H[i-1]) <= H[i] for i in range(1, n)) or H[-1] > n:
+                raise ValueError(f"{H} is not a Hessenberg function")
+            if k < 0 or k >= n:
+                raise ValueError(f"k must be between 0 and {n}")
+            ret = self.zero()
+            h = self.realization_of().h()
+            rho = self.realization_of().abreu_nigro(q)
+            from sage.combinat.permutation import Permutations
+            for sigma in Permutations(n):
+                # Filter out the permutations not used in the sum
+                if any(sigma[i] > H[i] for i in range(n)):
+                    continue
+                tau = sigma.to_cycles()
+                if len(tau[0]) < n - k:
+                    continue
+                sc = sum(tau, ())
+                # We use 0-based i and j
+                sc_pos = {i-1: pos for pos, i in enumerate(sc)}
+                inv = sum(1 for j in range(1, n) for i in range(j) if j < H[i]
+                          and sc_pos[j] < sc_pos[i])
+                K = len(tau[0]) - n + k
+                lam = [len(tau[i]) for i in range(1, len(tau))]
+                lam.sort(reverse=True)
+                ret += (-1)**K * q**inv * self(h[K] * h(rho[lam]).omega())
+            return ret
+
         def formal_series_ring(self):
             r"""
             Return the completion of all formal linear combinations of


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Following the definition given in (2.2) of https://arxiv.org/abs/2504.09123, we implement the Abreu-Nigro symmetric functions $g_{H,k}(x; q)$, where $H$ is a Hessenberg function. To do so, we also implement their $\rho$ basis.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


