### PR TITLE
Add support for Hilbert series of graded commutative algebras

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -3035,9 +3035,9 @@ class MPolynomialIdeal_singular_repr(
             sage: OS = M.orlik_solomon_algebra(QQ)
             sage: A = OS.as_gca()
             sage: I = A.defining_ideal()
-            sage: I.hilbert_series()
+            sage: HS = I.hilbert_series(); HS
             6*t^3 + 11*t^2 + 6*t + 1
-            sage: _.factor()
+            sage: HS.factor()
             (t + 1) * (2*t + 1) * (3*t + 1)
 
         TESTS::
@@ -3626,10 +3626,17 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
 
     def groebner_basis(self):
         r"""
-        Compute a Gröbner basis of the ideal. It is two-sided if and only if the ideal is two-sided.
+        Compute a Gröbner basis of the ideal.
 
-        This returns a polynomial sequence. See :func:`sage.rings.polynomial.multi_polynomial_sequence.PolynomialSequence`.
-        Under the hood, this uses the :meth:`std` or :meth:`twostd` methods.
+        The Gröbner basis is two-sided if and only if the ideal is two-sided.
+
+        OUTPUT:
+
+        :func:`~sage.rings.polynomial.multi_polynomial_sequence.PolynomialSequence`
+
+        ALGORITHM:
+
+        Use the :meth:`std` or :meth:`twostd` methods.
 
         EXAMPLES::
 
@@ -3642,9 +3649,7 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
             sage: I.groebner_basis()
             [z^2 - 1, y*z - y, x*z + x, y^2, 2*x*y - z - 1, x^2]
         """
-        # return a polynomial sequence for consistency with the MPolynomialIdeal.groebner_basis method
-        from sage.rings.polynomial.multi_polynomial_sequence import \
-                PolynomialSequence
+        from sage.rings.polynomial.multi_polynomial_sequence import PolynomialSequence
         return PolynomialSequence(self.std())
 
     def elimination_ideal(self, variables):
@@ -3884,7 +3889,7 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
             warn("The resulting resolution is one-sided (left)!")
         return self.__call_singular('res', length)
 
-    def is_homogeneous(self):
+    def is_homogeneous(self) -> bool:
         r"""
         Return ``True`` if this ideal is spanned by homogeneous
         polynomials, i.e., if it is a homogeneous ideal.

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -3637,7 +3637,7 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
 
         ALGORITHM:
 
-        Use the :meth:`std` or :meth:`twostd` methods.
+        Uses the :meth:`std` method.
 
         EXAMPLES::
 

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -3029,7 +3029,8 @@ class MPolynomialIdeal_singular_repr(
             sage: K.hilbert_series(grading=[2,1])                                       # needs sage.libs.flint
             (2*t^7 - t^6 - t^4 - t^2 - 1)/(t - 1)
 
-        This method also works for :class:`NCPolynomialRing_plural`::
+        This also works for
+        :class:`~sage.rings.polynomial.plural.NCPolynomialRing_plural`::
 
             sage: M = matroids.CompleteGraphic(4)
             sage: OS = M.orlik_solomon_algebra(QQ)

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -3067,8 +3067,6 @@ class MPolynomialIdeal_singular_repr(
             sage: I = Ideal([x^3*y^2 + 3*x^2*y^2*z + y^3*z^2 + z^5])                                                    # needs sage.rings.number_field
             sage: I.hilbert_series()                                                                                    # needs sage.rings.number_field
             (t^4 + t^3 + t^2 + t + 1)/(t^2 - 2*t + 1)
-        
-        
         """
         if not self.is_homogeneous():
             raise TypeError("ideal must be homogeneous")
@@ -3906,6 +3904,7 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
             True
         """
         return all(f.is_homogeneous() for f in self.gens())
+
 
 @richcmp_method
 class MPolynomialIdeal(MPolynomialIdeal_singular_repr,

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -3630,7 +3630,7 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
         r"""
         Compute a Gröbner basis of the ideal. It is two-sided if and only if the ideal is two-sided.
 
-        This returns a `PolynomialSequence`. See :func:`sage.rings.polynomial.multi_polynomial_sequence.PolynomialSequence`.
+        This returns a polynomial sequence. See :func:`sage.rings.polynomial.multi_polynomial_sequence.PolynomialSequence`.
         Under the hood, this uses the :meth:`std` or :meth:`twostd` methods.
 
         EXAMPLES::

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -3029,6 +3029,17 @@ class MPolynomialIdeal_singular_repr(
             sage: K.hilbert_series(grading=[2,1])                                       # needs sage.libs.flint
             (2*t^7 - t^6 - t^4 - t^2 - 1)/(t - 1)
 
+        This method also works for :class:`NCPolynomialRing_plural`::
+
+            sage: M = matroids.CompleteGraphic(4)
+            sage: OS = M.orlik_solomon_algebra(QQ)
+            sage: A = OS.as_gca()
+            sage: I = A.defining_ideal()
+            sage: I.hilbert_series()
+            6*t^3 + 11*t^2 + 6*t + 1
+            sage: _.factor()
+            (t + 1) * (2*t + 1) * (3*t + 1)
+
         TESTS::
 
             sage: # needs sage.libs.flint
@@ -3056,6 +3067,8 @@ class MPolynomialIdeal_singular_repr(
             sage: I = Ideal([x^3*y^2 + 3*x^2*y^2*z + y^3*z^2 + z^5])                                                    # needs sage.rings.number_field
             sage: I.hilbert_series()                                                                                    # needs sage.rings.number_field
             (t^4 + t^3 + t^2 + t + 1)/(t^2 - 2*t + 1)
+        
+        
         """
         if not self.is_homogeneous():
             raise TypeError("ideal must be homogeneous")
@@ -3873,6 +3886,26 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
             warn("The resulting resolution is one-sided (left)!")
         return self.__call_singular('res', length)
 
+    def is_homogeneous(self):
+        r"""
+        Return ``True`` if this ideal is spanned by homogeneous
+        polynomials, i.e., if it is a homogeneous ideal.
+
+        EXAMPLES::
+
+            sage: # needs sage.combinat sage.modules
+            sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
+            sage: H = A.g_algebra({y*x: x*y-z, z*x: x*z+2*x, z*y: y*z-2*y})
+            sage: H.inject_variables()
+            Defining x, y, z
+            sage: I = H.ideal([y^2, x^2, z^2 - H.one()], coerce=False)
+            sage: I.is_homogeneous()
+            False
+            sage: J = H.ideal([y^2, x^2, z^2 - x*y], coerce=False)
+            sage: J.is_homogeneous()
+            True
+        """
+        return all(f.is_homogeneous() for f in self.gens())
 
 @richcmp_method
 class MPolynomialIdeal(MPolynomialIdeal_singular_repr,

--- a/src/sage/rings/polynomial/multi_polynomial_ideal.py
+++ b/src/sage/rings/polynomial/multi_polynomial_ideal.py
@@ -2617,7 +2617,7 @@ class MPolynomialIdeal_singular_repr(
             sage: I = Ideal([x^2 - 1, y^2 - 1])                                         # needs sage.rings.finite_rings
             sage: sorted(I.variety(algorithm='msolve',          # optional - msolve, needs sage.rings.finite_rings
             ....:                  proof=False),
-            ....:        key=lambda d: str(sorted(d.items()))
+            ....:        key=lambda d: str(sorted(d.items())))
             [{y: 1, x: 1},
              {y: 1, x: 536870908},
              {y: 536870908, x: 1},
@@ -3612,6 +3612,29 @@ class NCPolynomialIdeal(MPolynomialIdeal_singular_repr, Ideal_nc):
             return self.twostd()
         return self.ring().ideal( self.__call_singular('std'), side=self.side())
 #        return self.__call_singular('std')
+
+    def groebner_basis(self):
+        r"""
+        Compute a Gröbner basis of the ideal. It is two-sided if and only if the ideal is two-sided.
+
+        This returns a `PolynomialSequence`. See :func:`sage.rings.polynomial.multi_polynomial_sequence.PolynomialSequence`.
+        Under the hood, this uses the :meth:`std` or :meth:`twostd` methods.
+
+        EXAMPLES::
+
+            sage: # needs sage.combinat sage.modules
+            sage: A.<x,y,z> = FreeAlgebra(QQ, 3)
+            sage: H = A.g_algebra({y*x: x*y-z, z*x: x*z+2*x, z*y: y*z-2*y})
+            sage: H.inject_variables()
+            Defining x, y, z
+            sage: I = H.ideal([y^2, x^2, z^2 - H.one()], coerce=False)
+            sage: I.groebner_basis()
+            [z^2 - 1, y*z - y, x*z + x, y^2, 2*x*y - z - 1, x^2]
+        """
+        # return a polynomial sequence for consistency with the MPolynomialIdeal.groebner_basis method
+        from sage.rings.polynomial.multi_polynomial_sequence import \
+                PolynomialSequence
+        return PolynomialSequence(self.std())
 
     def elimination_ideal(self, variables):
         r"""

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -170,6 +170,7 @@ from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF
 from sage.rings.infinity import Infinity
 from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal, NCPolynomialIdeal
 from sage.rings.polynomial.multi_polynomial_ring import MPolynomialRing_base
+from sage.rings.polynomial.plural import NCPolynomialRing_plural
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialRing_sparse
 from sage.rings.quotient_ring import QuotientRing_nc
@@ -316,6 +317,7 @@ def PolynomialSequence(arg1, arg2=None, immutable=False, cr=False, cr_str=None):
 
     def is_ring(r):
         return (isinstance(r, (MPolynomialRing_base,
+                               NCPolynomialRing_plural,
                                BooleanMonomialMonoid,
                                InfinitePolynomialRing_sparse))
                 or (isinstance(r, QuotientRing_nc)

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -168,7 +168,7 @@ from sage.misc.method_decorator import MethodDecorator
 from sage.rings.finite_rings.finite_field_base import FiniteField
 from sage.rings.finite_rings.finite_field_constructor import FiniteField as GF
 from sage.rings.infinity import Infinity
-from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
+from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal, NCPolynomialIdeal
 from sage.rings.polynomial.multi_polynomial_ring import MPolynomialRing_base
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialRing_sparse
@@ -330,7 +330,7 @@ def PolynomialSequence(arg1, arg2=None, immutable=False, cr=False, cr_str=None):
     elif isinstance(arg1, Matrix):
         ring, gens = arg1.base_ring(), arg1.list()
 
-    elif isinstance(arg1, MPolynomialIdeal):
+    elif isinstance(arg1, (MPolynomialIdeal, NCPolynomialIdeal)):
         ring, gens = arg1.ring(), arg1.gens()
     else:
         gens = list(arg1)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

All of the math that needs to be done to compute the Hilbert series of a GCA is already implemented, but the method `.hilbert_series()` is not implemented for homogeneous ideals of GCA's. This PR connects the existing dots. It also essentially aliases the `.std()` method for noncommutative polynomial rings with the `.groebner_basis()` method. It is not quite an alias because the `.std()` method returns an ideal following `Singular` and the `.groebner_basis()` method returns a `PolynomialSequence` for consistency with the existing `MPolynomialIdeal`. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


