### PR TITLE
Use 'python -m sage.doctest' instead of 'sage -t'

### DIFF
--- a/src/sage/doctest/test.py
+++ b/src/sage/doctest/test.py
@@ -25,7 +25,7 @@ Unset :envvar:`TERM` when running doctests, see :issue:`14370`::
 
 Check that :issue:`2235` has been fixed::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:       "--random-seed=0", "--optional=sage", "longtime.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -36,7 +36,7 @@ Check that :issue:`2235` has been fixed::
     ----------------------------------------------------------------------
     ...
     0
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "-l", "longtime.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -50,7 +50,7 @@ Check that :issue:`2235` has been fixed::
 
 Check handling of tolerances::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "tolerance.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -120,7 +120,7 @@ Check handling of tolerances::
 
 Test the ``--initial`` option::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "-i", "initial.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -151,7 +151,7 @@ Test the ``--initial`` option::
 
 Test the ``--exitfirst`` option::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--exitfirst", "initial.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -179,7 +179,7 @@ manner (:issue:`26912`)::
     sage: from copy import deepcopy
     sage: kwds2 = deepcopy(kwds)
     sage: kwds2['env'].update({'SAGE_TIMEOUT': '1', 'CYSIGNALS_CRASH_NDEBUG': '1'})
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "99seconds.rst"], **kwds2)
     Running doctests...
     Doctesting 1 file.
@@ -196,7 +196,7 @@ manner (:issue:`26912`)::
 
 Test handling of ``KeyboardInterrupt`` in doctests::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "keyboardinterrupt.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -219,7 +219,7 @@ Test handling of ``KeyboardInterrupt`` in doctests::
 
 Interrupt the doctester::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "interrupt.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -238,7 +238,7 @@ doesn't hurt::
     sage: from copy import deepcopy
     sage: kwds2 = deepcopy(kwds)
     sage: kwds2['env']['DOCTEST_TEST_PID_FILE'] = F  # Doctester will write its PID in this file
-    sage: subprocess.call(["sage", "-tp", "1000000", "--timeout=120",  # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "-p", "1000000", "--timeout=120",  # long time
     ....:      "--die_timeout=10", "--optional=sage",
     ....:      "--warn-long", "0", "99seconds.rst", "interrupt_diehard.rst"], **kwds2)
     Running doctests...
@@ -274,7 +274,7 @@ random`` tag.
 
 Test a doctest failing with ``abort()``::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "abort.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -300,7 +300,7 @@ A different kind of crash (also test printing of line continuation ``...:``,
 represented by ``<DOTSCOLON>`` below)::
 
     sage: # long time
-    sage: proc = subprocess.run(["python", "-m", "sage.doctest", "--warn-long", "0",
+    sage: proc = subprocess.run(["python3", "-m", "sage.doctest", "--warn-long", "0",
     ....:      "--random-seed=0", "--optional=sage", "fail_and_die.rst"], **kwds,
     ....:      stdout=subprocess.PIPE, text=True)
     sage: # the replacements are needed to avoid the strings being interpreted
@@ -336,7 +336,7 @@ represented by ``<DOTSCOLON>`` below)::
 
 Test that ``sig_on_count`` is checked correctly::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "sig_on.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -362,7 +362,7 @@ Test that ``sig_on_count`` is checked correctly::
 Test logfiles in serial and parallel mode (see :issue:`19271`)::
 
     sage: t = tmp_filename()
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--serial", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--serial", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--logfile", t, "simple_failure.rst"],
     ....:      stdout=open(os.devnull, "w"), **kwds)
     1
@@ -387,7 +387,7 @@ Test logfiles in serial and parallel mode (see :issue:`19271`)::
     ----------------------------------------------------------------------
     ...
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--logfile", t, "simple_failure.rst"],
     ....:      stdout=open(os.devnull, "w"), **kwds)
     1
@@ -414,7 +414,7 @@ Test logfiles in serial and parallel mode (see :issue:`19271`)::
 
 Test the ``--debug`` option::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--debug", "simple_failure.rst"],
     ....:      stdin=open(os.devnull), **kwds)
     Running doctests...
@@ -449,7 +449,7 @@ Test the ``--debug`` option::
 
 Test running under gdb, without and with a timeout::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest",  "--warn-long", "0",   # long time, optional: gdb
+    sage: subprocess.call(["python3", "-m", "sage.doctest",  "--warn-long", "0",   # long time, optional: gdb
     ....:      "--random-seed=0", "--optional=sage", "--gdb", "1second.rst"],
     ....:      stdin=open(os.devnull), **kwds)
     exec gdb ...
@@ -465,7 +465,7 @@ Test running under gdb, without and with a timeout::
 
 gdb might need a long time to start up, so we allow 30 seconds::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest",  "--warn-long", "0",   # long time, optional: gdb
