### PR TITLE
Fix an incorrect comparison in crypto/sbox

### DIFF
--- a/src/sage/crypto/sbox.pyx
+++ b/src/sage/crypto/sbox.pyx
@@ -252,7 +252,7 @@ cdef class SBox(SageObject):
             raise NotImplemented
 
         cdef SBox other = <SBox> rhs
-        return (self._S_list == other._S_list) and (self._big_endian == self._big_endian)
+        return (self._S_list == other._S_list) and (self._big_endian == other._big_endian)
 
     def __ne__(self, other):
         """


### PR DESCRIPTION
detected by the compiler

```
warning: self-comparison always evaluates to true [-Wtautological-compare]
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


