### PR TITLE
switch to n_vertices, n_edges and n_faces for graphs

### DIFF
--- a/src/doc/en/thematic_tutorials/sandpile.rst
+++ b/src/doc/en/thematic_tutorials/sandpile.rst
@@ -4365,7 +4365,7 @@ EXAMPLES::
     {0: 2, 1: 3, 2: 1, 3: 2}
     sage: n(mean([D.simulate_threshold().deg() for _ in range(10)]))  # random
     7.10000000000000
-    sage: n(s.stationary_density()*s.num_verts())
+    sage: n(s.stationary_density()*s.n_vertices())
     6.93750000000000
 
 .. NOTE::

--- a/src/sage/categories/coxeter_groups.py
+++ b/src/sage/categories/coxeter_groups.py
@@ -1885,11 +1885,11 @@ class CoxeterGroups(Category_singleton):
                 sage: W = WeylGroup(['A', 3], prefix='s')
                 sage: w0 = W.long_element()
                 sage: G = w0.reduced_word_graph()
-                sage: G.num_verts()
+                sage: G.n_vertices()
                 16
                 sage: len(w0.reduced_words())
                 16
-                sage: G.num_edges()
+                sage: G.n_edges()
                 18
                 sage: len([e for e in G.edges(sort=False) if e[2] == 2])
                 10
@@ -1906,9 +1906,9 @@ class CoxeterGroups(Category_singleton):
                 sage: # needs sage.combinat sage.graphs sage.groups
                 sage: w1 = W.one()
                 sage: G = w1.reduced_word_graph()
-                sage: G.num_verts()
+                sage: G.n_vertices()
                 1
-                sage: G.num_edges()
+                sage: G.n_edges()
                 0
 
             .. SEEALSO::

--- a/src/sage/categories/semigroups.py
+++ b/src/sage/categories/semigroups.py
@@ -208,7 +208,7 @@ class Semigroups(CategoryWithAxiom):
                 ....:          vertex_colors={(1,1,1): G.vertices(sort=True)},
                 ....:          bgcolor=(0,0,0), color_by_label=True,
                 ....:          xres=700, yres=700, iterations=200)
-                sage: G.num_edges()
+                sage: G.n_edges()
                 120
 
                 sage: # needs sage.combinat sage.graphs sage.groups
@@ -221,7 +221,7 @@ class Semigroups(CategoryWithAxiom):
 
                 sage: # needs sage.graphs sage.groups
                 sage: G = A5.cayley_graph(generators=[A5.gens()[0]])
