### PR TITLE
clean and annotate _gap_init_ -> str

### DIFF
--- a/src/sage/groups/abelian_gps/abelian_group.py
+++ b/src/sage/groups/abelian_gps/abelian_group.py
@@ -881,7 +881,7 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
         GapPackage("polycyclic", spkg='gap_packages').require()
         return libgap.AbelianPcpGroup(self.gens_orders())
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         r"""
         Return string that defines corresponding abelian group in GAP.
 
@@ -1404,7 +1404,7 @@ class AbelianGroup_class(UniqueRepresentation, AbelianGroupBase):
 
         # The group order is prod(p^e for (p,e) in primary_factors)
         primary_factors = list(chain.from_iterable(
-                        factor(ed) for ed in self.elementary_divisors()))
+            factor(ed) for ed in self.elementary_divisors()))
         sylow_types = defaultdict(list)
         for p, e in primary_factors:
             sylow_types[p].append(e)
@@ -1793,7 +1793,7 @@ class AbelianGroup_subgroup(AbelianGroup_class):
                 [g.list() for g in self._gens]
             )
             return (vector(ZZ, x.list())
-                in inv_basis.stack(gens_basis).row_module())
+                    in inv_basis.stack(gens_basis).row_module())
         return False
 
     def ambient_group(self):

--- a/src/sage/groups/class_function.py
+++ b/src/sage/groups/class_function.py
@@ -130,9 +130,10 @@ class ClassFunction_gap(SageObject):
         e = self._gap_classfunction.Conductor()
         self._base_ring = CyclotomicField(e)
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         r"""
         Return a string showing how to declare / initialize ``self`` in Gap.
+
         Stored in the \code{self._gap_string} attribute.
 
         EXAMPLES::

--- a/src/sage/groups/free_group.py
+++ b/src/sage/groups/free_group.py
@@ -821,7 +821,7 @@ class FreeGroup_class(CachedRepresentation, Group, ParentLibGAP):
         """
         return self.ngens()
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
         Return the string used to construct the object in gap.
 
@@ -831,9 +831,8 @@ class FreeGroup_class(CachedRepresentation, Group, ParentLibGAP):
             sage: G._gap_init_()
             'FreeGroup(["x0", "x1", "x2"])'
         """
-        gap_names = ['"' + s + '"' for s in self._gen_names]
-        gen_str = ', '.join(gap_names)
-        return 'FreeGroup(['+gen_str+'])'
+        gap_names = ('"' + s + '"' for s in self._gen_names)
+        return 'FreeGroup([' + ', '.join(gap_names) + '])'
 
     def _regina_(self, regina):
         r"""

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -622,9 +622,10 @@ class PermutationGroup_generic(FiniteGroup):
         natural_domain = FiniteEnumeratedSet(list(range(1, len(domain)+1)))
         return domain == natural_domain
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         r"""
         Return a string showing how to declare / initialize ``self`` in GAP.
+
         Stored in the ``self._gap_string`` attribute.
 
         EXAMPLES:
@@ -638,7 +639,7 @@ class PermutationGroup_generic(FiniteGroup):
             sage: A4._gap_init_()
             'Group([PermList([1, 3, 4, 2]), PermList([2, 3, 1, 4])])'
         """
-        return 'Group([%s])' % (', '.join([g._gap_init_() for g in self.gens()]))
+        return 'Group([%s])' % (', '.join(g._gap_init_() for g in self.gens()))
 
     @cached_method
     def gap(self):

--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -923,7 +923,7 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
     # see sage.groups.perm_gps.permgroup.PermutationGroup_generic.gap
     gap = _libgap_
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         r"""
         Return a GAP string representation for this
         PermutationGroupElement.
@@ -934,9 +934,9 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
             sage: g._gap_init_()
             'PermList([2, 3, 1, 5, 4])'
         """
-        return 'PermList(%s)' % self._gap_list()
+        return f'PermList({self._gap_list()})'
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         r"""
         Return string representation of this permutation.
 

--- a/src/sage/groups/perm_gps/permgroup_named.py
+++ b/src/sage/groups/perm_gps/permgroup_named.py
@@ -286,7 +286,7 @@ class SymmetricGroup(PermutationGroup_symalt):
             self._gens = tuple([self.element_class(g, self, check=False)
                                 for g in gens])
 
-    def _gap_init_(self, gap=None):
+    def _gap_init_(self) -> str:
         """
         Return the string used to create this group in GAP.
 
@@ -759,7 +759,7 @@ class AlternatingGroup(PermutationGroup_symalt):
         """
         PermutationGroup_symalt.__init__(self, gap_group='AlternatingGroup(%s)' % len(domain), domain=domain)
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         EXAMPLES::
 
@@ -768,7 +768,7 @@ class AlternatingGroup(PermutationGroup_symalt):
         """
         return "Alternating group of order %s!/2 as a permutation group" % self.degree()
 
-    def _gap_init_(self, gap=None):
+    def _gap_init_(self) -> str:
         """
         Return the string used to create this group in GAP.
 
