### PR TITLE
using _an_element_ in groups

### DIFF
--- a/src/sage/groups/additive_abelian/qmodnz.py
+++ b/src/sage/groups/additive_abelian/qmodnz.py
@@ -69,7 +69,7 @@ class QmodnZ(Parent, UniqueRepresentation):
     """
     Element = QmodnZ_Element
 
-    def __init__(self, n=1):
+    def __init__(self, n=1) -> None:
         r"""
         Initialization.
 
@@ -90,7 +90,7 @@ class QmodnZ(Parent, UniqueRepresentation):
         Parent.__init__(self, base=ZZ, category=category)
         self._populate_coercion_lists_(coerce_list=[QQ])
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         r"""
         Display the group.
 
@@ -156,7 +156,7 @@ class QmodnZ(Parent, UniqueRepresentation):
         """
         return self.element_class(self, QQ(x))
 
-    def an_element(self):
+    def _an_element_(self):
         """
         Return an element, for use in coercion system.
 
@@ -167,7 +167,7 @@ class QmodnZ(Parent, UniqueRepresentation):
         """
         return self(0)
 
-    def some_elements(self):
+    def some_elements(self) -> list:
         """
         Return some elements, for use in testing.
 

--- a/src/sage/groups/artin.py
+++ b/src/sage/groups/artin.py
@@ -162,7 +162,7 @@ class ArtinGroupElement(FinitelyPresentedGroupElement):
             W = self.parent().coxeter_group()
         s = W.simple_reflections()
         In = W.index_set()
-        return W.prod(s[In[abs(i)-1]] for i in self.Tietze())
+        return W.prod(s[In[abs(i) - 1]] for i in self.Tietze())
 
     def burau_matrix(self, var='t'):
         r"""
@@ -613,10 +613,10 @@ class ArtinGroup(UniqueRepresentation, FinitelyPresentedGroup):
             return super().__classcall__(cls, coxeter_data, names)
         if coxeter_data.coxeter_type().cartan_type().type() == 'A':
             from sage.groups.braid import BraidGroup
-            return BraidGroup(coxeter_data.rank()+1, names)
+            return BraidGroup(coxeter_data.rank() + 1, names)
         return FiniteTypeArtinGroup(coxeter_data, names)
 
-    def __init__(self, coxeter_matrix, names):
+    def __init__(self, coxeter_matrix, names) -> None:
         """
         Initialize ``self``.
 
@@ -635,7 +635,7 @@ class ArtinGroup(UniqueRepresentation, FinitelyPresentedGroup):
         I = coxeter_matrix.index_set()
         gens = free_group.gens()
         for ii, i in enumerate(I):
-            for jj, j in enumerate(I[ii + 1:], start=ii+1):
+            for jj, j in enumerate(I[ii + 1:], start=ii + 1):
                 m = coxeter_matrix[i, j]
                 if m == Infinity:  # no relation
                     continue
@@ -646,7 +646,7 @@ class ArtinGroup(UniqueRepresentation, FinitelyPresentedGroup):
                 rels.append(elt)
         FinitelyPresentedGroup.__init__(self, free_group, tuple(rels))
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         Return a string representation of ``self``.
 
@@ -779,7 +779,7 @@ class ArtinGroup(UniqueRepresentation, FinitelyPresentedGroup):
         return self.element_class(self, x)
 
     @cached_method
-    def an_element(self):
+    def _an_element_(self):
         """
         Return an element of ``self``.
 
@@ -791,7 +791,7 @@ class ArtinGroup(UniqueRepresentation, FinitelyPresentedGroup):
         """
         return self.gen(0)
 
-    def some_elements(self):
+    def some_elements(self) -> list:
         """
         Return a list of some elements of ``self``.
 
@@ -959,7 +959,8 @@ class ArtinGroup(UniqueRepresentation, FinitelyPresentedGroup):
                 elif x == 1:
                     return 1 + q**2
                 else:
-                    return q * (E(2*x) + ~E(2*x))
+                    E2x = E(2 * x)
+                    return q * (E2x + ~E2x)
         elif isinstance(base_ring, sage.rings.abc.NumberField_quadratic):
             from sage.rings.universal_cyclotomic_field import UniversalCyclotomicField
             E = UniversalCyclotomicField().gen

--- a/src/sage/groups/braid.py
+++ b/src/sage/groups/braid.py
@@ -2616,7 +2616,7 @@ class BraidGroup_class(FiniteTypeArtinGroup):
         sage: B1
         Braid group on 5 strands
         sage: B2 = BraidGroup(3)
-        sage: B1==B2
+        sage: B1 == B2
         False
         sage: B2 is BraidGroup(3)
         True
@@ -2788,7 +2788,7 @@ class BraidGroup_class(FiniteTypeArtinGroup):
                 x = self._standard_lift_Tietze(x)
         return self.element_class(self, x)
 
-    def an_element(self):
+    def _an_element_(self):
         """
         Return an element of the braid group.
 
@@ -3565,10 +3565,13 @@ class BraidGroup_class(FiniteTypeArtinGroup):
                                                     for u in self.gens()])
         g0quotients = [hom1g * h for h in gquotients]
         res = []
+
         # the following closure is needed to attach a specific value of quo to
         # each function in the different morphisms
-        fmap = lambda tup: (lambda a: H(prod(tup[abs(i)-1]**sign(i)
-                                             for i in a.Tietze())))
+        def fmap(tup):
+            return (lambda a: H(prod(tup[abs(i) - 1]**sign(i)
+                                     for i in a.Tietze())))
+
         for quo in g0quotients:
             tup = tuple(H(quo.ImageElm(i.gap()).sage()) for i in self.gens())
             fhom = GroupMorphismWithGensImages(HomSpace, fmap(tup))

--- a/src/sage/groups/group_exp.py
+++ b/src/sage/groups/group_exp.py
@@ -5,15 +5,15 @@ AUTHORS:
 
 - Mark Shimozono (2013): initial version
 """
-#*****************************************************************************
+# ***************************************************************************
 #       Copyright (C) 2013 <mshimo at math.vt.edu>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ***************************************************************************
 
 from sage.categories.commutative_additive_groups import CommutativeAdditiveGroups
 from sage.categories.functor import Functor
@@ -168,7 +168,10 @@ class GroupExp(Functor):
         """
         new_domain = self._apply_functor(f.domain())
         new_codomain = self._apply_functor(f.codomain())
-        new_f = lambda a: new_codomain(f(a.value))
+
+        def new_f(a):
+            return new_codomain(f(a.value))
+
         return SetMorphism(Hom(new_domain, new_codomain, Groups()), new_f)
 
 
@@ -254,7 +257,7 @@ class GroupExp_Class(UniqueRepresentation, Parent):
         sage: GroupExp()(QQ)
         Multiplicative form of Rational Field
     """
-    def __init__(self, G):
+    def __init__(self, G) -> None:
         r"""
 
         EXAMPLES::
@@ -267,7 +270,7 @@ class GroupExp_Class(UniqueRepresentation, Parent):
         self._G = G
         Parent.__init__(self, category=Groups())
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         r"""
         Return a string describing the multiplicative form of a commutative additive group.
 
@@ -307,7 +310,7 @@ class GroupExp_Class(UniqueRepresentation, Parent):
         """
         return GroupExpElement(self, self._G.zero())
 
-    def an_element(self):
+    def _an_element_(self):
         r"""
         Return an element of the multiplicative group.
 


### PR DESCRIPTION
instead of `an_element`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.

