### PR TITLE
Fix capitalization of PREP tutorial links

### DIFF
--- a/src/doc/en/thematic_tutorials/index.rst
+++ b/src/doc/en/thematic_tutorials/index.rst
@@ -30,7 +30,7 @@ This documentation is licensed under a `Creative Commons Attribution-Share Alike
 Introduction to Sage
 --------------------
 
-* `Introductory Sage Tutorial (PREP) <../prep/Intro-Tutorial.html>`_
+* `Introductory Sage Tutorial (PREP) <../prep/intro-tutorial.html>`_
 * `Sage's main tutorial <../tutorial/index.html>`_
 
 .. _programming_design:
@@ -38,7 +38,7 @@ Introduction to Sage
 Introduction to Python
 ----------------------
 
-* `Tutorial: Sage Introductory Programming (PREP) <../prep/Programming.html>`_
+* `Tutorial: Sage Introductory Programming (PREP) <../prep/programming.html>`_
 * :ref:`tutorial-programming-python`
 * :ref:`tutorial-comprehensions`
 * :ref:`tutorial-objects-and-classes`
@@ -47,9 +47,9 @@ Introduction to Python
 Calculus and Plotting
 ---------------------
 
-* `Tutorial: Symbolics and Plotting (PREP) <../prep/Symbolics-and-Basic-Plotting.html>`_
-* `Tutorial: Calculus (PREP) <../prep/Calculus.html>`_
-* `Tutorial: Advanced-2D Plotting (PREP) <../prep/Advanced-2DPlotting.html>`_
+* `Tutorial: Symbolics and Plotting (PREP) <../prep/symbolics-and-basic-plotting.html>`_
+* `Tutorial: Calculus (PREP) <../prep/calculus.html>`_
+* `Tutorial: Advanced-2D Plotting (PREP) <../prep/advanced-2D-plotting.html>`_
 * :ref:`vector_calculus`
 
 Algebra


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR fixes broken links to PREP tutorials in the thematic tutorials documentation.

The generated HTML files for PREP tutorials use lowercase filenames, but several links in thematic_tutorials/index.rst referenced capitalized versions. This causes 404 errors on case-sensitive filesystems.

The links have been updated to match the actual generated filenames. This fixes multiple PREP link mismatches, not just the one reported in the original issue.

Fixes #41463.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies
None.

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


