### PR TITLE
faster listing of oriented triangles in `src/sage/combinat/cluster_algebra_quiver/mutation_type.py`

### DIFF
--- a/src/sage/combinat/cluster_algebra_quiver/mutation_type.py
+++ b/src/sage/combinat/cluster_algebra_quiver/mutation_type.py
@@ -1011,9 +1011,10 @@ def _connected_mutation_type_AAtildeD(dg: DiGraph, ret_conn_vert=False):
         oriented_trian_edges.extend(oriented_trian)
 
     # test that no edge is in more than two oriented triangles
+    from collections import Counter
+    edge_count = Counter(oriented_trian_edges)
     multiple_trian_edges = []
-    for edge in oriented_trian_edges:
-        count = oriented_trian_edges.count(edge)
+    for edge, count in edge_count.items():
         if count > 2:
             return _false_return(17)
         elif count == 2:

--- a/src/sage/combinat/cluster_algebra_quiver/mutation_type.py
+++ b/src/sage/combinat/cluster_algebra_quiver/mutation_type.py
@@ -109,44 +109,41 @@ def _triangles(dg) -> list[tuple[list, bool]]:
         []
         sage: Q.mutate([0, 1])
         sage: _triangles(Q.digraph())
-        [([(2, 0), (0, 1), (1, 2)], True)]
+        [([(0, 1), (1, 2), (2, 0)], True)]
         sage: Q2 = ClusterQuiver(['A', [1, 2], 1])
         sage: _triangles(Q2.digraph())
-        [([(1, 2), (1, 0), (2, 0)], False)]
+        [([(1, 0), (1, 2), (2, 0)], False)]
         sage: Q2.mutate(2)
         sage: _triangles(Q2.digraph())
-        [([(1, 0), (0, 2), (2, 1)], True)]
+        [([(1, 0), (2, 1), (0, 2)], True)]
     """
-    E = dg.edges(sort=True, labels=False)
-    V = list(dg)
+    from itertools import combinations
     trians = []
-    flat_trians = []
-    for e in E:
-        v1, v2 = e
-        for v in V:
-            if v not in e:
-                if (v, v1) in E:
-                    if (v2, v) in E:
-                        flat_trian = sorted([v, v1, v2])
-                        if flat_trian not in flat_trians:
-                            flat_trians.append(flat_trian)
-                            trians.append(([(v, v1), (v1, v2), (v2, v)], True))
-                    elif (v, v2) in E:
-                        flat_trian = sorted([v, v1, v2])
-                        if flat_trian not in flat_trians:
-                            flat_trians.append(flat_trian)
-                            trians.append(([(v, v1), (v1, v2), (v, v2)], False))
-                if (v1, v) in E:
-                    if (v2, v) in E:
-                        flat_trian = sorted([v, v1, v2])
-                        if flat_trian not in flat_trians:
-                            flat_trians.append(flat_trian)
-                            trians.append(([(v1, v), (v1, v2), (v2, v)], False))
-                    elif (v, v2) in E:
-                        flat_trian = sorted([v, v1, v2])
-                        if flat_trian not in flat_trians:
-                            flat_trians.append(flat_trian)
-                            trians.append(([(v1, v), (v1, v2), (v, v2)], False))
+    for x in dg.vertices(sort=True):
+        nx = sorted(y for y in dg.neighbor_iterator(x) if x < y)
+        for y, z in combinations(nx, 2):
+            if dg.has_edge(y, z):
+                if dg.has_edge(x, y):
+                    if dg.has_edge(z, x):
+                        trians.append(([(x, y), (y, z), (z, x)], True))
+                    else:
+                        trians.append(([(x, y), (y, z), (x, z)], False))
+                else:
+                    if dg.has_edge(z, x):
+                        trians.append(([(y, x), (y, z), (z, x)], False))
+                    else:
+                        trians.append(([(y, x), (y, z), (x, z)], False))
+            elif dg.has_edge(z, y):
+                if dg.has_edge(x, y):
+                    if dg.has_edge(z, x):
+                        trians.append(([(x, y), (z, y), (z, x)], False))
+                    else:
+                        trians.append(([(x, y), (z, y), (x, z)], False))
+                else:
+                    if dg.has_edge(z, x):
+                        trians.append(([(y, x), (z, y), (z, x)], False))
+                    else:
+                        trians.append(([(y, x), (z, y), (x, z)], True))
     return trians
 
 


### PR DESCRIPTION
We change the algorithm used in `_triangles`. The new method ensures that a triple `(x, y, z)` is considered only once.  The idea is to do:
- consider the vertices by increasing label
- Let `x` be the current vertex and let `nx` be the neighbors of `x` with a larger label
- Consider the  pairs `(y, z)` of vertices in `nx`. We know that we have an edge between `x` and each of these vertices but we don't know which ones.
- Then when either `(y,z)` or `(z, y)` is an edge, we check if the triangle is well oriented or not.
- We repeat for the vertex after `x` in the ordering. Vertex `x` will never be considered again.

The time complexity of the previous algorithm was in $O(nm)$ and the new one is in $O(n\Delta^2)$, where $\Delta$ is the maximum (undirected) degree.

Let `old_triangles` be the previous method and `new_triangles` be the new method. We get:
```sage
sage: def foo(triangles):
....:     return set((frozenset(T), b) for T, b in triangles)
sage:
sage: D = graphs.CompleteGraph(5).random_orientation()
sage: %time A = old_triangles(D)
CPU times: user 187 µs, sys: 38 µs, total: 225 µs
Wall time: 229 µs
sage: %time B = new_triangles(D)
CPU times: user 115 µs, sys: 16 µs, total: 131 µs
Wall time: 134 µs
sage: len(A) == len(B) and foo(A) == foo(B)
True
sage:
sage: D = graphs.CompleteGraph(10).random_orientation()
sage: %time A = old_triangles(D)
CPU times: user 1.34 ms, sys: 1 µs, total: 1.34 ms
Wall time: 1.34 ms
sage: %time B = new_triangles(D)
CPU times: user 329 µs, sys: 18 µs, total: 347 µs
Wall time: 349 µs
sage: len(A) == len(B) and foo(A) == foo(B)
True
sage:
sage: D = graphs.CompleteGraph(50).random_orientation()
sage: %time A = old_triangles(D)
CPU times: user 7.33 s, sys: 20.3 ms, total: 7.35 s
Wall time: 7.35 s
sage: %time B = new_triangles(D)
CPU times: user 66 ms, sys: 3.03 ms, total: 69.1 ms
Wall time: 67.6 ms
sage: len(A) == len(B) and foo(A) == foo(B)
True
sage:
sage: D = graphs.CompleteGraph(60).random_orientation()
sage: %time A = old_triangles(D)
CPU times: user 26.1 s, sys: 54 ms, total: 26.2 s
Wall time: 26.2 s
sage: %time B = new_triangles(D)
CPU times: user 245 ms, sys: 2.21 ms, total: 247 ms
Wall time: 246 ms
sage: len(A) == len(B) and foo(A) == foo(B)
True
sage: len(A)
34220
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


