### PR TITLE
Clean up symbolic min max doctests

### DIFF
--- a/src/sage/functions/min_max.py
+++ b/src/sage/functions/min_max.py
@@ -239,10 +239,11 @@ class MaxSymbolic(MinMax_base):
         We can usually integrate these expressions, but can't
         guarantee a symbolic answer in closed form::
 
-            sage: f = max_symbolic(sin(x), cos(x))                                      # needs sage.symbolic
-            sage: r = integral(f, x, 0, 1)                                              # needs sage.symbolic
+            sage: # long time, needs sage.symbolic
+            sage: f = max_symbolic(sin(x), cos(x))
+            sage: r = integral(f, x, 0, 1)
             ...
-            sage: r.n()  # abs tol 1e-8                                                 # needs sage.symbolic
+            sage: r.n()  # abs tol 1e-8
             0.873911256504955
         """
         return max_symbolic(args)

--- a/src/sage/functions/min_max.py
+++ b/src/sage/functions/min_max.py
@@ -1,3 +1,4 @@
+# sage.doctest: needs sage.symbolic
 r"""
 Symbolic minimum and maximum
 
@@ -7,16 +8,15 @@ as users might expect. These functions wait to evaluate if there are variables.
 
 Here you can see some differences::
 
-   sage: max(x, x^2)                                                                    # needs sage.symbolic
+   sage: max(x, x^2)
    x
-   sage: max_symbolic(x, x^2)                                                           # needs sage.symbolic
+   sage: max_symbolic(x, x^2)
    max(x, x^2)
-   sage: f(x) = max_symbolic(x, x^2); f(1/2)                                            # needs sage.symbolic
+   sage: f(x) = max_symbolic(x, x^2); f(1/2)
    1/2
 
 This works as expected for more than two entries::
 
-   sage: # needs sage.symbolic
    sage: max(3, 5, x)
    5
    sage: min(3, 5, x)
@@ -48,7 +48,6 @@ class MinMax_base(BuiltinFunction):
         """
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: max_symbolic(3, 5, x)  # indirect doctest
             max(x, 5)
             sage: max_symbolic([5.0r])   # indirect doctest
@@ -93,20 +92,20 @@ class MinMax_base(BuiltinFunction):
         """
         EXAMPLES::
 
-            sage: max_symbolic(3, 5, x)                                                 # needs sage.symbolic
+            sage: max_symbolic(3, 5, x)
             max(x, 5)
-            sage: max_symbolic(3, 5, x, hold=True)                                      # needs sage.symbolic
+            sage: max_symbolic(3, 5, x, hold=True)
             max(3, 5, x)
-            sage: max_symbolic([3, 5, x])                                               # needs sage.symbolic
+            sage: max_symbolic([3, 5, x])
             max(x, 5)
 
         ::
 
-            sage: min_symbolic(3, 5, x)                                                 # needs sage.symbolic
+            sage: min_symbolic(3, 5, x)
             min(x, 3)
-            sage: min_symbolic(3, 5, x, hold=True)                                      # needs sage.symbolic
+            sage: min_symbolic(3, 5, x, hold=True)
             min(3, 5, x)
-            sage: min_symbolic([3, 5, x])                                               # needs sage.symbolic
+            sage: min_symbolic([3, 5, x])
             min(x, 3)
 
         TESTS:
@@ -120,7 +119,6 @@ class MinMax_base(BuiltinFunction):
 
         Check if a single argument which is not iterable works::
 
-            sage: # needs sage.symbolic
             sage: max_symbolic(None)
             Traceback (most recent call last):
             ...
@@ -161,13 +159,13 @@ class MaxSymbolic(MinMax_base):
         r"""
         Symbolic `\max` function.
 
-        The Python builtin :func:`max` function does not work as expected when symbolic
-        expressions are given as arguments. This function delays evaluation
-        until all symbolic arguments are substituted with values.
+        The Python builtin :func:`max` function does not work as
+        expected when symbolic expressions are given as
+        arguments. This function delays evaluation until all symbolic
+        arguments are substituted with values.
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: max_symbolic(3, x)
             max(3, x)
             sage: max_symbolic(3, x).subs(x=5)
@@ -179,11 +177,11 @@ class MaxSymbolic(MinMax_base):
 
         TESTS::
 
-            sage: loads(dumps(max_symbolic(x, 5)))                                      # needs sage.symbolic
+            sage: loads(dumps(max_symbolic(x, 5)))
             max(x, 5)
-            sage: latex(max_symbolic(x, 5))                                             # needs sage.symbolic
+            sage: latex(max_symbolic(x, 5))
             \max\left(x, 5\right)
-            sage: max_symbolic(x, 5)._sympy_()                                          # needs sympy sage.symbolic
+            sage: max_symbolic(x, 5)._sympy_()  # needs sympy
             Max(5, x)
         """
         BuiltinFunction.__init__(self, 'max', nargs=0, latex_name=r"\max",
@@ -193,7 +191,6 @@ class MaxSymbolic(MinMax_base):
         """
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: t = max_symbolic(x, 5); t
             max(x, 5)
             sage: t.subs(x=3)  # indirect doctest
@@ -222,7 +219,6 @@ class MaxSymbolic(MinMax_base):
         """
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: t = max_symbolic(sin(x), cos(x))
             sage: t.subs(x=1).n(200)
             0.84147098480789650665250232163029899962256306079837106567275
@@ -239,7 +235,7 @@ class MaxSymbolic(MinMax_base):
         We can usually integrate these expressions, but can't
         guarantee a symbolic answer in closed form::
 
-            sage: # long time, needs sage.symbolic
+            sage: # long time
             sage: f = max_symbolic(sin(x), cos(x))
             sage: r = integral(f, x, 0, 1)
             ...
@@ -263,7 +259,6 @@ class MinSymbolic(MinMax_base):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: min_symbolic(3, x)
             min(3, x)
             sage: min_symbolic(3, x).subs(x=5)
@@ -275,11 +270,11 @@ class MinSymbolic(MinMax_base):
 
         TESTS::
 
-            sage: loads(dumps(min_symbolic(x, 5)))                                      # needs sage.symbolic
+            sage: loads(dumps(min_symbolic(x, 5)))
             min(x, 5)
-            sage: latex(min_symbolic(x, 5))                                             # needs sage.symbolic
+            sage: latex(min_symbolic(x, 5))
             \min\left(x, 5\right)
-            sage: min_symbolic(x, 5)._sympy_()                                          # needs sympy sage.symbolic
+            sage: min_symbolic(x, 5)._sympy_()  # needs sympy
             Min(5, x)
         """
         BuiltinFunction.__init__(self, 'min', nargs=0, latex_name=r"\min",
@@ -289,7 +284,6 @@ class MinSymbolic(MinMax_base):
         """
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: t = min_symbolic(x, 5); t
             min(x, 5)
             sage: t.subs(x=3)  # indirect doctest
@@ -318,7 +312,6 @@ class MinSymbolic(MinMax_base):
         """
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: t = min_symbolic(sin(x), cos(x))
             sage: t.subs(x=1).n(200)
             0.54030230586813971740093660744297660373231042061792222767010


### PR DESCRIPTION
Add one `# long time` to fix some CI warnings, and move `# needs sage.symbolic` to the top level.
