### PR TITLE
Avoid mutating value field of constructed Integer

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7556,8 +7556,8 @@ def _check_global_dummy_Integer():
         sage: _check_global_dummy_Integer()
         True
     """
-    # Check that it has exactly one limb allocated
-    # This is assumed later in fast_tp_new() :issue:`33081`
+    # Check that it has no allocation (requires GMP >= 6.2, see :issue:`31340`)
+    # fast_tp_new() later assumes that memcpy this mpz object gives a valid new mpz
     cdef mpz_ptr dummy = global_dummy_Integer.value
     if dummy._mp_alloc == 0 and dummy._mp_size == 0:
         return True
@@ -7648,7 +7648,7 @@ cdef PyObject* fast_tp_new(type t, args, kwds) except NULL:
     # The global_dummy_Integer may have a reference count larger than
     # one, but it is expected that newly created objects have a
     # reference count of one. This is potentially unneeded if
-    # everybody plays nice, because the gobal_dummy_Integer has only
+    # everybody plays nice, because the global_dummy_Integer has only
     # one reference in that case.
 
     # Objects from the pool have reference count zero, so this

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -1782,9 +1782,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         cdef Integer temp
 
         if mpz_sgn(self.value) == 0:
-            temp = PY_NEW(Integer)
-            mpz_set_ui(temp.value, 0)
-            return temp
+            return self
 
         if mpz_sgn(self.value) > 0:
             temp = self.exact_log(base)
@@ -1816,7 +1814,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             mpz_add(x.value, (<Integer>left).value, (<Integer>right).value)
             return x
         elif type(right) is Rational:
-            y = <Rational> Rational.__new__(Rational)
+            y = <Rational>PY_NEW(Rational)
             mpq_add_z(y.value, (<Rational>right).value, (<Integer>left).value)
             return y
 
@@ -1899,7 +1897,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             mpz_sub(x.value, (<Integer>left).value, (<Integer>right).value)
             return x
         elif type(right) is Rational:
-            y = <Rational> Rational.__new__(Rational)
+            y = <Rational>PY_NEW(Rational)
             mpz_mul(mpq_numref(y.value), (<Integer>left).value,
                     mpq_denref((<Rational>right).value))
             mpz_sub(mpq_numref(y.value), mpq_numref(y.value),
@@ -2011,7 +2009,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             mpz_mul(x.value, (<Integer>left).value, (<Integer>right).value)
             return x
         elif type(right) is Rational:
-            y = <Rational> Rational.__new__(Rational)
+            y = <Rational>PY_NEW(Rational)
             mpq_mul_z(y.value, (<Rational>right).value, (<Integer>left).value)
             return y
 
@@ -2074,14 +2072,14 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         if type(left) is type(right):
             if mpz_sgn((<Integer>right).value) == 0:
                 raise ZeroDivisionError("rational division by zero")
-            x = <Rational> Rational.__new__(Rational)
+            x = <Rational>PY_NEW(Rational)
             mpq_div_zz(x.value, (<Integer>left).value, (<Integer>right).value)
             return x
         elif type(right) is Rational:
             if mpq_sgn((<Rational>right).value) == 0:
                 raise ZeroDivisionError("rational division by zero")
             # left * den(right) / num(right)
-            y = <Rational> Rational.__new__(Rational)
+            y = <Rational>PY_NEW(Rational)
             mpq_div_zz(y.value, (<Integer>left).value,
                        mpq_numref((<Rational>right).value))
             mpz_mul(mpq_numref(y.value), mpq_numref(y.value),
@@ -2103,7 +2101,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         """
         if mpz_sgn((<Integer>right).value) == 0:
             raise ZeroDivisionError("rational division by zero")
-        x = <Rational> Rational.__new__(Rational)
+        x = <Rational>PY_NEW(Rational)
         mpq_div_zz(x.value, self.value, (<Integer>right).value)
         return x
 
