### PR TITLE
Improve construction of narrow class groups

### DIFF
--- a/src/sage/rings/number_field/class_group.py
+++ b/src/sage/rings/number_field/class_group.py
@@ -321,6 +321,18 @@ class FractionalIdealClass(AbelianGroupWithValuesElement):
         """
         return self.ideal().gens()
 
+class NarrowFractionalIdealClass(FractionalIdealClass):
+    def _repr_(self):
+        r"""
+        Return a string representation of the narrow ideal class of this fractional ideal.
+
+        EXAMPLES::
+
+        """
+        if self.is_trivial():
+            return 'Trivial narrow ideal class'
+        return 'Fractional narrow ideal class %s' % self._value._repr_short()
+    pass
 
 class SFractionalIdealClass(FractionalIdealClass):
     r"""
@@ -628,6 +640,24 @@ class ClassGroup(AbelianGroupWithValues_class):
         """
         return self._number_field
 
+class NarrowClassGroup(ClassGroup):
+    Element = NarrowFractionalIdealClass
+
+    def __init__(self, gens_orders, names, number_field, gens, proof=True):
+        r"""
+        Create a narrow class group.
+        """
+        AbelianGroupWithValues_class.__init__(self, gens_orders, names, gens,
+                                              values_group=number_field.ideal_monoid())
+        self._proof_flag = proof
+        self._number_field = number_field
+
+    def _repr_(self):
+        s = 'Narrow class group of order %s ' % self.order()
+        if self.order() > 1:
+            s += 'with structure %s ' % self._group_notation(self.gens_orders())
+        s += 'of %s' % self.number_field()
+        return s
 
 class SClassGroup(ClassGroup):
     r"""

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -6719,12 +6719,12 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
 
             sage: x = polygen(QQ, 'x')
             sage: NumberField(x^3 + x + 9, 'a').narrow_class_group()
-            Multiplicative Abelian group isomorphic to C2
+            Narrow class group of order 2 with structure C2 of Number Field in a with defining polynomial x^3 + x + 9
 
         TESTS::
 
             sage: QuadraticField(3, 'a').narrow_class_group()
-            Multiplicative Abelian group isomorphic to C2
+            Narrow class group of order 2 with structure C2 of Number Field in a with defining polynomial x^2 - 3 with a = 1.732050807568878?
         """
         from .class_group import NarrowClassGroup
 


### PR DESCRIPTION
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
This PR attempts to construct narrow class fields with similar functionality to the class field.
<!-- v Why is this change required? What problem does it solve? -->
It will allow getting the narrow class of a given ideal, for example #40359.
### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


