### PR TITLE
Add exception handling to GAP element __call__ method

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2526,6 +2526,9 @@ cdef class GapElement_Function(GapElement):
                 arg_list = make_gap_list(args)
                 result = GAP_CallFuncList(self.value, arg_list)
             sig_off()
+        except:
+            sig_off()
+            raise
         finally:
             GAP_Leave()
         if result == NULL:


### PR DESCRIPTION
Follow #40548 @orlitzky 
This change adds proper exception handling to the `GapElement_Function.__call__` method to ensure that `sig_off()` is called even when exceptions occur during GAP function execution. This prevents signal handling issues that could occur if an exception is raised while signals are still active.

Changes:
- Added except block to catch any exceptions during GAP function calls
- Ensure `sig_off()` is called before re-raising exceptions
- Maintains signal safety and proper cleanup

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
#40548 

