### PR TITLE
Make RingExtension work with tower of finite field extension

### DIFF
--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -211,7 +211,7 @@ class CommutativeRings(CategoryWithAxiom):
                 else:
                     tester.assertTrue(test)
 
-        def over(self, base=None, gen=None, gens=None, name=None, names=None):
+        def over(self, base=None, gen=None, *, gens=None, name=None, names=None, check=True):
             r"""
             Return this ring, considered as an extension of ``base``.
 
@@ -231,6 +231,10 @@ class CommutativeRings(CategoryWithAxiom):
 
             - ``names`` -- list or a tuple of variable names or ``None``
               (default: ``None``)
+
+            - ``check`` -- forwarded to :class:`sage.rings.ring_extension.RingExtensionWithGen`
+              to check that the provided generator indeed generates the ring.
+              Might be ignored if :class:`sage.rings.ring_extension.RingExtension_generic` is selected
 
             EXAMPLES:
 
@@ -330,6 +334,17 @@ class CommutativeRings(CategoryWithAxiom):
                 [Field in b with defining polynomial x^2 - a over its base,
                  Field in a with defining polynomial x^2 - 2 over its base,
                  Rational Field]
+
+            TESTS:
+
+            Even when ``check=False``, the generator must be valid, the behavior is not guaranteed
+            otherwise. The behavior with ``check=False`` below may change any time::
+
+                sage: GF(5^2).over(GF(5), gen=1, name='t', check=True)
+                Traceback (most recent call last):
+                ...
+                ValueError: the given family is not a basis
+                sage: ignore = GF(5^2).over(GF(5), gen=1, name='t', check=False)
             """
             from sage.rings.ring_extension import RingExtension
             if name is not None:
@@ -340,7 +355,7 @@ class CommutativeRings(CategoryWithAxiom):
                 if gens is not None:
                     raise ValueError("keyword argument 'gen' cannot be combined with 'gens'")
                 gens = (gen,)
-            return RingExtension(self, base, gens, names)
+            return RingExtension(self, base, gens, names, check=check)
 
         def frobenius_endomorphism(self, n=1):
             """

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -1263,7 +1263,10 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
         return self.__ring
 
     def free_module(self, base=None, basis=None, map=True):
-        """
+        r"""
+        Return a free module `V` over the specified subring together with
+        maps to and from `V`.
+
         See :meth:`sage.categories.rings.Rings.ParentMethods.free_module`.
 
         TESTS::

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -1262,6 +1262,69 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
         """
         return self.__ring
 
+    def free_module(self, base=None, basis=None, map=True):
+        """
+        See :meth:`sage.categories.rings.Rings.ParentMethods.free_module`.
+
+        TESTS::
+
+            sage: R.<x> = QQ[]
+            sage: S.<y> = R.quotient(x^2+x+1)[]
+            sage: T = S.quotient(y^3-2)
+            sage: V, from_V, to_V = S.base_ring().free_module(QQ)
+            sage: from_V(V([1, 2]))
+            2*xbar + 1
+            sage: to_V(from_V(V([1, 2])))
+            (1, 2)
+            sage: V, from_V, to_V = T.free_module(QQ)
+            sage: V
+            Vector space of dimension 6 over Rational Field
+            sage: from_V(V([1, 2, 3, 4, 5, 6]))
+            (6*xbar + 5)*ybar^2 + (4*xbar + 3)*ybar + 2*xbar + 1
+            sage: to_V(from_V(V([1, 2, 3, 4, 5, 6])))
+            (1, 2, 3, 4, 5, 6)
+            sage: V, from_V, to_V = T.free_module(S.base_ring())
+            sage: V
+            Vector space of dimension 3 over Univariate Quotient Polynomial Ring in xbar over Rational Field with modulus x^2 + x + 1
+            sage: from_V(V([1*x+2, 3*x+4, 5*x+6]))
+            (5*xbar + 6)*ybar^2 + (3*xbar + 4)*ybar + xbar + 2
+            sage: to_V(from_V(V([1*x+2, 3*x+4, 5*x+6])))
+            (xbar + 2, 3*xbar + 4, 5*xbar + 6)
+        """
+        if basis is not None:
+            raise NotImplementedError
+        if base is None:
+            base = self.base_ring()
+        if base != self.base_ring():
+            V1, from_V1, to_V1 = self.base_ring().free_module(base=base, basis=None, map=True)
+            assert V1.base_ring() == base
+            d = self.degree()
+            V1_degree = V1.degree()
+            V = base ** (V1_degree * d)
+
+            def from_V(v):
+                assert len(v) == V1_degree * d
+                return self([from_V1(V1(v[i*V1_degree:(i+1)*V1_degree])) for i in range(d)])
+
+            def to_V(f):
+                list_f = list(f)
+                return V([c for coefficient in f for c in to_V1(coefficient)])
+
+        else:
+            V = base ** self.degree()
+
+            def from_V(v):
+                return self(list(v))
+
+            def to_V(f):
+                return V(list(f))
+
+        if not map:
+            return V
+        from sage.categories.morphism import SetMorphism
+        from sage.categories.homset import Hom
+        return V, SetMorphism(Hom(V, self), from_V), SetMorphism(Hom(self, V), to_V)
+
     cover_ring = polynomial_ring
 
     def random_element(self, degree=None, *args, **kwds):

--- a/src/sage/rings/ring_extension.pyx
+++ b/src/sage/rings/ring_extension.pyx
@@ -376,8 +376,8 @@ class RingExtensionFactory(UniqueFactory):
           (default: ``None``)
 
         - ``constructors`` -- list of constructors; each constructor
-          is a pair `(class, arguments)` where `class` is the class
-          implementing the extension and `arguments` is the dictionary
+          is a pair ``(class, arguments)`` where ``class`` is the class
+          implementing the extension and ``arguments`` is the dictionary
           of arguments to pass in to init function
 
         TESTS::
@@ -2397,7 +2397,7 @@ cdef class RingExtensionWithBasis(RingExtension_generic):
             Vector space of dimension 6 over Finite Field of size 11
 
         In this case, the isomorphisms between `V` and `L` are given by the
-        basis `(1, a, b, ab, b^2, ab^2)`:
+        basis `(1, a, b, ab, b^2, ab^2)`::
 
             sage: j(a*b)                                                                # needs sage.rings.finite_rings
             (0, 0, 0, 1, 0, 0)


### PR DESCRIPTION
This pull request makes RingExtension work over nontrivial tower of extension constructed using PolynomialQuotientRing. See the tests for details (previously they fail).

```
            sage: p = 886368969471450739924935101400677
            sage: K = GF(p)
            sage: Kx.<x> = K[]
            sage: K3.<u> = K.extension(Kx([4, 1, 0, 1]))
            sage: K3y.<y> = K3[]
            sage: K6.<t> = K3.extension(K3y([2, 0, 1]))
            sage: K6t.<t1> = K6.over(K, gen=t)
            Traceback (most recent call last):
            ...
            ValueError: the given family is not a basis
            sage: K6t.<t1> = K6.over(K, gen=t+u)
            sage: K6t(t1).minpoly()
            x^6 + 8*x^4 + 8*x^3 + 13*x^2 + 886368969471450739924935101400637*x + 18
            sage: K6t(t1).minpoly()(t1)
            0
```

The example is taken from https://github.com/sagemath/sage/issues/40764. For now, you need to provide a generator `t+u`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


