### PR TITLE
Remove compilation dependency of `rings/convert/mpfi` on cypari2

### DIFF
--- a/src/sage/doctest/rif_tol.py
+++ b/src/sage/doctest/rif_tol.py
@@ -27,7 +27,7 @@ Helpers for tolerance checking in doctests
 from sage.doctest.marked_output import MarkedOutput
 from sage.rings.real_mpfi import RealIntervalField, RealIntervalFieldElement
 
-_RIFtol: RealIntervalField | None = None
+_RIFtol: 'RealIntervalField | None' = None
 
 
 def RIFtol(*args) -> RealIntervalFieldElement:

--- a/src/sage/doctest/rif_tol.py
+++ b/src/sage/doctest/rif_tol.py
@@ -25,12 +25,12 @@ Helpers for tolerance checking in doctests
 # ****************************************************************************
 
 from sage.doctest.marked_output import MarkedOutput
+from sage.rings.real_mpfi import RealIntervalField, RealIntervalFieldElement
+
+_RIFtol: RealIntervalField | None = None
 
 
-_RIFtol = None
-
-
-def RIFtol(*args):
+def RIFtol(*args) -> RealIntervalFieldElement:
     """
     Create an element of the real interval field used for doctest tolerances.
 
@@ -57,18 +57,7 @@ def RIFtol(*args):
     """
     global _RIFtol
     if _RIFtol is None:
-        try:
-            # We need to import from sage.all to avoid circular imports.
-            from sage.rings.real_mpfi import RealIntervalField
-        except ImportError:
-            from warnings import warn
-            warn("RealIntervalField not available, ignoring all tolerance specifications in doctests")
-
-            def fake_RIFtol(*args):
-                return 0
-            _RIFtol = fake_RIFtol
-        else:
-            _RIFtol = RealIntervalField(1044)
+       _RIFtol = RealIntervalField(1044)
     return _RIFtol(*args)
 
 

--- a/src/sage/rings/convert/meson.build
+++ b/src/sage/rings/convert/meson.build
@@ -14,7 +14,7 @@ foreach name, pyx : extension_data
     subdir: 'sage/rings/convert',
     install: true,
     include_directories: [inc_cpython, inc_rings],
-    dependencies: [py_dep, cypari2, gmp, gsl, mpfi, mpfr, pari],
+    dependencies: [py_dep, gmp, gsl, mpfi, mpfr],
   )
 endforeach
 

--- a/src/sage/rings/convert/mpfi.pyx
+++ b/src/sage/rings/convert/mpfi.pyx
@@ -37,8 +37,6 @@ from sage.rings.complex_mpfr cimport ComplexNumber
 from sage.rings.complex_interval cimport ComplexIntervalFieldElement
 from sage.rings.complex_double cimport ComplexDoubleElement
 
-from cypari2.gen cimport Gen
-
 
 cdef inline int return_real(mpfi_ptr im) noexcept:
     """
@@ -440,6 +438,7 @@ cdef int mpfi_set_sage(mpfi_ptr re, mpfi_ptr im, x, field, int base) except -1:
             return return_real(im)
 
         # Complex
+        from cypari2.gen import Gen
         if isinstance(x, Gen):
             imag = x.imag()
             if im is NULL:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Make it possible to compile `rings/convert/mpfi` without cypari2 installed. Needed for windows support.

Also fail if RealIntervalField cannot be imported, instead of only issuing a warning (since the relevant doctests will fail anyway, there is little point in not failing early).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


