### PR TITLE
Fix libgap conversion of large Python integers and Sage integers

### DIFF
--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -225,7 +225,7 @@ cdef Obj make_gap_integer(sage_int) except NULL:
 
     TESTS:
 
-    Test small integers (fast path using GAP_NewObjIntFromInt)::
+    Test small Sage integers::
 
         sage: libgap(0)   # indirect doctest
         0
@@ -238,25 +238,7 @@ cdef Obj make_gap_integer(sage_int) except NULL:
         sage: libgap(-42)
         -42
 
-    Test boundary values for C int (32-bit and 64-bit)::
-
-        sage: libgap(127)   # 8-bit boundary
-        127
-        sage: libgap(-128)
-        -128
-        sage: libgap(32767)   # 16-bit boundary
-        32767
-        sage: libgap(-32768)
-        -32768
-
-    32-bit boundaries::
-
-        sage: libgap(2147483647)   # 32-bit max
-        2147483647
-        sage: libgap(-2147483648)   # 32-bit min
-        -2147483648
-
-    Test medium integers that overflow C int on some platforms::
+    Test medium Sage integers::
 
         sage: libgap(2**31)
         2147483648
@@ -269,7 +251,7 @@ cdef Obj make_gap_integer(sage_int) except NULL:
         sage: libgap(-(2**64))
         -18446744073709551616
 
-    Test large integers (GMP path with mpz_export)::
+    Test large Sage integers::
 
         sage: libgap(2**100)
         1267650600228229401496703205376
@@ -279,15 +261,6 @@ cdef Obj make_gap_integer(sage_int) except NULL:
         115792089237316195423570985008687907853269984665640564039457584007913129639936
         sage: libgap(-(2**256))
         -115792089237316195423570985008687907853269984665640564039457584007913129639936
-
-    Test very large integers (10000+ bits)::
-
-        sage: n = 2**10000
-        sage: gap_n = libgap(n)
-        sage: gap_n.sage() == n
-        True
-        sage: len(str(n))
-        3011
 
     Test with Python int (not Sage Integer)::
 
@@ -304,31 +277,14 @@ cdef Obj make_gap_integer(sage_int) except NULL:
         sage: libgap(int(2**100))
         1267650600228229401496703205376
 
-    Test with Sage Integer::
-
-        sage: from sage.rings.integer import Integer
-        sage: libgap(Integer(0))
-        0
-        sage: libgap(Integer(10**50))
-        100000000000000000000000000000000000000000000000000
-        sage: libgap(Integer(-10**50))
-        -100000000000000000000000000000000000000000000000000
-
     Test round-trip conversion::
 
-        sage: n = 123456789012345678901234567890
+        sage: n = int(123456789012345678901234567890)
         sage: gap_n = libgap(n)
         sage: gap_n.sage() == n
         True
 
         sage: n = factorial(100)
-        sage: gap_n = libgap(n)
-        sage: gap_n.sage() == n
-        True
-    
-    Test that the conversion is efficient (no exception on huge numbers)::
-
-        sage: n = 2**100000
         sage: gap_n = libgap(n)
         sage: gap_n.sage() == n
         True
@@ -341,13 +297,6 @@ cdef Obj make_gap_integer(sage_int) except NULL:
     cdef size_t limb_count
     cdef size_t i
     
-    # Fast path: try to fit in a C int
-    try:
-        return GAP_NewObjIntFromInt(<int>sage_int)
-    except OverflowError:
-        pass
-    
-    # Slow path: convert large integer via GMP
     # We need to handle this carefully to avoid accessing GMP internals
     mpz_init(temp)
     try:

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -272,7 +272,7 @@ cdef Obj make_gap_integer(sage_int) except NULL:
     cdef mpz_t temp
     cdef Obj result
     cdef Int size
-    cdef int sign
+    cdef Int sign
     cdef UInt* limbs = NULL
     cdef size_t limb_count
     cdef size_t i
@@ -289,7 +289,7 @@ cdef Obj make_gap_integer(sage_int) except NULL:
             return GAP_NewObjIntFromInt(0)
         
         # Get the sign: mpz_sgn returns -1, 0, or 1
-        sign = mpz_sgn(temp)
+        sign = <Int>mpz_sgn(temp)
         
         # Allocate limb buffer for export
         # sizeof(mp_limb_t) may differ from sizeof(UInt), so we need to handle this

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -225,7 +225,7 @@ cdef Obj make_gap_integer(sage_int) except NULL:
 
     TESTS:
 
-    Test small Sage integers::
+    Test with Sage integers::
 
         sage: libgap(0)   # indirect doctest
         0
@@ -233,32 +233,12 @@ cdef Obj make_gap_integer(sage_int) except NULL:
         1
         sage: libgap(-1)
         -1
-        sage: libgap(42)
-        42
-        sage: libgap(-42)
-        -42
-
-    Test medium Sage integers::
-
         sage: libgap(2**31)
         2147483648
-        sage: libgap(2**32)
-        4294967296
-        sage: libgap(2**63)
-        9223372036854775808
+        sage: libgap(-2**63)
+        -9223372036854775808
         sage: libgap(2**64)
         18446744073709551616
-        sage: libgap(-(2**64))
-        -18446744073709551616
-
-    Test large Sage integers::
-
-        sage: libgap(2**100)
-        1267650600228229401496703205376
-        sage: libgap(2**128)
-        340282366920938463463374607431768211456
-        sage: libgap(2**256)
-        115792089237316195423570985008687907853269984665640564039457584007913129639936
         sage: libgap(-(2**256))
         -115792089237316195423570985008687907853269984665640564039457584007913129639936
 

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -215,7 +215,7 @@ cdef Obj make_gap_record(sage_dict) except NULL:
 
 cdef Obj make_gap_integer(sage_int) except NULL:
     """
-    Convert Sage integer into Gap integer
+    Convert Sage integer or Python integer into Gap integer
 
     INPUT:
 
@@ -325,17 +325,7 @@ cdef Obj make_gap_integer(sage_int) except NULL:
         sage: gap_n = libgap(n)
         sage: gap_n.sage() == n
         True
-
-    Test special cases::
-
-        sage: libgap(ZZ(0))   # Zero
-        0
-        sage: libgap(ZZ(2**1000))   # Very large
-        10715086071862673209484250490600018105614048117055336074437503883703510511249361224931983788156958581275946729175531468251871452856923140435984577574698574803934567774824230985421074605062371141877954182153046474983581941267398767559165543946077062914571196477686542167660429831652624386837205668069376
-        sage: n = -factorial(50)   # Large negative
-        sage: libgap(n) == n
-        True
-
+    
     Test that the conversion is efficient (no exception on huge numbers)::
 
         sage: n = 2**100000

--- a/src/sage/libs/gap/gap_includes.pxd
+++ b/src/sage/libs/gap/gap_includes.pxd
@@ -70,6 +70,7 @@ cdef extern from "gap/libgap-api.h" nogil:
     bint GAP_IsInt(Obj)
     bint GAP_IsSmallInt(Obj)
     Obj GAP_NewObjIntFromInt(Int val)
+    Obj GAP_MakeObjInt(const UInt* limbs, Int size)
     Int GAP_ValueInt(Obj)
     Int GAP_SizeInt(Obj)
     const UInt* GAP_AddrInt(Obj)


### PR DESCRIPTION
This fix #41048 . Now we first convert use GMP, then directly pass the pointer to ``GAP_MakeObjInt``. It fixes the corner case when ``libgap(int)`` is large.


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


