### PR TITLE
Fix FinitelyPresentedGroupElement.__hash__

### DIFF
--- a/src/sage/groups/finitely_presented.py
+++ b/src/sage/groups/finitely_presented.py
@@ -363,9 +363,11 @@ class FinitelyPresentedGroupElement(FreeGroupElement):
 
     def _normal_form_by_gap_nffunction(self) -> GapElement:
         """
-        Internal method that calls ``FpElementNFFunction`` to compute some normal form
-        for this group element.
-        Note that this is not guaranteed to terminate.
+        Call ``FpElementNFFunction`` to compute some normal form for ``self``.
+
+        .. WARNING::
+
+            Note that this is not guaranteed to terminate.
 
         .. SEEALSO::
 
@@ -395,9 +397,11 @@ class FinitelyPresentedGroupElement(FreeGroupElement):
 
     def __hash__(self) -> int:
         """
-        Return some hash value, such that if ``x == y``
-        then ``hash(x) == hash(y)``.
-        Note that this is not guaranteed to terminate.
+        Return the hash of ``self`` based on a normal form.
+
+        .. WARNING::
+
+            Note that this is not guaranteed to terminate.
 
         TESTS::
 
@@ -1982,7 +1986,9 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
               or for a different (but equal) group. For the same group object,
               it is guaranteed to be the same.
 
-            - This function is not guaranteed to terminate.
+        .. WARNING::
+
+            This function is not guaranteed to terminate.
 
         EXAMPLES::
 

--- a/src/sage/groups/finitely_presented.py
+++ b/src/sage/groups/finitely_presented.py
@@ -351,7 +351,7 @@ class FinitelyPresentedGroupElement(FreeGroupElement):
             ...
             ValueError: the values do not satisfy all relations of the group
             sage: w(1, 2, check=False)    # result depends on presentation of the group element
-            2
+            8
         """
         values = list(values)
         if kwds.get('check', True):

--- a/src/sage/schemes/curves/zariski_vankampen.py
+++ b/src/sage/schemes/curves/zariski_vankampen.py
@@ -1367,8 +1367,8 @@ def braid_monodromy(f, arrangement=(), vertical=False):
     end_braid_computation = False
     while not end_braid_computation:
         try:
-            braidscomputed = (braid_in_segment([(glist, seg[0], seg[1])
-                                                for seg in segs]))
+            braidscomputed = braid_in_segment([(glist, seg[0], seg[1])
+                                               for seg in segs])
             segsbraids = {}
             for braidcomputed in braidscomputed:
                 seg = (braidcomputed[0][0][1], braidcomputed[0][0][2])
@@ -1816,7 +1816,7 @@ def fundamental_group_arrangement(flist, simplified=True, projective=False,
       each of this paths is the conjugated of a loop around one of the points
       in the discriminant of the projection of ``f``.
 
-    - A dictionary attaching to ``j`` a tuple a list of elements
+    - A dictionary attaching to ``j`` a list of elements
       of the group  which are meridians of the curve in position ``j``.
       If ``projective`` is ``False`` and the `y`-degree of the horizontal
       components coincide with the total degree, another key is added
@@ -1925,5 +1925,7 @@ def fundamental_group_arrangement(flist, simplified=True, projective=False,
     n = g1.ngens()
     rels = [rel.Tietze() for rel in g1.relations()]
     g1 = FreeGroup(n) / rels
-    dic1 = {i: list({g1(el.Tietze()) for el in dic1[i]}) for i in dic1}
+    dic1 = {i: [*{t: g1(t) for el in dic1[i] for t in (el.Tietze(),)}.values()] for i in dic1}
+    # each list in dic1.values() may have duplicates, but deduplicating it properly
+    # requires solving the group problem on g1 which can be prohibitive
     return (g1, dic1)

--- a/src/sage/topology/simplicial_set_examples.py
+++ b/src/sage/topology/simplicial_set_examples.py
@@ -835,25 +835,26 @@ def PresentationComplex(G):
     """
     O = AbstractSimplex(0)
     SO = O.apply_degeneracies(0)
