### PR TITLE
Revision of the Khovanov polynomial

### DIFF
--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -2029,7 +2029,7 @@ class KnotInfoBase(Enum):
             deprecation(40149, "base_ring is deprecated, use argument ring instead.")
 
         ch = ring.characteristic()
-        integral = ch == 0 and not ring.is_field()
+        integral = (ch == 0) and (not ring.is_field())
         if not self.is_knot():
             # KnotJob calculated results only available for knots
             if ch == 0 and ring.is_field():

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -1890,30 +1890,37 @@ class KnotInfoBase(Enum):
         return R(eval_knotinfo(conway_polynomial, locals=lc))
 
     @cached_method
-    def khovanov_polynomial(self, var1='q', var2='t', base_ring=ZZ, original=False, reduced=False, odd=False, KhoHo=False):
+    def khovanov_polynomial(self, var1='q', var2='t', torsion='T', ring=None, original=False,
+                            reduced=False, odd=False, base_ring=None):
         r"""
-        Return the Khovanov polynomial according to the value of column
-        ``khovanov_polynomial`` for this knot or link as an instance of
+        Return the Khovanov polynomial according to the value of columns
+        ``khovanov_*`` for this knot or link as an instance of
         :class:`~sage.rings.polynomial.laurent_polynomial.LaurentPolynomial_mpair`.
 
         INPUT:
 
-        - ``var1`` -- (default: ``'q'``) the first variable
-        - ``var2`` -- (default: ``'t'``) the second variable
-        - ``base_ring`` -- (default: ``ZZ``) the ring of the polynomial's
-          coefficients
+        - ``var1`` -- (default: ``'q'``) the first variable. Its exponents
+          correspond to the height of Khovanov homology
+        - ``var2`` -- (default: ``'t'``) the second variable. Its exponents
+          correspond to the degree of Khovanov homology
+        - ``torsion`` -- (default: ``'T'``) additional variable to indicate
+          the torsion of the integral homology group corresponding to the
+          monomial. Monomials without it correspond to torsion free ``ring``
+          modules.  If it appears its exponents stands for the modulus of
+          the torsion
+        - ``ring`` -- (default: ``ZZ`` for knots and ``QQ`` for proper links)
+          the ring for the homology
         - ``original`` -- boolean (default: ``False``); if set to
           ``True`` the original table entry is returned as a string
         - ``reduced`` -- boolean (default: ``False``); if set to ``True``
           the reduced version of the homology is used
         - ``odd`` -- boolean (default: ``False``); if set to ``True``
           the odd version of the homology is used
-        - ``KhoHo`` -- boolean (deprecated). The corresponding values have
-          disappeared from the database since January 2024
 
         OUTPUT:
 
-        A Laurent polynomial over the integers, more precisely an instance of
+        A two or three (for integral homology) variate Laurent polynomial over
+        ``ZZ``, more precisely an instance of
         :class:`~sage.rings.polynomial.laurent_polynomial.LaurentPolynomial_mpair`.
         If ``original`` is set to ``True`` then a string is returned.
 
@@ -1930,11 +1937,9 @@ class KnotInfoBase(Enum):
 
             sage: K = KnotInfo.K6_3
             sage: Kk = K.khovanov_polynomial(); Kk
-            q^7*t^3 + q^5*t^2 + q^3*t^2 + q^3*t + q*t + 2*q + 2*q^-1 + q^-1*t^-1
-            + q^-3*t^-1 + q^-3*t^-2 + q^-5*t^-2 + q^-7*t^-3
-            sage: Kk2 = K.khovanov_polynomial(var1='p', base_ring=GF(2)); Kk2
-            p^7*t^3 + p^5*t^3 + p^5*t^2 + p^3*t + p^-1 + p^-1*t^-1 + p^-3*t^-2 + p^-7*t^-3
-
+            q^7*t^3 + q^5*t^3*T^2 + q^5*t^2 + q^3*t^2*T^2 + q^3*t^2 + q^3*t + q*t*T^2 + q*t
+             + 2*q + q^-1*T^2 + 2*q^-1 + q^-1*t^-1 + q^-3*t^-1*T^2 + q^-3*t^-1 + q^-3*t^-2
+             + q^-5*t^-2*T^2 + q^-5*t^-2 + q^-7*t^-3
             sage: L = KnotInfo.L5a1_0
             sage: Lk = L.khovanov_polynomial(); Lk
             q^4*t^2 + t + 2 + 2*q^-2 + q^-2*t^-1 + q^-4*t^-2 + q^-6*t^-2 + q^-8*t^-3
@@ -1945,10 +1950,10 @@ class KnotInfoBase(Enum):
 
             sage: Kkr = K.khovanov_polynomial(reduced=True); Kkr
             q^6*t^3 + 2*q^4*t^2 + 2*q^2*t + 3 + 2*q^-2*t^-1 + 2*q^-4*t^-2 + q^-6*t^-3
-            sage: K.khovanov_polynomial(base_ring=QQ, reduced=True) == Kkr
+            sage: K.khovanov_polynomial(ring=QQ, reduced=True) == Kkr
             True
-            sage: Kkr2 = K.khovanov_polynomial(base_ring=GF(2), reduced=True); Kkr2
-            q^6*t^3 + 1 + q^-6*t^-3
+            sage: Kkr2 = K.khovanov_polynomial(var1='p', ring=GF(2), reduced=True); Kkr2
+            p^6*t^3 + 2*p^4*t^2 + 2*p^2*t + 3 + 2*p^-2*t^-1 + 2*p^-4*t^-2 + p^-6*t^-3
             sage: KnotInfo.K8_19.inject()                               # optional database_knotinfo
             Defining K8_19
             sage: K8kr = K8_19.khovanov_polynomial(reduced=True); K8kr  # optional database_knotinfo
@@ -1958,23 +1963,27 @@ class KnotInfoBase(Enum):
 
             sage: K.khovanov_polynomial(odd=True) == Kkr
             True
-            sage: K.khovanov_polynomial(base_ring=QQ, odd=True) == Kkr
+            sage: K.khovanov_polynomial(ring=QQ, odd=True) == Kkr
             True
-            sage: K.khovanov_polynomial(base_ring=GF(2), odd=True) == Kkr2
+            sage: K.khovanov_polynomial(var1='p', ring=GF(2), odd=True) == Kkr2
             True
             sage: K8ko = K8_19.khovanov_polynomial(odd=True); K8ko     # optional database_knotinfo
-            q^16*t^5 + q^10*t^2 + q^6
+            q^14*t^5*T^3 + q^16*t^5 + q^12*t^4*T^2 + q^10*t^2 + q^6
             sage: K8kr == K8ko                                         # optional database_knotinfo
             False
 
+        Caution:
+
+            sage: Kk2 = K.khovanov_polynomial(ring=GF(2))
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: unreduced Khovanov polynomial available only for integral homology
 
         Comparison to Sage's results::
 
             sage: Kk == K.link().khovanov_polynomial()
             True
-            sage: Kk2 == K.link().khovanov_polynomial(var1='p', base_ring=GF(2))
-            True
-            sage: Lk == L.link().khovanov_polynomial()
+            sage: Lk == L.link().khovanov_polynomial(ring=QQ)
             True
 
         TESTS::
@@ -1987,36 +1996,47 @@ class KnotInfoBase(Enum):
             1
             sage: K0_1.khovanov_polynomial(odd=True)
             1
-            sage: K0_1.khovanov_polynomial(base_ring=GF(3), reduced=True)
+            sage: K0_1.khovanov_polynomial(ring=GF(3), reduced=True)
             Traceback (most recent call last):
             ...
-            ValueError: characteristic 3 of base ring is not valid
-            sage: K0_1.khovanov_polynomial(base_ring=GF(3), odd=True)
+            ValueError: characteristic 3 of ring is not valid
+            sage: K0_1.khovanov_polynomial(ring=GF(3), odd=True)
             Traceback (most recent call last):
             ...
-            ValueError: characteristic 3 of base ring is not valid
-            sage: L.khovanov_polynomial(base_ring=GF(2))
+            ValueError: characteristic 3 of ring is not valid
+            sage: L.khovanov_polynomial(ring=GF(2))
             Traceback (most recent call last):
             ...
-            NotImplementedError: Khovanov polynomial available only for knots in characteristic 2
+            NotImplementedError: Khovanov polynomial not available for multi-component links for this ring
 
         REFERENCES:
 
         - :wikipedia:`Khovanov_homology`
         - :wikipedia:`Reduced_homology`
         - [ORS2013]_
+        - `KnotInfo <https://knotinfo.math.indiana.edu/descriptions/khovanov_unreduced_integral_polynomial.html>`__
         """
