### PR TITLE
get rid of some "is_commutative" methods, via the category framework

### DIFF
--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -528,12 +528,28 @@ class CliffordAlgebra(CombinatorialFreeModule):
             sage: ba = Cl.basis().keys()
             sage: all(FrozenBitset(format(i,'b')[::-1]) in ba for i in range(2**9))
             True
+
+        Check for the category::
+
+            sage: Q = QuadraticForm(ZZ, 3, [1,2,3,4,5,6])
+            sage: Cl.<x,y,z> = CliffordAlgebra(Q)
+            sage: Cl.is_commutative()
+            False
+            sage: Q = QuadraticForm(ZZ, 1, [1])
+            sage: Cl.<x> = CliffordAlgebra(Q)
+            sage: Cl.is_commutative()
+            True
         """
         self._quadratic_form = Q
         R = Q.base_ring()
         category = AlgebrasWithBasis(R.category()).Super().Filtered().FiniteDimensional().or_subcategory(category)
+
+        if self._quadratic_form.dim() < 2:
+            category = category.Commutative()
+
         indices = CliffordAlgebraIndices(Q.dim())
-        CombinatorialFreeModule.__init__(self, R, indices, category=category, sorting_key=tuple)
+        CombinatorialFreeModule.__init__(self, R, indices, category=category,
+                                         sorting_key=tuple)
         self._assign_names(names)
 
     def _repr_(self):
@@ -843,19 +859,6 @@ class CliffordAlgebra(CombinatorialFreeModule):
             0
         """
         return FrozenBitset()
-
-    def is_commutative(self) -> bool:
-        """
-        Check if ``self`` is a commutative algebra.
-
-        EXAMPLES::
-
-            sage: Q = QuadraticForm(ZZ, 3, [1,2,3,4,5,6])
-            sage: Cl.<x,y,z> = CliffordAlgebra(Q)
-            sage: Cl.is_commutative()
-            False
-        """
-        return self._quadratic_form.dim() < 2
 
     def quadratic_form(self):
         """

--- a/src/sage/algebras/iwahori_hecke_algebra.py
+++ b/src/sage/algebras/iwahori_hecke_algebra.py
@@ -459,6 +459,15 @@ class IwahoriHeckeAlgebra(Parent, UniqueRepresentation):
             sage: R.<q1,q2> = QQ[]
             sage: H = IwahoriHeckeAlgebra("A2", q1, q2=q2, base_ring=Frac(R))
             sage: TestSuite(H).run()
+
+        TESTS::
+
+            sage: T = IwahoriHeckeAlgebra("B2", 1).T()
+            sage: T.is_commutative()
+            False
+            sage: T = IwahoriHeckeAlgebra("A1", 1).T()
+            sage: T.is_commutative()
+            True
         """
         self._W = W
         self._coxeter_type = W.coxeter_type()
@@ -499,7 +508,12 @@ class IwahoriHeckeAlgebra(Parent, UniqueRepresentation):
             self._category = FiniteDimensionalAlgebrasWithBasis(base_ring)
         else:
             self._category = AlgebrasWithBasis(base_ring)
-        Parent.__init__(self, base=base_ring, category=self._category.WithRealizations())
+
+        if base_ring.is_commutative() and W.is_commutative():
+            self._category = self._category.Commutative()
+
+        Parent.__init__(self, base=base_ring,
+                        category=self._category.WithRealizations())
 
         self._is_generic = False  # needed for initialisation of _KLHeckeBasis
 
@@ -766,19 +780,6 @@ class IwahoriHeckeAlgebra(Parent, UniqueRepresentation):
                     False
                 """
                 return False
-
-            def is_commutative(self) -> bool:
-                """
-                Return whether this Iwahori-Hecke algebra is commutative.
-
-                EXAMPLES::
-
-                    sage: T = IwahoriHeckeAlgebra("B2", 1).T()
-                    sage: T.is_commutative()
-                    False
-                """
-                return self.base_ring().is_commutative() \
-                    and self.realization_of().coxeter_group().is_commutative()
 
             @cached_method
             def one_basis(self):

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -560,19 +560,6 @@ class QuaternionAlgebra_abstract(Parent):
         M.set_immutable()
         return M
 
-    def is_commutative(self) -> bool:
-        """
-        Return ``False`` always, since all quaternion algebras are
-        noncommutative.
-
-        EXAMPLES::
-
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3,-7)
-            sage: Q.is_commutative()
-            False
-        """
-        return False
-
     def is_division_algebra(self) -> bool:
         """
         Check whether this quaternion algebra is a division algebra,
@@ -871,6 +858,12 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             Traceback (most recent call last):
             ...
             ValueError: 2 is not invertible in Integer Ring
+
+        Check for category::
+
+            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3,-7)
+            sage: Q.is_commutative()
+            False
         """
         cat = Algebras(base_ring).Division().FiniteDimensional()
         Parent.__init__(self, base=base_ring, names=names, category=cat)

--- a/src/sage/combinat/chas/wqsym.py
+++ b/src/sage/combinat/chas/wqsym.py
@@ -471,8 +471,14 @@ class WordQuasiSymmetricFunctions(UniqueRepresentation, Parent):
 
             sage: A = algebras.WQSym(QQ)
             sage: TestSuite(A).run()  # long time
+
+            sage: M = algebras.WQSym(ZZ).M()
+            sage: M.is_commutative()
+            False
         """
         category = HopfAlgebras(R).Graded().Connected()
+        if R.is_zero():
+            category = category.Commutative()
         Parent.__init__(self, base=R, category=category.WithRealizations())
 
     def _repr_(self):
@@ -2040,18 +2046,6 @@ class WQSymBases(Category_realization_of_parent):
                 False
             """
             return False
-
-        def is_commutative(self):
-            """
-            Return whether ``self`` is commutative.
-
-            EXAMPLES::
-
-                sage: M = algebras.WQSym(ZZ).M()
-                sage: M.is_commutative()
-                False
-            """
-            return self.base_ring().is_zero()
 
         def one_basis(self):
             """

--- a/src/sage/combinat/fqsym.py
+++ b/src/sage/combinat/fqsym.py
@@ -363,8 +363,14 @@ class FreeQuasisymmetricFunctions(UniqueRepresentation, Parent):
 
             sage: F = algebras.FQSym(QQ)
             sage: TestSuite(F).run() # long time (3s)
+
+            sage: F = algebras.FQSym(ZZ).F()
+            sage: F.is_commutative()
+            False
         """
         category = HopfAlgebras(R).Graded().Connected()
+        if R.is_zero():
+            category = category.Commutative()
         Parent.__init__(self, base=R, category=category.WithRealizations())
 
         # Bases
@@ -1349,18 +1355,6 @@ class FQSymBases(Category_realization_of_parent):
                 False
             """
             return False
-
-        def is_commutative(self):
-            """
-            Return whether this `FQSym` is commutative.
-
-            EXAMPLES::
-
-                sage: F = algebras.FQSym(ZZ).F()
-                sage: F.is_commutative()
-                False
-            """
-            return self.base_ring().is_zero()
 
         def some_elements(self):
             """


### PR DESCRIPTION
Using the idea that, by default, a ring is not commutative unless it belongs to the category of CommutativeRings.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



