### PR TITLE
Add the Barker-Foran cone to the cone catalog

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -564,6 +564,11 @@ REFERENCES:
                  "PHOTON-BeetleAuthenticated Encryption and Hash Family"
                  https://csrc.nist.gov/CSRC/media/Projects/Lightweight-Cryptography/documents/round-1/spec-doc/PHOTON-Beetle-spec.pdf
 
+.. [BF1976] George Phillip Barker and James Foran.
+            *Self-Dual Cones in Euclidean Spaces*.
+            Linear Algebra and its Applications, 13(1-2):147-155, 1976.
+            :doi:`10.1016/0024-3795(76)90053-7`.
+
 .. [BH1965] \L. D. Baumert, M. Hall Jr.
             *A new construction for Hadamard matrices*.
             Bulletin of the American Mathematical Society 71(1):169-170, 1965.

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -236,7 +236,7 @@ def barker_foran(lattice=None):
            ( zero, -one,  one),
            ( one,  -one,  one)]  # noqa: E221
 
-    return Cone(ext, lattice)
+    return Cone(ext, lattice, check=False)
 
 
 def downward_monotone(ambient_dim=None, lattice=None):

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -8,6 +8,7 @@ globally-available ``cones`` prefix, to create some common cones:
 - The nonnegative orthant,
 - The rearrangement cone of order ``p``,
 - The Schur cone,
+- The Barker-Foran cone,
 - The trivial cone.
 
 At the moment, only convex rational polyhedral cones are
@@ -159,6 +160,83 @@ def _preprocess_args(ambient_dim, lattice):
                          "are incompatible" % (lattice.rank(), ambient_dim))
 
     return (ambient_dim, lattice)
+
+
+def barker_foran(lattice=None):
+    r"""
+    The Barker-Foran cone, an example of a "self-dual" cone with
+    five extreme rays in three dimensions.
+
+    In Sage, every dual cone lives in a distinct dual lattice, but we
+    use the term "self-dual" loosely to indicate that the cone and its
+    dual are equal as sets under a canonical lattice isomorphism.
+
+    INPUT:
+
+    - ``lattice`` -- a toric lattice (default: ``None``) of rank
+      three; the lattice in which the cone will live
+
+    If the ``lattice`` is omitted, then the default lattice of rank
+    three will be used.
+
+    OUTPUT:
+
+    A :class:`~sage.geometry.cone.ConvexRationalPolyhedralCone` living
+    in ``lattice`` that is self-dual and has five extreme rays.
+
+    A :exc:`ValueError` is raised if the ``lattice`` is of an
+    incompatible rank.
+
+    REFERENCES:
+
+    - [BF1976]_
+
+    EXAMPLES:
+
+    Basic usage; confirm self-duality::
+
+        sage: K = cones.barker_foran()
+        sage: K.nrays()
+        5
+        sage: K.is_proper()  # should be implied by self-duality
+        True
+        sage: K_ext = K.rays().matrix().rows()
+        sage: K_dual_ext = K.dual().rays().matrix().rows()
+        sage: set(K_ext) == set(K_dual_ext)  #  self-dual
+        True
+
+    TESTS:
+
+    If a ``lattice`` was given, it is actually used::
+
+        sage: M = ToricLattice(3, 'M')
+        sage: cones.barker_foran(lattice=M)
+        3-d cone in 3-d lattice M
+
+    Unless it has the wrong rank::
+
+        sage: M = ToricLattice(2, 'M')
+        sage: cones.barker_foran(lattice=M)
+        Traceback (most recent call last):
+        ...
+        ValueError: lattice rank=2 and ambient_dim=3 are incompatible
+
+    """
+    from sage.geometry.cone import Cone
+    from sage.rings.integer_ring import ZZ
+
+    ambient_dim = 3
+    ambient_dim, lattice = _preprocess_args(ambient_dim, lattice)
+
+    one = ZZ.one()
+    zero = ZZ.zero()
+    ext = [( one,   one,  one),
+           ( zero,  one,  one),
+           (-one,   zero, one),
+           ( zero, -one,  one),
+           ( one,  -one,  one)]
+
+    return Cone(ext, lattice)
 
 
 def downward_monotone(ambient_dim=None, lattice=None):

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -234,7 +234,7 @@ def barker_foran(lattice=None):
            ( zero,  one,  one),
            (-one,   zero, one),
            ( zero, -one,  one),
-           ( one,  -one,  one)]
+           ( one,  -one,  one)]  # noqa: E221
 
     return Cone(ext, lattice)
 


### PR DESCRIPTION
This is a handy example of a self-dual (but not symmetric) polyhedral cone given in [Self-dual cones in euclidean spaces](https://www.sciencedirect.com/science/article/pii/0024379576900537?via%3Dihub) by Barker & Foran. I mention it in [Gaddum's test for symmetric cones](https://michael.orlitzky.com/documents/papers/gaddums_test_for_symmetric_cones.pdf), which is freely available.

I've called it the Barker-Foran cone for lack of a better name. The authors define another, related family of cones in the same paper... but the coordinates of their extreme rays aren't rational, so there is no immediate risk of them being added to sage and causing a name clash.
