### PR TITLE
fix .inverse_image() returning the zero element on the wrong curve

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -633,6 +633,11 @@ class EllipticCurveHom(Morphism):
             sage: f.inverse_image(f.codomain().zero())
             (0 : 1 : 0)
 
+        Make sure the inverse image of zero is returned on the correct curve (:issue:`41529`)::
+
+            sage: f.inverse_image(0).curve() is f.domain()
+            True
+
         You can give a tuple as input::
 
             sage: f.inverse_image((0, 2))  # random
@@ -666,7 +671,7 @@ class EllipticCurveHom(Morphism):
             if all:
                 return self.kernel_points()
             else:
-                return Q
+                return self.domain().zero()
         if all:
             try:
                 P = self.inverse_image(Q)


### PR DESCRIPTION
Currently (Sage 10.8):
```sage
sage: E.<P, Q> = EllipticCurve(GF(5^2), [1, 2, 3, 3, 1])
sage: f = E.isogeny([P*3])
sage: f.inverse_image(0).curve() is f.domain()
False
```