### PR TITLE
add simple cycle enumeration by k shortest simple path algorithm

### DIFF
--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -2777,10 +2777,12 @@ class DiGraph(GenericGraph):
 
     def _all_cycles_iterator_vertex(self, vertex, starting_vertices=None, simple=False,
                                     rooted=False, max_length=None, trivial=False,
-                                    remove_acyclic_edges=True):
+                                    remove_acyclic_edges=True,
+                                    weight_function=None, by_weight=False,
+                                    check_weight=True, report_weight=False):
         r"""
         Return an iterator over the cycles of ``self`` starting with the given
-        vertex.
+        vertex in increasing length order. Each edge must have a positive weight.
 
         INPUT:
 
@@ -2810,6 +2812,22 @@ class DiGraph(GenericGraph):
         - ``remove_acyclic_edges`` -- boolean (default: ``True``); whether
           acyclic edges must be removed from the graph.  Used to avoid
           recomputing it for each vertex
+
+        - ``weight_function`` -- function (default: ``None``); a function that
+          takes as input an edge ``(u, v, l)`` and outputs its weight. If not
+          ``None``, ``by_weight`` is automatically set to ``True``. If ``None``
+          and ``by_weight`` is ``True``, we use the edge label ``l`` as a
+          weight.
+
+        - ``by_weight`` -- boolean (default: ``False``); if ``True``, the edges
+          in the graph are weighted, otherwise all edges have weight 1
+
+        - ``check_weight`` -- boolean (default: ``True``); whether to check that
+          the ``weight_function`` outputs a number for each edge
+
+        - ``report_weight`` -- boolean (default: ``False``); if ``False``, just
+          a cycle is returned. Otherwise a tuple of cycle length and cycle is
+          returned.
 
         OUTPUT: iterator
 
@@ -2858,12 +2876,41 @@ class DiGraph(GenericGraph):
             sage: it = g._all_cycles_iterator_vertex('d', simple=True, trivial=True)
             sage: list(it)
             [['d'], ['d', 'c', 'd']]
+
+        A cycle is enumerated in increasing length order for a weighted graph::
+
+            sage: g = DiGraph()
+            sage: g.add_edges([('a', 'b', 2), ('a', 'e', 2), ('b', 'a', 1), ('b', 'c', 1),
+            ....:              ('c', 'd', 2), ('d', 'b', 1), ('e', 'a', 2)])
+            sage: it = g._all_cycles_iterator_vertex('a', simple=False, max_length=None,
+            ....:                                    by_weight=True, report_weight=True)
+            sage: for i in range(7): print(next(it))
+            (3, ['a', 'b', 'a'])
+            (4, ['a', 'e', 'a'])
+            (6, ['a', 'b', 'a', 'b', 'a'])
+            (7, ['a', 'b', 'a', 'e', 'a'])
+            (7, ['a', 'b', 'c', 'd', 'b', 'a'])
+            (7, ['a', 'e', 'a', 'b', 'a'])
+            (8, ['a', 'e', 'a', 'e', 'a'])
+
+        Each edge must have a positive weight::
+
+            sage: g = DiGraph()
+            sage: g.add_edges([('a', 'b', -2), ('b', 'a', 1)])
+            sage: next(g._all_cycles_iterator_vertex('a', simple=False, max_length=None,
+            ....:                                     by_weight=True, report_weight=True))
+            Traceback (most recent call last):
+            ...
+            ValueError: negative weight is not allowed
         """
         if starting_vertices is None:
             starting_vertices = [vertex]
         # First enumerate the empty cycle
         if trivial:
-            yield [vertex]
+            if report_weight:
+                yield (0, [vertex])
+            else:
+                yield [vertex]
         # First we remove vertices and edges that are not part of any cycle
         if remove_acyclic_edges:
             sccs = self.strongly_connected_components()
@@ -2875,30 +2922,55 @@ class DiGraph(GenericGraph):
             h.delete_edges((u, v) for u, v in h.edge_iterator(labels=False) if d[u] != d[v])
         else:
             h = self
-        queue = [[vertex]]
+
+        # set by_weight, weight_function
+        if weight_function is not None:
+            by_weight = True
+
+        if weight_function is None and by_weight:
+            def weight_function(e):
+                return e[2]
+
+        by_weight, weight_function = self._get_weight_function(by_weight=by_weight,
+                                                               weight_function=weight_function,
+                                                               check_weight=check_weight)
+
+        for e in h.edge_iterator():
+            if weight_function(e) < 0:
+                raise ValueError("negative weight is not allowed")
+
+        from heapq import heapify, heappop, heappush
+        heap_queue = [(0, [vertex])]
         if max_length is None:
             from sage.rings.infinity import Infinity
             max_length = Infinity
-        while queue:
-            path = queue.pop(0)
+        while heap_queue:
+            length, path = heappop(heap_queue)
             # Checks if a cycle has been found
             if len(path) > 1 and path[0] == path[-1]:
-                yield path
-            # Makes sure that the current cycle is not too long
-            # Also if a cycle has been encountered and only simple cycles are
+                if report_weight:
+                    yield (length, path)
+                else:
+                    yield path
+            # If simple is set to True, only simple cycles are
             # allowed, Then it discards the current path
-            if len(path) <= max_length and (not simple or path.count(path[-1]) == 1):
-                for neighbor in h.neighbor_out_iterator(path[-1]):
+            if (not simple or path.count(path[-1]) == 1):
+                for e in h.outgoing_edge_iterator(path[-1]):
+                    neighbor = e[1]
+                    # Makes sure that the current cycle is not too long.
                     # If cycles are not rooted, makes sure to keep only the
                     # minimum cycle according to the lexicographic order
