### PR TITLE
Headless giac experiment

### DIFF
--- a/build/pkgs/giac/type
+++ b/build/pkgs/giac/type
@@ -1,1 +1,1 @@
-optional
+standard

--- a/build/pkgs/sagemath_giac/type
+++ b/build/pkgs/sagemath_giac/type
@@ -1,1 +1,1 @@
-optional
+standard

--- a/src/sage/features/giac.py
+++ b/src/sage/features/giac.py
@@ -25,7 +25,7 @@ class Giac(Executable):
             True
         """
         Executable.__init__(self, 'giac', executable='giac',
-                            spkg='giac', type='optional')
+                            spkg='giac', type='standard')
 
 
 def all_features():

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -560,7 +560,7 @@ class sage__libs__giac(JoinFeature):
         """
         JoinFeature.__init__(self, 'sage.libs.giac',
                              [PythonModule('sage.libs.giac.giac')],
-                             spkg='sagemath_giac', type='optional')
+                             spkg='sagemath_giac', type='standard')
 
 
 class sage__libs__homfly(JoinFeature):


### PR DESCRIPTION
Make giac and sagemath_giac standard packages again so that they'll be installed from the system before the CI runs. This should help us determine if https://github.com/sagemath/sage/pull/40559 is a new problem or not.
