### PR TITLE
Add LinBox algorithm for right kernel of sparse matrix over the rationals

### DIFF
--- a/src/sage/libs/linbox/givaro.pxd
+++ b/src/sage/libs/linbox/givaro.pxd
@@ -25,6 +25,7 @@ cdef extern from "gmp++/gmp++.h" namespace "Givaro":
         mpz_ptr get_mpz()
         mpz_srcptr get_mpz_const()
 
+cdef extern from "givaro/givrational.h" namespace "Givaro":
     cdef cppclass Rational:
         Rational()
         Rational(int32_t)

--- a/src/sage/libs/linbox/givaro.pxd
+++ b/src/sage/libs/linbox/givaro.pxd
@@ -25,6 +25,22 @@ cdef extern from "gmp++/gmp++.h" namespace "Givaro":
         mpz_ptr get_mpz()
         mpz_srcptr get_mpz_const()
 
+    cdef cppclass Rational:
+        Rational()
+        Rational(int32_t)
+        Rational(int64_t)
+        Rational(uint32_t)
+        Rational(uint64_t)
+        Rational(Integer&)
+        Rational(int32_t, int32_t)
+        Rational(int64_t, int64_t)
+        Rational(uint32_t, uint32_t)
+        Rational(uint64_t, uint64_t)
+        Rational(Integer&, Integer&, int)
+
+        Integer nume()
+        Integer deno()
+
 cdef extern from "givaro/givcategory.h" namespace "Givaro":
     cdef cppclass Sporadic:
         pass
@@ -40,6 +56,14 @@ cdef extern from "givaro/zring.h":
         Element zero
         Element one
         Element mone
+
+cdef extern from "givaro/qfield.h":
+    ## template<class RatElement> class QField
+    cdef cppclass QField "Givaro::QField<Givaro::Rational>":
+        ctypedef Rational Element
+        Element one
+        Element mOne
+        Element zero
 
 cdef extern from "givaro/modular-integral.h":
     cdef cppclass Modular_uint64 "Givaro::Modular<uint64_t>":

--- a/src/sage/libs/linbox/linbox.pxd
+++ b/src/sage/libs/linbox/linbox.pxd
@@ -7,6 +7,7 @@
 
 from libc.stdint cimport uint32_t, uint64_t
 from libcpp.vector cimport vector as cppvector
+from libcpp.pair cimport pair
 
 from sage.libs.linbox.givaro cimport *
 
@@ -46,6 +47,12 @@ cdef extern from "linbox/matrix/dense-matrix.h":
 
         ostream& write(ostream&)
 
+cdef extern from "linbox/vector/sparse.h":
+    cdef cppclass Sparse_Vector_rational "LinBox::Sparse_Vector<Givaro::Rational>":
+        ctypedef pair[unsigned int, Rational] Element
+        size_t size()
+        Element& operator[](size_t i)
+
 cdef extern from "linbox/matrix/sparse-matrix.h":
     ## template<class _Field, class _Storage = SparseMatrixFormat::SparseSeq >
     ## class SparseMatrix ;
@@ -71,6 +78,19 @@ cdef extern from "linbox/matrix/sparse-matrix.h":
         void setEntry(size_t i, size_t j, Element &a)
         Element &getEntry(size_t i, size_t j)
         Field& field()
+
+        ostream& write(ostream&)
+
+    cdef cppclass SparseMatrix_rational "LinBox::SparseMatrix<Givaro::QField<Givaro::Rational>>":
+        ctypedef QField Field
+        ctypedef Rational Element
+        SparseMatrix_rational(Field &F, size_t m, size_t n)
+        size_t rowdim()
+        size_t coldim()
+        void setEntry(size_t i, size_t j, Element &a)
+        Element &getEntry(size_t i, size_t j)
+        Field& field()
+        Sparse_Vector_rational& getRow(size_t i)
 
         ostream& write(ostream&)
 
@@ -157,6 +177,12 @@ cdef extern from "linbox/algorithms/gauss.h":
                                              SparseMatrix_Modular_uint64 &A,
                                              unsigned long Ni,
                                              unsigned long Nj)
+
+    cdef cppclass GaussDomain_rational "LinBox::GaussDomain<Givaro::QField<Givaro::Rational>>":
+        ctypedef QField Field
+        ctypedef Rational Element
+        GaussDomain_rational(Field &)
+        SparseMatrix_rational& nullspacebasisin(SparseMatrix_rational &X, SparseMatrix_rational &A)
 
 cdef extern from "linbox/solutions/echelon.h" namespace "LinBox":
     size_t rowEchelon (DenseMatrix_Modular_float&, const DenseMatrix_Modular_float&)

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -4859,8 +4859,11 @@ cdef class Matrix(Matrix1):
         elif algorithm == 'flint' and not isinstance(R, (IntegerRing_class,
                                                          RationalField)):
             raise ValueError("'flint' matrix kernel algorithm only available over the rationals and the integers, not over %s" % R)
