### PR TITLE
Call sig_block() in integral callback

### DIFF
--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -851,14 +851,14 @@ def ensure_interruptible_after(seconds: float, max_wait_after_interrupt: float =
         sage: with ensure_interruptible_after(1) as data: uninterruptible_sleep(2r)
         Traceback (most recent call last):
         ...
-        RuntimeError: Function is not interruptible within 1.0000 seconds, only after 2.00... seconds
-        sage: data  # abs tol 0.01
+        RuntimeError: Function is not interruptible within 1.0000 seconds, only after 2.0... seconds
+        sage: data  # abs tol 0.1
         {'alarm_raised': True, 'elapsed': 2.0}
         sage: with ensure_interruptible_after(1): uninterruptible_sleep(2r); raise RuntimeError
         Traceback (most recent call last):
         ...
-        RuntimeError: Function is not interruptible within 1.0000 seconds, only after 2.00... seconds
-        sage: data  # abs tol 0.01
+        RuntimeError: Function is not interruptible within 1.0000 seconds, only after 2.0... seconds
+        sage: data  # abs tol 0.1
         {'alarm_raised': True, 'elapsed': 2.0}
 
     ::
@@ -867,7 +867,7 @@ def ensure_interruptible_after(seconds: float, max_wait_after_interrupt: float =
         Traceback (most recent call last):
         ...
         ValueError
-        sage: data  # abs tol 0.01
+        sage: data  # abs tol 0.1
         {'alarm_raised': False, 'elapsed': 0.0}
     """
     from cysignals.alarm import alarm, cancel_alarm, AlarmInterrupt

--- a/src/sage/libs/gsl/rng.pxd
+++ b/src/sage/libs/gsl/rng.pxd
@@ -70,7 +70,7 @@ cdef extern from "gsl/gsl_rng.h":
   cdef gsl_rng_type *gsl_rng_default
   unsigned long int gsl_rng_default_seed
 
-  gsl_rng *gsl_rng_alloc ( gsl_rng_type * T)
+  gsl_rng *gsl_rng_alloc ( const gsl_rng_type * T)
   int gsl_rng_memcpy (gsl_rng * dest, gsl_rng * src)
   gsl_rng *gsl_rng_clone ( gsl_rng * r)
 


### PR DESCRIPTION
Fix https://github.com/sagemath/sage/issues/30379 .

The implementation mimic `acb_calc_func_callback`.

also increase tolerance for a few parts, since the CI system is somewhat unreliable (I've seen a 2.00 being 2.04). I guess 0.1s is still considered almost imperceptible by human.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


