### PR TITLE
Workaround for linbox charpoly/minpoly issues, take 2

### DIFF
--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1416,7 +1416,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
                 sig_on()
                 linbox_fmpz_mat_charpoly(g._poly, self._matrix)
                 sig_off()
-                if g.lc() == 1:
+                if g.lc() == 1 and g.degree() == self._nrows:
                     break
         elif algorithm == 'generic':
             g = Matrix_dense.charpoly(self, var)

--- a/src/sage/matrix/matrix_integer_sparse.pyx
+++ b/src/sage/matrix/matrix_integer_sparse.pyx
@@ -912,7 +912,7 @@ cdef class Matrix_integer_sparse(Matrix_sparse):
                 fmpz_poly_set_coeff_mpz(g._poly, i, tmp)
             _fmpz_poly_set_length(g._poly, p.size())
 
-            if g.lc() == 1:
+            if g.lc() == 1 and g.degree() == self._nrows:
                 break
 
         del M


### PR DESCRIPTION
Fix https://github.com/sagemath/sage/issues/40974 by checking the charpoly has the correct degree.

we unfortunately cannot do the same thing for minpoly, since we don't a priori know its degree.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


