### PR TITLE
Fix singular Z2m ring creation and polynomial comparison

### DIFF
--- a/src/sage/libs/singular/polynomial.pyx
+++ b/src/sage/libs/singular/polynomial.pyx
@@ -284,12 +284,19 @@ cdef int singular_polynomial_cmp(poly *p, poly *q, ring *r) noexcept:
         sage: P(0) > P(-1)
         True
     """
+    # similar to p_Compare in p_polys.h
     cdef int tmp
 
     if r != currRing:
         rChangeCurrRing(r)
 
     while True:
+        # workaround for https://github.com/Singular/Singular/issues/1293
+        while p != NULL and r.cf.cfIsZero(p_GetCoeff(p, r), r.cf):
+            p = pNext(p)
+        while q != NULL and r.cf.cfIsZero(p_GetCoeff(q, r), r.cf):
+            q = pNext(q)
+
         if p == NULL:
             if q == NULL:
                 return 0

--- a/src/sage/libs/singular/ring.pyx
+++ b/src/sage/libs/singular/ring.pyx
@@ -252,6 +252,16 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
         //        block   1 : ordering dp
         //                  : names    a b
         //        block   2 : ordering C
+        sage: R(2)^32 == R(0)
+        True
+
+    The following may use ``n_Z2m`` or ``n_Znm`` depends on ``sizeof(unsigned long)``::
+
+        sage: R = PolynomialRing(Zmod(2^64), ("a", "b"), implementation="singular")
+        sage: ZZ(R(3^1000)) == 3^1000 % 2^64
+        True
+        sage: ZZ(R(5^1000)) == 5^1000 % 2^64
+        True
 
     Integer modulo large power of 2::
 
@@ -262,6 +272,10 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
         //        block   1 : ordering dp
         //                  : names    a b
         //        block   2 : ordering C
+        sage: ZZ(R(5^1000)) == 5^1000 % 2^1000
+        True
+        sage: R(2)^1000 == R(0)
+        True
 
     Integer modulo large power of odd prime::
 
@@ -516,7 +530,7 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
         else:
             modbase, cexponent = ch.perfect_power()
 
-            if modbase == 2 and cexponent > 1:
+            if modbase == 2 and 1 < cexponent <= 8*sizeof(unsigned long):  # see :issue:`40855`
                 _cf = nInitChar(n_Z2m, <void *>cexponent)
 
             elif modbase.is_prime() and cexponent > 1:

--- a/src/sage/libs/singular/singular.pyx
+++ b/src/sage/libs/singular/singular.pyx
@@ -1542,7 +1542,6 @@ cdef inline number *sa2si_ZZmod(IntegerMod_abstract d, ring *_ring) noexcept:
 
     cdef number *nn
 
-    cdef int64_t _d
     cdef char *_name
     cdef char **_ext_names
 
@@ -1552,8 +1551,14 @@ cdef inline number *sa2si_ZZmod(IntegerMod_abstract d, ring *_ring) noexcept:
         return n_Init(int(d), _ring.cf)
 
     if _ring.cf.type == n_Z2m:
-        _d = d
-        return nr2mMapZp(<number *>_d, currRing.cf, _ring.cf)
+        if sizeof(number *) >= sizeof(unsigned long):
+            # one may also always choose the second branch,
+            # but the first branch may allow inlining (?)
+            # casting to unsigned long is safe because n_Z2m
+            # is only chosen if the exponent is small, see singular_ring_new
+            return nr2mMapZp(<number *> <unsigned long> d, currRing.cf, _ring.cf)
+        else:
+            return _ring.cf.cfInit(<long> <unsigned long> d, _ring.cf)
     elif _ring.cf.type == n_Zn or _ring.cf.type == n_Znm:
         lift = d.lift()
 


### PR DESCRIPTION
See the new test, previously it fails. 

The `n_Z2m` ring creation is caused by #39075.

Singular source code contains

```
      // is exponent <=2^(8*sizeof(unsigned long))
      mp_bitcnt_t l=mpz_scan1 (modBase,0);
      if ((l>0) && (l<=8*sizeof(unsigned long)))
      {
```

so the limit is taken from there.

The polynomial comparison fix is workaround for https://github.com/Singular/Singular/issues/1293. #39018 touches this part of the code, although I think it doesn't introduce the bug.



Fix https://github.com/sagemath/sage/issues/40838

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


