### PR TITLE
Trac #40167: Fix incorrect parent reuse in matrix-vector multiplication over GF(2)

### DIFF
--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -677,9 +677,25 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             sage: r1 = A*v1
             sage: r0.column(0) == r1
             True
+
+        Check that :issue:`40167` is fixed::
+
+            sage: M = matrix(GF(2), [[1,1],[0,1]])
+            sage: v = vector(GF(2), [0, 1])
+            sage: V = span([v])             # one-dimensional subspace of GF(2)^2
+            sage: image_basis = [M * b for b in V.basis()]
+            sage: image = span(image_basis)
+            sage: image_basis[0] in image.basis()
+            True
         """
         cdef mzd_t *tmp
-        if self._nrows == self._ncols and isinstance(v, Vector_mod2_dense):
+        if (
+            self._nrows == self._ncols and
+            isinstance(v, Vector_mod2_dense) and
+            v.parent().is_full() and
+            v.parent().degree() == self._nrows and
+            v.parent().base_ring() is self._base_ring
+            ):
             VS = v.parent()
         else:
             global VectorSpace

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -692,9 +692,7 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         if (
             self._nrows == self._ncols and
             isinstance(v, Vector_mod2_dense) and
-            v.parent().is_full() and
-            v.parent().degree() == self._nrows and
-            v.parent().base_ring() is self._base_ring
+            v.parent().rank() == self._ncols # check if the parent of v is full rank
             ):
             VS = v.parent()
         else:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes [#40167](https://github.com/sagemath/sage/issues/40167). This PR fixes a bug in `Matrix_mod2_dense._matrix_times_vector_` revealed in [#40167](https://github.com/sagemath/sage/issues/40167), where the parent of the resulting vector was incorrectly reused from the input vector.

The regression was introduced in [PR #37375](https://github.com/sagemath/sage/pull/37375), which added an optimization to speed up matrix-vector multiplication when the matrix is square and matches the vector dimension. However, it failed to account for edge cases where the input vector's parent is not the full ambient vector space—for example, when working with subspaces. In this case, we can no longer assume that the ambient space is the vector's ambient space.

In such cases, reusing the parent leads to incorrect coercion or a result vector with an invalid parent space. This patch introduces an explicit check: if the vector's parent is the full space `GF(2)^n`, it is reused; otherwise, a default parent is constructed to ensure correctness.

### Example (correct behavior restored)

```python
sage: M = Matrix(GF(2), [[1, 1], [0, 1]])
sage: v = vector(GF(2), [0, 1])
sage: V = span([v])             # one-dimensional subspace of GF(2)^2
sage: image_basis = [M * b for b in V.basis()]
sage: image = span(image_basis)
sage: image.basis() == [(1, 1)]
True # now returns True
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


