### PR TITLE
Warn on meson target generation when doc-build is enabled

### DIFF
--- a/src/doc/meson.build
+++ b/src/doc/meson.build
@@ -2,6 +2,8 @@ if not get_option('build-docs')
   subdir_done()
 endif
 
+warning('Documentation building enabled, generating targets may be slow. To disable this, pass -Dbuild-docs=false.')
+
 sphinx_check = py_module.find_installation(required: false, modules: ['sphinx'])
 if not sphinx_check.found()
   warning(


### PR DESCRIPTION
fix https://github.com/sagemath/sage/issues/41070

Some time ago it was not enabled by default. Not everyone needs building the docs.

This avoid wasting 5 minutes of developers' time when they upgrade a version or add/delete a file. (and maybe some hours of figuring what has changed)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


