### PR TITLE
Minor optimization for integer conversion to double

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7813,11 +7813,6 @@ cdef double mpz_get_d_nearest(mpz_t x) except? -648555075988944.5:
     # to have 54 bits remaining.
     cdef mp_bitcnt_t shift = sx - 54
 
-    # Compute q = trunc(x / 2^shift) and let remainder_is_zero be True
-    # if and only if no truncation occurred.
-    cdef int remainder_is_zero
-    remainder_is_zero = mpz_divisible_2exp_p(x, shift)
-
     sig_on()
 
     cdef mpz_t q
@@ -7842,12 +7837,16 @@ cdef double mpz_get_d_nearest(mpz_t x) except? -648555075988944.5:
         # Round towards zero
         pass
     else:
-        if not remainder_is_zero:
-            # Remainder is nonzero: round away from zero
+        if (q64 & 2) == 2:
+            # round to even and round away from zero gives the same result, no need to check
             q64 += 1
         else:
-            # Halfway case: round to even
-            q64 += (q64 & 2) - 1
+            if mpz_divisible_2exp_p(x, shift):
+                # Halfway case: round to even
+                q64 -= 1
+            else:
+                # Remainder is nonzero: round away from zero
+                q64 += 1
 
     # The conversion of q64 to double is *exact*.
     # This is because q64 is even and satisfies 2^53 <= q64 <= 2^54.


### PR DESCRIPTION
```
x = 2^553
%timeit float(x)

before:
114 ns ± 4.77 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
after:
106 ns ± 0.827 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

just avoid calling the function unless absolutely needed.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


