### PR TITLE
improvement of method vertex_separation_BAB

### DIFF
--- a/src/sage/graphs/graph_decompositions/vertex_separation.pyx
+++ b/src/sage/graphs/graph_decompositions/vertex_separation.pyx
@@ -1887,10 +1887,11 @@ cdef int vertex_separation_BAB_C(binary_matrix_t H,
     # The set S of vertices of a prefix P is in prefix_storage if the branch
     # with prefix P is such that c(P)<\min_{L\in{\cal L}_P(V)} c(L). In such
     # case, there is no need to continue exploration for the current branch.
-    cdef frozenset frozen_prefix
+    cdef tuple frozen_prefix
 
     if loc_level <= max_prefix_length:
-        frozen_prefix = frozenset(prefix[i] for i in range(loc_level))
+        frozen_prefix = tuple(loc_b_prefix.bits[i]
+                              for i in range(loc_b_prefix.limbs))
         if frozen_prefix in prefix_storage:
             return upper_bound
 


### PR DESCRIPTION
Method `vertex_separation_BAB` implements a branch and bound algorithm for the vertex separation of graphs. it uses the concept of memoization to cut some branches of the exploration tree of the branch and bound. Roughly, it stores some prefixes (sets of vertices) to avoid exploring multiple times branches starting with prefixes on the same set of vertices.
Previously, this was implemented by using a set of frozensets, each containing the set of vertices of a prefix.
This PR stores instead the bitset representation of a prefix as a tuple of integers. Hence, it uses less memory per stored prefix. In addition, the running time is slightly improved.

Before:
```sage
sage: for i in range(2, 7):
....:     G = graphs.MycielskiGraph(i)
....:     print(f"{G}: {G.order()} vertices; vs = {vertex_separation_BAB(G)[0]}")
....:     timeit("vs = vertex_separation_BAB(G)[0]")
....: 
Mycielski Graph 2: 2 vertices; vs = 1
625 loops, best of 3: 2.79 μs per loop
Mycielski Graph 3: 5 vertices; vs = 2
625 loops, best of 3: 4.58 μs per loop
Mycielski Graph 4: 11 vertices; vs = 5
625 loops, best of 3: 15.4 μs per loop
Mycielski Graph 5: 23 vertices; vs = 10
625 loops, best of 3: 353 μs per loop
Mycielski Graph 6: 47 vertices; vs = 20
5 loops, best of 3: 85.2 ms per loop
```

After:
```sage
Mycielski Graph 2: 2 vertices; vs = 1
625 loops, best of 3: 2.57 μs per loop
Mycielski Graph 3: 5 vertices; vs = 2
625 loops, best of 3: 4.23 μs per loop
Mycielski Graph 4: 11 vertices; vs = 5
625 loops, best of 3: 13.5 μs per loop
Mycielski Graph 5: 23 vertices; vs = 10
625 loops, best of 3: 277 μs per loop
Mycielski Graph 6: 47 vertices; vs = 20
5 loops, best of 3: 56.8 ms per loop
```

Before
```sage
sage: for i in range(5, 11):
....:     G = graphs.Grid2dGraph(i, i)
....:     print(f"{G}: {G.order()} vertices; vs = {vertex_separation_BAB(G)[0]}")
....:     timeit("vs = vertex_separation_BAB(G)[0]")
....: 
2D Grid Graph for [5, 5]: 25 vertices; vs = 5
625 loops, best of 3: 99.7 μs per loop
2D Grid Graph for [6, 6]: 36 vertices; vs = 6
625 loops, best of 3: 629 μs per loop
2D Grid Graph for [7, 7]: 49 vertices; vs = 7
125 loops, best of 3: 3.9 ms per loop
2D Grid Graph for [8, 8]: 64 vertices; vs = 8
25 loops, best of 3: 24.4 ms per loop
2D Grid Graph for [9, 9]: 81 vertices; vs = 9
5 loops, best of 3: 182 ms per loop
2D Grid Graph for [10, 10]: 100 vertices; vs = 10
5 loops, best of 3: 67.7 s per loop
```

After:
```sage
2D Grid Graph for [5, 5]: 25 vertices; vs = 5
625 loops, best of 3: 85.2 μs per loop
2D Grid Graph for [6, 6]: 36 vertices; vs = 6
625 loops, best of 3: 489 μs per loop
2D Grid Graph for [7, 7]: 49 vertices; vs = 7
125 loops, best of 3: 2.88 ms per loop
2D Grid Graph for [8, 8]: 64 vertices; vs = 8
25 loops, best of 3: 17.6 ms per loop
2D Grid Graph for [9, 9]: 81 vertices; vs = 9
5 loops, best of 3: 142 ms per loop
2D Grid Graph for [10, 10]: 100 vertices; vs = 10
5 loops, best of 3: 64.4 s per loop
```



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


