### PR TITLE
Fix const polynomial conversion to Singular interface

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -5298,6 +5298,25 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         self._parent._singular_().set_ring()
         return self._repr_short_()
 
+    def _singular_(self, singular=None):
+        """
+        Override :meth:`sage.structure.sage_object.SageObject._singular_`
+        to declare the type of ``self`` to be ``'poly'``.
+        Needed because even with ``setring``, constant polynomials are not considered
+        polynomials of the current ring.
+
+        TESTS::
+
+            sage: R.<x,y> = Zmod(5)[]
+            sage: a = singular(R(2)) + singular(R(2)) + singular(R(1)); a
+            0
+            sage: a == singular(R(0))
+            True
+        """
+        if singular is None:
+            from sage.interfaces.singular import singular
+        return singular(self._singular_init_(singular), type='poly')
+
     def sub_m_mul_q(self, MPolynomial_libsingular m, MPolynomial_libsingular q):
         """
         Return ``self - m*q``, where ``m`` must be a monomial and


### PR DESCRIPTION
See the newly added test. Previously, it fails.

This only affects the (slow) singular interface, not the libsingular interface.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


