### PR TITLE
on --disable-doc, prevent meson from scanning doc directories

### DIFF
--- a/build/bin/sage-build-env-config.in
+++ b/build/bin/sage-build-env-config.in
@@ -41,6 +41,9 @@ export SAGE_MPFR_PREFIX="@SAGE_MPFR_PREFIX@"
 
 export SAGE_MPC_PREFIX="@SAGE_MPC_PREFIX@"
 
+# empty if --disable-doc was passed
+export SAGE_DOCS="@SAGE_DOCS@"
+
 # Location of system crti.o, in case we build our own gcc
 export SAGE_CRTI_DIR="@SAGE_CRTI_DIR@"
 

--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -18,11 +18,18 @@ fi
 ## As a special exception, we feed SAGE_PKGS.
 ## They are needed by src/sage/misc/package.py.  See github issue #28815 for planned changes to this.
 
+if [ "$SAGE_DOCS" = '' ]; then
+   SAGE_BUILD_DOCS="False"
+else
+   SAGE_BUILD_DOCS="True"
+fi
+
 export SAGE_PKGS="$SAGE_ROOT"/build/pkgs
 export SAGE_ROOT=/doesnotexist
 export SAGE_SRC=/doesnotexist
 export SAGE_SRC_ROOT=/doesnotexist
 export SAGE_DOC_SRC=/doesnotexist
+export SAGE_DOCS=/doesnotexist
 
 # We also poison all directories below SAGE_LOCAL
 # except for SAGE_SPKG_SCRIPTS, which is needed by sage-dist-helpers
@@ -47,7 +54,8 @@ if [ "$SAGE_EDITABLE" = yes ]; then
     sdh_pip_editable_install . \
         --config-settings=build-dir="build/sage-distro" \
         --config-settings=setup-args="--native-file=$SAGE_PKGS/../platform/meson/sage-configure-native-file.ini" \
-        --config-settings=setup-args="-DSAGE_LOCAL=$SAGE_LOCAL"
+        --config-settings=setup-args="-DSAGE_LOCAL=$SAGE_LOCAL" \
+        --config-settings=setup-args="-Dbuild-docs=$SAGE_BUILD_DOCS"
 
     if [ "$SAGE_WHEELS" = yes ]; then
         # Additionally build a wheel (for use in other venvs)
@@ -63,7 +71,9 @@ else
     (cd "$SITEPACKAGESDIR" && rm -f sagemath-standard.egg-link)
     # Use --no-build-isolation to avoid rebuilds because of dependencies:
     # Compiling sage/interfaces/sagespawn.pyx because it depends on /private/var/folders/38/wnh4gf1552g_crsjnv2vmmww0000gp/T/pip-build-env-609n5985/overlay/lib/python3.10/site-packages/Cython/Includes/posix/unistd.pxd
-    sdh_pip_install --no-build-isolation . --config-setting=build-dir="build/sage-distro" --config-setting=setup-args="-DSAGE_LOCAL=$SAGE_LOCAL"
+    sdh_pip_install --no-build-isolation . --config-setting=build-dir="build/sage-distro" \
+        --config-setting=setup-args="-DSAGE_LOCAL=$SAGE_LOCAL" \
+        --config-setting=setup-args="-Dbuild-docs=$SAGE_BUILD_DOCS"
 fi
 
 # Remove (potentially invalid) star import caches.


### PR DESCRIPTION
sagelib's meson build already has an option to disable (very slow) scanning of doc directories;
here we connect this option to `./configure --disable-doc`

To test, use `./configure --disable-doc` and witness a speed-up in the beginning of sagelib build.
Namely,
```
[sagelib-10.9.beta2] [spkg-install]   Generating targets:   0%|          | 0/1681 eta ?
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  10%|▉         | 162/1681 eta 00:00
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  23%|██▎       | 386/1681 eta 00:00
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  42%|████▏     | 702/1681 eta 00:00
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  84%|████████▍ | 1412/1681 eta 00:00
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  84%|████████▍ | 1412/1681 eta 00:00
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  89%|████████▉ | 1494/1681 eta 00:04
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  89%|████████▉ | 1495/1681 eta 00:04
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  89%|████████▉ | 1495/1681 eta 00:04
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  91%|█████████ | 1528/1681 eta 00:09
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  91%|█████████ | 1529/1681 eta 00:10
[...]
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  96%|█████████▌| 1617/1681 eta 02:27
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  96%|█████████▋| 1618/1681 eta 02:21
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  98%|█████████▊| 1646/1681 eta 00:39
[sagelib-10.9.beta2] [spkg-install]   Generating targets:  99%|█████████▉| 1666/1681 eta 00:12
[sagelib-10.9.beta2] [spkg-install]   Generating targets: 100%|█████████▉| 1680/1681 eta 00:00
```
should be much faster (and also the number of targets is smaller, about 1400)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