-        elif algorithm == 'linbox' and not isinstance(R, RationalField):
-            raise ValueError("'linbox' matrix kernel algorithm only available over the rationals, not over %s" % R)
+        elif algorithm == 'linbox' and not isinstance(self, sage.matrix.matrix_rational_sparse.Matrix_rational_sparse):
+            if isinstance(R, RationalField):
+                raise ValueError("'linbox' matrix kernel algorithm only available for sparse matrices over the rationals")
+            else:
+                raise ValueError("'linbox' matrix kernel algorithm only available over the rationals, not over %s" % R)
         elif algorithm == 'pari' and not (isinstance(R, (IntegerRing_class, NumberField)) and not isinstance(R, RationalField)):
             raise ValueError("'pari' matrix kernel algorithm only available over non-trivial number fields and the integers, not over %s" % R)
         elif algorithm == 'generic' and R not in _Fields:

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -4296,9 +4296,11 @@ cdef class Matrix(Matrix1):
           - ``'generic'`` -- naive algorithm usable for matrices over any field
           - ``'flint'`` -- FLINT library code for matrices over the rationals
             or the integers
+          - ``'linbox'`` -- LinBox library code for sparse matrices over the
+            rationals
           - ``'pari'`` -- PARI library code for matrices over number fields
             or the integers
-          - ``'padic'`` -- padic algorithm from IML library for matrices
+          - ``'padic'`` -- `p`-adic algorithm from the IML library for matrices
             over the rationals and integers
           - ``'pluq'`` -- PLUQ matrix factorization for matrices mod 2
 
@@ -4348,12 +4350,17 @@ cdef class Matrix(Matrix1):
 
         Over the Rational Numbers:
 
