### PR TITLE
fix SAGE_DOC variables

### DIFF
--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -231,7 +231,7 @@ if [ -n "$SAGE_LOCAL" ]; then
     export SAGE_SPKG_INST="$SAGE_LOCAL/var/lib/sage/installed"  # deprecated
 fi
 if [ -n "$SAGE_SHARE" ]; then
-    export SAGE_DOC="$SAGE_SHARE/doc/sage"
+    export SAGE_DOC="$SAGE_ROOT/build/sage-distro/src/doc"
 fi
 if [ -d "$SAGE_ROOT" ]; then
     export SAGE_LOGS="$SAGE_ROOT/logs/pkgs"

--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -187,7 +187,7 @@ SAGE_VENV_SPKG_INST = var("SAGE_VENV_SPKG_INST", join(SAGE_VENV, "var", "lib", "
 # prefix hierarchy where non-Python packages are installed
 SAGE_LOCAL = var("SAGE_LOCAL", SAGE_VENV)
 SAGE_SHARE = var("SAGE_SHARE", join(SAGE_LOCAL, "share"))
-SAGE_DOC = var("SAGE_DOC", join(SAGE_SHARE, "doc", "sage"))
+SAGE_DOC = var("SAGE_DOC", join(SAGE_ROOT, "build", "sage-distro", "src", "doc"))
 SAGE_LOCAL_SPKG_INST = var("SAGE_LOCAL_SPKG_INST", join(SAGE_LOCAL, "var", "lib", "sage", "installed"))
 SAGE_SPKG_INST = var("SAGE_SPKG_INST", join(SAGE_LOCAL, "var", "lib", "sage", "installed"))  # deprecated
 


### PR DESCRIPTION
after switch to meson doc-build, SAGE_DOC points to a wrong location,
as reported on [sage-devel](https://groups.google.com/g/sage-devel/c/IVo1EI33CyU/m/ltcL1ZU4AQAJ). We fix it here


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


