### PR TITLE
Fix integer overflow in is_small_power() for large int values

### DIFF
--- a/src/sage/functions/log.py
+++ b/src/sage/functions/log.py
@@ -281,6 +281,18 @@ class Function_log2(GinacFunction):
         log(7)/log(2)
         sage: logb(int(7), 2)                                                           # needs sage.symbolic
         log(7)/log(2)
+
+    Check that :issue:`40883` is fixed::
+
+        sage: from sage.functions.log import logb
+        sage: logb(int(4294967300), 2)                                                  # needs sage.symbolic
+        log(4294967300)/log(2)
+        sage: float(logb(int(4294967300), 2))                                           # needs sage.symbolic
+        32.00000000134...
+        sage: logb(int(21743271936), 2)                                                 # needs sage.symbolic
+        log(21743271936)/log(2)
+        sage: float(logb(int(21743271936), 2))                                          # needs sage.symbolic
+        34.33985000288...
     """
     def __init__(self):
         """

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -1155,6 +1155,13 @@ def log(*args, **kwds):
         0
         sage: log(e, base=0)
         0
+
+    Check if :issue:`40883` is fixed::
+
+        sage: log(int(4294967300), 2)                                                   # needs sage.symbolic
+        log(4294967300)/log(2)
+        sage: float(log(int(4294967300), 2))                                            # needs sage.symbolic
+        32.00000000134...
     """
     base = kwds.pop('base', None)
     if base is not None:

--- a/src/sage/symbolic/ginac/numeric.cpp
+++ b/src/sage/symbolic/ginac/numeric.cpp
@@ -2854,7 +2854,7 @@ static void fill_small_powers()
 
 bool numeric::is_small_power(std::pair<int,int>& p) const
 {
-        int i;
+        long i;
         switch (t) {
         case LONG:
                 if (v._long < 2)


### PR DESCRIPTION
Fix issue #40883: `log(int(4294967300), 2)` incorrectly returned `2` instead of `log(4294967300)/log(2)` (~32.0).

### The Bug
The bug was in `is_small_power()` function in `src/sage/symbolic/ginac/numeric.cpp`. It used `int i` (32-bit) to store the value being checked. For values larger than 2^31, this caused integer overflow:
- `4294967300` (which is > 2^32) would overflow to `4`
- The code would then find `4 = 2^2` in the `small_powers` map
- This caused `log(4294967300, 2)` to incorrectly return `2`

### The Fix
Changed `int i` to `long i` (64-bit on Linux) in line 2857 of `numeric.cpp`. This matches the type already used in the `small_powers` map (line 2839) and prevents the overflow.

### Testing
- Added doctests in `functional.py` and `log.py` to verify the fix
- Tested with a C++ simulation proving the overflow behavior and fix

Fixes #40883