+    sage: subprocess.call(["python3", "-m", "sage.doctest",  "--warn-long", "0",   # long time, optional: gdb
     ....:      "--random-seed=0", "--optional=sage", "--gdb", "-T30", "99seconds.rst"],
     ....:      stdin=open(os.devnull), **kwds)
     exec gdb ...
@@ -475,7 +475,7 @@ gdb might need a long time to start up, so we allow 30 seconds::
 
 Test the ``--show-skipped`` option::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--show-skipped", "show_skipped.rst"], **kwds)
     Running doctests ...
     Doctesting 1 file.
@@ -494,7 +494,7 @@ Test the ``--show-skipped`` option::
 
 Optional tests are run correctly::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0", "--long",  # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0", "--long",  # long time
     ....:      "--random-seed=0", "--show-skipped", "--optional=sage,gap", "show_skipped.rst"], **kwds)
     Running doctests ...
     Doctesting 1 file.
@@ -509,7 +509,7 @@ Optional tests are run correctly::
     ...
     0
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0", "--long",  # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0", "--long",  # long time
     ....:      "--random-seed=0", "--show-skipped", "--optional=gAp", "show_skipped.rst"], **kwds)
     Running doctests ...
     Doctesting 1 file.
@@ -527,7 +527,7 @@ Optional tests are run correctly::
 
 Test an invalid value for ``--optional``::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",
     ....:      "--random-seed=0", "--optional=bad-option", "show_skipped.rst"], **kwds)
     Traceback (most recent call last):
     ...
@@ -542,7 +542,7 @@ Test ``atexit`` support in the doctesting framework::
     sage: from copy import deepcopy
     sage: kwds2 = deepcopy(kwds)
     sage: kwds2['env']['DOCTEST_DELETE_FILE'] = F
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "atexit.rst"], **kwds2)
     Running doctests...
     Doctesting 1 file.
@@ -562,7 +562,7 @@ Test ``atexit`` support in the doctesting framework::
 
 Test that random tests are reproducible::
 
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "random_seed.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -584,7 +584,7 @@ Test that random tests are reproducible::
     ----------------------------------------------------------------------
     ...
     1
-    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=1", "--optional=sage", "random_seed.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.

--- a/src/sage/doctest/test.py
+++ b/src/sage/doctest/test.py
@@ -10,6 +10,7 @@ EXAMPLES::
     sage: import signal
     sage: import subprocess
     sage: import time
+    sage: import os
     sage: from sage.env import SAGE_SRC
     sage: tests_dir = os.path.join(SAGE_SRC, 'sage', 'doctest', 'tests')
     sage: tests_env = dict(os.environ)
@@ -24,7 +25,7 @@ Unset :envvar:`TERM` when running doctests, see :issue:`14370`::
 
 Check that :issue:`2235` has been fixed::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:       "--random-seed=0", "--optional=sage", "longtime.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -35,7 +36,7 @@ Check that :issue:`2235` has been fixed::
     ----------------------------------------------------------------------
     ...
     0
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "-l", "longtime.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -49,7 +50,7 @@ Check that :issue:`2235` has been fixed::
 
 Check handling of tolerances::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "tolerance.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -119,7 +120,7 @@ Check handling of tolerances::
 
 Test the ``--initial`` option::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "-i", "initial.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -150,7 +151,7 @@ Test the ``--initial`` option::
 
 Test the ``--exitfirst`` option::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--exitfirst", "initial.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -178,7 +179,7 @@ manner (:issue:`26912`)::
     sage: from copy import deepcopy
     sage: kwds2 = deepcopy(kwds)
     sage: kwds2['env'].update({'SAGE_TIMEOUT': '1', 'CYSIGNALS_CRASH_NDEBUG': '1'})
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "99seconds.rst"], **kwds2)
     Running doctests...
     Doctesting 1 file.
@@ -195,7 +196,7 @@ manner (:issue:`26912`)::
 
 Test handling of ``KeyboardInterrupt`` in doctests::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "keyboardinterrupt.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -218,7 +219,7 @@ Test handling of ``KeyboardInterrupt`` in doctests::
 
 Interrupt the doctester::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "interrupt.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -273,7 +274,7 @@ random`` tag.
 
 Test a doctest failing with ``abort()``::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "abort.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -299,7 +300,7 @@ A different kind of crash (also test printing of line continuation ``...:``,
 represented by ``<DOTSCOLON>`` below)::
 
     sage: # long time
