### PR TITLE
src/sage/combinat/rsk.py: shorter long tests

### DIFF
--- a/src/sage/combinat/rsk.py
+++ b/src/sage/combinat/rsk.py
@@ -2587,6 +2587,8 @@ class RuleStar(Rule):
         sage: FC_tabs = [T for shape in shapes
         ....:                  for T in SemistandardTableaux(shape, max_entry=4)
         ....:                      if fc(row_reading(T.conjugate()))]
+        sage: from random import sample
+        sage: FC_tabs = sample(FC_tabs, 25)  # verify only a random subset
         sage: Checks = []
         sage: for T in FC_tabs:  # long time
         ....:    shape = T.shape().conjugate()


### PR DESCRIPTION
Two tests in this file are checking that RSK and RSK_inverse are in fact inverses on a (length 621) subset of the semistandard tableaux, but they are taking a long time to run.

Test 1:

```
2025-07-24T02:15:48.3913655Z ##[warning]slow doctest:
2025-07-24T02:15:48.3915925Z     for T in FC_tabs:  # long time
2025-07-24T02:15:48.3916340Z        shape = T.shape().conjugate()
2025-07-24T02:15:48.3916739Z        P = T.conjugate()
2025-07-24T02:15:48.3917158Z        Checks += [all((P,Q) == tuple(RSK(*RSK_inverse(P, Q,
2025-07-24T02:15:48.3917710Z                   insertion='Star', output='array'),
2025-07-24T02:15:48.3918480Z                   insertion='Star'))
2025-07-24T02:15:48.3918950Z                   for Q in SemistandardTableaux(shape, max_entry=5))]
2025-07-24T02:15:48.3919438Z Test ran for 35.12s cpu, 35.24s wall
2025-07-24T02:15:48.3919823Z Check ran for 0.00s cpu, 0.00s wall
```
 
Test 2:

```
2025-07-24T02:16:49.7199852Z ##[warning]slow doctest:
2025-07-24T02:16:49.7203007Z     for T in FC_tabs:  # long time
2025-07-24T02:16:49.7203451Z        shape = T.shape().conjugate()
2025-07-24T02:16:49.7203877Z        P = T.conjugate()
2025-07-24T02:16:49.7204303Z        Checks += [all((P,Q) == tuple(RSK(RSK_inverse(P, Q,
2025-07-24T02:16:49.7205293Z                   insertion='Star', output='DecreasingHeckeFactorization'),
2025-07-24T02:16:49.7205869Z                   insertion='Star'))
2025-07-24T02:16:49.7206370Z                   for Q in SemistandardTableaux(shape, max_entry=5))]
2025-07-24T02:16:49.7206924Z Test ran for 61.00s cpu, 61.33s wall
2025-07-24T02:16:49.7207363Z Check ran for 0.00s cpu, 0.00s wall

```

(Here, FC_tabs is the subset of the tableaux.) Rather than check all of these, we can instead test a random subset. This commit checks only 25 of them at a time to speed up the test runs.