### PR TITLE
Fix test failures with scipy 1.17

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -367,7 +367,7 @@ cdef class Matrix(Matrix1):
             sage: A.solve_left(b)                                                       # needs scipy
             Traceback (most recent call last):
             ...
-            LinAlgError: Matrix is singular.
+            LinAlgError: ...singular...
 
         The vector of constants needs the correct degree::
 
@@ -762,7 +762,7 @@ cdef class Matrix(Matrix1):
             sage: A.solve_right(b)
             Traceback (most recent call last):
             ...
-            LinAlgError: Matrix is singular.
+            LinAlgError: ...singular...
 
         The vector of constants needs the correct degree.  ::
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -367,7 +367,7 @@ cdef class Matrix(Matrix1):
             sage: A.solve_left(b)                                                       # needs scipy
             Traceback (most recent call last):
             ...
-            LinAlgError: ...singular...
+            LinAlgError: ...singular.
 
         The vector of constants needs the correct degree::
 
@@ -762,7 +762,7 @@ cdef class Matrix(Matrix1):
             sage: A.solve_right(b)
             Traceback (most recent call last):
             ...
-            LinAlgError: ...singular...
+            LinAlgError: ...singular.
 
         The vector of constants needs the correct degree.  ::
 


### PR DESCRIPTION
Fixes two minor failures caused by a differennt error message
```
**********************************************************************
File "/usr/lib/python3.14/site-packages/sage/matrix/matrix2.pyx", line 367, in sage.matrix.matrix2.Matrix.solve_left
Failed example:
    A.solve_left(b)                                                       # needs scipy
Expected:
    Traceback (most recent call last):
    ...
    LinAlgError: Matrix is singular.
Got:
    <BLANKLINE>
    Traceback (most recent call last):
      File "sage/matrix/matrix2.pyx", line 422, in sage.matrix.matrix2.Matrix.solve_left
        return self.transpose().solve_right(B, check=check, extend=extend)
      File "sage/matrix/matrix2.pyx", line 970, in sage.matrix.matrix2.Matrix.solve_right
        X = self._solve_right_nonsingular_square(C, check_rank=True)
      File "sage/matrix/matrix_double_dense.pyx", line 1729, in sage.matrix.matrix_double_dense.Matrix_double_dense._solve_right_nonsingular_square
        X._matrix_numpy = scipy.linalg.solve(self._matrix_numpy, B.numpy())
      File "/usr/lib/python3.14/site-packages/scipy/linalg/_basic.py", line 287, in solve
        _format_emit_errors_warnings(err_lst)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
      File "/usr/lib/python3.14/site-packages/scipy/linalg/_basic.py", line 81, in _format_emit_errors_warnings
        raise LinAlgError(
            f"A singular matrix detected: slice(s) {singular} are singular."
        )
    numpy.linalg.LinAlgError: A singular matrix detected: slice(s) [0] are singular.
    <BLANKLINE>
    During handling of the above exception, another exception occurred:
    <BLANKLINE>
    Traceback (most recent call last):
      File "/usr/lib/python3.14/site-packages/sage/doctest/forker.py", line 734, in _run
        self.compile_and_execute(example, compiler, test.globs)
        ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.14/site-packages/sage/doctest/forker.py", line 1158, in compile_and_execute
        exec(compiled, globs)
        ~~~~^^^^^^^^^^^^^^^^^
      File "<doctest sage.matrix.matrix2.Matrix.solve_left[45]>", line 1, in <module>
        A.solve_left(b)                                                       # needs scipy
        ~~~~~~~~~~~~^^^
      File "sage/matrix/matrix2.pyx", line 424, in sage.matrix.matrix2.Matrix.solve_left
        raise e.__class__(str(e).replace('row', 'column'))
    numpy.linalg.LinAlgError: A singular matrix detected: slice(s) [0] are singular.
**********************************************************************
```

