### PR TITLE
Fix primes_of_bounded_norm for noninteger entries

### DIFF
--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -3932,6 +3932,8 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
              Fractional ideal (3)]
             sage: K.primes_of_bounded_norm(1)
             []
+            sage: K.primes_of_bounded_norm(1.1)
+            []
             sage: x = polygen(QQ, 'x')
             sage: K.<a> = NumberField(x^3 - 2)
             sage: P = K.primes_of_bounded_norm(30)
@@ -3951,7 +3953,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             B = ZZ(B)
         except (TypeError, AttributeError):
             try:
-                B = ZZ(B.ceil())
+                B = ZZ(B.floor())
             except (TypeError, AttributeError):
                 raise TypeError("%s is not valid bound on prime ideals" % B)
         if B < 2:


### PR DESCRIPTION
For noninteger entries, primes_of_bouned_norm used the ceil function to convert it to an integer. This caused the function to sometimes return primes of norm bigger than the bound.

Using the floor function instead, fixes the issue.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.