### PR TITLE
Faster determinant for matrices over gf2e (M4RIE)

### DIFF
--- a/src/sage/libs/m4rie.pxd
+++ b/src/sage/libs/m4rie.pxd
@@ -5,7 +5,7 @@
 #                  http://www.gnu.org/licenses/
 ##############################################################################
 
-from sage.libs.m4ri cimport mzd_t, m4ri_word
+from sage.libs.m4ri cimport mzd_t, m4ri_word, mzp_t
 
 
 cdef extern from "m4rie/m4rie.h":
@@ -108,6 +108,8 @@ cdef extern from "m4rie/m4rie.h":
     size_t mzed_echelonize(mzed_t *, size_t)
 
     size_t mzed_echelonize_ple(mzed_t *, size_t)
+
+    int mzed_ple(mzed_t *A, mzp_t *P, mzp_t *Q)
 
 #cdef extern from "m4rie/strassen.h":
     mzed_t *mzed_mul_strassen(mzed_t *, mzed_t *, mzed_t *, size_t cutoff)

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1669,7 +1669,6 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         return det
 
 
-
 def unpickle_matrix_gf2e_dense_v0(Matrix_mod2_dense a, base_ring, nrows, ncols):
     r"""
     EXAMPLES::

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1630,6 +1630,10 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         if m == 0:
             return self._one
 
+        x = self.fetch('det')
+        if x is not None:
+            return x
+
         cdef mzed_t * A = mzed_copy(NULL, self._entries)
         cdef mzp_t * P = mzp_init(m)
         cdef mzp_t * Q = mzp_init(m)
@@ -1641,6 +1645,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         self.cache('rank', r)
 
         if r < m:
+            self.cache('det', self._zero)
             return self._zero
 
         cdef Cache_base cache = <Cache_base> self._base_ring._cache
@@ -1648,7 +1653,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         # characteristic 2, so det(P) == det(Q) == 1
         cdef Py_ssize_t i
         cdef int elt
-        det = self._one  # cdef?
+        cdef det = self._one
         for i from 0 <= i < m:
             elt = mzed_read_elem(A, i, i)
             det = det * cache.fetch_int(elt)
@@ -1657,6 +1662,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         mzp_free(Q)
         mzed_free(A)
 
+        self.cache('det', det)
         return det
 
 

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -1645,6 +1645,9 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         self.cache('rank', r)
 
         if r < m:
+            mzp_free(P)
+            mzp_free(Q)
+            mzed_free(A)
             self.cache('det', self._zero)
             return self._zero
 

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -95,7 +95,7 @@ from sage.misc.randstate cimport randstate, current_randstate
 from sage.matrix.matrix_mod2_dense cimport Matrix_mod2_dense
 from sage.matrix.args cimport SparseEntry, MatrixArgs_init
 
-from sage.libs.m4ri cimport m4ri_word, mzd_copy
+from sage.libs.m4ri cimport m4ri_word, mzd_copy, mzp_t, mzp_init, mzp_free
 from sage.libs.m4rie cimport *
 from sage.libs.m4rie cimport mzed_t
 
@@ -1585,6 +1585,80 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         mzed_set_ui(self._entries, 0)
         mzed_cling(self._entries, v)
         mzd_slice_free(v)
+
+    def determinant(self):
+        """
+        Return the determinant of this matrix.
+
+        Relies directly on M4RIE's PLE decomposition, and incidentally caches
+        the rank of ``self``.
+
+        EXAMPLES::
+
+            sage: gf4.<z> = GF(4)
+            sage: mat = matrix(gf4, 2, 2, [[z + 1, z + 1], [z, 1]])
+            sage: mat
+            [z + 1 z + 1]
+            [    z     1]
+            sage: mat.determinant()
+            z
+            sage: gf256.<t> = GF(2**8)
+            sage: mat = matrix(gf256, 3, 3, [[1, t, t**2],
+            ....:                            [t**2, 1, t],
+            ....:                            [t, t**2, 1]])
+            sage: mat.determinant()
+            t^6 + 1
+            sage: mat = matrix(gf256, 3, 3, [[1, t, t**2],
+            ....:                            [t**2, 1, t],
+            ....:                            [t**2 + 1, t + 1, t**2 + t]])
+            sage: mat.determinant()
+            0
+
+        Non-square matrices and the `0 \times 0` matrix are taken care of::
+
+            sage: matrix(gf4, 0, 0).determinant()
+            1
+            sage: matrix(gf4, 3, 2).determinant()
+            Traceback (most recent call last):
+            ...
+            ValueError: self must be a square matrix
+        """
+        cdef size_t m = self._nrows 
+
+        if m != self._ncols:
+            raise ValueError("self must be a square matrix")
+        if m == 0:
+            return self._one
+
+        cdef mzed_t * A = mzed_copy(NULL, self._entries)
+        cdef mzp_t * P = mzp_init(m)
+        cdef mzp_t * Q = mzp_init(m)
+
+        sig_on()
+        cdef int r = mzed_ple(A, P, Q)
+        sig_off()
+
+        self.cache('rank', r)
+
+        if r < m:
+            return self._zero
+
+        cdef Cache_base cache = <Cache_base> self._base_ring._cache
+
+        # characteristic 2, so det(P) == det(Q) == 1
+        cdef Py_ssize_t i
+        cdef int elt
+        det = self._one  # cdef?
+        for i from 0 <= i < m:
+            elt = mzed_read_elem(A, i, i)
+            det = det * cache.fetch_int(elt)
+
+        mzp_free(P)
+        mzp_free(Q)
+        mzed_free(A)
+
+        return det
+
 
 
 def unpickle_matrix_gf2e_dense_v0(Matrix_mod2_dense a, base_ring, nrows, ncols):


### PR DESCRIPTION
This computes the determinant for matrices over `GF(2**e)` by directly relying on the PLE decomposition of M4RIE. This provides a significant speed-up over the generic implementation used until now for this class.

Before:
```
sage: mat = matrix.random(GF(2**4), 200, 200)
sage: %time dd = mat.det()
CPU times: user 706 ms, sys: 2.26 ms, total: 708 ms
Wall time: 705 ms
sage: mat = matrix.random(GF(2**8), 200, 200)
sage: %time dd = mat.det()
CPU times: user 746 ms, sys: 890 µs, total: 747 ms
Wall time: 744 ms
sage: mat = matrix.random(GF(2**15), 200, 200)
sage: %time dd = mat.det()
CPU times: user 1.37 s, sys: 4.74 ms, total: 1.38 s
Wall time: 1.37 s
sage: mat = matrix.random(GF(2**4), 500, 500)
sage: %time dd = mat.det()
CPU times: user 10.8 s, sys: 23.8 ms, total: 10.8 s
Wall time: 10.7 s
sage: mat = matrix.random(GF(2**8), 500, 500)
sage: %time dd = mat.det()
CPU times: user 11.6 s, sys: 22.1 ms, total: 11.6 s
Wall time: 11.6 s
sage: mat = matrix.random(GF(2**15), 500, 500)
sage: %time dd = mat.det()
CPU times: user 21.7 s, sys: 37 ms, total: 21.7 s
Wall time: 21.7 s
```

After:
```
sage: mat = matrix.random(GF(2**4), 200, 200)
sage: %time dd = mat.det()
CPU times: user 275 µs, sys: 68 µs, total: 343 µs
Wall time: 356 µs
sage: mat = matrix.random(GF(2**8), 200, 200)
sage: %time dd = mat.det()
CPU times: user 1.1 ms, sys: 21 µs, total: 1.12 ms
Wall time: 1.13 ms
sage: mat = matrix.random(GF(2**15), 200, 200)
sage: %time dd = mat.det()
CPU times: user 81.2 ms, sys: 8.98 ms, total: 90.1 ms
Wall time: 89.7 ms
sage: mat = matrix.random(GF(2**4), 500, 500)
sage: %time dd = mat.det()
CPU times: user 1.84 ms, sys: 0 ns, total: 1.84 ms
Wall time: 1.86 ms
sage: mat = matrix.random(GF(2**8), 500, 500)
sage: %time dd = mat.det()
CPU times: user 5.23 ms, sys: 39 µs, total: 5.27 ms
Wall time: 5.44 ms
sage: mat = matrix.random(GF(2**15), 500, 500)
sage: %time dd = mat.det()
CPU times: user 719 ms, sys: 17.6 ms, total: 737 ms
Wall time: 732 ms
```