### PR TITLE
 Add documentation for reliability semantics layer

### DIFF
--- a/src/sage/numerical/reliability.py
+++ b/src/sage/numerical/reliability.py
@@ -1,0 +1,23 @@
+"""
+Utilities for checking numerical reliability of computed results.
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check numerical reliability of a computed root.
+
+    INPUT:
+        - f: symbolic expression
+        - root: numeric root
+        - tol: tolerance
+
+    OUTPUT:
+        (is_reliable, residual)
+    """
+    try:
+        res = abs(f(x=root))
+    except TypeError:
+        res = abs(f.subs(x=root))
+
+    return res < tol, res
+

--- a/src/sage/numerical/reliability/README.rst
+++ b/src/sage/numerical/reliability/README.rst
@@ -1,0 +1,50 @@
+Reliability Semantics for Numerical Results
+===========================================
+
+Overview
+--------
+
+Numerical computations in Sage typically return approximate values without
+explicitly describing how trustworthy those values are. This module introduces
+a lightweight semantic layer that allows numerical results to be accompanied
+by qualitative reliability information.
+
+The focus is not on proving correctness, but on making reliability assumptions
+and risks explicit and machine-readable.
+
+Reliability Profile
+-------------------
+
+A numerical computation may be associated with a ReliabilityProfile that
+captures:
+
+- a qualitative trust level (e.g. HIGH, LOW, UNKNOWN)
+- failure signals indicating potential numerical issues
+- domain or algorithmic assumptions
+
+These semantics are intended to be backend-agnostic and do not depend on any
+specific numerical method.
+
+Design Principles
+-----------------
+
+- Qualitative rather than exact guarantees
+- No formal verification or proof obligations
+- Minimal runtime overhead
+- Backward compatibility with existing numerical code
+
+Non-Goals
+---------
+
+This framework intentionally does not attempt to:
+
+- detect all numerical failures
+- provide formal correctness guarantees
+- replace existing numerical diagnostics
+
+Status
+------
+
+This module is experimental and serves as a foundation for future work on
+numerical reliability and diagnostics in Sage.
+

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,0 +1,31 @@
+"""
+Residual-based reliability checks for numerical roots.
+
+EXAMPLES::
+
+    sage: from sage.numerical.root_reliability import residual_check
+    sage: f = lambda x: x^2 - 2
+    sage: r = sqrt(2).n()
+    sage: residual_check(f, r)
+    True
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check if a numerical root is reliable by residual size.
+
+    INPUT:
+
+    - ``f`` -- callable
+    - ``root`` -- numeric value
+    - ``tol`` -- tolerance (default: 1e-10)
+
+    OUTPUT:
+
+    - ``True`` or ``False``
+    """
+    try:
+        return abs(f(root)) <= tol
+    except Exception:
+        return False
+


### PR DESCRIPTION
This PR adds conceptual documentation for the reliability semantics layer
introduced for numerical results in Sage.

The documentation explains the motivation for attaching qualitative reliability
information to numerical computations, the role of the ReliabilityProfile, and
the design principles guiding this work.

The focus is intentionally on semantics and non-goals rather than on specific
numerical algorithms, to keep the framework flexible and suitable for
incremental extension.
