### PR TITLE
Hack to use 10.8.beta5 docker image

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -163,7 +163,6 @@ passenv =
     docker:       DOCKER_CONFIG_FILE
     docker-incremental: FROM_DOCKER_REPOSITORY
     docker-incremental: FROM_DOCKER_TARGET
-    docker-incremental: FROM_DOCKER_TAG
     local:        MAKE
     local:        PREFIX
     local:        SAGE_NUM_THREADS
@@ -501,7 +500,8 @@ setenv =
     # Resulting full image:tag name
     #
     docker:             FULL_BASE_IMAGE_AND_TAG={env:ARCH_IMAGE_PREFIX:}{env:BASE_IMAGE}{env:ARCH_IMAGE_SUFFIX:}:{env:ARCH_TAG_PREFIX:}{env:BASE_TAG}{env:ARCH_TAG_SUFFIX:}
-    docker-incremental: FULL_BASE_IMAGE_AND_TAG={env:FROM_DOCKER_REPOSITORY:ghcr.io/sagemath/sage/}sage-$(echo {envname} | sed -E "s/(docker-|-incremental|-sitepackages)//g")-{env:FROM_DOCKER_TARGET:with-targets}:{env:FROM_DOCKER_TAG:dev}
+    docker-incremental: FULL_BASE_IMAGE_AND_TAG={env:FROM_DOCKER_REPOSITORY:ghcr.io/sagemath/sage/}sage-$(echo {envname} | sed -E "s/(docker-|-incremental|-sitepackages)//g")-{env:FROM_DOCKER_TARGET:with-targets}:10.8.beta5
+    docker-incremental: FROM_DOCKER_TAG=10.8.beta5
     # Can SKIP_SYSTEM_PKG_INSTALL if the base image already has git
     docker-incremental-{develop,recommended,maximal}:   SKIP_SYSTEM_PKG_INSTALL=yes
     docker-incremental-sitepackages:                    SKIP_SYSTEM_PKG_INSTALL=no


### PR DESCRIPTION
Starting from 10.8.beta6, test-long has been failing.

My speculation (see https://github.com/sagemath/sage/issues/41000 ) is that the docker build task happen to run on a machine that is newer than the machine that runs the test-long, thus the built package has AVX512F enabled but the machine that runs the test doesn't.

this pull request switches to build from the base image 10.8.beta5. the meson-based CI doesn't use tox/docker, so they're unaffected.

**Do not merge this!**

@vbraun please unset the "CI fix" label before releasing the next beta.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


