### PR TITLE
Make discarded-qualifiers compilation error in meson CI

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -135,6 +135,12 @@ jobs:
             export INCLUDE="$INCLUDE;$CONDA_PREFIX\\Library\\include"
           fi
 
+          export CFLAGS+=" -Werror=discarded-qualifiers"
+          export CXXFLAGS+=" -Werror=discarded-qualifiers"
+
+          echo "CFLAGS=$CFLAGS"
+          echo "CXXFLAGS=$CXXFLAGS"
+
           # Use --no-deps and pip check below to verify that all necessary dependencies are installed via conda
           pip install --no-build-isolation --no-deps --config-settings=builddir=builddir ${{ matrix.editable && '--editable' || '' }} . -v
 

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -130,8 +130,7 @@ jobs:
             export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
             export CC="ccache $CC"
             export CXX="ccache $CXX"
-            export CFLAGS+=" -Werror=discarded-qualifiers"
-            export CXXFLAGS+=" -Werror=discarded-qualifiers"
+            export CFLAGS+=" -Werror=discarded-qualifiers"  # discarded-qualifiers is not valid for C++
             echo "CFLAGS=$CFLAGS"
             echo "CXXFLAGS=$CXXFLAGS"
           else

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -130,16 +130,14 @@ jobs:
             export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
             export CC="ccache $CC"
             export CXX="ccache $CXX"
+            export CFLAGS+=" -Werror=discarded-qualifiers"
+            export CXXFLAGS+=" -Werror=discarded-qualifiers"
+            echo "CFLAGS=$CFLAGS"
+            echo "CXXFLAGS=$CXXFLAGS"
           else
             export LIB="$LIB;$CONDA_PREFIX\\Library\\lib"
             export INCLUDE="$INCLUDE;$CONDA_PREFIX\\Library\\include"
           fi
-
-          export CFLAGS+=" -Werror=discarded-qualifiers"
-          export CXXFLAGS+=" -Werror=discarded-qualifiers"
-
-          echo "CFLAGS=$CFLAGS"
-          echo "CXXFLAGS=$CXXFLAGS"
 
           # Use --no-deps and pip check below to verify that all necessary dependencies are installed via conda
           pip install --no-build-isolation --no-deps --config-settings=builddir=builddir ${{ matrix.editable && '--editable' || '' }} . -v

--- a/src/sage/arith/rational_reconstruction.pxd
+++ b/src/sage/arith/rational_reconstruction.pxd
@@ -1,3 +1,3 @@
-from sage.libs.gmp.types cimport mpz_t, mpq_t
+from sage.libs.gmp.types cimport mpz_srcptr, mpq_t
 
-cdef int mpq_rational_reconstruction(mpq_t answer, mpz_t a, mpz_t m) except -1
+cdef int mpq_rational_reconstruction(mpq_t answer, mpz_srcptr a, mpz_srcptr m) except -1

--- a/src/sage/arith/rational_reconstruction.pyx
+++ b/src/sage/arith/rational_reconstruction.pyx
@@ -28,7 +28,7 @@ from sage.libs.gmp.mpz cimport *
 from sage.libs.gmp.mpq cimport *
 
 
