### PR TITLE
is_geodetic: change documentation to match implementation

### DIFF
--- a/src/sage/graphs/convexity_properties.pyx
+++ b/src/sage/graphs/convexity_properties.pyx
@@ -701,11 +701,12 @@ def is_geodetic(G):
     r"""
     Check whether the input (di)graph is geodetic.
 
-    A graph `G` is *geodetic* if there exists only one shortest path between
+    A graph `G` is *geodetic* if there exists at most one shortest path between
     every pair of its vertices. This can be checked in time `O(nm)` for
     ``SparseGraph`` and `O(nm+n^2)` for ``DenseGraph`` in unweighted (di)graphs
     with `n` nodes and `m` edges. Examples of geodetic graphs are trees, cliques
     and odd cycles. See the :wikipedia:`Geodetic_graph` for more details.
+    Note that we do not require geodetic graphs to be connected.
 
     (Di)graphs with multiple edges are not considered geodetic.
 
@@ -741,6 +742,11 @@ def is_geodetic(G):
         sage: G = graphs.Grid2dGraph(2, 3)
         sage: G.is_geodetic()
         False
+
+    A graph is geodetic iff all its connected components are geodetic::
+
+        sage: all(G.is_geodetic() == all(H.is_geodetic() for H in G.connected_components_subgraphs()) for G in graphs(5))
+        True
 
     This method is also valid for digraphs::
 


### PR DESCRIPTION
This is a tiny fix to the reference manual for graph theory.

[`is_geodetic()`](https://doc-develop--sagemath.netlify.app/html/en/reference/graphs/sage/graphs/generic_graph#sage.graphs.generic_graph.GenericGraph.is_geodetic) returns `True` for edgeless graphs, where no paths between vertices exist. This seems to be intended as there is a doctest for edgeless graphs and the class documentation says:

> Using this class on non-connected graphs is a waste of space and
> efficiency ! If your graph is disconnected, the best for you is to
> deal independently with each connected component, whatever you are
> doing.

### :memo: Checklist


- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have updated the documentation and checked the documentation preview.

