### PR TITLE
Add support for solve_right in case of finite dimensional ZZ

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -969,19 +969,12 @@ cdef class Matrix(Matrix1):
             raise TypeError("base ring must be an integral domain or a ring of integers mod n")
 
         C = B.column() if b_is_vec else B
-        pid = False
-        try:
-            pid = P.is_pid()
-        except Exception:
-            pid = False
-        if (
-            P.base_ring() is ZZ
-            and hasattr(P, "basis")
-            and not pid
-            and not extend
-        ):
-            X = self._solve_right_finite_z(C)
-            return X.column(0) if b_is_vec else X
+        from sage.rings.number_field.order import Order
+        if isinstance(P, Order) and not extend:
+            is_pid = P.is_maximal() and P.class_number() == 1
+            if not is_pid:
+                X = self._solve_right_finite_z(C)
+                return X.column(0) if b_is_vec else X
 
         if P not in _Fields and not extend:
             if self.rank() == self.ncols():

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -875,6 +875,34 @@ cdef class Matrix(Matrix1):
             sage: m = matrix.identity(ZZ, 250).stack(matrix.identity(ZZ, 250))*2
             sage: v = m.solve_right(vector(ZZ, [2]*500), extend=False)  # <1s
             sage: m._solve_right_hermite_form(matrix(ZZ, [[2]]*500))  # not tested (slow)
+
+        Test method to solve over ring of integers which is not a PID.
+        (:issue:`40410`)
+            sage: R = QQ[sqrt(-5)]
+            sage: O = R.ring_of_integers()
+            sage: a = matrix([[O(2)], [O(1+sqrt(-5))]])
+            sage: a.solve_right(a, extend=False)
+            [1]
+
+            sage: A = matrix(O, 2, 2, [1, sqrt(-5), 0, 1])
+            sage: b = vector(O, [1+sqrt(-5), 2])
+            sage: c = A.solve_right(b, extend=False); c
+            (-a + 1, 2)
+            sage: A * c == b
+            True
+
+            sage: B = matrix(O, 2, 1, [1+sqrt(-5), 2])
+            sage: X = A.solve_right(B, extend=False)
+            sage: X
+            [-a + 1]
+            [     2]
+
+            sage: A = matrix(O, 1, 1, [2])
+            sage: b = vector(O, [1])
+            sage: A.solve_right(b, extend=False)
+            Traceback (most recent call last):
+            ...
+            ValueError: matrix equation has no solutions
         """
         try:
             L = B.base_ring()
@@ -939,6 +967,7 @@ cdef class Matrix(Matrix1):
                     return (K ** self.ncols())(ret)
             raise TypeError("base ring must be an integral domain or a ring of integers mod n")
 
+        C = B.column() if b_is_vec else B
         pid = False
         try:
             pid = P.is_pid()
@@ -950,9 +979,8 @@ cdef class Matrix(Matrix1):
             and not pid
             and not extend
         ):
-            return self._solve_right_finite_z(B)
-
-        C = B.column() if b_is_vec else B
+            X = self._solve_right_finite_z(C)
+            return X.column(0) if b_is_vec else X
 
         if P not in _Fields and not extend:
             if self.rank() == self.ncols():
@@ -1017,7 +1045,7 @@ cdef class Matrix(Matrix1):
                 Bint[i*d:(i+1)*d, j] = coeffs
 
         try:
-            Xint = Aint.solve_right(Bint)
+            Xint = Aint.solve_right(Bint, extend=False)
         except ValueError:
             raise ValueError("matrix equation has no solutions")
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -1020,7 +1020,7 @@ cdef class Matrix(Matrix1):
         d = R.degree()
         nrows = self.nrows()
         ncols = self.ncols()
-        rhsCols = B.ncols()
+        rhs_ncols = B.ncols()
 
         basis = R.basis()
         basis_vec = vector(R, basis)
@@ -1029,6 +1029,7 @@ cdef class Matrix(Matrix1):
 
         Aint = matrix(ZZ, nrows * d, ncols * d)
 
+        # form the matrix to solve in integral domain, by expanding
         for i in range(nrows):
             row_start = i*d
             for j in range(ncols):
@@ -1037,10 +1038,11 @@ cdef class Matrix(Matrix1):
                 block = sum(coeffs[k] * mult_mat[k] for k in range(d))
                 Aint[row_start:row_start+d, col_start:col_start+d] = block
 
-        Bint = matrix(ZZ, nrows * d, rhsCols)
+        Bint = matrix(ZZ, nrows * d, rhs_ncols)
 
+        # need to map the right matrix, similar to left matrix
         for i in range(nrows):
-            for j in range(rhsCols):
+            for j in range(rhs_ncols):
                 coeffs = B[i, j].vector()
                 Bint[i*d:(i+1)*d, j] = coeffs
 
@@ -1051,6 +1053,7 @@ cdef class Matrix(Matrix1):
 
         sol_cols = []
 
+        # map the new solution to the older required form
         for j in range(Xint.ncols()):
             col = Xint.column(j)
             coeff_mat = matrix(ZZ, ncols, d, col)

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -969,6 +969,54 @@ cdef class Matrix(Matrix1):
                 X = self._solve_right_general(C, check=check)
 
         return X.column(0) if b_is_vec else X
+    
+    def _solve_right_finite_z(self, B):
+        from sage.matrix.constructor import matrix
+        from sage.rings.integer_ring import ZZ
+        from sage.modules.free_module_element import vector
+
+        R = self.base_ring()
+        d = R.degree()
+        nrows = self.nrows()
+        ncols = self.ncols()
+        rhsCols = B.ncols()
+
+        basis = R.basis()
+        basis_vec = vector(R, basis)
+
+        mult_mat = [b.matrix().transpose() for b in basis]
+
+        Aint = matrix(ZZ, nrows * d, ncols * d)
+
+        for i in range(nrows):
+            row_start = i*d
+            for j in range(ncols):
+                col_start = j*d
+                coeffs = self[i, j].vector()
+                block = sum(coeffs[k] * mult_mat[k] for k in range(d))
+                Aint[row_start:row_start+d, col_start:col_start+d] = block
+
+        Bint = matrix(ZZ, nrows * d, rhsCols)
+
+        for i in range(nrows):
+            for j in range(rhsCols):
+                coeffs = B[i, j].vector()
+                Bint[i*d:(i+1)*d, j] = coeffs
+
+        try:
+            Xint = Aint.solve_right(Bint)
+        except ValueError:
+            raise ValueError("matrix equation has no solutions")
+
+        sol_cols = []
+
+        for j in range(Xint.ncols()):
+            col = Xint.column(j)
+            coeff_mat = matrix(ZZ, ncols, d, col)
+            sol_cols.append(coeff_mat * basis_vec)
+
+        return matrix(sol_cols).transpose()
+        
 
     def _solve_right_nonsingular_square(self, B, check_rank=True):
         r"""

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -877,7 +877,8 @@ cdef class Matrix(Matrix1):
             sage: m._solve_right_hermite_form(matrix(ZZ, [[2]]*500))  # not tested (slow)
 
         Test method to solve over ring of integers which is not a PID.
