### PR TITLE
remove deprecated (legacy) .discrete_log() method for elliptic-curve points

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -4521,32 +4521,6 @@ class EllipticCurvePoint_finite_field(EllipticCurvePoint_field):
 
         return ZZ(pari.elllog(self.curve(), self, base, n))
 
-    def discrete_log(self, Q):
-        r"""
-        Legacy version of :meth:`log` with its arguments swapped.
-
-        Note that this method uses the opposite argument ordering
-        of all other logarithm methods in Sage; see :issue:`37150`.
-
-        EXAMPLES::
-
-            sage: E = EllipticCurve(j=GF(101)(5))
-            sage: P, = E.gens()
-            sage: (2*P).log(P)
-            2
-            sage: (2*P).discrete_log(P)
-            doctest:warning ...
-            DeprecationWarning: The syntax P.discrete_log(Q) ... Please update your code. ...
-            45
-            sage: P.discrete_log(2*P)
-            2
-        """
-        from sage.misc.superseded import deprecation
-        deprecation(37150, 'The syntax P.discrete_log(Q) is being replaced by '
-                           'Q.log(P) to make the argument ordering of logarithm'
-                           ' methods in Sage uniform. Please update your code.')
-        return Q.log(self)
-
     def padic_elliptic_logarithm(self, Q, p):
         r"""
         Return the discrete logarithm of `Q` to base `P` = ``self``,

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -527,7 +527,7 @@ def _point_outside_subgroup(P):
         sage: P = E(4, 35)
         sage: Q = _point_outside_subgroup(P); Q     # random
         (14 : 11 : 1)
-        sage: Q.curve()(P).discrete_log(Q)
+        sage: Q.log(P)
         Traceback (most recent call last):
         ...
         ValueError: ECDLog problem has no solution (...)
@@ -539,7 +539,7 @@ def _point_outside_subgroup(P):
         True
         sage: Q = _point_outside_subgroup(P); Q     # random
         (35*z2 + 7 : 24*z2 + 7 : 1)
-        sage: Q.curve()(P).discrete_log(Q)
+        sage: Q.log(Q.curve()(P))
         Traceback (most recent call last):
         ...
         ValueError: ECDLog problem has no solution (...)
@@ -554,7 +554,7 @@ def _point_outside_subgroup(P):
         (18*z2 + 46 : 58*z2 + 61 : 1)
         sage: Q in E
         True
-        sage: P.discrete_log(Q)
+        sage: Q.log(P)
         Traceback (most recent call last):
         ...
         ValueError: ECDLog problem has no solution (...)


### PR DESCRIPTION
This method was superseded by `.log()`, whose interface is more in line with the rest of Sage, in #37150.