### PR TITLE
Fix typo in developer docs for ruff, clearer wording

### DIFF
--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -315,7 +315,7 @@ disables all rules that we do not already follow throughout the repository. Our 
 GitHub Action workflow requires ``ruff check --config .github/workflows/ruff.toml --preview``
 to pass. To speed up the code review process, developers should verify that this passes
 locally before submitting a PR. To make sure you are running the same version of ``ruff``
-locally as GitHub Actions, use the command
+locally as that is used by GitHub Actions, you can use the command
 ``uv run --frozen --only-group lint -- ruff check --config .github/workflows/ruff.toml --preview``.
 
 Developers are encouraged to locally run ``ruff check [path to changed files]``
@@ -328,7 +328,7 @@ code-style changes as this makes it harder for reviewers to evaluate the importa
 
 When working on PRs to improve our alignment with our linter rules, the ``--statistics``
 option can be passed to ``ruff`` to print out a list of all rules that are enabled in
-``pyproject.toml`` but are not currently followed throughout the repository and how many
+``pyproject.toml`` but are not currently followed throughout the repository, and how many
 times each rule is violated. This is useful for finding low-hanging fruit for formatting PRs.
 Developers can also use ``--select [RULE CODES]`` to override the list of rules enabled in
 ``pyproject.toml`` when testing additional rules to add to ``pyproject.toml``, or

--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -308,18 +308,19 @@ for Python code, written in Rust.
 It comes with a large choice of possible checks, and has the capacity
 to fix some of the warnings it emits.
 
-Sage we have two configuration files for ruff. ``pyproject.toml`` in the root of the
-repository defines all rules we wish to follow. ``.github/workflows/ruff.toml`` takes
-the configuration in ``pyproject.toml`` and disables all rules that we do not already
-follow throughout the repository. Our lint GitHub Action workflow requires
-``ruff check --config .github/workflows/ruff.toml --preview`` to pass. To speed up the
-code review process, developers should verify that this passes locally before submitting a PR.
-To make sure you are running the same version of ``ruff`` locally as GitHub Actions, use the command
+Sage has two configuration files for ruff. The default configuration is in
+``pyproject.toml`` in the root of the repository, and defines all rules we wish to follow.
+``.github/workflows/ruff.toml`` takes the configuration in ``pyproject.toml`` and
+disables all rules that we do not already follow throughout the repository. Our lint
+GitHub Action workflow requires ``ruff check --config .github/workflows/ruff.toml --preview``
+to pass. To speed up the code review process, developers should verify that this passes
+locally before submitting a PR. To make sure you are running the same version of ``ruff``
+locally as GitHub Actions, use the command
 ``uv run --frozen --only-group lint -- ruff check --config .github/workflows/ruff.toml --preview``.
 
 Developers are encouraged to locally run ``ruff check [path to changed files]``
 to run the stricter configuration defined in ``pyproject.toml`` and fix any linter
-failures on their new code. This will help to avoid follow-up formatting PRs as
+failures in their new code. This will help to avoid follow-up formatting PRs as
 Sage moves toward full PEP 8 compliance. Developers may also choose to fix existing
 linter failures on files that they modify, but use common sense when deciding whether
 or not to do so. A small bug fix PR should not include a large number of


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.