### PR TITLE
Fix MathJax rendering on `index.html` and image rendering in `a_tour_of_sage/index.rst` 

### DIFF
--- a/.github/workflows/create-changes-html.sh
+++ b/.github/workflows/create-changes-html.sh
@@ -58,36 +58,6 @@ diffParagraphs.forEach(paragraph => {
 });
 </script>
 EOF
-cat >> CHANGES.html << 'EOF'
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Normalize double backslashes 
-    const processText = (text) => {
-        return text.replace(
-            /(\$[^$]+\$)|(\\\([^)]+\\\))/g,
-            function(mathBlock) {
-                return mathBlock.replace(/\\\\/g, '\\');
-            }
-        );
-    };
-
-    const walker = document.createTreeWalker(
-        document.body,
-        NodeFilter.SHOW_TEXT,
-        null,
-        false
-    );
-
-    let node;
-    while ((node = walker.nextNode())) {
-        const newText = processText(node.textContent);
-        if (newText !== node.textContent) {
-            node.textContent = newText;
-        }
-    }
-});
-</script>
-EOF
 echo '</head>' >> CHANGES.html
 echo '<body>' >> CHANGES.html
 python3 - << EOF

--- a/.github/workflows/create-changes-html.sh
+++ b/.github/workflows/create-changes-html.sh
@@ -15,6 +15,7 @@ echo '<head>' >> CHANGES.html
 echo '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">' >> CHANGES.html
 echo '<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>' >> CHANGES.html
 echo '<script>hljs.highlightAll();</script>' >> CHANGES.html
+echo '<script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>' >> CHANGES.html
 cat >> CHANGES.html << EOF
 <style>
   p.diff a:first-child {
@@ -54,6 +55,36 @@ diffParagraphs.forEach(paragraph => {
     hunk.appendChild(anchor);
   });
 });
+});
+</script>
+EOF
+cat >> CHANGES.html << 'EOF'
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Normalize double backslashes 
+    const processText = (text) => {
+        return text.replace(
+            /(\$[^$]+\$)|(\\\([^)]+\\\))/g,
+            function(mathBlock) {
+                return mathBlock.replace(/\\\\/g, '\\');
+            }
+        );
+    };
+
+    const walker = document.createTreeWalker(
+        document.body,
+        NodeFilter.SHOW_TEXT,
+        null,
+        false
+    );
+
+    let node;
+    while ((node = walker.nextNode())) {
+        const newText = processText(node.textContent);
+        if (newText !== node.textContent) {
+            node.textContent = newText;
+        }
+    }
 });
 </script>
 EOF

--- a/src/doc/en/a_tour_of_sage/index.rst
+++ b/src/doc/en/a_tour_of_sage/index.rst
@@ -65,7 +65,7 @@ Sage can plot various useful functions, of course.
 
     sage: show(plot(sin(x) + sin(1.6*x), 0, 40))
 
-.. image:: sin_plot.*
+.. image:: sin_plot.png
 
 
 Sage is a very powerful calculator. To experience it, first we create a :math:`500 \times 500`
@@ -85,7 +85,7 @@ It takes Sage a second to compute the eigenvalues of the matrix and plot them.
     sage: w = [(i, abs(e[i])) for i in range(len(e))]
     sage: show(points(w))
 
-.. image:: eigen_plot.*
+.. image:: eigen_plot.png
 
 
 Sage can handle very large numbers, even numbers with millions or billions of

--- a/src/doc/en/website/templates/index.html
+++ b/src/doc/en/website/templates/index.html
@@ -1,3 +1,5 @@
+<script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+
 {% extends "layout.html" %}
 
 {% block htmltitle %}

--- a/src/doc/en/website/templates/index.html
+++ b/src/doc/en/website/templates/index.html
@@ -1,5 +1,3 @@
-<script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
-
 {% extends "layout.html" %}
 
 {% block htmltitle %}
@@ -7,6 +5,8 @@
 {% endblock %}
 
 {%- block extrahead %}
+{{ super() }}
+<script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
 <style type="text/css">
   img.icon {
     border: none;

--- a/src/doc/en/website/templates/index_furo.html
+++ b/src/doc/en/website/templates/index_furo.html
@@ -1,3 +1,5 @@
+<script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+
 {% extends "furo/page.html" %}
 
 {% block htmltitle %}

--- a/src/doc/en/website/templates/index_furo.html
+++ b/src/doc/en/website/templates/index_furo.html
@@ -1,5 +1,3 @@
-<script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
-
 {% extends "furo/page.html" %}
 
 {% block htmltitle %}
@@ -7,6 +5,8 @@
 {% endblock %}
 
 {%- block extrahead %}
+{{ super() }}
+<script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
 <style type="text/css">
   img.icon {
     border: none;


### PR DESCRIPTION
Currently, the math on the following documentation page is not rendered:
https://doc.sagemath.org/html/en/index.html

This PR fixes the issue, adds the MathJax script to `create-changes-html.sh` as a precautionary measure, and enables the plots to render in `a_tour_of_sage/index.rst`.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

<!-- ### :hourglass: Dependencies -->

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


