### PR TITLE
src/sage/groups/perm_gps/permgroup.py: bullet-proof a test

### DIFF
--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -3131,15 +3131,11 @@ class PermutationGroup_generic(FiniteGroup):
 
             sage: PermutationGroup([]).as_finitely_presented_group()
             Finitely presented group < a | a >
-            sage: S = SymmetricGroup(6)
+            sage: S = SymmetricGroup(4)
             sage: perm_ls = [S.random_element() for i in range(3)]
             sage: G = PermutationGroup(perm_ls)
-            sage: while True:
-            ....:     try:
-            ....:         assert G.as_finitely_presented_group().as_permutation_group().is_isomorphic(G)  # sometimes results in GAP error (see :issue:`32141`)
-            ....:         break
-            ....:     except ValueError:
-            ....:         pass
+            sage: G.as_finitely_presented_group().as_permutation_group().is_isomorphic(G)
+            True
 
         `D_9` is the only non-Abelian group of order 18
         with an automorphism group of order 54 [TW1980]_::


### PR DESCRIPTION
There's a test in this file that finds a random subgroup of `SymmetricGroup(6)` with three generators, round-trips it through a finite presentation, and then checks the result for isomorphism with itself. If you are unlucky, however, GAP will get confused, and raise a `GAPError` during the round trip. This was originally reported in https://github.com/sagemath/sage/issues/32141, and a workaround was added at some point.

The workaround is a bit ugly though, and it does not make a lot of sense to test something that in fact does not work. I have tried all 2024 of them, and the same problem does not arise with subgroups of `SymmetricGroup(4)`, so this commit reverts the workaround and then changes the 6 to a 4. (Five has the same problem that six does.)

Closes: https://github.com/sagemath/sage/issues/32141
