### PR TITLE
Remove programmatic usage of analyse()

### DIFF
--- a/src/sage/geometry/polyhedron/parent.py
+++ b/src/sage/geometry/polyhedron/parent.py
@@ -896,10 +896,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
         if not other_ring.is_exact():
             other_ring = RDF  # the only supported floating-point numbers for now
 
-        cm_map, cm_ring = get_coercion_model().analyse(self.base_ring(), other_ring)
-        if cm_ring is None:
-            raise TypeError(f'Could not coerce type {other} into ZZ, QQ, or RDF.')
-        return cm_ring
+        return get_coercion_model().common_parent(self.base_ring(), other_ring)
 
     def _coerce_map_from_(self, X):
         r"""

--- a/src/sage/structure/coerce.pyx
+++ b/src/sage/structure/coerce.pyx
@@ -808,6 +808,9 @@ cdef class CoercionModel:
         elements or parents). If the parent of the result can be determined
         then it will be returned.
 
+        For programmatic usages, use :meth:`canonical_coercion` and
+        :meth:`common_parent` instead.
+
         EXAMPLES::
 
             sage: cm = sage.structure.element.get_coercion_model()
@@ -937,6 +940,9 @@ cdef class CoercionModel:
         The :meth:`explain` method is easier to use, but if one wants access to
         the actual morphism and action objects (rather than their string
         representations), then this is the function to use.
+
+        For programmatic usages, use :meth:`canonical_coercion` and
+        :meth:`common_parent` instead.
 
         EXAMPLES::
 


### PR DESCRIPTION
`analyse` is meant to be used by the user, it is (very likely, because of all the extra explanation) slower than `common_parent`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


