### PR TITLE
Fix Drinfeld module frobenius_endomorphism doc

### DIFF
--- a/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/finite_drinfeld_module.py
@@ -230,12 +230,12 @@ class DrinfeldModule_finite(DrinfeldModule):
 
     def frobenius_endomorphism(self):
         r"""
-        Return the Frobenius endomorphism of the Drinfeld module as a
-        morphism object.
+        Return the Frobenius endomorphism of the Drinfeld module.
 
-        Let `q` be the order of the base field of the function ring. The
-        *Frobenius endomorphism* is defined as the endomorphism whose
-        defining Ore polynomial is `t^q`.
+        The *Frobenius endomorphism* is defined by the Ore polynomial
+        `tau^n`, where `n` is the degree of the base field `K` over
+        `\mathbb F_q`.
+
 
         EXAMPLES::
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixed an atrocious typo in the description of the `frobenius_endomorphism` method of the class `DrinfeldModule_finite`.

I followed the notation (the degree of `K` over `\mathbb F_q` is denoted by `n`) chosen by Xavier @xcaruso in his PR on homsets of Drinfeld modules (#40440).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

None.


