### PR TITLE
Fix BipartiteGraph construction from file with immutable=True and add doctest

### DIFF
--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -453,8 +453,6 @@ class BipartiteGraph(Graph):
         self.add_vertices = MethodType(Graph.add_vertices, self)
         self.add_edge = MethodType(Graph.add_edge, self)
         self.add_edges = MethodType(Graph.add_edges, self)
-        alist_file = True
-
         from sage.structure.element import Matrix
         if isinstance(data, BipartiteGraph):
             Graph.__init__(self, data, *args, **kwds)
@@ -463,19 +461,16 @@ class BipartiteGraph(Graph):
         elif isinstance(data, str):
             import os
             alist_file = os.path.exists(data)
-            kwds_for_init = kwds
-            if alist_file and immutable_request:
-                kwds_for_init = dict(kwds)
-                kwds_for_init["immutable"] = False
+            if alist_file:
+                self.load_afile(data, immutable=immutable_request)
+            else:
+                Graph.__init__(self, data, *args, **kwds)
 
-            Graph.__init__(self, data=None if alist_file else data, *args, **kwds_for_init)
+                # methods; initialize left and right attributes
+                self.left = set()
+                self.right = set()
 
-            # methods; initialize left and right attributes
-            self.left = set()
-            self.right = set()
-
-            # determine partitions and populate self.left and self.right
-            if not alist_file:
+                # determine partitions and populate self.left and self.right
                 if partition is not None:
                     left, right = set(partition[0]), set(partition[1])
 
@@ -587,17 +582,6 @@ class BipartiteGraph(Graph):
         del self.add_vertices
         del self.add_edge
         del self.add_edges
-
-        # post-processing
-        if isinstance(data, str):
-            if alist_file:
-                self.load_afile(data)
-                if immutable_request:
-                    from sage.graphs.base.static_sparse_backend import StaticSparseBackend
-                    self._backend = StaticSparseBackend(self,
-                                                        loops=self.allows_loops(),
-                                                        multiedges=self.allows_multiple_edges())
-                    self._immutable = True
 
         if hash_labels is None and hasattr(data, '_hash_labels'):
             hash_labels = data._hash_labels
@@ -1767,10 +1751,17 @@ class BipartiteGraph(Graph):
         for m in rec(G):
             yield from itertools.product(*[edges[frozenset(e)] for e in m])
 
-    def load_afile(self, fname):
+    def load_afile(self, fname, immutable=False):
         r"""
         Load into the current object the bipartite graph specified in the given
         file name.
+
+        INPUT:
+
+        - ``fname`` -- string; file name in alist format
+
+        - ``immutable`` -- boolean (default: ``False``); whether to load
+          the graph with an immutable backend
 
         This file should follow David MacKay's alist format, see
         http://www.inference.phy.cam.ac.uk/mackay/codes/data.html for examples
@@ -1807,6 +1798,8 @@ class BipartiteGraph(Graph):
              sage: B2 == B
              True
         """
+        from types import MethodType
+
         # open the file
         try:
             fi = open(fname)
@@ -1814,39 +1807,52 @@ class BipartiteGraph(Graph):
             print("unable to open file <<" + fname + ">>")
             return None
 
-        # read header information
-        num_cols, num_rows = (int(_) for _ in fi.readline().split())
-        # next are max_col_degree, max_row_degree, not used
-        _ = [int(_) for _ in fi.readline().split()]
-        col_degrees = [int(_) for _ in fi.readline().split()]
-        row_degrees = [int(_) for _ in fi.readline().split()]
+        with fi:
+            # read header information
+            num_cols, num_rows = (int(_) for _ in fi.readline().split())
+            # next are max_col_degree, max_row_degree, not used
+            _ = [int(_) for _ in fi.readline().split()]
+            col_degrees = [int(_) for _ in fi.readline().split()]
+            row_degrees = [int(_) for _ in fi.readline().split()]
 
