### PR TITLE
Linear isomorphisms for convex cones

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -3142,6 +3142,12 @@ REFERENCES:
              fundamental domains for the subgroups of the modular
              group*, preprint :arxiv:`0901.1340`
 
+.. [GowdaTrott2014] Muddappa Seetharama Gowda and David Trott. On the
+                    irreducibility, Lyapunov rank, and automorphisms
+                    of special Bishop–Phelps cones. Journal of
+                    Mathematical Analysis and Applications,
+                    419(1):172-184, 2014.
+
 .. [GP2012] Eddy Godelle and Luis Paris.
             *Basic questions on Artin-Tits groups*. A. Björner et al. (eds)
             Configuration spaces, CRM series. (2012) pp. 299--311.

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -3286,6 +3286,12 @@ REFERENCES:
              of SPQR-Trees*, International Symposium on Graph Drawing,
              (2001) 77-90
 
+.. [GulTunc1998] Osman Güler and Levent Tunçel.
+                 Characterization of the barrier parameter of
+                 homogenous convex cones.
+                 Mathematical Programming, 81(1):55-76, 1998,
+                 :doi:`10.1007/BF01584844`.
+
 .. [GW1999] Frederick M. Goodman and Hans Wenzl. *Crystal bases of quantum
             affine algebras and affine Kazhdan-Lusztig polyonmials*.
             Int. Math. Res. Notices **5** (1999), 251-275.

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -6451,6 +6451,12 @@ REFERENCES:
 
 .. [Sto2011] \A. Storjohann, Email Communication. 30 May 2011.
 
+.. [StoerWitz1970] Josef Stoer and Christoph Witzgall.
+                   Convexity and Optimization in Finite Dimensions I, vol.
+                   163 of Grundlehren der mathematischen Wissenschaften.
+                   Springer-Verlag, New York, 1970. ISBN 9783642462184,
+                   :doi:`10.1007/978-3-642-46216-0`.
+
 .. [Str1969] Volker Strassen. *Gaussian elimination is not
              optimal*. Numerische Mathematik, 13:354-356, 1969.
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6662,6 +6662,94 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
                     X.set_immutable()
                     yield X
 
+    def is_linearly_isomorphic(self, other):
+        r"""
+        Return ``True`` if ``self`` and ``other`` are linearly isomorphic
+        over the rationals, and ``False`` otherwise.
+
+        INPUT:
+
+        - ``other`` -- :class:`ConvexRationalPolyhedralCone`;
+          the cone to check for isomorphism with ``self``
+
+        OUTPUT:
+
+        ``True`` if there exists an invertible linear matrix with rational
+        entries mapping ``self`` to ``other``, and ``False`` otherwise.
+
+        ALGORITHM:
+
+        We attempt to construct an explicit isomorphism using
+        :meth:`linear_isomorphisms`. For more information, see the
+        documentation of that method.
+
+        .. SEEALSO::
+
+            :meth:`linear_isomorphisms`, :meth:`is_isomorphic`,
+            :meth:`is_equivalent`
+
+        EXAMPLES:
+
+        Two different descriptions of the plane should be isomorphic::
+
+            sage: K1 = Cone([(1,0), (-1,0), (0,1), (0,-1)])
+            sage: K2 = Cone([(1,1), (-1,1), (0,-1)])
+            sage: K1.is_equivalent(K2)
+            True
+            sage: K1.is_linearly_isomorphic(K2)
+            True
+
+        All simplicial cones with the same number of rays are isomorphic::
+
+            sage: K1 = random_cone(max_ambient_dim=5)
+            sage: while not K1.is_simplicial():
+            ....:     K1 = random_cone(max_ambient_dim=5)
+            sage: n = K1.lattice_dim()
+            sage: r = K1.nrays()
+            sage: K2 = random_cone(min_ambient_dim=n,
+            ....:                  max_ambient_dim=n,
+            ....:                  min_rays=r,
+            ....:                  max_rays=r,
+            ....:                  strictly_convex=True)
+            sage: K2.is_simplicial()
+            True
+            sage: K1.is_linearly_isomorphic(K2)
+            True
+
+        TESTS:
+
+        Every cone is isomorphic to itself::
+
+            sage: K = random_cone(max_ambient_dim=5)
+            sage: K.is_linearly_isomorphic(K)
+            True
+
+        Isomorphism is symmetric::
+
+            sage: K = random_cone(max_ambient_dim=5)
+            sage: J = random_cone(min_ambient_dim=K.lattice_dim(),
+            ....:                 max_ambient_dim=K.lattice_dim(),
+            ....:                 min_rays=K.nrays(),
+            ....:                 max_rays=K.nrays())
+            sage: K.is_linearly_isomorphic(J) == J.is_linearly_isomorphic(K)
+            True
+
+        Isomorphism is symmetric in the example from :issue:`37957`::
+
+            sage: K1 = Cone([(1,-5,8), (-1,4,8), (3,2,19)])
+            sage: K2 = Cone([(1,0,0), (0,1,0), (1,1,3)])
+            sage: K1.is_linearly_isomorphic(K2)
+            True
+            sage: K2.is_linearly_isomorphic(K1)
+            True
+
+        """
+        try:
+            next(self.linear_isomorphisms(other))
+            return True
+        except StopIteration:
+            return False
+
 
 def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
                 min_rays=0, max_rays=None, strictly_convex=None, solid=None):

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3067,16 +3067,26 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         - ``True`` if ``self`` and ``other`` define the same cones as sets of
           points in the same lattice, ``False`` otherwise.
 
