### PR TITLE
Fix artifact with this name already exists error

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -185,5 +185,5 @@ jobs:
         uses: actions/upload-artifact@v4.5.0
         if: failure()
         with:
-          name: ${{ runner.os }}-meson-${{ matrix.python }}${{ matrix.editable && '-editable' || '' }}-log
+          name: ${{ runner.os }}-meson-${{ matrix.python }}${{ matrix.editable && '-editable' || '' }}${{ matrix.tests == 'new' && '-new' || '' }}-log
           path: builddir/meson-logs/


### PR DESCRIPTION
Fix the first issue in https://github.com/sagemath/sage/issues/39727 . Also seen in https://github.com/sagemath/sage/actions/runs/17005745395/job/48215030949?pr=40597 .

I don't think anyone actually looks at the artifact, but either way…

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


