### PR TITLE
patching gfan

### DIFF
--- a/build/pkgs/gfan/patches/gfanlib_matrix.patch
+++ b/build/pkgs/gfan/patches/gfanlib_matrix.patch
@@ -1,0 +1,20 @@
+diff --git a/gfanlib/gfanlib_matrix.h b/gfanlib/gfanlib_matrix.h
+index cb5c35de8..fa5b82092 100644
+--- a/src/gfanlib_matrix.h
++++ b/src/gfanlib_matrix.h
+@@ -115,6 +115,7 @@ public:
+                   p[i][j]=s*(q[i][j]);
+       return p;
+     }
++  /*
+   friend Matrix operator*(const Matrix& a, const Matrix& b)
+     {
+       assert(a.width==b.height);
+@@ -123,6 +124,7 @@ public:
+         ret[i]=a.vectormultiply(b.column(i));
+       return ret.transposed();
+     }
++  */
+   /*  template<class T>
+     Matrix<T>(const Matrix<T>& c):v(c.size()){
+     for(int i=0;i<size();i++)v[i]=typ(c[i]);}


### PR DESCRIPTION
This fixes failed build on OSX:
```
[gfan-0.6.2.p1] [spkg-install] In file included from src/gfanlib_zcone.cpp:8:
[gfan-0.6.2.p1] [spkg-install] In file included from src/gfanlib_zcone.h:11:
[gfan-0.6.2.p1] [spkg-install] src/gfanlib_matrix.h:123:18: error: no member named 'vectormultiply' in 'Matrix<typ>'
[gfan-0.6.2.p1] [spkg-install]   123 |         ret[i]=a.vectormultiply(b.column(i));
[gfan-0.6.2.p1] [spkg-install]       |                ~ ^
[gfan-0.6.2.p1] [spkg-install] 1 error generated.
[gfan-0.6.2.p1] [spkg-install] make[3]: *** [src/gfanlib_zcone.o] Error 1
```


@fchapoton already implemented this fix in Singular https://github.com/fchapoton/Singular/commit/d3f73432d73ac0dd041af83cb35301498e9b57d9


### Boring details

this comments out a method
```c++
  friend Matrix operator*(const Matrix& a, const Matrix& b)
    {
      assert(a.width==b.height);
      Matrix ret(b.width,a.height);
      for(int i=0;i<b.width;i++)
        ret[i]=a.vectormultiply(b.column(i));
      return ret.transposed();
    }
```

which depends on a method already commented out (that also doesn't parse as valid code)
```c++
  /*IntegerVector vectormultiply(IntegerVector const &v)const
    {
      assert(v.size()==width);
      IntegerVector ret(height);
      for(int i=0;i<height;i++)
        ret[i]=dot(rows[i],v);
      return ret;
    }*/
```

