### PR TITLE
much faster count for linear intervals

### DIFF
--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -2772,6 +2772,10 @@ class FinitePoset(UniqueRepresentation, Parent):
         """
         if not self.cardinality():
             return []
+        # precomputation helps for speed:
+        if self.cardinality() > 60:
+            self.lequal_matrix()
+
         H = self._hasse_diagram
         stock = [(x, x, x) for x in H]
         poly = [len(stock)]


### PR DESCRIPTION
by caching the partial order in the adequate way

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.