### PR TITLE
ensure autoconf 2.69 compatiblity in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -310,8 +310,8 @@ fi
    AC_CHECK_HEADER(bzlib.h, [
       AC_SEARCH_LIBS([BZ2_bzCompress], [bz2], [
         AC_PATH_PROG([bzip2_prog], [bzip2])
-        AS_IF([test x$bzip2_prog = x
-	], [AC_MSG_ERROR([could not find bzip2 executable. Cf. https://doc.sagemath.org/html/en/reference/spkg/_prereq.html])])
+        AS_IF([test x$bzip2_prog = x],
+              [AC_MSG_ERROR([could not find bzip2 executable. Cf. https://doc.sagemath.org/html/en/reference/spkg/_prereq.html])])
       ], [AC_MSG_ERROR([could not find libbz2 library. Cf. https://doc.sagemath.org/html/en/reference/spkg/_prereq.html])])
     ], [AC_MSG_ERROR([could not find bzlib.h - the header of libbz2 library. Cf. https://doc.sagemath.org/html/en/reference/spkg/_prereq.html])
    ])


### PR DESCRIPTION
As reported by @jeriedel24 [here](https://github.com/sagemath/sage/commit/7f6dd7547ecf8c4d23099842f4ad4ace5f2f3072#commitcomment-160100961), old autoconf does not correctly deal with `test` clauses split across the lines. So we fix this regression, introduced in #40011,  here.

We still cannot drop autoconf 2.69, as various distros, e.g. Debian, are very slow in adapting 2.71+

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


