### PR TITLE
Fix external graph generators leaking file descriptors

### DIFF
--- a/src/sage/graphs/digraph_generators.py
+++ b/src/sage/graphs/digraph_generators.py
@@ -646,36 +646,36 @@ class DiGraphGenerators:
         from sage.features.nauty import NautyExecutable
         gentourng_path = NautyExecutable("gentourng").absolute_filename()
 
-        sp = subprocess.Popen(shlex.quote(gentourng_path) + " {0}".format(nauty_input),
+        with subprocess.Popen(shlex.quote(gentourng_path) + " {0}".format(nauty_input),
                               shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE, close_fds=True)
+                              stderr=subprocess.PIPE, close_fds=True) as sp:
 
-        if debug:
-            yield sp.stderr.readline()
+            if debug:
+                yield sp.stderr.readline()
 
-        def edges(s):
-            i = 0
-            j = 1
-            for b in s[:-1]:
-                yield (i, j) if b == '0' else (j, i)
+            def edges(s):
+                i = 0
+                j = 1
+                for b in s[:-1]:
+                    yield (i, j) if b == '0' else (j, i)
 
-                if j == n - 1:
-                    i += 1
-                    j = i + 1
-                else:
-                    j += 1
+                    if j == n - 1:
+                        i += 1
+                        j = i + 1
+                    else:
+                        j += 1
 
-        gen = sp.stdout
-        while True:
-            try:
-                s = bytes_to_str(next(gen))
-            except StopIteration:
-                # Exhausted list of graphs from nauty geng
-                return
+            gen = sp.stdout
+            while True:
+                try:
+                    s = bytes_to_str(next(gen))
+                except StopIteration:
+                    # Exhausted list of graphs from nauty geng
+                    return
 
-            yield DiGraph([range(n), edges(s)], format='vertices_and_edges',
-                          immutable=immutable)
+                yield DiGraph([range(n), edges(s)], format='vertices_and_edges',
+                              immutable=immutable)
 
     def nauty_directg(self, graphs, options='', debug=False, immutable=False):
         r"""
@@ -780,29 +780,29 @@ class DiGraphGenerators:
         from sage.features.nauty import NautyExecutable
         directg_path = NautyExecutable("directg").absolute_filename()
 
-        sub = subprocess.Popen(shlex.quote(directg_path) + ' {0}'.format(options),
+        with subprocess.Popen(shlex.quote(directg_path) + ' {0}'.format(options),
                                shell=True,
                                stdout=subprocess.PIPE,
                                stdin=subprocess.PIPE,
                                stderr=subprocess.STDOUT,
-                               encoding='latin-1')
-        out, err = sub.communicate(input=input)
+                               encoding='latin-1') as sub:
+            out, err = sub.communicate(input=input)
 
-        if debug:
-            if err:
-                print(err)
+            if debug:
+                if err:
+                    print(err)
 
-            if out:
-                print(out)
+                if out:
+                    print(out)
 
-        for line in out.split('\n'):
-            # directg return graphs in the digraph6 format.
-            # digraph6 is very similar with the dig6 format used in sage :
-            # digraph6_string = '&' +  dig6_string
-            # digraph6 specifications:
-            # http://users.cecs.anu.edu.au/~bdm/data/formats.txt
-            if line and line[0] == '&':
-                yield DiGraph(line[1:], format='dig6', immutable=immutable)
+            for line in out.split('\n'):
+                # directg return graphs in the digraph6 format.
+                # digraph6 is very similar with the dig6 format used in sage :
+                # digraph6_string = '&' +  dig6_string
+                # digraph6 specifications:
+                # http://users.cecs.anu.edu.au/~bdm/data/formats.txt
+                if line and line[0] == '&':
+                    yield DiGraph(line[1:], format='dig6', immutable=immutable)
 
     def nauty_posetg(self, options='', debug=False, immutable=False):
         r"""
@@ -845,23 +845,23 @@ class DiGraphGenerators:
         import shlex
         from sage.features.nauty import NautyExecutable
         geng_path = NautyExecutable("genposetg").absolute_filename()