-        ch = base_ring.characteristic()
-        integral = ch == 0 and base_ring.is_field()
+        if not ring:
+            if self.is_knot():
+                ring = ZZ
+            else:
+                from sage.rings.rational_field import QQ
+                ring = QQ
+
+        if base_ring:
+            ring = base_ring
+            from sage.misc.superseded import deprecation
+            deprecation(40199, "base_ring is deprecated, use argument ring instead.")
+
+        ch = ring.characteristic()
+        integral = ch == 0 and not ring.is_field()
         if not self.is_knot():
             # KnotJob calculated results only available for knots
-            khovanov_polynomial = self[self.items.khovanov_polynomial]
-            KhoHo = True
+            if ch == 0 and ring.is_field():
+                khovanov_polynomial = self[self.items.khovanov_polynomial]
+            else:
+                raise NotImplementedError('Khovanov polynomial not available for multi-component links for this ring')
         else:
-            if KhoHo:
-                KhoHo = False
-                from sage.misc.superseded import deprecation
-                deprecation(37014, "the KhoHo option is deprecated and ignored.")
             if reduced:
                 if integral:
                     khovanov_polynomial = self[self.items.khovanov_reduced_integral_polynomial]
@@ -2025,7 +2045,7 @@ class KnotInfoBase(Enum):
                 elif ch == 2:
                     khovanov_polynomial = self[self.items.khovanov_reduced_mod2_polynomial]
                 else:
