### PR TITLE
provide alias number_of_connected_components

### DIFF
--- a/src/sage/algebras/fusion_rings/f_matrix.py
+++ b/src/sage/algebras/fusion_rings/f_matrix.py
@@ -1717,7 +1717,7 @@ class FMatrix(SageObject):
         for eq_tup in eqns:
             partition[tuple(graph.connected_component_containing_vertex(variables(eq_tup)[0], sort=True))].append(eq_tup)
         if verbose:
-            print("Partitioned {} equations into {} components of size:".format(len(eqns), graph.connected_components_number()))
+            print("Partitioned {} equations into {} components of size:".format(len(eqns), graph.number_of_connected_components()))
             print(graph.connected_components_sizes())
         return partition
 

--- a/src/sage/combinat/root_system/cartan_matrix.py
+++ b/src/sage/combinat/root_system/cartan_matrix.py
@@ -934,7 +934,7 @@ class CartanMatrix(Base, CartanType_abstract,
             sage: M.is_indecomposable()
             False
         """
-        comp_num = self.dynkin_diagram().connected_components_number()
+        comp_num = self.dynkin_diagram().number_of_connected_components()
         # consider the empty matrix to be indecomposable
         return comp_num <= 1
 

--- a/src/sage/combinat/root_system/dynkin_diagram.py
+++ b/src/sage/combinat/root_system/dynkin_diagram.py
@@ -681,7 +681,7 @@ class DynkinDiagram_class(DiGraph, CartanType_abstract):
         """
         if self._cartan_type is not None:
             return self._cartan_type.is_irreducible()
-        return self.connected_components_number() == 1
+        return self.number_of_connected_components() == 1
 
     def is_crystallographic(self):
         """

--- a/src/sage/combinat/root_system/pieri_factors.py
+++ b/src/sage/combinat/root_system/pieri_factors.py
@@ -888,7 +888,9 @@ class PieriFactors_type_C_affine(PieriFactors_affine_type):
         # The algorithm="delete" is a workaround when the set of
         # vertices is empty, in which case subgraph tries another
         # method which turns out to currently fail with Dynkin diagrams
-        return DiGraph(DynkinDiagram(w.parent().cartan_type())).subgraph(set(w.reduced_word()), algorithm='delete').connected_components_number()
+        D = DiGraph(DynkinDiagram(w.parent().cartan_type()))
+        return D.subgraph(set(w.reduced_word()),
+                          algorithm='delete').number_of_connected_components()
 
 
 class PieriFactors_type_B_affine(PieriFactors_affine_type):
@@ -997,7 +999,8 @@ class PieriFactors_type_B_affine(PieriFactors_affine_type):
             support_complement = set(ct.index_set()).difference(support).difference(set([0, 1]))
         else:
             support_complement = set(ct.index_set()).difference(support).difference(set([0]))
-        return DiGraph(DynkinDiagram(ct)).subgraph(support_complement, algorithm='delete').connected_components_number() - 1
+        D = DiGraph(DynkinDiagram(ct))
+        return D.subgraph(support_complement, algorithm='delete').number_of_connected_components() - 1
 
 
 class PieriFactors_type_D_affine(PieriFactors_affine_type):
@@ -1120,7 +1123,8 @@ class PieriFactors_type_D_affine(PieriFactors_affine_type):
         if n in support or n - 1 in support:
             support = support.union(set([n - 2])).difference(set([n - 1]))
         support_complement = set(range(1, n - 1)).difference(support)
-        return DiGraph(DynkinDiagram(ct)).subgraph(support_complement).connected_components_number() - 1
+        D = DiGraph(DynkinDiagram(ct))
+        return D.subgraph(support_complement).number_of_connected_components() - 1
 
 
 # Inserts those classes in CartanTypes

--- a/src/sage/graphs/connectivity.pyx
+++ b/src/sage/graphs/connectivity.pyx
@@ -16,7 +16,7 @@ Here is what the module can do:
 
     :meth:`is_connected` | Check whether the (di)graph is connected.
     :meth:`connected_components` | Return the list of connected components
-    :meth:`connected_components_number` | Return the number of connected components.
+    :meth:`number_of_connected_components` | Return the number of connected components.
     :meth:`connected_components_subgraphs` | Return a list of connected components as graph objects.
     :meth:`connected_component_containing_vertex` | Return a list of the vertices connected to vertex.
     :meth:`connected_components_sizes` | Return the sizes of the connected components as a list.
@@ -238,7 +238,7 @@ def connected_components(G, sort=False, key=None, forbidden_vertices=None):
     return components
 
 
-def connected_components_number(G, forbidden_vertices=None):
+def number_of_connected_components(G, forbidden_vertices=None):
     """
     Return the number of connected components.
 
@@ -251,30 +251,32 @@ def connected_components_number(G, forbidden_vertices=None):
 
     EXAMPLES::
 
-        sage: from sage.graphs.connectivity import connected_components_number
+        sage: from sage.graphs.connectivity import number_of_connected_components
         sage: G = Graph({0: [1, 3], 1: [2], 2: [3], 4: [5, 6], 5: [6]})
-        sage: connected_components_number(G)
+        sage: number_of_connected_components(G)
         2
-        sage: G.connected_components_number()
+        sage: G.number_of_connected_components()
         2
         sage: D = DiGraph({0: [1, 3], 1: [2], 2: [3], 4: [5, 6], 5: [6]})
-        sage: connected_components_number(D)
+        sage: number_of_connected_components(D)
         2
-        sage: connected_components_number(D, forbidden_vertices=[1, 3])
+        sage: number_of_connected_components(D, forbidden_vertices=[1, 3])
         3
 
     TESTS:
 
     If ``G`` is not a Sage graph, an error is raised::
 
-        sage: from sage.graphs.connectivity import connected_components_number
-        sage: connected_components_number('I am not a graph')
+        sage: from sage.graphs.connectivity import number_of_connected_components
+        sage: number_of_connected_components('I am not a graph')
         Traceback (most recent call last):
         ...
         TypeError: the input must be a Sage graph
     """
     return len(connected_components(G, sort=False,
                                     forbidden_vertices=forbidden_vertices))
+
+connected_components_number = number_of_connected_components
 
 
 def connected_components_subgraphs(G, forbidden_vertices=None):

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -238,7 +238,7 @@ can be applied on both. Here is what it can do:
 
     :meth:`~GenericGraph.is_connected` | Test whether the (di)graph is connected.
     :meth:`~GenericGraph.connected_components` | Return the list of connected components
-    :meth:`~GenericGraph.connected_components_number` | Return the number of connected components.
+    :meth:`~GenericGraph.number_of_connected_components` | Return the number of connected components.
     :meth:`~GenericGraph.connected_components_subgraphs` | Return a list of connected components as graph objects.
     :meth:`~GenericGraph.connected_component_containing_vertex` | Return a list of the vertices connected to vertex.
     :meth:`~GenericGraph.connected_components_sizes` | Return the sizes of the connected components as a list.
@@ -7059,7 +7059,7 @@ class GenericGraph(GenericGraph_pyx):
             if embedding is None:
                 if self.is_planar():
                     # We use Euler's formula: V-E+F-C=1
-                    C = self.connected_components_number()
+                    C = self.number_of_connected_components()
                     return self.size() - self.order() + C + 1
                 else:
                     raise ValueError("no embedding is provided and the graph is not planar")
@@ -25997,6 +25997,7 @@ class GenericGraph(GenericGraph_pyx):
         connected_component_containing_vertex,
         connected_components,
         connected_components_number,
+        number_of_connected_components,
         connected_components_sizes,
         connected_components_subgraphs,
         edge_connectivity,
@@ -26383,7 +26384,7 @@ class GenericGraph(GenericGraph_pyx):
             sage: P = G.symmetric_edge_polytope()                                       # needs networkx sage.geometry.polyhedron
             sage: P.ambient_dim() == n                                                  # needs networkx sage.geometry.polyhedron
             True
-            sage: P.dim() == n - G.connected_components_number()                        # needs networkx sage.geometry.polyhedron
+            sage: P.dim() == n - G.number_of_connected_components()                     # needs networkx sage.geometry.polyhedron
             True
 
         The SEP of a graph is isomorphic to the subdirect sum of

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -273,7 +273,7 @@ def is_bicritical(G, matching=None, algorithm='Edmonds', coNP_certificate=False,
 
         sage: G = graphs.CycleGraph(4)
         sage: G += graphs.CycleGraph(6)
-        sage: G.connected_components_number()
+        sage: G.number_of_connected_components()
         2
         sage: G.is_bicritical()
         False

--- a/src/sage/graphs/matching_covered_graph.py
+++ b/src/sage/graphs/matching_covered_graph.py
@@ -388,7 +388,7 @@ class MatchingCoveredGraph(Graph):
 
         sage: G = graphs.CycleGraph(4)
         sage: G += graphs.CycleGraph(6)
-        sage: G.connected_components_number()
+        sage: G.number_of_connected_components()
         2
         sage: H = MatchingCoveredGraph(G)
         Traceback (most recent call last):

--- a/src/sage/graphs/tutte_polynomial.py
+++ b/src/sage/graphs/tutte_polynomial.py
@@ -648,12 +648,12 @@ def _tutte_polynomial_internal(G, x, y, edge_selector, cache=None):
     if len(blocks) > 1:
         return prod([recursive_tp(G.subgraph(block)) for block in blocks])
 
-    components = G.connected_components_number()
+    components = G.number_of_connected_components()
     edge = edge_selector(G)
     unlabeled_edge = edge[:2]
 
     with removed_edge(G, edge):
-        if G.connected_components_number() > components:
+        if G.number_of_connected_components() > components:
             with contracted_edge(G, unlabeled_edge):
                 return x*recursive_tp()
 

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -1921,7 +1921,7 @@ class Link(SageObject):
         for c in pd:
             G.add_edge(c[0], c[2])
             G.add_edge(c[3], c[1])
-        return G.connected_components_number()
+        return G.number_of_connected_components()
 
     def is_knot(self) -> bool:
         r"""

--- a/src/sage/matroids/graphic_matroid.pyx
+++ b/src/sage/matroids/graphic_matroid.pyx
@@ -710,13 +710,13 @@ cdef class GraphicMatroid(Matroid):
         cdef list edgelist = self._groundset_to_edges(Y)
         cdef GenericGraph_pyx g = self._subgraph_from_set(XX)
         cdef list V = g.vertices(sort=False)
-        cdef int components = g.connected_components_number()
+        cdef int components = g.number_of_connected_components()
         for e in edgelist:
             # a non-loop edge is in the closure iff both its vertices are
             # in the induced subgraph, and the edge doesn't connect components
             if e[0] in V and e[1] in V:
                 g.add_edge(e)
-                if g.connected_components_number() >= components:
+                if g.number_of_connected_components() >= components:
                     XX.add(e[2])
                 else:
                     g.delete_edge(e)
@@ -906,12 +906,12 @@ cdef class GraphicMatroid(Matroid):
         """
         cdef GenericGraph_pyx g = self.graph()
         g.delete_edges(self._groundset_to_edges(X))
-        cdef int components = g.connected_components_number()
+        cdef int components = g.number_of_connected_components()
         cdef set XX = set(X)
         cdef frozenset Y = self.groundset().difference(XX)
         for e in self._groundset_to_edges(Y):
             g.delete_edge(e)
-            if g.connected_components_number() > components:
+            if g.number_of_connected_components() > components:
                 XX.add(e[2])
             g.add_edge(e)
         return frozenset(XX)


### PR DESCRIPTION
fix #40935 for `connected_components`

as with #40939: we have to decide whether this does not pollute the name space too much.