### PR TITLE
Update CI matrix to exclude macOS version '13'

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '13'
           - '14'
           - '15'
 


### PR DESCRIPTION
Removed macOS version '13' from CI matrix. Refer to https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ . Maybe we can add macos-26
@tobiasdiez 
