### PR TITLE
Typo in meridians for projective curves

### DIFF
--- a/src/sage/schemes/curves/plane_curve_arrangement.py
+++ b/src/sage/schemes/curves/plane_curve_arrangement.py
@@ -954,11 +954,11 @@ class ProjectivePlaneCurveArrangementElement(PlaneCurveArrangementElement):
             sage: A.meridians()
             {0: [x0, x1*x0*x1^-1], 1: [x0^-1*x1^-1*x0^-1], 2: [x1]}
             sage: A = H(y^2 + x*z, z*x, y)
+            sage: A.meridians()
+            {0: [x0, x2*x0*x2^-1], 1: [x2, x0^-1*x2^-1*x1^-1*x0^-1], 2: [x1]}
             sage: A.fundamental_group()
             Finitely presented group < x0, x1, x2 | x2*x0*x1*x0^-1*x2^-1*x1^-1,
                                                     x1*(x2*x0)^2*x2^-1*x1^-1*x0^-1*x2^-1*x0^-1 >
-            sage: A.meridians()
-            {0: [x0, x2*x0*x2^-1], 1: [x2, x0^-1*x2^-1*x1^-1*x0^-1], 2: [x1]}
         """
         if simplified:
             computed = self._meridians_simpl
@@ -966,7 +966,7 @@ class ProjectivePlaneCurveArrangementElement(PlaneCurveArrangementElement):
             computed = self._meridians_nonsimpl
         if computed:
             return dict(computed)
-        self._fundamental_group(simplified=simplified)
+        self.fundamental_group(simplified=simplified)
         if simplified:
             return dict(self._meridians_simpl)
         else:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Due to a typo the method `meridians` does not work for `ProjectivePlaneCurveArrangement`. It is corrected.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


