### PR TITLE
Add retry mechanism for Conda environment setup in CI workflow

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Setup Conda environment
         uses: conda-incubator/setup-miniconda@v3
+        continue-on-error: true
+        id: conda1
         with:
           python-version: ${{ matrix.python }}
           miniforge-version: latest
@@ -82,6 +84,22 @@ jobs:
           channel-priority: true
           activate-environment: sage-dev
           environment-file: environment-${{ matrix.python }}-${{ startsWith(matrix.os, 'macos') && (startsWith(runner.arch, 'ARM') && 'macos' || 'macos-x86_64') || 'linux' }}.yml
+
+      # Sometimes the conda setup fails due to network issues.
+      # This is a workaround to retry the setup step if it fails.
+      # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/129
+      - name: Setup Conda environment (2nd time)
+        uses: conda-incubator/setup-miniconda@v3
+        if: steps.conda1.outcome == 'failure'
+        with:
+          python-version: ${{ matrix.python }}
+          miniforge-version: latest
+          use-mamba: true
+          channels: conda-forge
+          channel-priority: true
+          activate-environment: sage-dev
+          environment-file: environment-${{ matrix.python }}-${{ startsWith(matrix.os, 'macos') && (startsWith(runner.arch, 'ARM') && 'macos' || 'macos-x86_64') || 'linux' }}.yml
+
 
       - name: Print Conda environment
         shell: bash -l {0}


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Sometimes the conda setup fails due to network issues (e.g. https://github.com/sagemath/sage/actions/runs/15036287079/job/42258557067?pr=38872#step:9:7341). There is no easy way to configure conda to just retry this request again in a few seconds, so we just simply retry the whole conda env setup.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


