### PR TITLE
Fixed error when calling CRT_list() with list of 1 python int

### DIFF
--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -3601,7 +3601,7 @@ def CRT_list(values, moduli=None):
         sage: ms
         [5, 7, 9]
     
-    Tests for call with length 1 lists::
+    Tests for call with length 1 lists (:issue:`40074`)::
 
         sage: x = CRT_list([1], [2]); x
         1

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -3621,7 +3621,7 @@ def CRT_list(values, moduli=None):
         if not values:
             return ZZ.zero()
         if len(values) == 1:
-            return moduli[0].parent()(values[0])
+            return parent(moduli[0])(values[0])
 
     # The result is computed using a binary tree. In typical cases,
     # this scales much better than folding the list from one side.

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -3600,6 +3600,13 @@ def CRT_list(values, moduli=None):
         [1, 2, 3]
         sage: ms
         [5, 7, 9]
+    
+    Tests for call with length 1 lists::
+
+        sage: x = CRT_list([1], [2]); x
+        1
+        sage: x = CRT_list([int(1)], [int(2)]); x
+        1
     """
     if not isinstance(values, list) or (moduli is not None and not isinstance(moduli, list)):
         raise ValueError("arguments to CRT_list should be lists")


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes Issue #40067, refer to [this answer](https://ask.sagemath.org/question/82674/error-when-calling-crt-with-list-of-1-python-int/?answer=82706#post-id-82706).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


