### PR TITLE
Add vector_random.py to support vector.random (#40316)

### DIFF
--- a/src/sage/modules/vector_random.py
+++ b/src/sage/modules/vector_random.py
@@ -1,0 +1,9 @@
+from sage.modules.free_module import FreeModule
+
+def vector_random(R, n, *args, **kwargs):
+    """
+    Return a random vector over ring R of length n.
+
+    Mirrors matrix.random for API symmetry.
+    """
+    return FreeModule(R, n).random_element(*args, **kwargs)


### PR DESCRIPTION
Adds a helper function `vector_random(R, n, *args, **kwargs)` in a new file `src/sage/modules/vector_random.py`.

This mirrors `matrix.random()` for API consistency and calls `FreeModule(R, n).random_element(...)` internally.

This change avoids modifying core files directly and supports the enhancement in issue #40316.
