### PR TITLE
Replace dead HTTP links in docs

### DIFF
--- a/src/doc/de/thematische_anleitungen/sage_gymnasium.rst
+++ b/src/doc/de/thematische_anleitungen/sage_gymnasium.rst
@@ -1223,20 +1223,17 @@ Weiterführende Links und Literatur
 Das folgende Tutorial erklärt (auf englisch) wie Sage als einfacher Rechner benutzt werden kann. Hier
 finden sich auch viele Funktionen und Beispiele, welche für unsere Zwecke interessant sind.
 
-* http://www-rohan.sdsu.edu/~mosulliv/sagetutorial/sagecalc.html
+* https://mosullivan.sdsu.edu/sagetutorial/sagecalc.html
 
 Die offizielle deutsche Dokumentation von Sage ist noch im Aufbau und weit entfernt von einer
-vollständigen Dokumentation. Das Einführungstutorial ist jedoch auch auf deutsch verfügbar. Die offizielle
-Seite der deutschen Version von Sage findet sich hier:
-
-* http://www.sagemath.org/de/
+vollständigen Dokumentation. Das Einführungstutorial ist jedoch auch auf deutsch verfügbar.
 
 
 .. rubric:: Footnotes
 
-.. [#keywords] http://docs.python.org/2/reference/lexical_analysis.html#keywords
+.. [#keywords] https://docs.python.org/3/reference/lexical_analysis.html#keywords
 .. [#tutorial] http://doc.sagemath.org/html/de/tutorial/
 .. [#units] http://doc.sagemath.org/html/en/reference/calculus/sage/symbolic/units.html
 .. [#2dgraphics] http://doc.sagemath.org/html/en/reference/plotting/index.html
 .. [#scatterplot] http://doc.sagemath.org/html/en/reference/plotting/sage/plot/scatter_plot.html
-.. [#listcomp] http://docs.python.org/2/tutorial/datastructures.html#list-comprehensions
+.. [#listcomp] https://docs.python.org/3/tutorial/datastructures.html#list-comprehensions

--- a/src/doc/de/tutorial/programming.rst
+++ b/src/doc/de/tutorial/programming.rst
@@ -435,8 +435,8 @@ Dictionaries
 Ein Dictionary (manchmal auch assoziativer Array genannt) ist eine
 Abbildung von 'hashbaren' Objekten (z.B. Strings, Zahlen und Tupel;
 Lesen Sie die Python documentation
-http://docs.python.org/tut/node7.html und
-http://docs.python.org/lib/typesmapping.html für weitere Details) zu
+http://docs.python.org/3/tutorial/datastructures.html und
+https://docs.python.org/3/library/stdtypes.html#typesmapping für weitere Details) zu
 beliebigen Objekten.
 
 ::

--- a/src/doc/en/constructions/algebraic_geometry.rst
+++ b/src/doc/en/constructions/algebraic_geometry.rst
@@ -331,7 +331,7 @@ Singular itself to help an understanding of how the wrapper works.
 
 -  Using Singular's ``BrillNoether`` command (for details see the section
    Brill-Noether in the Singular online documentation
-   (http://www.singular.uni-kl.de/Manual/html/sing_960.htm and the
+   (https://www.singular.uni-kl.de/Manual/4-3-0/sing_2254.htm and the
    paper {CF}):
 
    ::

--- a/src/doc/en/developer/coding_basics.rst
+++ b/src/doc/en/developer/coding_basics.rst
@@ -901,7 +901,7 @@ in particular, it is turned into ``\begin{gather} block
 ``align``) which in ordinary LaTeX would not be wrapped like this, you
 must add a **:nowrap:** flag to the MATH mode. See also `Sphinx's
 documentation for math blocks
-<http://sphinx-doc.org/latest/ext/math.html?highlight=nowrap#directive-math>`_. :
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-math>`_. :
 
 .. CODE-BLOCK:: rest
 

--- a/src/doc/en/faq/faq-contribute.rst
+++ b/src/doc/en/faq/faq-contribute.rst
@@ -69,7 +69,7 @@ Another good place to take a look at is
 `Dive Into Python <https://diveintopython3.net>`_
 by Mark Pilgrim, which may be pretty helpful on some specific topics
 such as test-driven development. The book
-`Building Skills in Python <http://itmaybeahack.com/homepage/books/python.html>`_
+`Building Skills in Python <https://itmaybeahack.com/homepage/books/python.html>`_
 by Steven F. Lott is suitable for anyone who is already comfortable
 with programming.
 
@@ -129,9 +129,8 @@ resources can be found by a web search.
 * `pep8 <https://pypi.org/project/pep8>`_
 * `pydeps <https://pypi.org/project/pydeps>`_
 * `pycallgraph <https://pycallgraph.readthedocs.io>`_
-* `PyChecker <http://pychecker.sourceforge.net>`_
 * `PyFlakes <https://pypi.org/project/pyflakes>`_
-* `Pylint <https://www.logilab.org/project/pylint>`_
+* `Pylint <https://pylint.readthedocs.io>`_
 * `Python <https://www.python.org>`_ home page and the
   `Python standard documentation <https://docs.python.org>`_
 * `Snakefood <http://furius.ca/snakefood>`_
@@ -140,10 +139,10 @@ resources can be found by a web search.
 
 **Tutorials and books**
 
-* `Cython Tutorial <http://conference.scipy.org/proceedings/SciPy2009/paper_1/>`_
+* `Cython Tutorial <https://proceedings.scipy.org/articles/MJMV8092.pdf>`_
   by Stefan Behnel, Robert W. Bradshaw, and Dag Sverre Seljebotn
 * `Dive Into Python 3 <http://www.diveintopython3.net>`_ by Mark Pilgrim
-* `Fast Numerical Computations with Cython <http://conference.scipy.org/proceedings/SciPy2009/paper_2/>`_
+* `Fast Numerical Computations with Cython <https://proceedings.scipy.org/articles/GTCA8577.pdf>`_
   by Dag Sverre Seljebotn
 * `Official Python Tutorial <https://docs.python.org/3/tutorial/>`_
 

--- a/src/doc/en/faq/faq-general.rst
+++ b/src/doc/en/faq/faq-general.rst
@@ -199,8 +199,6 @@ functionalities are made possible through FOSS projects such as
 * `OpenBLAS <https://www.openblas.net/>`_  --- an optimized BLAS library.
 * `Pari/GP <https://pari.math.u-bordeaux.fr>`_ --- a computer algebra
   system for fast computations in number theory.
-* `Pynac <http://pynac.sagemath.org>`_ --- a modified version of GiNaC
-  that replaces the dependency on CLN by Python.
 * `R <http://www.r-project.org>`_ --- a language and environment for
   statistical computing and graphics.
 * And many more too numerous to list here.

--- a/src/doc/en/faq/faq-usage.rst
+++ b/src/doc/en/faq/faq-usage.rst
@@ -219,8 +219,8 @@ by a web search.
 
 * `Building Skills in Python <http://homepage.mac.com/s_lott/books/python.html>`_
   by Steven F. Lott
-* `Dive into Python <http://www.diveintopython.net>`_ by Mark Pilgrim
-* `How to Think Like a Computer Scientist <http://www.openbookproject.net/thinkCSpy>`_
+* `Dive into Python <https://diveintopython3.net>`_ by Mark Pilgrim
+* `How to Think Like a Computer Scientist <https://www.openbookproject.net/thinkcs/python/english3e/>`_
   by Jeffrey Elkner, Allen B. Downey, and Chris Meyers
 * `Official Python Tutorial <https://docs.python.org/tutorial>`_
 * `Python <https://www.python.org>`_ home page and the
@@ -562,7 +562,7 @@ include the following:
     limit maxproc 512 2048
 
 then reboot. See
-`this page <http://www.macosxhints.com/article.php?story=20050709233920660>`_
+`this page <https://web.archive.org/web/20051106134912/http://www.macosxhints.com/article.php?story=20050709233920660>`_
 for more details.
 
 How do I plot the cube root (or other odd roots) for negative input?

--- a/src/doc/en/prep/Advanced-2DPlotting.rst
+++ b/src/doc/en/prep/Advanced-2DPlotting.rst
@@ -15,7 +15,7 @@ Attribution\-ShareAlike 3.0 license (`CC BY\-SA
 <http://creativecommons.org/licenses/by-sa/3.0/>`_).
 
 Thanks to Sage's integration of projects like `matplotlib
-<http://matplotlib.sourceforge.net/>`_, Sage has comprehensive
+<https://matplotlib.org/>`_, Sage has comprehensive
 two-dimensional plotting capabilities.  This worksheet consists of the
 following sections:
 

--- a/src/doc/en/prep/Quickstarts/NumAnalysis.rst
+++ b/src/doc/en/prep/Quickstarts/NumAnalysis.rst
@@ -130,7 +130,7 @@ involved).
     425/32
 
 Now let's convert ``x`` to the IEEE 754 binary format that is commonly
-used in computers.  For `IEEE 754 <http://grouper.ieee.org/groups/754/>`_,
+used in computers.  For `IEEE 754 <https://en.wikipedia.org/wiki/IEEE_754>`_,
 the first step in getting the binary format is to normalize the number,
 or express the number as a number between 1 and 2 multiplied by a power of 2.
 For our ``x`` above, we multiply by `2^{-3}` to get a number between 1 and 2.

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -66,7 +66,7 @@ REFERENCES:
 
 .. [ABBR2011] \A. Abad, R. Barrio, F. Blesa, M. Rodriguez.
               "TIDES tutorial: Integrating ODEs by using the Taylor Series Method."
-              http://www.unizar.es/acz/05Publicaciones/Monografias/MonografiasPublicadas/Monografia36/IndMonogr36.htm
+              https://web.archive.org/web/20120206041615/http://www.unizar.es/acz/05Publicaciones/Monografias/MonografiasPublicadas/Monografia36/IndMonogr36.htm
 
 .. [ABBR2012] \A. Abad, R. Barrio, F. Blesa, M. Rodriguez. Algorithm 924.
               *ACM Transactions on Mathematical Software*, **39** no. 1 (2012), 1-28.
@@ -316,7 +316,7 @@ REFERENCES:
               On the Jacobians of plane cubics,
               Advances in Mathematics 198 (2005) 1, pp. 366--382
               :doi:`10.1016/j.aim.2005.06.004`
-              http://www.math.utexas.edu/users/villegas/publications/jacobian-cubics.pdf
+              https://web.archive.org/web/20100613171401/http://www.math.utexas.edu/users/villegas/publications/jacobian-cubics.pdf
 
 .. [AS-Bessel] \F. W. J. Olver: 9. Bessel Functions of Integer Order,
                in Abramowitz and Stegun: Handbook of Mathematical Functions.
@@ -375,7 +375,7 @@ REFERENCES:
              1991-1992. INRIA Research Report 1779, 1992,
              http://www.inria.fr/rrrt/rr-1779.html. Summary
              by F. Morain.
-             http://citeseer.ist.psu.edu/atkin92probabilistic.html
+             https://inria.hal.science/inria-00077019v1/file/RR-1779.pdf
 
 .. [Ath1996] \C. A. Athanasiadis,
             *Characteristic polynomials of subspace arrangements and finite fields*.
@@ -400,7 +400,7 @@ REFERENCES:
             ACM SIGPLAN Notices, 2006,
             vol. 41, n.5, pages 39--45.
             :doi:`10.1145/1149982.1149987`.
-            http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.86.1801&rep=rep1&type=pdf
+            https://citeseerx.ist.psu.edu/pdf/aa491fe18191e34e95f4f3658ba44b3e2542c847
 
 .. [AY1983] \I. A. Aizenberg and A. P. Yuzhakov.  *Integral
             representations and residues in multidimensional complex
@@ -685,7 +685,7 @@ REFERENCES:
 .. [BD2007] Michael Brickenstein, Alexander Dreyer; *PolyBoRi: A
             Groebner basis framework for Boolean polynomials*;
             pre-print available at
-            http://www.itwm.fraunhofer.de/fileadmin/ITWM-Media/Zentral/Pdf/Berichte_ITWM/2007/bericht122.pdf
+            https://kluedo.ub.rptu.de/frontdoor/deliver/index/docId/1976/file/bericht122.pdf
 
 .. [BDHPR2019] Marthe Bonamy, Oscar Defrain, Marc Heinrich, Michał
                Pilipczuk, and Jean-Florent Raymond.
@@ -766,7 +766,7 @@ REFERENCES:
              Graduate Studies in Mathematics, Volume 198. 2019.
 
 .. [Benasque2009] Fernando Rodriguez Villegas, *The L-function of the quintic*,
-   http://users.ictp.it/~villegas/hgm/benasque-2009-report.pdf
+   https://web.archive.org/web/20151112053901/http://users.ictp.it/~villegas/hgm/benasque-2009-report.pdf
 
 .. [Ber1987] \M. Berger, *Geometry I*, Springer (Berlin) (1987);
              :doi:`10.1007/978-3-540-93815-6`
@@ -916,7 +916,7 @@ REFERENCES:
          Computations with equivariant toric vector bundles,
          The Journal of Software for Algebra and Geometry: Macaulay2.
          http://msp.org/jsag/2010/2-1/p03.xhtml
-         http://www.math.uiuc.edu/Macaulay2/doc/Macaulay2-1.8.2/share/doc/Macaulay2/ToricVectorBundles/html/
+         https://web.archive.org/web/20150915112020/http://www.math.uiuc.edu/Macaulay2/doc/Macaulay2-1.8.2/share/doc/Macaulay2/ToricVectorBundles/html/
 
 .. [Bir1975] \J. Birman. *Braids, Links, and Mapping Class Groups*,
              Princeton University Press, 1975
@@ -1020,7 +1020,7 @@ REFERENCES:
             *Strongly regular graphs and partial geometries*,
             Enumeration and design,
             (Waterloo, Ont., 1982) (1984): 85-122.
-            http://oai.cwi.nl/oai/asset/1817/1817A.pdf
+            https://web.archive.org/web/20130423123100/http://oai.cwi.nl/oai/asset/1817/1817A.pdf
 
 .. [BL2000] Anders Björner and Frank H. Lutz, "Simplicial manifolds,
             bistellar flips and a 16-vertex triangulation of the
@@ -1276,7 +1276,7 @@ REFERENCES:
 .. [Brandes01] Ulrik Brandes,
                A faster algorithm for betweenness centrality,
                Journal of Mathematical Sociology 25.2 (2001): 163-177,
-               http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
+               https://web.archive.org/web/20060508220739/http://www.inf.uni-konstanz.de/algo/publications/b-fabc-01.pdf
 
 .. [Bra2011] Volker Braun,
              Toric Elliptic Fibrations and F-Theory Compactifications,
@@ -1418,7 +1418,7 @@ REFERENCES:
              Discrete Mathematics,
              vol.39, num.3, pages 263-281,
              1982
-             http://oai.cwi.nl/oai/asset/304/0304A.pdf
+             https://web.archive.org/web/20130423122429/http://oai.cwi.nl/oai/asset/304/0304A.pdf
 
 .. [BW1988] Anders Björner, Michelle L. Wachs,
             *Generalized quotients in Coxeter groups*.
@@ -1570,7 +1570,7 @@ REFERENCES:
 .. [Cer1994] \D. P. Cervone, "Vertex-minimal simplicial immersions of
              the Klein bottle in three-space", Geom. Ded. 50 (1994)
              117-141,
-             http://www.math.union.edu/~dpvc/papers/1993-03.kb/vmkb.pdf.
+             https://web.archive.org/web/20040309191227/http://www.math.union.edu/~dpvc/papers/1993-03.kb/vmkb.pdf.
 
 .. [CES2003] Brian Conrad, Bas Edixhoven, William Stein
              `J_1(p)` Has Connected Fibers
@@ -1740,7 +1740,7 @@ REFERENCES:
 
 .. [CK2015] \J. Campbell and V. Knight. *On testing degeneracy of
             bi-matrix
-            games*. http://vknight.org/unpeudemath/code/2015/06/25/on_testing_degeneracy_of_games/ (2015)
+            games*. https://vknight.org/unpeudemath/code/2015/06/25/on_testing_degeneracy_of_games.html (2015)
 
 .. [CKWL2019] Marcelo H. de Carvalho, Nishad Kothari, Xiumei Wang and Yixun
               Linc. *Birkhoff-von Neumann graphs that are PM-compact*. 2019.
@@ -1820,7 +1820,7 @@ REFERENCES:
 .. [CMR2005] C\. Cid, S\. Murphy, M\. Robshaw, *Small Scale Variants of
              the AES*; in Proceedings of Fast Software Encryption
              2005; LNCS 3557; Springer Verlag 2005; available at
-             http://www.isg.rhul.ac.uk/~sean/smallAES-fse05.pdf
+             https://web.archive.org/web/20060306144250/http://www.isg.rhul.ac.uk/~sean/smallAES-fse05.pdf
 
 .. [CMR2006] C\. Cid, S\. Murphy, and M\. Robshaw, *Algebraic Aspects
              of the Advanced Encryption Standard*; Springer Verlag
@@ -1858,7 +1858,7 @@ REFERENCES:
             *On blocks of Deligne's category*
             `\underline{\mathrm{Rep}}(S_t)`.
             :arxiv:`0910.5695v2`,
-            http://pages.uoregon.edu/jcomes/blocks.pdf
+            https://doi.org/10.1016/j.aim.2010.08.010
 
 .. [Coh1981] \A. M. Cohen,
              *A synopsis of known distance-regular graphs with large diameters*,
@@ -1896,7 +1896,7 @@ REFERENCES:
 
 .. [Col2013] Julia Collins. *An algorithm for computing the Seifert
              matrix of a link from a braid
-             representation*. (2013). http://www.maths.ed.ac.uk/~jcollins/SeifertMatrix/SeifertMatrix.pdf
+             representation*. (2013). https://ensaios.sbm.org.br/wp-content/uploads/sites/8/sites/8/2021/11/EM_30_Collins-1.pdf
 
 .. [Com2019] Camille Combe, *Réalisation cubique du poset des
              intervalles de Tamari*, preprint :arxiv:`1904.00658`
@@ -2118,7 +2118,7 @@ REFERENCES:
 .. [DCSW2008] \C. De Canniere, H. Sato, D. Watanabe,
               *Hash Function Luffa: Specification*; submitted to
               NIST SHA-3 Competition, 2008. Available at
-              http://www.sdl.hitachi.co.jp/crypto/luffa/
+              https://www.hitachi.com/rd/yrl/crypto/luffa/
 
 .. [DCW2016] Dan-Cohen, Ishai, and Stefan Wewers. "Mixed Tate motives and the
              unit equation." International Mathematics Research Notices
@@ -2135,7 +2135,7 @@ REFERENCES:
               Lyubashevsky. *Lattice Signatures and Bimodal
               Gaussians*; in Advances in Cryptology – CRYPTO 2013;
               Lecture Notes in Computer Science Volume 8042, 2013, pp
-              40-56 http://www.di.ens.fr/~lyubash/papers/bimodal.pdf
+              40-56 https://web.archive.org/web/20160429074431/http://www.di.ens.fr/~lyubash/papers/bimodal.pdf
 
 .. [Dec1998] \W. Decker and T. de Jong. Groebner Bases and Invariant
              Theory in Groebner Bases and Applications. London
@@ -2263,8 +2263,7 @@ REFERENCES:
 
 .. [Dil1940] Lattice with Unique Irreducible Decompositions
              \R. P. Dilworth, 1940 (Annals of Mathematics 41, 771-777)
-             With comments by B. Monjardet
-             http://cams.ehess.fr/docannexe.php?id=1145
+             https://doi.org/10.2307/1968857
 
 .. [Di2000] \L. Dissett, Combinatorial and computational aspects of
             finite geometries, 2000,
@@ -2380,7 +2379,7 @@ REFERENCES:
             Theory, 45 (4), pp. 1271-1275, 1999.
 
 .. [Dol2009] Igor Dolgachev. *McKay Correspondence*. (2009).
-             http://www.math.lsa.umich.edu/~idolga/McKaybook.pdf
+             https://web.archive.org/web/20100622092138/http://www.math.lsa.umich.edu/~idolga/McKaybook.pdf
 
 .. [dotspec] http://www.graphviz.org/doc/info/lang.html
 
@@ -2539,7 +2538,7 @@ REFERENCES:
 .. [Eh2013] Ehrhardt, Wolfgang. "The AMath and DAMath Special
             Functions: Reference Manual and Implementation Notes,
             Version
-            1.3". 2013. http://www.wolfgang-ehrhardt.de/specialfunctions.pdf.
+            1.3". 2013. https://web.archive.org/web/20131210061646/http://www.wolfgang-ehrhardt.de/specialfunctions.pdf.
 
 .. [EL2002] Ekedahl, Torsten & Laksov, Dan. (2002). *Splitting algebras, Symmetric functions and
             Galois Theory*. J. Algebra Appl. 4, :doi:`10.1142/S0219498805001034`
@@ -2550,7 +2549,7 @@ REFERENCES:
 
 .. [EMMN1998] \P. Eaded, J. Marks, P.Mutzel, S. North.
               *Fifth Annual Graph Drawing Contest*;
-              http://www.merl.com/papers/docs/TR98-16.pdf
+              https://web.archive.org/web/20080410114752/http://www.merl.com/papers/docs/TR98-16.pdf
 
 .. [Eny2012] \J. Enyang. *Jucys-Murphy elements and a presentation
              for the partition algebra*. J. Algebraic Combin.
@@ -2717,7 +2716,7 @@ REFERENCES:
 .. [FMSS1995] Fulton, MacPherson, Sottile, Sturmfels:
               *Intersection theory on spherical varieties*,
               J. of Alg. Geometry 4 (1995), 181-193.
-              http://www.math.tamu.edu/~frank.sottile/research/ps/spherical.ps.gz
+              https://web.archive.org/web/20220120030039/http://www.math.tamu.edu/~frank.sottile/research/ps/spherical.ps.gz
 
 .. [FMV2014] Xander Faber, Michelle Manes, and Bianca Viray. Computing
              Conjugating Sets and Automorphism Groups of Rational Functions.
@@ -2792,7 +2791,7 @@ REFERENCES:
             Toric Varieties*, :arxiv:`alg-geom/9403002`
 
 .. [FS2009] Philippe Flajolet and Robert Sedgewick,
-            `Analytic combinatorics <http://algo.inria.fr/flajolet/Publications/AnaCombi/book.pdf>`_.
+            `Analytic combinatorics <https://web.archive.org/web/20111206133426/http://algo.inria.fr/flajolet/Publications/AnaCombi/book.pdf>`_.
             Cambridge University Press, Cambridge, 2009.
             See also the `Errata list <http://ac.cs.princeton.edu/errata/>`_.
 
@@ -3094,7 +3093,7 @@ REFERENCES:
 .. [GPV2008] Craig Gentry, Chris Peikert, Vinod Vaikuntanathan. *How
              to Use a Short Basis: Trapdoors for Hard Lattices and New
              Cryptographic
-             Constructions*. STOC 2008. http://www.cc.gatech.edu/~cpeikert/pubs/trap_lattice.pdf
+             Constructions*. STOC 2008. https://web.archive.org/web/20121015230036/http://www.cc.gatech.edu/~cpeikert/pubs/trap_lattice.pdf
 
 .. [GR2001] Chris Godsil and Gordon Royle, *Algebraic Graph Theory*. Graduate
             Texts in Mathematics, Springer, 2001.
@@ -3129,7 +3128,7 @@ REFERENCES:
 
 .. [GR1989] \A. M. Garsia, C. Reutenauer. *A decomposition of Solomon's
             descent algebra.* Adv. Math. **77** (1989).
-            http://www.lacim.uqam.ca/~christo/Publi%C3%A9s/1989/Decomposition%20Solomon.pdf
+            https://web.archive.org/web/20210829143502/http://lacim-membre.uqam.ca/~christo/Publi%C3%A9s/1989/Decomposition%20Solomon.pdf
 
 .. [GR1993] Ira M. Gessel, Christophe Reutenauer.
             *Counting Permutations with Given Cycle Structure and Descent Set*. Journal of
@@ -3270,7 +3269,7 @@ REFERENCES:
              http://www.sciencedirect.com/science/article/pii/0012365X9290368P
 
 .. [Haj2000] \M. Hajiaghayi, *Consecutive Ones Property*, 2000.
-             http://www-math.mit.edu/~hajiagha/pp11.ps
+             https://web.archive.org/web/20040401033532/http://www-math.mit.edu/~hajiagha/pp11.ps
 
 .. [Han2016] \G.-N. Han, *Hankel continued fraction and its applications*,
              Adv. in Math., 303, 2016, pp. 295-321.
@@ -3280,7 +3279,7 @@ REFERENCES:
              pages 145--157, vol. 12,
              Canadian Journal of Mathematics,
              1960
-             http://cms.math.ca/cjm/v12/cjm1960v12.0145-0157.pdf
+             https://web.archive.org/web/20141206163905/http://cms.math.ca/cjm/v12/cjm1960v12.0145-0157.pdf
 
 .. [Har1962] Frank Harary. *The determinant of the adjacency matrix of a graph*.
              SIAM Review 4 (1962), pp. 202-210.
@@ -3430,7 +3429,7 @@ REFERENCES:
 
 .. [Hopkins2017] Sam Hopkins,
                  *RSK via local transformations*,
-                 http://web.mit.edu/~shopkins/docs/rsk.pdf
+                 https://web.archive.org/web/20150702045543/http://web.mit.edu/~shopkins/docs/rsk.pdf
 
 .. [HilGra1976] \A. P. Hillman, R. M. Grassl,
                 *Reverse plane partitions and tableau hook numbers*,
@@ -3472,7 +3471,7 @@ REFERENCES:
             *A survey of the algorithmic aspects of modular decomposition*.
             Computer Science Review
             vol 4, number 1, pages 41--59, 2010,
-            http://www.lirmm.fr/~paul/md-survey.pdf,
+            https://web.archive.org/web/20110725082702/http://www.lirmm.fr/~paul/md-survey.pdf,
             :doi:`10.1016/j.cosrev.2010.01.001`.
 
 .. [HP2016] \S. Hopkins, D. Perkinson. "Bigraphical
@@ -3482,7 +3481,7 @@ REFERENCES:
 .. [HPR2010] Gary Haggard, David J. Pearce and Gordon Royle.
              *Computing Tutte Polynomials*. In ACM Transactions on Mathematical
              Software, Volume 37(3), article 24, 2010. Preprint:
-             http://homepages.ecs.vuw.ac.nz/~djp/files/TOMS10.pdf
+             https://web.archive.org/web/20110401195911/http://homepages.ecs.vuw.ac.nz/~djp/files/TOMS10.pdf
 
 .. [HPS2008] \J. Hoffstein, J. Pipher, and J.H. Silverman. *An
              Introduction to Mathematical
@@ -3922,7 +3921,7 @@ REFERENCES:
             *Groups generated by involutions, Gelfand--Tsetlin patterns,
             and combinatorics of Young tableaux*,
             Algebra i Analiz, 1995, Volume 7, Issue 1, pp. 92--152.
-            http://math.uoregon.edu/~arkadiy/bk1.pdf
+            https://web.archive.org/web/20120616004248/http://pages.uoregon.edu/arkadiy/bk1.pdf
 
 .. [KD2015] Donald Keedwell and József Dénes, Latin Squares and their
             Applications (2nd ed.), Elsevier B.V., Amsterdam-Netherlands,
@@ -4115,12 +4114,12 @@ REFERENCES:
 
 .. [KohECHIDNA] Kohel, David.  ECHIDNA: Databases for Elliptic Curves and Higher
                 Dimensional Analogues.  Available at
-                http://echidna.maths.usyd.edu.au/~kohel/dbs/
+                https://www.i2m.univ-amu.fr/perso/david.kohel/dbs/index.html
 
 .. [Koh2007] \A. Kohnert, *Constructing two-weight codes with prescribed
              groups of automorphisms*, Discrete applied mathematics 155,
              no. 11 (2007):
-             1451-1457. http://linearcodes.uni-bayreuth.de/twoweight/
+             1451-1457. https://web.archive.org/web/20170826072136/http://linearcodes.uni-bayreuth.de/twoweight/
 
 .. [Kol1991] \V. A. Kolyvagin. On the structure of Shafarevich-Tate
              groups. Algebraic geometry, 94--121, Lecture Notes in Math., 1479,
@@ -4438,7 +4437,7 @@ REFERENCES:
 
 .. [Lim] \C. H. Lim,
          *CRYPTON: A New 128-bit Block Cipher*; available at
-         http://next.sejong.ac.kr/~chlim/pub/cryptonv05.ps
+         https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=89a685057c2ce4f632b105dcaec264b9162a1800
 
 .. [Lim2001] \C. H. Lim,
              *A Revised Version of CRYPTON: CRYPTON V1.0*; in FSE'01, pp. 31--45.
@@ -4472,7 +4471,7 @@ REFERENCES:
 
 .. [LLMS2013] Thomas Lam, Luc Lapointe, Jennifer Morse, and Mark Shimozono (2013).
               *The poset of k-shapes and branching rules for k-Schur functions*
-              <http://breakfreerun.org/index.php/ebooks/the-poset-of-k-shapes-and-branching-rules-for-k-schur-functions>`_. Memoirs of the American Mathematical Society, 223(1050), 1-113. DOI: 10.1090/S0065-9266-2012-00655-1
+              <https://www.ams.org/books/memo/1050/memo1050.pdf>`_. Memoirs of the American Mathematical Society, 223(1050), 1-113. DOI: 10.1090/S0065-9266-2012-00655-1
 
 .. [LLMSSZ2013] Thomas Lam, Luc Lapointe, Jennifer Morse, Anne
                 Schilling, Mark Shimozono and Mike Zabrocki.
@@ -4535,7 +4534,7 @@ REFERENCES:
 
 .. [Lod1995] Jean-Louis Loday. *Cup-product for Leibniz cohomology and
              dual Leibniz algebras*. Math. Scand., pp. 189--196
-             (1995). http://www.math.uiuc.edu/K-theory/0015/cup_product.pdf
+             (1995). https://web.archive.org/web/20080706173654/http://www.math.uiuc.edu/K-theory/0015/cup_product.pdf
 
 .. [Loe2007] David Loeffler, *Spectral expansions of overconvergent
              modular functions*, Int. Math. Res. Not 2007 (050).
@@ -4716,7 +4715,7 @@ REFERENCES:
 
 .. [Ltd06] Beijing Data Security Technology Co. Ltd,
            *Specification of SMS4, Block Cipher for WLAN Products - SMS4* (in Chinese);
-           Available at http://www.oscca.gov.cn/UpFile/200621016423197990.pdf, (2006).
+           Available at https://web.archive.org/web/20130108030812/http://www.oscca.gov.cn/UpFile/200621016423197990.pdf, (2006).
 
 .. [LTV1999] Bernard Leclerc, Jean-Yves Thibon, and Eric Vasserot.
              *Zelevinsky's involution at roots of unity*.
@@ -4971,7 +4970,7 @@ REFERENCES:
 .. [MKO1998] Hans Munthe--Kaas and Brynjulf Owren.
              *Computations in a free Lie algebra*. (1998).
              `Downloadable from Munthe-Kaas's website
-             <http://hans.munthe-kaas.no/work/Blog/Entries/1999/1/1_Article__Computations_in_a_Free_Lie-algebra.html>`_
+             <https://web.archive.org/web/20200321054221/http://hans.munthe-kaas.no/work/Blog/Entries/1999/1/1_Article__Computations_in_a_Free_Lie-algebra_files/munthe-kaas99cia.pdf>`_
 
 .. [MLH2008] \C. Magnien, M. Latapy, and M. Habib. *Fast computation of
              empirically tight bounds for the diameter of massive graphs*.
@@ -5057,7 +5056,7 @@ REFERENCES:
 .. [MPP2008] Conrado Martinez, Alois Panholzer and Helmut Prodinger,
              *Generating random derangements*
              :doi:`10.1137/1.9781611972986.7`
-             http://www.siam.org/proceedings/analco/2008/anl08_022martinezc.pdf
+             https://web.archive.org/web/20080517081306/http://www.siam.org/proceedings/analco/2008/anl08_022martinezc.pdf
 
 .. [MPPS2020] Jennifer Morse, Jianping Pan, Wencin Poh, Anne Schilling.
              *A Crystal on Decreasing Factorizations in the 0-Hecke Monoid*
@@ -5075,7 +5074,7 @@ REFERENCES:
 .. [MR1995] \C. Malvenuto, C. Reutenauer, *Duality between
             quasi-symmetric functions and the Solomon descent algebra*,
             Journal of Algebra 177 (1995), no. 3, 967-982.
-            http://www.lacim.uqam.ca/~christo/Publi%C3%A9s/1995/Duality.pdf
+            https://web.archive.org/web/20210829143748/http://lacim-membre.uqam.ca/~christo/Publi%C3%A9s/1995/Duality.pdf
 
 .. [MR1998] \P. P. Martin and G. Rollet.
             *The Potts model representation and a Robinson-Schensted
@@ -5468,7 +5467,7 @@ REFERENCES:
 .. [PoiReu95] Stephane Poirier, Christophe Reutenauer,
               *Algèbres de Hopf de tableaux*,
               Ann. Sci. Math. Québec, 19 (1): 79--90.
-              http://www.lacim.uqam.ca/~christo/Publi%C3%A9s/1995/Alg%C3%A8bres%20de%20Hopf%20de%20tableaux.pdf
+              https://web.archive.org/web/20210829143708/http://lacim-membre.uqam.ca/~christo/Publi%C3%A9s/1995/Alg%C3%A8bres%20de%20Hopf%20de%20tableaux.pdf
 
 .. [PM2019] \D. Penazzi, M. Montes. "Shamash (and Shamashash)"
             https://csrc.nist.gov/CSRC/media/Projects/Lightweight-Cryptography/documents/round-1/spec-doc/ShamashAndShamashash-spec.pdf
@@ -5637,7 +5636,7 @@ REFERENCES:
 .. [Ram1997] Arun Ram. *Seminormal representations of Weyl groups
              and Iwahori-Hecke algebras*. Proc. London Math. Soc. (3)
              **75** (1997). 99-133. :arxiv:`math/9511223v1`.
-             http://www.ms.unimelb.edu.au/~ram/Publications/1997PLMSv75p99.pdf
+             https://web.archive.org/web/20110304035530/http://www.ms.unimelb.edu.au/~ram/Publications/1997PLMSv75p99.pdf
 
 .. [RCES1994] Ruskey, R. Cohen, P. Eades, A. Scott.
               *Alley CATs in search of good homes.*
@@ -5656,7 +5655,7 @@ REFERENCES:
 
 .. [Red2001] Maria Julia Redondo. *Hochschild cohomology: some methods
              for computations*. Resenhas IME-USP 5 (2), 113-137
-             (2001). http://inmabb.criba.edu.ar/gente/mredondo/crasp.pdfc
+             (2001). https://inmabb.criba.edu.ar/gente/mredondo/crasp.pdf
 
 .. [Reg09] Oded Regev. On Lattices, Learning with Errors, Random
            Linear Codes, and Cryptography. in Journal of the ACM
@@ -5684,7 +5683,7 @@ REFERENCES:
              Preprint of a chapter in the Handbook of Algebra,
              2003.
              `Downloadable from Reutenauer's website
-             <http://www.lacim.uqam.ca/~christo/Publi%C3%A9s/2003/free%20Lie%20algebras.pdf>`_
+             <https://reutenauer.math.uqam.ca/wp-content/uploads/2024/05/Free-Lie-Algebras-Handbook-2003-compresse.pdf>`_
 
 .. [Rho69] John Rhodes, *Characters and complexity of finite semigroups*
            \J. Combinatorial Theory, vol 6, 1969
@@ -5834,7 +5833,7 @@ REFERENCES:
              tetrahedron*. Bull. Amer. Math. Soc. 64 (1958), 90-91.
 
 .. [Rus2003] Frank Ruskey. *Combinatorial Generation*. (2003).
-             http://www.1stworks.com/ref/ruskeycombgen.pdf
+             https://web.archive.org/web/20060306012047/http://www.1stworks.com/ref/RuskeyCombGen.pdf
 
 .. [Rüt2014] Julian Rüth, *Models of Curves and Valuations*. Open Access
              Repositorium der Universität Ulm. Dissertation (2014).
@@ -5930,7 +5929,7 @@ REFERENCES:
 
 .. [Sch2004] Manfred Schocker, *The descent algebra of the
              symmetric group*. Fields Inst. Comm. 40 (2004), pp. 145-161.
-             http://www.mathematik.uni-bielefeld.de/~ringel/schocker-neu.ps
+             https://www.ams.org/books/fic/040/
 
 .. [Sch2006] Oliver Schiffmann. *Lectures on Hall algebras*,
              preprint, 2006. :arxiv:`0611617v2`.
@@ -6373,7 +6372,7 @@ REFERENCES:
                    http://norvig.com/sudoku.html
 
 .. [sudoku:royle]  Gordon Royle, "Minimum Sudoku",
-                   http://people.csse.uwa.edu.au/gordon/sudokumin.php
+                   https://web.archive.org/web/20081019022329/http://people.csse.uwa.edu.au/gordon/sudokumin.php/sudokumin.php
 
 .. [sudoku:top95]  "95 Hard Puzzles", http://magictour.free.fr/top95,
                    or http://norvig.com/top95.txt
@@ -6440,7 +6439,7 @@ REFERENCES:
             curves---first report*. In *Algorithmic number theory
             (ANTS V), Sydney, 2002*, Lecture Notes in Computer Science
             2369, Springer, 2002,
-            p267--275. http://modular.math.washington.edu/papers/stein-watkins/
+            p267--275. https://web.archive.org/web/20060909093620/http://modular.math.washington.edu/papers/stein-watkins/ants.pdf
 
 .. [SW2012] John Shareshian and Michelle Wachs.
             *Chromatic quasisymmetric functions and Hessenberg varieties*.
@@ -6578,7 +6577,7 @@ REFERENCES:
 
 .. [TIDES] \A. Abad, R. Barrio, F. Blesa, M. Rodriguez. TIDES tutorial:
            Integrating ODEs by using the Taylor Series Method
-           (http://www.unizar.es/acz/05Publicaciones/Monografias/MonografiasPublicadas/Monografia36/IndMonogr36.htm)
+           (https://web.archive.org/web/20120206041615/http://www.unizar.es/acz/05Publicaciones/Monografias/MonografiasPublicadas/Monografia36/IndMonogr36.htm)
 
 .. [TingleyLN] Peter Tingley. *Explicit* `\widehat{\mathfrak{sl}}_n` *crystal
                maps between cylindric plane partitions, multi-partitions, and
@@ -6596,7 +6595,7 @@ REFERENCES:
             :doi:`10.3390/a6010100`.
 
 .. [TOPCOM] \J. Rambau, TOPCOM
-            <http://www.rambau.wm.uni-bayreuth.de/TOPCOM/>.
+            <https://web.archive.org/web/20160816104216/http://www.rambau.wm.uni-bayreuth.de/TOPCOM/>.
 
 .. [TT2023] Tan Nhat Tran and Shuhei Tsujie.
             *A type B analog of Ish arrangement*.
@@ -6687,7 +6686,7 @@ REFERENCES:
               The Electronic Journal of Combinatorics. 2016
 
 .. [Ver] Helena Verrill, "Fundamental domain drawer", Java program,
-         http://www.math.lsu.edu/~verrill/
+         https://web.archive.org/web/20031001201351/http://www.hverrill.net/fundomain/
 
 .. [Vie1979] Gérard Viennot. *Permutations ayant une forme
              donnée*.  Discrete Mathematics 26.3 (1979): 279-284.
@@ -7038,7 +7037,7 @@ REFERENCES:
 .. [ZS1998] Antoine Zoghbi, Ivan Stojmenovic,
             *Fast Algorithms for Generating Integer Partitions*,
             Intern. J. Computer Math., Vol. 70., pp. 319--332, 1998.
-            http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.42.1287
+            https://citeseerx.ist.psu.edu/pdf/9613c1666b5e48a5035141c8927ade99a9de450e
 
 .. [ZZ2005] Hechun Zhang and R. B. Zhang.
             *Dual canonical bases for the quantum special linear group

--- a/src/doc/en/reference/repl/environ.rst
+++ b/src/doc/en/reference/repl/environ.rst
@@ -49,7 +49,7 @@ default.
 - :envvar:`JUPYTER_CONFIG_DIR` --
   directory where the configuration of Jupyter is stored. By default,
   this is some directory inside :envvar:`DOT_SAGE`.
-  See http://jupyter.readthedocs.io/en/latest/projects/jupyter-directories.html
+  See https://docs.jupyter.org/en/latest/use/jupyter-directories.html
   for more information.
 
 - :envvar:`MPLCONFIGDIR` --

--- a/src/doc/en/reference/sat/index.rst
+++ b/src/doc/en/reference/sat/index.rst
@@ -147,10 +147,10 @@ REFERENCES:
 
 .. [RS] http://reasoning.cs.ucla.edu/rsat/
 
-.. [GL] http://www.lri.fr/~simon/?page=glucose
+.. [GL] https://www.labri.fr/perso/lsimon/research/glucose/
 
 .. [CMS] http://www.msoos.org
 
-.. [SG09] http://www.satcompetition.org/2009/format-benchmarks2009.html
+.. [SG09] https://web.archive.org/web/20090305015900/http://www.satcompetition.org/2009/format-benchmarks2009.html
 
 .. include:: ../footer.txt

--- a/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/half_integral.rst
+++ b/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/half_integral.rst
@@ -7,7 +7,7 @@ Basmaji's Algorithm
 Basmaji
 (page 55 of his Essen thesis, "Ein Algorithmus zur Berechnung von
 Hecke-Operatoren und Anwendungen auf modulare Kurven",
-http://wstein.org/scans/papers/basmaji/).
+https://web.archive.org/web/20160905111513/http://wstein.org/scans/papers/basmaji/thesis_of_basmaji.dvi).
 
 Let :math:`S = S_{k+1}(\varepsilon)` be the space of cusp forms of
 even integer weight :math:`k+1` and character :math:`\varepsilon = \chi

--- a/src/doc/en/thematic_tutorials/functional_programming.rst
+++ b/src/doc/en/thematic_tutorials/functional_programming.rst
@@ -396,14 +396,10 @@ by A. M. Kuchling. Steven F. Lott's book
 `Building Skills in Python <http://homepage.mac.com/s_lott/books/python.html#book-python>`_
 has a chapter on
 `Functional Programming using Collections <http://homepage.mac.com/s_lott/books/python/html/p02/p02c10_adv_seq.html>`_.
-See also the chapter
-`Functional Programming <http://www.diveintopython.net/functional_programming/index.html>`_
-from Mark Pilgrim's book
-`Dive Into Python <http://www.diveintopython.net/>`_.
 
 You might also want to consider experimenting with
 `Haskell <http://www.haskell.org>`_
 for expressing mathematical concepts. For an example of Haskell in
 expressing mathematical algorithms, see J. Gibbons' article
-`Unbounded Spigot Algorithms for the Digits of Pi <http://www.maa.org/pubs/monthly_apr06_toc.html>`_
+`Unbounded Spigot Algorithms for the Digits of Pi <https://www.cs.ox.ac.uk/people/jeremy.gibbons/publications/spigot.pdf>`_
 in the American Mathematical Monthly.

--- a/src/doc/en/thematic_tutorials/numerical_sage/comparison_to_cython.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/comparison_to_cython.rst
@@ -3,7 +3,7 @@ Comparison to Cython/Pyrex
 
 It is certainly possible to write a solver in Cython or Pyrex. From
 the
-http://www.scipy.org/PerformancePython?highlight=\%28performance\%29
+https://scipy.github.io/old-wiki/pages/PerformancePython.html
 website you can find an example. One potential downside to Cython over
 the previous solutions is it requires the user to understand how NumPy
 arrays or Sage matrices are implemented so as to be able to access

--- a/src/doc/en/thematic_tutorials/numerical_sage/ctypes.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/ctypes.rst
@@ -217,4 +217,4 @@ it must be a shared object library and all fortran arguments are
 passed by reference, that is as pointers or using byref. Also even
 though we used very simple data types, it is possible to deal with
 more complicated C structures. For this and more about ctypes see
-http://python.net/crew/theller/ctypes/
+https://docs.python.org/3/library/ctypes.html

--- a/src/doc/en/thematic_tutorials/numerical_sage/f2py.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/f2py.rst
@@ -3,7 +3,7 @@ f2py
 
 F2py is a very nice package that automatically wraps fortran code
 and makes it callable from Python. The Fibonacci examples are taken
-from the f2py webpage http://cens.ioc.ee/projects/f2py2e/.
+from the f2py webpage https://numpy.org/doc/stable/f2py/.
 
 From the notebook the magic %fortran will automatically compile any
 fortran code in a cell and all the subroutines will become callable
@@ -361,7 +361,7 @@ using (inout) or (in,out,overwrite). Remember though that your
 numpy array must use Fortran ordering to avoid the copying.
 
 For more examples and more advanced usage of F2py you should refer
-to the f2py webpage http://cens.ioc.ee/projects/f2py2e/. The
+to the f2py webpage https://numpy.org/doc/stable/f2py/. The
 command line f2py tool which is referred to in the f2py
 documentation can be called from the Sage shell using
 

--- a/src/doc/en/thematic_tutorials/numerical_sage/f2py_examples.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/f2py_examples.rst
@@ -4,7 +4,7 @@ More Interesting Examples with f2py
 Let us now look at some more interesting examples using f2py. We
 will implement a simple iterative method for solving laplace's
 equation in a square. Actually, this implementation is taken from
-http://www.scipy.org/PerformancePython?highlight=\%28performance\%29
+https://scipy.github.io/old-wiki/pages/PerformancePython.html
 page on the scipy website. It has lots of information on
 implementing numerical algorithms in python.
 

--- a/src/doc/en/thematic_tutorials/numerical_sage/numerical_tools.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/numerical_tools.rst
@@ -16,12 +16,12 @@ interface. Now we will spend a bit more time on each of these
 packages.
 
 Before we start let us point out
-http://www.scipy.org/NumPy_for_Matlab_Users, which has a
+https://numpy.org/doc/stable/user/numpy-for-matlab-users.html, which has a
 comparison between matlab and numpy and gives numpy equivalents of
 matlab commands. If you are not familiar with matlab, that's fine, even
 better, it means you won't have any pre-conceived notions of how
 things should work.  Also this
-http://www.scipy.org/Wiki/Documentation?action=AttachFile&do=get&target=scipy_tutorial.pdf
+https://docs.scipy.org/doc/scipy-1.8.1/scipy-ref-1.8.1.pdf
 is a very nice tutorial on SciPy and numpy which is more comprehensive
 than ours.
 

--- a/src/doc/en/thematic_tutorials/numerical_sage/scipy.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/scipy.rst
@@ -1,7 +1,7 @@
 SciPy
 =====
 Again I recommend this
-http://www.scipy.org/Wiki/Documentation?action=AttachFile&do=get&target=scipy_tutorial.pdf.
+https://docs.scipy.org/doc/scipy-1.8.1/scipy-ref-1.8.1.pdf.
 There are many useful SciPy modules, in particular scipy.optimize,
 scipy.stats, scipy.linalg, scipy.linsolve, scipy.sparse,
 scipy.integrate, scipy.fftpack, scipy.signal, scipy.special. Most

--- a/src/doc/en/thematic_tutorials/sandpile.rst
+++ b/src/doc/en/thematic_tutorials/sandpile.rst
@@ -4755,7 +4755,7 @@ Please contact davidp@reed.edu with questions, bug reports, and suggestions for
 additional features and other improvements.
 
 .. [BN] Matthew Baker, Serguei Norine, `Riemann-Roch and Abel-Jacobi Theory on a
-   Finite Graph <http://people.math.gatech.edu/~mbaker/papers.html>`_,
+   Finite Graph <https://web.archive.org/web/20170705081240fw_/http://people.math.gatech.edu/%7Embaker/pdf/graphs_long2.pdf>`_,
    Advances in Mathematics 215 (2007), 766--788.
 
 .. [BTW] Per Bak, Chao Tang and Kurt Wiesenfeld (1987).

--- a/src/doc/en/thematic_tutorials/tutorial-implementing-algebraic-structures.rst
+++ b/src/doc/en/thematic_tutorials/tutorial-implementing-algebraic-structures.rst
@@ -433,7 +433,7 @@ Coercions
 Once we have defined a morphism from `X \to Y`, we can register it as
 a coercion.  This will allow Sage to apply the morphism automatically
 whenever we combine elements of `X` and `Y` together. See
-http://sagemath.com/doc/reference/coercion.html for more
+https://doc.sagemath.org/html/en/reference/coercion/index.html for more
 information. As a training step, let us first define a morphism `X` to
 `Y`, and register it as a coercion::
 

--- a/src/doc/en/thematic_tutorials/tutorial-objects-and-classes.rst
+++ b/src/doc/en/thematic_tutorials/tutorial-objects-and-classes.rst
@@ -25,7 +25,7 @@ surprising for people used to imperative languages like C or Maple. The reason
 is that they are **not variables but names**.
 
 The following explanation is `borrowed from
-David Goodger <http://python.net/~goodger/projects/pycon/2007/idiomatic/handout.html#python-has-names>`_.
+David Goodger <https://web.archive.org/web/20070928013054/http://python.net/~goodger/projects/pycon/2007/idiomatic/handout.html#python-has-names>`_.
 
 Other languages have "variables"
 ================================

--- a/src/doc/en/thematic_tutorials/tutorial-programming-python.rst
+++ b/src/doc/en/thematic_tutorials/tutorial-programming-python.rst
@@ -12,9 +12,9 @@ This tutorial is an introduction to basic programming in Python and Sage, for
 readers with elementary notions of programming but not familiar with the Python
 language. It is far from exhaustive. For a more complete tutorial, have a look
 at the `Python Tutorial
-<http://docs.python.org/release/2.6.4/tutorial/index.html>`_. Also Python's
-`documentation <http://docs.python.org/release/2.6.4/>`_ and in particular the
-`standard library <http://docs.python.org/release/2.6.4/library>`_ can be
+<https://docs.python.org/3/tutorial/index.html>`_. Also Python's
+`documentation <https://docs.python.org/3/>`_ and in particular the
+`standard library <https://docs.python.org/3/library/>`_ can be
 useful.
 
 A :ref:`more advanced tutorial <tutorial-objects-and-classes>` presents the
@@ -24,15 +24,9 @@ Here are further resources to learn Python:
 
 * `Learn Python in 10 minutes
   <http://www.korokithakis.net/tutorials/python>`_ ou en français
-  `Python en 10 minutes
-  <http://mat.oxyg3n.org/index.php?post/2009/07/26/Python-en-10-minutes>`_
-* `Dive into Python <http://diveintopython.net/>`_
+* `Dive into Python <https://diveintopython3.net/>`_
   is a Python book for experienced programmers. Also available in
-  `other languages <http://diveintopython.net/#languages>`_.
-* `Discover Python
-  <http://www.ibm.com/developerworks/views/opensource/libraryview.jsp?search_by=Discover+Python+Part|>`_
-  is a series of articles published in IBM's `developerWorks
-  <http://www.ibm.com/developerworks/>`_ technical resource center.
+  `Spanish <https://www.jmgaguilera.com/inmersionenpython3html/>`_.
 
 Data structures
 ===============

--- a/src/doc/en/tutorial/programming.rst
+++ b/src/doc/en/tutorial/programming.rst
@@ -417,8 +417,8 @@ Dictionaries
 A dictionary (also sometimes called an associative array) is a
 mapping from 'hashable' objects (e.g., strings, numbers, and tuples
 of such; see the Python documentation
-http://docs.python.org/tut/node7.html and
-http://docs.python.org/lib/typesmapping.html for details) to
+http://docs.python.org/3/tutorial/datastructures.html and
+https://docs.python.org/3/library/stdtypes.html#typesmapping for details) to
 arbitrary objects.
 
 ::

--- a/src/doc/fr/tutorial/programming.rst
+++ b/src/doc/fr/tutorial/programming.rst
@@ -430,8 +430,8 @@ Dictionnaires
 Un dictionnaire (parfois appelé un tableau associatif) est une
 correspondance entre des objets « hachables » (par exemple des chaînes, des
 nombres, ou des n-uplets de tels objets, voir
-http://docs.python.org/tut/node7.html et
-http://docs.python.org/lib/typesmapping.html dans la documentation de
+http://docs.python.org/3/tutorial/datastructures.html et
+https://docs.python.org/3/library/stdtypes.html#typesmapping dans la documentation de
 Python pour plus de détails) vers des objets arbitraires.
 
 ::

--- a/src/doc/it/faq/faq-contribute.rst
+++ b/src/doc/it/faq/faq-contribute.rst
@@ -65,7 +65,7 @@ Un altro posto da guardare è al link
 `Dive Into Python <https://diveintopython3.net>`_ di Marc Pilgrim,
 che può essere veramente d'aiuto su temi specifici come
 lo sviluppo guidato dai test. Il libro
-`Building Skills in Python <http://itmaybeahack.com/homepage/books/python.html>`_
+`Building Skills in Python <https://itmaybeahack.com/homepage/books/python.html>`_
 di Steven F. Lott è adatto a chiunque sia già a suo agio nel programmare.
 
 Se desideri, puoi iniziare a imparare Python usando Sage.
@@ -119,9 +119,8 @@ Ulteriori risorse possono essere trovate cercando sul web.
 * `pep8 <https://pypi.org/project/pep8>`_
 * `pydeps <https://pypi.org/project/pydeps>`_
 * `pycallgraph <https://pycallgraph.readthedocs.io>`_
-* `PyChecker <http://pychecker.sourceforge.net>`_
 * `PyFlakes <https://pypi.org/project/pyflakes>`_
-* `Pylint <https://www.logilab.org/project/pylint>`_
+* `Pylint <https://pylint.readthedocs.io>`_
 * `Python <https://www.python.org>`_ home page e la
   `Documentazione standard su Python <https://docs.python.org>`_
 * `Snakefood <http://furius.ca/snakefood>`_
@@ -130,10 +129,10 @@ Ulteriori risorse possono essere trovate cercando sul web.
 
 **Tutorial e libri**
 
-* `Cython Tutorial <http://conference.scipy.org/proceedings/SciPy2009/paper_1/>`_
+* `Cython Tutorial <https://proceedings.scipy.org/articles/MJMV8092.pdf>`_
   di Stefan Behnel, Robert W. Bradshaw, e Dag Sverre Seljebotn
 * `Dive Into Python 3 <http://www.diveintopython3.net>`_ di Mark Pilgrim
-* `Fast Numerical Computations with Cython <http://conference.scipy.org/proceedings/SciPy2009/paper_2/>`_
+* `Fast Numerical Computations with Cython <https://proceedings.scipy.org/articles/GTCA8577.pdf>`_
   di Dag Sverre Seljebotn
 * `Tutorial ufficiale di Python <https://docs.python.org/3/tutorial/>`_
 

--- a/src/doc/it/faq/faq-general.rst
+++ b/src/doc/it/faq/faq-general.rst
@@ -80,7 +80,7 @@ Una lista di coloro che hanno dato un contributo diretto è reperibile al link
 "mappa di sviluppo di Sage"
 (`Sage Development Map <http://www.sagemath.org/development-map.html>`_)
 e la storia delle modifiche può essere reperita al link "changelog di
-alto livello" (`changelog <http://www.sagemath.org/mirror/src/changelog.txt>`_).
+alto livello" (`changelog <https://www.sagemath.org/changelogs/>`_).
 Fai riferimento alla
 `Pagina dei riconoscimenti <http://www.sagemath.org/development-ack.html>`_
 del sito web di Sage per una lista aggiornata di coloro che ci sostengono
@@ -188,16 +188,13 @@ realizzate attraverso progetti FOSS come
 * `Pari/GP <https://pari.math.u-bordeaux.fr>`_ --- software matematico per
   calcolo veloce in Teoria dei Numeri.
 
-* `Pynac <http://pynac.sagemath.org>`_ --- versione modificata di GiNaC che
-  rimpiazza la dipendenza da CLN con Python.
-
 * `R <http://www.r-project.org>`_ --- linguaggio ed ambiente operativo per
   calcolo statistico e grafici relativi.
 
 * E molti altri troppo numerosi per essere elencati qui.
 
 Una lista aggiornata può essere reperita alla seguente link:
-`repository dei pacchetti standard <http://www.sagemath.org/packages/standard>`_.
+`repository dei pacchetti standard <https://doc.sagemath.org/html/en/reference/spkg/>`_.
 
 I principali linguaggi di programmazione di Sage sono
 `Python <http://www.python.org>`_ e `Cython <http://www.cython.org>`_.

--- a/src/doc/it/faq/faq-usage.rst
+++ b/src/doc/it/faq/faq-usage.rst
@@ -196,9 +196,9 @@ Altre risorse possono essere trovate cercando sul web.
 
 * `Building Skills in Python <http://homepage.mac.com/s_lott/books/python.html>`_
   di Steven F. Lott
-* `Dive into Python <http://www.diveintopython.net>`_
+* `Dive into Python <https://diveintopython3.net>`_
   di Mark Pilgrim
-* `How to Think Like a Computer Scientist <http://www.openbookproject.net/thinkCSpy>`_
+* `How to Think Like a Computer Scientist <https://www.openbookproject.net/thinkcs/python/english3e/>`_
   di Jeffrey Elkner, Allen B. Downey, and Chris Meyers
 * `Official Python Tutorial <http://docs.python.org/tutorial>`_
 * `Python <http://www.python.org>`_ home page e
@@ -540,7 +540,7 @@ Se è così, prova a fare questo: crea (o modifica se c'è già) il file
     limit maxproc 512 2048
 
 Poi riavvia. Vedi
-`il seguente link <http://www.macosxhints.com/article.php?story=20050709233920660>`_
+`il seguente link <https://web.archive.org/web/20051106134912/http://www.macosxhints.com/article.php?story=20050709233920660>`_
 per maggiori dettagli.
 
 Come disegno la radice cubica (o altre radici dispari) di numeri negativi?

--- a/src/doc/ja/tutorial/bibliography.rst
+++ b/src/doc/ja/tutorial/bibliography.rst
@@ -21,7 +21,7 @@ Bibliography
     2004.
 
 ..  [Py] The Python language http://www.python.org/
-    Reference Manual http://docs.python.org/ref/ref.html.
+    Reference Manual https://docs.python.org/3/reference/index.html.
     日本Pythonユーザ会のサイト http://www.python.jp/ で日本語版ドキュメントが公開されている．感謝．
 
 ..  [PyB] The Python Beginner's Guide,

--- a/src/doc/ja/tutorial/programming.rst
+++ b/src/doc/ja/tutorial/programming.rst
@@ -396,7 +396,7 @@ Sageで使われる第三のリスト類似データ型が，シーケンスで�
 ===============
 
 ディクショナリ(「連想配列」と呼ばれる場合もある)とは，文字列、数値、タプルなどのハッシュ可能なオブジェクトから任意のオブジェクトへの写像のことである．
-(ハッシュ可能オブジェクトについての詳細は http://docs.python.org/tut/node7.html と http://docs.python.org/lib/typesmapping.html を参照．)
+(ハッシュ可能オブジェクトについての詳細は http://docs.python.org/3/tutorial/datastructures.html と https://docs.python.org/3/library/stdtypes.html#typesmapping を参照．)
 
 ::
 

--- a/src/doc/ru/tutorial/programming.rst
+++ b/src/doc/ru/tutorial/programming.rst
@@ -404,8 +404,8 @@ Python, сработает нормально.
 
 Словарь (также именуемый ассоциативным массивом) - это сопоставление
 'хэшируемых' объектов (как строки, числа и кортежи из них; см. документацию
-Python: http://docs.python.org/tut/node7.html и
-http://docs.python.org/lib/typesmapping.html) произвольным объектам.
+Python: http://docs.python.org/3/tutorial/datastructures.html и
+https://docs.python.org/3/library/stdtypes.html#typesmapping) произвольным объектам.
 
 ::
 

--- a/src/sage/calculus/desolvers.py
+++ b/src/sage/calculus/desolvers.py
@@ -1739,7 +1739,7 @@ def desolve_mintides(f, ics, initial, final, delta, tolrel=1e-16, tolabs=1e-16):
 
     - A. Abad, R. Barrio, F. Blesa, M. Rodriguez.
       `TIDES tutorial: Integrating ODEs by using the Taylor Series Method.
-      <http://www.unizar.es/acz/05Publicaciones/Monografias/MonografiasPublicadas/Monografia36/IndMonogr36.htm>`_
+      <https://web.archive.org/web/20120206041615/http://www.unizar.es/acz/05Publicaciones/Monografias/MonografiasPublicadas/Monografia36/IndMonogr36.htm>`_
     """
     import subprocess
     if subprocess.call('command -v gcc', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE):

--- a/src/sage/graphs/tutte_polynomial.py
+++ b/src/sage/graphs/tutte_polynomial.py
@@ -662,7 +662,7 @@ def _tutte_polynomial_internal(G, x, y, edge_selector, cache=None):
     ##################################
 
     # Theorem 4: from Haggard, Pearce, and Royle Note that the formula
-    # at http://homepages.ecs.vuw.ac.nz/~djp/files/TOMS10.pdf is
+    # at https://web.archive.org/web/20110401195911/http://homepages.ecs.vuw.ac.nz/~djp/files/TOMS10.pdf is
     # slightly incorrect.  The initial sum should only go to n-2
     # instead of n (allowing for the last part of the recursion).
     # Additionally, the first operand of the final product should be

--- a/src/sage/modular/modform/half_integral.py
+++ b/src/sage/modular/modform/half_integral.py
@@ -100,7 +100,7 @@ def half_integral_weight_modform_basis(chi, k, prec):
 
     ALGORITHM: Basmaji (page 55 of his Essen thesis, "Ein Algorithmus
     zur Berechnung von Hecke-Operatoren und Anwendungen auf modulare
-    Kurven", http://wstein.org/scans/papers/basmaji/).
+    Kurven", https://web.archive.org/web/20160905111513/http://wstein.org/scans/papers/basmaji/thesis_of_basmaji.dvi).
 
     Let `S = S_{k+1}(\epsilon)` be the space of cusp forms of
     even integer weight `k+1` and character

--- a/src/sage/plot/plot.py
+++ b/src/sage/plot/plot.py
@@ -504,7 +504,7 @@ the state of Sage, so that the examples below work!
 
     sage: reset()
 
-See http://matplotlib.sourceforge.net for complete documentation
+See https://matplotlib.org/stable/ for complete documentation
 about how to use Matplotlib.
 
 TESTS:

--- a/src/sage/sat/solvers/satsolver.pyx
+++ b/src/sage/sat/solvers/satsolver.pyx
@@ -94,7 +94,7 @@ cdef class SatSolver:
         adds the corresponding clauses into this solver instance. Note that the
         DIMACS format is not well specified, see
         http://people.sc.fsu.edu/~jburkardt/data/cnf/cnf.html,
-        http://www.satcompetition.org/2009/format-benchmarks2009.html, and
+        https://web.archive.org/web/20090305015900/http://www.satcompetition.org/2009/format-benchmarks2009.html, and
         http://elis.dvo.ru/~lab_11/glpk-doc/cnfsat.pdf.
 
         The differences were summarized in the discussion on the issue


### PR DESCRIPTION
I manually checked all links starting with "http://" and found replacements for the dead ones. Huge shoutouts to the Internet Archive.

### :memo: Checklist

- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

