### PR TITLE
Fix enumerating the same cycle twice in undirected graph

### DIFF
--- a/src/sage/graphs/cycle_enumeration.py
+++ b/src/sage/graphs/cycle_enumeration.py
@@ -572,7 +572,7 @@ def all_cycles_iterator(self, starting_vertices=None, simple=False,
         [0, 1, 2, 0]
         [2, 3, 4, 5, 2]
 
-    The algorithm ``'B'`` is available only when `simple=True`::
+    The algorithm ``'B'`` is available only when ``simple=True``::
 
         sage: g = DiGraph()
         sage: g.add_edges([('a', 'b', 1), ('b', 'a', 1)])

--- a/src/sage/graphs/cycle_enumeration.py
+++ b/src/sage/graphs/cycle_enumeration.py
@@ -220,10 +220,10 @@ def _all_cycles_iterator_vertex(self, vertex, starting_vertices=None, simple=Fal
                     report = False
                 L = len(path)
                 for i in range(1, L // 2):
-                    if path[i] > path[L - i - 1]:
+                    if vertex_to_int[path[i]] > vertex_to_int[path[L - i - 1]]:
                         report = False
                         break
-                    if path[i] < path[L - i - 1]:
+                    if vertex_to_int[path[i]] < vertex_to_int[path[L - i - 1]]:
                         break
             if report:
                 if report_weight:

--- a/src/sage/graphs/cycle_enumeration.py
+++ b/src/sage/graphs/cycle_enumeration.py
@@ -217,15 +217,16 @@ def _all_cycles_iterator_vertex(self, vertex, starting_vertices=None, simple=Fal
         if len(path) > 1 and path[0] == path[-1]:
             report = True
             if not self.is_directed():
-                if simple and len(path) <= 3:
-                    report = False
-                L = len(path)
-                for i in range(1, L // 2):
-                    if vertex_to_int[path[i]] > vertex_to_int[path[L - i - 1]]:
-                        report = False
-                        break
-                    if vertex_to_int[path[i]] < vertex_to_int[path[L - i - 1]]:
-                        break
+                if simple:
+                    report = len(path) > 3 and vertex_to_int[path[1]] < vertex_to_int[path[-2]]
+                else:
+                    L = len(path)
+                    for i in range(1, L // 2):
+                        if vertex_to_int[path[i]] > vertex_to_int[path[L - i - 1]]:
+                            report = False
+                            break
+                        if vertex_to_int[path[i]] < vertex_to_int[path[L - i - 1]]:
+                            break
             if report:
                 if report_weight:
                     yield (length, path)

--- a/src/sage/graphs/cycle_enumeration.py
+++ b/src/sage/graphs/cycle_enumeration.py
@@ -156,7 +156,8 @@ def _all_cycles_iterator_vertex(self, vertex, starting_vertices=None, simple=Fal
         ...
         ValueError: negative weight is not allowed
 
-    The function works for an undirected graph::
+    The function works for an undirected graph. Specifically, each cycle is
+    enumerated exactly once, meaning a cycle and its reverse are not listed separately::
 
         sage: g = Graph({0: [1, 2], 1: [0, 2], 2: [0, 1]})
         sage: it = g._all_cycles_iterator_vertex(0, simple=False)
@@ -581,7 +582,8 @@ def all_cycles_iterator(self, starting_vertices=None, simple=False,
         ...
         ValueError: The algorithm 'B' is available only when simple=True.
 
-    The algorithm ``'A'`` works for undirected graphs as well::
+    The algorithm ``'A'`` works for undirected graphs as well. Specifically, each cycle is
+    enumerated exactly once, meaning a cycle and its reverse are not listed separately::
 
         sage: g = Graph({0: [1, 2], 1: [0, 2], 2: [0, 1]})
         sage: for cycle in g.all_cycles_iterator(algorithm='A', simple=True):
@@ -883,7 +885,8 @@ def all_simple_cycles(self, starting_vertices=None, rooted=False,
         sage: cycles.sort() == cycles_B.sort()
         True
 
-    The algorithm ``'A'`` is available for undirected graphs::
+    The algorithm ``'A'`` is available for undirected graphs. Specifically, each cycle is
+    enumerated exactly once, meaning a cycle and its reverse are not listed separately::
 
         sage: g = Graph({0: [1, 2], 1: [0, 2], 2: [0, 1]})
         sage: g.all_simple_cycles(algorithm='A')


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The output for `algorithm="A"` and `algorithm="B"` in all_cycles_iterator function  is inconsistent as below.
This happens when a graph is undirected. `algorithm="A"` outputs the same cycle in reverse order, while `algorithm="B"` does not.

```python
sage: g = Graph({0: [1, 2], 1: [0, 2], 2: [0, 1]})
sage: list(g.all_cycles_iterator(algorithm='A', simple=True))
[[0, 1, 2, 0], [0, 2, 1, 0]]
sage: list(g.all_cycles_iterator(algorithm='B', simple=True))
[[0, 1, 2, 0]]
```

This PR fixes this issue by changing the current bahavior of `algorithm="A"` and output each cycle once.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


