### PR TITLE
Improve MIP print formatting, etc.

### DIFF
--- a/src/sage/combinat/matrices/dancing_links.pyx
+++ b/src/sage/combinat/matrices/dancing_links.pyx
@@ -1017,9 +1017,6 @@ cdef class dancing_linksWrapper:
         the `i`-th row is in the solution::
 
             sage: p.show()                                                              # needs sage.numerical.mip
-            Maximization:
-            <BLANKLINE>
-            <BLANKLINE>
             Constraints:...
               one 1 in 0-th column: 1.0 <= x_0 + x_1 <= 1.0
               one 1 in 1-th column: 1.0 <= x_0 + x_2 <= 1.0

--- a/src/sage/numerical/mip.pyx
+++ b/src/sage/numerical/mip.pyx
@@ -65,7 +65,7 @@ A mixed integer linear program can give you an answer:
 The following example shows all these steps::
 
     sage: p = MixedIntegerLinearProgram(maximization=False, solver='GLPK')
-    sage: w = p.new_variable(integer=True, nonnegative=True)
+    sage: w = p.new_variable(integer=True, nonnegative=True, name='w')
     sage: p.add_constraint(w[0] + w[1] + w[2] - 14*w[3] == 0)
     sage: p.add_constraint(w[1] + 2*w[2] - 8*w[3] == 0)
     sage: p.add_constraint(2*w[2] - 3*w[3] == 0)
@@ -74,18 +74,18 @@ The following example shows all these steps::
     sage: p.set_objective(w[3])
     sage: p.show()
     Minimization:
-       x_3
+      w[3]
     Constraints:
-      0.0 <= x_0 + x_1 + x_2 - 14.0 x_3 <= 0.0
-      0.0 <= x_1 + 2.0 x_2 - 8.0 x_3 <= 0.0
-      0.0 <= 2.0 x_2 - 3.0 x_3 <= 0.0
-      - x_0 + x_1 + x_2 <= 0.0
-      - x_3 <= -1.0
+      0.0 <= w[0] + w[1] + w[2] - 14.0 w[3] <= 0.0
+      0.0 <= w[1] + 2.0 w[2] - 8.0 w[3] <= 0.0
+      0.0 <= 2.0 w[2] - 3.0 w[3] <= 0.0
+      - w[0] + w[1] + w[2] <= 0.0
+      - w[3] <= -1.0
     Variables:
-      x_0 is an integer variable (min=0.0, max=+oo)
-      x_1 is an integer variable (min=0.0, max=+oo)
-      x_2 is an integer variable (min=0.0, max=+oo)
-      x_3 is an integer variable (min=0.0, max=+oo)
+      w[0] = x_0 is an integer variable (min=0.0, max=+oo)
+      w[1] = x_1 is an integer variable (min=0.0, max=+oo)
+      w[2] = x_2 is an integer variable (min=0.0, max=+oo)
+      w[3] = x_3 is an integer variable (min=0.0, max=+oo)
     sage: print('Objective Value: {}'.format(p.solve()))
     Objective Value: 2.0
     sage: for i, v in sorted(p.get_values(w, convert=ZZ, tolerance=1e-3).items()):
@@ -94,6 +94,34 @@ The following example shows all these steps::
     w_1 = 10
     w_2 = 3
     w_3 = 2
+
+If your problem is already in the standard form, for example::
+
+    sage: A = matrix([[1, 2], [3, 5]])
+    sage: b = vector([7, 11])
+    sage: c = vector([5, 9])
+
+You can add the constraint by treating the variable dictionary as a vector::
+
+    sage: p = MixedIntegerLinearProgram(maximization=True, solver='GLPK')
+    sage: w = p.new_variable(integer=True, name='w')
+    sage: p.add_constraint(A * w <= b)
+    sage: p.set_objective((c.row() * w)[0])
+    sage: p.show()
+    Maximization:
+      5.0 w[0] + 9.0 w[1]
+    Constraints:
+      w[0] + 2.0 w[1] <= 7.0
+      3.0 w[0] + 5.0 w[1] <= 11.0
+    Variables:
+      w[0] = x_0 is an integer variable (min=-oo, max=+oo)
+      w[1] = x_1 is an integer variable (min=-oo, max=+oo)
+    sage: print('Objective Value: {}'.format(p.solve()))
+    Objective Value: 25.0
+    sage: for i, v in sorted(p.get_values(w, convert=ZZ, tolerance=1e-3).items()):
+    ....:     print(f'w_{i} = {v}')
+    w_0 = -13
+    w_1 = 10
 
 Different backends compute with different base fields, for example::
 
@@ -144,8 +172,6 @@ also allowed::
     sage: a[4, 'string', QQ] - 7*b[2]
     x_2 - 7*x_3
     sage: mip.show()
-    Maximization:
-    <BLANKLINE>
     Constraints:
     Variables:
       a[1] = x_0 is a continuous variable (min=-oo, max=+oo)
@@ -778,8 +804,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             sage: p.add_constraint(x[0] + x[3] <= 8)
             sage: p.add_constraint(y[0] >= y[1])
             sage: p.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               x_0 + x_1 <= 8.0
               - x_2 + x_3 <= 0.0
