### PR TITLE
add parameter immutable to graph generators in `smallgraphs.py` (part 9)

### DIFF
--- a/src/sage/graphs/domination.py
+++ b/src/sage/graphs/domination.py
@@ -300,7 +300,7 @@ def dominating_sets(g, k=1, independent=False, total=False, connected=False,
         sage: G = graphs.PetersenGraph()
         sage: G.dominating_set(total=True, value_only=True)                             # needs sage.numerical.mip
         4
-        sage: sorted(G.dominating_sets(k=1))                                            # needs sage.numerical.mip
+        sage: sorted(sorted(d) for d in G.dominating_sets(k=1))                         # needs sage.numerical.mip
         [[0, 2, 6],
          [0, 3, 9],
          [0, 7, 8],
@@ -316,9 +316,9 @@ def dominating_sets(g, k=1, independent=False, total=False, connected=False,
 
         sage: # needs sage.numerical.mip
         sage: G = graphs.PathGraph(6)
-        sage: sorted(G.dominating_sets(k=1, independent=True))
+        sage: sorted(sorted(d) for d in G.dominating_sets(k=1, independent=True))
         [[1, 4]]
-        sage: sorted(G.dominating_sets(k=2, independent=True))
+        sage: sorted(sorted(d) for d in G.dominating_sets(k=2, independent=True))
         [[0, 3], [0, 4], [0, 5], [1, 3], [1, 4], [1, 5], [2, 4], [2, 5]]
         sage: sorted(G.dominating_sets(k=3, independent=True))
         [[2], [3]]
@@ -330,7 +330,7 @@ def dominating_sets(g, k=1, independent=False, total=False, connected=False,
         sage: g = digraphs.Path(3)
         sage: g.dominating_set(value_only=True)
         2
-        sage: list(g.dominating_sets())
+        sage: sorted(sorted(d) for d in g.dominating_sets())
         [[0, 1], [0, 2]]
         sage: list(g.dominating_sets(k=2))
         [[0]]
@@ -345,7 +345,7 @@ def dominating_sets(g, k=1, independent=False, total=False, connected=False,
         sage: G = graphs.PetersenGraph()
         sage: G.dominating_set(total=True, value_only=True)                             # needs sage.numerical.mip
         4
-        sage: sorted(G.dominating_sets(k=1, connected=True))                            # needs sage.numerical.mip
+        sage: sorted(sorted(d) for d in G.dominating_sets(k=1, connected=True))         # needs sage.numerical.mip
         [[0, 1, 2, 6],
          [0, 1, 4, 5],
          [0, 3, 4, 9],
@@ -367,8 +367,8 @@ def dominating_sets(g, k=1, independent=False, total=False, connected=False,
     Minimum distance-k connected dominating sets of the Tietze graph::
 
         sage: G = graphs.TietzeGraph()
-        sage: sorted(G.dominating_sets(k=2, connected=True))
-        [[0, 9], [1, 0], [2, 3], [4, 3], [5, 6], [7, 6], [8, 0], [10, 3], [11, 6]]
+        sage: sorted(sorted(d) for d in G.dominating_sets(k=2, connected=True))
+        [[0, 1], [0, 8], [0, 9], [2, 3], [3, 4], [3, 10], [5, 6], [6, 7], [6, 11]]
         sage: sorted(G.dominating_sets(k=3, connected=True))
         [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11]]
 

--- a/src/sage/graphs/generators/smallgraphs.py
+++ b/src/sage/graphs/generators/smallgraphs.py
@@ -4398,7 +4398,7 @@ def ShrikhandeGraph():
     return Graph(edge_dict, pos=pos_dict, name="Shrikhande graph")
 
 
-def SylvesterGraph():
+def SylvesterGraph(immutable=False):
     """
     Return the Sylvester Graph.
 
@@ -4412,6 +4412,11 @@ def SylvesterGraph():
     .. SEEALSO::
 
         * :meth:`~sage.graphs.graph_generators.GraphGenerators.HoffmanSingletonGraph`.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -4427,16 +4432,19 @@ def SylvesterGraph():
     g = HoffmanSingletonGraph()
     e = next(g.edge_iterator(labels=False))
     g.delete_vertices(g.neighbors(e[0]) + g.neighbors(e[1]))
-    g.relabel()
+    g.name("Sylvester Graph")
+    if immutable:
+        g = g.relabel(inplace=False, immutable=True)
+    else:
+        g.relabel()
     ordering = [0, 1, 2, 4, 5, 9, 16, 35, 15, 18, 20, 30, 22, 6, 33, 32, 14,
                 10, 28, 29, 7, 24, 23, 26, 19, 12, 13, 21, 11, 31, 3, 27, 25,
                 17, 8, 34]
     g._circle_embedding(ordering, shift=.5)
-    g.name("Sylvester Graph")
     return g
 
 
-def SimsGewirtzGraph():
+def SimsGewirtzGraph(immutable=False):
     r"""
     Return the Sims-Gewirtz Graph.
 
@@ -4453,6 +4461,11 @@ def SimsGewirtzGraph():
 
         * :meth:`~sage.graphs.graph_generators.GraphGenerators.HigmanSimsGraph`.
 
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     EXAMPLES::
 
         sage: g = graphs.SimsGewirtzGraph(); g
@@ -4467,17 +4480,20 @@ def SimsGewirtzGraph():
     g = HigmanSimsGraph()
     e = next(g.edge_iterator(labels=False))
     g.delete_vertices(g.neighbors(e[0]) + g.neighbors(e[1]))
-    g.relabel()
+    g.name("Sims-Gewirtz Graph")
+    if immutable:
+        g = g.relabel(inplace=False, immutable=True)
+    else:
+        g.relabel()
     ordering = [0, 2, 3, 4, 6, 7, 8, 17, 1, 41, 49, 5, 22, 26, 11, 27, 15, 47,
                 53, 52, 38, 43, 44, 18, 20, 32, 19, 42, 54, 36, 51, 30, 33, 35,
                 37, 28, 34, 12, 29, 23, 55, 25, 40, 24, 9, 14, 48, 39, 45, 16,
                 13, 21, 31, 50, 10, 46]
     g._circle_embedding(ordering)
-    g.name("Sims-Gewirtz Graph")
     return g
 
 
-def SousselierGraph():
+def SousselierGraph(immutable=False):
     r"""
     Return the Sousselier Graph.
 
@@ -4485,6 +4501,11 @@ def SousselierGraph():
     edges. For more information, see :wikipedia:`Sousselier_graph` or
     the corresponding French
     `Wikipedia page <https://fr.wikipedia.org/wiki/Graphe_de_Sousselier>`_.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -4516,15 +4537,20 @@ def SousselierGraph():
     g._circle_embedding(list(range(15)), shift=-.25)
     g._pos[15] = (0, 0)
 
-    return g
+    return g.copy(immutable=True) if immutable else g
 
 
-def SzekeresSnarkGraph():
+def SzekeresSnarkGraph(immutable=False):
     r"""
     Return the Szekeres Snark Graph.
 
     The Szekeres graph is a snark with 50 vertices and 75 edges. For more
     information on this graph, see the :wikipedia:`Szekeres_snark`.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -4557,12 +4583,13 @@ def SzekeresSnarkGraph():
                             shift=5.45 + 1.8 * i)
 
     g._circle_embedding(c, radius=1, shift=.25)
-
+    if immutable:
+        return g.relabel(inplace=False, immutable=True)
     g.relabel()
     return g
 
 
-def ThomsenGraph():
+def ThomsenGraph(immutable=False):
     """
     Return the Thomsen Graph.
 
@@ -4570,6 +4597,11 @@ def ThomsenGraph():
     (3, 3)`. It is also called the Utility graph.
 
     PLOTTING: See CompleteBipartiteGraph.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -4581,17 +4613,21 @@ def ThomsenGraph():
         sage: (graphs.ThomsenGraph()).show()    # long time                             # needs sage.plot
     """
     from sage.graphs.generators.basic import CompleteBipartiteGraph
-    G = CompleteBipartiteGraph(3, 3)
-    G.name("Thomsen graph")
-    return G
+    return CompleteBipartiteGraph(3, 3, immutable=immutable,
+                                  name="Thomsen graph")
 
 
-def TietzeGraph():
+def TietzeGraph(immutable=False):
     r"""
     Return the Tietze Graph.
 
     For more information on the Tietze Graph, see the
     :wikipedia:`Tietze%27s_graph`.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -4609,10 +4645,11 @@ def TietzeGraph():
         sage: g.automorphism_group().is_isomorphic(groups.permutation.Dihedral(6))      # needs sage.groups
         True
     """
-    g = Graph([(0, 9), (3, 10), (6, 11), (1, 5), (2, 7), (4, 8)],
-              name="Tietze Graph")
-    g.add_cycle(list(range(9)))
-    g.add_cycle([9, 10, 11])
+    edges = ((0, 1), (0, 8), (0, 9), (1, 2), (1, 5), (2, 3),
+             (2, 7), (3, 4), (3, 10), (4, 5), (4, 8), (5, 6),
+             (6, 7), (6, 11), (7, 8), (9, 10), (9, 11), (10, 11))
+    g = Graph([range(12), edges], format="vertices_and_edges",
+              name="Tietze Graph", immutable=immutable)
     g._circle_embedding(list(range(9)))
     g._circle_embedding([9, 10, 11], radius=.5)
     return g


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to some generators in `src/sage/graphs/generators/smallgraphs.py`.
- `SylvesterGraph`, `SimsGewirtzGraph`, `SousselierGraph`, `SzekeresSnarkGraph`, `ThomsenGraph`, `TietzeGraph`




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


