### PR TITLE
simplification in character_art

### DIFF
--- a/src/sage/typeset/ascii_art.py
+++ b/src/sage/typeset/ascii_art.py
@@ -181,7 +181,6 @@ class AsciiArt(CharacterArt):
          pi*x
         e
     """
-    _string_type = str
 
 
 _ascii_art_factory = CharacterArtFactory(

--- a/src/sage/typeset/character_art.py
+++ b/src/sage/typeset/character_art.py
@@ -103,8 +103,7 @@ class CharacterArt(SageObject):
             sage: from sage.typeset.ascii_art import AsciiArt
             sage: AsciiArt.empty()
         """
-        empty_string = cls._string_type()
-        return cls([empty_string])
+        return cls([''])
 
     def __getitem__(self, key):
         r"""
@@ -167,7 +166,7 @@ class CharacterArt(SageObject):
             sage: format(unicode_art(M))                                                # needs sage.modules
             '\u239b1 2\u239e\n\u239d3 4\u23a0'
         """
-        return format(self._string_type(self), fmt)
+        return format(str(self), fmt)
 
     def get_baseline(self):
         r"""

--- a/src/sage/typeset/character_art_factory.py
+++ b/src/sage/typeset/character_art_factory.py
@@ -37,8 +37,7 @@ class CharacterArtFactory(SageObject):
         - ``art_type`` -- type of the character art (i.e. a subclass of
           :class:`~sage.typeset.character_art.CharacterArt`)
 
-        - ``string_type`` -- type of strings (the lines in the
-          character art, e.g. ``str`` or ``unicode``)
+        - ``string_type`` -- ignored (always ``str``)
 
         - ``magic_method_name`` -- name of the Sage magic method (e.g.
           ``'_ascii_art_'`` or ``'_unicode_art_'``)
@@ -60,8 +59,6 @@ class CharacterArtFactory(SageObject):
             <class 'sage.typeset.character_art_factory.CharacterArtFactory'>
         """
         self.art_type = art_type
-        assert isinstance(string_type('a'), str)
-        self.string_type = string_type
         assert magic_method_name in ['_ascii_art_', '_unicode_art_']
         self.magic_method_name = magic_method_name
         self.left_parenthesis, self.right_parenthesis = parenthesis
@@ -204,13 +201,11 @@ class CharacterArtFactory(SageObject):
             bb
             ccc
         """
-        if self.string_type is str and not isinstance(obj, str):
+        if not isinstance(obj, str):
             if isinstance(obj, bytes):
                 obj = obj.decode('utf-8')
             else:
                 obj = str(obj)
-        if self.string_type is bytes and not isinstance(obj, bytes):
-            obj = str(obj).encode('utf-8')
         return self.art_type(obj.splitlines(), baseline=baseline)
 
     def build_container(self, content, left_border, right_border, baseline=0):
@@ -263,7 +258,7 @@ class CharacterArtFactory(SageObject):
         left_border = left_border.character_art(h)
         right_border = right_border.character_art(h)
         lines = []
-        pad = self.string_type(' ')
+        pad = ' '
         for left, line, right in zip(left_border, matrix, right_border):
             lines.append(left + pad + line.ljust(w) + pad + right)
         shift = len(left_border) + len(pad)
@@ -295,7 +290,7 @@ class CharacterArtFactory(SageObject):
             {            /\    /\      /\/\    /  \  }
             { /\/\/\, /\/  \, /  \/\, /    \, /    \ }
         """
-        comma = self.art_type([self.string_type(', ')], baseline=0)
+        comma = self.art_type([', '], baseline=0)
         repr_elems = self.concatenate(s, comma, nested=True)
         return self.build_container(
             repr_elems, self.left_curly_brace, self.right_curly_brace,
@@ -323,10 +318,10 @@ class CharacterArtFactory(SageObject):
             sage: ascii_art({'a': '', '': ''})
             { a:, : }
         """
-        comma = self.art_type([self.string_type(', ')],
+        comma = self.art_type([', '],
                               baseline=0,
                               breakpoints=[1])
-        colon = self.art_type([self.string_type(':')], baseline=0)
+        colon = self.art_type([':'], baseline=0)
 
         def concat_no_breakpoint(k, v):
             k = self.build(k)
@@ -378,7 +373,7 @@ class CharacterArtFactory(SageObject):
               22, 23, 24, 25 ], [ 1, 2, 3, 4, 5 ],\n\n
               [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ] ]'
         """
-        comma = self.art_type([self.string_type(', ')],
+        comma = self.art_type([', '],
                               baseline=0,
                               breakpoints=[1])
         repr_elems = self.concatenate(l, comma, nested=True)
@@ -397,7 +392,7 @@ class CharacterArtFactory(SageObject):
             (            /\    /\      /\/\    /  \  )
             ( /\/\/\, /\/  \, /  \/\, /    \, /    \ )
         """
-        comma = self.art_type([self.string_type(', ')],
+        comma = self.art_type([', '],
                               baseline=0,
                               breakpoints=[1])
         repr_elems = self.concatenate(t, comma, nested=True)

--- a/src/sage/typeset/unicode_art.py
+++ b/src/sage/typeset/unicode_art.py
@@ -49,7 +49,6 @@ class UnicodeArt(CharacterArt):
          π⋅x
         ℯ
     """
-    _string_type = str
 
 
 _unicode_art_factory = CharacterArtFactory(


### PR DESCRIPTION
There was a switch "string_type" that could be "str" or "unicode" as an old trace of python2.

Nowadays str is unicode and this switch is not needed.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.