-        sp = subprocess.Popen(shlex.quote(geng_path) + f" {options}", shell=True,
+        with subprocess.Popen(shlex.quote(geng_path) + f" {options}", shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE, close_fds=True,
-                              encoding='latin-1')
-        msg = sp.stderr.readline()
-        if debug:
-            yield msg
-        elif msg.startswith('>E'):
-            raise ValueError('wrong format of parameter option')
-        gen = sp.stdout
-        while True:
-            try:
-                s = next(gen)
-            except StopIteration:
-                # Exhausted list of graphs from nauty genposetg
-                return
-            yield DiGraph(s[1:-1], format='dig6', immutable=immutable)
+                              encoding='latin-1') as sp:
+            msg = sp.stderr.readline()
+            if debug:
+                yield msg
+            elif msg.startswith('>E'):
+                raise ValueError('wrong format of parameter option')
+            gen = sp.stdout
+            while True:
+                try:
+                    s = next(gen)
+                except StopIteration:
+                    # Exhausted list of graphs from nauty genposetg
+                    return
+                yield DiGraph(s[1:-1], format='dig6', immutable=immutable)
 
     def Complete(self, n, loops=False, immutable=False):
         r"""

--- a/src/sage/graphs/generators/trees.pyx
+++ b/src/sage/graphs/generators/trees.pyx
@@ -893,21 +893,21 @@ def nauty_gentreeg(options='', debug=False):
     import subprocess
     from sage.features.nauty import NautyExecutable
     gen_path = NautyExecutable("gentreeg").absolute_filename()
-    sp = subprocess.Popen(shlex.quote(gen_path) + " {0}".format(options), shell=True,
+    with subprocess.Popen(shlex.quote(gen_path) + " {0}".format(options), shell=True,
                           stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE, close_fds=True,
-                          encoding='latin-1')
-    msg = sp.stderr.readline()
-    if debug:
-        yield msg
-    elif msg.startswith('>E'):
-        raise ValueError('wrong format of parameter options')
-    gen = sp.stdout
-    while True:
-        try:
-            s = next(gen)
-        except StopIteration:
-            # Exhausted list of graphs from nauty geng
-            return
-        G = Graph(s[:-1], format='sparse6', loops=False, multiedges=False)
-        yield G
+                          encoding='latin-1') as sp:
+        msg = sp.stderr.readline()
+        if debug:
+            yield msg
+        elif msg.startswith('>E'):
+            raise ValueError('wrong format of parameter options')
+        gen = sp.stdout
+        while True:
+            try:
+                s = next(gen)
+            except StopIteration:
+                # Exhausted list of graphs from nauty geng
+                return
+            G = Graph(s[:-1], format='sparse6', loops=False, multiedges=False)
+            yield G

--- a/src/sage/graphs/graph_generators.py
+++ b/src/sage/graphs/graph_generators.py
@@ -1016,23 +1016,23 @@ class GraphGenerators:
 
         from sage.features.nauty import NautyExecutable
         geng_path = NautyExecutable("geng").absolute_filename()
-        sp = subprocess.Popen(shlex.quote(geng_path) + " {0}".format(options), shell=True,
+        with subprocess.Popen(shlex.quote(geng_path) + " {0}".format(options), shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE, close_fds=True,
-                              encoding='latin-1')
-        msg = sp.stderr.readline()
-        if debug:
-            yield msg
-        elif msg.startswith('>E'):
-            raise ValueError('wrong format of parameter option')
-        gen = sp.stdout
-        while True:
-            try:
-                s = next(gen)
-            except StopIteration:
-                # Exhausted list of graphs from nauty geng
-                return
-            yield graph.Graph(s[:-1], format='graph6', immutable=immutable)
+                              encoding='latin-1') as sp:
+            msg = sp.stderr.readline()
+            if debug:
+                yield msg
+            elif msg.startswith('>E'):
+                raise ValueError('wrong format of parameter option')
+            gen = sp.stdout
+            while True:
+                try:
+                    s = next(gen)
+                except StopIteration:
+                    # Exhausted list of graphs from nauty geng
+                    return
+                yield graph.Graph(s[:-1], format='graph6', immutable=immutable)
 
     def nauty_genbg(self, options='', debug=False, immutable=False):
         r"""
@@ -1203,41 +1203,41 @@ class GraphGenerators:
 
         from sage.features.nauty import NautyExecutable
         genbg_path = NautyExecutable("genbgL").absolute_filename()
