### PR TITLE
Explain how to disable generating targets for docbuilding at `pip install` step

### DIFF
--- a/src/doc/en/installation/source.rst
+++ b/src/doc/en/installation/source.rst
@@ -208,6 +208,15 @@ Remarks
   run in parallel based on the number of CPU available. This can be adjusted
   by passing ``--config-settings=compile-args=-jN`` to ``pip install``.
 
+  If you don't need to build the documentation, pass
+  ``--config-settings=setup-args=-Dbuild-docs=false`` to ``pip install``
+  to speed up the target generation step.
+
+  The parameter ``setup-args`` etc. are documented in
+  `<https://mesonbuild.com/meson-python/how-to-guides/config-settings.html>`_.
+  ``setup-args`` are passed to ``meson``, effect ``compile-args``
+  are passed to ``ninja``.
+
   ``--verbose`` can be passed to ``pip install``, then the meson commands
   internally used by pip will be printed out.
 


### PR DESCRIPTION
Follow-up on https://github.com/sagemath/sage/pull/41191. In the "background information" section below there's a guide how to do the equivalent with `meson`, but having more can't hurt (hopefully).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


