### PR TITLE
Fix matrix() and image() of certain module morphism

### DIFF
--- a/src/sage/categories/finite_dimensional_modules_with_basis.py
+++ b/src/sage/categories/finite_dimensional_modules_with_basis.py
@@ -662,10 +662,7 @@ class FiniteDimensionalModulesWithBasis(CategoryWithAxiom_over_base_ring):
             on_basis = self.on_basis()
             basis_keys = self.domain().basis().keys()
             from sage.matrix.matrix_space import MatrixSpace
-            if isinstance(basis_keys, list):
-                nrows = len(basis_keys)
-            else:
-                nrows = basis_keys.cardinality()
+            nrows = len(basis_keys)
             MS = MatrixSpace(base_ring, nrows, self.codomain().dimension())
             m = MS([on_basis(x)._vector_() for x in basis_keys])
             if side == "left":

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -189,6 +189,7 @@ from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.fields import Fields
 from sage.categories.infinite_enumerated_sets import InfiniteEnumeratedSets
 from sage.categories.integral_domains import IntegralDomains
+from sage.categories.modules_with_basis import ModulesWithBasis
 from sage.categories.principal_ideal_domains import PrincipalIdealDomains
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_attribute import lazy_attribute
@@ -891,7 +892,6 @@ class Module_free_ambient(Module):
         if degree < 0:
             raise ValueError("degree (=%s) must be nonnegative" % degree)
 
-        from sage.categories.modules_with_basis import ModulesWithBasis
         modules_category = ModulesWithBasis(base_ring.category()).FiniteDimensional()
         try:
             if base_ring.is_finite() or degree == 0:
@@ -1584,7 +1584,7 @@ class Module_free_ambient(Module):
 
     _submodule_class = LazyImport("sage.modules.submodule", "Submodule_free_ambient")
 
-    def span(self, gens, base_ring=None, check=True, already_echelonized=False):
+    def span(self, gens, base_ring=None, check=True, already_echelonized=False, *, category=None):
         r"""
         Return the `R`-span of ``gens``, where `R` is the ``base_ring``.
 
@@ -1702,7 +1702,7 @@ class Module_free_ambient(Module):
         if isinstance(gens, FreeModule_generic):
             gens = gens.gens()
         if base_ring is None or base_ring is self.base_ring():
-            return self._submodule_class(self.ambient_module(), gens, check=check, already_echelonized=already_echelonized)
+            return self._submodule_class(self.ambient_module(), gens, check=check, already_echelonized=already_echelonized, category=category)
 
         # The base ring has changed
         try:
@@ -1711,12 +1711,12 @@ class Module_free_ambient(Module):
             raise ValueError("argument base_ring (= %s) is not compatible " % base_ring +
                              "with the base ring (= %s)" % self.base_ring())
         try:
-            return M.span(gens)
+            return M.span(gens, check=check, category=category)
         except TypeError:
             raise ValueError("argument gens (= %s) is not compatible " % gens +
                              "with base_ring (= %s)" % base_ring)
 
-    def submodule(self, gens, check=True, already_echelonized=False):
+    def submodule(self, gens, check=True, already_echelonized=False, *, category=None):
         r"""
         Create the `R`-submodule of the ambient module with given generators,
         where `R` is the base ring of ``self``.
@@ -1790,7 +1790,7 @@ class Module_free_ambient(Module):
         """
         if isinstance(gens, Module_free_ambient):
             gens = gens.gens()
-        V = self.span(gens, check=check, already_echelonized=already_echelonized)
+        V = self.span(gens, check=check, already_echelonized=already_echelonized, category=category)
         if check:
             if not V.is_submodule(self):
                 raise ArithmeticError("argument gens (= %s) does not generate "
@@ -5489,6 +5489,7 @@ class FreeModule_ambient(FreeModule_generic):
                                     degree=rank, sparse=sparse,
                                     coordinate_ring=coordinate_ring,
                                     category=category)
+        self._indices = range(rank)  # cf. IndexedGenerators, used by basis
 
     def __hash__(self):
         """
@@ -5809,34 +5810,7 @@ class FreeModule_ambient(FreeModule_generic):
         """
         return self
 
-    def basis(self):
-        """
-        Return a basis for this ambient free module.
-
-        OUTPUT:
-
-        - ``Sequence`` -- an immutable sequence with universe
-          this ambient free module
-
-        EXAMPLES::
-
-            sage: A = ZZ^3; B = A.basis(); B
-            [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
-            sage: B.universe()
-            Ambient free module of rank 3 over the principal ideal domain Integer Ring
-        """
-        try:
-            return self.__basis
-        except AttributeError:
-            ZERO = self(0)
-            one = self.coordinate_ring().one()
-            w = []
-            for n in range(self.rank()):
-                v = ZERO.__copy__()
-                v.set(n, one)
-                w.append(v)
-            self.__basis = basis_seq(self, w)
-            return self.__basis
+    basis = ModulesWithBasis.ParentMethods.basis
 
     def echelonized_basis(self):
         """
@@ -6120,6 +6094,8 @@ class FreeModule_ambient(FreeModule_generic):
             v[i] = self.base_ring().one()
             v.set_immutable()
             return v
+
+    monomial = gen
 
     def _sympy_(self):
         """

--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -1236,7 +1236,7 @@ cdef class FreeModuleElement(Vector):   # abstract base class
             raise TypeError("mutable vectors are unhashable")
         return hash(tuple(self))
 
-    def _vector_(self, R=None):
+    def _vector_(self, R=None, *, order=None):
         r"""
         Return ``self`` as a vector.
 
@@ -1255,6 +1255,9 @@ cdef class FreeModuleElement(Vector):   # abstract base class
             sage: vector(vector(SR, (1, sqrt(2)) ) )                                    # needs sage.symbolic
             (1, sqrt(2))
         """
+        if order is not None:
+            # this parameter is for compatibility with FiniteDimensionalModulesWithBasis.ParentMethods.echelon_form
+            raise ValueError("order is not supported")
         if R is None:
             return self
         return self.change_ring(R)


### PR DESCRIPTION
Previously, this code raises some errors

```
C0=QQ^(4^2);C1=QQ^(4^3)
K=list(range(1<<4));K0=list(range(1<<6))
d1=matrix.zero(1<<4,1<<2);m1=C0.hom(d1).matrix()[K,:];m1=m1[:,list(range(1<<2))]
k1=m1.kernel()
d2=matrix.zero(1<<6,1<<4);m2=C1.hom(d2).matrix()[K0,:];m2=m2[:,K]
h1=k1/m2.image();i1=k1.hom(QQ^len(K))
(i1*h1.lift_map()).image()
(i1*h1.lift_map()).matrix()
```

Now it works.

The code above is a very minimal version, so its intention can be obscure (you can at least tell it computes some homology group). The causes of the issue are

- Free module like `QQ^2` has `.basis()` returning a `Sequence`, which does not work with the generic implementation, assuming `.keys()` is available. Now it returns a `Family`. (For comparison, `CombinatorialFreeModule.basis()` returns a `Family`.)
- `_vector_` method does not accept `order`, now it takes `order` but requires it to be `None` for compatibility with the generic implementation.
- make `span` takes `category` and propagate it accordingly.

Also, `len()` delegate to `.cardinality()` if the latter exists, so changing to always use `len()` simplifies code. (if the `.keys()` is a `range` object, then `.cardinality()` does not exist.)

Todo (I don't think it's too necessary, but reviewer decide)

- should the `basis` tests be modified and added back e.g. to `TESTS::` section in `__init__`?
- should the example above be added as a test?

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