-    edges = {g: AbstractSimplex(1, name=str(g)) for g in G.gens()}
-    inverseedges = {g.inverse(): AbstractSimplex(1, name=str(g.inverse())) for g in G.gens()}
+    F = G.free_group()
+    edges = {g: AbstractSimplex(1, name=str(g)) for g in F.gens()}
+    inverseedges = {g.inverse(): AbstractSimplex(1, name=str(g.inverse())) for g in F.gens()}
     all_edges = {}
     all_edges.update(edges)
     all_edges.update(inverseedges)
-    triangles = {g: AbstractSimplex(2, name='T' + str(g)) for g in G.gens()}
+    triangles = {g: AbstractSimplex(2, name='T' + str(g)) for g in F.gens()}
     face_maps = {g: [O, O] for g in all_edges.values()}
     face_maps.update({triangles[t]: [all_edges[t], SO, all_edges[t.inverse()]] for t in triangles})
     for r in G.relations():
         if len(r.Tietze()) == 1:
             pass
         elif len(r.Tietze()) == 2:
-            a = all_edges[G([r.Tietze()[0]])]
-            b = all_edges[G([r.Tietze()[1]])]
+            a = all_edges[F([r.Tietze()[0]])]
+            b = all_edges[F([r.Tietze()[1]])]
             T = AbstractSimplex(2, name=str(r))
             face_maps[T] = [a, SO, b]
         else:
-            words = [all_edges[G([a])] for a in r.Tietze()]
-            words[-1] = all_edges[G([-r.Tietze()[-1]])]
+            words = [all_edges[F([a])] for a in r.Tietze()]
+            words[-1] = all_edges[F([-r.Tietze()[-1]])]
             while len(words) > 3:
                 auxedge = AbstractSimplex(1)
                 face_maps[auxedge] = [O, O]


### PR DESCRIPTION
Replacement for https://github.com/sagemath/sage/pull/40563. Fix #40549

Note that `FpElementNFFunction` is what GAP uses internally for `==`


```
#############################################################################
##
#M  \=( <elm1>, <elm2> )  . . . . . . . . .  for two elements of a f.p. group
##
InstallMethod( \=, "for two f.p. group elements", IsIdenticalObj,
    [ IsElementOfFpGroup, IsElementOfFpGroup ],0,
# this is the only method that may ever be called!
function( left, right )
  if UnderlyingElement(left)=UnderlyingElement(right) then
    return true;
  fi;
  return FpElmEqualityMethod(FamilyObj(left))(left,right);
end );


InstallMethod( FpElmEqualityMethod, "generic dispatcher",
true,[IsElementOfFpGroupFamily],0,MakeFpGroupCompMethod(\=));


BindGlobal( "MakeFpGroupCompMethod", function(CMP)
  return function(fam)
    local hom,f,com;
    # if a normal form method is known, and it is not known to be crummy
    if HasFpElementNFFunction(fam) and not IsBound(fam!.hascrudeFPENFF) then
      f:=FpElementNFFunction(fam);
      com:=x->f(UnderlyingElement(x));
    # if we know a faithful representation, use it
    elif HasFPFaithHom(fam) and
     FPFaithHom(fam)<>fail then
      hom:=FPFaithHom(fam);
      com:=x->Image(hom,x);
	  ...
```


Sometimes `==` works better than `confluent_rewriting_system`. (Although I don't dare to include this as a test, otherwise upgrade to GAP that selects a different algorithm may randomly timeout the test)

```
sage: F.<a,b,c,d,e> = FreeGroup()
sage: rules = [e*d*c^-1*d*a, b^-1*a, a*e*b*d^-1*c]
sage: G = F / rules
sage: G(a) == G(1)
False
sage: G.confluent_rewriting_system()  # takes forever
```

Sometimes not. But gap appears to use some sort of caching system, so it might work anyway.

```
sage: F.<a,b,c> = FreeGroup()
sage: rules = [a^-1*b*c*a*b, a*c^-1*a*c^-1*a, a^2*c]
sage: G = F / rules
sage: G(a) == G(1)	# takes forever
```

When one compute one `confluent_rewriting_system` and one `hash` before the `==`, it finishes quickly.

```
sage: F.<a,b,c> = FreeGroup()
sage: rules = [a^-1*b*c*a*b, a*c^-1*a*c^-1*a, a^2*c]
sage: G = F / rules
sage: ignore = G.confluent_rewriting_system()
sage: G(a)._normal_form_by_gap_nffunction()
a
sage: G(a) == G(1)
False
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


