### PR TITLE
Find roots of low degree poly over Zmod

### DIFF
--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -1922,6 +1922,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             [107295314027801680550847462044796892009, 75545907600948005385964943744536832524]
 
         Roots of 0 or 1 degree polynomials should be computable without factoring the order:
+
             sage: set_random_seed(31337)
             sage: p = random_prime(2^512)
             sage: q = random_prime(2^512)
@@ -1934,6 +1935,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             []
 
         Even when leading coefficient of linear polynomial is not invertible:
+
             sage: set_random_seed(31337)
             sage: p = random_prime(2^10)
             sage: q = random_prime(2^512)
@@ -1942,6 +1944,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             857
 
         Test all linear polynomials modulo 10:
+
             sage: N = 10 # maybe make a for loop
             sage: R = Zmod(N)
             sage: for f in R["x"].polynomials(1):
@@ -1986,12 +1989,14 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
                     return [] # No solution
                 else:
                     # whole eqn divided by g
-                    _R = Zmod(N/g)
-                    assert _R(al / g).is_unit()
+                    N_by_g = N.divide_knowing_divisible_by(g)
+                    a_by_g = al.divide_knowing_divisible_by(g)
+                    _R = Zmod(N_by_g)
+                    assert _R(a_by_g).is_unit()
 
                     # single root
                     _root = self(f.roots(_R, multiplicities=False)[0])
-                    inc = self(N/g)
+                    inc = self(N_by_g)
                     return [_root + k*inc for k in range(g)]
 
 

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -1778,7 +1778,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             [19, 20, 21]
 
         We can find roots without multiplicities over a ring whose modulus is
-        a prime power, even a big power:
+        a prime power, even a big power::
 
             sage: R.<x> = Zmod(7^3)[]
             sage: (x^2 + x + 1).roots(multiplicities=False)
@@ -1788,14 +1788,14 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             [1125899906842623]
 
         We can also find roots without multiplicities over a ring whose modulus
-        is a product of primes or prime powers:
+        is a product of primes or prime powers::
 
             sage: R.<x> = Zmod(60)[]
             sage: (x^2 - 1).roots(multiplicities=False)
             [29, 41, 49, 1, 59, 11, 19, 31]
 
         We may also ask for roots modulo a quotient of the ring over which the
-        polynomial is defined:
+        polynomial is defined::
 
             sage: R.<x> = Zmod(120)[]
             sage: (x^2 - 1).roots(multiplicities=False)
@@ -1809,7 +1809,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: x.roots()
             [(0, 1)]
 
-        Test polynomials with content:
+        Test polynomials with content::
 
             sage: R.<x> = Zmod(4)[]
             sage: (2*x).roots(multiplicities=False)
@@ -1819,14 +1819,14 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: (3*x).roots(multiplicities=False)
             [0, 2, 4]
 
-        Test polynomial with many roots:
+        Test polynomial with many roots::
 
             sage: R.<x> = Zmod(6)[]
             sage: f = x * (x - 1) * (x - 2) * (x - 3) * (x - 4) * (x - 5)
             sage: len(f.roots(multiplicities=False))
             6
 
-        Test finding roots over large prime powers:
+        Test finding roots over large prime powers::
 
             sage: R.<x> = Zmod(2**16)[]
             sage: (x^3 + 5).roots(multiplicities=False)
@@ -1842,7 +1842,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: (x^3 + 8).roots(multiplicities=False)
             [14348905, 28697812, 43046719]
 
-        Test some larger primes:
+        Test some larger primes::
 
             sage: R.<x> = Zmod(41**4)[]
             sage: (x^2 + 2).roots(multiplicities=False)
@@ -1851,7 +1851,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: (x^2 + 3).roots(multiplicities=False)
             [3269879, 148922]
 
-        We can't find roots with multiplicities in non-fields:
+        We can't find roots with multiplicities in non-fields::
 
             sage: R.<x> = Zmod(6)[]
             sage: (x + 1).roots()
@@ -1870,7 +1870,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             NotImplementedError: root finding with multiplicities for this polynomial not implemented (try the multiplicities=False option)
 
         The zero polynomial has every residue class as a root, but we don't
-        support multiplicities even over fields (they would all be infinite).
+        support multiplicities even over fields (they would all be infinite).::
 
             sage: R.<x> = Zmod(6)[]
             sage: R.zero().roots()
@@ -1896,7 +1896,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: R.zero().roots(multiplicities=False)
             [0, 1, 2, 3, 4, 5, 6, 7]
 
