### PR TITLE
Complete function prototype gmp for C23 compatibility

### DIFF
--- a/build/pkgs/gmp/patches/gmp-6.3.0-c23.patch
+++ b/build/pkgs/gmp/patches/gmp-6.3.0-c23.patch
@@ -1,0 +1,28 @@
+Complete function prototype in acinclude.m4 & configure for C23 compatibility
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index fddb5fb07..4fca12de2 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long reliability test 1],
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+diff --git a/configure b/configure
+index 7910aa0..2794260 100755
+--- a/configure
++++ b/configure
+@@ -6568,7 +6568,7 @@ if test "$gmp_prog_cc_works" = yes; then
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}


### PR DESCRIPTION
Adapted from https://src.fedoraproject.org/rpms/gmp/blob/rawhide/f/gmp-6.3.0-c23.patch

Allows building gmp on Fedora 42