### PR TITLE
Fix bug with creation of extensions of function fields

### DIFF
--- a/src/sage/rings/function_field/function_field.py
+++ b/src/sage/rings/function_field/function_field.py
@@ -467,9 +467,22 @@ class FunctionField(Field):
 
             sage: K.extension(t*y^3 + (1/t)*y + t^3/(t+1))                              # needs sage.rings.function_field
             Function field in y defined by t*y^3 + 1/t*y + t^3/(t + 1)
+
+        TESTS:
+
+        Verify that :issue:`41095` has been resolved::
+
+            sage: K.<x> = FunctionField(GF(2))
+            sage: R.<t> = PolynomialRing(K)
+            sage: L.<y> = K.extension(t^2 + t*x)
+            sage: M.<z> = L.extension(t^3 + x)
+            sage: M.base_ring() is K
+            False
+            sage: M.base_ring() is L
+            True
         """
         from . import constructor
-        return constructor.FunctionFieldExtension(f, names)
+        return constructor.FunctionFieldExtension(f.change_ring(self), names)
 
     def order_with_basis(self, basis, check: bool = True):
         """

--- a/src/sage/rings/function_field/function_field_rational.py
+++ b/src/sage/rings/function_field/function_field_rational.py
@@ -430,38 +430,6 @@ class RationalFunctionField(FunctionField):
         from sage.structure.factorization import Factorization
         return Factorization(w, unit=unit)
 
-    def extension(self, f, names=None):
-        """
-        Create an extension `L = K[y]/(f(y))` of the rational function field.
-
-        INPUT:
-
-        - ``f`` -- univariate polynomial over self
-
-        - ``names`` -- string or length-1 tuple
-
-        OUTPUT: a function field
-
-        EXAMPLES::
-
-            sage: K.<x> = FunctionField(QQ); R.<y> = K[]
-            sage: K.extension(y^5 - x^3 - 3*x + x*y)                                    # needs sage.rings.function_field
-            Function field in y defined by y^5 + x*y - x^3 - 3*x
-
-        A nonintegral defining polynomial::
-
-            sage: K.<t> = FunctionField(QQ); R.<y> = K[]
-            sage: K.extension(y^3 + (1/t)*y + t^3/(t+1))                                # needs sage.rings.function_field
-            Function field in y defined by y^3 + 1/t*y + t^3/(t + 1)
-
-        The defining polynomial need not be monic or integral::
-
-            sage: K.extension(t*y^3 + (1/t)*y + t^3/(t+1))                              # needs sage.rings.function_field
-            Function field in y defined by t*y^3 + 1/t*y + t^3/(t + 1)
-        """
-        from . import constructor
-        return constructor.FunctionFieldExtension(f, names)
-
     @cached_method
     def polynomial_ring(self, var='x'):
         """


### PR DESCRIPTION
When creating a function field extension, it is never checked that the polynomial defining the extension is defined over that function field. Hence, when calling `base_ring` one gets a bug because the base ring of the polynomial ring is returned, and not the function field which we used to create the extension.

Fixes #41095.

When working on this, I remarked that the `extension` method of `RationalFunctionField` was just a copy paste (even for doctests) of the one of `FunctionField`, which is its parent. So I also removed it. But I can put it back if someone explains me why this can sometimes be useful to do so.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.

