### PR TITLE
avoid CommutativeRing in plural.pyx

### DIFF
--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -2962,8 +2962,9 @@ cpdef MPolynomialRing_libsingular new_CRing(RingWrap rw, base_ring):
     self._term_order = TermOrder(rw.ordering_string(), force=True)
 
     names = tuple(rw.var_names())
-    CommutativeRing.__init__(self, base_ring, names, category=Algebras(base_ring),
-                             normalize=False)
+    Parent.__init__(self, base=base_ring, names=names,
+                    category=Algebras(base_ring).Commutative(),
+                    normalize=False)
 
     self._has_singular = True
 
@@ -3031,7 +3032,8 @@ cpdef NCPolynomialRing_plural new_NRing(RingWrap rw, base_ring):
     self._ngens = rw.ngens()
     self._term_order = TermOrder(rw.ordering_string(), force=True)
 
-    Parent.__init__(self, base=base_ring, names=rw.var_names(), category=Algebras(base_ring))
+    Parent.__init__(self, base=base_ring, names=rw.var_names(),
+                    category=Algebras(base_ring))
 
     self._has_singular = True
     self._relations = self.relations()


### PR DESCRIPTION
by using Parent instead

another little step towards getting rid of `CommutativeRing`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.