### PR TITLE
Add warning about imports to all.py

### DIFF
--- a/src/sage/all.py
+++ b/src/sage/all.py
@@ -2,6 +2,20 @@
 all.py -- much of sage is imported into this module, so you don't
           have to import everything individually.
 
+WARNING:
+
+Do not import from this module into other modules. Instead, import
+from the orginal location. The tool `import_statements` helps in
+figuring out where that location is. For instance::
+
+    sage: import_statements("TensorAlgebra")
+    from sage.algebras.tensor_algebra import TensorAlgebra
+
+tells you that `TensorAlgebra` should be imported from
+`sage.algebras.tensor_algebra`. While the binding is available in `sage.all`
+as a `LazyImport`, you should not use that because it can lead to unexpected
+results.
+
 TESTS:
 
 This is to test :issue:`10570`. If the number of stackframes at startup


### PR DESCRIPTION
Warn about not importing from all and instead use `import_statements` to figure out where to import from instead.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes #41213 


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


