### PR TITLE
Improved string representation of Cartesian product when all factors equal

### DIFF
--- a/src/sage/categories/modules.py
+++ b/src/sage/categories/modules.py
@@ -769,7 +769,7 @@ class Modules(Category_module):
                 This ``base_ring`` method is actually overridden by
                 :meth:`sage.structure.category_object.CategoryObject.base_ring`::
 
-                    sage: H.base_ring.__module__
+                    sage: H.base_ring.__module__                                        # needs sage.modules
                     'sage.structure.category_object'
 
                 Here we call it directly::
@@ -926,9 +926,7 @@ class Modules(Category_module):
 
                     sage: A = FreeModule(ZZ, 2)                                         # needs sage.modules
                     sage: B = cartesian_product([A, A]); B                              # needs sage.modules
-                    The Cartesian product of
-                     (Ambient free module of rank 2 over the principal ideal domain Integer Ring,
-                      Ambient free module of rank 2 over the principal ideal domain Integer Ring)
+                    The Cartesian product of 2 copies of Ambient free module of rank 2 over the principal ideal domain Integer Ring
                     sage: 5*B(([1, 2], [3, 4]))                                         # needs sage.modules
                     ((5, 10), (15, 20))
                 """

--- a/src/sage/categories/unital_algebras.py
+++ b/src/sage/categories/unital_algebras.py
@@ -138,18 +138,18 @@ class UnitalAlgebras(CategoryWithAxiom_over_base_ring):
             Check that :issue:`19225` is solved::
 
                 sage: A = cartesian_product((QQ['z'],)); A
-                The Cartesian product of (Univariate Polynomial Ring in z over Rational Field,)
+                The Cartesian product of 1 copy of Univariate Polynomial Ring in z over Rational Field
                 sage: A.coerce_map_from(ZZ)
                 Composite map:
                   From: Integer Ring
-                  To:   The Cartesian product of (Univariate Polynomial Ring in z over Rational Field,)
+                  To:   The Cartesian product of 1 copy of Univariate Polynomial Ring in z over Rational Field
                   Defn:   Natural morphism:
                           From: Integer Ring
                           To:   Rational Field
                         then
                           Generic morphism:
                           From: Rational Field
-                          To:   The Cartesian product of (Univariate Polynomial Ring in z over Rational Field,)
+                          To:   The Cartesian product of 1 copy of Univariate Polynomial Ring in z over Rational Field
                 sage: A(1)
                 (1,)
             """
@@ -165,13 +165,13 @@ class UnitalAlgebras(CategoryWithAxiom_over_base_ring):
             TESTS::
 
                 sage: A = cartesian_product((QQ['z'],)); A
-                The Cartesian product of (Univariate Polynomial Ring in z over Rational Field,)
+                The Cartesian product of 1 copy of Univariate Polynomial Ring in z over Rational Field
                 sage: A.base_ring()
                 Rational Field
                 sage: A._coerce_map_from_base_ring()
                 Generic morphism:
-                From: Rational Field
-                To:   The Cartesian product of (Univariate Polynomial Ring in z over Rational Field,)
+                  From: Rational Field
+                  To:   The Cartesian product of 1 copy of Univariate Polynomial Ring in z over Rational Field
 
             Check that :issue:`29312` is fixed::
 

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -147,7 +147,9 @@ class CartesianProduct(UniqueRepresentation, Parent):
             return f"The Cartesian product of {self._sets}"
         first = self._sets[0]
         all_same = all(element == first for element in self._sets)
-        if all_same:
+        if all_same and len(self._sets) == 1:
+            return f"The Cartesian product of 1 copy of {first}"
+        elif all_same:
             return f"The Cartesian product of {len(self._sets)} copies of {first}"
         else:
             return f"The Cartesian product of {self._sets}"

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -147,9 +147,10 @@ class CartesianProduct(UniqueRepresentation, Parent):
             return f"The Cartesian product of {self._sets}"
         first = self._sets[0]
         all_same = all(element == first for element in self._sets)
-        return (f"The Cartesian product of {len(self._sets)} copies of {first}" 
-                if all_same 
-                else f"The Cartesian product of {self._sets}")
+        if all_same:
+            return f"The Cartesian product of {len(self._sets)} copies of {first}"
+        else:
+            return f"The Cartesian product of {self._sets}"
 
     def __contains__(self, x):
         """

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -146,7 +146,7 @@ class CartesianProduct(UniqueRepresentation, Parent):
         if not self._sets:
             return f"The Cartesian product of {self._sets}"
         first = self._sets[0]
-        all_same = all(ring == first for ring in self._sets)
+        all_same = all(element == first for element in self._sets)
         return (f"The Cartesian product of {len(self._sets)} copies of {first}" 
                 if all_same 
                 else f"The Cartesian product of {self._sets}")

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -140,8 +140,16 @@ class CartesianProduct(UniqueRepresentation, Parent):
 
             sage: cartesian_product([QQ, ZZ, ZZ]) # indirect doctest
             The Cartesian product of (Rational Field, Integer Ring, Integer Ring)
+            sage: cartesian_product([ZZ]*10) # indirect doctest
+            The Cartesian product of 10 copies of Integer Ring
         """
