### PR TITLE
Prevent leaking file descriptors when using database files

### DIFF
--- a/src/sage/databases/sql_db.py
+++ b/src/sage/databases/sql_db.py
@@ -1109,6 +1109,12 @@ class SQLDatabase(SageObject):
             raise RuntimeError('Cannot update skeleton of a read only '
                 + 'database.')
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.__connection__.close()
+
     def __repr__(self):
         """
         Override the print output to display useful info regarding the

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -436,8 +436,8 @@ class EllipticCurveFactory(UniqueFactory):
 
         if isinstance(x, str):
             # Interpret x as a Cremona or LMFDB label.
-            from sage.databases.cremona import CremonaDatabase
-            x, data = CremonaDatabase().coefficients_and_data(x)
+            with sage.databases.cremona.CremonaDatabase() as D:
+                x, data = D.coefficients_and_data(x)
             # data is only valid for elliptic curves over QQ.
             if R not in (None, QQ):
                 data = {}
@@ -753,10 +753,11 @@ def coefficients_from_j(j, minimal_twist=True):
         Elist = [E for E in Elist if E.conductor() == min_cond]
         if len(Elist) > 1:
             from sage.databases.cremona import CremonaDatabase, parse_cremona_label
-            if min_cond <= CremonaDatabase().largest_conductor():
-                sorter = lambda E: parse_cremona_label(E.label(), numerical_class_code=True)
-            else:
-                sorter = lambda E: E.ainvs()
+            with CremonaDatabase() as D:
+                if min_cond <= D.largest_conductor():
+                    sorter = lambda E: parse_cremona_label(E.label(), numerical_class_code=True)
+                else:
+                    sorter = lambda E: E.ainvs()
             Elist.sort(key=sorter)
         return Sequence(Elist[0].ainvs())
 

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -436,7 +436,8 @@ class EllipticCurveFactory(UniqueFactory):
 
         if isinstance(x, str):
             # Interpret x as a Cremona or LMFDB label.
-            with sage.databases.cremona.CremonaDatabase() as D:
+            from sage.databases.cremona import CremonaDatabase
+            with CremonaDatabase() as D:
                 x, data = D.coefficients_and_data(x)
             # data is only valid for elliptic curves over QQ.
             if R not in (None, QQ):

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -686,12 +686,13 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             LookupError: Cremona database does not contain entry for Elliptic Curve
             defined by y^2 + 8*x*y + 21*y = x^3 + 13*x^2 + 34*x + 55 over Rational Field
         """
-        from sage.databases.cremona import CremonaDatabase
         ainvs = self.minimal_model().ainvs()
-        try:
-            return CremonaDatabase().data_from_coefficients(ainvs)
-        except RuntimeError:
-            raise LookupError("Cremona database does not contain entry for " + repr(self))
+        with sage.databases.cremona.CremonaDatabase() as D:
+            try:
+                attrs = D.data_from_coefficients(ainvs)
+                return attrs
+            except RuntimeError:
+                raise LookupError("Cremona database does not contain entry for " + repr(self))
 
     def database_curve(self):
         r"""
@@ -718,10 +719,10 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             return self.__database_curve
         except AttributeError:
             verbose_verbose("Looking up %s in the database." % self)
-            D = sage.databases.cremona.CremonaDatabase()
             ainvs = list(self.minimal_model().ainvs())
             try:
-                self.__database_curve = D.elliptic_curve_from_ainvs(ainvs)
+                with sage.databases.cremona.CremonaDatabase() as D:
+                    self.__database_curve = D.elliptic_curve_from_ainvs(ainvs)
             except RuntimeError:
                 raise RuntimeError("Elliptic curve %s not in the database." % self)
             return self.__database_curve

--- a/src/sage/schemes/elliptic_curves/isogeny_class.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_class.py
@@ -1087,8 +1087,8 @@ class IsogenyClass_EC_Rational(IsogenyClass_EC_NumberField):
                 label = self.E.cremona_label(space=False)
             except RuntimeError:
                 raise RuntimeError("unable to find %s in the database" % self.E)
-            db = sage.databases.cremona.CremonaDatabase()
-            curves = db.isogeny_class(label)
+            with sage.databases.cremona.CremonaDatabase() as db:
+                curves = db.isogeny_class(label)
             if not curves:
                 raise RuntimeError("unable to find %s in the database" % self.E)
             # All curves will have the same conductor and isogeny class,


### PR DESCRIPTION
Currently, opening a database via a `SQLDatabase` derived class leaks the database file descriptor. Cleaning up the descriptor is left to the Python garbage collector. However, in Python 3.14 the GC has been optimized to run less often [1] which causes these descriptors to linger for a longer time.

This can cause these descriptors to pile up and even sometimes reach the allowed limit and cause a "Too many open files" error when doctesting [2].

We make the `SQLDatabase` class a context manager that cleans up the database file descriptor on exit, and make use of it in several instances of `CremonaDatabase`

Before this:
```
sage: len(os.listdir("/proc/self/fd"))
6
sage: from sage.schemes.elliptic_curves.constructor import EllipticCurves_with_good_reduction_outside_S
sage: elist = EllipticCurves_with_good_reduction_outside_S([2,3])
sage: len(os.listdir("/proc/self/fd"))
270
```
After this:
```
sage: len(os.listdir("/proc/self/fd"))
6
sage: from sage.schemes.elliptic_curves.constructor import EllipticCurves_with_good_reduction_outside_S
sage: elist = EllipticCurves_with_good_reduction_outside_S([2,3])
sage: len(os.listdir("/proc/self/fd"))
6
```
[1] https://github.com/python/cpython/commit/d1a434f7b211b7061883b8cf4c8687cf00e0c2c7
[2] https://github.com/sagemath/sage/pull/41023#issuecomment-3718036460
