### PR TITLE
Add "needs" tags for eclib and mwrank

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -129,10 +129,13 @@ class SageDoctestModule(DoctestModule):
                         # tests), but that would require duplication
                         # for as long as `sage -t` is still used.
                         from sage.features.coxeter3 import Coxeter3
-                        from sage.features.sagemath import sage__libs__giac
+                        from sage.features.sagemath import (sage__libs__eclib,
+                                                            sage__libs__giac)
                         from sage.features.standard import PythonModule
 
                         exc_list = ["valgrind"]
+                        if not sage__libs__eclib().is_present():
+                            exc_list.append("sage.libs.eclib")
                         if not PythonModule("rpy2").is_present():
                             exc_list.append("rpy2")
                         if not Coxeter3().is_present():
@@ -141,8 +144,9 @@ class SageDoctestModule(DoctestModule):
                             exc_list.append("sagemath_giac")
 
                         # Ignore import errors, but only when the associated
-                        # feature is actually disabled.
-                        if exception.name in exc_list:
+                        # feature is actually disabled. Use startswith() so
+                        # that sage.libs.foo matches all of sage.libs.foo.*
+                        if any(exception.name.startswith(e) for e in exc_list):
                             pytest.skip(
                                 f"unable to import module {self.path} due to missing feature {exception.name}"
                             )

--- a/meson.options
+++ b/meson.options
@@ -44,7 +44,7 @@ option(
 option(
   'eclib',
   type: 'feature',
-  value: 'auto',
+  value: 'disabled',
   description: 'eclib interface to mwrank and elliptic curves over Q'
 )
 

--- a/src/doc/de/tutorial/introduction.rst
+++ b/src/doc/de/tutorial/introduction.rst
@@ -45,7 +45,7 @@ Tutorial der richtige Ort um damit anzufangen. Zum Beispiel:
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs sage.libs.eclib
     1
 
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -52,6 +52,7 @@ Features
    sage/features/mcqd
    sage/features/meataxe
    sage/features/mip_backends
+   sage/features/mwrank
    sage/features/normaliz
    sage/features/pandoc
    sage/features/pdf2svg

--- a/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/birds_other.rst
+++ b/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/birds_other.rst
@@ -123,6 +123,7 @@ more general, but doesn't scale nearly so well (yet).
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: M = CremonaModularSymbols(20014)       # few seconds
     sage: M
     Cremona Modular Symbols space of dimension 5005 for

--- a/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/elliptic_curves.rst
+++ b/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/elliptic_curves.rst
@@ -138,6 +138,7 @@ the :math:`5`-adic and :math:`997`-adic regulators of this curve.
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: E = EllipticCurve('389a')
     sage: E.padic_regulator(5, 10)
     5^2 + 2*5^3 + 2*5^4 + 4*5^5 + 3*5^6 + 4*5^7 + 3*5^8 + 5^9 + O(5^11)
@@ -154,6 +155,7 @@ nontrivial computational challenge. Now in Sage computing the
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: E.padic_regulator(100003,5)  # a couple of seconds
     42582*100003^2 + 35250*100003^3 + 12790*100003^4 + 64078*100003^5 + O(100003^6)
 
@@ -176,6 +178,7 @@ rank :math:`2`.
 
 ::
 
+    sage: # needs.sage.libs.eclib
     sage: E = EllipticCurve('389a')
     sage: L = E.padic_lseries(5)
     sage: L
@@ -199,7 +202,7 @@ unpublished papers of Wuthrich and me.
     sage: E.sha().bound()            # so only 2 could divide sha
     [2]
     sage: E = EllipticCurve('37a1')  # so only 2 could divide sha
-    sage: E.sha().bound()
+    sage: E.sha().bound()  # needs sage.libs.eclib
     ([2], 1)
     sage: E = EllipticCurve('389a1')
     sage: E.sha().bound()
@@ -223,6 +226,7 @@ and :math:`7` do not divide the Shafarevich-Tate group of our rank
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: E = EllipticCurve('389a1')
     sage: sha = E.sha()
     sage: sha.p_primary_bound(5)  # iwasawa theory ==> 5 doesn't divide sha
@@ -242,6 +246,7 @@ number in general!
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: E.sha().an()
     1.00000000000000
 
@@ -257,7 +262,7 @@ GP scripts for computing Mordell-Weil groups of elliptic curves.
     sage: E = EllipticCurve([1,2,5,17,159])
     sage: E.conductor()       # not in the Tables
     10272987
-    sage: E.gens()            # a few seconds
+    sage: E.gens()            # a few seconds, needs sage.libs.eclib
     [(-3 : 9 : 1), (-3347/3249 : 1873597/185193 : 1)]
 
 
@@ -274,6 +279,7 @@ the only free open source implementation available.
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: E = EllipticCurve([1,2,5,7,17])
     sage: E.integral_points(both_signs=True)
     [(1 : -9 : 1), (1 : 3 : 1)]
@@ -283,6 +289,7 @@ rank :math:`3`, which has 36 integral points.
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: E = elliptic_curves.rank(3)[0]
     sage: E.integral_points(both_signs=True)   # less than 3 seconds
     [(-3 : -1 : 1), (-3 : 0 : 1), (-2 : -4 : 1), (-2 : 3 : 1), ...(816 : -23310 : 1), (816 : 23309 : 1)]
@@ -299,6 +306,7 @@ points).
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: E = elliptic_curves.rank(4)[0]
     sage: E.integral_points(both_signs=True)   # about a minute
     [(-10 : 3 : 1), (-10 : 7 : 1), ...

--- a/src/doc/en/tutorial/introduction.rst
+++ b/src/doc/en/tutorial/introduction.rst
@@ -42,7 +42,7 @@ tutorial is the place to start. For example:
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs sage.libs.eclib
     1
 
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/doc/es/tutorial/introduction.rst
+++ b/src/doc/es/tutorial/introduction.rst
@@ -41,7 +41,7 @@ lugar justo para empezar. Por ejemplo:
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs sage.libs.eclib
     1
 
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/doc/fr/tutorial/introduction.rst
+++ b/src/doc/fr/tutorial/introduction.rst
@@ -44,7 +44,7 @@ tutoriel est le bon endroit où commencer. Voici quelques exemples :
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs sage.libs.eclib
     1
 
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/doc/it/tutorial/introduction.rst
+++ b/src/doc/it/tutorial/introduction.rst
@@ -39,7 +39,7 @@ Per esempio:
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs sage.libs.eclib
     1
     
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/doc/ja/tutorial/introduction.rst
+++ b/src/doc/ja/tutorial/introduction.rst
@@ -38,7 +38,7 @@ Sageのかなりの部分がPythonを使って実装されているものの，�
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs.sage.libs.eclib
     1
 
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/doc/pt/tutorial/introduction.rst
+++ b/src/doc/pt/tutorial/introduction.rst
@@ -43,7 +43,7 @@ certo para começar. Por exemplo:
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs sage.libs.eclib
     1
 
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/doc/ru/tutorial/introduction.rst
+++ b/src/doc/ru/tutorial/introduction.rst
@@ -44,7 +44,7 @@
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs sage.libs.eclib
     1
 
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/doc/zh/tutorial/introduction.rst
+++ b/src/doc/zh/tutorial/introduction.rst
@@ -37,7 +37,7 @@ Python 初学者指南 [PyB]_ 列出了许多选择。如果你只是想快速�
     over Rational Field
     sage: E.anlist(10)
     [0, 1, 1, 0, -1, -3, 0, -1, -3, -3, -3]
-    sage: E.rank()
+    sage: E.rank()  # needs sage.libs.eclib
     1
 
     sage: k = 1/(sqrt(3)*I + 3/4 + sqrt(73)*5/9); k

--- a/src/sage/features/mwrank.py
+++ b/src/sage/features/mwrank.py
@@ -1,0 +1,34 @@
+# sage_setup: distribution = sagemath-environment
+r"""
+Feature for testing the presence of the ``mwrank`` program (part
+of eclib)
+"""
+
+from . import Executable, FeatureTestResult
+
+
+class Mwrank(Executable):
+    r"""
+    A :class:`~sage.features.Feature` describing the presence of
+    the ``mwrank`` program.
+
+    EXAMPLES::
+
+        sage: from sage.features.mwrank import Mwrank
+        sage: Mwrank().is_present()  # needs mwrank
+        FeatureTestResult('mwrank', True)
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.mwrank import Mwrank
+            sage: isinstance(Mwrank(), Mwrank)
+            True
+        """
+        Executable.__init__(self, 'mwrank', executable='mwrank',
+                            spkg='eclib', type='standard')
+
+
+def all_features():
+    return [Mwrank()]

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -537,6 +537,33 @@ class sage__libs__ntl(JoinFeature):
                              spkg='sagemath_ntl', type='standard')
 
 
+class sage__libs__eclib(JoinFeature):
+    r"""
+    A :class:`sage.features.Feature` describing the presence of
+    :mod:`sage.libs.eclib`.
+
+    In addition to the modularization purposes that this tag serves,
+    it also provides attribution to the upstream project.
+
+    TESTS::
+
+        sage: from sage.features.sagemath import sage__libs__eclib
+        sage: sage__libs__eclib().is_present()                                           # needs sage.libs.eclib
+        FeatureTestResult('sage.libs.eclib', True)
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.sagemath import sage__libs__eclib
+            sage: isinstance(sage__libs__eclib(), sage__libs__eclib)
+            True
+        """
+        JoinFeature.__init__(self, 'sage.libs.eclib',
+                             [PythonModule('sage.libs.eclib.mwrank')],
+                             spkg='eclib', type='standard')
+
+
 class sage__libs__giac(JoinFeature):
     r"""
     A :class:`sage.features.Feature` describing the presence of :mod:`sage.libs.giac`.

--- a/src/sage/interfaces/mwrank.py
+++ b/src/sage/interfaces/mwrank.py
@@ -1,3 +1,4 @@
+# sage.doctest: needs mwrank
 r"""
 Interface to mwrank
 """

--- a/src/sage/lfunctions/zero_sums.pyx
+++ b/src/sage/lfunctions/zero_sums.pyx
@@ -1624,7 +1624,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
             0
 
             sage: E = EllipticCurve([-39,123])
-            sage: E.rank()
+            sage: E.rank()  # needs sage.libs.eclib
             1
             sage: Z = LFunctionZeroSum(E)
             sage: Z.analytic_rank_upper_bound(max_Delta=1)

--- a/src/sage/libs/eclib/constructor.py
+++ b/src/sage/libs/eclib/constructor.py
@@ -1,3 +1,4 @@
+# sage.doctest: needs sage.libs.eclib
 "Cremona modular symbols"
 
 

--- a/src/sage/libs/eclib/homspace.pyx
+++ b/src/sage/libs/eclib/homspace.pyx
@@ -1,3 +1,4 @@
+# sage.doctest: needs sage.libs.eclib
 "Cremona modular symbols"
 
 from cysignals.signals cimport sig_on, sig_off

--- a/src/sage/libs/eclib/interface.py
+++ b/src/sage/libs/eclib/interface.py
@@ -1,3 +1,4 @@
+# sage.doctest: needs sage.libs.eclib
 r"""
 Sage interface to Cremona's ``eclib`` library (also known as ``mwrank``)
 

--- a/src/sage/libs/eclib/mat.pyx
+++ b/src/sage/libs/eclib/mat.pyx
@@ -1,3 +1,4 @@
+# sage.doctest: needs sage.libs.eclib
 """
 Cremona matrices
 """

--- a/src/sage/libs/eclib/mwrank.pyx
+++ b/src/sage/libs/eclib/mwrank.pyx
@@ -1,3 +1,4 @@
+# sage.doctest: needs sage.libs.eclib
 """
 Cython interface to Cremona's ``eclib`` library (also known as ``mwrank``)
 

--- a/src/sage/libs/eclib/newforms.pyx
+++ b/src/sage/libs/eclib/newforms.pyx
@@ -1,3 +1,4 @@
+# sage.doctest: needs sage.libs.eclib
 """
 Modular symbols using eclib newforms
 """

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -2011,7 +2011,7 @@ def block_matrix(*args, **kwds):
         ...
         ValueError: an element of parent <class 'list'> was passed in,
          but only matrices, vectors and ring elements are accepted
-        sage: matrix.block([
+        sage: matrix.block([  # needs sage.libs.eclib
         ....:     [EllipticCurve('37a1').0],
         ....:     ])
         Traceback (most recent call last):

--- a/src/sage/misc/benchmark.py
+++ b/src/sage/misc/benchmark.py
@@ -22,6 +22,7 @@ def benchmark(n=-1):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: from sage.misc.benchmark import *
         sage: _ = benchmark()
         Running benchmark 0
@@ -105,6 +106,7 @@ def bench1():
 
     BENCHMARK::
 
+        sage: # needs sage.libs.eclib
         sage: from sage.misc.benchmark import *
         sage: print(bench1()[0])
         Find the Mordell-Weil group of the elliptic curve 5077A using mwrank
@@ -208,6 +210,7 @@ def bench7():
 
     BENCHMARK::
 
+        sage: # needs sage.libs.eclib
         sage: from sage.misc.benchmark import *
         sage: print(bench7()[0])
         Compute the Mordell-Weil group of y^2 = x^3 + 37*x - 997.

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -1667,7 +1667,7 @@ def regulator(x):
         sage: x = polygen(ZZ, 'x')
         sage: regulator(NumberField(x^2 - 2, 'a'))                                      # needs sage.rings.number_field
         0.881373587019543
-        sage: regulator(EllipticCurve('11a'))                                           # needs sage.schemes
+        sage: regulator(EllipticCurve('11a'))                                           # needs sage.schemes sage.libs.eclib
         1.00000000000000
     """
     return x.regulator()

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -926,6 +926,7 @@ class ModularForm_abstract(ModuleElement):
         These can be used to express the periods of `f` as exact
         linear combinations of the real and the imaginary period of `E`::
 
+            sage: # needs sage.libs.eclib
             sage: s = E.modular_symbol(sign=+1)
             sage: t = E.modular_symbol(sign=-1, implementation='sage')
             sage: s(3/11), t(3/11)

--- a/src/sage/modular/pollack_stevens/fund_domain.py
+++ b/src/sage/modular/pollack_stevens/fund_domain.py
@@ -1448,6 +1448,7 @@ class ManinRelations(PollackStevensModularDomain):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -1518,6 +1519,7 @@ class ManinRelations(PollackStevensModularDomain):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()

--- a/src/sage/modular/pollack_stevens/manin_map.py
+++ b/src/sage/modular/pollack_stevens/manin_map.py
@@ -10,6 +10,7 @@ provides basic arithmetic and right action of matrices.
 
 EXAMPLES::
 
+    sage: # needs sage.libs.eclib
     sage: E = EllipticCurve('11a')
     sage: phi = E.pollack_stevens_modular_symbol()
     sage: phi
@@ -779,6 +780,7 @@ class ManinMap:
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -831,6 +833,7 @@ class ManinMap:
 
         EXAMPLES::
 
+            sage: # needs.sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: f = phi._map

--- a/src/sage/modular/pollack_stevens/modsym.py
+++ b/src/sage/modular/pollack_stevens/modsym.py
@@ -5,6 +5,7 @@ This is the class of elements in the spaces of Pollack-Steven's modular symbols 
 
 EXAMPLES::
 
+    sage: # needs sage.libs.eclib
     sage: E = EllipticCurve('11a')
     sage: phi = E.pollack_stevens_modular_symbol(); phi
     Modular symbol of level 11 with values in Sym^0 Q^2
@@ -81,6 +82,7 @@ def _iterate_Up(Phi, p, M, ap, q, aq, check):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('57a')
         sage: p = 5
         sage: prec = 4
@@ -121,6 +123,7 @@ class PSModSymAction(Action):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: g = phi._map._codomain._act._Sigma0(matrix(ZZ,2,2,[1,2,3,4]))
@@ -136,6 +139,7 @@ class PSModSymAction(Action):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: g = phi._map._codomain._act._Sigma0(matrix(ZZ,2,2,[2,1,5,-1]))
@@ -153,6 +157,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a')
             sage: phi = E.pollack_stevens_modular_symbol()
         """
@@ -168,6 +173,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi._repr_()
@@ -183,6 +189,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: Set([x.moment(0) for x in phi.dict().values()]) == Set([-1/5, 1, 0])
@@ -202,6 +209,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.weight()
@@ -217,6 +225,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -237,6 +246,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi._normalize()
@@ -256,6 +266,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi == phi
@@ -280,6 +291,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -297,6 +309,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -314,6 +327,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -331,6 +345,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -411,6 +426,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -433,6 +449,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -473,6 +490,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -485,7 +503,6 @@ class PSModularSymbolElement(ModuleElement):
             True
             sage: phi.hecke(101) == phi * E.ap(101)
             True
-
             sage: all(phi.hecke(p, algorithm='naive') == phi * E.ap(p) for p in [2,3,5,101]) # long time
             True
         """
