### PR TITLE
Use SAGE_DOC_SRC instead of relative path in docbuilder test

### DIFF
--- a/src/sage_docbuild/builders.py
+++ b/src/sage_docbuild/builders.py
@@ -1180,7 +1180,8 @@ def get_all_documents(source: Path) -> list[Path]:
     EXAMPLES::
 
         sage: from sage_docbuild.builders import get_all_documents
-        sage: documents = get_all_documents(Path('src/doc'))
+        sage: from sage.env import SAGE_DOC_SRC
+        sage: documents = get_all_documents(Path(SAGE_DOC_SRC))
         sage: Path('en/tutorial') in documents
         True
     """
@@ -1213,7 +1214,8 @@ def get_all_reference_documents(source: Path) -> list[Path]:
     EXAMPLES::
 
         sage: from sage_docbuild.builders import get_all_reference_documents
-        sage: documents = get_all_reference_documents(Path('src/doc/en'))
+        sage: from sage.env import SAGE_DOC_SRC
+        sage: documents = get_all_reference_documents(Path(SAGE_DOC_SRC) / 'en')
         sage: Path('reference/algebras') in documents
         True
     """


### PR DESCRIPTION
These two `sage_docbuild` tests use a relative path, requiring `sage -t --all` to be run from a specific directory. This was never needed before, so perhaps it was unintended.