-    sage: proc = subprocess.run(["sage", "-t", "--warn-long", "0",
+    sage: proc = subprocess.run(["python", "-m", "sage.doctest", "--warn-long", "0",
     ....:      "--random-seed=0", "--optional=sage", "fail_and_die.rst"], **kwds,
     ....:      stdout=subprocess.PIPE, text=True)
     sage: # the replacements are needed to avoid the strings being interpreted
@@ -335,7 +336,7 @@ represented by ``<DOTSCOLON>`` below)::
 
 Test that ``sig_on_count`` is checked correctly::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "sig_on.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -361,7 +362,7 @@ Test that ``sig_on_count`` is checked correctly::
 Test logfiles in serial and parallel mode (see :issue:`19271`)::
 
     sage: t = tmp_filename()
-    sage: subprocess.call(["sage", "-t", "--serial", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--serial", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--logfile", t, "simple_failure.rst"],
     ....:      stdout=open(os.devnull, "w"), **kwds)
     1
@@ -386,7 +387,7 @@ Test logfiles in serial and parallel mode (see :issue:`19271`)::
     ----------------------------------------------------------------------
     ...
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--logfile", t, "simple_failure.rst"],
     ....:      stdout=open(os.devnull, "w"), **kwds)
     1
@@ -413,7 +414,7 @@ Test logfiles in serial and parallel mode (see :issue:`19271`)::
 
 Test the ``--debug`` option::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--debug", "simple_failure.rst"],
     ....:      stdin=open(os.devnull), **kwds)
     Running doctests...
@@ -448,7 +449,7 @@ Test the ``--debug`` option::
 
 Test running under gdb, without and with a timeout::
 
-    sage: subprocess.call(["sage", "-t",  "--warn-long", "0",   # long time, optional: gdb
+    sage: subprocess.call(["python", "-m", "sage.doctest",  "--warn-long", "0",   # long time, optional: gdb
     ....:      "--random-seed=0", "--optional=sage", "--gdb", "1second.rst"],
     ....:      stdin=open(os.devnull), **kwds)
     exec gdb ...
@@ -464,7 +465,7 @@ Test running under gdb, without and with a timeout::
 
 gdb might need a long time to start up, so we allow 30 seconds::
 
-    sage: subprocess.call(["sage", "-t",  "--warn-long", "0",   # long time, optional: gdb
+    sage: subprocess.call(["python", "-m", "sage.doctest",  "--warn-long", "0",   # long time, optional: gdb
     ....:      "--random-seed=0", "--optional=sage", "--gdb", "-T30", "99seconds.rst"],
     ....:      stdin=open(os.devnull), **kwds)
     exec gdb ...
@@ -474,7 +475,7 @@ gdb might need a long time to start up, so we allow 30 seconds::
 
 Test the ``--show-skipped`` option::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "--show-skipped", "show_skipped.rst"], **kwds)
     Running doctests ...
     Doctesting 1 file.
@@ -493,7 +494,7 @@ Test the ``--show-skipped`` option::
 
 Optional tests are run correctly::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0", "--long",  # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0", "--long",  # long time
     ....:      "--random-seed=0", "--show-skipped", "--optional=sage,gap", "show_skipped.rst"], **kwds)
     Running doctests ...
     Doctesting 1 file.
@@ -508,7 +509,7 @@ Optional tests are run correctly::
     ...
     0
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0", "--long",  # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0", "--long",  # long time
     ....:      "--random-seed=0", "--show-skipped", "--optional=gAp", "show_skipped.rst"], **kwds)
     Running doctests ...
     Doctesting 1 file.
@@ -526,7 +527,7 @@ Optional tests are run correctly::
 
 Test an invalid value for ``--optional``::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",
     ....:      "--random-seed=0", "--optional=bad-option", "show_skipped.rst"], **kwds)
     Traceback (most recent call last):
     ...
@@ -541,7 +542,7 @@ Test ``atexit`` support in the doctesting framework::
     sage: from copy import deepcopy
     sage: kwds2 = deepcopy(kwds)
     sage: kwds2['env']['DOCTEST_DELETE_FILE'] = F
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "atexit.rst"], **kwds2)
     Running doctests...
     Doctesting 1 file.
@@ -561,7 +562,7 @@ Test ``atexit`` support in the doctesting framework::
 
 Test that random tests are reproducible::
 
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=0", "--optional=sage", "random_seed.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.
@@ -583,7 +584,7 @@ Test that random tests are reproducible::
     ----------------------------------------------------------------------
     ...
     1
-    sage: subprocess.call(["sage", "-t", "--warn-long", "0",    # long time
+    sage: subprocess.call(["python", "-m", "sage.doctest", "--warn-long", "0",    # long time
     ....:      "--random-seed=1", "--optional=sage", "random_seed.rst"], **kwds)
     Running doctests...
     Doctesting 1 file.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Since `sage -t` is not working with meson. Progress towards https://github.com/sagemath/sage/issues/39875 (not sure if I got all of them).


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