-        This method doesn't support root-finding over rings that aren't Z/nZ:
+        This method doesn't support root-finding over rings that aren't Z/nZ::
 
             sage: R.<x> = Zmod(120)[]
             sage: f = x^2 - 1
@@ -1906,13 +1906,13 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             NotImplementedError
 
         Sage allows us to coerce polynomials from one modulus to another,
-        and that makes the following defined:
+        and that makes the following defined::
 
             sage: R.<x> = Zmod(100)[]
             sage: (x^2 - 1).roots(Zmod(99), multiplicities=False) == (x^2 - 1).change_ring(Zmod(99)).roots(multiplicities=False)
             True
 
-        We can find roots of high degree polynomials in a reasonable time:
+        We can find roots of high degree polynomials in a reasonable time::
 
             sage: set_random_seed(31337)
             sage: p = random_prime(2^128)
@@ -1921,7 +1921,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: f.roots(multiplicities=False)
             [107295314027801680550847462044796892009, 75545907600948005385964943744536832524]
 
-        Roots of 0 or 1 degree polynomials should be computable without factoring the order:
+        Roots of 0 or 1 degree polynomials should be computable without factoring the order::
 
             sage: set_random_seed(31337)
             sage: p = random_prime(2^512)
@@ -1934,7 +1934,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: R(p*x + 1).roots(multiplicities=False)
             []
 
-        Even when leading coefficient of linear polynomial is not invertible:
+        Even when leading coefficient of linear polynomial is not invertible::
 
             sage: set_random_seed(31337)
             sage: p = random_prime(2^10)
@@ -1943,7 +1943,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: len(R(p*x + p*q).roots(multiplicities=False))
             857
 
-        Test all linear polynomials modulo 10:
+        Test all linear polynomials modulo 10::
 
             sage: N = 10 # maybe make a for loop
             sage: R = Zmod(N)

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -1977,12 +1977,10 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             if a.is_unit():
                 return [-b * (~a)]
             else:
-                from sage.arith.misc import gcd, inverse_mod
-
                 al, bl = a.lift(), b.lift()
 
                 N = self.order()
-                g = gcd(al, N)
+                g = N.gcd(al)
 
                 if bl % g != 0:
                     return [] # No solution

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -1922,23 +1922,26 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             [107295314027801680550847462044796892009, 75545907600948005385964943744536832524]
 
         Roots of 0 or 1 degree polynomials should be computable without factoring the order:
+            sage: set_random_seed(31337)
             sage: p = random_prime(2^512)
             sage: q = random_prime(2^512)
             sage: R.<x> = Zmod(p*q)[]
             sage: R(1).roots(multiplicities=False)
             []
             sage: R(x + 1).roots(multiplicities=False)
-            [20932782399867035867701073235059387032661707299288447557574121838579618476359634211081552977493131969052529752351633191492379453300900478503324525818607507392784556671676101684510085325278750507049307403510107189893569479818927534232271877140880692729275960696100923454176962401202024613799751530640160736972]
+            [3370329767268559825901742050737977765362112301264016666995728641595783763682895579491491312949884527233896437825100351818777861111199083287936712213803662588205628332090619063390145822822539640664875016851649375480771418576780687530310519702682544247717838214152013112397973300661385457793537189792695633500]
             sage: R(p*x + 1).roots(multiplicities=False)
             []
 
         Even when leading coefficient of linear polynomial is not invertible:
+            sage: set_random_seed(31337)
             sage: p = random_prime(2^10)
             sage: q = random_prime(2^512)
             sage: R.<x> = Zmod((p**2)*q)[]
             sage: len(R(p*x + p*q).roots(multiplicities=False))
-            823
+            857
 
+        Test all linear polynomials modulo 10:
             sage: N = 10 # maybe make a for loop
             sage: R = Zmod(N)
             sage: for f in R["x"].polynomials(1):
@@ -1977,7 +1980,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
                 from sage.arith.misc import gcd, inverse_mod
 
                 al, bl = a.lift(), b.lift()
-                
+
                 N = self.order()
                 g = gcd(al, N)
 
@@ -1992,7 +1995,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
                     _root = self(f.roots(_R, multiplicities=False)[0])
                     inc = self(N/g)
                     return [_root + k*inc for k in range(g)]
-                    
+
 
         # Finite fields are a base case
         if self.is_field():


### PR DESCRIPTION
Roots of low degree polynomials, ie, constant/linear polynomials should be
computable over any `IntegerModRing` without factorizing the order.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.