### PR TITLE
use generic isogeny call to opportunistically use velusqrt

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -219,7 +219,7 @@ def isogeny_codomain_from_kernel(E, kernel):
     if algorithm == 'velu':
         # if we are using Velu's formula, just instantiate the isogeny
         # and return the codomain
-        return EllipticCurveIsogeny(E, kernel).codomain()
+        return E.isogeny(kernel).codomain()
 
     if algorithm == 'kohel':
         return compute_codomain_kohel(E, kernel)


### PR DESCRIPTION
Before only velu formulas were used for this codomain, but for points with large or composite order we have better options within the E.isogeny method, so we should use these.