@@ -507,6 +524,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+           sage: # needs sage.libs.eclib
            sage: E = EllipticCurve('11a')
            sage: phi = E.pollack_stevens_modular_symbol()
            sage: phi.values()
@@ -524,6 +542,7 @@ class PSModularSymbolElement(ModuleElement):
            ...
            ValueError: you must specify a prime
 
+           sage: # needs sage.libs.eclib
            sage: phi2 = phi.lift(11, M=2)
            sage: phi2.valuation()
            0
@@ -547,6 +566,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -579,6 +599,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -625,6 +646,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -632,7 +654,6 @@ class PSModularSymbolElement(ModuleElement):
             sage: phi_ord = phi.p_stabilize(p = 3, ap = E.ap(3), M = 10, ordinary = True)
             sage: phi_ord.Tq_eigenvalue(2,3,10) + 2
             O(3^10)
-
             sage: phi_ord.Tq_eigenvalue(3,3,10)
             2 + 3^2 + 2*3^3 + 2*3^4 + 2*3^6 + 3^8 + 2*3^9 + O(3^10)
             sage: phi_ord.Tq_eigenvalue(3,3,100)
@@ -692,6 +713,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.is_ordinary(2)
@@ -752,22 +774,25 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('17a1')
-            sage: L = E.padic_lseries(5, implementation='pollackstevens', precision=4) #long time
-            sage: D = L.quadratic_twist()          # long time
-            sage: L.symbol().evaluate_twisted(1,D) # long time
+            sage: L = E.padic_lseries(5, implementation='pollackstevens', precision=4)
+            sage: D = L.quadratic_twist()
+            sage: L.symbol().evaluate_twisted(1,D)
             (1 + 5 + 3*5^2 + 5^3 + O(5^4), 5^2 + O(5^3), 1 + O(5^2), 2 + O(5))
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('40a4')
-            sage: L = E.padic_lseries(7, implementation='pollackstevens', precision=4) #long time
-            sage: D = L.quadratic_twist()          # long time
-            sage: L.symbol().evaluate_twisted(1,D) # long time
+            sage: L = E.padic_lseries(7, implementation='pollackstevens', precision=4)
+            sage: D = L.quadratic_twist()
+            sage: L.symbol().evaluate_twisted(1,D)
             (4 + 6*7 + 3*7^2 + O(7^4), 6*7 + 6*7^2 + O(7^3), 6 + O(7^2), 1 + O(7))
 
         TESTS:
 
         Check for :issue:`32878`::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: L = E.padic_lseries(3, implementation='pollackstevens', precision=4)
             sage: D = 5
@@ -798,6 +823,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi._consistency_check()
@@ -882,6 +908,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: p = 5
             sage: M = 10
@@ -992,6 +1019,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: p = 5
             sage: prec = 4
@@ -1010,6 +1038,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
             sage: phis.Tq_eigenvalue(5,M = 3)
             1 + 4*5 + 3*5^2 + O(5^3)
 
+            sage: # needs sage.libs.eclib
             sage: phis = phi.p_stabilize(p,M = prec,ordinary=False)
             sage: phis.Tq_eigenvalue(5)
             5 + 5^2 + 2*5^3 + O(5^5)
@@ -1149,6 +1178,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: f = E.pollack_stevens_modular_symbol()
             sage: g = f.lift(11,4,algorithm='stevens',eigensymbol=True)
@@ -1161,11 +1191,13 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         We check that lifting and then specializing gives back the original symbol::
 
+            sage: # needs sage.libs.eclib
             sage: g.specialize() == f
             True
 
         Another example, which showed precision loss in an earlier version of the code::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a')
             sage: p = 5
             sage: prec = 4
@@ -1176,6 +1208,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         Another example::
 
+            sage: # needs sage.libs.eclib
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('37a')
             sage: p = 5
@@ -1188,6 +1221,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         Examples using Greenberg's algorithm::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: Phi = phi.lift(11,8,algorithm='greenberg',eigensymbol=True)
@@ -1283,6 +1317,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: f = E.pollack_stevens_modular_symbol()
             sage: f._lift_to_OMS(11,4,Qp(11,4))
@@ -1362,6 +1397,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: f = E.pollack_stevens_modular_symbol()
             sage: f._find_aq(5,10,True)
@@ -1408,6 +1444,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: p = 5
             sage: M = 10
@@ -1473,14 +1510,15 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: f = E.pollack_stevens_modular_symbol()
-            sage: g = f.p_stabilize_and_lift(3,10)  # long time
-            sage: g.Tq_eigenvalue(5)                # long time
+            sage: g = f.p_stabilize_and_lift(3,10)
+            sage: g.Tq_eigenvalue(5)
             1 + O(3^10)
-            sage: g.Tq_eigenvalue(7)                # long time
+            sage: g.Tq_eigenvalue(7)
             1 + 2*3 + 2*3^2 + 2*3^3 + 2*3^4 + 2*3^5 + 2*3^6 + 2*3^7 + 2*3^8 + 2*3^9 + O(3^10)
-            sage: g.Tq_eigenvalue(3)                # long time
+            sage: g.Tq_eigenvalue(3)
             2 + 3^2 + 2*3^3 + 2*3^4 + 2*3^6 + 3^8 + 2*3^9 + O(3^10)
         """
         if check:
@@ -1577,11 +1615,12 @@ class PSModularSymbolElement_dist(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('37a')
             sage: phi = E.pollack_stevens_modular_symbol()
-            sage: L = phi.lift(37, M=6, eigensymbol=True).padic_lseries(); L  # long time
+            sage: L = phi.lift(37, M=6, eigensymbol=True).padic_lseries(); L
             37-adic L-series of Modular symbol of level 37 with values in Space of 37-adic distributions with k=0 action and precision cap 7
-            sage: L.series(2) # long time
+            sage: L.series(2)
             O(37^6) + (4 + 37 + 36*37^2 + 19*37^3 + 21*37^4 + O(37^5))*T + O(T^2)
         """
         from sage.modular.pollack_stevens.padic_lseries import pAdicLseries

--- a/src/sage/modular/pollack_stevens/padic_lseries.py
+++ b/src/sage/modular/pollack_stevens/padic_lseries.py
@@ -46,23 +46,25 @@ class pAdicLseries(SageObject):
 
     EXAMPLES::
 
+        sage: # long time, needs sage.libs.eclib
         sage: E = EllipticCurve('37a')
         sage: p = 5
         sage: prec = 4
-        sage: L = E.padic_lseries(p, implementation='pollackstevens', precision=prec) # long time
-        sage: L[1]                # long time
+        sage: L = E.padic_lseries(p, implementation='pollackstevens', precision=prec)
+        sage: L[1]
         1 + 4*5 + 2*5^2 + O(5^3)
-        sage: L.series(3)    # long time
+        sage: L.series(3)
         O(5^4) + (1 + 4*5 + 2*5^2 + O(5^3))*T + (3 + O(5^2))*T^2 + O(T^3)
 
     ::
 
+        sage: # long time, needs sage.libs.eclib
         sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
         sage: E = EllipticCurve('20a')
         sage: phi = E.pollack_stevens_modular_symbol()
-        sage: Phi = phi.p_stabilize_and_lift(3, 4) # long time
-        sage: L = pAdicLseries(Phi)                # long time
-        sage: L.series(4)                          # long time
+        sage: Phi = phi.p_stabilize_and_lift(3, 4)
+        sage: L = pAdicLseries(Phi)
+        sage: L.series(4)
         2*3 + O(3^4) + (3 + O(3^2))*T + (2 + O(3))*T^2 + O(3^0)*T^3 + O(T^4)
 
     An example of a `p`-adic `L`-series associated to a modular
@@ -92,17 +94,17 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('11a3')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: p = 11
             sage: prec = 3
-            sage: Phi = phi.lift(p, prec,eigensymbol=True) # long time
-            sage: L = pAdicLseries(Phi)                    # long time
-            sage: L.series(3)                              # long time
+            sage: Phi = phi.lift(p, prec,eigensymbol=True)
+            sage: L = pAdicLseries(Phi)
+            sage: L.series(3)
             O(11^3) + (2 + 5*11 + O(11^2))*T + (10 + O(11))*T^2 + O(T^3)
-
-            sage: TestSuite(L).run()                       # long time
+            sage: TestSuite(L).run()
         """
         self._coefficients = {}
 
@@ -129,11 +131,12 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('14a5')
-            sage: L = E.padic_lseries(7,implementation='pollackstevens',precision=5) # long time
-            sage: L[0]                                   # long time
+            sage: L = E.padic_lseries(7,implementation='pollackstevens',precision=5)
+            sage: L[0]
             O(7^5)
-            sage: L[1]                                   # long time
+            sage: L[1]
             5 + 5*7 + 2*7^2 + 2*7^3 + O(7^4)
         """
         if n in self._coefficients:
@@ -172,9 +175,10 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
-            sage: L = E.padic_lseries(11,implementation='pollackstevens',precision=6) # long time
-            sage: L == loads(dumps(L)) # indirect doctest, long time
+            sage: L = E.padic_lseries(11,implementation='pollackstevens',precision=6)
+            sage: L == loads(dumps(L))  # indirect doctest
             True
         """
         if not isinstance(other, pAdicLseries):
@@ -191,9 +195,10 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
-            sage: L = E.padic_lseries(11,implementation='pollackstevens',precision=6) # long time
-            sage: L != L  # long time
+            sage: L = E.padic_lseries(11,implementation='pollackstevens',precision=6)
+            sage: L != L
             False
         """
         return not self.__eq__(other)
@@ -204,15 +209,16 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('21a4')
             sage: phi = E.pollack_stevens_modular_symbol()
-            sage: Phi = phi.p_stabilize_and_lift(2,5)   # long time
-            sage: L = pAdicLseries(Phi)                 # long time
-            sage: L.symbol()                              # long time
+            sage: Phi = phi.p_stabilize_and_lift(2,5)
+            sage: L = pAdicLseries(Phi)
+            sage: L.symbol()
             Modular symbol of level 42 with values in Space of 2-adic
             distributions with k=0 action and precision cap 15
-            sage: L.symbol() is Phi                       # long time
+            sage: L.symbol() is Phi
             True
         """
         return self._symb
@@ -223,9 +229,10 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('19a')
-            sage: L = E.padic_lseries(19, implementation='pollackstevens',precision=6) # long time
-            sage: L.prime()                   # long time
+            sage: L = E.padic_lseries(19, implementation='pollackstevens',precision=6)
+            sage: L.prime()
             19
         """
         return self._symb.parent().prime()
@@ -236,6 +243,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('37a')
             sage: phi = E.pollack_stevens_modular_symbol()
@@ -252,9 +260,10 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('14a2')
-            sage: L = E.padic_lseries(3, implementation='pollackstevens', precision=4)  # long time
-            sage: L._repr_()                           # long time
+            sage: L = E.padic_lseries(3, implementation='pollackstevens', precision=4)
+            sage: L._repr_()
             '3-adic L-series of Modular symbol of level 42 with values in
             Space of 3-adic distributions with k=0 action and precision cap 8'
         """
@@ -272,16 +281,18 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve('14a2')
             sage: p = 3
             sage: prec = 6
-            sage: L = E.padic_lseries(p,implementation='pollackstevens',precision=prec) # long time
-            sage: L.series(4)          # long time
+            sage: L = E.padic_lseries(p,implementation='pollackstevens',precision=prec)
+            sage: L.series(4)
             2*3 + 3^4 + 3^5 + O(3^6) + (2*3 + 3^2 + O(3^4))*T + (2*3 + O(3^2))*T^2 + (3 + O(3^2))*T^3 + O(T^4)
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve("15a3")
-            sage: L = E.padic_lseries(5,implementation='pollackstevens',precision=15)  # long time
-            sage: L.series(3)            # long time
+            sage: L = E.padic_lseries(5,implementation='pollackstevens',precision=15)
+            sage: L.series(3)
             O(5^15) + (2 + 4*5^2 + 3*5^3 + 5^5 + 2*5^6 + 3*5^7 + 3*5^8 + 2*5^9 + 2*5^10 + 3*5^11 + 5^12 + O(5^13))*T + (4*5 + 4*5^3 + 3*5^4 + 4*5^5 + 3*5^6 + 2*5^7 + 5^8 + 4*5^9 + 3*5^10 + O(5^11))*T^2 + O(T^3)
 
             sage: E = EllipticCurve("79a1")
@@ -316,13 +327,16 @@ class pAdicLseries(SageObject):
         EXAMPLES::
 
             sage: E = EllipticCurve('19a2')
-            sage: L = E.padic_lseries(3,implementation='pollackstevens',precision=6)  # long time
-            sage: ap = E.ap(3)               # long time
-            sage: L.interpolation_factor(ap) # long time
+
+            sage: # long time, needs sage.libs.eclib
+            sage: L = E.padic_lseries(3,implementation='pollackstevens',precision=6)
+            sage: ap = E.ap(3)
+            sage: L.interpolation_factor(ap)
             3^2 + 3^3 + 2*3^5 + 2*3^6 + O(3^7)
 
         Comparing against a different implementation::
 
+            sage: # needs sage.libs.eclib
             sage: L = E.padic_lseries(3)
             sage: (1-1/L.alpha(prec=4))^2
             3^2 + 3^3 + O(3^5)
@@ -357,10 +371,11 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # long time, needs sage.libs.eclib
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('11a3')
-            sage: L = E.padic_lseries(5, implementation='pollackstevens', precision=4) #long time
-            sage: L._basic_integral(1,2) # long time
+            sage: L = E.padic_lseries(5, implementation='pollackstevens', precision=4)
+            sage: L._basic_integral(1,2)
             2*5^2 + 5^3 + O(5^4)
         """
         symb = self.symbol()

--- a/src/sage/modular/pollack_stevens/space.py
+++ b/src/sage/modular/pollack_stevens/space.py
@@ -48,6 +48,7 @@ classical modular symbols (or even elliptic curves) as follows::
 
 ::
 
+    sage: # needs sage.libs.eclib
     sage: E = EllipticCurve('37a1')
     sage: phi = E.pollack_stevens_modular_symbol(); phi
     Modular symbol of level 37 with values in Sym^0 Q^2
@@ -858,6 +859,7 @@ def ps_modsym_from_elliptic_curve(E, sign=0, implementation='eclib'):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('113a1')
         sage: symb = E.pollack_stevens_modular_symbol() # indirect doctest
         sage: symb
@@ -865,6 +867,7 @@ def ps_modsym_from_elliptic_curve(E, sign=0, implementation='eclib'):
         sage: symb.values()
         [-1/2, 1, -1, 0, 0, 1, 1, -1, 0, -1, 0, 0, 0, 1, -1, 0, 0, 0, 1, 0, 0]
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve([0,1])
         sage: symb = E.pollack_stevens_modular_symbol()
         sage: symb.values()
@@ -975,7 +978,7 @@ def ps_modsym_from_simple_modsym_space(A, name='alpha'):
 
         sage: from sage.modular.pollack_stevens.space import ps_modsym_from_simple_modsym_space
         sage: E = EllipticCurve('11a')
-        sage: f_E = E.pollack_stevens_modular_symbol(); f_E.values()
+        sage: f_E = E.pollack_stevens_modular_symbol(); f_E.values()  # needs sage.libs.eclib
         [-1/5, 1, 0]
         sage: A = ModularSymbols(11, sign=1, weight=2).decomposition()[0]
         sage: f_plus = ps_modsym_from_simple_modsym_space(A); f_plus.values()
@@ -991,7 +994,7 @@ def ps_modsym_from_simple_modsym_space(A, name='alpha'):
 
         sage: (-1/5)*vector(QQ, f_plus.values()) + (1/2)*vector(QQ, f_minus.values())
         (-1/5, 1, 0)
-        sage: vector(QQ, f_E.values())
+        sage: vector(QQ, f_E.values())  # needs sage.libs.eclib
         (-1/5, 1, 0)
 
     The next few examples all illustrate the ways in which exceptions are