-                    raise ValueError('characteristic %s of base ring is not valid' % ch)
+                    raise ValueError('characteristic %s of ring is not valid' % ch)
             elif odd:
                 if integral:
                     khovanov_polynomial = self[self.items.khovanov_odd_integral_polynomial]
@@ -2034,30 +2054,32 @@ class KnotInfoBase(Enum):
                 elif ch == 2:
                     khovanov_polynomial = self[self.items.khovanov_odd_mod2_polynomial]
                 else:
-                    raise ValueError('characteristic %s of base ring is not valid' % ch)
+                    raise ValueError('characteristic %s of ring is not valid' % ch)
             else:
-                khovanov_polynomial = self[self.items.khovanov_unreduced_integral_polynomial]
+                if integral:
+                    khovanov_polynomial = self[self.items.khovanov_unreduced_integral_polynomial]
+                else:
+                    raise NotImplementedError('unreduced Khovanov polynomial available only for integral homology')
 
         if original:
             return khovanov_polynomial
 
         from sage.rings.polynomial.laurent_polynomial_ring import LaurentPolynomialRing
-        var_names = [var1, var2]
-        R = LaurentPolynomialRing(base_ring, var_names)
+        if integral:
+            var_names = [var1, var2, torsion]
+        else:
+            var_names = [var1, var2]
+
+        R = LaurentPolynomialRing(ZZ, var_names)
 
         if not khovanov_polynomial and self.crossing_number() == 0:
             if reduced or odd:
                 return R.one()
             else:
