### PR TITLE
Fix(plot): Forward zorder option in bar_chart

### DIFF
--- a/src/sage/plot/bar_chart.py
+++ b/src/sage/plot/bar_chart.py
@@ -120,7 +120,7 @@ class BarChart(GraphicPrimitive):
         import numpy
         ind = numpy.array(self.ind, dtype=float)
         datalist = numpy.array(self.datalist, dtype=float)
-        subplot.bar(ind, datalist, color=color, width=width, label=options['legend_label'])
+        subplot.bar(ind, datalist, color=color, width=width, label=options['legend_label'], zorder=options.get('zorder'))
 
 
 @rename_keyword(color='rgbcolor')

--- a/src/sage/plot/bar_chart.py
+++ b/src/sage/plot/bar_chart.py
@@ -177,6 +177,12 @@ def bar_chart(datalist, **options):
     .. PLOT::
 
         sphinx_plot(bar_chart([-2,8,-7,3], rgbcolor=(1,0,0), axes=False))
+
+    Check that :issue:`41207` is fixed::
+
+        sage: b = bar_chart([1, 2, 3], zorder=5)
+        sage: b.matplotlib().axes[0].containers[0][0].get_zorder()
+        5
     """
     dl = len(datalist)
     if dl == 3:


### PR DESCRIPTION
## FIXED (https://github.com/sagemath/sage/issues/41207)

 The zorder parameter was previously ignored in bar_chart because it was not passed to the underlying matplotlib bar call in _render_on_subplot. This prevented users from controlling the layer order of bar charts (e.g. keeping bars above gridlines).

This change explicitly forwards the zorder option to subplot.bar, enabling correct z-ordering behavior.

Confirmed that bar_chart(..., zorder=10) now correctly sets the zorder on the generated matplotlib artists
