### PR TITLE
Add temporary naive transpose for GF(2^e)

### DIFF
--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1179,8 +1179,6 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         
         cdef Matrix_gf2e_dense A = self.new_matrix(ncols=nrows,
                                                    nrows=ncols)
-        if nrows == 0 or ncols == 0:
-            return A
         
         cdef Py_ssize_t i, j
         for i from 0 <= i < ncols:

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1138,40 +1138,41 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         We create a matrix, compute its transpose, and note that
         the original matrix is not changed. ::
 
-            sage: M = matrix(GF(4),[[0,[0,1],0],[0,[1,1],1],[0,0,0]])
+            sage: K.<a> = GF(4)
+            sage: M = matrix(K,[[0,[0,1],0],[0,[1,1],1],[0,0,0]])
             sage: M
-            [     0     z2      0]
-            [     0 z2 + 1      1]
-            [     0      0      0]
+            [    0     a     0]
+            [    0 a + 1     1]
+            [    0     0     0]
             sage: N = M.transpose()
             sage: N
-            [     0      0      0]
-            [    z2 z2 + 1      0]
-            [     0      1      0]
+            [    0     0     0]
+            [    a a + 1     0]
+            [    0     1     0]
             sage: M
-            [     0     z2      0]
-            [     0 z2 + 1      1]
-            [     0      0      0]
+            [    0     a     0]
+            [    0 a + 1     1]
+            [    0     0     0]
 
         ``.T`` is a convenient shortcut for the transpose::
 
             sage: M.T
-            [     0      0      0]
-            [    z2 z2 + 1      0]
-            [     0      1      0]
+            [    0     0     0]
+            [    a a + 1     0]
+            [    0     1     0]
 
         ::
 
             sage: M.subdivide(None, 1)
             sage: M
-            [     0|    z2      0]
-            [     0|z2 + 1      1]
-            [     0|     0      0]
+            [    0|    a     0]
+            [    0|a + 1     1]
+            [    0|    0     0]
             sage: M.transpose()
-            [     0      0      0]
-            [--------------------]
-            [    z2 z2 + 1      0]
-            [     0      1      0]
+            [    0     0     0]
+            [-----------------]
+            [    a a + 1     0]
+            [    0     1     0]
         """
         # temporary until mzed_transpose from M4RIE makes its way into Sage
         cdef Py_ssize_t nrows = self._nrows

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1129,6 +1129,68 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
             return
         mzed_col_swap(self._entries, col1, col2)
 
+    def transpose(self):
+        """
+        Return the transpose of ``self``, without changing ``self``.
+
+        EXAMPLES:
+
+        We create a matrix, compute its transpose, and note that
+        the original matrix is not changed. ::
+
+            sage: M = matrix(GF(4),[[0,[0,1],0],[0,[1,1],1],[0,0,0]])
+            sage: M
+            [     0     z2      0]
+            [     0 z2 + 1      1]
+            [     0      0      0]
+            sage: N = M.transpose()
+            sage: N
+            [     0      0      0]
+            [    z2 z2 + 1      0]
+            [     0      1      0]
+            sage: M
+            [     0     z2      0]
+            [     0 z2 + 1      1]
+            [     0      0      0]
+
+        ``.T`` is a convenient shortcut for the transpose::
+
+            sage: M.T
+            [     0      0      0]
+            [    z2 z2 + 1      0]
+            [     0      1      0]
+
+        ::
+
+            sage: M.subdivide(None, 1)
+            sage: M
+            [     0|    z2      0]
+            [     0|z2 + 1      1]
+            [     0|     0      0]
+            sage: M.transpose()
+            [     0      0      0]
+            [--------------------]
+            [    z2 z2 + 1      0]
+            [     0      1      0]
+        """
+        # temporary until mzed_transpose from M4RIE makes its way into Sage
+        cdef Py_ssize_t nrows = self._nrows
+        cdef Py_ssize_t ncols = self._ncols
+        
+        cdef Matrix_gf2e_dense A = self.new_matrix(ncols=nrows,
+                                                   nrows=ncols)
+        if nrows == 0 or ncols == 0:
+            return A
+        
+        cdef Py_ssize_t i, j
+        for i from 0 <= i < ncols:
+            for j from 0 <= j < nrows:
+                mzed_write_elem(A._entries, i, j, mzed_read_elem(self._entries, j, i))
+        if self._subdivisions is not None:
+            row_divs, col_divs = self.subdivisions()
+            A.subdivide(col_divs, row_divs)
+        return A
+
     def augment(self, right):
         """
         Augments ``self`` with ``right``.

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1139,7 +1139,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         the original matrix is not changed::
 
             sage: K.<a> = GF(4)
-            sage: M = matrix(K,[[0,[0,1],0],[0,[1,1],1],[0,0,0]])
+            sage: M = matrix(K, [[0, a, 0], [0, a+1, 1], [0, 0, 0]])
             sage: M
             [    0     a     0]
             [    0 a + 1     1]

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1131,7 +1131,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
 
     def transpose(self):
         """
-        Return the transpose of ``self``, without changing ``self``.
+        Return the transpose of ``self``.
 
         EXAMPLES:
 

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1136,7 +1136,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         EXAMPLES:
 
         We create a matrix, compute its transpose, and note that
-        the original matrix is not changed. ::
+        the original matrix is not changed::
 
             sage: K.<a> = GF(4)
             sage: M = matrix(K,[[0,[0,1],0],[0,[1,1],1],[0,0,0]])


### PR DESCRIPTION
The transpose for matrices over GF(2^e) is currently extremely slow due to the lack of mzed_transpose in M4RIE. I have made a PR to add one (https://github.com/malb/m4rie/pull/8), but in the mean time, this is a temporary performance fix direct in Sage.

Currently, the transpose is costly enough that for medium-sized matrices it takes a significant amount of the time of pivot_rows():

sage: fields = [GF(2\**2),GF(2\**4),GF(2\**8),GF(2\**16),GF(next_prime(2\**20))]
sage: for field in fields:
....:     M = matrix.random(field,512,512)
....:     print(field)
....:     timeit('M._clear_cache();M.transpose()')
....:     timeit('M._clear_cache();M.pivot_rows()')
....:
Finite Field in z2 of size 2^2
5 loops, best of 3: 128 ms per loop
5 loops, best of 3: 145 ms per loop
Finite Field in z4 of size 2^4
5 loops, best of 3: 130 ms per loop
5 loops, best of 3: 139 ms per loop
Finite Field in z8 of size 2^8
5 loops, best of 3: 145 ms per loop
5 loops, best of 3: 155 ms per loop
Finite Field in z16 of size 2^16
5 loops, best of 3: 1.12 s per loop
5 loops, best of 3: 3.82 s per loop
Finite Field of size 1048583
625 loops, best of 3: 1.15 ms per loop
25 loops, best of 3: 33.6 ms per loop

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
- #40435: I'm going to make a more generic version of this that can be used for general copying
