### PR TITLE
Fix missing file error with sage_getdoc

### DIFF
--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -2184,8 +2184,11 @@ def sage_getdoc(obj, obj_name='', embedded=False):
         ....:     '''
         ....:     docs
         ....:     '''
-        sage: sage_getdoc(C)
-        '   docs\n'
+        sage: import sys
+        sage: if sys.version_info >= (3, 13):
+        ....:     assert sage_getdoc(C) == 'docs\n', sage_getdoc(C)
+        ....: else:
+        ....:     assert sage_getdoc(C) == '   docs\n', sage_getdoc(C)
 
         sage: from sage.repl.interpreter import get_test_shell
         sage: shell = get_test_shell()


### PR DESCRIPTION
see the newly added test, previously it.

The reason this affect users is that if in a shell you type

```
sage: class C:
....:     '''
....:     docs
....:     '''
sage: C?
```

then you'd get an error. After this change, it prints out something somewhat sensible. (also added as a test)

I'm not 100% sure what's a good way out on it be this one. On one hand, you ought to make `sage_getfile` behave the same way as https://docs.python.org/3/library/inspect.html#inspect.getfile; on the other hand it is not documented by https://docs.python.org/3/library/inspect.html#inspect.getfile that it may raise `OSError`, so IPython isn't prepared to deal with it.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