--- a/src/sage/rings/padics/padic_template_element.pxi
+++ b/src/sage/rings/padics/padic_template_element.pxi
@@ -537,7 +537,7 @@ cdef class pAdicTemplateElement(pAdicGenericElement):
 
         Check to see that :issue:`10292` is resolved::
 
-            sage: # needs sage.schemes
+            sage: # needs sage.schemes sage.libs.eclib
             sage: E = EllipticCurve('37a')
             sage: R = E.padic_regulator(7)
             sage: len(R.expansion())

--- a/src/sage/schemes/elliptic_curves/BSD.py
+++ b/src/sage/schemes/elliptic_curves/BSD.py
@@ -86,6 +86,7 @@ def mwrank_two_descent_work(E, two_tor_rk) -> tuple:
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: from sage.schemes.elliptic_curves.BSD import mwrank_two_descent_work
         sage: E = EllipticCurve('14a')
         sage: mwrank_two_descent_work(E, E.two_torsion_rank())
@@ -130,7 +131,7 @@ def pari_two_descent_work(E) -> tuple:
         sage: pari_two_descent_work(E)
         (0, 0, 0, 0, [])
         sage: E = EllipticCurve('37a')
-        sage: pari_two_descent_work(E) # random, up to sign
+        sage: pari_two_descent_work(E) # random, up to sign, needs sage.libs.eclib
         (1, 1, 0, 0, [(0 : -1 : 1)])
         sage: E = EllipticCurve('210e7')
         sage: pari_two_descent_work(E)
@@ -215,6 +216,7 @@ def heegner_index_work(E) -> tuple:
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: from sage.schemes.elliptic_curves.BSD import heegner_index_work
         sage: heegner_index_work(EllipticCurve('14a'))
         (1, -31)
@@ -298,6 +300,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: EllipticCurve('11a').prove_BSD(verbosity=2)
         p = 2: True by 2-descent
         True for p not in {2, 5} by Kolyvagin.
@@ -305,6 +308,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         True for p = 5 by Kolyvagin bound
         []
 
+        sage: # needs sage.libs.eclib
         sage: EllipticCurve('14a').prove_BSD(verbosity=2)
         p = 2: True by 2-descent
         True for p not in {2, 3} by Kolyvagin.
@@ -312,6 +316,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         True for p = 3 by Kolyvagin bound
         []
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("20a1")
         sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent
@@ -319,6 +324,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         Kato further implies that #Sha[3] is trivial.
         []
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("50b1")
         sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent
@@ -337,16 +343,19 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     We know nothing with proof=True::
 
+        sage: # needs sage.libs.eclib
         sage: E.prove_BSD()
         Set of all prime numbers: 2, 3, 5, 7, ...
 
     We (think we) know everything with proof=False::
 
+        sage: # needs sage.libs.eclib
         sage: E.prove_BSD(proof=False)
         []
 
     A curve of rank 0 and prime conductor::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('19a')
         sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent
@@ -355,6 +364,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         True for p = 3 by Kolyvagin bound
         []
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('37a')
         sage: E.rank()
         1
@@ -370,6 +380,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     We test the consistency check for the 2-part of Sha::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('37a')
         sage: S = E.sha(); S
         Tate-Shafarevich group for the Elliptic Curve defined by y^2 + y = x^3 - x
@@ -384,6 +395,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     An example with a Tamagawa number at 5::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('123a1')
         sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent
@@ -394,8 +406,9 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     A curve for which 3 divides the order of the Tate-Shafarevich group::
 
+        sage: # long time, needs sage.libs.eclib
         sage: E = EllipticCurve('681b')
-        sage: E.prove_BSD(verbosity=2)               # long time
+        sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent...
         True for p not in {2, 3} by Kolyvagin....
         Remaining primes:
@@ -406,6 +419,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     A curve for which we need to use ``heegner_index_bound``::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('198b')
         sage: E.prove_BSD(verbosity=1, secs_hi=1)
         p = 2: True by 2-descent
@@ -415,6 +429,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
     The ``return_BSD`` option gives an object with detailed information
     about the proof::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('26b')
         sage: B = E.prove_BSD(return_BSD=True)
         sage: B.two_tor_rk
@@ -432,6 +447,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     This was fixed by :issue:`8184` and :issue:`7575`::
 
+        sage: # needs sage.libs.eclib
         sage: EllipticCurve('438e1').prove_BSD(verbosity=1)
         p = 2: True by 2-descent...
         True for p not in {2} by Kolyvagin.
@@ -439,14 +455,16 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     ::
 
+        sage: # long time, needs sage.libs.eclib
         sage: E = EllipticCurve('960d1')
-        sage: E.prove_BSD(verbosity=1)  # long time (4s on sage.math, 2011)
+        sage: E.prove_BSD(verbosity=1)
         p = 2: True by 2-descent
         True for p not in {2} by Kolyvagin.
         []
 
     ::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('66b3')
         sage: E.prove_BSD(two_desc="pari",verbosity=1)
         p = 2: True by 2-descent

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -472,9 +472,11 @@ class EllipticCurveFactory(UniqueFactory):
 
         ``names`` is ignored at the moment, however it is used to support a convenient way to get a generator::
 
+            sage: # needs sage.libs.eclib
             sage: E.<P> = EllipticCurve(QQ, [1, 3])
             sage: P
             (-1 : 1 : 1)
+
             sage: E.<P> = EllipticCurve(GF(5), [1, 3])
             sage: P
             (4 : 1 : 1)
@@ -936,13 +938,15 @@ def EllipticCurve_from_cubic(F, P=None, morphism=True):
     the generator::
 
         sage: E = f.codomain()
+        sage: finv = f.inverse()
+
+        sage: # needs sage.libs.eclib
         sage: E.label()
         '720e2'
         sage: E.rank()
         1
         sage: R = E.gens()[0]; R
         (-17280000/2527 : 9331200000/6859 : 1)
-        sage: finv = f.inverse()
         sage: [finv(k*R) for k in range(1,10)]
         [(-4 : 1 : 0),
         (-1 : 4 : 1),
@@ -1447,6 +1451,7 @@ def EllipticCurves_with_good_reduction_outside_S(S=[], proof=None, verbose=False
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: EllipticCurves_with_good_reduction_outside_S([])
         []
         sage: elist = EllipticCurves_with_good_reduction_outside_S([2])
@@ -1462,14 +1467,15 @@ def EllipticCurves_with_good_reduction_outside_S(S=[], proof=None, verbose=False
 
     Without ``Proof=False``, this example gives two warnings::
 
-        sage: elist = EllipticCurves_with_good_reduction_outside_S([11], proof=False)   # long time (14s on sage.math, 2011)
-        sage: len(elist)                                                                # long time
+        sage: # long time, needs sage.libs.eclib
+        sage: elist = EllipticCurves_with_good_reduction_outside_S([11], proof=False)
+        sage: len(elist)
         12
-        sage: ', '.join(e.label() for e in elist)                                       # long time
+        sage: ', '.join(e.label() for e in elist)
         '11a1, 11a2, 11a3, 121a1, 121a2, 121b1, 121b2, 121c1, 121c2, 121d1, 121d2, 121d3'
 
-        sage: # long time
-        sage: elist = EllipticCurves_with_good_reduction_outside_S([2,3])               # long time (26s on sage.math, 2011)
+        sage: # long time, needs sage.libs.eclib
+        sage: elist = EllipticCurves_with_good_reduction_outside_S([2,3])
         sage: len(elist)
         752
         sage: conds = sorted(set([e.conductor() for e in elist]))

--- a/src/sage/schemes/elliptic_curves/ell_egros.py
+++ b/src/sage/schemes/elliptic_curves/ell_egros.py
@@ -34,7 +34,8 @@ Using the ``proof=False`` flag suppresses these warnings.
 EXAMPLES: We find all elliptic curves with good reduction outside 2,
 listing the label of each::
 
-    sage: [e.label() for e in EllipticCurves_with_good_reduction_outside_S([2])]  # long time (5s on sage.math, 2013)
+    sage: # long time, needs sage.libs.eclib
+    sage: [e.label() for e in EllipticCurves_with_good_reduction_outside_S([2])]
     ['32a1',
     '32a2',
     '32a3',
@@ -65,7 +66,8 @@ printed without ``proof=False`` (unless the optional database is
 installed: two of the auxiliary curves whose Mordell-Weil bases are
 required have conductors 13068 and 52272 so are in the database)::
 
-    sage: [e.label() for e in EllipticCurves_with_good_reduction_outside_S([11], proof=False)]  # long time (13s on sage.math, 2011)
+    sage: # long time, needs sage.libs.eclib
+    sage: [e.label() for e in EllipticCurves_with_good_reduction_outside_S([11], proof=False)]
     ['11a1', '11a2', '11a3', '121a1', '121a2', '121b1', '121b2', '121c1', '121c2', '121d1', '121d2', '121d3']
 
 AUTHORS:
@@ -319,6 +321,7 @@ def egros_from_jlist(jlist, S=[]):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_get_j, egros_from_jlist
         sage: jlist=egros_get_j([3])
         sage: elist=egros_from_jlist(jlist,[3])
@@ -371,14 +374,17 @@ def egros_get_j(S=[], proof=None, verbose=False):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_get_j
         sage: egros_get_j([])
         [1728]
-        sage: egros_get_j([2])  # long time (3s on sage.math, 2013)
+
+        sage: # long time, needs sage.libs.eclib
+        sage: egros_get_j([2])
         [128, 432, -864, 1728, 3375/2, -3456, 6912, 8000, 10976, -35937/4, 287496, -784446336, -189613868625/128]
-        sage: egros_get_j([3])  # long time (3s on sage.math, 2013)
+        sage: egros_get_j([3])
         [0, -576, 1536, 1728, -5184, -13824, 21952/9, -41472, 140608/3, -12288000]
-        sage: jlist=egros_get_j([2,3]); len(jlist) # long time (30s)
+        sage: jlist=egros_get_j([2,3]); len(jlist)
         83
     """
     if not all(p.is_prime() for p in S):

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -1519,7 +1519,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
             ...
             NotImplementedError: not implemented.
             sage: E = EllipticCurve(QQ, [1,1])
-            sage: E.gens()
+            sage: E.gens()  # needs sage.libs.eclib
             [(0 : 1 : 1)]
         """
         raise NotImplementedError("not implemented.")
@@ -2196,12 +2196,14 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("37a")
             sage: P = E.gens()[0]
             sage: x = P[0]
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: (35*P)[0]
             -804287518035141565236193151/1063198259901027900600665796
             sage: E._multiple_x_numerator(35, x)
@@ -2211,6 +2213,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: (36*P)[0]
             54202648602164057575419038802/15402543997324146892198790401
             sage: E._multiple_x_numerator(36, x)
@@ -2318,6 +2321,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("43a")
             sage: P = E.gens()[0]
             sage: x = P[0]

--- a/src/sage/schemes/elliptic_curves/ell_modular_symbols.py
+++ b/src/sage/schemes/elliptic_curves/ell_modular_symbols.py
@@ -34,11 +34,14 @@ Modular symbols are used to compute `p`-adic `L`-functions.
 EXAMPLES::
 
     sage: E = EllipticCurve("19a1")
+
+    sage: # needs sage.libs.eclib
     sage: m = E.modular_symbol()
     sage: m(0)
     1/3
     sage: m(1/17)
     -2/3
+
     sage: m2 = E.modular_symbol(-1, implementation='sage')
     sage: m2(0)
     0
@@ -170,9 +173,11 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m.sign()
             1
+
             sage: m = EllipticCurve('11a1').modular_symbol(sign=-1, implementation='sage')
             sage: m.sign()
             -1
@@ -185,6 +190,7 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m.elliptic_curve()
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -197,6 +203,7 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m.base_ring()
             Rational Field
@@ -209,10 +216,12 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m
             Modular symbol with sign 1 over Rational Field attached to
              Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
+
             sage: m = EllipticCurve('43a1').modular_symbol(sign=-1, implementation='sage')
             sage: m
             Modular symbol with sign -1 over Rational Field attached to
@@ -245,6 +254,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: from sage.schemes.elliptic_curves.ell_modular_symbols import ModularSymbolECLIB
             sage: E = EllipticCurve('11a1')
             sage: M = ModularSymbolECLIB(E,+1)
@@ -260,6 +270,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         This is a rank 1 case with vanishing positive twists::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('121b1')
             sage: M = ModularSymbolECLIB(E,+1)
             sage: M(0)
@@ -267,16 +278,19 @@ class ModularSymbolECLIB(ModularSymbol):
             sage: M(1/7)
             1/2
 
+            sage: # needs sage.libs.eclib
             sage: M = EllipticCurve('121d1').modular_symbol(implementation='eclib')
             sage: M(0)
             2
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('15a1')
             sage: [C.modular_symbol(implementation='eclib')(0) for C in E.isogeny_class()]
             [1/4, 1/8, 1/4, 1/2, 1/8, 1/16, 1/2, 1]
 
         Since :issue:`10256`, the interface for negative modular symbols in eclib is available::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Mplus = E.modular_symbol(+1); Mplus
             Modular symbol with sign 1 over Rational Field attached to
@@ -291,6 +305,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         The scaling factor relative to eclib's normalization is 1/2 for curves of negative discriminant::
 
+            sage: # needs sage.libs.eclib
             sage: [E.discriminant() for E in cremona_curves([14])]
             [-21952, 941192, -1835008, -28, 25088, 98]
             sage: [E.modular_symbol()._scaling for E in cremona_curves([14])]
@@ -298,6 +313,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         TESTS (for :issue:`10236`)::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: m = E.modular_symbol(implementation='eclib')
             sage: m(1/7)
@@ -310,6 +326,7 @@ class ModularSymbolECLIB(ModularSymbol):
         v20210310 the value of ``nap`` is increased automatically by
         ``eclib``::
 
+            sage: # needs sage.libs.eclib
             sage: from sage.schemes.elliptic_curves.ell_modular_symbols import ModularSymbolECLIB
             sage: E = EllipticCurve('1590g1')
             sage: m = ModularSymbolECLIB(E, sign=+1, nap=300)
@@ -320,6 +337,7 @@ class ModularSymbolECLIB(ModularSymbol):
         effect.  The correct values may verified by the numerical
         implementation::
 
+            sage: # needs sage.libs.eclib
             sage: m = ModularSymbolECLIB(E, sign=+1, nap=400)
             sage: [m(a/5) for a in [1..4]]
             [13/2, -13/2, -13/2, 13/2]
@@ -346,6 +364,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='eclib')
             sage: m._call_with_caching(0)
             1/5
@@ -365,6 +384,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='eclib')
             sage: m(0)
             1/5
@@ -485,6 +505,14 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
+            sage: m = EllipticCurve('37a1').modular_symbol()
+            sage: m._scaling
+            1
+            sage: m = EllipticCurve('389a1').modular_symbol()
+            sage: m._scaling
+            1
+
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='sage')
             sage: m._scaling
             1/5
@@ -497,12 +525,6 @@ class ModularSymbolSage(ModularSymbol):
             sage: m = EllipticCurve('37a1').modular_symbol(implementation='sage')
             sage: m._scaling
             -1
-            sage: m = EllipticCurve('37a1').modular_symbol()
-            sage: m._scaling
-            1
-            sage: m = EllipticCurve('389a1').modular_symbol()
-            sage: m._scaling
-            1
             sage: m = EllipticCurve('389a1').modular_symbol(implementation='sage')
             sage: m._scaling
             1
@@ -519,8 +541,9 @@ class ModularSymbolSage(ModularSymbol):
 
         TESTS::
 
+            sage: # long time, needs sage.libs.eclib
             sage: rk0 = ['11a1', '11a2', '15a1', '27a1', '37b1']
-            sage: for la in rk0:  # long time (3s on sage.math, 2011)
+            sage: for la in rk0:
             ....:          E = EllipticCurve(la)
             ....:          me = E.modular_symbol(implementation='eclib')
             ....:          ms = E.modular_symbol(implementation='sage')
@@ -531,10 +554,11 @@ class ModularSymbolSage(ModularSymbol):
             1/3 1/3 1/3
             2/3 2/3 2/3
 
+            sage: # long time, needs sage.libs.eclib
             sage: rk1 = ['37a1','43a1','53a1', '91b1','91b2','91b3']
             sage: [EllipticCurve(la).modular_symbol()(0) for la in rk1]  # long time (1s on sage.math, 2011)
             [0, 0, 0, 0, 0, 0]
-            sage: for la in rk1:  # long time (8s on sage.math, 2011)
+            sage: for la in rk1:
             ....:       E = EllipticCurve(la)
             ....:       m = E.modular_symbol()
             ....:       lp = E.padic_lseries(5)

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -152,6 +152,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         Check that non-torsion points are remembered when extending
         the base field (see :issue:`16034`)::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([1, 0, 1, -1751, -31352])
             sage: K.<d> = QuadraticField(5)
             sage: E.gens()
@@ -329,13 +330,14 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 0, 1, -1, 0])
             sage: E.height_pairing_matrix()
             [0.0511114082399688]
 
         For rank 0 curves, the result is a valid 0x0 matrix::
 
