### PR TITLE
Make update-meson.py script compatible with meson 1.9

### DIFF
--- a/tools/update-meson.py
+++ b/tools/update-meson.py
@@ -298,5 +298,6 @@ meson_format(
         output=None,
         configuration=options.sourcedir / "meson.format",
         editor_config=None,
+        source_file_path=None,
     )
 )


### PR DESCRIPTION
`mformat.run` now requires a `source_file_path` argument

https://mesonbuild.com/Release-notes-for-1-9-0.html#meson-format-now-has-a-sourcefilepath-argument-when-reading-from-stdin
