### PR TITLE
Remove unnecessary _zero_word field in matrix_gf2e_dense

### DIFF
--- a/src/sage/matrix/matrix_gf2e_dense.pxd
+++ b/src/sage/matrix/matrix_gf2e_dense.pxd
@@ -7,7 +7,6 @@ cdef class Matrix_gf2e_dense(Matrix_dense):
     cdef mzed_t *_entries
     cdef object _one
     cdef object _zero
-    cdef m4ri_word _zero_word  # m4ri_word representation of _zero
 
     cpdef Matrix_gf2e_dense _multiply_newton_john(Matrix_gf2e_dense self, Matrix_gf2e_dense right)
     cpdef Matrix_gf2e_dense _multiply_karatsuba(Matrix_gf2e_dense self, Matrix_gf2e_dense right)

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -188,9 +188,8 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
                 _m4rie_finite_field_cache[poly] = FF
 
         # cache elements
-        self._zero = self._base_ring(0)
-        self._zero_word = poly_to_word(self._zero)
-        self._one = self._base_ring(1)
+        self._zero = self._base_ring.zero()
+        self._one = self._base_ring.one()
 
     def __dealloc__(self):
         """
@@ -350,7 +349,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
             [0 1]
             [1 0]
         """
-        return mzed_read_elem(self._entries, i, j) == self._zero_word
+        return mzed_read_elem(self._entries, i, j) == 0
 
     cpdef _add_(self, right):
         r"""


### PR DESCRIPTION
Plus use `.zero()`/`.one()` instead of `(0)`/`(1)`.

it's faster in all cases

```
sage: F = GF(2)
sage: %timeit F.zero()
106 ns ± 5.28 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
sage: %timeit F(0r)
221 ns ± 19.1 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
sage: F = GF(4)
sage: %timeit F.zero()
112 ns ± 5.57 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
sage: F = GF(2^200)
sage: %timeit F(0r)
475 ns ± 39.9 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
sage: %timeit F.zero()
106 ns ± 5.19 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.




