### PR TITLE
remove `unset TERM` when initializing non-interactive sage

### DIFF
--- a/src/bin/sage
+++ b/src/bin/sage
@@ -578,7 +578,6 @@ fi
 if [ "$1" = '-c' ]; then
     shift
     sage_setup
-    unset TERM  # See Issue #12263
     exec sage-eval "$@"
 fi
 
@@ -1116,7 +1115,6 @@ if [ $# -ge 1 ]; then
         exit 1
     fi
     sage_setup
-    unset TERM  # See Issue #12263
     # sage-run rejects all command line options as the first argument.
     exec sage-run "$@"
 fi


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Sage unsets the environment variable `TERM`, which disables colored output by default. This behavior also causes error for packages that depend on `curses.setupterm` because `curses.setupterm` raises an error when `TERM` is unset.

`pwntools` is also affected by this issue. https://github.com/sagemath/sage/issues/39334 https://github.com/3-manifolds/Sage_macOS/issues/78

The original issue https://github.com/sagemath/sage/issues/12263 is 13 years ago and has been [resolved](https://bugs.python.org/issue19884) since python 3.5.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


