### PR TITLE
Fix an occurrence of lazy_import

### DIFF
--- a/src/sage/misc/lazy_import.pyx
+++ b/src/sage/misc/lazy_import.pyx
@@ -36,6 +36,23 @@ that (s)he can remove the flag::
     UserWarning: Option ``at_startup=True`` for lazy import ZZ not needed anymore
     Integer Ring
 
+.. WARNING::
+
+    After the first usage, the imported object is directly injected into the
+    namespace; however, before that, the :class:`LazyImport` object
+    is not exactly equivalent to the actual imported object. For example::
+
+        sage: from sage.misc.lazy_import import LazyImport
+        sage: my_qqbar = LazyImport('sage.rings.qqbar', 'QQbar')
+        sage: my_qqbar(5) == QQbar(5)  # good
+        True
+        sage: isinstance(QQbar, Parent)
+        True
+        sage: isinstance(my_qqbar, Parent)  # fails!
+        False
+
+    To avoid this issue, you may execute the import inside the function instead.
+
 .. SEEALSO:: :func:`lazy_import`, :class:`LazyImport`
 
 AUTHOR:

--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -159,7 +159,6 @@ from sage.schemes.projective.projective_subscheme import (AlgebraicScheme_subsch
 
 lazy_import('sage.interfaces.singular', 'singular')
 lazy_import('sage.rings.number_field.number_field', 'NumberField')
-lazy_import('sage.rings.qqbar', ['number_field_elements_from_algebraics', 'QQbar'])
 
 from .curve import Curve_generic
 
@@ -1452,6 +1451,7 @@ class ProjectivePlaneCurve(ProjectiveCurve):
         """
         # helper function for extending the base field
 
+        from sage.rings.qqbar import number_field_elements_from_algebraics, QQbar
         def extension(self):
             F = self.base_ring()
             pts = self.change_ring(F.embeddings(QQbar)[0]).rational_points()

--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -1449,10 +1449,10 @@ class ProjectivePlaneCurve(ProjectiveCurve):
                       + (1/16*a + 1/16)*x*y*z^2 + (3/16*a + 3/16)*y^2*z^2
                       + (-3/16*a - 1/4)*y*z^3 + (1/16*a + 3/32)*z^4)
         """
-        # helper function for extending the base field
-
         from sage.rings.qqbar import number_field_elements_from_algebraics, QQbar
+
         def extension(self):
+            # helper function for extending the base field
             F = self.base_ring()
             pts = self.change_ring(F.embeddings(QQbar)[0]).rational_points()
             L = [t for pt in pts for t in pt]


### PR DESCRIPTION
Previously the following code fails if executed right after Sage starts:

```python
P.<x,y,z> = ProjectiveSpace(QQ, 2)
C = Curve([(x^2 + y^2 - y*z - 2*z^2)*(y*z - x^2 + 2*z^2)*z + y^5], P)
C.ordinary_model()
```

The error is:

```python
NotImplementedError: object does not support iteration
```

This pull request fixes it. The reason why it is fixed is explained in the code edit.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


