### PR TITLE
GSoC 25: Implementation of Martens' algorithm for reduction of Riemann matrices

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -4880,6 +4880,9 @@ REFERENCES:
              Notes in Computer Science, volume 5856, pp 272-278,
              Springer, Berlin (2009).
 
+.. [Mar1992] H. H. Martens, "A footnote to the Poincaré complete reducibility theorem",
+             *Publicacions Matemàtiques* **36** (1992), no. 1, 111–129.
+
 .. [Mar1997] \C.-M. Marle, *The Schouten-Nijenhuis bracket and interior
              products*, Journal of Geometry and Physics **23**, 350
              (1997); :doi:`10.1016/S0393-0440(97)80009-5`

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -5256,6 +5256,9 @@ REFERENCES:
              PhD Thesis, Carl von Ossietzky Universität Oldenburg
              http://oops.uni-oldenburg.de/3607.
 
+.. [New1972] \M. Newman, Integral Matrices, Academic Press, 
+             New York and London (1972).
+
 .. [New2003] Newman, M.E.J. *The Structure and function of complex
              networks*, SIAM Review vol. 45, no. 2 (2003), pp. 167-256.
              :doi:`10.1137/S003614450342480`.

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -4880,8 +4880,8 @@ REFERENCES:
              Notes in Computer Science, volume 5856, pp 272-278,
              Springer, Berlin (2009).
 
-.. [Mar1992] H. H. Martens, "A footnote to the Poincaré complete reducibility theorem",
-             *Publicacions Matemàtiques* **36** (1992), no. 1, 111–129.
+.. [Mar1992] \H. H. Martens, "A footnote to the Poincaré complete reducibility theorem",
+             Publicacions Matemàtiques 36 (1992), no. 1, 111-129.
 
 .. [Mar1997] \C.-M. Marle, *The Schouten-Nijenhuis bracket and interior
              products*, Journal of Geometry and Physics **23**, 350

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1762,6 +1762,51 @@ cdef class Matrix_integer_dense(Matrix_dense):
         import sage.matrix.symplectic_basis
         return sage.matrix.symplectic_basis.symplectic_basis_over_ZZ(self)
 
