### PR TITLE
Docutils 0.22 compatibility

### DIFF
--- a/src/sage/categories/primer.py
+++ b/src/sage/categories/primer.py
@@ -2,10 +2,6 @@
 r"""
 Elements, parents, and categories in Sage: a primer
 
-.. contents::
-   :depth: 2
-   :class: this-will-duplicate-information-and-it-is-still-useful-here
-
 Abstract
 ========
 

--- a/src/sage/misc/sagedoc_conf.py
+++ b/src/sage/misc/sagedoc_conf.py
@@ -191,7 +191,7 @@ class SagemathTransform(Transform):
     default_priority = 500
 
     def apply(self):
-        for node in self.document.traverse(nodes.literal_block):
+        for node in self.document.findall(nodes.literal_block):
             if node.get('language') is None and node.astext().startswith('sage:'):
                 node['language'] = 'ipycon'
                 source = node.rawsource


### PR DESCRIPTION
- Port away from deprecated `nodes.Node.traverse`
- Remove no longer supported `contents` directive from py files

sage-the-distro still doesn't build docs since sphinx-inline-tabs needs patching, but this makes sagelib build and pass tests with fixed distro packages.