### PR TITLE
the poset of conjugacy classes of subgroups of the symmetric group is not a lattice

### DIFF
--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1352,7 +1352,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 sage: M(DihedralGroup(4)) < M(CyclicPermutationGroup(4))
                 True
 
-            We create the lattice of molecular species of degree four::
+            We create the poset of molecular species of degree four::
 
                 sage: P = Poset([M.subset(4), lambda b, c: b <= c])
                 sage: len(P.cover_relations())


### PR DESCRIPTION
(for degree at least 5)

This PR fixes wording that is misleading at best.