### PR TITLE
Method to add multiples of a matrix row to another, ending at some column index

### DIFF
--- a/src/sage/matrix/matrix0.pxd
+++ b/src/sage/matrix/matrix0.pxd
@@ -60,7 +60,7 @@ cdef class Matrix(sage.structure.element.Matrix):
     cdef swap_rows_c(self, Py_ssize_t r1, Py_ssize_t r2)
     cdef swap_columns_c(self, Py_ssize_t c1, Py_ssize_t c2)
     cdef add_multiple_of_row_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_col)
-    cdef add_multiple_of_row_end_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t end_col)
+    cdef add_multiple_of_row_c_end(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_col, Py_ssize_t end_col)
     cdef add_multiple_of_column_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_row)
     cdef rescale_row_c(self, Py_ssize_t i, s, Py_ssize_t start_col)
     cdef rescale_col_c(self, Py_ssize_t i, s, Py_ssize_t start_row)

--- a/src/sage/matrix/matrix0.pxd
+++ b/src/sage/matrix/matrix0.pxd
@@ -62,6 +62,7 @@ cdef class Matrix(sage.structure.element.Matrix):
     cdef add_multiple_of_row_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_col)
     cdef add_multiple_of_row_c_end(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_col, Py_ssize_t end_col)
     cdef add_multiple_of_column_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_row)
+    cdef add_multiple_of_column_c_end(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_row, Py_ssize_t end_row)
     cdef rescale_row_c(self, Py_ssize_t i, s, Py_ssize_t start_col)
     cdef rescale_col_c(self, Py_ssize_t i, s, Py_ssize_t start_row)
 

--- a/src/sage/matrix/matrix0.pxd
+++ b/src/sage/matrix/matrix0.pxd
@@ -59,8 +59,9 @@ cdef class Matrix(sage.structure.element.Matrix):
     cdef check_column_bounds_and_mutability(self, Py_ssize_t c1, Py_ssize_t c2)
     cdef swap_rows_c(self, Py_ssize_t r1, Py_ssize_t r2)
     cdef swap_columns_c(self, Py_ssize_t c1, Py_ssize_t c2)
-    cdef add_multiple_of_row_c(self, Py_ssize_t i, Py_ssize_t j,    s, Py_ssize_t col_start)
-    cdef add_multiple_of_column_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t row_start)
+    cdef add_multiple_of_row_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_col)
+    cdef add_multiple_of_row_end_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t end_col)
+    cdef add_multiple_of_column_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_row)
     cdef rescale_row_c(self, Py_ssize_t i, s, Py_ssize_t start_col)
     cdef rescale_col_c(self, Py_ssize_t i, s, Py_ssize_t start_row)
 

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -3049,7 +3049,7 @@ cdef class Matrix(sage.structure.element.Matrix):
         This operates on columns ``c`` such that ``start_col <= c <= end_col``.
 
         The parameters ``start_col`` and ``end_col`` may be negative,
-        representing indices from the end of the row::
+        representing indices from the end of the row.
 
         EXAMPLES: We add -3 times the first row to the second row of an
         integer matrix, remembering to start numbering rows at zero::

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -3042,7 +3042,7 @@ cdef class Matrix(sage.structure.element.Matrix):
         return self.with_permuted_rows(row_permutation).with_permuted_columns(column_permutation)
 
     def add_multiple_of_row(self, Py_ssize_t i, Py_ssize_t j, s,
-                            Py_ssize_t start_col=0, end_col=None):
+                            Py_ssize_t start_col=0, Py_ssize_t end_col=-1):
         """
         Add s times row j to row i.
 
@@ -3085,12 +3085,12 @@ cdef class Matrix(sage.structure.element.Matrix):
             [  8   9  10  11]
         """
         self.check_row_bounds_and_mutability(i, j)
+        nc = self._ncols
+        if start_col < 0: start_col += nc
+        if end_col < 0: end_col += nc
         try:
             s = self._coerce_element(s)
-            if end_col is None:
-                self.add_multiple_of_row_c(i, j, s, start_col)
-            else:
-                self.add_multiple_of_row_c_end(i, j, s, start_col, end_col)
+            self.add_multiple_of_row_c_end(i, j, s, start_col, end_col)
         except TypeError:
             raise TypeError('Multiplying row by %s element cannot be done over %s, use change_ring or with_added_multiple_of_row instead.' % (s.parent(), self.base_ring()))
 

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -3167,7 +3167,7 @@ cdef class Matrix(sage.structure.element.Matrix):
         This operates on rows ``r`` such that ``start_row <= r <= end_row``.
 
         The parameters ``start_row`` and ``end_row`` may be negative,
