### PR TITLE
Make the `is_isomorphic` method for `AbelianGroup` and `PermutationGroup` work for more groups

### DIFF
--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -207,7 +207,7 @@ from sage.arith.functions import lcm
 from sage.arith.misc import divisors, gcd
 from sage.categories.groups import Groups
 from sage.groups.abelian_gps.abelian_group_element import AbelianGroupElement
-from sage.groups.group import AbelianGroup as AbelianGroupBase
+from sage.groups.group import AbelianGroup as AbelianGroupBase, Group
 from sage.matrix.constructor import matrix
 from sage.matrix.special import diagonal_matrix
 from sage.misc.cachefunc import cached_method
@@ -573,9 +573,9 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
 
         INPUT:
 
-        - ``right`` -- anything
+        - ``right`` -- a group
 
-        OUTPUT: boolean; whether ``left`` and ``right`` are isomorphic as abelian groups
+        OUTPUT: boolean; whether ``left`` and ``right`` are isomorphic as groups
 
         .. WARNING::
 
@@ -618,6 +618,8 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
             ...
             sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
         """
+        if not isinstance(right, Group):
+            raise TypeError("right must be a group")
         if not isinstance(right, AbelianGroup_class):
             iso = left._libgap_().IsomorphismGroups(right)
             return str(iso) != "fail"

--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -577,15 +577,50 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
 
         OUTPUT: boolean; whether ``left`` and ``right`` are isomorphic as abelian groups
 
+        .. WARNING::
+
+           When ``right`` is not an instance of ``AbelianGroup`` and both ``left`` and ``right``
+           are infinite, this method will throw a ``GAPError``.
+
         EXAMPLES::
 
             sage: G1 = AbelianGroup([2,3,4,5])
             sage: G2 = AbelianGroup([2,3,4,5,1])
             sage: G1.is_isomorphic(G2)
             True
+
+        TESTS:
+
+        Check that :issue:`39893` is fixed::
+
+            sage: G = AbelianGroup([2, 3])
+            sage: H = G.permutation_group()
+            sage: G.is_isomorphic(H)
+            True
+            sage: G = AbelianGroup([2, 3])
+            sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
+            sage: G.is_isomorphic(H)
+            True
+            sage: G = AbelianGroup([2, 3, 0])
+            sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
+            sage: G.is_isomorphic(H)
+            False
+            sage: G = AbelianGroup([0])
+            sage: H = FreeGroup(1)
+            sage: G.is_isomorphic(H)
+            Traceback (most recent call last):
+            ...
+            sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
+            sage: G = AbelianGroup([2, 3, 0])
+            sage: H = FreeGroup(1)
+            sage: G.is_isomorphic(H)
+            Traceback (most recent call last):
+            ...
+            sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
         """
         if not isinstance(right, AbelianGroup_class):
-            return False
+            iso = left._libgap_().IsomorphismGroups(right)
+            return str(iso) != "fail"
         return left.elementary_divisors() == right.elementary_divisors()
 
     def is_subgroup(left, right):

--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -579,8 +579,8 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
 
         .. WARNING::
 
-           When ``right`` is not an instance of ``AbelianGroup`` and both ``left`` and ``right``
-           are infinite, this method will throw a ``GAPError``.
+           This method may fail if ``right`` is not an instance of
+           ``AbelianGroup`` and both ``left`` and ``right`` are infinite.
 
         EXAMPLES::
 
@@ -618,11 +618,12 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
             ...
             sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
         """
+        from sage.libs.gap.libgap import libgap
         if not isinstance(right, Group):
             raise TypeError("right must be a group")
         if not isinstance(right, AbelianGroup_class):
             iso = left._libgap_().IsomorphismGroups(right)
-            return str(iso) != "fail"
+            return iso != libgap.eval('fail')
         return left.elementary_divisors() == right.elementary_divisors()
 
     def is_subgroup(left, right):

--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -207,7 +207,7 @@ from sage.arith.functions import lcm
 from sage.arith.misc import divisors, gcd
 from sage.categories.groups import Groups
 from sage.groups.abelian_gps.abelian_group_element import AbelianGroupElement
-from sage.groups.group import AbelianGroup as AbelianGroupBase
+from sage.groups.group import AbelianGroup as AbelianGroupBase, Group
 from sage.matrix.constructor import matrix
 from sage.matrix.special import diagonal_matrix
 from sage.misc.cachefunc import cached_method
@@ -550,9 +550,9 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
 
         INPUT:
 
-        - ``right`` -- anything
+        - ``right`` -- a group
 
-        OUTPUT: boolean; whether ``left`` and ``right`` are isomorphic as abelian groups
+        OUTPUT: boolean; whether ``left`` and ``right`` are isomorphic as groups
 
         .. WARNING::
 
@@ -595,6 +595,8 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
             ...
             sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
         """
