### PR TITLE
sage.rings.polynomial.polynomial_singular_interface: drop unused import

### DIFF
--- a/src/sage/rings/polynomial/polynomial_singular_interface.py
+++ b/src/sage/rings/polynomial/polynomial_singular_interface.py
@@ -45,8 +45,6 @@ from sage.rings.finite_rings.finite_field_base import FiniteField
 from sage.rings.integer_ring import ZZ
 from sage.rings.number_field.number_field_base import NumberField
 
-import sage.rings.finite_rings.finite_field_constructor
-
 
 def _do_singular_init_(singular, base_ring, char, _vars, order):
     r"""


### PR DESCRIPTION
Drop the import of `sage.rings.finite_rings.finite_field_constructor` from this file, since it is unused. I noticed this because it leads to circular imports:

```
$ python
Python 3.13.7 (main, Aug 22 2025, 06:36:41) [GCC 15.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sage.rings.function_field.constructor import FunctionField
>>> from sage.rings.integer import Integer
>>> from sage.rings.rational_field import QQ
>>> K = FunctionField(QQ, 'x')
Traceback (most recent call last):
...
ImportError: cannot import name PolynomialRing_generic
```

(The unneccessary import from `sage.rings.integer` is due to another, harder instance of this problem.)
