### PR TITLE
Speedup Integer + int

### DIFF
--- a/src/sage/libs/mpmath/ext_impl.pyx
+++ b/src/sage/libs/mpmath/ext_impl.pyx
@@ -54,8 +54,8 @@ cdef inline void mpz_add_si(mpz_t a, mpz_t b, long x) noexcept:
     if x >= 0:
         mpz_add_ui(a, b, x)
     else:
-        # careful: overflow when negating INT_MIN
-        mpz_sub_ui(a, b, <unsigned long>(-x))
+        # careful: overflow when negating LONG_MIN
+        mpz_sub_ui(a, b, -<unsigned long>x)
 
 cdef inline mpzi(mpz_t n):
     return mpz_get_pyintlong(n)


### PR DESCRIPTION
Before:

```
sage: a = ZZ(5)
sage: %timeit a + 1r
295 ns ± 5.14 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
sage: %timeit a + ZZ.one()
114 ns ± 1.1 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

After:

```
sage: a = ZZ(5)
sage: %timeit a + 1r
41.3 ns ± 0.354 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
sage: %timeit 1r + a
51.6 ns ± 0.692 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
sage: %timeit a + ZZ.one()
120 ns ± 1.22 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

as far as I can tell, the increase in the last one is unrelated.

note that the overhead comes from the cached function call

```
sage: a = ZZ(5)
sage: b = ZZ.one()
sage: %timeit a + b
49.1 ns ± 2.81 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


