### PR TITLE
Optimise instantiation of free nilpotent Lie algebras

### DIFF
--- a/src/sage/algebras/lie_algebras/nilpotent_lie_algebra.py
+++ b/src/sage/algebras/lie_algebras/nilpotent_lie_algebra.py
@@ -394,6 +394,10 @@ class FreeNilpotentLieAlgebra(NilpotentLieAlgebra_dense):
 
         # extract structural coefficients from the free Lie algebra
         s_coeff = {}
+        ls_cache = {W: W.leading_support()
+                    for d, bd in basis_by_deg.items()
+                    if d <= s
+                    for _, W in bd}
         for dx in range(1, s + 1):
             # Brackets are only computed when deg(X) + deg(Y) <= s
             # We also require deg(Y) >= deg(X) by the ordering
@@ -404,14 +408,14 @@ class FreeNilpotentLieAlgebra(NilpotentLieAlgebra_dense):
                         for Y_ind, Y in basis_by_deg[dy][i + 1:]:
                             Z = L[X, Y]
                             if not Z.is_zero():
-                                s_coeff[(X_ind, Y_ind)] = {W_ind: Z[W.leading_support()]
+                                s_coeff[(X_ind, Y_ind)] = {W_ind: Z[ls_cache[W]]
                                                            for W_ind, W in basis_by_deg[dx + dy]}
                 else:
                     for X_ind, X in basis_by_deg[dx]:
                         for Y_ind, Y in basis_by_deg[dy]:
                             Z = L[X, Y]
                             if not Z.is_zero():
-                                s_coeff[(X_ind, Y_ind)] = {W_ind: Z[W.leading_support()]
+                                s_coeff[(X_ind, Y_ind)] = {W_ind: Z[ls_cache[W]]
                                                            for W_ind, W in basis_by_deg[dx + dy]}
 
         names, index_set = standardize_names_index_set(names, index_set)


### PR DESCRIPTION
A [MathOverflow question](https://mathoverflow.net/q/490938) asked about inefficiency in the instantiation of free nilpotent Lie algebras. Some basic profiling shows that the bottleneck is the calls to `leading_support()` when extracting the structural coefficients. A larger refactor to avoid precalculating the table might be worth considering, but simply caching the calls gives a notable improvement, about 50% for `LieAlgebra(QQ, 3, 9)`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
