### PR TITLE
Modify one occurrence of singular version from 4.4.0 to 4.4.1

### DIFF
--- a/subprojects/packagefiles/singular/meson.build
+++ b/subprojects/packagefiles/singular/meson.build
@@ -1,7 +1,7 @@
 project(
     'Singular',
     'cpp',
-    version: '4.4.0'
+    version: '4.4.1'
 )
 
 cpp = meson.get_compiler('cpp')


### PR DESCRIPTION
Not sure if this is the cause of https://github.com/sagemath/sage/issues/40120 , let's try. Maybe not (test-long doesn't touch meson.build at all?)


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


