### PR TITLE
add parameter immutable to graph generators in families.py (part 3)

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -2298,6 +2298,10 @@ REFERENCES:
             Journal of Combinatorial Designs 22(6) (2014): 270-277.
             :doi:`10.1002/jcd.21358`
 
+.. [DGM2002] \S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes.
+             *Pseudofractal scale-free web*, Physical Review E 066122, 2002.
+             :doi:`10.1103/PhysRevE.65.066122`
+
 .. [DGMPPS2019] \N. Datta, A. Ghoshal, D. Mukhopadhyay, S. Patranabis,
                 S. Picek, R. Sashukhan. "TRIFLE"
                 https://csrc.nist.gov/CSRC/media/Projects/Lightweight-Cryptography/documents/round-1/spec-doc/trifle-spec.pdf

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1222,7 +1222,7 @@ def CubeGraph(n, embedding=1, immutable=False):
     return G
 
 
-def GoethalsSeidelGraph(k, r):
+def GoethalsSeidelGraph(k, r, immutable=False):
     r"""
     Return the graph `\text{Goethals-Seidel}(k,r)`.
 
@@ -1242,6 +1242,9 @@ def GoethalsSeidelGraph(k, r):
 
     - ``k``, ``r`` -- integers
 
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     .. SEEALSO::
 
         - :func:`~sage.graphs.strongly_regular_db.is_goethals_seidel`
@@ -1249,7 +1252,7 @@ def GoethalsSeidelGraph(k, r):
     EXAMPLES::
 
         sage: graphs.GoethalsSeidelGraph(3,3)                                           # needs sage.combinat sage.modules
-        Graph on 28 vertices
+        Goethals-Seidel(3, 3): Graph on 28 vertices
         sage: graphs.GoethalsSeidelGraph(3,3).is_strongly_regular(parameters=True)      # needs sage.combinat sage.modules
         (28, 15, 6, 10)
     """
@@ -1284,8 +1287,8 @@ def GoethalsSeidelGraph(k, r):
     for i in range(n):
         PP[i, i] = 0
 
-    G = Graph(PP, format='seidel_adjacency_matrix')
-    return G
+    return Graph(PP, format='seidel_adjacency_matrix',
+                 name=f"Goethals-Seidel({k}, {r})", immutable=immutable)
 
 
 def DorogovtsevGoltsevMendesGraph(n):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -966,7 +966,7 @@ def chang_graphs():
     return [g1, g2, g3]
 
 
-def CirculantGraph(n, adjacency):
+def CirculantGraph(n, adjacency, immutable=False):
     r"""
     Return a circulant graph with `n` nodes.
 
@@ -978,6 +978,9 @@ def CirculantGraph(n, adjacency):
     -  ``n`` -- number of vertices in the graph
 
     -  ``adjacency`` -- the list of `j` values
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return
+      immutable or mutable graphs
 
     PLOTTING: Upon construction, the position dictionary is filled to
     override the spring-layout algorithm. By convention, each circulant
@@ -1064,12 +1067,11 @@ def CirculantGraph(n, adjacency):
     if not isinstance(adjacency, list):
         adjacency = [adjacency]
 
-    G = Graph(n, name=f"Circulant graph ({adjacency})")
+    edges = ((v, (v + j) % n) for v in range(n) for j in adjacency)
+    G = Graph([range(n), edges], format="vertices_and_edges",
+              name=f"Circulant graph ({adjacency})",
+              immutable=immutable)
     G._circle_embedding(list(range(n)))
-
-    for v in G:
-        G.add_edges([(v, (v + j) % n) for j in adjacency])
-
     return G
 
 

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1497,7 +1497,7 @@ def FriendshipGraph(n, immutable=False):
     return G
 
 
-def FuzzyBallGraph(partition, q):
+def FuzzyBallGraph(partition, q, immutable=False):
     r"""
     Construct a Fuzzy Ball graph with the integer partition
     ``partition`` and ``q`` extra vertices.
@@ -1513,9 +1513,19 @@ def FuzzyBallGraph(partition, q):
     all partitions `p` of `m` with `k` parts are cospectral with
     respect to the normalized Laplacian.
 
