### PR TITLE
Add __reduce__ method to LazyImport class for pickle support

### DIFF
--- a/src/sage/misc/lazy_import.pyx
+++ b/src/sage/misc/lazy_import.pyx
@@ -1007,25 +1007,39 @@ cdef class LazyImport():
         EXAMPLES::
 
             sage: from sage.misc.lazy_import import LazyImport
-            sage: lazy_ZZ = LazyImport('sage.rings.integer_ring', 'ZZ')
             sage: from pickle import loads, dumps
+            sage: lazy_ZZ = LazyImport('sage.rings.integer_ring', 'ZZ')
             sage: restored = loads(dumps(lazy_ZZ))
             sage: type(restored)
             <class 'sage.misc.lazy_import.LazyImport'>
-            sage: restored._module
-            'sage.rings.integer_ring'
-            sage: restored._name
-            'ZZ'
 
         The restored LazyImport can still be used normally::
 
             sage: restored(42)
             42
-
-        When used, it resolves to the same object::
-
             sage: restored._get_object() is ZZ
             True
+
+        Test equality after unpickling::
+
+            sage: lazy_QQ = LazyImport('sage.rings.rational_field', 'QQ')
+            sage: restored_QQ = loads(dumps(lazy_QQ))
+            sage: lazy_QQ == restored_QQ
+            True
+            sage: lazy_QQ._get_object() is restored_QQ._get_object()
+            True
+
+        Pickling works even after the lazy import has been used::
+
+            sage: lazy_Integer = LazyImport('sage.rings.integer', 'Integer')
+            sage: val = lazy_Integer(5)
+            sage: type(lazy_Integer)
+            <class 'sage.misc.lazy_import.LazyImport'>
+            sage: restored_Integer = loads(dumps(lazy_Integer))
+            sage: type(restored_Integer)
+            <class 'sage.misc.lazy_import.LazyImport'>
+            sage: restored_Integer(10)
+            10
         """
         # Pickle the LazyImport itself, preserving the lazy behavior
         # We exclude namespace since it may reference unpicklable objects


### PR DESCRIPTION
When you run doctest using ``sage -t``, it failed in ``fricas==loads(dumps(fricas))``.  and it is OK in ``./sage -c``. The error message like this.
```
cd /home/zhongcx/sage && ./sage -c "from sage.repl.ipython_kernel.all_jupyter import *; from sage.misc.persist import loads, dumps; print('Type of fricas:', type(fricas)); result = loads(dumps(fricas)); print('Success!')"
cd /home/zhongcx/sage && ./sage -c "from sage.repl.ipython_kernel.all_jupyter import *; from sage.misc.persist import loads, dumps; print('Type of fricas:', type(fricas)); result = loads(dumps(fricas)); print('Success')"
Type of fricas: <class 'sage.misc.lazy_import.LazyImport'>
Traceback (most recent call last):
  File "sage/misc/persist.pyx", line 338, in sage.misc.persist.dumps
  File "sage/structure/sage_object.pyx", line 508, in sage.structure.sage_object.SageObject.dumps
  File "sage/misc/persist.pyx", line 306, in sage.misc.persist._base_dumps
  File "sage/misc/persist.pyx", line 830, in sage.misc.persist.SagePickler.dumps
TypeError: cannot pickle 'sage.misc.lazy_import.LazyImport' object


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/zhongcx/sage/src/bin/sage-eval", line 11, in <module>
    eval(compile(s,'<cmdline>','exec'))
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<cmdline>", line 1, in <module>
  File "sage/misc/persist.pyx", line 340, in sage.misc.persist.dumps
  File "sage/misc/persist.pyx", line 306, in sage.misc.persist._base_dumps
  File "sage/misc/persist.pyx", line 830, in sage.misc.persist.SagePickler.dumps
TypeError: cannot pickle 'sage.misc.lazy_import.LazyImport' object
```
We do not have a ``_reduce_`` method in ``lazy_import``. We just added this in the PR.

The __reduce__ method:
- Preserves LazyImport semantics (doesn't force early resolution)
- Returns the class and constructor arguments needed for reconstruction
- Uses namespace=None to avoid pickling unpicklable namespace dictionaries
- Works for all lazy imports throughout Sage

This allows lazy imports to be used in contexts that require pickling, such as doctests, while maintaining their lazy evaluation behavior.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


