### PR TITLE
Update Meson build dependencies for polynomial modules to be more specific

### DIFF
--- a/src/sage/libs/pari/convert_sage.pyx
+++ b/src/sage/libs/pari/convert_sage.pyx
@@ -21,6 +21,7 @@ from cypari2.types cimport (GEN, typ, t_INT, t_FRAC, t_REAL, t_COMPLEX,
                             t_VECSMALL, t_MAT, t_STR,
                             lg, precp)
 from cypari2.paridecl cimport (
+    avma,
     divisorsu,
     FF_to_FpXQ_i,
     inf_get_sign,

--- a/src/sage/libs/pari/convert_sage.pyx
+++ b/src/sage/libs/pari/convert_sage.pyx
@@ -20,7 +20,20 @@ from cypari2.types cimport (GEN, typ, t_INT, t_FRAC, t_REAL, t_COMPLEX,
                             t_INTMOD, t_PADIC, t_INFINITY, t_VEC, t_COL,
                             t_VECSMALL, t_MAT, t_STR,
                             lg, precp)
-from cypari2.paridecl cimport *
+from cypari2.paridecl cimport (
+    divisorsu,
+    FF_to_FpXQ_i,
+    inf_get_sign,
+    is_rational_t,
+    maxprime,
+    pari_PRIMES, 
+    pari_sp, 
+    t_FFELT,
+    t_POLMOD,
+    uisprime,
+    uisprimepower,
+    ulong, 
+)
 from cypari2.stack cimport new_gen
 from sage.libs.pari.convert_gmp cimport INT_to_mpz, new_gen_from_mpz_t, new_gen_from_mpq_t, INTFRAC_to_mpq
 

--- a/src/sage/rings/polynomial/meson.build
+++ b/src/sage/rings/polynomial/meson.build
@@ -191,8 +191,18 @@ foreach name, pyx : extension_data_cpp
     deps += [cypari2, flint]
   elif name == 'polynomial_integer_dense_flint'
     deps += [cypari2, flint, ntl]
-  else
-    deps += [cypari2, givaro, mpfi, mpfr, ntl, singular]
+  elif name == 'multi_polynomial_ideal_libsingular' or name == 'multi_polynomial_libsingular'
+    deps += [cypari2, singular]
+  elif name == 'plural'
+    deps += [singular]
+  elif name == 'polynomial_zz_pex'
+    deps += [cypari2]
+  elif name == 'polynomial_integer_dense_ntl' or name == 'polynomial_modn_dense_ntl'
+    deps += [cypari2]
+  elif name == 'polynomial_gf2x'
+    deps += [cypari2]
+  elif name == 'evaluation_ntl'
+    deps += [ntl, mpfr, mpfi] # Runtime dependencies
   endif
   py.extension_module(
     name,

--- a/src/sage/rings/polynomial/meson.build
+++ b/src/sage/rings/polynomial/meson.build
@@ -202,7 +202,7 @@ foreach name, pyx : extension_data_cpp
   elif name == 'polynomial_gf2x'
     deps += [cypari2]
   elif name == 'evaluation_ntl'
-    deps += [ntl, mpfr, mpfi] # Runtime dependencies
+    deps += [ntl, mpfr, mpfi]    # Runtime dependencies
   endif
   py.extension_module(
     name,


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

These files have slightly different build dependencies, and this is now reflected in the meson build file (eg if ntl is not available, we can still build polynomial_gf2x but not evaluation_ntl).

(Also contains a somewhat silly removal of a star import for pari).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


