### PR TITLE
implement naive default inverse methods for finite monoids

### DIFF
--- a/src/sage/categories/finite_monoids.py
+++ b/src/sage/categories/finite_monoids.py
@@ -304,6 +304,8 @@ class FiniteMonoids(CategoryWithAxiom):
             """
             parent = self.parent()
             one = parent.one()
+            if self == one:
+                return one
             it = (v for v in parent if v * self == one)
             try:
                 return next(it)

--- a/src/sage/categories/finite_monoids.py
+++ b/src/sage/categories/finite_monoids.py
@@ -306,7 +306,7 @@ class FiniteMonoids(CategoryWithAxiom):
             one = parent.one()
             if self == one:
                 return one
-            it = (v for v in parent if v * self == one)
+            it = (v for v in parent if v * self == one == self * v)
             try:
                 return next(it)
             except StopIteration:

--- a/src/sage/categories/finite_monoids.py
+++ b/src/sage/categories/finite_monoids.py
@@ -8,7 +8,7 @@ Finite monoids
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
-
+from sage.misc.cachefunc import cached_method
 from sage.categories.category_with_axiom import CategoryWithAxiom
 
 
@@ -29,6 +29,12 @@ class FiniteMonoids(CategoryWithAxiom):
     TESTS::
 
         sage: TestSuite(FiniteMonoids()).run()
+
+        sage: R = IntegerModRing(15)
+        sage: M = R.subsemigroup([R(5)], one=R(10),
+        ....:     category=Semigroups().Finite().Subobjects() & Groups())
+        sage: M.one()
+        10
     """
     class ParentMethods:
 
@@ -270,3 +276,36 @@ class FiniteMonoids(CategoryWithAxiom):
                 k += 1
                 self_power_k = self_power_k * self
             return [k, self_powers[self_power_k]]
+
+        @cached_method
+        def __invert__(self):
+            """
+            Return the inverse of ``self`` if it exists.
+
+            This is the generic implementation, very naive and slow.
+
+            EXAMPLES::
+
+                sage: R = IntegerModRing(15)
+                sage: M = R.subsemigroup([R(5)], one=R(10),
+                ....:     category=Semigroups().Finite().Subobjects() & Groups())
+                sage: [~x for x in M]
+                [10, 5]
+
+            TESTS::
+
+                sage: R = IntegerModRing(15)
+                sage: M = R.subsemigroup([R(3)], one=R(1),
+                ....:     category=Semigroups().Finite().Subobjects())
+                sage: ~M(3)
+                Traceback (most recent call last):
+                ...
+                ValueError: the element 3 is not invertible
+            """
+            parent = self.parent()
+            one = parent.one()
+            it = (v for v in parent if v * self == one)
+            try:
+                return next(it)
+            except StopIteration:
+                raise ValueError(f"the element {self} is not invertible")

--- a/src/sage/categories/semigroups.py
+++ b/src/sage/categories/semigroups.py
@@ -434,19 +434,6 @@ class Semigroups(CategoryWithAxiom):
             TESTS::
 
                 sage: TestSuite(M).run()                                                # needs sage.combinat
-                Failure in _test_inverse:
-                Traceback (most recent call last):
-                ...
-                The following tests failed: _test_inverse
-
-            .. TODO::
-
-                - Fix the failure in TESTS by providing a default
-                  implementation of ``__invert__`` for finite groups
-                  (or even finite monoids).
-                - Provide a default implementation of ``one`` for a
-                  finite monoid, so that we would not need to specify
-                  it explicitly?
             """
             from sage.monoids.automatic_semigroup import AutomaticSemigroup
             return AutomaticSemigroup(generators, ambient=self, one=one,


### PR DESCRIPTION
This is implementing very naive `one` and `__invert__` methods in the category of finite monoids.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.



