### PR TITLE
Fix GF(2) matrix transpose with subdivisions

### DIFF
--- a/src/sage/matrix/matrix_complex_ball_dense.pyx
+++ b/src/sage/matrix/matrix_complex_ball_dense.pyx
@@ -575,17 +575,17 @@ cdef class Matrix_complex_ball_dense(Matrix_dense):
 
             sage: m = matrix(CBF,0,2)
             sage: m.subdivide([],[1])
-            sage: m._subdivisions
-            ([0, 0], [0, 1, 2])
-            sage: m.transpose()._subdivisions
-            ([0, 1, 2], [0, 0])
+            sage: m.subdivisions()
+            ([], [1])
+            sage: m.transpose().subdivisions()
+            ([1], [])
 
             sage: m = matrix(CBF,2,0)
             sage: m.subdivide([1],[])
-            sage: m._subdivisions
-            ([0, 1, 2], [0, 0])
-            sage: m.transpose()._subdivisions
-            ([0, 0], [0, 1, 2])
+            sage: m.subdivisions()
+            ([1], [])
+            sage: m.transpose().subdivisions()
+            ([], [1])
         """
         cdef Py_ssize_t nc = self._ncols
         cdef Py_ssize_t nr = self._nrows

--- a/src/sage/matrix/matrix_complex_ball_dense.pyx
+++ b/src/sage/matrix/matrix_complex_ball_dense.pyx
@@ -558,6 +558,34 @@ cdef class Matrix_complex_ball_dense(Matrix_dense):
             [3.000000000000000 6.000000000000000]
             sage: m.transpose().parent()
             Full MatrixSpace of 3 by 2 dense matrices over Complex ball field with 53 bits of precision
+
+        TESTS::
+
+            sage: m = matrix(CBF,2,3,range(6))
+            sage: m.subdivide([1],[2])
+            sage: m
+            [                0 1.000000000000000|2.000000000000000]
+            [-----------------------------------+-----------------]
+            [3.000000000000000 4.000000000000000|5.000000000000000]
+            sage: m.transpose()
+            [                0|3.000000000000000]
+            [1.000000000000000|4.000000000000000]
+            [-----------------+-----------------]
+            [2.000000000000000|5.000000000000000]
+
+            sage: m = matrix(CBF,0,2)
+            sage: m.subdivide([],[1])
+            sage: m._subdivisions
+            ([0, 0], [0, 1, 2])
+            sage: m.transpose()._subdivisions
+            ([0, 1, 2], [0, 0])
+
+            sage: m = matrix(CBF,2,0)
+            sage: m.subdivide([1],[])
+            sage: m._subdivisions
+            ([0, 1, 2], [0, 0])
+            sage: m.transpose()._subdivisions
+            ([0, 0], [0, 1, 2])
         """
         cdef Py_ssize_t nc = self._ncols
         cdef Py_ssize_t nr = self._nrows

--- a/src/sage/matrix/matrix_complex_ball_dense.pyx
+++ b/src/sage/matrix/matrix_complex_ball_dense.pyx
@@ -563,6 +563,9 @@ cdef class Matrix_complex_ball_dense(Matrix_dense):
         cdef Py_ssize_t nr = self._nrows
         cdef Matrix_complex_ball_dense trans = self._new(nc, nr)
         acb_mat_transpose(trans.value, self.value)
+        if self._subdivisions is not None:
+            row_divs, col_divs = self.subdivisions()
+            trans.subdivide(col_divs, row_divs)
         return trans
 
     def _solve_right_nonsingular_square(self, Matrix_complex_ball_dense rhs, check_rank=None):

--- a/src/sage/matrix/matrix_gap.pyx
+++ b/src/sage/matrix/matrix_gap.pyx
@@ -361,18 +361,18 @@ cdef class Matrix_gap(Matrix_dense):
             sage: M = MatrixSpace(QQ, 0, 2, implementation='gap')
             sage: m = M([])
             sage: m.subdivide([],[1])
-            sage: m._subdivisions
-            ([0, 0], [0, 1, 2])
-            sage: m.transpose()._subdivisions
-            ([0, 1, 2], [0, 0])
+            sage: m.subdivisions()
+            ([], [1])
+            sage: m.transpose().subdivisions()
+            ([1], [])
 
             sage: M = MatrixSpace(QQ, 2, 0, implementation='gap')
             sage: m = M([])
             sage: m.subdivide([1],[])
