### PR TITLE
Fixing SyntaxWarning: invalid escape sequence in src/sage/combinat/posets/poset_examples.py

### DIFF
--- a/src/sage/combinat/posets/poset_examples.py
+++ b/src/sage/combinat/posets/poset_examples.py
@@ -464,7 +464,7 @@ class Posets(metaclass=ClasscallMetaclass):
 
     @staticmethod
     def DivisorLattice(n, facade=None):
-        """
+        r"""
         Return the divisor lattice of an integer.
 
         Elements of the lattice are divisors of `n`, and we have
@@ -539,7 +539,7 @@ class Posets(metaclass=ClasscallMetaclass):
 
     @staticmethod
     def IntegerCompositions(n):
-        """
+        r"""
         Return the poset of integer compositions of the integer ``n``.
 
         A composition of a positive integer `n` is a list of positive


### PR DESCRIPTION
Before:
```
/Applications/sage/src/sage/combinat/posets/poset_examples.py:471: SyntaxWarning: invalid escape sequence '\l'
  `x \leq y` in the lattice if `x` divides `y`.
/Applications/sage/src/sage/combinat/posets/poset_examples.py:547: SyntaxWarning: invalid escape sequence '\l'
  `p = [p_1,p_2,...,p_l] \leq q = [q_1,q_2,...,q_m]` if `q`
  ```

