### PR TITLE
Use LaTeX commands instead of Unicode characters

### DIFF
--- a/src/doc/es/tutorial/tour_help.rst
+++ b/src/doc/es/tutorial/tour_help.rst
@@ -280,7 +280,7 @@ El indexado de una lista comienza en el cero, como en muchos lenguajes de progra
 
 La función ``len(v)`` devuelve la longitud de ``v``. Utiliza ``v.append(obj)`` para
 añadir un nuevo objeto al final de ``v``, y utiliza ``del v[i]`` para borrar
-el :math:`i-ésimo` elemento de ``v``:
+el :math:`i`-ésimo elemento de ``v``:
 
 .. link
 

--- a/src/sage/combinat/matrices/dancing_links.pyx
+++ b/src/sage/combinat/matrices/dancing_links.pyx
@@ -886,7 +886,7 @@ cdef class dancing_linksWrapper:
         Return the SAT solver solving an equivalent problem.
 
         Note that row index `i` in the dancing links solver corresponds to
-        the boolean variable index `ì+1` for the SAT solver to avoid
+        the boolean variable index `i+1` for the SAT solver to avoid
         the variable index `0`.
 
         See also :mod:`sage.sat.solvers.satsolver`.

--- a/src/sage/graphs/matching_covered_graph.py
+++ b/src/sage/graphs/matching_covered_graph.py
@@ -2617,7 +2617,7 @@ class MatchingCoveredGraph(Graph):
 
         For a brace `G[A, B]` of order six or more, `|N(X)| \geq |X| + 2`, for
         all `X \subset A` such that `0 < |X| <|A| - 1`, where
-        `N(S) := \{b | (a, b) \in E \^ a \in S\}` is called the neighboring set
+        `N(S) := \{b | (a, b) \in E \wedge a \in S\}` is called the neighboring set
         of `S`::
 
             sage: H = graphs.MoebiusLadderGraph(15)

--- a/src/sage/stats/distributions/discrete_gaussian_integer.pyx
+++ b/src/sage/stats/distributions/discrete_gaussian_integer.pyx
@@ -169,7 +169,7 @@ cdef class DiscreteGaussianDistributionIntegerSampler(SageObject):
         INPUT:
 
         - ``sigma`` -- samples `x` are accepted with probability proportional to
-          `\exp(-(x-c)²/(2σ²))`
+          `\exp(-(x-c)^2/(2σ^2))`
 
         - ``c`` -- the mean of the distribution. The value of ``c`` does not have
           to be an integer. However, some algorithms only support integer-valued
@@ -191,25 +191,25 @@ cdef class DiscreteGaussianDistributionIntegerSampler(SageObject):
 
         - ``'uniform+table'`` -- classical rejection sampling, sampling from the
           uniform distribution and accepted with probability proportional to
-          `\exp(-(x-c)²/(2σ²))` where `\exp(-(x-c)²/(2σ²))` is precomputed and
+          `\exp(-(x-c)^2/(2σ^2))` where `\exp(-(x-c)^2/(2σ^2))` is precomputed and
           stored in a table. Any real-valued `c` is supported.
 
         - ``'uniform+logtable'`` -- samples are drawn from a uniform distribution and
-          accepted with probability proportional to `\exp(-(x-c)²/(2σ²))` where
-          `\exp(-(x-c)²/(2σ²))` is computed using logarithmically many calls to
+          accepted with probability proportional to `\exp(-(x-c)^2/(2σ^2))` where
+          `\exp(-(x-c)^2/(2σ^2))` is computed using logarithmically many calls to
           Bernoulli distributions. See [DDLL2013]_ for details.  Only
           integer-valued `c` are supported.
 
         - ``'uniform+online'`` -- samples are drawn from a uniform distribution and
-          accepted with probability proportional to `\exp(-(x-c)²/(2σ²))` where
-          `\exp(-(x-c)²/(2σ²))` is computed in each invocation. Typically this
+          accepted with probability proportional to `\exp(-(x-c)^2/(2σ^2))` where
+          `\exp(-(x-c)^2/(2σ^2))` is computed in each invocation. Typically this
           is very slow.  See [DDLL2013]_ for details.  Any real-valued `c` is
           accepted.
 
         - ``'sigma2+logtable'`` -- samples are drawn from an easily samplable
           distribution with `σ = k·σ_2` with `σ_2 = \sqrt{1/(2\log 2)}` and accepted
-          with probability proportional to `\exp(-(x-c)²/(2σ²))` where
-          `\exp(-(x-c)²/(2σ²))` is computed using  logarithmically many calls to Bernoulli
+          with probability proportional to `\exp(-(x-c)^2/(2σ^2))` where
+          `\exp(-(x-c)^2/(2σ^2))` is computed using  logarithmically many calls to Bernoulli
           distributions (but no calls to `\exp`). See [DDLL2013]_ for details. Note that this
           sampler adjusts `σ` to match `k·σ_2` for some integer `k`.
           Only integer-valued `c` are supported.

--- a/src/sage/stats/distributions/discrete_gaussian_polynomial.py
+++ b/src/sage/stats/distributions/discrete_gaussian_polynomial.py
@@ -3,7 +3,7 @@ Discrete Gaussian Samplers for `\ZZ[x]`
 
 This class realizes oracles which returns polynomials in `\ZZ[x]`
 where each coefficient is sampled independently with a probability
-proportional to `\exp(-(x-c)²/(2σ²))`.
+proportional to `\exp(-(x-c)^2/(2σ^2))`.
 
 AUTHORS:
 
@@ -89,7 +89,7 @@ class DiscreteGaussianDistributionPolynomialSampler(SageObject):
         - ``P`` -- a univariate polynomial ring over the Integers
         - ``n`` -- number of coefficients to be sampled
         - ``sigma`` -- coefficients `x` are accepted with probability
-          proportional to `\exp(-x²/(2σ²))`. If an object of type
+          proportional to `\exp(-x^2/(2σ^2))`. If an object of type
           :class:`sage.stats.distributions.discrete_gaussian_integer.DiscreteGaussianDistributionIntegerSampler`
           is passed, then this sampler is used to sample coefficients.
 


### PR DESCRIPTION
Because PDF build does not handle Unicode characters correctly. And some are genuine bugs.

With this change, there should be less

```
Missing character: There is no τ (U+03C4) in font cmmi10!
```

in the documentation.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


