### PR TITLE
Fix G.subgraph(edges=generator) deleting all edges

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -14367,6 +14367,14 @@ class GenericGraph(GenericGraph_pyx):
             sage: g.subgraph(list(range(10)))  # uses the 'add' algorithm
             Subgraph of (Path graph): Graph on 10 vertices
 
+        The vertices and edges can be specified using generator expressions
+        (see :issue:`41130`)::
+
+            sage: g = graphs.CompleteGraph(5)
+            sage: h = g.subgraph(vertices=(v for v in range(4)), edges=((0, v) for v in range(5)))
+            sage: h.edges(labels=False)
+            [(0, 1), (0, 2), (0, 3)]
+
         TESTS:
 
         The appropriate properties are preserved::
@@ -14519,8 +14527,13 @@ class GenericGraph(GenericGraph_pyx):
             G.add_vertices(self if vertices is None else vertices)
 
             if edges is not None:
-                edges_to_keep_labeled = frozenset(e for e in edges if len(e) == 3)
-                edges_to_keep_unlabeled = frozenset(e for e in edges if len(e) == 2)
+                edges_to_keep_labeled = set()
+                edges_to_keep_unlabeled = set()
+                for e in edges:
+                    if len(e) == 3:
+                        edges_to_keep_labeled.add(e)
+                    elif len(e) == 2:
+                        edges_to_keep_unlabeled.add(e)
 
                 edges_to_keep = []
                 if self._directed:
@@ -14701,8 +14714,13 @@ class GenericGraph(GenericGraph_pyx):
 
         edges_to_delete = []
         if edges is not None:
-            edges_to_keep_labeled = frozenset(e for e in edges if len(e) == 3)
-            edges_to_keep_unlabeled = frozenset(e for e in edges if len(e) == 2)
+            edges_to_keep_labeled = set()
+            edges_to_keep_unlabeled = set()
+            for e in edges:
+                if len(e) == 3:
+                    edges_to_keep_labeled.add(e)
+                elif len(e) == 2:
+                    edges_to_keep_unlabeled.add(e)
             edges_to_delete = []
             if G._directed:
                 for e in G.edge_iterator():


### PR DESCRIPTION
This is a simple fix for a nasty issue:
I would expect that the Sage expression `graphs.CompleteGraph(5).subgraph(edges=((0, v) for v in range(5)))` returns a star graph on 4 edges. But it actually returned an edgeless graph! This is because the `subgraph` function expects the `edges` parameter to be a list that can be iterated over twice but the [generator expression](https://peps.python.org/pep-0289/) `((0, v) for v in range(5))` becomes empty after looping over it once, which caused `edges_to_keep_unlabeled` to be empty.

While the [documentation for `subgraph()`](https://doc-develop--sagemath.netlify.app/html/en/reference/graphs/sage/graphs/generic_graph.html#sage.graphs.generic_graph.GenericGraph.subgraph) does not mention that `edges` is allowed to be a generator expression, many other functions that expect an "iterable container" as parameter work just fine if a  generator expression is passed instead. For example, `subdivide_edges()`, `delete_edges()` and `G.subgraph(v for v in range(4))` work as expected.

There are multiple ways to fix this issue. The simplest and most reliable would be to write `edges = list(edges)`, which would go well with [`vertices = list(vertices)`](https://github.com/sagemath/sage/blob/aa27703384a568d85f1751197efe06ff135be352/src/sage/graphs/generic_graph.py#L14400). Instead I opted to fix the symptom by only iterating over `edges` once, which I believe is faster and uses less memory.