@@ -2346,7 +2344,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         else:
             if mpz_sgn(self.value) == 0:
                 raise ZeroDivisionError("rational division by zero")
-            q = Rational.__new__(Rational)
+            q = <Rational>PY_NEW(Rational)
             sig_on()
             mpz_pow_ui(mpq_denref(q.value), self.value, -n)
             if mpz_sgn(mpq_denref(q.value)) > 0:
@@ -3620,7 +3618,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             ZeroDivisionError: rational reconstruction with zero modulus
         """
         cdef Integer a
-        cdef Rational x = <Rational>Rational.__new__(Rational)
+        cdef Rational x = <Rational>PY_NEW(Rational)
         try:
             mpq_rational_reconstruction(x.value, self.value, m.value)
         except ValueError:
@@ -6924,8 +6922,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         """
         if mpz_sgn(self.value) == 0:
             raise ZeroDivisionError("rational division by zero")
-        cdef Rational x
-        x = <Rational> Rational.__new__(Rational)
+        cdef Rational x = <Rational>PY_NEW(Rational)
         mpz_set_ui(mpq_numref(x.value), 1)
         mpz_set(mpq_denref(x.value), self.value)
         if mpz_sgn(self.value) == -1:


### PR DESCRIPTION
## Problem

Run the following code

```
a = [Integer(i) for i in range(100)]
try:
	b = pow(2^100000, 3^100000, 5^100000)
finally:
	del a
```

it will take a while. Press Ctrl-C before it finishes. Then **it will hang** for a while before printing `KeyboardInterrupt`.

Meanwhile, the similar-looking code

```
a = [int(i) for i in range(100)]
try:
	b = pow(2^100000, 3^100000, 5^100000)
finally:
	del a
```

does not suffer from the problem.

## Reason

There are several places in SageMath code that does something like the following

```
cdef Integer x = <Integer>PY_NEW(Integer)
sig_on()
mpz_powm(x.value, ...)  # mutate x.value, slow
sig_off()
return x
```

If the user press ctrl-C, the destructor for `x` will be called, but because `mpz_powm` is interrupted, `mpz_powm` may be in an **inconsistent state**, so the destructor might do the wrong thing.

## The band-aid fix

The band-aid is described in https://github.com/sagemath/sage/issues/24986 : a function `sig_occurred()` is implemented in cysignals that checks whether a signal thrown by `sig_on()` is currently being processed, and the destructor of `Integer` checks:

```
if sig_occurred():
    leak this Integer object just in case
else:
    put this Integer object into a common object pool
```

## The issue

There are two problems with this.

* This leaks integers **indiscriminately**. In particular, in the example above, **all** the 100 `Integer` objects in `a` are leaked, even though only one is being mutated, being a local variable in the powering method.

  At any point in the code, we know exactly which object is currently being mutated, as such this indiscriminate leak is unnecessary.

* `sig_occurred()` is **slow**: in the example above, it runs the **garbage collector** each time it's called. So, the reason for the hang is that after the user presses Ctrl-C, Python needs to run the garbage collector 100 times before reporting `KeyboardInterrupt`.

## The actual fix

I look at the example reported in https://github.com/sagemath/sage/issues/24986 — `coerce_actions.pyx`. The problematic doctest is

```
E = EllipticCurve(GF(5), [4,0])
P = E([2,1,1])
from sage.doctest.util import ensure_interruptible_after
with ensure_interruptible_after(0.001): 2^(10^8) * P
```

by some analysis, I determine that the responsible function is `_pow_long`.

As such, this pull request makes sure to not call the destructor when the user interrupts.

After this pull request, we can remove the `sig_occurred()` workaround introduced in https://github.com/sagemath/sage/issues/24986 .

## Other reported issues

* https://github.com/sagemath/sage/issues/39224

* https://github.com/sagemath/cysignals/issues/215#issuecomment-2565535289

* https://github.com/sagemath/cysignals/pull/227

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


