### PR TITLE
Add numerical reliability registry and diagnostics layerNumerical reliability registry

### DIFF
--- a/src/sage/numerical/reliability.py
+++ b/src/sage/numerical/reliability.py
@@ -1,0 +1,23 @@
+"""
+Utilities for checking numerical reliability of computed results.
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check numerical reliability of a computed root.
+
+    INPUT:
+        - f: symbolic expression
+        - root: numeric root
+        - tol: tolerance
+
+    OUTPUT:
+        (is_reliable, residual)
+    """
+    try:
+        res = abs(f(x=root))
+    except TypeError:
+        res = abs(f.subs(x=root))
+
+    return res < tol, res
+

--- a/src/sage/numerical/reliability_base.py
+++ b/src/sage/numerical/reliability_base.py
@@ -1,0 +1,10 @@
+class NumericalReliabilityChecker:
+    """
+    Base class for numerical reliability checks.
+    """
+
+    name = "base"
+
+    def check(self, *args, **kwargs):
+        raise NotImplementedError("Subclasses must implement check()")
+

--- a/src/sage/numerical/reliability_certificate.py
+++ b/src/sage/numerical/reliability_certificate.py
@@ -1,0 +1,19 @@
+class NumericalReliabilityCertificate:
+    """
+    Certificate explaining why a numerical result is reliable.
+    """
+
+    def __init__(self, method, metrics, tolerance, passed):
+        self.method = method
+        self.metrics = metrics
+        self.tolerance = tolerance
+        self.passed = passed
+
+    def explain(self):
+        lines = [f"Method: {self.method}"]
+        for k, v in self.metrics.items():
+            lines.append(f"{k}: {v}")
+        lines.append(f"Tolerance: {self.tolerance}")
+        lines.append("Result: PASSED" if self.passed else "Result: FAILED")
+        return "\n".join(lines)
+

--- a/src/sage/numerical/reliability_certify.py
+++ b/src/sage/numerical/reliability_certify.py
@@ -1,0 +1,20 @@
+from .reliability_certificate import NumericalReliabilityCertificate
+
+def certify_residual(f, root, tol=1e-10):
+    try:
+        res = abs(f(root))
+        passed = res <= tol
+        return NumericalReliabilityCertificate(
+            method="residual",
+            metrics={"residual": res},
+            tolerance=tol,
+            passed=passed,
+        )
+    except Exception as e:
+        return NumericalReliabilityCertificate(
+            method="residual",
+            metrics={"error": str(e)},
+            tolerance=tol,
+            passed=False,
+        )
+

--- a/src/sage/numerical/reliability_diagnostics.py
+++ b/src/sage/numerical/reliability_diagnostics.py
@@ -1,0 +1,28 @@
+"""
+Numerical Reliability Registry
+
+Central registry for numerical reliability checkers.
+"""
+
+class NumericalReliabilityRegistry:
+    def __init__(self):
+        self._checkers = {}
+
+    def register(self, name, checker):
+        if name in self._checkers:
+"""
+Diagnostics container for numerical reliability checks.
+"""
+
+class NumericalReliabilityResult:
+    def __init__(self, reliable, residual=None, tolerance=None, message=None, suggestion=None):
+        self.reliable = reliable
+        self.residual = residual
+        self.tolerance = tolerance
+        self.message = message
+        self.suggestion = suggestion
+
+    def __repr__(self):
+        status = "reliable" if self.reliable else "unreliable"
+        return f"<NumericalReliabilityResult {status}>"
+

--- a/src/sage/numerical/reliability_diagnostics.py
+++ b/src/sage/numerical/reliability_diagnostics.py
@@ -1,28 +1,21 @@
-"""
-Numerical Reliability Registry
-
-Central registry for numerical reliability checkers.
-"""
-
-class NumericalReliabilityRegistry:
-    def __init__(self):
-        self._checkers = {}
-
-    def register(self, name, checker):
-        if name in self._checkers:
-"""
-Diagnostics container for numerical reliability checks.
-"""
-
 class NumericalReliabilityResult:
-    def __init__(self, reliable, residual=None, tolerance=None, message=None, suggestion=None):
-        self.reliable = reliable
+    """
+    Container for numerical reliability diagnostics.
+    """
+
+    def __init__(self, reliable, residual=None, message=""):
+        self.reliable = bool(reliable)
         self.residual = residual
-        self.tolerance = tolerance
         self.message = message
-        self.suggestion = suggestion
+
+    def __bool__(self):
+        return self.reliable
 
     def __repr__(self):
-        status = "reliable" if self.reliable else "unreliable"
-        return f"<NumericalReliabilityResult {status}>"
+        return (
+            f"NumericalReliabilityResult("
+            f"reliable={self.reliable}, "
+            f"residual={self.residual}, "
+            f"message={self.message!r})"
+        )
 

