### PR TITLE
Update Meson and Conda install instructions 

### DIFF
--- a/.devcontainer/onCreate-meson.sh
+++ b/.devcontainer/onCreate-meson.sh
@@ -20,10 +20,11 @@ uv venv
 uv pip install \
     meson-python \
     "cypari2 >=2.2.1" \
-    "cysignals >=1.11.2, != 1.12.0" \
+    "cython >=3.0, != 3.0.3, != 3.1.0" \
     "cython >=3.0, != 3.0.3" \
     "gmpy2 ~=2.1.b999" \
     memory_allocator \
     "numpy >=1.25" \
-    jinja2
-uv sync --frozen --inexact --no-build-isolation-package=sagemath
+    jinja2 \
+    setuptool
+uv sync --frozen --inexact --no-build-isolation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,16 +62,16 @@ jobs:
         run: |
           # Install build dependencies manually as workaround for https://github.com/astral-sh/uv/issues/1516
           uv pip install \
-            meson-python \
-            "cypari2 >=2.2.1" \
-            "cysignals >=1.11.2, != 1.12.0" \
-            "cython >=3.0, != 3.0.3" \
-            "gmpy2 ~=2.1.b999" \
-            memory_allocator \
-            "numpy >=1.25" \
-            jinja2
-
-          uv sync --frozen --inexact --no-build-isolation-package=sagemath
+              meson-python \
+              "cypari2 >=2.2.1" \
+              "cython >=3.0, != 3.0.3, != 3.1.0" \
+              "cython >=3.0, != 3.0.3" \
+              "gmpy2 ~=2.1.b999" \
+              memory_allocator \
+              "numpy >=1.25" \
+              jinja2 \
+              setuptool
+          uv sync --frozen --inexact --no-build-isolation
 
       - name: Test
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,6 +70,8 @@
         "mathrm",
         "Michal",
         "micjung",
+        "Miniconda",
+        "Miniforge",
         "Minkowski",
         "Möbius",
         "mpfr",

--- a/src/doc/en/installation/conda.rst
+++ b/src/doc/en/installation/conda.rst
@@ -9,19 +9,17 @@ SageMath can be installed on Linux and macOS via Conda from the
 Both the ``x86_64`` (Intel) architecture and the ``arm64``/``aarch64``
 architectures (including Apple Silicon, M1, M2, M3, M4) are supported.
 
-You will need a working Conda installation: either Miniforge (or Mambaforge),
-Miniconda or Anaconda. If you don't have one yet, we recommend installing
-`Miniforge <https://github.com/conda-forge/miniforge>`_ as
-follows. In a terminal,
+You will need a working Conda installation: either Miniforge, Miniconda or
+Anaconda. If you don't have one yet, we recommend installing `Miniforge
+<https://github.com/conda-forge/miniforge>`_ as follows. In a terminal,
 
 .. code-block:: shell
 
-   $ curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-   $ bash Miniforge3-$(uname)-$(uname -m).sh
+    $ curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+    $ bash Miniforge3-$(uname)-$(uname -m).sh
 
-* Miniforge (and Mambaforge) use conda-forge as the default channel.
-
-* If you are using Miniconda or Anaconda, set it up to use conda-forge:
+* Miniforge uses conda-forge as the default channel. However, if you are using
+  Miniconda or Anaconda, set it up to use conda-forge:
 
   * Add the conda-forge channel: ``conda config --add channels conda-forge``
 
@@ -42,15 +40,13 @@ Create a new conda environment containing SageMath, either with ``mamba`` or ``c
 
   .. code-block:: shell
 
-      $ mamba create -n sage sage python=X
+      $ mamba create -n sage sage
 
 .. tab:: conda
 
   .. code-block:: shell
 
-      $ conda create -n sage sage python=X
-
-where ``X`` is version of Python, e.g. ``3.12``.
+      $ conda create -n sage sage
 
 To use Sage from there,
 
@@ -60,95 +56,3 @@ To use Sage from there,
 If there are any installation failures, please report them to
 the conda-forge maintainers by opening a `GitHub Issue for
 conda-forge/sage-feedstock <https://github.com/conda-forge/sage-feedstock/issues>`_.
