### PR TITLE
Remove duplicate 'doc-html' target from CI

### DIFF
--- a/.github/workflows/ci-linux-incremental.yml
+++ b/.github/workflows/ci-linux-incremental.yml
@@ -94,7 +94,7 @@ jobs:
       from_docker_target: "with-targets"
       from_docker_tag: "dev"
       docker_targets: "with-targets"
-      targets: "${{needs.changed_files.outputs.build_targets}} ci-build-with-fallback doc-html ptest-nodoc"
+      targets: "${{needs.changed_files.outputs.build_targets}} ci-build-with-fallback ptest-nodoc"
       tox_system_factors: >-
         ["ubuntu-focal",
          "ubuntu-jammy",

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   TARGETS_PRE: all-sage-local
-  TARGETS: build doc-html
+  TARGETS: build
   TARGETS_OPTIONAL: ptest
 
 permissions:
@@ -41,7 +41,7 @@ jobs:
       docker_targets: "with-system-packages configured with-targets-pre with-targets with-targets-optional"
       # FIXME: duplicated from env.TARGETS
       targets_pre: all-sage-local
-      targets: build doc-html
+      targets: build
       targets_optional: ptest
       tox_system_factors: >-
           ["ubuntu-jammy"]
@@ -56,7 +56,7 @@ jobs:
       # Build from scratch
       docker_targets: "with-system-packages configured with-targets-pre with-targets with-targets-optional"
       targets_pre: all-sage-local
-      targets: build doc-html
+      targets: build
       targets_optional: ptest
       tox_packages_factors: >-
           ["standard"]

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -30,7 +30,7 @@ on:
 
 env:
   TARGETS_PRE: all-sage-local
-  TARGETS: build doc-html
+  TARGETS: build
   TARGETS_OPTIONAL: ptest
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -120,7 +120,7 @@ jobs:
           case "${{ inputs.stage }}" in
             1)               export TARGETS_PRE="all-sage-local" TARGETS="all-sage-local" TARGETS_OPTIONAL="build/make/Makefile"
                              ;;
-            2)               export TARGETS_PRE="all-sage-local" TARGETS="build doc-html" TARGETS_OPTIONAL="ptest"
+            2)               export TARGETS_PRE="all-sage-local" TARGETS="build" TARGETS_OPTIONAL="ptest"
                              ;;
             2-optional*)     export TARGETS_PRE="build/make/Makefile" TARGETS="build/make/Makefile"
                              targets_pattern="${{ inputs.stage }}"

--- a/build/pkgs/sagemath_doc_html/type
+++ b/build/pkgs/sagemath_doc_html/type
@@ -1,1 +1,1 @@
-standard
+optional

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -101,7 +101,7 @@ class sagemath_doc_html(StaticFile):
                             filename='html',
                             search_path=(SAGE_DOC,),
                             spkg='sagemath_doc_html',
-                            type='standard')
+                            type='optional')
 
 
 class sage__combinat(JoinFeature):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Docbuilding is done in a seperate CI workflow, so there is no need to also build the docs as part of the normal CI runs.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


