### PR TITLE
src/sage/symbolic/integration/integral.py: delete a few giac doctests

### DIFF
--- a/src/sage/symbolic/integration/integral.py
+++ b/src/sage/symbolic/integration/integral.py
@@ -999,46 +999,6 @@ def integrate(expression, v=None, a=None, b=None, algorithm=None, hold=False):
         sage: bool(actual == expected)
         True
 
-    ::
-
-        sage: # needs sage.libs.giac
-        sage: result = integrate(cos(x + abs(x)), x)
-        ...
-        sage: result
-        sin(x*sgn(x) + x)/(sgn(x) + 1)
-
-    ::
-
-        sage: # needs sage.libs.giac
-        sage: result = integrate(1/(1 + abs(x)), x)
-        ...
-        sage: result
-        log(abs(x*sgn(x) + 1))/sgn(x)
-
-    ::
-
-        sage: # needs sage.libs.giac
-        sage: result = integrate(1/sqrt(abs(x)), x)
-        ...
-        sage: result
-        2*sqrt(x*sgn(x))/sgn(x)
-
-    ::
-
-        sage: # needs sage.libs.giac
-        sage: result = integrate(1/(1 + abs(x)), x)
-        ...
-        sage: result
-        log(abs(x*sgn(x) + 1))/sgn(x)
-
-    ::
-
-        sage: # needs sage.libs.giac
-        sage: result = integrate(cos(x + abs(x)), x)
-        ...
-        sage: result
-        sin(x*sgn(x) + x)/(sgn(x) + 1)
-
     Some tests for :issue:`17468`::
 
         sage: integral(log(abs(2*sin(x))), x, 0, pi/3)


### PR DESCRIPTION
Several tests in this file are computing integrals that "can only be solved by giac." But since re-enabling abs_integrate for maxima, that is no longer true: maxima is able to solve them, and the answer is often an improvement (defined on a larger set, for example).

Since these examples were meant to demonstrate the fallback to giac, we delete them rather than update the expected output to conform with maxima's. We have enough trouble updating the existing maxima expressions every time a new version of maxima is released.
