### PR TITLE
Make discrete_log accept ord=oo

### DIFF
--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -385,6 +385,13 @@ def bsgs(a, b, bounds, operation='*', identity=None, inverse=None, op=None):
     arguments are provided automatically; otherwise they must be
     provided by the caller.
 
+    .. SEEALSO::
+
+        - :func:`discrete_log` for a potentially faster algorithm by combining
+          Pohlig-Hellman with baby-step adjacent-step;
+        - :func:`order_from_bounds` to find the exact order instead of just some
+          multiple of the order.
+
     INPUT:
 
     - ``a`` -- group element
@@ -694,7 +701,9 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
 
     - ``a`` -- group element
     - ``base`` -- group element (the base)
-    - ``ord`` -- integer (multiple of order of base, or ``None``)
+    - ``ord`` -- integer (multiple of order of base, or ``None``). Can also be
+      :mod:`oo <sage.rings.infinity>` to explicitly not use this, for example
+      when factorizing the order is difficult.
     - ``bounds`` -- a priori bounds on the log
     - ``operation`` -- string: ``'*'``, ``'+'``, other
     - ``identity`` -- the group's identity
@@ -864,6 +873,14 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
         sage: discrete_log(u, g, algorithm='rho')
         123456789
 
+    Pass ``ord=oo`` to avoid attempts to factorize the group order::
+
+        sage: p, q = next_prime(2^128), next_prime(2^129)
+        sage: a = mod(2, p*q*124+1)
+        sage: discrete_log(a^100, a, bounds=(1, 500))  # not tested (takes very long, but pari.addprimes(p) makes it faster)
+        sage: discrete_log(a^100, a, ord=oo, bounds=(1, 500))
+        100
+
     TESTS:
 
     Random testing::
@@ -917,6 +934,7 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
         lb, ub = map(integer_ring.ZZ, bounds)
     if (op is None or identity is None or inverse is None or ord is None) and operation not in addition_names + multiplication_names:
         raise ValueError("ord, op, identity, and inverse must all be specified for this operation")
+    from sage.rings.infinity import Infinity
     if ord is None:
         if operation in multiplication_names:
             try:
@@ -928,11 +946,10 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
                 ord = base.additive_order()
             except Exception:
                 ord = base.order()
-    else:
+    elif ord != Infinity:
         ord = integer_ring.ZZ(ord)
     try:
-        from sage.rings.infinity import Infinity
-        if ord == +Infinity:
+        if ord == Infinity:
             return bsgs(base, a, bounds, identity=identity, inverse=inverse, op=op, operation=operation)
         if base == power(base, 0) and a != base:
             raise ValueError

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -701,9 +701,10 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
 
     - ``a`` -- group element
     - ``base`` -- group element (the base)
-    - ``ord`` -- integer (multiple of order of base, or ``None``). Can also be
-      :mod:`oo <sage.rings.infinity>` to explicitly not use this, for example
-      when factorizing the order is difficult.
+    - ``ord`` -- integer (multiple of order of base, ``None``, or
+      :mod:`oo <sage.rings.infinity>``); if this is
+      :mod:`oo <sage.rings.infinity>`, then it explicitly does
+      not use this, for example when factorizing the order is difficult
     - ``bounds`` -- a priori bounds on the log
     - ``operation`` -- string: ``'*'``, ``'+'``, other
     - ``identity`` -- the group's identity


### PR DESCRIPTION
The code is intended to do so, but this path cannot be executed when the user explistly pass `ord=oo`, only when the element naturally has infinite order.

You can argue that `oo` is a multiple of every positive integer as well, so nothing particularly wrong with doing that.

Related to this part of code: https://github.com/sagemath/sage/pull/40223

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


