### PR TITLE
Avoid excessive interpolation in pari gphelp script.

### DIFF
--- a/build/pkgs/pari/patches/gphelp-quoting.patch
+++ b/build/pkgs/pari/patches/gphelp-quoting.patch
@@ -1,0 +1,15 @@
+diff --git a/doc/gphelp.in b/doc/gphelp.in
+index 549b289f33..167e24ed37 100755
+--- a/doc/gphelp.in
++++ b/doc/gphelp.in
+@@ -1,6 +1,9 @@
+ #!@runtime_perl@
+ $version= "@version@";
+-$datadir= "@datadir@";
++$datadir= <<'END_OF_DATADIR';
++@datadir@
++END_OF_DATADIR
++chomp($datadir);
+ # no expanded material (@key@) below
+ # Copyright (C) 2000  The PARI group.
+ #


### PR DESCRIPTION
Currently sage does not build if `SAGE_LOCAL` contains an `@` sign. While admittedly not common, it should not cause failure.

The offender is pari. pari itself compiles fine, but cypari calls `gphelp -raw Catalan` to see if everything works alright, and this fails.

The reason is that `gphelp` is malformed, and can't find its data directory. Primarily, this is based on the following erroneous perl construct:
```
$datadir= "@datadir@";
```
which is found near the top of the `doc/gphelp.in` file.

This goes obviously amiss if `@datadir@` contains an `@` sign, because of the double quotes. AFAIK, the best perl-ish way to be robust to semi-crap that can be found in paths is to use a quoted here-doc, which is what this patch does.

Also reported upstream https://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=2621