### PR TITLE
src/sage/matrix/matrix_integer_dense_hnf.py: more reliable HNF

### DIFF
--- a/src/sage/matrix/matrix_integer_dense_hnf.py
+++ b/src/sage/matrix/matrix_integer_dense_hnf.py
@@ -899,7 +899,12 @@ def probable_hnf(A, include_zero_rows, proof):
     B = A.matrix_from_rows(rows)
     cols = list(probable_pivot_columns(B))
     C = B.matrix_from_columns(cols)
-    # Now C is a submatrix of A that has full rank and is square.
+    # Now C is a submatrix of A that has full rank and is (probably)
+    # square, unless reduction mod p in probable_pivot_columns()
+    # was unlucky enough to introduce a linear dependence.
+    while not C.is_square():
+        cols = list(probable_pivot_columns(B))
+        C = B.matrix_from_columns(cols)
 
     # We compute the HNF of C, which is a square nonsingular matrix.
     try:


### PR DESCRIPTION
We have a random test for the HNF of an integer dense matrix that is failing on one particular example. The HNF algorithm is probabilistic, and we call `probable_pivot_columns()` expecting the matrix consisting of those columns to be square. But if you are unlucky, the reduction modulo a random prime in probable_pivot_columns() can reduce the rank of the matrix, and you'll get something non-square. This kills the `hnf_square()` function that is called shortly thereafter.

For the fix, we simply loop until `probable_pivot_columns()` does in fact give us a square matrix. Since at each iteration a random prime in the range (10007, 46000) is used, it should (ha ha) succeed eventually.

### Fixes

* https://github.com/sagemath/sage/issues/40751