-                return R({(1, 0): 1, (-1, 0): 1})
-
-        if ch == 2:
-            if not self.is_knot():
-                raise NotImplementedError('Khovanov polynomial available only for knots in characteristic 2')
-            if KhoHo:
-                khovanov_torsion_polynomial = self[self.items.khovanov_torsion_polynomial]
-                khovanov_torsion_polynomial = khovanov_torsion_polynomial.replace('Q', 'q')
-                khovanov_polynomial = '%s + %s' % (khovanov_polynomial, khovanov_torsion_polynomial)
+                if integral:
+                    return R({(1, 0, 0): 1, (-1, 0, 0): 1})
+                else:
+                    return R({(1, 0): 1, (-1, 0): 1})
 
         if not khovanov_polynomial:
             # given just for links with less than 12 crossings
@@ -2074,10 +2096,8 @@ class KnotInfoBase(Enum):
         lc = {}
         lc['q'] = gens[var1]
         lc['t'] = gens[var2]
-        if ch == 2:
-            lc['T'] = 1
-        else:
-            lc['T'] = 0
+        if integral:
+            lc['T'] = gens[torsion]
 
         return R(eval_knotinfo(khovanov_polynomial, locals=lc))
 

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -1899,14 +1899,14 @@ class KnotInfoBase(Enum):
 
         INPUT:
 
-        - ``var1`` -- (default: ``'q'``) the first variable. Its exponents
+        - ``var1`` -- (default: ``'q'``) the first variable; its exponents
           correspond to the height of Khovanov homology
-        - ``var2`` -- (default: ``'t'``) the second variable. Its exponents
+        - ``var2`` -- (default: ``'t'``) the second variable; its exponents
           correspond to the degree of Khovanov homology
         - ``torsion`` -- (default: ``'T'``) additional variable to indicate
           the torsion of the integral homology group corresponding to the
-          monomial. Monomials without it correspond to torsion free ``ring``
-          modules.  If it appears its exponents stands for the modulus of
+          monomial; monomials without it correspond to torsion free ``ring``
+          modules; if it appears, its exponents stands for the modulus of
           the torsion
         - ``ring`` -- (default: ``ZZ`` for knots and ``QQ`` for proper links)
           the ring for the homology

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -1972,7 +1972,7 @@ class KnotInfoBase(Enum):
             sage: K8kr == K8ko                                         # optional database_knotinfo
             False
 
-        Caution:
+        Caution::
 
             sage: Kk2 = K.khovanov_polynomial(ring=GF(2))
             Traceback (most recent call last):

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -2026,7 +2026,7 @@ class KnotInfoBase(Enum):
         if base_ring:
             ring = base_ring
             from sage.misc.superseded import deprecation
-            deprecation(40199, "base_ring is deprecated, use argument ring instead.")
+            deprecation(40149, "base_ring is deprecated, use argument ring instead.")
 
         ch = ring.characteristic()
         integral = ch == 0 and not ring.is_field()

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -2064,12 +2064,14 @@ class Link(SageObject):
           correspond to the degree of Khovanov homology
         - ``torsion`` -- (default: ``'T'``) additional variable to indicate
           the torsion of the integral homology group corresponding to the
-          monomial. Monomials without it correspond to torsion free ``ring``
-          modules.  If it appears its exponents stands for the modulus of
-          the torsion. Here we follow the conventions used on
-          `KnotInfo <https://knotinfo.math.indiana.edu/descriptions/khovanov_unreduced_integral_polynomial.html>`__
+          monomial; monomials without it correspond to torsion free ``ring``
+          modules; if it appears its exponents stands for the modulus of
+          the torsion
         - ``ring`` -- (default: ``ZZ``) the ring of the homology. This will
           be transferred to :meth:`khovanov_homology`
+
+        Here we follow the conventions used in
+        `KnotInfo <https://knotinfo.math.indiana.edu/descriptions/khovanov_unreduced_integral_polynomial.html>`__
 
         OUTPUT:
 

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -2108,7 +2108,7 @@ class Link(SageObject):
         if base_ring:
             ring = base_ring
             from sage.misc.superseded import deprecation