+        if not isinstance(right, Group):
+            raise TypeError("right must be a group")
         if not isinstance(right, AbelianGroup_class):
             iso = left._libgap_().IsomorphismGroups(right)
             return str(iso) != "fail"

--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -580,17 +580,17 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
             True
             sage: G = AbelianGroup([2, 3, 0])
             sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
-            sage: G.is_isomorphic(H)
+            sage: G.is_isomorphic(H) # needs sage.libs.gap  # optional - gap_package_polycyclic
             False
             sage: G = AbelianGroup([0])
             sage: H = FreeGroup(1)
-            sage: G.is_isomorphic(H)
+            sage: G.is_isomorphic(H) # needs sage.libs.gap  # optional - gap_package_polycyclic
             Traceback (most recent call last):
             ...
             sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
             sage: G = AbelianGroup([2, 3, 0])
             sage: H = FreeGroup(1)
-            sage: G.is_isomorphic(H)
+            sage: G.is_isomorphic(H) # needs sage.libs.gap  # optional - gap_package_polycyclic
             Traceback (most recent call last):
             ...
             sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups

--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -597,7 +597,7 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
         """
         from sage.libs.gap.libgap import libgap
         if not isinstance(right, Group):
-            raise TypeError("right must be a group")
+            raise TypeError("right must be a Sage group supported by GAP/libgap")
         if not isinstance(right, AbelianGroup_class):
             iso = left._libgap_().IsomorphismGroups(right)
             return iso != libgap.eval('fail')

--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -556,8 +556,8 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
 
         .. WARNING::
 
-           When ``right`` is not an instance of ``AbelianGroup`` and both ``left`` and ``right``
-           are infinite, this method will throw a ``GAPError``.
+           This method may fail if ``right`` is not an instance of
+           ``AbelianGroup`` and both ``left`` and ``right`` are infinite.
 
         EXAMPLES::
 
@@ -595,11 +595,12 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
             ...
             sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
         """
+        from sage.libs.gap.libgap import libgap
         if not isinstance(right, Group):
             raise TypeError("right must be a group")
         if not isinstance(right, AbelianGroup_class):
             iso = left._libgap_().IsomorphismGroups(right)
-            return str(iso) != "fail"
+            return iso != libgap.eval('fail')
         return left.elementary_divisors() == right.elementary_divisors()
 
     def is_subgroup(left, right):

--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -554,15 +554,50 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
 
         OUTPUT: boolean; whether ``left`` and ``right`` are isomorphic as abelian groups
 
+        .. WARNING::
+
+           When ``right`` is not an instance of ``AbelianGroup`` and both ``left`` and ``right``
+           are infinite, this method will throw a ``GAPError``.
+
         EXAMPLES::
 
             sage: G1 = AbelianGroup([2,3,4,5])
             sage: G2 = AbelianGroup([2,3,4,5,1])
             sage: G1.is_isomorphic(G2)
             True
+
+        TESTS:
+
+        Check that :issue:`39893` is fixed::
+
+            sage: G = AbelianGroup([2, 3])
+            sage: H = G.permutation_group()
+            sage: G.is_isomorphic(H)
+            True
+            sage: G = AbelianGroup([2, 3])
+            sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
+            sage: G.is_isomorphic(H)
+            True
+            sage: G = AbelianGroup([2, 3, 0])
+            sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
+            sage: G.is_isomorphic(H)
+            False
+            sage: G = AbelianGroup([0])
+            sage: H = FreeGroup(1)
+            sage: G.is_isomorphic(H)
+            Traceback (most recent call last):
+            ...
+            sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
+            sage: G = AbelianGroup([2, 3, 0])
+            sage: H = FreeGroup(1)
+            sage: G.is_isomorphic(H)
+            Traceback (most recent call last):
+            ...
+            sage.libs.gap.util.GAPError: Error, cannot test isomorphism of infinite groups
         """
         if not isinstance(right, AbelianGroup_class):
-            return False
+            iso = left._libgap_().IsomorphismGroups(right)
+            return str(iso) != "fail"
         return left.elementary_divisors() == right.elementary_divisors()
 
     def is_subgroup(left, right):

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -137,7 +137,7 @@ from __future__ import annotations
 from functools import wraps
 
 from sage.misc.randstate import current_randstate
-from sage.groups.group import FiniteGroup
+from sage.groups.group import FiniteGroup, Group
 
 from sage.rings.rational_field import QQ
 from sage.rings.integer import Integer
@@ -4339,7 +4339,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         - ``self`` -- this group
 
-        - ``right`` -- a permutation group
+        - ``right`` -- a group
 
         OUTPUT: boolean; ``True`` if ``self`` and ``right`` are isomorphic
         groups; ``False`` otherwise
@@ -4355,9 +4355,24 @@ class PermutationGroup_generic(FiniteGroup):
             True
             sage: G.is_isomorphic(PermutationGroup(list(reversed(v))))
             True
+
+        Check that :issue:`39893` is fixed::
+
+            sage: G = AbelianGroup([2, 3])
+            sage: H = G.permutation_group()
+            sage: H.is_isomorphic(G)
+            True
+            sage: G = AbelianGroup([2, 3])
+            sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
+            sage: H.is_isomorphic(G)
+            True
+            sage: G = AbelianGroup([2, 3, 0])
+            sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
+            sage: H.is_isomorphic(G)
+            False
         """