-        (:issue:`40410`)
+        (:issue:`40410`)::
+
             sage: R = QQ[sqrt(-5)]
             sage: O = R.ring_of_integers()
             sage: a = matrix([[O(2)], [O(1+sqrt(-5))]])

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -969,7 +969,7 @@ cdef class Matrix(Matrix1):
                 X = self._solve_right_general(C, check=check)
 
         return X.column(0) if b_is_vec else X
-    
+
     def _solve_right_finite_z(self, B):
         from sage.matrix.constructor import matrix
         from sage.rings.integer_ring import ZZ
@@ -1016,7 +1016,6 @@ cdef class Matrix(Matrix1):
             sol_cols.append(coeff_mat * basis_vec)
 
         return matrix(sol_cols).transpose()
-        
 
     def _solve_right_nonsingular_square(self, B, check_rank=True):
         r"""

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -939,6 +939,19 @@ cdef class Matrix(Matrix1):
                     return (K ** self.ncols())(ret)
             raise TypeError("base ring must be an integral domain or a ring of integers mod n")
 
+        pid = False
+        try:
+            pid = P.is_pid()
+        except Exception:
+            pid = False
+        if (
+            P.base_ring() is ZZ
+            and hasattr(P, "basis")
+            and not pid
+            and not extend
+        ):
+            return self._solve_right_finite_z(B)
+
         C = B.column() if b_is_vec else B
 
         if P not in _Fields and not extend:

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -876,7 +876,7 @@ cdef class Matrix(Matrix1):
             sage: v = m.solve_right(vector(ZZ, [2]*500), extend=False)  # <1s
             sage: m._solve_right_hermite_form(matrix(ZZ, [[2]]*500))  # not tested (slow)
 
-        Test method to solve over ring of integers which is not a PID.
+        Test method to solve over ring of integers which is not a PID
         (:issue:`40410`)::
 
             sage: R = QQ[sqrt(-5)]
@@ -1011,7 +1011,7 @@ cdef class Matrix(Matrix1):
         from sage.modules.free_module_element import vector
 
         R = self.base_ring()
-        d = R.degree()
+        d = R.rank()
         nrows = self.nrows()
         ncols = self.ncols()
         rhs_ncols = B.ncols()


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fixes #40410 

```
sage: R = QQ[sqrt(-5)]
sage: O = R.ring_of_integers()
sage: a = matrix([[O(2)], [O(1+sqrt(-5))]])
sage: a.solve_right(a, extend=False)
```
Proposed Solution

This can be solved by expanding out the coefficients and solve the corresponding equation over ℤ, which is a PID.

Applied the approach given in the issue description. I have currently made the helper function which is to be used in the main solve_right function. A proper dispatch is to be added for the case of finite dimensional Z in the solve_right function.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


