### PR TITLE
Fix release dist workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -78,7 +78,7 @@ jobs:
             upstream
           name: release_dist
 
-  sdists_for_pypi:
+  sdists:
 
     runs-on: ubuntu-latest
     env:
@@ -102,15 +102,6 @@ jobs:
         run: |
           conda install --yes python-build
           python -m build --sdist --no-isolation --outdir dist .
-
-      - name: Old sagemath-standard
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install $(build/bin/sage-get-system-packages debian _bootstrap _prereq)
-          ./bootstrap
-          ./configure
-          make pypi-sdists V=0
-          mv upstream/sage*.tar.gz dist/
           ls -l dist
 
       - uses: actions/upload-artifact@v4
@@ -127,92 +118,37 @@ jobs:
         if: env.CAN_DEPLOY == 'true'
 
   release:
-
-    needs: [release_dist, sdists_for_pypi]
+    needs: [release_dist, sdists]
     runs-on: ubuntu-latest
-    if: (success() || failure()) && github.repository == 'sagemath/sage' && startsWith(github.ref, 'refs/tags/')
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: release_dist
+
       - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-      - name: Create release
-        env:
-          GITHUB_PAT: ${{ secrets.RELEASE_CREATION_TOKEN }}
-        run: |
-          latest_release_tag=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases \
-          | jq -r 'sort_by(.created_at) | last(.[]).tag_name')
-          release_notes=$(curl -s \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/releases/generate-notes \
-            -d "{
-              \"tag_name\": \"${{ github.ref_name }}\",
-              \"previous_tag_name\": \"$latest_release_tag\"
-            }" | jq -r '.body')
-          # escape special characters for json
-          release_notes=$(jq -R -s '.' <<< "$release_notes")
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/releases \
-            -d "{
-              \"tag_name\": \"${{ github.ref_name }}\",
-              \"prerelease\": ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }},
-              \"body\": $release_notes
-            }"
+
       - name: Create release assets
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/*
             upstream/*
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: ${{ github.ref_name }}
-    permissions:
-      contents: write
-
-  noarch_wheels_for_pypi:
-
-    runs-on: ubuntu-latest
-    env:
-      CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' && github.event_name != 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install bootstrap prerequisites
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install $(build/bin/sage-get-system-packages debian _bootstrap _prereq)
-      - name: make pypi-noarch-wheels
-        run: |
-          ./bootstrap
-          ./configure
-          make pypi-noarch-wheels V=0
-          (mkdir dist && mv venv/var/lib/sage/wheels/sage*-none-any.whl dist/)
-          ls -l dist
-      - uses: actions/upload-artifact@v4
-        with:
-          path: "dist/*.whl"
-          name: noarch-wheels
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.SAGEMATH_PYPI_API_TOKEN }}
-          skip-existing: true
-          verbose: true
-        if: env.CAN_DEPLOY == 'true'
+          token: ${{ secrets.RELEASE_CREATION_TOKEN }}
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
 
   build_wheels:
+    # Temporarily disabled due to build errors
+    if: false
     name: wheels ${{ matrix.build }}*_${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-    needs: sdists_for_pypi
+    needs: sdists
     strategy:
       fail-fast: false
       matrix:
@@ -292,10 +228,6 @@ jobs:
           for sdist in dist/$pkg*.tar.gz; do
               (cd unpacked && tar xfz - ) < $sdist
           done
-
-      - name: sagemath-objects
-        run: |
-          "${{ steps.python.outputs.python-path }}" -m cibuildwheel unpacked/sagemath*objects*
 
       - name: sagemath-bliss
         run: |

--- a/build/make/Makefile.in
+++ b/build/make/Makefile.in
@@ -130,16 +130,8 @@ PIP_PACKAGES = @SAGE_PIP_PACKAGES@
 # Packages that use the 'script' package build rules
 SCRIPT_PACKAGES = @SAGE_SCRIPT_PACKAGES@
 
-# Packages for which we build platform-independent wheels for PyPI
-PYPI_NOARCH_WHEEL_PACKAGES =			\
-	sage_setup				\
-	sagemath_environment			\
-
 # Packages for which we build wheels for PyPI
-PYPI_WHEEL_PACKAGES = $(PYPI_NOARCH_WHEEL_PACKAGES) \
-	sagemath_objects			\
-	sagemath_repl				\
-	sagemath_categories			\
+PYPI_WHEEL_PACKAGES = \
 	sagemath_bliss 				\
 	sagemath_mcqd 				\
 	sagemath_tdlib				\
@@ -224,7 +216,7 @@ SAGE_I_TARGETS = sagelib doc
 # Tell make not to look for files with these names:
 .PHONY: all all-sage all-toolchain all-build all-sageruntime \
 	all-start build-start toolchain toolchain-deps base-toolchain \
-	pypi-sdists pypi-noarch-wheels pypi-wheels wheels \
+	pypi-sdists pypi-wheels wheels \
 	sagelib \
 	doc doc-html doc-html-jsmath doc-html-mathjax doc-pdf \
 	doc-uninstall \
@@ -450,13 +442,6 @@ pypi-sdists: $(PYPI_SDIST_PACKAGES:%=%-sdist)
 # Ensuring wheels are present, even for packages that may have been installed
 # as editable. Until we have better uninstallation of script packages, we
 # just remove the timestamps, which will lead to rebuilds of the packages.
-pypi-noarch-wheels:
-	for a in $(PYPI_NOARCH_WHEEL_PACKAGES); do \
-	    rm -f $(SAGE_VENV)/var/lib/sage/installed/$$a-*; \
-	done
-	$(MAKE_REC) SAGE_EDITABLE=no SAGE_WHEELS=yes $(PYPI_NOARCH_WHEEL_PACKAGES)
-	@echo "Built wheels are in venv/var/lib/sage/wheels/"
-
 pypi-wheels:
 	for a in $(PYPI_WHEEL_PACKAGES); do \
 	    rm -f $(SAGE_VENV)/var/lib/sage/installed/$$a-*; \


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The release workflow fails currently (https://github.com/sagemath/sage/actions/runs/16854260655/job/47745153961) at those two points:
- Upload release assests
- Build wheels

The first is fixed by using the action `softprops/action-gh-release` to create the release and upload the assets at the same time. The second issue is fixed by disabling wheel building for now (it would be good to investigate wheel building for sagelib).

Along the way, removed a few outdated things (like sdist for old sagelib-with-setuptools or wheel building for sage-conf).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


