### PR TITLE
approximate imaginary-quadratic class numbers using analytic class number formula

### DIFF
--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -185,7 +185,7 @@ def quadratic_order_approximate_class_number(disc, *, bound=10**4):
     w = 6 if disc == -3 else 4 if disc == -4 else 2
     RR = RealField(max(53, disc.bit_length()))  # wild guess!
 
-    # compute numerator and denominator separately for numerical stability
+    # compute numerator and denominator separately for speed
     L1 = L2 = RR(1)
     for ell in primes(bound):
         L1 *= ell

--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -143,9 +143,9 @@ def quadratic_order_approximate_class_number(disc, *, bound=10**4):
         sage: QuadraticField(-d).class_number(proof=False)
         14414435
         sage: round(quadratic_order_approximate_class_number(-d))
-        144...
+        14407657
         sage: round(quadratic_order_approximate_class_number(-d, bound=10**6))
-        1441...
+        14413626
 
     Test it against the exact class number computed for the CSIDH-512 prime (source: https://eprint.iacr.org/2019/498.pdf)::
 
@@ -154,21 +154,21 @@ def quadratic_order_approximate_class_number(disc, *, bound=10**4):
         sage: hreal = 84884147409828091725676728670213067387206838101828807864190286991865870575397
         sage: assert not hreal * BQFClassGroup(-p).random_element()
         sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**3)); h
-        8...
+        85020334529027955331134025285584937708277525762952749243936367281020276898911
         sage: RR(h / hreal)
-        1.00...
+        1.00160438813790
         sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**4)); h
-        84...
+        84396416322932187013685015858232028818143153418602750494380687212063263982976
         sage: RR(h / hreal)
-        0.99...
+        0.994254155790231
         sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**5)); h
-        848...
+        84823787383264935642168065590216697209124465727576867303448690101681967969348
         sage: RR(h / hreal)
-        0.999...
+        0.999288912848806
         sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**6)); h  # long time -- 2s
-        84884...
+        84884627342209070883738394179700676127184729325091471467872632417652836154863
         sage: RR(h / hreal)  # long time -- 2s
-        1.00000...
+        1.00000565396951
 
     ALGORITHM: Finite approximation of the infinite product given by
     the analytic class number formula, using primes up to ``bound``.

--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -142,9 +142,9 @@ def quadratic_order_approximate_class_number(disc, *, bound=10**4):
         sage: d = 100000000000031
         sage: QuadraticField(-d).class_number(proof=False)
         14414435
-        sage: round(quadratic_order_approximate_class_number(-d))
+        sage: round(quadratic_order_approximate_class_number(-d))  # rel tol .01
         14407657
-        sage: round(quadratic_order_approximate_class_number(-d, bound=10**6))
+        sage: round(quadratic_order_approximate_class_number(-d, bound=10**6))  # rel tol .01
         14413626
 
     Test it against the exact class number computed for the CSIDH-512 prime (source: https://eprint.iacr.org/2019/498.pdf)::
@@ -153,21 +153,21 @@ def quadratic_order_approximate_class_number(disc, *, bound=10**4):
         sage: p = 4 * prod(primes(3,374)) * 587 - 1
         sage: hreal = 84884147409828091725676728670213067387206838101828807864190286991865870575397
         sage: assert not hreal * BQFClassGroup(-p).random_element()
-        sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**3)); h
+        sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**3)); h  # rel tol .01
         85020334529027955331134025285584937708277525762952749243936367281020276898911
-        sage: RR(h / hreal)
+        sage: RR(h / hreal)  # abs tol .01
         1.00160438813790
-        sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**4)); h
+        sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**4)); h  # rel tol .01
         84396416322932187013685015858232028818143153418602750494380687212063263982976
-        sage: RR(h / hreal)
+        sage: RR(h / hreal)  # abs tol .01
         0.994254155790231
-        sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**5)); h
+        sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**5)); h  # rel tol .01
         84823787383264935642168065590216697209124465727576867303448690101681967969348
-        sage: RR(h / hreal)
+        sage: RR(h / hreal)  # abs tol .01
         0.999288912848806
-        sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**6)); h  # long time -- 2s
+        sage: h = round(quadratic_order_approximate_class_number(-p, bound=10**6)); h  # rel tol .01, long time (2s)
         84884627342209070883738394179700676127184729325091471467872632417652836154863
-        sage: RR(h / hreal)  # long time -- 2s
+        sage: RR(h / hreal)  # abs tol .01, long time (2s)
         1.00000565396951
 
     ALGORITHM: Finite approximation of the infinite product given by

--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -133,8 +133,8 @@ def quadratic_order_approximate_class_number(disc, *, bound=10**4):
         sage: from sage.rings.number_field.order import quadratic_order_approximate_class_number
         sage: QuadraticField(-419).class_number()
         9
-        sage: quadratic_order_approximate_class_number(-419)
-        9.0...
+        sage: quadratic_order_approximate_class_number(-419)  # rel tol .01
+        9.01653836091712
 
     ::
 

--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -119,6 +119,7 @@ def quadratic_order_class_number(disc):
         h = pari.qfbclassno(disc)
     return ZZ(h)
 
+
 def quadratic_order_approximate_class_number(disc, *, bound=10**4):
     r"""
     Return *an approximation of* the class number of

--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -146,11 +146,9 @@ def quadratic_order_approximate_class_number(disc, *, bound=10**4):
         sage: round(quadratic_order_approximate_class_number(-d, bound=10**6))
         1441...
 
-    ::
+    Test it against the exact class number computed for the CSIDH-512 prime (source: https://eprint.iacr.org/2019/498.pdf)::
 
         sage: from sage.rings.number_field.order import quadratic_order_approximate_class_number
-        sage: # Test it against the exact class number computed for the CSIDH-512 prime
-        sage: # Source: https://eprint.iacr.org/2019/498.pdf
         sage: p = 4 * prod(primes(3,374)) * 587 - 1
         sage: hreal = 84884147409828091725676728670213067387206838101828807864190286991865870575397
         sage: assert not hreal * BQFClassGroup(-p).random_element()

--- a/src/sage/rings/number_field/order.py
+++ b/src/sage/rings/number_field/order.py
@@ -1167,6 +1167,15 @@ class Order(Parent, sage.rings.abc.Order):
         r"""
         Return the class number of this order.
 
+        .. NOTE::
+
+            For some applications (e.g., in algorithms for computing
+            class groups) it is required to merely *approximate* the
+            class number. The function
+            :func:`quadratic_order_approximate_class_number`
+            can be used to compute such an approximation (currently
+            restricted to maximal imaginary-quadratic orders).
+
         EXAMPLES::
 
             sage: ZZ[2^(1/3)].class_number()                                            # needs sage.symbolic


### PR DESCRIPTION
This patch adds a simple function to *approximate* class numbers of imaginary-quadratic fields using the analytic class number formula. This approximation is accurate to a relative error factor of $<2$ even with comparatively low precision, making it useful in the context of class-group computations.

An obvious next step would be to generalize it to non-fundamental and/or positive discriminants. This is left for future work.