### PR TITLE
Fix tests with scipy 1.16

### DIFF
--- a/src/sage/numerical/optimize.py
+++ b/src/sage/numerical/optimize.py
@@ -567,12 +567,12 @@ def minimize_constrained(func, cons, x0, gradient=None, algorithm='default', **a
         if isinstance(cons[0], (tuple, list)) or cons[0] is None:
             if gradient is not None:
                 if algorithm == 'l-bfgs-b':
-                    min = optimize.fmin_l_bfgs_b(f, x0, gradient, bounds=cons, iprint=-1, **args)[0]
+                    min = optimize.fmin_l_bfgs_b(f, x0, gradient, bounds=cons, **args)[0]
                 else:
                     min = optimize.fmin_tnc(f, x0, gradient, bounds=cons, messages=0, **args)[0]
             else:
                 if algorithm == 'l-bfgs-b':
-                    min = optimize.fmin_l_bfgs_b(f, x0, approx_grad=True, bounds=cons, iprint=-1, **args)[0]
+                    min = optimize.fmin_l_bfgs_b(f, x0, approx_grad=True, bounds=cons, **args)[0]
                 else:
                     min = optimize.fmin_tnc(f, x0, approx_grad=True, bounds=cons, messages=0, **args)[0]
         elif isinstance(cons[0], (function_type, Expression)):

--- a/src/sage/numerical/optimize.py
+++ b/src/sage/numerical/optimize.py
@@ -519,9 +519,9 @@ def minimize_constrained(func, cons, x0, gradient=None, algorithm='default', **a
         sage: x, y = var('x y')
         sage: f(x,y) = (100 - x) + (1000 - y)
         sage: c(x,y) = x + y - 479  # > 0
-        sage: minimize_constrained(f, [c], [100, 300])
+        sage: minimize_constrained(f, [c], [100, 300]) # random
         (805.985..., 1005.985...)
-        sage: minimize_constrained(f, c, [100, 300])
+        sage: minimize_constrained(f, c, [100, 300])   # random
         (805.985..., 1005.985...)
 
     If ``func`` is symbolic, its minimizer should be in the same order
@@ -532,7 +532,7 @@ def minimize_constrained(func, cons, x0, gradient=None, algorithm='default', **a
         sage: f(y,x) = x - y
         sage: c1(y,x) = x
         sage: c2(y,x) = 1-y
-        sage: minimize_constrained(f, [c1, c2], (0,0))
+        sage: minimize_constrained(f, [c1, c2], (0,0)) # abs tol 1e-04
         (1.0, 0.0)
     """
     from sage.structure.element import Expression


### PR DESCRIPTION
Make tests pass with scipy 1.16:

- Drop deprecated `iprint` parameter for `l-bfgs-b` algorithm.
- Adapt to output changes with new COBYLA implementation.

In particular, the tests in https://github.com/sagemath/sage/blob/10.7.beta6/src/sage/numerical/optimize.py#L522-L525 give a completely different answer, which is as meaningless as the previous one since the function does not have a minimum. We mark them as random, since their only purpose is to test that it doesn't throw an error.