### PR TITLE
implement new `.torsion_basis` method based on random sampling

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1121,7 +1121,9 @@ class EllipticCurve_finite_field(EllipticCurve_field):
           If ``algorithm`` is set to anything else, this argument is ignored.
 
         OUTPUT: a pair of points generating `E[n]` when it is isomorphic to `(\Z
-        / n\Z)^2`; otherwise raises an error
+        / n\Z)^2`; otherwise raises an error. The result is cached separately
+        for each algorithm and outputs may differ between algorithms and between
+        runs.
 
         EXAMPLES::
 
@@ -1161,6 +1163,8 @@ class EllipticCurve_finite_field(EllipticCurve_field):
              : 60*z11^10 + 91*z11^9 + 89*z11^8 + 7*z11^7 + 63*z11^6
              + 55*z11^5 + 23*z11^4 + 17*z11^3 + 90*z11^2 + 91*z11 + 68
              : 1)
+            sage: (P, Q) == E.torsion_basis(23)
+            True
 
         ::
 
@@ -1189,10 +1193,12 @@ class EllipticCurve_finite_field(EllipticCurve_field):
         :meth:`AdditiveAbelianGroupWrapper.torsion_subgroup`.
         """
         if algorithm == "random_sampling":
-            return self._torsion_basis_from_random_sampling(n,
-                                                            num_random_trials=num_random_trials)
+            if not hasattr(self, "_torsion_basis_random_sampling"):
+                self._torsion_basis_random_sampling = self._torsion_basis_from_random_sampling(n, num_random_trials=num_random_trials)
+            return self._torsion_basis_random_sampling
 
         if algorithm == "abelian_group":
+            # this is always cached as .abelian_group is cached
             return self._torsion_basis_from_abelian_group(n)
 
         raise ValueError("only algorithms 'random_sampling' and 'abelian_group' supported")

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1170,6 +1170,7 @@ class EllipticCurve_finite_field(EllipticCurve_field):
             sage: E = EllipticCurve(GF(p), [a4, a6])
             sage: P, Q = E.torsion_basis(210)
             sage: P.weil_pairing(Q, 210).multiplicative_order()
+            210
 
         .. SEEALSO::
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1109,13 +1109,13 @@ class EllipticCurve_finite_field(EllipticCurve_field):
         - ``algorithm`` -- (optional) string:
 
           - ``"random_sampling"`` -- samples random points and check they
-            generate `E[n]`.
+            generate `E[n]`
 
           - ``"abelian_group"`` -- use :meth:`abelian_group` and
-            :meth:`AdditiveAbelianGroupWrapper.torsion_subgroup`.
+            :meth:`AdditiveAbelianGroupWrapper.torsion_subgroup`
 
         OUTPUT: a pair of points generating `E[n]` when it is isomorphic to `(\Z
-        / n\Z)^2`, else error.
+        / n\Z)^2`; otherwise raises an error
 
         EXAMPLES::
 
@@ -1177,7 +1177,7 @@ class EllipticCurve_finite_field(EllipticCurve_field):
         point by `|E| / n`. Other random points `Q` of order `n` are generated,
         and `e_n(P, Q)` is checked to generate `\mu_n`.
 
-        When ``algorithm'' is set to "abelian_group", this method currently uses
+        When ``algorithm`` is set to "abelian_group", this method currently uses
         :meth:`abelian_group` and
         :meth:`AdditiveAbelianGroupWrapper.torsion_subgroup`.
         """


### PR DESCRIPTION
This implements a new algorithm for computing `E.torsion_basis` when `E` is an elliptic curve. The method is very simple: sample points, check order, then check they're linearly independent by pairing.

From my testing, the algorithm is always faster than the previous "abelian_group" algorithm, so I set the default to "random_sampling" instead.

By factoring out the algorithm code, we can add algorithms more easily in the future.

We should probably have a method/flag to return also generators of $E[n]$ even when it's not isomorphic to $(Z / nZ)^2$,