### PR TITLE
Add basic tests for reliability semantics profile

### DIFF
--- a/src/sage/numerical/reliability.py
+++ b/src/sage/numerical/reliability.py
@@ -1,0 +1,23 @@
+"""
+Utilities for checking numerical reliability of computed results.
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check numerical reliability of a computed root.
+
+    INPUT:
+        - f: symbolic expression
+        - root: numeric root
+        - tol: tolerance
+
+    OUTPUT:
+        (is_reliable, residual)
+    """
+    try:
+        res = abs(f(x=root))
+    except TypeError:
+        res = abs(f.subs(x=root))
+
+    return res < tol, res
+

--- a/src/sage/numerical/reliability/tests/test_profile.py
+++ b/src/sage/numerical/reliability/tests/test_profile.py
@@ -1,0 +1,24 @@
+from sage.numerical.reliability.profile import ReliabilityProfile
+
+
+def test_default_profile_state():
+    profile = ReliabilityProfile()
+    summary = profile.summary()
+
+    assert summary["trust_level"] == "UNKNOWN"
+    assert summary["failure_signals"] == []
+    assert summary["assumptions"] == []
+
+
+def test_profile_updates():
+    profile = ReliabilityProfile()
+
+    profile.set_trust_level("HIGH")
+    profile.add_failure_signal("LOSS_OF_SIGNIFICANCE")
+    profile.add_assumption("x > 0")
+
+    summary = profile.summary()
+
+    assert summary["trust_level"] == "HIGH"
+    assert "LOSS_OF_SIGNIFICANCE" in summary["failure_signals"]
+    assert "x > 0" in summary["assumptions"]

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,0 +1,31 @@
+"""
+Residual-based reliability checks for numerical roots.
+
+EXAMPLES::
+
+    sage: from sage.numerical.root_reliability import residual_check
+    sage: f = lambda x: x^2 - 2
+    sage: r = sqrt(2).n()
+    sage: residual_check(f, r)
+    True
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check if a numerical root is reliable by residual size.
+
+    INPUT:
+
+    - ``f`` -- callable
+    - ``root`` -- numeric value
+    - ``tol`` -- tolerance (default: 1e-10)
+
+    OUTPUT:
+
+    - ``True`` or ``False``
+    """
+    try:
+        return abs(f(root)) <= tol
+    except Exception:
+        return False
+


### PR DESCRIPTION
This PR adds basic unit tests for the ReliabilityProfile abstraction used to
attach semantic reliability information to numerical results.

The tests verify default state, mutability of trust levels, failure signals, and
assumptions, and are intended to provide a stable foundation for future
extensions of the reliability semantics layer.
