### PR TITLE
Coerce `int` to `ZZ` for `lift_x` method

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -924,6 +924,8 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
             {(t + 1 : 39*t^2 + 14*t + 12 : 1)}
         """
         K = self.base_ring()
+        if isinstance(x, int):
+            x = Integer(x)
         L = x.parent()
         E = self
 

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -71,6 +71,7 @@ from sage.rings.rational_field import RationalField
 from sage.rings.real_mpfr import RealField
 from sage.misc.cachefunc import cached_method
 from sage.misc.fast_methods import WithEqualityById
+from sage.structure.coerce import py_scalar_to_element
 
 # Schemes
 import sage.schemes.projective.projective_space as projective_space
@@ -922,10 +923,15 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
             sage: E = EllipticCurve(F, [1,1])
             sage: {E.lift_x(t+1) for _ in range(1000)}  # but .lift_x() uses a fixed one
             {(t + 1 : 39*t^2 + 14*t + 12 : 1)}
+
+        Check python types::
+
+            sage: E = EllipticCurve('37a').short_weierstrass_model().change_ring(GF(17))
+            sage: E.lift_x(int(7), all=True)
+            [(7 : 3 : 1), (7 : 14 : 1)]
         """
         K = self.base_ring()
-        if isinstance(x, int):
-            x = Integer(x)
+        x = py_scalar_to_element(x)
         L = x.parent()
         E = self
 


### PR DESCRIPTION
Currently there is a call to `x.parent()` which crashes for `x` of type `int`, but I think it should silently coerce to `ZZ`


