### PR TITLE
Fix Ctrl-C segfaults in sage.libs.gap

### DIFF
--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -887,8 +887,7 @@ def ensure_interruptible_after(seconds: float, max_wait_after_interrupt: float =
         e.__traceback__ = None  # workaround for https://github.com/python/cpython/pull/129276
         alarm_raised = True
     except KeyboardInterrupt as e:
-        from sage.libs.gap.util import GAPError
-        if isinstance(e.__cause__, GAPError):
+        if "user interrupt" in str(e):
             # To handle SIGALRM in GAP we install its SIGINT handler
             # as the SIGALRM handler. When it gets Ctrl-C, we turn the
             # resulting GAPError into a KeyboardInterrupt... but

--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -883,17 +883,12 @@ def ensure_interruptible_after(seconds: float, max_wait_after_interrupt: float =
 
     try:
         yield data
-    except AlarmInterrupt as e:
-        e.__traceback__ = None  # workaround for https://github.com/python/cpython/pull/129276
-        alarm_raised = True
     except KeyboardInterrupt as e:
-        if "user interrupt" in str(e):
-            # To handle SIGALRM in GAP we install its SIGINT handler
-            # as the SIGALRM handler. When it gets Ctrl-C, we turn the
-            # resulting GAPError into a KeyboardInterrupt... but
-            # there's no real way to distinguish the SIGALRM case
-            # (doctesting) from the SIGINT case (interactive Ctrl-C)
-            # except for context.
+        # AlarmInterrupt is a subclass of KeyboardInterrupt, so this
+        # catches both. The "user interrupt" message is a quirk of
+        # GAP interrupts that result from SIGALRM.
+        if isinstance(e, AlarmInterrupt) or "user interrupt" in str(e):
+            # workaround for https://github.com/python/cpython/pull/129276
             e.__traceback__ = None
             alarm_raised = True
         else:

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2501,11 +2501,12 @@ cdef class GapElement_Function(GapElement):
         cdef Obj a[3]
 
         if n <= 3:
-            if n:
+            if not all(isinstance(x, GapElement) for x in args):
                 libgap = self.parent()
+                args = tuple(x if isinstance(x, GapElement) else libgap(x) for x in args)
             for i in range(n):
                 x = args[i]
-                a[i] = (<GapElement>(x if isinstance(x, GapElement) else libgap(x))).value
+                a[i] = (<GapElement>x).value
         else:
             arg_list = make_gap_list(args)
 

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -939,12 +939,6 @@ cdef class GapElement(RingElement):
             gap_sig_on()
             GAP_Enter()
             return GAP_EQ(self.value, c_other.value)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -969,12 +963,6 @@ cdef class GapElement(RingElement):
             gap_sig_on()
             GAP_Enter()
             return GAP_LT(self.value, c_other.value)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -1004,12 +992,6 @@ cdef class GapElement(RingElement):
             gap_sig_on()
             GAP_Enter()
             result = GAP_SUM(self.value, (<GapElement>right).value)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -1038,12 +1020,6 @@ cdef class GapElement(RingElement):
             gap_sig_on()
             GAP_Enter()
             result = GAP_DIFF(self.value, (<GapElement>right).value)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -1073,12 +1049,6 @@ cdef class GapElement(RingElement):
             gap_sig_on()
             GAP_Enter()
             result = GAP_PROD(self.value, (<GapElement>right).value)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -1113,12 +1083,6 @@ cdef class GapElement(RingElement):
             gap_sig_on()
             GAP_Enter()
             result = GAP_QUO(self.value, (<GapElement>right).value)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -1146,12 +1110,6 @@ cdef class GapElement(RingElement):
             gap_sig_on()
             GAP_Enter()
             result = GAP_MOD(self.value, (<GapElement>right).value)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -1199,12 +1157,6 @@ cdef class GapElement(RingElement):
             gap_sig_on()
             GAP_Enter()  # GAPError raised from here
             result = GAP_POW(self.value, (<GapElement>other).value)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -2574,12 +2526,6 @@ cdef class GapElement_Function(GapElement):
                 result = GAP_CallFunc3Args(self.value, a[0], a[1], a[2])
             else:
                 result = GAP_CallFuncList(self.value, arg_list)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()
@@ -3211,12 +3157,6 @@ cdef class GapElement_Record(GapElement):
             gap_sig_on()
             GAP_Enter()
             result = ELM_REC(self.value, i)
-        except GAPError as e:
-            if "user interrupt" in str(e):
-                # Ctrl-C
-                raise KeyboardInterrupt from e
-            else:
-                raise
         finally:
             GAP_Leave()
             gap_sig_off()

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2498,11 +2498,16 @@ cdef class GapElement_Function(GapElement):
         cdef Obj result = NULL
         cdef Obj arg_list
         cdef int n = len(args)
-        cdef volatile Obj v2
+        cdef Obj a[3]
 
-        if n > 0 and n <= 3:
-            libgap = self.parent()
-            a = [x if isinstance(x, GapElement) else libgap(x) for x in args]
+        if n <= 3:
+            if n:
+                libgap = self.parent()
+            for i in range(n):
+                x = args[i]
+                a[i] = (<GapElement>(x if isinstance(x, GapElement) else libgap(x))).value
+        else:
+            arg_list = make_gap_list(args)
 
         try:
             sig_GAP_Enter()
@@ -2510,20 +2515,12 @@ cdef class GapElement_Function(GapElement):
             if n == 0:
                 result = GAP_CallFunc0Args(self.value)
             elif n == 1:
-                result = GAP_CallFunc1Args(self.value,
-                                           (<GapElement>a[0]).value)
+                result = GAP_CallFunc1Args(self.value, a[0])
             elif n == 2:
-                result = GAP_CallFunc2Args(self.value,
-                                           (<GapElement>a[0]).value,
-                                           (<GapElement>a[1]).value)
+                result = GAP_CallFunc2Args(self.value, a[0], a[1])
             elif n == 3:
-                v2 = (<GapElement>a[2]).value
-                result = GAP_CallFunc3Args(self.value,
-                                           (<GapElement>a[0]).value,
-                                           (<GapElement>a[1]).value,
-                                           v2)
+                result = GAP_CallFunc3Args(self.value, a[0], a[1], a[2])
             else:
-                arg_list = make_gap_list(args)
                 result = GAP_CallFuncList(self.value, arg_list)
             sig_off()
         finally:

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -1245,7 +1245,11 @@ cdef class GapElement(RingElement):
             sage: libgap('this is a string').is_string()
             True
         """
-        return IS_STRING(self.value)
+        try:
+            GAP_Enter()
+            return GAP_IsString(self.value)
+        finally:
+            GAP_Leave()
 
     def is_permutation(self):
         r"""

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -309,6 +309,8 @@ cdef GapElement make_any_gap_element(parent, Obj obj):
     """
     if obj is NULL:
         return make_GapElement(parent, obj)
+    if (obj is GAP_True) or (obj is GAP_False) or (obj is GAP_Fail):
+        return make_GapElement_Boolean(parent, obj)
 
     # The object's type, if it can be determined from the libgap API.
     # Defaults to "undefined."
@@ -370,9 +372,7 @@ cdef GapElement make_any_gap_element(parent, Obj obj):
     # Since TNUM_OBJ does not invoke the public libgap API, it is not
     # wrapped in GAP_Enter / GAP_Leave.
     cdef int num = TNUM_OBJ(obj)
-    if num == T_BOOL:
-        return make_GapElement_Boolean(parent, obj)
-    elif num == T_RAT:
+    if num == T_RAT:
         return make_GapElement_Rational(parent, obj)
     elif num == T_FUNCTION:
         return make_GapElement_Function(parent, obj)

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -1201,7 +1201,11 @@ cdef class GapElement(RingElement):
             sage: libgap.eval('3/2').is_list()
             False
         """
-        return GAP_IsList(self.value)
+        try:
+            GAP_Enter()
+            return GAP_IsList(self.value)
+        finally:
+            GAP_Leave()
 
     def is_record(self):
         r"""
@@ -1216,7 +1220,11 @@ cdef class GapElement(RingElement):
             sage: libgap.eval('rec(a:=1, b:=3)').is_record()
             True
         """
-        return GAP_IsRecord(self.value)
+        try:
+            GAP_Enter()
+            return GAP_IsRecord(self.value)
+        finally:
+            GAP_Leave()
 
     cpdef is_bool(self):
         r"""

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -316,6 +316,10 @@ cdef GapElement make_any_gap_element(parent, Obj obj):
     # Defaults to "undefined."
     cdef int obj_type = OBJ_TYPE_UND
 
+    # The length of obj, if it's a list. Needed to exclude the empty
+    # list from the string <=> list-of-char equivalence.
+    cdef unsigned int list_len
+
     # Plan A: Determine the type of ``obj`` using the libgap API.
     # Make all libgap-api calls here, between GAP_Enter/GAP_Leave.
     # In particular we avoid any *other* functions that may invoke
@@ -333,6 +337,7 @@ cdef GapElement make_any_gap_element(parent, Obj obj):
             obj_type = OBJ_TYPE_STR
         elif GAP_IsList(obj):
             obj_type = OBJ_TYPE_LST
+            list_len = GAP_LenList(obj)
         elif GAP_IsRecord(obj):
             obj_type = OBJ_TYPE_REC
     finally:
@@ -351,7 +356,7 @@ cdef GapElement make_any_gap_element(parent, Obj obj):
         return make_GapElement_String(parent, obj)
     elif obj_type == OBJ_TYPE_LST:
         result = make_GapElement_List(parent, obj)
-        if result.IsString() and result.Length() > 0:
+        if list_len > 0 and result.IsString():
             # IsString() thinks a list-of-char is a string, but
             # GAP_IsString() does not. For backwards compatibility we
             # convert list-of-char to an efficient string here, and

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -1391,11 +1391,6 @@ cdef class GapElement(RingElement):
                 x = R.gen()
                 return x**val * R(num) / R(den)
 
-        elif self.IsList():
-            # May be a list-like collection of some other type of GapElements
-            # that we can convert
-            return [item.sage() for item in self.AsList()]
-
         elif self.IsFreeGroup():
             from sage.groups.free_group import FreeGroup_class
             names = tuple(str(g) for g in self.GeneratorsOfGroup())

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -1189,17 +1189,29 @@ cdef class GapElement(RingElement):
 
         TESTS:
 
-        Check that this can be interrupted gracefully::
+        Check that this method can be interrupted gracefully. The
+        repeats build confidence that everything remains sane after an
+        interruption::
 
-            sage: a, b = libgap.GL(1000, 3).GeneratorsOfGroup(); g = a * b
+            sage: # long time
+            sage: a, b = libgap.GL(1000, 3).GeneratorsOfGroup()
+            sage: g = a * b
+            sage: e = libgap(2^400000)
             sage: from sage.doctest.util import ensure_interruptible_after
-            sage: with ensure_interruptible_after(0.5): g ^ (2 ^ 10000)
+            sage: for _ in range(10):
+            ....:     with ensure_interruptible_after(0.1, max_wait_after_interrupt=5):
+            ....:         g._pow_(e)
+
+        Check that a :exc:`sage.libs.gap.util.GAPError` is raised
+        under error conditions::
 
             sage: libgap.CyclicGroup(2) ^ 2
             Traceback (most recent call last):
             ...
             GAPError: Error, no method found!
             Error, no 1st choice method found for `^' on 2 arguments
+
+        ::
 
             sage: libgap(3) ^ Infinity
             Traceback (most recent call last):

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -27,9 +27,6 @@ cdef extern from "gap/calls.h" nogil:
 
 
 cdef extern from "gap/libgap-api.h" nogil:
-    """
-    #define sig_GAP_Enter()  {int t = GAP_Enter(); if (!t) sig_error();}
-    """
     ctypedef void (*GAP_CallbackFunc)()
     void GAP_Initialize(int argc, char ** argv,
             GAP_CallbackFunc markBagsCallback, GAP_CallbackFunc errorCallback,
@@ -40,7 +37,6 @@ cdef extern from "gap/libgap-api.h" nogil:
     cdef void GAP_EnterStack()
     cdef void GAP_LeaveStack()
     cdef int GAP_Enter() except 0
-    cdef void sig_GAP_Enter()
     cdef void GAP_Leave()
     cdef int GAP_Error_Setjmp() except 0
 

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -148,6 +148,10 @@ cdef extern from "gap/stringobj.h" nogil:
     Obj NEW_STRING(Int)
 
 
+cdef extern from "gap/stats.h" nogil:
+    void InterruptExecStat()
+
+
 cdef extern from "<structmember.h>" nogil:
     """
     /* Hack: Cython 3.0 automatically includes <structmember.h>, which

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -55,6 +55,7 @@ cdef extern from "gap/libgap-api.h" nogil:
 
     cdef Obj GAP_True
     cdef Obj GAP_False
+    cdef Obj GAP_Fail
 
     Obj GAP_CallFuncList(Obj func, Obj args);
     Obj GAP_CallFuncArray(Obj func, UInt narg, Obj * args);

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -87,7 +87,7 @@ cdef extern from "gap/libgap-api.h" nogil:
     char* GAP_CSTR_STRING(Obj list)
     Obj GAP_MakeStringWithLen(const char* buf, UInt len)
 
-    Int GAP_ValueOfChar(Obj obj)
+    bint GAP_IsChar(Obj obj)
 
 
 cdef extern from "gap/lists.h" nogil:
@@ -139,7 +139,6 @@ cdef extern from "gap/records.h" nogil:
 
 
 cdef extern from "gap/stringobj.h" nogil:
-    bint IsStringConv(Obj obj)
     Obj NEW_STRING(Int)
 
 

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -139,7 +139,6 @@ cdef extern from "gap/records.h" nogil:
 
 
 cdef extern from "gap/stringobj.h" nogil:
-    bint IS_STRING(Obj obj)
     bint IsStringConv(Obj obj)
     Obj NEW_STRING(Int)
 

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -163,17 +163,84 @@ Using the GAP C library from Cython
    We are using the GAP API provided by the GAP project since
    GAP 4.10.
 
+   All GAP library usage should be sandwiched between calls to
+   ``GAP_Enter()`` and ``GAP_Leave()``. These are macros defined in
+   ``libgap-api.h`` and must be used carefully because ``GAP_Enter()``
+   is defined as two function calls in succession without braces. The
+   first thing that ``GAP_Enter()`` does is a ``setjmp()`` which plays
+   an important role in handling errors. The return value from
+   ``GAP_Enter()`` is non-zero (success) the first time around, and if
+   an error occurs, execution "jumps" back to ``GAP_Enter()``, this
+   time with a return value of zero (failure). Due to these
+   implementation details, we cannot simply check the return value
+   before executing Cython code; the following *does not* work::
 
-   One unusual aspect of this interface is its signal handling.
-   Typically, cysignals' ``sig_on()`` and ``sig_off()`` functions are
-   used to wrap code that may take a long time, and as a result, may
-   need to be interrupted with Ctrl-C. However, it is possible that
-   interrupting a function execution at an arbitrary location will
-   lead to inconsistent state. Internally, GAP provides a mechanism
-   using ``InterruptExecStat``, which sets a flag that tells GAP to
-   gracefully exit with an error as early as possible. We make use of
-   this internal mechanism to prevent segmentation fault when GAP
-   functions are interrupted.
+       if (GAP_Enter()):
+          # further calls to libgap
+          GAP_Leave()
+
+   Instead you will see something like::
+
+       try:
+           GAP_Enter()
+           # further calls to libgap
+       finally:
+           GAP_Leave()
+
+   How this works is subtle. When GAP is initialized, we install an
+   ``error_handler()`` callback that GAP invokes on error. This
+   function sets a python exception using ``PyErr_Restore()``, but so
+   long as we remain in C, this exception will not actually be
+   raised. When ``error_handler()`` finishes executing, control
+   returns to GAP which then jumps back to the previous
+   ``GAP_Enter()``. It is at this point that we need to raise the
+   (already set) exception, to prevent re-executing the code that
+   caused an error. To facilitate this, ``GAP_Enter()`` is wrapped by
+   Cython, and the wrapper is qualified with ``except 0``. This means
+   that Cython will treat a return value from the ``GAP_Enter()``
+   macro as an error, and raise an exception if one is set. (One will
+   be if there was an error because our ``error_handler()`` sets
+   it). Here is a real example::
+
+       try:
+           GAP_Enter()
+           libgap.Sum(1,2,3,4)
+       finally:
+           GAP_Leave()
+
+   The call to ``libgap.Sum(1,2,3,4)`` is an error in this case,
+   because summing four numbers requires them to be passed as a
+   list. In any case, what happens is,
+
+   #. We call the ``GAP_Enter()`` Cython wrapper, which invokes the
+      macro, and additionally generates some C code to raise an
+      exception if that return value is zero (error). But this is the
+      first pass, so for now the macro returns a non-zero (success)
+      value.
+   #. We call ``libgap.Sum(1,2,3,4)``, which is an error.
+   #. GAP invokes our ``error_handler()``, which creates a
+      :exc:`sage.libs.gap.util.GAPError`, and sets it active.
+   #. Control returns to GAP.
+   #. GAP jumps back to ``GAP_Enter()``.
+   #. The error branch of ``GAP_Enter()`` is executed. In other words
+      we proceed from ``GAP_Enter()`` as if it returned zero (error).
+   #. An exception is raised, because the ``except 0`` qualifier on the
+      Cython wrapper for ``GAP_Enter()`` specifically checks for zero
+      and raises any exceptions in that case.
+   #. Finally, ``GAP_Leave()`` is called to clean up. In a more
+      realistic example where failure is not guaranteed, this would
+      also have been run to clean up if no errors were raised.
+
+   Another unusual aspect of the libgap interface is its signal
+   handling. Typically, cysignals' ``sig_on()`` and ``sig_off()``
+   functions are used to wrap code that may take a long time, and as a
+   result, may need to be interrupted with Ctrl-C. However, it is
+   possible that interrupting a function execution at an arbitrary
+   location will lead to inconsistent state. Internally, GAP provides
+   a mechanism using ``InterruptExecStat``, which sets a flag that
+   tells GAP to gracefully exit with an error as early as possible. We
+   make use of this internal mechanism to prevent segmentation faults
+   when GAP functions are interrupted.
 
    Specifically, we install GAP's own ``SIGINT`` handler (to catch
    Ctrl-C) before executing any long-running GAP code, and then later
@@ -181,14 +248,10 @@ Using the GAP C library from Cython
    is accomplished using the suggestively-named ``gap_sig_on()`` and
    ``gap_sig_off()`` functions. After you have called
    ``gap_sig_on()``, if GAP receives Ctrl-C, it will invoke our custom
-   ``error_handler()`` that will raise a
-   :exc:`sage.libs.gap.util.GAPError` containing the phrase "user
-   interrupt". As a result you will often find GAP code sandwiched
-   between ``gap_sig_on()`` and ``gap_sig_off()``, in a ``try/except``
-   block, with special handling for these GAP errors. The goal is to
-   catch and re-raise them as :exc:`KeyboardInterrupt` so that they
-   can be caught in user code just like you would with a cysignals
-   interrupt.
+   ``error_handler()`` that will set a :exc:`KeyboardInterrupt`
+   containing the phrase "user interrupt". Eventually (as explained in
+   the preceding paragraphs), control will jump back to the Cython
+   wrapper for ``GAP_Enter()``, and this exception will be raised.
 
    Before you attempt to change any of this, please make sure that you
    understand the issues that it is intended to fix, e.g.

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -160,10 +160,42 @@ using the recursive expansion of the
 Using the GAP C library from Cython
 ===================================
 
-.. TODO:: Expand the following text
-
    We are using the GAP API provided by the GAP project since
    GAP 4.10.
+
+   One unusual aspect of this interface is its signal handling.
+   Typically, cysignals' ``sig_on()`` and ``sig_off()`` functions are
+   used to wrap code that may take a long time, and, as a result, may
+   need to be interrupted with Ctrl-C. Those functions are implemented
+   with setjmp and longjmp however, and cause hard-to-diagnose issues
+   arising from their interaction with ``GAP_enter()`` and
+   ``GAP_Leave()`` -- also implemented via setjmp and longjmp. This
+   has lead to many segfaults when GAP errors are raised, or when
+   Ctrl-C is used to interrupt GAP computations.
+
+   The approach we are using instead is to install GAP's own
+   ``SIGINT`` handler (to catch Ctrl-C) before executing any
+   long-running GAP code, and then to later uninstall it when the GAP
+   code has finished. This is accomplished using the
+   suggestively-named ``gap_sig_on()`` and ``gap_sig_off()``
+   functions. After you have called ``gap_sig_on()``, if GAP receives
+   Ctrl-C, it will invoke our custom ``error_handler()`` that will
+   raise a :exc:`sage.libs.gap.util.GAPError` containing the phrase
+   "user interrupt". As a result you will often find GAP code
+   sandwiched between ``gap_sig_on()`` and ``gap_sig_off()``, in a
+   ``try/except`` block, with special handling for these GAP
+   errors. The goal is to catch and re-raise them as
+   :exc:`KeyboardInterrupt` so that they can be caught in user code
+   just like you would with a cysignals interrupt.
+
+   Before you attempt to change any of this, please make sure that you
+   understand the issues that it is intended to fix, e.g.
+
+     * https://github.com/sagemath/sage/issues/37026
+     * https://trofi.github.io/posts/312-the-sagemath-saga.html
+     * https://github.com/sagemath/sage/pull/40585
+     * https://github.com/sagemath/sage/pull/40594
+     * https://github.com/sagemath/sage/issues/40598
 
 AUTHORS:
 

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -202,22 +202,26 @@ Using the GAP C library from Cython
    be if there was an error because our ``error_handler()`` sets
    it). Here is a real example::
 
-       try:
-           GAP_Enter()
-           libgap.Sum(1,2,3,4)
-       finally:
-           GAP_Leave()
+       cpdef void crash_and_burn() except *:
+           cdef GapElement x = <GapElement>libgap({'a': 1, 'b': 2})
+           cdef unsigned int xlen
+           try:
+               GAP_Enter()
+               xlen = GAP_LenList(x.value)
+           finally:
+               GAP_Leave()
+           print(xlen)
 
-   The call to ``libgap.Sum(1,2,3,4)`` is an error in this case,
-   because summing four numbers requires them to be passed as a
-   list. In any case, what happens is,
+   The call to ``GAP_LenList()`` is an error in this case, because
+   ``x.value`` is a GAP record, not a GAP list. In any case, what
+   happens is,
 
    #. We call the ``GAP_Enter()`` Cython wrapper, which invokes the
       macro, and additionally generates some C code to raise an
       exception if that return value is zero (error). But this is the
       first pass, so for now the macro returns a non-zero (success)
       value.
-   #. We call ``libgap.Sum(1,2,3,4)``, which is an error.
+   #. We call ``GAP_LenList(x.value)``, which is an error.
    #. GAP invokes our ``error_handler()``, which creates a
       :exc:`sage.libs.gap.util.GAPError`, and sets it active.
    #. Control returns to GAP.

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -271,13 +271,13 @@ you understand the issues that it is intended to fix, e.g.
 
 AUTHORS:
 
-  - William Stein, Robert Miller (2009-06-23): first version
-  - Volker Braun, Dmitrii Pasechnik, Ivan Andrus (2011-03-25, Sage Days 29):
-    almost complete rewrite; first usable version.
-  - Volker Braun (2012-08-28, GAP/Singular workshop): update to
-    gap-4.5.5, make it ready for public consumption.
-  - Dima Pasechnik (2018-09-18, GAP Days): started the port to native
-    libgap API
+- William Stein, Robert Miller (2009-06-23): first version
+- Volker Braun, Dmitrii Pasechnik, Ivan Andrus (2011-03-25, Sage Days 29):
+  almost complete rewrite; first usable version.
+- Volker Braun (2012-08-28, GAP/Singular workshop): update to
+  gap-4.5.5, make it ready for public consumption.
+- Dima Pasechnik (2018-09-18, GAP Days): started the port to native
+  libgap API
 """
 
 ###############################################################################

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -163,17 +163,18 @@ Using the GAP C library from Cython
    We are using the GAP API provided by the GAP project since
    GAP 4.10.
 
-   All GAP library usage should be sandwiched between calls to
-   ``GAP_Enter()`` and ``GAP_Leave()``. These are macros defined in
-   ``libgap-api.h`` and must be used carefully because ``GAP_Enter()``
-   is defined as two function calls in succession without braces. The
-   first thing that ``GAP_Enter()`` does is a ``setjmp()`` which plays
-   an important role in handling errors. The return value from
-   ``GAP_Enter()`` is non-zero (success) the first time around, and if
-   an error occurs, execution "jumps" back to ``GAP_Enter()``, this
-   time with a return value of zero (failure). Due to these
-   implementation details, we cannot simply check the return value
-   before executing Cython code; the following *does not* work::
+   Calls to the GAP C library (functions declared in libgap-api.h)
+   should be sandwiched between calls to ``GAP_Enter()`` and
+   ``GAP_Leave()``. These are macros defined in ``libgap-api.h`` and
+   must be used carefully because ``GAP_Enter()`` is defined as two
+   function calls in succession without braces. The first thing that
+   ``GAP_Enter()`` does is a ``setjmp()`` which plays an important
+   role in handling errors. The return value from ``GAP_Enter()`` is
+   non-zero (success) the first time around, and if an error occurs,
+   execution "jumps" back to ``GAP_Enter()``, this time with a return
+   value of zero (failure). Due to these implementation details, we
+   cannot simply check the return value before executing Cython code;
+   the following *does not* work::
 
        if (GAP_Enter()):
           # further calls to libgap

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -162,8 +162,8 @@ Using the GAP C library from Cython
 
 We are using the GAP API provided by the GAP project since GAP 4.10.
 
-Calls to the GAP C library (functions declared in libgap-api.h) should
-be sandwiched between calls to ``GAP_Enter()`` and
+Calls to the GAP C library (functions declared in ``libgap-api.h``)
+should be sandwiched between calls to ``GAP_Enter()`` and
 ``GAP_Leave()``. These are macros defined in ``libgap-api.h`` and must
 be used carefully because ``GAP_Enter()`` is defined as two function
 calls in succession without braces. The first thing that

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -160,117 +160,114 @@ using the recursive expansion of the
 Using the GAP C library from Cython
 ===================================
 
-    We are using the GAP API provided by the GAP project since
-    GAP 4.10.
+We are using the GAP API provided by the GAP project since GAP 4.10.
 
-    Calls to the GAP C library (functions declared in libgap-api.h)
-    should be sandwiched between calls to ``GAP_Enter()`` and
-    ``GAP_Leave()``. These are macros defined in ``libgap-api.h`` and
-    must be used carefully because ``GAP_Enter()`` is defined as two
-    function calls in succession without braces. The first thing that
-    ``GAP_Enter()`` does is a ``setjmp()`` which plays an important
-    role in handling errors. The return value from ``GAP_Enter()`` is
-    non-zero (success) the first time around, and if an error occurs,
-    execution "jumps" back to ``GAP_Enter()``, this time with a return
-    value of zero (failure). Due to these quirks, naive attempts to
-    handle the return value of ``GAP_Enter()`` are doomed to fail.
-    The correct pattern to use is,
+Calls to the GAP C library (functions declared in libgap-api.h) should
+be sandwiched between calls to ``GAP_Enter()`` and
+``GAP_Leave()``. These are macros defined in ``libgap-api.h`` and must
+be used carefully because ``GAP_Enter()`` is defined as two function
+calls in succession without braces. The first thing that
+``GAP_Enter()`` does is a ``setjmp()`` which plays an important role
+in handling errors. The return value from ``GAP_Enter()`` is non-zero
+(success) the first time around, and if an error occurs, execution
+"jumps" back to ``GAP_Enter()``, this time with a return value of zero
+(failure). Due to these quirks, naive attempts to handle the return
+value of ``GAP_Enter()`` are doomed to fail.  The correct pattern to
+use is::
 
+    try:
+        GAP_Enter()
+        # further calls to libgap
+    finally:
+        GAP_Leave()
+
+How this works is subtle. When GAP is initialized, we install an
+``error_handler()`` callback that GAP invokes on error. This function
+sets a python exception using ``PyErr_Restore()``, but so long as we
+remain in C, this exception will not actually be raised. When
+``error_handler()`` finishes executing, control returns to GAP which
+then jumps back to the previous ``GAP_Enter()``. It is at this point
+that we need to raise the (already set) exception, to prevent
+re-executing the code that caused an error. To facilitate this,
+``GAP_Enter()`` is wrapped by Cython, and the wrapper is qualified
+with ``except 0``. This tells Cython to treat a return value of zero
+as an error, and raise an exception if an exception is set. (One will
+be set if there was an error because our ``error_handler()`` sets
+it). Here is a real example::
+
+    cpdef void crash_and_burn() except *:
+        x = libgap({'a': 1, 'b': 2})
+        cdef unsigned int xlen
         try:
             GAP_Enter()
-            # further calls to libgap
+            xlen = GAP_LenList((<GapElement>x).value)
         finally:
             GAP_Leave()
+        print(xlen)
 
-    How this works is subtle. When GAP is initialized, we install an
-    ``error_handler()`` callback that GAP invokes on error. This
-    function sets a python exception using ``PyErr_Restore()``, but so
-    long as we remain in C, this exception will not actually be
-    raised. When ``error_handler()`` finishes executing, control
-    returns to GAP which then jumps back to the previous
-    ``GAP_Enter()``. It is at this point that we need to raise the
-    (already set) exception, to prevent re-executing the code that
-    caused an error. To facilitate this, ``GAP_Enter()`` is wrapped by
-    Cython, and the wrapper is qualified with ``except 0``. This tells
-    Cython to treat a return value of zero as an error, and raise an
-    exception if an exception is set. (One will be set if there was an
-    error because our ``error_handler()`` sets it). Here is a real
-    example::
+The call to ``GAP_LenList()`` is an error in this case, because
+``x.value`` is a GAP record, not a GAP list. In any case, what happens
+is,
 
-        cpdef void crash_and_burn() except *:
-            x = libgap({'a': 1, 'b': 2})
-            cdef unsigned int xlen
-            try:
-                GAP_Enter()
-                xlen = GAP_LenList((<GapElement>x).value)
-            finally:
-                GAP_Leave()
-            print(xlen)
+#. We call the ``GAP_Enter()`` Cython wrapper, which invokes the
+   macro, and additionally generates some C code to raise an
+   exception if that return value is zero (error). But this is the
+   first pass, so for now the macro returns a non-zero (success)
+   value.
+#. We call ``GAP_LenList(x.value)``, which is an error.
+#. GAP invokes our ``error_handler()``, which creates a
+   :exc:`sage.libs.gap.util.GAPError`, and sets it active.
+#. Control returns to GAP.
+#. GAP jumps back to ``GAP_Enter()``.
+#. The error branch of ``GAP_Enter()`` is executed. In other words
+   we proceed from ``GAP_Enter()`` as if it returned zero (error).
+#. An exception is raised, because the ``except 0`` qualifier on the
+   Cython wrapper for ``GAP_Enter()`` specifically checks for zero
+   and raises any exceptions in that case.
+#. Finally, ``GAP_Leave()`` is called to clean up. In a more
+   realistic example where failure is not guaranteed, this would
+   also have been run to clean up if no errors were raised.
 
-    The call to ``GAP_LenList()`` is an error in this case, because
-    ``x.value`` is a GAP record, not a GAP list. In any case, what
-    happens is,
+Another unusual aspect of the libgap interface is its signal
+handling. Typically, cysignals' ``sig_on()`` and ``sig_off()``
+functions are used to wrap code that may take a long time, and as a
+result, may need to be interrupted with Ctrl-C. However, it is
+possible that interrupting a function execution at an arbitrary
+location will lead to inconsistent state. Internally, GAP provides a
+mechanism using ``InterruptExecStat``, which sets a flag that tells
+GAP to gracefully exit with an error as early as possible. We make use
+of this internal mechanism to prevent segmentation faults when GAP
+functions are interrupted.
 
-    #. We call the ``GAP_Enter()`` Cython wrapper, which invokes the
-       macro, and additionally generates some C code to raise an
-       exception if that return value is zero (error). But this is the
-       first pass, so for now the macro returns a non-zero (success)
-       value.
-    #. We call ``GAP_LenList(x.value)``, which is an error.
-    #. GAP invokes our ``error_handler()``, which creates a
-       :exc:`sage.libs.gap.util.GAPError`, and sets it active.
-    #. Control returns to GAP.
-    #. GAP jumps back to ``GAP_Enter()``.
-    #. The error branch of ``GAP_Enter()`` is executed. In other words
-       we proceed from ``GAP_Enter()`` as if it returned zero (error).
-    #. An exception is raised, because the ``except 0`` qualifier on the
-       Cython wrapper for ``GAP_Enter()`` specifically checks for zero
-       and raises any exceptions in that case.
-    #. Finally, ``GAP_Leave()`` is called to clean up. In a more
-       realistic example where failure is not guaranteed, this would
-       also have been run to clean up if no errors were raised.
+Specifically, we install GAP's own ``SIGINT`` handler (to catch
+Ctrl-C) before executing any long-running GAP code, and then later
+reinstall the original handler when the GAP code has finished. This is
+accomplished using the suggestively-named ``gap_sig_on()`` and
+``gap_sig_off()`` functions. After you have called ``gap_sig_on()``,
+if GAP receives Ctrl-C, it will invoke our custom ``error_handler()``
+that will set a :exc:`KeyboardInterrupt` containing the phrase "user
+interrupt". Eventually (as explained in the preceding paragraphs),
+control will jump back to the Cython wrapper for ``GAP_Enter()``, and
+this exception will be raised.
 
-    Another unusual aspect of the libgap interface is its signal
-    handling. Typically, cysignals' ``sig_on()`` and ``sig_off()``
-    functions are used to wrap code that may take a long time, and as
-    a result, may need to be interrupted with Ctrl-C. However, it is
-    possible that interrupting a function execution at an arbitrary
-    location will lead to inconsistent state. Internally, GAP provides
-    a mechanism using ``InterruptExecStat``, which sets a flag that
-    tells GAP to gracefully exit with an error as early as
-    possible. We make use of this internal mechanism to prevent
-    segmentation faults when GAP functions are interrupted.
+The safest pattern to use for interruptible libgap code is::
 
-    Specifically, we install GAP's own ``SIGINT`` handler (to catch
-    Ctrl-C) before executing any long-running GAP code, and then later
-    reinstall the original handler when the GAP code has
-    finished. This is accomplished using the suggestively-named
-    ``gap_sig_on()`` and ``gap_sig_off()`` functions. After you have
-    called ``gap_sig_on()``, if GAP receives Ctrl-C, it will invoke
-    our custom ``error_handler()`` that will set a
-    :exc:`KeyboardInterrupt` containing the phrase "user
-    interrupt". Eventually (as explained in the preceding paragraphs),
-    control will jump back to the Cython wrapper for ``GAP_Enter()``,
-    and this exception will be raised.
+    try:
+        gap_sig_on()
+        GAP_Enter()
+        # further calls to libgap
+    finally:
+        GAP_Leave()
+        gap_sig_off()
 
-    The safest pattern to use for interruptible libgap code is,
+Before you attempt to change any of this, please make sure that
+you understand the issues that it is intended to fix, e.g.
 
-        try:
-            gap_sig_on()
-            GAP_Enter()
-            # further calls to libgap
-        finally:
-            GAP_Leave()
-            gap_sig_off()
-
-    Before you attempt to change any of this, please make sure that
-    you understand the issues that it is intended to fix, e.g.
-
-    * https://github.com/sagemath/sage/issues/37026
-    * https://trofi.github.io/posts/312-the-sagemath-saga.html
-    * https://github.com/sagemath/sage/pull/40585
-    * https://github.com/sagemath/sage/pull/40594
-    * https://github.com/sagemath/sage/issues/40598
+* https://github.com/sagemath/sage/issues/37026
+* https://trofi.github.io/posts/312-the-sagemath-saga.html
+* https://github.com/sagemath/sage/pull/40585
+* https://github.com/sagemath/sage/pull/40594
+* https://github.com/sagemath/sage/issues/40598
 
 AUTHORS:
 

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -160,112 +160,113 @@ using the recursive expansion of the
 Using the GAP C library from Cython
 ===================================
 
-   We are using the GAP API provided by the GAP project since
-   GAP 4.10.
+    We are using the GAP API provided by the GAP project since
+    GAP 4.10.
 
-   Calls to the GAP C library (functions declared in libgap-api.h)
-   should be sandwiched between calls to ``GAP_Enter()`` and
-   ``GAP_Leave()``. These are macros defined in ``libgap-api.h`` and
-   must be used carefully because ``GAP_Enter()`` is defined as two
-   function calls in succession without braces. The first thing that
-   ``GAP_Enter()`` does is a ``setjmp()`` which plays an important
-   role in handling errors. The return value from ``GAP_Enter()`` is
-   non-zero (success) the first time around, and if an error occurs,
-   execution "jumps" back to ``GAP_Enter()``, this time with a return
-   value of zero (failure). Due to these implementation details, we
-   cannot simply check the return value before executing Cython code;
-   the following *does not* work::
+    Calls to the GAP C library (functions declared in libgap-api.h)
+    should be sandwiched between calls to ``GAP_Enter()`` and
+    ``GAP_Leave()``. These are macros defined in ``libgap-api.h`` and
+    must be used carefully because ``GAP_Enter()`` is defined as two
+    function calls in succession without braces. The first thing that
+    ``GAP_Enter()`` does is a ``setjmp()`` which plays an important
+    role in handling errors. The return value from ``GAP_Enter()`` is
+    non-zero (success) the first time around, and if an error occurs,
+    execution "jumps" back to ``GAP_Enter()``, this time with a return
+    value of zero (failure). Due to these implementation details, we
+    cannot simply check the return value before executing Cython code;
+    the following *does not* work::
 
-       if (GAP_Enter()):
-          # further calls to libgap
-          GAP_Leave()
-
-   Instead you will see something like::
-
-       try:
-           GAP_Enter()
+        if (GAP_Enter()):
            # further calls to libgap
-       finally:
            GAP_Leave()
 
-   How this works is subtle. When GAP is initialized, we install an
-   ``error_handler()`` callback that GAP invokes on error. This
-   function sets a python exception using ``PyErr_Restore()``, but so
-   long as we remain in C, this exception will not actually be
-   raised. When ``error_handler()`` finishes executing, control
-   returns to GAP which then jumps back to the previous
-   ``GAP_Enter()``. It is at this point that we need to raise the
-   (already set) exception, to prevent re-executing the code that
-   caused an error. To facilitate this, ``GAP_Enter()`` is wrapped by
-   Cython, and the wrapper is qualified with ``except 0``. This means
-   that Cython will treat a return value from the ``GAP_Enter()``
-   macro as an error, and raise an exception if one is set. (One will
-   be if there was an error because our ``error_handler()`` sets
-   it). Here is a real example::
+    Instead you will see something like::
 
-       cpdef void crash_and_burn() except *:
-           cdef GapElement x = <GapElement>libgap({'a': 1, 'b': 2})
-           cdef unsigned int xlen
-           try:
-               GAP_Enter()
-               xlen = GAP_LenList(x.value)
-           finally:
-               GAP_Leave()
-           print(xlen)
+        try:
+            GAP_Enter()
+            # further calls to libgap
+        finally:
+            GAP_Leave()
 
-   The call to ``GAP_LenList()`` is an error in this case, because
-   ``x.value`` is a GAP record, not a GAP list. In any case, what
-   happens is,
+    How this works is subtle. When GAP is initialized, we install an
+    ``error_handler()`` callback that GAP invokes on error. This
+    function sets a python exception using ``PyErr_Restore()``, but so
+    long as we remain in C, this exception will not actually be
+    raised. When ``error_handler()`` finishes executing, control
+    returns to GAP which then jumps back to the previous
+    ``GAP_Enter()``. It is at this point that we need to raise the
+    (already set) exception, to prevent re-executing the code that
+    caused an error. To facilitate this, ``GAP_Enter()`` is wrapped by
+    Cython, and the wrapper is qualified with ``except 0``. This means
+    that Cython will treat a return value from the ``GAP_Enter()``
+    macro as an error, and raise an exception if one is set. (One will
+    be if there was an error because our ``error_handler()`` sets
+    it). Here is a real example::
 
-   #. We call the ``GAP_Enter()`` Cython wrapper, which invokes the
-      macro, and additionally generates some C code to raise an
-      exception if that return value is zero (error). But this is the
-      first pass, so for now the macro returns a non-zero (success)
-      value.
-   #. We call ``GAP_LenList(x.value)``, which is an error.
-   #. GAP invokes our ``error_handler()``, which creates a
-      :exc:`sage.libs.gap.util.GAPError`, and sets it active.
-   #. Control returns to GAP.
-   #. GAP jumps back to ``GAP_Enter()``.
-   #. The error branch of ``GAP_Enter()`` is executed. In other words
-      we proceed from ``GAP_Enter()`` as if it returned zero (error).
-   #. An exception is raised, because the ``except 0`` qualifier on the
-      Cython wrapper for ``GAP_Enter()`` specifically checks for zero
-      and raises any exceptions in that case.
-   #. Finally, ``GAP_Leave()`` is called to clean up. In a more
-      realistic example where failure is not guaranteed, this would
-      also have been run to clean up if no errors were raised.
+        cpdef void crash_and_burn() except *:
+            cdef GapElement x = <GapElement>libgap({'a': 1, 'b': 2})
+            cdef unsigned int xlen
+            try:
+                GAP_Enter()
+                xlen = GAP_LenList(x.value)
+            finally:
+                GAP_Leave()
+            print(xlen)
 
-   Another unusual aspect of the libgap interface is its signal
-   handling. Typically, cysignals' ``sig_on()`` and ``sig_off()``
-   functions are used to wrap code that may take a long time, and as a
-   result, may need to be interrupted with Ctrl-C. However, it is
-   possible that interrupting a function execution at an arbitrary
-   location will lead to inconsistent state. Internally, GAP provides
-   a mechanism using ``InterruptExecStat``, which sets a flag that
-   tells GAP to gracefully exit with an error as early as possible. We
-   make use of this internal mechanism to prevent segmentation faults
-   when GAP functions are interrupted.
+    The call to ``GAP_LenList()`` is an error in this case, because
+    ``x.value`` is a GAP record, not a GAP list. In any case, what
+    happens is,
 
-   Specifically, we install GAP's own ``SIGINT`` handler (to catch
-   Ctrl-C) before executing any long-running GAP code, and then later
-   reinstall the original handler when the GAP code has finished. This
-   is accomplished using the suggestively-named ``gap_sig_on()`` and
-   ``gap_sig_off()`` functions. After you have called
-   ``gap_sig_on()``, if GAP receives Ctrl-C, it will invoke our custom
-   ``error_handler()`` that will set a :exc:`KeyboardInterrupt`
-   containing the phrase "user interrupt". Eventually (as explained in
-   the preceding paragraphs), control will jump back to the Cython
-   wrapper for ``GAP_Enter()``, and this exception will be raised.
+    #. We call the ``GAP_Enter()`` Cython wrapper, which invokes the
+       macro, and additionally generates some C code to raise an
+       exception if that return value is zero (error). But this is the
+       first pass, so for now the macro returns a non-zero (success)
+       value.
+    #. We call ``GAP_LenList(x.value)``, which is an error.
+    #. GAP invokes our ``error_handler()``, which creates a
+       :exc:`sage.libs.gap.util.GAPError`, and sets it active.
+    #. Control returns to GAP.
+    #. GAP jumps back to ``GAP_Enter()``.
+    #. The error branch of ``GAP_Enter()`` is executed. In other words
+       we proceed from ``GAP_Enter()`` as if it returned zero (error).
+    #. An exception is raised, because the ``except 0`` qualifier on the
+       Cython wrapper for ``GAP_Enter()`` specifically checks for zero
+       and raises any exceptions in that case.
+    #. Finally, ``GAP_Leave()`` is called to clean up. In a more
+       realistic example where failure is not guaranteed, this would
+       also have been run to clean up if no errors were raised.
 
-   Before you attempt to change any of this, please make sure that you
-   understand the issues that it is intended to fix, e.g.
+    Another unusual aspect of the libgap interface is its signal
+    handling. Typically, cysignals' ``sig_on()`` and ``sig_off()``
+    functions are used to wrap code that may take a long time, and as
+    a result, may need to be interrupted with Ctrl-C. However, it is
+    possible that interrupting a function execution at an arbitrary
+    location will lead to inconsistent state. Internally, GAP provides
+    a mechanism using ``InterruptExecStat``, which sets a flag that
+    tells GAP to gracefully exit with an error as early as
+    possible. We make use of this internal mechanism to prevent
+    segmentation faults when GAP functions are interrupted.
 
-     * https://github.com/sagemath/sage/issues/37026
-     * https://trofi.github.io/posts/312-the-sagemath-saga.html
-     * https://github.com/sagemath/sage/pull/40585
-     * https://github.com/sagemath/sage/pull/40594
-     * https://github.com/sagemath/sage/issues/40598
+    Specifically, we install GAP's own ``SIGINT`` handler (to catch
+    Ctrl-C) before executing any long-running GAP code, and then later
+    reinstall the original handler when the GAP code has
+    finished. This is accomplished using the suggestively-named
+    ``gap_sig_on()`` and ``gap_sig_off()`` functions. After you have
+    called ``gap_sig_on()``, if GAP receives Ctrl-C, it will invoke
+    our custom ``error_handler()`` that will set a
+    :exc:`KeyboardInterrupt` containing the phrase "user
+    interrupt". Eventually (as explained in the preceding paragraphs),
+    control will jump back to the Cython wrapper for ``GAP_Enter()``,
+    and this exception will be raised.
+
+    Before you attempt to change any of this, please make sure that you
+    understand the issues that it is intended to fix, e.g.
+
+    * https://github.com/sagemath/sage/issues/37026
+    * https://trofi.github.io/posts/312-the-sagemath-saga.html
+    * https://github.com/sagemath/sage/pull/40585
+    * https://github.com/sagemath/sage/pull/40594
+    * https://github.com/sagemath/sage/issues/40598
 
 AUTHORS:
 

--- a/src/sage/libs/gap/libgap.pyx
+++ b/src/sage/libs/gap/libgap.pyx
@@ -198,11 +198,11 @@ Using the GAP C library from Cython
     example::
 
         cpdef void crash_and_burn() except *:
-            cdef GapElement x = <GapElement>libgap({'a': 1, 'b': 2})
+            x = libgap({'a': 1, 'b': 2})
             cdef unsigned int xlen
             try:
                 GAP_Enter()
-                xlen = GAP_LenList(x.value)
+                xlen = GAP_LenList((<GapElement>x).value)
             finally:
                 GAP_Leave()
             print(xlen)

--- a/src/sage/libs/gap/meson.build
+++ b/src/sage/libs/gap/meson.build
@@ -33,7 +33,7 @@ foreach name, pyx : extension_data
     subdir: 'sage/libs/gap',
     install: true,
     include_directories: [inc_cpython, inc_rings],
-    dependencies: [py_dep, cysignals, gap, gmp],
+    dependencies: [py_dep, gap, gmp],
   )
 endforeach
 

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -187,6 +187,11 @@ cdef sigaction_t gap_sigint_sa
 cdef sigaction_t sage_sigint_sa
 cdef sigaction_t sage_sigalrm_sa
 
+cdef void gap_interrupt_asap(int signum):
+    # A wrapper around InterruptExecStat(). This tells GAP to raise an
+    # error at the next opportunity.
+    InterruptExecStat()
+
 cdef initialize():
     """
     Initialize the GAP library, if it hasn't already been
@@ -276,7 +281,7 @@ cdef initialize():
     # own SIGINT handler (but without the double-Ctrl-C behavior), and
     # is less crashy than when we mix cysignals with GAP code.
     global gap_sigint_sa
-    gap_sigint_sa.sa_handler = <void (*)(int) noexcept>InterruptExecStat
+    gap_sigint_sa.sa_handler = gap_interrupt_asap
     sigemptyset(&(gap_sigint_sa.sa_mask))
     gap_sigint_sa.sa_flags = 0;
 

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -421,12 +421,6 @@ cdef Obj gap_eval(str gap_string) except? NULL:
         # this like returning None)
 
         return GAP_ElmList(result, 2)
-    except GAPError as e:
-        if "user interrupt" in str(e):
-            # Ctrl-C
-            raise KeyboardInterrupt from e
-        else:
-            raise
     finally:
         GAP_Leave()
         gap_sig_off()

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -12,8 +12,9 @@ Utility functions for GAP
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from libc.signal cimport signal, SIGCHLD, SIG_DFL
+from libc.signal cimport signal, SIGALRM, SIGCHLD, SIG_DFL, SIGINT
 from posix.dlfcn cimport dlopen, dlclose, dlerror, RTLD_LAZY, RTLD_GLOBAL
+from posix.signal cimport sigaction, sigaction_t, sigemptyset
 
 from cpython.exc cimport PyErr_Fetch, PyErr_Restore
 from cpython.object cimport Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE
@@ -180,6 +181,12 @@ MakeReadOnlyGlobal("ERROR_OUTPUT");
 MakeImmutable(libgap_errout);
 """
 
+# "Global" signal handler info structs. The GAP one we enable/disable
+# before/after GAP code. The Sage ones we use to store the existing
+# handlers before we do that.
+cdef sigaction_t gap_sigint_sa
+cdef sigaction_t sage_sigint_sa
+cdef sigaction_t sage_sigalrm_sa
 
 cdef initialize():
     """
@@ -259,10 +266,22 @@ cdef initialize():
     argv[argc] = NULL
 
     sig_on()
-    # Initialize GAP but disable their SIGINT handler
+    # Initialize GAP but disable its signal handlers: we only want
+    # them to be invoked while libgap code is executing, whereas the
+    # default would enable them globally. We will explicitly wrap GAP
+    # computations in gap_sig_on() and gap_sig_off() instead.
     GAP_Initialize(argc, argv, gasman_callback, error_handler,
                    handleSignals=False)
     sig_off()
+
+    # Configure a SIGINT handler (which can be enabled by calling
+    # gap_sig_on) to run InterruptExecStat. This is essentially GAP's
+    # own SIGINT handler (but without the double-Ctrl-C behavior), and
+    # is less crashy than when we mix cysignals with GAP code.
+    global gap_sigint_sa
+    gap_sigint_sa.sa_handler = <void (*)(int) noexcept>InterruptExecStat
+    sigemptyset(&(gap_sigint_sa.sa_mask))
+    gap_sigint_sa.sa_flags = 0;
 
     # Disable GAP's SIGCHLD handler ChildStatusChanged(), which calls
     # waitpid() on random child processes.
@@ -283,6 +302,23 @@ cdef initialize():
             f.close()
             gap_eval('SaveWorkspace("{0}")'.format(f.name))
 
+cpdef void gap_sig_on() noexcept:
+    # Install GAP's own SIGINT handler, typically for the duration of
+    # some libgap commands. We install it for SIGALRM too so that the
+    # doctest runner can use alarm() to interrupt it.
+    global gap_sigint_sa
+    global sage_sigint_sa
+    global sage_sigalrm_sa
+    sigaction(SIGINT, &gap_sigint_sa, &sage_sigint_sa)
+    sigaction(SIGALRM, &gap_sigint_sa, &sage_sigalrm_sa)
+
+cpdef void gap_sig_off() noexcept:
+    # Restore the Sage handlers that were saved & overwritten in
+    # gap_sig_on(). Better make sure the two are paired correctly!
+    global sage_sigint_sa
+    global sage_sigalrm_sa
+    sigaction(SIGINT, &sage_sigint_sa, NULL)
+    sigaction(SIGALRM, &sage_sigalrm_sa, NULL)
 
 ############################################################################
 ### Evaluate string in GAP #################################################

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -510,7 +510,10 @@ cdef void error_handler() noexcept with gil:
         # Note that we manually need to deal with refcounts here.
         Py_XDECREF(exc_type)
         Py_XDECREF(exc_val)
-        exc_type = <PyObject*>GAPError
+        if "user interrupt" in msg:
+            exc_type = <PyObject*>KeyboardInterrupt
+        else:
+            exc_type = <PyObject*>GAPError
         exc_val = <PyObject*>msg
         Py_XINCREF(exc_type)
         Py_XINCREF(exc_val)

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -186,7 +186,7 @@ cdef sigaction_t gap_sigint_sa
 cdef sigaction_t sage_sigint_sa
 cdef sigaction_t sage_sigalrm_sa
 
-cdef void gap_interrupt_asap(int signum):
+cdef void gap_interrupt_asap(int signum) noexcept:
     # A wrapper around InterruptExecStat(). This tells GAP to raise an
     # error at the next opportunity.
     InterruptExecStat()

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -130,7 +130,6 @@ cdef void reference_obj(Obj obj) noexcept:
     """
     cdef ObjWrapper wrapped = wrap_obj(obj)
     global owned_objects_refcount
-#    print("reference_obj called "+ crepr(obj) +"\n")
     if wrapped in owned_objects_refcount:
         owned_objects_refcount[wrapped] += 1
     else:

--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -1187,8 +1187,8 @@ class ComplexBallField(UniqueRepresentation, sage.rings.abc.ComplexBallField):
             [0.4596976941318602825990633926 +/- ...e-29]
 
             sage: from sage.doctest.util import ensure_interruptible_after
-            sage: with ensure_interruptible_after(0.1):
-            ....:     C = ComplexBallField(1000000)
+            sage: C = ComplexBallField(1000000)
+            sage: with ensure_interruptible_after(0.1, max_wait_after_interrupt=5):
             ....:     C.integral(lambda x, _: x.cos() * x.sin(), 0, 1)
         """
         cdef IntegrationContext ctx = IntegrationContext()


### PR DESCRIPTION
Replace cysignals' `sig_on()` and `sig_off()` with custom `gap_sig_on()` and `gap_sig_off()` wrappers that use GAP's own `SIGINT` handling. This fixes an uncommon, but ultimately reproducible segfault when Ctrl-C is used to interrupt a GAP computation.

In concert with https://github.com/sagemath/sage/pull/40594 this has allowed `sage/libs/gap/element.pyx` to pass many thousands of test iterations.

### Fixes

* https://github.com/sagemath/sage/issues/40598

### Dependencies

* https://github.com/sagemath/sage/pull/40594