### PR TITLE
Fix a segmentation fault in Jacobian()

### DIFF
--- a/src/sage/geometry/integral_points.pxi
+++ b/src/sage/geometry/integral_points.pxi
@@ -535,6 +535,7 @@ cpdef rectangular_box_points(list box_min, list box_max,
         sage: with ensure_interruptible_after(0.5): P.integral_points()
     """
     assert len(box_min) == len(box_max)
+    assert box_min
     assert not (count_only and return_saturated)
     cdef int d = len(box_min)
     cdef int i, j

--- a/src/sage/geometry/integral_points.pxi
+++ b/src/sage/geometry/integral_points.pxi
@@ -533,6 +533,14 @@ cpdef rectangular_box_points(list box_min, list box_max,
         sage: P = Polyhedron(ieqs=ieqs)
         sage: from sage.doctest.util import ensure_interruptible_after
         sage: with ensure_interruptible_after(0.5): P.integral_points()
+
+    Check that the following doesn't segmentation fault
+    (the error message could be improved)::
+
+        sage: rectangular_box_points([], [])
+        Traceback (most recent call last):
+        ...
+        AssertionError
     """
     assert len(box_min) == len(box_max)
     assert box_min

--- a/src/sage/schemes/elliptic_curves/jacobian.py
+++ b/src/sage/schemes/elliptic_curves/jacobian.py
@@ -96,6 +96,16 @@ def Jacobian(X, **kwds):
                 (-u^4*v^4*w - u^4*v*w^4 - u*v^4*w^4 :
                  1/2*u^6*v^3 - 1/2*u^3*v^6 - 1/2*u^6*w^3 + 1/2*v^6*w^3 + 1/2*u^3*w^6 - 1/2*v^3*w^6 :
                  u^3*v^3*w^3)
+
+    TESTS:
+
+    Check that the following doesn't segmentation fault
+    (the error message could be improved)::
+
+        sage: Jacobian(GF(11)['x,y'](3))
+        Traceback (most recent call last):
+        ...
+        AssertionError
     """
     try:
         return X.jacobian(**kwds)


### PR DESCRIPTION
See the newly added test, previously it segmentation faults.

the reason is the inner loop `loop_over_rectangular_box_points` accesses `i_min = box_min[0]` without any bound checking, this will segmentation fault if `box_min` is empty.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