-            sage: EllipticCurve('11a').height_pairing_matrix()
+            sage: EllipticCurve('11a').height_pairing_matrix()  # needs sage.libs.eclib
             []
             sage: E = EllipticCurve('5077a1')
             sage: E.height_pairing_matrix([E.lift_x(x) for x in [-2,-7/4,1]], precision=100)
@@ -343,6 +345,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             [ -1.3095767070865761992624519454   2.7173593928122930896610589220   1.0998184305667292139777571432]
             [-0.63486715783715592064475542573   1.0998184305667292139777571432  0.66820516565192793503314205089]
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('389a1')
             sage: E = EllipticCurve('389a1')
             sage: P, Q = E.point([-1,1,1]), E.point([0,-1,1])
@@ -352,6 +355,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Over a number field::
 
+            sage: # needs sage.libs.eclib
             sage: x = polygen(QQ)
             sage: K.<t> = NumberField(x^2 + 47)
             sage: EK = E.base_extend(K)
@@ -490,6 +494,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('389a1')
             sage: P,Q = E.gens()
             sage: E.regulator_of_points([P,Q])
@@ -2329,7 +2334,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 + 23, 'a')
             sage: E = EllipticCurve(K,[0,0,0,101,0])
-            sage: E.gens()
+            sage: E.gens()  # needs sage.libs.eclib
             ((23831509/8669448*a - 2867471/8669448 : 76507317707/18049790736*a - 424166479633/18049790736 : 1),
              (-2031032029/969232392*a + 58813561/969232392 : -15575984630401/21336681877488*a + 451041199309/21336681877488 : 1),
              (-186948623/4656964 : 549438861195/10049728312*a : 1))
@@ -2337,6 +2342,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         It can happen that no points are found if the height bounds
         used in the search are too small (see :issue:`10745`)::
 
+            sage: # needs sage.libs.eclib
             sage: K.<t> = NumberField(x^4 + x^2 - 7)
             sage: E = EllipticCurve(K, [1, 0, 5*t^2 + 16, 0, 0])
             sage: E.gens(lim1=1, lim3=1)
@@ -2348,6 +2354,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Check that the point found has infinite order, and that it is on the curve::
 
+            sage: # needs sage.libs.eclib
             sage: P=gg[0]; P.order()  # long time
             +Infinity
             sage: E.defining_polynomial()(*P)  # long time
@@ -2355,6 +2362,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Here is a curve of rank 2::
 
+            sage: # needs sage.libs.eclib
             sage: K.<t> = NumberField(x^2 - 17)
             sage: E = EllipticCurve(K, [-4, 0])
             sage: E.gens()
@@ -2364,6 +2372,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Test that points of finite order are not included (see :issue:`13593`)::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("17a3")
             sage: K.<t> = NumberField(x^2 + 3)
             sage: EK = E.base_extend(K)
@@ -3368,6 +3377,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Some examples over `\QQ`::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 1, 1, -2, 42])
             sage: Pi = E.gens(); Pi
             [(-4 : 1 : 1), (-3 : 5 : 1), (-11/4 : 43/8 : 1), (-2 : 6 : 1)]
@@ -3417,6 +3427,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         An example to show the explicit use of the height pairing matrix::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 1, 1, -2, 42])
             sage: Pi = E.gens()
             sage: H = E.height_pairing_matrix(Pi,3)
@@ -4055,13 +4066,14 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: E = EllipticCurve([1,2,3,40,50])
             sage: E.conductor()
             2123582
-            sage: E.gens()
+            sage: E.gens()  # needs sage.libs.eclib
             [(5 : 17 : 1)]
             sage: K.<i> = QuadraticField(-1)
             sage: EK = E.change_ring(K)
-            sage: EK.gens_quadratic()
+            sage: EK.gens_quadratic()  # needs sage.libs.eclib
             [(5 : 17 : 1), (-13 : 48*i + 5 : 1)]
 
+            sage: # needs sage.libs.eclib
             sage: E.change_ring(QuadraticField(3, 'a')).gens_quadratic()
             [(5 : 17 : 1), (-1 : 2*a - 1 : 1), (11/4 : 33/4*a - 23/8 : 1)]
 
@@ -4069,16 +4081,16 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: E = EllipticCurve([0,0,0,197,0])
             sage: E.conductor()
             2483776
-            sage: E.gens()
+            sage: E.gens()  # needs sage.libs.eclib
             [(47995604297578081/7389879786648100 : -25038161802544048018837479/635266655830129794121000 : 1)]
             sage: K.<a> = QuadraticField(7)
-            sage: E.change_ring(K).gens_quadratic()
+            sage: E.change_ring(K).gens_quadratic()  # needs sage.libs.eclib
             [(-1209642055/59583566*a + 1639995844/29791783 : -377240626321899/1720892553212*a + 138577803462855/245841793316 : 1),
              (1/28 : 393/392*a : 1),
              (-61*a + 162 : 1098*a - 2916 : 1)]
 
             sage: E = EllipticCurve([1, a])
-            sage: E.gens_quadratic()
+            sage: E.gens_quadratic()  # needs sage.libs.eclib
             Traceback (most recent call last):
             ...
             ValueError: gens_quadratic() requires the elliptic curve to be a base change from Q

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -539,6 +539,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
     Test pickling an elliptic curve that has known points on it::
 
+        sage: # needs sage.libs.eclib
         sage: e = EllipticCurve([0, 0, 1, -1, 0]); g = e.gens(); loads(dumps(e)) == e
         True
 
@@ -788,6 +789,8 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
             (0 : 1 : 0)
             sage: P.is_zero()
             True
+
+            sage: # needs sage.libs.eclib
             sage: P = E.gens()[0]
             sage: P.is_zero()
             False
@@ -992,6 +995,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         Example to show that bug :issue:`4820` is fixed::
 
+            sage: # needs sage.libs.eclib
             sage: [type(c) for c in 2*EllipticCurve('37a1').gen(0)]
             [<... 'sage.rings.rational.Rational'>,
             <... 'sage.rings.rational.Rational'>,
@@ -1083,6 +1087,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         Example to show that bug :issue:`4820` is fixed::
 
+            sage: # needs sage.libs.eclib
             sage: [type(c) for c in -EllipticCurve('37a1').gen(0)]
             [<... 'sage.rings.rational.Rational'>,
              <... 'sage.rings.rational.Rational'>,
@@ -2717,6 +2722,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
     Test pickling an elliptic curve that has known points on it::
 
+        sage: # needs sage.libs.eclib
         sage: e = EllipticCurve([0, 0, 1, -1, 0]); g = e.gens(); loads(dumps(e)) == e
         True
     """
@@ -3032,14 +3038,16 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('990e1')
-            sage: P = E.gen(0); P
-            (15 : 51 : 1)
             sage: [E.has_good_reduction(p) for p in [2,3,5,7]]
             [False, False, False, True]
-            sage: [P.has_good_reduction(p) for p in [2,3,5,7]]
-            [True, False, True, True]
             sage: [E.tamagawa_exponent(p) for p in [2,3,5,7]]
             [2, 2, 1, 1]
+
+            sage: # needs sage.libs.eclib
+            sage: P = E.gen(0); P
+            (15 : 51 : 1)
+            sage: [P.has_good_reduction(p) for p in [2,3,5,7]]
+            [True, False, True, True]
             sage: [(2*P).has_good_reduction(p) for p in [2,3,5,7]]
             [True, True, True, True]
             sage: P.has_good_reduction()
@@ -3242,7 +3250,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
             0.0511114082399688
             sage: P.order()
             +Infinity
-            sage: E.regulator()
+            sage: E.regulator()  # needs sage.libs.eclib
             0.0511114082399688...
 
             sage: def naive_height(P):
@@ -4396,6 +4404,8 @@ class EllipticCurvePoint_finite_field(EllipticCurvePoint_field):
             sage: E = EllipticCurve([0,1,1,a,a])
             sage: E.cardinality()
             762
+
+            sage: # needs sage.libs.eclib
             sage: P = E.gens()[0]
             sage: Q = 400*P
             sage: Q.log(P)

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -169,6 +169,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         right curve (see :issue:`10999`: the following used not to work when
         the large database was installed)::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('389a1')
             sage: [P.curve() is E for P in E.gens()]
             [True, True]
@@ -225,7 +226,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E.rank()         # returns bogus cached value
             99
             sage: E._EllipticCurve_rational_field__rank = None # undo the damage
-            sage: E.rank()         # the correct rank
+            sage: E.rank()         # the correct rank, needs sage.libs.eclib
             1
         """
         self.__rank = (Integer(r), True)
@@ -329,6 +330,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('5077a1')
             sage: E.rank()
             3
@@ -443,6 +445,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs mwrank
             sage: E = EllipticCurve('37a1')
             sage: E.mwrank() # random
             ...
@@ -464,14 +467,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         Run mwrank with ``'verbose'`` flag set to 0 but list generators if
         found::
 
-            sage: print(E.mwrank('-v0 -l'))
+            sage: print(E.mwrank('-v0 -l'))  # needs mwrank
             Curve [0,0,0,877,0] :   0 <= rank <= 1
             Regulator = 1
 
         Run mwrank again, this time with a higher bound for point searching
         on homogeneous spaces::
 
-            sage: print(E.mwrank('-v0 -l -b11'))
+            sage: print(E.mwrank('-v0 -l -b11'))  # needs mwrank
             Curve [0,0,0,877,0] :   Rank = 1
             Generator 1 is [29604565304828237474403861024284371796799791624792913256602210:-256256267988926809388776834045513089648669153204356603464786949:490078023219787588959802933995928925096061616470779979261000]; height 95.98037...
             Regulator = 95.98037...
@@ -512,13 +515,13 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([1, -1, 1, -29372, -1932937])
             sage: E.conductor(algorithm='pari')
             3006
-            sage: E.conductor(algorithm='mwrank')
+            sage: E.conductor(algorithm='mwrank')  # needs sage.libs.eclib
             3006
             sage: E.conductor(algorithm='gp')
             3006
             sage: E.conductor(algorithm='generic')
             3006
-            sage: E.conductor(algorithm='all')
+            sage: E.conductor(algorithm='all')  # needs sage.libs.eclib
             3006
 
         .. NOTE::
@@ -774,6 +777,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: EE = E.mwrank_curve()
             sage: EE
@@ -841,6 +845,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1')
             sage: E.two_descent(verbose=False)
             True
@@ -1094,6 +1099,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         TESTS::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1')
             sage: E.modular_symbol(implementation = 'eclib') is E.modular_symbol(implementation = 'eclib', normalize = 'L_ratio')
             True
@@ -1190,6 +1196,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1')
             sage: M = E.modular_symbol(); M
             Modular symbol with sign 1 over Rational Field attached to
@@ -1221,6 +1228,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         Different curves in an isogeny class have modular symbols
         which differ by a nonzero rational factor::
 
+            sage: # needs sage.libs.eclib
             sage: E1 = EllipticCurve('11a1')
             sage: M1 = E1.modular_symbol()
             sage: M1(0)
@@ -1244,7 +1252,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         normalized::
 
             sage: E = EllipticCurve('11a2')
-            sage: E.modular_symbol(implementation = 'eclib')(0)
+            sage: E.modular_symbol(implementation = 'eclib')(0)  # needs sage.libs.eclib
             1
             sage: E.modular_symbol(implementation = 'sage', normalize='L_ratio')(0)
             1
@@ -1257,7 +1265,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         while the non-normalized symbol is incorrect::
 
             sage: E = EllipticCurve('11a3')
-            sage: E.modular_symbol(implementation = 'eclib')(0)
+            sage: E.modular_symbol(implementation = 'eclib')(0)  # needs sage.libs.eclib
             1/25
             sage: E.modular_symbol(implementation = 'sage', normalize='none')(0)
             1
@@ -1268,6 +1276,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         Since :issue:`10256`, the interface for negative modular symbols in eclib is available::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Mplus = E.modular_symbol(+1); Mplus
             Modular symbol with sign 1 over Rational Field attached to
@@ -1288,8 +1297,10 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         See :issue:`31443`::
 
             sage: E = EllipticCurve('1590g1')
-            sage: m = E.modular_symbol(nap=300)     # long time
-            sage: [m(a/5) for a in [1..4]]          # long time
+
+            sage: # long time, needs sage.libs.eclib
+            sage: m = E.modular_symbol(nap=300)
+            sage: [m(a/5) for a in [1..4]]
             [13/2, -13/2, -13/2, 13/2]
 
         These values are correct, as verified by the numerical
@@ -1343,6 +1354,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('19a1')
             sage: f = E.modular_symbol_numerical(1)
             sage: g = E.modular_symbol(1)
@@ -1386,6 +1398,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('113a1')
             sage: symb = E.pollack_stevens_modular_symbol()
             sage: symb
@@ -1393,6 +1406,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: symb.values()
             [-1/2, 1, -1, 0, 0, 1, 1, -1, 0, -1, 0, 0, 0, 1, -1, 0, 0, 0, 1, 0, 0]
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0,1])
             sage: symb = E.pollack_stevens_modular_symbol(+1)
             sage: symb.values()
@@ -1679,6 +1693,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("11a")
             sage: E.rank()
             0
@@ -1694,6 +1709,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: for r in range(9):
             ....:     E = elliptic_curves.rank(r)[0]
             ....:     print((r, E.analytic_rank_upper_bound(max_Delta=1,
@@ -1858,14 +1874,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             See https://github.com/sagemath/sage/issues/38461 for details.
             (0, 0, [])
             sage: E = EllipticCurve('37a1')
-            sage: E.simon_two_descent()
+            sage: E.simon_two_descent()  # needs sage.libs.eclib
             (1, 1, [(0 : 0 : 1)])
             sage: E = EllipticCurve('389a1')
             sage: E._known_points = []  # clear cached points
-            sage: E.simon_two_descent()
+            sage: E.simon_two_descent()  # needs sage.libs.eclib
             (2, 2, [(-3/4 : 7/8 : 1), (5/4 : 5/8 : 1)])
             sage: E = EllipticCurve('5077a1')
-            sage: E.simon_two_descent()
+            sage: E.simon_two_descent()  # needs sage.libs.eclib
             (3, 3, [(1 : 0 : 1), (2 : 0 : 1), (0 : 2 : 1)])
 
         In this example Simon's program does not find any points, though it
@@ -1882,24 +1898,26 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve([1, -1, 0, -79, 289])
             sage: E.simon_two_descent()
             (4, 4, [(6 : -1 : 1), (4 : 3 : 1), (5 : -2 : 1), (8 : 7 : 1)])
             sage: E = EllipticCurve([0, 0, 1, -79, 342])
-            sage: E.simon_two_descent()  # long time (9s on sage.math, 2011)
+            sage: E.simon_two_descent()
             (5, 5, [(5 : 8 : 1), (10 : 23 : 1), (3 : 11 : 1), (-3 : 23 : 1), (0 : 18 : 1)])
             sage: E = EllipticCurve([1, 1, 0, -2582, 48720])
             sage: r, s, G = E.simon_two_descent(); r,s
             (6, 6)
             sage: E = EllipticCurve([0, 0, 0, -10012, 346900])
-            sage: r, s, G = E.simon_two_descent(); r,s  # long time
+            sage: r, s, G = E.simon_two_descent(); r,s
             (7, 7)
             sage: E = EllipticCurve([0, 0, 1, -23737, 960366])
-            sage: r, s, G = E.simon_two_descent(); r,s  # long time
+            sage: r, s, G = E.simon_two_descent(); r,s
             (8, 8)
 
         Example from :issue:`10832`::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([1,0,0,-6664,86543])
             sage: E.simon_two_descent()
             (2, 3, [(-1/4 : 2377/8 : 1), (323/4 : 1891/8 : 1)])
@@ -1912,16 +1930,18 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         despite that the algorithm has not found any
         points of infinite order ::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([1, 1, 0, -23611790086, 1396491910863060])
             sage: E.simon_two_descent()
             (1, 2, [])
             sage: E.rank()
             1
-            sage: E.gens()     # uses mwrank
+            sage: E.gens()
             [(4311692542083/48594841 : -13035144436525227/338754636611 : 1)]
 
         Example for :issue:`5153`::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([3,0])
             sage: E.simon_two_descent()
             (1, 2, [(1 : 2 : 1)])
@@ -2051,6 +2071,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('11a').rank()
             0
             sage: EllipticCurve('37a').rank()
@@ -2068,6 +2089,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         Examples with denominators in defining equations::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 0, 0, 0, -675/4])
             sage: E.rank()
             0
@@ -2079,6 +2101,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         A large example where mwrank doesn't determine the result with certainty, but pari does::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve([1,0,0,0,37455]).rank(proof=False)
             0
             sage: EllipticCurve([1,0,0,0,37455]).rank(proof=True)
@@ -2097,6 +2120,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         An example to check if the points are saturated::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0,0, 1, -7, 6])
             sage: E.gens(use_database=False, algorithm='pari') # random
             [(2 : 0 : 1), (-1 : 3 : 1), (11 : 35 : 1)]
