### PR TITLE
use pathlib and decode in Kohel database

### DIFF
--- a/src/sage/databases/db_modular_polynomials.py
+++ b/src/sage/databases/db_modular_polynomials.py
@@ -32,11 +32,10 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 import bz2
-import os
-from sage.cpython.string import bytes_to_str
+from pathlib import Path
 
 
-def _dbz_to_string(name):
+def _dbz_to_string(name) -> str:
     r"""
     TESTS::
 
@@ -54,17 +53,16 @@ def _dbz_to_string(name):
         '0\n1\n'
     """
     from sage.env import SAGE_SHARE
-    dblocation = os.path.join(SAGE_SHARE, 'kohel')
-    filename = os.path.join(dblocation, name)
+    filename = Path(SAGE_SHARE) / 'kohel' / name
     try:
         with open(filename, 'rb') as f:
             data = bz2.decompress(f.read())
     except OSError:
-        raise ValueError('file not found in the Kohel database')
-    return bytes_to_str(data)
+        raise FileNotFoundError('file not found in the Kohel database')
+    return data.decode()
 
 
-def _dbz_to_integer_list(name):
+def _dbz_to_integer_list(name) -> list[list]:
     r"""
     TESTS::
 
@@ -90,7 +88,7 @@ def _dbz_to_integer_list(name):
             for row in data.split("\n")[:-1]]
 
 
-def _dbz_to_integers(name):
+def _dbz_to_integers(name) -> list:
     r"""
     TESTS::
 
@@ -103,19 +101,20 @@ def _dbz_to_integers(name):
 
 
 class ModularPolynomialDatabase:
-    def _dbpath(self, level):
+    def _dbpath(self, level) -> Path:
         r"""
         TESTS::
 
             sage: C = ClassicalModularPolynomialDatabase()
             sage: C._dbpath(3)
-            'PolMod/Cls/pol.003.dbz'
+            PosixPath('PolMod/Cls/pol.003.dbz')
             sage: C._dbpath(8)
-            'PolMod/Cls/pol.008.dbz'
+            PosixPath('PolMod/Cls/pol.008.dbz')
         """
-        return "PolMod/%s/pol.%03d.dbz" % (self.model, level)
+        path = Path("PolMod")
+        return path / self.model / ("pol.%03d.dbz" % level)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         r"""
         EXAMPLES::
 
@@ -161,7 +160,7 @@ class ModularPolynomialDatabase:
             sage: DBMP[50]
             Traceback (most recent call last):
             ...
-            ValueError: file not found in the Kohel database
+            FileNotFoundError: file not found in the Kohel database
         """
         from sage.rings.integer import Integer
         from sage.rings.integer_ring import IntegerRing
@@ -198,16 +197,16 @@ class ModularPolynomialDatabase:
 
 
 class ModularCorrespondenceDatabase(ModularPolynomialDatabase):
-    def _dbpath(self, level):
+    def _dbpath(self, level) -> Path:
         r"""
         TESTS::
 
             sage: DB = DedekindEtaModularCorrespondenceDatabase()
             sage: DB._dbpath((2,4))
-            'PolMod/EtaCrr/crr.02.004.dbz'
+            PosixPath('PolMod/EtaCrr/crr.02.004.dbz')
         """
-        (Nlevel, crrlevel) = level
-        return "PolMod/%s/crr.%02d.%03d.dbz" % (self.model, Nlevel, crrlevel)
+        path = Path("PolMod")
+        return path / self.model / ("crr.%02d.%03d.dbz" % level)
 
 
 class ClassicalModularPolynomialDatabase(ModularPolynomialDatabase):

--- a/src/sage/schemes/elliptic_curves/mod_poly.py
+++ b/src/sage/schemes/elliptic_curves/mod_poly.py
@@ -118,12 +118,13 @@ def classical_modular_polynomial(l, j=None):
 
         try:
             Phi = ZZ['X,Y'](_db[l])
-        except ValueError:
+        except (FileNotFoundError, ValueError):
             try:
                 pari_Phi = pari.polmodular(l)
             except PariError:
                 raise NotImplementedError('modular polynomial is not in database and computing it on the fly is not yet implemented')
-            d = {(i, j): c for i,f in enumerate(pari_Phi) for j, c in enumerate(f)}
+            d = {(i, j): c for i, f in enumerate(pari_Phi)
+                 for j, c in enumerate(f)}
             Phi = ZZ['X,Y'](d)
 
         if l <= _cache_bound:
@@ -140,7 +141,7 @@ def classical_modular_polynomial(l, j=None):
         return _cache[l](j, Y)
     try:
         Phi = _db[l]
-    except ValueError:
+    except (ValueError, FileNotFoundError):
         pass
     else:
         if l <= _cache_bound:


### PR DESCRIPTION
some changes in the kohel_database file

- use the decode method of bytes instead of our custom `bytes_to_str`
- use pathlib.Path instead of os

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
