### PR TITLE
Trac #40127: Pass factor_on_left in linear_combination

### DIFF
--- a/src/sage/data_structures/blas_dict.pyx
+++ b/src/sage/data_structures/blas_dict.pyx
@@ -350,7 +350,8 @@ cpdef dict linear_combination(dict_factor_iter, bint factor_on_left=True):
         if not result and a == 1:
             result = D.copy()
         else:
-            iaxpy(a, D, result, remove_zeros=False)
+            iaxpy(a, D, result, remove_zeros=False, 
+                  factor_on_left=factor_on_left)
 
     return remove_zeros(result)
 

--- a/src/sage/data_structures/blas_dict.pyx
+++ b/src/sage/data_structures/blas_dict.pyx
@@ -340,6 +340,20 @@ cpdef dict linear_combination(dict_factor_iter, bint factor_on_left=True):
         {0: 10, 1: 10}
         sage: blas.linear_combination( [(D,1), (D,-1)] )
         {}
+
+    Check right multiplication with coefficients in a noncommutative ring::
+
+        sage: SGA = SymmetricGroupAlgebra(QQ, 3)
+        sage: s1 = SGA([2, 1, 3]) # (1 2)
+        sage: s2 = SGA([3, 1, 2]) # (1 3)
+        sage: D1 = {0: s1}
+        sage: blas.linear_combination([(D1, s2)], factor_on_left=False)
+        {0: s1 * s2}
+
+    Check left multiplication with coefficients in a noncommutative ring::
+    
+        sage: blas.linear_combination([(D1, s2)], factor_on_left=True)
+        {0: s2 * s1}
     """
     cdef dict result = {}
     cdef dict D

--- a/src/sage/data_structures/blas_dict.pyx
+++ b/src/sage/data_structures/blas_dict.pyx
@@ -347,13 +347,13 @@ cpdef dict linear_combination(dict_factor_iter, bint factor_on_left=True):
         sage: s1 = SGA([2, 1, 3]) # (1 2)
         sage: s2 = SGA([3, 1, 2]) # (1 3)
         sage: D1 = {0: s1}
-        sage: blas.linear_combination([(D1, s2)], factor_on_left=False)
-        {0: s1 * s2}
+        sage: blas.linear_combination([(D1, s2)], factor_on_left=False) # s1 * s2
+        {0: [1, 3, 2]} 
 
     Check left multiplication with coefficients in a noncommutative ring::
     
-        sage: blas.linear_combination([(D1, s2)], factor_on_left=True)
-        {0: s2 * s1}
+        sage: blas.linear_combination([(D1, s2)], factor_on_left=True) # s2 * s1
+        {0: [3, 2, 1]} 
     """
     cdef dict result = {}
     cdef dict D


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes [#40127](https://github.com/sagemath/sage/issues/40127).

Passes `factor_on_left` correctly to `iaxpy()` in `linear_combination`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


