### PR TITLE
fix: support ideals over finite fields where p > 2^29

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -2768,14 +2768,27 @@ class MPolynomialIdeal_singular_repr(
             sage: R.<x,y,z> = F[]
             sage: I = Ideal([x^2 - 5*y + z, x*21 + y - z, 20*x + 20*y - 15*z + 20])
             sage: I.variety()
-            verbose 0 (...: multi_polynomial_ideal.py, variety) Warning: falling back to very slow toy implementation.
             [{z: 475236874226935968499387140880743357810239093941490264140142,
             y: 303497730986201757454241700121162099180641015844366285478588,
             x: 366193016391757014347340764061969600539773744194969974791622},
             {z: 151289309188577622354697076164405004915231785224946860207259,
             y: 323028452429311833399842516923986263544829863322070838864298,
             x: 260333167023756576506743452983178762185697134971467149538802}]
-        """
+
+        We can compute the variety of an Ideal over a Multivariate Polynomial Ring over a finite field with characteristic `> 2^{29}`, which Singular doesn't support. ::
+
+            sage: set_random_seed(1338)
+            sage: p = random_prime(2**128)
+            sage: F = GF(p)
+            sage: R.<x,y> = F[]
+            sage: pols = R.random_element(2), R.random_element(2)
+            sage: I = Ideal(pols)
+            sage: I.variety()
+            [{y: 34191056801670425306813798231492473135,
+              x: 81420596822501885717789433703045952013},
+             {y: 3395018777162596028775438528622086168,
+              x: 45870466766175542261798731841601367018}]
+"""
 
         def _variety(T, V, v=None):
             """
@@ -2818,12 +2831,12 @@ class MPolynomialIdeal_singular_repr(
         if ring is not None:
             P = P.change_ring(ring)
         T = None
-        if P.characteristic() < 2**29:
-            try:
-                TI = self.triangular_decomposition('singular:triangLfak')
-                T = [list(each.gens()) for each in TI]
-            except TypeError:  # conversion to Singular not supported
-                pass
+        try:
+            TI = self.triangular_decomposition('singular:triangLfak' if P.characteristic() < 2**29 else 'singular:triangL')
+            T = [list(each.gens()) for each in TI]
+        except TypeError:  # conversion to Singular not supported
+            pass
+
         if T is None:
             if self.ring().term_order().is_global():
                 verbose("Warning: falling back to very slow toy implementation.", level=0, caller_name='variety')


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

#40628 fixed some cases, but not all of them, see the added test

+ using singular for this should be faster than the toy implementatio

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