-        There are three different equivalences between cones `C_1` and `C_2`
-        in the same lattice:
+        .. NOTE::
 
-        #. They have the same generating rays in the same order.
-           This is tested by ``C1 == C2``.
-        #. They describe the same sets of points.
-           This is tested by ``C1.is_equivalent(C2)``.
-        #. They are in the same orbit of `GL(n,\ZZ)` (and, therefore,
-           correspond to isomorphic affine toric varieties).
-           This is tested by ``C1.is_isomorphic(C2)``.
+            There are four different equivalences between cones `C_1`
+            and `C_2` in the same lattice:
+
+            #. They have the same generating rays in the same order.
+               This is tested by ``C1 == C2``.
+            #. They describe the same sets of points. This is tested
+               by ``C1.is_equivalent(C2)``.
+            #. They are in the same orbit of `GL(n,\ZZ)` (and,
+               therefore, correspond to isomorphic affine toric
+               varieties).  This is tested by
+               ``C1.is_isomorphic(C2)``.
+            #. They are equivalent under an invertible linear map of
+               their ambient vector spaces. This is tested by
+               ``C1.is_linearly_isomorphic(C2)``.
+
+        .. SEEALSO::
+
+            :meth:`is_isomorphic`, :meth:`is_linearly_isomorphic`
 
         EXAMPLES::
 
@@ -3188,19 +3198,31 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         - ``other`` -- cone
 
-        OUTPUT: ``True`` if ``self`` and ``other`` are in the same
+        OUTPUT:
+
+        ``True`` if ``self`` and ``other`` are in the same
         `GL(n, \ZZ)`-orbit, ``False`` otherwise
 
-        There are three different equivalences between cones `C_1` and `C_2`
-        in the same lattice:
+        .. NOTE::
 
-        #. They have the same generating rays in the same order.
-           This is tested by ``C1 == C2``.
-        #. They describe the same sets of points.
-           This is tested by ``C1.is_equivalent(C2)``.
-        #. They are in the same orbit of `GL(n,\ZZ)` (and, therefore,
-           correspond to isomorphic affine toric varieties).
-           This is tested by ``C1.is_isomorphic(C2)``.
+            There are four different equivalences between cones `C_1`
+            and `C_2` in the same lattice:
+
+            #. They have the same generating rays in the same order.
+               This is tested by ``C1 == C2``.
+            #. They describe the same sets of points. This is tested
+               by ``C1.is_equivalent(C2)``.
+            #. They are in the same orbit of `GL(n,\ZZ)` (and,
+               therefore, correspond to isomorphic affine toric
+               varieties).  This is tested by
+               ``C1.is_isomorphic(C2)``.
+            #. They are equivalent under an invertible linear map of
+               their ambient vector spaces. This is tested by
+               ``C1.is_linearly_isomorphic(C2)``.
+
+        .. SEEALSO::
+
+            :meth:`is_equivalent`, :meth:`is_linearly_isomorphic`
 
         EXAMPLES::
 