@@ -795,8 +819,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             sage: mip.<x, y, z> = MixedIntegerLinearProgram(solver='GLPK')
             sage: mip.add_constraint(x[0] + y[1] + z[2] <= 10)
             sage: mip.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               x[0] + y[1] + z[2] <= 10.0
             Variables:
@@ -860,8 +882,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             sage: a[0] + b[2]
             x_0 + x_1
             sage: mip.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
             Variables:
               a[0] = x_0 is a continuous variable (min=-oo, max=+oo)
@@ -1251,23 +1271,24 @@ cdef class MixedIntegerLinearProgram(SageObject):
                 varid_explainer[i] = varid_name[i] = default_name
 
         ##### Sense and objective function
-        print("Maximization:" if b.is_maximization() else "Minimization:")
-        print(" ", end=" ")
+        formula_parts = []
         first = True
         for 0<= i< b.ncols():
             c = b.objective_coefficient(i)
             if c == 0:
                 continue
-            print((("+ " if (not first and c>0) else "") +
-                   ("" if c == 1 else ("- " if c == -1 else str(c)+" "))+varid_name[i]
-                   ), end=" ")
+            formula_parts.append(("+ " if (not first and c>0) else "") +
+                         ("" if c == 1 else ("- " if c == -1 else str(c)+" "))+varid_name[i]
+                         )
             first = False
         d = b.objective_constant_term()
         if d > self._backend.zero():
-            print("+ {} ".format(d))
+            formula_parts.append("+ {}".format(d))
         elif d < self._backend.zero():
-            print("- {} ".format(-d))
-        print("\n")
+            formula_parts.append("- {}".format(-d))
+        if formula_parts:
+            print("Maximization:" if b.is_maximization() else "Minimization:")
+            print("  " + " ".join(formula_parts))
 
         ##### Constraints
         print("Constraints:")
@@ -2001,8 +2022,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             sage: b = p.new_variable(nonnegative=True)
             sage: p.add_constraint(b[8] - b[15] <= 3*b[8] + 9)
             sage: p.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               -2.0 x_0 - x_1 <= 9.0
             Variables:
@@ -2043,8 +2062,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             sage: for each in range(10):
             ....:     lp.add_constraint(lp[0]-lp[1], min=1)
             sage: lp.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               1.0 <= x_0 - x_1
             Variables:
@@ -2056,8 +2073,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             sage: for each in range(10):
             ....:     lp.add_constraint(2*lp[0] - 2*lp[1], min=2)
             sage: lp.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               1.0 <= x_0 - x_1
             Variables:
@@ -2069,8 +2084,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
               sage: for each in range(10):
               ....:     lp.add_constraint(-2*lp[0] + 2*lp[1], min=-2)
               sage: lp.show()
-              Maximization:
-              <BLANKLINE>
               Constraints:
                 1.0 <= x_0 - x_1
                 -2.0 <= -2.0 x_0 + 2.0 x_1
@@ -2268,8 +2281,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             sage: p.add_constraint(x - y, max=0)
             sage: p.add_constraint(x, max=4)
             sage: p.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               x_0 + x_1 <= 10.0
               x_0 - x_1 <= 0.0
@@ -2277,8 +2288,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             ...
             sage: p.remove_constraint(1)
             sage: p.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               x_0 + x_1 <= 10.0
               x_0 <= 4.0
@@ -2306,8 +2315,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             sage: p.add_constraint(x - y, max=0)
             sage: p.add_constraint(x, max=4)
             sage: p.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               x_0 + x_1 <= 10.0
               x_0 - x_1 <= 0.0
@@ -2315,8 +2322,6 @@ cdef class MixedIntegerLinearProgram(SageObject):
             ...
             sage: p.remove_constraints([0, 1])
             sage: p.show()
-            Maximization:
-            <BLANKLINE>
             Constraints:
               x_0 <= 4.0
             ...
@@ -3627,8 +3632,19 @@ cdef class MIPVariable(FiniteFamily):
             (1, 1/2)*x_0 + (2/3, 3/4)*x_1
             sage: m * v
             (1, 2/3)*x_0 + (1/2, 3/4)*x_1
+
+            sage: c = vector([1, 2])
+            sage: v * c
+            x_0 + 2*x_1
+            sage: c * v
+            x_0 + 2*x_1
         """
+        from sage.structure.element import Vector
+        if isinstance(left, Vector):
+            left, right = right, left
         if isinstance(left, MIPVariable):
+            if isinstance(right, Vector):
+                return (<MIPVariable> left)._matrix_rmul_impl(right.column())[0]
             if not isinstance(right, Matrix):
                 return NotImplemented
             return (<MIPVariable> left)._matrix_rmul_impl(right)


### PR DESCRIPTION
Just some minor improvements in mixed linear integer programming logic.

In particular, previously, the line after `Maximization:` or `Minutization:` is always printed even if cothe coefficients are zero. Now in that case it is no longer printed. Besides, if it is printed, the trailing space is no longer there.

Also add documentation for how to add a linear program already in standard form.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


