### PR TITLE
restore lazy_import of maxima in calculus.py

### DIFF
--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -426,7 +426,8 @@ import re
 from types import FunctionType
 
 from sage.arith.misc import algebraic_dependency
-from sage.interfaces.maxima_lib import maxima
+from sage.misc.lazy_import import lazy_import
+lazy_import("sage.interfaces.maxima_lib","maxima")
 from sage.misc.latex import latex
 from sage.misc.parser import LookupNameMaker, Parser
 from sage.rings.cc import CC

--- a/src/sage/calculus/desolvers.py
+++ b/src/sage/calculus/desolvers.py
@@ -75,7 +75,8 @@ import os
 import shutil
 
 from sage.calculus.functional import diff
-from sage.interfaces.maxima_lib import maxima
+from sage.misc.lazy_import import lazy_import
+lazy_import("sage.interfaces.maxima_lib","maxima")
 from sage.misc.functional import N
 from sage.rings.real_mpfr import RealField
 from sage.structure.element import Expression


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
On #40265 the lazy import of the maxima interface in calculus.py was converted to a normal import. This PR restores the lazy import.
<!-- v Why is this change required? What problem does it solve? -->
The maxima interface is imported lazily to avoid the significant cost of starting and initializing the ECL and maxima_lib interfaces.
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


