### PR TITLE
Add vector.random method to FreeModule for consistency with matrix.random

### DIFF
--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -225,20 +225,6 @@ from sage.structure.sequence import Sequence
 #
 ###############################################################################
 
-def vector_random(R, n, *args, **kwargs):
-    r"""
-    Return a random element of the free module of rank ``n`` over ``R``.
-
-    EXAMPLES::
-
-        sage: from sage.modules.free_module import vector_random
-        sage: v = vector_random(ZZ, 3)
-        sage: len(v)
-        3
-        sage: v.parent().base_ring() is ZZ
-        True
-    """
-    return FreeModule(R, n).random_element(*args, **kwargs)
 
 
 class FreeModuleFactory(UniqueFactory):
@@ -5530,6 +5516,8 @@ class FreeModule_ambient(FreeModule_generic):
                                     coordinate_ring=coordinate_ring,
                                     category=category)
 
+
+
     def __hash__(self):
         """
         The hash is obtained from the rank and the base ring.
@@ -5551,6 +5539,22 @@ class FreeModule_ambient(FreeModule_generic):
             # reconstruction (unpickle), and the above fields haven't been
             # filled in yet.
             return 0
+
+    def random(self, *args, **kwargs):
+        """
+        Return a random element (i.e., a vector) from this free module.
+
+        This method is available on all free modules and serves as a shortcut
+        to calling ``V.random_element()``.
+
+        EXAMPLES::
+
+            sage: V = FreeModule(ZZ, 3)
+            sage: v = V.random()
+            sage: v in V
+            True
+        """
+        return self.random_element(*args, **kwargs)
 
     def _coerce_map_from_(self, M):
         """

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -175,6 +175,8 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 ###########################################################################
 
+
+
 import itertools
 from warnings import warn
 
@@ -222,6 +224,34 @@ from sage.structure.sequence import Sequence
 # Constructor functions
 #
 ###############################################################################
+
+def vector_random(R, n, *args, **kwargs):
+    r"""
+    Return a random vector over the ring ``R`` of length ``n``.
+
+    This wraps ``FreeModule(R, n).random_element(*args, **kwargs)``, and mirrors
+    the ``matrix.random()`` function for API consistency.
+
+    INPUT:
+
+    - ``R`` -- base ring (e.g., ``ZZ``, ``QQ``, ``GF(p)``)
+    - ``n`` -- integer (dimension of the vector)
+    - ``*args, **kwargs`` -- passed to ``random_element``
+
+    OUTPUT:
+
+    A randomly generated vector of dimension ``n`` over ``R``.
+
+    EXAMPLES::
+
+        sage: from sage.modules.free_module import vector_random
+        sage: v = vector_random(ZZ, 3, bound=10)
+        sage: len(v)
+        3
+        sage: v.parent().base_ring()
+        Integer Ring
+    """
+    return FreeModule(R, n).random_element(*args, **kwargs)
 
 
 class FreeModuleFactory(UniqueFactory):

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -5542,10 +5542,9 @@ class FreeModule_ambient(FreeModule_generic):
 
     def random(self, *args, **kwargs):
         """
-        Return a random element (i.e., a vector) from this free module.
+        Return a random element of this free module.
 
-        This method is available on all free modules and serves as a shortcut
-        to calling ``V.random_element()``.
+        Equivalent to ``self.random_element()``.
 
         EXAMPLES::
 

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -5544,7 +5544,7 @@ class FreeModule_ambient(FreeModule_generic):
         """
         Return a random element of this free module.
 
-        Equivalent to ``self.random_element()``.
+        Equal to ``self.random_element()``.
 
         EXAMPLES::
 

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -227,29 +227,16 @@ from sage.structure.sequence import Sequence
 
 def vector_random(R, n, *args, **kwargs):
     r"""
-    Return a random vector over the ring ``R`` of length ``n``.
-
-    This wraps ``FreeModule(R, n).random_element(*args, **kwargs)``, and mirrors
-    the ``matrix.random()`` function for API consistency.
-
-    INPUT:
-
-    - ``R`` -- base ring (e.g., ``ZZ``, ``QQ``, ``GF(p)``)
-    - ``n`` -- integer (dimension of the vector)
-    - ``*args, **kwargs`` -- passed to ``random_element``
-
-    OUTPUT:
-
-    A randomly generated vector of dimension ``n`` over ``R``.
+    Return a random element of the free module of rank ``n`` over ``R``.
 
     EXAMPLES::
 
         sage: from sage.modules.free_module import vector_random
-        sage: v = vector_random(ZZ, 3, bound=10)
+        sage: v = vector_random(ZZ, 3)
         sage: len(v)
         3
-        sage: v.parent().base_ring()
-        Integer Ring
+        sage: v.parent().base_ring() is ZZ
+        True
     """
     return FreeModule(R, n).random_element(*args, **kwargs)
 
@@ -263,6 +250,7 @@ class FreeModuleFactory(UniqueFactory):
         TESTS::
 
             sage: loads(dumps(ZZ^6)) is ZZ^6
+
             True
             sage: loads(dumps(RDF^3)) is RDF^3
             True


### PR DESCRIPTION
**Updated**

This PR moves vector_random(R, n, *args, **kwargs) into the FreeModule_ambient class as a **method** and NOT a function:

random(self, *args, **kwargs) in src/sage/modules/free_module.py.

—Also, I did my best to eliminate verbosity and follow the project guidelines. I hope this satisfies. 

I’m still new to contributing here, so I really appreciate your guidance and patience. Thank you!

Ps. I will probably be stepping away from this project. I feel a little in too deep. Thanks again. 