-                    if rooted or neighbor not in starting_vertices or path[0] <= neighbor:
-                        queue.append(path + [neighbor])
+                    if length + weight_function(e) <= max_length and \
+                       (rooted or neighbor not in starting_vertices or path[0] <= neighbor):
+                        heappush(heap_queue, (length + weight_function(e), path + [neighbor]))
 
     def all_cycles_iterator(self, starting_vertices=None, simple=False,
-                            rooted=False, max_length=None, trivial=False):
+                            rooted=False, max_length=None, trivial=False,
+                            weight_function=None, by_weight=False,
+                            check_weight=True, report_weight=False):
         r"""
         Return an iterator over all the cycles of ``self`` starting with one of
-        the given vertices.
+        the given vertices. Each edge must have a positive weight.
 
         The cycles are enumerated in increasing length order.
 
@@ -2924,6 +2996,22 @@ class DiGraph(GenericGraph):
 
         - ``trivial`` -- boolean (default: ``False``); if set to ``True``, then
           the empty paths are also enumerated
+
+        - ``weight_function`` -- function (default: ``None``); a function that
+          takes as input an edge ``(u, v, l)`` and outputs its weight. If not
+          ``None``, ``by_weight`` is automatically set to ``True``. If ``None``
+          and ``by_weight`` is ``True``, we use the edge label ``l`` as a
+          weight.
+
+        - ``by_weight`` -- boolean (default: ``False``); if ``True``, the edges
+          in the graph are weighted, otherwise all edges have weight 1
+
+        - ``check_weight`` -- boolean (default: ``True``); whether to check that
+          the ``weight_function`` outputs a number for each edge
+
+        - ``report_weight`` -- boolean (default: ``False``); if ``False``, just
+          a cycle is returned. Otherwise a tuple of cycle length and cycle is
+          returned.
 
         OUTPUT: iterator
 
@@ -2997,6 +3085,34 @@ class DiGraph(GenericGraph):
             sage: g = digraphs.Circuit(4)
             sage: list(g.all_cycles_iterator(simple=True))
             [[0, 1, 2, 3, 0]]
+
+        A cycle is enumerated in increasing length order for a weighted graph::
+
+            sage: g = DiGraph()
+            sage: g.add_edges([('a', 'b', 2), ('a', 'e', 2), ('b', 'a', 1), ('b', 'c', 1),
+            ....:              ('c', 'd', 2), ('d', 'b', 1), ('e', 'a', 2)])
+            sage: it = g.all_cycles_iterator(simple=False, max_length=None,
+            ....:                            by_weight=True, report_weight=True)
+            sage: for i in range(9): print(next(it))
+            (3, ['a', 'b', 'a'])
+            (4, ['a', 'e', 'a'])
+            (4, ['b', 'c', 'd', 'b'])
+            (6, ['a', 'b', 'a', 'b', 'a'])
+            (7, ['a', 'b', 'a', 'e', 'a'])
+            (7, ['a', 'b', 'c', 'd', 'b', 'a'])
+            (7, ['a', 'e', 'a', 'b', 'a'])
+            (8, ['a', 'e', 'a', 'e', 'a'])
+            (8, ['b', 'c', 'd', 'b', 'c', 'd', 'b'])
+
+        Each edge must have a positive weight::
+
+            sage: g = DiGraph()
+            sage: g.add_edges([('a', 'b', -2), ('b', 'a', 1)])
+            sage: next(g.all_cycles_iterator(simple=False, max_length=None,
+            ....:                            by_weight=True, report_weight=True))
+            Traceback (most recent call last):
+            ...
+            ValueError: negative weight is not allowed
         """
         if starting_vertices is None:
             starting_vertices = self
@@ -3010,6 +3126,22 @@ class DiGraph(GenericGraph):
         h = copy(self)
         h.delete_edges((u, v) for u, v in h.edge_iterator(labels=False) if d[u] != d[v])
 
+        # set by_weight, weight_function
+        if weight_function is not None:
+            by_weight = True
+
+        if weight_function is None and by_weight:
+            def weight_function(e):
+                return e[2]
+
+        by_weight, weight_function = self._get_weight_function(by_weight=by_weight,
+                                                               weight_function=weight_function,
+                                                               check_weight=check_weight)
+
+        for e in h.edge_iterator():
+            if weight_function(e) < 0:
+                raise ValueError("negative weight is not allowed")
+
         # We create one cycles iterator per vertex. This is necessary if we
         # want to iterate over cycles with increasing length.
         def cycle_iter(v):
@@ -3019,15 +3151,19 @@ class DiGraph(GenericGraph):
                                                  rooted=rooted,
                                                  max_length=max_length,
                                                  trivial=trivial,
-                                                 remove_acyclic_edges=False)
+                                                 remove_acyclic_edges=False,
+                                                 weight_function=weight_function,
+                                                 by_weight=by_weight,
+                                                 check_weight=check_weight,
+                                                 report_weight=True)
 
         vertex_iterators = {v: cycle_iter(v) for v in starting_vertices}
 
         cycles = []
         for vi in vertex_iterators.values():
             try:
-                cycle = next(vi)
-                cycles.append((len(cycle), cycle))
+                length, cycle = next(vi)
+                cycles.append((length, cycle))
             except StopIteration:
                 pass
         # Since we always extract a shortest path, using a heap
@@ -3036,20 +3172,27 @@ class DiGraph(GenericGraph):
         heapify(cycles)
         while cycles:
             # We choose the shortest available cycle
