### PR TITLE
fix the infinite loop in lie algebra

### DIFF
--- a/src/sage/algebras/lie_algebras/lie_algebra.py
+++ b/src/sage/algebras/lie_algebras/lie_algebra.py
@@ -616,8 +616,8 @@ class LieAlgebra(Parent, UniqueRepresentation):  # IndexedGenerators):
 
     def _coerce_map_from_(self, R):
         """
-        Return ``True`` if there is a coercion from ``R`` into ``self`` and
-        ``False`` otherwise.
+        Return a coercion map from ``R`` into ``self`` if one exists,
+        or ``True`` if a generic coercion exists, or ``False`` otherwise.
 
         The things that coerce into ``self`` are:
 
@@ -625,19 +625,38 @@ class LieAlgebra(Parent, UniqueRepresentation):  # IndexedGenerators):
           map into ``self.base_ring()``.
 
         - A module which coerces into the base vector space of ``self``.
+          In this case, the coercion map is given by :meth:`from_vector`
+          (composed with the appropriate coercion on the base module).
 
         TESTS::
 
             sage: L.<x,y> = LieAlgebra(QQ, abelian=True)
             sage: L._coerce_map_from_(L.module())
+            <bound method ...from_vector of Abelian Lie algebra on 2 generators (x, y) over Rational Field>
+            sage: cm = L._coerce_map_from_(FreeModule(ZZ, 2))
+            sage: cm.domain()
+            Ambient free module of rank 2 over the principal ideal domain Integer Ring
+            sage: cm.codomain()
+            Abelian Lie algebra on 2 generators (x, y) over Rational Field
+
+        Test that a morphism can be created from generator images
+        (see :issue:`40780`)::
+
+            sage: gl = lie_algebras.gl(QQ, 2)
+            sage: phi = gl.morphism({e: e for e in gl.gens()})
+            sage: phi.domain() is gl
             True
-            sage: L._coerce_map_from_(FreeModule(ZZ, 2))
+            sage: phi.codomain() is gl
             True
         """
         if not isinstance(R, LieAlgebra):
             # Should be moved to LieAlgebrasWithBasis somehow since it is a generic coercion
             if self.module is not NotImplemented:
-                return self.module().has_coerce_map_from(R)
+                M = self.module()
+                if R is M:
+                    return self.from_vector
+                elif M.has_coerce_map_from(R):
+                    return self._coerce_map_via([M], R)
             return False
 
         # We check if it is a subalgebra of something that can coerce into ``self``

--- a/src/sage/algebras/lie_algebras/lie_algebra.py
+++ b/src/sage/algebras/lie_algebras/lie_algebra.py
@@ -646,6 +646,9 @@ class LieAlgebra(Parent, UniqueRepresentation):  # IndexedGenerators):
             True
             sage: phi.codomain() is gl
             True
+            sage: gl(gl.an_element().to_vector().change_ring(ZZ))
+            [1 1]
+            [1 1]
         """
         if not isinstance(R, LieAlgebra):
             # Should be moved to LieAlgebrasWithBasis somehow since it is a generic coercion

--- a/src/sage/algebras/lie_algebras/lie_algebra.py
+++ b/src/sage/algebras/lie_algebras/lie_algebra.py
@@ -625,8 +625,6 @@ class LieAlgebra(Parent, UniqueRepresentation):  # IndexedGenerators):
           map into ``self.base_ring()``.
 
         - A module which coerces into the base vector space of ``self``.
-          In this case, the coercion map is given by :meth:`from_vector`
-          (composed with the appropriate coercion on the base module).
 
         TESTS::
 

--- a/src/sage/algebras/lie_algebras/lie_algebra.py
+++ b/src/sage/algebras/lie_algebras/lie_algebra.py
@@ -629,9 +629,9 @@ class LieAlgebra(Parent, UniqueRepresentation):  # IndexedGenerators):
         TESTS::
 
             sage: L.<x,y> = LieAlgebra(QQ, abelian=True)
-            sage: L._coerce_map_from_(L.module())
-            <bound method ...from_vector of Abelian Lie algebra on 2 generators (x, y) over Rational Field>
-            sage: cm = L._coerce_map_from_(FreeModule(ZZ, 2))
+            sage: L.has_coerce_map_from(L.module())
+            True
+            sage: cm = L.coerce_map_from(FreeModule(ZZ, 2))
             sage: cm.domain()
             Ambient free module of rank 2 over the principal ideal domain Integer Ring
             sage: cm.codomain()


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
### Solutions
This fixes #40780
Add an explicit check in `_element_constructor_` to handle vectors directly using `from_vector()` before attempting to use `self._assoc(x)`:

```python
def _element_constructor_(self, x):
    if isinstance(x, list) and len(x) == 2:
        return self(x[0])._bracket_(self(x[1]))
    
    # Check if x is a vector from the module to avoid infinite recursion
    try:
        if hasattr(x, 'parent') and x.parent() == self.module():
            return self.from_vector(x)
    except (AttributeError, NotImplementedError):
        pass
    
    return self.element_class(self, self._assoc(x))
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.


### The Infinite Loop Cycle

The infinite recursion occurs in the following cycle:

```
1. gl(vector) 
   ↓
2. LieAlgebraFromAssociative._element_constructor_(vector)
   ↓
3. self._assoc(vector)  # _assoc is a MatrixSpace
   ↓
4. MatrixSpace.__call__(vector)
   ↓
5. Uses coercion: VectorSpace → LieAlgebra → MatrixSpace
   ↓
6. Back to step 1: gl(vector)
```

### Detailed Breakdown

1. **Morphism Construction Context**:
   - When creating a morphism via `gl.morphism({e:e for e in gl.gens()})`, the morphism code (in `morphism.py`) computes brackets to extend the spanning set
   - It calls `domain.bracket(spanning_set[i], spanning_set[j])` where `spanning_set` contains vectors

2. **Bracket Computation**:
   - The `bracket` method in `lie_algebras.py` line 290:
     ```python
     return self(lhs)._bracket_(self(rhs))
     ```
   - This attempts to convert vectors (`lhs`, `rhs`) to Lie algebra elements by calling `self(vector)`

3. **Element Constructor Issue**:
   - `LieAlgebraFromAssociative._element_constructor_` (line 1246) was:
     ```python
     return self.element_class(self, self._assoc(x))
     ```
   - When `x` is a vector, it calls `self._assoc(vector)`

4. **Coercion Map Problem**:
   - `self._assoc` is a `MatrixSpace`
   - There exists a composite coercion map:
     ```
     VectorSpace → LieAlgebra → MatrixSpace
     ```
   - This map was registered when `LiftMorphismToAssociative` was set up as a coercion

5. **The Loop Closes**:
   - `MatrixSpace(vector)` uses the coercion map
   - First step: `VectorSpace → LieAlgebra` calls `gl(vector)`
   - This triggers `_element_constructor_` again with the same vector
   - The cycle repeats infinitely
### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


