### PR TITLE
Fix a test failure with numpy 2.4

### DIFF
--- a/src/sage/calculus/desolvers.py
+++ b/src/sage/calculus/desolvers.py
@@ -1621,7 +1621,7 @@ def desolve_odeint(des, ics, times, dvars, ivar=None, compute_jac=False, args=()
             assert len(des) == 1
             dvar = dvars[0]
             de = des[0]
-            func = fast_float(de, dvar, ivar)
+            func = lambda y, t: fast_float(de, dvar, ivar)(y.item(), t)
             if not compute_jac:
                 Dfun = None
             else:


### PR DESCRIPTION
Fixes
```
Doctesting 1 file.
python3 -m sage.doctest --long --warn-long 30.0 --random-seed=71187948303511356729678632353360243674 src/sage/calculus/desolvers.py
**********************************************************************
File "src/sage/calculus/desolvers.py", line 1589, in sage.calculus.desolvers.?
Failed example:
    sol = desolve_odeint(f, ic, t, y,                                         # needs scipy
                         rtol=1e-9, atol=1e-10, compute_jac=True)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python3.13/site-packages/sage/doctest/forker.py", line 734, in _run
        self.compile_and_execute(example, compiler, test.globs)
        ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/sage/doctest/forker.py", line 1158, in compile_and_execute
        exec(compiled, globs)
        ~~~~^^^^^^^^^^^^^^^^^
      File "<doctest sage.calculus.desolvers.?[19]>", line 1, in <module>
        sol = desolve_odeint(f, ic, t, y,                                         # needs scipy
                             rtol=RealNumber('1e-9'), atol=RealNumber('1e-10'), compute_jac=True)
      File "/usr/lib/python3.13/site-packages/sage/calculus/desolvers.py", line 1676, in desolve_odeint
        return desolve_odeint_inner(ivar)
      File "/usr/lib/python3.13/site-packages/sage/calculus/desolvers.py", line 1657, in desolve_odeint_inner
        return odeint(func, ics, times, args=args, Dfun=Dfun, rtol=rtol, atol=atol,
                      tcrit=tcrit, h0=h0, hmax=hmax, hmin=hmin, ixpr=ixpr, mxstep=mxstep,
                      mxhnil=mxhnil, mxordn=mxordn, mxords=mxords, printmessg=printmessg)
      File "/usr/lib/python3.13/site-packages/scipy/integrate/_odepack_py.py", line 254, in odeint
        output = _odepack.odeint(func, y0, t, args, Dfun, col_deriv, ml, mu,
                                full_output, rtol, atol, tcrit, h0, hmax, hmin,
                                ixpr, mxstep, mxhnil, mxordn, mxords,
                                int(bool(tfirst)))
      File "src/sage/ext/interpreters/wrapper_rdf.pyx", line 75, in interpreters.wrapper_rdf.Wrapper_rdf.__call__
    TypeError: only 0-dimensional arrays can be converted to Python scalars
**********************************************************************
```
caused by https://github.com/numpy/numpy/commit/e7276da07f6fc69cc2947f4dc67a87472e4b3a8b


