### PR TITLE
Fix incorrect tests and override canonical associate

### DIFF
--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -2406,7 +2406,6 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
             sage: K5.<sqrt5> = QuadraticField(5)
             sage: for _ in range(100):
             ....:    a = QQ.random_element(1000,20)
-            ....:    b = QQ.random_element(1000,20)
             ....:    assert a.round() == round(K2(a)), a
             ....:    assert a.round() == round(K3(a)), a
             ....:    assert a.round() == round(K5(a)), a

--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -2406,9 +2406,16 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
             sage: K5.<sqrt5> = QuadraticField(5)
             sage: for _ in range(100):
             ....:    a = QQ.random_element(1000,20)
+            ....:    b = QQ.random_element(1000,20)
             ....:    assert a.round() == round(K2(a)), a
             ....:    assert a.round() == round(K3(a)), a
             ....:    assert a.round() == round(K5(a)), a
+            ....:    #outside of rounding half integers, rounding between quadratic numbers are
+            ....:    #floats should agree (assuming enough precision is available)
+            ....:    if b != 0 or a + 1/2 not in ZZ:
+            ....:        assert round(a+b*sqrt(2.)) == round(a+b*sqrt2), (a, b)
+            ....:        assert round(a+b*sqrt(3.)) == round(a+b*sqrt3), (a, b)
+            ....:        assert round(a+b*sqrt(5.)) == round(a+b*sqrt5), (a, b)
         """
         n = self.floor()
         test = 2 * (self - n)
@@ -2946,6 +2953,24 @@ cdef class OrderElement_quadratic(NumberFieldElement_quadratic):
             scale = lin / beta
             const = const - scale * alpha
             return const.denominator().lcm(scale.denominator())
+
+    def canonical_associate(self):
+        """
+        Return a canonical associate.
+
+        Only implemented here because order elements inherit from field elements,
+        but the canonical associate implemented there does not apply here.
+
+        EXAMPLES::
+
+            sage: x = polygen(ZZ, 'x')
+            sage: K = NumberField(x^2 - 27, 'a')
+            sage: OK = K.ring_of_integers()
+            sage: (OK.1).canonical_associate()
+            NotImplemented
+        """
+        return NotImplemented
+
 
 cdef class Z_to_quadratic_field_element(Morphism):
     """

--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -2410,9 +2410,6 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
             ....:    assert a.round() == round(K2(a)), a
             ....:    assert a.round() == round(K3(a)), a
             ....:    assert a.round() == round(K5(a)), a
-            ....:    assert round(a+b*sqrt(2.)) == round(a+b*sqrt2), (a, b)
-            ....:    assert round(a+b*sqrt(3.)) == round(a+b*sqrt3), (a, b)
-            ....:    assert round(a+b*sqrt(5.)) == round(a+b*sqrt5), (a, b)
         """
         n = self.floor()
         test = 2 * (self - n)


### PR DESCRIPTION
Because one use roundtieeven, one use roundawayzero. They are not equal when half integers
And also move https://github.com/passagemath/passagemath/pull/1770 into this file
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