-            sage: m._subdivisions
-            ([0, 1, 2], [0, 0])
-            sage: m.transpose()._subdivisions
-            ([0, 0], [0, 1, 2])
+            sage: m.subdivisions()
+            ([1], [])
+            sage: m.transpose().subdivisions()
+            ([], [1])
         """
         cdef Matrix_gap M
         M = self._new(self._ncols, self._nrows)

--- a/src/sage/matrix/matrix_gap.pyx
+++ b/src/sage/matrix/matrix_gap.pyx
@@ -342,6 +342,37 @@ cdef class Matrix_gap(Matrix_dense):
             [ 4]
             [ 2]
             [52]
+
+        TESTS::
+
+            sage: M = MatrixSpace(QQ, 2, 3, implementation='gap')
+            sage: m = M(range(6))
+            sage: m.subdivide([1],[2])
+            sage: m
+            [0 1|2]
+            [---+-]
+            [3 4|5]
+            sage: m.transpose()
+            [0|3]
+            [1|4]
+            [-+-]
+            [2|5]
+
+            sage: M = MatrixSpace(QQ, 0, 2, implementation='gap')
+            sage: m = M([])
+            sage: m.subdivide([],[1])
+            sage: m._subdivisions
+            ([0, 0], [0, 1, 2])
+            sage: m.transpose()._subdivisions
+            ([0, 1, 2], [0, 0])
+
+            sage: M = MatrixSpace(QQ, 2, 0, implementation='gap')
+            sage: m = M([])
+            sage: m.subdivide([1],[])
+            sage: m._subdivisions
+            ([0, 1, 2], [0, 0])
+            sage: m.transpose()._subdivisions
+            ([0, 0], [0, 1, 2])
         """
         cdef Matrix_gap M
         M = self._new(self._ncols, self._nrows)

--- a/src/sage/matrix/matrix_gap.pyx
+++ b/src/sage/matrix/matrix_gap.pyx
@@ -346,6 +346,9 @@ cdef class Matrix_gap(Matrix_dense):
         cdef Matrix_gap M
         M = self._new(self._ncols, self._nrows)
         M._libgap = self._libgap.TransposedMat()
+        if self._subdivisions is not None:
+            row_divs, col_divs = self.subdivisions()
+            M.subdivide(col_divs, row_divs)
         return M
 
     def determinant(self):

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1496,10 +1496,9 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         """
         cdef Matrix_mod2_dense A = self.new_matrix(ncols=self._nrows,
                                                    nrows=self._ncols)
-        if self._nrows == 0 or self._ncols == 0:
-            return A
+        if self._nrows != 0 and self._ncols != 0:
+            A._entries = mzd_transpose(A._entries, self._entries)
 
-        A._entries = mzd_transpose(A._entries, self._entries)
         if self._subdivisions is not None:
             row_divs, col_divs = self.subdivisions()
             A.subdivide(col_divs, row_divs)

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1493,6 +1493,20 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             sage: A[0,0] = 0
             sage: B[0,0]
             1
+
+            sage: m = matrix(GF(2),0,2)
+            sage: m.subdivide([],[1])
+            sage: m._subdivisions
+            ([0, 0], [0, 1, 2])
+            sage: m.transpose()._subdivisions
+            ([0, 1, 2], [0, 0])
+
+            sage: m = matrix(GF(2),2,0)
+            sage: m.subdivide([1],[])
+            sage: m._subdivisions
+            ([0, 1, 2], [0, 0])
+            sage: m.transpose()._subdivisions
+            ([0, 0], [0, 1, 2])
         """
         cdef Matrix_mod2_dense A = self.new_matrix(ncols=self._nrows,
                                                    nrows=self._ncols)

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1496,17 +1496,17 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
 
             sage: m = matrix(GF(2),0,2)
             sage: m.subdivide([],[1])
-            sage: m._subdivisions
-            ([0, 0], [0, 1, 2])
-            sage: m.transpose()._subdivisions
-            ([0, 1, 2], [0, 0])
+            sage: m.subdivisions()
+            ([], [1])
+            sage: m.transpose().subdivisions()
+            ([1], [])
 
             sage: m = matrix(GF(2),2,0)
             sage: m.subdivide([1],[])
