### PR TITLE
StandardTableaux_residue passes incorrect args on its super().__init__() call

### DIFF
--- a/src/sage/combinat/tableau_tuple.py
+++ b/src/sage/combinat/tableau_tuple.py
@@ -5077,7 +5077,7 @@ class StandardTableaux_residue(StandardTableauTuples):
             sage: T = StandardTableauTuple([[[6],[7]],[[1,2,3],[4,5]]]).residue_sequence(2,(0,0)).standard_tableaux()
             sage: TestSuite(T).run()
         """
-        super().__init__(residue, category=FiniteEnumeratedSets())
+        super().__init__(category=FiniteEnumeratedSets())
         self._level = residue.level()
         self._multicharge = residue.multicharge()
         self._quantum_characteristic = residue.quantum_characteristic()


### PR DESCRIPTION
So it thinks it has a base ring:
```
sage: T = StandardTableau([[1,2,3],[4,5]]).residue_sequence(3).standard_tableaux()
sage: T.base_ring()
3-residue sequence (0,1,2,2,0) with multicharge (0)
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