-
-.. _sec-installation-conda-develop:
-
-Using conda to provide all dependencies for the Sage library
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can build and install the Sage library from source, using conda to
-provide all of its dependencies. This bypasses most of the build
-system of the Sage distribution and is the fastest way to set up an
-environment for Sage development.
-
-Here we assume that you are using a git checkout.
-
-- Optionally, set the build parallelism for the Sage library. Use
-  whatever the meaningful value for your machine is - no more than
-  the number of cores::
-
-    $ export SAGE_NUM_THREADS=24
-
-- Create and activate a new conda environment with the dependencies of Sage
-  and a few additional developer tools:
-
-  .. tab:: mamba
-
-    .. code-block:: shell
-
-        $ mamba env create --file environment-3.12-linux.yml --name sage-dev
-        $ conda activate sage-dev
-
-  .. tab:: conda
-
-    .. code-block:: shell
-
-        $ conda env create --file environment-3.12-linux.yml --name sage-dev
-        $ conda activate sage-dev
-
-  Alternatively, you can use ``environment-3.12-linux.yml`` or
-  ``environment-optional-3.12-linux.yml``, which will only install standard
-  (and optional) packages without any additional developer tools.
-
-  A different Python version can be selected by replacing ``3.12`` with the 
-  desired version.
-
-- Bootstrap the source tree and install the build prerequisites and the Sage library::
-
-    $ ./bootstrap
-    $ pip install --no-build-isolation --config-settings editable_mode=compat -v -v --editable ./src
-
-- Verify that Sage has been installed::
-
-    $ sage -c 'print(version())'
-    SageMath version 10.2.beta4, Release Date: 2023-09-24
-
-Note that ``make`` is not used at all. All dependencies
-(including all Python packages) are provided by conda.
-
-Thus, you will get a working version of Sage much faster.  However,
-note that this will invalidate the use of any Sage-the-distribution
-commands such as ``sage -i``. Do not use them.
-
-By using ``pip install --editable`` in the above steps, the Sage
-library is installed in editable mode.  This means that when you only
-edit Python files, there is no need to rebuild the library; it
-suffices to restart Sage.
-
-After editing any Cython files, rebuild the Sage library using::
-
-  $ pip install --no-build-isolation --config-settings editable_mode=compat -v -v --editable src
-
-In order to update the conda environment later, you can run::
-
-  $ mamba env update --file environment-3.12-linux.yml --name sage-dev
-
-To build the documentation, use::
-
-  $ pip install --no-build-isolation -v -v --editable ./pkgs/sage-docbuild
-  $ sage --docbuild all html
-
-.. NOTE::
-
-   The switch ``--config-settings editable_mode=compat`` restores the
-   `legacy setuptools implementation of editable installations
-   <https://setuptools.pypa.io/en/latest/userguide/development_mode.html>`_.
-   Adventurous developers may omit this switch to try the modern,
-   PEP-660 implementation of editable installations, see :issue:`34209`.
-
-.. NOTE::
-
-  You can update the conda lock files by running
-  ``.github/workflows/conda-lock-update.py`` or by running
-  ``conda-lock --platform linux-64 --filename environment-3.12-linux.yml --lockfile environment-3.12-linux.lock``
-  manually.

--- a/src/doc/en/installation/meson.rst
+++ b/src/doc/en/installation/meson.rst
@@ -162,16 +162,18 @@ To compile and install Sage in editable install, then just use:
 
 .. code-block:: shell-session
 
+    $ uv venv
     $ uv pip install \
         meson-python \
         "cypari2 >=2.2.1" \
-        "cysignals >=1.11.2, != 1.12.0" \
+        "cython >=3.0, != 3.0.3, != 3.1.0" \
         "cython >=3.0, != 3.0.3" \
         "gmpy2 ~=2.1.b999" \
         memory_allocator \
         "numpy >=1.25" \
-        jinja2
-    $ uv sync --frozen --inexact
+        jinja2 \
+        setuptool
+    $ uv sync --frozen --inexact --no-build-isolation
 
 You can then start Sage from the command line with ``./sage``
 or run the tests with ``./sage -t``.

--- a/src/doc/en/installation/meson.rst
+++ b/src/doc/en/installation/meson.rst
@@ -9,83 +9,7 @@ This is a short guide on how to build the Sage from source using Meson.
 Walkthrough
 ===========
 