-        if not isinstance(right, PermutationGroup_generic):
-            raise TypeError("right must be a permutation group")
+        if not isinstance(right, Group):
+            raise TypeError("right must be a group")
         iso = self._libgap_().IsomorphismGroups(right)
         return str(iso) != 'fail'
 

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -4356,6 +4356,8 @@ class PermutationGroup_generic(FiniteGroup):
             sage: G.is_isomorphic(PermutationGroup(list(reversed(v))))
             True
 
+        TESTS:
+
         Check that :issue:`39893` is fixed::
 
             sage: G = AbelianGroup([2, 3])

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -137,7 +137,7 @@ from __future__ import annotations
 from functools import wraps
 
 from sage.misc.randstate import current_randstate
-from sage.groups.group import FiniteGroup
+from sage.groups.group import FiniteGroup, Group
 
 from sage.rings.rational_field import QQ
 from sage.rings.integer import Integer
@@ -4363,7 +4363,7 @@ class PermutationGroup_generic(FiniteGroup):
 
         - ``self`` -- this group
 
-        - ``right`` -- a permutation group
+        - ``right`` -- a group
 
         OUTPUT: boolean; ``True`` if ``self`` and ``right`` are isomorphic
         groups; ``False`` otherwise
@@ -4379,9 +4379,24 @@ class PermutationGroup_generic(FiniteGroup):
             True
             sage: G.is_isomorphic(PermutationGroup(list(reversed(v))))
             True
+
+        Check that :issue:`39893` is fixed::
+
+            sage: G = AbelianGroup([2, 3])
+            sage: H = G.permutation_group()
+            sage: H.is_isomorphic(G)
+            True
+            sage: G = AbelianGroup([2, 3])
+            sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
+            sage: H.is_isomorphic(G)
+            True
+            sage: G = AbelianGroup([2, 3, 0])
+            sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
+            sage: H.is_isomorphic(G)
+            False
         """
-        if not isinstance(right, PermutationGroup_generic):
-            raise TypeError("right must be a permutation group")
+        if not isinstance(right, Group):
+            raise TypeError("right must be a group")
         iso = self._libgap_().IsomorphismGroups(right)
         return str(iso) != 'fail'
 

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -4398,7 +4398,7 @@ class PermutationGroup_generic(FiniteGroup):
             False
         """
         if not isinstance(right, Group):
-            raise TypeError("right must be a group")
+            raise TypeError("right must be a Sage group supported by GAP/libgap")
         iso = self._libgap_().IsomorphismGroups(right)
         return str(iso) != 'fail'
 

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -4394,7 +4394,7 @@ class PermutationGroup_generic(FiniteGroup):
             True
             sage: G = AbelianGroup([2, 3, 0])
             sage: H = PermutationGroup([(1, 2, 3), (4, 5)])
-            sage: H.is_isomorphic(G)
+            sage: H.is_isomorphic(G) # needs sage.libs.gap  # optional - gap_package_polycyclic
             False
         """
         if not isinstance(right, Group):

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -4380,6 +4380,8 @@ class PermutationGroup_generic(FiniteGroup):
             sage: G.is_isomorphic(PermutationGroup(list(reversed(v))))
             True
 
+        TESTS:
+
         Check that :issue:`39893` is fixed::
 
             sage: G = AbelianGroup([2, 3])


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR fixes #39893, see also #39890. The crux of the issue is that the `G.is_isomorphic(H)` method of `AbelianGroup` returns `False` if the group `H` is not an instance of `AbelianGroup_class`, which caused quite confusing behavior in combination with `permutation_group`, where `G.is_isomorphic(G.permutation_group())` returns `False`, even though `permutation_group` in its documentation states that it "Return the permutation group isomorphic to this abelian group".
This seems undesirable, so I've fixed it by making the method use the GAP group isomorphism method when both groups are not instances of `AbelianGroup`.

Similarly, the `PermutationGroup` `is_isomorphic` method seems to reject non-permutation group instances, and then uses the GAP isomorphism function anyway. Since the GAP isomorphism checking function can handle isomorphisms between permutation and non-permutation groups, I relaxed the constraint there, so now `G.permutation_group().is_isomorphic(G)` also returns true for an `AbelianGroup` instance `G`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

No PR dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


