### PR TITLE
Fix conftest.py being deleted by configure script

### DIFF
--- a/configure_wrapper
+++ b/configure_wrapper
@@ -4,10 +4,12 @@
 # pytest conftest.py. We work around this by making a copy and
 # restoring when we are done, regardless of whether configure succeeds
 # or fails.
+# The backup file must NOT start with "conftest" to avoid being deleted
+# by the "rm -rf conftest*" commands in the configure script.
 
 set -e
 
-trap 'mv bak_conftest.py conftest.py; trap - EXIT; exit' EXIT INT HUP TERM
+trap 'mv .backup_conftest.py conftest.py; trap - EXIT; exit' EXIT INT HUP TERM
 
-cp conftest.py bak_conftest.py
+cp conftest.py .backup_conftest.py
 ./real_configure $@

--- a/configure_wrapper
+++ b/configure_wrapper
@@ -4,12 +4,14 @@
 # pytest conftest.py. We work around this by making a copy and
 # restoring when we are done, regardless of whether configure succeeds
 # or fails.
-# The backup file must NOT start with "conftest" to avoid being deleted
-# by the "rm -rf conftest*" commands in the configure script.
 
 set -e
 
-trap 'mv .backup_conftest.py conftest.py; trap - EXIT; exit' EXIT INT HUP TERM
+trap 'mv bak_conftest.py conftest.py; trap - EXIT; exit' EXIT INT HUP TERM
 
-cp conftest.py .backup_conftest.py
-./real_configure $@
+cp conftest.py bak_conftest.py
+./real_configure "$@"
+
+# Fix config.status to call ./configure instead of ./real_configure
+# so that --recheck also protects conftest.py
+sed -i "s|'./real_configure'|'./configure'|g" config.status


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

## Problem

When running `make` after switching branches or when reconfiguration is needed, `conftest.py` (the pytest configuration file) gets deleted.

### Root Cause

The `configure_wrapper` script backs up `conftest.py` before running `./real_configure` and restores it afterward:

```bash
trap 'mv bak_conftest.py conftest.py; trap - EXIT; exit' EXIT INT HUP TERM
cp conftest.py bak_conftest.py
./real_configure $@
```

However, when `make` triggers a reconfigure, it runs:
```bash
./config.status --recheck
```

The `config.status` file is generated by `real_configure` and contains a hardcoded path:
```bash
# Line 502 in config.status
set X /bin/bash './real_configure' $ac_configure_extra_args --no-create --no-recursion
```

This **bypasses the `./configure` wrapper entirely**, so:
1. `conftest.py` is not backed up
2. `real_configure` runs and deletes all `conftest*` files
3. `conftest.py` is gone

## When This Happens

- Running `make` after `git checkout` to a different branch
- Running `make` after any change that triggers `reconfigure` target
- Running `./config.status --recheck` directly

## Potential Solutions

**Modify `config.status` generation** - Patch the autoconf output to call `./configure` instead of `./real_configure`


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


