### PR TITLE
Annoate methods with `Self`

### DIFF
--- a/src/sage/algebras/cellular_basis.py
+++ b/src/sage/algebras/cellular_basis.py
@@ -108,9 +108,11 @@ REFERENCES:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.misc.cachefunc import cached_method
-from sage.combinat.free_module import CombinatorialFreeModule
+from typing import Self
+
 from sage.categories.algebras import Algebras
+from sage.combinat.free_module import CombinatorialFreeModule
+from sage.misc.cachefunc import cached_method
 
 
 class CellularBasis(CombinatorialFreeModule):
@@ -283,7 +285,7 @@ class CellularBasis(CombinatorialFreeModule):
         """
         return self._algebra.cell_module_indices(la)
 
-    def cellular_basis(self):
+    def cellular_basis(self) -> Self:
         """
         Return the cellular basis of ``self``, which is ``self``.
 

--- a/src/sage/algebras/lie_algebras/bgg_dual_module.py
+++ b/src/sage/algebras/lie_algebras/bgg_dual_module.py
@@ -16,20 +16,22 @@ AUTHORS:
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.misc.lazy_attribute import lazy_attribute
-from sage.misc.cachefunc import cached_method
+from typing import Self
+
+from sage.algebras.lie_algebras.verma_module import ModulePrinting
 from sage.categories.enumerated_sets import EnumeratedSets
 from sage.categories.monoids import Monoids
-from sage.structure.parent import Parent
-from sage.structure.indexed_generators import IndexedGenerators
-from sage.monoids.indexed_free_monoid import IndexedFreeAbelianMonoid, IndexedMonoid
 from sage.combinat.free_module import CombinatorialFreeModule
+from sage.data_structures.blas_dict import iaxpy
+from sage.matrix.constructor import matrix
+from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_attribute import lazy_attribute
+from sage.monoids.indexed_free_monoid import IndexedFreeAbelianMonoid, IndexedMonoid
+from sage.rings.integer_ring import ZZ
 from sage.sets.family import Family
 from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
-from sage.matrix.constructor import matrix
-from sage.rings.integer_ring import ZZ
-from sage.data_structures.blas_dict import iaxpy
-from sage.algebras.lie_algebras.verma_module import ModulePrinting
+from sage.structure.indexed_generators import IndexedGenerators
+from sage.structure.parent import Parent
 
 
 class BGGDualModule(CombinatorialFreeModule):
@@ -779,7 +781,9 @@ class SimpleModuleIndices(IndexedFreeAbelianMonoid):
             P = Phi.weight_lattice()
             coroots = Phi.root_lattice().simple_coroots()
             la = P._from_dict({i: weight.scalar(ac) for i, ac in coroots.items()})
-            from sage.combinat.crystals.monomial_crystals import CrystalOfNakajimaMonomials
+            from sage.combinat.crystals.monomial_crystals import (
+                CrystalOfNakajimaMonomials,
+            )
             return CrystalOfNakajimaMonomials(la).cardinality()
         from sage.rings.infinity import infinity
         return infinity
@@ -979,7 +983,7 @@ class SimpleModule(ModulePrinting, CombinatorialFreeModule):
             raise ValueError(f"{m} does not index a basis element")
         return self._indices._basis[m]
 
