### PR TITLE
Avoid excessive parallelism for doc/bootstrap

### DIFF
--- a/src/doc/bootstrap
+++ b/src/doc/bootstrap
@@ -183,4 +183,4 @@ cat <<EOF
 
 EOF
 ) > "$OUTPUT_DIR"/index_alph.rst
-sage-package list --has-file SPKG.rst | OUTPUT_DIR=$OUTPUT_DIR OUTPUT_RST=1 xargs -P 99 -n 1 sage-spkg-info
+sage-package list --has-file SPKG.rst | OUTPUT_DIR=$OUTPUT_DIR OUTPUT_RST=1 xargs -P $(nproc 2> /dev/null || echo 8) -n 1 sage-spkg-info


### PR DESCRIPTION
fix https://github.com/sagemath/sage/issues/38753

there's also `docker/setup-make-parallelity.sh` and `src/bin/sage-num-threads.py` which we should probably prefer to use instead. If you invoke `meson compile doc-html` with say `-j3`, this isn't respected either.

But at least this is an improvement of the status quo (99).


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


