### PR TITLE
sage.rings.polynomial.multi_polynomial_libsingular: add one "needs"

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -663,6 +663,7 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
 
         Coercion from boolean polynomials, also by index::
 
+            sage: # needs sage.rings.polynomial.pbori
             sage: B.<x,y,z> = BooleanPolynomialRing(3)
             sage: P.<x,y,z> = QQ[]
             sage: P(B.gen(0))


### PR DESCRIPTION
A coercion test for `BooleanPolynomialRing` requires polybori/brial. We already have a "feature" for this; it's just missing the "needs" bit.

