### PR TITLE
Symbolic heuristic inequality

### DIFF
--- a/src/sage/numerical/reliability.py
+++ b/src/sage/numerical/reliability.py
@@ -1,0 +1,23 @@
+"""
+Utilities for checking numerical reliability of computed results.
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check numerical reliability of a computed root.
+
+    INPUT:
+        - f: symbolic expression
+        - root: numeric root
+        - tol: tolerance
+
+    OUTPUT:
+        (is_reliable, residual)
+    """
+    try:
+        res = abs(f(x=root))
+    except TypeError:
+        res = abs(f.subs(x=root))
+
+    return res < tol, res
+

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,0 +1,31 @@
+"""
+Residual-based reliability checks for numerical roots.
+
+EXAMPLES::
+
+    sage: from sage.numerical.root_reliability import residual_check
+    sage: f = lambda x: x^2 - 2
+    sage: r = sqrt(2).n()
+    sage: residual_check(f, r)
+    True
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check if a numerical root is reliable by residual size.
+
+    INPUT:
+
+    - ``f`` -- callable
+    - ``root`` -- numeric value
+    - ``tol`` -- tolerance (default: 1e-10)
+
+    OUTPUT:
+
+    - ``True`` or ``False``
+    """
+    try:
+        return abs(f(root)) <= tol
+    except Exception:
+        return False
+

--- a/src/sage/symbolic/heuristics.py
+++ b/src/sage/symbolic/heuristics.py
@@ -1,0 +1,26 @@
+from sage.all import QQ
+
+def definitely_not_equal(expr1, expr2, samples=3):
+    """
+    Heuristic check to detect that two symbolic expressions are not equal.
+    """
+    vars1 = set(expr1.variables())
+    vars2 = set(expr2.variables())
+    if vars1 != vars2:
+        return False
+
+    vars = list(vars1)
+
+    for i in range(1, samples + 1):
+        subs = {v: QQ(i) for v in vars}
+        try:
+            v1 = expr1.subs(subs)
+            v2 = expr2.subs(subs)
+        except Exception:
+            continue
+
+        if v1 != v2:
+            return True
+
+    return False
+

--- a/src/sage/symbolic/tests/test_heuristic_inequality.py
+++ b/src/sage/symbolic/tests/test_heuristic_inequality.py
@@ -1,0 +1,11 @@
+from sage.all import SR
+from sage.symbolic.heuristics import definitely_not_equal
+
+def test_simple_not_equal():
+    x = SR.var('x')
+    assert definitely_not_equal(x + 1, x + 2)
+
+def test_same_expression():
+    x = SR.var('x')
+    assert not definitely_not_equal(x^2, x*x)
+


### PR DESCRIPTION
This PR adds a small heuristic helper to quickly detect when two symbolic
expressions are not equal by evaluating them at a few exact sample points.

The helper is conservative: it only returns True when a concrete
counterexample is found, and otherwise returns False.

Tests are included.
