### PR TITLE
Fix rendering issues via known workaround

### DIFF
--- a/src/doc/common/static/jupyter-sphinx-furo.js
+++ b/src/doc/common/static/jupyter-sphinx-furo.js
@@ -1,28 +1,87 @@
 document.addEventListener('DOMContentLoaded', function() {
-    // Fix double backslashes
-    const processText = (text) => {
-        return text.replace(
-            /(\$[^$]+\$)|(\\\([^)]+\\\))/g,
-            function(mathBlock) {
-                return mathBlock.replace(/\\\\/g, '\\');
-            }
-        );
+  function fixMathContent(text) {
+    return text
+      .replace(/\\\[([\s\S]*?)\\\]/g, function(match, inner) {
+        let fixed = inner;
+        fixed = fixed.replace(/\\\\([a-zA-Z@])/g, '\\$1');
+        fixed = fixed.replace(/\\\\([\[\]{}()|_^])/g, '\\$1');
+        return '\\[' + fixed + '\\]';
+      })
+      .replace(/\$\$([\s\S]*?)\$\$/g, function(match, inner) {
+        let fixed = inner;
+        fixed = fixed.replace(/\\\\([a-zA-Z@])/g, '\\$1');
+        fixed = fixed.replace(/\\\\([\[\]{}()|_^])/g, '\\$1');
+        return '$$' + fixed + '$$';
+      })
+      .replace(/\\\(([\s\S]*?)\\\)/g, function(match, inner) {
+        const fixed = inner.replace(/\\\\/g, '\\');
+        return '\\(' + fixed + '\\)';
+      })
+      .replace(/\$([^$]+)\$/g, function(match, inner) {
+        const fixed = inner.replace(/\\\\/g, '\\');
+        return '$' + fixed + '$';
+      });
+  }
+  
+  // Process text nodes
+  const walker = document.createTreeWalker(
+    document.body,
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode(node) {
+        const parent = node.parentElement;
+        if (!parent) return NodeFilter.FILTER_SKIP;
+        
+        const tag = parent.tagName;
+        if (['SCRIPT', 'STYLE', 'NOSCRIPT', 'CODE', 'PRE', 'TEXTAREA'].includes(tag)) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        
+        if (parent.closest && parent.closest('.MathJax')) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    },
+    false
+  );
+  
+  let node;
+  const nodesToProcess = [];
+  
+  while ((node = walker.nextNode())) {
+    nodesToProcess.push(node);
+  }
+  
+  nodesToProcess.forEach(node => {
+    const newText = fixMathContent(node.textContent);
+    if (newText !== node.textContent) {
+      node.textContent = newText;
+    }
+  });
+
+  const hasMath = /(?:\$[^$\n]+\$|\\\([^]*?\\\)|\\\[[^]*?\\\]|\\begin\{[^}]*\})/.test(document.body.textContent);
+  
+  if (hasMath) {
+    window.MathJax = {
+      tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']],
+        displayMath: [['$$', '$$'], ['\\[', '\\]']],
+        processEscapes: true,
+        processEnvironments: true
+      },
+      options: {
+        skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+        ignoreHtmlClass: 'no-mathjax'
+      }
     };
     
-    const walker = document.createTreeWalker(
-        document.body, 
-        NodeFilter.SHOW_TEXT, 
-        null, 
-        false
-    );
-    
-    let node;
-    while (node = walker.nextNode()) {
-        const newText = processText(node.textContent);
-        if (newText !== node.textContent) {
-            node.textContent = newText;
-        }
-    }
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/mathjax@4/tex-chtml.js'; // Using v4
+    script.async = true;
+    document.head.appendChild(script);
+  }
 });
 
 // Change the editor theme according to the furo light/dark/auto mode

