### PR TITLE
sage.categories.finite_fields: don't import from integer_ring

### DIFF
--- a/src/sage/categories/finite_fields.py
+++ b/src/sage/categories/finite_fields.py
@@ -16,7 +16,6 @@ Finite fields
 from sage.categories.category_with_axiom import CategoryWithAxiom
 from sage.categories.enumerated_sets import EnumeratedSets
 from sage.rings.integer import Integer
-from sage.rings.integer_ring import ZZ
 from sage.misc.cachefunc import cached_method
 
 
@@ -332,7 +331,7 @@ class FiniteFields(CategoryWithAxiom):
             if not self.is_square():
                 raise ValueError("element is not a square")
             g = self.parent().quadratic_nonresidue()
-            even_exp, odd_order = (q - ZZ.one()).val_unit(2)
+            even_exp, odd_order = (q - Integer(1)).val_unit(2)
             e = 0
             for i in range(2, even_exp+1):
                 tmp = self * (pow(g, -e))


### PR DESCRIPTION
Importing `ZZ` from the integer ring creates an import cycle,

```
integer_ring -> integer
             -> rational
             -> rational_field
             -> categories/finite_fields
             -> integer_ring
```

I noticed this because the cycle has started causing an `ImportError` when I attempt to import `ZZ`. This commit doesn't fix the problem (there are other cycles), but it is minimally invasive and does improve the import graph a tiny bit.

Edit: a better fix for this would be to break the dependence of integers on rationals, but that would be a much larger change.