### PR TITLE
Improve _element_constructor_ of image set

### DIFF
--- a/src/sage/sets/image_set.py
+++ b/src/sage/sets/image_set.py
@@ -80,6 +80,17 @@ class ImageSubobject(Parent):
             sage: Im = f.image()
             sage: TestSuite(Im).run(skip=['_test_an_element', '_test_pickling',
             ....:                         '_test_some_elements', '_test_elements'])
+
+        TESTS:
+
+        Implementing ``inverse_image`` automatically makes :meth:`__contains__` work::
+
+            sage: R.<x> = QQ[]
+            sage: S.<y> = QQ[]
+            sage: R.hom([y^2]).inverse_image(y^4)
+            x^2
+            sage: y^4 in R.hom([y^2]).image()
+            True
         """
         if not isinstance(domain_subset, Parent):
             from sage.sets.set import Set
@@ -127,6 +138,11 @@ class ImageSubobject(Parent):
         Parent.__init__(self, category=category)
 
         self._map = map
+        if inverse is not None:
+            from sage.misc.superseded import deprecation
+            deprecation(40250, "passing inverse is deprecated, implement inverse_image() for map instead")
+        if inverse is None:
+            inverse = map.inverse_image
         self._inverse = inverse
         self._domain_subset = domain_subset
         self._is_injective = is_injective

--- a/src/sage/sets/image_set.py
+++ b/src/sage/sets/image_set.py
@@ -142,7 +142,10 @@ class ImageSubobject(Parent):
             from sage.misc.superseded import deprecation
             deprecation(40250, "passing inverse is deprecated, implement inverse_image() for map instead")
         if inverse is None:
-            inverse = map.inverse_image
+            try:
+                inverse = map.inverse_image
+            except AttributeError:
+                pass
         self._inverse = inverse
         self._domain_subset = domain_subset
         self._is_injective = is_injective

--- a/src/sage/sets/image_set.py
+++ b/src/sage/sets/image_set.py
@@ -53,9 +53,9 @@ class ImageSubobject(Parent):
       - ``True``: ``map`` is known to be injective
       - ``'check'``: raise an error when ``map`` is not injective
 
-    - ``inverse`` -- a function (optional); a map from `f(X)` to `X`.
-      It is not recommended to provide this, if ``map.inverse_image`` exists,
-      it will be used automatically.
+    - ``inverse`` -- function (optional); a map from `f(X)` to `X`;
+      if ``map.inverse_image`` exists, it is not recommended to provide this
+      as it will be used automatically
 
     EXAMPLES::
 

--- a/src/sage/sets/image_set.py
+++ b/src/sage/sets/image_set.py
@@ -53,7 +53,9 @@ class ImageSubobject(Parent):
       - ``True``: ``map`` is known to be injective
       - ``'check'``: raise an error when ``map`` is not injective
 
-    - ``inverse`` -- a function (optional); a map from `f(X)` to `X`
+    - ``inverse`` -- a function (optional); a map from `f(X)` to `X`.
+      It is not recommended to provide this, if ``map.inverse_image`` exists,
+      it will be used automatically.
 
     EXAMPLES::
 
@@ -138,9 +140,6 @@ class ImageSubobject(Parent):
         Parent.__init__(self, category=category)
 
         self._map = map
-        if inverse is not None:
-            from sage.misc.superseded import deprecation
-            deprecation(40250, "passing inverse is deprecated, implement inverse_image() for map instead")
         if inverse is None:
             try:
                 inverse = map.inverse_image


### PR DESCRIPTION
Allow the example shown to work.

            sage: R.<x> = QQ[]
            sage: S.<y> = QQ[]
            sage: R.hom([y^2]).inverse_image(y^4)
            x^2
            sage: y^4 in R.hom([y^2]).image()
            True

Also mention that it is not recommended to pass `inverse=...` to `ImageSubobject` constructor — there should be no need for this, it is better (and more discoverable) to define the `.inverse_image` method on the map.

I could have deprecated it, but decide to leave it there just in case. The only place within the doctest that it is used is in the file itself.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