+    INPUT:
+
+    - ``partition`` -- non empty list of positive integers
+
+    - ``q`` -- nonnegative integer; number of extra vertices
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     EXAMPLES::
 
-        sage: F = graphs.FuzzyBallGraph([3,1],2)
+        sage: F = graphs.FuzzyBallGraph([3,1],2); F
+        Fuzzy-Ball([3, 1], 2): Graph on 8 vertices
         sage: F.adjacency_matrix(vertices=list(F))                                      # needs sage.modules
         [0 0 1 1 1 0 0 0]
         [0 0 0 0 0 1 0 0]
@@ -1541,15 +1551,23 @@ def FuzzyBallGraph(partition, q):
           - 120877/3240*x^3 + 1351/100*x^2 - 931/450*x}
     """
     from sage.graphs.generators.basic import CompleteGraph
-    if len(partition) < 1:
+    if not partition or any(i <= 0 for i in partition):
         raise ValueError("partition must be a nonempty list of positive integers")
+    if q < 0:
+        raise ValueError("q must be larger or equal to 0")
     n = q + sum(partition)
-    g = CompleteGraph(n)
-    curr_vertex = 0
-    for e, p in enumerate(partition):
-        g.add_edges([(curr_vertex + i, 'a{0}'.format(e + 1)) for i in range(p)])
-        curr_vertex += p
-    return g
+
+    def edges():
+        yield from combinations(range(n), 2)
+        curr_vertex = 0
+        for e, p in enumerate(partition):
+            v = 'a{0}'.format(e + 1)
+            for u in range(curr_vertex, curr_vertex + p):
+                yield (u, v)
+            curr_vertex += p
+
+    return Graph(edges(), format="list_of_edges", immutable=immutable,
+                 name=f"Fuzzy-Ball({partition}, {q})")
 
 
 def GeneralizedPetersenGraph(n, k):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1335,7 +1335,7 @@ def DorogovtsevGoltsevMendesGraph(n, immutable=False):
                  immutable=immutable)
 
 
-def FoldedCubeGraph(n):
+def FoldedCubeGraph(n, immutable=False):
     r"""
     Return the folded cube graph of order `2^{n-1}`.
 
@@ -1347,6 +1347,13 @@ def FoldedCubeGraph(n):
 
     See the :wikipedia:`Folded_cube_graph` for more information.
 
+    INPUT:
+
+    - ``n`` -- integer `\geq 2`; the dimension of the folded cube
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     EXAMPLES:
 
     The folded cube graph of order five is the Clebsch graph::
@@ -1356,11 +1363,8 @@ def FoldedCubeGraph(n):
         sage: fc.is_isomorphic(clebsch)
         True
     """
-    if n < 1:
-        raise ValueError("The value of n must be at least 2")
-
-    g = CubeGraph(n - 1)
-    g.name("Folded Cube Graph")
+    if n < 2:
+        raise ValueError("the value of n must be at least 2")
 
     # Complementing the binary word
     def complement(x):
@@ -1369,11 +1373,12 @@ def FoldedCubeGraph(n):
         x = x.replace('a', '1')
         return x
 
-    for x in g:
-        if x[0] == '0':
-            g.add_edge(x, complement(x))
-
-    return g
+    from itertools import chain
+    H = CubeGraph(n - 1)
+    extra = ((x, complement(x)) for x in H if x[0] == '0')
+    return Graph([H, chain(H.edges(labels=False), extra)],
+                 format="vertices_and_edges", immutable=immutable,
+                 name="Folded Cube Graph")
 
 
 def FriendshipGraph(n):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1381,7 +1381,7 @@ def FoldedCubeGraph(n, immutable=False):
                  name="Folded Cube Graph")
 
 
-def FriendshipGraph(n):
+def FriendshipGraph(n, immutable=False):
     r"""
     Return the friendship graph `F_n`.
 
@@ -1396,6 +1396,9 @@ def FriendshipGraph(n):
 
     - ``n`` -- positive integer; the number of copies of `C_3` to use in
       constructing `F_n`
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     OUTPUT:
 
@@ -1478,15 +1481,17 @@ def FriendshipGraph(n):
     # construct the friendship graph
     if n == 1:
         from sage.graphs.generators.basic import CycleGraph
