### PR TITLE
Use pytest for more TestSuite tests

### DIFF
--- a/src/sage/combinat/backtrack.py
+++ b/src/sage/combinat/backtrack.py
@@ -117,15 +117,6 @@ class PositiveIntegerSemigroup(UniqueRepresentation, RecursivelyEnumeratedSet_fo
         sage: some_elements = list(PP.some_elements()); some_elements
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100]
 
-    TESTS::
-
-        sage: from sage.combinat.backtrack import PositiveIntegerSemigroup
-        sage: PP = PositiveIntegerSemigroup()
-
-    We factor out the long test from the ``TestSuite``::
-
-        sage: TestSuite(PP).run(skip='_test_enumerated_set_contains')
-        sage: PP._test_enumerated_set_contains()  # long time
     """
 
     def __init__(self):

--- a/src/sage/combinat/meson.build
+++ b/src/sage/combinat/meson.build
@@ -90,6 +90,7 @@ py.install_sources(
   'permutation_cython.pxd',
   'permutation_cython.pyx',
   'plane_partition.py',
+  'positive_integer_semigroup_test.py',
   'q_analogues.py',
   'q_bernoulli.pyx',
   'quickref.py',

--- a/src/sage/combinat/positive_integer_semigroup_test.py
+++ b/src/sage/combinat/positive_integer_semigroup_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def test_positive_integer_semigroup():
+    r"""
+    Run the ``TestSuite()`` for ``PositiveIntegerSemigroup``
+    (this can take quite a long time).
+    """
+    from sage.misc.sage_unittest import TestSuite
+    from sage.combinat.backtrack import PositiveIntegerSemigroup
+    PP = PositiveIntegerSemigroup()
+
+    # fewer max_runs since these are kind of slow
+    TestSuite(PP).run(verbose=True,
+                      raise_on_failure=True,
+                      max_runs=256)

--- a/src/sage/misc/dev_tools.py
+++ b/src/sage/misc/dev_tools.py
@@ -275,8 +275,12 @@ def find_objects_from_name(name, module_name=None, include_lazy_imports=False):
     """
     from sage.misc.lazy_import import LazyImport
 
+    # Create a copy to avoid errors if the sys.modules dict changes
+    # while we are iterating over it.
+    mods = sys.modules.copy()
+
     obj = []
-    for smodule_name, smodule in sys.modules.items():
+    for smodule_name, smodule in mods.items():
         if module_name and not smodule_name.startswith(module_name):
             continue
         if hasattr(smodule, '__dict__') and name in smodule.__dict__:

