### PR TITLE
Speed up random_element of finite field

### DIFF
--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -1013,6 +1013,8 @@ cdef class FiniteField(Field):
         """
         if self.degree() == 1:
             return self(randrange(self.order()))
+        if not args and not kwds:
+            return self.from_integer(randrange(self.order()))
         v = self.vector_space(map=False).random_element(*args, **kwds)
         return self(v)
 


### PR DESCRIPTION
Test code:

```python
for order in [2, 2^5, 2^20, 2^63, 3, 3^4, 3^20, 1000000007, 1000000007^5]:
	print(f"{order=}")
	R.<a> = GF(order)
	%timeit R.random_element()
```

Before:

```
order=2
1.59 μs ± 58.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=32
299 ns ± 14.1 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=1048576
66.3 μs ± 1.47 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
order=9223372036854775808
168 μs ± 1.79 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
order=3
1.47 μs ± 13.4 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=81
288 ns ± 1.89 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=3486784401
58.2 μs ± 573 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
order=1000000007
1.51 μs ± 14.8 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=1000000035000000490000003430000012005000016807
23.2 μs ± 510 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

After:
	
```
order=2
1.52 μs ± 42.7 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=32
288 ns ± 9.51 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=1048576
2.14 μs ± 21.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
order=9223372036854775808
2.86 μs ± 49.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
order=3
1.44 μs ± 10.9 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=81
287 ns ± 8.11 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=3486784401
50.4 μs ± 2.57 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
order=1000000007
1.45 μs ± 17.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
order=1000000035000000490000003430000012005000016807
16.1 μs ± 70.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

For some orders (e.g. 2^63), there are 50× speedup. This is because the generic code for constructing a vector space etc. are extremely slow.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


