### PR TITLE
Run python3 directly instead of `sage -python` in sage/tests/startup.py

### DIFF
--- a/src/sage/tests/startup.py
+++ b/src/sage/tests/startup.py
@@ -8,7 +8,7 @@ not work. Instead, we test this by starting a new Python process::
     sage: from sage.tests.cmdline import test_executable
     sage: environment = "sage.all"
     sage: cmd = f"from {environment} import *\nprint('IPython' in sys.modules)\n"
-    sage: print(test_executable(["sage", "--python"], cmd)[0])  # long time
+    sage: print(test_executable(["python3"], cmd)[0])  # long time
     False
 
 Check that numpy (:issue:`11714`) and pyparsing are not imported on startup

--- a/src/sage/tests/startup.py
+++ b/src/sage/tests/startup.py
@@ -8,7 +8,7 @@ not work. Instead, we test this by starting a new Python process::
     sage: from sage.tests.cmdline import test_executable
     sage: environment = "sage.all"
     sage: cmd = f"from {environment} import *\nprint('IPython' in sys.modules)\n"
-    sage: print(test_executable(["python3"], cmd)[0])  # long time
+    sage: print(test_executable(["python"], cmd)[0])  # long time
     False
 
 Check that numpy (:issue:`11714`) and pyparsing are not imported on startup

--- a/src/sage/tests/startup.py
+++ b/src/sage/tests/startup.py
@@ -8,7 +8,7 @@ not work. Instead, we test this by starting a new Python process::
     sage: from sage.tests.cmdline import test_executable
     sage: environment = "sage.all"
     sage: cmd = f"from {environment} import *\nprint('IPython' in sys.modules)\n"
-    sage: print(test_executable(["python"], cmd)[0])  # long time
+    sage: print(test_executable(["python3"], cmd)[0])  # long time
     False
 
 Check that numpy (:issue:`11714`) and pyparsing are not imported on startup


### PR DESCRIPTION
`sage -python` is no longer available in the meson build
