### PR TITLE
Silence more rpy2 3.6 warnings

### DIFF
--- a/src/sage/all__sagemath_repl.py
+++ b/src/sage/all__sagemath_repl.py
@@ -103,7 +103,7 @@ warnings.filterwarnings('ignore', category=DeprecationWarning,
 # rpy2>=3.6 emits warnings for R modifying LD_LIBRARY_PATH
 warnings.filterwarnings('ignore', category=UserWarning,
                         message=r".*redefined by R and overriding existing variable.*",
-                        module='rpy2.robjects')
+                        module='rpy2.*')
 
 from sage.all__sagemath_objects import *
 from sage.all__sagemath_environment import *


### PR DESCRIPTION
The `rpy2.rinterface` module throws warnings in 3.6, silence them too
