### PR TITLE
Add method to compute independence polynomial

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -2924,6 +2924,9 @@ REFERENCES:
               *On the category* `\mathcal{O}` *for rational Cherednik algebras*.
               Invent. Math. **154** (2003). :arxiv:`math/0212036`.
 
+.. [GH1983] \I. Gutman, F. Harary. *Generalizations of the matching polynomial*.
+            Utilitas Math. 24, 1983 pp. 97-106.
+
 .. [GHJ2016] Ewgenij Gawrilow, Simon Hampe, and Michael Joswig, The polymake XML
              file format, Mathematical software – ICMS 2016. 5th international
              congress, Berlin, Germany, July 11–14, 2016. Proceedings, Berlin:

--- a/src/sage/graphs/independent_sets.pxd
+++ b/src/sage/graphs/independent_sets.pxd
@@ -10,3 +10,4 @@ cdef class IndependentSets:
     cdef int i
     cdef int count_only
     cdef int maximal
+    cdef int size_only


### PR DESCRIPTION
I find myself defining a function to compute independence polynomials a lot when working with sage. This PR adds such a function to `sage.graphs.independent_sets.pxd` as well as introducing another option for the `IndependentSets` class which defines a generator for independent sets that avoids the overhead of constructing the actual set and simply returns its size. This is not a required change, it simply adds a feature that I would find convenient.

I did not add the new function to the `Graph` class, this is something that could be nice to do so that `g.independence_polynomial` appears alongside `g.matching_polynomial`. That is, there are similar functions that already appear in the `Graph` class so the case for inclusion seems reasonably strong. I'd be happy to add that in another commit to this PR but wanted to get a discussion started with commits to fewer files. 

There is no relevant issue or discussion to link. If it's best to start feature proposals with an issue so that I can get some guidance from the community before any implementation work then I'm happy to do that.

There is at least one debatable aspect of the implementation. I chose to define the independence polynomial of a graph `Graph(0)` with no vertices as `1`. This is consistent with the already-existing decision that `list(IndependentSets(Graph(0)) == [[]]`.

I am interested in adding some code to sage for working with spin systems such as the hard-core model and Ising model developed as part of my research. It is perhaps best to maintain the main bulk of that code outside sage as an independent package while it stabilizes, but this seemed like an innocuous and hopefully uncontroversial way to start engaging with the community. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.



