### PR TITLE
Fix a few compiler warnings in `sage.rings`

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7641,7 +7641,7 @@ cdef class int_to_Z(Morphism):
 
     cpdef Element _call_(self, a):
         cdef Integer r
-        cdef long l
+        cdef long l = 0
         cdef int err = 0
 
         integer_check_long_py(a, &l, &err)
@@ -7827,12 +7827,6 @@ cdef hook_fast_tp_functions():
     # Finally replace the functions called when an Integer needs
     # to be constructed/destructed.
     hook_tp_functions(global_dummy_Integer, <newfunc>(&fast_tp_new), <destructor>(&fast_tp_dealloc), False)
-
-cdef integer(x):
-    if isinstance(x, Integer):
-        return x
-    return Integer(x)
-
 
 def free_integer_pool():
     cdef int i

--- a/src/sage/rings/real_lazy.pyx
+++ b/src/sage/rings/real_lazy.pyx
@@ -524,21 +524,6 @@ def ComplexLazyField():
     return CLF
 
 
-cdef int get_new_prec(R, int depth) except -1:
-    """
-    There are depth operations, so we want at least that many more digits of
-    precision.
-
-    Field creation may be expensive, so we want to avoid incrementing by 1 so
-    that it is more likely for cached fields to be used.
-    """
-    cdef int needed_prec = R.prec()
-    needed_prec += depth
-    if needed_prec % 10 != 0:
-        needed_prec += 10 - needed_prec % 10
-    return needed_prec
-
-
 cdef class LazyFieldElement(FieldElement):
 
     cpdef _add_(left, right):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

About unused functions and uninitalized variables, eg
```
src/sage/rings/integer.cpython-313-x86_64-linux-gnu.so.p/src/sage/rings/integer.pyx.c:61228:18: warning: ‘__pyx_f_4sage_5rings_7integer_integer’ defined but not used [-Wunused-function]
61228 | static PyObject *__pyx_f_4sage_5rings_7integer_integer(PyObject *__pyx_v_x) {
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/sage/rings/integer.cpython-313-x86_64-linux-gnu.so.p/src/sage/rings/integer.pyx.c: In function ‘__pyx_f_4sage_5rings_7integer_8int_to_Z__call_’:
src/sage/rings/integer.cpython-313-x86_64-linux-gnu.so.p/src/sage/rings/integer.pyx.c:60400:30: warning: ‘__pyx_v_l’ may be used uninitialized [-Wmaybe-uninitialized]
60400 |     __pyx_t_1 = ((PyObject *)__pyx_f_4sage_5rings_7integer_smallInteger(__pyx_v_l)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 7649, __pyx_L1_error)
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/sage/rings/integer.cpython-313-x86_64-linux-gnu.so.p/src/sage/rings/integer.pyx.c:60287:8: note: ‘__pyx_v_l’ was declared here
60287 |   long __pyx_v_l;
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


