### PR TITLE
Fix multiprocessing start method for Python 3.14 compatibility

### DIFF
--- a/src/sage/doctest/external.py
+++ b/src/sage/doctest/external.py
@@ -37,8 +37,9 @@ import platform
 # With OS X, Python 3.8 defaults to use 'spawn' instead of 'fork' in
 # multiprocessing, and Sage doctesting doesn't work with 'spawn'. See
 # trac #27754.
-if platform.system() == 'Darwin':
-    multiprocessing.set_start_method('fork', force=True)
+# With Python 3.14, the default changed to 'forkserver' on Linux as well.
+# Sage doctesting requires 'fork' method.
+multiprocessing.set_start_method('fork', force=True)
 Array = multiprocessing.Array
 
 # Functions in this module whose name is of the form 'has_xxx' tests if the

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -91,8 +91,9 @@ if typing.TYPE_CHECKING:
 # With OS X, Python 3.8 defaults to use 'spawn' instead of 'fork' in
 # multiprocessing, and Sage doctesting doesn't work with 'spawn'. See
 # trac #27754.
-if platform.system() == 'Darwin':
-    multiprocessing.set_start_method('fork', force=True)
+# With Python 3.14, the default changed to 'forkserver' on Linux as well.
+# Sage doctesting requires 'fork' method.
+multiprocessing.set_start_method('fork', force=True)
 
 
 def _sorted_dict_pprinter_factory(start, end):


### PR DESCRIPTION
Python 3.14 changed the default multiprocessing start method from ``fork`` to ``forkserver`` on Linux. This caused pickling errors in the doctest framework because DocTestWorker objects contained unpicklable local functions.

The fix ensures that the ``fork`` start method is always used on all platforms, not just macOS, since Sage's doctesting framework requires the 'fork' method to function correctly.

Changes:
- src/sage/doctest/forker.py: Remove Darwin-only check, always use fork
- src/sage/doctest/external.py: Remove Darwin-only check, always use fork

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