@@ -781,7 +781,7 @@ class AlternatingGroup(PermutationGroup_symalt):
             sage: A._gap_init_()
             'AlternatingGroup(3)'
         """
-        return 'AlternatingGroup(%s)' % self.degree()
+        return f'AlternatingGroup({self.degree()})'
 
 
 class CyclicPermutationGroup(PermutationGroup_unique):

--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -90,9 +90,9 @@ cdef class Matrix(Matrix0):
         from sage.libs.pari import pari
         return pari.matrix(self._nrows, self._ncols, self._list())
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
-        Return a string defining a gap representation of ``self``.
+        Return a string defining a GAP representation of ``self``.
 
         EXAMPLES::
 

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1619,7 +1619,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
         """
         return self
 
-    def _gap_init_(FiniteField_givaroElement self):
+    def _gap_init_(FiniteField_givaroElement self) -> str:
         """
         Return a string that evaluates to the GAP representation of
         this element.

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -1131,7 +1131,7 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
         """
         return self
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         r"""
         Return a string that evaluates to the GAP representation of
         this element.

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -1359,7 +1359,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         zero = "%s*a" % self._parent.characteristic()
         return "subst(%s+%s,a,%s)" % (self, zero, ffgen)
 
-    def _magma_init_(self, magma):
+    def _magma_init_(self, magma) -> str:
         """
         Return a string representing ``self`` in Magma.
 
@@ -1372,7 +1372,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         km = magma(k)
         return str(self).replace(k.variable_name(), km.gen(1).name())
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         r"""
         Return the string representing ``self`` in GAP.
 

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -551,7 +551,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
     def __pari__(self):
         return self.lift().__pari__().Mod(self._modulus.sageInteger)
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         r"""
         Return string representation of corresponding GAP object.
 
@@ -570,7 +570,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         """
         return '%s*One(ZmodnZ(%s))' % (self, self._modulus.sageInteger)
 
-    def _magma_init_(self, magma):
+    def _magma_init_(self, magma) -> str:
         """
         Coercion to Magma.
 
@@ -586,7 +586,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         """
         return '%s!%s' % (self.parent()._magma_init_(magma), self)
 
-    def _axiom_init_(self):
+    def _axiom_init_(self) -> str:
         """
         Return a string representation of the corresponding to
         (Pan)Axiom object.

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -2040,7 +2040,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
     #######################################################
     # Suppose for interfaces
     #######################################################
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
         EXAMPLES::
 
@@ -2050,9 +2050,9 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: gap(R)  # indirect doctest                                            # needs sage.libs.gap
             (Integers mod 12345678900)
         """
-        return 'ZmodnZ({})'.format(self.order())
+        return f'ZmodnZ({self.order()})'
 
-    def _magma_init_(self, magma):
+    def _magma_init_(self, magma) -> str:
         """
         EXAMPLES::
 
@@ -2062,7 +2062,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             sage: magma(R)  # indirect doctest, optional - magma
             Residue class ring of integers modulo 12345678900
         """
-        return 'Integers({})'.format(self.order())
+        return f'Integers({self.order()})'
 
     def degree(self):
         """

--- a/src/sage/rings/integer_ring.pyx
+++ b/src/sage/rings/integer_ring.pyx
@@ -1456,7 +1456,7 @@ cdef class IntegerRing_class(CommutativeRing):
     #  Coercions to interfaces
     #################################
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
         Return a GAP representation of ``self``.
 
@@ -1467,7 +1467,7 @@ cdef class IntegerRing_class(CommutativeRing):
         """
         return 'Integers'
 
-    def _fricas_init_(self):
+    def _fricas_init_(self) -> str:
         """
         Return a FriCAS representation of ``self``.
 
@@ -1478,7 +1478,7 @@ cdef class IntegerRing_class(CommutativeRing):
         """
         return 'Integer'
 
-    def _magma_init_(self, magma):
+    def _magma_init_(self, magma) -> str:
         """
         Return a magma representation of ``self``.
 
@@ -1489,7 +1489,7 @@ cdef class IntegerRing_class(CommutativeRing):
         """
         return 'IntegerRing()'
 
-    def _macaulay2_init_(self, macaulay2=None):
+    def _macaulay2_init_(self, macaulay2=None) -> str:
         """
         Return a macaulay2 representation of ``self``.
 

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -477,7 +477,7 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         latex_name = self.number_field().latex_variable_names()[0]
         return self.polynomial()._latex_(name=latex_name)
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
         Return gap string representation of ``self``.
 

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -813,20 +813,9 @@ cdef class MPolynomialRing_base(CommutativeRing):
                                           self.term_order().magma_str())
         return magma._with_names(s, self.variable_names())
 