@@ -2106,6 +2130,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         Since :issue:`23962`, the default is to use the Cremona
         database. We also check that the result is cached correctly::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([-517, -4528])  # 1888b1
             sage: E.rank(use_database=False)
             Traceback (most recent call last):
@@ -2312,6 +2337,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('389a')
             sage: E.gens()                 # random output
             [(-1 : 1 : 1), (0 : 0 : 1)]
@@ -2323,12 +2349,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         A non-integral example::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([-3/8,-2/3])
             sage: E.gens() # random (up to sign)
             [(10/9 : 29/54 : 1)]
 
         A non-minimal example::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('389a1')
             sage: E1 = E.change_weierstrass_model([1/20,0,0,0]); E1
             Elliptic Curve defined by y^2 + 8000*y = x^3 + 400*x^2 - 320000*x
@@ -2340,6 +2368,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         TESTS::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('389a')
             sage: len(E.gens())
             2
@@ -2356,7 +2385,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         Check that :issue:`38813` has been fixed::
 
-            sage: # long time
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve([-127^2,0])
             sage: l = E.gens(use_database=False, algorithm='pari', pari_effort=4); l   # random
             [(611429153205013185025/9492121848205441 : 15118836457596902442737698070880/924793900700594415341761 : 1)]
@@ -2408,21 +2437,24 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([-3/8, -2/3])
             sage: gens, proved = E._compute_gens(proof=False)
             sage: proved
             True
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve([-127^2,0])
-            sage: E.gens(use_database=False, algorithm='pari', pari_effort=4)   # long time, random
+            sage: E.gens(use_database=False, algorithm='pari', pari_effort=4)  # random
             [(611429153205013185025/9492121848205441 : 15118836457596902442737698070880/924793900700594415341761 : 1)]
 
         TESTS::
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve([-127^2,0])
             sage: P = E.lift_x(611429153205013185025/9492121848205441)
-            sage: ge = set(E.gens(use_database=False, algorithm='pari',pari_effort=4))   # long time
-            sage: ge <= set([P+T for T in E.torsion_points()]  # long time
+            sage: ge = set(E.gens(use_database=False, algorithm='pari',pari_effort=4))
+            sage: ge <= set([P+T for T in E.torsion_points()]
             ....:        + [-P+T for T in E.torsion_points()])
             True
         """
@@ -2561,6 +2593,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1')
             sage: E.gens()                   # random (up to sign)
             [(0 : -1 : 1)]
@@ -2569,6 +2602,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         TESTS::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1')
             sage: P = E([0,-1])
             sage: set(E.gens()) <= set([P,-P])
@@ -2598,15 +2632,18 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1')
             sage: E.ngens()
             1
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0,0,0,877,0])
             sage: E.ngens()
             1
 
-            sage: print(E.mwrank('-v0 -b12 -l'))
+            sage: E = EllipticCurve([0,0,0,877,0])
+            sage: print(E.mwrank('-v0 -b12 -l'))  # needs mwrank
             Curve [0,0,0,877,0] :   Rank = 1
             Generator 1 is [29604565304828237474403861024284371796799791624792913256602210:-256256267988926809388776834045513089648669153204356603464786949:490078023219787588959802933995928925096061616470779979261000]; height 95.98037...
             Regulator = 95.980...
@@ -2630,6 +2667,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 0, 1, -1, 0])
             sage: E.regulator()
             0.0511114082399688
@@ -2743,6 +2781,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1')
             sage: P=E(0,0)
             sage: Q=5*P; Q
@@ -2756,6 +2795,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         ``v20190909``, this example would loop forever at default
         precision.  Since version ``v20210310`` it runs fine::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([1, 0, 1, -977842, -372252745])
             sage: P = E([-192128125858676194585718821667542660822323528626273/336995568430319276695106602174283479617040716649, 70208213492933395764907328787228427430477177498927549075405076353624188436/195630373799784831667835900062564586429333568841391304129067339731164107, 1])
             sage: P.height()
@@ -2773,6 +2813,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         See :issue:`10840`.  This used to cause eclib to crash since the
         curve is non-minimal at 2::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0,0,0,-13711473216,0])
             sage: P = E([-19992,16313472])
             sage: Q = E([-24108,-17791704])
@@ -2783,6 +2824,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         See :issue:`34029`.  With eclib versions prior to 20220621 this failed to saturate::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 0, 0, -17607, -889490])
             sage: Q = E([-82,54])
             sage: E.saturation([2*Q], max_prime=10)
@@ -2843,6 +2885,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("11a")
             sage: E.CPS_height_bound()
             2.8774743273580445
@@ -2911,9 +2954,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve('37a1')
             sage: E.silverman_height_bound()
             4.825400758180918
-            sage: E.silverman_height_bound(algorithm='mwrank')
+            sage: E.silverman_height_bound(algorithm='mwrank')  # needs sage.libs.eclib
             4.825400758180918
-            sage: E.CPS_height_bound()
+            sage: E.CPS_height_bound()  # needs sage.libs.eclib
             0.16397076103046915
         """
         if algorithm == 'default':
@@ -2969,13 +3012,13 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         EXAMPLES::
 
             sage: E = EllipticCurve('389a1')
-            sage: E.point_search(1, verbose=False)
+            sage: E.point_search(1, verbose=False)  # needs sage.libs.eclib
             [(-1 : 1 : 1), (0 : 0 : 1)]
 
         Increasing the height_limit takes longer, but finds no more
         points::
 
-            sage: E.point_search(10, verbose=False)  # long time
+            sage: E.point_search(10, verbose=False)  # long time, needs sage.libs.eclib
             [(-1 : 1 : 1), (0 : 0 : 1)]
 
         In fact this curve has rank 2 so no more than 2 points will ever be
@@ -2983,7 +3026,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
-            sage: E.saturation(_)
+            sage: E.saturation(_)  # needs sage.libs.eclib
             ([(-1 : 1 : 1), (0 : 0 : 1)], 1, 0.152460177943144)
 
         What this shows is that if the rank is 2 then the points listed do
@@ -2991,12 +3034,12 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
-            sage: E.rank()
+            sage: E.rank()  # needs sage.libs.eclib
             2
 
         If we only need one independent generator::
 
-            sage: E.point_search(5, verbose=False, rank_bound=1)
+            sage: E.point_search(5, verbose=False, rank_bound=1)  # needs sage.libs.eclib
             [(-2 : 0 : 1)]
         """
         # Convert logarithmic height to height
@@ -3030,7 +3073,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([1, 1, 1, 508, -2551])
             sage: E.selmer_rank()
             4
-            sage: E.selmer_rank(algorithm='mwrank')
+            sage: E.selmer_rank(algorithm='mwrank')  # needs sage.libs.eclib
             4
 
         The following is the curve 960d1, which has rank 0, but
@@ -3039,7 +3082,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([0, -1, 0, -900, -10098])
             sage: E.selmer_rank()
             3
-            sage: E.selmer_rank(algorithm='mwrank')
+            sage: E.selmer_rank(algorithm='mwrank')  # needs sage.libs.eclib
             3
 
         This curve has rank 1, and 4 elements in Sha[2].
@@ -3055,7 +3098,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([1, 0, 0, -49280, -4214808])
             sage: E.selmer_rank()
             5
-            sage: E.rank()
+            sage: E.rank()  # needs sage.libs.eclib
             0
         """
         try:
@@ -3099,7 +3142,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([0, -1, 1, -929, -10595])
             sage: E.rank_bound()
             0
-            sage: E.rank_bound(algorithm='mwrank')
+            sage: E.rank_bound(algorithm='mwrank')  # needs sage.libs.eclib
             2
 
         In the following last example, both algorithm only determine a rank bound larger than the actual rank::
@@ -3107,7 +3150,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: E = EllipticCurve([1, 1, 1, -896670, -327184905])
             sage: E.rank_bound()
             2
-            sage: E.rank_bound(algorithm='mwrank')
+            sage: E.rank_bound(algorithm='mwrank')  # needs sage.libs.eclib
             2
             sage: E.rank(only_use_mwrank=False) # uses L-function
             0
@@ -5667,7 +5710,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: S
             Tate-Shafarevich group for the Elliptic Curve
              defined by y^2 + y = x^3 - x over Rational Field
-            sage: S.bound_kolyvagin()
+            sage: S.bound_kolyvagin()  # needs sage.libs.eclib
             ([2], 1)
         """
         try:
@@ -6002,6 +6045,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         The bug reported on :issue:`22719` is now fixed::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("141d1")
             sage: E.integral_points()
             [(0 : -1 : 1), (2 : -2 : 1)]
@@ -6050,7 +6094,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
             sage: E = EllipticCurve([0,0,1,-7,6])
             sage: P1 = E.point((2,0)); P2 = E.point((-1,3)); P3 = E.point((4,6))
-            sage: a = E.integral_points([P1,P2,P3]); a
+            sage: a = E.integral_points([P1,P2,P3]); a  # needs sage.libs.eclib
             [(-3 : -1 : 1), (-2 : -4 : 1), (-1 : -4 : 1), (0 : -3 : 1),
              (1 : -1 : 1), (2 : -1 : 1), (3 : -4 : 1), (4 : -7 : 1),
              (8 : -22 : 1), (11 : -36 : 1), (14 : -52 : 1), (21 : -96 : 1),
@@ -6059,6 +6103,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: a = E.integral_points([P1,P2,P3], verbose=True)
             Using mw_basis  [(2 : 0 : 1), (3 : -4 : 1), (8 : -22 : 1)]
             e1,e2,e3:  -3.0124303725933... 1.0658205476962... 1.94660982489710
@@ -6078,6 +6123,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0,0,1,-7,6])
             sage: a = E.integral_points(both_signs=True); a
             [(-3 : -1 : 1), (-3 : 0 : 1), (-2 : -4 : 1), (-2 : 3 : 1), (-1 : -4 : 1),
@@ -6091,6 +6137,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         An example with negative discriminant::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('900d1').integral_points()
             [(-11 : -27 : 1), (-4 : -34 : 1), (4 : -18 : 1), (16 : -54 : 1)]
 
@@ -6107,21 +6154,25 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         The bug reported on :issue:`4525` is now fixed::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('91b1').integral_points()
             [(-1 : -4 : 1), (1 : -1 : 1), (3 : -5 : 1)]
 
         ::
 
-            sage: [len(e.integral_points(both_signs=False)) for e in cremona_curves([11..100])]  # long time (15s on sage.math, 2011)
+            sage: # long time, needs sage.libs.eclib
+            sage: [len(e.integral_points(both_signs=False)) for e in cremona_curves([11..100])]
             [2, 0, 2, 3, 2, 1, 3, 0, 2, 4, 2, 4, 3, 0, 0, 1, 2, 1, 2, 0, 2, 1, 0, 1, 3, 3, 1, 1, 4, 2, 3, 2, 0, 0, 5, 3, 2, 2, 1, 1, 1, 0, 1, 3, 0, 1, 0, 1, 1, 3, 6, 1, 2, 2, 2, 0, 0, 2, 3, 1, 2, 2, 1, 1, 0, 3, 2, 1, 0, 1, 0, 1, 3, 3, 1, 1, 5, 1, 0, 1, 1, 0, 1, 2, 0, 2, 0, 1, 1, 3, 1, 2, 2, 4, 4, 2, 1, 0, 0, 5, 1, 0, 1, 2, 0, 2, 2, 0, 0, 0, 1, 0, 3, 1, 5, 1, 2, 4, 1, 0, 1, 0, 1, 0, 1, 0, 2, 2, 0, 0, 1, 0, 1, 1, 4, 1, 0, 1, 1, 0, 4, 2, 0, 1, 1, 2, 3, 1, 1, 1, 1, 6, 2, 1, 1, 0, 2, 0, 6, 2, 0, 4, 2, 2, 0, 0, 1, 2, 0, 2, 1, 0, 3, 1, 2, 1, 4, 6, 3, 2, 1, 0, 2, 2, 0, 0, 5, 4, 1, 0, 0, 1, 0, 2, 2, 0, 0, 2, 3, 1, 3, 1, 1, 0, 1, 0, 0, 1, 2, 2, 0, 2, 0, 0, 1, 2, 0, 0, 4, 1, 0, 1, 1, 0, 1, 2, 0, 1, 4, 3, 1, 2, 2, 1, 1, 1, 1, 6, 3, 3, 3, 3, 1, 1, 1, 1, 1, 0, 7, 3, 0, 1, 3, 2, 1, 0, 3, 2, 1, 0, 2, 2, 6, 0, 0, 6, 2, 2, 3, 3, 5, 5, 1, 0, 6, 1, 0, 3, 1, 1, 2, 3, 1, 2, 1, 1, 0, 1, 0, 1, 0, 5, 5, 2, 2, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1]
 
         The bug reported at :issue:`4897` is now fixed::
 
+            sage: # needs sage.libs.eclib
             sage: [P[0] for P in EllipticCurve([0,0,0,-468,2592]).integral_points()]
             [-24, -18, -14, -6, -3, 4, 6, 18, 21, 24, 36, 46, 102, 168, 186, 381, 1476, 2034, 67246]
 
         See :issue:`22063`::
 
+            sage: # needs sage.libs.eclib
             sage: for n in [67,71,74,91]:  # long time
             ....:     assert 4*n^6 + 4*n^2 in [P[0] for P in EllipticCurve([0,0,0,2,n^2]).integral_points()]
 
@@ -6541,12 +6592,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # needs sage.libs.eclib
             sage: a = E.S_integral_points([2,3])
             sage: len(a)
             43
 
         An example with negative discriminant::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('900d1').S_integral_points([17], both_signs=True)
             [(-11 : -27 : 1), (-11 : 27 : 1), (-4 : -34 : 1), (-4 : 34 : 1), (4 : -18 : 1),
              (4 : 18 : 1), (2636/289 : -98786/4913 : 1), (2636/289 : 98786/4913 : 1),
@@ -6554,17 +6607,20 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         Output checked with Magma (corrected in 3 cases)::
 
-            sage: [len(e.S_integral_points([2], both_signs=False)) for e in cremona_curves([11..100])] # long time (17s on sage.math, 2011)
+            sage: # long time, needs sage.libs.eclib
+            sage: [len(e.S_integral_points([2], both_signs=False)) for e in cremona_curves([11..100])]
             [2, 0, 2, 3, 3, 1, 3, 1, 3, 5, 3, 5, 4, 1, 1, 2, 2, 2, 3, 1, 2, 1, 0, 1, 3, 3, 1, 1, 5, 3, 4, 2, 1, 1, 5, 3, 2, 2, 1, 1, 1, 0, 1, 3, 0, 1, 0, 1, 1, 3, 7, 1, 3, 3, 3, 1, 1, 2, 3, 1, 2, 3, 1, 2, 1, 3, 3, 1, 1, 1, 0, 1, 3, 3, 1, 1, 7, 1, 0, 1, 1, 0, 1, 2, 0, 3, 1, 2, 1, 3, 1, 2, 2, 4, 5, 3, 2, 1, 1, 6, 1, 0, 1, 3, 1, 3, 3, 1, 1, 1, 1, 1, 3, 1, 5, 1, 2, 4, 1, 1, 1, 1, 1, 0, 1, 0, 2, 2, 0, 0, 1, 0, 1, 1, 6, 1, 0, 1, 1, 0, 4, 3, 1, 2, 1, 2, 3, 1, 1, 1, 1, 8, 3, 1, 2, 1, 2, 0, 8, 2, 0, 6, 2, 3, 1, 1, 1, 3, 1, 3, 2, 1, 3, 1, 2, 1, 6, 9, 3, 3, 1, 1, 2, 3, 1, 1, 5, 5, 1, 1, 0, 1, 1, 2, 3, 1, 1, 2, 3, 1, 3, 1, 1, 1, 1, 0, 0, 1, 3, 3, 1, 3, 1, 1, 2, 2, 0, 0, 6, 1, 0, 1, 1, 1, 1, 3, 1, 2, 6, 3, 1, 2, 2, 1, 1, 1, 1, 7, 5, 4, 3, 3, 1, 1, 1, 1, 1, 1, 8, 5, 1, 1, 3, 3, 1, 1, 3, 3, 1, 1, 2, 3, 6, 1, 1, 7, 3, 3, 4, 5, 9, 6, 1, 0, 7, 1, 1, 3, 1, 1, 2, 3, 1, 2, 1, 1, 1, 1, 1, 1, 1, 7, 8, 2, 3, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1]
 
         An example from [PZGH1999]_::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0,0,0,-172,505])
             sage: E.rank(), len(E.S_integral_points([3,5,7]))  # long time (5s on sage.math, 2011)
             (4, 72)
 
         This is curve "7690e1" which failed until :issue:`4805` was fixed::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve([1,1,1,-301,-1821]).S_integral_points([13,2])
             [(-13 : -4 : 1), (-9 : -12 : 1), (-7 : 2 : 1), (21 : -52 : 1),
              (23 : -76 : 1), (63 : -516 : 1), (71 : -620 : 1), (87 : -844 : 1),
@@ -7099,6 +7155,7 @@ def cremona_curves(conductors):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: [(E.label(), E.rank()) for E in cremona_curves(srange(35,40))]
         [('35a1', 0),
          ('35a2', 0),
@@ -7133,6 +7190,7 @@ def cremona_optimal_curves(conductors):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: [(E.label(), E.rank()) for E in cremona_optimal_curves(srange(35,40))]
         [('35a1', 0),
          ('36a1', 0),
@@ -7176,11 +7234,12 @@ def integral_points_with_bounded_mw_coeffs(E, mw_base, N, x_bound):
 
     We check that some large integral points in a paper of Zagier are found::
 
+        sage: # long time, needs sage.libs.eclib
         sage: def t(a, b, x): # indirect doctest
         ....:     E = EllipticCurve([0,0,0,a,b])
         ....:     xs = [P[0] for P in E.integral_points()]
         ....:     return x in xs
-        sage: all(t(a,b,x) for a,b,x in [(-2,5, 1318), (4,-1, 4321),  # long time
+        sage: all(t(a,b,x) for a,b,x in [(-2,5, 1318), (4,-1, 4321),
         ....: (0,17, 5234), (11,4, 16833), (-13,37, 60721), (-12,-10, 80327),
         ....: (-7,22, 484961), (-9,28, 764396), (-13,4, 1056517), (-19,-51,
         ....: 2955980), (-24,124, 4435710), (-30,133, 5143326), (-37,60,

--- a/src/sage/schemes/elliptic_curves/ell_tate_curve.py
+++ b/src/sage/schemes/elliptic_curves/ell_tate_curve.py
@@ -584,6 +584,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: e = EllipticCurve('130a1')
             sage: eq = e.tate_curve(5)
             sage: h = eq.padic_height(prec=10)
@@ -593,6 +594,7 @@ class TateCurve(SageObject):
 
         Check that it is a quadratic function::
 
+            sage: # needs sage.libs.eclib
             sage: h(3*P)-3^2*h(P)
             O(5^9)
         """
@@ -641,6 +643,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.padic_regulator()
             2*5^-1 + 1 + 2*5 + 2*5^2 + 3*5^3 + 3*5^6 + 5^7 + 3*5^9 + 3*5^10 + 3*5^12 + 4*5^13 + 3*5^15 + 2*5^16 + 3*5^18 + 4*5^19 +  4*5^20 + 3*5^21 + 4*5^22 + O(5^23)

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -69,7 +69,7 @@ Here we find that the Heegner point generates a subgroup of index 3::
     sage: P = E.heegner_point(-7)
     sage: z = P.point_exact(); z == E(0, 1, 1)  or -z == E(0, 1, 1)
     True
-    sage: E.regulator()
+    sage: E.regulator()  # needs sage.libs.eclib
     0.0498083972980648
     sage: z.height()
     0.448275575682583
@@ -82,6 +82,7 @@ Here we find that the Heegner point generates a subgroup of index 3::
 
 The above is consistent with the following analytic computation::
 
+    sage: # needs sage.libs.eclib
     sage: E.heegner_index(-7)
     3.0000?
 """
@@ -3231,9 +3232,9 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             sage: P = E.heegner_point(-19); y = P._trace_numerical_conductor_1()
             sage: [c.real() for c in y]
             [-1.2...e-16, -1.00000000000000, 1.00000000000000]
-            sage: -2*E.gens()[0]
+            sage: -2*E.gens()[0]  # needs sage.libs.eclib
             (0 : -1 : 1)
-            sage: P._trace_index()
+            sage: P._trace_index()  # needs sage.libs.eclib
             2
 
             sage: P = E.heegner_point(-68); P
@@ -3241,7 +3242,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             sage: N(P)
             (0.219223593595584 - 1.87443160153148*I
              : -1.34232921921325 - 1.52356748877889*I : 1.00000000000000)
-            sage: P._trace_index()
+            sage: P._trace_index()  # needs sage.libs.eclib
             0
         """
         if self.conductor() != 1:
@@ -3784,7 +3785,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             0.150298370947295
             sage: P.height()
             0.0375745927368238
-            sage: E.heegner_index(-8)
+            sage: E.heegner_index(-8)  # needs sage.libs.eclib
             2.0000?
             sage: E.torsion_order()
             1
@@ -4137,6 +4138,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67); P.index()
             6
         """
@@ -4187,6 +4189,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         A rank 1 curve::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: P.point_exact()
             (6 : -15 : 1)
@@ -4199,6 +4202,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         A rank 0 curve::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1'); P = E.kolyvagin_point(-7)
             sage: P.point_exact()
             (-1/2*sqrt_minus_7 + 1/2 : -2*sqrt_minus_7 - 2 : 1)
@@ -4335,6 +4339,8 @@ class KolyvaginPoint(HeegnerPoint):
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: P.trace_to_real_numerical()
             (1.61355529131986 : -2.18446840788880 : 1.00000000000000)
+
+            sage: # needs sage.libs.eclib
             sage: P._trace_exact_conductor_1()  # the actual point we're reducing
             (1357/841 : -53277/24389 : 1)
             sage: (P._trace_exact_conductor_1().height() / E.regulator()).sqrt()
@@ -4361,7 +4367,7 @@ class KolyvaginPoint(HeegnerPoint):
             sage: E = EllipticCurve('43a'); P = E.heegner_point(-20).kolyvagin_point()
             sage: PP = P.numerical_approx(); PP
             (0.000000000000000 : -1.00000000000000 : 1.00000000000000)
-            sage: P._recognize_point_over_QQ(PP, 4)
+            sage: P._recognize_point_over_QQ(PP, 4)  # needs sage.libs.eclib
             (0 : -1 : 1)
         """
         # Here is where we *should* implement the "method of Cremona
