### PR TITLE
Remove incorrect packages in macos ci

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -37,23 +37,17 @@ jobs:
         version:
           - '14'
           - '15'
+          - '26'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-        
-      - name: Install test prerequisites
-        run: python -m pip install tox
-
       - name: Install dependencies
         run: |
-          brew uninstall --force cmake || true
           eval $(build/bin/sage-print-system-package-command homebrew update)
           eval $(build/bin/sage-print-system-package-command homebrew --yes --ignore-missing install $(build/bin/sage-get-system-packages homebrew _bootstrap _prereq $(build/bin/sage-package list :standard:)))
+          brew uninstall --force singular flint ntl || true
 
       - name: Build
         run: |


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
- Add macos-26 in the macos ci.
- Remove unnecessary set python setup. (Sage do not accept this python)
- Remove incorrect singular flint and ntl. Singular version in homebrew is 4.4.1p4. And ntl is not compatible in macos-14.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


