### PR TITLE
Fix loading symbolic expressions containing symbolic functions

### DIFF
--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -1348,6 +1348,15 @@ cdef class SymbolicFunction(Function):
             foo(x)^2 + foo(0) + 1
             sage: u.subs(y=0).n()                                                       # needs sage.symbolic
             43.0000000000000
+
+        Check that :issue:`40292` is fixed::
+
+            sage: # needs sage.symbolic
+            sage: var('x,y')
+            (x, y)
+            sage: u = function('u')(x, y)
+            sage: loads(dumps(u))
+            u(x, y)
         """
         return (2, self._name, self._nargs, self._latex_name, self._conversions,
                 self._evalf_params_first,

--- a/src/sage/symbolic/pynac_impl.pxi
+++ b/src/sage/symbolic/pynac_impl.pxi
@@ -817,7 +817,16 @@ cdef unsigned py_get_serial_for_new_sfunction(stdstring &s,
     create one and set up the function tables properly.
     """
     from sage.symbolic.function_factory import function_factory
-    cdef Function fn = function_factory(s.c_str(), nargs)
+    # The input string s comes from GiNaC::function::function, the constructor
+    # that reads the function name from an archive.
+    # The archive is created by GiNaC::function::archive, which sets the name
+    # to GiNaC::function::registered_functions()[serial].name.
+    # Functions are registered using GiNaC::function::register_new.
+    # For symbolic functions this happens in the register_or_update_function
+    # which is defined in src/sage/symbolic/pynac_function_impl.pxi.
+    # In there, str_to_bytes is applied to the name.
+    # Hence we must apply the inverse char_to_str here.
+    cdef Function fn = function_factory(char_to_str(s.c_str()), nargs)
     return fn._serial
 
 


### PR DESCRIPTION
- Fixes https://github.com/sagemath/sage/issues/40292
- Fixes https://github.com/sagemath/sage/issues/30018

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


