### PR TITLE
fix the non-extendable DOL-language missing terms in WordMorphism

### DIFF
--- a/src/sage/combinat/words/morphism.py
+++ b/src/sage/combinat/words/morphism.py
@@ -2175,6 +2175,15 @@ class WordMorphism(SageObject):
              ...
              word: 1010010001,
              word: 1010010100]
+
+        A non-extendable D0L-language (Thue-Morse with cube axiom). We
+        check that factors from the axiom and early iterations are included::
+
+            sage: m = WordMorphism('0->01,1->10')
+            sage: Word('000') in m.language(3, Word('000'))
+            True
+            sage: Word('010101') in m.language(6, Word('000'))
+            True
         """
         W = self.domain()
         if self.codomain() != W:
@@ -2206,10 +2215,19 @@ class WordMorphism(SageObject):
         # of two letter words
         L2 = (w for w in self._language_naive(3, u) if len(w) == 2)
         L = set()
-        for u in L2:
-            v = im[u[0]] + im[u[1]]
+        for v in L2:
+            w = im[v[0]] + im[v[1]]
+            for k in range(len(w) - n + 1):
+                L.add(w[k:k + n])
+
+        # Also add factors from the axiom and early iterations
+        # to handle non-extendable elements in the D0L-language
+        v = u
+        for _ in range(p + 1):
             for k in range(len(v) - n + 1):
                 L.add(v[k:k + n])
+            v = self(v)
+
         return L
 
     def conjugate(self, pos):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
fix #40466 
The Problem: The optimized algorithm assumes that all factors of length n in the D0L-language can be obtained by:

1. Taking 2-letter words from the language
2. Applying a high power of the morphism to each letter
3. Concatenating the images and extracting n-factors

What's Missing: This misses factors that:

Come directly from the axiom word u (like '000' from u='000')
Come from early iterations ``s^k(u)`` where ``k`` is small (like '010101' from m(000))
Are not extendable on both sides (non-extendable elements)


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


