### PR TITLE
some annotations for _gap_init_ -> str

### DIFF
--- a/src/sage/combinat/designs/incidence_structures.py
+++ b/src/sage/combinat/designs/incidence_structures.py
@@ -143,7 +143,7 @@ class IncidenceStructure(SageObject):
         True
     """
     def __init__(self, points=None, blocks=None, incidence_matrix=None,
-                 name=None, check=True, copy=True):
+                 name=None, check=True, copy=True) -> None:
         r"""
         TESTS::
 
@@ -261,7 +261,7 @@ class IncidenceStructure(SageObject):
             for b in self._blocks:
                 yield [self._points[i] for i in b]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         A print method.
 
@@ -276,7 +276,7 @@ class IncidenceStructure(SageObject):
 
     __str__ = __repr__
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """
         Test whether the two incidence structures are equal.
 
@@ -321,7 +321,7 @@ class IncidenceStructure(SageObject):
         other_blocks = sorted(sorted(p_to_i[p] for p in b) for b in other.blocks())
         return self._blocks == other_blocks
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         r"""
         Difference test.
 
@@ -335,7 +335,7 @@ class IncidenceStructure(SageObject):
         """
         return not self == other
 
-    def __contains__(self, block):
+    def __contains__(self, block) -> bool:
         r"""
         Test if a block belongs to the incidence structure.
 
@@ -1068,7 +1068,7 @@ class IncidenceStructure(SageObject):
         B = self._blocks
         return all(B[i] != B[i + 1] for i in range(len(B) - 1))
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
         Return the GAP string describing the design.
 

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -1315,7 +1315,8 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
     """
     def __init__(self, polynomial, name, latex_name,
                  check=True, embedding=None, category=None,
-                 assume_disc_small=False, maximize_at_primes=None, structure=None):
+                 assume_disc_small=False, maximize_at_primes=None,
+                 structure=None) -> None:
         """
         Create a number field.
 
@@ -4512,10 +4513,12 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
         Kbnf = self.pari_bnf(proof=proof)
         return Kbnf.rnfisnorminit(L.pari_relative_polynomial())
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
-        Implements :meth:`sage.structure.sage_object.SageObject._gap_init_` for number fields
-        to make ``gap(K)`` work. Not to be used directly.
+        Implements :meth:`sage.structure.sage_object.SageObject._gap_init_`
+        for number fields to make ``gap(K)`` work.
+
+        Not to be used directly.
 
         EXAMPLES::
 
@@ -4565,6 +4568,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
         because the current implementation of :meth:`_gap_init_` doesn't work with libgap,
         and it is cleaner to implement this using ``libgap`` object manipulations
         instead of ``libgap.eval(self._gap_init_())``.
+
         Not to be used directly, use ``libgap(K)`` instead.
 
         EXAMPLES::
@@ -11038,7 +11042,7 @@ class NumberField_cyclotomic(NumberField_absolute, sage.rings.abc.NumberField_cy
         s = 'CyclotomicField(%s)' % self.__n
         return magma._with_names(s, self.variable_names())
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
         Return a string that provides a representation of ``self`` in GAP.
 
@@ -11071,7 +11075,7 @@ class NumberField_cyclotomic(NumberField_absolute, sage.rings.abc.NumberField_cy
             zeta3
             -zeta3 - 1
         """
-        return 'CyclotomicField(%s)' % self.__n
+        return f'CyclotomicField({self.__n})'
 
     def _libgap_(self):
         """

--- a/src/sage/structure/sage_object.pyx
+++ b/src/sage/structure/sage_object.pyx
@@ -769,7 +769,7 @@ cdef class SageObject:
             G = sage.interfaces.gap.gap
         return self._interface_(G)
 
-    def _gap_init_(self):
+    def _gap_init_(self) -> str:
         """
         Return a string that provides a representation of ``self`` in GAP.
 


### PR DESCRIPTION
as this was missing in a few cases

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.