### PR TITLE
Add long time marker to several slow tests

### DIFF
--- a/src/sage/algebras/lie_conformal_algebras/n2_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/n2_lie_conformal_algebra.py
@@ -80,7 +80,7 @@ class N2LieConformalAlgebra(GradedLieConformalAlgebra):
         TESTS::
 
             sage: V = lie_conformal_algebras.N2(QQ)
-            sage: TestSuite(V).run()
+            sage: TestSuite(V).run()  # long time (:issue:`39569`)
         """
         n2dict = {('L', 'L'): {0: {('L', 1): 1},
                                1: {('L', 0): 2},

--- a/src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py
@@ -400,13 +400,13 @@ class OrderedHyperplaneArrangementElement(HyperplaneArrangementElement):
             (0, 0, 0, 0, 0)
             sage: A4.<t1, t2, t3, t4> = OrderedHyperplaneArrangements(QQ)
             sage: H = A4(hyperplane_arrangements.braid(4))
-            sage: G4 = H.projective_fundamental_group(); G4.sorted_presentation()
+            sage: G4 = H.projective_fundamental_group(); G4.sorted_presentation()  # long time (:issue:`39569`)
             Finitely presented group
             < x0, x1, x2, x3, x4 | x4^-1*x3^-1*x2^-1*x3*x4*x0*x2*x0^-1,
                                    x4^-1*x2^-1*x4*x2, x4^-1*x1^-1*x0^-1*x1*x4*x0,
                                    x4^-1*x1^-1*x0^-1*x4*x0*x1,
                                    x3^-1*x2^-1*x1^-1*x0^-1*x3*x0*x1*x2, x3^-1*x1^-1*x3*x1 >
-            sage: G4.abelian_invariants()
+            sage: G4.abelian_invariants()  # long time (:issue:`39569`)
             (0, 0, 0, 0, 0)
 
             sage: # needs sirocco

--- a/src/sage/graphs/graph_decompositions/modular_decomposition.pyx
+++ b/src/sage/graphs/graph_decompositions/modular_decomposition.pyx
@@ -84,7 +84,7 @@ def corneil_habib_paul_tedder_algorithm(G):
         ....:                                                         3, 4, 0.2)
         sage: recreate_decomposition(10, corneil_habib_paul_tedder_algorithm,
         ....:                                                         4, 5, 0.2)
-        sage: recreate_decomposition(3, corneil_habib_paul_tedder_algorithm,
+        sage: recreate_decomposition(3, corneil_habib_paul_tedder_algorithm,  # long time (:issue:`39569`)
         ....:                                                         6, 5, 0.2)
 
         sage: H = Graph('Hv|mmjz', format='graph6')

--- a/src/sage/graphs/independent_sets.pyx
+++ b/src/sage/graphs/independent_sets.pyx
@@ -161,7 +161,7 @@ cdef class IndependentSets:
             ....:         IS2.extend(map(Set, list(G.subgraph_search_iterator(Graph(n), induced=True, return_graphs=False))))
             ....:     if len(IS) != len(set(IS2)):
             ....:        raise ValueError("something goes wrong")
-            sage: for i in range(5):                                                    # needs sage.modules
+            sage: for i in range(5):                                                    # needs sage.modules, long time (:issue:`39569`)
             ....:     check_with_subgraph_search(graphs.RandomGNP(11, .3))
 
         Empty graph::

--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -304,7 +304,7 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
         EXAMPLES::
 
             # The output is kind of random
-            sage: sorted(maxima._commands(verbose=False))
+            sage: sorted(maxima._commands(verbose=False))  # long time (:issue:`39569`)
             [...
              'display',
              ...

--- a/src/sage/libs/singular/polynomial.pyx
+++ b/src/sage/libs/singular/polynomial.pyx
@@ -270,6 +270,7 @@ cdef int singular_polynomial_cmp(poly *p, poly *q, ring *r) noexcept:
 
     ::
 
+        sage: # long time (:issue:`39569`)
         sage: R.<x,y> = Integers(10)[]
         sage: l = [i*x+j*y+k for i in range(10) for j in range(10) for k in range(10)]
         sage: l.sort()

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -2760,6 +2760,7 @@ class ModularFormElement(ModularForm_abstract, element.HeckeModuleElement):
 
         Testing modular forms of nontrivial character::
 
+            sage: # long time (:issue:`39569`)
             sage: F = ModularForms(DirichletGroup(17).0^2, 2).2
             sage: F3 = F^3; F3
             q^3 + (-3*zeta8^2 + 6)*q^4 + (-12*zeta8^2 + 3*zeta8 + 18)*q^5 + O(q^6)

--- a/src/sage/rings/function_field/khuri_makdisi.pyx
+++ b/src/sage/rings/function_field/khuri_makdisi.pyx
@@ -820,6 +820,7 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         Check that :issue:`40237` is fixed::
 
+            sage: # long time (:issue:`39569`)
             sage: K = GF(2)
             sage: F.<x> = FunctionField(K)
             sage: t = polygen(F)
@@ -873,6 +874,7 @@ cdef class KhuriMakdisi_small(KhuriMakdisi_base):
 
         Check that :issue:`39148` is fixed::
 
+            sage: # long time (:issue:`39569`)
             sage: k.<x> = FunctionField(GF(17)); t = polygen(k)
             sage: F.<y> = k.extension(t^4 + (14*x + 14)*t^3 + 9*t^2 + (10*x^2 + 15*x + 8)*t
             ....:  + 7*x^3 + 15*x^2 + 6*x + 16)

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -507,7 +507,7 @@ cdef class NumberFieldElement(NumberFieldElement_base):
 
         Check that :issue:`15276` is fixed::
 
-            sage: for n in range(2,20):                                                 # needs sage.libs.gap
+            sage: for n in range(2,20):                                                 # needs sage.libs.gap, long time (:issue:`39569`)
             ....:     K = CyclotomicField(n)
             ....:     assert K(gap(K.gen())) == K.gen(), "n = {}".format(n)
             ....:     assert K(gap(K.one())) == K.one(), "n = {}".format(n)

--- a/src/sage/rings/semirings/tropical_mpolynomial.py
+++ b/src/sage/rings/semirings/tropical_mpolynomial.py
@@ -543,6 +543,7 @@ class TropicalMPolynomial(MPolynomial_polydict):
 
         A subdivision with many faces, not all of which are triangles::
 
+            sage: # long time (:issue:`39569`)
             sage: T = TropicalSemiring(QQ)
             sage: R.<x,y> = PolynomialRing(T)
             sage: p3 = (R(8) + R(4)*x + R(2)*y + R(1)*x^2 + x*y + R(1)*y^2
@@ -578,6 +579,7 @@ class TropicalMPolynomial(MPolynomial_polydict):
 
         Dual subdivision of a tropical surface::
 
+            sage: # long time (:issue:`39569`)
             sage: T = TropicalSemiring(QQ)
             sage: R.<x,y,z> = PolynomialRing(T)
             sage: p1 = x + y + z + x^2 + R(1)

--- a/src/sage/rings/semirings/tropical_variety.py
+++ b/src/sage/rings/semirings/tropical_variety.py
@@ -589,7 +589,7 @@ class TropicalVariety(UniqueRepresentation, SageObject):
             sage: T = TropicalSemiring(QQ)
             sage: R.<a,b,c,d> = PolynomialRing(T)
             sage: f = R.random_element()
-            sage: vec = f.tropical_variety().weight_vectors()[2].values()
+            sage: vec = f.tropical_variety().weight_vectors()[2].values()  # long time (:issue:`39569`)
             sage: all(a == vector([0,0,0,0]) for a in [sum(lst) for lst in vec])  # not tested (:issue:`39663`)
             True
         """

