### PR TITLE
Remove giac as dependency, and add sagemath_giac as optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ requires-python = ">=3.11, <3.14"
 R = [
     'rpy2 >=3.3',
 ]
+giac = [
+    'sagemath_giac',
+]
 
 [project.readme]
 file = "README.md"
@@ -120,7 +123,6 @@ host-requires = [
   "pkg:generic/libgd",
   "pkg:generic/gap",
   "pkg:generic/gfan",
-  "pkg:generic/giac",
   "pkg:generic/givaro",
   "pkg:generic/glpk",
   "pkg:generic/gmp",


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Not sure if this change is completely right. It seems to me that there is still a giac expect interface in use, so perhaps giac should now be a runtime dependency instead of build dependency of sagelib? Or is that interface obsolete and should/can be removed?

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


