### PR TITLE
src/sage/interfaces/maxima_lib.py: remove old workaround

### DIFF
--- a/src/sage/interfaces/maxima_lib.py
+++ b/src/sage/interfaces/maxima_lib.py
@@ -173,15 +173,9 @@ ecl_eval("(setf $errormsg nil)")
 # question and returning the answer. Our version throws an error in
 # which the text of the question is included. This is accomplished by
 # redirecting *standard-output* to a string.
-#
-# After an update in Issue 31553, this routine also preprocesses the
-# text to replace space symbols with strings. This prevents those
-# symbols from being turned into ugly newlines -- a problem that we
-# used to avoid with a custom patch.
 ecl_eval(r"""
 (defun retrieve (msg flag &aux (print? nil))
   (declare (special msg flag print?))
-  (setq msg (mapcar #'(lambda (x) (if (eq x '| |) " " x)) msg))
   (or (eq flag 'noprint) (setq print? t))
   (error
     (concatenate 'string


### PR DESCRIPTION
One of our Maxima monkey-patches was merged upstream some time ago: https://sourceforge.net/p/maxima/patches/102/

Now that it has been a while, we may assume that the fix is present in Maxima. As a result, the workaround from https://github.com/sagemath/sage/issues/31553 can be removed.

Closes: https://github.com/sagemath/sage/issues/32611