-        sp = subprocess.Popen(shlex.quote(genbg_path) + " {0}".format(options), shell=True,
+        with subprocess.Popen(shlex.quote(genbg_path) + " {0}".format(options), shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE, close_fds=True,
-                              encoding='latin-1')
-        msg = sp.stderr.readline()
-        if debug:
-            yield msg
-        elif msg.startswith('>E'):
-            raise ValueError('wrong format of parameter options')
+                              encoding='latin-1') as sp:
+            msg = sp.stderr.readline()
+            if debug:
+                yield msg
+            elif msg.startswith('>E'):
+                raise ValueError('wrong format of parameter options')
 
-        if msg.startswith('>A'):
-            # We extract the partition of the vertices from the msg string
-            for s in msg.split(' '):
-                if s.startswith('n='):
-                    from sage.rings.integer import Integer
-                    n1, n2 = (Integer(t) for t in s[2:].split('+') if t.isdigit())
-                    partition = [set(range(n1)), set(range(n1, n1 + n2))]
-                    break
+            if msg.startswith('>A'):
+                # We extract the partition of the vertices from the msg string
+                for s in msg.split(' '):
+                    if s.startswith('n='):
+                        from sage.rings.integer import Integer
+                        n1, n2 = (Integer(t) for t in s[2:].split('+') if t.isdigit())
+                        partition = [set(range(n1)), set(range(n1, n1 + n2))]
+                        break
+                else:
+                    # should never happen
+                    raise ValueError('unable to recover the partition')
             else:
-                # should never happen
-                raise ValueError('unable to recover the partition')
-        else:
-            # Either msg starts with >E or option -q has been given
-            partition = None
+                # Either msg starts with >E or option -q has been given
+                partition = None
 
-        gen = sp.stdout
-        from sage.graphs.bipartite_graph import BipartiteGraph
-        while True:
-            try:
-                s = next(gen)
-            except StopIteration:
-                # Exhausted list of bipartite graphs from nauty genbgL
-                return
-            yield BipartiteGraph(s[:-1], format='graph6', partition=partition,
-                                 immutable=immutable)
+            gen = sp.stdout
+            from sage.graphs.bipartite_graph import BipartiteGraph
+            while True:
+                try:
+                    s = next(gen)
+                except StopIteration:
+                    # Exhausted list of bipartite graphs from nauty genbgL
+                    return
+                yield BipartiteGraph(s[:-1], format='graph6', partition=partition,
+                                     immutable=immutable)
 
     def nauty_genktreeg(self, options='', debug=False, immutable=False):
         r"""
@@ -1339,23 +1339,23 @@ class GraphGenerators:
 
         from sage.features.nauty import NautyExecutable
         geng_path = NautyExecutable("genktreeg").absolute_filename()
-        sp = subprocess.Popen(shlex.quote(geng_path) + " {0}".format(options), shell=True,
+        with subprocess.Popen(shlex.quote(geng_path) + " {0}".format(options), shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE, close_fds=True,
-                              encoding='latin-1')
-        msg = sp.stderr.readline()
-        if debug:
-            yield msg
-        elif msg.startswith('>E'):
-            raise ValueError('wrong format of parameter option')
-        gen = sp.stdout
-        while True:
-            try:
-                s = next(gen)
-            except StopIteration:
-                # Exhausted list of graphs from nauty geng
-                return
-            yield graph.Graph(s[:-1], format='graph6', immutable=immutable)
+                              encoding='latin-1') as sp:
+            msg = sp.stderr.readline()
+            if debug:
+                yield msg
+            elif msg.startswith('>E'):
+                raise ValueError('wrong format of parameter option')
+            gen = sp.stdout
+            while True:
+                try:
+                    s = next(gen)
+                except StopIteration:
+                    # Exhausted list of graphs from nauty geng
+                    return
+                yield graph.Graph(s[:-1], format='graph6', immutable=immutable)
 
     def cospectral_graphs(self, vertices, matrix_function=None, graphs=None,
                           immutable=False):
@@ -1718,11 +1718,11 @@ class GraphGenerators:
         command = shlex.quote(Buckygen().absolute_filename())
         command += ' -' + ('I' if ipr else '') + 'd {0}d'.format(order)
 
-        sp = subprocess.Popen(command, shell=True,
+        with subprocess.Popen(command, shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE, close_fds=True)
+                              stderr=subprocess.PIPE, close_fds=True) as sp:
 
-        yield from graphs._read_planar_code(sp.stdout, immutable=immutable)
+            yield from graphs._read_planar_code(sp.stdout, immutable=immutable)
 
     def fusenes(self, hexagon_count, benzenoids=False, immutable=False):
         r"""
