### PR TITLE
moving the _pseudo_fraction_field method to categories

### DIFF
--- a/src/doc/en/thematic_tutorials/coercion_and_categories.rst
+++ b/src/doc/en/thematic_tutorials/coercion_and_categories.rst
@@ -118,7 +118,6 @@ as this base class still provides a few more methods than a general parent::
      '_latex_names',
      '_list',
      '_one_element',
-     '_pseudo_fraction_field',
      '_zero_element',
      'base_extend',
      'extension',

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -539,34 +539,6 @@ cdef class CommutativeRing(Ring):
             self.__fraction_field = K
         return self.__fraction_field
 
-    def _pseudo_fraction_field(self):
-        r"""
-        This method is used by the coercion model to determine if `a / b`
-        should be treated as `a * (1/b)`, for example when dividing an element
-        of `\ZZ[x]` by an element of `\ZZ`.
-
-        The default is to return the same value as ``self.fraction_field()``,
-        but it may return some other domain in which division is usually
-        defined (for example, ``\ZZ/n\ZZ`` for possibly composite `n`).
-
-        EXAMPLES::
-
-            sage: ZZ._pseudo_fraction_field()
-            Rational Field
-            sage: ZZ['x']._pseudo_fraction_field()
-            Fraction Field of Univariate Polynomial Ring in x over Integer Ring
-            sage: Integers(15)._pseudo_fraction_field()
-            Ring of integers modulo 15
-            sage: Integers(15).fraction_field()
-            Traceback (most recent call last):
-            ...
-            TypeError: self must be an integral domain.
-        """
-        try:
-            return self.fraction_field()
-        except (NotImplementedError,TypeError):
-            return coercion_model.division_parent(self)
-
     def extension(self, poly, name=None, names=None, **kwds):
         """
         Algebraically extend ``self`` by taking the quotient


### PR DESCRIPTION
after #39713, it is no longer needed to have this method in ring.pyx

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.

