### PR TITLE
src/sage/crypto/block_cipher/des.py: run fewer DES test cases

### DIFF
--- a/src/sage/crypto/block_cipher/des.py
+++ b/src/sage/crypto/block_cipher/des.py
@@ -155,8 +155,9 @@ class DES(SageObject):
 
     TESTS:
 
-    Test test vectors from [KeSm1998]_ pp. 125-136::
+    Test a random subset of the test vectors in [KeSm1998]_ pp. 125-136::
 
+        sage: # long time
         sage: from sage.crypto.block_cipher.des import DES
         sage: test = \
         ....: [[0x0101010101010101, 0x8000000000000000, 0x95F8A5E5DD31D900],
@@ -331,10 +332,10 @@ class DES(SageObject):
         ....:  [0x018310DC409B26D6, 0x1D9D5C5018F728C2, 0x5F4C038ED12B2E41],
         ....:  [0x1C587F1C13924FEF, 0x305532286D6F295A, 0x63FAC0D034D9F793]]
         sage: des = DES()
-        sage: for K, P, C in test: # long time
-        ....:    if des.encrypt(P, K) != C or des.decrypt(C, K) != P:
-        ....:        print("DES tests failed for K=0x%s, P=0x%s, C=0x%s" %
-        ....:              (K.hex(), P.hex(), C.hex()))
+        sage: from random import sample
+        sage: all( des.encrypt(P,K) == C and des.decrypt(C,K) == P
+        ....:      for (K,P,C) in sample(test,5) )
+        True
 
     .. automethod:: __init__
     .. automethod:: __call__


### PR DESCRIPTION
We have one DES doctest that checks all of the test vectors given in its reference, but checking them is slow:

```
2025-07-24T02:20:21.8128567Z ##[warning]slow doctest:
2025-07-24T02:20:21.8129623Z     for K, P, C in test: # long time
2025-07-24T02:20:21.8130081Z        if des.encrypt(P, K) != C or des.decrypt(C, K) != P:
2025-07-24T02:20:21.8130602Z            print("DES tests failed for K=0x%s, P=0x%s, C=0x%s" %
2025-07-24T02:20:21.8131064Z                  (K.hex(), P.hex(), C.hex()))
2025-07-24T02:20:21.8131458Z Test ran for 31.91s cpu, 31.97s wall
```

Rather than check them all (there are 171 in total), we may check only a random subset. This commit takes a random sample of 5 test vectors, and checks those. This speeds up the test significantly and should still detect problems.
