### PR TITLE
Fixed small typo in p-adic Smith form

### DIFF
--- a/src/sage/rings/padics/local_generic.py
+++ b/src/sage/rings/padics/local_generic.py
@@ -1304,6 +1304,10 @@ class LocalGeneric(Parent):
             sage: M.smith_form(transformation=False, exact=False)  # indirect doctest
             [O(5^10) O(5^10)]
             [O(5^10) O(5^10)]
+
+            sage: A = Zp(5)
+            sage: matrix(A,[1,1]).smith_form(transformation=False, integral=False, exact=False)
+            [1 + O(5^20)     O(5^20)]
         """
         from sage.rings.infinity import infinity
         from .precision_error import PrecisionError
@@ -1460,8 +1464,8 @@ class LocalGeneric(Parent):
                 if exact:
                     smith[i,i] = self(1)
                 else:
-                    for j in range(n):
-                        smith[i,j] = smith[i,j] >> v
+                    for j in range(m):
+                        smith[i,j] >>= v
             if transformation:
                 for i in range(n):
                     for j in range(n):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

There is a small typo in a loop bound, which causes `_matrix_smith_form()` to throw whenever given a nonsquare matrix with parameters `integral=False, exact=False`. For example
```sage
sage: A = Zp(5)
sage: matrix(A,[1,1]).smith_form(transformation=False, integral=False, exact=False)
```
should compute `[1 + O(5^20)   O(5^20)]` but throws an IndexError instead.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


