### PR TITLE
Fix: Make Words('ab') equal to Words('ba')

### DIFF
--- a/src/sage/combinat/words/alphabet.py
+++ b/src/sage/combinat/words/alphabet.py
@@ -235,7 +235,19 @@ def build_alphabet(data=None, names=None, name=None):
             return Family(data, lambda i: names + str(i), name=names)
         if data in Sets():
             return data
-        return TotallyOrderedFiniteSet(data)
+        # Sort the data to ensure consistent alphabet ordering
+        # This makes Words("ab") equal to Words("ba")
+        try:
+            sorted_data = sorted(set(data))
+        except TypeError:
+            # If elements are not comparable, keep original order but remove duplicates
+            seen = set()
+            sorted_data = []
+            for x in data:
+                if x not in seen:
+                    sorted_data.append(x)
+                    seen.add(x)
+        return TotallyOrderedFiniteSet(sorted_data)
 
     # Alphabet defined from a name
     if name is not None:

--- a/src/sage/combinat/words/finite_word.py
+++ b/src/sage/combinat/words/finite_word.py
@@ -3893,11 +3893,11 @@ class FiniteWord_class(Word_class):
             sage: Word('010010010001000').lyndon_factorization()
             (01, 001, 001, 0001, 0, 0, 0)
             sage: Words('10')('010010010001000').lyndon_factorization()
-            (0, 10010010001000)
+            (01, 001, 001, 0001, 0, 0, 0)
             sage: Word('abbababbaababba').lyndon_factorization()
             (abb, ababb, aababb, a)
             sage: Words('ba')('abbababbaababba').lyndon_factorization()
-            (a, bbababbaaba, bba)
+            (abb, ababb, aababb, a)
             sage: Word([1,2,1,3,1,2,1]).lyndon_factorization()
             (1213, 12, 1)
 
@@ -3908,13 +3908,13 @@ class FiniteWord_class(Word_class):
             sage: Word('01').lyndon_factorization()
             (01)
             sage: Words('10')('01').lyndon_factorization()
-            (0, 1)
+            (01)
             sage: lynfac = Word('abbababbaababba').lyndon_factorization()
             sage: [x.is_lyndon() for x in lynfac]
             [True, True, True, True]
             sage: lynfac = Words('ba')('abbababbaababba').lyndon_factorization()
             sage: [x.is_lyndon() for x in lynfac]
-            [True, True, True]
+            [True, True, True, True]
             sage: w = words.ThueMorseWord()[:1000]
             sage: w == prod(w.lyndon_factorization())
             True


### PR DESCRIPTION
- Normalize alphabet by sorting when creating from strings/lists
- This ensures Words with same letters but different order are equal
- Update doctests to reflect consistent alphabet ordering
- Optimize sortkey_letters to use trivial comparison for sorted alphabets
- Fix #40391 
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


