### PR TITLE
fixes for the linter and unused imports

### DIFF
--- a/src/sage/doctest/rif_tol.py
+++ b/src/sage/doctest/rif_tol.py
@@ -57,7 +57,7 @@ def RIFtol(*args) -> RealIntervalFieldElement:
     """
     global _RIFtol
     if _RIFtol is None:
-       _RIFtol = RealIntervalField(1044)
+        _RIFtol = RealIntervalField(1044)
     return _RIFtol(*args)
 
 

--- a/src/sage/graphs/graph_decompositions/modular_decomposition.pyx
+++ b/src/sage/graphs/graph_decompositions/modular_decomposition.pyx
@@ -35,7 +35,6 @@ from sage.graphs.base.c_graph cimport CGraph, CGraphBackend
 from sage.graphs.graph_decompositions.slice_decomposition cimport \
         extended_lex_BFS
 from sage.groups.perm_gps.permgroup_element import PermutationGroupElement
-from sage.misc.lazy_import import lazy_import
 from sage.misc.random_testing import random_testing
 
 

--- a/src/sage/matrix/matrix_modn_sparse.pyx
+++ b/src/sage/matrix/matrix_modn_sparse.pyx
@@ -117,7 +117,6 @@ from sage.rings.fast_arith cimport arith_int
 from sage.rings.finite_rings.integer_mod cimport IntegerMod_int, IntegerMod_abstract
 from sage.rings.integer cimport Integer
 from sage.rings.integer_ring import ZZ
-from sage.rings.rational_field import QQ
 from sage.structure.element cimport Matrix
 
 ################

--- a/src/sage/matroids/graphic_matroid.pyx
+++ b/src/sage/matroids/graphic_matroid.pyx
@@ -90,7 +90,6 @@ from sage.matroids.matroid cimport Matroid
 from copy import copy
 from sage.matroids.utilities import newlabel, split_vertex, sanitize_contractions_deletions
 from itertools import combinations
-from sage.rings.integer import Integer
 from sage.sets.disjoint_set cimport DisjointSet_of_hashables
 
 cdef class GraphicMatroid(Matroid):

--- a/src/sage/misc/misc_c.pyx
+++ b/src/sage/misc/misc_c.pyx
@@ -23,7 +23,6 @@ AUTHORS:
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
-from copy import copy
 
 from cpython.sequence cimport *
 from cpython.list cimport *

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -4296,6 +4296,7 @@ class LazyDirichletSeriesRing(LazySeriesRing):
 
     polylog = polylogarithm
 
+
 def _skip_leading_zeros(iterator):
     """
     Return an iterator which discards all leading zeros.

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -8873,7 +8873,6 @@ cdef class Polynomial(CommutativePolynomial):
             sage: all(r.parent() is K for r in f.roots(multiplicities=False))           # needs sage.rings.finite_rings
             True
         """
-        from sage.rings.finite_rings.finite_field_constructor import GF
         K = self._parent.base_ring()
 
         # If the base ring has a method _roots_univariate_polynomial,


### PR DESCRIPTION
This makes some fixes for our own ruff-minimal and pycodestyle-minimal .

Also removes some unused imports in pyx files as suggested by cython-lint

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.


