### PR TITLE
is_commutative for coxeter3

### DIFF
--- a/src/sage/categories/coxeter_groups.py
+++ b/src/sage/categories/coxeter_groups.py
@@ -437,6 +437,30 @@ class CoxeterGroups(Category_singleton):
                     pass
             return self.element_class(self, x, **args)
 
+        def is_commutative(self) -> bool:
+            """
+            Return whether this Coxeter group is commutative.
+
+            EXAMPLES::
+
+                sage: W = CoxeterGroup(['B', 3])
+                sage: W.is_commutative()
+                False
+
+            TESTS::
+
+                sage: # optional - coxeter3
+                sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+                sage: W.is_commutative()
+                False
+                sage: W = CoxeterGroup(['A', 1], implementation='coxeter3')
+                sage: W.is_commutative()
+                True
+            """
+            M = self.coxeter_matrix()
+            n = M.nrows()
+            return all(M[i, j] == 2 for j in range(1, n) for i in range(j))
+
         def weak_order_ideal(self, predicate, side='right', category=None):
             """
             Return a weak order ideal defined by a predicate.

--- a/src/sage/categories/coxeter_groups.py
+++ b/src/sage/categories/coxeter_groups.py
@@ -9,9 +9,11 @@ Coxeter Groups
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
-# With contributions from Dan Bump, Steve Pon, Qiang Wang, Anne Schilling, Christian Stump, Mark Shimozono
+# With contributions from Dan Bump, Steve Pon, Qiang Wang, Anne
+# Schilling, Christian Stump, Mark Shimozono
 from copy import copy
 from collections import deque
+from itertools import combinations
 
 from sage.categories.category_singleton import Category_singleton
 from sage.categories.enumerated_sets import EnumeratedSets
@@ -458,8 +460,8 @@ class CoxeterGroups(Category_singleton):
                 True
             """
             M = self.coxeter_matrix()
-            n = M.nrows()
-            return all(M[i, j] == 2 for j in range(1, n) for i in range(j))
+            Idx = M.index_set()
+            return all(M[i, j] == 2 for i, j in combinations(Idx, 2))
 
         def weak_order_ideal(self, predicate, side='right', category=None):
             """

--- a/src/sage/groups/matrix_gps/coxeter_group.py
+++ b/src/sage/groups/matrix_gps/coxeter_group.py
@@ -417,7 +417,7 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
         """
         return self._matrix.bilinear_form(self.base_ring().fraction_field())
 
-    def is_finite(self):
+    def is_finite(self) -> bool:
         """
         Return ``True`` if this group is finite.
 
@@ -448,7 +448,7 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
         # the category of ``self``.
         return "Finite" in self.category().axioms()
 
-    def is_commutative(self):
+    def is_commutative(self) -> bool:
         """
         Return whether ``self`` is commutative.
 

--- a/src/sage/libs/coxeter3/coxeter.pyx
+++ b/src/sage/libs/coxeter3/coxeter.pyx
@@ -543,27 +543,6 @@ cdef class CoxGroup(SageObject):
         """
         return isFiniteType(self.x)
 
-    def is_commutative(self) -> bool:
-        """
-        Return whether this Coxeter group is commutative.
-
-        EXAMPLES::
-
-            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
-            sage: W = CoxGroup(['A', 3])
-            sage: W.is_commutative()
-            False
-            sage: W = CoxGroup(['A', 1])
-            sage: W.is_commutative()
-            True
-        """
-        for ii, jj in combinations(self.cartan_type.index_set(), 2):
-            ii = self.in_ordering[ii] - 1
-            jj = self.in_ordering[jj] - 1
-            if self.x.M(ii, jj) != 2:
-                return False
-        return True
-
     cpdef full_context(self) noexcept:
         """
         Make all of the elements of a finite Coxeter group available.

--- a/src/sage/libs/coxeter3/coxeter.pyx
+++ b/src/sage/libs/coxeter3/coxeter.pyx
@@ -16,6 +16,7 @@ Low level part of the interface to Fokko Ducloux's Coxeter 3 library
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+from itertools import combinations
 
 from sage.libs.coxeter3.decl cimport *
 from cpython.object cimport Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE
@@ -533,7 +534,7 @@ cdef class CoxGroup(SageObject):
         EXAMPLES::
 
             sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
-            sage: W = CoxGroup(['A', 5])
+            sage: W = CoxGroup(['A', 3])
             sage: W.is_finite()
             True
             sage: W = CoxGroup(['A', 3, 1])
@@ -541,6 +542,27 @@ cdef class CoxGroup(SageObject):
             False
         """
         return isFiniteType(self.x)
+
+    def is_commutative(self) -> bool:
+        """
+        Return whether this Coxeter group is commutative.
+
+        EXAMPLES::
+
+            sage: from sage.libs.coxeter3.coxeter import get_CoxGroup as CoxGroup
+            sage: W = CoxGroup(['A', 3])
+            sage: W.is_commutative()
+            False
+            sage: W = CoxGroup(['A', 1])
+            sage: W.is_commutative()
+            True
+        """
+        for ii, jj in combinations(self.cartan_type.index_set(), 2):
+            ii = self.in_ordering[ii] - 1
+            jj = self.in_ordering[jj] - 1
+            if self.x.M(ii, jj) != 2:
+                return False
+        return True
 
     cpdef full_context(self) noexcept:
         """

--- a/src/sage/libs/coxeter3/coxeter.pyx
+++ b/src/sage/libs/coxeter3/coxeter.pyx
@@ -16,8 +16,6 @@ Low level part of the interface to Fokko Ducloux's Coxeter 3 library
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
-from itertools import combinations
-
 from sage.libs.coxeter3.decl cimport *
 from cpython.object cimport Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE
 from sage.cpython.string cimport str_to_bytes, bytes_to_str

--- a/src/sage/libs/coxeter3/coxeter_group.py
+++ b/src/sage/libs/coxeter3/coxeter_group.py
@@ -205,18 +205,6 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         """
         return self._coxgroup.is_finite()
 
-    def is_commutative(self) -> bool:
-        """
-        Return ``True`` if this is a commutative Coxeter group.
-
-        EXAMPLES::
-
-            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
-            sage: W.is_commutative()
-            False
-        """
-        return self._coxgroup.is_commutative()
-
     def length(self, x):
         """
         Return the length of an element ``x`` in this Coxeter group.

--- a/src/sage/libs/coxeter3/coxeter_group.py
+++ b/src/sage/libs/coxeter3/coxeter_group.py
@@ -181,7 +181,9 @@ class CoxeterGroup(UniqueRepresentation, Parent):
 
     def rank(self):
         """
-        Return the rank of this Coxeter group, that is, the number of generators.
+        Return the rank of this Coxeter group.
+
+        This is the number of generators.
 
         EXAMPLES::
 
@@ -203,9 +205,22 @@ class CoxeterGroup(UniqueRepresentation, Parent):
         """
         return self._coxgroup.is_finite()
 
+    def is_commutative(self) -> bool:
+        """
+        Return ``True`` if this is a commutative Coxeter group.
+
+        EXAMPLES::
+
+            sage: W = CoxeterGroup(['A', 3], implementation='coxeter3')
+            sage: W.is_commutative()
+            False
+        """
+        return self._coxgroup.is_commutative()
+
     def length(self, x):
         """
         Return the length of an element ``x`` in this Coxeter group.
+
         This is just the length of a reduced word for ``x``.
 
         EXAMPLES::


### PR DESCRIPTION
endow the Coxeter groups of coxeter3 with the missing "is_commutative" method.

https://github.com/sagemath/sage/issues/40328#issuecomment-3214104890_

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.


