### PR TITLE
Build metadata fixes 10.8.beta2

### DIFF
--- a/build/pkgs/pybind11/version_requirements.txt
+++ b/build/pkgs/pybind11/version_requirements.txt
@@ -1,2 +1,2 @@
-pybind11>=2.13.2,<2.14.0
+pybind11>=2.13.2
 # see https://github.com/scipy/scipy/blob/maintenance/1.15.x/pyproject.toml

--- a/build/pkgs/python_build/distros/gentoo.txt
+++ b/build/pkgs/python_build/distros/gentoo.txt
@@ -1,0 +1,1 @@
+dev-python/build


### PR DESCRIPTION
correct version constraints for pybind11, add gentoo package info  for python-build

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


