### PR TITLE
Prevent "too many open file" errors from throwing an exception when doctesting

### DIFF
--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -310,7 +310,8 @@ class Timer:
                                             ZombieProcess)
                         try:
                             cputime += sum(Process(S.pid()).cpu_times()[0:2])
-                        except (ValueError, NoSuchProcess, ZombieProcess):
+                        except (OSError, ValueError, NoSuchProcess, ZombieProcess):
+                            # OSError: too many open files
                             # ValueError: invalid (e.g. negative) PID
                             # NoSuchProcess: it's gone
                             # ZombieProcess: PID refers to a zombie


### PR DESCRIPTION
Since the Python 3.14 update, running doctests with `-p 10` occasionally aborts due to "OSError: too many open files" errors when computing CPU time.

Make these non-fatal.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


