### PR TITLE
`CircuitsMatroid`: check for empty dict before min

### DIFF
--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -547,10 +547,15 @@ cdef class CircuitsMatroid(Matroid):
             sage: M = CircuitsMatroid(matroids.CompleteGraphic(6))
             sage: len(M.nonbases())
             1707
+            sage: M = CircuitsMatroid(matroids.Uniform(5, 5))
+            sage: M.dependent_sets(3)  # self._k_C is empty
+            SetSystem of 0 sets over 5 elements
         """
         cdef int i
         cdef set D_k = set()
         cdef frozenset S
+        if not self._k_C:
+            return SetSystem(self._groundset)
         for i in range(min(self._k_C), k + 1):
             if i in self._k_C:
                 for S in self._k_C[i]:


### PR DESCRIPTION
This was already working as intented (confusingly), probably due to some Cython optimization which avoided the min on an empty dict. I added the check for clarity and robustness.

For example, this calls min on an empty dict:
```python
sage: from sage.matroids.circuits_matroid import CircuitsMatroid
sage: M = matroids.Uniform(5, 5)
sage: CM = CircuitsMatroid(M)
sage: CM.dependent_sets(2)
SetSystem of 0 sets over 5 elements
```

The addition of a `print(min(self._k_C))` makes the issue clear, as it raises:
```
ValueError: min() iterable argument is empty
```


