### PR TITLE
Fix bugs in word concatenation

### DIFF
--- a/src/sage/combinat/words/word_char.pyx
+++ b/src/sage/combinat/words/word_char.pyx
@@ -443,26 +443,56 @@ cdef class WordDatatype_char(WordDatatype):
         TESTS:
 
             sage: W = Words(IntegerRange(0,255))
-            sage: W([0,1]) * W([2,0])
+            sage: W([0, 1]) * W([2, 0])
             word: 0120
 
-        The result is automatically converted to a WordDatatype_char. Currently we can
-        even do::
+        The result of a concatenation is always a WordDatatype_char. Currently there is no
+        check on the resulting parent and concatenation might lead to invalid words::
 
-            sage: w = W([0,1,2,3])
-            sage: w * [4,0,4,0]
-            word: 01234040
+            sage: W = Words([0, 1, 2, 3])
+            sage: w = W([0, 1, 2, 3, 2, 1, 0])
+            sage: w * [4, 0, 4, 0]
+            word: 01232104040
+            sage: (w * [4, 0, 4, 0]).parent()
+            Finite words over {0, 1, 2, 3}
+
+        TESTS:
+
+        Tests for :issue:`40690` and :issue:`41289`::
+
+            sage: W = Words([0,1])
+
+            sage: W([0]) + [0]
+            word: 00
+            sage: [0] + W([0])
+            word: 00
+
+            sage: W([0]) + W([1])**oo
+            word: 0111111111111111111111111111111111111111...
         """
         cdef WordDatatype_char w
 
         if isinstance(other, WordDatatype_char):
             return (<WordDatatype_char> self)._concatenate(other)
 
-        elif PySequence_Check(other):
+        elif isinstance(other, (tuple, list)):
             # we convert other to a WordDatatype_char and perform the concatenation
             w = (<WordDatatype_char> self)._new_c(NULL, 0, None)
             w._set_data(other)
             return (<WordDatatype_char> self)._concatenate(w)
+
+        else:
+            from sage.combinat.words.finite_word import FiniteWord_class
+            return FiniteWord_class.concatenate(self, other)
+
+    def __rmul__(self, other):
+        cdef WordDatatype_char w
+
+        if isinstance(other, (tuple, list)):
+            # we convert other to a WordDatatype_char and perform the concatenation
+            w = (<WordDatatype_char> self)._new_c(NULL, 0, None)
+            w._set_data(other)
+            return (<WordDatatype_char> w)._concatenate(self)
 
         else:
             from sage.combinat.words.finite_word import FiniteWord_class

--- a/src/sage/combinat/words/word_char.pyx
+++ b/src/sage/combinat/words/word_char.pyx
@@ -486,6 +486,15 @@ cdef class WordDatatype_char(WordDatatype):
             return FiniteWord_class.concatenate(self, other)
 
     def __rmul__(self, other):
+        r"""
+        Return the concatenation ``other * self``.
+
+        TESTS:
+
+            sage: W = Words(IntegerRange(0,255))
+            sage: [1] * W([0])
+            word: 10
+        """
         cdef WordDatatype_char w
 
         if isinstance(other, (tuple, list)):
@@ -496,7 +505,7 @@ cdef class WordDatatype_char(WordDatatype):
 
         else:
             from sage.combinat.words.finite_word import FiniteWord_class
-            return FiniteWord_class.concatenate(self, other)
+            return FiniteWord_class.concatenate(other, self)
 
     def __add__(self, other):
         r"""


### PR DESCRIPTION
The concatenation of words with underlying "datatype" `char` has some limitations. Fixes #40690 and #41298.