### PR TITLE
Fix the wrong vertices number of Cayley graphs of finitely presented groups

### DIFF
--- a/src/sage/combinat/root_system/weyl_group.py
+++ b/src/sage/combinat/root_system/weyl_group.py
@@ -267,11 +267,12 @@ class WeylGroup_gens(UniqueRepresentation,
 
         EXAMPLES::
 
-            sage: W = CoxeterGroup(['A',2], implementation='matrix')                    # needs sage.libs.gap
-            sage: G = MatrixGroup(W.gens())                                             # needs sage.libs.gap
-            sage: W == G                                                                # needs sage.libs.gap
+            sage: # needs sage.libs.gap
+            sage: W = CoxeterGroup(['A',2], implementation='matrix')
+            sage: G = MatrixGroup(W.gens())
+            sage: W == G
             True
-            sage: hash(W) == hash(G)                                                    # needs sage.libs.gap
+            sage: hash(W) == hash(G)
             True
         """
         return FinitelyGeneratedMatrixGroup_gap.__hash__(self)

--- a/src/sage/combinat/root_system/weyl_group.py
+++ b/src/sage/combinat/root_system/weyl_group.py
@@ -261,6 +261,21 @@ class WeylGroup_gens(UniqueRepresentation,
         FinitelyGeneratedMatrixGroup_gap.__init__(
             self, degree, ring, libgap_group, category=category)
 
+    def __hash__(self):
+        r"""
+        Return a hash compatible with matrix-group equality.
+
+        EXAMPLES::
+
+            sage: W = CoxeterGroup(['A',2], implementation='matrix')                    # needs sage.libs.gap
+            sage: G = MatrixGroup(W.gens())                                             # needs sage.libs.gap
+            sage: W == G                                                                # needs sage.libs.gap
+            True
+            sage: hash(W) == hash(G)                                                    # needs sage.libs.gap
+            True
+        """
+        return FinitelyGeneratedMatrixGroup_gap.__hash__(self)
+
     @cached_method
     def cartan_type(self):
         """

--- a/src/sage/groups/finitely_presented.py
+++ b/src/sage/groups/finitely_presented.py
@@ -408,9 +408,8 @@ class FinitelyPresentedGroupElement(FreeGroupElement):
         if rws is not None:
             return hash(rws.reduce(self).Tietze())
         # Finite groups - hash by permutation representation
-        phi = libgap.IsomorphismPermGroup(G.gap())
-        # IsomorphismPermGroup returns 'fail' for infinite groups
-        if str(phi) == 'fail':
+        phi = G._perm_isomorphism()
+        if phi is None:
             raise NotImplementedError(
                 "hashing requires a confluent rewriting system\n"
                 "for infinite non-free finitely presented groups;\n"
@@ -1021,6 +1020,32 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
             True
         """
         return self._relations
+
+    @cached_method
+    def _perm_isomorphism(self):
+        r"""
+        Return a permutation representation isomorphism, if available.
+
+        OUTPUT:
+
+        A GAP isomorphism from ``self`` to a permutation group, or ``None``
+        if ``libgap.IsomorphismPermGroup`` returns ``fail``.
+
+        EXAMPLES::
+
+            sage: F.<a,b> = FreeGroup()
+            sage: H = F / [a^2, b^3, a*b*a^-1*b^-1]
+            sage: H._perm_isomorphism() is not None
+            True
+
+            sage: G = F / [a*b*a^-1*b^-2]
+            sage: G._perm_isomorphism() is None
+            True
+        """
+        phi = libgap.IsomorphismPermGroup(self.gap())
+        if str(phi) == 'fail':
+            return None
+        return phi
 
     @cached_method
     def cardinality(self, limit=4096000):

--- a/src/sage/groups/finitely_presented.py
+++ b/src/sage/groups/finitely_presented.py
@@ -2061,6 +2061,8 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
             raise TypeError("expected a RewritingSystem")
         if not rws.is_confluent():
             raise ValueError("the rewriting system must be confluent")
+        if rws.finitely_presented_group() is not self:
+            raise ValueError("the rewriting system must belong to this group")
         self._confluent_rewriting_system = rws
 
     from sage.groups.generic import structure_description

--- a/src/sage/groups/finitely_presented.py
+++ b/src/sage/groups/finitely_presented.py
@@ -84,6 +84,9 @@ obtained by modding out the commutator subgroup of the free group::
     sage: G = FreeGroup(2)
     sage: G_ab = G / [G([1, 2, -1, -2])];  G_ab
     Finitely presented group < x0, x1 | x0*x1*x0^-1*x1^-1 >
+    sage: k = G_ab.rewriting_system()
+    sage: k.make_confluent()
+    sage: G_ab.set_confluent_rewriting_system(k)
     sage: a,b = G_ab.gens()
     sage: g =  a * b
     sage: M1 = matrix([[1,0],[0,2]])
@@ -313,6 +316,111 @@ class FinitelyPresentedGroupElement(FreeGroupElement):
         tl = self.gap().UnderlyingElement().TietzeWordAbstractWord()
         return tuple(tl.sage())
 
+    def __hash__(self):
+        r"""
+        Return a hash for this group element.
+
+        For free groups (no relations), hashing is based on the Tietze word.
+        For finite groups, the element is converted to a permutation group
+        element which has a well-defined hash.
+        For infinite non-free groups with a confluent rewriting system,
+        hashing is based on the canonical reduced form.
+        For general infinite finitely presented groups without a confluent
+        rewriting system, hashing is not supported because the word problem
+        is undecidable.
+
+        .. WARNING::
+
+            Computing a confluent rewriting system via Knuth-Bendix
+            completion is not guaranteed to terminate, since the word
+            problem for finitely presented groups is undecidable in
+            general. The call to ``make_confluent()`` may run forever
+            for some groups.
+
+        EXAMPLES:
+
+        Free groups support hashing::
+
+            sage: F.<a,b> = FreeGroup()
+            sage: H = F / []  # trivial quotient = free group
+            sage: hash(H([1,2])) == hash(H([1,2]))
+            True
+
+        Finite groups support hashing::
+
+            sage: G.<a,b> = FreeGroup()
+            sage: H = G / [a^2, b^3, a*b*a^-1*b^-1]
+            sage: H.inject_variables()
+            Defining a, b
+            sage: hash(a) == hash(a)
+            True
+            sage: hash(a*a) == hash(H.one())  # equal elements have equal hashes
+            True
+
+        Infinite groups with a confluent rewriting system support hashing::
+
+            sage: F.<x,y> = FreeGroup()
+            sage: D = F / [x^2, y^2]  # infinite dihedral group
+            sage: k = D.rewriting_system()
+            sage: k.make_confluent()
+            sage: D.set_confluent_rewriting_system(k)
+            sage: a, b = D.gens()
+            sage: hash(a) == hash(a)
+            True
+            sage: hash(a*a) == hash(D.one())  # a^2 = 1
+            True
+            sage: hash(a*b) != hash(b*a)  # different elements
+            True
+
+        Infinite groups without a confluent rewriting system raise an error;
+        use :meth:`~FinitelyPresentedGroup.set_confluent_rewriting_system`
+        to enable hashing::
+
+            sage: F.<a,b> = FreeGroup()
+            sage: G = F / [a*b*a^-1*b^-2]  # Baumslag-Solitar group, infinite
+            sage: hash(G([1]))
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: hashing requires a confluent rewriting system
+            for infinite non-free finitely presented groups;
+            first compute one via k = G.rewriting_system(); k.make_confluent();
+            G.set_confluent_rewriting_system(k)
+
+        TESTS:
+
+        Check that :issue:`40549` is fixed::
+
+            sage: F.<x,y> = FreeGroup()
+            sage: G = F / [x^4, y^13, x*y*x^-1*y^-5]
+            sage: a, b = G.gens()
+            sage: G.order()
+            52
+            sage: cg = G.cayley_graph()
+            sage: cg.num_verts()
+            52
+        """
+        G = self.parent()
+        # Free groups (no relations) - hash by Tietze word
+        if len(G.relations()) == 0:
+            return hash(self.Tietze())
+        # Confluent rewriting system - hash by canonical reduced form
+        rws = G._confluent_rewriting_system
+        if rws is not None:
+            return hash(rws.reduce(self).Tietze())
+        # Finite groups - hash by permutation representation
+        phi = libgap.IsomorphismPermGroup(G.gap())
+        # IsomorphismPermGroup returns 'fail' for infinite groups
+        if str(phi) == 'fail':
+            raise NotImplementedError(
+                "hashing requires a confluent rewriting system\n"
+                "for infinite non-free finitely presented groups;\n"
+                "first compute one via "
+                "k = G.rewriting_system(); k.make_confluent();\n"
+                "G.set_confluent_rewriting_system(k)"
+            )
+        perm_elem = libgap.Image(phi, self.gap())
+        return hash(perm_elem)
+
     def __call__(self, *values, **kwds):
         """
         Replace the generators of the free group with ``values``.
@@ -340,6 +448,9 @@ class FinitelyPresentedGroupElement(FreeGroupElement):
         The generator `b` can be eliminated using the relation `a=b`. Any
         values that you plug into a word must satisfy this relation::
 
+            sage: k = H.rewriting_system()
+            sage: k.make_confluent()
+            sage: H.set_confluent_rewriting_system(k)
             sage: A, B = H.gens()
             sage: w = A^2 * B
             sage: w(2,2)
@@ -350,8 +461,8 @@ class FinitelyPresentedGroupElement(FreeGroupElement):
             Traceback (most recent call last):
             ...
             ValueError: the values do not satisfy all relations of the group
-            sage: w(1, 2, check=False)    # result depends on presentation of the group element
-            2
+            sage: w(1, 2, check=False)   # result depends on presentation of the group element
+            8
         """
         values = list(values)
         if kwds.get('check', True):
@@ -780,6 +891,7 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
             libgap_fpgroup = free_group.gap() / libgap([rel.gap() for rel in relations])
         ParentLibGAP.__init__(self, libgap_fpgroup)
         Group.__init__(self, category=category)
+        self._confluent_rewriting_system = None
 
     def __hash__(self):
         """
@@ -1907,5 +2019,48 @@ class FinitelyPresentedGroup(GroupMixinLibGAP, CachedRepresentation, Group, Pare
             a*b
         """
         return RewritingSystem(self)
+
+    def set_confluent_rewriting_system(self, rws):
+        r"""
+        Store a confluent rewriting system for use by element hashing.
+
+        For infinite non-free finitely presented groups, elements cannot
+        be hashed by default because the word problem is undecidable.
+        However, if the user has computed a confluent rewriting system
+        (via Knuth-Bendix completion), the canonical reduced forms
+        provide a valid basis for hashing.
+
+        INPUT:
+
+        - ``rws`` -- a :class:`RewritingSystem` that is confluent
+
+        EXAMPLES::
+
+            sage: F.<x,y> = FreeGroup()
+            sage: D = F / [x^2, y^2]  # infinite dihedral group
+            sage: k = D.rewriting_system()
+            sage: k.make_confluent()
+            sage: D.set_confluent_rewriting_system(k)
+            sage: a, b = D.gens()
+            sage: hash(a) == hash(a)
+            True
+            sage: hash(a*a) == hash(D.one())
+            True
+
+        The rewriting system must be confluent::
+
+            sage: F.<a,b> = FreeGroup()
+            sage: G = F / [a^2, b^3]
+            sage: k = G.rewriting_system()
+            sage: G.set_confluent_rewriting_system(k)
+            Traceback (most recent call last):
+            ...
+            ValueError: the rewriting system must be confluent
+        """
+        if not isinstance(rws, RewritingSystem):
+            raise TypeError("expected a RewritingSystem")
+        if not rws.is_confluent():
+            raise ValueError("the rewriting system must be confluent")
+        self._confluent_rewriting_system = rws
 
     from sage.groups.generic import structure_description

--- a/src/sage/groups/matrix_gps/matrix_group.py
+++ b/src/sage/groups/matrix_gps/matrix_group.py
@@ -558,6 +558,48 @@ class MatrixGroup_generic(MatrixGroup_base):
                 return richcmp_not_equal(lx, rx, op)
         return rich_to_bool(op, 0)
 
+    def __hash__(self):
+        r"""
+        Return a hash for this matrix group.
+
+        The hash is computed from the same data used by equality:
+        the matrix space together with the ordered generator matrices.
+        Groups whose equality falls back to identity are also hashed by
+        identity.
+
+        EXAMPLES::
+
+            sage: R.<t> = LaurentSeriesRing(QQ)
+            sage: m = matrix(R, [[1, t], [0, 1]])
+            sage: G = MatrixGroup([m])
+            sage: H = MatrixGroup(G.gens())
+            sage: G == H
+            True
+            sage: hash(G) == hash(H)
+            True
+
+            sage: K = G.subgroup(G.gens())
+            sage: G == K
+            True
+            sage: hash(G) == hash(K)
+            True
+        """
+        try:
+            ngens = self.ngens()
+        except (AttributeError, NotImplementedError):
+            return hash(id(self))
+
+        from sage.structure.element import InfinityElement as Infinity
+        if isinstance(ngens, Infinity):
+            return hash(id(self))
+
+        try:
+            gens = self.gens()
+        except (AttributeError, NotImplementedError):
+            return hash(id(self))
+
+        return hash((self.matrix_space(), tuple(g.matrix() for g in gens)))
+
     def is_trivial(self):
         r"""
         Return ``True`` if this group is the trivial group.

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -815,6 +815,34 @@ class PermutationGroup_generic(FiniteGroup):
 
         return gSelf._richcmp_(gRight, op)
 
+    def __hash__(self):
+        r"""
+        Return a hash for this permutation group.
+
+        The hash is computed from GAP's canonical smallest generating set,
+        ensuring compatibility with equality of permutation groups.
+
+        EXAMPLES::
+
+            sage: G = SymmetricGroup(3)
+            sage: H = PermutationGroup([(1,2,3), (1,2)])
+            sage: G == H
+            True
+            sage: hash(G) == hash(H)
+            True
+
+        This is also compatible with permutation subgroups that compare
+        equal to their ambient group::
+
+            sage: G3 = G.subgroup([G((1,2,3)), G((1,2))])
+            sage: G == G3
+            True
+            sage: hash(G) == hash(G3)
+            True
+        """
+        gens = self._libgap_().GeneratorsSmallest()
+        return hash(tuple(self.element_class(g, self, check=False) for g in gens))
+
     Element = PermutationGroupElement
 
     def _element_constructor_(self, x, check=True):

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -819,8 +819,10 @@ class PermutationGroup_generic(FiniteGroup):
         r"""
         Return a hash for this permutation group.
 
-        The hash is computed from GAP's canonical smallest generating set,
-        ensuring compatibility with equality of permutation groups.
+        The hash is computed from the group order. For permutation groups,
+        GAP obtains the size from a stabilizer chain, so this remains
+        compatible with equality while keeping the hash inexpensive at the
+        cost of allowing many collisions.
 
         EXAMPLES::
 
@@ -840,8 +842,7 @@ class PermutationGroup_generic(FiniteGroup):
             sage: hash(G) == hash(G3)
             True
         """
-        gens = self._libgap_().GeneratorsSmallest()
-        return hash(tuple(self.element_class(g, self, check=False) for g in gens))
+        return hash(self._libgap_().Size().sage())
 
     Element = PermutationGroupElement
 

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -819,10 +819,10 @@ class PermutationGroup_generic(FiniteGroup):
         r"""
         Return a hash for this permutation group.
 
-        The hash is computed from the group order. For permutation groups,
-        GAP obtains the size from a stabilizer chain, so this remains
-        compatible with equality while keeping the hash inexpensive at the
-        cost of allowing many collisions.
+        The hash is computed from the group order together with the largest
+        moved point and the moved-point orbits. This remains compatible with
+        equality while reducing collisions compared to hashing by the group
+        order alone.
 
         EXAMPLES::
 
@@ -842,7 +842,8 @@ class PermutationGroup_generic(FiniteGroup):
             sage: hash(G) == hash(G3)
             True
         """
-        return hash(self._libgap_().Size().sage())
+        g = self._libgap_()
+        return hash((g.Size(), g.LargestMovedPoint(), g.OrbitsMovedPoints()))
 
     Element = PermutationGroupElement
 

--- a/src/sage/groups/perm_gps/permgroup_named.py
+++ b/src/sage/groups/perm_gps/permgroup_named.py
@@ -109,20 +109,13 @@ from sage.structure.unique_representation import CachedRepresentation
 
 class PermutationGroup_unique(CachedRepresentation, PermutationGroup_generic):
     """
-    .. TODO::
-
-        Fix the broken hash. ::
-
-            sage: G = SymmetricGroup(6)
-            sage: G3 = G.subgroup([G((1,2,3,4,5,6)),G((1,2))])
-            sage: hash(G) == hash(G3)  # todo: Should be True!
-            False
-
     TESTS::
 
         sage: G = SymmetricGroup(6)
         sage: G3 = G.subgroup([G((1,2,3,4,5,6)),G((1,2))])
         sage: G == G3
+        True
+        sage: hash(G) == hash(G3)
         True
     """
     @weak_cached_function

--- a/src/sage/schemes/curves/zariski_vankampen.py
+++ b/src/sage/schemes/curves/zariski_vankampen.py
@@ -1365,8 +1365,8 @@ def braid_monodromy(f, arrangement=(), vertical=False) -> tuple:
     end_braid_computation = False
     while not end_braid_computation:
         try:
-            braidscomputed = (braid_in_segment([(glist, seg[0], seg[1])
-                                                for seg in segs]))
+            braidscomputed = braid_in_segment([(glist, seg[0], seg[1])
+                                               for seg in segs])
             segsbraids = {}
             for braidcomputed in braidscomputed:
                 seg = (braidcomputed[0][0][1], braidcomputed[0][0][2])
@@ -1815,7 +1815,7 @@ def fundamental_group_arrangement(flist, simplified=True, projective=False,
       each of these paths is the conjugated of a loop around one of the points
       in the discriminant of the projection of ``f``.
 
-    - A dictionary attaching to ``j`` a tuple a list of elements
+    - A dictionary attaching to ``j`` a list of elements
       of the group  which are meridians of the curve in position ``j``.
       If ``projective`` is ``False`` and the `y`-degree of the horizontal
       components coincide with the total degree, another key is added
@@ -1924,5 +1924,7 @@ def fundamental_group_arrangement(flist, simplified=True, projective=False,
     n = g1.ngens()
     rels = [rel.Tietze() for rel in g1.relations()]
     g1 = FreeGroup(n) / rels
-    dic1 = {i: list({g1(el.Tietze()) for el in dic1[i]}) for i in dic1}
+    dic1 = {i: [*{t: g1(t) for el in dic1[i] for t in (el.Tietze(),)}.values()] for i in dic1}
+    # each list in dic1.values() may have duplicates, but deduplicating it properly
+    # requires solving the group problem on g1 which can be prohibitive
     return (g1, dic1)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
fix #40549 Alternative https://github.com/sagemath/sage/pull/41173
Now, we only implement hash for finite groups and finite groups. They are well-defined behavior. for general infinite f.p. group, we can not decide word problem. I think setting they are unhashable is better

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