@@ -4395,16 +4401,18 @@ class KolyvaginPoint(HeegnerPoint):
         A Kolyvagin point on a rank 1 curve::
 
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
-            sage: P.mod(2)
+            sage: P.mod(2)  # needs sage.libs.eclib
             (1 : 1 : 1)
-            sage: P.mod(3)
+            sage: P.mod(3)  # needs sage.libs.eclib
             (1 : 0 : 1)
-            sage: P.mod(5)
+            sage: P.mod(5)  # needs sage.libs.eclib
             (2 : 2 : 1)
-            sage: P.mod(7)
+            sage: P.mod(7)  # needs sage.libs.eclib
             (6 : 0 : 1)
             sage: P.trace_to_real_numerical()
             (1.61355529131986 : -2.18446840788880 : 1.00000000000000)
+
+            sage: # needs sage.libs.eclib
             sage: P._trace_exact_conductor_1()  # the actual point we're reducing
             (1357/841 : -53277/24389 : 1)
             sage: (P._trace_exact_conductor_1().height() / E.regulator()).sqrt()
@@ -4414,9 +4422,9 @@ class KolyvaginPoint(HeegnerPoint):
         rank 1), and we reduce it modulo several primes.::
 
             sage: E = EllipticCurve('11a1'); P = E.kolyvagin_point(-7)
-            sage: P.mod(3,70)  # long time (4s on sage.math, 2013)
+            sage: P.mod(3,70)  # long time, needs sage.libs.eclib
             (1 : 2 : 1)
-            sage: P.mod(5,70)
+            sage: P.mod(5,70)  # needs sage.libs.eclib
             (1 : 4 : 1)
             sage: P.mod(7,70)
             Traceback (most recent call last):
@@ -4426,7 +4434,7 @@ class KolyvaginPoint(HeegnerPoint):
             Traceback (most recent call last):
             ...
             ValueError: p must be coprime to conductors and discriminant
-            sage: P.mod(13,70)
+            sage: P.mod(13,70)  # needs sage.libs.eclib
             (3 : 4 : 1)
         """
         # check preconditions
@@ -5679,11 +5687,13 @@ def kolyvagin_reduction_data(E, q, first_only=True):
 
     A rank 1 example::
 
+        sage: # needs sage.libs.eclib
         sage: kolyvagin_reduction_data(EllipticCurve('37a1'), 3)
         (17, -7, 1, 52)
 
     A rank 3 example::
 
+        sage: # needs sage.libs.eclib
         sage: kolyvagin_reduction_data(EllipticCurve('5077a1'), 3)
         (11, -47, 5, 4234)
         sage: H = heegner_points(5077, -47)
@@ -5699,7 +5709,7 @@ def kolyvagin_reduction_data(E, q, first_only=True):
     present)::
 
         sage: E = elliptic_curves.rank(4)[0]
-        sage: kolyvagin_reduction_data(E,3)              # long time
+        sage: kolyvagin_reduction_data(E,3)  # long time, needs sage.libs.eclib
         (11, -71, 7, 293060)
         sage: H = heegner_points(293060, -71)
         sage: H.kolyvagin_conductors(1,4,E,3)
@@ -5707,6 +5717,7 @@ def kolyvagin_reduction_data(E, q, first_only=True):
 
     The first rank 2 example::
 
+        sage: # needs sage.libs.eclib
         sage: kolyvagin_reduction_data(EllipticCurve('389a'), 3)
         (5, -7, 1, 130)
         sage: kolyvagin_reduction_data(EllipticCurve('389a'), 3, first_only=False)
@@ -5714,11 +5725,13 @@ def kolyvagin_reduction_data(E, q, first_only=True):
 
     A large `q = 7`::
 
+        sage: # needs sage.libs.eclib
         sage: kolyvagin_reduction_data(EllipticCurve('1143c1'), 7, first_only=False)
         (13, 83, -59, 3, 1536, 10496)
 
     Additive reduction::
 
+        sage: # needs sage.libs.eclib
         sage: kolyvagin_reduction_data(EllipticCurve('2350g1'), 5, first_only=False)
         (19, 239, -311, 19, 6480, 85680)
     """
@@ -6457,10 +6470,10 @@ def kolyvagin_point(self, D, c=ZZ(1), check=True):
         Kolyvagin point of discriminant -67 on elliptic curve of conductor 37
         sage: P.numerical_approx()  # abs tol 1e-14
         (6.00000000000000 : -15.0000000000000 : 1.00000000000000)
-        sage: P.index()
+        sage: P.index()  # needs sage.libs.eclib
         6
         sage: g = E((0,-1,1)) # a generator
-        sage: E.regulator() == E.regulator_of_points([g])
+        sage: E.regulator() == E.regulator_of_points([g])  # needs sage.libs.eclib
         True
         sage: 6*g
         (6 : -15 : 1)
@@ -6649,7 +6662,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
         sage: E = EllipticCurve('11a')
         sage: E.heegner_discriminants(50)
         [-7, -8, -19, -24, -35, -39, -40, -43]
-        sage: E.heegner_index(-7)
+        sage: E.heegner_index(-7)  # needs sage.libs.eclib
         1.00000?
 
     ::
@@ -6657,13 +6670,14 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
         sage: E = EllipticCurve('37b')
         sage: E.heegner_discriminants(100)
         [-3, -4, -7, -11, -40, -47, -67, -71, -83, -84, -95]
-        sage: E.heegner_index(-95)          # long time (1 second)
+        sage: E.heegner_index(-95)  # long time, needs sage.libs.eclib
         2.00000?
 
     This tests doing direct computation of the Mordell-Weil group.
 
     ::
 
+        sage: # needs sage.libs.eclib
         sage: EllipticCurve('675b').heegner_index(-11)
         3.0000?
 
@@ -6676,8 +6690,9 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
 
     The curve 681b returns the true index, which is `3`::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('681b')
-        sage: I = E.heegner_index(-8); I
+        sage: I = E.heegner_index(-8);
         3.0000?
 
     In fact, whenever the returned index has a denominator of
@@ -6690,6 +6705,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
     which can be used to fine tune the 2-descent used to compute
     the regulator of the twist::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve([1,-1,0,-1228,-16267])
         sage: E.heegner_index(-8)
         Traceback (most recent call last):
@@ -6698,7 +6714,8 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
 
     However when we search higher, we find the points we need::
 
-        sage: E.heegner_index(-8, descent_second_limit=16, check_rank=False)  # long time
+        sage: # long time, needs sage.libs.eclib
+        sage: E.heegner_index(-8, descent_second_limit=16, check_rank=False)
         2.00000?
 
     Two higher rank examples (of ranks 2 and 3)::
@@ -6709,9 +6726,9 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
         sage: E = EllipticCurve('5077a')
         sage: E.heegner_index(-7)
         +Infinity
-        sage: E.heegner_index(-7, check_rank=False)
+        sage: E.heegner_index(-7, check_rank=False)  # needs sage.libs.eclib
         0.001?
