### PR TITLE
fix corner case of plethysm with tensors

### DIFF
--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -3601,6 +3601,8 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             sage: s = SymmetricFunctions(T).s()
             sage: s[2](5)
             15*B[] # B[]
+            sage: s[[]](tensor([p[1], s[1]]))
+            p[] # s[]
 
         .. TODO::
 
@@ -3646,11 +3648,11 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
         if tensorflag:
             tparents = Px._sets
             lincomb = Px.linear_combination
-            elt = lincomb((prod(lincomb((tensor([p[r].plethysm(base(la))
+            elt = lincomb((prod((lincomb((tensor([p[r].plethysm(base(la))
                                                  for base, la in zip(tparents, trm)]),
                                          _raise_variables(c, r, degree_one))
                                         for trm, c in x)
-                                for r in mu),
+                                for r in mu),tensor([base.one() for base in tparents])),
                            d)
                           for mu, d in p(self))
             return Px(elt)

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -3569,6 +3569,11 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             sage: (1+p[2]).plethysm(p[2])
             p[] + p[4]
 
+        Fixed :issue:`41257`::
+
+            sage: s[[]](tensor([p[1], s[1]]))
+            p[] # s[]
+
         Check that degree one elements are treated in the correct way::
 
             sage: R.<a1,a2,a11,b1,b21,b111> = QQ[]
@@ -3601,11 +3606,6 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             sage: s = SymmetricFunctions(T).s()
             sage: s[2](5)
             15*B[] # B[]
-
-        Fixed :issue:`41257`::
-
-            sage: s[[]](tensor([p[1], s[1]]))
-            p[] # s[]
 
         .. TODO::
 

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -3655,7 +3655,7 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
                                                  for base, la in zip(tparents, trm)]),
                                          _raise_variables(c, r, degree_one))
                                         for trm, c in x)
-                                for r in mu),tensor([base.one() for base in tparents])),
+                                for r in mu), tensor([base.one() for base in tparents])),
                            d)
                           for mu, d in p(self))
             return Px(elt)

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -3601,6 +3601,9 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             sage: s = SymmetricFunctions(T).s()
             sage: s[2](5)
             15*B[] # B[]
+
+        Fixed :issue:`41257`::
+
             sage: s[[]](tensor([p[1], s[1]]))
             p[] # s[]
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

There was a corner case of the plethysm function that was failing when computing a plethysm of an empty partition and a tensor of symmetric functions.

This change inserts the base case of a product in the plethsym formula as a default of 1 to the .one() of the ring.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