--- a/src/doc/common/static/jupyter-sphinx-furo.js
+++ b/src/doc/common/static/jupyter-sphinx-furo.js
@@ -1,3 +1,30 @@
+document.addEventListener('DOMContentLoaded', function() {
+    // Fix double backslashes
+    const processText = (text) => {
+        return text.replace(
+            /(\$[^$]+\$)|(\\\([^)]+\\\))/g,
+            function(mathBlock) {
+                return mathBlock.replace(/\\\\/g, '\\');
+            }
+        );
+    };
+    
+    const walker = document.createTreeWalker(
+        document.body, 
+        NodeFilter.SHOW_TEXT, 
+        null, 
+        false
+    );
+    
+    let node;
+    while (node = walker.nextNode()) {
+        const newText = processText(node.textContent);
+        if (newText !== node.textContent) {
+            node.textContent = newText;
+        }
+    }
+});
+
 // Change the editor theme according to the furo light/dark/auto mode
 function changeTheme(editor, theme) {
   if (theme === 'dark') {

--- a/src/doc/en/a_tour_of_sage/index.rst
+++ b/src/doc/en/a_tour_of_sage/index.rst
@@ -25,7 +25,7 @@ The caret symbol means "raise to a power".
     sage: 57.1^100
     4.60904368661396e175
 
-We compute the inverse of a $2 \\times 2$ matrix in Sage.
+We compute the inverse of a $2 \times 2$ matrix in Sage.
 
 ::
 
@@ -68,7 +68,7 @@ Sage can plot various useful functions, of course.
 .. image:: sin_plot.png
 
 
-Sage is a very powerful calculator. To experience it, first we create a $500 \\times 500$
+Sage is a very powerful calculator. To experience it, first we create a $500 \times 500$
 matrix of random numbers.
 
 ::
@@ -102,7 +102,7 @@ digits.
     sage: len(n.digits())
     5565709
 
-This computes at least 100 digits of $\\pi$.
+This computes at least 100 digits of $\pi$.
 
 ::
 

--- a/src/doc/en/a_tour_of_sage/index.rst
+++ b/src/doc/en/a_tour_of_sage/index.rst
@@ -25,7 +25,7 @@ The caret symbol means "raise to a power".
     sage: 57.1^100
     4.60904368661396e175
 
-We compute the inverse of a :math:`2 \times 2` matrix in Sage.
+We compute the inverse of a $2 \\times 2$ matrix in Sage.
 
 ::
 
@@ -65,10 +65,10 @@ Sage can plot various useful functions, of course.
 
     sage: show(plot(sin(x) + sin(1.6*x), 0, 40))
 
-.. image:: sin_plot.*
+.. image:: sin_plot.png
 
 
-Sage is a very powerful calculator. To experience it, first we create a :math:`500 \times 500`
+Sage is a very powerful calculator. To experience it, first we create a $500 \\times 500$
 matrix of random numbers.
 
 ::
@@ -85,7 +85,7 @@ It takes Sage a second to compute the eigenvalues of the matrix and plot them.
     sage: w = [(i, abs(e[i])) for i in range(len(e))]
     sage: show(points(w))
 
-.. image:: eigen_plot.*
+.. image:: eigen_plot.png
 
 
 Sage can handle very large numbers, even numbers with millions or billions of
@@ -102,7 +102,7 @@ digits.
     sage: len(n.digits())
     5565709
 
-This computes at least 100 digits of :math:`\pi`.
+This computes at least 100 digits of $\\pi$.
 
 ::
 

--- a/src/doc/en/a_tour_of_sage/index.rst
+++ b/src/doc/en/a_tour_of_sage/index.rst
@@ -25,7 +25,7 @@ The caret symbol means "raise to a power".
     sage: 57.1^100
     4.60904368661396e175
 
-We compute the inverse of a $2 \times 2$ matrix in Sage.
+We compute the inverse of a $2 \\times 2$ matrix in Sage.
 
 ::
 
@@ -68,7 +68,7 @@ Sage can plot various useful functions, of course.
 .. image:: sin_plot.png
 
 
-Sage is a very powerful calculator. To experience it, first we create a $500 \times 500$
+Sage is a very powerful calculator. To experience it, first we create a $500 \\times 500$
 matrix of random numbers.
 
 ::
@@ -102,7 +102,7 @@ digits.
     sage: len(n.digits())
     5565709
 
-This computes at least 100 digits of $\pi$.
+This computes at least 100 digits of $\\pi$.
 
 ::
 

--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -534,16 +534,29 @@ mathjax3_config = {
         # Add custom sage macros
         # http://docs.mathjax.org/en/latest/input/tex/macros.html
         "macros": sage_mathjax_macros(),
+        
         # Add $...$ as possible inline math
         # https://docs.mathjax.org/en/latest/input/tex/delimiters.html#tex-and-latex-math-delimiters
         "inlineMath": [["$", "$"], ["\\(", "\\)"]],
+        
+        # Allow $$...$$ and \[ ... \] if used
+        "displayMath": [["$$", "$$"], ["\\[", "\\]"]],
+        
         # Increase the limit the size of the string to be processed
         # https://docs.mathjax.org/en/latest/options/input/tex.html#option-descriptions
         "maxBuffer": 50 * 1024,
+        
         # Use colorv2 extension instead of built-in color extension
         # https://docs.mathjax.org/en/latest/input/tex/extensions/autoload.html#tex-autoload-options
         # https://docs.mathjax.org/en/latest/input/tex/extensions/colorv2.html#tex-colorv2
         "autoload": {"color": [], "colorv2": ["color"]},
+        
+        "processEscapes": True, #process escapes
+        "processEnvironments": True, #for multi-line envs 
+    },
+    "options": {
+        "skipHtmlTags": ["script", "noscript", "style", "textarea", "pre", "code"],
+        "ignoreHtmlClass": "no-mathjax",
     },
 }
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
Fixes rendering of math symbol(s) and images for `index.rst`.
Path: `src/doc/en/a_tour_of_sage/index.rst`
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

<!-- ### :hourglass: Dependencies -->

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