+    def skew_form(self, transformation=False):
+        r"""
+        Compute the skew Smith normal form of this square integer matrix as defined
+        in Theorem IV.1 in [New1972]_.
+
+        Given an integer skew-symmetric matrix `M`, compute a unimodular matrix `S`
+        such that `S^T M S` is block diagonal with `2x2` blocks `(0, d_i; -d_i, 0)`
+        where `d_i` are positive integers with `d_i | d_{i+1}`. If ``transformation``
+        is True, also return ``S``.
+
+        INPUT:
+
+        - ``transformation`` -- boolean (default: ``False``); if ``True``,
+          return transformation matrix ``S``
+
+        OUTPUT:
+
+        - ``M'`` -- integer n x n matrix in skew Smith normal form
+        - ``S``  -- integer n x n unimodular matrix with `S^T M S = M'`
+          (if ``transformation`` is True)
+
+        EXAMPLES::
+
+            sage: M = matrix(ZZ, [
+            ....:     [   0,    8,    0,   -4,   -2,   12 ],
+            ....:     [  -8,    0,   12,    0,    0,    0 ],
+            ....:     [   0,  -12,    0,    6,    0,  -18 ],
+            ....:     [   4,    0,   -6,    0,    0,    0 ],
+            ....:     [   2,    0,    0,    0,    0,    0 ],
+            ....:     [ -12,    0,   18,    0,    0,    0 ]
+            ....: ])
+            sage: M_prime, S = M.skew_form(transformation=True)
+            sage: M_prime
+            [ 0  2  0  0  0  0]
+            [-2  0  0  0  0  0]
+            [ 0  0  0  6  0  0]
+            [ 0  0 -6  0  0  0]
+            [ 0  0  0  0  0  0]
+            [ 0  0  0  0  0  0]
+            sage: bool(S.transpose() * M * S == M_prime)
+            True
+        """
+        from sage.matrix.matrix_integer_dense_skew import skew_form
+        return skew_form(self, transformation=transformation)
+
     hermite_form = echelon_form
 
     def echelon_form(self, algorithm='default', proof=None, include_zero_rows=True,

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1764,13 +1764,15 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
     def skew_form(self, transformation=False):
         r"""
-        Compute the skew Smith normal form of this square integer matrix as defined
-        in Theorem IV.1 in [New1972]_.
+        Computes the skew normal form of a square integer matrix. 
+        
+        This is defined as in Theorem IV.1 in [New1972]_. This is 
+        equivalent (up to permutation) to the alternating Frobenius form.
 
-        Given an integer skew-symmetric matrix `M`, compute a unimodular matrix `S`
-        such that `S^T M S` is block diagonal with `2x2` blocks `(0, d_i; -d_i, 0)`
-        where `d_i` are positive integers with `d_i | d_{i+1}`. If ``transformation``
-        is True, also return ``S``.
+        Given an integer skew-symmetric matrix `M`, compute a unimodular 
+        matrix `S` such that `S^T M S` is block diagonal with `2x2` blocks 
+        `(0, d_i; -d_i, 0)` where `d_i` are positive integers with 
+        `d_i | d_{i+1}`. If ``transformation`` is True, also return ``S``.
 
         INPUT:
 
@@ -1782,6 +1784,20 @@ cdef class Matrix_integer_dense(Matrix_dense):
         - ``M'`` -- integer n x n matrix in skew Smith normal form
         - ``S``  -- integer n x n unimodular matrix with `S^T M S = M'`
           (if ``transformation`` is True)
+
+        ALGORITHM:
+
+        This is based on the algorithm in [New1972]_. 
+        Given a skew-symmetric matrix over a principal ideal ring with 
+        characteristic != 2. We use congruence operations only: apply a 
+        row move with the matching column move (conjugation by a unimodular 
+        matrix). Permute so that there is a nonzero off-diagonal in the first 
+        row; combine columns so that entry equals the row greatest common 
+        divisor; then zero the remaining first row and column to obtain a 
+        tridiagonal matrix. If this leading entry does not divide all entries 
+        we replace it by the row gcd (which strictly decreases) and repeat 
+        until it does; then split a two-by-two block; recurse, yielding blocks 
+        with nondecreasing divisors.
 
         EXAMPLES::
 

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1772,7 +1772,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         Given an integer skew-symmetric matrix `M`, compute a unimodular 
         matrix `S` such that `S^T M S` is block diagonal with `2x2` blocks 
         `(0, d_i; -d_i, 0)` where `d_i` are positive integers with 
-        `d_i | d_{i+1}`. If ``transformation`` is True, also return ``S``.
+        `d_i | d_{i+1}`. If ``transformation`` is ``True``, also return ``S``.
 
         INPUT:
 
@@ -1783,7 +1783,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         - ``M'`` -- integer n x n matrix in skew Smith normal form
         - ``S``  -- integer n x n unimodular matrix with `S^T M S = M'`
-          (if ``transformation`` is True)
+          (if ``transformation`` is ``True``)
 
         ALGORITHM:
 

--- a/src/sage/matrix/matrix_integer_dense_skew.py
+++ b/src/sage/matrix/matrix_integer_dense_skew.py
@@ -17,7 +17,7 @@ def skew_form(M, transformation=False):
     Given an integer skew-symmetric matrix `M`, compute a unimodular 
     matrix `S` such that `S^T M S` is block diagonal with `2x2` blocks 
     `(0, d_i; -d_i, 0)` where `d_i` are positive integers with 
-    `d_i | d_{i+1}`. If ``transformation`` is True, also return ``S``.
+    `d_i | d_{i+1}`. If ``transformation`` is ``True``, also return ``S``.
 
     INPUT:
     
@@ -30,7 +30,7 @@ def skew_form(M, transformation=False):
 
     - ``M'`` -- integer ``n x n`` matrix in skew Smith normal form
     - ``S``  -- integer ``n x n`` unimodular matrix with ``S^T M S = M'``
-      (if ``transformation`` is True)
+      (if ``transformation`` is ``True``)
 
     ALGORITHM:
 

--- a/src/sage/matrix/matrix_integer_dense_skew.py
+++ b/src/sage/matrix/matrix_integer_dense_skew.py
@@ -1,0 +1,181 @@
+"""
+Skew Smith normal form over ZZ
+"""
+
+from sage.matrix.constructor import Matrix
+from sage.rings.integer_ring import ZZ
+from sage.arith.misc import xgcd
+
+
+def skew_form(M, transformation=False):
+    r"""
+    Compute the skew Smith normal form of this square integer matrix as defined
+    in Theorem IV.1 in [New1972]_.
+
+    Given an integer skew-symmetric matrix `M`, compute a unimodular matrix `S`
+    such that `S^T M S` is block diagonal with `2x2` blocks `(0, d_i; -d_i, 0)`
+    where `d_i` are positive integers with `d_i | d_{i+1}`. If ``transformation``
+    is True, also return ``S``.
+
+    INPUT:
+    
+    - ``M`` -- integer n x n skew-symmetric matrix
+
+    - ``transformation`` -- boolean (default: ``False``); if ``True``,
+      return transformation matrix ``S``
+
+    OUTPUT:
+
+    - ``M'`` -- integer n x n matrix in skew Smith normal form
+    - ``S``  -- integer n x n unimodular matrix with `S^T M S = M'`
+      (if ``transformation`` is True)
+
+    EXAMPLES::
+
+        sage: M = matrix(ZZ, [
+        ....:     [   0,    8,    0,   -4,   -2,   12 ],
+        ....:     [  -8,    0,   12,    0,    0,    0 ],
+        ....:     [   0,  -12,    0,    6,    0,  -18 ],
+        ....:     [   4,    0,   -6,    0,    0,    0 ],
+        ....:     [   2,    0,    0,    0,    0,    0 ],
+        ....:     [ -12,    0,   18,    0,    0,    0 ]
+        ....: ])
+        sage: M_prime, S = M.skew_form(transformation=True)
+        sage: M_prime
+        [ 0  2  0  0  0  0]
+        [-2  0  0  0  0  0]
+        [ 0  0  0  6  0  0]
+        [ 0  0 -6  0  0  0]
+        [ 0  0  0  0  0  0]
+        [ 0  0  0  0  0  0]
+        sage: bool(S.transpose() * M * S == M_prime)
+        True
+    """
+    if M.ncols() != M.nrows():
+        raise TypeError("Input must be a square matrix.")
+    if M != -M.transpose():
+        raise ValueError("Input matrix must be skew-symmetric.")
+
+    A = M.change_ring(ZZ)
+    n = A.nrows()
+    S = Matrix.identity(ZZ, n) if transformation else None
+
+    k = 0
+    while k < n - 1:
+        # We work on the submatrix A[k:, k:]
+        m = n - k
+
+        # Find a non-zero entry in the strict upper triangle of the submatrix
+        piv_row, piv_col = None, None
+        min_abs_val = float("inf")
+        for r in range(m):
+            for c in range(r + 1, m):
+                val = A[k + r, k + c]
+                if val != 0 and abs(val) < min_abs_val:
+                    min_abs_val = abs(val)
+                    piv_row, piv_col = r, c
+
+        # If the submatrix is zero, we are done
+        if piv_row is None:
+            break
+
+        # Move the pivot to the (k, k+1) position using swaps
+        if piv_row != 0:
+            E = Matrix.identity(ZZ, n)
+            E.swap_columns(k, k + piv_row)
+            A = E.transpose() * A * E
+            if transformation:
+                S = S * E
+
+        if piv_col != 1:
+            E = Matrix.identity(ZZ, n)
+            E.swap_columns(k + 1, k + piv_col)
+            A = E.transpose() * A * E
+            if transformation:
+                S = S * E
+
+        # GCD descent loop
+        while True:
+            # Step 1: Clear the first row of the submatrix (row k)
+            for j in range(2, m):
+                g, h = A[k, k + 1], A[k, k + j]
+                if h == 0:
+                    continue
+                d, x, y = xgcd(g, h)
+                g_inv, h_inv = g // d, h // d
+
+                # Create the elementary matrix for the GCD step
+                E = Matrix.identity(ZZ, n)
+                i1, i2 = k + 1, k + j
+                E[i1, i1], E[i2, i1] = x, y
+                E[i1, i2], E[i2, i2] = -h_inv, g_inv
+
+                # Apply the congruence transformation
+                A = E.transpose() * A * E
+                if transformation:
+                    S = S * E
+
+            # Step 2: Check for divisibility
+            h = A[k, k + 1]
+            if h == 0:
+                break
+
+            bad_entry_row = None
+            for r in range(1, m):
+                for c in range(r, m):
+                    if A[k + r, k + c] % h != 0:
+                        bad_entry_row = r
+                        break
+                if bad_entry_row is not None:
+                    break
+
+            if bad_entry_row is None:
+                break
+
+            # Perturb to improve divisibility
+            r_idx = k + bad_entry_row
+            E = Matrix.identity(ZZ, n)
+            E[r_idx, k] = 1
+
+            # Apply the congruence transformation
+            A = E.transpose() * A * E
+            if transformation:
+                S = S * E
+
+        h = A[k, k + 1]
+        if h == 0:
+            continue
+
+        # Step 3: Extract the 2x2 block by zeroing out the rest of rows/cols k, k+1
+        for j in range(2, m):
+            val = A[k + 1, k + j]
+            if val == 0:
+                continue
+            q = val // h
+
+            E = Matrix.identity(ZZ, n)
+            E[k, k + j] = q
+
+            # Apply the congruence transformation
+            A = E.transpose() * A * E
+            if transformation:
+                S = S * E
+
+        k += 2
+
+    # Final normalisation to make diagonal entries positive
+    for i in range(n // 2):
+        if A[2 * i, 2 * i + 1] < 0:
+            idx = 2 * i + 1
+            # Create elementary matrix to rescale a column by -1
+            E = Matrix.identity(ZZ, n)
+            E[idx, idx] = -1
+
+            # Apply the congruence transformation
+            A = E.transpose() * A * E
+            if transformation:
+                S = S * E
+
+    if transformation:
+        return A, S
+    return A

--- a/src/sage/matrix/matrix_integer_dense_skew.py
+++ b/src/sage/matrix/matrix_integer_dense_skew.py
@@ -28,8 +28,8 @@ def skew_form(M, transformation=False):
 
     OUTPUT:
 
-    - ``M'`` -- integer n x n matrix in skew Smith normal form
-    - ``S``  -- integer n x n unimodular matrix with `S^T M S = M'`
+    - ``M'`` -- integer ``n x n`` matrix in skew Smith normal form
+    - ``S``  -- integer ``n x n`` unimodular matrix with ``S^T M S = M'``
       (if ``transformation`` is True)
 
     ALGORITHM:

--- a/src/sage/matrix/meson.build
+++ b/src/sage/matrix/meson.build
@@ -32,6 +32,7 @@ py.install_sources(
   'matrix_integer_dense.pxd',
   'matrix_integer_dense_hnf.py',
   'matrix_integer_dense_saturation.py',
+  'matrix_integer_dense_skew.py',
   'matrix_integer_sparse.pxd',
   'matrix_laurent_mpolynomial_dense.pxd',
   'matrix_misc.py',

--- a/src/sage/schemes/riemann_surfaces/riemann_surface.py
+++ b/src/sage/schemes/riemann_surfaces/riemann_surface.py
@@ -4016,7 +4016,7 @@ def poincare_form(M, transformation=False):
     r"""
     Compute the Poincare normal form of a matrix.
 
-    We follow the method described by Martens in [Mar1992]_. Given a matrix M,
+    We follow the method described by Martens in [Mar1992]_. Given a matrix ``M``,
     we first check the GCD of the subdeterminants of ``M``. If it is 1, we can use the
     we proceed otherwise we factor out a matrix on the left to make the GCD 1.
     We then proceed with the reduction algorithm.
@@ -4026,7 +4026,7 @@ def poincare_form(M, transformation=False):
 
     INPUT:
 
-    - ``M`` -- matrix with integer entries of size 2m * 2g, (m < g)
+    - ``M`` -- matrix with integer entries of size ``2m * 2g`` (``m < g``)
     - ``transformation`` -- boolean (default: ``False``); if ``True``,
     return transformation matrix ``S`` and ``T``
 
@@ -4585,8 +4585,8 @@ def reduce_riemann_matrix(M, Z):
     `Z'` represents the effect of a symplectic change of homology basis, often
     defined by a matrix `T` (e.g., from `poincare_form(M)`) which transforms
     the homology basis such that the reduction encoded by `M` corresponds to
-    a projection onto the first 2m basis elements of the new lattice, where
-    2m is the dimension of the reduced Jacobian factor.
+    a projection onto the first `2m` basis elements of the new lattice, where
+    `2m` is the dimension of the reduced Jacobian factor.
 
     INPUT:
 

--- a/src/sage/schemes/riemann_surfaces/riemann_surface.py
+++ b/src/sage/schemes/riemann_surfaces/riemann_surface.py
@@ -4021,7 +4021,7 @@ def poincare_form(M, transformation=False):
     we proceed otherwise we factor out a matrix on the left to make the GCD 1.
     We then proceed with the reduction algorithm.
 
-    If ``transformation`` is True, we also return the transformation matrices
+    If ``transformation`` is ``True``, we also return the transformation matrices
     ``S`` and ``T`` such that ``S * N * T`` is equal to ``M``.
 
     INPUT:
@@ -4033,8 +4033,8 @@ def poincare_form(M, transformation=False):
     OUTPUT:
 
     - ``N`` -- the Poincare normal form of M
-    - ``S`` -- the transformation matrix such that ``S * N * T == M`` (if ``transformation`` is True)
-    - ``T`` -- the transformation matrix such that ``S * N * T == M`` (if ``transformation`` is True)
+    - ``S`` -- the transformation matrix such that ``S * N * T == M`` (if ``transformation`` is ``True``)
+    - ``T`` -- the transformation matrix such that ``S * N * T == M`` (if ``transformation`` is ``True``)
 
     EXAMPLES::
 

--- a/src/sage/schemes/riemann_surfaces/riemann_surface.py
+++ b/src/sage/schemes/riemann_surfaces/riemann_surface.py
@@ -4603,17 +4603,13 @@ def reduce_riemann_matrix(M, Z):
     - ``Z'`` -- the reduced Riemann matrix
 
     EXAMPLES::
-
-        sage: from sage.schemes.riemann_surfaces.riemann_surface import RiemannSurface, reduce_riemann_matrix
-        sage: R.<x,y> = QQ[]
-        sage: f = y^2 - x^6 - 1
-        sage: S = RiemannSurface(f, prec=50, integration_method='rigorous')
+        sage: from sage.schemes.riemann_surfaces.riemann_surface import reduce_riemann_matrix
+        sage: CC = ComplexField(53)
+        sage: Z = Matrix(CC, [[1 + I, 1/2], [1/2, 1 + I]])
         sage: M = Matrix(ZZ, [[1, 1, 0, 0], [0, 0, 1, 1]])
-        sage: Z = S.riemann_matrix()
-        sage: Z_prime = reduce_riemann_matrix(M, Z)
-        sage: Z_prime # abs tol 1e-10
-        [   -0.37500000000000 + 0.21650635094611*I -0.50000000000000 - 4.4408920985006e-16*I]
-        [-0.50000000000000 - 3.0730409244296e-16*I      1.5000000000000 + 0.86602540378444*I]
+        sage: reduce_riemann_matrix(M, Z)  # abs tol 1e-10
+        [-0.230769230769231 + 0.153846153846154*I                       -0.500000000000000]
+        [                      -0.500000000000000  0.250000000000000 + 0.500000000000000*I]
     """
     _, _, T = poincare_form(M, transformation=True)
     n = M.ncols() // 2

--- a/src/sage/schemes/riemann_surfaces/riemann_surface.py
+++ b/src/sage/schemes/riemann_surfaces/riemann_surface.py
@@ -4027,14 +4027,19 @@ def poincare_form(M, transformation=False):
     INPUT:
 
     - ``M`` -- matrix with integer entries of size ``2m * 2g`` (``m < g``)
+
     - ``transformation`` -- boolean (default: ``False``); if ``True``,
-    return transformation matrix ``S`` and ``T``
+      return transformation matrices ``S`` and ``T``
 
     OUTPUT:
 
-    - ``N`` -- the Poincare normal form of M
-    - ``S`` -- the transformation matrix such that ``S * N * T == M`` (if ``transformation`` is ``True``)
-    - ``T`` -- the transformation matrix such that ``S * N * T == M`` (if ``transformation`` is ``True``)
+    - ``N`` -- the Poincare normal form of ``M``
+
+    - ``S`` -- the transformation matrix such that ``S * N * T == M``
+      (if ``transformation`` is ``True``)
+
+    - ``T`` -- the transformation matrix such that ``S * N * T == M``
+      (if ``transformation`` is ``True``)
 
     EXAMPLES::
 


### PR DESCRIPTION
This adds implementation of the algorithm in Martens for the integral reduction of Riemann matrices to partially complete issue #40293. This addition was done under the supervision of @DisneyHogg. 

**New functionality**

* `poincare_form(M, transformation=False)`
  Here, we compute the Poincaré normal form of an integral $2m\times 2g$ matrix $M$ with $M J M^{\top}$ non-singular. Returns the normal form $N$; if `transformation=True`, also returns integral $S$ and symplectic $T$ such that $S\,N\,T = M$ (after the necessary corrections are made to $M$ see below).

* `alternating_smith_form(M)`
  Here, the function first computes the skew normal form as defined by Newman (Theorem IV.1) of $M J M^{\top}$ and then produces unimodular/symplectic matrices to transform $M J M^{\top}$ into 
```
[0  D]
[-D 0]
```

with $D=\text{diag}(d_1,\dots)$ and $d_i\mid d_{i+1}$ as required by Martens.

* `reduce_riemann_matrix(M, Z)`
  Given a reduction matrix $M$ and a Riemann matrix $Z$, compute the reduced $Z'$ so that, after a symplectic change of basis, the full period matrix is equivalent to 
```
[E Z] -> [E [Z1   Q]
            [Q^T Z2]]
```
with $Q$ rational.

**Problem solved**

Solves 2 & 3 of the original issue #40293 in that we have the Poincaré normal form computation and the reduction of Riemann matrices.

**Testing**
Testing was done on a variety of curves with genus $g \leq 6$ (degree 14 hyperelliptics). Due to the high computational expenses of $g > 7$ further testing on those curves were not possible. However, for all genus $g \leq 6$ curves, the function worked as expected. The example used inside the docstring is as follows:
```
EXAMPLES::
        sage: from sage.schemes.riemann_surfaces.riemann_surface import RiemannSurface, reduce_riemann_matrix
        sage: R.<x,y> = QQ[]
        sage: f = y^2 - x^6 - 1
        sage: S = RiemannSurface(f, prec=50, integration_method='rigorous')
        sage: M = Matrix(ZZ, [[1, 1, 0, 0], [0, 0, 1, 1]])
        sage: Z = S.riemann_matrix()
        sage: Z_prime = reduce_riemann_matrix(M, Z)
        sage: Z_prime
        [   -0.37500000000000 + 0.21650635094611*I -0.50000000000000 + 1.3322676295502e-15*I]
        [-0.50000000000000 - 1.1102230246252e-16*I    0.26923076923077 + 0.066617338752649*I]
```

**Documentation**

* Adds `[Mar1992]_` to `reference/references/index.rst` and cites it from function docstrings.

**Backward compatibility**

* Additive only; no changes to existing APIs.

**Issue**

* Fixes #40293.

**References**
_H. H. Martens, A footnote to the Poincaré complete reducibility theorem, Publ. Mat. 36 (1992), 111–129.
Newman, Morris. Integral Matrices. New York and London: Academic Press, 1972_