### PR TITLE
Prevent segfault on GF(2^e) dense matrix row/column swap

### DIFF
--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1085,6 +1085,8 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
             sage: B[2] == A[2]
             True
         """
+        if self._ncols == 0:
+            return
         mzed_row_swap(self._entries, row1, row2)
 
     cdef swap_columns_c(self, Py_ssize_t col1, Py_ssize_t col2):
@@ -1123,6 +1125,8 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
             sage: A.column(14) == B.column(0)
             True
         """
+        if self._nrows == 0:
+            return
         mzed_col_swap(self._entries, col1, col2)
 
     def augment(self, right):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

There is currently a problem with n x 0 and 0 x n matrices over GF(2^e). When performing row or column swaps, a segmentation fault is produced. The underlying issue seems to be within the M4RI library. Although the existing library code already has checks for these, they seem to be failing. A simple example to reproduce the problem is:

sage: matrix.zero(GF(4),2,0).with_permuted_rows(Permutation([2,1]))

The issue may be avoided in Sage by only performing swaps on non-empty rows and columns. I have added a simple condition to the swap logic for matrix_gf2e_dense

Related issue raised in M4RI: https://github.com/malb/m4ri/issues/32

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None