### PR TITLE
Fix the compatibility issue for ipython 9.7.0

### DIFF
--- a/src/sage/repl/display/formatter.py
+++ b/src/sage/repl/display/formatter.py
@@ -62,7 +62,6 @@ This other facility uses a simple
 from io import StringIO
 
 from IPython.core.formatters import DisplayFormatter, PlainTextFormatter
-from IPython.utils.py3compat import unicode_to_str
 from IPython.core.display import DisplayObject
 
 from ipywidgets import Widget
@@ -311,7 +310,7 @@ class SagePlainTextFormatter(PlainTextFormatter):
             print('---- calling ipython formatter ----')
         stream = StringIO()
         printer = SagePrettyPrinter(
-            stream, self.max_width, unicode_to_str(self.newline))
+            stream, self.max_width, self.newline)
         printer.pretty(obj)
         printer.flush()
         return stream.getvalue()


### PR DESCRIPTION
Remove the outdate unicode_to_str. Solve #41140 
This function is mainly used to compatible for python2. Now it is gone.
It cause crash when run sage
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


