### PR TITLE
typing annotation in Dirichlet characters

### DIFF
--- a/src/sage/modular/dirichlet.py
+++ b/src/sage/modular/dirichlet.py
@@ -191,7 +191,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
     """
     A Dirichlet character.
     """
-    def __init__(self, parent, x, check=True):
+    def __init__(self, parent, x, check=True) -> None:
         r"""
         Create a Dirichlet character with specified values on
         generators of `(\ZZ/n\ZZ)^*`.
@@ -401,7 +401,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
         G = self.parent().change_ring(R)
         return G.element_class(G, [R(x) for x in self.values_on_gens()])
 
-    def _richcmp_(self, other, op):
+    def _richcmp_(self, other, op) -> bool:
         """
         Compare ``self`` to ``other``.
 
@@ -429,7 +429,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
         """
         return richcmp(self.values_on_gens(), other.values_on_gens(), op)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """
         Return the hash of ``self``.
 
@@ -527,7 +527,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
             x = tuple(z**n for z in self.values_on_gens())
         return G.element_class(G, x, check=False)
 
-    def _repr_short_(self):
+    def _repr_short_(self) -> str:
         r"""
         A short string representation of ``self``, often used in string representations of modular forms.
 
@@ -539,7 +539,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
         """
         return str(list(self.values_on_gens()))
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         String representation of ``self``.
 
@@ -569,7 +569,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
             s += str(self.parent().unit_gens()[i]) + ' |--> ' + str(self.values_on_gens()[i])
         return s
 
-    def _latex_(self):
+    def _latex_(self) -> str:
         r"""
         LaTeX representation of ``self``.
 
@@ -1048,7 +1048,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
         return NumberField(self.fixed_field_polynomial(), 'a')
 
     @cached_method
-    def decomposition(self):
+    def decomposition(self) -> list:
         r"""
         Return the decomposition of ``self`` as a product of Dirichlet
         characters of prime power modulus, where the prime powers exactly
@@ -1229,7 +1229,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
         G, v = self._pari_init_()
         return pari.znconreyexp(G, v).sage()
 
-    def lmfdb_page(self):
+    def lmfdb_page(self) -> None:
         r"""
         Open the LMFDB web page of the character in a browser.
 
@@ -1246,7 +1246,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
         url = lmfdb_url.format(self.modulus(), self.conrey_number())
         webbrowser.open(url)
 
-    def galois_orbit(self, sort=True):
+    def galois_orbit(self, sort=True) -> list:
         r"""
         Return the orbit of this character under the action of the absolute
         Galois group of the prime subfield of the base ring.
@@ -1548,7 +1548,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
 
         And sums where exactly one character is nontrivial (see :issue:`6393`)::
 
-            sage: G = DirichletGroup(5); X = G.list(); Y=X[0]; Z=X[1]
+            sage: G = DirichletGroup(5); X = G.list(); Y = X[0]; Z = X[1]
             sage: Y.jacobi_sum(Z)
             -1
             sage: Z.jacobi_sum(Y)
@@ -1828,7 +1828,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
         one = self.base_ring().one()
         return all(x == one for x in self.values_on_gens())
 
-    def kernel(self):
+    def kernel(self) -> list:
         r"""
         Return the kernel of this character.
 
@@ -2042,7 +2042,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
         return H(self)
 
     @cached_method
-    def values(self):
+    def values(self) -> list:
         """
         Return a list of the values of this character on each integer
         between 0 and the modulus.
@@ -2130,7 +2130,7 @@ class DirichletCharacter(MultiplicativeGroupElement):
                 i += 1
 
     @cached_method(do_pickle=True)