-        # sanity checks on header info
-        if len(col_degrees) != num_cols:
-            print("invalid Alist format: ")
-            print("number of column degree entries does not match number of columns")
-            return None
-        if len(row_degrees) != num_rows:
-            print("invalid Alist format: ")
-            print("number of row degree entries does not match number of rows")
-            return None
+            # sanity checks on header info
+            if len(col_degrees) != num_cols:
+                print("invalid Alist format: ")
+                print("number of column degree entries does not match number of columns")
+                return None
+            if len(row_degrees) != num_rows:
+                print("invalid Alist format: ")
+                print("number of row degree entries does not match number of rows")
+                return None
 
-        # clear out self
-        self.clear()
-        self.add_vertices(range(num_cols), left=True)
-        self.add_vertices(range(num_cols, num_cols + num_rows), right=True)
+            def edges():
+                # A-list uses 1-based indices with 0s as place-holders.
+                for cidx in range(num_cols):
+                    for ridx in map(int, fi.readline().split()):
+                        if ridx > 0:
+                            yield (cidx, num_cols + ridx - 1)
 
-        # read adjacency information
-        for cidx in range(num_cols):
-            for ridx in map(int, fi.readline().split()):
-                # A-list uses 1-based indices with 0s as place-holders
-                if ridx > 0:
-                    self.add_edge(cidx, num_cols + ridx - 1)
+            saved_methods = {}
+            graph_methods = (("add_vertex", Graph.add_vertex),
+                             ("add_vertices", Graph.add_vertices),
+                             ("add_edge", Graph.add_edge),
+                             ("add_edges", Graph.add_edges))
+            for name, method in graph_methods:
+                if name in self.__dict__:
+                    saved_methods[name] = self.__dict__[name]
+                setattr(self, name, MethodType(method, self))
 
-        # NOTE:: we could read in the row adjacency information as well to
-        #        double-check....
-        # NOTE:: we could check the actual node degrees against the reported
-        #        node degrees....
+            try:
+                Graph.__init__(self, [range(num_cols + num_rows), edges()],
+                               format='vertices_and_edges',
+                               loops=False, multiedges=False,
+                               immutable=immutable)
+            finally:
+                for name, _ in graph_methods:
+                    if name in saved_methods:
+                        setattr(self, name, saved_methods[name])
+                    else:
+                        delattr(self, name)
 
         # now we have all the edges in our graph, just fill in the
         # bipartite partitioning

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -427,6 +427,8 @@ class BipartiteGraph(Graph):
                 raise ValueError('loops are not allowed in bipartite graphs')
             kwds['loops'] = False
 
+        immutable_request = kwds.pop("immutable", False)
+
         if data is None:
             if partition is not None and check:
                 if partition[0] or partition[1]:
@@ -583,7 +585,8 @@ class BipartiteGraph(Graph):
         if hash_labels is None and hasattr(data, '_hash_labels'):
             hash_labels = data._hash_labels
         self._hash_labels = hash_labels
-
+        if immutable_request:
+            self._backend = self._backend.to_immutable()
         return
 
     @cached_method

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -437,6 +437,7 @@ class BipartiteGraph(Graph):
             self.left = set()
             self.right = set()
             self._hash_labels = hash_labels
+
             return
 
         # need to turn off partition checking for Graph.__init__() adding
@@ -457,7 +458,12 @@ class BipartiteGraph(Graph):
         elif isinstance(data, str):
             import os
             alist_file = os.path.exists(data)
-            Graph.__init__(self, data=None if alist_file else data, *args, **kwds)
+            kwds_for_init = kwds
+            if alist_file and immutable_request:
+	            kwds_for_init = dict(kwds)
+	            kwds_for_init["immutable"] = False
+
+            Graph.__init__(self, data=None if alist_file else data, *args, **kwds_for_init)
 
             # methods; initialize left and right attributes
             self.left = set()
@@ -585,8 +591,7 @@ class BipartiteGraph(Graph):
         if hash_labels is None and hasattr(data, '_hash_labels'):
             hash_labels = data._hash_labels
         self._hash_labels = hash_labels