--- a/src/sage/schemes/curves/plane_curve_arrangement.py
+++ b/src/sage/schemes/curves/plane_curve_arrangement.py
@@ -528,8 +528,8 @@ class AffinePlaneCurveArrangementElement(PlaneCurveArrangementElement):
             sage: A.meridians(simplified=False, vertical=False)
             {0: [x2, x3], 1: [x1], 2: [x0], 3: [x3^-1*x2^-1*x1^-1*x0^-1]}
             sage: A = H(x * y^2 + x + y, y + x -1, x, y)
-            sage: G = A.fundamental_group()
-            sage: G.sorted_presentation()
+            sage: G = A.fundamental_group()  # long time (:issue:`39569`)
+            sage: G.sorted_presentation()  # long time (:issue:`39569`)
             Finitely presented group
             < x0, x1, x2, x3 | x3^-1*x2^-1*x3*x2, x3^-1*x1^-1*x3*x1,
                                x3^-1*x0^-1*x3*x0, x2^-1*x1^-1*x2*x1,

--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -1804,8 +1804,8 @@ class ProjectivePlaneCurve_field(ProjectivePlaneCurve, ProjectiveCurve_field):
             sage: C = P.curve(z^2*y^3 - z*(33*x*z+2*x^2+8*z^2)*y^2
             ....:             + (21*z^2+21*x*z-x^2)*(z^2+11*x*z-x^2)*y
             ....:             + (x-18*z)*(z^2+11*x*z-x^2)^2)
