### PR TITLE
Replace 'sage-python' with 'python3' in various scripts for Meson

### DIFF
--- a/src/bin/math-readline
+++ b/src/bin/math-readline
@@ -1,14 +1,16 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 
 # Cleverly run Mathematica with the benefit of readline, which
 # is something the usual commercial mathematica doesn't provide!
 # See
 #    http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/363500
 
-import sys
 import signal
 import subprocess
+import sys
+
 from sage.cpython.string import str_to_bytes
+
 
 def child_exited(*args):
     global child

--- a/src/bin/sage
+++ b/src/bin/sage
@@ -944,7 +944,7 @@ fi
 
 if [ "$1" = '-fixdistributions' -o "$1" = '--fixdistributions' ]; then
     shift
-    exec sage-python -m sage.misc.package_dir "$@"
+    exec python3 -m sage.misc.package_dir "$@"
 fi
 
 if [ "$1" = '-tox' -o "$1" = '--tox' ]; then
@@ -1012,7 +1012,7 @@ if [ "$1" = "-docbuild" -o "$1" = "--docbuild" ]; then
     # Redirect stdin from /dev/null. This helps with running TeX which
     # tends to ask interactive questions if something goes wrong. These
     # cause the build to hang. If stdin is /dev/null, TeX just aborts.
-    exec sage-python -m sage_docbuild "$@" </dev/null
+    exec python3 -m sage_docbuild "$@" </dev/null
 fi
 
 #####################################################################
@@ -1047,7 +1047,7 @@ if [ "$1" = '-gdb' -o "$1" = "--gdb" ]; then
         gdb --eval-command "run" \
             -args python "${SELF}-ipython" "$@" -i
     else
-        sage_dir=$(sage-python -c 'import os, sage; print(os.path.dirname(sage.__file__))')
+        sage_dir=$(python3 -c 'import os, sage; print(os.path.dirname(sage.__file__))')
         cygdb "$sage_dir" "$SAGE_SRC/sage" \
             -- --eval-command "run" \
             -args python "${SELF}-ipython" "$@" -i

--- a/src/bin/sage-cachegrind
+++ b/src/bin/sage-cachegrind
@@ -21,5 +21,5 @@ else
     echo $CACHEGRIND_FLAGS
 fi
 
-valgrind --tool=cachegrind $CACHEGRIND_FLAGS sage-python -i
+valgrind --tool=cachegrind $CACHEGRIND_FLAGS python3 -i
 

--- a/src/bin/sage-cleaner
+++ b/src/bin/sage-cleaner
@@ -1,4 +1,4 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 
 #*****************************************************************************
 # This is the sage monitor *daemon*, which cleans up after Sage.
@@ -17,8 +17,14 @@
 #*****************************************************************************
 
 
-import os, shutil, sys, time, socket, errno, signal, atexit
-
+import atexit
+import errno
+import os
+import shutil
+import signal
+import socket
+import sys
+import time
 
 HOSTNAME = os.environ.get('HOSTNAME', socket.gethostname())
 DOT_SAGE = os.environ['DOT_SAGE']
@@ -30,6 +36,7 @@ pidfile = os.path.join(SAGE_TMP_ROOT, 'cleaner.pid')
 old_pidfile = os.path.join(DOT_SAGE, 'temp', 'cleaner-%s.pid'%HOSTNAME)
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/bin/sage-eval
+++ b/src/bin/sage-eval
@@ -1,8 +1,9 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 
 import sys
+
 from sage.all import *
-from sage.calculus.predefined import x
+from sage.calculus.predefined import x  # noqa: F401
 from sage.repl.preparse import preparse
 
 if len(sys.argv) > 1:

--- a/src/bin/sage-fixdoctests
+++ b/src/bin/sage-fixdoctests
@@ -1,4 +1,4 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 """
 Given the output of doctest and a file, adjust the doctests so they won't fail.
 

--- a/src/bin/sage-ipython
+++ b/src/bin/sage-ipython
@@ -1,4 +1,4 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Sage IPython startup script.
@@ -7,6 +7,7 @@ Sage IPython startup script.
 # Display startup banner. Do this before anything else to give the user
 # early feedback that Sage is starting.
 from sage.misc.banner import banner
+
 banner()
 
 from sage.repl.interpreter import SageTerminalApp

--- a/src/bin/sage-list-packages
+++ b/src/bin/sage-list-packages
@@ -1,4 +1,4 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 r"""
 Script to list the Sage packages
 

--- a/src/bin/sage-massif
+++ b/src/bin/sage-massif
@@ -21,5 +21,5 @@ else
     echo $MASSIF_FLAGS
 fi
 
-valgrind --tool=massif $MASSIF_FLAGS sage-python -i
+valgrind --tool=massif $MASSIF_FLAGS python3 -i
 

--- a/src/bin/sage-notebook
+++ b/src/bin/sage-notebook
@@ -1,19 +1,16 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python -*-
 
-import os
-import sys
-import ast
 import argparse
 import logging
-import textwrap
+import os
+import sys
 from contextlib import contextmanager
 
 logging.basicConfig()
 logger = logging.getLogger()
 
 from sage.misc.banner import banner
-
 
 _system_jupyter_url = "https://doc.sagemath.org/html/en/installation/launching.html#setting-up-sagemath-as-a-jupyter-kernel-in-an-existing-jupyter-notebook-or-jupyterlab-installation"
 
