### PR TITLE
Clarify deprecation message for krull_dimension

### DIFF
--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -939,7 +939,7 @@ def krull_dimension(x):
         sage: U.krull_dimension()
         4
     """
-    deprecation(39311, "please use the krull_dimension method")
+    deprecation(39311, "This method is deprecated; use ``krull_dimension()`` instead.")
     return x.krull_dimension()
 
 

--- a/src/sage/schemes/elliptic_curves/gp_simon.py
+++ b/src/sage/schemes/elliptic_curves/gp_simon.py
@@ -109,7 +109,7 @@ def simon_two_descent(E, verbose=0, lim1=None, lim3=None, limtriv=None,
             K_pari = pari.bnfinit(K.polynomial(), 1)
         known_points = [P.change_ring(to_K) for P in known_points]
     else:
-        deprecation(38461, "please use the 2-descent algorithm over QQ inside pari")
+        deprecation(38461, "This method is deprecated; use the 2-descent algorithm over QQ in PARI instead.")
         from_K = lambda x: x
 
     # The block below mimics the defaults in Simon's scripts.


### PR DESCRIPTION
 This PR improves the clarity of the deprecation warning for ``krull_dimension``.
Previously, the warning message ("please use the krull_dimension method") was
ambiguous and did not explicitly tell users which API should be used instead.
The message is now updated to clearly state the recommended replacement,
``x.krull_dimension()``, making the guidance unambiguous and consistent with the
actual Sage API. No functional code, algorithms, or numerical behavior are
changed; this is a documentation/message-only update that has no backward
compatibility impact and is safe to merge.