-        representing indices from the end of the column::
+        representing indices from the end of the column.
 
         EXAMPLES: We add -1 times the third column to the second column of
         an integer matrix, remembering to start numbering cols at zero::

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -3044,7 +3044,12 @@ cdef class Matrix(sage.structure.element.Matrix):
     def add_multiple_of_row(self, Py_ssize_t i, Py_ssize_t j, s,
                             Py_ssize_t start_col=0, Py_ssize_t end_col=-1):
         """
-        Add s times row j to row i.
+        Add ``s`` times row ``j`` to row ``i``.
+
+        This operates on columns ``c`` such that ``start_col <= c <= end_col``.
+
+        The parameters ``start_col`` and ``end_col`` may be negative,
+        representing indices from the end of the row::
 
         EXAMPLES: We add -3 times the first row to the second row of an
         integer matrix, remembering to start numbering rows at zero::
@@ -3073,8 +3078,7 @@ cdef class Matrix(sage.structure.element.Matrix):
             TypeError: Multiplying row by Symbolic Ring element cannot be done over
             Rational Field, use change_ring or with_added_multiple_of_row instead.
 
-        This operates on columns ``c`` such that ``start_col <= c <= end_col``,
-        where ``start_col`` and ``end_col`` may be negative indices::
+        Using the optional parameters::
 
             sage: m = matrix(3, 4, range(12)); m
             [ 0  1  2  3]
@@ -3155,7 +3159,12 @@ cdef class Matrix(sage.structure.element.Matrix):
     def add_multiple_of_column(self, Py_ssize_t i, Py_ssize_t j, s,
                                Py_ssize_t start_row=0, Py_ssize_t end_row=-1):
         """
-        Add s times column j to column i.
+        Add ``s`` times column ``j`` to column ``i``.
+
+        This operates on rows ``r`` such that ``start_row <= r <= end_row``.
+
+        The parameters ``start_row`` and ``end_row`` may be negative,
+        representing indices from the end of the column::
 
         EXAMPLES: We add -1 times the third column to the second column of
         an integer matrix, remembering to start numbering cols at zero::
@@ -3184,8 +3193,7 @@ cdef class Matrix(sage.structure.element.Matrix):
             TypeError: Multiplying column by Symbolic Ring element cannot be done over
             Rational Field, use change_ring or with_added_multiple_of_column instead.
 
-        This operates on rows ``r`` such that ``start_row <= r <= end_row``,
-        where ``start_row`` and ``end_row`` may be negative indices::
+        Using the optional parameters::
 
             sage: m = matrix(4, 3, range(12)); m
             [ 0  1  2]

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -3084,6 +3084,33 @@ cdef class Matrix(sage.structure.element.Matrix):
         for c from start_col <= c < self._ncols:
             self.set_unsafe(i, c, self.get_unsafe(i, c) + s*self.get_unsafe(j, c))
 
+    def add_multiple_of_row_end(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t end_col):
+        r"""
+        Add s times row j to row i for columns 0 to ``end_col``.
+
+        EXAMPLES::
+
+            sage: m = matrix(3, range(9)); m
+            [0 1 2]
+            [3 4 5]
+            [6 7 8]
+            sage: m.add_multiple_of_row_end(0, 1, -2, 1); m
+            [-6 -7  2]
+            [ 3  4  5]
+            [ 6  7  8]
+        """
+        self.check_row_bounds_and_mutability(i, j)
+        try:
+            s = self._coerce_element(s)
+            self.add_multiple_of_row_end_c(i, j, s, end_col)
+        except TypeError:
+            raise TypeError('Multiplying row by %s element cannot be done over %s, use change_ring instead.' % (s.parent(), self.base_ring()))
+
+    cdef add_multiple_of_row_end_c(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t end_col):
+        cdef Py_ssize_t c
+        for c from 0 <= c <= end_col:
+            self.set_unsafe(i, c, self.get_unsafe(i, c) + s*self.get_unsafe(j, c))
+
     def with_added_multiple_of_row(self, Py_ssize_t i, Py_ssize_t j, s, Py_ssize_t start_col=0):
         """
         Add s times row j to row i, returning new matrix.

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -3095,7 +3095,10 @@ cdef class Matrix(sage.structure.element.Matrix):
         if end_col < 0: end_col += nc
         try:
             s = self._coerce_element(s)
-            self.add_multiple_of_row_c_end(i, j, s, start_col, end_col)
+            if end_col == nc - 1:
+                self.add_multiple_of_row_c(i, j, s, start_col)
+            else:
+                self.add_multiple_of_row_c_end(i, j, s, start_col, end_col)
         except TypeError:
             raise TypeError('Multiplying row by %s element cannot be done over %s, use change_ring or with_added_multiple_of_row instead.' % (s.parent(), self.base_ring()))
 
@@ -3212,7 +3215,10 @@ cdef class Matrix(sage.structure.element.Matrix):
         if end_row < 0: end_row += nr
         try:
             s = self._coerce_element(s)
-            self.add_multiple_of_column_c_end(i, j, s, start_row, end_row)
+            if end_row == nr - 1:
+                self.add_multiple_of_column_c(i, j, s, start_row)
+            else:
+                self.add_multiple_of_column_c_end(i, j, s, start_row, end_row)
         except TypeError:
             raise TypeError('Multiplying column by %s element cannot be done over %s, use change_ring or with_added_multiple_of_column instead.' % (s.parent(), self.base_ring()))
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The method `add_multiple_of_row` has an optional parameter to start the addition from a certain index `start_col`. This adds a method `add_multiple_of_row_end` which ends the addition at an index `end_col`. This is useful for computing some transformation matrices faster.
The associated issue is #40459.

Also, I believe the documentation is good, but I cannot get it to build one way or another.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.