### PR TITLE
add parameter immutable to `cosetGraph`

### DIFF
--- a/src/sage/coding/linear_code.py
+++ b/src/sage/coding/linear_code.py
@@ -2053,7 +2053,7 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
         T = RT.gen()
         return P/((1-T)*(1-q*T))
 
-    def cosetGraph(self):
+    def cosetGraph(self, immutable=False):
         r"""
         Return the coset graph of this linear code.
 
@@ -2061,6 +2061,11 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
         are the cosets of `C`, considered as a subgroup of the additive
         group of the ambient vector space, and two cosets are adjacent
         if they have representatives that differ in exactly one coordinate.
+
+        INPUT:
+
+        - ``immutable`` -- boolean (default: ``False``); whether to return an
+          immutable or a mutable graph
 
         EXAMPLES::
 
@@ -2094,6 +2099,10 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
             [0]
             sage: G.edges(sort=False)
             []
+            sage: C.cosetGraph(immutable=False).is_immutable()
+            False
+            sage: C.cosetGraph(immutable=True).is_immutable()
+            True
         """
         from sage.matrix.constructor import matrix
         from sage.graphs.graph import Graph
@@ -2107,12 +2116,11 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
 
         # Handle special cases
         if len(self.basis()) == self.length():
-            G = Graph(1)
-            G.name(f"coset graph of {self.__repr__()}")
-            return G
+            return Graph(1, name=f"coset graph of {self.__repr__()}",
+                         immutable=immutable)
         if len(self.basis()) == 0:
-            from sage.graphs.graph_generators import GraphGenerators
-            return GraphGenerators.HammingGraph(self.length(), F.order())
+            from sage.graphs.generators.families import HammingGraph
+            return HammingGraph(self.length(), F.order(), immutable=immutable)
 
         # we need to find a basis for the complement
         M = matrix(F, self.basis())
@@ -2154,17 +2162,17 @@ class AbstractLinearCode(AbstractLinearCodeNoMetric):
 
         lPei = [l*u for l in F for u in Pei if not l.is_zero()]
 
-        edges = []
-        for v in vertices:
-            v.set_immutable()
-            for u in lPei:
-                w = v + u
-                w.set_immutable()
-                edges.append((v, w))
+        def edges():
+            for v in vertices:
+                v.set_immutable()
+                for u in lPei:
+                    w = v + u
+                    w.set_immutable()
+                    yield (v, w)
 
-        G = Graph(edges, format='list_of_edges')
-        G.name(f"coset graph of {self.__repr__()}")
-        return G
+        return Graph(edges(), format="list_of_edges",
+                     name=f"coset graph of {self.__repr__()}",
+                     immutable=immutable)
 
 
 # ########################### linear codes python class ########################

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -456,10 +456,15 @@ def DoublyTruncatedWittGraph(immutable=False):
     return G.copy(immutable=True) if immutable else G
 
 
-def distance_3_doubly_truncated_Golay_code_graph():
+def distance_3_doubly_truncated_Golay_code_graph(immutable=False):
     r"""
     Return a distance-regular graph with intersection array
     `[9, 8, 6, 3; 1, 1, 3, 8]`.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -480,16 +485,12 @@ def distance_3_doubly_truncated_Golay_code_graph():
 
     Description and construction of this graph are taken from [BCN1989]_ p. 364.
     """
-    G = codes.GolayCode(GF(2), extended=False).punctured([0, 1]).cosetGraph()
-    v = G.vertices(sort=False)[0]
+    P = codes.GolayCode(GF(2), extended=False).punctured([0, 1])
+    G = P.cosetGraph(immutable=True)  # use immutable for faster iterations
+    v = next(G.vertex_iterator())
     it = G.breadth_first_search(v, distance=3, report_distance=True)
-    vertices = [w for (w, d) in it if d == 3]
-
-    edges = [(a, b) for a, b in itertools.combinations(vertices, 2)
-             if G.has_edge((a, b))]
-
-    H = Graph(edges, format='list_of_edges')
-    return H
+    return G.subgraph(vertices=[w for w, d in it if d == 3],
+                      immutable=immutable)
 
 
 def shortened_00_11_binary_Golay_code_graph():

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -493,10 +493,15 @@ def distance_3_doubly_truncated_Golay_code_graph(immutable=False):
                       immutable=immutable)
 
 
