### PR TITLE
Restore release notes creation step

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -133,14 +133,32 @@ jobs:
           name: dist
           path: dist
 
-      - name: Create release assets
+      - name: Create release notes
+        env:
+          GITHUB_PAT: ${{ secrets.RELEASE_CREATION_TOKEN }}
+        run: |
+          latest_release_tag=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases \
+          | jq -r 'sort_by(.created_at) | last(.[]).tag_name')
+          release_notes=$(curl -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_PAT" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/releases/generate-notes \
+            -d "{
+              \"tag_name\": \"${{ github.ref_name }}\",
+              \"previous_tag_name\": \"$latest_release_tag\"
+            }" | jq -r '.body')
+          echo "$release_notes" > release_notes
+
+      - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/*
             upstream/*
           token: ${{ secrets.RELEASE_CREATION_TOKEN }}
-          generate_release_notes: true
+          body_path: release_notes
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
 
   build_wheels:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

fixes the issue discussed in https://groups.google.com/g/sage-devel/c/LFfhN0CpGJ8.

However, we retain the idea of #40709 that a github release is made only in one step in the workflow. Previously, before #40709, a github release was made in two steps "Create release" and "Create release assets". This strategy worked well but started failing some months ago.

Test (with #40840): https://github.com/kwankyu/sage/actions/runs/17846547780. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


