### PR TITLE
Speed up the maxima _commands() list

### DIFF
--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -293,13 +293,9 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
         return [x for x in cmd_list if x.find(s) == 0]
 
     @cached_method
-    def _commands(self, verbose=True):
+    def _commands(self):
         """
         Return list of all commands defined in Maxima.
-
-        INPUT:
-
-        - ``verbose`` -- boolean; ignored (obsolete)
 
         OUTPUT:
 
@@ -385,7 +381,7 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
                 print("\nBuilding Maxima command completion list (this takes")
                 print("a few seconds only the first time you do it).")
                 print("To force rebuild later, delete %s." % COMMANDS_CACHE)
-            v = self._commands(verbose=verbose)
+            v = self._commands()
             if verbose:
                 print("\nDone!")
             self.__tab_completion = v

--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -344,10 +344,10 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
         # with random leading spaces: ' tminverse', ' toeplitz', etc.
         #
         bad_chars = ("\\", "/", "?", "%")
-        return [c.strip()
-                for c in all_names
-                if c
-                and (c[0] in a_to_Z or c[0] == " ")
+        return [c
+                for n in all_names
+                if (c := n.strip())
+                and c[0] in a_to_Z
                 and not any(bad in c for bad in bad_chars)]
 
     def _tab_completion(self, verbose=True, use_disk_cache=True):

--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -317,10 +317,11 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
 
         """
         # Passing the empty string to apropos() gets ALL names.
-        all_names = self._eval_line('apropos("")', error_check=False).split(",")
-        a_to_Z = tuple( chr(i+j)
-                        for i in range(ord('A'),ord('Z')+1)
-                        for j in (0, 32) )  # 'a' = 'A' + 32
+        all_names = self._eval_line('apropos("")',
+                                    error_check=False).split(",")
+        a_to_Z = tuple(chr(i+j)
+                       for i in range(ord('A'),ord('Z')+1)
+                       for j in (0, 32))  # 'a' = 'A' + 32
 
         # Whack-a-mole to kill junk entries:
         #
@@ -339,12 +340,12 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
         # show up with a random leading spaces: ' tminverse',
         # ' toeplitz', etc.
         #
-        bad_chars = ( "-", "/", "?", "%" )
-        return [ c.strip()
-                 for c in all_names
-                 if c
-                 and (c[0] in a_to_Z or c[0] == " ")
-                 and not any( bad in c for bad in bad_chars ) ]
+        bad_chars = ("-", "/", "?", "%")
+        return [c.strip()
+                for c in all_names
+                if c
+                and (c[0] in a_to_Z or c[0] == " ")
+                and not any(bad in c for bad in bad_chars)]
 
     def _tab_completion(self, verbose=True, use_disk_cache=True):
         r"""

--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -307,7 +307,7 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
         Maxima), so we look only for a few reliable commands::
 
             sage: # long time
-            sage: cs = maxima._commands()
+            sage: cs = maxima_calculus._commands()
             sage: "display" in cs
             True
             sage: "gcd" in cs

--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -319,9 +319,12 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
         # Passing the empty string to apropos() gets ALL names.
         all_names = self._eval_line('apropos("")',
                                     error_check=False).split(",")
-        a_to_Z = tuple(chr(i+j)
-                       for i in range(ord('A'),ord('Z')+1)
-                       for j in (0, 32))  # 'a' = 'A' + 32
+
+        # At the time of writing, searching a string for a specific
+        # character was much much faster than searching a list/tuple.
+        a_to_Z = "".join(chr(i+j)
+                         for i in range(ord('A'),ord('Z')+1)
+                         for j in (0, 32))  # 'a' = 'A' + 32
 
         # Whack-a-mole to kill junk entries:
         #

--- a/src/sage/interfaces/maxima_abstract.py
+++ b/src/sage/interfaces/maxima_abstract.py
@@ -332,15 +332,15 @@ class MaximaAbstract(ExtraTabCompletion, Interface):
         #  * 'maybe\\-boole\\-verify'
         #  * 'time\\/\\/call'
         #  * 'unknown\\?'
+        #  * 'SPLITS\\ IN\\ Q'
         #
-        # None of these are documented, and the minus sign / question
+        # None of these are documented, and the backslash / question
         # mark / percent symbol probably aren't going to do what you
-        # think they're going to do if you try to type them in an
-        # ipython shell. We have to trim spaces too because some names
-        # show up with a random leading spaces: ' tminverse',
-        # ' toeplitz', etc.
+        # think they're going to do if you type them in an ipython
+        # shell. We have to trim spaces too because some names show up
+        # with random leading spaces: ' tminverse', ' toeplitz', etc.
         #
-        bad_chars = ("-", "/", "?", "%")
+        bad_chars = ("\\", "/", "?", "%")
         return [c.strip()
                 for c in all_names
                 if c


### PR DESCRIPTION
Reimplement the `_commands()` method that queries maxima for a list of valid commands. Gives about a 9x speedup here, and should eliminate one of the CI "slow doctest" warnings.