### PR TITLE
Restrict Cython's version and fix the uv building workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
           fi
 
       - name: Checkout code
-        # cannot use v4 yet because of https://github.com/actions/checkout/issues/1487
         uses: actions/checkout@v6.0.1
 
       - name: Install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
 
       - name: Checkout code
         # cannot use v4 yet because of https://github.com/actions/checkout/issues/1487
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.7.0
+        uses: astral-sh/setup-uv@v7.1.4
 
       # We cannot use the setup python action because it doesn't support all containers
       # https://github.com/actions/setup-python/issues/527
@@ -95,8 +95,8 @@ jobs:
           uv pip install \
             meson-python \
             "cypari2 >=2.2.1" \
-            "cysignals >=1.11.2, != 1.12.0" \
-            "cython >=3.0, != 3.0.3, < 3.1.0" \
+            "cysignals >=1.12.1" \
+            "cython >=3.1.0" \
             "gmpy2 >=2.1.5" \
             memory_allocator \
             "numpy >=1.25" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires = [
   'meson-python',
   # Exclude 1.12.0 because of https://github.com/sagemath/cysignals/issues/212
   'cysignals >=1.11.2, != 1.12.0',
-  # Exclude 3.0.3 because of https://github.com/cython/cython/issues/5748
   'cython >=3.1.0',
   'gmpy2 >=2.1.5',
   'jinja2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
   # Exclude 1.12.0 because of https://github.com/sagemath/cysignals/issues/212
   'cysignals >=1.11.2, != 1.12.0',
   # Exclude 3.0.3 because of https://github.com/cython/cython/issues/5748
-  'cython >=3.1.0,
+  'cython >=3.1.0',
   'gmpy2 >=2.1.5',
   'jinja2',
   'memory_allocator',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
   'cypari2 >=2.2.1; sys_platform != "win32"',
   'meson-python',
   # Exclude 1.12.0 because of https://github.com/sagemath/cysignals/issues/212
-  'cysignals >=1.11.2, != 1.12.0',
+  'cysignals >=1.12.1',
   'cython >=3.1.0',
   'gmpy2 >=2.1.5',
   'jinja2',
@@ -45,8 +45,8 @@ dependencies = [
   'cypari2 >=2.2.1; sys_platform != "win32"',
   'six >=1.15.0',
   # Exclude 1.12.0 because of https://github.com/sagemath/cysignals/issues/212
-  'cysignals >=1.11.2, != 1.12.0',
-  'cython >=3.0, != 3.0.3',
+  'cysignals >=1.12.1',
+  'cython >=3.1.0',
   'fpylll >=0.5.9; sys_platform != "win32"',
   'gmpy2 >=2.1.5',
   'ipykernel >=5.2.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
   # Exclude 1.12.0 because of https://github.com/sagemath/cysignals/issues/212
   'cysignals >=1.11.2, != 1.12.0',
   # Exclude 3.0.3 because of https://github.com/cython/cython/issues/5748
-  'cython >=3.0, != 3.0.3',
+  'cython >=3.1.0,
   'gmpy2 >=2.1.5',
   'jinja2',
   'memory_allocator',


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Relate to #41137, these two functions are only support on cython>=3.1.0
@tobiasdiez Can you help me upgrade uv lock file? I use conda but not uv.
https://github.com/cython/cython/commit/b684235561fbf1049927a6fda9ad3cd9f7e096f6


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


