### PR TITLE
check for presense of the patch utility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,14 @@ then
     AC_MSG_ERROR([Exiting, as the archiver 'ar' can not be found.])
 fi
 
+AC_CHECK_PROG(found_patch, patch, yes, no)
+if test x$found_patch != xyes
+then
+    AC_MSG_NOTICE([Sorry, the 'patch' command must be in the path to build AC_PACKAGE_NAME])
+    AC_MSG_NOTICE([See e.g. https://www.gnu.org/software/patch/])
+    AC_MSG_ERROR([Exiting, as the utility 'patch' can not be found.])
+fi
+
 AC_CHECK_PROG(found_m4, m4, yes, no)
 if test x$found_m4 != xyes
 then


### PR DESCRIPTION
some systems might have no `patch` installed, and then the build fails at the 1st spkg to be patched.
As reported on https://groups.google.com/g/sage-devel/c/hmIBRrkdecw/m/aQpIcWwXAgAJ


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


