### PR TITLE
Fix error in latex (pgf) generation of Graphics objects due to spec changes upstream (matplotlib)

### DIFF
--- a/src/sage/plot/graphics.py
+++ b/src/sage/plot/graphics.py
@@ -3381,11 +3381,12 @@ class Graphics(WithEqualityById, SageObject):
                 if latex_implementations[0] == "pdflatex":
                     # use pdflatex and set font encoding as per
                     # matplotlib documentation:
-                    # https://matplotlib.org/users/pgf.html#pgf-tutorial
+                    # https://matplotlib.org/stable/users/explain/text/pgf.html
+                    # Note that pgf.preamble should be a string now, not a list
                     pgf_options = {"pgf.texsystem": "pdflatex",
-                                   "pgf.preamble": [
+                                   "pgf.preamble": "\n".join([
                                        r"\usepackage[utf8x]{inputenc}",
-                                       r"\usepackage[T1]{fontenc}"]}
+                                       r"\usepackage[T1]{fontenc}"])}
                 else:
                     pgf_options = {
                         "pgf.texsystem": latex_implementations[0],


### PR DESCRIPTION
This pull request fixes a problem of latex generation of ``Graphics`` objects due to upstream spec change.

Symptom: When trying to generate latex for a ``Graphics`` object, even simple, sage produces the following error.

```
sage: latex(line([(0, 0), (1, 1)]))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], line 1
----> 1 latex(line([(Integer(0), Integer(0)), (Integer(1), Integer(1))]))

File ~/svn/sage/src/sage/misc/latex.py:922, in LatexCall.__call__(self, x, combine_all)
    893 r"""
    894 Return a :class:`LatexExpr` built out of the argument ``x``.
    895 
   (...)
    919     x 2
    920 """
    921 if has_latex_attr(x):
--> 922     return LatexExpr(x._latex_())
    923 try:
    924     f = latex_table[type(x)]

File ~/svn/sage/src/sage/plot/graphics.py:3440, in Graphics._latex_(self, **kwds)
   3424 """
   3425 Return a string plotting ``self`` with PGF.
   3426 
   (...)
   3437     '%% Creator: Matplotlib, PGF backend...
   3438 """
   3439 tmpfilename = tmp_filename(ext='.pgf')
-> 3440 self.save(filename=tmpfilename, **kwds)
   3441 with open(tmpfilename) as tmpfile:
   3442     latex_list = tmpfile.readlines()

File ~/svn/sage/src/sage/misc/decorators.py:416, in suboptions.__call__.<locals>.wrapper(*args, **kwds)
    412         del kwds[key]
    414 kwds[self.name + "options"] = suboptions
--> 416 return func(*args, **kwds)

File ~/svn/sage/src/sage/plot/graphics.py:3394, in Graphics.save(self, filename, **kwds)
   3390     pgf_options = {
   3391         "pgf.texsystem": latex_implementations[0],
   3392     }
   3393 from matplotlib import rcParams
-> 3394 rcParams.update(pgf_options)
   3395 from matplotlib.backends.backend_pgf import FigureCanvasPgf
   3396 figure.set_canvas(FigureCanvasPgf(figure))

File <frozen _collections_abc>:982, in update(self, other, **kwds)

File ~/svn/sage/local/var/lib/sage/venv-python3.12.5/lib/python3.12/site-packages/matplotlib/__init__.py:774, in RcParams.__setitem__(self, key, val)
    772         cval = self.validate[key](val)
    773     except ValueError as ve:
--> 774         raise ValueError(f"Key {key}: {ve}") from None
    775     self._set(key, cval)
    776 except KeyError as err:

ValueError: Key pgf.preamble: Could not convert ['\\usepackage[utf8x]{inputenc}', '\\usepackage[T1]{fontenc}'] to str
```

This is due to a change of spec in matplotlib. More precisely, the option ``pgf.preamble`` accepts no longer a list of strings, but only a string. This can be seen also in the [updated tutorial](https://matplotlib.org/stable/users/explain/text/pgf.html).

The current pull request resolves this problem. After applying the changes, the previous command produces some pgf output that can be used as a latex presentation of the ``Graphics`` object.

I am not sure about how to add test for this change. There are already some tests in the ``_latex_`` function, but somehow it is not executed.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.