### PR TITLE
Implement composition of pseudomorphisms

### DIFF
--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -21,7 +21,6 @@ AUTHORS:
 #                  http://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.categories.map import FormalCompositeMap
 from sage.categories.morphism import Morphism
 from sage.structure.richcmp import richcmp
 from sage.modules.free_module_morphism import FreeModuleMorphism
@@ -583,7 +582,7 @@ class FreeModulePseudoMorphism(Morphism):
             if self.side() == 'right' and right.side() == 'right':
                 f._side = "right"
             return f
-        return FormalCompositeMap(homset, right, self)
+        return super()._composition_(right, homset)
 
     def ore_module(self, names=None):
         r"""

--- a/src/sage/modules/free_module_pseudomorphism.py
+++ b/src/sage/modules/free_module_pseudomorphism.py
@@ -577,7 +577,7 @@ class FreeModulePseudoMorphism(Morphism):
                     morphism = self._morphism
                 else:
                     morphism = self._morphism * right._morphism
-                mat = right._matrix.map_coefficients(self._morphism) * self._matrix
+                mat = right._matrix.apply_map(self._morphism) * self._matrix
             parent = right.domain().pseudoHom(morphism, codomain=self.codomain())
             f = FreeModulePseudoMorphism(parent, mat, "left")
             if self.side() == 'right' and right.side() == 'right':


### PR DESCRIPTION
If $f$ and $g$ are composable pseudomorphisms, in general the composite $f \circ g$ is no longer a pseudomorphism. It is however the case when there is no twisting derivation.
In this PR, we implement the computation of the composition in this case.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.