### PR TITLE
Fix meson build on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - debian:forky
           - ghcr.io/void-linux/void-glibc-full
           - archlinux
-          - ubuntu:22.04
+          #- ubuntu:22.04 - gap is outdated there (only 4.11)
           - ubuntu:24.04
           - ubuntu:25.04
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
           - debian:forky
           - ghcr.io/void-linux/void-glibc-full
           - archlinux
-          #- ubuntu:22.04 - fails due to issue with cypari2
-          #- ubuntu:24.04 - fails due to issue with cypari2
+          - ubuntu:22.04
+          - ubuntu:24.04
           - ubuntu:25.04
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
             # but we need the maxima help to be in place
             sed -i '/^NoExtract/d' /etc/pacman.conf
           fi
+          if [ "${{ matrix.container }}" = "ubuntu:22.04" ]; then
+            apt-get update
+            apt-get install -y git
+          fi
 
       - name: Checkout code
         # cannot use v4 yet because of https://github.com/actions/checkout/issues/1487

--- a/build/bin/sage-print-system-package-command
+++ b/build/bin/sage-print-system-package-command
@@ -153,7 +153,7 @@ case $system:$command in
         fi
         ;;
     @(fedora*|redhat*|centos*):install)
-        [ "$YES" = yes ] && options="$options -y"
+        [ "$YES" = yes ] && options="$options -y --allowerasing"
         [ "$IGNORE_MISSING" = yes ] && options="$options --skip-unavailable"
         [ -n "$system_packages" ] && print_shell_command ${SUDO}dnf install $options $system_packages
         ;;

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   version: files('VERSION.txt'),
   license: 'GPL v3',
   default_options: ['c_std=c17', 'cpp_std=c++17', 'python.install_env=auto'],
-  meson_version: '>=1.2',
+  meson_version: '>=1.5',
 )
 
 # Python module

--- a/src/meson.build
+++ b/src/meson.build
@@ -87,6 +87,32 @@ except Exception:
 endif
 # Cannot be found via pkg-config
 pari = cc.find_library('pari', required: not is_windows, disabler: true)
+if pari.found() and not meson.is_cross_build()
+  # Verify PARI version
+  pari_version_code = '''
+  #include <stdio.h>
+  #include <pari/pari.h>
+  int main(void) {
+    pari_init(1000000, 2);
+    GEN v = pari_version(), M = gel(v,1), m = gel(v,2), p = gel(v,3);
+    printf("%ld.%ld.%ld", itos(M), itos(m), itos(p));
+    pari_close();
+    return 0;
+  }
+  '''
+  pari_version = cc.run(
+    pari_version_code,
+    args: ['-v'],
+    name: 'pari version',
+    dependencies: [pari],
+    required: true,
+  ).stdout().strip()
+  if pari_version.version_compare('<=2.17.0')
+    message('PARI version > 2.17.0 required, found ' + pari_version)
+    pari = disabler()
+  endif
+endif
+
 
 mpfr = dependency('mpfr')
 

--- a/subprojects/flint.wrap
+++ b/subprojects/flint.wrap
@@ -3,6 +3,8 @@ url = https://github.com/flintlib/flint.git
 revision = main
 depth = 1
 patch_directory = flint
+diff_files = flint/cmakelinux.patch
+method = cmake
 
 [provide]
-dependency_names = flint
+flint = flint_dep

--- a/subprojects/packagefiles/flint/cmakelinux.patch
+++ b/subprojects/packagefiles/flint/cmakelinux.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8d959fb..5dcbf6e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,10 +12,6 @@
+ 
+ cmake_minimum_required(VERSION 3.22)
+ 
+-if(NOT WIN32)
+-    message(FATAL_ERROR "Detected system is not Windows.  Please use the Autotools configuration along with the Makefile instead as it is more up-to-date.  Read INSTALL.md.")
+-endif()
+-
+ include(CheckCCompilerFlag)
+ include(CheckCSourceRuns)
+ include(CheckIPOSupported)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fix the meson build on Ubuntu 24.04 by:
- Changing the flint subproject to use cmake (which is offically only supported on windows, but seems to work well also on Ubuntu)
- Add a check for the pari version (because the older ubuntu only comes with 2.15.4, against which sage doesn't actually compile)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


