### PR TITLE
Fix crash in higher-level FockSpace G-basis conversion

### DIFF
--- a/src/sage/algebras/quantum_groups/fock_space.py
+++ b/src/sage/algebras/quantum_groups/fock_space.py
@@ -1354,7 +1354,6 @@ class FockSpace(Parent, UniqueRepresentation):
                 return fock.sum_of_terms((fock._indices([[]]*k + list(pt)), c) for pt,c in cur)
 
             cur = R.A()._A_to_fock_basis(la)
-
             # In level > 1, the default comparison on PartitionTuples is lexicographic
             # and does not necessarily refine the dominance order used by this algorithm.
             # Build the elimination list s so that whenever y.dominates(x),
@@ -1369,9 +1368,8 @@ class FockSpace(Parent, UniqueRepresentation):
                         break
                 else:
                     s.insert(0, x)
-
-
             q = R._q
+          
             while s:
                 mu = s.pop()
                 if mu not in self._indices:
@@ -1386,7 +1384,6 @@ class FockSpace(Parent, UniqueRepresentation):
                     gamma += n[k]
                     cur -= gamma * self._G_to_fock_basis(mu)
 
-                    # Add any new support elements
                     # Add any new support elements
                     for x in cur.support():
                         if x == mu or x not in self._indices or not mu.dominates(x):

--- a/src/sage/algebras/quantum_groups/fock_space.py
+++ b/src/sage/algebras/quantum_groups/fock_space.py
@@ -1421,14 +1421,6 @@ class FockSpace(Parent, UniqueRepresentation):
 
     lower_global_crystal = G
     canonical = G
-  
-    # TESTS::
-    #     sage: Fock = FockSpace(3,[0,1])
-    #     sage: F = Fock.natural()
-    #     sage: G = Fock.G()
-    #     sage: v = F(G([[6],[5,5,1]]))   # used to crash in higher level
-    #     sage: v.parent() is F
-    #     True
 
 ###############################################################################
 # Bases Category

--- a/src/sage/algebras/quantum_groups/fock_space.py
+++ b/src/sage/algebras/quantum_groups/fock_space.py
@@ -1422,6 +1422,7 @@ class FockSpace(Parent, UniqueRepresentation):
     lower_global_crystal = G
     canonical = G
 
+
 ###############################################################################
 # Bases Category
 

--- a/src/sage/algebras/quantum_groups/fock_space.py
+++ b/src/sage/algebras/quantum_groups/fock_space.py
@@ -1325,6 +1325,20 @@ class FockSpace(Parent, UniqueRepresentation):
                 |3> + q*|2, 1>
                 sage: G._G_to_fock_basis(Partition([2,1]))
                 |2, 1> + q*|1, 1, 1>
+
+            TESTS:
+
+            Check that :issue:`41408` is fixed::
+
+                sage: Fock = FockSpace(3, [0, 1])
+                sage: G = Fock.G()
+                sage: la = PartitionTuple([[6], [5,5,1]])
+                sage: v = G._G_to_fock_basis(la)
+                sage: len(v.support())
+                261
+                sage: v
+                |[6], [5, 5, 1]> + q*|[6], [5, 4, 1, 1]> + q*|[6], [5, 3, 3]>
+                 + ... + q^7*|[], [3, 3, 3, 2, 1, 1, 1, 1, 1, 1]>
             """
             # Special case for the empty partition
             if la.size() == 0:
@@ -1354,26 +1368,38 @@ class FockSpace(Parent, UniqueRepresentation):
                 return fock.sum_of_terms((fock._indices([[]]*k + list(pt)), c) for pt,c in cur)
 
             cur = R.A()._A_to_fock_basis(la)
-            # In level > 1, the default comparison on PartitionTuples is lexicographic
-            # and does not necessarily refine the dominance order used by this algorithm.
+
+            def domorder_insertion(data, elt):
+                """
+                Add ``elt`` at the largest position of ``data`` such that
+                it dominants all larger entries.
+                """
+                for i in range(len(data)-1, -1, -1):
+                    if not data[i].dominates(elt):
+                        data.insert(i+1, elt)
+                        return
+                data.insert(0, elt)
+
             # Build the elimination list s so that whenever y.dominates(x),
             # y appears after x.
-            s = []
-            for x in sorted(cur.support()):
-                if x == la or x not in self._indices:
-                    continue
-                for i in reversed(range(len(s))):
-                    if not s[i].dominates(x):
-                        s.insert(i+1, x)
-                        break
-                else:
-                    s.insert(0, x)
+            if len(R._multicharge) == 1:
+                s = [x for x in cur.support() if x in self._indices]
+                s.sort()  # Sort lex, which respects dominance order
+                s.pop()  # Remove the largest
+            else:
+                # In level > 1, the default comparison on PartitionTuples is lexicographic
+                # and does not necessarily refine dominance order.
+                s = []
+                for x in cur.support():
+                    if x == la or x not in self._indices:
+                        continue
+                    domorder_insertion(s, x)
+
             q = R._q
-          
+
             while s:
                 mu = s.pop()
-                if mu not in self._indices:
-                    continue
+                # assert mu in self._indices
                 d = cur[mu].denominator()
 
                 k = d.degree()
@@ -1384,18 +1410,13 @@ class FockSpace(Parent, UniqueRepresentation):
                     gamma += n[k]
                     cur -= gamma * self._G_to_fock_basis(mu)
 
-                    # Add any new support elements
                     for x in cur.support():
-                        if x == mu or x not in self._indices or not mu.dominates(x):
+                        # Add only new support elements that are (strictly) dominanted by mu
+                        # and correspond to crystal basis elements.
+                        if x == mu or x in s or not mu.dominates(x) or x not in self._indices:
                             continue
-                        if x in s:
-                            continue
-                        for i in reversed(range(len(s))):
-                            if not s[i].dominates(x):
-                                s.insert(i+1, x)
-                                break
-                        else:
-                            s.insert(0, x)
+                        domorder_insertion(s, x)
+
             return cur
 
     lower_global_crystal = G

--- a/src/sage/algebras/quantum_groups/fock_space.py
+++ b/src/sage/algebras/quantum_groups/fock_space.py
@@ -1400,8 +1400,7 @@ class FockSpace(Parent, UniqueRepresentation):
 
     lower_global_crystal = G
     canonical = G
-
-
+  
     # TESTS::
     #     sage: Fock = FockSpace(3,[0,1])
     #     sage: F = Fock.natural()
@@ -1409,7 +1408,6 @@ class FockSpace(Parent, UniqueRepresentation):
     #     sage: v = F(G([[6],[5,5,1]]))   # used to crash in higher level
     #     sage: v.parent() is F
     #     True
-
 
 ###############################################################################
 # Bases Category


### PR DESCRIPTION
Problem
-------
In level > 1, G()._G_to_fock_basis builds an elimination list from sorted(cur.support()) and implicitly relies on the default ordering of PartitionTuples. This can lead to recursion/elimination on indices outside self._indices (e.g. non e-regular components) and a ValueError during coercion into RegularPartitions.

Reproducer
----------
    Fock = FockSpace(3,[0,1])
    F = Fock.natural()
    G = Fock.G()
    F(G([[6],[5,5,1]]))

Fix
---
- Build the elimination list in a dominance-compatible order (rather than relying on lex order).
- Only enqueue/eliminate pivots in self._indices.
- When new support elements appear during elimination, enqueue only those in self._indices, avoid duplicates, and insert with the same dominance rule.

Tests
-----
Added a regression doctest exercising the reproducer (previously crashed).

CC: @tscrim
