### PR TITLE
replace spanning_trees_count with number_of_spanning_trees for consistency

### DIFF
--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -3568,7 +3568,7 @@ class DiGraph(GenericGraph):
               -- iterator over in-branchings rooted at given vertex.
             - :meth:`~sage.graphs.graph.Graph.spanning_trees`
               -- returns all spanning trees.
-            - :meth:`~sage.graphs.generic_graph.GenericGraph.spanning_trees_count`
+            - :meth:`~sage.graphs.generic_graph.GenericGraph.number_of_spanning_trees`
               -- counts the number of spanning trees.
 
         ALGORITHM:
@@ -3784,7 +3784,7 @@ class DiGraph(GenericGraph):
               -- iterator over out-branchings rooted at given vertex.
             - :meth:`~sage.graphs.graph.Graph.spanning_trees`
               -- returns all spanning trees.
-            - :meth:`~sage.graphs.generic_graph.GenericGraph.spanning_trees_count`
+            - :meth:`~sage.graphs.generic_graph.GenericGraph.number_of_spanning_trees`
               -- counts the number of spanning trees.
 
         ALGORITHM:

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -266,7 +266,7 @@ can be applied on both. Here is what it can do:
     :meth:`~GenericGraph.transitive_closure` | Compute the transitive closure of a graph and returns it.
     :meth:`~GenericGraph.transitive_reduction` | Return a transitive reduction of a graph.
     :meth:`~GenericGraph.min_spanning_tree` | Return the edges of a minimum spanning tree.
-    :meth:`~GenericGraph.spanning_trees_count` | Return the number of spanning trees in a graph.
+    :meth:`~GenericGraph.number_of_spanning_trees` | Return the number of spanning trees in a graph.
     :meth:`~GenericGraph.dominator_tree`    | Return a dominator tree of the graph.
     :meth:`~GenericGraph.connected_subgraph_iterator` | Iterator over the induced connected subgraphs of order at most `k`
 
@@ -5359,7 +5359,7 @@ class GenericGraph(GenericGraph_pyx):
                     for u, v in E]
         raise NotImplementedError("minimum spanning tree algorithm '%s' is not implemented" % algorithm)
 
-    def spanning_trees_count(self, root_vertex=None):
+    def number_of_spanning_trees(self, root_vertex=None):
         r"""
         Return the number of spanning trees in a graph.
 
@@ -5402,14 +5402,14 @@ class GenericGraph(GenericGraph_pyx):
         EXAMPLES::
 
             sage: G = graphs.PetersenGraph()
-            sage: G.spanning_trees_count()                                              # needs sage.modules
+            sage: G.number_of_spanning_trees()                                          # needs sage.modules
             2000
 
         ::
 
             sage: n = 11
             sage: G = graphs.CompleteGraph(n)
-            sage: ST = G.spanning_trees_count()                                         # needs sage.modules
+            sage: ST = G.number_of_spanning_trees()                                     # needs sage.modules
             sage: ST == n ^ (n - 2)                                                     # needs sage.modules
             True
 
@@ -5418,11 +5418,11 @@ class GenericGraph(GenericGraph_pyx):
             sage: # needs sage.modules
             sage: M = matrix(3, 3, [0, 1, 0, 0, 0, 1, 1, 1, 0])
             sage: D = DiGraph(M)
-            sage: D.spanning_trees_count()
+            sage: D.number_of_spanning_trees()
             1
-            sage: D.spanning_trees_count(0)
+            sage: D.number_of_spanning_trees(0)
             1
-            sage: D.spanning_trees_count(2)
+            sage: D.number_of_spanning_trees(2)
             2
         """
         if not self.order():
@@ -5447,6 +5447,8 @@ class GenericGraph(GenericGraph_pyx):
         M[index, index] += 1
         return abs(M.determinant())
 
+    spanning_trees_count = number_of_spanning_trees
+    
     def cycle_basis(self, output='vertex'):
         r"""
         Return a list of cycles which form a basis of the cycle space of

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -5448,7 +5448,7 @@ class GenericGraph(GenericGraph_pyx):
         return abs(M.determinant())
 
     spanning_trees_count = number_of_spanning_trees
-    
+
     def cycle_basis(self, output='vertex'):
         r"""
         Return a list of cycles which form a basis of the cycle space of

--- a/src/sage/graphs/spanning_tree.pyx
+++ b/src/sage/graphs/spanning_tree.pyx
@@ -947,7 +947,7 @@ def random_spanning_tree(G, output_as_graph=False, by_weight=False, weight_funct
 
     .. SEEALSO::
 
-        :meth:`~sage.graphs.generic_graph.GenericGraph.spanning_trees_count`
+        :meth:`~sage.graphs.generic_graph.GenericGraph.number_of_spanning_trees`
         and :meth:`~sage.graphs.graph.Graph.spanning_trees`
 
     EXAMPLES::
@@ -1096,17 +1096,17 @@ def spanning_trees(g, labels=False):
         sage: G = Graph([(1,2),(1,2),(1,3),(1,3),(2,3),(1,4)], multiedges=True)
         sage: len(list(G.spanning_trees()))
         8
-        sage: G.spanning_trees_count()                                                  # needs sage.modules
+        sage: G.number_of_spanning_trees()                                              # needs sage.modules
         8
         sage: G = Graph([(1,2),(2,3),(3,1),(3,4),(4,5),(4,5),(4,6)], multiedges=True)
         sage: len(list(G.spanning_trees()))
         6
-        sage: G.spanning_trees_count()                                                  # needs sage.modules
+        sage: G.number_of_spanning_trees()                                              # needs sage.modules
         6
 
     .. SEEALSO::
 
-        - :meth:`~sage.graphs.generic_graph.GenericGraph.spanning_trees_count`
+        - :meth:`~sage.graphs.generic_graph.GenericGraph.number_of_spanning_trees`
           -- counts the number of spanning trees
 
         - :meth:`~sage.graphs.graph.Graph.random_spanning_tree`

--- a/src/sage/graphs/tutte_polynomial.py
+++ b/src/sage/graphs/tutte_polynomial.py
@@ -550,7 +550,7 @@ def tutte_polynomial(G, edge_selector=None, cache=None):
         sage: G = graphs.RandomGNP(10,0.6)
         sage: while not G.is_connected():
         ....:     G = graphs.RandomGNP(10,0.6)
-        sage: G.tutte_polynomial()(1,1) == G.spanning_trees_count()                     # needs sage.modules
+        sage: G.tutte_polynomial()(1,1) == G.number_of_spanning_trees()                 # needs sage.modules
         True
 
     Given that `T(x,y)` is the Tutte polynomial of a graph `G` with
@@ -580,7 +580,7 @@ def tutte_polynomial(G, edge_selector=None, cache=None):
         sage: g.add_edges([(0,1,1),(1,5,2),(5,3,3),(5,2,4),(2,4,5),(0,2,6),(0,3,7),(0,4,8),(0,5,9)])
         sage: g.tutte_polynomial()(1,1)
         52
-        sage: g.spanning_trees_count()                                                  # needs sage.modules
+        sage: g.number_of_spanning_trees()                                              # needs sage.modules
         52
     """
     R = ZZ['x, y']


### PR DESCRIPTION
See also #40935.

We do not deprecate `spanning_trees_count`, but we do not advertise it anymore.