-        G = CycleGraph(3)
-        G.name("Friendship graph")
+        G = CycleGraph(3, immutable=immutable)
+        G._name = "Friendship graph"
         return G
     # build the edges and position dictionaries
     N = 2 * n + 1           # order of F_n
     center = 2 * n
-    G = Graph(N, name="Friendship graph")
-    for i in range(0, N - 1, 2):
-        G.add_cycle([center, i, i + 1])
+    edges = (e
+             for i in range(0, N - 1, 2)
+             for e in combinations([center, i, i + 1], 2))
+    G = Graph([range(N), edges], format="vertices_and_edges",
+              name="Friendship graph", immutable=immutable)
     G.set_pos({center: (0, 0)})
     G._circle_embedding(list(range(N - 1)), radius=1)
     return G

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1738,7 +1738,7 @@ def IGraph(n, j, k, immutable=False):
     return G
 
 
-def DoubleGeneralizedPetersenGraph(n, k):
+def DoubleGeneralizedPetersenGraph(n, k, immutable=False):
     r"""
     Return a double generalized Petersen graph with `4n` nodes.
 
@@ -1753,6 +1753,9 @@ def DoubleGeneralizedPetersenGraph(n, k):
 
     - ``k`` -- integer such that `0 < k \leq \lfloor (n-1) / 2 \rfloor`
       determining how vertices on second and third inner rims are connected
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     PLOTTING: Upon construction, the position dictionary is filled to override
     the spring-layout algorithm. By convention, the double generalized Petersen
@@ -1794,14 +1797,16 @@ def DoubleGeneralizedPetersenGraph(n, k):
     if k < 1 or k > (n - 1) // 2:
         raise ValueError("k must be in 1 <= k <= floor((n - 1) / 2)")
 
-    G = Graph(4 * n, name=f"Double generalized Petersen graph (n={n}, k={k})")
-    for i in range(n):
-        G.add_edge(i, (i + 1) % n)
-        G.add_edge(i + 3 * n, (i + 1) % n + 3 * n)
-        G.add_edge(i, i + n)
-        G.add_edge(i + 2 * n, i + 3 * n)
-        G.add_edge(i + n, (i + k) % n + 2 * n)
-        G.add_edge(i + 2 * n, (i + k) % n + n)
+    from itertools import chain
+    E1 = ((i, (i + 1) % n) for i in range(n))
+    E2 = ((i + 3 * n, (i + 1) % n + 3 * n) for i in range(n))
+    E3 = ((i, i + n) for i in range(n))
+    E4 = ((i + 2 * n, i + 3 * n) for i in range(n))
+    E5 = ((i + n, (i + k) % n + 2 * n) for i in range(n))
+    E6 = ((i + 2 * n, (i + k) % n + n) for i in range(n))
+    G = Graph([range(4*n), chain(E1, E2, E3, E4, E5, E6)],
+              format="vertices_and_edges", immutable=immutable,
+              name=f"Double generalized Petersen graph (n={n}, k={k})")
     G._circle_embedding(list(range(n)), radius=3, angle=pi/2)
     G._circle_embedding(list(range(n, 2 * n)), radius=2, angle=pi/2)
     G._circle_embedding(list(range(2 * n, 3 * n)), radius=1.5, angle=pi/2)

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1570,7 +1570,7 @@ def FuzzyBallGraph(partition, q, immutable=False):
                  name=f"Fuzzy-Ball({partition}, {q})")
 
 
-def GeneralizedPetersenGraph(n, k):
+def GeneralizedPetersenGraph(n, k, immutable=False):
     r"""
     Return a generalized Petersen graph with `2n` nodes. The variables
     `n`, `k` are integers such that `n>2` and `0<k\leq\lfloor(n-1)`/`2\rfloor`
@@ -1586,6 +1586,9 @@ def GeneralizedPetersenGraph(n, k):
 
     - ``k`` -- integer (`0<k\leq\lfloor(n-1)`/`2\rfloor`); decides
       how inner vertices are connected
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     PLOTTING: Upon construction, the position dictionary is filled to
     override the spring-layout algorithm. By convention, the generalized
