### PR TITLE
pass TERM="dumb" to expect

### DIFF
--- a/src/sage/interfaces/expect.py
+++ b/src/sage/interfaces/expect.py
@@ -500,7 +500,8 @@ If this all works, you can then make calls like:
         # See Issue #12221 and #13859.
         pexpect_env = dict(os.environ)
         pexpect_env.update(self._env)
-        pexpect_del_vars = ['TERM', 'COLUMNS']
+        pexpect_env['TERM'] = "dumb"
+        pexpect_del_vars = ['COLUMNS']
         for i in pexpect_del_vars:
             try:
                 del pexpect_env[i]


### PR DESCRIPTION
a problem with pexpect interfaces on macOS and Python 3.14 surfaced in #41438

Apparently the problem is that on macOS libedit (via a newish Python readline module) uses the default fancy macOS term settings if it is not given by `TERM` envvar.

This fixes #41438 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