--- a/src/sage/numerical/reliability_registry.py
+++ b/src/sage/numerical/reliability_registry.py
@@ -1,42 +1,17 @@
-"""
-Numerical Reliability Registry
-
-Central registry for numerical reliability checkers.
-"""
-
 class NumericalReliabilityRegistry:
+    """
+    Registry for numerical reliability checkers.
+    """
+
     def __init__(self):
-        self._checkers = {}
+        self._registry = {}
 
-    def register(self, name, checker):
-        if name in self._checkers:
-            raise ValueError(f"Checker '{name}' already registered")
-        self._checkers[name] = checker
+    def register(self, checker):
+        self._registry[checker.name] = checker
 
-    def check(self, name, *args, **kwargs):
-        if name not in self._checkers:
-            raise KeyError(f"No checker registered under '{name}'")
-"""
-Numerical Reliability Registry
+    def get(self, name):
+        return self._registry.get(name)
 
-Central registry for numerical reliability checkers.
-"""
-
-class NumericalReliabilityRegistry:
-    def __init__(self):
-        self._checkers = {}
-
-    def register(self, name, checker):
-        if name in self._checkers:
-            raise ValueError(f"Checker '{name}' already registered")
-        self._checkers[name] = checker
-
-    def check(self, name, *args, **kwargs):
-        if name not in self._checkers:
-            raise KeyError(f"No checker registered under '{name}'")
-        return self._checkers[name].check(*args, **kwargs)
-
-
-# Global default registry
-default_registry = NumericalReliabilityRegistry()
+    def available(self):
+        return sorted(self._registry.keys())
 

--- a/src/sage/numerical/reliability_registry.py
+++ b/src/sage/numerical/reliability_registry.py
@@ -1,0 +1,42 @@
+"""
+Numerical Reliability Registry
+
+Central registry for numerical reliability checkers.
+"""
+
+class NumericalReliabilityRegistry:
+    def __init__(self):
+        self._checkers = {}
+
+    def register(self, name, checker):
+        if name in self._checkers:
+            raise ValueError(f"Checker '{name}' already registered")
+        self._checkers[name] = checker
+
+    def check(self, name, *args, **kwargs):
+        if name not in self._checkers:
+            raise KeyError(f"No checker registered under '{name}'")
+"""
+Numerical Reliability Registry
+
+Central registry for numerical reliability checkers.
+"""
+
+class NumericalReliabilityRegistry:
+    def __init__(self):
+        self._checkers = {}
+
+    def register(self, name, checker):
+        if name in self._checkers:
+            raise ValueError(f"Checker '{name}' already registered")
+        self._checkers[name] = checker
+
+    def check(self, name, *args, **kwargs):
+        if name not in self._checkers:
+            raise KeyError(f"No checker registered under '{name}'")
+        return self._checkers[name].check(*args, **kwargs)
+
+
+# Global default registry
+default_registry = NumericalReliabilityRegistry()
+

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,31 +1,17 @@
-"""
-Residual-based reliability checks for numerical roots.
-
-EXAMPLES::
-
-    sage: from sage.numerical.root_reliability import residual_check
-    sage: f = lambda x: x^2 - 2
-    sage: r = sqrt(2).n()
-    sage: residual_check(f, r)
-    True
-"""
-
-def residual_check(f, root, tol=1e-10):
-    """
-    Check if a numerical root is reliable by residual size.
-
-    INPUT:
-
-    - ``f`` -- callable
-    - ``root`` -- numeric value
-    - ``tol`` -- tolerance (default: 1e-10)
-
-    OUTPUT:
-
-    - ``True`` or ``False``
-    """
-    try:
-        return abs(f(root)) <= tol
-    except Exception:
-        return False
+try:
+    residual = abs(f(root))
+    return NumericalReliabilityResult(
+        residual=residual,
+        tolerance=tol,
+        reliable=residual <= tol,
+        method="root_residual"
+    )
+except Exception as err:
+    return NumericalReliabilityResult(
+        residual=None,
+        tolerance=tol,
+        reliable=False,
+        error=str(err),
+        method="root_residual"
+    )
 

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,0 +1,31 @@
+"""
+Residual-based reliability checks for numerical roots.
+
+EXAMPLES::
+
+    sage: from sage.numerical.root_reliability import residual_check
+    sage: f = lambda x: x^2 - 2
+    sage: r = sqrt(2).n()
+    sage: residual_check(f, r)
+    True
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check if a numerical root is reliable by residual size.
+
+    INPUT:
+
+    - ``f`` -- callable
+    - ``root`` -- numeric value
+    - ``tol`` -- tolerance (default: 1e-10)
+
+    OUTPUT:
+
+    - ``True`` or ``False``
+    """
+    try:
+        return abs(f(root)) <= tol
+    except Exception:
+        return False
+

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,36 +1,46 @@
-from sage.numerical.reliability_base import NumericalReliabilityChecker
-from sage.numerical.reliability_diagnostics import NumericalReliabilityResult
+"""
+Residual-based reliability checks for numerical roots.
+
+This module provides certificate-based reliability checks
+for numerical root approximations.
+"""
+
+from sage.numerical.reliability_certify import certify_residual
 
 
-class RootResidualReliability(NumericalReliabilityChecker):
+def certify_root(f, root, tol=1e-10):
     """
-    Residual-based reliability check for numerical roots.
+    Certify the numerical reliability of a root approximation.
+
+    INPUT:
+
+    - ``f`` -- callable
+    - ``root`` -- numeric value
+    - ``tol`` -- tolerance (default: 1e-10)
+
+    OUTPUT:
+
+    - ``NumericalReliabilityCertificate``
+
+    EXAMPLES::
+
+        sage: from sage.numerical.root_reliability import certify_root
+        sage: f = lambda x: x^2 - 2
+        sage: r = sqrt(2).n()
+        sage: cert = certify_root(f, r)
+        sage: cert.passed
+        True
     """