-Assume we're starting from a clean repo and a fully set up conda environment
-(modify ``-linux`` according to your operating system):
-        
-.. tab:: Linux
-
-    .. code-block:: shell
-
-        $ mamba env create --file environment-3.11-linux.yml --name sage-dev
-        $ mamba activate sage-dev
-
-.. tab:: macOS
-    
-    .. code-block:: shell
-
-        $ mamba env create --file environment-3.11-macos.yml --name sage-dev
-        $ mamba activate sage-dev
-
-.. tab:: Windows
-    
-    .. note::
-
-        Windows support is very experimental and many features are not working
-        yet.
-
-    First you need to install the Microsoft Visual C++ compiler.
-    You can download the 
-    `Visual Studio Build Tools <https://aka.ms/vs/17/release/vs_BuildTools.exe>`_.
-    Make sure to select "VC++ 2022 version xx.x build tools" and "Windows SDK".
-    If you prefer, you can also run the following command to install the necessary
-    components:
-    
-    .. code-block:: shell
-
-        $ winget install Microsoft.VisualStudio.2022.BuildTools --force --override "--wait --passive --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621"
- 
-    Alternatively, you can use the compiler that comes bundled with Visual Studio.
-
-    If you haven't already, install the latest version of Conda from
-    `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#windows>`_.
-    It is strongly recommended to choose the option to add Conda to the `PATH`
-    during installation (because we will not use the Miniforge prompt).
-
-    Open the "VS x64 Native Tools Command Prompt" (for 64bit) or 
-    "Developer Command Prompt for VS2022 (or 2019)" (for 32bit).
-
-    .. code-block:: shell
-
-        $ mamba env create --file environment-3.11-win.yml --name sage-dev
-        $ conda activate sage-dev
-        $ set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
-        $ set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
-
-    Windows support is experimental and not fully working yet.
-    In fact, the Sage prompt is not working at all, but you can use the Python
-    prompt to run certain commands. For example, the following should work:
-
-    .. code-block:: python
-
-        >>> from sage.rings.integer import Integer
-        >>> Integer(5)
-        5
-        >>> Integer(5) + 2.0
-        7.0
-
-
-Alternatively, install all build requirements as described in section
-:ref:`section-prereqs`. In the likely case that you have to install some
-dependencies manually, set the correct environment variables to point
-to the installed libraries:
-
-.. CODE-BLOCK:: shell-session
-
-    $ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/your/path/to/include
-    $ export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/your/path/to/include
-    $ export LIBRARY_PATH=$LIBRARY_PATH:/your/path/to/lib
-
-.. NOTE::
+.. note::
 
     If you have previously build Sage in-place, you first have to delete the
     already compiled files, e.g. with ``shopt -s globstar`` followed by
@@ -94,21 +18,168 @@ to the installed libraries:
     ``find src/sage/ext/interpreters -type f ! -name 'meson.build' -delete``.
     Also uninstall the 'old' sage packages with ``pip uninstall sage-conf sage-setup sagemath-standard``.
 
-To compile and install the project in editable install, just use:
+Sage relies on a number of external libraries, which have to be installed
+before building. The easiest way to install them is to use Conda.
+Alternatively, you can install them via your system package manager.
+Both methods are described below.
 
-.. CODE-BLOCK:: shell-session
+Using Conda
+~~~~~~~~~~~
 
