### PR TITLE
explictly install jupyter kernel, harmonise with meson

### DIFF
--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -54,6 +54,7 @@ if [ "$SAGE_EDITABLE" = yes ]; then
         # Additionally build a wheel (for use in other venvs)
         cd $SAGE_PKGS/sagelib/src && time sdh_build_and_store_wheel --no-build-isolation .
     fi
+    jupyter kernelspec install --name=sagemath --sys-prefix $SAGE_LOCAL/share/notebook
 else
     # Now implied: "$SAGE_WHEELS" = yes
     # We should remove the egg-link that may have been installed previously.

--- a/configure.ac
+++ b/configure.ac
@@ -575,6 +575,11 @@ AC_CONFIG_FILES([src/bin/sage-env-config src/bin/sage-src-env-config build/bin/s
 
 AC_CONFIG_FILES([pkgs/sage-conf/_sage_conf/_conf.py])
 
+# install jupyter kernel data
+AC_CONFIG_FILES([$SAGE_LOCAL/share/notebook/kernel.json:src/sage/ext_data/notebook-ipython/kernel.json.in]
+                [$SAGE_LOCAL/share/notebook/logo.svg:src/sage/ext_data/notebook-ipython/logo.svg]
+                [$SAGE_LOCAL/share/notebook/logo-64x64.png:src/sage/ext_data/notebook-ipython/logo-64x64.png])
+
 dnl Create basic directories needed for Sage
 AC_CONFIG_COMMANDS(mkdirs,
     [

--- a/src/sage/ext_data/notebook-ipython/kernel.json.in
+++ b/src/sage/ext_data/notebook-ipython/kernel.json.in
@@ -6,6 +6,6 @@
     "-f",
     "{connection_file}"
   ],
-  "display_name": "SageMath @SAGE_VERSION@",
+  "display_name": "SageMath @PACKAGE_VERSION@",
   "language": "sage"
 }

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -2,7 +2,7 @@ sage_install_dir = py.get_install_dir() / 'sage'
 
 # Generate the configuration file
 conf_data = configuration_data()
-conf_data.set('PACKAGE_VERSION', '1.2.3')
+conf_data.set('SAGE_MESON_PKG_VERSION', '1.2.3')
 # We use Python's prefix here to make it work with conda
 prefix = fs.as_posix(py.get_variable('prefix', ''))
 conf_data.set('prefix', prefix)
@@ -144,7 +144,7 @@ kernel_dir = get_option('datadir') / 'share/jupyter/kernels/sagemath'
 install_data('ext_data/notebook-ipython/logo.svg', install_dir: kernel_dir)
 install_data('ext_data/notebook-ipython/logo-64x64.png', install_dir: kernel_dir)
 kernel_data = configuration_data()
-kernel_data.set('SAGE_VERSION', meson.project_version())
+kernel_data.set('PACKAGE_VERSION', meson.project_version())
 configure_file(
   input: 'ext_data/notebook-ipython/kernel.json.in',
   output: 'kernel.json',

--- a/subprojects/packagefiles/mpfi/meson.build
+++ b/subprojects/packagefiles/mpfi/meson.build
@@ -12,7 +12,7 @@ mpfr = dependency('mpfr', version: '>= 4.0.1')
 
 # Configuration data
 conf = configuration_data()
-conf.set('PACKAGE_VERSION', '"' + meson.project_version() + '"')
+conf.set('SAGE_MESON_PKG_VERSION', '"' + meson.project_version() + '"')
 # Check for functions
 conf.set('HAVE_DUP2', c.has_function('dup2') ? 1 : 0)
 conf.set('HAVE_GETTIMEOFDAY', c.has_function('gettimeofday') ? 1 : 0)


### PR DESCRIPTION
10.8.beta0 broke installation of sagemath's jupyter kernel, apparently by upgrading setuptools (sic!),
see https://github.com/sagemath/sage/pull/40586#issuecomment-3218213183
and #40633

Here we implement the explicit installation of the kernel in the classic build, and make it compatible with meson

## :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

#39030 - meson build for sagelib 


