### PR TITLE
Fixes #40134: correct signs in inner_product_matrix docstring

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -543,7 +543,7 @@ class QuaternionAlgebra_abstract(Parent):
         This is the
         Gram matrix of the reduced norm as a quadratic form on ``self``.
         The standard basis `1`, `i`, `j`, `k` is orthogonal, so this matrix
-        is just the diagonal matrix with diagonal entries `2`, `2a`, `2b`,
+        is just the diagonal matrix with diagonal entries `2`, `-2a`, `-2b`,
         `2ab`.
 
         EXAMPLES::


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->


Fixes [#40134](https://github.com/sagemath/sage/issues/40134). This PR corrects the explanatory text in the docstring of `QuaternionAlgebra.inner_product_matrix`.

The original docstring claimed that the inner product matrix has diagonal entries `2`, `2a`, `2b`, `2ab` in the standard basis $1, i, j, k$. However, this contradicts both the actual implementation and the mathematical definition of the inner product used in the code, which should be, instead, `2`, `-2a`, `-2b`, `2ab`.

This PR updates the docstring to reflect this, fixing the incorrect signs. All doctests in `src/sage/algebras/quaternion_algebra.py` pass.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


