### PR TITLE
Fix finite field GF(p).extension(1, names=tuple)

### DIFF
--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -1421,6 +1421,21 @@ cdef class FiniteField(Field):
             sage: L.<v> = K.extension(b)
             sage: L(u).minpoly() == u.minpoly()
             True
+
+        Check the test above when `a=b=1`, see :issue:`40926`.
+        While in general it doesn't make much sense to talk about the generator
+        of a prime finite field (:meth:`gen` returns 1), generic code may find
+        it convenient to always specify the variable name when it is not known
+        in advance whether the exponent is 1.
+
+        The reason why one may want to specify ``name`` is :issue:`38376`.
+
+        ::
+
+            sage: K.<u> = GF((random_prime(10^100), 1))
+            sage: L.<v> = K.extension(1)
+            sage: L(u).minpoly() == u.minpoly()
+            True
         """
         from sage.rings.finite_rings.finite_field_constructor import GF
         from sage.rings.polynomial.polynomial_element import Polynomial

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -597,7 +597,7 @@ class FiniteFieldFactory(UniqueFactory):
             sage: GF((5, 1), 3)
             Traceback (most recent call last):
             ...
-            TypeError: variable name 3 must be a string, not <class 'sage.rings.integer.Integer'>
+            TypeError: 'sage.rings.integer.Integer' object is not iterable
             sage: GF((5, 2), 3)
             Traceback (most recent call last):
             ...
@@ -610,6 +610,35 @@ class FiniteFieldFactory(UniqueFactory):
             Traceback (most recent call last):
             ...
             ValueError: the order of a finite field must be a prime power
+
+        We expect ``name`` to be a string (if it is a single name) and ``names`` to be
+        a tuple of strings, but for backwards compatibility this is not enforced.
+        This behavior might change in the future. ::
+
+            sage: GF(7, name='aa')
+            Finite Field of size 7
+            sage: GF(7^2, name='aa')
+            Finite Field in aa of size 7^2
+            sage: GF(7, name=('aa',))
+            Finite Field of size 7
+            sage: GF(7^2, name=('aa',))
+            Finite Field in aa of size 7^2
+            sage: GF(7, name=['aa'])
+            Finite Field of size 7
+            sage: GF(7^2, name=['aa'])
+            Finite Field in aa of size 7^2
+            sage: GF(7, names='aa')
+            Finite Field of size 7
+            sage: GF(7^2, names='aa')
+            Finite Field in aa of size 7^2
+            sage: GF(7, names=('aa',))
+            Finite Field of size 7
+            sage: GF(7^2, names=('aa',))
+            Finite Field in aa of size 7^2
+            sage: GF(7, names=['aa'])
+            Finite Field of size 7
+            sage: GF(7^2, names=['aa'])
+            Finite Field in aa of size 7^2
         """
         for key, val in kwds.items():
             if key not in ['structure', 'implementation', 'prec', 'embedding', 'latex_names']:
@@ -646,7 +675,7 @@ class FiniteFieldFactory(UniqueFactory):
                 if impl is None:
                     impl = 'modn'
                 if name is not None:
-                    certify_names((name,))
+                    certify_names((name,) if isinstance(name, str) else name)
                 name = ('x',)  # Ignore name
                 # Every polynomial of degree 1 is irreducible
                 check_irreducible = False


### PR DESCRIPTION
Fix #40926 .

there's an alternative way of calling `normalize_names(1, name)` (which internally calls `certify_name` anyway) where `normalize_names` accepts various name formats, but as far as I can see, that will accept any additional name format than what is accepted by 1 generator.

See also the follow-up in https://github.com/sagemath/sage/pull/40949

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


