### PR TITLE
Use SPDX license expression instead of deprecated license classifiers

### DIFF
--- a/m4/pyproject_toml_metadata.m4
+++ b/m4/pyproject_toml_metadata.m4
@@ -9,6 +9,9 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Mathematics",
 ]

--- a/m4/pyproject_toml_metadata.m4
+++ b/m4/pyproject_toml_metadata.m4
@@ -1,12 +1,11 @@
 dnl Standard metadata of SageMath distribution packages
 dnl
-license = {text = "GNU General Public License (GPL) v2 or later"}
+license = "GPL-2.0-or-later"
 authors = [{name = "The Sage Developers", email = "sage-support@googlegroups.com"}]
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3 :: Only",

--- a/m4/pyproject_toml_metadata.m4
+++ b/m4/pyproject_toml_metadata.m4
@@ -9,9 +9,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Mathematics",
 ]

--- a/m4/setup_cfg_metadata.m4
+++ b/m4/setup_cfg_metadata.m4
@@ -1,6 +1,6 @@
 dnl Standard metadata of SageMath distribution packages
 dnl
-license = GNU General Public License (GPL) v2 or later
+license = "GPL-2.0-or-later"
 author = The Sage Developers
 author_email = sage-support@googlegroups.com
 url = https://www.sagemath.org

--- a/m4/setup_cfg_metadata.m4
+++ b/m4/setup_cfg_metadata.m4
@@ -9,7 +9,6 @@ classifiers =
     Development Status :: 6 - Mature
     Intended Audience :: Education
     Intended Audience :: Science/Research
-    License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
     Operating System :: POSIX
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python :: 3 :: Only

--- a/m4/setup_cfg_metadata.m4
+++ b/m4/setup_cfg_metadata.m4
@@ -12,9 +12,8 @@ classifiers =
     Operating System :: POSIX
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Mathematics

--- a/pkgs/sage-docbuild/pyproject.toml
+++ b/pkgs/sage-docbuild/pyproject.toml
@@ -14,10 +14,9 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Mathematics",
 ]

--- a/pkgs/sage-docbuild/pyproject.toml
+++ b/pkgs/sage-docbuild/pyproject.toml
@@ -5,13 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sage-docbuild"
 description = "Sage: Open Source Mathematics Software: Build system of the Sage documentation"
-license = {text = "GNU General Public License (GPL) v2 or later"}
+license = "GPL-2.0-or-later"
 authors = [{name = "The Sage Developers", email = "sage-support@googlegroups.com"}]
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3 :: Only",

--- a/pkgs/sage-setup/pyproject.toml
+++ b/pkgs/sage-setup/pyproject.toml
@@ -5,13 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sage-setup"
 description = "Sage: Open Source Mathematics Software: Build system of the Sage library"
-license = {text = "GNU General Public License (GPL) v2 or later"}
+license = "GPL-2.0-or-later"
 authors = [{name = "The Sage Developers", email = "sage-support@googlegroups.com"}]
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3 :: Only",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
   "Development Status :: 6 - Mature",
   "Intended Audience :: Education",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: POSIX",
   "Programming Language :: Python :: 3 :: Only",
@@ -76,7 +75,7 @@ dependencies = [
 ]
 description = "Sage: Open Source Mathematics Software: Standard Python Library"
 dynamic = ["version"]
-license = { text = "GNU General Public License (GPL) v2 or later" }
+license = "GPL-2.0-or-later"
 name = "sagemath"
 requires-python = ">=3.12, <3.15"
 urls = { Homepage = "https://www.sagemath.org" }


### PR DESCRIPTION
Replace deprecated license classifiers with modern SPDX license expression (GPL-2.0-or-later) following PEP 639 to fix setuptools deprecation warnings in Python 3.14.

Changes:
- ``pyproject.toml``: Use ``license = "GPL-2.0-or-later"`` and remove duplicate license field
- ``m4/pyproject_toml_metadata.m4``: Update template for generated ``pyproject.toml`` files
- ``m4/setup_cfg_metadata.m4``: Remove deprecated License classifier
- ``pkgs/sage-docbuild/pyproject.toml``: Use SPDX license format
- ``pkgs/sage-setup/pyproject.toml``: Use SPDX license format

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


