### PR TITLE
fix reference in btquotient.py

### DIFF
--- a/src/sage/modular/btquotients/btquotient.py
+++ b/src/sage/modular/btquotients/btquotient.py
@@ -1714,7 +1714,7 @@ class BruhatTitsQuotient(SageObject, UniqueRepresentation):
         Compute certain invariants from the level data of the quotient
         which allow one to compute the genus of the curve.
 
-        Details to be found in Theorem 9 of [FM2014]_.
+        Details to be found in Theorem 3.8 of [FM2014]_.
 
         EXAMPLES::
 


### PR DESCRIPTION
I'm looking at https://doi.org/10.1112/S1461157013000235, and there is no Theorem 9. I think it should be 3.8 instead.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

