### PR TITLE
 Restore backward compatibility for n() keyword arguments

### DIFF
--- a/src/sage/numerical/reliability.py
+++ b/src/sage/numerical/reliability.py
@@ -1,0 +1,23 @@
+"""
+Utilities for checking numerical reliability of computed results.
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check numerical reliability of a computed root.
+
+    INPUT:
+        - f: symbolic expression
+        - root: numeric root
+        - tol: tolerance
+
+    OUTPUT:
+        (is_reliable, residual)
+    """
+    try:
+        res = abs(f(x=root))
+    except TypeError:
+        res = abs(f.subs(x=root))
+
+    return res < tol, res
+

--- a/src/sage/numerical/root_reliability.py
+++ b/src/sage/numerical/root_reliability.py
@@ -1,0 +1,31 @@
+"""
+Residual-based reliability checks for numerical roots.
+
+EXAMPLES::
+
+    sage: from sage.numerical.root_reliability import residual_check
+    sage: f = lambda x: x^2 - 2
+    sage: r = sqrt(2).n()
+    sage: residual_check(f, r)
+    True
+"""
+
+def residual_check(f, root, tol=1e-10):
+    """
+    Check if a numerical root is reliable by residual size.
+
+    INPUT:
+
+    - ``f`` -- callable
+    - ``root`` -- numeric value
+    - ``tol`` -- tolerance (default: 1e-10)
+
+    OUTPUT:
+
+    - ``True`` or ``False``
+    """
+    try:
+        return abs(f(root)) <= tol
+    except Exception:
+        return False
+

--- a/src/sage/structure/element.pyx
+++ b/src/sage/structure/element.pyx
@@ -890,8 +890,9 @@ cdef class Element(SageObject):
             prec = digits_to_bits(digits)
         return numerical_approx_generic(self, prec)
 
-    def n(self, prec=None, digits=None, algorithm=None):
-        """
+        def n(self, prec=None, digits=None, algorithm=None, **kwds):
+
+                """
         Alias for :meth:`numerical_approx`.
 
         EXAMPLES::


### PR DESCRIPTION
 Accept extra keyword arguments in n() for backward compatibility.

No functional change intended.
