### PR TITLE
Accept both 'implementation' and 'impl' parameters for GF()

### DIFF
--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -3534,8 +3534,6 @@ class AlgebraicExtensionFunctor(ConstructionFunctor):
         # integers to encode degrees of extensions.
         from sage.rings.integer import Integer
         kwds_self = dict(self.kwds.items())
-        if 'implementation' in kwds_self:
-            del kwds_self['implementation']
         kwds_other = dict(other.kwds.items())
         if (isinstance(self.polys[0], Integer)
                 and isinstance(other.polys[0], Integer)

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -3529,11 +3529,11 @@ class AlgebraicExtensionFunctor(ConstructionFunctor):
         # integers to encode degrees of extensions.
         from sage.rings.integer import Integer
         kwds_self = dict(self.kwds.items())
-        if 'impl' in kwds_self:
-            del kwds_self['impl']
+        if 'implementation' in kwds_self:
+            del kwds_self['implementation']
         kwds_other = dict(other.kwds.items())
-        if 'impl' in kwds_other:
-            del kwds_other['impl']
+        if 'implementation' in kwds_other:
+            del kwds_other['implementation']
         if (isinstance(self.polys[0], Integer)
                 and isinstance(other.polys[0], Integer)
                 and self.embeddings == other.embeddings == [None]

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -3294,7 +3294,10 @@ class AlgebraicExtensionFunctor(ConstructionFunctor):
                 if latex_names[i] == latex_variable_name(name):
                     latex_names[i] = None
         self.latex_names = latex_names
-        self.kwds = kwds
+        kwds_self = dict(kwds.items())
+        if 'implementation' in kwds_self:
+            del kwds_self['implementation']
+        self.kwds = kwds_self
 
     def _apply_functor(self, R):
         """

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -3296,6 +3296,7 @@ class AlgebraicExtensionFunctor(ConstructionFunctor):
         self.latex_names = latex_names
         kwds_self = dict(kwds.items())
         if 'implementation' in kwds_self:
+            self.implementations[0] = kwds_self['implementation']
             del kwds_self['implementation']
         self.kwds = kwds_self
 

--- a/src/sage/categories/pushout.py
+++ b/src/sage/categories/pushout.py
@@ -3296,7 +3296,8 @@ class AlgebraicExtensionFunctor(ConstructionFunctor):
         self.latex_names = latex_names
         kwds_self = dict(kwds.items())
         if 'implementation' in kwds_self:
-            self.implementations[0] = kwds_self['implementation']
+            assert len(self.polys) == 1
+            self.implementations = [kwds_self['implementation']]
             del kwds_self['implementation']
         self.kwds = kwds_self
 
@@ -3536,8 +3537,6 @@ class AlgebraicExtensionFunctor(ConstructionFunctor):
         if 'implementation' in kwds_self:
             del kwds_self['implementation']
         kwds_other = dict(other.kwds.items())
-        if 'implementation' in kwds_other:
-            del kwds_other['implementation']
         if (isinstance(self.polys[0], Integer)
                 and isinstance(other.polys[0], Integer)
                 and self.embeddings == other.embeddings == [None]

--- a/src/sage/homology/homology_vector_space_with_basis.py
+++ b/src/sage/homology/homology_vector_space_with_basis.py
@@ -1444,7 +1444,7 @@ def is_GF2(R):
         sage: from sage.homology.homology_vector_space_with_basis import is_GF2
         sage: is_GF2(GF(2))
         True
-        sage: is_GF2(GF(2, impl='ntl'))
+        sage: is_GF2(GF(2, implementation='ntl'))
         True
         sage: is_GF2(GF(3))
         False

--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -1085,7 +1085,7 @@ cdef class FreeModuleElement(Vector):   # abstract base class
         Create the multiplication table of `GF(4)` using GP::
 
             sage: # needs sage.libs.pari
-            sage: k.<a> = GF(4, impl='pari_ffelt')
+            sage: k.<a> = GF(4, implementation="pari_ffelt")
             sage: v = gp(vector(list(k)))
             sage: v
             [0, 1, a, a + 1]

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -738,16 +738,16 @@ cdef class FinitePolyExtElement(FiniteRingElement):
 
         EXAMPLES::
 
-            sage: k.<a> = FiniteField(9, impl='givaro', modulus='primitive')            # needs sage.libs.linbox
+            sage: k.<a> = FiniteField(9, implementation='givaro', modulus='primitive')            # needs sage.libs.linbox
             sage: a.is_square()                                                         # needs sage.libs.linbox
             False
             sage: (a**2).is_square()                                                    # needs sage.libs.linbox
             True
-            sage: k.<a> = FiniteField(4, impl='ntl', modulus='primitive')               # needs sage.libs.ntl
+            sage: k.<a> = FiniteField(4, implementation='ntl', modulus='primitive')               # needs sage.libs.ntl
             sage: (a**2).is_square()                                                    # needs sage.libs.ntl
             True
-            sage: k.<a> = FiniteField(17^5, impl='pari_ffelt', modulus='primitive')     # needs sage.libs.pari
-            sage: a.is_square()                                                         # needs sage.libs.pari
+            sage: k.<a> = FiniteField(17^5, implementation='pari_ffelt', modulus='primitive')     # needs sage.libs.pari
+            sage: a.is_square()
             False
             sage: (a**2).is_square()                                                    # needs sage.libs.pari
             True
@@ -796,7 +796,7 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             3
             sage: F(4).square_root()
             2
-            sage: K = FiniteField(7^3, 'alpha', impl='pari_ffelt')
+            sage: K = FiniteField(7^3, 'alpha', implementation='pari_ffelt')
             sage: K(3).square_root()
             Traceback (most recent call last):
             ...

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -580,12 +580,12 @@ cdef class Cache_givaro(Cache_base):
             sage: k._cache._element_repr(a^20)
             '2*a^3 + 2*a^2 + 2'
 
-            sage: k = FiniteField(3^4,'a', impl='givaro', repr='int')
+            sage: k = FiniteField(3^4,'a', implementation='givaro', repr='int')
             sage: a = k.gen()
             sage: k._cache._element_repr(a^20)
             '74'
 
-            sage: k = FiniteField(3^4,'a', impl='givaro', repr='log')
+            sage: k = FiniteField(3^4,'a', implementation='givaro', repr='log')
             sage: a = k.gen()
             sage: k._cache._element_repr(a^20)
             '20'

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -144,7 +144,7 @@ cdef class Cache_ntl_gf2e(Cache_base):
 
         TESTS::
 
-            sage: k.<a> = GF(2^8, impl='ntl')
+            sage: k.<a> = GF(2^8, implementation="ntl")
         """
         self._parent = <FiniteField?>parent
         self._zero_element = self._new()
@@ -262,10 +262,10 @@ cdef class Cache_ntl_gf2e(Cache_base):
 
         We can coerce from PARI finite field implementations::
 
-            sage: K.<a> = GF(2^19, impl='ntl')
+            sage: K.<a> = GF(2^19, implementation="ntl")
             sage: a^20
             a^6 + a^3 + a^2 + a
-            sage: M.<c> = GF(2^19, impl='pari_ffelt')
+            sage: M.<c> = GF(2^19, implementation="pari_ffelt")
             sage: K(c^20)
             a^6 + a^3 + a^2 + a
         """
@@ -501,7 +501,7 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(2^8, impl='ntl') # indirect doctest
+            sage: k.<a> = GF(2^8, implementation="ntl") # indirect doctest
         """
         if parent is None:
             return
@@ -998,7 +998,7 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(2^8, impl='ntl')
+            sage: k.<a> = GF(2^8, implementation="ntl")
             sage: b = a^3 + a
             sage: b.minpoly()
             x^4 + x^3 + x^2 + x + 1

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -92,7 +92,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
     EXAMPLES::
 
-        sage: K = FiniteField(10007^10, 'a', impl='pari_ffelt')
+        sage: K = FiniteField(10007^10, 'a', implementation='pari_ffelt')
         sage: a = K.gen(); a
         a
         sage: type(a)
@@ -102,7 +102,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         sage: n = 63
         sage: m = 3
-        sage: K.<a> = GF(2^n, impl='pari_ffelt')
+        sage: K.<a> = GF(2^n, implementation='pari_ffelt')
         sage: f = conway_polynomial(2, n)
         sage: f(a) == 0
         True
@@ -110,7 +110,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         sage: conway_polynomial(2, m)(a^e) == 0
         True
 
-        sage: K.<a> = FiniteField(2^16, impl='pari_ffelt')
+        sage: K.<a> = FiniteField(2^16, implementation='pari_ffelt')
         sage: K(0).is_zero()
         True
         sage: (a - a).is_zero()
@@ -127,13 +127,13 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
     Test creating elements from basic Python types::
 
-        sage: K.<a> = FiniteField(7^20, impl='pari_ffelt')
+        sage: K.<a> = FiniteField(7^20, implementation='pari_ffelt')
         sage: K(int(8))
         1
 
     ::
 
-        sage: k = FiniteField(3^4, 'a', impl='pari_ffelt')
+        sage: k = FiniteField(3^4, 'a', implementation='pari_ffelt')
         sage: b = k(5) # indirect doctest
         sage: b.parent()
         Finite Field in a of size 3^4
@@ -145,7 +145,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
     the polynomial at the field's generator::
 
         sage: R.<x> = QQ[]
-        sage: k.<a> = FiniteField(5^2, 'a', impl='pari_ffelt')
+        sage: k.<a> = FiniteField(5^2, 'a', implementation='pari_ffelt')
         sage: k(R(2/3))
         4
         sage: k(x^2)
@@ -159,13 +159,13 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         sage: k(x^25)
         a
 
-        sage: Q.<q> = FiniteField(5^7, 'q', impl='pari_ffelt')
+        sage: Q.<q> = FiniteField(5^7, 'q', implementation='pari_ffelt')
         sage: L = GF(5)
         sage: LL.<xx> = L[]
         sage: Q(xx^2 + 2*xx + 4)
         q^2 + 2*q + 4
 
-        sage: k = FiniteField(3^11, 't', impl='pari_ffelt')
+        sage: k = FiniteField(3^11, 't', implementation='pari_ffelt')
         sage: k.polynomial()
         t^11 + 2*t^2 + 1
         sage: P = k.polynomial_ring()
@@ -175,7 +175,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
     An element can be specified by its vector of coordinates with
     respect to the basis consisting of powers of the generator:
 
-        sage: k = FiniteField(3^11, 't', impl='pari_ffelt')
+        sage: k = FiniteField(3^11, 't', implementation='pari_ffelt')
         sage: V = k.vector_space(map=False)
         sage: V
         Vector space of dimension 11 over Finite Field of size 3
@@ -185,7 +185,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
     Multivariate polynomials only coerce if constant::
 
-        sage: k = FiniteField(5^2, 'a', impl='pari_ffelt')
+        sage: k = FiniteField(5^2, 'a', implementation='pari_ffelt')
         sage: R = k['x,y,z']; R
         Multivariate Polynomial Ring in x, y, z over Finite Field in a of size 5^2
         sage: k(R(2))
@@ -198,7 +198,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
     Gap elements can also be coerced into finite fields::
 
-        sage: F = FiniteField(2^3, 'a', impl='pari_ffelt')
+        sage: F = FiniteField(2^3, 'a', implementation='pari_ffelt')
         sage: a = F.multiplicative_generator(); a
         a
         sage: b = gap(a^3); b                                                           # needs sage.libs.gap
@@ -213,7 +213,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         sage: a.parent()
         Finite Field of size 13
 
-        sage: F = FiniteField(2^4, 'a', impl='pari_ffelt')
+        sage: F = FiniteField(2^4, 'a', implementation='pari_ffelt')
         sage: F(gap('Z(16)^3'))                                                         # needs sage.libs.gap
         a^3
         sage: F(gap('Z(16)^2'))                                                         # needs sage.libs.gap
@@ -230,7 +230,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
     TESTS::
 
-        sage: k = FiniteField(3^2, 'a', impl='pari_ffelt')
+        sage: k = FiniteField(3^2, 'a', implementation='pari_ffelt')
         sage: a = k(11); a
         2
         sage: a.parent()
@@ -242,7 +242,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
     We create elements using a list and verify that :issue:`10486` has
     been fixed::
 
-        sage: k = FiniteField(3^11, 't', impl='pari_ffelt')
+        sage: k = FiniteField(3^11, 't', implementation='pari_ffelt')
         sage: x = k([1,0,2,1]); x
         t^3 + 2*t^2 + 1
         sage: x + x + x
@@ -264,7 +264,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
     When initializing from a list, the elements are first coerced
     to the prime field (:issue:`11685`)::
 
-        sage: k = FiniteField(3^11, 't', impl='pari_ffelt')
+        sage: k = FiniteField(3^11, 't', implementation='pari_ffelt')
         sage: k([ 0, 1/2 ])
         2*t
         sage: k([ 0, 1/2, 0, 0, 0, 0, 0, 0, 0, -1, 0 ])
@@ -283,7 +283,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
     Check that zeros are created correctly (:issue:`11685`)::
 
-        sage: K = FiniteField(3^11, 't', impl='pari_ffelt'); a = K.0
+        sage: K = FiniteField(3^11, 't', implementation='pari_ffelt'); a = K.0
         sage: v = 0; pari(K(v))
         0
         sage: v = Mod(0,3); pari(K(v))
@@ -328,7 +328,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         TESTS::
 
             sage: from sage.rings.finite_rings.element_pari_ffelt import FiniteFieldElement_pari_ffelt
-            sage: K = FiniteField(101^2, 'a', impl='pari_ffelt')
+            sage: K = FiniteField(101^2, 'a', implementation='pari_ffelt')
             sage: x = FiniteFieldElement_pari_ffelt(K, 'a + 1')
             sage: x
             a + 1
@@ -535,7 +535,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<c> = GF(3^17, impl='pari_ffelt')
+            sage: k.<c> = GF(3^17, implementation='pari_ffelt')
             sage: c^20  # indirect doctest
             c^4 + 2*c^3
 
@@ -557,7 +557,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^15, impl='pari_ffelt')
+            sage: k.<a> = GF(3^15, implementation='pari_ffelt')
             sage: R = GF(3)['a']; aa = R.gen()
             sage: hash(a^2 + 1) == hash(aa^2 + 1)
             True
@@ -570,7 +570,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         TESTS::
 
-            sage: K.<a> = FiniteField(10007^10, impl='pari_ffelt')
+            sage: K.<a> = FiniteField(10007^10, implementation='pari_ffelt')
             sage: loads(a.dumps()) == a
             True
         """
@@ -580,7 +580,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         """
         TESTS::
 
-            sage: k.<a> = FiniteField(3^3, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(3^3, implementation='pari_ffelt')
             sage: a
             a
             sage: b = copy(a); b
@@ -595,7 +595,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         """
         TESTS::
 
-            sage: k.<a> = FiniteField(3^3, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(3^3, implementation='pari_ffelt')
             sage: a
             a
             sage: b = deepcopy(a); b
@@ -619,7 +619,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         EXAMPLES::
 
             sage: # needs sage.modules
-            sage: k.<a> = GF(2^20, impl='pari_ffelt')
+            sage: k.<a> = GF(2^20, implementation='pari_ffelt')
             sage: e = k.random_element()
             sage: f = loads(dumps(e))
             sage: e is f
@@ -631,7 +631,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         ::
 
-            sage: K.<a> = GF(2^100, impl='pari_ffelt')
+            sage: K.<a> = GF(2^100, implementation='pari_ffelt')
             sage: a < a^2
             True
             sage: a > a^2
@@ -649,7 +649,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         TESTS::
 
-            sage: k.<a> = FiniteField(3^3, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(3^3, implementation='pari_ffelt')
             sage: a == 1
             False
             sage: a^0 == 1
@@ -673,7 +673,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: a + a^2 # indirect doctest
             a^2 + a
         """
@@ -689,7 +689,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: a - a # indirect doctest
             0
         """
@@ -705,7 +705,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: (a^12 + 1)*(a^15 - 1) # indirect doctest
             a^15 + 2*a^12 + a^11 + 2*a^10 + 2
         """
@@ -721,7 +721,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: (a - 1) / (a + 1) # indirect doctest
             2*a^16 + a^15 + 2*a^14 + a^13 + 2*a^12 + a^11 + 2*a^10 + a^9 + 2*a^8 + a^7 + 2*a^6 + a^5 + 2*a^4 + a^3 + 2*a^2 + a + 1
         """
@@ -739,7 +739,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: F.<a> = FiniteField(5^3, impl='pari_ffelt')
+            sage: F.<a> = FiniteField(5^3, implementation='pari_ffelt')
             sage: a.is_zero()
             False
             sage: (a - a).is_zero()
@@ -753,7 +753,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: F.<a> = FiniteField(5^3, impl='pari_ffelt')
+            sage: F.<a> = FiniteField(5^3, implementation='pari_ffelt')
             sage: a.is_one()
             False
             sage: (a/a).is_one()
@@ -767,7 +767,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: F.<a> = FiniteField(5^3, impl='pari_ffelt')
+            sage: F.<a> = FiniteField(5^3, implementation='pari_ffelt')
             sage: a.is_unit()
             True
         """
@@ -781,7 +781,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: +a
             a
         """
@@ -793,7 +793,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: -a
             2*a
         """
@@ -808,7 +808,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = FiniteField(3^2, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(3^2, implementation='pari_ffelt')
             sage: ~a
             a + 2
             sage: (a+1)*a
@@ -829,7 +829,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         TESTS::
 
-            sage: K.<a> = GF(5^10, impl='pari_ffelt')
+            sage: K.<a> = GF(5^10, implementation='pari_ffelt')
             sage: n = (2*a)/a
             sage: n^-15
             2
@@ -881,7 +881,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         TESTS::
 
             sage: # needs sage.modules
-            sage: F.<a> = GF(13^64, impl='pari_ffelt'); F
+            sage: F.<a> = GF(13^64, implementation='pari_ffelt'); F
             Finite Field in a of size 13^64
             sage: x = F.random_element()
             sage: x.pth_power(0) == x
@@ -894,7 +894,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             True
 
             sage: # needs sage.modules
-            sage: F.<a> = GF(127^16, impl='pari_ffelt'); F
+            sage: F.<a> = GF(127^16, implementation='pari_ffelt'); F
             Finite Field in a of size 127^16
             sage: x = F.random_element()
             sage: x.pth_power(0) == x
@@ -936,7 +936,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = FiniteField(3^2, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(3^2, implementation='pari_ffelt')
             sage: pol = a.polynomial()
             sage: pol
             a
@@ -945,7 +945,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         ::
 
-            sage: k = FiniteField(3^4, 'alpha', impl='pari_ffelt')
+            sage: k = FiniteField(3^4, 'alpha', implementation='pari_ffelt')
             sage: a = k.gen()
             sage: a.polynomial()
             alpha
@@ -971,7 +971,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         EXAMPLES::
 
             sage: R.<x> = PolynomialRing(FiniteField(3))
-            sage: F.<a> = FiniteField(3^2, modulus=x^2 + 1, impl='pari_ffelt')
+            sage: F.<a> = FiniteField(3^2, modulus=x^2 + 1, implementation='pari_ffelt')
             sage: a.minpoly('y')
             y^2 + 1
         """
@@ -990,7 +990,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         EXAMPLES::
 
             sage: R.<x> = PolynomialRing(FiniteField(3))
-            sage: F.<a> = FiniteField(3^2, modulus=x^2 + 1, impl='pari_ffelt')
+            sage: F.<a> = FiniteField(3^2, modulus=x^2 + 1, implementation='pari_ffelt')
             sage: a.charpoly('y')
             y^2 + 1
         """
@@ -1005,17 +1005,17 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = FiniteField(3^2, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(3^2, implementation='pari_ffelt')
             sage: a.is_square()
             False
             sage: (a**2).is_square()
             True
 
-            sage: k.<a> = FiniteField(2^2, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(2^2, implementation='pari_ffelt')
             sage: (a**2).is_square()
             True
 
-            sage: k.<a> = FiniteField(17^5, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(17^5, implementation='pari_ffelt')
             sage: (a**2).is_square()
             True
             sage: a.is_square()
@@ -1060,7 +1060,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: F = FiniteField(7^2, 'a', impl='pari_ffelt')
+            sage: F = FiniteField(7^2, 'a', implementation='pari_ffelt')
             sage: F(2).sqrt()
             4
             sage: F(3).sqrt() in (2*F.gen() + 6, 5*F.gen() + 1)
@@ -1070,7 +1070,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             sage: F(4).sqrt(all=True)
             [2, 5]
 
-            sage: K = FiniteField(7^3, 'alpha', impl='pari_ffelt')
+            sage: K = FiniteField(7^3, 'alpha', implementation='pari_ffelt')
             sage: K(3).sqrt()
             Traceback (most recent call last):
             ...
@@ -1078,7 +1078,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             sage: K(3).sqrt(all=True)
             []
 
-            sage: K.<a> = GF(3^17, impl='pari_ffelt')
+            sage: K.<a> = GF(3^17, implementation='pari_ffelt')
             sage: (a^3 - a - 1).sqrt()
             a^16 + 2*a^15 + a^13 + 2*a^12 + a^10 + 2*a^9 + 2*a^8 + a^7 + a^6 + 2*a^5 + a^4 + 2*a^2 + 2*a + 2
         """
@@ -1126,7 +1126,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: F.<g> = FiniteField(2^10, impl='pari_ffelt')
+            sage: F.<g> = FiniteField(2^10, implementation='pari_ffelt')
             sage: b = g; a = g^37
             sage: a.log(b)
             37
@@ -1136,7 +1136,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         ::
 
-            sage: F.<a> = FiniteField(5^2, impl='pari_ffelt')
+            sage: F.<a> = FiniteField(5^2, implementation='pari_ffelt')
             sage: F(-1).log(F(2))
             2
             sage: F(1).log(a)
@@ -1161,7 +1161,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         Some cases where the logarithm is not defined or does not exist::
 
-            sage: F.<a> = GF(3^10, impl='pari_ffelt')
+            sage: F.<a> = GF(3^10, implementation='pari_ffelt')
             sage: a.log(-1)
             Traceback (most recent call last):
             ...
@@ -1221,7 +1221,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: a = FiniteField(5^3, 'a', impl='pari_ffelt').0
+            sage: a = FiniteField(5^3, 'a', implementation='pari_ffelt').0
             sage: a.multiplicative_order()
             124
             sage: a**124
@@ -1241,7 +1241,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k = FiniteField(next_prime(10^10)^2, 'u', impl='pari_ffelt')
+            sage: k = FiniteField(next_prime(10^10)^2, 'u', implementation='pari_ffelt')
             sage: a = k(17)/k(19)
             sage: b = a.lift(); b
             7894736858
@@ -1262,7 +1262,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: b = k(2)
             sage: b._integer_()
             2
@@ -1279,7 +1279,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: b = k(2)
             sage: int(b)
             2
@@ -1296,7 +1296,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: b = k(2)
             sage: float(b)
             2.0
@@ -1309,7 +1309,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = FiniteField(3^3, impl='pari_ffelt')
+            sage: k.<a> = FiniteField(3^3, implementation='pari_ffelt')
             sage: b = a**2 + 2*a + 1
             sage: b.__pari__()
             a^2 + 2*a + 1
@@ -1332,7 +1332,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
 
         EXAMPLES::
 
-            sage: k.<a> = GF(3^17, impl='pari_ffelt')
+            sage: k.<a> = GF(3^17, implementation='pari_ffelt')
             sage: a._pari_init_()
             'subst(a+3*a,a,ffgen(Mod(1, 3)*x^17 + Mod(2, 3)*x + Mod(1, 3),a))'
             sage: k(1)._pari_init_()
@@ -1387,7 +1387,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         EXAMPLES::
 
             sage: # needs sage.libs.gap
-            sage: F = FiniteField(2^3, 'aa', impl='pari_ffelt')
+            sage: F = FiniteField(2^3, 'aa', implementation='pari_ffelt')
             sage: aa = F.multiplicative_generator()
             sage: gap(aa)  # indirect doctest
             Z(2^3)
@@ -1405,7 +1405,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         You can specify the instance of the Gap interpreter that is used::
 
             sage: # needs sage.libs.gap
-            sage: F = FiniteField(next_prime(200)^2, 'a', impl='pari_ffelt')
+            sage: F = FiniteField(next_prime(200)^2, 'a', implementation='pari_ffelt')
             sage: a = F.multiplicative_generator()
             sage: a._gap_(gap)
             Z(211^2)
@@ -1415,7 +1415,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         Gap only supports relatively small finite fields::
 
             sage: # needs sage.libs.gap
-            sage: F = FiniteField(next_prime(1000)^2, 'a', impl='pari_ffelt')
+            sage: F = FiniteField(next_prime(1000)^2, 'a', implementation='pari_ffelt')
             sage: a = F.multiplicative_generator()
             sage: a._gap_init_()
             Traceback (most recent call last):
@@ -1443,7 +1443,7 @@ def unpickle_FiniteFieldElement_pari_ffelt(parent, elem):
     EXAMPLES::
 
         sage: # needs sage.modules
-        sage: k.<a> = GF(2^20, impl='pari_ffelt')
+        sage: k.<a> = GF(2^20, implementation='pari_ffelt')
         sage: e = k.random_element()
         sage: f = loads(dumps(e)) # indirect doctest
         sage: e == f

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -120,7 +120,7 @@ cdef class FiniteField(Field):
             False
             sage: F == FiniteField(3^2, 'd')
             False
-            sage: F == FiniteField(3^2, 'c', impl='pari_ffelt')
+            sage: F == FiniteField(3^2, 'c', implementation='pari_ffelt')
             False
         """
         if self is other:
@@ -311,14 +311,14 @@ cdef class FiniteField(Field):
 
         EXAMPLES::
 
-            sage: k.<a> = FiniteField(9, impl='pari')
+            sage: k.<a> = FiniteField(9, implementation="pari")
             sage: list(k)
             [0, 1, 2, a, a + 1, a + 2, 2*a, 2*a + 1, 2*a + 2]
 
         Partial iteration of a very large finite field::
 
             sage: p = next_prime(2^64)
-            sage: k.<a> = FiniteField(p^2, impl='pari')
+            sage: k.<a> = FiniteField(p^2, implementation="pari")
             sage: it = iter(k); it
             <...generator object at ...>
             sage: [next(it) for i in range(10)]
@@ -330,11 +330,11 @@ cdef class FiniteField(Field):
 
             sage: L = []
             sage: from sage.rings.finite_rings.finite_field_base import FiniteField
-            sage: print(list(FiniteField.__iter__(GF(8, impl='givaro', names='z'))))    # needs sage.libs.linbox
+            sage: print(list(FiniteField.__iter__(GF(8, implementation='givaro', names='z'))))    # needs sage.libs.linbox
             [0, 1, z, z + 1, z^2, z^2 + 1, z^2 + z, z^2 + z + 1]
-            sage: print(list(FiniteField.__iter__(GF(8, impl='pari', names='z'))))
+            sage: print(list(FiniteField.__iter__(GF(8, implementation='pari', names='z'))))
             [0, 1, z, z + 1, z^2, z^2 + 1, z^2 + z, z^2 + z + 1]
-            sage: print(list(FiniteField.__iter__(GF(8, impl='ntl', names='z'))))       # needs sage.libs.ntl
+            sage: print(list(FiniteField.__iter__(GF(8, implementation='ntl', names='z'))))       # needs sage.libs.ntl
             [0, 1, z, z + 1, z^2, z^2 + 1, z^2 + z, z^2 + z + 1]
         """
         cdef Py_ssize_t n = self.degree()
@@ -902,7 +902,7 @@ cdef class FiniteField(Field):
 
         The given modulus is always made monic::
 
-            sage: k.<a> = GF(7^2, modulus=2*x^2 - 3, impl='pari_ffelt')
+            sage: k.<a> = GF(7^2, modulus=2*x^2-3, implementation="pari_ffelt")
             sage: k.modulus()
             x^2 + 2
 
@@ -910,21 +910,21 @@ cdef class FiniteField(Field):
 
         We test the various finite field implementations::
 
-            sage: GF(2, impl='modn').modulus()
+            sage: GF(2, implementation="modn").modulus()
             x + 1
-            sage: GF(2, impl='givaro').modulus()                                        # needs sage.libs.linbox
+            sage: GF(2, implementation="givaro").modulus()
             x + 1
-            sage: GF(2, impl='ntl').modulus()                                           # needs sage.libs.ntl
+            sage: GF(2, implementation="ntl").modulus()
             x + 1
-            sage: GF(2, impl='modn', modulus=x).modulus()
+            sage: GF(2, implementation="modn", modulus=x).modulus()
             x
-            sage: GF(2, impl='givaro', modulus=x).modulus()                             # needs sage.libs.linbox
+            sage: GF(2, implementation="givaro", modulus=x).modulus()
             x
-            sage: GF(2, impl='ntl', modulus=x).modulus()                                # needs sage.libs.ntl
+            sage: GF(2, implementation="ntl", modulus=x).modulus()
             x
-            sage: GF(13^2, 'a', impl='givaro', modulus=x^2 + 2).modulus()               # needs sage.libs.linbox
+            sage: GF(13^2, 'a', implementation="givaro", modulus=x^2+2).modulus()
             x^2 + 2
-            sage: GF(13^2, 'a', impl='pari_ffelt', modulus=x^2 + 2).modulus()           # needs sage.libs.pari
+            sage: GF(13^2, 'a', implementation="pari_ffelt", modulus=x^2+2).modulus()
             x^2 + 2
         """
         # Normally, this is set by the constructor of the implementation
@@ -964,18 +964,18 @@ cdef class FiniteField(Field):
             sage: k.polynomial()
             a^2 + 2*a + 2
 
-            sage: F = FiniteField(9, 'a', impl='pari_ffelt')
+            sage: F = FiniteField(9, 'a', implementation='pari_ffelt')
             sage: F.polynomial()
             a^2 + 2*a + 2
 
-            sage: F = FiniteField(7^20, 'a', impl='pari_ffelt')
+            sage: F = FiniteField(7^20, 'a', implementation='pari_ffelt')
             sage: f = F.polynomial(); f
             a^20 + a^12 + 6*a^11 + 2*a^10 + 5*a^9 + 2*a^8 + 3*a^7 + a^6 + 3*a^5 + 3*a^3 + a + 3
             sage: f(F.gen())
             0
 
             sage: # needs sage.libs.ntl
-            sage: k.<a> = GF(2^20, impl='ntl')
+            sage: k.<a> = GF(2^20, implementation='ntl')
             sage: k.polynomial()
             a^20 + a^10 + a^9 + a^7 + a^6 + a^5 + a^4 + a + 1
             sage: k.polynomial('FOO')
@@ -1316,14 +1316,14 @@ cdef class FiniteField(Field):
 
         The implementation is taken into account, by :issue:`15223`::
 
-            sage: k = FiniteField(9, 'a', impl='pari_ffelt')
+            sage: k = FiniteField(9, 'a', implementation='pari_ffelt')
             sage: F, R = k.construction()
             sage: F(R) is k
             True
         """
         from sage.categories.pushout import AlgebraicExtensionFunctor
         try:
-            kwds = {'impl': self._factory_data[2][3]}
+            kwds = {'implementation': self._factory_data[2][3]}
         except (AttributeError, IndexError, TypeError):
             kwds = {}
         if self.degree() == 1:

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -193,7 +193,7 @@ except ImportError:
 
 
 from sage.structure.factory import UniqueFactory
-
+from sage.misc.decorators import rename_keyword
 
 class FiniteFieldFactory(UniqueFactory):
     """
@@ -513,6 +513,7 @@ class FiniteFieldFactory(UniqueFactory):
         self._modulus_cache = defaultdict(dict)
         super().__init__(*args, **kwds)
 
+    @rename_keyword(impl='implementation')
     def create_key_and_extra_args(self, order, name=None, modulus=None, names=None,
                                   implementation=None, proof=None,
                                   check_prime: bool = True, check_irreducible: bool = True,
@@ -564,15 +565,16 @@ class FiniteFieldFactory(UniqueFactory):
             sage: GF.create_key_and_extra_args(9, 'a', structure=None)                  # needs sage.libs.linbox
             ((9, ('a',), x^2 + 2*x + 2, 'givaro', 3, 2, True, None, 'poly', True, True, True), {})
 
-        The ``implementation`` parameter is preferred, but ``impl`` is accepted
-        for backwards compatibility::
+        We do not allow giving both ``implementation`` and ``impl``::
 
             sage: GF.create_key_and_extra_args(9, 'a', implementation='givaro')          # needs sage.libs.linbox
             ((9, ('a',), x^2 + 2*x + 2, 'givaro', 3, 2, True, None, 'poly', True, True, True), {})
             sage: GF.create_key_and_extra_args(9, 'a', impl='givaro')                   # needs sage.libs.linbox
             ((9, ('a',), x^2 + 2*x + 2, 'givaro', 3, 2, True, None, 'poly', True, True, True), {})
             sage: GF.create_key_and_extra_args(9, 'a', implementation='givaro', impl='ntl')  # needs sage.libs.linbox
-            ((9, ('a',), x^2 + 2*x + 2, 'givaro', 3, 2, True, None, 'poly', True, True, True), {})
+            Traceback (most recent call last):
+            ...
+            TypeError: create_key_and_extra_args() got an unexpected keyword argument 'impl'
 
         TESTS::
 
@@ -650,19 +652,10 @@ class FiniteFieldFactory(UniqueFactory):
             Finite Field in aa of size 7^2
         """
         for key, val in kwds.items():
-            if key not in ['structure', 'prec', 'embedding', 'latex_names', 'impl']:
+            if key not in ['structure', 'prec', 'embedding', 'latex_names']:
                 raise TypeError("create_key_and_extra_args() got an unexpected keyword argument '%s'" % key)
             if not (val is None or isinstance(val, list) and all(c is None for c in val)):
                 raise NotImplementedError("ring extension with prescribed %s is not implemented" % key)
-
-        # Accept both 'implementation' (preferred) and 'impl' (for backwards compatibility)
-        # Priority: 'implementation' takes precedence over 'impl' if both are provided
-        impl = kwds.get('impl')
-        if implementation is not None:
-            impl = implementation
-        elif impl is None:
-            # Keep impl as None, will be set to default later
-            pass
 
         from sage.structure.proof.proof import WithProof
         from sage.structure.proof.all import arithmetic
@@ -690,8 +683,8 @@ class FiniteFieldFactory(UniqueFactory):
             # note that we haven't tested p for primality
 
             if n == 1:
-                if impl is None:
-                    impl = 'modn'
+                if implementation is None:
+                    implementation = 'modn'
                 if name is not None:
                     certify_names((name,) if isinstance(name, str) else name)
                 name = ('x',)  # Ignore name
@@ -715,19 +708,19 @@ class FiniteFieldFactory(UniqueFactory):
                     check_irreducible = False
                 name = normalize_names(1, name)
 
-                if impl is None:
+                if implementation is None:
                     if order < zech_log_bound and FiniteField_givaro is not None:
-                        impl = 'givaro'
+                        implementation = 'givaro'
                     elif p == 2 and FiniteField_ntl_gf2e is not None:
-                        impl = 'ntl'
+                        implementation = 'ntl'
                     else:
-                        impl = 'pari_ffelt'
+                        implementation = 'pari_ffelt'
 
             # Determine modulus.
             # For the 'modn' implementation, we use the following
             # optimization which we also need to avoid an infinite loop:
             # a modulus of None is a shorthand for x-1.
-            if modulus is not None or impl != 'modn':
+            if modulus is not None or implementation != 'modn':
                 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
                 R = PolynomialRing(FiniteField(p), 'x')
                 if modulus is None:
@@ -745,15 +738,15 @@ class FiniteFieldFactory(UniqueFactory):
 
                     if modulus.degree() != n:
                         raise ValueError("the degree of the modulus does not equal the degree of the field")
-                # If modulus is x - 1 for impl="modn", set it to None
-                if impl == 'modn' and modulus.list() == [-1,1]:
+                # If modulus is x - 1 for implementation="modn", set it to None
+                if implementation == 'modn' and modulus.list() == [-1,1]:
                     modulus = None
             if modulus is None:
                 check_irreducible = False
 
             # Check extra arguments for givaro and setup their defaults
             # TODO: ntl takes a repr, but ignores it
-            if impl == 'givaro':
+            if implementation == 'givaro':
                 if repr is None:
                     repr = 'poly'
                 if elem_cache is None:
@@ -763,7 +756,7 @@ class FiniteFieldFactory(UniqueFactory):
                 repr = None
                 elem_cache = None
 
-            return (order, name, modulus, impl, p, n, proof, prefix, repr, elem_cache, check_prime, check_irreducible), {}
+            return (order, name, modulus, implementation, p, n, proof, prefix, repr, elem_cache, check_prime, check_irreducible), {}
 
     def create_object(self, version, key, **kwds):
         """

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -195,6 +195,7 @@ except ImportError:
 from sage.structure.factory import UniqueFactory
 from sage.misc.decorators import rename_keyword
 
+
 class FiniteFieldFactory(UniqueFactory):
     """
     Return the globally unique finite field of given order with

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -563,7 +563,8 @@ class FiniteFieldFactory(UniqueFactory):
             sage: GF.create_key_and_extra_args(9, 'a', structure=None)                  # needs sage.libs.linbox
             ((9, ('a',), x^2 + 2*x + 2, 'givaro', 3, 2, True, None, 'poly', True, True, True), {})
 
-        We do not allow giving both ``implementation`` and ``impl``::
+        We do not allow giving both ``implementation`` and ``impl``,
+        but we do allow ``impl`` for backwards compatibility::
 
             sage: GF.create_key_and_extra_args(9, 'a', implementation='givaro')          # needs sage.libs.linbox
             ((9, ('a',), x^2 + 2*x + 2, 'givaro', 3, 2, True, None, 'poly', True, True, True), {})

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -174,7 +174,6 @@ AUTHORS:
 # ****************************************************************************
 
 from collections import defaultdict
-from typing import Optional
 from sage.structure.category_object import normalize_names, certify_names
 from sage.rings.polynomial.polynomial_element import Polynomial
 from sage.rings.integer import Integer
@@ -515,7 +514,7 @@ class FiniteFieldFactory(UniqueFactory):
         super().__init__(*args, **kwds)
 
     def create_key_and_extra_args(self, order, name=None, modulus=None, names=None,
-                                  implementation: Optional[str] = None, proof=None,
+                                  implementation=None, proof=None,
                                   check_prime: bool = True, check_irreducible: bool = True,
                                   prefix=None, repr=None, elem_cache=None,
                                   **kwds):
@@ -651,7 +650,7 @@ class FiniteFieldFactory(UniqueFactory):
             Finite Field in aa of size 7^2
         """
         for key, val in kwds.items():
-            if key not in ['structure', 'implementation', 'prec', 'embedding', 'latex_names', 'impl']:
+            if key not in ['structure', 'prec', 'embedding', 'latex_names', 'impl']:
                 raise TypeError("create_key_and_extra_args() got an unexpected keyword argument '%s'" % key)
             if not (val is None or isinstance(val, list) and all(c is None for c in val)):
                 raise NotImplementedError("ring extension with prescribed %s is not implemented" % key)

--- a/src/sage/rings/finite_rings/finite_field_givaro.py
+++ b/src/sage/rings/finite_rings/finite_field_givaro.py
@@ -86,19 +86,19 @@ class FiniteField_givaro(FiniteField):
 
     Three different representations are possible::
 
-        sage: FiniteField(9, 'a', impl='givaro', repr='poly').gen()
+        sage: FiniteField(9, 'a', implementation='givaro', repr='poly').gen()
         a
-        sage: FiniteField(9, 'a', impl='givaro', repr='int').gen()
+        sage: FiniteField(9, 'a', implementation='givaro', repr='int').gen()
         3
-        sage: FiniteField(9, 'a', impl='givaro', repr='log').gen()
+        sage: FiniteField(9, 'a', implementation='givaro', repr='log').gen()
         1
 
     For prime fields, the default modulus is the polynomial `x - 1`,
     but you can ask for a different modulus::
 
-        sage: GF(1009, impl='givaro').modulus()
+        sage: GF(1009, implementation='givaro').modulus()
         x + 1008
-        sage: GF(1009, impl='givaro', modulus='conway').modulus()
+        sage: GF(1009, implementation='givaro', modulus='conway').modulus()
         x + 998
     """
     def __init__(self, q, name='a', modulus=None, repr='poly', cache=False):
@@ -279,7 +279,7 @@ class FiniteField_givaro(FiniteField):
         the polynomial at the field's generator::
 
             sage: R.<x> = QQ[]
-            sage: k.<a> = FiniteField(5^2, 'a', impl='givaro')
+            sage: k.<a> = FiniteField(5^2, 'a', implementation='givaro')
             sage: k(R(2/3))
             4
             sage: k(x^2)
@@ -292,7 +292,7 @@ class FiniteField_givaro(FiniteField):
             sage: k(x^25)
             a
 
-            sage: Q.<q> = FiniteField(5^3, 'q', impl='givaro')
+            sage: Q.<q> = FiniteField(5^3, 'q', implementation='givaro')
             sage: L = GF(5)
             sage: LL.<xx> = L[]
             sage: Q(xx^2 + 2*xx + 4)
@@ -327,22 +327,22 @@ class FiniteField_givaro(FiniteField):
 
         We can coerce from PARI finite field implementations::
 
-            sage: K.<a> = GF(3^10, impl='givaro')
+            sage: K.<a> = GF(3^10, implementation="givaro")
             sage: a^20
             2*a^9 + 2*a^8 + a^7 + 2*a^5 + 2*a^4 + 2*a^3 + 1
-            sage: M.<c> = GF(3^10, impl='pari_ffelt')
+            sage: M.<c> = GF(3^10, implementation="pari_ffelt")
             sage: K(c^20)
             2*a^9 + 2*a^8 + a^7 + 2*a^5 + 2*a^4 + 2*a^3 + 1
 
         GAP elements need to be finite field elements::
 
             sage: x = gap('Z(13)')
-            sage: F = FiniteField(13, impl='givaro')
+            sage: F = FiniteField(13, implementation='givaro')
             sage: F(x)
             2
             sage: F(gap('0*Z(13)'))
             0
-            sage: F = FiniteField(13^2, 'a', impl='givaro')
+            sage: F = FiniteField(13^2, 'a', implementation='givaro')
             sage: x = gap('Z(13)')
             sage: F(x)
             2
@@ -356,8 +356,8 @@ class FiniteField_givaro(FiniteField):
             sage: k(48771/1225)
             28
 
-            sage: F9 = FiniteField(9, impl='givaro', prefix='a')
-            sage: F81 = FiniteField(81, impl='givaro', prefix='a')
+            sage: F9 = FiniteField(9, implementation='givaro', prefix='a')
+            sage: F81 = FiniteField(81, implementation='givaro', prefix='a')
             sage: F81(F9.gen())
             2*a4^3 + 2*a4^2 + 1
         """
@@ -392,7 +392,7 @@ class FiniteField_givaro(FiniteField):
             Traceback (most recent call last):
             ...
             IndexError: only one generator
-            sage: F = FiniteField(31, impl='givaro')
+            sage: F = FiniteField(31, implementation='givaro')
             sage: F.gen()
             1
         """

--- a/src/sage/rings/finite_rings/finite_field_ntl_gf2e.py
+++ b/src/sage/rings/finite_rings/finite_field_ntl_gf2e.py
@@ -104,7 +104,7 @@ class FiniteField_ntl_gf2e(FiniteField):
             sage: k2.<a> = GF(2^17)
             sage: k1 == k2
             False
-            sage: k3.<a> = GF(2^16, impl='pari_ffelt')
+            sage: k3.<a> = GF(2^16, implementation="pari_ffelt")
             sage: k1 == k3
             False
 
@@ -239,9 +239,9 @@ class FiniteField_ntl_gf2e(FiniteField):
 
         TESTS::
 
-            sage: GF(2, impl='ntl').gen()
+            sage: GF(2, implementation='ntl').gen()
             1
-            sage: GF(2, impl='ntl', modulus=polygen(GF(2)) ).gen()
+            sage: GF(2, implementation='ntl', modulus=polygen(GF(2)) ).gen()
             0
             sage: GF(2^19, 'a').gen(1)
             Traceback (most recent call last):

--- a/src/sage/rings/finite_rings/finite_field_pari_ffelt.py
+++ b/src/sage/rings/finite_rings/finite_field_pari_ffelt.py
@@ -51,13 +51,13 @@ class FiniteField_pari_ffelt(FiniteField):
         requires specifying a characteristic and a modulus.  To
         construct a finite field by specifying a cardinality and an
         algorithm for finding an irreducible polynomial, use the
-        ``FiniteField`` constructor with ``impl='pari_ffelt'``.
+        ``FiniteField`` constructor with ``implementation='pari_ffelt'``.
 
     EXAMPLES:
 
     Some computations with a finite field of order 9::
 
-        sage: k = FiniteField(9, 'a', impl='pari_ffelt')
+        sage: k = FiniteField(9, 'a', implementation='pari_ffelt')
         sage: k
         Finite Field in a of size 3^2
         sage: k.is_field()
@@ -77,7 +77,7 @@ class FiniteField_pari_ffelt(FiniteField):
 
     Next we compute with a finite field of order 16::
 
-        sage: k16 = FiniteField(16, 'b', impl='pari_ffelt')
+        sage: k16 = FiniteField(16, 'b', implementation='pari_ffelt')
         sage: z = k16.gen()
         sage: z
         b
@@ -92,11 +92,11 @@ class FiniteField_pari_ffelt(FiniteField):
 
     Illustration of dumping and loading::
 
-        sage: K = FiniteField(7^10, 'b', impl='pari_ffelt')
+        sage: K = FiniteField(7^10, 'b', implementation='pari_ffelt')
         sage: loads(K.dumps()) == K
         True
 
-        sage: K = FiniteField(10007^10, 'a', impl='pari_ffelt')
+        sage: K = FiniteField(10007^10, 'a', implementation='pari_ffelt')
         sage: loads(K.dumps()) == K
         True
     """
@@ -151,7 +151,7 @@ class FiniteField_pari_ffelt(FiniteField):
 
         EXAMPLES::
 
-            sage: k.<b> = FiniteField(5^20, impl='pari_ffelt')
+            sage: k.<b> = FiniteField(5^20, implementation='pari_ffelt')
             sage: type(k)
             <class 'sage.rings.finite_rings.finite_field_pari_ffelt.FiniteField_pari_ffelt_with_category'>
             sage: k is loads(dumps(k))
@@ -183,9 +183,9 @@ class FiniteField_pari_ffelt(FiniteField):
         EXAMPLES::
 
             sage: R.<x> = PolynomialRing(GF(2))
-            sage: FiniteField(2^4, 'b', impl='pari_ffelt').gen()
+            sage: FiniteField(2^4, 'b', implementation='pari_ffelt').gen()
             b
-            sage: k = FiniteField(3^4, 'alpha', impl='pari_ffelt')
+            sage: k = FiniteField(3^4, 'alpha', implementation='pari_ffelt')
             sage: a = k.gen()
             sage: a
             alpha
@@ -202,7 +202,7 @@ class FiniteField_pari_ffelt(FiniteField):
 
         EXAMPLES::
 
-            sage: F = FiniteField(3^4, 'a', impl='pari_ffelt')
+            sage: F = FiniteField(3^4, 'a', implementation='pari_ffelt')
             sage: F.characteristic()
             3
         """
@@ -215,7 +215,7 @@ class FiniteField_pari_ffelt(FiniteField):
 
         EXAMPLES::
 
-            sage: F = FiniteField(3^20, 'a', impl='pari_ffelt')
+            sage: F = FiniteField(3^20, 'a', implementation='pari_ffelt')
             sage: F.degree()
             20
         """
@@ -228,10 +228,9 @@ class FiniteField_pari_ffelt(FiniteField):
 
         TESTS::
 
-            sage: F = FiniteField(37^10, 'a', impl='pari_ffelt')
-            sage: x = F.random_element()                                                # needs sage.modules
-            sage: all(x**(37**k) == F(F._pari_frobenius(k).ffmap(x))                    # needs sage.modules
-            ....:     for k in range(1, 30) if k % 10 != 0)
+            sage: F = FiniteField(37^10, 'a', implementation='pari_ffelt')
+            sage: x = F.random_element()
+            sage: all(x**(37**k) == F(F._pari_frobenius(k).ffmap(x)) for k in range(1, 30) if k % 10 != 0)
             True
             sage: F(F._pari_frobenius(-1).ffmap(x))**37 == x                            # needs sage.modules
             True

--- a/src/sage/rings/finite_rings/residue_field.pyx
+++ b/src/sage/rings/finite_rings/residue_field.pyx
@@ -306,7 +306,7 @@ class ResidueFieldFactory(UniqueFactory):
         sage: K.residue_field(K.ideal(3))                                               # needs sage.rings.number_field
         Residue field of Fractional ideal (3)
     """
-    def create_key_and_extra_args(self, p, names=None, check=True, impl=None, **kwds):
+    def create_key_and_extra_args(self, p, names = None, check=True, implementation=None, **kwds):
         """
         Return a tuple containing the key (uniquely defining data)
         and any extra arguments.
@@ -351,7 +351,7 @@ class ResidueFieldFactory(UniqueFactory):
                 names = None
         if names is None and p.ring() is not ZZ:
             names = '%sbar' % p.ring().fraction_field().variable_name()
-        key = (p, names, impl)
+        key = (p, names, implementation)
         return key, kwds
 
     def create_object(self, version, key, **kwds):
@@ -367,7 +367,7 @@ class ResidueFieldFactory(UniqueFactory):
             sage: ResidueField(P) is ResidueField(P)  # indirect doctest                # needs sage.rings.number_field
             True
         """
-        p, names, impl = key
+        p, names, implementation = key
         pring = p.ring()
 
         if pring is ZZ:
@@ -377,31 +377,31 @@ class ResidueFieldFactory(UniqueFactory):
             Kbase = pring.base_ring()
             f = p.gen()
             characteristic = Kbase.order()
-            if f.degree() == 1 and Kbase.is_prime_field() and (impl is None or impl == 'modn'):
+            if f.degree() == 1 and Kbase.is_prime_field() and (implementation is None or implementation == 'modn'):
                 return ResidueFiniteField_prime_modn(p, None, Kbase.order(), None, None, None)
             else:
                 q = characteristic**(f.degree())
-                if q < zech_log_bound and (impl is None or impl == 'givaro'):
+                if q < zech_log_bound and (implementation is None or implementation == 'givaro'):
                     try:
                         from sage.rings.finite_rings.residue_field_givaro import ResidueFiniteField_givaro
                     except ImportError:
-                        if impl is not None:
+                        if implementation is not None:
                             raise
                     else:
                         return ResidueFiniteField_givaro(p, q, names, f, None, None, None)
-                if q % 2 == 0 and (impl is None or impl == 'ntl'):
+                if q % 2 == 0 and (implementation is None or implementation == 'ntl'):
                     try:
                         from sage.rings.finite_rings.residue_field_ntl_gf2e import ResidueFiniteField_ntl_gf2e
                     except ImportError:
-                        if impl is not None:
+                        if implementation is not None:
                             raise
                     else:
                         return ResidueFiniteField_ntl_gf2e(q, names, f, "poly", p, None, None, None)
-                if impl is None or impl == 'pari':
+                if implementation is None or implementation == 'pari':
                     try:
                         from sage.rings.finite_rings.residue_field_pari_ffelt import ResidueFiniteField_pari_ffelt
                     except ImportError:
-                        if impl is not None:
+                        if implementation is not None:
                             raise
                     else:
                         return ResidueFiniteField_pari_ffelt(p, characteristic, names, f, None, None, None)
@@ -457,27 +457,27 @@ class ResidueFieldFactory(UniqueFactory):
             return ResidueFiniteField_prime_modn(p, names, p.smallest_integer(), to_vs, to_order, PB)
         else:
             q = characteristic**(f.degree())
-            if q < zech_log_bound and (impl is None or impl == 'givaro'):
+            if q < zech_log_bound and (implementation is None or implementation == 'givaro'):
                 try:
                     from sage.rings.finite_rings.residue_field_givaro import ResidueFiniteField_givaro
                 except ImportError:
-                    if impl is not None:
+                    if implementation is not None:
                         raise
                 else:
                     return ResidueFiniteField_givaro(p, q, names, f, to_vs, to_order, PB)
-            elif q % 2 == 0 and (impl is None or impl == 'ntl'):
+            elif q % 2 == 0 and (implementation is None or implementation == 'ntl'):
                 try:
                     from sage.rings.finite_rings.residue_field_ntl_gf2e import ResidueFiniteField_ntl_gf2e
                 except ImportError:
-                    if impl is not None:
+                    if implementation is not None:
                         raise
                 else:
                     return ResidueFiniteField_ntl_gf2e(q, names, f, "poly", p, to_vs, to_order, PB)
-            if impl is None or impl == 'pari':
+            if implementation is None or implementation == 'pari':
                 try:
                     from sage.rings.finite_rings.residue_field_pari_ffelt import ResidueFiniteField_pari_ffelt
                 except ImportError:
-                    if impl is not None:
+                    if implementation is not None:
                         raise
                 else:
                     return ResidueFiniteField_pari_ffelt(p, characteristic, names, f, to_vs, to_order, PB)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

1.Changed primary parameter from impl to implementation in docstrings
2.Marked impl as deprecated (backwards compatibility)
3.Updated examples to use implementation instead of impl
4.Added examples showing both parameters work
5. clean commit history 
@nbruin review this 


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
related to #41123


