### PR TITLE
Absolute and resorted imports in `sage.algebras`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,6 +269,9 @@ select = [
 "all.py" = [
   "F401", # Unused import - these files are by definition collections of imports.
 ]
+"src/sage/algebras/lie_conformal_algebras/examples.py" = [
+  "F401", # Unused import - reexports for convenience.
+]
 
 [tool.uv]
 # Don't use build isolation for sage (it's incompatible with meson-python's editable install)

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -74,35 +74,35 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.structure.unique_representation import UniqueRepresentation, CachedRepresentation
-from sage.structure.sage_object import SageObject
-from sage.misc.cachefunc import cached_method
-from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
-from sage.misc.functional import is_odd, is_even
-from sage.misc.misc_c import prod
-from sage.categories.chain_complexes import ChainComplexes
-from sage.categories.algebras import Algebras
-from sage.categories.morphism import Morphism
-from sage.categories.modules import Modules
-from sage.categories.homset import Hom
-
+import sage.interfaces.abc
 from sage.algebras.free_algebra import FreeAlgebra
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.categories.algebras import Algebras
+from sage.categories.chain_complexes import ChainComplexes
+from sage.categories.homset import Hom
+from sage.categories.modules import Modules
+from sage.categories.morphism import Morphism
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.combinat.integer_vector_weighted import WeightedIntegerVectors
 from sage.groups.additive_abelian.additive_abelian_group import AdditiveAbelianGroup
 from sage.matrix.constructor import matrix
+from sage.misc.cachefunc import cached_function, cached_method
+from sage.misc.functional import is_even, is_odd
+from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
+from sage.misc.misc_c import prod
 from sage.modules.free_module import VectorSpace
 from sage.modules.free_module_element import vector
-from sage.rings.integer_ring import ZZ
 from sage.rings.homset import RingHomset_generic
+from sage.rings.integer_ring import ZZ
 from sage.rings.morphism import RingHomomorphism_im_gens
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.polynomial.term_order import TermOrder
 from sage.rings.quotient_ring import QuotientRing_nc
 from sage.rings.quotient_ring_element import QuotientRingElement
-from sage.misc.cachefunc import cached_function
-
-import sage.interfaces.abc
+from sage.structure.sage_object import SageObject
+from sage.structure.unique_representation import (
+    CachedRepresentation,
+    UniqueRepresentation,
+)
 
 
 def sorting_keys(element):
@@ -1530,9 +1530,8 @@ class GCAlgebra(UniqueRepresentation, QuotientRing_nc):
             for m in self.monomials():
                 if degree is None:
                     degree = m.degree(total)
-                else:
-                    if degree != m.degree(total):
-                        return False
+                elif degree != m.degree(total):
+                    return False
             return True
 
         def homogeneous_parts(self):
@@ -3651,7 +3650,7 @@ def GradedCommutativeAlgebra(ring, names=None, degrees=None, max_degree=None,
         ValueError: you must specify names or degrees
     """
     if max_degree:
-        from .finite_gca import FiniteGCAlgebra
+        from sage.algebras.finite_gca import FiniteGCAlgebra
         return FiniteGCAlgebra(ring, names=names, degrees=degrees,
                                max_degree=max_degree, **kwargs)
     multi = False

--- a/src/sage/algebras/free_algebra.py
+++ b/src/sage/algebras/free_algebra.py
@@ -162,9 +162,11 @@ Some tests for the category::
 from sage.algebras.free_algebra_element import FreeAlgebraElement
 from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.categories.functor import Functor
-from sage.categories.pushout import (ConstructionFunctor,
-                                     CompositeConstructionFunctor,
-                                     IdentityConstructionFunctor)
+from sage.categories.pushout import (
+    CompositeConstructionFunctor,
+    ConstructionFunctor,
+    IdentityConstructionFunctor,
+)
 from sage.categories.rings import Rings
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.combinat.words.word import Word
@@ -362,10 +364,14 @@ class FreeAlgebraFactory(UniqueFactory):
             False
         """
         if len(key) == 1:
-            from sage.algebras.letterplace.free_algebra_letterplace import FreeAlgebra_letterplace
+            from sage.algebras.letterplace.free_algebra_letterplace import (
+                FreeAlgebra_letterplace,
+            )
             return FreeAlgebra_letterplace(key[0])
         if isinstance(key[0], tuple):
-            from sage.algebras.letterplace.free_algebra_letterplace import FreeAlgebra_letterplace
+            from sage.algebras.letterplace.free_algebra_letterplace import (
+                FreeAlgebra_letterplace,
+            )
             return FreeAlgebra_letterplace(key[1], degrees=key[0])
         if len(key) == 2:
             return FreeAlgebra_generic(key[0], len(key[1]), key[1])
@@ -878,7 +884,7 @@ class FreeAlgebra_generic(CombinatorialFreeModule):
         """
         if mats is None:
             return super().quotient(mons, names)
-        from . import free_algebra_quotient
+        from sage.algebras import free_algebra_quotient
         return free_algebra_quotient.FreeAlgebraQuotient(self, mons, mats, names)
 
     quo = quotient

--- a/src/sage/algebras/lie_conformal_algebras/abelian_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/abelian_lie_conformal_algebra.py
@@ -21,7 +21,9 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
 from sage.structure.indexed_generators import standardize_names_index_set
 
 

--- a/src/sage/algebras/lie_conformal_algebras/affine_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/affine_lie_conformal_algebra.py
@@ -31,9 +31,11 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from sage.rings.integer import Integer
 from sage.algebras.lie_algebras.lie_algebra import LieAlgebra
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
+from sage.rings.integer import Integer
 
 
 class AffineLieConformalAlgebra(GradedLieConformalAlgebra):

--- a/src/sage/algebras/lie_conformal_algebras/bosonic_ghosts_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/bosonic_ghosts_lie_conformal_algebra.py
@@ -29,9 +29,11 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
 from sage.matrix.special import identity_matrix
 from sage.structure.indexed_generators import standardize_names_index_set
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
 
 
 class BosonicGhostsLieConformalAlgebra(GradedLieConformalAlgebra):
@@ -97,8 +99,8 @@ class BosonicGhostsLieConformalAlgebra(GradedLieConformalAlgebra):
         latex_names = None
         half = ngens // 2
         if (names is None) and (index_set is None):
-            from sage.misc.defaults import variable_names as varnames
             from sage.misc.defaults import latex_variable_names as laxnames
+            from sage.misc.defaults import variable_names as varnames
             names = varnames(half, 'beta') + varnames(half, 'gamma')
             latex_names = tuple(laxnames(half, r'\beta') +
                                 laxnames(half, r'\gamma')) + ('K',)

--- a/src/sage/algebras/lie_conformal_algebras/examples.py
+++ b/src/sage/algebras/lie_conformal_algebras/examples.py
@@ -30,13 +30,33 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from .abelian_lie_conformal_algebra import AbelianLieConformalAlgebra as Abelian
-from .affine_lie_conformal_algebra import AffineLieConformalAlgebra as Affine
-from .bosonic_ghosts_lie_conformal_algebra import BosonicGhostsLieConformalAlgebra as BosonicGhosts
-from .fermionic_ghosts_lie_conformal_algebra import FermionicGhostsLieConformalAlgebra as FermionicGhosts
-from .free_bosons_lie_conformal_algebra import FreeBosonsLieConformalAlgebra as FreeBosons
-from .free_fermions_lie_conformal_algebra import FreeFermionsLieConformalAlgebra as FreeFermions
-from .n2_lie_conformal_algebra import N2LieConformalAlgebra as N2
-from .neveu_schwarz_lie_conformal_algebra import NeveuSchwarzLieConformalAlgebra as NeveuSchwarz
-from .virasoro_lie_conformal_algebra import VirasoroLieConformalAlgebra as Virasoro
-from .weyl_lie_conformal_algebra import WeylLieConformalAlgebra as Weyl
+from sage.algebras.lie_conformal_algebras.abelian_lie_conformal_algebra import (
+    AbelianLieConformalAlgebra as Abelian,
+)
+from sage.algebras.lie_conformal_algebras.affine_lie_conformal_algebra import (
+    AffineLieConformalAlgebra as Affine,
+)
+from sage.algebras.lie_conformal_algebras.bosonic_ghosts_lie_conformal_algebra import (
+    BosonicGhostsLieConformalAlgebra as BosonicGhosts,
+)
+from sage.algebras.lie_conformal_algebras.fermionic_ghosts_lie_conformal_algebra import (
+    FermionicGhostsLieConformalAlgebra as FermionicGhosts,
+)
+from sage.algebras.lie_conformal_algebras.free_bosons_lie_conformal_algebra import (
+    FreeBosonsLieConformalAlgebra as FreeBosons,
+)
+from sage.algebras.lie_conformal_algebras.free_fermions_lie_conformal_algebra import (
+    FreeFermionsLieConformalAlgebra as FreeFermions,
+)
+from sage.algebras.lie_conformal_algebras.n2_lie_conformal_algebra import (
+    N2LieConformalAlgebra as N2,
+)
+from sage.algebras.lie_conformal_algebras.neveu_schwarz_lie_conformal_algebra import (
+    NeveuSchwarzLieConformalAlgebra as NeveuSchwarz,
+)
+from sage.algebras.lie_conformal_algebras.virasoro_lie_conformal_algebra import (
+    VirasoroLieConformalAlgebra as Virasoro,
+)
+from sage.algebras.lie_conformal_algebras.weyl_lie_conformal_algebra import (
+    WeylLieConformalAlgebra as Weyl,
+)

--- a/src/sage/algebras/lie_conformal_algebras/fermionic_ghosts_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/fermionic_ghosts_lie_conformal_algebra.py
@@ -28,7 +28,9 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
 
 
 class FermionicGhostsLieConformalAlgebra(GradedLieConformalAlgebra):
@@ -89,14 +91,13 @@ class FermionicGhostsLieConformalAlgebra(GradedLieConformalAlgebra):
         latex_names = None
         half = ngens // 2
         if (names is None) and (index_set is None):
-            from sage.misc.defaults import variable_names as varnames
             from sage.misc.defaults import latex_variable_names as laxnames
+            from sage.misc.defaults import variable_names as varnames
             names = varnames(half, 'b') + varnames(half, 'c')
             latex_names = tuple(laxnames(half, 'b') +
                                 laxnames(half, 'c')) + ('K',)
 
-        from sage.structure.indexed_generators import \
-            standardize_names_index_set
+        from sage.structure.indexed_generators import standardize_names_index_set
         names, index_set = standardize_names_index_set(names=names,
                                                        index_set=index_set,
                                                        ngens=ngens)

--- a/src/sage/algebras/lie_conformal_algebras/finitely_freely_generated_lca.py
+++ b/src/sage/algebras/lie_conformal_algebras/finitely_freely_generated_lca.py
@@ -15,9 +15,10 @@ AUTHORS:
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
+from sage.algebras.lie_conformal_algebras.freely_generated_lie_conformal_algebra import (
+    FreelyGeneratedLieConformalAlgebra,
+)
 from sage.categories.lie_conformal_algebras import LieConformalAlgebras
-from .freely_generated_lie_conformal_algebra import \
-    FreelyGeneratedLieConformalAlgebra
 from sage.misc.cachefunc import cached_method
 
 

--- a/src/sage/algebras/lie_conformal_algebras/free_bosons_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/free_bosons_lie_conformal_algebra.py
@@ -32,8 +32,10 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
 from sage.matrix.special import identity_matrix
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
 from sage.structure.indexed_generators import standardize_names_index_set
 
 

--- a/src/sage/algebras/lie_conformal_algebras/free_fermions_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/free_fermions_lie_conformal_algebra.py
@@ -33,7 +33,9 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
 
 
 class FreeFermionsLieConformalAlgebra(GradedLieConformalAlgebra):
@@ -119,8 +121,7 @@ class FreeFermionsLieConformalAlgebra(GradedLieConformalAlgebra):
             latex_names = tuple(r"\psi_{%d}" % i
                                 for i in range(ngens)) + ('K',)
 
-        from sage.structure.indexed_generators import \
-            standardize_names_index_set
+        from sage.structure.indexed_generators import standardize_names_index_set
         names, index_set = standardize_names_index_set(names=names,
                                                        index_set=index_set,
                                                        ngens=ngens)

--- a/src/sage/algebras/lie_conformal_algebras/freely_generated_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/freely_generated_lie_conformal_algebra.py
@@ -17,12 +17,14 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from .lie_conformal_algebra_with_basis import LieConformalAlgebraWithBasis
-from sage.sets.non_negative_integers import NonNegativeIntegers
+from sage.algebras.lie_conformal_algebras.lie_conformal_algebra_with_basis import (
+    LieConformalAlgebraWithBasis,
+)
 from sage.categories.cartesian_product import cartesian_product
 from sage.rings.integer import Integer
-from sage.sets.family import Family
 from sage.sets.disjoint_union_enumerated_sets import DisjointUnionEnumeratedSets
+from sage.sets.family import Family
+from sage.sets.non_negative_integers import NonNegativeIntegers
 
 
 class FreelyGeneratedLieConformalAlgebra(LieConformalAlgebraWithBasis):

--- a/src/sage/algebras/lie_conformal_algebras/graded_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/graded_lie_conformal_algebra.py
@@ -47,9 +47,10 @@ AUTHORS:
 # ***************************************************************************
 
 
+from sage.algebras.lie_conformal_algebras.lie_conformal_algebra_with_structure_coefs import (
+    LieConformalAlgebraWithStructureCoefficients,
+)
 from sage.categories.lie_conformal_algebras import LieConformalAlgebras
-from .lie_conformal_algebra_with_structure_coefs import \
-    LieConformalAlgebraWithStructureCoefficients
 
 
 class GradedLieConformalAlgebra(LieConformalAlgebraWithStructureCoefficients):

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra.py
@@ -173,10 +173,10 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from sage.structure.unique_representation import UniqueRepresentation
-from sage.sets.family import Family
 from sage.categories.commutative_rings import CommutativeRings
+from sage.sets.family import Family
 from sage.structure.parent import Parent
+from sage.structure.unique_representation import UniqueRepresentation
 
 
 class LieConformalAlgebra(UniqueRepresentation, Parent):
@@ -334,8 +334,9 @@ class LieConformalAlgebra(UniqueRepresentation, Parent):
         if isinstance(arg0, dict) and arg0:
             graded = kwds.pop("graded", False)
             if weights is not None or graded:
-                from .graded_lie_conformal_algebra import \
-                    GradedLieConformalAlgebra
+                from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+                    GradedLieConformalAlgebra,
+                )
                 return GradedLieConformalAlgebra(
                     R, Family(arg0),
                     index_set=index_set, central_elements=central_elements,
@@ -343,8 +344,9 @@ class LieConformalAlgebra(UniqueRepresentation, Parent):
                     latex_names=latex_names, parity=parity, weights=weights,
                     **kwds)
             else:
-                from .lie_conformal_algebra_with_structure_coefs import \
-                    LieConformalAlgebraWithStructureCoefficients
+                from sage.algebras.lie_conformal_algebras.lie_conformal_algebra_with_structure_coefs import (
+                    LieConformalAlgebraWithStructureCoefficients,
+                )
                 return LieConformalAlgebraWithStructureCoefficients(
                     R, Family(arg0),
                     index_set=index_set, central_elements=central_elements,

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
@@ -17,14 +17,20 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
+from sage.algebras.lie_conformal_algebras.finitely_freely_generated_lca import (
+    FinitelyFreelyGeneratedLCA,
+)
+from sage.algebras.lie_conformal_algebras.lie_conformal_algebra_element import (
+    LCAStructureCoefficientsElement,
+)
 from sage.arith.misc import binomial
-from sage.sets.family import Family
-from .lie_conformal_algebra_element import LCAStructureCoefficientsElement
 from sage.categories.lie_conformal_algebras import LieConformalAlgebras
-from .finitely_freely_generated_lca import FinitelyFreelyGeneratedLCA
 from sage.sets.disjoint_union_enumerated_sets import DisjointUnionEnumeratedSets
-from sage.structure.indexed_generators import (IndexedGenerators,
-                                               standardize_names_index_set)
+from sage.sets.family import Family
+from sage.structure.indexed_generators import (
+    IndexedGenerators,
+    standardize_names_index_set,
+)
 
 
 class LieConformalAlgebraWithStructureCoefficients(

--- a/src/sage/algebras/lie_conformal_algebras/n2_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/n2_lie_conformal_algebra.py
@@ -30,7 +30,9 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
 
 
 class N2LieConformalAlgebra(GradedLieConformalAlgebra):

--- a/src/sage/algebras/lie_conformal_algebras/neveu_schwarz_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/neveu_schwarz_lie_conformal_algebra.py
@@ -25,7 +25,9 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
 
 
 class NeveuSchwarzLieConformalAlgebra(GradedLieConformalAlgebra):

--- a/src/sage/algebras/lie_conformal_algebras/virasoro_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/virasoro_lie_conformal_algebra.py
@@ -26,7 +26,9 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ***************************************************************************
 
-from .graded_lie_conformal_algebra import GradedLieConformalAlgebra
+from sage.algebras.lie_conformal_algebras.graded_lie_conformal_algebra import (
+    GradedLieConformalAlgebra,
+)
 
 
 class VirasoroLieConformalAlgebra(GradedLieConformalAlgebra):

--- a/src/sage/algebras/lie_conformal_algebras/weyl_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/weyl_lie_conformal_algebra.py
@@ -34,8 +34,9 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from .lie_conformal_algebra_with_structure_coefs import \
-    LieConformalAlgebraWithStructureCoefficients
+from sage.algebras.lie_conformal_algebras.lie_conformal_algebra_with_structure_coefs import (
+    LieConformalAlgebraWithStructureCoefficients,
+)
 from sage.matrix.special import identity_matrix
 from sage.structure.indexed_generators import standardize_names_index_set
 

--- a/src/sage/algebras/quaternion_algebra.py
+++ b/src/sage/algebras/quaternion_algebra.py
@@ -15,5 +15,5 @@ def unpickle_QuaternionAlgebra_v0(*key):
         sage: sage.algebras.quaternion_algebra.unpickle_QuaternionAlgebra_v0(*t)
         Quaternion Algebra (-5, -19) with base ring Rational Field
     """
-    from .quatalg.quaternion_algebra import QuaternionAlgebra
+    from sage.algebras.quatalg.quaternion_algebra import QuaternionAlgebra
     return QuaternionAlgebra(*key)

--- a/src/sage/algebras/steenrod/steenrod_algebra.py
+++ b/src/sage/algebras/steenrod/steenrod_algebra.py
@@ -497,7 +497,10 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             sage: SteenrodAlgebra(p=5) is SteenrodAlgebra(p=5, generic=True)
             True
         """
-        from .steenrod_algebra_misc import get_basis_name, normalize_profile
+        from sage.algebras.steenrod.steenrod_algebra_misc import (
+            get_basis_name,
+            normalize_profile,
+        )
         profile = kwds.get('profile', None)
         precision = kwds.get('precision', None)
         truncation_type = kwds.get('truncation_type', 'auto')
@@ -587,15 +590,18 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             sage: A1 == SteenrodAlgebra(2, profile=[2,1], basis='pst')
             False
         """
+        from functools import partial
+
+        from sage.algebras.steenrod.steenrod_algebra_bases import steenrod_algebra_basis
         from sage.arith.misc import is_prime
-        from sage.categories.super_hopf_algebras_with_basis import SuperHopfAlgebrasWithBasis
-        from sage.categories.infinite_enumerated_sets import InfiniteEnumeratedSets
         from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
+        from sage.categories.infinite_enumerated_sets import InfiniteEnumeratedSets
+        from sage.categories.super_hopf_algebras_with_basis import (
+            SuperHopfAlgebrasWithBasis,
+        )
+        from sage.rings.finite_rings.finite_field_constructor import GF
         from sage.rings.infinity import Infinity
         from sage.sets.set_from_iterator import EnumeratedSetFromIterator
-        from functools import partial
-        from .steenrod_algebra_bases import steenrod_algebra_basis
-        from sage.rings.finite_rings.finite_field_constructor import GF
         profile = kwds.get('profile', None)
         truncation_type = kwds.get('truncation_type', 'auto')
         self._generic = kwds.get('generic')
@@ -637,7 +643,10 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
                                          scalar_mult=' ')
 
         # For the graded modules
-        from sage.modules.fp_graded.steenrod.module import SteenrodFPModule, SteenrodFreeModule
+        from sage.modules.fp_graded.steenrod.module import (
+            SteenrodFPModule,
+            SteenrodFreeModule,
+        )
         self._fp_graded_module_class = SteenrodFPModule
         self._free_graded_module_class = SteenrodFreeModule
 
@@ -661,12 +670,13 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             >  9 (0, 2, 1)            P^2 beta
             > 10 (1, 2, 1)            beta P^2 beta
         """
-        from .steenrod_algebra_bases import steenrod_algebra_basis
-        from sage.sets.integer_range import IntegerRange
-        from sage.rings.integer import Integer
-        from sage.rings.infinity import Infinity
-        from functools import partial
         import itertools
+        from functools import partial
+
+        from sage.algebras.steenrod.steenrod_algebra_bases import steenrod_algebra_basis
+        from sage.rings.infinity import Infinity
+        from sage.rings.integer import Integer
+        from sage.sets.integer_range import IntegerRange
         if self.is_finite():
             maxdim = self.top_class().degree()
             Ir = IntegerRange(Integer(0), Integer(maxdim + 1))
@@ -869,12 +879,18 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             sage: SteenrodAlgebra(2, generic=True, basis='pst').P(0,0,2)
             P^1_3
         """
-        from .steenrod_algebra_misc import milnor_mono_to_string, \
-            serre_cartan_mono_to_string, wood_mono_to_string, \
-            wall_mono_to_string, wall_long_mono_to_string, \
-            arnonA_mono_to_string, arnonA_long_mono_to_string, \
-            pst_mono_to_string, \
-            comm_long_mono_to_string, comm_mono_to_string
+        from sage.algebras.steenrod.steenrod_algebra_misc import (
+            arnonA_long_mono_to_string,
+            arnonA_mono_to_string,
+            comm_long_mono_to_string,
+            comm_mono_to_string,
+            milnor_mono_to_string,
+            pst_mono_to_string,
+            serre_cartan_mono_to_string,
+            wall_long_mono_to_string,
+            wall_mono_to_string,
+            wood_mono_to_string,
+        )
         p = self.prime()
         basis = self.basis_name()
         if basis == 'milnor':
@@ -1188,14 +1204,20 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
         basis = self.basis_name()
         if basis == 'milnor':
             if not self._generic:
-                from .steenrod_algebra_mult import milnor_multiplication
+                from sage.algebras.steenrod.steenrod_algebra_mult import (
+                    milnor_multiplication,
+                )
                 d = milnor_multiplication(t1, t2)
             else:
-                from .steenrod_algebra_mult import milnor_multiplication_odd
+                from sage.algebras.steenrod.steenrod_algebra_mult import (
+                    milnor_multiplication_odd,
+                )
                 d = milnor_multiplication_odd(t1, t2, p)
             return self._from_dict(d, coerce=True)
         elif basis == 'serre-cartan':
-            from .steenrod_algebra_mult import make_mono_admissible
+            from sage.algebras.steenrod.steenrod_algebra_mult import (
+                make_mono_admissible,
+            )
             if self._generic:
                 # make sure output has an odd number of terms.  if both t1
                 # and t2 have an odd number, concatenate them, adding the
@@ -1287,7 +1309,7 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
                 ans.extend([[i] + x for x in coprod_list(t[1:])])
             return ans
 
-        from .steenrod_algebra_misc import get_basis_name
+        from sage.algebras.steenrod.steenrod_algebra_misc import get_basis_name
         p = self.prime()
         basis = self.basis_name()
         if algorithm is None:
@@ -1318,8 +1340,10 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
                     tens = dict.fromkeys(zip(left, right), 1)
                     return self.tensor_square()._from_dict(tens, coerce=True)
                 else:  # p odd
+                    from sage.algebras.steenrod.steenrod_algebra_misc import (
+                        convert_perm,
+                    )
                     from sage.combinat.permutation import Permutation
-                    from .steenrod_algebra_misc import convert_perm
                     from sage.sets.set import Set
                     left_p = coprod_list(t[1])
                     right_p = [[x - y for x, y in zip(t[1], m)] for m in left_p]
@@ -1789,11 +1813,13 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             sage: SteenrodAlgebra(generic=True).P(0,2).change_basis('serre-cartan')
             P^4 P^2 + P^5 P^1 + P^6
         """
+        from sage.algebras.steenrod.steenrod_algebra_bases import (
+            convert_from_milnor_matrix,
+            steenrod_algebra_basis,
+        )
+        from sage.algebras.steenrod.steenrod_algebra_misc import get_basis_name
         from sage.matrix.constructor import matrix
         from sage.rings.finite_rings.finite_field_constructor import GF
-        from .steenrod_algebra_bases import steenrod_algebra_basis, \
-            convert_from_milnor_matrix
-        from .steenrod_algebra_misc import get_basis_name
         basis = get_basis_name(basis, self.prime(), generic=self._generic)
         if basis == self.basis_name():
             return self({t: 1})
@@ -2046,9 +2072,9 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             sage: B3._coerce_map_from_(A31)
             False
         """
-        from sage.rings.integer_ring import ZZ
         from sage.rings.finite_rings.finite_field_constructor import GF
         from sage.rings.infinity import Infinity
+        from sage.rings.integer_ring import ZZ
         p = self.prime()
         if S == ZZ or S == GF(p):
             return True
@@ -2067,7 +2093,7 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
                             for i in range(1, max(self_prec, S_prec)+1)))
         if (isinstance(S, CombinatorialFreeModule)
                 and S.dimension() < Infinity and p == S.base_ring().characteristic()):
