### PR TITLE
Fix docstring for enumerate_totallyreal_fields_rel

### DIFF
--- a/src/sage/rings/number_field/totallyreal_rel.py
+++ b/src/sage/rings/number_field/totallyreal_rel.py
@@ -650,9 +650,9 @@ def enumerate_totallyreal_fields_rel(F, m, B, a=[], verbose=0,
 
     ::
 
-        a[d]*x^n + ... + a[0]*x^(n-d)
+        a[k]*x^m + ... + a[0]*x^(m-k)
 
-    if ``length(a) = d+1``, so in particular always ``a[d] = 1``.
+    if ``length(a) = k+1``, so in particular always ``a[k] = 1``.
 
     .. NOTE::
 


### PR DESCRIPTION
This PR fixes the docsting for enumerate_totallyreal_fields_rel.

- Avoids using `d` as discriminant and index of a list.
- Avoids using `n` and `m` for the degree.

Should we clarify this? 
> with *absolute* discriminant `d \leq B`;

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.


