### PR TITLE
src/sage/plot/plot.py: fix random test failure

### DIFF
--- a/src/sage/plot/plot.py
+++ b/src/sage/plot/plot.py
@@ -1854,9 +1854,9 @@ def plot(funcs, *args, **kwds):
     ``exclude`` and ``detect_poles`` can be used together::
 
         sage: f(x) = (floor(x)+0.5) / (1-(x-0.5)^2)
-        sage: plot(f, (x, -3.5, 3.5), detect_poles='show', exclude=[-3..3],
+        sage: plot(f, (x, 0, 3.5), detect_poles='show', exclude=[1,2,3],
         ....:      ymin=-5, ymax=5)
-        Graphics object consisting of 12 graphics primitives
+        Graphics object consisting of 6 graphics primitives
 
     .. PLOT::
 


### PR DESCRIPTION
One test in this file can fail because the wrong number of graphics primitives are rendered. The test is using `detect_poles="show"`, which detects poles using a slope tolerance for jumps from negative to positive, or vice-versa. The function in question has a jump from negative to positive, and the problem arises when our plot points are randomly generated close enough to the jump that it looks like a pole. The extra graphics primitive is a rendering of the "pole."

To fix it, we change the domain of the plot to exclude the jump from negative to positive. There are still jumps around points that have been excluded from the plot, and at least one pole is still shown, so the purpose of the test has not been defeated.

This does not fix the underlying problem that `detect_poles="show"` is non-deterministic, and rather simplistic. I have opened https://github.com/sagemath/sage/issues/40760 to track that.

### Fixes

* https://github.com/sagemath/sage/issues/33129
* https://github.com/sagemath/sage/issues/34772
* https://github.com/sagemath/sage/issues/35470