### PR TITLE
Fix test failure with giac 2.0.0.10

### DIFF
--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -1243,8 +1243,8 @@ def limit(ex, *args, dir=None, taylor=False, algorithm='maxima', **kwargs):
 
         sage: limit(sin(x)/x, x, 0, algorithm='sympy')
         1
-        sage: limit(abs(x)/x, x, 0, algorithm='giac') # needs sage.libs.giac # Two-sided limit -> undefined
-        und
+        sage: limit(sin(x)/x, x, 0, algorithm='giac') # needs sage.libs.giac
+        1
         sage: limit(x^x, x, 0, dir='+', algorithm='fricas') # optional - fricas
         1
 


### PR DESCRIPTION
giac now returns an error for mismatching unidirectional limits instead of "und". Change the example to a different one that doesn't error out.