-            sage: G0 = C.fundamental_group()                    # needs sirocco
-            sage: G.is_isomorphic(G0)                           # needs sirocco
+            sage: G0 = C.fundamental_group()                    # needs sirocco, long time (:issue:`39569`)
+            sage: G.is_isomorphic(G0)                           # needs sirocco, long time (:issue:`39569`)
             True
             sage: C = P.curve(z)
             sage: C.fundamental_group()                         # needs sirocco

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2116,7 +2116,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         ::
 
             sage: E = EllipticCurve(GF(next_prime(2^32)), j=1728)
-            sage: sorted([phi.codomain().j_invariant() for phi in E.isogenies_degree(11 * 17 * 19^2)])
+            sage: sorted([phi.codomain().j_invariant() for phi in E.isogenies_degree(11 * 17 * 19^2)])  # long time (:issue:`39569`)
             [1348157279, 1348157279, 1713365879, 1713365879, 3153894341, 3153894341,
              3225140514, 3225140514, 3673460198, 3673460198, 3994312564, 3994312564]
             sage: it = E.isogenies_degree(2^2); it
@@ -2187,7 +2187,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                To:   Elliptic Curve defined by y^2 = x^3 + 4294967267*x + 112 over Finite Field of size 4294967311]
             sage: all(isog.domain() is E for isog in _)
             True
-            sage: all(isog.domain() is E for isog in E.isogenies_degree(2^5, _intermediate=True))
+            sage: all(isog.domain() is E for isog in E.isogenies_degree(2^5, _intermediate=True))  # long time (:issue:`39569`)
             True
 
         The following curve has no degree-`53` isogenies, so the code is quick::

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -2476,6 +2476,8 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
             sage: assert(E(eval(f,P)) == 2*P)
 
         The following test shows that :issue:`6413` is fixed for elliptic curves over finite fields::
+
+            sage: # long time (:issue:`39569`)
             sage: p = 7
             sage: K.<a> = GF(p^2)
             sage: E = EllipticCurve(K, [a + 3, 5 - a])

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -194,11 +194,11 @@ def _compute_factored_isogeny_prime_power(P, l, n, split=.8, velu_sqrt_bound=Non
         sage: phis = hom_composite._compute_factored_isogeny_prime_power(P,l,n)
         sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0)  # long time -- about 10s
         True
-        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.1)
+        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.1)  # long time (:issue:`39569`)
         True
-        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.5)
+        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.5)  # long time (:issue:`39569`)
         True
-        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.9)
+        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.9)  # long time (:issue:`39569`)
         True
         sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=1)
         True

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -187,18 +187,18 @@ def _compute_factored_isogeny_prime_power(P, l, n, split=.8, velu_sqrt_bound=Non
     All choices of ``split`` produce the same result, albeit
     not equally fast::
 
-        sage: # needs sage.rings.finite_rings
+        sage: # needs sage.rings.finite_rings, long time (:issue:`39569`)
         sage: E = EllipticCurve(GF(2^127 - 1), [1,0])
         sage: P, = E.gens()
         sage: (l,n), = P.order().factor()
         sage: phis = hom_composite._compute_factored_isogeny_prime_power(P,l,n)
         sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0)  # long time -- about 10s
         True
-        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.1)  # long time (:issue:`39569`)
+        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.1)
         True
-        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.5)  # long time (:issue:`39569`)
+        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.5)
         True
-        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.9)  # long time (:issue:`39569`)
+        sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=0.9)
         True
         sage: phis == hom_composite._compute_factored_isogeny_prime_power(P,l,n, split=1)
         True

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -13221,7 +13221,7 @@ cdef class Expression(Expression_abc):
         answer::
 
             sage: f = ln(1+4/5*sin(x))
-            sage: integrate(f, x, -3.1415, 3.1415)  # random
+            sage: integrate(f, x, -3.1415, 3.1415)  # random, long time (:issue:`39569`)
             integrate(log(4/5*sin(x) + 1), x, -3.14150000000000,
             3.14150000000000)
             sage: # needs sage.libs.giac


### PR DESCRIPTION
This gets rid of about half of the warnings, until someone figure out whether they're intended to be slow, or how they can be sped up.

Reference: https://github.com/sagemath/sage/issues/39569, https://github.com/sagemath/sage/pull/39746

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


