### PR TITLE
Ensure _charpoly_df is interruptible, take 2

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -3485,6 +3485,7 @@ cdef class Matrix(Matrix1):
                 for k in range(p):
                     s = s - A[k] * F[p-k-1]
                 F[p] = s - A[p]
+                sig_check()
 
         X = S.gen(0)
         f = X**n + S(list(reversed(F)))


### PR DESCRIPTION
previously I added some `sig_check` to this function in https://github.com/sagemath/sage/pull/39757 , but I didn't realize this loop does an O(n^2) amount of work without `sig_check`. (for p in range(t+1), for k in range(p))

or maybe I did realize but didn't think O(n^2) is a big deal, considering the whole algorithm is O(n^4).

@tobiasdiez report a test failure in https://github.com/sagemath/sage/issues/40715#issuecomment-3369069147 . Hopefully this fixes it, or at least reduce its probability.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


