### PR TITLE
Fix inline literal interpreted as LaTeX math

### DIFF
--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -14,7 +14,7 @@ uv
 `uv <https://docs.astral.sh/uv/>`_ is a versatile tool for
 managing and synchronizing project dependencies.
 
-The lockfile `uv.lock` in the root captures the exact package versions for
+The lockfile ``uv.lock`` in the root captures the exact package versions for
 all systems and ensures consistent, reproducible installations.
 It is automatically updated during ``uv`` operations like ``uv add``
 and ``uv run``, or explicitly with ``uv lock``.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Currently, the rendered HTML shows the word uv.lock wrapped in MathJax.

Doubling the backticks fixes the markup so that the enclosed is correctly rendered as a code fragment.

I had to refer to [reStructuredText Markup Specification](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html) to make sure this is supposed to be a mistake.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