-    def dual(self):
+    def dual(self) -> Self:
         r"""
         Return the dual module of ``self``, which is ``self`` since simple
         modules are self-dual.

--- a/src/sage/categories/additive_magmas.py
+++ b/src/sage/categories/additive_magmas.py
@@ -9,16 +9,18 @@ Additive magmas
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from sage.misc.lazy_import import LazyImport
-from sage.misc.abstract_method import abstract_method
-from sage.misc.cachefunc import cached_method
-from sage.categories.category_with_axiom import CategoryWithAxiom
-from sage.categories.category_singleton import Category_singleton
+from typing import Self
+
 from sage.categories.algebra_functor import AlgebrasCategory
 from sage.categories.cartesian_product import CartesianProductsCategory
+from sage.categories.category_singleton import Category_singleton
+from sage.categories.category_with_axiom import CategoryWithAxiom
 from sage.categories.homsets import HomsetsCategory
-from sage.categories.with_realizations import WithRealizationsCategory
 from sage.categories.sets_cat import Sets
+from sage.categories.with_realizations import WithRealizationsCategory
+from sage.misc.abstract_method import abstract_method
+from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_import import LazyImport
 
 
 class AdditiveMagmas(Category_singleton):
@@ -384,8 +386,9 @@ class AdditiveMagmas(Category_singleton):
                 y| y z x
                 z| z x y
             """
-            from sage.matrix.operation_table import OperationTable
             import operator
+
+            from sage.matrix.operation_table import OperationTable
             return OperationTable(self, operation=operator.add,
                                   names=names, elements=elements)
 
@@ -596,7 +599,7 @@ class AdditiveMagmas(Category_singleton):
 
     class AdditiveUnital(CategoryWithAxiom):
 
-        def additional_structure(self):
+        def additional_structure(self) -> Self:
             r"""
             Return whether ``self`` is a structure category.
 

--- a/src/sage/categories/cartesian_product.py
+++ b/src/sage/categories/cartesian_product.py
@@ -13,9 +13,14 @@ AUTHORS:
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.misc.lazy_import import lazy_import
-from sage.categories.covariant_functorial_construction import CovariantFunctorialConstruction, CovariantConstructionCategory
+from typing import Self
+
+from sage.categories.covariant_functorial_construction import (
+    CovariantConstructionCategory,
+    CovariantFunctorialConstruction,
+)
 from sage.categories.pushout import MultivariateConstructionFunctor
+from sage.misc.lazy_import import lazy_import
 
 native_python_containers = {tuple, list, set, frozenset, range}
 
@@ -245,7 +250,7 @@ class CartesianProductsCategory(CovariantConstructionCategory):
         # This method is only required for the capital `C`
         return "Cartesian products of %s" % (self.base_category()._repr_object_names())
 
-    def CartesianProducts(self):
+    def CartesianProducts(self) -> Self:
         """
         Return the category of (finite) Cartesian products of objects
         of ``self``.

--- a/src/sage/categories/category.py
+++ b/src/sage/categories/category.py
@@ -103,19 +103,24 @@ A parent ``P`` is in a category ``C`` if ``P.category()`` is a subcategory of
 # ****************************************************************************
 
 import inspect
+from typing import Self
 from warnings import warn
+
+from sage.categories.category_cy_helper import (
+    _flatten_categories,
+    _sort_uniq,
+    category_sort_key,
+    join_as_tuple,
+)
 from sage.misc.abstract_method import abstract_method, abstract_methods_of_class
-from sage.misc.cachefunc import cached_method, cached_function
-from sage.misc.c3_controlled import _cmp_key, _cmp_key_named, C3_sorted_merge
+from sage.misc.c3_controlled import C3_sorted_merge, _cmp_key, _cmp_key_named
+from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.lazy_attribute import lazy_attribute
 from sage.misc.unknown import Unknown
 from sage.misc.weak_dict import WeakValueDictionary
-
+from sage.structure.dynamic_class import DynamicMetaclass, dynamic_class
 from sage.structure.sage_object import SageObject
 from sage.structure.unique_representation import UniqueRepresentation
-from sage.structure.dynamic_class import DynamicMetaclass, dynamic_class
-
-from sage.categories.category_cy_helper import category_sort_key, _sort_uniq, _flatten_categories, join_as_tuple
 
 _join_cache = WeakValueDictionary()
 
@@ -1045,7 +1050,7 @@ class Category(UniqueRepresentation, SageObject):
     # Methods handling of full subcategories
     ##########################################################################
 
