### PR TITLE
Fix superscript for 2^{32} in prime_pi.pyx

### DIFF
--- a/src/sage/functions/prime_pi.pyx
+++ b/src/sage/functions/prime_pi.pyx
@@ -49,7 +49,7 @@ cdef class PrimePi(BuiltinFunction):
         INPUT:
 
         - ``x`` -- a real number
-        - ``prime_bound`` -- (default: 0) a real number `< 2^32`; :func:`prime_pi`
+        - ``prime_bound`` -- (default: 0) a real number `< 2^{32}`; :func:`prime_pi`
           will make sure to use all the primes up to ``prime_bound`` (although,
           possibly more) in computing ``prime_pi``, this can potentially
           speedup the time of computation, at a cost to memory usage.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

![image](https://github.com/user-attachments/assets/755ba22f-bfaf-4d75-82b1-00c0c10d32c2)


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