-    $ pip install --no-build-isolation --editable .
+- If you haven't already, download and install Miniforge for your platform
+  following the `Miniforge instructions <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_.
+  Other Conda distributions like Miniconda should work as well, but
+  may require additional configuration (see :ref:`sec-installation-conda`).
 
-This will install Sage in the current Python environment.
-In a Conda environment, the ``--no-build-isolation`` flag is necessary to
-allow the build system to reuse the already installed build dependencies.
-If you don't use Conda, you can omit this flag.
+- Create and activate a new conda environment with the dependencies of Sage
+  and a few additional developer tools:
+
+    .. tab:: Linux
+
+        .. code-block:: shell
+
+            $ mamba env create --file environment-3.12-linux.yml --name sage-dev
+            $ mamba activate sage-dev
+
+    .. tab:: macOS
+
+        .. code-block:: shell
+
+            $ mamba env create --file environment-3.12-macos.yml --name sage-dev
+            $ mamba activate sage-dev
+
+    .. tab:: Windows
+
+        .. note::
+
+            Windows support is very experimental and many features are not working
+            yet.
+
+        First you need to install the Microsoft Visual C++ compiler.
+        You can download the
+        `Visual Studio Build Tools <https://aka.ms/vs/17/release/vs_BuildTools.exe>`_.
+        Make sure to select "VC++ 2022 version xx.x build tools" and "Windows SDK".
+        If you prefer, you can also run the following command to install the necessary
+        components:
+
+        .. code-block:: shell
+
+            $ winget install Microsoft.VisualStudio.2022.BuildTools --force --override "--wait --passive --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621"
+
+        Alternatively, you can use the compiler that comes bundled with Visual Studio.
+
+        If you haven't already, install the latest version of Conda from
+        `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#windows>`_.
+        It is strongly recommended to choose the option to add Conda to the `PATH`
+        during installation (because we will not use the Miniforge prompt).
+
+        Open the "VS x64 Native Tools Command Prompt" (for 64bit) or
+        "Developer Command Prompt for VS2022 (or 2019)" (for 32bit).
+
+        .. code-block:: shell
+
+            $ mamba env create --file environment-3.12-win.yml --name sage-dev
+            $ conda activate sage-dev
+            $ set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
+            $ set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
+
+        Windows support is experimental and not fully working yet.
+        In fact, the Sage prompt is not working at all, but you can use the Python
+        prompt to run certain commands. For example, the following should work
+        after building Sage:
+
+        .. code-block:: python
+
+            >>> from sage.rings.integer import Integer
+            >>> Integer(5)
+            5
+            >>> Integer(5) + 2.0
+            7.0
+
+    A different Python version can be selected by replacing ``3.12`` with the
+    desired version.
+
+- To compile and install Sage in editable install, just use:
+  .. code-block:: shell-session
+
+      $ pip install --no-build-isolation --editable .
+
+  This will install Sage in the current Conda environment.
+  The ``--no-build-isolation`` flag is necessary to allow the build system
+  to reuse the already installed build dependencies.
+
+- You can then start Sage from the command line with ``./sage``
+  or run the tests with ``./sage -t``.
+
+Using system package manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can also install the dependencies via your system package manager.
+Note, however, that not all dependencies may be available for your system,
+and that the versions may be outdated.
+In this case, Meson will try to build certain dependencies from source,
+or it will fail with an error message.
+In this case, you can either install the missing dependencies manually,
+or use Conda to install them.
+
+Depending on your distribution, install the following packages:
+
+.. tab:: Debian/Ubuntu
+
+    Not yet supported.
+
+   .. .. literalinclude:: debian.txt
+
+.. tab:: Fedora
+
+    At least Fedora 41 is required.
+
+   .. literalinclude:: fedora.txt
+
+
+.. tab:: Arch Linux
+
+   .. literalinclude:: arch.txt
+
+.. tab:: Void Linux
+
+   .. literalinclude:: void.txt
+
+
+In the case that you want to install some dependencies manually, set the
+correct environment variables to point to the installed libraries:
+
+.. code-block:: shell-session
+
+    $ export C_INCLUDE_PATH=$C_INCLUDE_PATH:/your/path/to/include
+    $ export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/your/path/to/include
+    $ export LIBRARY_PATH=$LIBRARY_PATH:/your/path/to/lib
+
+We also recommend to install the Python package manager
+`uv <https://docs.astral.sh/uv/getting-started/installation/>`_.
+
+To compile and install Sage in editable install, then just use:
+
+.. code-block:: shell-session
+
+    $ uv pip install \
+        meson-python \
+        "cypari2 >=2.2.1" \
+        "cysignals >=1.11.2, != 1.12.0" \
+        "cython >=3.0, != 3.0.3" \
+        "gmpy2 ~=2.1.b999" \
+        memory_allocator \
+        "numpy >=1.25" \
+        jinja2
+    $ uv sync --frozen --inexact
 
 You can then start Sage from the command line with ``./sage``
 or run the tests with ``./sage -t``.
 
-.. NOTE::
+Remarks
+~~~~~~~
+
+.. note::
 
     By using ``pip install --editable`` in the above steps, the Sage library
     is installed in editable mode. This means that when you only edit source
@@ -117,13 +188,13 @@ or run the tests with ``./sage -t``.
     automatically), so you no longer need to manually compile after editing Cython
     files.
 
-.. NOTE::
+.. note::
 
     Note that ``make`` is not used at all, nor is ``configure``.
     This means that any Sage-the-distribution commands such as ``sage -i``
     will not work.
 
-.. NOTE::
+.. note::
 
     By default, Meson will automatically determine the number of jobs to
     run in parallel based on the number of CPU available. This can be adjusted
