### PR TITLE
forbid to be both Finite and Infinite

### DIFF
--- a/src/sage/categories/finite_sets.py
+++ b/src/sage/categories/finite_sets.py
@@ -49,9 +49,9 @@ class FiniteSets(CategoryWithAxiom):
                 sage: P.Infinite()
                 Traceback (most recent call last):
                 ...
-                TypeError: incompatible axioms
+                TypeError: incompatible axioms: finite and infinite
             """
-            raise TypeError("incompatible axioms")
+            raise TypeError("incompatible axioms: finite and infinite")
 
     class ParentMethods:
 

--- a/src/sage/categories/finite_sets.py
+++ b/src/sage/categories/finite_sets.py
@@ -37,6 +37,21 @@ class FiniteSets(CategoryWithAxiom):
         sage: C is Sets().Finite()
         True
     """
+    class SubcategoryMethods:
+
+        def Infinite(self):
+            """
+            Incompatible axiom.
+
+            EXAMPLES::
+
+                sage: P = Posets().Finite()
+                sage: P.Infinite()
+                Traceback (most recent call last):
+                ...
+                TypeError: incompatible axioms
+            """
+            raise TypeError("incompatible axioms")
 
     class ParentMethods:
 

--- a/src/sage/categories/sets_cat.py
+++ b/src/sage/categories/sets_cat.py
@@ -1888,6 +1888,21 @@ Please use, e.g., S.algebra(QQ, category=Semigroups())""".format(self))
     from sage.categories.facade_sets import FacadeSets as Facade
 
     class Infinite(CategoryWithAxiom):
+        class SubcategoryMethods:
+
+            def Finite(self):
+                """
+                Incompatible axiom.
+
+                EXAMPLES::
+
+                    sage: C = NN.category()
+                    sage: C.Finite()
+                    Traceback (most recent call last):
+                    ...
+                    TypeError: incompatible axioms
+                """
+                raise TypeError("incompatible axioms")
 
         class ParentMethods:
 

--- a/src/sage/categories/sets_cat.py
+++ b/src/sage/categories/sets_cat.py
@@ -1900,9 +1900,9 @@ Please use, e.g., S.algebra(QQ, category=Semigroups())""".format(self))
                     sage: C.Finite()
                     Traceback (most recent call last):
                     ...
-                    TypeError: incompatible axioms
+                    TypeError: incompatible axioms: finite and infinite
                 """
-                raise TypeError("incompatible axioms")
+                raise TypeError("incompatible axioms: finite and infinite")
 
         class ParentMethods:
 

--- a/src/sage/groups/cubic_braid.py
+++ b/src/sage/groups/cubic_braid.py
@@ -969,10 +969,6 @@ class CubicBraidGroup(UniqueRepresentation, FinitelyPresentedGroup):
         MatDEF = self.as_matrix_group()
         self._internal_test_attached_group(MatDEF, tester)
 
-        if not self.is_finite():
-            # infinite groups cannot be embedded into finite rings
-            return
-
         from sage.rings.finite_rings.finite_field_constructor import GF
 
         F3 = GF(3)

--- a/src/sage/groups/cubic_braid.py
+++ b/src/sage/groups/cubic_braid.py
@@ -1554,7 +1554,8 @@ class CubicBraidGroup(UniqueRepresentation, FinitelyPresentedGroup):
             matrix_group = base_group.subgroup(gen_list)
         else:
             from sage.groups.matrix_gps.finitely_generated import MatrixGroup
-            matrix_group = MatrixGroup(gen_list, category=self.category())
+            cat = self.category() if self.is_finite() else None
+            matrix_group = MatrixGroup(gen_list, category=cat)
 
         # --------------------------------------------------------------------
         # check if there is a well defined group homomorphism to matrix_group

--- a/src/sage/groups/cubic_braid.py
+++ b/src/sage/groups/cubic_braid.py
@@ -93,11 +93,7 @@ from sage.misc.cachefunc import cached_method
 from sage.rings.integer import Integer
 from sage.structure.unique_representation import UniqueRepresentation
 
-
-try:
-    from sage.libs.gap.element import GapElement
-except ImportError:
-    GapElement = ()
+from sage.libs.gap.element import GapElement
 
 
 ##############################################################################
@@ -909,7 +905,7 @@ class CubicBraidGroup(UniqueRepresentation, FinitelyPresentedGroup):
         """
         elem = self.an_element()
         att_grp_elem = attached_group(elem)
-        if self.is_finite() and self.strands() <= 7: # not realistic for larger number of strands
+        if self.is_finite() and self.strands() <= 7:  # not realistic for larger number of strands
             att_grp_elem_back = self(att_grp_elem)
             tester.assertEqual(att_grp_elem_back, elem)
 
@@ -973,21 +969,22 @@ class CubicBraidGroup(UniqueRepresentation, FinitelyPresentedGroup):
         MatDEF = self.as_matrix_group()
         self._internal_test_attached_group(MatDEF, tester)
 
-        try:
-            from sage.rings.finite_rings.finite_field_constructor import GF
-        except ImportError:
+        if not self.is_finite():
+            # infinite groups cannot be embedded into finite rings
             return
+
+        from sage.rings.finite_rings.finite_field_constructor import GF
 
         F3 = GF(3)
         r63 = F3(2)
         F4 = GF(4)
         r64 = F4.gen()
 
-        if self._cbg_type != CubicBraidGroup.type.AssionU or self.strands() < 5: # not well defined else-wise
+        if self._cbg_type != CubicBraidGroup.type.AssionU or self.strands() < 5:  # not well defined else-wise
             matrix_grpF3 = self.as_matrix_group(root_bur=r63)
             self._internal_test_attached_group(matrix_grpF3, tester)
 
-        if self._cbg_type != CubicBraidGroup.type.AssionS or self.strands() < 5: # not well defined else-wise
+        if self._cbg_type != CubicBraidGroup.type.AssionS or self.strands() < 5:  # not well defined else-wise
             matrix_grpF4 = self.as_matrix_group(root_bur=r64)
             self._internal_test_attached_group(matrix_grpF4, tester)
 
@@ -1454,7 +1451,7 @@ class CubicBraidGroup(UniqueRepresentation, FinitelyPresentedGroup):
     def as_matrix_group(self, root_bur=None, domain=None, characteristic=None, var='t', reduced=False):
         r"""
         Create an epimorphic image of ``self`` as a matrix group by use of
-        the burau representation.
+        the Burau representation.
 
         INPUT:
 


### PR DESCRIPTION
Currently, one can create

`Posets().Finite().Infinite()`

and 

`Posets().Infinite().Finite()`

which is not desirable..

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.


