### PR TITLE
Add numerical root reliability check via residual evaluationAdd numerical root residual reliability checker

### DIFF
--- a/src/sage/numerical/reliability.py
+++ b/src/sage/numerical/reliability.py
@@ -1,0 +1,23 @@
+"""
+Utilities for checking numerical reliability of computed results.
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check numerical reliability of a computed root.
+
+    INPUT:
+        - f: symbolic expression
+        - root: numeric root
+        - tol: tolerance
+
+    OUTPUT:
+        (is_reliable, residual)
+    """
+    try:
+        res = abs(f(x=root))
+    except TypeError:
+        res = abs(f.subs(x=root))
+
+    return res < tol, res
+

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,0 +1,31 @@
+"""
+Residual-based reliability checks for numerical roots.
+
+EXAMPLES::
+
+    sage: from sage.numerical.root_reliability import residual_check
+    sage: f = lambda x: x^2 - 2
+    sage: r = sqrt(2).n()
+    sage: residual_check(f, r)
+    True
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check if a numerical root is reliable by residual size.
+
+    INPUT:
+
+    - ``f`` -- callable
+    - ``root`` -- numeric value
+    - ``tol`` -- tolerance (default: 1e-10)
+
+    OUTPUT:
+
+    - ``True`` or ``False``
+    """
+    try:
+        return abs(f(root)) <= tol
+    except Exception:
+        return False
+


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
This pull request introduces a numerical reliability check for approximate roots.

Two new modules are added:
- sage.numerical.reliability
- sage.numerical.root_reliability

The implementation evaluates the residual |f(root)| to assess whether a
numerically computed root is reliable. This provides a simple and useful
diagnostic for numerical computations in SageMath.




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


