### PR TITLE
Absolute and resorted imports in `sage.interfaces`

### DIFF
--- a/src/sage/interfaces/expect.py
+++ b/src/sage/interfaces/expect.py
@@ -55,6 +55,7 @@ from pexpect import ExceptionPexpect
 import sage.interfaces.abc
 from sage.cpython.string import bytes_to_str, str_to_bytes
 from sage.env import LOCAL_IDENTIFIER, SAGE_EXTCODE
+from sage.interfaces import quit
 from sage.interfaces.interface import (
     Interface,
     InterfaceElement,
@@ -64,8 +65,6 @@ from sage.interfaces.interface import (
 from sage.misc.instancedoc import instancedoc
 from sage.misc.object_multiplexer import Multiplex
 from sage.structure.element import RingElement
-
-from . import quit
 
 BAD_SESSION = -2
 

--- a/src/sage/interfaces/gp.py
+++ b/src/sage/interfaces/gp.py
@@ -149,7 +149,12 @@ from sage.misc.verbose import verbose
 
 lazy_import('sage.rings.cc', 'CC')
 
-from .expect import Expect, ExpectElement, ExpectFunction, FunctionElement
+from sage.interfaces.expect import (
+    Expect,
+    ExpectElement,
+    ExpectFunction,
+    FunctionElement,
+)
 
 
 class Gp(ExtraTabCompletion, Expect):

--- a/src/sage/interfaces/kash.py
+++ b/src/sage/interfaces/kash.py
@@ -435,10 +435,10 @@ unlike for the other interfaces.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from .expect import Expect, ExpectElement
-from sage.misc.instancedoc import instancedoc
 import os
 
+from sage.interfaces.expect import Expect, ExpectElement
+from sage.misc.instancedoc import instancedoc
 from sage.misc.sage_eval import sage_eval
 
 

--- a/src/sage/interfaces/magma.py
+++ b/src/sage/interfaces/magma.py
@@ -214,19 +214,24 @@ AUTHORS:
 #
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
-from pathlib import Path
+import os
 import re
 import sys
-import os
+from pathlib import Path
 
-from sage.structure.parent import Parent
-from .expect import Expect, ExpectElement, ExpectFunction, FunctionElement
-from sage.env import SAGE_EXTCODE, DOT_SAGE
+import sage.interfaces.abc
 import sage.misc.misc
 import sage.misc.sage_eval
-import sage.interfaces.abc
+from sage.env import DOT_SAGE, SAGE_EXTCODE
+from sage.interfaces.expect import (
+    Expect,
+    ExpectElement,
+    ExpectFunction,
+    FunctionElement,
+)
 from sage.interfaces.tab_completion import ExtraTabCompletion
 from sage.misc.instancedoc import instancedoc
+from sage.structure.parent import Parent
 
 PROMPT = ">>>"
 
@@ -2888,10 +2893,9 @@ class MagmaGBLogPrettyPrinter:
                     if style == "sage" and verbosity >= 1:
                         print("Leading term degree: %2d. Critical pairs: %d." %
                               (self.curr_deg, self.curr_npairs))
-                else:
-                    if style == "sage" and verbosity >= 1:
-                        print("Leading term degree: %2d. Critical pairs: %d (all pairs of current degree eliminated by criteria)." %
-                              (self.curr_deg, self.curr_npairs))
+                elif style == "sage" and verbosity >= 1:
+                    print("Leading term degree: %2d. Critical pairs: %d (all pairs of current degree eliminated by criteria)." %
+                          (self.curr_deg, self.curr_npairs))
 
             if style == "magma" and verbosity >= 1:
                 print(line)

--- a/src/sage/interfaces/matlab.py
+++ b/src/sage/interfaces/matlab.py
@@ -154,7 +154,7 @@ language works). Use square brackets or the set function::
 
 import os
 
-from .expect import Expect, ExpectElement
+from sage.interfaces.expect import Expect, ExpectElement
 from sage.misc.instancedoc import instancedoc
 
 

--- a/src/sage/interfaces/mupad.py
+++ b/src/sage/interfaces/mupad.py
@@ -94,11 +94,15 @@ TESTS::
 
 import os
 
-from .expect import (Expect, ExpectElement, ExpectFunction,
-                    FunctionElement)
+from sage.env import DOT_SAGE
+from sage.interfaces.expect import (
+    Expect,
+    ExpectElement,
+    ExpectFunction,
+    FunctionElement,
+)
 from sage.interfaces.interface import AsciiArtString
 from sage.interfaces.tab_completion import ExtraTabCompletion
-from sage.env import DOT_SAGE
 from sage.misc.instancedoc import instancedoc
 
 COMMANDS_CACHE = '%s/mupad_commandlist_cache.sobj' % DOT_SAGE

--- a/src/sage/interfaces/mwrank.py
+++ b/src/sage/interfaces/mwrank.py
@@ -18,8 +18,10 @@ Interface to mwrank
 # ****************************************************************************
 
 import os
+import re
 import weakref
-from .expect import Expect
+
+from sage.interfaces.expect import Expect
 
 instances = {}
 
@@ -69,7 +71,6 @@ def Mwrank(options='', server=None, server_tmpdir=None):
     return X
 
 
-import re
 # regex matching '[a1,a2,a3,a4,a6]', no spaces, each ai a possibly signed integer
 AINVS_LIST_RE = re.compile(r'\[[+-]?(\d+)(,[+-]?\d+){4}]')
 # regex matching ' a1 a2 a3 a4 a6 ', any whitespace, each ai a possibly signed integer

--- a/src/sage/interfaces/polymake.py
+++ b/src/sage/interfaces/polymake.py
@@ -28,10 +28,14 @@ polymake has been described in [GJ1997]_, [GJ2006]_, [JMP2009]_, [GJRW2010]_,
 import os
 import re
 
-from .interface import (Interface, InterfaceElement, InterfaceFunctionElement)
-from sage.misc.verbose import get_verbose
-from sage.misc.cachefunc import cached_method
+from sage.interfaces.interface import (
+    Interface,
+    InterfaceElement,
+    InterfaceFunctionElement,
+)
 from sage.interfaces.tab_completion import ExtraTabCompletion
+from sage.misc.cachefunc import cached_method
+from sage.misc.verbose import get_verbose
 from sage.structure.richcmp import rich_to_bool
 
 _name_pattern = re.compile('SAGE[0-9]+')

--- a/src/sage/interfaces/psage.py
+++ b/src/sage/interfaces/psage.py
@@ -43,8 +43,9 @@ finished::
 import os
 import time
 
-from .sage0 import Sage, SageElement
 from pexpect import ExceptionPexpect
+
+from sage.interfaces.sage0 import Sage, SageElement
 
 number = 0
 

--- a/src/sage/interfaces/qepcad.py
+++ b/src/sage/interfaces/qepcad.py
@@ -604,19 +604,20 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 import os
-from sage.env import SAGE_LOCAL
-import pexpect
 import re
 import sys
 
+import pexpect
+
 from sage.cpython.string import bytes_to_str
+from sage.env import SAGE_LOCAL
+from sage.interfaces.expect import Expect, ExpectFunction
+from sage.interfaces.interface import AsciiArtString
+from sage.interfaces.tab_completion import ExtraTabCompletion
 from sage.misc.flatten import flatten
+from sage.misc.instancedoc import instancedoc
 from sage.misc.sage_eval import sage_eval
 from sage.repl.preparse import implicit_mul
-from sage.interfaces.tab_completion import ExtraTabCompletion
-from sage.misc.instancedoc import instancedoc
-from .expect import Expect, ExpectFunction
-from sage.interfaces.interface import AsciiArtString
 
 
 def _qepcad_atoms(formula):
@@ -2336,10 +2337,10 @@ def _eval_qepcad_algebraic(text):
         sage: 8*x^2 - 8*x - 29 == 0
         True
     """
-    from sage.rings.rational_field import QQ
     from sage.rings.polynomial.polynomial_ring import polygen
-    from sage.rings.real_mpfi import RealIntervalField
     from sage.rings.qqbar import AA
+    from sage.rings.rational_field import QQ
+    from sage.rings.real_mpfi import RealIntervalField
 
     match = _qepcad_algebraic_re.match(text)
 

--- a/src/sage/interfaces/rubik.py
+++ b/src/sage/interfaces/rubik.py
@@ -32,16 +32,15 @@ AUTHOR:
 #                  https://www.gnu.org/licenses/
 ########################################################################
 
-import pexpect
-import time
 import shlex
+import time
 
-from . import quit
+import pexpect
 
+import sage.features.rubiks
 from sage.cpython.string import bytes_to_str
 from sage.groups.perm_gps.cubegroup import index2singmaster
-import sage.features.rubiks
-
+from sage.interfaces import quit
 
 # Can't seem to find consistency in letter ordering
 # between us and them... These are copied from the source.

--- a/src/sage/interfaces/scilab.py
+++ b/src/sage/interfaces/scilab.py
@@ -197,7 +197,7 @@ AUTHORS:
 
 import os
 
-from .expect import Expect, ExpectElement
+from sage.interfaces.expect import Expect, ExpectElement
 from sage.misc.instancedoc import instancedoc
 
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

For consistency and to fix some import issues, the relative imports in `sage.interfaces` are migrated to absolute ones. I took the opportunity to reorder the imports to fix Ruff I001.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


