### PR TITLE
__iter__ method for the AffineGroup class

### DIFF
--- a/src/sage/groups/affine_gps/affine_group.py
+++ b/src/sage/groups/affine_gps/affine_group.py
@@ -532,3 +532,17 @@ class AffineGroup(UniqueRepresentation, Group):
         vecs = self.vector_space().some_elements()
         return [self.element_class(self, A, b, check=False, convert=False)
                 for A in mats for b in vecs]
+
+    def __iter__(self):
+        """
+        TESTS::
+
+            sage: G = AffineGroup(2, 3)
+            sage: len([g for g in G]) == G.cardinality()  # indirect doctest
+            True
+        """
+        for A in self._GL:
+            for b in self.vector_space():
+                yield self.element_class(self, A, b, check=False, convert=False)
+
+    __len__ = cardinality


### PR DESCRIPTION
Fixes #40412.

If it is possible to iterate over a vector space and the corresponding general linear group, then it should also be possible to iterate over the associated affine group.  So we add an `__iter__` method to the `AffineGroup` class (and also a `__len__` method).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


