### PR TITLE
add extra time tolerance to a doctest in `src/sage/doctest/util.py`

### DIFF
--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -801,7 +801,7 @@ def ensure_interruptible_after(seconds: float, max_wait_after_interrupt: float =
         ....:     check_interrupt_only_occasionally()
         Traceback (most recent call last):
         ...
-        RuntimeError: Function is not interruptible within 1.0000 seconds, only after 1.60... seconds
+        RuntimeError: Function is not interruptible within 1.0000 seconds, only after 1.6... seconds
         sage: with ensure_interruptible_after(1, max_wait_after_interrupt=0.9):
         ....:     check_interrupt_only_occasionally()
 


### PR DESCRIPTION
This should fix an issue that regularly makes some CI fail.
For instance https://github.com/sagemath/sage/actions/runs/14820026479/job/41605704677?pr=39755#step:12:3011

```sage
sage -t --warn-long 5.0 --random-seed=314994774945004744184521593085130720001 src/sage/doctest/util.py
**********************************************************************
Error: Failed example:: Got: 
cysignals.signals.AlarmInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/forker.py", line 730, in _run
    self.compile_and_execute(example, compiler, test.globs)
  File "/Users/runner/miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/forker.py", line 1154, in compile_and_execute
    exec(compiled, globs)
  File "<doctest sage.doctest.util.inaccuracy_tolerance[4]>", line 1, in <module>
    with ensure_interruptible_after(Integer(1)):  # not passing max_wait_after_interrupt will raise an error
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/sage-dev/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/Users/runner/miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/util.py", line 894, in ensure_interruptible_after
    raise RuntimeError(
RuntimeError: Function is not interruptible within 1.0000 seconds, only after 1.6246 seconds

    with ensure_interruptible_after(1):  # not passing max_wait_after_interrupt will raise an error
        check_interrupt_only_occasionally()
Expected:
    Traceback (most recent call last):
    ...
    RuntimeError: Function is not interruptible within 1.0000 seconds, only after 1.60... seconds
Got:
    <BLANKLINE>
    cysignals.signals.AlarmInterrupt
    <BLANKLINE>
    During handling of the above exception, another exception occurred:
    <BLANKLINE>
    Traceback (most recent call last):
      File "/Users/runner/miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/forker.py", line 730, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/Users/runner/miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/forker.py", line 1154, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.doctest.util.inaccuracy_tolerance[4]>", line 1, in <module>
        with ensure_interruptible_after(Integer(1)):  # not passing max_wait_after_interrupt will raise an error
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/runner/miniconda3/envs/sage-dev/lib/python3.12/contextlib.py", line 158, in __exit__
        self.gen.throw(value)
      File "/Users/runner/miniconda3/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/util.py", line 894, in ensure_interruptible_after
        raise RuntimeError(
    RuntimeError: Function is not interruptible within 1.0000 seconds, only after 1.6246 seconds
```



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