@@ -1618,6 +1621,13 @@ def GeneralizedPetersenGraph(n, k):
         sage: graphs.GeneralizedPetersenGraph(7, 2).name()
         'Generalized Petersen graph (n=7,k=2)'
 
+    Check the behavior of parameter immutable::
+
+        sage: graphs.GeneralizedPetersenGraph(7, 2).is_immutable()
+        False
+        sage: graphs.GeneralizedPetersenGraph(7, 2, immutable=True).is_immutable()
+        True
+
     AUTHORS:
 
     - Anders Jonsson (2009-10-15)
@@ -1626,11 +1636,13 @@ def GeneralizedPetersenGraph(n, k):
         raise ValueError("n must be larger than 2")
     if k < 1 or k > (n - 1) // 2:
         raise ValueError("k must be in 1<= k <=floor((n-1)/2)")
-    G = Graph(2 * n, name=f"Generalized Petersen graph (n={n},k={k})")
-    for i in range(n):
-        G.add_edge(i, (i+1) % n)
-        G.add_edge(i, i+n)
-        G.add_edge(i+n, n + (i+k) % n)
+    from itertools import chain
+    E1 = ((i, (i + 1) % n) for i in range(n))
+    E2 = ((i, i + n) for i in range(n))
+    E3 = (( i + n, n + (i + k) % n) for i in range(n))
+    G = Graph([range(2*n), chain(E1, E2, E3)], format="vertices_and_edges",
+              name=f"Generalized Petersen graph (n={n},k={k})",
+              immutable=immutable)
     G._circle_embedding(list(range(n)), radius=1, angle=pi/2)
     G._circle_embedding(list(range(n, 2*n)), radius=.5, angle=pi/2)
     return G

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1814,7 +1814,7 @@ def DoubleGeneralizedPetersenGraph(n, k, immutable=False):
     return G
 
 
-def RoseWindowGraph(n, a, r):
+def RoseWindowGraph(n, a, r, immutable=False):
     r"""
     Return a rose window graph with `2n` nodes.
 
@@ -1830,6 +1830,9 @@ def RoseWindowGraph(n, a, r):
 
     - ``r`` -- integer such that `1 \leq r < n` and `r \neq n / 2` determining
       how inner vertices are connected
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     PLOTTING: Upon construction, the position dictionary is filled to override
     the spring-layout algorithm. By convention, the rose window graphs are
@@ -1892,12 +1895,14 @@ def RoseWindowGraph(n, a, r):
     if r == n / 2:
         raise ValueError("r must be different than n / 2")
 
-    G = Graph(2 * n, name=f"Rose window graph (n={n}, a={a}, r={r})")
-    for i in range(n):
-        G.add_edge(i, (i + 1) % n)
-        G.add_edge(i, i + n)
-        G.add_edge((i + a) % n, i + n)
-        G.add_edge(i + n, (i + r) % n + n)
+    from itertools import chain
+    E1 = ((i, (i + 1) % n) for i in range(n))
+    E2 = ((i, i + n) for i in range(n))
+    E3 = (((i + a) % n, i + n) for i in range(n))
+    E4 = ((i + n, (i + r) % n + n) for i in range(n))
+    G = Graph([range(2*n), chain(E1, E2, E3, E4)],
+              format="vertices_and_edges", immutable=immutable,
+              name=f"Rose window graph (n={n}, a={a}, r={r})")
     G._circle_embedding(list(range(n)), radius=1, angle=pi/2)
     G._circle_embedding(list(range(n, 2 * n)), radius=0.5, angle=pi/2)
     return G

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -979,8 +979,8 @@ def CirculantGraph(n, adjacency, immutable=False):
 
     -  ``adjacency`` -- the list of `j` values
 
-    - ``immutable`` -- boolean (default: ``False``); whether to return
-      immutable or mutable graphs
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     PLOTTING: Upon construction, the position dictionary is filled to
     override the spring-layout algorithm. By convention, each circulant
@@ -1075,7 +1075,7 @@ def CirculantGraph(n, adjacency, immutable=False):
     return G
 
 
-def CubeGraph(n, embedding=1):
+def CubeGraph(n, embedding=1, immutable=False):
     r"""
     Return the `n`-cube graph, also called the hypercube in `n` dimensions.
 
