### PR TITLE
Make preparser can handle large(4301+ digits) integers

### DIFF
--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1189,6 +1189,8 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         'Integer(42)'
         sage: preparse_numeric_literals('000042')
         'Integer(42)'
+
+    Cheeck that :issue:`40179` is fixed::
         sage: preparse_numeric_literals("1" * 4300) == f"Integer({"1" * 4300})"
         True
         sage: preparse_numeric_literals("1" * 4301) == f"Integer({"1" * 4301})"

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1190,7 +1190,7 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         sage: preparse_numeric_literals('000042')
         'Integer(42)'
 
-    Cheeck that :issue:`40179` is fixed::
+    Check that :issue:`40179` is fixed::
 
         sage: preparse_numeric_literals("1" * 4300) == f"Integer({"1" * 4300})"
         True

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1124,8 +1124,9 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
       name-construction pairs
 
     - ``quotes`` -- string (default: ``"'"``); used to surround string
-      arguments to RealNumber and ComplexNumber. If ``None``, will rebuild
-      the string using a list of its Unicode code-points.
+      arguments to RealNumber and ComplexNumber, and Integer when the
+      number is longer than 4300 digits. If ``None``, will rebuild the
+      string using a list of its Unicode code-points.
 
     OUTPUT:
 
@@ -1188,6 +1189,12 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         'Integer(42)'
         sage: preparse_numeric_literals('000042')
         'Integer(42)'