--- a/src/sage/rings/padics/meson.build
+++ b/src/sage/rings/padics/meson.build
@@ -39,6 +39,7 @@ py.install_sources(
   'padic_generic_element.pxd',
   'padic_generic_element.pyx',
   'padic_lattice_element.py',
+  'padic_lattice_element_test.py',
   'padic_printing.pxd',
   'padic_printing.pyx',
   'padic_relaxed_element.pxd',

--- a/src/sage/rings/padics/padic_lattice_element.py
+++ b/src/sage/rings/padics/padic_lattice_element.py
@@ -48,6 +48,7 @@ def unpickle_le(parent, value, prec):
 
         sage: from sage.rings.padics.padic_lattice_element import unpickle_le
         sage: R = ZpLC(5,8)
+        doctest:...: FutureWarning:...
         sage: a = unpickle_le(R, 42, 6); a
         2 + 3*5 + 5^2 + O(5^6)
         sage: a.parent() is R
@@ -192,6 +193,7 @@ class pAdicLatticeElement(pAdicGenericElement):
         EXAMPLES::
 
             sage: K = QpLC(7)
+            doctest:...: FutureWarning:...
             sage: K.random_element()._is_base_elt(7)  # not tested, known bug (see :issue:`32126`)
             True
         """
@@ -1291,6 +1293,7 @@ class pAdicLatticeFloatElement(pAdicLatticeElement):
         TESTS::
 
             sage: R = ZpLF(17)
+            doctest:...: FutureWarning:...
             sage: prec = R.precision()
 
             sage: prec.del_elements()

--- a/src/sage/rings/padics/padic_lattice_element.py
+++ b/src/sage/rings/padics/padic_lattice_element.py
@@ -5,23 +5,6 @@ AUTHOR:
 
 - Xavier Caruso (2018-02): initial version
 
-TESTS:
-
-We create some rings and run the test suite for them. We skip the Smith form
-tests because they take a few minutes as of mid 2018, see :issue:`25431`::
-
-    sage: R1 = ZpLC(2)
-    doctest:...: FutureWarning: This class/method/function is marked as experimental. It, its functionality or its interface might change without a formal deprecation.
-    See https://github.com/sagemath/sage/issues/23505 for details.
-    sage: R2 = ZpLF(2)
-    sage: R3 = QpLC(2)
-    sage: R4 = QpLF(2)
-
-    sage: # long time, needs sage.rings.padics
-    sage: TestSuite(R1).run(skip=['_test_teichmuller', '_test_matrix_smith'])
-    sage: TestSuite(R2).run(skip=['_test_teichmuller', '_test_matrix_smith'])
-    sage: TestSuite(R3).run(skip=['_test_teichmuller', '_test_matrix_smith'])
-    sage: TestSuite(R4).run(skip=['_test_teichmuller', '_test_matrix_smith'])
 """
 
 # ****************************************************************************

--- a/src/sage/rings/padics/padic_lattice_element_test.py
+++ b/src/sage/rings/padics/padic_lattice_element_test.py
@@ -1,0 +1,27 @@
+import pytest
+import warnings
+
+
+def test_padic_lattice_element():
+    r"""
+    Run the ``TestSuite()`` for some examples that previously
+    lived in the TESTS:: block of the padic_lattice_element module.
+    """
+    from sage.misc.sage_unittest import TestSuite
+    from sage.rings.padics.factory import ZpLC, ZpLF, QpLC, QpLF
+
+    with warnings.catch_warnings(category=FutureWarning):
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        # These all raise FutureWarnings
+        R1 = ZpLC(2)
+        R2 = ZpLF(2)
+        R3 = QpLC(2)
+        R4 = QpLF(2)
+
+    for R in (R1, R2, R3, R4):
+        # Only do a few runs, _test_matrix_smith() in particular is
+        # sloooooow.
+        TestSuite(R).run(verbose=True,
+                         raise_on_failure=True,
+                         skip="_test_teichmuller",
+                         max_runs=8)

--- a/src/sage/rings/padics/padic_lattice_element_test.py
+++ b/src/sage/rings/padics/padic_lattice_element_test.py
@@ -1,40 +1,29 @@
 import pytest
+from sage.rings.padics.factory import ZpLC, ZpLF, QpLC, QpLF
+
+# ZpLC, ZpLF, QpLC, and QpLF all raise FutureWarnings
+from warnings import catch_warnings, filterwarnings
+filterwarnings("ignore", category=FutureWarning)
 
 
 @pytest.fixture
 def R1():
-    from warnings import catch_warnings, filterwarnings
-    from sage.rings.padics.factory import ZpLC
-    with catch_warnings(category=FutureWarning):
-        filterwarnings("ignore", category=FutureWarning)
-        return ZpLC(2)
+    return ZpLC(2)
 
 
 @pytest.fixture
 def R2():
-    from warnings import catch_warnings, filterwarnings
-    from sage.rings.padics.factory import ZpLF
-    with catch_warnings(category=FutureWarning):
-        filterwarnings("ignore", category=FutureWarning)
-        return ZpLF(2)
+    return ZpLF(2)
 
 
 @pytest.fixture
 def R3():
-    from warnings import catch_warnings, filterwarnings
-    from sage.rings.padics.factory import QpLC
-    with catch_warnings(category=FutureWarning):
-        filterwarnings("ignore", category=FutureWarning)
-        return QpLC(2)
+    return QpLC(2)
 
 
 @pytest.fixture
 def R4():
-    from warnings import catch_warnings, filterwarnings
-    from sage.rings.padics.factory import QpLF
-    with catch_warnings(category=FutureWarning):
-        filterwarnings("ignore", category=FutureWarning)
-        return QpLF(2)
+    return QpLF(2)
 
 
 # Use strings for the fixture names here, and then later convert them

--- a/src/sage/rings/padics/padic_lattice_element_test.py
+++ b/src/sage/rings/padics/padic_lattice_element_test.py
@@ -1,27 +1,65 @@
 import pytest
-import warnings
 
 
-def test_padic_lattice_element():
+@pytest.fixture
+def R1():
+    from warnings import catch_warnings, filterwarnings
+    from sage.rings.padics.factory import ZpLC
+    with catch_warnings(category=FutureWarning):
+        filterwarnings("ignore", category=FutureWarning)
+        return ZpLC(2)
+
+
+@pytest.fixture
+def R2():
+    from warnings import catch_warnings, filterwarnings
+    from sage.rings.padics.factory import ZpLF
+    with catch_warnings(category=FutureWarning):
+        filterwarnings("ignore", category=FutureWarning)
+        return ZpLF(2)
+
+
+@pytest.fixture
+def R3():
+    from warnings import catch_warnings, filterwarnings
+    from sage.rings.padics.factory import QpLC
+    with catch_warnings(category=FutureWarning):
+        filterwarnings("ignore", category=FutureWarning)
+        return QpLC(2)
+
+
+@pytest.fixture
+def R4():
+    from warnings import catch_warnings, filterwarnings
+    from sage.rings.padics.factory import QpLF
+    with catch_warnings(category=FutureWarning):
+        filterwarnings("ignore", category=FutureWarning)
+        return QpLF(2)
+
+
+# Use strings for the fixture names here, and then later convert them
+# to the actual fixture objects using request.getfixturevalue(). This
+# is a workaround for being unable to pass fixtures directly as
+# parameters:
+#
+#   https://github.com/pytest-dev/pytest/issues/349
+#
+elements = ( "R1", "R2", "R3", "R4" )
+
+
+@pytest.mark.parametrize("e", elements)
+def test_padic_lattice_element(e, request):
     r"""
     Run the ``TestSuite()`` for some examples that previously
     lived in the TESTS:: block of the padic_lattice_element module.
     """
     from sage.misc.sage_unittest import TestSuite
-    from sage.rings.padics.factory import ZpLC, ZpLF, QpLC, QpLF
 
-    with warnings.catch_warnings(category=FutureWarning):
-        warnings.filterwarnings("ignore", category=FutureWarning)
-        # These all raise FutureWarnings
-        R1 = ZpLC(2)
-        R2 = ZpLF(2)
-        R3 = QpLC(2)
-        R4 = QpLF(2)
+    # Convert the string to a real fixture
+    e = request.getfixturevalue(e)
 
-    for R in (R1, R2, R3, R4):
-        # Only do a few runs, _test_matrix_smith() in particular is
-        # sloooooow.
-        TestSuite(R).run(verbose=True,
-                         raise_on_failure=True,
-                         skip="_test_teichmuller",
-                         max_runs=8)
+    # Only do a few runs, _test_matrix_smith() in particular is slow.
+    TestSuite(e).run(verbose=True,
+                     raise_on_failure=True,
+                     skip="_test_teichmuller",
+                     max_runs=8)

--- a/src/sage/rings/valuation/mapped_valuation.py
+++ b/src/sage/rings/valuation/mapped_valuation.py
@@ -595,10 +595,6 @@ class FiniteExtensionFromLimitValuation(FiniteExtensionFromInfiniteValuation):
         [[ (x - 1)-adic valuation, v(y + 1) = 1 ]-adic valuation,
          [ (x - 1)-adic valuation, v(y - 1) = 1 ]-adic valuation]
 
-    TESTS::
-
-        sage: TestSuite(w[0]).run()             # long time                             # needs sage.rings.function_field
-        sage: TestSuite(w[1]).run()             # long time                             # needs sage.rings.function_field
     """
     def __init__(self, parent, approximant, G, approximants):
         r"""

--- a/src/sage/rings/valuation/mapped_valuation_test.py
+++ b/src/sage/rings/valuation/mapped_valuation_test.py
@@ -1,12 +1,8 @@
 import pytest
 
 
-def test_finite_extension_from_limit_valuation():
-    r"""
-    Run the ``TestSuite()`` for two examples given in the
-    ``FiniteExtensionFromLimitValuation`` documentation.
-    """
-    from sage.misc.sage_unittest import TestSuite
+@pytest.fixture
+def w():
     from sage.rings.function_field.constructor import FunctionField
     from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
     from sage.rings.integer import Integer
@@ -18,10 +14,42 @@ def test_finite_extension_from_limit_valuation():
     y = R.gen()
     L = K.extension(y**2 - x)
     v = K.valuation(Integer(1))
-    w = v.extensions(L)
 
-    for ext in w:
-        # fewer max_runs, these are kind of slow
-        TestSuite(ext).run(verbose=True,
-                           raise_on_failure=True,
-                           max_runs=512)
+    return v.extensions(L)
+
+
+@pytest.fixture
+def w0(w):
+    return w[0]
+
+
+@pytest.fixture
+def w1(w):
+    return w[1]
+
+
+# Use strings for the fixture names here, and then later convert them
+# to the actual fixture objects using request.getfixturevalue(). This
+# is a workaround for being unable to pass fixtures directly as
+# parameters:
+#
+#   https://github.com/pytest-dev/pytest/issues/349
+#
+extensions = ( "w0", "w1" )
+
+
+@pytest.mark.parametrize("e", extensions)
+def test_finite_extension_from_limit_valuation(e, request):
+    r"""
+    Run the ``TestSuite()`` for two examples given in the
+    ``FiniteExtensionFromLimitValuation`` documentation.
+    """
+    from sage.misc.sage_unittest import TestSuite
+
+    # Convert the string to a real fixture
+    e = request.getfixturevalue(e)
+
+    # fewer max_runs, these are kind of slow
+    TestSuite(e).run(verbose=True,
+                     raise_on_failure=True,
+                     max_runs=512)

--- a/src/sage/rings/valuation/mapped_valuation_test.py
+++ b/src/sage/rings/valuation/mapped_valuation_test.py
@@ -18,38 +18,15 @@ def w():
     return v.extensions(L)
 
 
-@pytest.fixture
-def w0(w):
-    return w[0]
-
-
-@pytest.fixture
-def w1(w):
-    return w[1]
-
-
-# Use strings for the fixture names here, and then later convert them
-# to the actual fixture objects using request.getfixturevalue(). This
-# is a workaround for being unable to pass fixtures directly as
-# parameters:
-#
-#   https://github.com/pytest-dev/pytest/issues/349
-#
-extensions = ( "w0", "w1" )
-
-
-@pytest.mark.parametrize("e", extensions)
-def test_finite_extension_from_limit_valuation(e, request):
+@pytest.mark.parametrize("idx", [0,1])
+def test_finite_extension_from_limit_valuation_w(w, idx):
     r"""
     Run the ``TestSuite()`` for two examples given in the
     ``FiniteExtensionFromLimitValuation`` documentation.
     """
     from sage.misc.sage_unittest import TestSuite
 
-    # Convert the string to a real fixture
-    e = request.getfixturevalue(e)
-
     # fewer max_runs, these are kind of slow
-    TestSuite(e).run(verbose=True,
-                     raise_on_failure=True,
-                     max_runs=512)
+    TestSuite(w[idx]).run(verbose=True,
+                          raise_on_failure=True,
+                          max_runs=512)

--- a/src/sage/rings/valuation/mapped_valuation_test.py
+++ b/src/sage/rings/valuation/mapped_valuation_test.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+def test_finite_extension_from_limit_valuation():
+    r"""
+    Run the ``TestSuite()`` for two examples given in the
+    ``FiniteExtensionFromLimitValuation`` documentation.
+    """
+    from sage.misc.sage_unittest import TestSuite
+    from sage.rings.function_field.constructor import FunctionField
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    from sage.rings.integer import Integer
+    from sage.rings.rational_field import QQ
+
+    K = FunctionField(QQ, 'x')
+    x = K.gen()
+    R = PolynomialRing(K, 'y')
+    y = R.gen()
+    L = K.extension(y**2 - x)
+    v = K.valuation(Integer(1))
+    w = v.extensions(L)
+
+    for ext in w:
+        # fewer max_runs, these are kind of slow
+        TestSuite(ext).run(verbose=True,
+                           raise_on_failure=True,
+                           max_runs=512)


### PR DESCRIPTION
Fix some "slow doctest" warning by moving these out of the doctests, and into pytest where (IMO) they belong. They aren't for end-user consumption, and we aren't checking the output from them (as is the point of a doctest).
