### PR TITLE
remove a deprecated method in typeset/

### DIFF
--- a/src/sage/typeset/character_art.py
+++ b/src/sage/typeset/character_art.py
@@ -37,7 +37,7 @@ MAX_WIDTH = None
 
 class CharacterArt(SageObject):
 
-    def __init__(self, lines=[], breakpoints=[], baseline=None):
+    def __init__(self, lines=[], breakpoints=[], baseline=None) -> None:
         r"""
         Abstract base class for character art.
 
@@ -135,7 +135,7 @@ class CharacterArt(SageObject):
         """
         yield from self._matrix
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         r"""
         TESTS::
 
@@ -203,38 +203,7 @@ class CharacterArt(SageObject):
         """
         return self._baseline
 
-    def get_breakpoints(self):
-        r"""
-        Return an iterator of breakpoints where the object can be split.
-
-        This method is deprecated, as its output is an implementation detail.
-        The mere breakpoints of a character art element do not reflect the best
-        way to split it if nested structures are involved. For details, see
-        :issue:`29204`.
-
-        For example the expression::
-
-               5    4
-            14x + 5x
-
-        can be split on position 4 (on the ``+``).
-
-        EXAMPLES::
-
-            sage: from sage.typeset.ascii_art import AsciiArt
-            sage: p3 = AsciiArt([" * ", "***"])
-            sage: p5 = AsciiArt(["  *  ", " * * ", "*****"])
-            sage: aa = ascii_art([p3, p5])
-            sage: aa.get_breakpoints()
-            doctest:...: DeprecationWarning: get_breakpoints() is deprecated
-            See https://github.com/sagemath/sage/issues/29204 for details.
-            [6]
-        """
-        from sage.misc.superseded import deprecation
-        deprecation(29204, "get_breakpoints() is deprecated")
-        return self._breakpoints
-
-    def _isatty(self):
+    def _isatty(self) -> bool:
         """
         Test whether ``stdout`` is a TTY.
 
@@ -357,7 +326,7 @@ class CharacterArt(SageObject):
         if bp is not None:
             yield bp
 
-    def _split_repr_(self, size):
+    def _split_repr_(self, size) -> str:
         r"""
         Split the representation into chunks of length at most ``size``.
 


### PR DESCRIPTION
as deprecated in #29204

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.