-            deprecation(40199, "base_ring is deprecated, use argument ring instead.")
+            deprecation(40149, "base_ring is deprecated, use argument ring instead.")
 
         ch = ring.characteristic()
         integral = False

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -2127,12 +2127,17 @@ class Link(SageObject):
                 H = kh[h][d]
                 gens = {g: g.order() for g in H.gens()}
                 if integral:
-                    for tor in gens.values():
-                        l = len([g for g in gens if gens[g] == tor])
-                        if tor is infinity:
-                            coeff[(h, d, 0)] = l
+                    tor_count = {}
+                    for g, tor in gens.items():
+                        if tor in tor_count:
+                            tor_count[tor] += 1
                         else:
-                            coeff[(h, d, tor)] = l
+                            tor_count[tor] = 1
+                    for tor, ell in tor_count.items():
+                        if tor is infinity:
+                            coeff[(h, d, 0)] = ell
+                        else:
+                            coeff[(h, d, tor)] = ell
                 else:
                     coeff[(h, d)] = len(gens)
         return L(coeff)

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -2050,7 +2050,7 @@ class Link(SageObject):
             conway += coeff * t_poly**M
         return conway
 
-    def khovanov_polynomial(self, var1='q', var2='t', base_ring=ZZ):
+    def khovanov_polynomial(self, var1='q', var2='t', torsion='T', ring=ZZ, base_ring=None):
         r"""
         Return the Khovanov polynomial of ``self``.
 
@@ -2059,32 +2059,41 @@ class Link(SageObject):
         INPUT:
 
         - ``var1`` -- (default: ``'q'``) the first variable. Its exponents
-          give the (torsion free) rank of the height of Khovanov homology
+          correspond to the height of Khovanov homology
         - ``var2`` -- (default: ``'t'``) the second variable. Its exponents
-          give the (torsion free) rank of the degree of Khovanov homology
-        - ``base_ring`` -- (default: ``ZZ``) the ring of the polynomial's
-          coefficients
+          correspond to the degree of Khovanov homology
+        - ``torsion`` -- (default: ``'T'``) additional variable to indicate
+          the torsion of the integral homology group corresponding to the
+          monomial. Monomials without it correspond to torsion free ``ring``
+          modules.  If it appears its exponents stands for the modulus of
+          the torsion. Here we follow the conventions used on
+          `KnotInfo <https://knotinfo.math.indiana.edu/descriptions/khovanov_unreduced_integral_polynomial.html>`__
+        - ``ring`` -- (default: ``ZZ``) the ring of the homology. This will
+          be transferred to :meth:`khovanov_homology`
 
         OUTPUT:
 
-        A two variate Laurent Polynomial over the ``base_ring``, more precisely an
-        instance of :class:`~sage.rings.polynomial.laurent_polynomial.LaurentPolynomial`.
+        A two or three (for integral homology) variate Laurent polynomial over
+        ``ZZ``, more precisely an instance of
+        :class:`~sage.rings.polynomial.laurent_polynomial.LaurentPolynomial_mpair`.
 
         EXAMPLES::
 
             sage: K = Link([[[1, -2, 3, -1, 2, -3]],[-1, -1, -1]])
             sage: K.khovanov_polynomial()                                               # needs sage.modules
-            q^-1 + q^-3 + q^-5*t^-2 + q^-9*t^-3
-            sage: K.khovanov_polynomial(base_ring=GF(2))                                # needs sage.modules
-            q^-1 + q^-3 + q^-5*t^-2 + q^-7*t^-2 + q^-9*t^-3
+            q^-1 + q^-3 + q^-5*t^-2 + q^-7*t^-2*T^2 + q^-9*t^-3
+            sage: K.khovanov_polynomial(ring=GF(2))                                     # needs sage.modules
+            q^-1 + q^-3 + q^-5*t^-2 + q^-7*t^-2 + q^-7*t^-3 + q^-9*t^-3
 
         The figure eight knot::
 
             sage: L = Link([[1, 6, 2, 7], [5, 2, 6, 3], [3, 1, 4, 8], [7, 5, 8, 4]])
             sage: L.khovanov_polynomial(var1='p')                                       # needs sage.modules
-            p^5*t^2 + p*t + p + p^-1 + p^-1*t^-1 + p^-5*t^-2
-            sage: L.khovanov_polynomial(var1='p', var2='s', base_ring=GF(4))            # needs sage.modules sage.rings.finite_rings
-            p^5*s^2 + p^3*s^2 + p*s + p + p^-1 + p^-1*s^-1 + p^-3*s^-1 + p^-5*s^-2
+            p^5*t^2 + p^3*t^2*T^2 + p*t + p + p^-1 + p^-1*t^-1
+              + p^-3*t^-1*T^2 + p^-5*t^-2
+            sage: L.khovanov_polynomial(var1='p', var2='s', ring=GF(4))                 # needs sage.modules sage.rings.finite_rings
+            p^5*s^2 + p^3*s^2 + p^3*s + p*s + p + p^-1 + p^-1*s^-1
+              + p^-3*s^-1 + p^-3*s^-2 + p^-5*s^-2
 
         The Hopf link::
 
@@ -2096,18 +2105,34 @@ class Link(SageObject):
 
         .. SEEALSO:: :meth:`khovanov_homology`
         """
