### PR TITLE
Add some missing docstrings to `multi_polynomial_ring_base.pyx`

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -868,6 +868,21 @@ cdef class MPolynomialRing_base(CommutativeRing):
         return False
 
     def term_order(self):
+        """
+        Return the term order of ``self``.
+
+        OUTPUT: a :class:`sage.rings.polynomial.term_order.TermOrder` of the
+        variables of ``self``.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 3)
+            sage: R.term_order()
+            Degree reverse lexicographic term order
+            sage: S.<t,u> = PolynomialRing(QQ, 2, order='lex')
+            sage: S.term_order()
+            Lexicographic term order
+        """
         return self._term_order
 
     def characteristic(self):
@@ -886,6 +901,28 @@ cdef class MPolynomialRing_base(CommutativeRing):
         return self.base_ring().characteristic()
 
     def gen(self, n=0):
+        """
+        Return the ``n``-th indeterminate generator of ``self``.
+
+        INPUT:
+
+        - ``n`` -- integer (default: ``0``) number of the generator
+
+        EXAMPLES::
+
+            sage: R = ZZ['x,y,z']
+            sage: x = R.gen()
+            sage: x
+            x
+            sage: parent(x)
+            Multivariate Polynomial Ring in x, y, z over Integer Ring
+            sage: R.gen(2)
+            z
+            sage: R.gen(23)
+            Traceback (most recent call last):
+            ...
+            ValueError: Generator not defined.
+        """
         if n < 0 or n >= self._ngens:
             raise ValueError("generator not defined")
         return self._gens[int(n)]
@@ -943,9 +980,30 @@ cdef class MPolynomialRing_base(CommutativeRing):
                 return self.base_ring()
 
     def krull_dimension(self):
+        """
+        Return the Krull dimension of ``self``.
+
+        EXAMPLES::
+
+            sage: R = ZZ['t,u']
+            sage: R.krull_dimension()
+            3
+            sage: S = QQ['x,y']
+            sage: S.krull_dimension()
+            2
+        """
         return self.base_ring().krull_dimension() + self.ngens()
 
     def ngens(self):
+        """
+        Return the number of indeterminate generators of ``self``.
+
+        EXAMPLES::
+
+            sage: R = RR['x,y']
+            sage: R.ngens()
+            2
+        """
         return self._ngens
 
     def _monomial_order_function(self):

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -871,7 +871,7 @@ cdef class MPolynomialRing_base(CommutativeRing):
         """
         Return the term order of ``self``.
 
-        OUTPUT: a :class:`sage.rings.polynomial.term_order.TermOrder` of the
+        OUTPUT: a :class:`~sage.rings.polynomial.term_order.TermOrder` of the
         variables of ``self``.
 
         EXAMPLES::
@@ -906,22 +906,23 @@ cdef class MPolynomialRing_base(CommutativeRing):
 
         INPUT:
 
-        - ``n`` -- integer (default: ``0``) number of the generator
+        - ``n`` -- integer (default: ``0``); number of the generator
 
         EXAMPLES::
 
-            sage: R = ZZ['x,y,z']
+            sage: R = CC['x,y,z']
             sage: x = R.gen()
             sage: x
             x
             sage: parent(x)
-            Multivariate Polynomial Ring in x, y, z over Integer Ring
+            Multivariate Polynomial Ring in x, y, z over Complex Field with 53
+            bits of precision
             sage: R.gen(2)
             z
             sage: R.gen(23)
             Traceback (most recent call last):
             ...
-            ValueError: Generator not defined.
+            ValueError: generator not defined
         """
         if n < 0 or n >= self._ngens:
             raise ValueError("generator not defined")

--- a/src/sage/schemes/generic/scheme.py
+++ b/src/sage/schemes/generic/scheme.py
@@ -120,7 +120,7 @@ class Scheme(Parent):
             # X is a morphism of Rings
             self._base_ring = X.codomain()
         else:
-            raise ValueError('The base must be define by a scheme, '
+            raise ValueError('The base must be defined by a scheme, '
                              'scheme morphism, or commutative ring.')
 
         from sage.categories.schemes import Schemes


### PR DESCRIPTION
This PR adds a few missing docstrings and doctests to `multi_polynomial_ring_base.pyx`.

While I am at it, I also fixed a typo in `scheme.py`.

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.