### PR TITLE
Add check for Arch Linux in configure to recommend meson build

### DIFF
--- a/.github/workflows/ci-linux-incremental.yml
+++ b/.github/workflows/ci-linux-incremental.yml
@@ -20,6 +20,7 @@ on:
     paths:
       - '.github/workflows/ci-linux-incremental.yml'
       - 'build/pkgs/**'
+      - 'configure.ac'
       - '!build/pkgs/sage_conf/**'
       - '!build/pkgs/sage_docbuild/**'
       - '!build/pkgs/sage_setup/**'

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,23 @@
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
+# Check for systems where Meson build is recommended
+AC_ARG_ENABLE([meson-check],
+  [AS_HELP_STRING([--disable-meson-check],
+    [do not fail the build if running on systems where Meson is preferred (default: enabled)])],
+  [enable_meson_check=$enableval],
+  [enable_meson_check=yes])
+
+if test "x$enable_meson_check" != "xno"; then
+  AC_MSG_CHECKING([for Arch Linux])
+  if grep -qi 'arch' /etc/os-release 2>/dev/null || test -f /etc/arch-release; then
+    AC_MSG_RESULT([yes])
+    AC_MSG_ERROR([Building on Arch Linux using make is not recommended. Please use Meson as described at https://doc.sagemath.org/html/en/installation/meson.html. Use --disable-meson-check to override.])
+  else
+    AC_MSG_RESULT([no])
+  fi
+fi
+
 dnl If you are going to update this, please stick the recommended layout
 dnl in the autoconf manual - i.e.
 

--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,7 @@ if test "$enable_meson_check" != no; then
     AC_MSG_RESULT([yes])
     AC_MSG_ERROR([Building on Arch Linux using make is not recommended. Please use Meson as described at https://doc.sagemath.org/html/en/installation/meson.html. Use --disable-meson-check to override.])
   else
-    AC_MSG_ERROR([no])
+    AC_MSG_RESULT([no])
   fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,23 +17,6 @@
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-# Check for systems where Meson build is recommended
-AC_ARG_ENABLE([meson-check],
-  [AS_HELP_STRING([--disable-meson-check],
-    [do not fail the build if running on systems where Meson is preferred (default: enabled)])],
-  [enable_meson_check=$enableval],
-  [enable_meson_check=yes])
-
-if test "x$enable_meson_check" != "xno"; then
-  AC_MSG_CHECKING([for Arch Linux])
-  if grep -qi 'arch' /etc/os-release 2>/dev/null || test -f /etc/arch-release; then
-    AC_MSG_RESULT([yes])
-    AC_MSG_ERROR([Building on Arch Linux using make is not recommended. Please use Meson as described at https://doc.sagemath.org/html/en/installation/meson.html. Use --disable-meson-check to override.])
-  else
-    AC_MSG_RESULT([no])
-  fi
-fi
-
 dnl If you are going to update this, please stick the recommended layout
 dnl in the autoconf manual - i.e.
 
@@ -117,6 +100,23 @@ AC_SUBST([SAGE_VENV])
 AC_SUBST([SAGE_DOCS], ['${SAGE_LOCAL}'])dnl Quoted so that it is resolved at build time by shell/Makefile
 
 #---------------------------------------------------------
+
+# Check for systems where Meson build is recommended
+AC_ARG_ENABLE([meson-check],
+  [AS_HELP_STRING([--disable-meson-check],
+    [do not fail the build if running on systems where Meson is preferred])],
+  [enable_meson_check=$enableval],
+  [enable_meson_check=yes])
+
+if test "$enable_meson_check" != no; then
+  AC_MSG_CHECKING([for Arch Linux])
+  if grep -qi 'arch' /etc/os-release 2>/dev/null || test -f /etc/arch-release; then
+    AC_MSG_RESULT([yes])
+    AC_MSG_ERROR([Building on Arch Linux using make is not recommended. Please use Meson as described at https://doc.sagemath.org/html/en/installation/meson.html. Use --disable-meson-check to override.])
+  else
+    AC_MSG_ERROR([no])
+  fi
+fi
 
 AC_ARG_ENABLE([build-as-root],
               [AS_HELP_STRING([--enable-build-as-root],


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Add a check if the configure is run on Arch Linux. If yes, then recommend to use Meson instead since there is little need for configure + make on Arch and the Meson build works nicely there.
This check can be disabled by passing `--disable-meson-check`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