-cdef int mpq_rational_reconstruction(mpq_t answer, mpz_t a, mpz_t m) except -1:
+cdef int mpq_rational_reconstruction(mpq_t answer, mpz_srcptr a, mpz_srcptr m) except -1:
     """
     Set ``answer`` to a rational number which is `a` modulo `m` and
     such that the numerator and denominator of the result is bounded by

--- a/src/sage/calculus/integration.pyx
+++ b/src/sage/calculus/integration.pyx
@@ -570,7 +570,7 @@ def monte_carlo_integral(func, xl, xu, size_t calls, algorithm='plain',
     cdef gsl_monte_plain_state* state_plain = NULL
     cdef gsl_monte_miser_state* state_miser = NULL
     cdef gsl_monte_vegas_state* state_vegas = NULL
-    cdef gsl_rng_type *type_rng
+    cdef const gsl_rng_type *type_rng
     cdef gsl_rng *_rng
     cdef size_t dim
     cdef double *_xl

--- a/src/sage/calculus/ode.pxd
+++ b/src/sage/calculus/ode.pxd
@@ -1,4 +1,4 @@
 cdef class ode_system:
-    cdef int  c_j(self, double , double *, double *, double *) noexcept
+    cdef int  c_j(self, double , const double *, double *, double *) noexcept
 
-    cdef int c_f(self, double t, double* , double*) noexcept
+    cdef int c_f(self, double t, const double* , double*) noexcept

--- a/src/sage/calculus/ode.pyx
+++ b/src/sage/calculus/ode.pyx
@@ -452,7 +452,7 @@ class ode_solver():
             raise MemoryError("error allocating memory")
         result = []
         v = [0] * dim
-        cdef gsl_odeiv_step_type * T
+        cdef const gsl_odeiv_step_type * T
 
         for i in range(dim):  # copy initial conditions into C array
             y[i] = self.y_0[i]

--- a/src/sage/calculus/ode.pyx
+++ b/src/sage/calculus/ode.pyx
@@ -37,10 +37,10 @@ cdef class PyFunctionWrapper:
         self.y_n = x
 
 cdef class ode_system:
-    cdef int c_j(self, double t, double *y, double *dfdy, double *dfdt) noexcept:
+    cdef int c_j(self, double t, const double *y, double *dfdy, double *dfdt) noexcept:
         return 0
 
-    cdef int c_f(self, double t, double* y, double* dydt) noexcept:
+    cdef int c_f(self, double t, const double* y, double* dydt) noexcept:
         return 0
 
 cdef int c_jac_compiled(double t, const double *y, double *dfdy, double *dfdt, void *params) noexcept:
@@ -303,35 +303,32 @@ class ode_solver():
     is slow on systems that require many function evaluations.  It
     is possible to pass a compiled function by deriving from the
     class :class:`ode_system` and overloading ``c_f`` and ``c_j`` with C
-    functions that specify the system. The following will work in the
-    notebook:
+    functions that specify the system. (You can also use the ``%%cython``
+    cell magic, see :meth:`~sage.repl.ipython_extension.SageMagics.cython`.) ::
 
-    .. code-block:: cython
-
-          %cython
-          cimport sage.calculus.ode
-          import sage.calculus.ode
-          from sage.libs.gsl.all cimport *
-
-          cdef class van_der_pol(sage.calculus.ode.ode_system):
-              cdef int c_f(self, double t, double *y, double *dydt):
-                  dydt[0]=y[1]
-                  dydt[1]=-y[0]-1000*y[1]*(y[0]*y[0]-1)
-                  return GSL_SUCCESS
-              cdef int c_j(self, double t, double *y, double *dfdy, double *dfdt):
-                  dfdy[0]=0
-                  dfdy[1]=1.0
-                  dfdy[2]=-2.0*1000*y[0]*y[1]-1.0
-                  dfdy[3]=-1000*(y[0]*y[0]-1.0)
-                  dfdt[0]=0
-                  dfdt[1]=0
-                  return GSL_SUCCESS
+        sage: cython('''
+        ....: cimport sage.calculus.ode
+        ....: import sage.calculus.ode
+        ....: from sage.libs.gsl.all cimport *
+        ....:
+        ....: cdef class van_der_pol(sage.calculus.ode.ode_system):
+        ....:     cdef int c_f(self, double t, const double *y, double *dydt) noexcept:
+        ....:         dydt[0]=y[1]
+        ....:         dydt[1]=-y[0]-1000*y[1]*(y[0]*y[0]-1)
+        ....:         return GSL_SUCCESS
+        ....:     cdef int c_j(self, double t, const double *y, double *dfdy, double *dfdt) noexcept:
+        ....:         dfdy[0]=0
+        ....:         dfdy[1]=1.0
+        ....:         dfdy[2]=-2.0*1000*y[0]*y[1]-1.0
+        ....:         dfdy[3]=-1000*(y[0]*y[0]-1.0)
+        ....:         dfdt[0]=0
+        ....:         dfdt[1]=0
+        ....:         return GSL_SUCCESS
+        ....: ''')
 
     After executing the above block of code you can do the
-    following (WARNING: the following is *not* automatically
-    doctested)::
+    following::
 
-        sage: # not tested
         sage: T = ode_solver()
         sage: T.algorithm = "bsimp"
         sage: vander = van_der_pol()

--- a/src/sage/libs/gsl/rng.pxd
+++ b/src/sage/libs/gsl/rng.pxd
@@ -4,73 +4,73 @@
 from sage.libs.gsl.types cimport *
 
 cdef extern from "gsl/gsl_rng.h":
-  cdef gsl_rng_type *gsl_rng_borosh13
-  cdef gsl_rng_type *gsl_rng_coveyou
-  cdef gsl_rng_type *gsl_rng_cmrg
-  cdef gsl_rng_type *gsl_rng_fishman18
-  cdef gsl_rng_type *gsl_rng_fishman20
-  cdef gsl_rng_type *gsl_rng_fishman2x
-  cdef gsl_rng_type *gsl_rng_gfsr4
-  cdef gsl_rng_type *gsl_rng_knuthran
-  cdef gsl_rng_type *gsl_rng_knuthran2
-  cdef gsl_rng_type *gsl_rng_lecuyer21
-  cdef gsl_rng_type *gsl_rng_minstd
-  cdef gsl_rng_type *gsl_rng_mrg
-  cdef gsl_rng_type *gsl_rng_mt19937
-  cdef gsl_rng_type *gsl_rng_mt19937_1999
-  cdef gsl_rng_type *gsl_rng_mt19937_1998
-  cdef gsl_rng_type *gsl_rng_r250
-  cdef gsl_rng_type *gsl_rng_ran0
-  cdef gsl_rng_type *gsl_rng_ran1
-  cdef gsl_rng_type *gsl_rng_ran2
-  cdef gsl_rng_type *gsl_rng_ran3
-  cdef gsl_rng_type *gsl_rng_rand
-  cdef gsl_rng_type *gsl_rng_rand48
-  cdef gsl_rng_type *gsl_rng_random128_bsd
-  cdef gsl_rng_type *gsl_rng_random128_glibc2
-  cdef gsl_rng_type *gsl_rng_random128_libc5
-  cdef gsl_rng_type *gsl_rng_random256_bsd
-  cdef gsl_rng_type *gsl_rng_random256_glibc2
-  cdef gsl_rng_type *gsl_rng_random256_libc5
-  cdef gsl_rng_type *gsl_rng_random32_bsd
-  cdef gsl_rng_type *gsl_rng_random32_glibc2
-  cdef gsl_rng_type *gsl_rng_random32_libc5
-  cdef gsl_rng_type *gsl_rng_random64_bsd
-  cdef gsl_rng_type *gsl_rng_random64_glibc2
-  cdef gsl_rng_type *gsl_rng_random64_libc5
-  cdef gsl_rng_type *gsl_rng_random8_bsd
-  cdef gsl_rng_type *gsl_rng_random8_glibc2
-  cdef gsl_rng_type *gsl_rng_random8_libc5
-  cdef gsl_rng_type *gsl_rng_random_bsd
-  cdef gsl_rng_type *gsl_rng_random_glibc2
-  cdef gsl_rng_type *gsl_rng_random_libc5
-  cdef gsl_rng_type *gsl_rng_randu
-  cdef gsl_rng_type *gsl_rng_ranf
-  cdef gsl_rng_type *gsl_rng_ranlux
-  cdef gsl_rng_type *gsl_rng_ranlux389
-  cdef gsl_rng_type *gsl_rng_ranlxd1
-  cdef gsl_rng_type *gsl_rng_ranlxd2
-  cdef gsl_rng_type *gsl_rng_ranlxs0
-  cdef gsl_rng_type *gsl_rng_ranlxs1
-  cdef gsl_rng_type *gsl_rng_ranlxs2
-  cdef gsl_rng_type *gsl_rng_ranmar
-  cdef gsl_rng_type *gsl_rng_slatec
-  cdef gsl_rng_type *gsl_rng_taus
-  cdef gsl_rng_type *gsl_rng_taus2
-  cdef gsl_rng_type *gsl_rng_taus113
-  cdef gsl_rng_type *gsl_rng_transputer
-  cdef gsl_rng_type *gsl_rng_tt800
-  cdef gsl_rng_type *gsl_rng_uni
-  cdef gsl_rng_type *gsl_rng_uni32
-  cdef gsl_rng_type *gsl_rng_vax
-  cdef gsl_rng_type *gsl_rng_waterman14
-  cdef gsl_rng_type *gsl_rng_zuf
+  cdef const gsl_rng_type *gsl_rng_borosh13
+  cdef const gsl_rng_type *gsl_rng_coveyou
+  cdef const gsl_rng_type *gsl_rng_cmrg
+  cdef const gsl_rng_type *gsl_rng_fishman18
+  cdef const gsl_rng_type *gsl_rng_fishman20
+  cdef const gsl_rng_type *gsl_rng_fishman2x
+  cdef const gsl_rng_type *gsl_rng_gfsr4
+  cdef const gsl_rng_type *gsl_rng_knuthran
+  cdef const gsl_rng_type *gsl_rng_knuthran2
+  cdef const gsl_rng_type *gsl_rng_lecuyer21
+  cdef const gsl_rng_type *gsl_rng_minstd
+  cdef const gsl_rng_type *gsl_rng_mrg
+  cdef const gsl_rng_type *gsl_rng_mt19937
+  cdef const gsl_rng_type *gsl_rng_mt19937_1999
+  cdef const gsl_rng_type *gsl_rng_mt19937_1998
+  cdef const gsl_rng_type *gsl_rng_r250
+  cdef const gsl_rng_type *gsl_rng_ran0
+  cdef const gsl_rng_type *gsl_rng_ran1
+  cdef const gsl_rng_type *gsl_rng_ran2
+  cdef const gsl_rng_type *gsl_rng_ran3
+  cdef const gsl_rng_type *gsl_rng_rand
+  cdef const gsl_rng_type *gsl_rng_rand48
+  cdef const gsl_rng_type *gsl_rng_random128_bsd
+  cdef const gsl_rng_type *gsl_rng_random128_glibc2
+  cdef const gsl_rng_type *gsl_rng_random128_libc5
+  cdef const gsl_rng_type *gsl_rng_random256_bsd
+  cdef const gsl_rng_type *gsl_rng_random256_glibc2
+  cdef const gsl_rng_type *gsl_rng_random256_libc5
+  cdef const gsl_rng_type *gsl_rng_random32_bsd
+  cdef const gsl_rng_type *gsl_rng_random32_glibc2
+  cdef const gsl_rng_type *gsl_rng_random32_libc5
+  cdef const gsl_rng_type *gsl_rng_random64_bsd
+  cdef const gsl_rng_type *gsl_rng_random64_glibc2
+  cdef const gsl_rng_type *gsl_rng_random64_libc5
+  cdef const gsl_rng_type *gsl_rng_random8_bsd
+  cdef const gsl_rng_type *gsl_rng_random8_glibc2
+  cdef const gsl_rng_type *gsl_rng_random8_libc5
+  cdef const gsl_rng_type *gsl_rng_random_bsd
+  cdef const gsl_rng_type *gsl_rng_random_glibc2
+  cdef const gsl_rng_type *gsl_rng_random_libc5
+  cdef const gsl_rng_type *gsl_rng_randu
+  cdef const gsl_rng_type *gsl_rng_ranf
+  cdef const gsl_rng_type *gsl_rng_ranlux
+  cdef const gsl_rng_type *gsl_rng_ranlux389
+  cdef const gsl_rng_type *gsl_rng_ranlxd1
+  cdef const gsl_rng_type *gsl_rng_ranlxd2
+  cdef const gsl_rng_type *gsl_rng_ranlxs0
+  cdef const gsl_rng_type *gsl_rng_ranlxs1
+  cdef const gsl_rng_type *gsl_rng_ranlxs2
+  cdef const gsl_rng_type *gsl_rng_ranmar
+  cdef const gsl_rng_type *gsl_rng_slatec
+  cdef const gsl_rng_type *gsl_rng_taus
+  cdef const gsl_rng_type *gsl_rng_taus2
+  cdef const gsl_rng_type *gsl_rng_taus113
+  cdef const gsl_rng_type *gsl_rng_transputer
+  cdef const gsl_rng_type *gsl_rng_tt800
+  cdef const gsl_rng_type *gsl_rng_uni
+  cdef const gsl_rng_type *gsl_rng_uni32
+  cdef const gsl_rng_type *gsl_rng_vax
+  cdef const gsl_rng_type *gsl_rng_waterman14
+  cdef const gsl_rng_type *gsl_rng_zuf
 
 
-  cdef gsl_rng_type *gsl_rng_default
+  cdef const gsl_rng_type *gsl_rng_default
   unsigned long int gsl_rng_default_seed
 
-  gsl_rng *gsl_rng_alloc ( gsl_rng_type * T)
+  gsl_rng *gsl_rng_alloc ( const gsl_rng_type * T)
   int gsl_rng_memcpy (gsl_rng * dest, gsl_rng * src)
   gsl_rng *gsl_rng_clone ( gsl_rng * r)
 
@@ -89,7 +89,7 @@ cdef extern from "gsl/gsl_rng.h":
 
   void gsl_rng_print_state ( gsl_rng * r)
 
-  gsl_rng_type * gsl_rng_env_setup ()
+  const gsl_rng_type * gsl_rng_env_setup ()
 
   unsigned long int gsl_rng_get ( gsl_rng * r)
   double gsl_rng_uniform ( gsl_rng * r)

--- a/src/sage/libs/pari/convert_gmp.pxd
+++ b/src/sage/libs/pari/convert_gmp.pxd
@@ -1,12 +1,12 @@
 from cypari2.types cimport GEN
 from cypari2.gen cimport Gen
-from sage.libs.gmp.types cimport mpz_t, mpq_t, mpz_ptr, mpq_ptr
+from sage.libs.gmp.types cimport mpz_srcptr, mpq_t, mpz_ptr, mpq_ptr
 
-cdef Gen new_gen_from_mpz_t(mpz_t value)
-cdef GEN _new_GEN_from_mpz_t(mpz_t value) noexcept
+cdef Gen new_gen_from_mpz_t(mpz_srcptr value)
+cdef GEN _new_GEN_from_mpz_t(mpz_srcptr value) noexcept
 cdef Gen new_gen_from_mpq_t(mpq_t value)
 cdef GEN _new_GEN_from_mpq_t(mpq_t value) noexcept
-cdef Gen new_gen_from_padic(long ordp, long relprec, mpz_t prime, mpz_t p_pow, mpz_t unit)
+cdef Gen new_gen_from_padic(long ordp, long relprec, mpz_srcptr prime, mpz_srcptr p_pow, mpz_srcptr unit)
 cdef GEN _new_GEN_from_mpq_t_matrix(mpq_t** B, long nr, long nc) noexcept
 cdef Gen rational_matrix(mpq_t** B, long nr, long nc)
 cdef void INT_to_mpz(mpz_ptr value, GEN g) noexcept

--- a/src/sage/libs/pari/convert_gmp.pyx
+++ b/src/sage/libs/pari/convert_gmp.pyx
@@ -27,7 +27,7 @@ from sage.libs.gmp.all cimport *
 from cypari2.paridecl cimport *
 from cypari2.stack cimport new_gen
 
-cdef Gen new_gen_from_mpz_t(mpz_t value):
+cdef Gen new_gen_from_mpz_t(mpz_srcptr value):
     """
     Create a new PARI Gen of type ``t_INT`` from a given
     GMP integer ``value``.