-    def _gap_init_(self, gap=None):
+    def _gap_init_(self) -> str:
         """
         Return a string that yields a representation of ``self`` in GAP.
-
-        INPUT:
-
-        - ``gap`` -- (optional GAP instance) interface to which the
-          string is addressed
-
-        NOTE:
-
-        - If the optional argument ``gap`` is provided, the base ring
-          of ``self`` will be represented as ``gap(self.base_ring()).name()``.
-        - The result of applying the GAP interface to ``self`` is cached.
 
         EXAMPLES::
 
@@ -838,10 +827,7 @@ cdef class MPolynomialRing_base(CommutativeRing):
             sage: libgap(P)
             <field in characteristic 0>[x,y]
         """
-        L = ['"%s"' % t for t in self.variable_names()]
-        if gap is not None:
-            return 'PolynomialRing(%s,[%s])' % (gap(self.base_ring()).name(),
-                                                ','.join(L))
+        L = ('"%s"' % t for t in self.variable_names())
         return 'PolynomialRing(%s,[%s])' % (self.base_ring()._gap_init_(),
                                             ','.join(L))
 

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -938,13 +938,9 @@ class PolynomialRing_generic(Ring):
         s = 'PolynomialRing(%s)' % (Bref)
         return magma._with_names(s, self.variable_names())
 
-    def _gap_init_(self, gap=None):
+    def _gap_init_(self) -> str:
         """
         String for representing this polynomial ring in GAP.
-
-        INPUT:
-
-        - ``gap`` -- (optional GAP instance) used for representing the base ring
 
         EXAMPLES::
 
@@ -969,10 +965,7 @@ class PolynomialRing_generic(Ring):
             sage: gap(S) is gap(S)                                                      # needs sage.libs.gap
             True
         """
-        if gap is not None:
-            base_ring = gap(self.base_ring()).name()
-        else:
-            base_ring = self.base_ring()._gap_init_()
+        base_ring = self.base_ring()._gap_init_()
         return 'PolynomialRing(%s, ["%s"])' % (base_ring, self.variable_name())
 
     def _sage_input_(self, sib, coerced):

--- a/src/sage/rings/rational_field.py
+++ b/src/sage/rings/rational_field.py
@@ -1514,7 +1514,7 @@ class RationalField(Singleton, number_field_base.NumberField):
     #################################
     #  Coercions to interfaces
     #################################
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         r"""
         Return the GAP representation of `\QQ`.
 
@@ -1525,7 +1525,7 @@ class RationalField(Singleton, number_field_base.NumberField):
         """
         return 'Rationals'
 
-    def _magma_init_(self, magma):
+    def _magma_init_(self, magma) -> str:
         r"""
         Return the magma representation of `\QQ`.
 
@@ -1543,7 +1543,7 @@ class RationalField(Singleton, number_field_base.NumberField):
         """
         return 'RationalField()'
 
-    def _macaulay2_init_(self, macaulay2=None):
+    def _macaulay2_init_(self, macaulay2=None) -> str:
         r"""
         Return the macaulay2 representation of `\QQ`.
 
@@ -1554,7 +1554,7 @@ class RationalField(Singleton, number_field_base.NumberField):
         """
         return "QQ"
 
-    def _axiom_init_(self):
+    def _axiom_init_(self) -> str:
         r"""
         Return the axiom/fricas representation of `\QQ`.
 
@@ -1569,7 +1569,7 @@ class RationalField(Singleton, number_field_base.NumberField):
 
     _fricas_init_ = _axiom_init_
 
-    def _polymake_init_(self):
+    def _polymake_init_(self) -> str:
         r"""
         Return the polymake representation of `\QQ`.
 

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -1183,7 +1183,7 @@ cdef class Expression(Expression_abc):
         from sage.symbolic.expression_conversions import InterfaceInit
         return InterfaceInit(I)(self)
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
         Convert symbolic object to GAP string.
 
@@ -1192,9 +1192,9 @@ cdef class Expression(Expression_abc):
             sage: gap(e + pi^2 + x^3)                                                   # needs sage.libs.gap
             x^3 + pi^2 + e
         """
-        return '"%s"' % repr(self)
+        return f'"{repr(self)}"'
 
-    def _singular_init_(self):
+    def _singular_init_(self) -> str:
         """
         Conversion of a symbolic object to Singular string.
 
@@ -1203,9 +1203,9 @@ cdef class Expression(Expression_abc):
             sage: singular(e + pi^2 + x^3)                                              # needs sage.libs.singular
             x^3 + pi^2 + e
         """
-        return '"%s"' % repr(self)
+        return f'"{repr(self)}"'
 
-    def _magma_init_(self, magma):
+    def _magma_init_(self, magma) -> str:
         """
         Return string representation in Magma of this symbolic expression.
 


### PR DESCRIPTION
first add the annotation `-> str` after most `_gap_init_` methods

second, remove some unused second argument, appearing only a in a few instances

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.