### PR TITLE
correct syntax in maxima's spkg-configure.m4

### DIFF
--- a/build/pkgs/maxima/spkg-configure.m4
+++ b/build/pkgs/maxima/spkg-configure.m4
@@ -1,9 +1,9 @@
 SAGE_SPKG_CONFIGURE([maxima], [
-  m4_pushdef([SAGE_MAXIMA_MINVER],["5.45.0"])dnl this version and higher allowed
+  m4_pushdef([SAGE_MAXIMA_MINVER],[5.45.0])dnl this version and higher allowed
   SAGE_SPKG_DEPCHECK([ecl], [
     dnl First check for the "maxima" executable in the user's PATH, because
     dnl we still use pexpect to communicate with it in a few places.
-    AC_CACHE_CHECK([for Maxima >= $SAGE_MAXIMA_MINVER], [ac_cv_path_MAXIMA], [
+    AC_CACHE_CHECK([for Maxima >= SAGE_MAXIMA_MINVER], [ac_cv_path_MAXIMA], [
         AC_PATH_PROGS_FEATURE_CHECK([MAXIMA], [maxima], [
             maxima_version=`$ac_path_MAXIMA --version 2>&1 | tail -n 1\
                 | $SED -n -e 's/Maxima *\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\)/\1/p'`


### PR DESCRIPTION
remove `$` to print the version correctly, and remove unneeded `"..."`

the extra `$` leads to the minimal version not being printed, and extra `"..."` around minimal version are confusing (and not needed)


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


