### PR TITLE
Add flatter support

### DIFF
--- a/src/sage/features/flatter.py
+++ b/src/sage/features/flatter.py
@@ -1,0 +1,30 @@
+r"""
+Features for testing the presence of ``flatter``
+"""
+
+from . import Executable
+
+
+class flatter(Executable):
+    """
+    A :class:`~sage.features.Feature` describing the presence of ``flatter``.
+
+    EXAMPLES::
+
+        sage: from sage.features.flatter import flatter
+        sage: flatter().is_present()  # optional - flatter
+        FeatureTestResult('flatter', True)
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.flatter import flatter
+            sage: isinstance(flatter(), flatter)
+            True
+        """
+        Executable.__init__(self, "flatter", executable="flatter")
+
+
+def all_features():
+    return [flatter()]

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -3026,7 +3026,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         - ``'flatter'`` -- external executable ``flatter``, requires manual install (see caveats below).
           Note that sufficiently new version of ``pari`` also supports FLATTER algorithm, see
-          <https://pari.math.u-bordeaux.fr/dochtml/html/Vectors__matrices__linear_algebra_and_sets.html#qflll>_.
+          https://pari.math.u-bordeaux.fr/dochtml/html/Vectors__matrices__linear_algebra_and_sets.html#qflll.
 
         OUTPUT: a matrix over the integers
 


### PR DESCRIPTION
Supports calling external `flatter` executable for `LLL` algorithm. (If the user wants to use this it is necessary to install from source from https://github.com/keeganryan/flatter)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


