### PR TITLE
Fix caching in Khuri-Makdisi Jacobian implementation

### DIFF
--- a/src/sage/rings/function_field/jacobian_base.py
+++ b/src/sage/rings/function_field/jacobian_base.py
@@ -52,7 +52,6 @@ is simply represented by the divisor `D`. ::
 
 We can get the corresponding point in the Jacobian in a different model. ::
 
-    sage: # long time
     sage: p1km = J_km(p1)
     sage: p1km.order()
     5
@@ -112,7 +111,6 @@ class JacobianPoint_finite_field_base(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(29), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: F = C.function_field()
@@ -642,7 +640,6 @@ class Jacobian_base(Parent):
 
         TESTS::
 
-            sage: # long time
             sage: K.<x> = FunctionField(GF(2)); _.<Y> = K[]
             sage: F.<y> = K.extension(Y^2 + Y + x + 1/x)
             sage: J_hess = F.jacobian(model='hess')

--- a/src/sage/rings/function_field/jacobian_khuri_makdisi.py
+++ b/src/sage/rings/function_field/jacobian_khuri_makdisi.py
@@ -626,8 +626,7 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
             if n in self._V_cache:
                 return self._V_cache[n]
 
-            Vn, from_Vn, to_Vn = (n * D0).function_space()
-            self._V_cache[n] = (Vn, from_Vn, to_Vn)
+            self._V_cache[n] = (n * D0).function_space()
             return self._V_cache[n]
 
         def mu(n, m, i, j):

--- a/src/sage/rings/function_field/jacobian_khuri_makdisi.py
+++ b/src/sage/rings/function_field/jacobian_khuri_makdisi.py
@@ -628,8 +628,7 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
 
             Vn, from_Vn, to_Vn = (n * D0).function_space()
             self._V_cache[n] = (Vn, from_Vn, to_Vn)
-
-            return Vn, from_Vn, to_Vn
+            return self._V_cache[n]
 
         def mu(n, m, i, j):
             Vn, from_Vn, to_Vn = V(n)

--- a/src/sage/rings/function_field/jacobian_khuri_makdisi.py
+++ b/src/sage/rings/function_field/jacobian_khuri_makdisi.py
@@ -68,7 +68,6 @@ Riemann-Roch space.
 
 EXAMPLES::
 
-    sage: # long time
     sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
     sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
     sage: F = C.function_field()
@@ -155,7 +154,6 @@ class JacobianPoint(JacobianPoint_base):
 
     EXAMPLES::
 
-        sage: # long time
         sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
         sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
         sage: b = C([0,1,0]).place()
@@ -178,7 +176,6 @@ class JacobianPoint(JacobianPoint_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: b = C([0,1,0]).place()
@@ -199,7 +196,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -222,7 +218,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: F = C.function_field()
@@ -247,7 +242,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -281,7 +275,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -313,7 +306,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: F = C.function_field()
@@ -348,7 +340,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -372,7 +363,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -404,7 +394,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -437,7 +426,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -462,7 +450,6 @@ class JacobianPoint(JacobianPoint_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: F = C.function_field()
@@ -506,7 +493,6 @@ class JacobianGroupEmbedding(Map):
 
     EXAMPLES::
 
-        sage: # long time
         sage: k = GF(5)
         sage: P2.<x,y,z> = ProjectiveSpace(k, 2)
         sage: C = Curve(x^3 + z^3 - y^2*z, P2)
@@ -528,7 +514,6 @@ class JacobianGroupEmbedding(Map):
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(5)
             sage: P2.<x,y,z> = ProjectiveSpace(k, 2)
             sage: C = Curve(x^3 + z^3 - y^2*z, P2)
@@ -553,7 +538,6 @@ class JacobianGroupEmbedding(Map):
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(5)
             sage: P2.<x,y,z> = ProjectiveSpace(k, 2)
             sage: C = Curve(x^3 + z^3 - y^2*z, P2)
@@ -577,7 +561,6 @@ class JacobianGroupEmbedding(Map):
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(5)
             sage: P2.<x,y,z> = ProjectiveSpace(k, 2)
             sage: C = Curve(x^3 + z^3 - y^2*z, P2)
@@ -609,7 +592,6 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
 
     EXAMPLES::
 
-        sage: # long time
         sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
         sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
         sage: h = C.function(y/x).divisor_of_poles()
@@ -627,7 +609,6 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -639,16 +620,14 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
         D0 = base_div
 
         self._base_div_degree = base_div.degree()
-        self._V_cache = 10*[None]
-
-        V_cache = self._V_cache
+        self._V_cache = dict()
 
         def V(n):
-            if n in V_cache:
-                return V_cache[n]
+            if n in self._V_cache:
+                return self._V_cache[n]
 
             Vn, from_Vn, to_Vn = (n * D0).function_space()
-            V_cache[n] = (Vn, from_Vn, to_Vn)
+            self._V_cache[n] = (Vn, from_Vn, to_Vn)
 
             return Vn, from_Vn, to_Vn
 
@@ -692,7 +671,6 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -714,7 +692,6 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
 
         TESTS:
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -741,7 +718,6 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -800,7 +776,6 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -834,7 +809,6 @@ class JacobianGroup(UniqueRepresentation, JacobianGroup_base):
 
         EXAMPLES::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -866,7 +840,6 @@ class JacobianGroup_finite_field(JacobianGroup, JacobianGroup_finite_field_base)
 
     EXAMPLES::
 
-        sage: # long time
         sage: k = GF(7)
         sage: P2.<x,y,z> = ProjectiveSpace(k, 2)
         sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
@@ -890,7 +863,6 @@ class JacobianGroup_finite_field(JacobianGroup, JacobianGroup_finite_field_base)
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(7)
             sage: P2.<x,y,z> = ProjectiveSpace(k, 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
@@ -981,7 +953,6 @@ class JacobianGroup_finite_field(JacobianGroup, JacobianGroup_finite_field_base)
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(7)
             sage: A.<x,y> = AffineSpace(k,2)
             sage: C = Curve(y^2 + x^3 + 2*x + 1).projective_closure()
@@ -1016,7 +987,6 @@ class Jacobian(UniqueRepresentation, Jacobian_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: J = C.jacobian(model='km_large')
@@ -1024,7 +994,6 @@ class Jacobian(UniqueRepresentation, Jacobian_base):
 
         ::
 
-            sage: # long time
             sage: J = C.jacobian(model='km_unknown')
             Traceback (most recent call last):
             ...

--- a/src/sage/rings/function_field/khuri_makdisi.pyx
+++ b/src/sage/rings/function_field/khuri_makdisi.pyx
@@ -86,7 +86,6 @@ cdef class KhuriMakdisi_base(object):
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(7)
             sage: A.<x,y> = AffineSpace(k,2)
             sage: C = Curve(y^2 + x^3 + 2*x + 1).projective_closure()
@@ -181,7 +180,6 @@ cdef class KhuriMakdisi_base(object):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -207,7 +205,6 @@ cdef class KhuriMakdisi_base(object):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -233,7 +230,6 @@ cdef class KhuriMakdisi_base(object):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -259,7 +255,6 @@ cdef class KhuriMakdisi_base(object):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -329,7 +324,6 @@ cdef class KhuriMakdisi_base(object):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -363,7 +357,6 @@ cdef class KhuriMakdisi_large(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -421,7 +414,6 @@ cdef class KhuriMakdisi_large(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: J = C.jacobian(model='km_large')
@@ -484,7 +476,6 @@ cdef class KhuriMakdisi_large(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: F = C.function_field()
@@ -516,7 +507,6 @@ cdef class KhuriMakdisi_large(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(7)
             sage: A.<x,y> = AffineSpace(k,2)
             sage: C = Curve(y^2 + x^3 + 2*x + 1).projective_closure()
@@ -547,7 +537,6 @@ cdef class KhuriMakdisi_medium(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -599,7 +588,6 @@ cdef class KhuriMakdisi_medium(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -635,7 +623,6 @@ cdef class KhuriMakdisi_medium(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: h = C.function(y/x).divisor_of_poles()
@@ -655,7 +642,6 @@ cdef class KhuriMakdisi_medium(KhuriMakdisi_base):
 
         We check the computation in other model::
 
-            sage: # long time
             sage: J = C.jacobian(model='km_large', base_div=h)
             sage: G = J.group()
             sage: p1 = G.point(pl1 - b)
@@ -685,7 +671,6 @@ cdef class KhuriMakdisi_medium(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(7)
             sage: A.<x,y> = AffineSpace(k,2)
             sage: C = Curve(y^2 + x^3 + 2*x + 1).projective_closure()
@@ -717,7 +702,6 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: b = C([0,1,0]).place()
@@ -775,7 +759,6 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: b = C([0,1,0]).place()
@@ -810,7 +793,6 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(17), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: b = C([0,1,0]).place()
@@ -830,7 +812,6 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         We check the computation in other model::
 
-            sage: # long time
             sage: h = C.function(y/x).divisor_of_poles()
             sage: Jl = C.jacobian(model='km_large', base_div=h)
             sage: G = J.group()
@@ -859,7 +840,6 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: P2.<x,y,z> = ProjectiveSpace(GF(7), 2)
             sage: C = Curve(x^3 + 5*z^3 - y^2*z, P2)
             sage: b = C([0,1,0]).place()
@@ -874,7 +854,6 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         Check that :issue:`39148` is fixed::
 
-            sage: # long time
             sage: k.<x> = FunctionField(GF(17)); t = polygen(k)
             sage: F.<y> = k.extension(t^4 + (14*x + 14)*t^3 + 9*t^2 + (10*x^2 + 15*x + 8)*t
             ....:  + 7*x^3 + 15*x^2 + 6*x + 16)
@@ -912,7 +891,6 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         TESTS::
 
-            sage: # long time
             sage: k = GF(7)
             sage: A.<x,y> = AffineSpace(k,2)
             sage: C = Curve(y^2 + x^3 + 2*x + 1).projective_closure()


### PR DESCRIPTION
This PR fixes a bug with caching of some expensive parts of the Khuri-Makdisi Jacobian implementation. This speeds up constructing the Jacobian group by approximately 95% on the example below. The speedup was significant enough that I was able to remove `long test` from all but one test in the Khuri-Makdisi implementation. Testing the entire Khuri-Makdisi implementation takes slightly longer now that we are including more tests, but all the tests I've included finish in under 5 seconds (at least on my machine, if the CI complains we can put back some of the `long test` markers).

```
K = GF(5)
Kx.<x> = FunctionField(K)
t = polygen(Kx)
F.<y> = Kx.extension(t^3 + (2*x^2 + 3*x + 3)*t^2 + (3*x^2 + x)*t + x^5 + 3*x^4 + 4*x^3 + 4*x^2 + x + 4)
J = F.jacobian(model='km_small')
%time J.group()  # Before: About 1 minute. After: about 3 seconds.
```

The performance increase is similar for `km_medium` and `km_large`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies
None