### PR TITLE
build givaro, fflas-ffpack and linbox without native arch in SAGE_FAT_BINARY

### DIFF
--- a/build/pkgs/fflas_ffpack/spkg-install.in
+++ b/build/pkgs/fflas_ffpack/spkg-install.in
@@ -20,7 +20,7 @@ FFLAS_FFPACK_CONFIGURE="$SAGE_CONFIGURE_FFLAS_FFPACK $FFLAS_FFPACK_CONFIGURE"
 
 # If SAGE_FAT_BINARY is set, disable all processor-specific optimizations
 if [ "$SAGE_FAT_BINARY" = yes ]; then
-    FFLAS_FFPACK_CONFIGURE="--disable-sse --disable-sse2 --disable-sse3 --disable-ssse3 --disable-sse41 --disable-sse42 --disable-fma --disable-fma4 --disable-avx --disable-avx2 --disable-avx512f --disable-avx512dq --disable-avx512vl $FFLAS_FFPACK_CONFIGURE"
+    FFLAS_FFPACK_CONFIGURE="--without-archnative $FFLAS_FFPACK_CONFIGURE"
 fi
 
 # Need to use 'bash' for configure, see

--- a/build/pkgs/givaro/spkg-install.in
+++ b/build/pkgs/givaro/spkg-install.in
@@ -6,7 +6,7 @@ cd src
 
 # When SAGE_FAT_BINARY is set, disable processor-specific optimizations
 if [ "$SAGE_FAT_BINARY" = yes ]; then
-    GIVARO_CONFIGURE="--disable-sse --disable-sse2 --disable-sse3 --disable-ssse3 --disable-sse41 --disable-sse42 --disable-fma --disable-fma4 --disable-avx --disable-avx2  $GIVARO_CONFIGURE"
+    GIVARO_CONFIGURE="--without-archnative $GIVARO_CONFIGURE"
 fi
 
 cp "$SAGE_ROOT"/config/config.* build-aux/

--- a/build/pkgs/linbox/spkg-install.in
+++ b/build/pkgs/linbox/spkg-install.in
@@ -15,7 +15,7 @@ export CPPFLAGS="$CPPFLAGS -DDISABLE_COMMENTATOR"
 
 # If SAGE_FAT_BINARY is set, disable dependency that be discovered on the building system.
 if [ "$SAGE_FAT_BINARY" = yes ]; then
-    LINBOX_CONFIGURE="--disable-sse3 --disable-ssse3 --disable-sse41 --disable-sse42 --disable-fma --disable-fma4 --disable-avx --disable-avx2 --without-ocl $LINBOX_CONFIGURE"
+    LINBOX_CONFIGURE="--without-archnative --without-ocl $LINBOX_CONFIGURE"
 fi
 
 # Disable fplll as version 5.x is not supported by linbox <= 1.5.0.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Fix https://github.com/sagemath/sage/issues/41000
Fix https://github.com/sagemath/sage/issues/39460
Fix https://github.com/sagemath/sage/issues/41273
Fix https://github.com/sagemath/sage/issues/41066
Test in https://github.com/sagemath/sage/pull/41277
It fixes the docker build and docker runner have different arch. 
Refer to https://github.com/passagemath/passagemath/pull/1820

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


