### PR TITLE
PolynomialRingConstructor: Use IntegerModRing.is_field() instead of K.order().is_prime() as it is cached

### DIFF
--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -820,10 +820,9 @@ def _single_variate(base_ring, name, sparse=None, implementation=None, order=Non
     # Specialized implementations
     specialized = None
     if isinstance(base_ring, sage.rings.abc.IntegerModRing):
-        n = base_ring.order()
-        if n.is_prime():
+        if base_ring.is_field():
             specialized = polynomial_ring.PolynomialRing_dense_mod_p
-        elif n > 1:  # Specialized code breaks for n == 1
+        elif base_ring.order() > 1:  # Specialized code breaks for ord(K) == 1
             specialized = polynomial_ring.PolynomialRing_dense_mod_n
     elif isinstance(base_ring, FiniteField):
         specialized = polynomial_ring.PolynomialRing_dense_finite_field


### PR DESCRIPTION


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Currently

```sage
p = random_prime(2^2000)

F = GF(p) # checks primality once, which is expected
R = F['x'] # also does a primality check (slow)
``` 

instead of checking if the order of the ring is prime, we can use `K.is_field()` which does the same but is cached

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


