### PR TITLE
Add print_mode='digits-unicode' to p-adic numbers

### DIFF
--- a/src/sage/rings/padics/factory.py
+++ b/src/sage/rings/padics/factory.py
@@ -1989,6 +1989,11 @@ class Zp_class(UniqueFactory):
             check = True
         if label is not None and type not in ['lattice-cap','lattice-float']:
             raise ValueError("label keyword only supported for lattice precision")
+        if print_mode == 'digits-unicode':
+            print_mode = 'digits'  # Treat as digits but we'll handle unicode later
+        elif print_mode not in ['series', 'val-unit', 'terse', 'digits', 'bars']:
+            raise ValueError("invalid print_mode: %s" % print_mode)
+
         return get_key_base(p, prec, type, print_mode, names, ram_name, print_pos, print_sep, print_alphabet,
                             print_max_terms, show_prec, check,
                             ['capped-rel', 'fixed-mod', 'capped-abs', 'floating-point', 'lattice-cap', 'lattice-float', 'relaxed'],


### PR DESCRIPTION
This adds support for using Unicode ellipsis character (U+2026) instead of three ASCII dots in digits print mode. This helps with doctest matching issues where '...' is a special marker.

Fixes #41219

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


