### PR TITLE
add meson_python to PYTHON_TOOLCHAIN

### DIFF
--- a/build/make/Makefile.in
+++ b/build/make/Makefile.in
@@ -310,7 +310,7 @@ all-toolchain: base-toolchain
 
 # Shorthand for a list of packages sufficient for building and installing
 # typical Python packages from source. Wheel packages only need pip.
-PYTHON_TOOLCHAIN = setuptools pip setuptools_scm wheel flit_core hatchling python_build
+PYTHON_TOOLCHAIN = setuptools pip setuptools_scm wheel flit_core hatchling python_build meson_python
 
 # Issue #32056: Avoid installed setuptools leaking into the build of python3 by uninstalling it.
 # It will have to be reinstalled anyway because of its dependency on $(PYTHON).

--- a/build/pkgs/contourpy/dependencies
+++ b/build/pkgs/contourpy/dependencies
@@ -1,4 +1,4 @@
- numpy | $(PYTHON_TOOLCHAIN) pybind11 meson_python $(PYTHON)
+ numpy | $(PYTHON_TOOLCHAIN) pybind11 $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/cysignals/dependencies
+++ b/build/pkgs/cysignals/dependencies
@@ -1,4 +1,4 @@
- cython | $(PYTHON_TOOLCHAIN) meson_python $(PYTHON)
+ cython | $(PYTHON_TOOLCHAIN) $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/meson/dependencies
+++ b/build/pkgs/meson/dependencies
@@ -1,4 +1,4 @@
- | $(PYTHON_TOOLCHAIN) $(PYTHON)
+ | setuptools pip setuptools_scm wheel flit_core hatchling python_build $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/meson_python/dependencies
+++ b/build/pkgs/meson_python/dependencies
@@ -1,4 +1,4 @@
- meson pyproject_metadata ninja_build patchelf | $(PYTHON_TOOLCHAIN) $(PYTHON)
+meson pyproject_metadata ninja_build patchelf packaging | $(PYTHON) pip wheel flit_core python_build
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/numpy/dependencies
+++ b/build/pkgs/numpy/dependencies
@@ -1,4 +1,4 @@
-$(BLAS) gfortran | $(PYTHON_TOOLCHAIN) pkgconfig cython meson_python $(PYTHON)
+$(BLAS) gfortran | $(PYTHON_TOOLCHAIN) pkgconfig cython $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/sagelib/dependencies
+++ b/build/pkgs/sagelib/dependencies
@@ -1,4 +1,4 @@
-FORCE $(SCRIPTS) $(BLAS) brial cliquer cypari cysignals cython ecl eclib ecm flint libgd gap givaro glpk gmpy2 gsl iml importlib_metadata importlib_resources jupyter_core lcalc lrcalc_python libbraiding libhomfly libpng linbox m4ri m4rie memory_allocator mpc mpfi mpfr $(MP_LIBRARY) ntl numpy pari pip pkgconfig planarity ppl pplpy primesieve primecount primecountpy $(PYTHON) requests rw singular symmetrica typing_extensions $(PCFILES) | $(PYTHON_TOOLCHAIN) meson_python $(PYTHON) pythran
+FORCE $(SCRIPTS) $(BLAS) brial cliquer cypari cysignals cython ecl eclib ecm flint libgd gap givaro glpk gmpy2 gsl iml importlib_metadata importlib_resources jupyter_core lcalc lrcalc_python libbraiding libhomfly libpng linbox m4ri m4rie memory_allocator mpc mpfi mpfr $(MP_LIBRARY) ntl numpy pari pip pkgconfig planarity ppl pplpy primesieve primecount primecountpy $(PYTHON) requests rw singular symmetrica typing_extensions $(PCFILES) | $(PYTHON_TOOLCHAIN) $(PYTHON) pythran
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/scipy/dependencies
+++ b/build/pkgs/scipy/dependencies
@@ -1,4 +1,4 @@
- $(BLAS) gfortran numpy pybind11 cython pythran | $(PYTHON_TOOLCHAIN) meson_python $(PYTHON)
+ $(BLAS) gfortran numpy pybind11 cython pythran | $(PYTHON_TOOLCHAIN) $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
several packages miss `meson_python` in their deps (see e.g. https://github.com/sagemath/sage/pull/41409#issuecomment-3727915483), so it's more logical to put it into `PYTHON_TOOLCHAIN`


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