@@ -1108,6 +1108,9 @@ def CubeGraph(n, embedding=1):
         plane, offering a geometrically consistent visualization.
 
       - ``None`` or ``O`` -- no embedding is provided
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -1180,7 +1183,8 @@ def CubeGraph(n, embedding=1):
             p, pn = pn, {}
 
         # construct the graph
-        G = Graph(d, format='dict_of_lists', pos=p, name=f"{n}-Cube")
+        G = Graph(d, format='dict_of_lists', pos=p, name=f"{n}-Cube",
+                  immutable=immutable)
 
     else:
         # construct recursively the adjacency dict
@@ -1201,7 +1205,7 @@ def CubeGraph(n, embedding=1):
             d, dn = dn, {}
 
         # construct the graph
-        G = Graph(d, name=f"{n}-Cube", format='dict_of_lists')
+        G = Graph(d, name=f"{n}-Cube", format='dict_of_lists', immutable=immutable)
 
         if embedding == 2:
             # Orthogonal projection

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1291,10 +1291,19 @@ def GoethalsSeidelGraph(k, r, immutable=False):
                  name=f"Goethals-Seidel({k}, {r})", immutable=immutable)
 
 
-def DorogovtsevGoltsevMendesGraph(n):
+def DorogovtsevGoltsevMendesGraph(n, immutable=False):
     """
     Construct the `n`-th generation of the Dorogovtsev-Goltsev-Mendes
     graph.
+
+    See [DGM2002]_ for more details.
+
+    INPUT:
+
+    - ``n`` -- nonnegative integer; index of the generation
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -1302,15 +1311,28 @@ def DorogovtsevGoltsevMendesGraph(n):
         sage: G.size()                                                                  # needs networkx
         6561
 
-    REFERENCE:
+    TESTS::
 
-    - [1] Dorogovtsev, S. N., Goltsev, A. V., and Mendes, J.
-      F. F., Pseudofractal scale-free web, Phys. Rev. E 066122
-      (2002).
+        sage: # needs networkx
+        sage: G = graphs.DorogovtsevGoltsevMendesGraph(0)
+        sage: G.order(), G.size()
+        (2, 1)
+        sage: G.is_immutable()
+        False
+        sage: G = graphs.DorogovtsevGoltsevMendesGraph(0, immutable=True)
+        sage: G.is_immutable()
+        True
+        sage: graphs.DorogovtsevGoltsevMendesGraph(-1)
+        Traceback (most recent call last):
+        ...
+        ValueError: n must be greater than or equal to 0
     """
+    if n < 0:
+        raise ValueError("n must be greater than or equal to 0")
     import networkx
     return Graph(networkx.dorogovtsev_goltsev_mendes_graph(n),
-                 name=f"Dorogovtsev-Goltsev-Mendes Graph, {n}-th generation")
+                 name=f"Dorogovtsev-Goltsev-Mendes Graph, {n}-th generation",
+                 immutable=immutable)
 
 
 def FoldedCubeGraph(n):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1908,7 +1908,7 @@ def RoseWindowGraph(n, a, r, immutable=False):
     return G
 
 