-        return "The Cartesian product of %s" % (self._sets,)
+        if not self._sets:
+            return f"The Cartesian product of {self._sets}"
+        first = self._sets[0]
+        all_same = all(ring == first for ring in self._sets)
+        return (f"The Cartesian product of {len(self._sets)} copies of {first}" 
+                if all_same 
+                else f"The Cartesian product of {self._sets}")
 
     def __contains__(self, x):
         """

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -145,8 +145,8 @@ class CartesianProduct(UniqueRepresentation, Parent):
         """
         if len(self._sets) == 1:
             return f"The Cartesian product of 1 copy of {self._sets[0]}"
-        first = self._sets[0]
-        if all(element == first for element in self._sets):
+        if len(self._sets) > 0: first = self._sets[0]
+        if all(element is first for element in self._sets) and len(self._sets) > 0:
             return f"The Cartesian product of {len(self._sets)} copies of {first}"
         return f"The Cartesian product of {self._sets}"
 

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -143,13 +143,10 @@ class CartesianProduct(UniqueRepresentation, Parent):
             sage: cartesian_product([ZZ]*10) # indirect doctest
             The Cartesian product of 10 copies of Integer Ring
         """
-        if not self._sets:
-            return f"The Cartesian product of {self._sets}"
+        if len(self._sets) == 1:
+            return f"The Cartesian product of 1 copy of {self._sets[0]}"
         first = self._sets[0]
-        all_same = all(element == first for element in self._sets)
-        if all_same and len(self._sets) == 1:
-            return f"The Cartesian product of 1 copy of {first}"
-        if all_same:
+        if all(element == first for element in self._sets):
             return f"The Cartesian product of {len(self._sets)} copies of {first}"
         return f"The Cartesian product of {self._sets}"
 

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -143,10 +143,12 @@ class CartesianProduct(UniqueRepresentation, Parent):
             sage: cartesian_product([ZZ]*10) # indirect doctest
             The Cartesian product of 10 copies of Integer Ring
         """
+        if not self._sets:
+            return f"The Cartesian product of {self._sets}"
         if len(self._sets) == 1:
             return f"The Cartesian product of 1 copy of {self._sets[0]}"
-        if len(self._sets) > 0: first = self._sets[0]
-        if all(element is first for element in self._sets) and len(self._sets) > 0:
+        first = self._sets[0]
+        if all(element is first for element in self._sets):
             return f"The Cartesian product of {len(self._sets)} copies of {first}"
         return f"The Cartesian product of {self._sets}"
 

--- a/src/sage/sets/cartesian_product.py
+++ b/src/sage/sets/cartesian_product.py
@@ -149,10 +149,9 @@ class CartesianProduct(UniqueRepresentation, Parent):
         all_same = all(element == first for element in self._sets)
         if all_same and len(self._sets) == 1:
             return f"The Cartesian product of 1 copy of {first}"
-        elif all_same:
+        if all_same:
             return f"The Cartesian product of {len(self._sets)} copies of {first}"
-        else:
-            return f"The Cartesian product of {self._sets}"
+        return f"The Cartesian product of {self._sets}"
 
     def __contains__(self, x):
         """

--- a/src/sage/tests/books/computational-mathematics-with-sagemath/domaines_doctest.py
+++ b/src/sage/tests/books/computational-mathematics-with-sagemath/domaines_doctest.py
@@ -144,7 +144,7 @@ Sage example in ./domaines.tex, line 543::
 Sage example in ./domaines.tex, line 568::
 
   sage: cartesian_product([QQ, QQ])
-    The Cartesian product of 2 copies of Rational Field
+  The Cartesian product of 2 copies of Rational Field
 
 Sage example in ./domaines.tex, line 574::
 

--- a/src/sage/tests/books/computational-mathematics-with-sagemath/domaines_doctest.py
+++ b/src/sage/tests/books/computational-mathematics-with-sagemath/domaines_doctest.py
@@ -144,7 +144,7 @@ Sage example in ./domaines.tex, line 543::
 Sage example in ./domaines.tex, line 568::
 
   sage: cartesian_product([QQ, QQ])
-  The Cartesian product of (Rational Field, Rational Field)
+    The Cartesian product of 2 copies of Rational Field
 
 Sage example in ./domaines.tex, line 574::
 


### PR DESCRIPTION
Fixes #40623 

Currently, the display of Cartesian product is not very readable when all factors are equal. 

```
sage: cartesian_product([ZZ]*10)
The Cartesian product of (Integer Ring, Integer Ring, Integer Ring, Integer Ring, Integer Ring, Integer Ring, Integer Ring, Integer Ring, Integer Ring, Integer Ring)
```

This fix modifies Cartesian product so that when all factors are equal, its string representation is much cleaner.

```
sage: cartesian_product([ZZ]*10)
The Cartesian product of 10 copies of Integer Ring
```

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


