### PR TITLE
never append ':' to the end of PKG_CONFIG_PATH in .homebrew-build-env

### DIFF
--- a/.homebrew-build-env
+++ b/.homebrew-build-env
@@ -8,7 +8,11 @@ for l in bzip2 texinfo polymake; do
     fi
 done
 export PATH
-PKG_CONFIG_PATH="$HOMEBREW/lib/pkgconfig:$PKG_CONFIG_PATH"
+if [ -z "$PKG_CONFIG_PATH" ]; then
+    PKG_CONFIG_PATH="$HOMEBREW/lib/pkgconfig"
+else
+    PKG_CONFIG_PATH="$HOMEBREW/lib/pkgconfig:$PKG_CONFIG_PATH"
+fi
 # libpng.pc depends on zlib.pc
 for l in openblas openssl readline sqlite zlib; do
     if [ -d "$HOMEBREW/opt/$l/lib/pkgconfig" ]; then


### PR DESCRIPTION
if `PKG_CONFIG_PATH` is not set, then `.homebrew-build-env` adds a spurious `:` at the end. We fix this here.




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


