### PR TITLE
Fix polynomial schoolbook multiplication interruptibility

### DIFF
--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -11818,6 +11818,7 @@ cdef list do_schoolbook_product(list x, list y, Py_ssize_t deg):
         return [a*c for a in x[:deg]] # beware of noncommutative rings
     coeffs = [None]*deg
     for k in range(deg):
+        sig_check()
         start = 0 if k <= d2 else k-d2  # max(0, k-d2)
         end = k if k <= d1 else d1    # min(k, d1)
         sum = x[start] * y[k-start]


### PR DESCRIPTION
Add ```sig_check()``` call in the outer loop of ```do_schoolbook_product``` function to ensure polynomial multiplication with large polynomials can be interrupted within reasonable time. Previously, the function could run for extended periods (>1.8s) before becoming interruptible, causing doctest failures. The fix ensures interruption checks occur at least once per coefficient computation.

Fixes failing doctest:
- sage.rings.polynomial.polynomial_element
```
File "src/sage/rings/polynomial/polynomial_element.pyx", line 11803, in sage.rings.polynomial.polynomial_element.do_schoolbook_product
Failed example:
    with ensure_interruptible_after(0.5): h = f*g
Exception raised:
    cysignals.signals.AlarmInterrupt

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/home/zhongcx/sage/src/sage/doctest/forker.py", line 733, in _run
        self.compile_and_execute(example, compiler, test.globs)
        ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/zhongcx/sage/src/sage/doctest/forker.py", line 1157, in compile_and_execute
        exec(compiled, globs)
        ~~~~^^^^^^^^^^^^^^^^^
      File "<doctest sage.rings.polynomial.polynomial_element.do_schoolbook_product[8]>", line 1, in <module>
        with ensure_interruptible_after(RealNumber('0.5')): h = f*g
             ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.13/contextlib.py", line 162, in __exit__
        self.gen.throw(value)
        ~~~~~~~~~~~~~~^^^^^^^
      File "/home/zhongcx/sage/src/sage/doctest/util.py", line 897, in ensure_interruptible_after
        raise RuntimeError(
                f"Function is not interruptible within {seconds:.4f} seconds, only after {elapsed:.4f} seconds"
                + ("" if alarm_raised else " (__exit__ called before interrupt check)"))
    RuntimeError: Function is not interruptible within 0.5000 seconds, only after 1.8404 secondsexit
```
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


