### PR TITLE
Add back ubuntu-noble-standard to ci-linux

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ on:
           [
            "ubuntu-focal",
            "ubuntu-jammy",
+           "ubuntu-noble",
            "debian-bullseye",
            "debian-bookworm",
            "fedora-40",


### PR DESCRIPTION
Fixes https://github.com/sagemath/sage/issues/40120 — I believe.

As explained there, the root cause is that `ci-linux.yml` no longer build from scratch on `ubuntu-noble-standard` to generate the base docker image for the incremental builds to base on.

In any case this appears to be harmless enough.

From some [testing](https://github.com/user202729/sage/actions/workflows/ci-linux.yml) this works _some_ of the time (the debug statements are harmless)… which is not great, but the **current** `standard` runs aren't completely reliable either.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


