### PR TITLE
Fix test failures with pyparsing 3.3

### DIFF
--- a/src/sage/topology/simplicial_set_examples.py
+++ b/src/sage/topology/simplicial_set_examples.py
@@ -655,7 +655,7 @@ def simplicial_data_from_kenzo_output(filename) -> dict:
         sage: S4.homology(reduced=False)                                                # needs pyparsing
         {0: Z, 1: 0, 2: 0, 3: 0, 4: Z}
     """
-    from pyparsing import OneOrMore, nestedExpr
+    from pyparsing import OneOrMore, nested_expr
 
     with open(filename) as f:
         data = f.read()
@@ -675,7 +675,7 @@ def simplicial_data_from_kenzo_output(filename) -> dict:
             end = new_dim_idx
         if dim == 0:
             simplex_string = data[data.find('Vertices :') + len('Vertices :'):end]
-            vertices = OneOrMore(nestedExpr()).parseString(simplex_string).asList()[0]
+            vertices = OneOrMore(nested_expr()).parse_string(simplex_string).asList()[0]
             for v in vertices:
                 vertex = AbstractSimplex(0, name=v)
                 simplex_data[vertex] = None


### PR DESCRIPTION
Fixes
```
File "src/sage/topology/simplicial_set.py", line 1686, in sage.topology.simplicial_set.SimplicialSet_arbitrary.graph
Failed example:
    CP3 = simplicial_sets.ComplexProjectiveSpace(3)
Expected nothing
Got:
    doctest:warning
      File "<doctest sage.topology.simplicial_set.SimplicialSet_arbitrary.graph[6]>", line 1, in <module>
        CP3 = simplicial_sets.ComplexProjectiveSpace(Integer(3))
      File "/usr/lib/python3.14/site-packages/sage/topology/simplicial_set_examples.py", line 622, in ComplexProjectiveSpace
        data = simplicial_data_from_kenzo_output(file)
      File "/usr/lib/python3.14/site-packages/sage/topology/simplicial_set_examples.py", line 678, in simplicial_data_from_kenzo_output
        vertices = OneOrMore(nestedExpr()).parseString(simplex_string).asList()[0]
      File "/usr/lib/python3.14/site-packages/pyparsing/util.py", line 445, in _inner
        warnings.warn(
      File "/usr/lib/python3.14/_py_warnings.py", line 230, in _showwarnmsg
        sw(msg.message, msg.category, msg.filename, msg.lineno,
    :
    DeprecationWarning: 'nestedExpr' deprecated - use 'nested_expr'
    doctest:warning
      File "<doctest sage.topology.simplicial_set.SimplicialSet_arbitrary.graph[6]>", line 1, in <module>
        CP3 = simplicial_sets.ComplexProjectiveSpace(Integer(3))
      File "/usr/lib/python3.14/site-packages/sage/topology/simplicial_set_examples.py", line 622, in ComplexProjectiveSpace
        data = simplicial_data_from_kenzo_output(file)
      File "/usr/lib/python3.14/site-packages/sage/topology/simplicial_set_examples.py", line 678, in simplicial_data_from_kenzo_output
        vertices = OneOrMore(nestedExpr()).parseString(simplex_string).asList()[0]
      File "/usr/lib/python3.14/site-packages/pyparsing/util.py", line 434, in _inner
        warnings.warn(
      File "/usr/lib/python3.14/_py_warnings.py", line 230, in _showwarnmsg
        sw(msg.message, msg.category, msg.filename, msg.lineno,
    :
    DeprecationWarning: 'parseString' deprecated - use 'parse_string'
```

