### PR TITLE
avoid using networkx in `src/sage/matroids/transversal_matroid.pyx`

### DIFF
--- a/src/sage/matroids/transversal_matroid.pxd
+++ b/src/sage/matroids/transversal_matroid.pxd
@@ -1,10 +1,11 @@
 from sage.matroids.matroid cimport Matroid
 from sage.matroids.basis_exchange_matroid cimport BasisExchangeMatroid
+from sage.graphs.generic_graph_pyx cimport GenericGraph_pyx
 
 cdef class TransversalMatroid(BasisExchangeMatroid):
     cdef dict _matching
     cdef object _sets
-    cdef object _D
+    cdef GenericGraph_pyx _D
     cdef list _set_labels, _sets_input, _set_labels_input
 
     cpdef list sets(self)


### PR DESCRIPTION
Store the digraph using a `DiGraph` to avoid conversions with `networkx` graphs.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