-            _, shortest_cycle = heappop(cycles)
-            yield shortest_cycle
+            length, shortest_cycle = heappop(cycles)
+            if report_weight:
+                yield (length, shortest_cycle)
+            else:
+                yield shortest_cycle
             # We update the cycle iterator to its next available cycle if it
             # exists
             try:
-                cycle = next(vertex_iterators[shortest_cycle[0]])
-                heappush(cycles, (len(cycle), cycle))
+                length, cycle = next(vertex_iterators[shortest_cycle[0]])
+                heappush(cycles, (length, cycle))
             except StopIteration:
                 pass
 
     def all_simple_cycles(self, starting_vertices=None, rooted=False,
-                          max_length=None, trivial=False):
+                          max_length=None, trivial=False,
+                          weight_function=None, by_weight=False,
+                          check_weight=True, report_weight=False):
         r"""
-        Return a list of all simple cycles of ``self``.
+        Return a list of all simple cycles of ``self``. The cycles are
+        enumerated in increasing length order. Each edge must have a
+        positive weight.
 
         INPUT:
 
@@ -3069,6 +3212,22 @@ class DiGraph(GenericGraph):
 
         - ``trivial`` -- boolean (default: ``False``); if set to ``True``, then
           the empty paths are also enumerated
+
+        - ``weight_function`` -- function (default: ``None``); a function that
+          takes as input an edge ``(u, v, l)`` and outputs its weight. If not
+          ``None``, ``by_weight`` is automatically set to ``True``. If ``None``
+          and ``by_weight`` is ``True``, we use the edge label ``l`` as a
+          weight.
+
+        - ``by_weight`` -- boolean (default: ``False``); if ``True``, the edges
+          in the graph are weighted, otherwise all edges have weight 1
+
+        - ``check_weight`` -- boolean (default: ``True``); whether to check that
+          the ``weight_function`` outputs a number for each edge
+
+        - ``report_weight`` -- boolean (default: ``False``); if ``False``, just
+          a cycle is returned. Otherwise a tuple of cycle length and cycle is
+          returned.
 
         OUTPUT: list
 
@@ -3129,52 +3288,46 @@ class DiGraph(GenericGraph):
 
             sage: g = graphs.CompleteGraph(20).to_directed()
             sage: g.all_simple_cycles(max_length=2)
-            [[0, 16, 0], [0, 1, 0], [0, 17, 0], [0, 2, 0], [0, 18, 0],
-             [0, 3, 0], [0, 19, 0], [0, 4, 0], [0, 5, 0], [0, 6, 0], [0, 7, 0],
-             [0, 8, 0], [0, 9, 0], [0, 10, 0], [0, 11, 0], [0, 12, 0],
-             [0, 13, 0], [0, 14, 0], [0, 15, 0], [1, 16, 1], [1, 17, 1],
-             [1, 2, 1], [1, 18, 1], [1, 3, 1], [1, 19, 1], [1, 4, 1], [1, 5, 1],
-             [1, 6, 1], [1, 7, 1], [1, 8, 1], [1, 9, 1], [1, 10, 1], [1, 11, 1],
-             [1, 12, 1], [1, 13, 1], [1, 14, 1], [1, 15, 1], [2, 16, 2],
-             [2, 17, 2], [2, 18, 2], [2, 3, 2], [2, 19, 2], [2, 4, 2],
-             [2, 5, 2], [2, 6, 2], [2, 7, 2], [2, 8, 2], [2, 9, 2], [2, 10, 2],
-             [2, 11, 2], [2, 12, 2], [2, 13, 2], [2, 14, 2], [2, 15, 2],
-             [3, 16, 3], [3, 17, 3], [3, 18, 3], [3, 19, 3], [3, 4, 3],
-             [3, 5, 3], [3, 6, 3], [3, 7, 3], [3, 8, 3], [3, 9, 3], [3, 10, 3],
-             [3, 11, 3], [3, 12, 3], [3, 13, 3], [3, 14, 3], [3, 15, 3],
-             [4, 16, 4], [4, 17, 4], [4, 18, 4], [4, 19, 4], [4, 5, 4],
-             [4, 6, 4], [4, 7, 4], [4, 8, 4], [4, 9, 4], [4, 10, 4], [4, 11, 4],
-             [4, 12, 4], [4, 13, 4], [4, 14, 4], [4, 15, 4], [5, 16, 5],
-             [5, 17, 5], [5, 18, 5], [5, 19, 5], [5, 6, 5], [5, 7, 5],
-             [5, 8, 5], [5, 9, 5], [5, 10, 5], [5, 11, 5], [5, 12, 5],
-             [5, 13, 5], [5, 14, 5], [5, 15, 5], [6, 16, 6], [6, 17, 6],
-             [6, 18, 6], [6, 19, 6], [6, 7, 6], [6, 8, 6], [6, 9, 6],
-             [6, 10, 6], [6, 11, 6], [6, 12, 6], [6, 13, 6], [6, 14, 6],
-             [6, 15, 6], [7, 16, 7], [7, 17, 7], [7, 18, 7], [7, 19, 7],
-             [7, 8, 7], [7, 9, 7], [7, 10, 7], [7, 11, 7], [7, 12, 7],
-             [7, 13, 7], [7, 14, 7], [7, 15, 7], [8, 16, 8], [8, 17, 8],
-             [8, 18, 8], [8, 19, 8], [8, 9, 8], [8, 10, 8], [8, 11, 8],
-             [8, 12, 8], [8, 13, 8], [8, 14, 8], [8, 15, 8], [9, 16, 9],
-             [9, 17, 9], [9, 18, 9], [9, 19, 9], [9, 10, 9], [9, 11, 9],
-             [9, 12, 9], [9, 13, 9], [9, 14, 9], [9, 15, 9], [10, 16, 10],
-             [10, 17, 10], [10, 18, 10], [10, 19, 10], [10, 11, 10],
-             [10, 12, 10], [10, 13, 10], [10, 14, 10], [10, 15, 10],
-             [11, 16, 11], [11, 17, 11], [11, 18, 11], [11, 19, 11],
-             [11, 12, 11], [11, 13, 11], [11, 14, 11], [11, 15, 11],
-             [12, 16, 12], [12, 17, 12], [12, 18, 12], [12, 19, 12],
-             [12, 13, 12], [12, 14, 12], [12, 15, 12], [13, 16, 13],
-             [13, 17, 13], [13, 18, 13], [13, 19, 13], [13, 14, 13],
-             [13, 15, 13], [14, 16, 14], [14, 17, 14], [14, 18, 14],
-             [14, 19, 14], [14, 15, 14], [15, 16, 15], [15, 17, 15],
-             [15, 18, 15], [15, 19, 15], [16, 17, 16], [16, 18, 16],
-             [16, 19, 16], [17, 18, 17], [17, 19, 17], [18, 19, 18]]
+            [[0, 1, 0], [0, 2, 0], [0, 3, 0], [0, 4, 0], [0, 5, 0], [0, 6, 0], [0, 7, 0],
+             [0, 8, 0], [0, 9, 0], [0, 10, 0], [0, 11, 0], [0, 12, 0], [0, 13, 0],
+             [0, 14, 0], [0, 15, 0], [0, 16, 0], [0, 17, 0], [0, 18, 0], [0, 19, 0],
+             [1, 2, 1], [1, 3, 1], [1, 4, 1], [1, 5, 1], [1, 6, 1], [1, 7, 1], [1, 8, 1],
+             [1, 9, 1], [1, 10, 1], [1, 11, 1], [1, 12, 1], [1, 13, 1], [1, 14, 1],
+             [1, 15, 1], [1, 16, 1], [1, 17, 1], [1, 18, 1], [1, 19, 1], [2, 3, 2],
+             [2, 4, 2], [2, 5, 2], [2, 6, 2], [2, 7, 2], [2, 8, 2], [2, 9, 2], [2, 10, 2],
+             [2, 11, 2], [2, 12, 2], [2, 13, 2], [2, 14, 2], [2, 15, 2], [2, 16, 2],
+             [2, 17, 2], [2, 18, 2], [2, 19, 2], [3, 4, 3], [3, 5, 3], [3, 6, 3],
+             [3, 7, 3], [3, 8, 3], [3, 9, 3], [3, 10, 3], [3, 11, 3], [3, 12, 3],
+             [3, 13, 3], [3, 14, 3], [3, 15, 3], [3, 16, 3], [3, 17, 3], [3, 18, 3],
+             [3, 19, 3], [4, 5, 4], [4, 6, 4], [4, 7, 4], [4, 8, 4], [4, 9, 4], [4, 10, 4],
+             [4, 11, 4], [4, 12, 4], [4, 13, 4], [4, 14, 4], [4, 15, 4], [4, 16, 4],
+             [4, 17, 4], [4, 18, 4], [4, 19, 4], [5, 6, 5], [5, 7, 5], [5, 8, 5],
+             [5, 9, 5], [5, 10, 5], [5, 11, 5], [5, 12, 5], [5, 13, 5], [5, 14, 5],
+             [5, 15, 5], [5, 16, 5], [5, 17, 5], [5, 18, 5], [5, 19, 5], [6, 7, 6],
+             [6, 8, 6], [6, 9, 6], [6, 10, 6], [6, 11, 6], [6, 12, 6], [6, 13, 6],
+             [6, 14, 6], [6, 15, 6], [6, 16, 6], [6, 17, 6], [6, 18, 6], [6, 19, 6],
+             [7, 8, 7], [7, 9, 7], [7, 10, 7], [7, 11, 7], [7, 12, 7], [7, 13, 7],
+             [7, 14, 7], [7, 15, 7], [7, 16, 7], [7, 17, 7], [7, 18, 7], [7, 19, 7],
+             [8, 9, 8], [8, 10, 8], [8, 11, 8], [8, 12, 8], [8, 13, 8], [8, 14, 8],
+             [8, 15, 8], [8, 16, 8], [8, 17, 8], [8, 18, 8], [8, 19, 8], [9, 10, 9],
+             [9, 11, 9], [9, 12, 9], [9, 13, 9], [9, 14, 9], [9, 15, 9], [9, 16, 9],
+             [9, 17, 9], [9, 18, 9], [9, 19, 9], [10, 11, 10], [10, 12, 10], [10, 13, 10],
+             [10, 14, 10], [10, 15, 10], [10, 16, 10], [10, 17, 10], [10, 18, 10],
+             [10, 19, 10], [11, 12, 11], [11, 13, 11], [11, 14, 11], [11, 15, 11],
+             [11, 16, 11], [11, 17, 11], [11, 18, 11], [11, 19, 11], [12, 13, 12],
+             [12, 14, 12], [12, 15, 12], [12, 16, 12], [12, 17, 12], [12, 18, 12],
+             [12, 19, 12], [13, 14, 13], [13, 15, 13], [13, 16, 13], [13, 17, 13],
+             [13, 18, 13], [13, 19, 13], [14, 15, 14], [14, 16, 14], [14, 17, 14],
+             [14, 18, 14], [14, 19, 14], [15, 16, 15], [15, 17, 15], [15, 18, 15],
+             [15, 19, 15], [16, 17, 16], [16, 18, 16], [16, 19, 16], [17, 18, 17],
+             [17, 19, 17], [18, 19, 18]]
 
             sage: g = graphs.CompleteGraph(20).to_directed()
             sage: g.all_simple_cycles(max_length=2, starting_vertices=[0])
-            [[0, 16, 0], [0, 1, 0], [0, 17, 0], [0, 2, 0], [0, 18, 0],
-             [0, 3, 0], [0, 19, 0], [0, 4, 0], [0, 5, 0], [0, 6, 0],
-             [0, 7, 0], [0, 8, 0], [0, 9, 0], [0, 10, 0], [0, 11, 0],
-             [0, 12, 0], [0, 13, 0], [0, 14, 0], [0, 15, 0]]
+            [[0, 1, 0], [0, 2, 0], [0, 3, 0], [0, 4, 0], [0, 5, 0],
+             [0, 6, 0], [0, 7, 0], [0, 8, 0], [0, 9, 0], [0, 10, 0],
+             [0, 11, 0], [0, 12, 0], [0, 13, 0], [0, 14, 0], [0, 15, 0],
+             [0, 16, 0], [0, 17, 0], [0, 18, 0], [0, 19, 0]]
 
         One may prefer to distinguish equivalent cycles having distinct starting
         vertices (compare the following examples)::
@@ -3185,10 +3338,25 @@ class DiGraph(GenericGraph):
             sage: g.all_simple_cycles(max_length=2, rooted=True)
             [[0, 1, 0], [0, 2, 0], [0, 3, 0], [1, 0, 1], [1, 2, 1], [1, 3, 1],
              [2, 0, 2], [2, 1, 2], [2, 3, 2], [3, 0, 3], [3, 1, 3], [3, 2, 3]]
+
+        A cycle is enumerated in increasing length order for a weighted graph::
+
+            sage: g.all_simple_cycles(weight_function=lambda e:e[0]+e[1], by_weight=True,
+            ....:                     report_weight=True)
+            [(2, [0, 1, 0]), (4, [0, 2, 0]), (6, [0, 1, 2, 0]), (6, [0, 2, 1, 0]),
+             (6, [0, 3, 0]), (6, [1, 2, 1]), (8, [0, 1, 3, 0]), (8, [0, 3, 1, 0]),
+             (8, [1, 3, 1]), (10, [0, 2, 3, 0]), (10, [0, 3, 2, 0]), (10, [2, 3, 2]),
+             (12, [0, 1, 2, 3, 0]), (12, [0, 1, 3, 2, 0]), (12, [0, 2, 1, 3, 0]),
+             (12, [0, 2, 3, 1, 0]), (12, [0, 3, 1, 2, 0]), (12, [0, 3, 2, 1, 0]),
+             (12, [1, 2, 3, 1]), (12, [1, 3, 2, 1])]
         """
         return list(self.all_cycles_iterator(starting_vertices=starting_vertices,
                                              simple=True, rooted=rooted,
-                                             max_length=max_length, trivial=trivial))
+                                             max_length=max_length, trivial=trivial,
+                                             weight_function=weight_function,
+                                             by_weight=by_weight,
+                                             check_weight=check_weight,
+                                             report_weight=report_weight))
 
     def path_semigroup(self):
         """

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -3148,7 +3148,7 @@ class DiGraph(GenericGraph):
         .. SEEALSO::
 
             - :meth:`all_simple_cycles`
-            - :math:`~sage.graphs.path_enumeration.shortest_simple_paths`
+            - :meth:`~sage.graphs.path_enumeration.shortest_simple_paths`
 
         AUTHOR:
 

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -3021,6 +3021,21 @@ class DiGraph(GenericGraph):
             Traceback (most recent call last):
             ...
             ValueError: negative weight is not allowed
+
+        TESTS:
+
+        A graph with a loop::
+
+            sage: g = DiGraph(loops=True)
+            sage: g.add_edges([('a', 'b'), ('b', 'c'), ('c', 'a'), ('c', 'c')])
+            sage: it = g._all_simple_cycles_iterator_edge(('a', 'b'), remove_acyclic_edges=True)
+            sage: next(it)
+            ['a', 'b', 'c', 'a']
+            sage: g = DiGraph(loops=True)
+            sage: g.add_edges([('a', 'b'), ('b', 'c'), ('c', 'c')])
+            sage: it = g._all_simple_cycles_iterator_edge(('c', 'c'), remove_acyclic_edges=True)
+            sage: next(it)
+            ['c', 'c']
         """
         # First we remove vertices and edges that are not part of any cycle
         if remove_acyclic_edges:
