### PR TITLE
Fix InterfaceMagic compatibility with IPython >= 9.6

### DIFF
--- a/src/sage/repl/interface_magic.py
+++ b/src/sage/repl/interface_magic.py
@@ -249,6 +249,11 @@ class InterfaceMagic:
             Traceback (most recent call last):
             ...
             SyntaxError: Interface magics have no options, got "foo"
+            sage: try:
+            ....:     cell_magic('foo', '1+1;')
+            ....: except SyntaxError as e:
+            ....:     print(f"text attribute: {e.text!r}")
+            text attribute: '%%gap foo'
 
         This is how the built cell magic is used in practice::
 
@@ -289,7 +294,9 @@ class InterfaceMagic:
             options.
             """
             if line:
-                raise SyntaxError('Interface magics have no options, got "{0}"'.format(line))
+                err = SyntaxError('Interface magics have no options, got "{0}"'.format(line))
+                err.text = '%%{0} {1}'.format(self._name, line)
+                raise err
             output = self._interface.eval(cell)
             print(output)
         cell_magic.__doc__ = CELL_DOCSTRING.format(name=self._name)


### PR DESCRIPTION
Since IPython 9.6 (with Python 3.12+), the traceback formatter in ``IPython.core.ultratb.ListTB._format_exception_only()`` introduced a stricter assertion that requires ``SyntaxError.text`` to be a string.

When interface cell magics are invoked with invalid options (e.g., ``'%%gap foo'``), Sage's InterfaceMagic.cell_magic() raised a SyntaxError without setting the .text attribute. This caused IPython 8.27+ to trigger an additional AssertionError during traceback rendering:
```   
    AssertionError: assert isinstance(value. Text, str)
```
This fix ensures that the SyntaxError has a properly formatted .text attribute set before raising it, preventing the assertion failure and providing better error messages.

The fix also includes a regression test verifying that the .text attribute is correctly set.

Fix errors raised in #41036 https://github.com/sagemath/sage/actions/runs/18470853388

you can refer to https://github.com/ipython/ipython/commit/db0fde0f4911f7e08a98eec2f5fdbee98852c5d0

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