@@ -6676,6 +6698,23 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         ``True`` if there exists an invertible linear matrix with rational
         entries mapping ``self`` to ``other``, and ``False`` otherwise.
+
+        .. NOTE::
+
+            There are four different equivalences between cones `C_1`
+            and `C_2` in the same lattice:
+
+            #. They have the same generating rays in the same order.
+               This is tested by ``C1 == C2``.
+            #. They describe the same sets of points. This is tested
+               by ``C1.is_equivalent(C2)``.
+            #. They are in the same orbit of `GL(n,\ZZ)` (and,
+               therefore, correspond to isomorphic affine toric
+               varieties).  This is tested by
+               ``C1.is_isomorphic(C2)``.
+            #. They are equivalent under an invertible linear map of
+               their ambient vector spaces. This is tested by
+               ``C1.is_linearly_isomorphic(C2)``.
 
         ALGORITHM:
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6423,7 +6423,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         subspaces of the same dimension, so in this case, the cone
         isomorphisms we generate should be considered unique only up
         to vector-space isomorphisms of the lineality spaces and
-        othogonal complements.
+        orthogonal complements.
 
         Every closed convex cone is a direct sum of three components,
         themselves closed convex cones [StoerWitz1970]_:

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6483,7 +6483,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         have computed the automorphism groups of these cones, and we
         recover them all up to a positive scalar::
 
-            sage: # long time
             sage: K1 = Cone([(1,0,1), (-1,0,1), (0,1,1), (0,-1,1)])
             sage: G = set(K1.linear_isomorphisms(K1)); G
             {[-1  0  0]

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6285,6 +6285,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         equal in the next two cases without a little nudge in the
         right direction, and, moreover, it's crashy about it::
 
+            sage: # long time
             sage: n = 4
             sage: K = cones.schur(n)
             sage: actual = K.max_angle()[0].simplify()._sympy_()._sage_()

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6668,8 +6668,8 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         MS = V.basis_matrix().matrix_space()
         from itertools import permutations
         for rs1 in permutations(L_perps, n):
+            A = MS(list(rs1) + self_extra_rows)
             for rs2 in permutations(M_perps, n):
-                A = MS(list(rs1) + self_extra_rows)
                 B = MS(list(rs2) + other_extra_rows)
                 try:
                     X = A.solve_right(B, extend=False)

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6439,7 +6439,8 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         .. SEEALSO::
 
-            :func:`sage.geometry.fan_isomorphism.fan_isomorphism_generator`
+            :func:`sage.geometry.fan_isomorphism.fan_isomorphism_generator`,
+            :meth:`is_linearly_isomorphic`
 
         EXAMPLES:
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6673,11 +6673,14 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         #      original cone
         #
         MS = V.basis_matrix().matrix_space()
-        from itertools import permutations
+        from itertools import combinations, permutations
         for rs1 in permutations(L_perps, n):
             rs1 = list(rs1)
             A = MS(rs1 + self_extra_rows)
-            for rs2 in permutations(M_perps, n):
+
+            # We don't need the reorderings of the second set because
+            # we're trying all possible orderings of the first.
+            for rs2 in combinations(M_perps, n):
                 rs2 = list(rs2)
                 B = MS(rs2 + other_extra_rows)
                 try:

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6717,16 +6717,16 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
                their ambient vector spaces. This is tested by
                ``C1.is_linearly_isomorphic(C2)``.
 
+        .. SEEALSO::
+
+            :meth:`linear_isomorphisms`, :meth:`is_isomorphic`,
+            :meth:`is_equivalent`
+
         ALGORITHM:
 
         We attempt to construct an explicit isomorphism using
         :meth:`linear_isomorphisms`. For more information, see the
         documentation of that method.
-
-        .. SEEALSO::
-
-            :meth:`linear_isomorphisms`, :meth:`is_isomorphic`,
-            :meth:`is_equivalent`
 
         EXAMPLES:
 


### PR DESCRIPTION
Implement linear isomorphism generation and testing for convex cones. Convex cones can be created in Sage with the `Cone()` function. These cones already have an `is_isomorphic()` method, but this tests a property that is relevant in toric geometry rather than the equivalence under an invertible linear map. The latter is more useful in optimization, in particular.