-            from .steenrod_algebra_misc import get_basis_name
+            from sage.algebras.steenrod.steenrod_algebra_misc import get_basis_name
             try:
                 get_basis_name(S.prefix(), S.base_ring().characteristic())
                 # return all(a in self for a in S.basis())
@@ -2109,8 +2135,8 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             sage: A1({(2,): 1, (1,): 13})
             Sq(1) + Sq(2)
         """
-        from sage.rings.integer_ring import ZZ
         from sage.rings.finite_rings.finite_field_constructor import GF
+        from sage.rings.integer_ring import ZZ
         if x in GF(self.prime()) or x in ZZ:
             return self.from_base_ring_from_one_basis(x)
 
@@ -2678,8 +2704,8 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             sage: SteenrodAlgebra(p=5, profile=[[2,1], [2,2,2]]).algebra_generators()
             Family (Q_0, P(1), P(5))
         """
-        from sage.sets.non_negative_integers import NonNegativeIntegers
         from sage.rings.infinity import Infinity
+        from sage.sets.non_negative_integers import NonNegativeIntegers
         n = self.ngens()
         if n < Infinity:
             return Family([self.gen(i) for i in range(n)])

--- a/src/sage/algebras/steenrod/steenrod_algebra_bases.py
+++ b/src/sage/algebras/steenrod/steenrod_algebra_bases.py
@@ -165,9 +165,9 @@ def convert_to_milnor_matrix(n, basis, p=2, generic='auto'):
         [0 1 0]
         [1 2 0]
     """
+    from sage.algebras.steenrod.steenrod_algebra import SteenrodAlgebra
     from sage.matrix.constructor import matrix
     from sage.rings.finite_rings.finite_field_constructor import GF
-    from .steenrod_algebra import SteenrodAlgebra
     if generic == 'auto':
         generic = p != 2
     if n == 0:
@@ -335,7 +335,7 @@ def steenrod_algebra_basis(n, basis='milnor', p=2, **kwds):
         sage: steenrod_algebra_basis(5, 'pst-rlex')
         (((0, 1), (2, 1)), ((1, 1), (0, 2)))
     """
