### PR TITLE
Remove bin/sage-python since it has been removed

### DIFF
--- a/pkgs/sagemath-environment/pyproject.toml.m4
+++ b/pkgs/sagemath-environment/pyproject.toml.m4
@@ -47,8 +47,6 @@ script-files = [
     "bin/sage-num-threads.py",
     "bin/sage-venv-config",
     "bin/sage-version.sh",
-    # Auxiliary script for invoking Python in the Sage environment
-    "bin/sage-python",
     # Not included:
     # - bin/sage-env-config                  -- installed by sage_conf
     # - bin/sage-env-config.in               -- not to be installed


### PR DESCRIPTION
Remove bin/sage-python since it has been removed.

See
https://github.com/sagemath/sage/commit/c4f7b06a43c72f09df743772ff8f9ff00dcbf97b#commitcomment-163324918
and
https://www.google.com/url?q=https://groups.google.com/d/msgid/sage-release/3D750982-2C9C-49E1-BA4A-9B9F3072E1D6%2540gmail.com