-def shortened_00_11_binary_Golay_code_graph():
+def shortened_00_11_binary_Golay_code_graph(immutable=False):
     r"""
     Return a distance-regular graph with intersection array
     `[21, 20, 16, 6, 2, 1; 1, 2, 6, 16, 20, 21]`.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -528,8 +533,8 @@ def shortened_00_11_binary_Golay_code_graph():
 
     code = LinearCode(Matrix(GF(2), C_basis))
 
-    G = code.cosetGraph()
-    G.name("Shortened 00 11 binary Golay code")
+    G = code.cosetGraph(immutable=immutable)
+    G._name = "Shortened 00 11 binary Golay code"
     return G
 
 

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -602,12 +602,17 @@ def shortened_000_111_extended_binary_Golay_code_graph():
     return G
 
 
-def vanLintSchrijverGraph():
+def vanLintSchrijverGraph(immutable=False):
     r"""
     Return the van Lint-Schrijver graph.
 
     The graph is distance-regular with intersection array
     `[6, 5, 5, 4; 1, 1, 2, 6]`.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -622,14 +627,11 @@ def vanLintSchrijverGraph():
     from sage.coding.linear_code import LinearCode
 
     one = vector(GF(3), [1, 1, 1, 1, 1, 1])
-    G = LinearCode(Matrix(GF(3), one)).cosetGraph()
+    G = LinearCode(Matrix(GF(3), one)).cosetGraph(immutable=True)
 
-    vertices = [v for v in G.vertices(sort=False) if v.dot_product(one) in {1, 2}]
-    edges = [(v, w) for v, w in itertools.combinations(vertices, 2)
-             if G.has_edge((v, w))]
-
-    H = Graph(edges, format='list_of_edges')
-    H.name("Linst-Schrijver graph")
+    H = G.subgraph(vertices=[v for v in G if v.dot_product(one) in {1, 2}],
+                   immutable=immutable)
+    H._name = "Linst-Schrijver graph"
     return H
 
 

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -485,8 +485,7 @@ def distance_3_doubly_truncated_Golay_code_graph(immutable=False):
 
     Description and construction of this graph are taken from [BCN1989]_ p. 364.
     """
-    P = codes.GolayCode(GF(2), extended=False).punctured([0, 1])
-    G = P.cosetGraph(immutable=True)  # use immutable for faster iterations
+    G = codes.GolayCode(GF(2), extended=False).punctured([0, 1]).cosetGraph()
     v = next(G.vertex_iterator())
     it = G.breadth_first_search(v, distance=3, report_distance=True)
     return G.subgraph(vertices=[w for w, d in it if d == 3],
@@ -627,7 +626,7 @@ def vanLintSchrijverGraph(immutable=False):
     from sage.coding.linear_code import LinearCode
 
     one = vector(GF(3), [1, 1, 1, 1, 1, 1])
-    G = LinearCode(Matrix(GF(3), one)).cosetGraph(immutable=True)
+    G = LinearCode(Matrix(GF(3), one)).cosetGraph()
 
     H = G.subgraph(vertices=[v for v in G if v.dot_product(one) in {1, 2}],
                    immutable=immutable)

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -415,7 +415,7 @@ def EgawaGraph(p, s):
     return g
 
 
-def HammingGraph(n, q, X=None):
+def HammingGraph(n, q, X=None, immutable=False):
     r"""
     Return the Hamming graph with parameters `n`, `q` over `X`.
 
@@ -438,6 +438,9 @@ def HammingGraph(n, q, X=None):
     - ``X`` -- list of labels representing the vertices of the underlying graph
       the Hamming graph will be based on; if ``None`` (or left unused), the
       list `[0, ... , q-1]` will be used
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     OUTPUT:
 
@@ -481,18 +484,23 @@ def HammingGraph(n, q, X=None):
         X = list(range(q))
     if q != len(X):
         raise ValueError("q must be the cardinality of X")
-    g = Graph(name=f"Hamming Graph with parameters {n},{q}", multiedges=False)
-    g.add_vertices(product(*repeat(X, n)))
-    for v in g:
-        for i in range(n):
-            prefix = v[:i]
-            suffix = v[i+1:]
-            for el in X:
-                if el == v[i]:
-                    continue
-                u = prefix + (el,) + suffix
-                g.add_edge(v, u)
-    return g
+
+    vertices = list(product(*repeat(X, n)))
+
+    def edges():
+        for v in vertices:
+            for i in range(n):
+                prefix = v[:i]
+                suffix = v[i+1:]
+                for el in X:
+                    if el == v[i]:
+                        continue
+                    u = prefix + (el,) + suffix
+                    yield (v, u)
+
+    return Graph([vertices, edges()], format="vertices_and_edges",
+                 name=f"Hamming Graph with parameters {n},{q}",
+                 multiedges=False, immutable=immutable)
 
 
 def BarbellGraph(n1, n2):


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to method `cosetGraph` of class `AbstractLinearCode`.
On the way, we add parameter immutable to method `sage.graphs.generators.families.HammingGraph` and to some methods using `cosetGraph` in `src/sage/graphs/generators/distance_regular.pyx`.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


