### PR TITLE
Build sirocco extension with C++

### DIFF
--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -48,7 +48,6 @@ extension_data = {
   'ecl' : files('ecl.pyx'),
   'homfly' : files('homfly.pyx'),
   'libecm' : files('libecm.pyx'),
-  'sirocco': files('sirocco.pyx'),
   'meataxe': files('meataxe.pyx'),
 }
 
@@ -56,9 +55,7 @@ dependencies = [py_dep, cysignals, ecl, gc, gmp]
 
 foreach name, pyx : extension_data
   deps = dependencies
-  if name == 'sirocco'
-    deps += [sirocco]
-  elif name == 'meataxe'
+  if name == 'meataxe'
     deps += [mtx]
   elif name == 'homfly'
     deps += [homfly]
@@ -76,12 +73,17 @@ foreach name, pyx : extension_data
   )
 endforeach
 
-extension_data_cpp = {'braiding': files('braiding.pyx')}
+extension_data_cpp = {
+  'braiding': files('braiding.pyx'),
+  'sirocco': files('sirocco.pyx'),
+}
 
 foreach name, pyx : extension_data_cpp
   deps = dependencies
   if name == 'braiding'
     deps += [braiding]
+  elif name == 'sirocco'
+    deps += [sirocco]
   endif
   py.extension_module(
     name,


### PR DESCRIPTION
Sirocco is a C++ library. Without this, the library symbols are not mangled and the extension is unloadable:

```
sage: from sage.libs.sirocco import contpath
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[1], line 1
----> 1 from sage.libs.sirocco import contpath

ImportError: /usr/lib/python3.13/site-packages/sage/libs/sirocco.cpython-313-x86_64-linux-gnu.so: undefined symbol: homotopyPath_mp_comps
```