@@ -188,7 +185,9 @@ def sage_doc_server():
     from functools import partial
     from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
     from threading import Thread
-    from sage.env import SAGE_DOC, SAGE_DOC_LOCAL_PORT as port
+
+    from sage.env import SAGE_DOC
+    from sage.env import SAGE_DOC_LOCAL_PORT as port
 
     server = ThreadingHTTPServer(('127.0.0.1', int(port)),
         partial(SimpleHTTPRequestHandler, directory=SAGE_DOC))

--- a/src/bin/sage-omega
+++ b/src/bin/sage-omega
@@ -21,5 +21,5 @@ else
     echo $OMEGA_FLAGS
 fi
 
-valgrind --tool=exp-omega $OMEGA_FLAGS sage-python -i
+valgrind --tool=exp-omega $OMEGA_FLAGS python3 -i
 

--- a/src/bin/sage-preparse
+++ b/src/bin/sage-preparse
@@ -1,4 +1,4 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 """
 Preparse .sage files and save the result to .sage.py files.
 
@@ -11,11 +11,11 @@ AUTHOR:
 """
 
 import os
-import sys
 import re
+import sys
 
-from sage.repl.preparse import preparse_file
 from sage.misc.temporary_file import atomic_write
+from sage.repl.preparse import preparse_file
 
 # The spkg/bin/sage script passes the files to be preparsed as
 # arguments (but remove sys.argv[0]).

--- a/src/bin/sage-python
+++ b/src/bin/sage-python
@@ -1,2 +1,0 @@
-#!/bin/sh
-sage -python "$@"

--- a/src/bin/sage-run
+++ b/src/bin/sage-run
@@ -1,6 +1,7 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 
-import os, sys
+import os
+import sys
 from subprocess import call
 
 if len(sys.argv) < 2:
@@ -20,8 +21,8 @@ if fn.startswith('-'):
 if fn.endswith('.sage'):
     if call(['sage-preparse', fn]) != 0:
         sys.exit(1)
-    os.execvp('sage-python', ['sage-python', fn + '.py'] + opts)
+    os.execvp('python3', ['python3', fn + '.py'] + opts)
 elif fn.endswith('.pyx') or fn.endswith('.spyx'):
     os.execvp('sage-run-cython', ['sage-run-cython', fn] + opts)
 else:
-    os.execvp('sage-python', ['sage-python', fn] + opts)
+    os.execvp('python3', ['python3', fn] + opts)

--- a/src/bin/sage-run-cython
+++ b/src/bin/sage-run-cython
@@ -1,10 +1,10 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 
 import sys
-from sage.repl.load import load_cython
+
 from sage.misc.temporary_file import tmp_filename
+from sage.repl.load import load_cython
 
 if len(sys.argv) > 1:
     s = load_cython(sys.argv.pop(1))
-    import sage.all
     eval(compile(s, tmp_filename(), 'exec'))

--- a/src/bin/sage-runtests
+++ b/src/bin/sage-runtests
@@ -1,9 +1,8 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 
 import sys
 
 from sage.doctest.__main__ import main
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/bin/sage-startuptime.py
+++ b/src/bin/sage-startuptime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 
 ########################################################################
 # Originally based on a script by Andrew Dalke:

--- a/src/doc/en/developer/packaging.rst
+++ b/src/doc/en/developer/packaging.rst
@@ -347,10 +347,6 @@ Likewise for :envvar:`CXXFLAGS`, :envvar:`FCFLAGS`, and :envvar:`F77FLAGS`.
     python3.  You should use this if you are installing a Python package
     to make sure that the libraries are installed in the right place.
 
-    By the way, there is also a script ``sage-python``. This should be
-    used at runtime, for example in scripts in ``SAGE_LOCAL/bin`` which
-    expect Sage's Python to already be built.
-
 Many packages currently do not separate the build and install steps and only
 provide a ``spkg-install.in`` file that does both.  The separation is useful in
 particular for root-owned install hierarchies, where something like ``sudo``

--- a/src/sage/categories/crystals.py
+++ b/src/sage/categories/crystals.py
@@ -923,7 +923,7 @@ class Crystals(Category_singleton):
             Export a file, suitable for pdflatex, to ``filename``.
 
             This requires
-            a proper installation of ``dot2tex`` in sage-python. For more
+            a proper installation of ``dot2tex``. For more
             information see the documentation for ``self.latex()``.
 
             EXAMPLES::

--- a/src/sage/ext_data/nbconvert/postprocess.py
+++ b/src/sage/ext_data/nbconvert/postprocess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env sage-python
+#!/usr/bin/env python3
 
 r"""
 This postprocess script fixes some issues with .rst files returned by nbconvert:

--- a/src/setup.cfg.m4
+++ b/src/setup.cfg.m4
@@ -82,7 +82,6 @@ scripts =
     bin/sage-notebook
     bin/sage-num-threads.py
     bin/sage-preparse
-    bin/sage-python
     bin/sage-run
     bin/sage-run-cython
     bin/sage-startuptime.py


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

In a pure meson build there is no `sage-python`, so scripts declaring using `sage-python` are not working in this context. To remedy this, simply `python3` is used instead. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


