### PR TITLE
Do not ignore env.py fallbacks for empty variables in config.py

### DIFF
--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -159,9 +159,9 @@ def var(key: str, *fallbacks: Optional[str], force: bool = False) -> Optional[st
             except ImportError:
                 pass
 
-    # Try all fallbacks in order as long as we don't have a value
+    # Try all fallbacks in order as long as we don't have a non-empty value
     for f in fallbacks:
-        if value is not None:
+        if value not in (None, ""):
             break
         value = f
     SAGE_ENV[key] = value


### PR DESCRIPTION
If a variable is set to the empty string in config.py, consider the fallbacks defined in env.py

In particular, this fixes MATHJAX_DIR outside sage-the-distro