+        sage: preparse_numeric_literals("1" * 4300) == f"Integer({"1" * 4300})"
+        True
+        sage: preparse_numeric_literals("1" * 4301) == f"Integer({"1" * 4301})"
+        False
+        sage: preparse_numeric_literals("1" * 4301) == f"Integer('{"1" * 4301}')"
+        True
 
     Test underscores as digit separators (PEP 515,
     https://www.python.org/dev/peps/pep-0515/)::
@@ -1253,6 +1260,10 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         'RealNumber(str().join(map(chr, [51, 46, 49, 52])))'
         sage: preparse_numeric_literals('5j', quotes=None)
         'ComplexNumber(0, str().join(map(chr, [53])))'
+        sage: preparse_numeric_literals("1" * 4301, quotes=None) == f'Integer(str().join(map(chr, {[49] * 4301})))'
+        True
+        sage: preparse_numeric_literals("1" * 4301, quotes="'''") == f"Integer('''{"1" * 4301}''')"
+        True
     """
     literals = {}
     last = 0

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1198,6 +1198,8 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         False
         sage: preparse_numeric_literals("1" * 4301) == f"Integer('{'1' * 4301}')"
         True
+        sage: preparse_numeric_literals("1" * 4301, quotes=None) == f'Integer(str().join(map(chr, {[49] * 4301})))'
+        True
 
     Test underscores as digit separators (PEP 515,
     https://www.python.org/dev/peps/pep-0515/)::
@@ -1262,12 +1264,7 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         sage: preparse_numeric_literals('3.14', quotes=None)
         'RealNumber(str().join(map(chr, [51, 46, 49, 52])))'
         sage: preparse_numeric_literals('5j', quotes=None)
-        'ComplexNumber(0, str().join(map(chr, [53])))'
-
-    Using the ``quote`` parameter for the case for :issue:`40179`::
-    
-        sage: preparse_numeric_literals("1" * 4301, quotes=None) == f'Integer(str().join(map(chr, {[49] * 4301})))'
-        True
+        'ComplexNumber(0, str().join(map(chr, [53])))'    
     """
     literals = {}
     last = 0

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1192,11 +1192,11 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
 
     Check that :issue:`40179` is fixed::
 
-        sage: preparse_numeric_literals("1" * 4300) == f"Integer({"1" * 4300})"
+        sage: preparse_numeric_literals("1" * 4300) == f"Integer({'1' * 4300})"
         True
-        sage: preparse_numeric_literals("1" * 4301) == f"Integer({"1" * 4301})"
+        sage: preparse_numeric_literals("1" * 4301) == f"Integer({'1' * 4301})"
         False
-        sage: preparse_numeric_literals("1" * 4301) == f"Integer('{"1" * 4301}')"
+        sage: preparse_numeric_literals("1" * 4301) == f"Integer('{'1' * 4301}')"
         True
 
     Test underscores as digit separators (PEP 515,
@@ -1263,9 +1263,10 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         'RealNumber(str().join(map(chr, [51, 46, 49, 52])))'
         sage: preparse_numeric_literals('5j', quotes=None)
         'ComplexNumber(0, str().join(map(chr, [53])))'
+
+    Using the ``quote`` parameter for the case for :issue:`40179`::
+    
         sage: preparse_numeric_literals("1" * 4301, quotes=None) == f'Integer(str().join(map(chr, {[49] * 4301})))'
-        True
-        sage: preparse_numeric_literals("1" * 4301, quotes="'''") == f"Integer('''{"1" * 4301}''')"
         True
     """
     literals = {}

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1324,7 +1324,9 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
                 # Python 3 does not allow leading zeroes. Sage does, so just strip them out.
                 # The number is still interpreted as decimal, not octal!
                 num = re.sub(r'^0+', '', num)
-                if quotes:
+                if len(num) <= 4300:
+                    num_make = "Integer(%s)" % num
+                elif quotes:
                     num_make = "Integer(%s%s%s)" % (quotes, num, quotes)
                 else:
                     code_points = list(map(ord, list(num)))

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1191,6 +1191,7 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         'Integer(42)'
 
     Cheeck that :issue:`40179` is fixed::
+
         sage: preparse_numeric_literals("1" * 4300) == f"Integer({"1" * 4300})"
         True
         sage: preparse_numeric_literals("1" * 4301) == f"Integer({"1" * 4301})"

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1194,8 +1194,6 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
 
         sage: preparse_numeric_literals("1" * 4300) == f"Integer({'1' * 4300})"
         True
-        sage: preparse_numeric_literals("1" * 4301) == f"Integer({'1' * 4301})"
-        False
         sage: preparse_numeric_literals("1" * 4301) == f"Integer('{'1' * 4301}')"
         True
         sage: preparse_numeric_literals("1" * 4301, quotes=None) == f'Integer(str().join(map(chr, {[49] * 4301})))'
@@ -1264,7 +1262,7 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
         sage: preparse_numeric_literals('3.14', quotes=None)
         'RealNumber(str().join(map(chr, [51, 46, 49, 52])))'
         sage: preparse_numeric_literals('5j', quotes=None)
-        'ComplexNumber(0, str().join(map(chr, [53])))'    
+        'ComplexNumber(0, str().join(map(chr, [53])))'
     """
     literals = {}
     last = 0

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1324,7 +1324,7 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
                 # Python 3 does not allow leading zeroes. Sage does, so just strip them out.
                 # The number is still interpreted as decimal, not octal!
                 num = re.sub(r'^0+', '', num)
-                num_make = "Integer(%s)" % num
+                num_make = "Integer('%s')" % num
 
             literals[num_name] = num_make
 

--- a/src/sage/repl/preparse.py
+++ b/src/sage/repl/preparse.py
@@ -1324,7 +1324,11 @@ def preparse_numeric_literals(code, extract=False, quotes="'"):
                 # Python 3 does not allow leading zeroes. Sage does, so just strip them out.
                 # The number is still interpreted as decimal, not octal!
                 num = re.sub(r'^0+', '', num)
-                num_make = "Integer('%s')" % num
+                if quotes:
+                    num_make = "Integer(%s%s%s)" % (quotes, num, quotes)
+                else:
+                    code_points = list(map(ord, list(num)))
+                    num_make = "Integer(str().join(map(chr, %s)))" % code_points
 
             literals[num_name] = num_make
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

I'm pretty sure sage wants to use all kinds of numbers without losing precision, or errors, since I can see `sys.set_int_max_str_digits(0)` in all.py.

However, even with the limit set to 0 (unlimited) in all.py which is called during import, it still cannot handle 4301+ digits integers, because Python refuses to run if there's 4301+ digit number in the first place.

For example, the following sage code has the following error (the 11...11 is actually 5000 digits of 1):

**long.sage**
```
a = 11...11
```

```
sage long.sage
  File "/home/soon_haari/mysage/long.sage.py", line 6
    _sage_const_11...11
SyntaxError: Exceeds the limit (4300 digits) for integer string conversion: value has 5000 digits; use sys.set_int_max_str_digits() to increase the limit - Consider hexadecimal for huge integer literals to avoid decimal conversion limits.
```


In more details, `11...11` parses to `Integer(11...11)` where 11...11 in Integer is supposed to be `<class 'int'>` in Python.
I suggest it parses to `Integer('11...11')` instead.

Funnily enough, real/complex numbers like `1.1` or `1j` or even `1.1j` have no problem due to long digits, because it parses to `RealNumber('1.1')`, `ComplexNumber(0, '1')`, `ComplexNumber(0, '1.1')` which use string as arguments already. I suggest the same fix.

This fixes https://github.com/sagemath/sage/issues/40179.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


