### PR TITLE
Refactor generic ideal method + avoid computing principal generator of ideal of PolynomialRing on construction

### DIFF
--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -1887,11 +1887,8 @@ def __GCD_sequence(v, **kwargs):
     """
     if len(v) == 0:
         return ZZ.zero()
-    if hasattr(v, 'universe'):
-        g = v.universe()(0)
-    else:
-        g = ZZ.zero()
-    for vi in v:
+    g = v[0]
+    for vi in v[1:]:
         g = vi.gcd(g, **kwargs)
     return g
 

--- a/src/sage/categories/rings.py
+++ b/src/sage/categories/rings.py
@@ -1000,7 +1000,7 @@ class Rings(CategoryWithAxiom):
             from sage.rings.integer import Integer
             tester.assertIsInstance(characteristic, Integer)
 
-        def ideal(self, *args, **kwds):
+        def ideal(self, *args, coerce=True, ideal_class=None, **kwds):
             """
             Create an ideal of this ring.
 
@@ -1096,15 +1096,9 @@ class Rings(CategoryWithAxiom):
                 sage: type(ZZ.ideal((), ideal_class=CustomIdealClass))
                 <class '...CustomIdealClass'>
             """
-            if 'coerce' in kwds:
-                coerce = kwds['coerce']
-                del kwds['coerce']
-            else:
-                coerce = True
-
             from sage.rings.ideal import Ideal_generic
             if not args:
-                gens = [self(0)]
+                gens = []
             else:
                 gens = args
                 while isinstance(gens, (list, tuple, GeneratorType)) and len(gens) == 1:
@@ -1132,29 +1126,11 @@ class Rings(CategoryWithAxiom):
             elif coerce:
                 gens = [self(g) for g in gens]
 
-            from sage.categories.principal_ideal_domains import PrincipalIdealDomains
-            if self in PrincipalIdealDomains():
-                # Use GCD algorithm to obtain a principal ideal
-                g = gens[0]
-                if len(gens) == 1:
-                    try:
-                        # note: we set g = gcd(g, g) to "canonicalize" the generator:
-                        # make polynomials monic, etc.
-                        g = g.gcd(g)
-                    except (AttributeError, NotImplementedError, IndexError):
-                        pass
-                else:
-                    for h in gens[1:]:
-                        g = g.gcd(h)
-                gens = [g]
-            if 'ideal_class' in kwds:
-                C = kwds['ideal_class']
-                del kwds['ideal_class']
-            else:
-                C = self._ideal_class_(len(gens))
+            if ideal_class is None:
+                ideal_class = self._ideal_class_(len(gens))
             if len(gens) == 1 and isinstance(gens[0], (list, tuple)):
                 gens = gens[0]
-            return C(self, gens, **kwds)
+            return ideal_class(self, gens, **kwds)
 
         # Quotient rings
         def quotient(self, I, names=None, **kwds):

--- a/src/sage/categories/rings.py
+++ b/src/sage/categories/rings.py
@@ -1132,19 +1132,18 @@ class Rings(CategoryWithAxiom):
             if getattr(self, 'eagerly_reduce_ideal_gens_by_gcd', True):
                 from sage.categories.principal_ideal_domains import PrincipalIdealDomains
                 if self in PrincipalIdealDomains():
+                    from sage.arith.misc import gcd
                     # Use GCD algorithm to obtain a principal ideal
-                    g = gens[0]
                     if len(gens) == 1:
                         try:
                             # note: we set g = gcd(g, g) to "canonicalize" the generator:
                             # make polynomials monic, etc.
-                            g = g.gcd(g)
+                            g = gens[0]
+                            gens = g.gcd(g),
                         except (AttributeError, NotImplementedError, IndexError):
                             pass
                     else:
-                        for h in gens[1:]:
-                            g = g.gcd(h)
-                    gens = [g]
+                        gens = gcd(gens),
 
             if ideal_class is None:
                 ideal_class = self._ideal_class_(len(gens))

--- a/src/sage/categories/rings.py
+++ b/src/sage/categories/rings.py
@@ -1126,6 +1126,26 @@ class Rings(CategoryWithAxiom):
             elif coerce:
                 gens = [self(g) for g in gens]
 
+            # Parent classes may define eagerly_reduce_gens_by_gcd = False to opt out of this
+            # either because gcd() is expensive, checking whether self is PID is expensive,
+            # or because ideal_class constructor already have a more efficient gcd()
+            if getattr(self, 'eagerly_reduce_ideal_gens_by_gcd', True):
+                from sage.categories.principal_ideal_domains import PrincipalIdealDomains
+                if self in PrincipalIdealDomains():
+                    # Use GCD algorithm to obtain a principal ideal
+                    g = gens[0]
+                    if len(gens) == 1:
+                        try:
+                            # note: we set g = gcd(g, g) to "canonicalize" the generator:
+                            # make polynomials monic, etc.
+                            g = g.gcd(g)
+                        except (AttributeError, NotImplementedError, IndexError):
+                            pass
+                    else:
+                        for h in gens[1:]:
+                            g = g.gcd(h)
+                    gens = [g]
+
             if ideal_class is None:
                 ideal_class = self._ideal_class_(len(gens))
             if len(gens) == 1 and isinstance(gens[0], (list, tuple)):

--- a/src/sage/rings/ideal.py
+++ b/src/sage/rings/ideal.py
@@ -28,6 +28,7 @@ a right ideal, and ``R*[a,b,...]*R`` creates a two-sided ideal.
 
 from types import GeneratorType
 
+from sage.misc.cachefunc import cached_method
 from sage.categories.rings import Rings
 from sage.categories.fields import Fields
 from sage.structure.element import MonoidElement
@@ -702,6 +703,7 @@ class Ideal_generic(MonoidElement):
         """
         return len(self.__gens)
 
+    @cached_method
     def gens_reduced(self):
         r"""
         Same as :meth:`gens()` for this ideal, since there is currently no
@@ -715,6 +717,11 @@ class Ideal_generic(MonoidElement):
             sage: ZZ.ideal(5).gens_reduced()
             (5,)
         """
+        if not getattr(self.__ring, 'eagerly_reduce_ideal_gens_by_gcd', True):
+            from sage.categories.principal_ideal_domains import PrincipalIdealDomains
+            if self.__ring in PrincipalIdealDomains():
+                from sage.arith.misc import gcd
+                return gcd(self.gens()),
         return self.gens()
 
     def is_maximal(self):

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -241,6 +241,7 @@ class PolynomialRing_generic(Ring):
     """
     Univariate polynomial ring over a ring.
     """
+    eagerly_reduce_ideal_gens_by_gcd = False
 
     def __init__(self, base_ring, name=None, sparse=False, implementation=None,
                  element_class=None, category=None):


### PR DESCRIPTION
- use keyword arguments.
- delete the special case logic where naive `.gcd()` is ran for univariate polynomial ring.

Reason:

There's a doctest

```
K.<a> = QuadraticField(4569)
j = 46969655/32768
E = EllipticCurve(j=K(j))
C = E.isogeny_class()
```

that now takes very long to run. With this change, the runtime is cut in half. (Finding a single generator for a number field ideal is usually harder than finding a HNF basis of the ideal, and the latter is all pari needs to do relevant computations.)

**Note**: this is kind of a breaking change, in that `ZZ.ideal(1, 2, 3).gens()` will now return `(1, 2, 3)`. I think it is preferable (users who want reduced generators can run `gens_reduced`).

Indeed, some tests break https://github.com/sagemath/sage/actions/runs/20863923668/job/59950182623 --- but ideally they should be refactored to avoid relying specifically on this behavior.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