@@ -3030,7 +3045,7 @@ class DiGraph(GenericGraph):
                     h = component
             if h is None:
                 # edge connects two strongly connected components, so
-                # no simple cycle starting with edge does not exist.
+                # no simple cycle starting with edge exists.
                 return
         else:
             h = copy(self)

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -2956,10 +2956,150 @@ class DiGraph(GenericGraph):
                        (rooted or neighbor not in starting_vertices or path[0] <= neighbor):
                         heappush(heap_queue, (length + weight_function(e), path + [neighbor]))
 
+    def _all_simple_cycles_iterator_edge(self, edge, starting_vertices=None,
+                                         rooted=False, max_length=None,
+                                         remove_acyclic_edges=True,
+                                         weight_function=None, by_weight=False,
+                                         check_weight=True, report_weight=False):
+        r"""
+        Return an iterator over the **simple** cycles of ``self`` starting with the
+        given edge in increasing length order. Each edge must have a positive weight.
+
+        INPUT:
+
+        - ``edge`` -- the starting edge of the cycle.
+
+        - ``starting_vertices`` -- iterable (default: ``None``); vertices from
+          which the cycles must start. If ``None``, then all vertices of the
+          graph can be starting points. This argument is necessary if ``rooted``
+          is set to ``True``.
+
+        - ``rooted`` -- boolean (default: ``False``); if set to False, then
+          cycles differing only by their starting vertex are considered the same
+          (e.g. ``['a', 'b', 'c', 'a']`` and ``['b', 'c', 'a',
+          'b']``). Otherwise, all cycles are enumerated.
+
+        - ``max_length`` -- nonnegative integer (default: ``None``); the
+          maximum length of the enumerated paths. If set to ``None``, then all
+          lengths are allowed.
+
+        - ``remove_acyclic_edges`` -- boolean (default: ``True``); whether
+          acyclic edges must be removed from the graph.  Used to avoid
+          recomputing it for each edge
+
+        - ``weight_function`` -- function (default: ``None``); a function that
+          takes as input an edge ``(u, v, l)`` and outputs its weight. If not
+          ``None``, ``by_weight`` is automatically set to ``True``. If ``None``
+          and ``by_weight`` is ``True``, we use the edge label ``l`` as a
+          weight.
+
+        - ``by_weight`` -- boolean (default: ``False``); if ``True``, the edges
+          in the graph are weighted, otherwise all edges have weight 1
+
+        - ``check_weight`` -- boolean (default: ``True``); whether to check that
+          the ``weight_function`` outputs a number for each edge
+
+        - ``report_weight`` -- boolean (default: ``False``); if ``False``, just
+          a cycle is returned. Otherwise a tuple of cycle length and cycle is
+          returned.
+
+        OUTPUT: iterator
+
+        ALGORITHM:
+
+        Given an edge `uv`, this algorithm extracts k-shortest `vu`-path in `G-uv`
+        in increasing length order by using k-shortest path algorithm. Thus, it
+        extracts only simple cycles. See
+        :math:`~sage.graphs.path_enumeration.shortest_simple_paths` for more
+        information.
+
+        EXAMPLES:
+
+            sage: g = graphs.Grid2dGraph(2, 5).to_directed()
+            sage: it = g._all_simple_cycles_iterator_edge(((0, 0), (0, 1), None), report_weight=True)
+            sage: for i in range(5): print(next(it))
+            (2, [(0, 0), (0, 1), (0, 0)])
+            (4, [(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
+            (6, [(0, 0), (0, 1), (0, 2), (1, 2), (1, 1), (1, 0), (0, 0)])
+            (8, [(0, 0), (0, 1), (0, 2), (0, 3), (1, 3), (1, 2), (1, 1), (1, 0), (0, 0)])
+            (10, [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (1, 4), (1, 3), (1, 2), (1, 1), (1, 0), (0, 0)])
+
+        Each edge must have a positive weight::
+
+            sage: g = DiGraph()
+            sage: g.add_edges([('a', 'b', -2), ('b', 'a', 1)])
+            sage: next(g._all_simple_cycles_iterator_edge(('a', 'b', -2), max_length=None, by_weight=True))
+            Traceback (most recent call last):
+            ...
+            ValueError: negative weight is not allowed
+        """
+        if starting_vertices is None:
+            starting_vertices = [edge[0]]
+        if edge[0] not in starting_vertices:
+            raise ValueError("the tail of edge must be one of the starting vertices")
+
+        # First we remove vertices and edges that are not part of any cycle
+        if remove_acyclic_edges:
+            sccs = self.strongly_connected_components()
+            d = {}
+            for id, component in enumerate(sccs):
+                for v in component:
+                    d[v] = id
+            h = copy(self)
+            h.delete_edges((u, v) for u, v in h.edge_iterator(labels=False) if d[u] != d[v])
+        else:
+            h = copy(self)
+        # delete edge
+        h.delete_edge(edge)
+        # delete vertices unnecessary for enumearting cycles
+        if not rooted:
+            for v in starting_vertices:
+                if v < edge[0]:
+                    h.delete_vertex(v)
+                    if v == edge[1]:
+                        return
+
+        by_weight, weight_function = self._get_weight_function(by_weight=by_weight,
+                                                               weight_function=weight_function,
+                                                               check_weight=check_weight)
+
+        if by_weight:
+            for e in self.edge_iterator():
+                if weight_function(e) < 0:
+                    raise ValueError("negative weight is not allowed")
+
+        it = h.shortest_simple_paths(source=edge[1], target=edge[0],
+                                     weight_function=weight_function,
+                                     by_weight=by_weight,
+                                     check_weight=check_weight,
+                                     algorithm='Feng',
+                                     report_edges=False,
+                                     report_weight=True)
+
+        edge_weight = weight_function(edge)
+
+        if max_length is None:
+            from sage.rings.infinity import Infinity
+            max_length = Infinity
+        while True:
+            try:
+                length, path = next(it)
+            except StopIteration:
+                break
+
+            if length + edge_weight > max_length:
+                break
+
+            if report_weight:
+                yield length + edge_weight, [edge[0]] + path
+            else:
+                yield [edge[0]] + path
+
     def all_cycles_iterator(self, starting_vertices=None, simple=False,
                             rooted=False, max_length=None, trivial=False,
                             weight_function=None, by_weight=False,
-                            check_weight=True, report_weight=False):
+                            check_weight=True, report_weight=False,
+                            algorithm='A'):
         r"""
         Return an iterator over all the cycles of ``self`` starting with one of
         the given vertices. Each edge must have a positive weight.
@@ -3005,11 +3145,22 @@ class DiGraph(GenericGraph):
           a cycle is returned. Otherwise a tuple of cycle length and cycle is
           returned.
 
+        - ``algorithm`` -- string (default: ``'A'``); the algorithm used to
+          enumerate the cycles.
+
+          - The algorithm ``'A'`` holds cycle iterators starting with each vertex,
+            and output them in increasing length order.
+
+          - The algorithm ``'B'`` holds cycle iterators starting with each edge,
+            and output them in increasing length order. It depends on the k-shortest
+            simple paths algorithm. Thus, it is not available if ``simple=False``.
+
         OUTPUT: iterator
 
         .. SEEALSO::
 
             - :meth:`all_simple_cycles`
+            - :math:`~sage.graphs.path_enumeration.shortest_simple_paths`
 
         AUTHOR:
 
@@ -3127,28 +3278,50 @@ class DiGraph(GenericGraph):
                 if weight_function(e) < 0:
                     raise ValueError("negative weight is not allowed")
 
-        # We create one cycles iterator per vertex. This is necessary if we
-        # want to iterate over cycles with increasing length.
-        def cycle_iter(v):
-            return h._all_cycles_iterator_vertex(v,
-                                                 starting_vertices=starting_vertices,
-                                                 simple=simple,
-                                                 rooted=rooted,
-                                                 max_length=max_length,
-                                                 trivial=trivial,
-                                                 remove_acyclic_edges=False,
-                                                 weight_function=weight_function,
-                                                 by_weight=by_weight,
-                                                 check_weight=check_weight,
-                                                 report_weight=True)
+        if algorithm == 'A':
+            # We create one cycles iterator per vertex. This is necessary if we
+            # want to iterate over cycles with increasing length.
+            def cycle_iter(v):
+                return h._all_cycles_iterator_vertex(v,
+                                                    starting_vertices=starting_vertices,
+                                                    simple=simple,
+                                                    rooted=rooted,
+                                                    max_length=max_length,
+                                                    trivial=trivial,
+                                                    remove_acyclic_edges=False,
+                                                    weight_function=weight_function,
+                                                    by_weight=by_weight,
+                                                    check_weight=check_weight,
+                                                    report_weight=True)
 
-        vertex_iterators = {v: cycle_iter(v) for v in starting_vertices}
+            iterators = {v: cycle_iter(v) for v in starting_vertices}
+        elif algorithm == 'B':
+            if not simple:
+                raise ValueError("The algorithm 'B' is available only when simple=True.")
+            def simple_cycle_iter(e):
+                return h._all_simple_cycles_iterator_edge(e,
+                                                          starting_vertices=starting_vertices,
+                                                          rooted=rooted,
+                                                          max_length=max_length,
+                                                          remove_acyclic_edges=False,
+                                                          weight_function=weight_function,
+                                                          by_weight=by_weight,
+                                                          check_weight=check_weight,
+                                                          report_weight=True)
+            iterators = dict()
+            for s in starting_vertices:
+                for e in h.outgoing_edge_iterator(s):
+                    iterators[e] = simple_cycle_iter(e)
+        else:
+            raise ValueError(f"The algorithm {algorithm} is not valid. \
+                               Use the algorithm 'A' or 'B'.")
+
 
         cycles = []
-        for vi in vertex_iterators.values():
+        for key, it in iterators.items():
             try:
-                length, cycle = next(vi)
-                cycles.append((length, cycle))
+                length, cycle = next(it)
+                cycles.append((length, cycle, key))
             except StopIteration:
                 pass
         # Since we always extract a shortest path, using a heap
@@ -3157,7 +3330,7 @@ class DiGraph(GenericGraph):
         heapify(cycles)
         while cycles:
             # We choose the shortest available cycle
-            length, shortest_cycle = heappop(cycles)
+            length, shortest_cycle, key = heappop(cycles)
             if report_weight:
                 yield (length, shortest_cycle)
             else:
@@ -3165,15 +3338,16 @@ class DiGraph(GenericGraph):
             # We update the cycle iterator to its next available cycle if it
             # exists
             try:
-                length, cycle = next(vertex_iterators[shortest_cycle[0]])
-                heappush(cycles, (length, cycle))
+                length, cycle = next(iterators[key])
+                heappush(cycles, (length, cycle, key))
             except StopIteration:
                 pass
 
     def all_simple_cycles(self, starting_vertices=None, rooted=False,
                           max_length=None, trivial=False,
                           weight_function=None, by_weight=False,
-                          check_weight=True, report_weight=False):
+                          check_weight=True, report_weight=False,
+                          algorithm='A'):
         r"""
         Return a list of all simple cycles of ``self``. The cycles are
         enumerated in increasing length order. Each edge must have a
