### PR TITLE
src/sage/symbolic/random_tests.py: fewer random test repetitions

### DIFF
--- a/src/sage/symbolic/random_tests.py
+++ b/src/sage/symbolic/random_tests.py
@@ -430,8 +430,7 @@ def check_symbolic_expression_order(repetitions=100):
     EXAMPLES::
 
         sage: from sage.symbolic.random_tests import check_symbolic_expression_order
-        sage: check_symbolic_expression_order(200)
-        sage: check_symbolic_expression_order(10000)  # long time
+        sage: check_symbolic_expression_order(500)  # long time
     """
     rnd_length = 50
     nvars = 10


### PR DESCRIPTION
We currently run

```
sage: check_symbolic_expression_order(200)
sage: check_symbolic_expression_order(10000)  # long time
```

in succession, for a total of 10200 total repetitions of this random test. The second one is slow and is raising warnings in the CI:

```
2025-07-24T02:19:27.8495248Z ##[warning]slow doctest:
2025-07-24T02:19:27.8496718Z     check_symbolic_expression_order(10000)
2025-07-24T02:19:27.8497325Z Test ran for 34.32s cpu, 34.36s wall
2025-07-24T02:19:27.8498929Z Check ran for 0.00s cpu, 0.00s wall
```

This commit combines the two lines into a single test,

```
sage: check_symbolic_expression_order(500)  # long time
```

to eliminate the warning. We run these tests on every pull request, so if there is a problem, we will catch it eventually, even with fewer repetitions per run. And anyone messing with the ordering on SR can of course run the tests with as many repetitions as he likes.
