### PR TITLE
CBF, RBF, RR, RIF elements should be `FieldElement`s

### DIFF
--- a/src/sage/rings/complex_arb.pxd
+++ b/src/sage/rings/complex_arb.pxd
@@ -1,7 +1,7 @@
 from sage.libs.flint.acb cimport acb_t
 from sage.rings.complex_interval cimport ComplexIntervalFieldElement
 from sage.rings.real_arb cimport RealBall
-from sage.structure.element cimport RingElement
+from sage.structure.element cimport FieldElement
 from sage.rings.ring cimport Field
 
 cdef void ComplexIntervalFieldElement_to_acb(
@@ -12,7 +12,7 @@ cdef int acb_to_ComplexIntervalFieldElement(
     ComplexIntervalFieldElement target,
     const acb_t source) except -1
 
-cdef class ComplexBall(RingElement):
+cdef class ComplexBall(FieldElement):
     cdef acb_t value
     cdef ComplexBall _new(self)
     cpdef _add_(self, other)

--- a/src/sage/rings/complex_arb.pyi
+++ b/src/sage/rings/complex_arb.pyi
@@ -3,7 +3,7 @@ from typing import Any
 from sage.libs.flint.acb import acb_t
 from sage.rings.complex_interval import ComplexIntervalFieldElement
 from sage.rings.real_arb import RealBall
-from sage.structure.element import RingElement
+from sage.structure.element import FieldElement
 from sage.rings.ring import Field
 
 def ComplexIntervalFieldElement_to_acb(target: acb_t, source: ComplexIntervalFieldElement) -> None:
@@ -12,7 +12,7 @@ def ComplexIntervalFieldElement_to_acb(target: acb_t, source: ComplexIntervalFie
 def acb_to_ComplexIntervalFieldElement(target: ComplexIntervalFieldElement, source: acb_t) -> int:
     ...
 
-class ComplexBall(RingElement):
+class ComplexBall(FieldElement):
     value: acb_t
 
     def _new(self) -> 'ComplexBall':

--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -189,7 +189,7 @@ from sage.rings.real_arb import RealBallField
 from sage.rings.real_mpfi cimport RealIntervalField_class
 from sage.rings.real_mpfr cimport RealField_class, RealField, RealNumber
 from sage.rings.ring import Field
-from sage.structure.element cimport Element
+from sage.structure.element cimport Element, FieldElement
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.arith.long cimport is_small_python_int
 
@@ -1368,7 +1368,7 @@ cdef bint arb_gt_neg_one(arb_t b) noexcept:
 cdef inline real_ball_field(ComplexBall ball):
     return ball._parent._base
 
-cdef class ComplexBall(RingElement):
+cdef class ComplexBall(FieldElement):
     """
     Hold one ``acb_t`` of the `FLINT library <https://flintlib.org>`_.
 

--- a/src/sage/rings/real_arb.pxd
+++ b/src/sage/rings/real_arb.pxd
@@ -2,12 +2,12 @@ from sage.libs.flint.arb cimport arb_t
 from sage.libs.mpfi.types cimport mpfi_t
 from sage.rings.real_mpfi cimport RealIntervalField_class, RealIntervalFieldElement
 from sage.structure.parent cimport Parent
-from sage.structure.element cimport RingElement
+from sage.structure.element cimport FieldElement
 
 cdef void mpfi_to_arb(arb_t target, const mpfi_t source, const long precision) noexcept
 cdef int arb_to_mpfi(mpfi_t target, arb_t source, const long precision) except -1
 
-cdef class RealBall(RingElement):
+cdef class RealBall(FieldElement):
     cdef arb_t value
     cpdef _add_(self, other)
     cpdef _mul_(self, other)

--- a/src/sage/rings/real_arb.pyx
+++ b/src/sage/rings/real_arb.pyx
@@ -216,7 +216,7 @@ from sage.libs.mpfi cimport *
 from sage.libs.mpfr cimport *
 from sage.libs.mpfr cimport MPFR_RNDN, MPFR_RNDU, MPFR_RNDD, MPFR_RNDZ
 
-from sage.structure.element cimport Element, RingElement
+from sage.structure.element cimport Element, FieldElement
 from sage.rings.ring cimport Field
 import sage.rings.abc
 from sage.rings.integer cimport Integer
@@ -1184,7 +1184,7 @@ def create_RealBall(parent, serialized):
         return res
 
 
-cdef class RealBall(RingElement):
+cdef class RealBall(FieldElement):
     """
     Hold one ``arb_t``.
 

--- a/src/sage/rings/real_mpfi.pxd
+++ b/src/sage/rings/real_mpfi.pxd
@@ -3,12 +3,12 @@ from sage.libs.mpfi.types cimport mpfi_t
 
 from sage.rings.ring cimport Field
 cimport sage.rings.abc
-from sage.structure.element cimport RingElement
+from sage.structure.element cimport FieldElement
 
 from sage.rings.rational cimport Rational
 from sage.rings.real_mpfr cimport RealField_class
 
-cdef class RealIntervalFieldElement(RingElement)  # forward decl
+cdef class RealIntervalFieldElement(FieldElement)  # forward decl
 
 cdef class RealIntervalField_class(sage.rings.abc.RealIntervalField):
     cdef mpfr_prec_t _prec
@@ -38,7 +38,7 @@ cdef class RealIntervalField_class(sage.rings.abc.RealIntervalField):
         return <RealIntervalFieldElement>(t.__new__(t, self))
 
 
-cdef class RealIntervalFieldElement(RingElement):
+cdef class RealIntervalFieldElement(FieldElement):
     cdef mpfi_t value
 
     cdef inline RealIntervalFieldElement _new(self):

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -288,7 +288,7 @@ from sage.libs.mpfi cimport *
 from sage.arith.constants cimport LOG_TEN_TWO_PLUS_EPSILON
 
 cimport sage.structure.element
-from sage.structure.element cimport RingElement, Element
+from sage.structure.element cimport FieldElement, Element
 from sage.structure.element cimport have_same_parent
 from sage.structure.parent cimport Parent
 from sage.structure.richcmp cimport richcmp
@@ -1188,7 +1188,7 @@ cdef class RealIntervalField_class(sage.rings.abc.RealIntervalField):
 #     RealIntervalFieldElement -- element of Real Interval Field
 #
 # ****************************************************************************
-cdef class RealIntervalFieldElement(RingElement):
+cdef class RealIntervalFieldElement(FieldElement):
     """
     A real number interval.
     """
@@ -4437,10 +4437,10 @@ cdef class RealIntervalFieldElement(RingElement):
         if isinstance(exponent, (int, Integer)):
             q, r = divmod (exponent, 2)
             if r == 0:  # x^(2q) = (x^q)^2
-                xq = RingElement.__pow__(self, q)
+                xq = FieldElement.__pow__(self, q)
                 return xq.abs().square()
             else:
-                return RingElement.__pow__(self, exponent)
+                return FieldElement.__pow__(self, exponent)
         return (self.log() * exponent).exp()
 
     def log(self, base='e'):

--- a/src/sage/rings/real_mpfr.pxd
+++ b/src/sage/rings/real_mpfr.pxd
@@ -3,7 +3,7 @@ from sage.libs.mpfr.types cimport mpfr_rnd_t, mpfr_t, mpfr_prec_t
 cimport sage.rings.abc
 cimport sage.structure.element
 
-cdef class RealNumber(sage.structure.element.RingElement)  # forward decl
+cdef class RealNumber(sage.structure.element.FieldElement)  # forward decl
 
 cdef class RealField_class(sage.rings.abc.RealField):
     cdef mpfr_prec_t _prec
@@ -14,7 +14,7 @@ cdef class RealField_class(sage.rings.abc.RealField):
         """Return a new real number with parent ``self``."""
         return <RealNumber>(RealNumber.__new__(RealNumber, self))
 
-cdef class RealNumber(sage.structure.element.RingElement):
+cdef class RealNumber(sage.structure.element.FieldElement):
     cdef mpfr_t value
     cdef inline RealNumber _new(self):
         """Return a new real number with same parent as ``self``."""

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -1341,7 +1341,7 @@ cdef class RealField_class(sage.rings.abc.RealField):
 
 cdef class RealLiteral(RealNumber)
 
-cdef class RealNumber(sage.structure.element.RingElement):
+cdef class RealNumber(sage.structure.element.FieldElement):
     """
     A floating point approximation to a real number using any specified
     precision. Answers derived from calculations with such


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

I changed the base class of:
- `sage.rings.complex_arb.ComplexBall`
- `sage.rings.real_arb.RealBall`
- `sage.rings.real_mpfi.RealIntervalFieldElement`
- `sage.rings.real_mpfr.RealNumber`
from `sage.structure.element.RingElement` to `sage.structure.element.FieldElement`, 
since:
1. I think they should be considered as elements of (real/complex) fields (although being inexact);
2. Their parents are subclasses of `sage.rings.ring.Field`;
3. Other inexact numbers e.g. `sage.rings.real_double.RealDoubleElement`, `sage.rings.complex_mpfr.ComplexNumber`, etc are also subclasses `sage.structure.element.FieldElement`.

[I posed on Zulip](https://sagemath.zulipchat.com/#narrow/channel/271069-help---support/topic/Why.20isn't.20a.20RealNumber.20a.20FieldElement.3F/near/566733593) yesterday and this PR shall complete that.

I am new to the SageMath codebase so I might have made some mistakes or wrong assumptions (like, the reason why these classes cannot be subcalsses of `FieldElement`?). 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes. (I do not know how to, and the change seems minor unless someone explicitly relies on  something like `not isinstance(RR(1), FieldElement)`)
- [x] I have updated the documentation and checked the documentation preview.




