### PR TITLE
Fix "DeprecationWarning: invalid escape sequence"

### DIFF
--- a/src/sage/combinat/posets/poset_examples.py
+++ b/src/sage/combinat/posets/poset_examples.py
@@ -464,7 +464,7 @@ class Posets(metaclass=ClasscallMetaclass):
 
     @staticmethod
     def DivisorLattice(n, facade=None):
-        """
+        r"""
         Return the divisor lattice of an integer.
 
         Elements of the lattice are divisors of `n`, and we have
@@ -539,7 +539,7 @@ class Posets(metaclass=ClasscallMetaclass):
 
     @staticmethod
     def IntegerCompositions(n):
-        """
+        r"""
         Return the poset of integer compositions of the integer ``n``.
 
         A composition of a positive integer `n` is a list of positive


### PR DESCRIPTION
This fixes failing doctests in the CI by turning two docstrings with an invalid escape sequence (`\leq`) into raw string literals. These can be found via `ruff check --select W605 ./src` or `pylint -d all -e W1401 ./src`