-        L = LaurentPolynomialRing(base_ring, [var1, var2])
-        ch = base_ring.characteristic()
+        if base_ring:
+            ring = base_ring
+            from sage.misc.superseded import deprecation
+            deprecation(40199, "base_ring is deprecated, use argument ring instead.")
+
+        ch = ring.characteristic()
+        integral = False
+        if ch == 0 and not ring.is_field():
+            integral = True
+            L = LaurentPolynomialRing(ZZ, [var1, var2, torsion])
+        else:
+            L = LaurentPolynomialRing(ZZ, [var1, var2])
         coeff = {}
-        kh = self.khovanov_homology()
+        kh = self.khovanov_homology(ring=ring)
         from sage.rings.infinity import infinity
         for h in kh:
             for d in kh[h]:
                 H = kh[h][d]
-                gens = [g for g in H.gens() if g.order() == infinity or ch.divides(g.order())]
-                l = len(gens)
-                if l:
-                    coeff[(h, d)] = l
+                gens = {g: g.order() for g in H.gens()}
+                if integral:
+                    for tor in gens.values():
+                        l = len([g for g in gens if gens[g] == tor])
+                        if tor is infinity:
+                            coeff[(h, d, 0)] = l
+                        else:
+                            coeff[(h, d, tor)] = l
+                else:
+                    coeff[(h, d)] = len(gens)
         return L(coeff)
 
     def determinant(self):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

In #33965 and #33969, I introduced two methods named `khovanov_polynomial`, one for the `Link` class and the other for `KnotInfo`. Unfortunately, I misused the ring argument in both. IIRC, the analogy to the other polynomial link invariants led me to use the `base_ring` argument to specify the base ring of the polynomial. However, this was not a good idea, since the Khovanov polynomial, as a Poincaré polynomial of homology, always has integer coefficients. On the other hand, a ring argument is needed to specify the underlying homology.

This will be corrected in this PR. In particular, I will deprecate the existing `base_ring` argument and introduce a new `ring` argument, which corresponds to the `ring` argument of the `khovanov_homology` method of the `Link` class. I take the occasion to remove the deprecation warning for the argument `KhoHo` released in March 2024.

Furthermore, I introduce a new argument `torsion` to display the torsion parts of the integral homology according to the [KnotInfo convention](https://knotinfo.math.indiana.edu/descriptions/khovanov_odd_integral_polynomial.html).


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


