### PR TITLE
Fix test failure from #40435

### DIFF
--- a/src/sage/matrix/matrix_gfpn_dense.pyx
+++ b/src/sage/matrix/matrix_gfpn_dense.pyx
@@ -689,6 +689,7 @@ cdef class Matrix_gfpn_dense(Matrix_dense):
 
         TESTS::
 
+            sage: from sage.matrix.matrix_gfpn_dense import Matrix_gfpn_dense
             sage: K.<z> = GF(59)
             sage: M = MatrixSpace(K, 3, 4, implementation=Matrix_gfpn_dense)(range(12))
             sage: M


### PR DESCRIPTION
Fixes
```
File "sage-src/src/sage/matrix/matrix_gfpn_dense.pyx", line 693, in sage.matrix.matrix_gfpn_dense.Matrix_gfpn_dense.copy_from_unsafe
Failed example:
    M = MatrixSpace(K, 3, 4, implementation=Matrix_gfpn_dense)(range(12))
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python3.13/site-packages/sage/doctest/forker.py", line 733, in _run
        self.compile_and_execute(example, compiler, test.globs)
        ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/sage/doctest/forker.py", line 1157, in compile_and_execute
        exec(compiled, globs)
        ~~~~^^^^^^^^^^^^^^^^^
      File "<doctest sage.matrix.matrix_gfpn_dense.Matrix_gfpn_dense.copy_from_unsafe[1]>", line 1, in <module>
        M = MatrixSpace(K, Integer(3), Integer(4), implementation=Matrix_gfpn_dense)(range(Integer(12)))
                                                                  ^^^^^^^^^^^^^^^^^
    NameError: name 'Matrix_gfpn_dense' is not defined
```
This isn't detected by CI as it depends on the optional meataxe package
