### PR TITLE
Hide spurious stderr output in notebook_cmd_test.py

### DIFF
--- a/src/sage/cli/notebook_cmd_test.py
+++ b/src/sage/cli/notebook_cmd_test.py
@@ -26,11 +26,12 @@ def test_jupyterlab_explicitly():
     assert args.notebook == "jupyterlab"
 
 
-def test_invalid_notebook_choice():
+def test_invalid_notebook_choice(capsys):
     parser = argparse.ArgumentParser()
     JupyterNotebookCmd.extend_parser(parser)
     with pytest.raises(SystemExit):
         parser.parse_args(["--notebook", "invalid"])
+    assert "argument -n/--notebook: invalid choice: 'invalid'" in capsys.readouterr()[1]
 
 
 def test_help():


### PR DESCRIPTION
If you look at the log on the CI, without this change, it would print out some stuff on stderr.

```
============================= test session starts ==============================
platform linux -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/runner/work/sage/sage
configfile: pyproject.toml
plugins: xdist-3.8.0
collected 76 items / 2 skipped

src/sage/cli/eval_cmd_test.py ..
usage: pytest [-h] [-n [{jupyter,jupyterlab}]]
pytest: error: argument -n/--notebook: invalid choice: 'invalid' (choose from jupyter, jupyterlab)
src/sage/cli/notebook_cmd_test.py .....
src/sage/doctest/parsing_test.py ...........
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


