### PR TITLE
Add references to Sage Constructions and the Sage Reference Manual in `tour.rst` (en)

### DIFF
--- a/src/doc/en/tutorial/tour.rst
+++ b/src/doc/en/tutorial/tour.rst
@@ -3,7 +3,7 @@ A Guided Tour
 *************
 
 This section is a guided tour of some of what is available in Sage.
-For many more examples, see `Sage Constructions <http://doc.sagemath.org/html/en/constructions/>`_, which is intended
+For many more examples, see `Sage Constructions <https://doc.sagemath.org/html/en/constructions/>`_, which is intended
 to answer the general question "How do I construct ...?". See also
 the `Sage Reference Manual <https://doc.sagemath.org/html/en/reference/>`_, which has thousands more examples.
 Also note that you can interactively work through this tour in the

--- a/src/doc/en/tutorial/tour.rst
+++ b/src/doc/en/tutorial/tour.rst
@@ -3,9 +3,9 @@ A Guided Tour
 *************
 
 This section is a guided tour of some of what is available in Sage.
-For many more examples, see "Sage Constructions", which is intended
+For many more examples, see `Sage Constructions <http://doc.sagemath.org/html/en/constructions/>`_, which is intended
 to answer the general question "How do I construct ...?". See also
-the "Sage Reference Manual", which has thousands more examples.
+the `Sage Reference Manual <https://doc.sagemath.org/html/en/reference/>`_, which has thousands more examples.
 Also note that you can interactively work through this tour in the
 Sage notebook by clicking the ``Help`` link.
 

--- a/src/doc/en/tutorial/tour.rst
+++ b/src/doc/en/tutorial/tour.rst
@@ -3,9 +3,9 @@ A Guided Tour
 *************
 
 This section is a guided tour of some of what is available in Sage.
-For many more examples, see `Sage Constructions <https://doc.sagemath.org/html/en/constructions/>`_, which is intended
+For many more examples, see `Sage Constructions <../constructions/index.html>`_, which is intended
 to answer the general question "How do I construct ...?". See also
-the `Sage Reference Manual <https://doc.sagemath.org/html/en/reference/>`_, which has thousands more examples.
+the `Sage Reference Manual <../reference/index.html>`_, which has thousands more examples.
 Also note that you can interactively work through this tour in the
 Sage notebook by clicking the ``Help`` link.
 

--- a/src/doc/en/tutorial/tour.rst
+++ b/src/doc/en/tutorial/tour.rst
@@ -3,9 +3,9 @@ A Guided Tour
 *************
 
 This section is a guided tour of some of what is available in Sage.
-For many more examples, see `Sage Constructions <../constructions/index.html>`_, which is intended
+For many more examples, see :ref:`Sage Constructions <constructions>`, which is intended
 to answer the general question "How do I construct ...?". See also
-the `Sage Reference Manual <../reference/index.html>`_, which has thousands more examples.
+the :ref:`Sage Reference Manual <reference-manual>`, which has thousands more examples.
 Also note that you can interactively work through this tour in the
 Sage notebook by clicking the ``Help`` link.
 


### PR DESCRIPTION
Without the links, it's a pain to go through the docs or find/search elsewhere. Hence, I've added the hyperlinks. I've removed the quotes because these aren't quotations.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

<!-- ### :hourglass: Dependencies -->

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