@@ -1806,11 +1806,11 @@ class GraphGenerators:
         command = shlex.quote(Benzene().absolute_filename())
         command += (' b' if benzenoids else '') + ' {0} p'.format(hexagon_count)
 
-        sp = subprocess.Popen(command, shell=True,
+        with subprocess.Popen(command, shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE, close_fds=True)
+                              stderr=subprocess.PIPE, close_fds=True) as sp:
 
-        yield from graphs._read_planar_code(sp.stdout, immutable=immutable)
+            yield from graphs._read_planar_code(sp.stdout, immutable=immutable)
 
     def plantri_gen(self, options="", immutable=False):
         r"""
@@ -1991,14 +1991,14 @@ class GraphGenerators:
         import shlex
         command = '{} {}'.format(shlex.quote(Plantri().absolute_filename()),
                                  options)
-        sp = subprocess.Popen(command, shell=True,
+        with subprocess.Popen(command, shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE, close_fds=True)
+                              stderr=subprocess.PIPE, close_fds=True) as sp:
 
-        try:
-            yield from graphs._read_planar_code(sp.stdout, immutable=immutable)
-        except (TypeError, AssertionError):
-            raise AttributeError("invalid options '{}'".format(options))
+            try:
+                yield from graphs._read_planar_code(sp.stdout, immutable=immutable)
+            except (TypeError, AssertionError):
+                raise AttributeError("invalid options '{}'".format(options))
 
     def planar_graphs(self, order, minimum_degree=None,
                       minimum_connectivity=None,

--- a/src/sage/graphs/hypergraph_generators.py
+++ b/src/sage/graphs/hypergraph_generators.py
@@ -182,26 +182,26 @@ class HypergraphGenerators:
 
         nauty_input += " " + str(number_of_vertices) + " " + str(number_of_sets) + " "
 
-        sp = subprocess.Popen(shlex.quote(genbgL_path) + " {0}".format(nauty_input), shell=True,
+        with subprocess.Popen(shlex.quote(genbgL_path) + " {0}".format(nauty_input), shell=True,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE, close_fds=True)
+                              stderr=subprocess.PIPE, close_fds=True) as sp:
 
-        if debug:
-            yield sp.stderr.readline()
+            if debug:
+                yield sp.stderr.readline()
 
-        gen = sp.stdout
-        total = number_of_sets + number_of_vertices
-        from sage.graphs.graph import Graph
-        while True:
-            try:
-                s = next(gen)
-            except StopIteration:
-                # Exhausted list of graphs from nauty geng
-                return
+            gen = sp.stdout
+            total = number_of_sets + number_of_vertices
+            from sage.graphs.graph import Graph
+            while True:
+                try:
+                    s = next(gen)
+                except StopIteration:
+                    # Exhausted list of graphs from nauty geng
+                    return
 
-            G = Graph(s[:-1], format='graph6')
+                G = Graph(s[:-1], format='graph6')
 
-            yield tuple(tuple(G.neighbor_iterator(v)) for v in range(number_of_vertices, total))
+                yield tuple(tuple(G.neighbor_iterator(v)) for v in range(number_of_vertices, total))
 
     def CompleteUniform(self, n, k):
         r"""


### PR DESCRIPTION
This fixes a "Too many open files" error when running

```sage
import resource
max_open_files = 20
resource.setrlimit(resource.RLIMIT_NOFILE,(max_open_files,max_open_files))

for _ in range(max_open_files):
    for G in graphs.nauty_geng("9"):
        break
```

The above relies on the fact that `geng 9` takes a while to finish. While the first `geng 9` process is still running, up to 20 other processes are started until the operating system runs out of file descriptors. This pull request fixes this by making sure a process is terminated when it's no longer needed.

I did not (and do not plan to) add any tests for this.