@@ -3213,6 +3387,15 @@ class DiGraph(GenericGraph):
         - ``report_weight`` -- boolean (default: ``False``); if ``False``, just
           a cycle is returned. Otherwise a tuple of cycle length and cycle is
           returned.
+
+        - ``algorithm`` -- string (default: ``'A'``); the algorithm used to
+          enumerate the cycles.
+
+          - The algorithm ``'A'`` holds cycle iterators starting with each vertex,
+            and output them in increasing length order.
+
+          - The algorithm ``'B'`` holds cycle iterators starting with each edge,
+            and output them in increasing length order.
 
         OUTPUT: list
 
@@ -3326,14 +3509,29 @@ class DiGraph(GenericGraph):
 
         A cycle is enumerated in increasing length order for a weighted graph::
 
-            sage: g.all_simple_cycles(weight_function=lambda e:e[0]+e[1], by_weight=True,
-            ....:                     report_weight=True)
+            sage: cycles = g.all_simple_cycles(weight_function=lambda e:e[0]+e[1],
+            ....:                              by_weight=True, report_weight=True)
+            sage: cycles
             [(2, [0, 1, 0]), (4, [0, 2, 0]), (6, [0, 1, 2, 0]), (6, [0, 2, 1, 0]),
              (6, [0, 3, 0]), (6, [1, 2, 1]), (8, [0, 1, 3, 0]), (8, [0, 3, 1, 0]),
              (8, [1, 3, 1]), (10, [0, 2, 3, 0]), (10, [0, 3, 2, 0]), (10, [2, 3, 2]),
              (12, [0, 1, 2, 3, 0]), (12, [0, 1, 3, 2, 0]), (12, [0, 2, 1, 3, 0]),
              (12, [0, 2, 3, 1, 0]), (12, [0, 3, 1, 2, 0]), (12, [0, 3, 2, 1, 0]),
              (12, [1, 2, 3, 1]), (12, [1, 3, 2, 1])]