-def TabacjnGraph(n, a, b, r):
+def TabacjnGraph(n, a, b, r, immutable=False):
     r"""
     Return a Tabačjn graph with `2n` nodes.
 
@@ -1929,6 +1929,9 @@ def TabacjnGraph(n, a, b, r):
 
     - ``r`` -- integer such that `0 < r < n` and `r \neq n/2` determining how
       inner vertices are connected
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     PLOTTING: Upon construction, the position dictionary is filled to override
     the spring-layout algorithm. By convention, the rose window graphs are
@@ -2005,13 +2008,15 @@ def TabacjnGraph(n, a, b, r):
     if r == n/2:
         raise ValueError("r must be different than n / 2")
 
-    G = Graph(2 * n, name=f"Tabačjn graph (n={n}, a={a}, b={b}, r={r})")
-    for i in range(n):
-        G.add_edge(i, (i + 1) % n)
-        G.add_edge(i, i + n)
-        G.add_edge(i + n, n + (i + r) % n)
-        G.add_edge(i, (i + a) % n + n)
-        G.add_edge(i, (i + b) % n + n)
+    from itertools import chain
+    E1 = ((i, (i + 1) % n) for i in range(n))
+    E2 = ((i, i + n) for i in range(n))
+    E3 = ((i + n, n + (i + r) % n) for i in range(n))
+    E4 = ((i, (i + a) % n + n) for i in range(n))
+    E5 = ((i, (i + b) % n + n) for i in range(n))
+    G = Graph([range(2*n), chain(E1, E2, E3, E4, E5)],
+              format="vertices_and_edges", immutable=immutable,
+              name=f"Tabačjn graph (n={n}, a={a}, b={b}, r={r})")
     G._circle_embedding(list(range(n)), radius=1, angle=pi/2)
     G._circle_embedding(list(range(n, 2 * n)), radius=0.5, angle=pi/2)
     return G

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1648,7 +1648,7 @@ def GeneralizedPetersenGraph(n, k, immutable=False):
     return G
 
 
-def IGraph(n, j, k):
+def IGraph(n, j, k, immutable=False):
     r"""
     Return an I-graph with `2n` nodes.
 
@@ -1667,6 +1667,9 @@ def IGraph(n, j, k):
 
     - ``k`` -- integer such that `0 < k \leq \lfloor (n-1) / 2 \rfloor`
       determining how inner vertices are connected
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     PLOTTING: Upon construction, the position dictionary is filled to override
     the spring-layout algorithm. By convention, the I-graphs are displayed as an
@@ -1723,11 +1726,13 @@ def IGraph(n, j, k):
     if k < 1 or k > (n - 1) // 2:
         raise ValueError("k must be in 1 <= k <= floor((n - 1) / 2)")
 
-    G = Graph(2 * n, name=f"I-graph (n={n}, j={j}, k={k})")
-    for i in range(n):
-        G.add_edge(i, (i + j) % n)
-        G.add_edge(i, i + n)
-        G.add_edge(i + n, n + (i + k) % n)
+    from itertools import chain
+    E1 = ((i, (i + j) % n) for i in range(n))
+    E2 = ((i, i + n) for i in range(n))
+    E3 = (( i + n, n + (i + k) % n) for i in range(n))
+    G = Graph([range(2*n), chain(E1, E2, E3)], format="vertices_and_edges",
+              name=f"I-graph (n={n}, j={j}, k={k})",
+              immutable=immutable)
     G._circle_embedding(list(range(n)), radius=1, angle=pi/2)
     G._circle_embedding(list(range(n, 2 * n)), radius=.5, angle=pi/2)
     return G

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1252,7 +1252,7 @@ def GoethalsSeidelGraph(k, r, immutable=False):
     EXAMPLES::
 
         sage: graphs.GoethalsSeidelGraph(3,3)                                           # needs sage.combinat sage.modules
-        Goethals-Seidel(3, 3): Graph on 28 vertices
+        Graph on 28 vertices
         sage: graphs.GoethalsSeidelGraph(3,3).is_strongly_regular(parameters=True)      # needs sage.combinat sage.modules
         (28, 15, 6, 10)
     """
@@ -1287,8 +1287,7 @@ def GoethalsSeidelGraph(k, r, immutable=False):
     for i in range(n):
         PP[i, i] = 0
 
-    return Graph(PP, format='seidel_adjacency_matrix',
-                 name=f"Goethals-Seidel({k}, {r})", immutable=immutable)
+    return Graph(PP, format='seidel_adjacency_matrix', immutable=immutable)
 
 
 def DorogovtsevGoltsevMendesGraph(n, immutable=False):


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to some generators in `src/sage/graphs/generators/families.py`.

- `CirculantGraph`, `CubeGraph`, `GoethalsSeidelGraph`, `DorogovtsevGoltsevMendesGraph`, `FoldedCubeGraph`, `FriendshipGraph`, `FuzzyBallGraph`, `GeneralizedPetersenGraph`, `IGraph`, `DoubleGeneralizedPetersenGraph`, `RoseWindowGraph` and `TabacjnGraph`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


