### PR TITLE
catch TypeError if magma is not available

### DIFF
--- a/src/sage/modular/btquotients/btquotient.py
+++ b/src/sage/modular/btquotients/btquotient.py
@@ -1468,7 +1468,7 @@ class BruhatTitsQuotient(SageObject, UniqueRepresentation):
                 else:
                     self._magma = magma_session
                 self._magma(p)
-            except RuntimeError:
+            except TypeError:
                 raise NotImplementedError('Sage does not know yet how to work with the kind of orders that you are trying to use. Try installing Magma first and set it up so that Sage can use it.')
 
             # This is added for debugging, in order to have reproducible results


### PR DESCRIPTION
<!-- v Describe your changes below in detail. -->

When magma is not available it raises a `TypeError`.

<!-- v Why is this change required? What problem does it solve? -->

```python
sage: BruhatTitsQuotient(2, 3)
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
...

TypeError: unable to start magma because the command 'magma -n' failed: The command was not found or was not executable: magma.
```

<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