-    def additional_structure(self):
+    def additional_structure(self) -> Self:
         """
         Return whether ``self`` defines additional structure.
 
@@ -2214,7 +2219,7 @@ class Category(UniqueRepresentation, SageObject):
         else:
             raise ValueError("Cannot remove axiom {} from {}".format(axiom, self))
 
-    def _without_axioms(self, named=False):
+    def _without_axioms(self, named=False) -> Self:
         r"""
         Return the category without the axioms that have been added
         to create it.

--- a/src/sage/categories/complete_discrete_valuation.py
+++ b/src/sage/categories/complete_discrete_valuation.py
@@ -10,6 +10,8 @@ Complete Discrete Valuation Rings (CDVR) and Fields (CDVF)
 #**************************************************************************
 
 
+from typing import Self
+
 from sage.categories.category_singleton import Category_singleton
 from sage.categories.discrete_valuation import (
     DiscreteValuationFields,
@@ -97,7 +99,7 @@ class CompleteDiscreteValuationRings(Category_singleton):
             """
             return self.parent()(1)
 
-        def numerator(self):
+        def numerator(self) -> Self:
             """
             Return the numerator of this element, normalized in such a
             way that `x = x.numerator() / x.denominator()` always holds

--- a/src/sage/categories/covariant_functorial_construction.py
+++ b/src/sage/categories/covariant_functorial_construction.py
@@ -42,13 +42,15 @@ AUTHORS:
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  http://www.gnu.org/licenses/
 #******************************************************************************
+from typing import Self
+
+from sage.categories.category import Category
 from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.lazy_attribute import lazy_class_attribute
 from sage.misc.lazy_import import LazyImport
-from sage.categories.category import Category
+from sage.structure.dynamic_class import DynamicMetaclass
 from sage.structure.sage_object import SageObject
 from sage.structure.unique_representation import UniqueRepresentation
-from sage.structure.dynamic_class import DynamicMetaclass
 
 
 class CovariantFunctorialConstruction(UniqueRepresentation, SageObject):
@@ -624,7 +626,7 @@ class CovariantConstructionCategory(FunctorialConstructionCategory):
         f = self._functor_category
         return not any(hasattr(C, f) for C in base.super_categories())
 
-    def additional_structure(self):
+    def additional_structure(self) -> Self | None:
         r"""
         Return the additional structure defined by ``self``.
 

--- a/src/sage/categories/dedekind_domains.py
+++ b/src/sage/categories/dedekind_domains.py
@@ -6,6 +6,8 @@ Dedekind Domains
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
+from typing import Self
+
 from sage.categories.category import Category
 from sage.categories.integral_domains import IntegralDomains
 
@@ -86,7 +88,7 @@ class DedekindDomains(Category):
             """
             return True
 
-        def integral_closure(self):
+        def integral_closure(self) -> Self:
             r"""
             Return ``self`` since Dedekind domains are integrally closed.
 

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -27,6 +27,7 @@ Coercion via construction functors
 # ****************************************************************************
 
 import operator
+from typing import Self
 
 from sage.categories.functor import Functor, IdentityFunctor_generic
 from sage.misc.lazy_import import lazy_import
@@ -255,7 +256,7 @@ class ConstructionFunctor(Functor):
         import re
         return re.sub(r"<.*'.*\.([^.]*)'>", "\\1", s)
 
-    def merge(self, other):
+    def merge(self, other) -> Self | None:
         """
         Merge ``self`` with another construction functor, or return ``None``.
 
@@ -1434,18 +1435,14 @@ class InfinitePolynomialFunctor(ConstructionFunctor):
                                     if i == i0 and int(n) > int(n0):  # wrong order
                                         BadOverlap = True
                                 OverlappingVars.append(x)
-                            else:
-                                if IsOverlap: # The overlap must be on the right end of the variable list
-                                    BadOverlap = True
-                        else:
-                            if IsOverlap: # The overlap must be on the right end of the variable list
+                            elif IsOverlap: # The overlap must be on the right end of the variable list
                                 BadOverlap = True
-                    else:
-                        if IsOverlap: # The overlap must be on the right end of the variable list
+                        elif IsOverlap: # The overlap must be on the right end of the variable list
                             BadOverlap = True
-                else:
-                    if IsOverlap: # The overlap must be on the right end of the variable list
+                    elif IsOverlap: # The overlap must be on the right end of the variable list
                         BadOverlap = True
+                elif IsOverlap: # The overlap must be on the right end of the variable list
+                    BadOverlap = True
 
             if BadOverlap: # the overlapping variables appear in the wrong order
                 raise CoercionException("Overlapping variables (%s,%s) are incompatible" % (self._gens, OverlappingVars))
@@ -2545,9 +2542,8 @@ class CompletionFunctor(ConstructionFunctor):
             if self.p == Infinity:
                 if self.type not in self._real_types:
                     raise ValueError("completion type must be one of %s" % (", ".join(self._real_types)))
-            else:
-                if self.type not in self._dvr_types:
-                    raise ValueError("completion type must be one of %s" % (", ".join(self._dvr_types[1:])))
+            elif self.type not in self._dvr_types:
+                raise ValueError("completion type must be one of %s" % (", ".join(self._dvr_types[1:])))
 
     def _repr_(self):
         """
@@ -4499,44 +4495,42 @@ def pushout(R, S):
                 all = apply_from(Rc)
             elif Sc[-1].rank < Rc[-1].rank:
                 all = apply_from(Sc)
-            else:
-                # the ranks are the same, so things are a bit subtler
-                if Rc[-1] == Sc[-1]:
-                    # If they are indeed the same operation, we only do it once.
-                    # The \code{merge} function here takes into account non-mathematical
-                    # distinctions (e.g. single vs. multivariate polynomials).
-                    cR = Rc.pop()
-                    cS = Sc.pop()
-                    c = cR.merge(cS) or cS.merge(cR)
-                    if c:
-                        all = c * all
-                    else:
-                        raise CoercionException("Incompatible Base Extension %r, %r (on %r, %r)" % (R, S, cR, cS))
+            # the ranks are the same, so things are a bit subtler
+            elif Rc[-1] == Sc[-1]:
+                # If they are indeed the same operation, we only do it once.
+                # The \code{merge} function here takes into account non-mathematical
+                # distinctions (e.g. single vs. multivariate polynomials).
+                cR = Rc.pop()
+                cS = Sc.pop()
+                c = cR.merge(cS) or cS.merge(cR)
+                if c:
+                    all = c * all
                 else:
-                    # Now we look ahead to see if either top functor is
-                    # applied later on in the other tower.
-                    # If this is the case for exactly one of them, we unambiguously
-                    # postpone that operation, but if both then we abort.
-                    if Rc[-1] in Sc:
-                        if Sc[-1] in Rc:
-                            raise CoercionException("Ambiguous Base Extension", R, S)
-                        else:
-                            all = apply_from(Sc)
-                    elif Sc[-1] in Rc:
-                        all = apply_from(Rc)
-                    # If, perchance, the two functors commute, then we may do them in any order.
-                    elif Rc[-1].commutes(Sc[-1]) or Sc[-1].commutes(Rc[-1]):
-                        all = Sc.pop() * Rc.pop() * all
-                    else:
-                        # try and merge (default merge is failure for unequal functors)
-                        cR = Rc.pop()
-                        cS = Sc.pop()
-                        c = cR.merge(cS) or cS.merge(cR)
-                        if c is not None:
-                            all = c * all
-                        else:
-                            # Otherwise, we cannot proceed.
-                            raise CoercionException("Ambiguous Base Extension", R, S)
+                    raise CoercionException("Incompatible Base Extension %r, %r (on %r, %r)" % (R, S, cR, cS))
+            # Now we look ahead to see if either top functor is
+            # applied later on in the other tower.
+            # If this is the case for exactly one of them, we unambiguously
+            # postpone that operation, but if both then we abort.
+            elif Rc[-1] in Sc:
+                if Sc[-1] in Rc:
+                    raise CoercionException("Ambiguous Base Extension", R, S)
+                else:
+                    all = apply_from(Sc)
+            elif Sc[-1] in Rc:
+                all = apply_from(Rc)
+            # If, perchance, the two functors commute, then we may do them in any order.
+            elif Rc[-1].commutes(Sc[-1]) or Sc[-1].commutes(Rc[-1]):
+                all = Sc.pop() * Rc.pop() * all
+            else:
+                # try and merge (default merge is failure for unequal functors)
+                cR = Rc.pop()
+                cS = Sc.pop()
+                c = cR.merge(cS) or cS.merge(cR)
+                if c is not None:
+                    all = c * all
+                else:
+                    # Otherwise, we cannot proceed.
+                    raise CoercionException("Ambiguous Base Extension", R, S)
 
         return all(Z)
 
@@ -4658,15 +4652,14 @@ def pushout_lattice(R, S):
                     lattice[i + 1, j + 1] = Sc[j](lattice[i + 1, j])
                 elif Sc[j] is None:
                     lattice[i + 1, j + 1] = Rc[i](lattice[i, j + 1])
+                # For now, we just look at the rank.
+                # TODO: be more sophisticated and query the functors themselves
+                elif Rc[i].rank < Sc[j].rank:
+                    lattice[i + 1, j + 1] = Sc[j](lattice[i + 1, j])
+                    Rc[i] = None  # force us to use pre-applied Rc[i]
                 else:
-                    # For now, we just look at the rank.
-                    # TODO: be more sophisticated and query the functors themselves
-                    if Rc[i].rank < Sc[j].rank:
-                        lattice[i + 1, j + 1] = Sc[j](lattice[i + 1, j])
-                        Rc[i] = None  # force us to use pre-applied Rc[i]
-                    else:
-                        lattice[i + 1, j + 1] = Rc[i](lattice[i, j + 1])
-                        Sc[j] = None  # force us to use pre-applied Sc[i]
+                    lattice[i + 1, j + 1] = Rc[i](lattice[i, j + 1])
+                    Sc[j] = None  # force us to use pre-applied Sc[i]
             except (AttributeError, NameError):
                 # pp(lattice)
                 for ni in range(100):

--- a/src/sage/combinat/combinatorial_map.py
+++ b/src/sage/combinat/combinatorial_map.py
@@ -55,6 +55,9 @@ thereof, for all the combinatorial maps that apply to it.
 # ****************************************************************************
 
 
+from typing import Self
+
+
 def combinatorial_map_trivial(f=None, order=None, name=None):
     r"""
     Combinatorial map decorator.
@@ -268,7 +271,7 @@ class CombinatorialMap:
         from sage.misc.sageinspect import sage_getsourcelines
         return sage_getsourcelines(self._f)
 
-    def __get__(self, inst, cls=None):
+    def __get__(self, inst, cls=None) -> Self:
         """
         Bounds the method of ``self`` to the given instance.
 

--- a/src/sage/manifolds/chart_func.py
+++ b/src/sage/manifolds/chart_func.py
@@ -33,6 +33,8 @@ AUTHORS:
 #  the License, or (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+from typing import Self
+
 from sage.categories.commutative_algebras import CommutativeAlgebras
 from sage.manifolds.utilities import ExpressionNice
 from sage.misc.cachefunc import cached_method
@@ -2426,7 +2428,7 @@ class ChartFunction(AlgebraElement, ModuleElementWithMutability):
         """
         self._der = None  # reset of the partial derivatives
 
-    def simplify(self):
+    def simplify(self) -> Self:
         r"""
         Simplify the coordinate expression of ``self``.
 
@@ -2548,7 +2550,7 @@ class ChartFunction(AlgebraElement, ModuleElementWithMutability):
         self._del_derived()
         return self
 
-    def factor(self):
+    def factor(self) -> Self:
         r"""
         Factorize the coordinate expression of ``self``.
 
@@ -2585,7 +2587,7 @@ class ChartFunction(AlgebraElement, ModuleElementWithMutability):
         self._del_derived()
         return self
 
-    def expand(self):
+    def expand(self) -> Self:
         r"""
         Expand the coordinate expression of ``self``.
 
@@ -2620,7 +2622,7 @@ class ChartFunction(AlgebraElement, ModuleElementWithMutability):
         self._del_derived()
         return self
 
-    def collect(self, s):
+    def collect(self, s) -> Self:
         r"""
         Collect the coefficients of `s` in the expression of ``self``
         into a group.
@@ -2665,7 +2667,7 @@ class ChartFunction(AlgebraElement, ModuleElementWithMutability):
         self._del_derived()
         return self
 
-    def collect_common_factors(self):
+    def collect_common_factors(self) -> Self:
         r"""
         Collect common factors in the expression of ``self``.
 

--- a/src/sage/misc/lazy_format.py
+++ b/src/sage/misc/lazy_format.py
@@ -4,6 +4,9 @@ Lazy format strings
 """
 
 
+from typing import Self
+
+
 class LazyFormat(str):
     """
     Lazy format strings.
@@ -82,7 +85,7 @@ class LazyFormat(str):
         AssertionError: ...
     """
 
-    def __mod__(self, args):
+    def __mod__(self, args) -> Self:
         """
         Bind the lazy format string with its parameters.
 
@@ -100,7 +103,7 @@ class LazyFormat(str):
         self._args = args
         return self
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         TESTS::
 

--- a/src/sage/misc/method_decorator.py
+++ b/src/sage/misc/method_decorator.py
@@ -5,6 +5,8 @@ AUTHOR:
 
 - Martin Albrecht (2009-05): inspired by a conversation with and code by Mike Hansen
 """
+from typing import Self
+
 from sage.structure.sage_object import SageObject
 
 
@@ -64,7 +66,7 @@ class MethodDecorator(SageObject):
         """
         return self.f(self._instance, *args, **kwds)
 
-    def __get__(self, inst, cls=None):
+    def __get__(self, inst, cls=None) -> Self:
         """
         EXAMPLES:
 

--- a/src/sage/modular/hecke/element.py
+++ b/src/sage/modular/hecke/element.py
@@ -24,8 +24,10 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.structure.richcmp import richcmp, op_NE
+from typing import Self
+
 from sage.structure.element import ModuleElement
+from sage.structure.richcmp import op_NE, richcmp
 
 
 def is_HeckeModuleElement(x):
@@ -209,7 +211,7 @@ class HeckeModuleElement(ModuleElement):
         """
         return self.parent()(-self.element())
 
-    def _pos_(self):
+    def _pos_(self) -> Self:
         """
         EXAMPLES::
 

--- a/src/sage/modular/local_comp/local_comp.py
+++ b/src/sage/modular/local_comp/local_comp.py
@@ -20,22 +20,28 @@ AUTHORS:
 - Jared Weinstein
 """
 
-from sage.structure.sage_object import SageObject
+from typing import Self
+
+from sage.misc.abstract_method import abstract_method
+from sage.misc.cachefunc import cached_method
+from sage.misc.flatten import flatten
+from sage.misc.lazy_import import lazy_import
+from sage.misc.verbose import verbose
+from sage.modular.modform.element import Newform
 from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.polynomial_ring import polygen
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.misc.abstract_method import abstract_method
-from sage.misc.cachefunc import cached_method
-from sage.misc.lazy_import import lazy_import
-from sage.misc.verbose import verbose
-from sage.misc.flatten import flatten
-from sage.modular.modform.element import Newform
+from sage.structure.sage_object import SageObject
 from sage.structure.sequence import Sequence
 
 lazy_import('sage.rings.qqbar', 'QQbar')
 
+from .smoothchar import (
+    SmoothCharacterGroupQp,
+    SmoothCharacterGroupRamifiedQuadratic,
+    SmoothCharacterGroupUnramifiedQuadratic,
+)
 from .type_space import TypeSpace
-from .smoothchar import SmoothCharacterGroupQp, SmoothCharacterGroupUnramifiedQuadratic, SmoothCharacterGroupRamifiedQuadratic
 
 
 def LocalComponent(f, p, twist_factor=None):
@@ -332,7 +338,7 @@ class PrimitiveLocalComponent(LocalComponentBase):
         """
         return True
 
-    def minimal_twist(self):
+    def minimal_twist(self) -> Self:
         r"""
         Return a twist of this local component which has the minimal possible
         conductor.

--- a/src/sage/modular/pollack_stevens/manin_map.py
+++ b/src/sage/modular/pollack_stevens/manin_map.py
@@ -43,12 +43,15 @@ EXAMPLES::
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.rings.continued_fraction import convergents
-from .sigma0 import Sigma0
-from .fund_domain import t00, t10, t01, t11, M2Z
+from typing import Self
+
 from sage.matrix.matrix_space import MatrixSpace
+from sage.rings.continued_fraction import convergents
 from sage.rings.integer_ring import ZZ
 from sage.structure.element import coercion_model
+
+from .fund_domain import M2Z, t00, t01, t10, t11
+from .sigma0 import Sigma0
 
 
 def unimod_matrices_to_infty(r, s):
@@ -690,7 +693,7 @@ class ManinMap:
             D[ky] = self(gamma * ky) * gamma
         return self.__class__(self._codomain, self._manin, D, check=False)
 
-    def normalize(self):
+    def normalize(self) -> Self:
         r"""
         Normalize every value of ``self`` -- e.g., reduce each value's
         `j`-th moment modulo `p^{N-j}`.

--- a/src/sage/modular/pollack_stevens/modsym.py
+++ b/src/sage/modular/pollack_stevens/modsym.py
@@ -36,8 +36,9 @@ EXAMPLES::
 # *****************************************************************************
 
 import operator
+from typing import Self
 
-from sage.arith.misc import next_prime, gcd, kronecker
+from sage.arith.misc import gcd, kronecker, next_prime
 from sage.categories.action import Action
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_import import lazy_import
@@ -52,10 +53,9 @@ from sage.structure.richcmp import op_EQ, op_NE
 lazy_import('sage.rings.padics.factory', 'Qp')
 lazy_import('sage.rings.padics.padic_generic', 'pAdicGeneric')
 
+from .fund_domain import M2Z
 from .manin_map import ManinMap
 from .sigma0 import Sigma0
-from .fund_domain import M2Z
-
 
 minusproj = [1, 0, 0, -1]
 
@@ -232,7 +232,7 @@ class PSModularSymbolElement(ModuleElement):
         """
         return [self._map[g] for g in self.parent().source().gens()]
 
-    def _normalize(self, **kwds):
+    def _normalize(self, **kwds) -> Self:
         """
         Normalize all of the values of the symbol ``self``.
 
@@ -825,11 +825,10 @@ class PSModularSymbolElement(ModuleElement):
             if not (g in MR.reps_with_two_torsion()
                     or g in MR.reps_with_three_torsion()):
                 t += f[g] * MR.gammas[g] - f[g]
+            elif g in MR.reps_with_two_torsion():
+                t -= f[g]
             else:
-                if g in MR.reps_with_two_torsion():
-                    t -= f[g]
-                else:
-                    t -= f[g]   # what ?? same thing ??
+                t -= f[g]   # what ?? same thing ??
 
         id = MR.gens()[0]
         if f[id] * MR.gammas[id] - f[id] != -t:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Wanting to join the annoate-return-types-club, some methods that return `self` are annoted by `typing.Self`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


