### PR TITLE
Remove precisely the prefix instead of strip

### DIFF
--- a/src/sage/interfaces/singular.py
+++ b/src/sage/interfaces/singular.py
@@ -1654,7 +1654,7 @@ class SingularElement(ExtraTabCompletion, ExpectElement, sage.interfaces.abc.Sin
             is_extension = False
         else:
             # it ought to be a finite field
-            q = ZZ(charstr[0].lstrip('ZZ/'))
+            q = ZZ(charstr[0].removeprefix('ZZ/'))
             from sage.rings.finite_rings.finite_field_constructor import GF
             if q.is_prime():
                 br = GF(q)

--- a/src/sage/plot/misc.py
+++ b/src/sage/plot/misc.py
@@ -420,20 +420,20 @@ def get_matplotlib_linestyle(linestyle, return_type):
         return None
 
     if linestyle.startswith("default"):
-        return get_matplotlib_linestyle(linestyle.strip("default"), "short")
+        return get_matplotlib_linestyle(linestyle.removeprefix("default"), "short")
     elif linestyle.startswith("steps"):
         if linestyle.startswith("steps-mid"):
             return "steps-mid" + get_matplotlib_linestyle(
-                linestyle.strip("steps-mid"), "short")
+                linestyle.removeprefix("steps-mid"), "short")
         elif linestyle.startswith("steps-post"):
             return "steps-post" + get_matplotlib_linestyle(
-                linestyle.strip("steps-post"), "short")
+                linestyle.removeprefix("steps-post"), "short")
         elif linestyle.startswith("steps-pre"):
             return "steps-pre" + get_matplotlib_linestyle(
-                linestyle.strip("steps-pre"), "short")
+                linestyle.removeprefix("steps-pre"), "short")
         else:
             return "steps" + get_matplotlib_linestyle(
-                linestyle.strip("steps"), "short")
+                linestyle.removeprefix("steps"), "short")
 
     if return_type == 'short':
         if linestyle in short_to_long_dict.keys():


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Hello,

I am a first time contributor, still navigating the `sage` huge codebase. Please let me know if I am not aware of something. 

This PR resolves a few occurrences of the error [B005](https://docs.astral.sh/ruff/rules/strip-with-multi-characters/) from `ruff`. 

It looks pretty clear to me that that intent of the code is to remove precisely these prefixes rather than, for example, removing all the leading occurrences of the letters d, e, f, a, u, l, t. I think the example in the docs of `ruff` illustrates quite well the difference. 

Tested with `ruff check src/sage --select B005`

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