@@ -131,6 +202,21 @@ or run the tests with ``./sage -t``.
 
     ``--verbose`` can be passed to ``pip install``, then the meson commands
     internally used by pip will be printed out.
+
+.. note::
+
+    To build the documentation, use::
+
+        $ pip install --no-build-isolation -v -v --editable ./pkgs/sage-docbuild
+        $ sage --docbuild all html
+
+.. note::
+
+  You can update the conda lock files by running ``tools/update-conda.py``.
+  In order to update the conda environment afterwards use::
+
+    $ mamba env update --file environment-3.12-linux.yml --name sage-dev
+
 
 Background information
 ======================
@@ -140,52 +226,55 @@ We can also use meson directly as follows.
 
 To configure the project, we need to run the following command:
 
-.. CODE-BLOCK:: shell-session
+.. code-block:: shell-session
 
     $ meson setup builddir
 
-This will create a build directory ``builddir`` that will hold the build artifacts.
+This will create a build directory ``builddir`` that will hold the build
+artifacts.
 
 If pip is used as above with ``--editable``, ``builddir`` is set to be
-``build/cp[Python major version][Python minor version]``, such as ``build/cp311``.
+``build/cp[Python major version][Python minor version]``, such as
+``build/cp311``.
 
 To compile the project, run the following command:
 
-.. CODE-BLOCK:: shell-session
+.. code-block:: shell-session
 
     $ meson compile -C builddir
 
 Installing is done with the following command:
 
-.. CODE-BLOCK:: shell-session
+.. code-block:: shell-session
 
     $ meson install -C builddir
 
-This will install the project to currently active Python environment, 
+This will install the project to currently active Python environment,
 or to the system Python environment if no environment is active.
-When editable install is used, it is not necessary to reinstall after each compilation.
+When editable install is used, it is not necessary to reinstall after each
+compilation.
 
-.. NOTE::
+.. note::
 
     If you want to install the project to a different directory, you can specify
     the ``--prefix`` option when running the ``meson setup`` command:
 
-    .. CODE-BLOCK:: shell-session
+    .. code-block:: shell-session
 
         $ meson setup builddir --prefix=/desired/install/path -Dpython.install_env=prefix
 
     This will then install in the directory specified by ``--prefix``,
     in particular the root folder will be be installed to
-    ``/desired/install/path/lib/python3.11/site-packages/sage``.
+    ``/desired/install/path/lib/python3.12/site-packages/sage``.
     Usually, this directory is not on your Python path, so you have to use:
 
-    .. CODE-BLOCK:: shell-session
+    .. code-block:: shell-session
 
         $ PYTHONPATH=/desired/install/path ./sage
 
 Alternatively, we can still use pip to install:
 
-.. CODE-BLOCK:: shell-session
+.. code-block:: shell-session
 
     $ pip install --no-build-isolation --config-settings=builddir=builddir --editable .
 
@@ -195,7 +284,7 @@ Alternatively, we can still use pip to install:
     to install to a different directory than the install prefix.
     Both are supported naturally by Meson:
 
-    .. CODE-BLOCK:: shell-session
+    .. code-block:: shell-session
 
         $ meson setup builddir --prefix=/usr --libdir=... -Dcpp_args=...
         $ meson compile -C builddir
@@ -216,10 +305,11 @@ The environment variable ``MESONPY_EDITABLE_VERBOSE=1`` can be set while running
 so that when Cython files are recompiled a message is printed out.
 See `<https://mesonbuild.com/meson-python/how-to-guides/editable-installs.html#verbose-mode>`_.
 
-If a new ``.pyx`` file is added, it need to be added to ``meson.build`` file in the
-containing directory.
+If a new ``.pyx`` file is added, it need to be added to ``meson.build`` file in
+the containing directory.
 
-Unlike the ``make``-based build system which relies on header comments ``# distutils: language = c++``
-to determine whether C++ should be used, Meson-based build system requires specifying
+Unlike the ``make``-based build system which relies on header comments
+``# distutils: language = c++`` to determine whether C++ should be used,
+Meson-based build system requires specifying
 ``override_options: ['cython_language=cpp']`` in the ``meson.build`` file.
 Similarly, dependencies need to be specified by ``dependencies: [...]``.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Make the Meson build instructions independent from the Conda and sage-the-distro instructions (previously it was linking to the relevant section for the basic setup).
Also includes now how to use `uv` to setup a python env.

The conda instructions have been also updated, based on the work in https://github.com/sagemath/sage/pull/39515.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