-        if immutable_request:
-            self._backend = self._backend.to_immutable()
+
         return
 
     @cached_method

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -351,7 +351,19 @@ class BipartiteGraph(Graph):
         Traceback (most recent call last):
         ...
         ValueError: cannot add edge from 0 to 0 in graph without loops
+        
+    Check that construction from a file works with immutable graphs::
+    sage: import tempfile, os
+    sage: content = "2 2\n1 1\n1 1\n"
+    sage: fd, path = tempfile.mkstemp()
+    sage: with os.fdopen(fd, 'w') as f:
+    ....:     _ = f.write(content)
+    sage: B = BipartiteGraph(path, immutable=True)
+    sage: B.is_immutable()
+    True
+
     """
+
 
     def __init__(self, data=None, partition=None, check=True, hash_labels=None, *args, **kwds):
         """

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -351,19 +351,24 @@ class BipartiteGraph(Graph):
         Traceback (most recent call last):
         ...
         ValueError: cannot add edge from 0 to 0 in graph without loops
-        
+
     Check that construction from a file works with immutable graphs::
-    sage: import tempfile, os
-    sage: content = "2 2\n1 1\n1 1\n"
-    sage: fd, path = tempfile.mkstemp()
-    sage: with os.fdopen(fd, 'w') as f:
-    ....:     _ = f.write(content)
-    sage: B = BipartiteGraph(path, immutable=True)
-    sage: B.is_immutable()
-    True
 
+        sage: import tempfile, os
+        sage: content = "2 2\n2 2\n2 2\n2 2\n1 2\n1 2\n1 2\n1 2\n"
+        sage: fd, path = tempfile.mkstemp()
+        sage: with os.fdopen(fd, 'w') as f:
+        ....:     _ = f.write(content)
+        sage: B = BipartiteGraph(path, immutable=False)
+        sage: B.is_immutable()
+        False
+        sage: B = BipartiteGraph(path, immutable=True)
+        sage: B.is_immutable()
+        True
+        sage: set((u, v) for u, v, _ in B.edges()) == {(0,2), (0,3), (1,2), (1,3)}
+        True
+        sage: os.unlink(path)
     """
-
 
     def __init__(self, data=None, partition=None, check=True, hash_labels=None, *args, **kwds):
         """
@@ -427,7 +432,7 @@ class BipartiteGraph(Graph):
                 raise ValueError('loops are not allowed in bipartite graphs')
             kwds['loops'] = False
 
-        immutable_request = kwds.pop("immutable", False)
+        immutable_request = kwds.get("immutable", False)
 
         if data is None:
             if partition is not None and check:
@@ -460,8 +465,8 @@ class BipartiteGraph(Graph):
             alist_file = os.path.exists(data)
             kwds_for_init = kwds
             if alist_file and immutable_request:
-	            kwds_for_init = dict(kwds)
-	            kwds_for_init["immutable"] = False
+                kwds_for_init = dict(kwds)
+                kwds_for_init["immutable"] = False
 
             Graph.__init__(self, data=None if alist_file else data, *args, **kwds_for_init)
 
@@ -587,6 +592,12 @@ class BipartiteGraph(Graph):
         if isinstance(data, str):
             if alist_file:
                 self.load_afile(data)
+                if immutable_request:
+                    from sage.graphs.base.static_sparse_backend import StaticSparseBackend
+                    self._backend = StaticSparseBackend(self,
+                                                        loops=self.allows_loops(),
+                                                        multiedges=self.allows_multiple_edges())
+                    self._immutable = True
 
         if hash_labels is None and hasattr(data, '_hash_labels'):
             hash_labels = data._hash_labels


### PR DESCRIPTION
This PR fixes the construction of BipartiteGraph from file input when
immutable=True, and adds a doctest covering this case.

Previously, the constructor could attempt to modify the graph after
initialization when immutable=True, which is not allowed. The constructor
is adjusted so that the graph is fully constructed before converting the
backend to immutable.

A doctest is added in bipartite_graph.py to prevent regressions.