-    def values_on_gens(self):
+    def values_on_gens(self) -> tuple:
         r"""
         Return a tuple of the values of ``self`` on the standard
         generators of `(\ZZ/N\ZZ)^*`, where `N` is the modulus.
@@ -2456,6 +2456,12 @@ class DirichletGroupFactory(UniqueFactory):
 
         sage: DirichletGroup(60) is DirichletGroup(60)
         True
+
+    Test for pickling::
+
+        sage: G = DirichletGroup(9)
+        sage: loads(dumps(G)) is G
+        True
     """
     def create_key(self, N, base_ring=None, zeta=None, zeta_order=None,
                    names=None, integral=False):
@@ -2563,7 +2569,7 @@ class DirichletGroupFactory(UniqueFactory):
 DirichletGroup = DirichletGroupFactory("DirichletGroup")
 
 
-def is_DirichletGroup(x):
+def is_DirichletGroup(x) -> bool:
     """
     Return ``True`` if ``x`` is a Dirichlet group.
 
@@ -2592,7 +2598,7 @@ class DirichletGroup_class(WithEqualityById, Parent):
 
     Element = DirichletCharacter
 
-    def __init__(self, base_ring, modulus, zeta, zeta_order):
+    def __init__(self, base_ring, modulus, zeta, zeta_order) -> None:
         """
         Create a Dirichlet group.
 
@@ -2630,21 +2636,6 @@ class DirichletGroup_class(WithEqualityById, Parent):
         self._zeta_order = zeta_order
         self._modulus = modulus
         self._integers = IntegerModRing(modulus)
-
-    def __setstate__(self, state):
-        """
-        Used for unpickling old instances.
-
-        TESTS::
-
-            sage: G = DirichletGroup(9)
-            sage: loads(dumps(G)) is G
-            True
-        """
-        self._set_element_constructor()
-        if '_zeta_order' in state:
-            state['_zeta_order'] = Integer(state['_zeta_order'])
-        super().__setstate__(state)
 
     @property
     def _module(self):
@@ -2686,7 +2677,7 @@ class DirichletGroup_class(WithEqualityById, Parent):
         return w
 
     @property
-    def _zeta_dlog(self):
+    def _zeta_dlog(self) -> dict:
         """
         Return a dictionary that can be used to compute discrete
         logarithms in the value group of this Dirichlet group.
@@ -2870,7 +2861,7 @@ class DirichletGroup_class(WithEqualityById, Parent):
             a.append(R(x(v)))
         return self.element_class(self, a)
 
-    def _coerce_map_from_(self, X):
+    def _coerce_map_from_(self, X) -> bool:
         """
         Decide whether there is a coercion map from `X`.
 
@@ -2915,7 +2906,7 @@ class DirichletGroup_class(WithEqualityById, Parent):
         """
         return self.order()
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         Return a print representation of this group, which can be renamed.
 
@@ -2935,7 +2926,7 @@ class DirichletGroup_class(WithEqualityById, Parent):
         return s
 
     @cached_method
-    def decomposition(self):
+    def decomposition(self) -> list:
         r"""
         Return the Dirichlet groups of prime power modulus corresponding
         to primes dividing modulus.
@@ -3140,7 +3131,7 @@ class DirichletGroup_class(WithEqualityById, Parent):
 
     __iter__ = multiplicative_iterator
 
-    def list(self):
+    def list(self) -> list:
         """
         Return a list of the Dirichlet characters in this group.
 
@@ -3166,7 +3157,7 @@ class DirichletGroup_class(WithEqualityById, Parent):
         """
         return self._modulus
 
-    def ngens(self):
+    def ngens(self) -> int:
         """
         Return the number of generators of ``self``.
 
@@ -3244,7 +3235,7 @@ class DirichletGroup_class(WithEqualityById, Parent):
             e *= g**n
         return e
 
-    def unit_gens(self):
+    def unit_gens(self) -> tuple:
         r"""
         Return the minimal generators for the units of
         `(\ZZ/N\ZZ)^*`, where `N` is the


### PR DESCRIPTION
and also getting rid of an old `set_element_constructor` that was used for old pickles.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
