### PR TITLE
Speedup and proper fix for gap conversion from sage/python integer

### DIFF
--- a/src/sage/libs/gap/element.pxd
+++ b/src/sage/libs/gap/element.pxd
@@ -15,7 +15,7 @@ from sage.structure.element cimport Element, ModuleElement, RingElement
 cdef Obj make_gap_list(sage_list) except NULL
 cdef Obj make_gap_matrix(sage_list, gap_ring) except NULL
 cdef Obj make_gap_record(sage_dict) except NULL
-cdef Obj make_gap_integer(sage_int) except NULL
+cdef Obj make_gap_integer(x) except NULL
 cdef Obj make_gap_string(sage_string) except NULL
 
 cdef GapElement make_any_gap_element(parent, Obj obj)

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -6362,6 +6362,19 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         """
         return str(self)
 
+    def _libgap_(self):
+        """
+        Convert this integer to ``libgap``. Not to be used directly, use ``libgap(x)``.
+
+        EXAMPLES::
+
+            sage: libgap(1)
+            1
+        """
+        from sage.libs.gap.element import make_GapElement_Integer_from_sage_integer  # avoid compile-time dependency
+        from sage.libs.gap.libgap import libgap
+        return make_GapElement_Integer_from_sage_integer(libgap, self)
+
     @property
     def __array_interface__(self):
         """


### PR DESCRIPTION
follow up to https://github.com/sagemath/sage/pull/41057

My machine has `sizeof(mp_limb_t) == sizeof(UInt)` true, but I've tested both branches by changing the `if ...` to `if False` and see that the tests pass.

the expression `num_gmp_limbs * sizeof(mp_limb_t)` cannot overflow (because there's a buffer in memory with that size), so as long as `sizeof(mp_limb_t) > 1` (which must be the case, see below), `-num_gmp_limbs` cannot overflow `UInt`.

## note on word size

From `gmp-h.in`:

```
#ifdef __GMP_SHORT_LIMB
typedef unsigned int		mp_limb_t;
typedef int			mp_limb_signed_t;
#else
#ifdef _LONG_LONG_LIMB
typedef unsigned long long int	mp_limb_t;
typedef long long int		mp_limb_signed_t;
#else
typedef unsigned long int	mp_limb_t;
typedef long int		mp_limb_signed_t;
#endif
#endif
typedef unsigned long int	mp_bitcnt_t;

/* For reference, note that the name __mpz_struct gets into C++ mangled
   function names, which means although the "__" suggests an internal, we
   must leave this name for binary compatibility.  */
typedef struct
{
  int _mp_alloc;		/* Number of *limbs* allocated and pointed
				   to by the _mp_d field.  */
  int _mp_size;			/* abs(_mp_size) is the number of limbs the
				   last field points to.  If _mp_size is
				   negative this is a negative number.  */
  mp_limb_t *_mp_d;		/* Pointer to the limbs.  */
} __mpz_struct;
```

From `gap/src/common.h`:

```
typedef intptr_t  Int;
typedef uintptr_t UInt;
```

so their sizes need not always be equal.

## note on gap internal implementation of integer

That said, `gap/src/integer.c` contains this

```
GAP_STATIC_ASSERT( sizeof(mp_limb_t) == sizeof(UInt), "gmp limb size incompatible with GAP word size");
```

maybe we're safe...? On the other hand it's entirely possible that gap and sage are compared with different settings of gmp, they're distinct shared libraries.

also there's this

```
/****************************************************************************
**
**  'ADDR_INT' returns a pointer to the limbs of the large integer 'obj'.
**  'CONST_ADDR_INT' does the same, but returns a const pointer.
*/
EXPORT_INLINE UInt * ADDR_INT(Obj obj)
{
    GAP_ASSERT(IS_LARGEINT(obj));
    return (UInt *)ADDR_OBJ(obj);
}


static Obj GMPorINTOBJ_MPZ( mpz_t v )
{
    return MakeObjInt((const UInt *)v->_mp_d, v->_mp_size);
}
```

the former is actually exported. If we're fine with using more internals, we could call `NewBag` directly with the correct size, but I think that's unnecessary.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