-        sage: E.heegner_index(-7, check_rank=False).lower() == 0
+        sage: E.heegner_index(-7, check_rank=False).lower() == 0  # needs sage.libs.eclib
         True
     """
     if not self.satisfies_heegner_hypothesis(D):
@@ -6861,6 +6878,7 @@ def heegner_index_bound(self, D=0, prec=5, max_height=None):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('11a1')
         sage: E.heegner_index_bound()
         ([2], -7, 2)
@@ -6965,6 +6983,8 @@ def _heegner_index_in_EK(self, D):
     We compute the index for a rank 2 curve and found that it is 2::
 
         sage: E = EllipticCurve('389a')
+
+        sage: # needs sage.libs.eclib
         sage: E._heegner_index_in_EK(-7)
         2
 
@@ -7077,48 +7097,54 @@ def heegner_sha_an(self, D, prec=53):
 
     An example where E has conductor 11::
 
+        sage: # long time, needs sage.libs.eclib
         sage: E = EllipticCurve('11a')
-        sage: E.heegner_sha_an(-7)                                  # long time
+        sage: E.heegner_sha_an(-7)
         1.00000000000000
 
     The cache works::
 
-        sage: E.heegner_sha_an(-7) is E.heegner_sha_an(-7)          # long time
+        sage: # long time, needs sage.libs.eclib
+        sage: E.heegner_sha_an(-7) is E.heegner_sha_an(-7)
         True
 
     Lower precision::
 
-        sage: E.heegner_sha_an(-7,10)                               # long time
+        sage: # long time, needs sage.libs.eclib
+        sage: E.heegner_sha_an(-7,10)
         1.0
 
     Checking that the cache works for any precision::
 
-        sage: E.heegner_sha_an(-7,10) is E.heegner_sha_an(-7,10)    # long time
+        sage: # long time, needs sage.libs.eclib
+        sage: E.heegner_sha_an(-7,10) is E.heegner_sha_an(-7,10)
         True
 
     Next we consider a rank 1 curve with nontrivial Sha over the
     quadratic imaginary field `K`; however, there is no Sha for `E`
     over `\QQ` or for the quadratic twist of `E`::
 
+        sage: # long time, needs sage.libs.eclib
         sage: E = EllipticCurve('37a')
-        sage: E.heegner_sha_an(-40)                                 # long time
+        sage: E.heegner_sha_an(-40)
         4.00000000000000
-        sage: E.quadratic_twist(-40).sha().an()                     # long time
+        sage: E.quadratic_twist(-40).sha().an()
         1
-        sage: E.sha().an()                                          # long time
+        sage: E.sha().an()
         1
 
     A rank 2 curve::
 
-        sage: E = EllipticCurve('389a')                             # long time
-        sage: E.heegner_sha_an(-7)                                  # long time
+        sage: # long time, needs sage.libs.eclib
+        sage: E = EllipticCurve('389a')
+        sage: E.heegner_sha_an(-7)
         1.00000000000000
 
     If we remove the hypothesis that `E(K)` has rank 1 in Conjecture
     2.3 in [GZ1986]_ page 311, then that conjecture is
     false, as the following example shows::
 
-        sage: # long time
+        sage: # long time, needs sage.libs.eclib
         sage: E = EllipticCurve('65a')
         sage: E.heegner_sha_an(-56)
         1.00000000000000

--- a/src/sage/schemes/elliptic_curves/height.py
+++ b/src/sage/schemes/elliptic_curves/height.py
@@ -2071,7 +2071,7 @@ class EllipticCurveCanonicalHeight:
             sage: h = E.height_function()
             sage: h.min(.01, 5)
             0.03987318057488725
-            sage: E.gen(0).height()
+            sage: E.gen(0).height()  # needs sage.libs.eclib
             0.0511114082399688
 
         After base change the lower bound can decrease::
@@ -2084,7 +2084,7 @@ class EllipticCurveCanonicalHeight:
             sage: h = E.height_function()
             sage: h.min(0.1, 5)
             0.05731275270029196
-            sage: [P.height() for P in E.gens()]
+            sage: [P.height() for P in E.gens()]  # needs sage.libs.eclib
             [0.686667083305587, 0.327000773651605]
         """
         # The lcm of the exponents of all the component groups at

--- a/src/sage/schemes/elliptic_curves/lseries_ell.py
+++ b/src/sage/schemes/elliptic_curves/lseries_ell.py
@@ -843,7 +843,9 @@ class Lseries_ell(SageObject):
 
             sage: EllipticCurve([0,0,0,-193^2,0]).sha().an()
             4
-            sage: EllipticCurve([1, 0, 1, -131, 558]).sha().an()  # long time
+
+            sage: # long time, needs sage.libs.eclib
+            sage: EllipticCurve([1, 0, 1, -131, 558]).sha().an()
             1.00000000000000
 
         ALGORITHM: Compute the root number.  If it is -1 then `L(E,s)`

--- a/src/sage/schemes/elliptic_curves/padic_lseries.py
+++ b/src/sage/schemes/elliptic_curves/padic_lseries.py
@@ -99,6 +99,7 @@ class pAdicLseries(SageObject):
 
     An ordinary example::
 
+        sage: # needs sage.libs.eclib
         sage: e = EllipticCurve('389a')
         sage: L = e.padic_lseries(5)
         sage: L.series(0)
@@ -116,6 +117,7 @@ class pAdicLseries(SageObject):
 
     A prime p such that E[p] is reducible::
 
+        sage: # needs sage.libs.eclib
         sage: L = EllipticCurve('11a').padic_lseries(5)
         sage: L.series(1)
         5 + O(5^2) + O(T)
@@ -126,6 +128,7 @@ class pAdicLseries(SageObject):
 
     An example showing the calculation of nontrivial Teichmueller twists::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('11a1')
         sage: lp = E.padic_lseries(7)
         sage: lp.series(4,eta=1)