-
-    name = "root_residual"
-
-    def check(self, f, root, tol=1e-10):
-        try:
-            residual = abs(f(root))
-            return NumericalReliabilityResult(
-                reliable=residual <= tol,
-                residual=residual,
-                message="Residual check passed"
-                if residual <= tol
-                else "Residual too large",
-            )
-        except Exception as e:
-            return NumericalReliabilityResult(
-                reliable=False,
-                residual=None,
-                message=str(e),
-            )
+    return certify_residual(f, root, tol)
 
 
 def residual_check(f, root, tol=1e-10):
     """
-    Convenience wrapper for residual-based root reliability.
+    Boolean wrapper for backward compatibility.
+
+    This preserves the old API while internally using
+    certificate-based reliability checking.
     """
-    checker = RootResidualReliability()
-    return checker.check(f, root, tol)
+    cert = certify_root(f, root, tol)
+    return cert.passed
 

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,17 +1,36 @@
-try:
-    residual = abs(f(root))
-    return NumericalReliabilityResult(
-        residual=residual,
-        tolerance=tol,
-        reliable=residual <= tol,
-        method="root_residual"
-    )
-except Exception as err:
-    return NumericalReliabilityResult(
-        residual=None,
-        tolerance=tol,
-        reliable=False,
-        error=str(err),
-        method="root_residual"
-    )
+from sage.numerical.reliability_base import NumericalReliabilityChecker
+from sage.numerical.reliability_diagnostics import NumericalReliabilityResult
+
+
+class RootResidualReliability(NumericalReliabilityChecker):
+    """
+    Residual-based reliability check for numerical roots.
+    """
+
+    name = "root_residual"
+
+    def check(self, f, root, tol=1e-10):
+        try:
+            residual = abs(f(root))
+            return NumericalReliabilityResult(
+                reliable=residual <= tol,
+                residual=residual,
+                message="Residual check passed"
+                if residual <= tol
+                else "Residual too large",
+            )
+        except Exception as e:
+            return NumericalReliabilityResult(
+                reliable=False,
+                residual=None,
+                message=str(e),
+            )
+
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Convenience wrapper for residual-based root reliability.
+    """
+    checker = RootResidualReliability()
+    return checker.check(f, root, tol)
 

--- a/test_numerical_reliability.py
+++ b/test_numerical_reliability.py
@@ -1,0 +1,28 @@
+"""
+Tests for numerical reliability framework.
+"""
+
+from sage.numerical.root_reliability import residual_check
+from sage.all import sqrt
+
+
+def test_residual_check_reliable():
+    """
+    Test that a correct numerical root is marked reliable.
+    """
+    f = lambda x: x^2 - 2
+    r = sqrt(2).n()
+    result = residual_check(f, r)
+    assert result.reliable is True
+    assert result.residual < 1e-10
+
+
+def test_residual_check_unreliable():
+    """
+    Test that an incorrect root is marked unreliable.
+    """
+    f = lambda x: x^2 - 2
+    r = 1.0
+    result = residual_check(f, r)
+    assert result.reliable is False
+


### PR DESCRIPTION
 This PR extends the numerical reliability framework by adding
a registry and diagnostics layer.

It introduces:
- A reliability registry for pluggable reliability checkers
- Diagnostics utilities for introspecting numerical failures
- Integration hooks for future numerical subsystems

This builds on the previously introduced numerical reliability
framework and enables scalable extension across Sage’s numerical
components.
