### PR TITLE
Simplify group generic algorithm

### DIFF
--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -953,9 +953,12 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
         if ord == Infinity:
             if algorithm == 'bsgs':
                 return bsgs(base, a, bounds, identity=identity, inverse=inverse, op=op, operation=operation)
-            else:
-                assert algorithm == 'lambda'
+            elif algorithm == 'lambda':
                 return discrete_log_lambda(base, a, bounds, inverse=inverse, identity=identity, op=op, operation=operation)
+            elif algorithm == 'rho':
+                raise ValueError('pollard rho algorithm does not work with infinite order elements')
+            else:
+                raise ValueError(f"unknown algorithm {algorithm}")
         if base == power(base, 0) and a != base:
             raise ValueError
         f = ord.factor()
@@ -986,9 +989,10 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
                     c = bsgs(gamma, h, (0, temp_bound), inverse=inverse, identity=identity, op=op, operation=operation)
                 elif algorithm == 'rho':
                     c = discrete_log_rho(h, gamma, ord=pi, inverse=inverse, identity=identity, op=op, operation=operation)
-                else:
-                    assert algorithm == 'lambda'
+                elif algorithm == 'lambda':
                     c = discrete_log_lambda(h, gamma, (0, temp_bound), inverse=inverse, identity=identity, op=op, operation=operation)
+                else:
+                    raise ValueError(f"unknown algorithm {algorithm}")
                 l[i] += c * (pi**j)
                 running_bound //= pi
                 running_mod *= pi

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -951,7 +951,11 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
         ord = integer_ring.ZZ(ord)
     try:
         if ord == Infinity:
-            return bsgs(base, a, bounds, identity=identity, inverse=inverse, op=op, operation=operation)
+            if algorithm == 'bsgs':
+                return bsgs(base, a, bounds, identity=identity, inverse=inverse, op=op, operation=operation)
+            else:
+                assert algorithm == 'lambda'
+                return discrete_log_lambda(base, a, bounds, inverse=inverse, identity=identity, op=op, operation=operation)
         if base == power(base, 0) and a != base:
             raise ValueError
         f = ord.factor()
@@ -982,7 +986,8 @@ def discrete_log(a, base, ord=None, bounds=None, operation='*', identity=None, i
                     c = bsgs(gamma, h, (0, temp_bound), inverse=inverse, identity=identity, op=op, operation=operation)
                 elif algorithm == 'rho':
                     c = discrete_log_rho(h, gamma, ord=pi, inverse=inverse, identity=identity, op=op, operation=operation)
-                elif algorithm == 'lambda':
+                else:
+                    assert algorithm == 'lambda'
                     c = discrete_log_lambda(h, gamma, (0, temp_bound), inverse=inverse, identity=identity, op=op, operation=operation)
                 l[i] += c * (pi**j)
                 running_bound //= pi
@@ -1100,14 +1105,14 @@ def discrete_log_lambda(a, base, bounds, operation='*', identity=None, inverse=N
             c += r
         if mut:
             H.set_immutable()
-        mem = {H}
+        mem = H
         # second random walk
         H = a
         d = 0
         while c - d >= lb:
             if mut:
                 H.set_immutable()
-            if ub >= c - d and H in mem:
+            if ub >= c - d and H == mem:
                 return c - d
             r, e = M[hash_function(H) % k]
             H = mult(H, e)


### PR DESCRIPTION
change a singleton set to a single element. The difference is that in case of singleton set, the element's hash is computed then compared with the pre-stored hash, but then both computing the hash and equality checking is linear time.

not sure if it's an improvement. on the other hand the new implementation works even when the type is not hashable.

edit: it's likely an improvement, for example with ZZ:

```
a = 3^floor(log(2, 3)*1000)
b = 5^floor(log(2, 5)*1000)
set_a = {a}
%timeit a == b  # 32.4 ns
%timeit b in set_a  # 106 ns
```

`==` can be done in sublinear time too if `==` exits early.

The second modification is to call discrete_log_lambda if ord=oo and algorithm parameter is 'lambda' (the documentation says algorithm is only used for prime order group, but discrete_log_lambda works either way). Which makes more sense.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