@@ -137,6 +140,7 @@ class pAdicLseries(SageObject):
 
     (Note that the last series vanishes at `T = 0`, which is consistent with ::
 
+        sage: # needs sage.libs.eclib
         sage: E.quadratic_twist(-7).rank()
         1
 
@@ -146,6 +150,7 @@ class pAdicLseries(SageObject):
 
     The load-dumps test::
 
+        sage: # needs sage.libs.eclib
         sage: lp = EllipticCurve('11a').padic_lseries(5)
         sage: lp == loads(dumps(lp))
         True
@@ -166,6 +171,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(3)
             sage: Lp.series(2,prec=3)
@@ -201,6 +207,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: lp = E.padic_lseries(5)
             sage: lp.modular_symbol(1/7,sign=-1)  #indirect doctest
@@ -214,6 +221,7 @@ class pAdicLseries(SageObject):
 
         TESTS::
 
+            sage: # needs sage.libs.eclib
             sage: lp1 = EllipticCurve('11a1').padic_lseries(5)
             sage: lp2 = EllipticCurve('11a1').padic_lseries(7)
             sage: lp3 = EllipticCurve('11a2').padic_lseries(5)
@@ -234,6 +242,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.elliptic_curve()
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -246,6 +255,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.prime()
             5
@@ -258,6 +268,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: e = EllipticCurve('37a')
             sage: e.padic_lseries(3)._repr_()
             '3-adic L-series of Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field'
@@ -297,6 +308,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: lp = E.padic_lseries(5)
             sage: [lp.modular_symbol(r) for r in [0,1/5,oo,1/11]]
@@ -306,6 +318,7 @@ class pAdicLseries(SageObject):
             sage: [lp.modular_symbol(r,quadratic_twist=-20) for r in [0,1/5,oo,1/11]]
             [1, 1, 0, 1/2]
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('20a1')
             sage: Et = E.quadratic_twist(-4)
             sage: lpt = Et.padic_lseries(5)
@@ -387,6 +400,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a')
             sage: L = E.padic_lseries(5)
             sage: L.measure(1,2, prec=9)
@@ -396,6 +410,7 @@ class pAdicLseries(SageObject):
             sage: L.measure(1,2, quadratic_twist=-4,prec=15)
             4 + 4*5 + 4*5^2 + 3*5^3 + 2*5^4 + 5^5 + 3*5^6 + 5^8 + 2*5^9 + 3*5^12 + 2*5^13 + 4*5^14 + O(5^15)
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: a = E.quadratic_twist(-3).padic_lseries(5).measure(1,2,prec=15)
             sage: b = E.padic_lseries(5).measure(1,2, quadratic_twist=-3,prec=15)
@@ -465,6 +480,7 @@ class pAdicLseries(SageObject):
 
         An ordinary prime::
 
+            sage: # needs sage.libs.eclib
             sage: L = E.padic_lseries(5)
             sage: alpha = L.alpha(10); alpha
             3 + 2*5 + 4*5^2 + 2*5^3 + 5^4 + 4*5^5 + 2*5^7 + 5^8 + 5^9 + O(5^10)
@@ -473,6 +489,7 @@ class pAdicLseries(SageObject):
 
         A supersingular prime::
 
+            sage: # needs sage.libs.eclib
             sage: L = E.padic_lseries(3)
             sage: alpha = L.alpha(10); alpha
             alpha + O(alpha^21)
@@ -481,6 +498,7 @@ class pAdicLseries(SageObject):
 
         A reducible prime::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.alpha(5)
             1 + 4*5 + 3*5^2 + 2*5^3 + 4*5^4 + O(5^5)
@@ -534,6 +552,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(3)
             sage: L.order_of_vanishing()
             0
@@ -593,6 +612,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(7)
             sage: L.teichmuller(1)
             [0, 1, 2, 3, 4, 5, 6]
@@ -612,6 +632,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(2)
             sage: Lp._e_bounds(1,10)
@@ -641,6 +662,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(5)
             sage: Lp._pAdicLseries__series = {}  # clear cached series
@@ -668,6 +690,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(5)
             sage: Lp.series(3,prec=5)
@@ -693,6 +716,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37b1')
             sage: lp = E.padic_lseries(3)
             sage: lp._quotient_of_periods_to_twist(-20)
@@ -710,6 +734,7 @@ class pAdicLseries(SageObject):
             sage: lp._quotient_of_periods_to_twist(12)
             1
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Et = E.quadratic_twist(-3)
             sage: lpt = Et.padic_lseries(5)
@@ -770,6 +795,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
         We compute some `p`-adic `L`-functions associated to the elliptic
         curve 11a::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: p = 3
             sage: E.is_ordinary(p)
@@ -782,6 +808,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
         `p`-adic `L`-function has an extra 0 (compared to the non
         `p`-adic `L`-function)::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a')
             sage: p = 11
             sage: E.is_ordinary(p)
@@ -792,6 +819,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         We compute a `p`-adic `L`-function that vanishes to order 2::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('389a')
             sage: p = 3
             sage: E.is_ordinary(p)
@@ -806,6 +834,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         Checks if the precision can be changed (:issue:`5846`)::
 
+            sage: # needs sage.libs.eclib
             sage: L.series(3,prec=4)
             O(3^5) + O(3^2)*T + (2 + 2*3 + O(3^2))*T^2 + (2 + O(3))*T^3 + O(T^4)
             sage: L.series(3,prec=6)
@@ -814,6 +843,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
         Rather than computing the `p`-adic `L`-function for the curve '15523a1', one can
         compute it as a quadratic_twist::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('43a1')
             sage: lp = E.padic_lseries(3)
             sage: lp.series(2,quadratic_twist=-19)
@@ -834,11 +864,13 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         It should now also work with `p=2` (:issue:`20798`)::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("53a1")
             sage: lp = E.padic_lseries(2)
             sage: lp.series(7)
             O(2^8) + (1 + 2^2 + 2^3 + O(2^5))*T + (1 + 2^3 + O(2^4))*T^2 + (2^2 + 2^3 + O(2^4))*T^3 + (2 + 2^2 + O(2^3))*T^4 + O(T^5)
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("109a1")
             sage: lp = E.padic_lseries(2)
             sage: lp.series(6)
@@ -987,6 +1019,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.is_ordinary()
             True
@@ -1000,6 +1033,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.is_supersingular()
             False
@@ -1024,6 +1058,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(5)
             sage: Lp._c_bound()
@@ -1032,16 +1067,17 @@ class pAdicLseriesOrdinary(pAdicLseries):
             0
             sage: EllipticCurve('11a3').padic_lseries(5)._c_bound()
             2
-            sage: EllipticCurve('11a3').padic_lseries(5, implementation='sage')._c_bound()
-            2
             sage: EllipticCurve('50b1').padic_lseries(3)._c_bound()
             0
-            sage: EllipticCurve('50b1').padic_lseries(3, implementation='sage')._c_bound()
-            1
             sage: l = EllipticCurve("11a1").padic_lseries(5)
             sage: ls = l.series(1,eta=1);
             sage: l._c_bound(sign=-1)
             0
+
+            sage: EllipticCurve('11a3').padic_lseries(5, implementation='sage')._c_bound()
+            2
+            sage: EllipticCurve('50b1').padic_lseries(3, implementation='sage')._c_bound()
+            1
         """
         E = self._E
         p = self._p
@@ -1122,6 +1158,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(5)
             sage: Lp._prec_bounds(3,10)
@@ -1133,6 +1170,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
             sage: Lp._prec_bounds(15,10)
             [+Infinity, 13, 13, 13, 13, 12, 12, 12, 12, 12]
 
+            sage: # needs sage.libs.eclib
             sage: Lp = E.padic_lseries(3)
             sage: Lp._prec_bounds(15,10)
             [+Infinity, 14, 14, 13, 13, 13, 13, 13, 13, 12]
@@ -1184,6 +1222,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         A supersingular example, where we must compute to higher precision to see anything::
 
+            sage: # needs sage.libs.eclib
             sage: e = EllipticCurve('37a')
             sage: L = e.padic_lseries(3); L
             3-adic L-series of Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
@@ -1196,6 +1235,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         An example where we only compute the leading term (:issue:`15737`)::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("17a1")
             sage: L = E.padic_lseries(3)
             sage: L.series(4,prec=1)
@@ -1203,6 +1243,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         It works also for `p=2`::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("11a1")
             sage: lp = E.padic_lseries(2)
             sage: lp.series(10)
@@ -1327,6 +1368,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(19)
             sage: L.is_ordinary()
             False
@@ -1340,6 +1382,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: L = EllipticCurve('11a').padic_lseries(19)
             sage: L.is_supersingular()
             True
@@ -1355,6 +1398,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(19)
             sage: Lp._prec_bounds(3,5)
@@ -1378,6 +1422,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("14a1")
             sage: lp = E.padic_lseries(5)
             sage: K = lp.alpha().parent()
@@ -1424,6 +1469,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('14a')
             sage: L = E.padic_lseries(5)
             sage: L.Dp_valued_series(4)  # long time (9s on sage.math, 2011)
@@ -1469,6 +1515,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('14a')
             sage: L = E.padic_lseries(5)
             sage: phi = L.frobenius(5)
@@ -1531,12 +1578,14 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('11a1')
             sage: lp = E.padic_lseries(19)
             sage: lp.frobenius(prec=1,algorithm='approx')   #indirect doctest
             [          O(19^0) 4*19^-1 + O(19^0)]
             [       14 + O(19)           O(19^0)]
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('17a1')
             sage: lp = E.padic_lseries(3)
             sage: lp.frobenius(prec=3,algorithm='approx')
@@ -1618,6 +1667,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('14a')
             sage: L = E.padic_lseries(5)
             sage: L.bernardi_sigma_function(prec=5) # Todo: some sort of consistency check!?
@@ -1657,6 +1707,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('53a')
             sage: L = E.padic_lseries(5)
             sage: h = L.Dp_valued_height(7)
@@ -1713,6 +1764,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('43a')
             sage: L = E.padic_lseries(7)
             sage: L.Dp_valued_regulator(7)

--- a/src/sage/schemes/elliptic_curves/padics.py
+++ b/src/sage/schemes/elliptic_curves/padics.py
@@ -131,6 +131,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('37a')
         sage: L = E.padic_lseries(5); L
         5-adic L-series of Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
@@ -141,6 +142,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
     rank `0` and in each case verify the interpolation property
     for their leading coefficient (i.e., value at 0)::
 
+        sage: # needs sage.libs.eclib
         sage: e = EllipticCurve('11a')
         sage: ms = e.modular_symbol()
         sage: [ms(1/11), ms(1/3), ms(0), ms(oo)]
@@ -166,6 +168,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     Next consider the curve 37b::
 
+        sage: # needs sage.libs.eclib
         sage: e = EllipticCurve('37b')
         sage: L = e.padic_lseries(3)
         sage: P = L.series(5)
@@ -195,6 +198,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     Finally, we can use the overconvergent method of Pollack-Stevens.::
 
+        sage: # needs sage.libs.eclib
         sage: e = EllipticCurve('11a')
         sage: L = e.padic_lseries(3, implementation = 'pollackstevens', precision = 6)
         sage: L.series(5)
@@ -204,6 +208,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     Another example with a semistable prime.::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("11a1")
         sage: L = E.padic_lseries(11, implementation = 'pollackstevens', precision=3)
         sage: L[1]
@@ -271,23 +276,27 @@ def padic_regulator(self, p, prec=20, height=None, check_hypotheses=True):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("37a")
         sage: E.padic_regulator(5, 10)
         5 + 5^2 + 5^3 + 3*5^6 + 4*5^7 + 5^9 + O(5^10)
 
     An anomalous case::
 
+        sage: # needs sage.libs.eclib
         sage: E.padic_regulator(53, 10)
         26*53^-1 + 30 + 20*53 + 47*53^2 + 10*53^3 + 32*53^4 + 9*53^5 + 22*53^6 + 35*53^7 + 30*53^8 + O(53^9)
 
     An anomalous case where the precision drops some::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("5077a")
         sage: E.padic_regulator(5, 10)
         5 + 5^2 + 4*5^3 + 2*5^4 + 2*5^5 + 2*5^6 + 4*5^7 + 2*5^8 + 5^9 + O(5^10)
 
     Check that answers agree over a range of precisions::
 
+        sage: # needs sage.libs.eclib
         sage: max_prec = 30    # make sure we get past p^2    # long time
         sage: full = E.padic_regulator(5, max_prec)           # long time
         sage: for prec in range(1, max_prec):                 # long time
@@ -296,12 +305,14 @@ def padic_regulator(self, p, prec=20, height=None, check_hypotheses=True):
     A case where the generator belongs to the formal group already
     (:issue:`3632`)::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve([37,0])
         sage: E.padic_regulator(5,10)
         2*5^2 + 2*5^3 + 5^4 + 5^5 + 4*5^6 + 3*5^8 + 4*5^9 + O(5^10)
 
     The result is not dependent on the model for the curve::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve([0,0,0,0,2^12*17])
         sage: Em = E.minimal_model()
         sage: E.padic_regulator(7) == Em.padic_regulator(7)
@@ -309,6 +320,7 @@ def padic_regulator(self, p, prec=20, height=None, check_hypotheses=True):
 
     Allow a python int as input::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('37a')
         sage: E.padic_regulator(int(5))
         5 + 5^2 + 5^3 + 3*5^6 + 4*5^7 + 5^9 + 5^10 + 3*5^11 + 3*5^12 + 5^13 + 4*5^14 + 5^15 + 2*5^16 + 5^17 + 2*5^18 + 4*5^19 + O(5^20)
@@ -373,6 +385,7 @@ def padic_height_pairing_matrix(self, p, prec=20, height=None, check_hypotheses=
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("37a")
         sage: E.padic_height_pairing_matrix(5, 10)
         [5 + 5^2 + 5^3 + 3*5^6 + 4*5^7 + 5^9 + O(5^10)]
@@ -495,6 +508,7 @@ def _multiply_point(E, R, P, m):
     Test over a range of `n` for a single curve with fairly
     random coefficients::
 
+        sage: # needs sage.libs.eclib
         sage: R = Integers(625)
         sage: E = EllipticCurve([4, -11, 17, -8, -10])
         sage: P = E.gens()[0] * LCM(E.tamagawa_numbers())
@@ -708,6 +722,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("37a")
         sage: P = E.gens()[0]
         sage: h = E.padic_height(5, 10)
@@ -716,22 +731,26 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     An anomalous case::
 
+        sage: # needs sage.libs.eclib
         sage: h = E.padic_height(53, 10)
         sage: h(P)
         26*53^-1 + 30 + 20*53 + 47*53^2 + 10*53^3 + 32*53^4 + 9*53^5 + 22*53^6 + 35*53^7 + 30*53^8 + 17*53^9 + O(53^10)
 
     Boundary case::
 
+        sage: # needs sage.libs.eclib
         sage: E.padic_height(5, 3)(P)
         5 + 5^2 + O(5^3)
 
     A case that works the division polynomial code a little harder::
 
+        sage: # needs sage.libs.eclib
         sage: E.padic_height(5, 10)(5*P)
         5^3 + 5^4 + 5^5 + 3*5^8 + 4*5^9 + O(5^10)
 
     Check that answers agree over a range of precisions::
 
+        sage: # needs sage.libs.eclib
         sage: max_prec = 30    # make sure we get past p^2    # long time
         sage: full = E.padic_height(5, max_prec)(P)           # long time
         sage: for prec in range(1, max_prec):                 # long time
@@ -739,6 +758,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     A supersingular prime for a curve::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('37a')
         sage: E.is_supersingular(3)
         True
@@ -752,6 +772,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     A torsion point in both the good and supersingular cases::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('11a')
         sage: P = E.torsion_subgroup().gen(0).element(); P
         (5 : 5 : 1)
@@ -764,6 +785,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     The result is not dependent on the model for the curve::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve([0,0,0,0,2^12*17])
         sage: Em = E.minimal_model()
         sage: P = E.gens()[0]
@@ -777,6 +799,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     Check that issue :issue:`20798` is solved::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("91b")
         sage: h = E.padic_height(7,10)
         sage: P = E.gen(0)
@@ -903,6 +926,7 @@ def padic_height_via_multiply(self, p, prec=20, E2=None, check_hypotheses=True):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve("37a")
         sage: P = E.gens()[0]
         sage: h = E.padic_height_via_multiply(5, 10)
@@ -911,12 +935,14 @@ def padic_height_via_multiply(self, p, prec=20, E2=None, check_hypotheses=True):
 
     An anomalous case::
 
+        sage: # needs sage.libs.eclib
         sage: h = E.padic_height_via_multiply(53, 10)
         sage: h(P)
         26*53^-1 + 30 + 20*53 + 47*53^2 + 10*53^3 + 32*53^4 + 9*53^5 + 22*53^6 + 35*53^7 + 30*53^8 + 17*53^9 + O(53^10)
 
     Supply the value of E2 manually::
 
+        sage: # needs sage.libs.eclib
         sage: E2 = E.padic_E2(5, 8)
         sage: E2
         2 + 4*5 + 2*5^3 + 5^4 + 3*5^5 + 2*5^6 + O(5^8)
@@ -926,11 +952,13 @@ def padic_height_via_multiply(self, p, prec=20, E2=None, check_hypotheses=True):
 
     Boundary case::
 
+        sage: # needs sage.libs.eclib
         sage: E.padic_height_via_multiply(5, 3)(P)
         5 + 5^2 + O(5^3)
 
     Check that answers agree over a range of precisions::
 
+        sage: # needs sage.libs.eclib
         sage: max_prec = 30    # make sure we get past p^2    # long time
         sage: full = E.padic_height(5, max_prec)(P)           # long time
         sage: for prec in range(2, max_prec):                 # long time

--- a/src/sage/schemes/elliptic_curves/sha_tate.py
+++ b/src/sage/schemes/elliptic_curves/sha_tate.py
@@ -34,6 +34,7 @@ triviality the `p`-primary part of `Sha`.
 
 EXAMPLES::
 
+    sage: # needs sage.libs.eclib
     sage: E = EllipticCurve('11a1')
     sage: S = E.sha()
     sage: S.bound_kato()
@@ -47,6 +48,7 @@ EXAMPLES::
     sage: S.an_numerical()
     1.00000000000000
 
+    sage: # needs sage.libs.eclib
     sage: E = EllipticCurve('389a')
     sage: S = E.sha(); S
     Tate-Shafarevich group for the
@@ -110,6 +112,7 @@ class Sha(SageObject):
 
     EXAMPLES::
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('571a1')
         sage: E._set_gens([])   # curve has rank 0, but non-trivial Sha[2]
         sage: S = E.sha()
@@ -124,6 +127,7 @@ class Sha(SageObject):
         sage: S.an_numerical()
         4.00000000000000
 
+        sage: # needs sage.libs.eclib
         sage: E = EllipticCurve('389a')
         sage: S = E.sha(); S
         Tate-Shafarevich group for the
@@ -238,6 +242,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs.sage.libs.eclib
             sage: EllipticCurve('11a').sha().an_numerical()
             1.00000000000000
             sage: EllipticCurve('37a').sha().an_numerical()
@@ -251,18 +256,21 @@ class Sha(SageObject):
 
         A rank 4 curve::
 
+            sage: # needs.sage.libs.eclib
             sage: EllipticCurve([1, -1, 0, -79, 289]).sha().an_numerical()  # long time (3s on sage.math, 2011)
             1.00000000000000
 
         A rank 5 curve::
 
-            sage: EllipticCurve([0, 0, 1, -79, 342]).sha().an_numerical(prec=10, proof=False)  # long time (22s on sage.math, 2011)
+            sage: # long time, needs.sage.libs.eclib
+            sage: EllipticCurve([0, 0, 1, -79, 342]).sha().an_numerical(prec=10, proof=False)
             1.0
 
         See :issue:`1115`::
 
+            sage: # long time, needs.sage.libs.eclib
             sage: sha = EllipticCurve('37a1').sha()
-            sage: [sha.an_numerical(prec) for prec in range(40,100,10)]  # long time (3s on sage.math, 2013)
+            sage: [sha.an_numerical(prec) for prec in range(40,100,10)]
             [1.0000000000,
              1.0000000000000,
              1.0000000000000000,
@@ -324,6 +332,7 @@ class Sha(SageObject):
 
         If you come across the following error::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 0, 1, -34874, -2506691])
             sage: E.sha().an()
             Traceback (most recent call last):
@@ -335,11 +344,13 @@ class Sha(SageObject):
         You can increase the ``descent_second_limit`` (in the above example,
         set to the default, 12) option to try again::
 
+            sage: # needs sage.libs.eclib
             sage: E.sha().an(descent_second_limit=16)  # long time (2s on sage.math, 2011)
             1
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, -1, 1, -10, -20])   # 11A  = X_0(11)
             sage: E.sha().an()
             1
@@ -347,6 +358,7 @@ class Sha(SageObject):
             sage: E.sha().an()
             1
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('14a4').sha().an()
             1
             sage: EllipticCurve('14a4').sha().an(use_database=True)   # will be faster if you have large Cremona database installed
@@ -354,12 +366,14 @@ class Sha(SageObject):
 
         The smallest conductor curve with nontrivial `Sha`::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([1,1,1,-352,-2689])     # 66b3
             sage: E.sha().an()
             4
 
         The four optimal quotients with nontrivial `Sha` and conductor <= 1000::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, -1, 1, -929, -10595])       # 571A
             sage: E.sha().an()
             4
@@ -375,6 +389,7 @@ class Sha(SageObject):
 
         The smallest conductor curve of rank > 1::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 1, 1, -2, 0])       # 389A (rank 2)
             sage: E.sha().an()
             1.00000000000000
@@ -382,10 +397,12 @@ class Sha(SageObject):
         The following are examples that require computation of the Mordell-
         Weil group and regulator::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, 0, 1, -1, 0])                     # 37A  (rank 1)
             sage: E.sha().an()
             1
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("1610f3")
             sage: E.sha().an()
             4
@@ -393,6 +410,7 @@ class Sha(SageObject):
         In this case the input curve is not minimal, and if this function did
         not transform it to be minimal, it would give nonsense::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([0, -432*6^2])
             sage: E.sha().an()
             1
@@ -400,6 +418,7 @@ class Sha(SageObject):
         See :issue:`10096`: this used to give the wrong result 6.0000
         before since the minimal model was not used::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([1215*1216, 0]) # non-minimal model
             sage: E.sha().an()  # long time (2s on sage.math, 2011)
             1.00000000000000
@@ -485,6 +504,7 @@ class Sha(SageObject):
 
         Good ordinary examples::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('11a1').sha().an_padic(5)    # rank 0
             1 + O(5^22)
             sage: EllipticCurve('43a1').sha().an_padic(5)    # rank 1
@@ -500,6 +520,7 @@ class Sha(SageObject):
 
         Exceptional cases::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('11a1').sha().an_padic(11) # rank 0
             1 + O(11^22)
             sage: EllipticCurve('130a1').sha().an_padic(5) # rank 1
@@ -507,16 +528,19 @@ class Sha(SageObject):
 
         Non-split, but rank 0 case (:issue:`7331`)::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('270b1').sha().an_padic(5) # rank 0, long time (2s on sage.math, 2011)
             1 + O(5^22)
 
         The output has the correct sign::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('123a1').sha().an_padic(41) # rank 1, long time (3s on sage.math, 2011)
             1 + O(41)
 
         Supersingular cases::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('34a1').sha().an_padic(5) # rank 0
             1 + O(5^22)
             sage: EllipticCurve('53a1').sha().an_padic(5) # rank 1, long time (11s on sage.math, 2011)
@@ -524,6 +548,7 @@ class Sha(SageObject):
 
         Cases that use a twist to a lower conductor::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('99a1').sha().an_padic(5)
             1 + O(5)
             sage: EllipticCurve('240d3').sha().an_padic(5)  # sha has 4 elements here
@@ -535,6 +560,7 @@ class Sha(SageObject):
 
         Test for :issue:`15737`::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve([-100,0])
             sage: s = E.sha()
             sage: s.an_padic(13)
@@ -734,6 +760,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve("389a1")  # rank 2
             sage: E.sha().p_primary_order(5)
             0
@@ -811,6 +838,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: e = EllipticCurve('11a3')
             sage: e.sha().p_primary_bound(3)
             0
@@ -823,6 +851,7 @@ class Sha(SageObject):
             sage: e.sha().p_primary_bound(13)
             0
 
+            sage: # needs sage.libs.eclib
             sage: e = EllipticCurve('389a1')
             sage: e.sha().p_primary_bound(5)
             0
@@ -833,13 +862,15 @@ class Sha(SageObject):
             sage: e.sha().p_primary_bound(13)
             0
 
+            sage: # long time, needs sage.libs.eclib
             sage: e = EllipticCurve('858k2')
-            sage: e.sha().p_primary_bound(3)  # long time (10s on sage.math, 2011)
+            sage: e.sha().p_primary_bound(3)
             0
 
         Some checks for :issue:`6406` and :issue:`16959`::
 
-            sage: e.sha().p_primary_bound(7)  # long time
+            sage: # long time, needs sage.libs.eclib
+            sage: e.sha().p_primary_bound(7)
             2
 
             sage: E = EllipticCurve('608b1')
@@ -850,11 +881,13 @@ class Sha(SageObject):
             Current knowledge about Euler systems does not provide an upper bound
             in this case. Try an_padic for a conjectural bound.
 
-            sage: E.sha().an_padic(5)           # long time
+            sage: # long time, needs sage.libs.eclib
+            sage: E.sha().an_padic(5)
             1 + O(5^22)
 
+            sage: # long time, needs sage.libs.eclib
             sage: E = EllipticCurve("5040bi1")
-            sage: E.sha().p_primary_bound(5)    # long time
+            sage: E.sha().p_primary_bound(5)
             0
         """
         p = Integer(p)
@@ -957,6 +990,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('37a')
             sage: E.sha().bound_kolyvagin()
             ([2], 1)
@@ -968,6 +1002,7 @@ class Sha(SageObject):
 
         We get no information when the curve has rank 2.::
 
+            sage: # needs sage.libs.eclib
             sage: E = EllipticCurve('389a')
             sage: E.sha().bound_kolyvagin()
             (0, 0)
@@ -1148,6 +1183,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs sage.libs.eclib
             sage: EllipticCurve('37a').sha().bound()
             ([2], 1)
         """

--- a/src/sage/tests/benchmark.py
+++ b/src/sage/tests/benchmark.py
@@ -1635,7 +1635,7 @@ class EllipticCurveMW(Benchmark):
 
             sage: from sage.tests.benchmark import EllipticCurveMW
             sage: B = EllipticCurveMW([1,2,3,4,5])
-            sage: isinstance(B.sage()[1], float)
+            sage: isinstance(B.sage()[1], float)  # needs sage.libs.eclib
             True
         """
         E = EllipticCurve(self.ainvs)

--- a/src/sage/tests/book_stein_ent.py
+++ b/src/sage/tests/book_stein_ent.py
@@ -628,20 +628,20 @@ sage: r([-3024, 46224])
 2
 sage: r([-112, 400])
 3
-sage: r([-102627, 12560670])
+sage: r([-102627, 12560670])  # needs sage.libs.eclib
 4
 sage: def cong(n):
 ....:     G = EllipticCurve([-n^2,0]).gens()
 ....:     if len(G) == 0: return False
 ....:     x,y,_ = G[0]
 ....:     return ((n^2-x^2)/y,-2*x*n/y,(n^2+x^2)/y)
-sage: cong(6)
+sage: cong(6)  # needs sage.libs.eclib
 (3, 4, 5)
-sage: cong(5)
+sage: cong(5)  # needs sage.libs.eclib
 (3/2, 20/3, 41/6)
-sage: cong(1)
+sage: cong(1)  # needs sage.libs.eclib
 False
-sage: cong(13)
+sage: cong(13)  # needs sage.libs.eclib
 (323/30, 780/323, 106921/9690)
 sage: (323/30 * 780/323)/2
 13


### PR DESCRIPTION
Sage can now be built without eclib/mwrank, but the tests will fail (https://github.com/sagemath/sage/issues/40543). This adds two features, one for sage.libs.eclib and one for mwrank, and then adds "needs" tags as appropriate.

This works now, but can wait until meson is used in sage-the-distro and the explicit options PR is merged. This will make it easy to run both long and non-long test suites on the CI with eclib disabled.

### Dependencies

* https://github.com/sagemath/sage/pull/39030
* https://github.com/sagemath/sage/pull/40485
* https://github.com/sagemath/sage/pull/41550

### Fixes

* https://github.com/sagemath/sage/issues/40543