-                sage: G.num_edges()
+                sage: G.n_edges()
                 60
                 sage: g = PermutationGroup([(i + 1, j + 1)
                 ....:                       for i in range(5)
@@ -242,7 +242,7 @@ class Semigroups(CategoryWithAxiom):
                 ....:             for w in sum((list(Words(M.semigroup_generators(), k))
                 ....:                           for k in range(4)), [])]
                 sage: G = M.cayley_graph(elements=elements)
-                sage: G.num_verts(), G.num_edges()
+                sage: G.n_vertices(), G.n_edges()
                 (85, 84)
                 sage: G.show3d(color_by_label=True, edge_size=0.001, vertex_size=0.01)  # needs sage.plot
 

--- a/src/sage/combinat/constellation.py
+++ b/src/sage/combinat/constellation.py
@@ -885,9 +885,9 @@ class Constellation_class(Element):
             g1 (0)(1,4)(2)(3)
             g2 (0,1,3,2,4)
             sage: G = c.braid_group_orbit()
-            sage: G.num_verts()
+            sage: G.n_vertices()
             4
-            sage: G.num_edges()
+            sage: G.n_edges()
             12
         """
         G = DiGraph(multiedges=True, loops=True)

--- a/src/sage/combinat/designs/bibd.py
+++ b/src/sage/combinat/designs/bibd.py
@@ -334,7 +334,7 @@ def balanced_incomplete_block_design(v, k, lambd=1, existence=False, use_LJCR=Fa
                     return False
                 raise EmptySetError(f"there exists no ({v},{k},{lambd})-BIBD")
             B = B.incidence_structure()
-            if B.num_blocks() == expected_n_of_blocks:
+            if B.n_blocks() == expected_n_of_blocks:
                 if existence:
                     return True
                 else:
@@ -1467,7 +1467,7 @@ class PairwiseBalancedDesign(GroupDivisibleDesign):
             (13,3,1)-Balanced Incomplete Block Design
         """
         bsizes = list(frozenset(self.block_sizes()))
-        return "Pairwise Balanced Design on {} points with sets of sizes in {}".format(self.num_points(), bsizes)
+        return "Pairwise Balanced Design on {} points with sets of sizes in {}".format(self.n_points(), bsizes)
 
 
 class BalancedIncompleteBlockDesign(PairwiseBalancedDesign):
@@ -1526,10 +1526,10 @@ class BalancedIncompleteBlockDesign(PairwiseBalancedDesign):
             sage: b=designs.balanced_incomplete_block_design(9,3); b
             (9,3,1)-Balanced Incomplete Block Design
         """
-        v = self.num_points()
+        v = self.n_points()
         k = len(self._blocks[0]) if self._blocks else 0
         l = self._lambd
-        return "({},{},{})-Balanced Incomplete Block Design".format(v,k,l)
+        return f"({v},{k},{l})-Balanced Incomplete Block Design"
 
     def arc(self, s=2, solver=None, verbose=0, *, integrality_tolerance=1e-3):
         r"""

--- a/src/sage/combinat/designs/gen_quadrangles_with_spread.pyx
+++ b/src/sage/combinat/designs/gen_quadrangles_with_spread.pyx
@@ -217,7 +217,7 @@ def dual_GQ_ovoid(GQ, O):
 
     # GQ.ground_set()[i] becomes newBlocks[i]
     # GQ.blocks()[i] becomes i
-    newBlocks = [[] for _ in range(GQ.num_points())]
+    newBlocks = [[] for _ in range(GQ.n_points())]
     pointsToInt = {p: i for i, p in enumerate(GQ.ground_set())}
 
     for i, b in enumerate(GQ.blocks()):

--- a/src/sage/combinat/designs/group_divisible_designs.py
+++ b/src/sage/combinat/designs/group_divisible_designs.py
@@ -292,7 +292,7 @@ class GroupDivisibleDesign(IncidenceStructure):
 
         if check or groups is None:
             is_gdd = is_group_divisible_design(self._groups, self._blocks,
-                                               self.num_points(), G, K,
+                                               self.n_points(), G, K,
                                                lambd, verbose=1)
             assert is_gdd
             if groups is None:
@@ -355,6 +355,6 @@ class GroupDivisibleDesign(IncidenceStructure):
         if not gdd_type:
             gdd_type = "1^0"
 
-        v = self.num_points()
+        v = self.n_points()
 
         return "Group Divisible Design on {} points of type {}".format(v, gdd_type)

--- a/src/sage/combinat/designs/incidence_structures.py
+++ b/src/sage/combinat/designs/incidence_structures.py
@@ -271,7 +271,7 @@ class IncidenceStructure:
             Incidence structure with 7 points and 7 blocks
         """
         return 'Incidence structure with {} points and {} blocks'.format(
-            self.num_points(), self.num_blocks())
+            self.n_points(), self.n_blocks())
 
     __str__ = __repr__
 
@@ -308,11 +308,11 @@ class IncidenceStructure:
         if self._points == other._points:
             return self._blocks == other._blocks
 
-        if (self.num_points() != other.num_points() or
-                self.num_blocks() != other.num_blocks()):
+        if (self.n_points() != other.n_points() or
+                self.n_blocks() != other.n_blocks()):
             return False
 
-        p_to_i = self._point_to_index if self._point_to_index else list(range(self.num_points()))
+        p_to_i = self._point_to_index if self._point_to_index else list(range(self.n_points()))
 
         if any(p not in p_to_i for p in other.ground_set()):
             return False
@@ -408,9 +408,9 @@ class IncidenceStructure:
         if self._canonical_label is None:
             from sage.graphs.graph import Graph
             g = Graph()
-            n = self.num_points()
+            n = self.n_points()
             g.add_edges((i+n, x) for i, b in enumerate(self._blocks) for x in b)
-            canonical_label = g.canonical_label([list(range(n)), list(range(n, n+self.num_blocks()))], certificate=True)[1]
+            canonical_label = g.canonical_label([list(range(n)), list(range(n, n+self.n_blocks()))], certificate=True)[1]
             canonical_label = [canonical_label[x] for x in range(n)]
             self._canonical_label = canonical_label
 
@@ -473,8 +473,8 @@ class IncidenceStructure:
             sage: IS1._canonical_label is None or IS2._canonical_label is None
             False
         """
-        if (self.num_points() != other.num_points() or
-            self.num_blocks() != other.num_blocks() or
+        if (self.n_points() != other.n_points() or
+            self.n_blocks() != other.n_blocks() or
                 sorted(self.block_sizes()) != sorted(other.block_sizes())):
             return {} if certificate else False
 
@@ -581,7 +581,7 @@ class IncidenceStructure:
         IS = IncidenceStructure(self._blocks,
                                 name=self._name,
                                 check=False)
-        IS.relabel(dict(zip(range(self.num_points()), self._points)))
+        IS.relabel(dict(zip(range(self.n_points()), self._points)))
         IS._canonical_label = None if self._canonical_label is None else self._canonical_label[:]
 
         return IS
@@ -631,7 +631,7 @@ class IncidenceStructure:
         """
         # Checking the input
         if self._point_to_index is None:
-            n = self.num_points()
+            n = self.n_points()
             for x in points:
                 x = int(x)
                 if x < 0 or x >= n:
@@ -706,7 +706,7 @@ class IncidenceStructure:
         """
         # Checking the input
         if self._point_to_index is None:
-            n = self.num_points()
+            n = self.n_points()
             int_points = frozenset(int(x) for x in points)
             for x in int_points:
                 if x < 0 or x >= n:
@@ -737,33 +737,51 @@ class IncidenceStructure:
         """
         return self._points[:]
 
-    def num_points(self):
+    def n_points(self) -> int:
         r"""
         Return the size of the ground set.
 
         EXAMPLES::
 
-            sage: designs.DesarguesianProjectivePlaneDesign(2).num_points()
+            sage: designs.DesarguesianProjectivePlaneDesign(2).n_points()
             7
             sage: B = IncidenceStructure(4, [[0,1],[0,2],[0,3],[1,2], [1,2,3]])
-            sage: B.num_points()
+            sage: B.n_points()
             4
+
+        TESTS:
+
+        The old method name is kept as an alias::
+
+            sage: designs.DesarguesianProjectivePlaneDesign(2).npoints()
+            7
         """
         return len(self._points)
 
-    def num_blocks(self):
+    num_points = n_points
+
+    def n_blocks(self) -> int:
         r"""
         Return the number of blocks.
 
         EXAMPLES::
 
-            sage: designs.DesarguesianProjectivePlaneDesign(2).num_blocks()
+            sage: designs.DesarguesianProjectivePlaneDesign(2).n_blocks()
             7
             sage: B = IncidenceStructure(4, [[0,1],[0,2],[0,3],[1,2], [1,2,3]])
-            sage: B.num_blocks()
+            sage: B.n_blocks()
             5
+
+        TESTS:
+
+        The old method name is kept as an alias::
+
+            sage: designs.DesarguesianProjectivePlaneDesign(2).npoints()
+            7
         """
         return len(self._blocks)
+
+    num_blocks = n_blocks
 
     def blocks(self):
         """
@@ -881,14 +899,14 @@ class IncidenceStructure:
             True
         """
         if size is None:
-            d = [0]*self.num_points()
+            d = [0]*self.n_points()
             for b in self._blocks:
                 for x in b:
                     d[x] += 1
             return {p: d[i] for i, p in enumerate(self._points)}
         else:
             from itertools import combinations
-            d = {t: 0 for t in combinations(range(self.num_points()), size)}
+            d = {t: 0 for t in combinations(range(self.n_points()), size)}
             for b in self._blocks:
                 for s in combinations(b, size):
                     d[s] += 1
@@ -947,9 +965,9 @@ class IncidenceStructure:
             ...
             ValueError: This incidence structure has no points.
         """
-        if self.num_points() == 0:
+        if self.n_points() == 0:
             raise ValueError("This incidence structure has no points.")
-        count = [0] * self.num_points()
+        count = [0] * self.n_points()
         for b in self._blocks:
             for x in b:
                 count[x] += 1
@@ -998,7 +1016,7 @@ class IncidenceStructure:
             ...
             ValueError: This incidence structure has no blocks.
         """
-        if self.num_blocks() == 0:
+        if self.n_blocks() == 0:
             raise ValueError("This incidence structure has no blocks.")
         sizes = set(self.block_sizes())
         if len(sizes) != 1:
@@ -1019,7 +1037,7 @@ class IncidenceStructure:
             False
         """
         from sage.sets.disjoint_set import DisjointSet
-        D = DisjointSet(self.num_points())
+        D = DisjointSet(self.n_points())
         for B in self._blocks:
             x = B[0]
             for i in range(1, len(B)):
@@ -1059,7 +1077,7 @@ class IncidenceStructure:
             sage: BD._gap_()
             'BlockDesign(7,[[1, 2, 3], [1, 4, 5], [1, 6, 7], [2, 4, 6], [2, 5, 7], [3, 4, 7], [3, 5, 6]])'
         """
-        v = self.num_points()
+        v = self.n_points()
         gB = [[x + 1 for x in b] for b in self._blocks]
         return "BlockDesign({},{})".format(v, gB)
 
@@ -1075,7 +1093,7 @@ class IncidenceStructure:
             isBlockDesign := true, v := 4 )
         """
         libgap.load_package("design")
-        v = self.num_points()
+        v = self.n_points()
         gB = [[x + 1 for x in b] for b in self._blocks]
         return libgap.BlockDesign(v, gB)
 
@@ -1144,7 +1162,7 @@ class IncidenceStructure:
         """
         from sage.matrix.constructor import matrix
         from sage.rings.integer_ring import ZZ
-        A = matrix(ZZ, self.num_points(), self.num_blocks(), sparse=True)
+        A = matrix(ZZ, self.n_points(), self.n_blocks(), sparse=True)
         for j, b in enumerate(self._blocks):
             for i in b:
                 A[i, j] = 1
@@ -1300,23 +1318,23 @@ class IncidenceStructure:
                 raise ValueError("The incidence structure is not uniform.")
 
             blocks = []
-            num_blocks = self.num_blocks()
+            n_blocks = self.n_blocks()
             i = 0
             from itertools import combinations
-            for B in combinations(range(self.num_points()), k):
+            for B in combinations(range(self.n_points()), k):
                 B = list(B)
-                while i < num_blocks and self._blocks[i] < B:
+                while i < n_blocks and self._blocks[i] < B:
                     i += 1
-                if i < num_blocks and self._blocks[i] == B:
+                if i < n_blocks and self._blocks[i] == B:
                     i += 1
                     continue
                 blocks.append(B)
             I = IncidenceStructure(blocks, copy=False)
         else:
-            X = set(range(self.num_points()))
+            X = set(range(self.n_points()))
             I = IncidenceStructure([X.difference(B) for B in self._blocks])
 
-        I.relabel({i: self._points[i] for i in range(self.num_points())})
+        I.relabel({i: self._points[i] for i in range(self.n_points())})
         return I
 
     def relabel(self, perm=None, inplace=True):
@@ -1387,7 +1405,7 @@ class IncidenceStructure:
             return G
 
         if perm is None:
-            self._points = list(range(self.num_points()))
+            self._points = list(range(self.n_points()))
             self._point_to_index = None
             return
 
@@ -1408,7 +1426,7 @@ class IncidenceStructure:
             raise ValueError("two points are getting relabelled with the same name")
 
         self._points = [perm[x] for x in self._points]
-        if self._points == list(range(self.num_points())):
+        if self._points == list(range(self.n_points())):
             self._point_to_index = None
         else:
             self._point_to_index = {v: i for i, v in enumerate(self._points)}
@@ -1470,7 +1488,7 @@ class IncidenceStructure:
             p.add_constraint(p.sum([b[i] for i in L]) <= 1)
 
         # Maximum number of blocks
-        p.set_objective(p.sum([b[i] for i in range(self.num_blocks())]))
+        p.set_objective(p.sum([b[i] for i in range(self.n_blocks())]))
 
         p.solve(log=verbose)
 
@@ -1615,7 +1633,7 @@ class IncidenceStructure:
 
         # Missing parameters ?
         if v is None:
-            v = self.num_points()
+            v = self.n_points()
 
         if k is None:
             k = len(self._blocks[0]) if self._blocks else 0
@@ -1623,11 +1641,11 @@ class IncidenceStructure:
         if l is not None and t is None:
             raise ValueError("t must be set when l=None")
 
-        b = self.num_blocks()
+        b = self.n_blocks()
 
         # Trivial wrong answers
         if (any(len(block) != k for block in self._blocks) or  # non k-uniform
-                v != self.num_points()):
+                v != self.n_points()):
             return (False, (0, 0, 0, 0)) if return_parameters else False
 
         # Trivial case t>k
@@ -1873,10 +1891,10 @@ class IncidenceStructure:
         from sage.graphs.graph import Graph
         from sage.groups.perm_gps.permgroup import PermutationGroup
         g = Graph()
-        n = self.num_points()
+        n = self.n_points()
         g.add_edges((i + n, x) for i, b in enumerate(self._blocks) for x in b)
         ag = g.automorphism_group(partition=[list(range(n)),
-                                             list(range(n, n + self.num_blocks()))])
+                                             list(range(n, n + self.n_blocks()))])
 
         if self._point_to_index:
             gens = [[tuple([self._points[i] for i in cycle if (not cycle or cycle[0] < n)])
@@ -1985,7 +2003,7 @@ class IncidenceStructure:
                 n_classes = degrees.pop()
                 p = MixedIntegerLinearProgram(solver=solver)
                 b = p.new_variable(binary=True)
-                domain = list(range(self.num_points()))
+                domain = list(range(self.n_points()))
 
                 # Lists of blocks containing i for every i
                 dual = [[] for _ in domain]
@@ -2015,7 +2033,7 @@ class IncidenceStructure:
 
         if check and self._classes is not False:
             assert sorted(id(c) for cls in self._classes for c in cls) == sorted(id(b) for b in self._blocks), "some set does not appear exactly once"
-            domain = list(range(self.num_points()))
+            domain = list(range(self.n_points()))
             for i, c in enumerate(self._classes):
                 assert sorted(sum(c, [])) == domain, "class {} is not a partition".format(i)
 
@@ -2034,7 +2052,7 @@ class IncidenceStructure:
             return True
 
     def coloring(self, k=None, solver=None, verbose=0,
-                 *, integrality_tolerance=1e-3):
+                 *, integrality_tolerance=1e-3) -> list:
         r"""
         Compute a (weak) `k`-coloring of the hypergraph.
 
@@ -2087,14 +2105,14 @@ class IncidenceStructure:
             3
         """
         if k is None:
-            for k in range(self.num_points() + 1):
+            for k in range(self.n_points() + 1):
                 try:
                     return self.coloring(k)
                 except ValueError:
                     pass
 
         if k == 0:
-            if self.num_points():
+            if self.n_points():
                 raise ValueError("Only empty hypergraphs are 0-chromatic")
             return []
         elif any(len(x) == 1 for x in self._blocks):
@@ -2110,7 +2128,7 @@ class IncidenceStructure:
         p = MixedIntegerLinearProgram(solver=solver)
         b = p.new_variable(binary=True)
 
-        for x in range(self.num_points()):
+        for x in range(self.n_points()):
             p.add_constraint(p.sum(b[x, i] for i in range(k)) == 1)
 
         for s in self._blocks:
@@ -2130,7 +2148,7 @@ class IncidenceStructure:
 
         return col
 
-    def edge_coloring(self) -> list:
+    def edge_coloring(self) -> list[list]:
         r"""
         Compute a proper edge-coloring.
 
@@ -2154,12 +2172,12 @@ class IncidenceStructure:
         from sage.graphs.graph import Graph
         blocks = self.blocks()
         blocks_sets = [frozenset(b) for b in blocks]
-        g = Graph([list(range(self.num_blocks())),
+        g = Graph([list(range(self.n_blocks())),
                    lambda x, y: len(blocks_sets[x] & blocks_sets[y])],
                   loops=False)
         return [[blocks[i] for i in C] for C in g.coloring(algorithm='MILP')]
 
-    def _spring_layout(self):
+    def _spring_layout(self) -> dict:
         r"""
         Return a spring layout for the points.
 
@@ -2345,7 +2363,6 @@ class IncidenceStructure:
             sage: E.is_spread([[1]])
             True
         """
-
         points = set(self.ground_set())
         allBlocks = set(map(frozenset, self.blocks()))
         for block in spread:

--- a/src/sage/combinat/designs/incidence_structures.py
+++ b/src/sage/combinat/designs/incidence_structures.py
@@ -753,7 +753,7 @@ class IncidenceStructure:
 
         The old method name is kept as an alias::
 
-            sage: designs.DesarguesianProjectivePlaneDesign(2).npoints()
+            sage: designs.DesarguesianProjectivePlaneDesign(2).num_points()
             7
         """
         return len(self._points)
@@ -776,7 +776,7 @@ class IncidenceStructure:
 
         The old method name is kept as an alias::
 
-            sage: designs.DesarguesianProjectivePlaneDesign(2).npoints()
+            sage: designs.DesarguesianProjectivePlaneDesign(2).num_blocks()
             7
         """
         return len(self._blocks)

--- a/src/sage/combinat/designs/resolvable_bibd.py
+++ b/src/sage/combinat/designs/resolvable_bibd.py
@@ -804,10 +804,10 @@ def PBD_4_7_from_Y(gdd, check=True):
     for G in gdd.groups():
         gs = len(G)
         for B in group_PBD[gs]:
-            PBD.append([3*G[x//3]+(x % 3) if x < 3*gs else 3*gdd.num_points()
+            PBD.append([3*G[x//3]+(x % 3) if x < 3*gs else 3*gdd.n_points()
                         for x in B])
 
-    return PairwiseBalancedDesign(3*gdd.num_points()+1,
+    return PairwiseBalancedDesign(3*gdd.n_points()+1,
                                   blocks=PBD,
                                   K=[4, 7],
                                   check=check,

--- a/src/sage/combinat/designs/steiner_quadruple_systems.py
+++ b/src/sage/combinat/designs/steiner_quadruple_systems.py
@@ -83,7 +83,7 @@ def two_n(B):
         ....:         if not two_n(sqs).is_t_design(3,2*n,4,1):
         ....:             print("Something is wrong !")
     """
-    n = B.num_points()
+    n = B.n_points()
     Y = []
 
     # Line 1
@@ -121,7 +121,7 @@ def three_n_minus_two(B):
         ....:         if not three_n_minus_two(sqs).is_t_design(3,3*n-2,4,1):
         ....:             print("Something is wrong !")
     """
-    n = B.num_points()
+    n = B.n_points()
     A = n-1
     Y = []
     # relabel function
@@ -178,7 +178,7 @@ def three_n_minus_eight(B):
         ....:         if not three_n_minus_eight(sqs).is_t_design(3,3*n-8,4,1):
         ....:             print("Something is wrong !")
     """
-    n = B.num_points()
+    n = B.n_points()
 
     if (n % 12) != 2:
         raise ValueError("n must be equal to 2 mod 12")
@@ -240,7 +240,7 @@ def three_n_minus_four(B):
         ....:         if not three_n_minus_four(sqs).is_t_design(3,3*n-4,4,1):
         ....:             print("Something is wrong !")
     """
-    n = B.num_points()
+    n = B.n_points()
 
     if n % 12 != 10:
         raise ValueError("n must be equal to 10 mod 12")
@@ -305,7 +305,7 @@ def four_n_minus_six(B):
         ....:         if not four_n_minus_six(sqs).is_t_design(3,4*n-6,4,1):
         ....:             print("Something is wrong !")
     """
-    n = B.num_points()
+    n = B.n_points()
     f = n-2
     r = lambda i,ii,x : (2*(i % 2)+(ii % 2))*(n-2)+(x) % (n-2)
 
@@ -378,7 +378,7 @@ def twelve_n_minus_ten(B):
         ....:         if not twelve_n_minus_ten(sqs).is_t_design(3,12*n-10,4,1):
         ....:             print("Something is wrong !")
     """
-    n = B.num_points()
+    n = B.n_points()
     B14 = steiner_quadruple_system(14)
     r = lambda i,x : i % (n-1)+(x % 12)*(n-1)
 
@@ -474,7 +474,7 @@ def relabel_system(B):
         sage: relabel_system(SQS8)
         Incidence structure with 8 points and 14 blocks
     """
-    n = B.num_points()
+    n = B.n_points()
     B0 = B._blocks[0]
 
     label = {

--- a/src/sage/combinat/designs/subhypergraph_search.pyx
+++ b/src/sage/combinat/designs/subhypergraph_search.pyx
@@ -360,16 +360,16 @@ cdef class SubHypergraphSearch:
         self.points1 = H1._points
         self.points2 = H2._points
         self.induced = induced
-        cdef int n1 = H1.num_points()
-        cdef int n2 = H2.num_points()
+        cdef int n1 = H1.n_points()
+        cdef int n2 = H2.n_points()
 
-        if n2>64:
-            raise RuntimeError("H2 has {}>64 points".format(n2))
+        if n2 > 64:
+            raise RuntimeError(f"H2 has {n2}>64 points")
 
-        self.h1   = h_init(n1,H1._blocks)
-        self.h2   = h_init(n2,H2._blocks)
-        self.tmp1 = h_init(n1,H1._blocks) # No actual need to fill them,
-        self.tmp2 = h_init(n2,H2._blocks) # only allocate the memory
+        self.h1   = h_init(n1, H1._blocks)
+        self.h2   = h_init(n2, H2._blocks)
+        self.tmp1 = h_init(n1, H1._blocks)  # No actual need to fill them,
+        self.tmp2 = h_init(n2, H2._blocks)  # only allocate the memory
 
         self.step = <int *> sig_malloc((n2+1)*sizeof(int))
 

--- a/src/sage/combinat/designs/twographs.py
+++ b/src/sage/combinat/designs/twographs.py
@@ -237,7 +237,7 @@ def is_twograph(T) -> bool:
         return False
 
     # A structure for a fast triple existence check
-    v_to_blocks = {v: set() for v in range(T.num_points())}
+    v_to_blocks = {v: set() for v in range(T.n_points())}
     for B in T._blocks:
         B = frozenset(B)
         for x in B:
@@ -248,11 +248,8 @@ def is_twograph(T) -> bool:
         return bool(v_to_blocks[x] & v_to_blocks[y] & v_to_blocks[z])
 
     # Check that every quadruple contains an even number of triples
-    for quad in combinations(range(T.num_points()), 4):
-        if sum(map(has_triple, combinations(quad, 3))) % 2:
-            return False
-
-    return True
+    return not any(sum(map(has_triple, combinations(quad, 3))) % 2
+                   for quad in combinations(range(T.n_points()), 4))
 
 
 def twograph_descendant(G, v, name=None):

--- a/src/sage/combinat/posets/hasse_diagram.py
+++ b/src/sage/combinat/posets/hasse_diagram.py
@@ -942,7 +942,7 @@ class HasseDiagram(DiGraph):
             sage: H = L.hasse_diagram()
             sage: H.size()
             80
-            sage: H.size() == H.num_edges()
+            sage: H.size() == H.n_edges()
             True
         """
         return self.order()

--- a/src/sage/graphs/base/c_graph.pyx
+++ b/src/sage/graphs/base/c_graph.pyx
@@ -1418,7 +1418,7 @@ cdef class CGraphBackend(GenericGraphBackend):
         else:
             self._loops = False
 
-    def num_edges(self, directed):
+    def n_edges(self, directed):
         """
         Return the number of edges in ``self``.
 
@@ -1434,13 +1434,13 @@ cdef class CGraphBackend(GenericGraphBackend):
 
         .. SEEALSO::
 
-            - :meth:`num_verts`
+            - :meth:`n_vertices`
               -- return the order of this graph.
 
         EXAMPLES::
 
             sage: G = Graph(graphs.PetersenGraph())
-            sage: G._backend.num_edges(False)
+            sage: G._backend.n_edges(False)
             15
 
         TESTS:
@@ -1485,23 +1485,23 @@ cdef class CGraphBackend(GenericGraphBackend):
             2
             sage: from sage.graphs.base.sparse_graph import SparseGraphBackend
             sage: S = SparseGraphBackend(7)
-            sage: S.num_edges(False)
+            sage: S.n_edges(False)
             0
             sage: S.loops(True)
             sage: S.add_edge(1, 1, None, directed=False)
-            sage: S.num_edges(False)
+            sage: S.n_edges(False)
             1
             sage: S.multiple_edges(True)
             sage: S.add_edge(1, 1, None, directed=False)
-            sage: S.num_edges(False)
+            sage: S.n_edges(False)
             2
             sage: from sage.graphs.base.dense_graph import DenseGraphBackend
             sage: D = DenseGraphBackend(7)
-            sage: D.num_edges(False)
+            sage: D.n_edges(False)
             0
             sage: D.loops(True)
             sage: D.add_edge(1, 1, None, directed=False)
-            sage: D.num_edges(False)
+            sage: D.n_edges(False)
             1
         """
         if directed:
@@ -1521,7 +1521,9 @@ cdef class CGraphBackend(GenericGraphBackend):
             i = (i - k) // 2
             return i + k
 
-    def num_verts(self):
+    num_edges = n_edges
+
+    def n_vertices(self):
         """
         Return the number of vertices in ``self``.
 
@@ -1529,16 +1531,18 @@ cdef class CGraphBackend(GenericGraphBackend):
 
         .. SEEALSO::
 
-            - :meth:`num_edges`
+            - :meth:`n_edges`
               -- return the number of (directed) edges in this graph.
 
         EXAMPLES::
 
             sage: G = Graph(graphs.PetersenGraph())
-            sage: G._backend.num_verts()
+            sage: G._backend.n_vertices()
             10
         """
         return self.cg().num_verts
+
+    num_verts = n_vertices
 
     cdef bint _delete_edge_before_adding(self) noexcept:
         """

--- a/src/sage/graphs/base/graph_backends.pyx
+++ b/src/sage/graphs/base/graph_backends.pyx
@@ -35,8 +35,8 @@ Any graph backend must redefine the following methods (for which
     :meth:`~GenericGraphBackend.loops` | Get/set whether or not ``self`` allows loops.
     :meth:`~GenericGraphBackend.multiple_edges` | Get/set whether or not ``self`` allows multiple edges.
     :meth:`~GenericGraphBackend.name` | Get/set name of ``self``.
-    :meth:`~GenericGraphBackend.num_edges` | The number of edges in ``self``
-    :meth:`~GenericGraphBackend.num_verts` | The number of vertices in ``self``
+    :meth:`~GenericGraphBackend.n_edges` | The number of edges in ``self``
+    :meth:`~GenericGraphBackend.n_vertices` | The number of vertices in ``self``
     :meth:`~GenericGraphBackend.relabel` | Relabel the vertices of ``self`` by a permutation.
     :meth:`~GenericGraphBackend.set_edge_label` | Label the edge `(u,v)` by `l`.
 
@@ -583,7 +583,7 @@ cdef class GenericGraphBackend(SageObject):
         """
         raise NotImplementedError()
 
-    def num_edges(self, directed):
+    def n_edges(self, directed):
         """
         Return the number of edges in ``self``.
 
@@ -594,30 +594,34 @@ cdef class GenericGraphBackend(SageObject):
         TESTS::
 
             sage: G = sage.graphs.base.graph_backends.GenericGraphBackend()
-            sage: G.num_edges(True)
+            sage: G.n_edges(True)
             Traceback (most recent call last):
             ...
             NotImplementedError
-            sage: G.num_edges(False)
+            sage: G.n_edges(False)
             Traceback (most recent call last):
             ...
             NotImplementedError
         """
         raise NotImplementedError()
 
-    def num_verts(self):
+    num_edges = n_edges
+
+    def n_vertices(self):
         """
         Return the number of vertices in ``self``.
 
         TESTS::
 
             sage: G = sage.graphs.base.graph_backends.GenericGraphBackend()
-            sage: G.num_verts()
+            sage: G.n_vertices()
             Traceback (most recent call last):
             ...
             NotImplementedError
         """
         raise NotImplementedError()
+
+    num_verts = n_vertices
 
     def relabel(self, perm, directed):
         """

--- a/src/sage/graphs/base/static_sparse_backend.pyx
+++ b/src/sage/graphs/base/static_sparse_backend.pyx
@@ -980,7 +980,7 @@ cdef class StaticSparseBackend(CGraphBackend):
                 yield x
         return
 
-    def num_verts(self):
+    def n_vertices(self):
         r"""
         Return the number of vertices.
 
@@ -988,10 +988,12 @@ cdef class StaticSparseBackend(CGraphBackend):
 
             sage: from sage.graphs.base.static_sparse_backend import StaticSparseBackend
             sage: g = StaticSparseBackend(graphs.PetersenGraph())
-            sage: g.num_verts()
+            sage: g.n_vertices()
             10
         """
         return self._order
+
+    num_verts = n_vertices
 
     def allows_loops(self, value=None):
         r"""
@@ -1043,7 +1045,7 @@ cdef class StaticSparseBackend(CGraphBackend):
         else:
             raise ValueError("the graph is immutable and cannot be changed in any way")
 
-    def num_edges(self, directed):
+    def n_edges(self, directed):
         r"""
         Return the number of edges.
 
@@ -1056,13 +1058,13 @@ cdef class StaticSparseBackend(CGraphBackend):
 
             sage: from sage.graphs.base.static_sparse_backend import StaticSparseBackend
             sage: g = StaticSparseBackend(graphs.PetersenGraph())
-            sage: g.num_edges(False)
+            sage: g.n_edges(False)
             15
 
         Testing the exception::
 
             sage: g = StaticSparseBackend(digraphs.Circuit(4))
-            sage: g.num_edges(False)
+            sage: g.n_edges(False)
             Traceback (most recent call last):
             ...
             NotImplementedError: Sorry, I have no idea what is expected in this situation. I don't think that it is well-defined either, especially for multigraphs.
@@ -1094,6 +1096,8 @@ cdef class StaticSparseBackend(CGraphBackend):
             else:
                 # Returns the number of edges
                 return int(cg.g.m)
+
+    num_edges = n_edges
 
     def iterator_edges(self, vertices, bint labels):
         r"""

--- a/src/sage/graphs/bliss.pyx
+++ b/src/sage/graphs/bliss.pyx
@@ -476,7 +476,7 @@ cpdef canonical_form(G, partition=None, return_graph=False,
         ....:     for labels in product([0,1], repeat=len(edges)):
         ....:         g = Graph([(u,v,l) for ((u,v),l) in zip(edges, labels)])
         ....:         gcan = canonical_form(g, use_edge_labels=True)
-        ....:         for p in permutations(range(g.num_verts())):
+        ....:         for p in permutations(range(g.n_vertices())):
         ....:             h = Graph([(p[u], p[v], lab) for u,v,lab in g.edges(sort=True)])
         ....:             hcan = canonical_form(h, use_edge_labels=True)
         ....:             if gcan != hcan: print(edges, labels, p)

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -1494,7 +1494,7 @@ class DiGraph(GenericGraph):
 
         .. SEEALSO::
 
-            :meth:`num_verts` for the value at `(x, y) = (1, 1)`
+            :meth:`n_vertices` for the value at `(x, y) = (1, 1)`
 
         EXAMPLES::
 

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -1611,7 +1611,7 @@ class DiGraph(GenericGraph):
         `vu` is in the returned feedback arc set::
 
            sage: g = graphs.RandomGNP(5,.3)
-           sage: while not g.num_edges():
+           sage: while not g.n_edges():
            ....:     g = graphs.RandomGNP(5,.3)
            sage: dg = DiGraph(g)
            sage: feedback = dg.feedback_edge_set()                                      # needs sage.numerical.mip

--- a/src/sage/graphs/digraph_generators.py
+++ b/src/sage/graphs/digraph_generators.py
@@ -1536,9 +1536,9 @@ class DiGraphGenerators:
 
             sage: # needs networkx
             sage: D = digraphs.RandomDirectedGN(25)
-            sage: D.num_verts()
+            sage: D.n_vertices()
             25
-            sage: D.num_edges()
+            sage: D.n_edges()
             24
             sage: D.is_connected()
             True
@@ -1618,7 +1618,7 @@ class DiGraphGenerators:
         EXAMPLES::
 
             sage: D = digraphs.RandomDirectedGNP(10, .2)
-            sage: D.num_verts()
+            sage: D.n_vertices()
             10
             sage: D.parent() is DiGraph
             True
@@ -1654,15 +1654,15 @@ class DiGraphGenerators:
         EXAMPLES::
 
             sage: D = digraphs.RandomDirectedGNM(10, 5)
-            sage: D.num_verts()
+            sage: D.n_vertices()
             10
-            sage: D.num_edges()
+            sage: D.n_edges()
             5
 
         With loops::
 
             sage: D = digraphs.RandomDirectedGNM(10, 100, loops = True)
-            sage: D.num_verts()
+            sage: D.n_vertices()
             10
             sage: D.loops()
             [(0, 0, None), (1, 1, None), (2, 2, None), (3, 3, None),

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -561,9 +561,9 @@ def BarbellGraph(n1, n2):
 
         sage: n1, n2 = randint(3, 10), randint(0, 10)
         sage: g = graphs.BarbellGraph(n1, n2)
-        sage: g.num_verts() == 2 * n1 + n2
+        sage: g.n_vertices() == 2 * n1 + n2
         True
-        sage: g.num_edges() == 2 * binomial(n1, 2) + n2 + 1                             # needs sage.symbolic
+        sage: g.n_edges() == 2 * binomial(n1, 2) + n2 + 1                               # needs sage.symbolic
         True
         sage: g.is_connected()
         True
@@ -638,9 +638,9 @@ def LollipopGraph(n1, n2):
 
         sage: n1, n2 = randint(3, 10), randint(0, 10)
         sage: g = graphs.LollipopGraph(n1, n2)
-        sage: g.num_verts() == n1 + n2
+        sage: g.n_vertices() == n1 + n2
         True
-        sage: g.num_edges() == binomial(n1, 2) + n2                                     # needs sage.symbolic
+        sage: g.n_edges() == binomial(n1, 2) + n2                                       # needs sage.symbolic
         True
         sage: g.is_connected()
         True
@@ -711,9 +711,9 @@ def TadpoleGraph(n1, n2):
 
         sage: n1, n2 = randint(3, 10), randint(0, 10)
         sage: g = graphs.TadpoleGraph(n1, n2)
-        sage: g.num_verts() == n1 + n2
+        sage: g.n_vertices() == n1 + n2
         True
-        sage: g.num_edges() == n1 + n2
+        sage: g.n_edges() == n1 + n2
         True
         sage: g.girth() == n1
         True
@@ -761,10 +761,10 @@ def AztecDiamondGraph(n):
         sage: graphs.AztecDiamondGraph(2)
         Aztec Diamond graph of order 2
 
-        sage: [graphs.AztecDiamondGraph(i).num_verts() for i in range(8)]
+        sage: [graphs.AztecDiamondGraph(i).n_vertices() for i in range(8)]
         [0, 4, 12, 24, 40, 60, 84, 112]
 
-        sage: [graphs.AztecDiamondGraph(i).num_edges() for i in range(8)]
+        sage: [graphs.AztecDiamondGraph(i).n_edges() for i in range(8)]
         [0, 4, 16, 36, 64, 100, 144, 196]
 
         sage: G = graphs.AztecDiamondGraph(3)
@@ -803,9 +803,9 @@ def DipoleGraph(n):
 
         sage: n = randint(0, 10)
         sage: g = graphs.DipoleGraph(n)
-        sage: g.num_verts() == 2
+        sage: g.n_vertices() == 2
         True
-        sage: g.num_edges() == n
+        sage: g.n_edges() == n
         True
         sage: g.is_connected() == (n > 0)
         True
@@ -2660,7 +2660,7 @@ def HanoiTowerGraph(pegs, disks, labels=True, positions=True):
     A slightly larger instance. ::
 
         sage: H = graphs.HanoiTowerGraph(4, 6, labels=False, positions=False)
-        sage: H.num_verts()
+        sage: H.n_vertices()
         4096
         sage: H.distance(0, 4^6-1)
         17

--- a/src/sage/graphs/generators/smallgraphs.py
+++ b/src/sage/graphs/generators/smallgraphs.py
@@ -3285,7 +3285,7 @@ def HoffmanSingletonGraph():
         5
         sage: HS.diameter()
         2
-        sage: HS.num_verts()
+        sage: HS.n_vertices()
         50
 
     Note that you get a different layout each time you create the graph.  ::

--- a/src/sage/graphs/generators/trees.pyx
+++ b/src/sage/graphs/generators/trees.pyx
@@ -306,7 +306,7 @@ def RandomLobster(n, p, q, seed=None):
         sage: G.delete_vertices(leaves)                                 # path
         sage: s = G.degree_sequence()
         sage: if G:
-        ....:     if G.num_verts() == 1:
+        ....:     if G.n_vertices() == 1:
         ....:         assert s == [0]
         ....:     else:
         ....:         assert s[-2:] == [1, 1]
@@ -511,7 +511,7 @@ cdef class TreeIterator:
         ....:     for t in TreeIterator(n):
         ....:         if not t.is_tree():
         ....:             return False
-        ....:         if t.num_verts() != n:
+        ....:         if t.n_vertices() != n:
         ....:             return False
         ....:         if t.num_edges() != n - 1:
         ....:             return False

--- a/src/sage/graphs/generators/trees.pyx
+++ b/src/sage/graphs/generators/trees.pyx
@@ -513,7 +513,7 @@ cdef class TreeIterator:
         ....:             return False
         ....:         if t.n_vertices() != n:
         ....:             return False
-        ....:         if t.num_edges() != n - 1:
+        ....:         if t.n_edges() != n - 1:
         ....:             return False
         ....:         for tree in trees:
         ....:             if tree.is_isomorphic(t):

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -4803,8 +4803,8 @@ class GenericGraph(GenericGraph_pyx):
         """
         Return the number of vertices.
 
-        Note that ``len(G)`` and :meth:`num_verts` also return the number of
-        vertices in `G`.
+        Note that ``len(G)`` and :meth:`n_vertices` also return the
+        number of vertices in `G`.
 
         EXAMPLES::
 
@@ -4817,6 +4817,7 @@ class GenericGraph(GenericGraph_pyx):
             sage: G = graphs.TetrahedralGraph()
             sage: len(G)
             4
+
         """
         return self._backend.num_verts()
 
@@ -4824,21 +4825,26 @@ class GenericGraph(GenericGraph_pyx):
 
     num_verts = order
 
+    n_vertices = order
+
     def size(self):
         """
         Return the number of edges.
 
-        Note that :meth:`num_edges` also returns the number of edges in `G`.
+        Note that :meth:`n_edges` also returns the number of edges in `G`.
 
         EXAMPLES::
 
             sage: G = graphs.PetersenGraph()
             sage: G.size()
             15
+
         """
         return self._backend.num_edges(self._directed)
 
     num_edges = size
+
+    n_edges = size
 
     def eulerian_circuit(self, return_vertices=False, labels=True, path=False):
         r"""
@@ -6987,7 +6993,7 @@ class GenericGraph(GenericGraph_pyx):
             faces.append(path)
         return faces
 
-    def num_faces(self, embedding=None):
+    def n_faces(self, embedding=None):
         """
         Return the number of faces of an embedded graph.
 
@@ -7073,6 +7079,8 @@ class GenericGraph(GenericGraph_pyx):
             emb = None if embedding is None else {v: embedding[v] for v in g}
             F += g.num_faces(emb) - 1
         return F
+
+    num_faces = n_faces
 
     def planar_dual(self, embedding=None):
         """

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -870,7 +870,7 @@ class GenericGraph(GenericGraph_pyx):
             '101001100110000010000001001000010110000010110'
             sage: len([a for a in G._bit_vector() if a == '1'])
             15
-            sage: G.num_edges()
+            sage: G.n_edges()
             15
 
         TESTS:
@@ -7021,35 +7021,35 @@ class GenericGraph(GenericGraph_pyx):
         EXAMPLES::
 
             sage: T = graphs.TetrahedralGraph()
-            sage: T.num_faces()
+            sage: T.n_faces()
             4
 
         The external face of a disconnected graph is counted only once::
 
-            sage: (T + T).num_faces()
+            sage: (T + T).n_faces()
             7
-            sage: (T + T + T).num_faces()
+            sage: (T + T + T).n_faces()
             10
 
         Trees and forests have a single face::
 
             sage: T = graphs.RandomTree(10)
-            sage: T.num_faces()
+            sage: T.n_faces()
             1
-            sage: (T + T).num_faces()
+            sage: (T + T).n_faces()
             1
 
         TESTS::
 
             sage: G = graphs.CompleteBipartiteGraph(3, 3)
-            sage: G.num_faces()
+            sage: G.n_faces()
             Traceback (most recent call last):
             ...
             ValueError: no embedding is provided and the graph is not planar
 
         Issue :issue:`22003` is fixed::
 
-            sage: Graph(1).num_faces()
+            sage: Graph(1).n_faces()
             1
         """
         if not self:
@@ -13297,10 +13297,10 @@ class GenericGraph(GenericGraph_pyx):
         ::
 
             sage: G = Graph({0: {1: 1}}, sparse=True)
-            sage: G.num_edges()
+            sage: G.n_edges()
             1
             sage: G.set_edge_label(0, 1, 1)
-            sage: G.num_edges()
+            sage: G.n_edges()
             1
         """
         if self.allows_multiple_edges():
@@ -20260,7 +20260,7 @@ class GenericGraph(GenericGraph_pyx):
              ((1, 'ab'), (1, 'ba')), ((1, 'ab'), (1, 'bb')),
              ((1, 'ba'), (1, 'aa')), ((1, 'ba'), (1, 'ab')),
              ((1, 'bb'), (1, 'ba')), ((1, 'bb'), (1, 'bb'))]
-            sage: Q.strongly_connected_components_digraph().num_verts()                 # needs sage.combinat
+            sage: Q.strongly_connected_components_digraph().n_vertices()                # needs sage.combinat
             2
             sage: V = Q.strongly_connected_component_containing_vertex((0, 'aa'))       # needs sage.combinat
             sage: B.is_isomorphic(Q.subgraph(V))                                        # needs sage.combinat
@@ -26383,7 +26383,7 @@ class GenericGraph(GenericGraph_pyx):
 
             sage: n = randint(5, 12)
             sage: G = Graph()
-            sage: while not G.num_edges():                                              # needs networkx
+            sage: while not G.n_edges():                                                # needs networkx
             ....:     G = graphs.RandomGNP(n, 0.2)
             sage: P = G.symmetric_edge_polytope()                                       # needs networkx sage.geometry.polyhedron
             sage: P.ambient_dim() == n                                                  # needs networkx sage.geometry.polyhedron

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -968,9 +968,9 @@ class Graph(GenericGraph):
         Loops are not counted as multiedges (see :issue:`11693`) and edges are
         not counted twice ::
 
-            sage: Graph({1:[1]}).num_edges()
+            sage: Graph({1:[1]}).n_edges()
             1
-            sage: Graph({1:[2,2]}).num_edges()
+            sage: Graph({1:[2,2]}).n_edges()
             2
 
         An empty list or dictionary defines a simple graph
@@ -5363,7 +5363,7 @@ class Graph(GenericGraph):
 
             sage: G = graphs.OddGraph(4)
             sage: d = G.diameter()
-            sage: n = G.num_verts()
+            sage: n = G.n_vertices()
             sage: H = G.distance_graph(list(range(d+1)))
             sage: H.is_isomorphic(graphs.CompleteGraph(n))
             False
@@ -5418,10 +5418,10 @@ class Graph(GenericGraph):
         Empty input, or unachievable distances silently yield empty graphs::
 
             sage: G = graphs.CompleteGraph(5)
-            sage: G.distance_graph([]).num_edges()
+            sage: G.distance_graph([]).n_edges()
             0
             sage: G = graphs.CompleteGraph(5)
-            sage: G.distance_graph(23).num_edges()
+            sage: G.distance_graph(23).n_edges()
             0
 
         It is an error to provide a distance that is not an integer type::

--- a/src/sage/graphs/graph_generators.py
+++ b/src/sage/graphs/graph_generators.py
@@ -798,7 +798,7 @@ class GraphGenerators:
         ::
 
             sage: for g in graphs():
-            ....:    if g.num_verts() > 3: break
+            ....:    if g.n_vertices() > 3: break
             ....:    print(g)
             Graph on 0 vertices
             Graph on 1 vertex

--- a/src/sage/graphs/graph_generators_pyx.pyx
+++ b/src/sage/graphs/graph_generators_pyx.pyx
@@ -52,7 +52,7 @@ def RandomGNP(n, p, bint directed=False, bint loops=False, seed=None,
 
         sage: from sage.graphs.graph_generators_pyx import RandomGNP
         sage: D = RandomGNP(10, .2, directed=True, seed=0)
-        sage: D.num_verts()
+        sage: D.n_vertices()
         10
         sage: D.edges(sort=True, labels=False)
         [(0, 3), (0, 6), (1, 7), (1, 9), (4, 6), (4, 7), (5, 4), (5, 6),

--- a/src/sage/graphs/hypergraph_generators.py
+++ b/src/sage/graphs/hypergraph_generators.py
@@ -304,9 +304,9 @@ class HypergraphGenerators:
 
         EXAMPLES::
 
-            sage: hypergraphs.BinomialRandomUniform(50, 3, 1).num_blocks()              # needs numpy, long time
+            sage: hypergraphs.BinomialRandomUniform(50, 3, 1).n_blocks()              # needs numpy, long time
             19600
-            sage: hypergraphs.BinomialRandomUniform(50, 3, 0).num_blocks()              # needs numpy
+            sage: hypergraphs.BinomialRandomUniform(50, 3, 0).n_blocks()              # needs numpy
             0
 
         TESTS::

--- a/src/sage/groups/perm_gps/partn_ref/refinement_graphs.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/refinement_graphs.pyx
@@ -362,18 +362,18 @@ def search_tree(G_in, partition, lab=True, dig=False, dict_rep=False, certificat
     Certain border cases need to be tested as well::
 
         sage: G = Graph('Fll^G')
-        sage: a,b,c = st(G, [range(G.num_verts())], order=True); b
+        sage: a,b,c = st(G, [range(G.n_vertices())], order=True); b
         Graph on 7 vertices
         sage: c
         48
         sage: G = Graph(21)
-        sage: st(G, [range(G.num_verts())], order=True)[2] == factorial(21)
+        sage: st(G, [range(G.n_vertices())], order=True)[2] == factorial(21)
         True
 
         sage: G = Graph('^????????????????????{??N??@w??FaGa?PCO@CP?AGa?_QO?Q@G?CcA??cc????Bo????{????F_')
         sage: perm = {3:15, 15:3}
         sage: H = G.relabel(perm, inplace=False)
-        sage: st(G, [range(G.num_verts())])[1] == st(H, [range(H.num_verts())])[1]
+        sage: st(G, [range(G.n_vertices())])[1] == st(H, [range(H.n_vertices())])[1]
         True
 
         sage: st(Graph(':Dkw'), [range(5)], lab=False, dig=True)

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -21078,13 +21078,13 @@ def _matrix_power_symbolic(A, n):
 
     # Where each Jordan block starts, and number of blocks
     block_start = [0] + J.subdivisions()[0]
-    num_blocks = len(block_start)
+    n_blocks = len(block_start)
 
     # Prepare matrix M to store `J^n`, computed by Jordan block
     M = matrix(SR, J.ncols())
     M.subdivide(J.subdivisions())
 
-    for k in range(num_blocks):
+    for k in range(n_blocks):
 
         # Jordan block Jk, its dimension nk, the eigenvalue m
         Jk = J.subdivision(k, k)

--- a/src/sage/matroids/graphic_matroid.pyx
+++ b/src/sage/matroids/graphic_matroid.pyx
@@ -66,7 +66,7 @@ modified::
     sage: N1 = M1.contract((0,1))
     sage: N1.graph().edges_incident(0, sort=True)
     [(0, 2, (0, 2)), (0, 2, (1, 2)), (0, 3, (1, 3))]
-    sage: M2 = Matroid(range(G.num_edges()), G)
+    sage: M2 = Matroid(range(G.n_edges()), G)
     sage: N2 = M2.contract(0)
     sage: N1.is_isomorphic(N2)
     True
@@ -229,7 +229,7 @@ cdef class GraphicMatroid(Matroid):
             sage: sorted(M.groundset())
             [(0, 1), (0, 2), (1, 2), (1, 3), (2, 3)]
             sage: G = graphs.CompleteGraph(3).disjoint_union(graphs.CompleteGraph(4))
-            sage: M = Matroid(range(G.num_edges()), G); sorted(M.groundset())
+            sage: M = Matroid(range(G.n_edges()), G); sorted(M.groundset())
             [0, 1, 2, 3, 4, 5, 6, 7, 8]
             sage: M = Matroid(Graph([(0, 1, 'a'), (0, 2, 'b'), (0, 3, 'c')]))
             sage: sorted(M.groundset())
@@ -1178,7 +1178,7 @@ cdef class GraphicMatroid(Matroid):
 
             sage: G = Graph([(0, 1), (0, 2), (1, 2), (3, 4), (3, 5), (4, 5),
             ....: (6, 7), (6, 8), (7, 8), (8, 8), (7, 8)], multiedges=True, loops=True)
-            sage: M = Matroid(range(G.num_edges()), G)
+            sage: M = Matroid(range(G.n_edges()), G)
             sage: M.graph().edges(sort=True)
             [(0, 1, 0),
              (0, 2, 1),

--- a/src/sage/sandpiles/sandpile.py
+++ b/src/sage/sandpiles/sandpile.py
@@ -4879,7 +4879,7 @@ class SandpileDivisor(dict):
             {0: 2, 1: 3, 2: 1, 3: 2}
             sage: n(mean([D.simulate_threshold().deg() for _ in range(10)]))  # random
             7.10000000000000
-            sage: n(s.stationary_density()*s.num_verts())
+            sage: n(s.stationary_density()*s.n_vertices())
             6.93750000000000
 
         .. NOTE::


### PR DESCRIPTION
This provides aliases `n_vertices`, `n_edges` and `n_faces`, and uses them throughout the docstring `EXAMPLES`.

The old aliases `num_verts`,`num_edges` and `num_faces` are kept.  Also, they are kept in the code base, to avoid touching too many files.