-    from .steenrod_algebra_misc import get_basis_name
+    from sage.algebras.steenrod.steenrod_algebra_misc import get_basis_name
     try:
         if n < 0 or int(n) != n:
             return ()
@@ -580,8 +580,8 @@ def milnor_basis(n, p=2, **kwds):
         else:
             return (((), ()),)
 
-    from sage.rings.infinity import Infinity
     from sage.combinat.integer_vector_weighted import WeightedIntegerVectors
+    from sage.rings.infinity import Infinity
     profile = kwds.get("profile", None)
     trunc = kwds.get("truncation_type", None)
     if trunc is None:
@@ -715,42 +715,41 @@ def serre_cartan_basis(n, p=2, bound=1, **kwds):
 
     if n == 0:
         return ((),)
-    else:
-        if not generic:
-            # Build basis recursively.  last = last term.
-            # last is >= bound, and we will append (last,) to the end of
-            # elements from serre_cartan_basis (n - last, bound=2 * last).
-            # This means that 2 last <= n - last, or 3 last <= n.
-            result = [(n,)]
-            for last in range(bound, 1+n//3):
-                for vec in serre_cartan_basis(n - last, bound=2 * last):
-                    new = vec + (last,)
-                    result.append(new)
-        else:  # p odd
-            if n % (2 * (p-1)) == 0 and n//(2 * (p-1)) >= bound:
-                result = [(0, int(n//(2 * (p-1))), 0)]
-            elif n == 1:
-                result = [(1,)]
-            else:
-                result = []
-            # 2 cases: append P^{last}, or append P^{last} beta
-            # case 1: append P^{last}
-            for last in range(bound, 1+n//(2*(p - 1))):
-                if n - 2*(p-1)*last > 0:
-                    for vec in serre_cartan_basis(n - 2*(p-1)*last,
-                                                  p, p*last, generic=generic):
-                        result.append(vec + (last, 0))
-            # case 2: append P^{last} beta
-            if bound == 1:
-                bound = 0
-            for last in range(bound+1, 1+n//(2*(p - 1))):
-                basis = serre_cartan_basis(n - 2*(p-1)*last - 1,
-                                           p, p*last, generic=generic)
-                for vec in basis:
-                    if vec == ():
-                        vec = (0,)
-                    new = vec + (last, 1)
-                    result.append(new)
+    elif not generic:
+        # Build basis recursively.  last = last term.
+        # last is >= bound, and we will append (last,) to the end of
+        # elements from serre_cartan_basis (n - last, bound=2 * last).
+        # This means that 2 last <= n - last, or 3 last <= n.
+        result = [(n,)]
+        for last in range(bound, 1+n//3):
+            for vec in serre_cartan_basis(n - last, bound=2 * last):
+                new = vec + (last,)
+                result.append(new)
+    else:  # p odd
+        if n % (2 * (p-1)) == 0 and n//(2 * (p-1)) >= bound:
+            result = [(0, int(n//(2 * (p-1))), 0)]
+        elif n == 1:
+            result = [(1,)]
+        else:
+            result = []
+        # 2 cases: append P^{last}, or append P^{last} beta
+        # case 1: append P^{last}
+        for last in range(bound, 1+n//(2*(p - 1))):
+            if n - 2*(p-1)*last > 0:
+                for vec in serre_cartan_basis(n - 2*(p-1)*last,
+                                              p, p*last, generic=generic):
+                    result.append(vec + (last, 0))
+        # case 2: append P^{last} beta
+        if bound == 1:
+            bound = 0
+        for last in range(bound+1, 1+n//(2*(p - 1))):
+            basis = serre_cartan_basis(n - 2*(p-1)*last - 1,
+                                       p, p*last, generic=generic)
+            for vec in basis:
+                if vec == ():
+                    vec = (0,)
+                new = vec + (last, 1)
+                result.append(new)
     return tuple(result)
 
 
@@ -1046,9 +1045,9 @@ def atomic_basis_odd(n, basis, p, **kwds):
         else:
             return (((), ()),)
 
-    from sage.rings.integer import Integer
-    from sage.rings.infinity import Infinity
     from sage.combinat.integer_vector_weighted import WeightedIntegerVectors
+    from sage.rings.infinity import Infinity
+    from sage.rings.integer import Integer
     profile = kwds.get("profile", None)
     trunc = kwds.get("truncation_type", 0)
 

--- a/src/sage/homology/algebraic_topological_model.py
+++ b/src/sage/homology/algebraic_topological_model.py
@@ -24,13 +24,13 @@ AUTHORS:
 
 # TODO: cythonize this.
 
-from sage.modules.free_module_element import vector
-from sage.modules.free_module import VectorSpace
+from sage.homology.chain_complex import ChainComplex
+from sage.homology.chain_complex_morphism import ChainComplexMorphism
+from sage.homology.chain_homotopy import ChainContraction
 from sage.matrix.constructor import matrix, zero_matrix
 from sage.matrix.matrix_space import MatrixSpace
-from .chain_complex import ChainComplex
-from .chain_complex_morphism import ChainComplexMorphism
-from .chain_homotopy import ChainContraction
+from sage.modules.free_module import VectorSpace
+from sage.modules.free_module_element import vector
 from sage.rings.rational_field import QQ
 
 
@@ -502,13 +502,12 @@ def algebraic_topological_model_delta_complex(K, base_ring=None):
             if not diff:
                 c_bar = c
                 pi_bdry_c_bar = False
+            elif base_ring == QQ:
+                c_bar = c - phi_old * (diff * c)
+                pi_bdry_c_bar = conditionally_sparse(pi_old) * (diff * c_bar)
             else:
-                if base_ring == QQ:
-                    c_bar = c - phi_old * (diff * c)
-                    pi_bdry_c_bar = conditionally_sparse(pi_old) * (diff * c_bar)
-                else:
-                    c_bar = c - phi_old * diff * c
-                    pi_bdry_c_bar = conditionally_sparse(pi_old) * diff * c_bar
+                c_bar = c - phi_old * diff * c
+                pi_bdry_c_bar = conditionally_sparse(pi_old) * diff * c_bar
 
             # One small typo in the published algorithm: it says
             # "if bdry(c_bar) == 0", but should say

--- a/src/sage/homology/chain_homotopy.py
+++ b/src/sage/homology/chain_homotopy.py
@@ -41,8 +41,8 @@ isomorphic.
 #                  https://www.gnu.org/licenses/
 ########################################################################
 
-from sage.categories.morphism import Morphism
 from sage.categories.homset import Hom
+from sage.categories.morphism import Morphism
 from sage.homology.chain_complex_morphism import ChainComplexMorphism
 
 
@@ -459,8 +459,8 @@ class ChainContraction(ChainHomotopy):
             ...
             ValueError: not an algebraic gradient vector field
         """
+        from sage.homology.chain_complex_morphism import ChainComplexMorphism
         from sage.matrix.constructor import identity_matrix
-        from .chain_complex_morphism import ChainComplexMorphism
 
         if not (pi.domain() == iota.codomain()
                 and pi.codomain() == iota.domain()):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

For consistency and to fix some import issues, the relative imports are migrated to absolute ones. I took the opportunity to reorder the imports to fix Ruff I001.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


