### PR TITLE
Fix matrix construction over GCAlgebra

### DIFF
--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -1321,6 +1321,26 @@ class GCAlgebra(UniqueRepresentation, QuotientRing_nc):
             ...
             NotImplementedError: homomorphisms of graded commutative algebras
             have only been implemented when the base rings are the same
+
+        Fixed a bug where creating matrices with graded commutative algebra
+        elements would fail. The system now correctly handles
+        how these elements relate to other structures instead of throwing an error(:issue:41434)::
+
+            sage: R.<dx> = GradedCommutativeAlgebra(QQ)
+            sage: matrix([dx])
+            [dx]
+            sage: matrix([[dx, dx], [dx, dx]])
+            [dx dx]
+            [dx dx]
+
+        Similarly, this works with multiple generators and different base rings::
+
+            sage: S.<a,b> = GradedCommutativeAlgebra(GF(5), degrees=(1,2))
+            sage: matrix([a, b])
+            [a b]
+            sage: matrix([[a*b], [b]])
+            [a*b]
+            [  b]
         """
         if not isinstance(B, GCAlgebra):
             return super()._Hom_(B, category)

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -1322,6 +1322,8 @@ class GCAlgebra(UniqueRepresentation, QuotientRing_nc):
             NotImplementedError: homomorphisms of graded commutative algebras
             have only been implemented when the base rings are the same
         """
+        if not isinstance(B, GCAlgebra):
+            return super()._Hom_(B, category)
         R = self.base_ring()
         # The base rings need to be checked before the categories, or
         # else the function sage.categories.homset.Hom catches the

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -1322,7 +1322,7 @@ class GCAlgebra(UniqueRepresentation, QuotientRing_nc):
             NotImplementedError: homomorphisms of graded commutative algebras
             have only been implemented when the base rings are the same
 
-        Ensure this method does not fail when constructing a matrix
+        Test that it's possible to construct a matrix
         with GCAlgebra elements.when B is not a GCAlgebra
         the call is handed to the parent class (:issue:41434)::
 

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -1322,9 +1322,9 @@ class GCAlgebra(UniqueRepresentation, QuotientRing_nc):
             NotImplementedError: homomorphisms of graded commutative algebras
             have only been implemented when the base rings are the same
 
-        Test that it's possible to construct a matrix
-        with GCAlgebra elements.when B is not a GCAlgebra
-        the call is handed to the parent class (:issue:41434)::
+        It is possible to construct a matrix with GCAlgebra elements.
+        when B is not a GCAlgebra the call is handed to the parent class
+        (:issue:41434)::
 
             sage: R.<dx> = GradedCommutativeAlgebra(QQ)
             sage: matrix([dx])

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -1323,8 +1323,8 @@ class GCAlgebra(UniqueRepresentation, QuotientRing_nc):
             have only been implemented when the base rings are the same
 
         It is possible to construct a matrix with GCAlgebra elements.
-        when B is not a GCAlgebra the call is handed to the parent class
-        (:issue:41434)::
+        When B is not a GCAlgebra the call is handed to the parent class
+        (:issue:`41434`)::
 
             sage: R.<dx> = GradedCommutativeAlgebra(QQ)
             sage: matrix([dx])

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -1322,9 +1322,9 @@ class GCAlgebra(UniqueRepresentation, QuotientRing_nc):
             NotImplementedError: homomorphisms of graded commutative algebras
             have only been implemented when the base rings are the same
 
-        Fixed a bug where creating matrices with graded commutative algebra
-        elements would fail. The system now correctly handles
-        how these elements relate to other structures instead of throwing an error(:issue:41434)::
+        Ensure this method does not fail when constructing a matrix
+        with GCAlgebra elements.when B is not a GCAlgebra
+        the call is handed to the parent class (:issue:41434)::
 
             sage: R.<dx> = GradedCommutativeAlgebra(QQ)
             sage: matrix([dx])


### PR DESCRIPTION
### Description
it addresses issue #41434 
when you compute the matrix-valued differential forms.
but fails when called because the `_Hom_` function was expecting GCAlgebra
but received a different type
### Changes
- add an if condition to make sure it receives GCAlgebra
- in case not receiving GCAlgebra, let the parent class handles it
-  Added doctests to cover matrix construction with GCAlgebra elements

### tests

- [x] passed all related tests
- [x] recreated the test from addressed issue and it worked