### PR TITLE
Change mul to * in generic matrix dense

### DIFF
--- a/src/sage/matrix/matrix_generic_dense.pyx
+++ b/src/sage/matrix/matrix_generic_dense.pyx
@@ -375,9 +375,9 @@ cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
         zero = R.zero()
         p = 0
         for i in range(nr):
+            m = i*snc
             for j in range(nc):
                 z = zero
-                m = i*snc
                 for k in range(snc):
                     z += self._entries[m+k] * (right._entries[k*nc+j])
                 v[p] = z

--- a/src/sage/matrix/matrix_generic_dense.pyx
+++ b/src/sage/matrix/matrix_generic_dense.pyx
@@ -343,12 +343,12 @@ cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
         TESTS::
 
             sage: Ext=ExteriorAlgebra(QQ,['p'])
-            sage: Ext.inject_variables()
+            sage: Ext.inject_variables(verbose=False)
             sage: Mp = matrix(1,1,[[p]])
             sage: Mp[0,0]*Mp[0,0]
             0
             sage: Mp*Mp
-            [[0]]
+            [0]
         """
         cdef Py_ssize_t i, j, k, m, nr, nc, snc, p
         cdef Matrix_generic_dense right = _right

--- a/src/sage/matrix/matrix_generic_dense.pyx
+++ b/src/sage/matrix/matrix_generic_dense.pyx
@@ -339,6 +339,16 @@ cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
             [0 0 0 0]
             [0 0 0 0]
             [0 0 0 0]
+
+        TESTS::
+
+            sage: Ext=ExteriorAlgebra(QQ,['p'])
+            sage: Ext.inject_variables()
+            sage: Mp = matrix(1,1,[[p]])
+            sage: Mp[0,0]*Mp[0,0]
+            0
+            sage: Mp*Mp
+            [[0]]
         """
         cdef Py_ssize_t i, j, k, m, nr, nc, snc, p
         cdef Matrix_generic_dense right = _right
@@ -358,7 +368,7 @@ cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
                 z = zero
                 m = i*snc
                 for k in range(snc):
-                    z += self._entries[m+k]._mul_(right._entries[k*nc+j])
+                    z += self._entries[m+k] * (right._entries[k*nc+j])
                 v[p] = z
                 p += 1
 

--- a/src/sage/matrix/matrix_generic_dense.pyx
+++ b/src/sage/matrix/matrix_generic_dense.pyx
@@ -349,6 +349,17 @@ cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
             0
             sage: Mp*Mp
             [0]
+
+            sage: # needs sage.modules
+            sage: MS = MatrixSpace(MatrixSpace(ZZ, 2, 2), 2, 2)
+            sage: A = MS([matrix(ZZ, 2, [n, 0, 0, n]) for n in range(1, 5)])
+            sage: B = A * A
+            sage: B[0, 0]
+            [7 0]
+            [0 7]
+            sage: B[1, 1]
+            [22  0]
+            [ 0 22]
         """
         cdef Py_ssize_t i, j, k, m, nr, nc, snc, p
         cdef Matrix_generic_dense right = _right


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This changes `_mul_` in generic matrix to `*` in order to allow for the coercion framework to take over when there is a `cdef _mul_`.
 
This fixes #39648 and #42134, following discussion in the sage-support Google group: https://groups.google.com/g/sage-support/c/I3UKrO3mceA/m/BEaB3Yk1AAAJ

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