-            sage: m._subdivisions
-            ([0, 1, 2], [0, 0])
-            sage: m.transpose()._subdivisions
-            ([0, 0], [0, 1, 2])
+            sage: m.subdivisions()
+            ([1], [])
+            sage: m.transpose().subdivisions()
+            ([], [1])
         """
         cdef Matrix_mod2_dense A = self.new_matrix(ncols=self._nrows,
                                                    nrows=self._ncols)

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1501,7 +1501,8 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
 
         A._entries = mzd_transpose(A._entries, self._entries)
         if self._subdivisions is not None:
-            A.subdivide(*self.subdivisions())
+            row_divs, col_divs = self.subdivisions()
+            A.subdivide(col_divs, row_divs)
         return A
 
     cpdef _richcmp_(self, right, int op):

--- a/src/sage/matrix/matrix_numpy_dense.pyx
+++ b/src/sage/matrix/matrix_numpy_dense.pyx
@@ -266,6 +266,33 @@ cdef class Matrix_numpy_dense(Matrix_dense):
             []
             sage: m.transpose().parent()
             Full MatrixSpace of 3 by 0 dense matrices over Real Double Field
+
+        TESTS::
+            sage: m = matrix(RDF,2,3,range(6))
+            sage: m.subdivide([1],[2])
+            sage: m
+            [0.0 1.0|2.0]
+            [-------+---]
+            [3.0 4.0|5.0]
+            sage: m.transpose()
+            [0.0|3.0]
+            [1.0|4.0]
+            [---+---]
+            [2.0|5.0]
+
+            sage: m = matrix(RDF,0,2)
+            sage: m.subdivide([],[1])
+            sage: m._subdivisions
+            ([0, 0], [0, 1, 2])
+            sage: m.transpose()._subdivisions
+            ([0, 1, 2], [0, 0])
+
+            sage: m = matrix(RDF,2,0)
+            sage: m.subdivide([1],[])
+            sage: m._subdivisions
+            ([0, 1, 2], [0, 0])
+            sage: m.transpose()._subdivisions
+            ([0, 0], [0, 1, 2])
         """
         cdef Matrix_numpy_dense trans = self._new(self._ncols, self._nrows)
 

--- a/src/sage/matrix/matrix_numpy_dense.pyx
+++ b/src/sage/matrix/matrix_numpy_dense.pyx
@@ -267,12 +267,11 @@ cdef class Matrix_numpy_dense(Matrix_dense):
             sage: m.transpose().parent()
             Full MatrixSpace of 3 by 0 dense matrices over Real Double Field
         """
-        if self._nrows == 0 or self._ncols == 0:
-            return self.new_matrix(self._ncols, self._nrows)
+        cdef Matrix_numpy_dense trans = self._new(self._ncols, self._nrows)
 
-        cdef Matrix_numpy_dense trans
-        trans = self._new(self._ncols, self._nrows)
-        trans._matrix_numpy = self._matrix_numpy.transpose().copy()
+        if self._nrows != 0 and self._ncols != 0:
+            trans._matrix_numpy = self._matrix_numpy.transpose().copy()
+
         if self._subdivisions is not None:
             row_divs, col_divs = self.subdivisions()
             trans.subdivide(col_divs, row_divs)

--- a/src/sage/matrix/matrix_numpy_dense.pyx
+++ b/src/sage/matrix/matrix_numpy_dense.pyx
@@ -268,6 +268,7 @@ cdef class Matrix_numpy_dense(Matrix_dense):
             Full MatrixSpace of 3 by 0 dense matrices over Real Double Field
 
         TESTS::
+
             sage: m = matrix(RDF,2,3,range(6))
             sage: m.subdivide([1],[2])
             sage: m
@@ -282,17 +283,17 @@ cdef class Matrix_numpy_dense(Matrix_dense):
 
             sage: m = matrix(RDF,0,2)
             sage: m.subdivide([],[1])
-            sage: m._subdivisions
-            ([0, 0], [0, 1, 2])
-            sage: m.transpose()._subdivisions
-            ([0, 1, 2], [0, 0])
+            sage: m.subdivisions()
+            ([], [1])
+            sage: m.transpose().subdivisions()
+            ([1], [])
 
             sage: m = matrix(RDF,2,0)
             sage: m.subdivide([1],[])
-            sage: m._subdivisions
-            ([0, 1, 2], [0, 0])
-            sage: m.transpose()._subdivisions
-            ([0, 0], [0, 1, 2])
+            sage: m.subdivisions()
+            ([1], [])
+            sage: m.transpose().subdivisions()
+            ([], [1])
         """
         cdef Matrix_numpy_dense trans = self._new(self._ncols, self._nrows)
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

A small bug I noticed when looking at the code for transposing matrices. GF(2) does not properly transpose its subdivisions, meaning transposed matrices can have incorrect subdivisions or cause errors if the indices fall out of range.

sage: M = matrix.random(GF(2),3,3)
sage: N = matrix.block([[M,M,M]])
sage: M
[1 0 0]
[0 0 1]
[0 1 0]
sage: N
[1 0 0|1 0 0|1 0 0]
[0 0 1|0 0 1|0 0 1]
[0 1 0|0 1 0|0 1 0]
sage: N.transpose()
<repr(<sage.matrix.matrix_mod2_dense.Matrix_mod2_dense at 0x7f1eb7f0c1c0>) failed: IndexError: list index out of range>

This also adds subdivision handling to transposes of matrix_complex_ball_dense, matrix_gap, and fixes subdivisions for transposes of empty matrices of type matrix_mod2_dense, matrix_numpy_dense