### PR TITLE
 Ensuring PALP fails consistently without returning misleading data

### DIFF
--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -3718,43 +3718,42 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             M(1)
             in 1-d lattice M
         """
-        if not hasattr(self, "_points"):
-            M = self.lattice()
-            nv = self.n_vertices()
-            points = self._vertices
-            if self.dim() == 1:
-                v = points[1] - points[0]
-                l_gcd = gcd(v)
-                if l_gcd > 1:
-                    v = M(v.base_extend(QQ) / l_gcd)
-                    points = list(points)
-                    current = points[0]
-                    for i in range(l_gcd - 1):
-                        current += v
-                        current.set_immutable()
-                        points.append(current)
-            if self.dim() > 1:
-                try:
-                    result = self. poly_x("p", reduce_dimension=True)
-                    if self.dim() == self.lattice_dim():
-                        points = read_palp_point_collection(StringIO(result), M)
-                    else:
-                        m = self._embed(read_palp_matrix(result))
-                        if m.ncols() > nv:
-                            points = list(points)
-                            for j in range(nv, m.ncols()):
-                                current = M.element_class(
-                                    M, [m[i, j] for i in range(M. rank())])
-                                current. set_immutable()
-                                points.append(current)
-                except (ValueError, RuntimeError):
-                    # PALP failed - re-raise to avoid caching wrong data
-                    raise
-            # Convert to PointCollection if needed and cache
-            if len(points) > nv:
-                self._points = PointCollection(points, M)
+        if hasattr(self, "_points"):
+            if args or kwds:
+                return self._points(*args, **kwds)
             else:
-                self._points = points
+                return self._points
+        M = self.lattice()
+        nv = self.n_vertices()
+        points = self._vertices
+        if self.dim() == 1:
+            v = points[1] - points[0]
+            l_gcd = gcd(v)
+            if l_gcd > 1:
+                v = M(v.base_extend(QQ) / l_gcd)
+                points = list(points)
+                current = points[0]
+                for i in range(l_gcd - 1):
+                    current += v
+                    current.set_immutable()
+                    points.append(current)
+        if self.dim() > 1:
+            result = self. poly_x("p", reduce_dimension=True)
+            if self.dim() == self.lattice_dim():
+                points = read_palp_point_collection(StringIO(result), M)
+            else:
+                m = self._embed(read_palp_matrix(result))
+                if m.ncols() > nv:
+                    points = list(points)
+                    for j in range(nv, m.ncols()):
+                        current = M.element_class(
+                            M, [m[i, j] for i in range(M. rank())])
+                        current. set_immutable()
+                        points.append(current)
+        if len(points) > nv:
+            self._points = PointCollection(points, M)
+        else:
+            self._points = points
         if args or kwds:
             return self._points(*args, **kwds)
         else:

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -3721,7 +3721,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         if not hasattr(self, "_points"):
             M = self.lattice()
             nv = self.n_vertices()
-            self._points = points = self._vertices
+            points = self._vertices
             if self.dim() == 1:
                 v = points[1] - points[0]
                 l_gcd = gcd(v)
@@ -3734,20 +3734,27 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
                         current.set_immutable()
                         points.append(current)
             if self.dim() > 1:
-                result = self.poly_x("p", reduce_dimension=True)
-                if self.dim() == self.lattice_dim():
-                    points = read_palp_point_collection(StringIO(result), M)
-                else:
-                    m = self._embed(read_palp_matrix(result))
-                    if m.ncols() > nv:
-                        points = list(points)
-                        for j in range(nv, m.ncols()):
-                            current = M.element_class(
-                                M, [m[i, j] for i in range(M.rank())])
-                            current.set_immutable()
-                            points.append(current)
+                try:
+                    result = self. poly_x("p", reduce_dimension=True)
+                    if self.dim() == self.lattice_dim():
+                        points = read_palp_point_collection(StringIO(result), M)
+                    else:
+                        m = self._embed(read_palp_matrix(result))
+                        if m.ncols() > nv:
+                            points = list(points)
+                            for j in range(nv, m.ncols()):
+                                current = M.element_class(
+                                    M, [m[i, j] for i in range(M. rank())])
+                                current. set_immutable()
+                                points.append(current)
+                except (ValueError, RuntimeError):
+                    # PALP failed - re-raise to avoid caching wrong data
+                    raise
+            # Convert to PointCollection if needed and cache
             if len(points) > nv:
                 self._points = PointCollection(points, M)
+            else:
+                self._points = points
         if args or kwds:
             return self._points(*args, **kwds)
         else:

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -3719,7 +3719,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             in 1-d lattice M
 
         Regression test for a 6-dimensional polytope that previously failed
-        due to PALP limitations (: issue:`#41400`)::
+        due to PALP limitations (:issue:`41400`)::
 
             sage: V = [(-1, -1, 0, 0, 0, 0),
             ....:      (-1, 0, 0, 0, 0, 0),

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -3717,6 +3717,31 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             sage: p.points()
             M(1)
             in 1-d lattice M
+
+        Regression test for a 6-dimensional polytope that previously failed
+        due to PALP limitations (: issue:`#41400`)::
+
+            sage: V = [(-1, -1, 0, 0, 0, 0),
+            ....:      (-1, 0, 0, 0, 0, 0),
+            ....:      (-1, -1, -1, 0, 0, 0),
+            ....:      (-1, -1, -1, -1, 0, 0),
+            ....:      (-1, -1, -1, 0, -1, 0),
+            ....:      (-1, -1, -1, -1, -1, 0),
+            ....:      (-1, -1, -1, -1, -1, -1),
+            ....:      (-1, -1, -1, 0, -1, -1),
+            ....:      (0, 0, 0, 1, 0, 0),
+            ....:      (0, 1, 0, 0, 0, 0),
+            ....:      (1, 0, 0, 0, 0, 0),
+            ....:      (0, 0, 1, 0, 0, 0),
+            ....:      (0, 0, 0, 0, 1, 0),
+            ....:      (0, 0, 0, 0, 0, 1)]
+            sage: Q = LatticePolytope(V)
+            sage: Q.points()  # needs palp
+            Traceback (most recent call last):
+            ...
+            RuntimeError: Error executing ...
+            Output:
+            ...Transpose_PM failed...
         """
         if hasattr(self, "_points"):
             if args or kwds:
@@ -3738,7 +3763,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
                     current.set_immutable()
                     points.append(current)
         if self.dim() > 1:
-            result = self. poly_x("p", reduce_dimension=True)
+            result = self.poly_x("p", reduce_dimension=True)
             if self.dim() == self.lattice_dim():
                 points = read_palp_point_collection(StringIO(result), M)
             else:
@@ -3747,8 +3772,8 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
                     points = list(points)
                     for j in range(nv, m.ncols()):
                         current = M.element_class(
-                            M, [m[i, j] for i in range(M. rank())])
-                        current. set_immutable()
+                            M, [m[i, j] for i in range(M.rank())])
+                        current.set_immutable()
                         points.append(current)
         if len(points) > nv:
             self._points = PointCollection(points, M)


### PR DESCRIPTION
### Description

it addresses issue https://github.com/sagemath/sage/issues/41400
where PALP fails and in the first call for n_points it fails (good)
second time it returns the number of vertices (wrong)
Changes

- delayed the assignment of self._points
- added try catch, to make behavior more consistent
- added doctest for related issue
- ---

### tests

- passed all related tests
- recreated the test from addressed issue and it worked