### PR TITLE
Update maxima package use flags for Gentoo

### DIFF
--- a/build/pkgs/maxima/distros/gentoo.txt
+++ b/build/pkgs/maxima/distros/gentoo.txt
@@ -1,2 +1,1 @@
-sci-mathematics/maxima[ecl]
-
+sci-mathematics/maxima[-sbcl,-clozurecl,-clozurecl64,-gcl,-clisp,ecl]


### PR DESCRIPTION
makes sure maxima on Gentoo is maxima[ecl], not maxima[sbcl]
See https://bugs.gentoo.org/964693

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


