### PR TITLE
speed up construction of kernel polynomial for Vélu isogeny using product tree

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -2244,11 +2244,10 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         else:
             invX = x
 
-        psi = poly_ring.one()
-        for xQ in self.__kernel_mod_sign.keys():
-            psi *= x - invX(xQ)
+        from sage.misc.misc_c import prod
+        psi = prod([x - invX(xQ) for xQ in self.__kernel_mod_sign.keys()])  # building the list is not redundant; this is slightly faster
 
-        self.__kernel_polynomial = psi
+        self.__kernel_polynomial = poly_ring(psi)
 
     ###################################
     # Kohel's Variant of Velu's Formula


### PR DESCRIPTION
Computing a product of a collection of linear polynomials is best done using a balanced product tree.

Example:
```sage
sage: E = EllipticCurve(GF(16411), [1,0])
sage: P = E.lift_x(25)
sage: phi = E.isogeny(P)
sage: assert phi._EllipticCurveIsogeny__algorithm == 'velu'
sage: %time _ = phi.kernel_polynomial()
```

Current `develop`:
```
CPU times: user 25.6 ms, sys: 0 ns, total: 25.6 ms
Wall time: 25.7 ms
```

This branch:
```
CPU times: user 13.7 ms, sys: 0 ns, total: 13.7 ms
Wall time: 13.8 ms
```