### PR TITLE
New feature for eclib/mwrank

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -129,10 +129,13 @@ class SageDoctestModule(DoctestModule):
                         # tests), but that would require duplication
                         # for as long as `sage -t` is still used.
                         from sage.features.coxeter3 import Coxeter3
-                        from sage.features.sagemath import sage__libs__giac
+                        from sage.features.sagemath import (sage__libs__eclib,
+                                                            sage__libs__giac)
                         from sage.features.standard import PythonModule
 
                         exc_list = ["valgrind"]
+                        if not sage__libs__eclib().is_present():
+                            exc_list.append("sage.libs.eclib")
                         if not PythonModule("rpy2").is_present():
                             exc_list.append("rpy2")
                         if not Coxeter3().is_present():
@@ -141,8 +144,9 @@ class SageDoctestModule(DoctestModule):
                             exc_list.append("sagemath_giac")
 
                         # Ignore import errors, but only when the associated
-                        # feature is actually disabled.
-                        if exception.name in exc_list:
+                        # feature is actually disabled. Use startswith() so
+                        # that sage.libs.foo matches all of sage.libs.foo.*
+                        if any(exception.name.startswith(e) for e in exc_list):
                             pytest.skip(
                                 f"unable to import module {self.path} due to missing feature {exception.name}"
                             )

--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -52,6 +52,7 @@ Features
    sage/features/mcqd
    sage/features/meataxe
    sage/features/mip_backends
+   sage/features/mwrank
    sage/features/normaliz
    sage/features/pandoc
    sage/features/pdf2svg

--- a/src/sage/features/mwrank.py
+++ b/src/sage/features/mwrank.py
@@ -1,0 +1,33 @@
+r"""
+Feature for testing the presence of the ``mwrank`` program (part
+of eclib)
+"""
+
+from . import Executable, FeatureTestResult
+
+
+class Mwrank(Executable):
+    r"""
+    A :class:`~sage.features.Feature` describing the presence of
+    the ``mwrank`` program.
+
+    EXAMPLES::
+
+        sage: from sage.features.mwrank import Mwrank
+        sage: Mwrank().is_present()  # needs mwrank
+        FeatureTestResult('mwrank', True)
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.mwrank import Mwrank
+            sage: isinstance(Mwrank(), Mwrank)
+            True
+        """
+        Executable.__init__(self, 'mwrank', executable='mwrank',
+                            spkg='eclib', type='standard')
+
+
+def all_features():
+    return [Mwrank()]

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -512,6 +512,33 @@ class sage__libs__ntl(JoinFeature):
                              spkg='sagemath_ntl', type='standard')
 
 
+class sage__libs__eclib(JoinFeature):
+    r"""
+    A :class:`sage.features.Feature` describing the presence of
+    :mod:`sage.libs.eclib`.
+
+    In addition to the modularization purposes that this tag serves,
+    it also provides attribution to the upstream project.
+
+    TESTS::
+
+        sage: from sage.features.sagemath import sage__libs__eclib
+        sage: sage__libs__eclib().is_present()  # needs sage.libs.eclib
+        FeatureTestResult('sage.libs.eclib', True)
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.sagemath import sage__libs__eclib
+            sage: isinstance(sage__libs__eclib(), sage__libs__eclib)
+            True
+        """
+        JoinFeature.__init__(self, 'sage.libs.eclib',
+                             [PythonModule('sage.libs.eclib.mwrank')],
+                             spkg='eclib', type='standard')
+
+
 class sage__libs__giac(JoinFeature):
     r"""
     A :class:`sage.features.Feature` describing the presence of :mod:`sage.libs.giac`.


### PR DESCRIPTION
eclib and mwrank are now optional for sagelib, but without them, the tests fail. This PR addresses the easy part of that problem, by cherry-picking the new features and pytest tweaks from https://github.com/sagemath/sage/pull/40546

I will make https://github.com/sagemath/sage/pull/40546, which is a review nightmare, depend on this one.