### PR TITLE
cddlib[tools] needed for cddlib on gentoo

### DIFF
--- a/build/pkgs/cddlib/distros/gentoo.txt
+++ b/build/pkgs/cddlib/distros/gentoo.txt
@@ -1,1 +1,1 @@
-sci-libs/cddlib
+sci-libs/cddlib[tools]


### PR DESCRIPTION
without tools option, cddexec etc aren't installed, and libcdd cannot be used with Sage

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


