### PR TITLE
Linbox patch

### DIFF
--- a/build/pkgs/linbox/patches/319.patch
+++ b/build/pkgs/linbox/patches/319.patch
@@ -1,0 +1,216 @@
+From 4a1e1395804d4630ec556c61ba3f2cb67e140248 Mon Sep 17 00:00:00 2001
+From: Jean-Guillaume Dumas <Jean-Guillaume.Dumas@imag.fr>
+Date: Thu, 5 Dec 2024 15:38:58 +0100
+Subject: [PATCH] solving issue #319
+
+---
+ linbox/vector/blas-subvector.h | 52 +++++++++++++++++-----------------
+ tests/test-subvector.C         |  6 ++++
+ 2 files changed, 32 insertions(+), 26 deletions(-)
+
+diff --git a/linbox/vector/blas-subvector.h b/linbox/vector/blas-subvector.h
+index e1582723c3..8f290dd436 100644
+--- a/linbox/vector/blas-subvector.h
++++ b/linbox/vector/blas-subvector.h
+@@ -1,6 +1,6 @@
+ /* linbox/matrix/blas-vector.h
+  * Copyright (C) 2013 the LinBox group
+- *               2019 Pascal Giorgi 
++ *               2019 Pascal Giorgi
+  *
+  * Written by :
+  *               Pascal Giorgi  pascal.giorgi@lirmm.fr
+@@ -45,7 +45,7 @@ namespace LinBox {
+     // forward declaration
+     template <class Field, class Storage>
+     class BlasVector;
+-    
++
+ 
+     template <typename _Vector>
+     class VectorEltPointer {
+@@ -61,7 +61,7 @@ namespace LinBox {
+         typedef typename _Vector::Storage::const_reference   reference;
+         using Element=const typename _Vector::Field::Element;
+     };
+-    
++
+     template<class _Vector>
+     class BlasSubvector {
+ 
+@@ -88,7 +88,7 @@ namespace LinBox {
+ 		typedef std::reverse_iterator<const_iterator>  const_reverse_iterator;
+ 
+     protected:
+-		pointer	     		    _ptr;
++		pointer			    _ptr;
+         size_t			       _size;
+         size_t                  _inc;
+ 		Field		    const*_field;
+@@ -101,7 +101,7 @@ namespace LinBox {
+ 		//////////////////
+ 
+         BlasSubvector(){}
+-        
++
+         /** Constructor from an existing @ref BlasVector and dimensions.
+          * \param V Pointer to @ref BlasVector of which to construct subvector
+          * \param beg Starting idx
+@@ -110,7 +110,7 @@ namespace LinBox {
+          */
+         BlasSubvector (vectorType &V, size_t beg, size_t inc, size_t dim) :
+             _ptr(V.getPointer()+beg), _size(dim), _inc(inc), _field(&V.field()) {}
+-        
++
+         /** Constructor from an existing @ref BlasSubvector and dimensions.
+          * \param V Pointer to @ref DenseSubector of which to construct subvector
+          * \param beg Starting idx
+@@ -118,9 +118,9 @@ namespace LinBox {
+          * \param inc distance between two element
+          */
+         BlasSubvector (Self_t &V, size_t beg, size_t inc, size_t dim) :
+-            _ptr(V.data()+beg), _size(dim), _inc(inc), _field(&V.field()) {}
++            _ptr(V.getPointer()+beg), _size(dim), _inc(inc), _field(&V.field()) {}
++
+ 
+-        
+         /** Constructor from an existing @ref BlasVector
+          * \param V Pointer to @ref BlasVector of which to construct submatrix
+          */
+@@ -132,17 +132,17 @@ namespace LinBox {
+          */
+         BlasSubvector (const Field& F, pointer ptr, size_t inc,  size_t dim) :
+             _ptr(ptr), _size(dim), _inc(inc), _field(&F) {}
+-        
+-        
++
++
+ 
+         BlasSubvector (const Field& F, std::vector<Element>& v) :
+-            _ptr(v.data()), _size(v.size()), _inc(1), _field(&F) 
++            _ptr(v.data()), _size(v.size()), _inc(1), _field(&F)
+         {
+             std::cerr<<"WARNING "<<__LINE__<<" ("<<__FILE__<<") : creating a BlasSubvector from a std::vector -> MUST BE DEPRECATED"<<std::endl;
+             throw LinBoxError("Deprecated Subvector cstor from std::vector");
+         }
+-            
+-        
++
++
+ 
+         /** Copy operator */
+         BlasSubvector& operator= (const BlasSubvector& V){
+@@ -157,18 +157,18 @@ namespace LinBox {
+ 
+         template<class Vect>
+         Self_t& copy(const Vect& A){
+-            assert(_size == A.size());            
++            assert(_size == A.size());
+             auto it=A.begin(); auto jt=begin();
+ 			for( ; it!=A.end();++it,++jt)
+                 field().assign(*jt,*it);
+             return *this;
+         }
+-        
++
+ 		//! Rebind operator
+         template<typename _Tp1, typename _Rep2 = typename Rebind<Storage, _Tp1>::other>
+ 		struct rebind {
+ 			typedef BlasVector<_Tp1, _Rep2> other;
+-            
++
+ 			void operator() (other & Ap, const Self_t& A) {
+ 				typedef typename Self_t::const_iterator ConstSelfIterator ;
+ 				typedef typename other::iterator OtherIterator ;
+@@ -180,14 +180,14 @@ namespace LinBox {
+ 			}
+ 		};
+ 
+-        
++
+ 
+ 		/////////////////
+ 		//  ACCESSORS  //
+ 		/////////////////
+ 
+         const Field& field() const { return *_field;}
+-        
++
+         // dimension of the vector
+         size_t size() const{ return _size; }
+         size_t max_size() const{ return _size; }
+@@ -203,14 +203,14 @@ namespace LinBox {
+          * @return the inc value of the subvector
+          */
+         size_t getInc() const {return _inc;}
+-        
++
+ 
+ 		void setEntry (size_t i, const Element &a_i){ field().assign(_ptr[i],a_i); }
+-		
++
+ 		reference refEntry (size_t i){ return _ptr[i]; }
+ 
+ 		const_reference getEntry (size_t i) const { return _ptr[i]; }
+-		
++
+ 		Element& getEntry (Element &x, size_t i) const{	return field().assign(x,_ptr[i]); }
+ 
+ 		// write
+@@ -226,7 +226,7 @@ namespace LinBox {
+ 			case (Tag::FileFormat::Maple) :
+ 				{
+ 					os << '<' ;
+-                    for(size_t i=0; i<_size; i++){ 
++                    for(size_t i=0; i<_size; i++){
+ 						field().write(os, *(_ptr+_inc*i));
+ 						if (i != _size-1)
+ 							os << ',' ;
+@@ -237,7 +237,7 @@ namespace LinBox {
+ 				return os << "not implemented" ;
+ 			}
+         }
+-        
++
+         //read
+ 		std::istream &read ( std::istream &is, Tag::FileFormat fmt = Tag::FileFormat::Pretty ) {
+             return is;
+@@ -275,10 +275,10 @@ namespace LinBox {
+ 		const_reference  front (void) const { return _ptr[0];}
+ 		reference        back  (void)       { return _ptr[(_size-1)*_inc];}
+ 		const_reference  back  (void) const { return _ptr[(_size-1)*_inc];}
+-        
++
+         bool empty() const {return (_size==0);}
+     };
+-    
++
+     template <class Vector>
+     std::ostream& operator<< (std::ostream & os, const BlasSubvector<Vector> & V) {
+ 		return V.write(os);
+@@ -296,7 +296,7 @@ namespace LinBox {
+ 
+ 
+ 
+-    
++
+ } // LinBox
+ #endif
+ // Local Variables:
+diff --git a/tests/test-subvector.C b/tests/test-subvector.C
+index be4850e233..fc1d2c658a 100644
+--- a/tests/test-subvector.C
++++ b/tests/test-subvector.C
+@@ -752,6 +752,12 @@ static bool testSubvector3(Field &F, size_t n)
+ 	//vector<int> ww(3, 77);
+ 	w = ww;
+ 	report << ww << std::endl;
++
++	report << "Constructing subvectors from subvector: ";
++	subVector ww1(w, 0, 0, Length);
++	report << ww1 << std::endl;
++
++
+ #if 0
+ 	report << "Constructing subvector from iterators: ";
+ 	Subvect www(w.begin(), w.end());

--- a/build/pkgs/linbox/patches/323.patch
+++ b/build/pkgs/linbox/patches/323.patch
@@ -1,0 +1,56 @@
+A subset of https://github.com/linbox-team/linbox/pull/323
+
+
+diff --git a/linbox/matrix/sparsematrix/sparse-tpl-matrix-omp.h b/linbox/matrix/sparsematrix/sparse-tpl-matrix-omp.h
+index feca4cf35d..e179a75aa1 100644
+--- a/linbox/matrix/sparsematrix/sparse-tpl-matrix-omp.h
++++ b/linbox/matrix/sparsematrix/sparse-tpl-matrix-omp.h
+@@ -318,9 +318,9 @@ class SparseMatrix<Field_, SparseMatrixFormat::TPL_omp> : public BlackboxInterfa
+ 			typedef typename selfvec::const_iterator selfiter;
+ 			otheriter vp_p; selfiter v_p;
+ 
+-			Ap.data_.resize(A.data.size());
++			Ap.data_.resize(A.data_.size());
+ 			for (v_p = A.data_.begin(), vp_p = Ap.data_.begin();
+-			     v_p != A.data.end(); ++ v_p, ++ vp_p)
++			     v_p != A.data_.end(); ++ v_p, ++ vp_p)
+ 				hom.image (vp_p->elt, v_p->elt);
+ 		}
+ 	};
+
+
+diff --git a/linbox/blackbox/block-hankel.h b/linbox/blackbox/block-hankel.h
+index a4bc7bfc9a..c8e27562c5 100644
+--- a/linbox/blackbox/block-hankel.h
++++ b/linbox/blackbox/block-hankel.h
+@@ -345,8 +345,8 @@ namespace LinBox
+ 		template<class Vector1, class Vector2>
+ 		Vector1& apply(Vector1 &x, const Vector2 &y) const
+ 		{
+-			linbox_check(this->_coldim == y.size());
+-			linbox_check(this->_rowdim == x.size());
++			linbox_check(this->coldim() == y.size());
++			linbox_check(this->rowdim() == x.size());
+ 			BlasMatrixDomain<Field> BMD(field());
+ #ifdef BHANKEL_TIMER
+ 			_chrono.clear();
+
+diff --git a/linbox/ring/polynomial-local-x.h b/linbox/ring/polynomial-local-x.h
+index b444ca198f..968714fc77 100644
+--- a/linbox/ring/polynomial-local-x.h
++++ b/linbox/ring/polynomial-local-x.h
+@@ -61,14 +61,14 @@ namespace LinBox
+ 			zero({0, _F.zero}), one({0, _F.one}), mOne({0, _F.mOne}),
+ 			X({1, _F.one}), exp(exponent)
+ 			{}
+			
+ 		PolynomialLocalX(const PolynomialLocalX &P) : _F(P._F), zero(P.zero),
+ 			one(P.one), mOne(P.mOne), X(P.X), exp(P.exp) {}
+			
+-		PolynomialLocalX(const PolynomialLocalX &P, size_t exponent) : _F(P.F),
++		PolynomialLocalX(const PolynomialLocalX &P, size_t exponent) : _F(P._F),
+ 			zero(P.zero), one(P.one), mOne(P.mOne), X(P.X), exp(exponent) {}
+			
+ 		void setExponent(size_t exponent) {
+ 			exp = exponent;
+ 		}


### PR DESCRIPTION
This patch fixes on OSX
```
[spkg-install] ../../linbox/vector/blas-subvector.h:121:20: error: no member named 'data' in 'BlasSubvector<_Vector>'
[spkg-install]   121 |             _ptr(V.data()+beg), _size(dim), _inc(inc), _field(&V.field()) {}
[spkg-install]       |                  ~ ^
```
```
g++ -std=gnu++11 -g -O2 -Isage/libs/flint -I/Applications/sage/src -I/Applications/sage/local/var/lib/sage/venv-python3.13/lib/python3.13/site-packages/numpy/_core/include -I/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/include/python3.13 -I/Applications/sage/local/var/lib/sage/venv-python3.13/include -I/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/include/python3.13 -c sage/libs/linbox/linbox_flint_interface.cpp -o build/temp.macosx-15.0-arm64-cpython-313/sage/libs/linbox/linbox_flint_interface.o -DDISABLE_COMMENTATOR -DFFLAS_COMPILED -DFFPACK_COMPILED -std=gnu++11
    In file included from sage/libs/linbox/linbox_flint_interface.cpp:1963:
    In file included from /Applications/sage/local/include/linbox/solutions/charpoly.h:34:
    In file included from /Applications/sage/local/include/linbox/algorithms/bbcharpoly.h:46:
    In file included from /Applications/sage/local/include/linbox/solutions/det.h:608:
    In file included from /Applications/sage/local/include/linbox/algorithms/det-rational.h:41:
    In file included from /Applications/sage/local/include/linbox/algorithms/last-invariant-factor.h:30:
    In file included from /Applications/sage/local/include/linbox/algorithms/rational-solver.h:583:
    In file included from /Applications/sage/local/include/linbox/algorithms/./dixon-solver/dixon-solver-dense.h:363:
    In file included from /Applications/sage/local/include/linbox/algorithms/./dixon-solver/./dixon-solver-dense.inl:26:
    In file included from /Applications/sage/local/include/linbox/algorithms/lifting-container.h:49:
    In file included from /Applications/sage/local/include/linbox/blackbox/block-hankel-inverse.h:36:
    /Applications/sage/local/include/linbox/blackbox/block-hankel.h:348:23: error: no member named '_coldim' in 'BlockHankel<_Field>'; did you mean 'coldim'?
      348 |                         linbox_check(this->_coldim == y.size());
          |                                            ^~~~~~~
          |                                            coldim
```

By applying: 
https://github.com/linbox-team/linbox/commit/4a1e1395804d4630ec556c61ba3f2cb67e140248?w=1#diff-6344b04fac6de3b0e7ff00458910d867c9ee947aff5797a459c0e2c9403da1f4L118-L124)
Mentioned here https://github.com/linbox-team/linbox/issues/320

and a subset of https://github.com/linbox-team/linbox/pull/323