+
+        The algorithm ``'B'`` can be used::
+
+            sage: cycles_B = g.all_simple_cycles(weight_function=lambda e:e[0]+e[1], by_weight=True,
+            ....:                                report_weight=True, algorithm='B')
+            sage: cycles_B
+            [(2, [0, 1, 0]), (4, [0, 2, 0]), (6, [0, 1, 2, 0]), (6, [0, 2, 1, 0]),
+             (6, [0, 3, 0]), (6, [1, 2, 1]), (8, [0, 1, 3, 0]), (8, [0, 3, 1, 0]),
+             (8, [1, 3, 1]), (10, [0, 2, 3, 0]), (10, [0, 3, 2, 0]), (10, [2, 3, 2]),
+             (12, [0, 1, 3, 2, 0]), (12, [0, 1, 2, 3, 0]), (12, [0, 2, 3, 1, 0]),
+             (12, [0, 2, 1, 3, 0]), (12, [0, 3, 2, 1, 0]), (12, [0, 3, 1, 2, 0]),
+             (12, [1, 2, 3, 1]), (12, [1, 3, 2, 1])]
+            sage: cycles.sort() == cycles_B.sort()
+            True
         """
         return list(self.all_cycles_iterator(starting_vertices=starting_vertices,
                                              simple=True, rooted=rooted,
@@ -3341,7 +3539,8 @@ class DiGraph(GenericGraph):
                                              weight_function=weight_function,
                                              by_weight=by_weight,
                                              check_weight=check_weight,
-                                             report_weight=report_weight))
+                                             report_weight=report_weight,
+                                             algorithm=algorithm))
 
     def path_semigroup(self):
         """

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -3024,13 +3024,14 @@ class DiGraph(GenericGraph):
         """
         # First we remove vertices and edges that are not part of any cycle
         if remove_acyclic_edges:
-            sccs = self.strongly_connected_components()
-            d = {}
-            for id, component in enumerate(sccs):
-                for v in component:
-                    d[v] = id
-            h = copy(self)
-            h.delete_edges((u, v) for u, v in h.edge_iterator(labels=False) if d[u] != d[v])
+            h = None
+            for component in self.strongly_connected_components_subgraphs():
+                if component.has_edge(edge):
+                    h = component
+            if h is None:
+                # edge connects two strongly connected components, so
+                # no simple cycle starting with edge does not exist.
+                return
         else:
             h = copy(self)
         # delete edge

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -2923,21 +2923,13 @@ class DiGraph(GenericGraph):
         else:
             h = self
 
-        # set by_weight, weight_function
-        if weight_function is not None:
-            by_weight = True
-
-        if weight_function is None and by_weight:
-            def weight_function(e):
-                return e[2]
-
         by_weight, weight_function = self._get_weight_function(by_weight=by_weight,
                                                                weight_function=weight_function,
                                                                check_weight=check_weight)
-
-        for e in h.edge_iterator():
-            if weight_function(e) < 0:
-                raise ValueError("negative weight is not allowed")
+        if by_weight:
+            for e in h.edge_iterator():
+                if weight_function(e) < 0:
+                    raise ValueError("negative weight is not allowed")
 
         from heapq import heapify, heappop, heappush
         heap_queue = [(0, [vertex])]
@@ -3126,21 +3118,14 @@ class DiGraph(GenericGraph):
         h = copy(self)
         h.delete_edges((u, v) for u, v in h.edge_iterator(labels=False) if d[u] != d[v])
 
-        # set by_weight, weight_function
-        if weight_function is not None:
-            by_weight = True
-
-        if weight_function is None and by_weight:
-            def weight_function(e):
-                return e[2]
-
         by_weight, weight_function = self._get_weight_function(by_weight=by_weight,
                                                                weight_function=weight_function,
                                                                check_weight=check_weight)
 
-        for e in h.edge_iterator():
-            if weight_function(e) < 0:
-                raise ValueError("negative weight is not allowed")
+        if by_weight:
+            for e in h.edge_iterator():
+                if weight_function(e) < 0:
+                    raise ValueError("negative weight is not allowed")
 
         # We create one cycles iterator per vertex. This is necessary if we
         # want to iterate over cycles with increasing length.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Add another algorithm of enumearting simple cycles in digraph, which is based on k shortest simple path algorithm.

For each edge e=uv, delete e from the original graph and enumerate vu simple path in increasing length order by k shortest simple path algorithm to obtain simple cycles that contain e in increasing length order.

Using iterators for each edge e and priority queue makes it possible to enumerate simple cycles in increasing length order.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

#40114