@@ -53,9 +53,9 @@ cdef Gen new_gen_from_mpz_t(mpz_t value):
     return new_gen(_new_GEN_from_mpz_t(value))
 
 
-cdef inline GEN _new_GEN_from_mpz_t(mpz_t value) noexcept:
+cdef inline GEN _new_GEN_from_mpz_t(mpz_srcptr value) noexcept:
     r"""
-    Create a new PARI ``t_INT`` from a ``mpz_t``.
+    Create a new PARI ``t_INT`` from a ``mpz_srcptr``.
 
     For internal use only; this directly uses the PARI stack.
     One should call ``sig_on()`` before and ``sig_off()`` after.
@@ -121,7 +121,7 @@ cdef inline GEN _new_GEN_from_mpq_t(mpq_t value) noexcept:
 
 
 cdef Gen new_gen_from_padic(long ordp, long relprec,
-                            mpz_t prime, mpz_t p_pow, mpz_t unit):
+                            mpz_srcptr prime, mpz_srcptr p_pow, mpz_srcptr unit):
     """
     Create a new PARI Gen of type ``t_PADIC`` from the given input data
     as GMP integers.

--- a/src/sage/misc/cython.py
+++ b/src/sage/misc/cython.py
@@ -656,8 +656,8 @@ def compile_and_load(code, **kwds):
     r"""
     INPUT:
 
-    - ``code`` -- string containing code that could be in a .pyx file
-      that is attached or put in a %cython block in the notebook
+    - ``code`` -- string containing code that could be in a ``.pyx`` file
+      that is attached or put in a ``%%cython`` block
 
     See the function :func:`sage.misc.cython.cython` for documentation
     for the other inputs.

--- a/src/sage/probability/probability_distribution.pyx
+++ b/src/sage/probability/probability_distribution.pyx
@@ -217,7 +217,7 @@ cdef class SphericalDistribution(ProbabilityDistribution):
     """
 
     cdef gsl_rng *r
-    cdef gsl_rng_type *T
+    cdef const gsl_rng_type *T
     cdef long int seed
     cdef Py_ssize_t dimension
     cdef double* vec
@@ -571,7 +571,7 @@ cdef class RealDistribution(ProbabilityDistribution):
         sage: len(set(Xs)) > 2^^32
         True
     """
-    cdef gsl_rng_type *T
+    cdef const gsl_rng_type *T
     cdef gsl_rng *r
     cdef int distribution_type
     cdef double* parameters
@@ -1097,7 +1097,7 @@ cdef class GeneralDiscreteDistribution(ProbabilityDistribution):
         ...
         ValueError: The distribution probabilities must be nonnegative
     """
-    cdef gsl_rng_type * T
+    cdef const gsl_rng_type * T
     cdef gsl_rng * r
     cdef gsl_ran_discrete_t *dist
     cdef long seed


### PR DESCRIPTION
Avoid errors of the form fixed in the dependencies below.

We only do this in the CI instead of modifying meson.build so that if the user's compile somehow doesn't have the flag or is otherwise stricter etc., the compilation does not fail for the user.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


https://github.com/sagemath/sage/pull/41311

https://github.com/sagemath/sage/pull/41314