-        Kernels are computed by the IML library in
-        :meth:`~sage.matrix.matrix_rational_dense.Matrix_rational_dense._right_kernel_matrix`.
-        Setting the `algorithm` keyword to 'default', 'padic' or unspecified
-        will yield the same result, as there is no optional behavior.
-        The 'computed' format of the basis vectors are exactly the negatives
-        of the vectors in the 'pivot' format. ::
+        The ``algorithm`` keyword can be set to ``'default'`` or ``'padic'`` to
+        use the `p`-adic algorithm from the IML library (for dense or sparse
+        matrices), or to ``'linbox'`` to use the LinBox library (only for
+        sparse matrices).
+        Kernels are computed by the IML library for dense matrices in
+        :meth:`~sage.matrix.matrix_rational_dense.Matrix_rational_dense._right_kernel_matrix`,
+        and sparse matrices are first converted to dense matrices.
+        Kernels are computed by the LinBox library for sparse matrices in
+        :meth:`~sage.matrix.matrix_rational_sparse.Matrix_rational_sparse._right_kernel_matrix_linbox`.
+        The 'computed' format of the basis vectors returned by IML are exactly
+        the negatives of the vectors in the 'pivot' format. ::
 
             sage: A = matrix(QQ, [[1, 0, 1, -3, 1],
             ....:                 [-5, 1, 0, 7, -3],
@@ -4417,6 +4424,11 @@ cdef class Matrix(Matrix1):
             [   0    1 -1/2 -1/4 -1/4]
             sage: set_verbose(0)
             sage: D == S
+            True
+            sage: K = B.right_kernel_matrix(algorithm='linbox', basis='computed'); K
+            [ 1 -2  2  1  0]
+            [-1 -2  0  0  1]
+            sage: B*K.transpose() == zero_matrix(QQ, 4, 2, sparse=True)
             True
 
         Over Number Fields:
@@ -4839,7 +4851,7 @@ cdef class Matrix(Matrix1):
         algorithm = kwds.pop('algorithm', None)
         if algorithm is None:
             algorithm = 'default'
-        elif algorithm not in ['default', 'generic', 'flint', 'pari', 'padic', 'pluq']:
+        elif algorithm not in ['default', 'generic', 'flint', 'linbox', 'pari', 'padic', 'pluq']:
             raise ValueError("matrix kernel algorithm '%s' not recognized" % algorithm)
         elif algorithm == 'padic' and not isinstance(R, (IntegerRing_class,
                                                          RationalField)):
@@ -4847,6 +4859,8 @@ cdef class Matrix(Matrix1):
         elif algorithm == 'flint' and not isinstance(R, (IntegerRing_class,
                                                          RationalField)):
             raise ValueError("'flint' matrix kernel algorithm only available over the rationals and the integers, not over %s" % R)
+        elif algorithm == 'linbox' and not isinstance(R, RationalField):
+            raise ValueError("'linbox' matrix kernel algorithm only available over the rationals, not over %s" % R)
         elif algorithm == 'pari' and not (isinstance(R, (IntegerRing_class, NumberField)) and not isinstance(R, RationalField)):
             raise ValueError("'pari' matrix kernel algorithm only available over non-trivial number fields and the integers, not over %s" % R)
         elif algorithm == 'generic' and R not in _Fields:
@@ -4996,9 +5010,11 @@ cdef class Matrix(Matrix1):
           - ``'generic'`` -- naive algorithm usable for matrices over any field
           - ``'flint'`` -- FLINT library code for matrices over the rationals
             or the integers
+          - ``'linbox'`` -- LinBox library code for sparse matrices over the
+            rationals
           - ``'pari'`` -- PARI library code for matrices over number fields
             or the integers
-          - ``'padic'`` -- padic algorithm from IML library for matrices
+          - ``'padic'`` -- `p`-adic algorithm from the IML library for matrices
             over the rationals and integers
           - ``'pluq'`` -- PLUQ matrix factorization for matrices mod 2
 
@@ -5233,7 +5249,7 @@ cdef class Matrix(Matrix1):
             Quaternion Algebra (-1, -1) with base ring Rational Field
 
         Sparse matrices, over the rationals and the integers,
-        use the same routines as the dense versions. ::
+        use the same routines as the dense versions by default. ::
 
             sage: A = matrix(ZZ, [[0, -1, 1, 1, 2],
             ....:                 [1, -2, 0, 1, 3],
@@ -5365,9 +5381,11 @@ cdef class Matrix(Matrix1):
           - ``'generic'`` -- naive algorithm usable for matrices over any field
           - ``'flint'`` -- FLINT library code for matrices over the rationals
             or the integers
+          - ``'linbox'`` -- LinBox library code for sparse matrices over the
+            rationals
           - ``'pari'`` -- PARI library code for matrices over number fields
             or the integers
-          - ``'padic'`` -- padic algorithm from IML library for matrices
+          - ``'padic'`` -- `p`-adic algorithm from the IML library for matrices
             over the rationals and integers
           - ``'pluq'`` -- PLUQ matrix factorization for matrices mod 2
 

--- a/src/sage/matrix/meson.build
+++ b/src/sage/matrix/meson.build
@@ -84,7 +84,6 @@ extension_data = {
   'matrix_numpy_dense' : files('matrix_numpy_dense.pyx'),
   'matrix_numpy_integer_dense' : files('matrix_numpy_integer_dense.pyx'),
   'matrix_polynomial_dense' : files('matrix_polynomial_dense.pyx'),
-  'matrix_rational_sparse' : files('matrix_rational_sparse.pyx'),
   'matrix_real_double_dense' : files('matrix_real_double_dense.pyx'),
   'matrix_sparse' : files('matrix_sparse.pyx'),
   'matrix_symbolic_dense' : files('matrix_symbolic_dense.pyx'),
@@ -138,6 +137,7 @@ extension_data_cpp = {
   'matrix_modn_sparse': files('matrix_modn_sparse.pyx'),
   'matrix_mpolynomial_dense': files('matrix_mpolynomial_dense.pyx'),
   'matrix_rational_dense': files('matrix_rational_dense.pyx'),
+  'matrix_rational_sparse': files('matrix_rational_sparse.pyx'),
 }
 
 foreach name, pyx : extension_data_cpp
@@ -148,6 +148,7 @@ foreach name, pyx : extension_data_cpp
     'matrix_modn_dense_float',
     'matrix_modn_dense_double',
     'matrix_modn_sparse',
+    'matrix_rational_sparse',
   ]
     # Temporary workaround for https://github.com/linbox-team/linbox/issues/306
     override_options += ['cpp_std=c++11']


### PR DESCRIPTION
This uses less memory than the only alternative which is a dense option, so it can handle some bigger matrices.

The code is based on analogous existing/surrounding Sage code and LinBox's example [`nullspacebasis_rat.C`](https://github.com/linbox-team/linbox/blob/d93e497b6233175addf34891ca8f7a37aa4b2f41/examples/nullspacebasis_rat.C).

I'm not yet fluent in Cythonese so comments are welcome.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.