### PR TITLE
Fix libgap(<NumberField>)

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -2167,7 +2167,9 @@ cdef class GapElement_Ring(GapElement):
         """
         Construct the Sage integers.
 
-        EXAMPLES::
+        This method is not meant to be called directly, use :meth:`sage` instead.
+
+        TESTS::
 
             sage: libgap.eval('Integers').ring_integer()
             Integer Ring
@@ -2178,7 +2180,9 @@ cdef class GapElement_Ring(GapElement):
         """
         Construct the Sage rationals.
 
-        EXAMPLES::
+        This method is not meant to be called directly, use :meth:`sage` instead.
+
+        TESTS::
 
             sage: libgap.eval('Rationals').ring_rational()
             Rational Field
@@ -2189,7 +2193,9 @@ cdef class GapElement_Ring(GapElement):
         """
         Construct a Sage integer mod ring.
 
-        EXAMPLES::
+        This method is not meant to be called directly, use :meth:`sage` instead.
+
+        TESTS::
 
             sage: libgap.eval('ZmodnZ(15)').ring_integer_mod()
             Ring of integers modulo 15
@@ -2199,9 +2205,21 @@ cdef class GapElement_Ring(GapElement):
 
     def ring_finite_field(self, var='a'):
         """
-        Construct an integer ring.
+        Construct a finite field.
 
-        EXAMPLES::
+        This method is not meant to be called directly, use :meth:`sage` instead.
+
+        Note that for non-prime finite fields, this method is likely **unintended**,
+        it always use the default-constructed finite field with ``var`` provided,
+        which means the ``DefiningPolynomial`` of the GAP field is often not the same as the
+        ``.modulus()`` of the Sage field. They are isomorphic, but the isomorphism may be
+        difficult to compute.
+
+        INPUT:
+
+        - ``var`` -- string (default: 'a'); name of the generator of the finite field
+
+        TESTS::
 
             sage: libgap.GF(3,2).ring_finite_field(var='A')
             Finite Field in A of size 3^2
@@ -2212,9 +2230,11 @@ cdef class GapElement_Ring(GapElement):
 
     def ring_cyclotomic(self):
         """
-        Construct an integer ring.
+        Construct a cyclotomic field.
 
-        EXAMPLES::
+        This method is not meant to be called directly, use :meth:`sage` instead.
+
+        TESTS::
 
             sage: libgap.CyclotomicField(6).ring_cyclotomic()
             Cyclotomic Field of order 3 and degree 2
@@ -2227,7 +2247,9 @@ cdef class GapElement_Ring(GapElement):
         """
         Construct a polynomial ring.
 
-        EXAMPLES::
+        This method is not meant to be called directly, use :meth:`sage` instead.
+
+        TESTS::
 
             sage: B = libgap(QQ['x'])
             sage: B.ring_polynomial()

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -199,6 +199,12 @@ cdef class FiniteField(Field):
         Return string that initializes the GAP version of
         this finite field.
 
+        Note that for non-prime finite fields, the result is likely **unintended**,
+        it always use GAP's default-constructed finite field,
+        which means the ``DefiningPolynomial`` of the GAP field is often not the same as the
+        ``.modulus()`` of the Sage field. They are isomorphic, but the isomorphism may be
+        difficult to compute.
+
         EXAMPLES::
 
             sage: GF(9,'a')._gap_init_()

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -4522,7 +4522,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             sage: # needs sage.libs.gap
             sage: z = QQ['z'].0
             sage: K.<zeta> = NumberField(z^2 - 2)
-            sage: K._gap_init_()  # random (the variable name $sage1 represents F.base_ring() in gap is somehow random)
+            sage: K._gap_init_()  # random (the variable name $sage1 represents F.base_ring() in gap and is random)
             'CallFuncList(function() local z,E; z:=Indeterminate($sage1,"z"); E:=AlgebraicExtension($sage1,z^2 - 2,"zeta"); return E; end,[])'
             sage: k = gap(K); k
             <algebraic extension over the Rationals of degree 2>
@@ -4582,8 +4582,8 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             sage: gapK.PrimitiveElement()
             a
 
-        Check that libgap global variables does not interfere with this method
-        (as it should if the method is correctly implemented and avoid ``libgap.eval``)::
+        Check that libgap global variables do not interfere with this method
+        (as it should if the method is correctly implemented and avoids ``libgap.eval``)::
 
             sage: libgap.eval("x:=1")
             1
@@ -4603,10 +4603,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             raise NotImplementedError("Currently, only simple algebraic extensions are implemented in libgap")
 
         from sage.libs.gap.libgap import libgap
-        q = self.polynomial()
-        R = libgap(self.base_ring())
-        E = R.AlgebraicExtension(self.polynomial(), str(self.gen()))
-        return E
+        return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
 
     def characteristic(self):
         """

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -4561,8 +4561,11 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
 
     def _libgap_(self):
         """
-        Override :meth:`sage.structure.sage_object.SageObject._libgap_`
-        for better performance. Not to be used directly, use ``libgap(K)`` instead.
+        Override :meth:`sage.structure.sage_object.SageObject._libgap_`,
+        because the current implementation of :meth:`_gap_init_` doesn't work with libgap,
+        and it is cleaner to implement this using ``libgap`` object manipulations
+        instead of ``libgap.eval(self._gap_init_())``.
+        Not to be used directly, use ``libgap(K)`` instead.
 
         EXAMPLES::
 


### PR DESCRIPTION
Previously `libgap(QQ[I])` fails. Now it works.

also add some minor clean-ups and documentation changes.

The pointed out bug (that is, Sage FiniteField ↔ GAP GF does not keep the `DefiningPolynomial`) is to be addressed in a subsequent pull request.

context: I was trying to improve the performance of `GF(next_prime(2^128)^4)` by using GAP's `StandardFF` package, see https://github.com/sagemath/sage/issues/38376#event-20086585888. but at the moment the conversion between Sage and Gap FiniteField is wrong.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


