### PR TITLE
src/sage/doctest/sources.py: add "long time" for two tests

### DIFF
--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -219,6 +219,7 @@ class DocTestSource:
 
         EXAMPLES::
 
+            sage: # long time
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.parsing import SageDocTestParser
@@ -931,6 +932,7 @@ class SourceLanguage:
 
         EXAMPLES::
 
+            sage: # long time
             sage: from sage.doctest.control import DocTestDefaults
             sage: from sage.doctest.sources import FileDocTestSource
             sage: from sage.doctest.parsing import SageDocTestParser


### PR DESCRIPTION
Two calls to `FileDocTestSource.create_doctests()` in this file can take a while (about 5s) on the first run. This now triggers a "slow doctest" warning if you are unlucky, and is unusually annoying because doctesting this file is expected to produce no output in a doctest in `src/sage/doctest/forker.py`.

We add `# long time` to correct that random doctest failure. In any case, the two tests do take a long time.

### Fixes
* https://github.com/sagemath/sage/issues/40661