### PR TITLE
Disable most hashing for fraction field elements

### DIFF
--- a/src/sage/modular/modform_hecketriangle/graded_ring_element.py
+++ b/src/sage/modular/modform_hecketriangle/graded_ring_element.py
@@ -146,7 +146,7 @@ class FormsRingElement(CommutativeAlgebraElement, UniqueRepresentation,
             sage: MeromorphicModularFormsRing(n=3)(x) == MeromorphicModularFormsRing(n=4)(x)
             False
             sage: MeromorphicModularFormsRing()(-1/x) is MeromorphicModularFormsRing()(1/(-x))
-            False
+            True
             sage: MeromorphicModularFormsRing()(-1/x) == MeromorphicModularFormsRing()(1/(-x))
             True
             sage: MeromorphicModularFormsRing(base_ring=CC)(-1/x) == MeromorphicModularFormsRing()(1/(-x))

--- a/src/sage/rings/fraction_field.py
+++ b/src/sage/rings/fraction_field.py
@@ -70,10 +70,8 @@ Test that :issue:`15971` is fixed::
 """
 # ****************************************************************************
 #
-#   Sage: Open Source Mathematical Software
-#
-#       Copyright (C) 2005 William Stein <wstein@gmail.com>
-#                     2017 Julian Rüth <julian.rueth@fsfe.org>
+#       Copyright (C)      2005 William Stein <wstein@gmail.com>
+#                     2017-2025 Julian Rüth <julian.rueth@fsfe.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -921,6 +919,33 @@ class FractionField_generic(ring.Field):
         # to avoid having exactly the same hash as the base ring,
         # we change this hash using a random number
         return hash(self._R) ^ 147068341996611
+
+    def _test_element_hash(self, **options):
+        r"""
+        Verify that ``__hash__`` for elements is implemented correctly.
+
+        EXAMPLES::
+
+
+            sage: A.<x, y> = QQ[]
+            sage: K = A.fraction_field()
+            sage: K._test_element_hash()
+
+        """
+        tester = self._tester(**options)
+
+        # Verify that num/1 and num have the same hash.
+        # According to the docstring of __hash__ this is necessary to make
+        # some legacy code work that mixes generators of the base ring
+        # with fraction field elements in dictionaries.
+        for num in tester.some_elements(self.base().some_elements()):
+            try:
+                h = hash(num)
+            except TypeError:
+                # num is unhashable
+                continue
+
+            tester.assertEqual(h, hash(self(num)))
 
     def ngens(self):
         """

--- a/src/sage/rings/fraction_field_element.pyx
+++ b/src/sage/rings/fraction_field_element.pyx
@@ -417,22 +417,14 @@ cdef class FractionFieldElement(FieldElement):
             0
 
         """
-        if self._denominator.is_one():
-            # Handle this case even over rings that don't support reduction, to
-            # avoid breaking existing code that carelessly mixes p and p/1
-            return hash(self._numerator)
-        if self._parent.is_exact():
-            # May fail; let the exception propagate then.
-            # (In contrast, over inexact rings, we hash unreduced fractions
-            # without complaining. This is not ideal, but there is code in Sage
-            # that uses dictionaries indexed by rational functions with
-            # floating-point coefficients, and since the equality test involves
-            # potentially inexact operations, there would be compatibility
-            # issues even if we didn't...)
-            self.reduce()
         try:
             x = self.parent().base()(self)
         except (TypeError, ValueError, NotImplementedError):
+            # In general there does not seem to be a good hash function here so
+            # we can only return a constant value.
+            # In special cases, we could try to bring this fraction into some
+            # sort of normal form, however, note that self.reduce() does not
+            # produce such a normal form.
             return 0
         else:
             return hash(x)

--- a/src/sage/rings/fraction_field_element.pyx
+++ b/src/sage/rings/fraction_field_element.pyx
@@ -11,6 +11,7 @@ AUTHORS:
 
 # ****************************************************************************
 #       Copyright (C) 2005 William Stein <wstein@gmail.com>
+#                     2025 Julian Rüth <julian.rueth@fsfe.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -406,6 +407,15 @@ cdef class FractionFieldElement(FieldElement):
             True
             sage: ((x+1)/(x^2+1)).subs({x: 1})
             1
+
+        Check that :issue:`35238` is fixed::
+
+            sage: A.<x,y> = QQ[]
+            sage: K = A.fraction_field()
+            sage: d = { x/y: 0 }
+            sage: d[K(2*x, 2*y)]
+            0
+
         """
         if self._denominator.is_one():
             # Handle this case even over rings that don't support reduction, to
@@ -420,13 +430,12 @@ cdef class FractionFieldElement(FieldElement):
             # potentially inexact operations, there would be compatibility
             # issues even if we didn't...)
             self.reduce()
-        # Same algorithm as for elements of QQ
-        n = hash(self._numerator)
-        d = hash(self._denominator)
-        if d == 1:
-            return n
+        try:
+            x = self.parent().base()(self)
+        except (TypeError, ValueError, NotImplementedError):
+            return 0
         else:
-            return n ^ d
+            return hash(x)
 
     def __call__(self, *x, **kwds):
         """

--- a/src/sage/rings/function_field/element_polymod.pyx
+++ b/src/sage/rings/function_field/element_polymod.pyx
@@ -101,14 +101,19 @@ cdef class FunctionFieldElement_polymod(FunctionFieldElement):
 
     def __hash__(self):
         """
-        Return the hash of the element.
+        Return a hash value for this element.
 
-        TESTS::
+        TESTS:
+
+        Ideally, we would see 25 different hashes here. However, the hash of an
+        underlying fraction field element is usually a constant 0 when there is
+        a denominator so we only see different hash values for positive
+        exponents::
 
             sage: K.<x> = FunctionField(QQ); R.<y> = K[]
             sage: L.<y> = K.extension(y^2 - x*y + 4*x^3)
-            sage: len({hash(y^i+x^j) for i in [-2..2] for j in [-2..2]})
-            1
+            sage: len({hash(y^i+x^j) for i in [-2..2] for j in [-2..2]}) >= 9
+            True
 
         """
         return hash(self._x)

--- a/src/sage/rings/function_field/element_polymod.pyx
+++ b/src/sage/rings/function_field/element_polymod.pyx
@@ -107,8 +107,9 @@ cdef class FunctionFieldElement_polymod(FunctionFieldElement):
 
             sage: K.<x> = FunctionField(QQ); R.<y> = K[]
             sage: L.<y> = K.extension(y^2 - x*y + 4*x^3)
-            sage: len({hash(y^i+x^j) for i in [-2..2] for j in [-2..2]}) >= 24
-            True
+            sage: len({hash(y^i+x^j) for i in [-2..2] for j in [-2..2]})
+            1
+
         """
         return hash(self._x)
 

--- a/src/sage/rings/function_field/element_rational.pyx
+++ b/src/sage/rings/function_field/element_rational.pyx
@@ -138,8 +138,9 @@ cdef class FunctionFieldElement_rational(FunctionFieldElement):
         15 distinct hashes::
 
             sage: K.<t> = FunctionField(QQ)
-            sage: len({hash(t^i+t^j) for i in [-2..2] for j in [i..2]}) >= 10
-            True
+            sage: len({hash(t^i+t^j) for i in [-2..2] for j in [i..2]})
+            1
+
         """
         return hash(self._x)
 

--- a/src/sage/rings/function_field/element_rational.pyx
+++ b/src/sage/rings/function_field/element_rational.pyx
@@ -134,12 +134,14 @@ cdef class FunctionFieldElement_rational(FunctionFieldElement):
 
         TESTS:
 
-        It would be nice if the following would produce a list of
-        15 distinct hashes::
+        Ideally, we would see 15 different hashes here. However, the hash of an
+        underlying fraction field element is usually a constant 0 when there is
+        a denominator so we only see different hash values for positive
+        exponents::
 
             sage: K.<t> = FunctionField(QQ)
-            sage: len({hash(t^i+t^j) for i in [-2..2] for j in [i..2]})
-            1
+            sage: len({hash(t^i+t^j) for i in [-2..2] for j in [i..2]}) >= 7
+            True
 
         """
         return hash(self._x)


### PR DESCRIPTION
previously hashing of fraction field elements relied on .reduce() to produce a normal form of an element. This is however a misconception, the reduced fraction is not normalized. (And also that does not seem to be possible in general.)

Instead, we rather produce correct output here instead of just making things fail in weird ways. This comes with a performance cost of course as can be seen in the strange outputs of the hashes of function field elements.

Fixes #35238.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


