### PR TITLE
more algorithms for .torsion_basis() over {finite, number, ""} fields

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1087,15 +1087,14 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             L = L, F_to_K.post_compose(K_to_L)
         return L
 
-    def torsion_basis(self, n, *, algorithm=None):
+    def torsion_subgroup(self, n, *, extend=False, algorithm=None):
         r"""
-        Return a basis of the `n`-torsion subgroup of this elliptic curve
-        assuming it is isomorphic to `\ZZ/n\times\ZZ/n` and fully rational.
-
 
         INPUT:
 
-        - ``n`` -- integer
+        - ``extend`` -- boolean (default: ``False``):
+          Whether or not to extend the base field to find all
+          `n`-torsion points.
 
         - ``algorithm`` -- string (default: ``None``).
           Over general fields, only ``"divpoly"`` is available,
@@ -1105,13 +1104,393 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         EXAMPLES::
 
+            sage: E = EllipticCurve('90c3')
+            sage: E.torsion_subgroup(5, algorithm='divpoly').invariants()
+            ()
+            sage: E.torsion_subgroup(2, algorithm='divpoly').invariants()
+            (2,)
+            sage: E.torsion_subgroup(3, algorithm='divpoly').invariants()
+            (3,)
+            sage: E.torsion_subgroup(6, algorithm='divpoly').invariants()
+            (6,)
+            sage: E.torsion_subgroup(666, algorithm='divpoly').invariants()
+            (6,)
+            sage: E.torsion_subgroup(1332, algorithm='divpoly').invariants()
+            (12,)
+            sage: E.torsion_subgroup().invariants()
+            (12,)
+            sage: E.torsion_subgroup(5, algorithm='structure').invariants()
+            ()
+            sage: E.torsion_subgroup(2, algorithm='structure').invariants()
+            (2,)
+            sage: E.torsion_subgroup(3, algorithm='structure').invariants()
+            (3,)
+            sage: E.torsion_subgroup(6, algorithm='structure').invariants()
+            (6,)
+            sage: E.torsion_subgroup(666, algorithm='structure').invariants()
+            (6,)
+            sage: E.torsion_subgroup(1332, algorithm='structure').invariants()
+            (12,)
+
+        ::
+
+            sage: E = EllipticCurve('30a2')
+            sage: E.torsion_subgroup(5, algorithm='divpoly').invariants()
+            ()
+            sage: E.torsion_subgroup(2, algorithm='divpoly').invariants()
+            (2, 2)
+            sage: E.torsion_subgroup(3, algorithm='divpoly').invariants()
+            (3,)
+            sage: E.torsion_subgroup(6, algorithm='divpoly').invariants()
+            (2, 6)
+            sage: E.torsion_subgroup(666, algorithm='divpoly').invariants()
+            (2, 6)
+            sage: E.torsion_subgroup().invariants()
+            (2, 6)
+            sage: E.torsion_subgroup(5, algorithm='structure').invariants()
+            ()
+            sage: E.torsion_subgroup(2, algorithm='structure').invariants()
+            (2, 2)
+            sage: E.torsion_subgroup(3, algorithm='structure').invariants()
+            (3,)
+            sage: E.torsion_subgroup(6, algorithm='structure').invariants()
+            (2, 6)
+            sage: E.torsion_subgroup(666, algorithm='structure').invariants()
+            (2, 6)
+
+        ::
+
+            sage: # LMFDB 196.2-a3
+            sage: R.<x> = QQ[]
+            sage: K.<a> = NumberField(R([1, -1, 1]))
+            sage: E = EllipticCurve(K, [[1,1], -a, 1, [-5,4], -6])
+            sage: E.torsion_subgroup(2, algorithm='divpoly').invariants()
+            (2,)
+            sage: E.torsion_subgroup(3, algorithm='divpoly').invariants()
+            (3, 3)
+            sage: E.torsion_subgroup(6, algorithm='divpoly').invariants()
+            (3, 6)
+            sage: E.torsion_subgroup(666, algorithm='divpoly').invariants()
+            (3, 6)
+            sage: E.torsion_subgroup().invariants()
+            (3, 6)
+            sage: E.torsion_subgroup(2, algorithm='structure').invariants()
+            (2,)
+            sage: E.torsion_subgroup(3, algorithm='structure').invariants()
+            (3, 3)
+            sage: E.torsion_subgroup(6, algorithm='structure').invariants()
+            (3, 6)
+            sage: E.torsion_subgroup(666, algorithm='structure').invariants()
+            (3, 6)
+            sage: E.torsion_subgroup(6, extend=True, algorithm='divpoly').invariants()
+            (6, 6)
+            sage: E.torsion_subgroup(6, extend=True, algorithm='structure').invariants()
+            (6, 6)
+
+        ::
+
+            sage: # LMFDB 1.1-a2
+            sage: R.<x> = QQ[]
+            sage: K.<a> = NumberField(R([-1, -2, 7, 2, -7, -1, 1]))
+            sage: E = EllipticCurve([K([-2,-9,4,14,1,-2]), K([0,-12,3,20,2,-3]), K([-7,-26,18,37,1,-5]), K([11,27,-28,-51,-1,7]), K([-16,-56,40,92,4,-13])])
+            sage: E.torsion_subgroup(31, algorithm='divpoly').invariants()  # long time -- 7s
+            ()
+            sage: E.torsion_subgroup(37, algorithm='divpoly').invariants()  # long time -- 7s
+            (37,)
+            sage: E.torsion_subgroup().invariants()  # long time -- 7s
+            (37,)
+            sage: E.torsion_subgroup(31, algorithm='structure').invariants()  # long time -- 7s
+            ()
+            sage: E.torsion_subgroup(37, algorithm='structure').invariants()  # long time -- 7s
+            (37,)
+
+        ::
+
+            sage: # LMFDB 8.1-a1
+            sage: R.<x> = QQ[]
+            sage: K.<a> = NumberField(R([-1, -3, 0, 1]))
+            sage: E = EllipticCurve([K([-1,1,1]), K([2,1,-1]), K([-2,0,1]), K([-44,2,13]), K([88,-3,-22])])
+            sage: E.torsion_subgroup(5, algorithm='divpoly').invariants()
+            ()
+            sage: E.torsion_subgroup(9, algorithm='divpoly').invariants()
+            (3,)
+            sage: E.torsion_subgroup(14, algorithm='divpoly').invariants()
+            (7,)
+            sage: E.torsion_subgroup(42, algorithm='divpoly').invariants()
+            (21,)
+            sage: E.torsion_subgroup().invariants()
+            (21,)
+            sage: E.torsion_subgroup(5, algorithm='structure').invariants()
+            ()
+            sage: E.torsion_subgroup(9, algorithm='structure').invariants()
+            (3,)
+            sage: E.torsion_subgroup(14, algorithm='structure').invariants()
+            (7,)
+            sage: E.torsion_subgroup(42, algorithm='structure').invariants()
+            (21,)
+            sage: E.torsion_subgroup(3, extend=True, algorithm='divpoly').invariants()
+            (3, 3)
+            sage: E.torsion_subgroup(3, extend=True, algorithm='structure').invariants()
+            (3, 3)
+
+        ::
+
+            sage: # LMFDB 11.1-a3
+            sage: R.<x> = QQ[]
+            sage: K.<a> = NumberField(R([-1, 3, 3, -4, -1, 1]))
+            sage: E = EllipticCurve(K, [0, -1, 1, 0, 0])
+            sage: E.torsion_subgroup(5, algorithm='divpoly').invariants()
+            (5,)
+            sage: E.torsion_subgroup(25, algorithm='divpoly').invariants()
+            (25,)
+            sage: E.torsion_subgroup(125, algorithm='divpoly').invariants()
+            (25,)
+            sage: E.torsion_subgroup().invariants()
+            (25,)
+            sage: E.torsion_subgroup(5, algorithm='structure').invariants()
+            (5,)
+            sage: E.torsion_subgroup(25, algorithm='structure').invariants()
+            (25,)
+            sage: E.torsion_subgroup(125, algorithm='structure').invariants()
+            (25,)
+
+        .. SEEALSO::
+
+            Use :meth:`~sage.schemes.elliptic_curves.ell_field.EllipticCurve_field.division_field`
+            to determine a field extension containing the full `n`-torsion subgroup.
+
+        ALGORITHM:
+
+        If ``algorithm`` is ``divpoly``, this method uses division
+        polynomials to construct a basis of the `n`-torsion. The
+        complexity of this approach scales with the size of the prime
+        factors of `n`.
+
+        If ``algorithm`` is ``"structure"``, this method calls
+        :meth:`torsion_subgroup` and
+        :meth:`sage.groups.additive_abelian.additive_abelian_wrapper.AdditiveAbelianGroupWrapper.torsion_subgroup`.
+        """
+        if algorithm is None:
+            if hasattr(self, '_cached_torsion_subgroup'):
+                algorithm = 'structure'
+            else:
+                algorithm = 'divpoly'
+
+        n = ZZ(n)
+        if n <= 0:
+            raise ValueError('n must be a positive integer')
+
+        E = self
+        if extend:
+            E = E.change_ring(E.division_field(n, map=True)[1])
+
+        if algorithm == 'structure':
+            return E.torsion_subgroup().torsion_subgroup(n)
+
+        elif algorithm == 'divpoly':
+            accP = accQ = E.zero()
+
+            for l,m in n.factor():
+                pts = filter(bool, E.zero().division_points(l))
+                try:
+                    P = Pl = next(pts)
+                except StopIteration:
+                    continue
+
+                for i in range(1, m):
+                    try:
+                        P = P.division_points(l)[0]
+                    except IndexError:
+                        break
+
+                for Ql in pts:
+                    if Ql < -Ql:
+                        # deduplicate point and its negative
+                        continue
+
+                    if Pl.weil_pairing(Ql, l) != 1:
+                        Q = Ql
+                        break
+                else:
+                    # easy case: cyclic
+                    Q = E.zero()
+
+                if Q:
+                    for i in range(1, m):
+                        try:
+                            Q = Q.division_points(l)[0]
+                        except IndexError:
+                            break
+
+                    if P._order < Q._order:
+                        P, Q = Q, P
+
+                    if (F := self.base_field()).is_finite():
+                        # We're in luck! Strategy: https://ia.cr/2025/477 §5.5
+
+                        z = F.primitive_element()**(F.order()//l)
+                        profile = lambda U: tuple(B.tate_pairing(U, l, 1).log(z, order=l) for B in (Pl, Ql))
+
+                        from sage.rings.finite_rings.integer_mod_ring import Zmod
+                        from sage.matrix.constructor import matrix
+
+                        while P._order < l**m:
+                            mat = matrix(Zmod(l), [profile(R) for R in (P, Q)])
+                            ker = mat.left_kernel()
+                            if not ker:
+                                break
+                            ker, = tuple(ker.basis())
+                            P, P._order = P + ker[1]/ker[0] * Q, P._order
+                            P = P.division_points(l)[0]
+
+                            if P._order < Q._order:
+                                P, Q = Q, P
+
+                    else:
+                        # We're not in luck: Simple brute-force search.
+
+                        while P._order < l**m:
+                            for i in range(l):
+                                if i:
+                                    P, P._order = P + Q, P._order
+                                try:
+                                    P = P.division_points(l)[0]
+                                    break
+                                except IndexError:
+                                    pass
+                            else:
+                                break
+
+                            if P._order < Q._order:
+                                P, Q = Q, P
+
+#                if __debug__:
+#                    from sage.groups.generic import has_order
+#
+#                    assert has_order(P.weil_pairing(Q, P._order), Q._order, operation='*')
+
+                accP, accP._order = accP + P, accP._order.lcm(P._order)
+                accQ, accQ._order = accQ + Q, accQ._order.lcm(Q._order)
+
+            gens = list(filter(bool, [accP, accQ]))
+
+            from sage.groups.additive_abelian.additive_abelian_wrapper import AdditiveAbelianGroupWrapper
+            return AdditiveAbelianGroupWrapper(E.point_homset(), gens, [pt.order() for pt in gens])
+
+        else:
+            raise ValueError(f'unknown algorithm {algorithm!r}')
+
+    def torsion_gens(self, n, *args, **kwds):
+        r"""
+        Return a (minimal) set of generators for the `n`-torsion
+        subgroup of this elliptic curve.
+
+        This is a thin convenience wrapper around :meth:`torsion_subgroup`;
+        all extra arguments ``args`` and keyword arguments ``kwds`` are
+        passed on to that method.
+
+        EXAMPLES::
+
+            sage: E = EllipticCurve(GF(419), [1,0])
+            sage: P, = E.torsion_gens(7); P.order()
+            7
+            sage: P, = E.torsion_gens(9); P.order()
+            3
+            sage: E.torsion_gens(11)
+            ()
+            sage: P, Q = E.torsion_gens(11, extend=True); (P.order(), Q.order())
+            (11, 11)
+
+        ::
+
+            sage: E = EllipticCurve(GF(419^2), [1,0])
+            sage: P, Q = E.torsion_gens(7); (P.order(), Q.order())
+            (7, 7)
+            sage: P, Q = E.torsion_gens(9); (P.order(), Q.order())
+            (3, 3)
+            sage: E.torsion_gens(11)
+            ()
+
+        ::
+
+            sage: E = EllipticCurve('11a1')
+            sage: P, Q = E.torsion_gens(2, extend=True); (P.order(), Q.order())
+            (2, 2)
+        """
+        T = self.torsion_subgroup(n, *args, **kwds)
+        return tuple(g.element() for g in T.gens())
+
+    def torsion_basis(self, n, *args, **kwds):
+        r"""
+        Return a basis `(P,Q)` of the `n`-torsion subgroup of this elliptic
+        curve assuming it is isomorphic to `\ZZ/n\times\ZZ/n`.
+
+        If ``extend`` is set to ``True``, the base field is extended as much
+        as needed to find the full `n`-torsion that exists over the algebraic
+        closure.
+
+        INPUT:
+
+        - ``n`` -- integer
+
+        - ``extend`` -- boolean (default: ``False``): Extend the base
+          field to the `n`-division field (:meth:`division_field`)
+          prior to computing the `n`-torsion subgroup.
+
+        - ``args``, ``kwds``: Further arguments and keyword arguments
+          to be passed on to one of the following methods:
+          - :meth:`sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.torsion_subgroup()`
+          - :meth:`sage.schemes.elliptic_curves.ell_number_field.EllipticCurve_number_field.torsion_subgroup()`
+          - :meth:`sage.schemes.elliptic_curves.ell_number_field.EllipticCurve_field.torsion_subgroup()`
+
+        EXAMPLES::
+
             sage: E = EllipticCurve('15a1')
             sage: E.torsion_basis(2)
             ((-13/4 : 9/8 : 1), (-1 : 0 : 1))
             sage: E.torsion_basis(4)
             Traceback (most recent call last):
             ...
-            ValueError: curve does not have full rational 2^2-torsion
+            ValueError: curve does not have full rational 4-torsion
+
+        ::
+
+            sage: # needs sage.rings.finite_rings
+            sage: E = EllipticCurve(GF(62207^2), [1,0])
+            sage: E.abelian_group()
+            Additive abelian group isomorphic to Z/62208 + Z/62208 embedded in
+             Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+              over Finite Field in z2 of size 62207^2
+            sage: PA,QA = E.torsion_basis(2^8)
+            sage: PA.weil_pairing(QA, 2^8).multiplicative_order()
+            256
+            sage: PB,QB = E.torsion_basis(3^5)
+            sage: PB.weil_pairing(QB, 3^5).multiplicative_order()
+            243
+
+        ::
+
+            sage: E = EllipticCurve(GF(101), [4,4])
+            sage: E.torsion_basis(23)
+            Traceback (most recent call last):
+            ...
+            ValueError: curve does not have full rational 23-torsion
+            sage: F = E.division_field(23); F
+            Finite Field in t of size 101^11
+            sage: EE = E.change_ring(F)
+            sage: P, Q = EE.torsion_basis(23)
+            sage: P  # random
+            (89*z11^10 + 51*z11^9 + 96*z11^8 + 8*z11^7 + 67*z11^6
+             + 31*z11^5 + 55*z11^4 + 59*z11^3 + 28*z11^2 + 8*z11 + 88
+             : 40*z11^10 + 33*z11^9 + 80*z11^8 + 87*z11^7 + 97*z11^6
+             + 69*z11^5 + 56*z11^4 + 17*z11^3 + 26*z11^2 + 69*z11 + 11
+             : 1)
+            sage: Q  # random
+            (25*z11^10 + 61*z11^9 + 49*z11^8 + 17*z11^7 + 80*z11^6
+             + 20*z11^5 + 49*z11^4 + 52*z11^3 + 61*z11^2 + 27*z11 + 61
+             : 60*z11^10 + 91*z11^9 + 89*z11^8 + 7*z11^7 + 63*z11^6
+             + 55*z11^5 + 23*z11^4 + 17*z11^3 + 90*z11^2 + 91*z11 + 68
+             : 1)
 
         ::
 
@@ -1139,70 +1518,11 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
              (104/150625*t^19 - 312/150625*t^18 + 728/150625*t^17 - 1456/150625*t^16 + 5723/301250*t^15 - 416/150625*t^14 + 728/150625*t^13 - 16952/150625*t^12 + 91104/150625*t^11 - 617317/301250*t^10 + 246688/150625*t^9 - 94744/150625*t^8 - 271544/150625*t^7 - 268112/150625*t^6 + 12021881/301250*t^5 - 245128/150625*t^4 + 91104/150625*t^3 + 284544/150625*t^2 + 179712/150625*t - 13340968/150625
               : 3531/301250*t^19 - 10593/301250*t^18 + 24717/301250*t^17 - 24717/150625*t^16 + 48692/150625*t^15 - 7062/150625*t^14 + 24717/301250*t^13 - 575553/301250*t^12 + 1546578/150625*t^11 - 5246148/150625*t^10 + 4187766/150625*t^9 - 3216741/301250*t^8 - 9219441/301250*t^7 - 4551459/150625*t^6 + 102245379/150625*t^5 - 8322567/301250*t^4 + 1546578/150625*t^3 + 4830408/150625*t^2 + 3050784/150625*t - 95627989/150625
               : 1))
-
-        .. SEEALSO::
-
-            Use :meth:`~sage.schemes.elliptic_curves.ell_field.EllipticCurve_field.division_field`
-            to determine a field extension containing the full `n`-torsion subgroup.
-
-        ALGORITHM:
-
-        If ``algorithm`` is ``divpoly``, this method uses division
-        polynomials to construct a basis of the `n`-torsion. The
-        complexity of this approach scales with the size of the prime
-        factors of `n`.
-
-        If ``algorithm`` is ``"structure"``, this method calls
-        :meth:`torsion_subgroup` and
-        :meth:`AdditiveAbelianGroupWrapper.torsion_subgroup`.
         """
-        if algorithm is None:
-            if hasattr(self, 'torsion_subgroup') and self.torsion_subgroup.is_in_cache():
-                algorithm = 'structure'
-            else:
-                algorithm = 'divpoly'
-
-        if algorithm == 'structure':
-            T = self.torsion_subgroup().torsion_subgroup(n)
-            if T.invariants() != (n, n):
-                raise ValueError(f'curve does not have full rational {n}-torsion')
-            return tuple(P.element() for P in T.gens())
-
-        elif algorithm == 'divpoly':
-            from sage.groups.generic import has_order
-
-            n = ZZ(n)
-            if n < 2:
-                raise ValueError('computing an n-torsion basis only makes sense for n >= 2')
-
-            P = Q = self.zero()
-
-            for l,m in n.factor():
-                pts = filter(bool, self.zero().division_points(l))
-                Pl = next(pts)
-                for Ql in pts:
-                    if not Pl.weil_pairing(Ql, l).is_one():
-                        break
-                else:
-                    raise ValueError(f'curve does not have full rational {l}-torsion')
-
-                for i in range(1, m):
-                    try:
-                        Pl = Pl.division_points(l)[0]
-                        Ql = Ql.division_points(l)[0]
-                    except (StopIteration, IndexError):
-                        raise ValueError(f'curve does not have full rational {l}^{i+1}-torsion')
-#                    assert has_order(Pl.weil_pairing(Ql, l**(i+1)), l**(i+1), operation='*')
-
-                P += Pl
-                Q += Ql
-
-#            assert has_order(P.weil_pairing(Q, n), n, operation='*')
-            P._order = Q._order = n
-            return P, Q
-
-        else:
-            raise ValueError(f'unknown algorithm {algorithm!r}')
+        T = self.torsion_subgroup(n, *args, **kwds)
+        if T.invariants() != (n, n):
+            raise ValueError(f'curve does not have full rational {n}-torsion')
+        return tuple(P.element() for P in T.gens())
 
     def _Hom_(self, other, category=None):
         r"""

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1163,14 +1163,12 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                 algorithm = 'divpoly'
 
         if algorithm == 'structure':
-
             T = self.torsion_subgroup().torsion_subgroup(n)
             if T.invariants() != (n, n):
                 raise ValueError(f'curve does not have full rational {n}-torsion')
             return tuple(P.element() for P in T.gens())
 
         elif algorithm == 'divpoly':
-
             from sage.groups.generic import has_order
 
             n = ZZ(n)

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1087,6 +1087,125 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             L = L, F_to_K.post_compose(K_to_L)
         return L
 
+    def torsion_basis(self, n, *, algorithm=None):
+        r"""
+        Return a basis of the `n`-torsion subgroup of this elliptic curve
+        assuming it is isomorphic to `\ZZ/n\times\ZZ/n` and fully rational.
+
+
+        INPUT:
+
+        - ``n`` -- integer
+
+        - ``algorithm`` -- string (default: ``None``).
+          Over general fields, only ``"divpoly"`` is available,
+          and over number fields, additionally ``"structure"``.
+          If ``algorithm`` is ``None``, the method attempts to
+          select the most suitable algorithm automatically.
+
+        EXAMPLES::
+
+            sage: E = EllipticCurve('15a1')
+            sage: E.torsion_basis(2)
+            ((-13/4 : 9/8 : 1), (-1 : 0 : 1))
+            sage: E.torsion_basis(4)
+            Traceback (most recent call last):
+            ...
+            ValueError: curve does not have full rational 2^2-torsion
+
+        ::
+
+            sage: E = EllipticCurve('11a2')
+            sage: E.torsion_subgroup()
+            Torsion Subgroup isomorphic to Trivial group
+              associated to the Elliptic Curve defined by y^2 + y = x^3 - x^2 - 7820*x - 263580
+                over Rational Field
+            sage: EE = E.change_ring(E.division_field(5))
+            sage: EE.torsion_subgroup()
+            Torsion Subgroup isomorphic to Z/5 + Z/5
+              associated to the Elliptic Curve defined by y^2 + y = x^3 + (-1)*x^2 + (-7820)*x + (-263580)
+                over Number Field in t with defining polynomial x^20 - 5*x^19 + 15*x^18 - 35*x^17 + 70*x^16 - 77*x^15 + 20*x^14 - 35*x^13 + 815*x^12 - 4380*x^11 + 9489*x^10 - 11860*x^9 + 4555*x^8 + 13055*x^7 + 12890*x^6 - 30338*x^5 + 11785*x^4 - 4380*x^3 - 13680*x^2 - 8640*x + 20736
+            sage: EE.torsion_basis(5, algorithm='divpoly')
+            ((595183/1928000*t^19 - 35292739/17352000*t^18 + 131419817/17352000*t^17 - 40329101/1928000*t^16 + 413372581/8676000*t^15 - 1379566363/17352000*t^14 + 376817699/4338000*t^13 - 1250892533/17352000*t^12 + 4879989161/17352000*t^11 - 7497101897/4338000*t^10 + 10429892351/1928000*t^9 - 15364091329/1446000*t^8 + 227824771789/17352000*t^7 - 114698642023/17352000*t^6 + 14739878027/8676000*t^5 - 46311365527/8676000*t^4 + 181688916383/17352000*t^3 - 55952844001/4338000*t^2 + 2240720131/361500*t - 199444/30125
+              : 67907087/13014000*t^19 - 224388017/6507000*t^18 + 2323846/18075*t^17 - 2312207969/6507000*t^16 + 10537958483/13014000*t^15 - 17608556113/13014000*t^14 + 19262352991/13014000*t^13 - 3191379809/2602800*t^12 + 30969621131/6507000*t^11 - 42357264953/1446000*t^10 + 398711684093/4338000*t^9 - 2352287312003/13014000*t^8 + 582276824761/2602800*t^7 - 367880125799/3253500*t^6 + 363704361121/13014000*t^5 - 73759615534/813375*t^4 + 2318110141133/13014000*t^3 - 7627182061/34704*t^2 + 3195593808/30125*t + 48027902/30125
+              : 1),
+             (104/150625*t^19 - 312/150625*t^18 + 728/150625*t^17 - 1456/150625*t^16 + 5723/301250*t^15 - 416/150625*t^14 + 728/150625*t^13 - 16952/150625*t^12 + 91104/150625*t^11 - 617317/301250*t^10 + 246688/150625*t^9 - 94744/150625*t^8 - 271544/150625*t^7 - 268112/150625*t^6 + 12021881/301250*t^5 - 245128/150625*t^4 + 91104/150625*t^3 + 284544/150625*t^2 + 179712/150625*t - 13340968/150625
+              : 3531/301250*t^19 - 10593/301250*t^18 + 24717/301250*t^17 - 24717/150625*t^16 + 48692/150625*t^15 - 7062/150625*t^14 + 24717/301250*t^13 - 575553/301250*t^12 + 1546578/150625*t^11 - 5246148/150625*t^10 + 4187766/150625*t^9 - 3216741/301250*t^8 - 9219441/301250*t^7 - 4551459/150625*t^6 + 102245379/150625*t^5 - 8322567/301250*t^4 + 1546578/150625*t^3 + 4830408/150625*t^2 + 3050784/150625*t - 95627989/150625
+              : 1))
+            sage: EE.torsion_basis(5, algorithm='structure')
+            ((595183/1928000*t^19 - 35292739/17352000*t^18 + 131419817/17352000*t^17 - 40329101/1928000*t^16 + 413372581/8676000*t^15 - 1379566363/17352000*t^14 + 376817699/4338000*t^13 - 1250892533/17352000*t^12 + 4879989161/17352000*t^11 - 7497101897/4338000*t^10 + 10429892351/1928000*t^9 - 15364091329/1446000*t^8 + 227824771789/17352000*t^7 - 114698642023/17352000*t^6 + 14739878027/8676000*t^5 - 46311365527/8676000*t^4 + 181688916383/17352000*t^3 - 55952844001/4338000*t^2 + 2240720131/361500*t - 199444/30125
+              : 67907087/13014000*t^19 - 224388017/6507000*t^18 + 2323846/18075*t^17 - 2312207969/6507000*t^16 + 10537958483/13014000*t^15 - 17608556113/13014000*t^14 + 19262352991/13014000*t^13 - 3191379809/2602800*t^12 + 30969621131/6507000*t^11 - 42357264953/1446000*t^10 + 398711684093/4338000*t^9 - 2352287312003/13014000*t^8 + 582276824761/2602800*t^7 - 367880125799/3253500*t^6 + 363704361121/13014000*t^5 - 73759615534/813375*t^4 + 2318110141133/13014000*t^3 - 7627182061/34704*t^2 + 3195593808/30125*t + 48027902/30125
+              : 1),
+             (104/150625*t^19 - 312/150625*t^18 + 728/150625*t^17 - 1456/150625*t^16 + 5723/301250*t^15 - 416/150625*t^14 + 728/150625*t^13 - 16952/150625*t^12 + 91104/150625*t^11 - 617317/301250*t^10 + 246688/150625*t^9 - 94744/150625*t^8 - 271544/150625*t^7 - 268112/150625*t^6 + 12021881/301250*t^5 - 245128/150625*t^4 + 91104/150625*t^3 + 284544/150625*t^2 + 179712/150625*t - 13340968/150625
+              : 3531/301250*t^19 - 10593/301250*t^18 + 24717/301250*t^17 - 24717/150625*t^16 + 48692/150625*t^15 - 7062/150625*t^14 + 24717/301250*t^13 - 575553/301250*t^12 + 1546578/150625*t^11 - 5246148/150625*t^10 + 4187766/150625*t^9 - 3216741/301250*t^8 - 9219441/301250*t^7 - 4551459/150625*t^6 + 102245379/150625*t^5 - 8322567/301250*t^4 + 1546578/150625*t^3 + 4830408/150625*t^2 + 3050784/150625*t - 95627989/150625
+              : 1))
+
+        .. SEEALSO::
+
+            Use :meth:`~sage.schemes.elliptic_curves.ell_field.EllipticCurve_field.division_field`
+            to determine a field extension containing the full `n`-torsion subgroup.
+
+        ALGORITHM:
+
+        If ``algorithm`` is ``divpoly``, this method uses division
+        polynomials to construct a basis of the `n`-torsion. The
+        complexity of this approach scales with the size of the prime
+        factors of `n`.
+
+        If ``algorithm`` is ``"structure"``, this method calls
+        :meth:`torsion_subgroup` and
+        :meth:`AdditiveAbelianGroupWrapper.torsion_subgroup`.
+        """
+        if algorithm is None:
+            if hasattr(self, 'torsion_subgroup') and self.torsion_subgroup.is_in_cache():
+                algorithm = 'structure'
+            else:
+                algorithm = 'divpoly'
+
+        if algorithm == 'structure':
+
+            T = self.torsion_subgroup().torsion_subgroup(n)
+            if T.invariants() != (n, n):
+                raise ValueError(f'curve does not have full rational {n}-torsion')
+            return tuple(P.element() for P in T.gens())
+
+        elif algorithm == 'divpoly':
+
+            from sage.groups.generic import has_order
+
+            n = ZZ(n)
+            if n < 2:
+                raise ValueError('computing an n-torsion basis only makes sense for n >= 2')
+
+            P = Q = self.zero()
+
+            for l,m in n.factor():
+                pts = filter(bool, self.zero().division_points(l))
+                Pl = next(pts)
+                for Ql in pts:
+                    if not Pl.weil_pairing(Ql, l).is_one():
+                        break
+                else:
+                    raise ValueError(f'curve does not have full rational {l}-torsion')
+
+                for i in range(1, m):
+                    try:
+                        Pl = Pl.division_points(l)[0]
+                        Ql = Ql.division_points(l)[0]
+                    except (StopIteration, IndexError):
+                        raise ValueError(f'curve does not have full rational {l}^{i+1}-torsion')
+#                    assert has_order(Pl.weil_pairing(Ql, l**(i+1)), l**(i+1), operation='*')
+
+                P += Pl
+                Q += Ql
+
+#            assert has_order(P.weil_pairing(Q, n), n, operation='*')
+            P._order = Q._order = n
+            return P, Q
+
+        else:
+            raise ValueError(f'unknown algorithm {algorithm!r}')
+
     def _Hom_(self, other, category=None):
         r"""
         Hook to make :class:`~sage.categories.homset.Hom`

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1328,8 +1328,9 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                     if (F := self.base_field()).is_finite():
                         # We're in luck! Strategy: https://ia.cr/2025/477 §5.5
 
-                        z = F.primitive_element()**(F.order()//l)
-                        profile = lambda U: tuple(B.tate_pairing(U, l, 1).log(z, order=l) for B in (Pl, Ql))
+                        q = F.order()
+                        z = F.primitive_element()**(q//l)
+                        profile = lambda U: tuple(B.tate_pairing(U, l, 1, q=q).log(z, order=l) for B in (Pl, Ql))
 
                         from sage.rings.finite_rings.integer_mod_ring import Zmod
                         from sage.matrix.constructor import matrix

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1239,6 +1239,24 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
               embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
                 over Finite Field in t of size 170141183460469231731687303715884105727^2
 
+        A relatively tricky case for ``algorithm="random"``::
+
+            sage: E = EllipticCurve(GF(67^2), [14, 33])
+            sage: A1 = E.torsion_subgroup(12, algorithm='random'); A1
+            Additive abelian group isomorphic to Z/12 + Z/4
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 14*x + 33
+                over Finite Field in z2 of size 67^2
+            sage: A2 = E.torsion_subgroup(12, algorithm='divpoly'); A2
+            Additive abelian group isomorphic to Z/12 + Z/4
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 14*x + 33
+                over Finite Field in z2 of size 67^2
+            sage: A3 = E.torsion_subgroup(12, algorithm='structure'); A3
+            Additive abelian group isomorphic to Z/12 + Z/4
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 14*x + 33
+                over Finite Field in z2 of size 67^2
+            sage: A1 == A2 == A3
+            True
+
         TESTS:
 
         Check on random curves that all three algorithms return
@@ -1309,14 +1327,14 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
                 assert Q._order.divides(P._order)
 #                assert generic.has_order(P.weil_pairing(Q, P._order), Q._order, operation='*')
 
-                if Q._order == n:
+                if n.divides(Q._order):
                     P *= P._order // n
+                    Q *= Q._order // n
                     break
 
                 if P._order * Q._order == M:
-                    if P._order > n:
-                        assert n.divides(P._order)
-                        P *= P._order // n
+                    P *= P._order // n.gcd(P._order)
+                    Q *= Q._order // n.gcd(Q._order)
                     break
 
                 cof = N.prime_to_m_part(n)
@@ -1339,9 +1357,6 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
                 T -= x * P
                 T.set_order(multiple=P._order, check=False)
 
-                # for Q we only need the n-torsion part of T
-                T *= T._order // n.gcd(T._order)
-
                 # extend Q as much as possible
                 Q, m = generic.merge_points((Q, Q._order), (T, T._order))
                 Q._order = m
@@ -1357,6 +1372,11 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
 
             assert hasattr(P, '_order')
             assert hasattr(Q, '_order')
+
+#            if P and Q:
+#                assert Q._order.divides(P._order)
+#                assert generic.has_order(P.weil_pairing(Q, P._order), Q._order, operation='*')
+
             gens = list(filter(bool, [P, Q]))
             return AdditiveAbelianGroupWrapper(E.point_homset(), gens, [pt._order for pt in gens])
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1353,7 +1353,7 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
                 Q.set_order(multiple=P._order, check=False)
 
             else:
-                raise RuntimeError(f'overwhelmingly unlikely event, or (more likely) a bug in EllipticCurve_finite_field.torsion_subgroup()')
+                raise RuntimeError('overwhelmingly unlikely event, or (more likely) a bug in EllipticCurve_finite_field.torsion_subgroup()')
 
             assert hasattr(P, '_order')
             assert hasattr(Q, '_order')

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1142,14 +1142,24 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
         self.gens.set_cache(gens)
         return AdditiveAbelianGroupWrapper(self.point_homset(), gens, orders)
 
-    def torsion_basis(self, n, *, algorithm=None):
+    def torsion_subgroup(self, n, *, extend=False, algorithm=None):
         r"""
-        Return a basis of the `n`-torsion subgroup of this elliptic curve,
-        assuming it is isomorphic to `\ZZ/n\times\ZZ/n` and fully rational.
+        Return a the `n`-torsion subgroup of this elliptic curve
+        as an :class:`AdditiveAbelianGroupWrapper`.
+
+        If ``extend`` is set to ``False`` (the default), this
+        method returns the *rational* `n`-torsion subgroup.
+        Otherwise (if ``extend`` is ``True``), it first extends
+        the base field as much as needed to represent the full
+        `n`-torsion that exists over the algebraic closure.
 
         INPUT:
 
         - ``n`` -- integer
+
+        - ``extend`` -- boolean (default: ``False``): Extend the base
+          field to the `n`-division field (:meth:`division_field`)
+          prior to computing the `n`-torsion subgroup.
 
         - ``algorithm`` -- string (default: ``None``).
           Currently available choices are ``"random"``, ``"structure"``,
@@ -1158,68 +1168,90 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
 
         EXAMPLES::
 
-            sage: # needs sage.rings.finite_rings
-            sage: E = EllipticCurve(GF(62207^2), [1,0])
-            sage: E.abelian_group()
-            Additive abelian group isomorphic to Z/62208 + Z/62208 embedded in
-             Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
-              over Finite Field in z2 of size 62207^2
-            sage: PA,QA = E.torsion_basis(2^8)
-            sage: PA.weil_pairing(QA, 2^8).multiplicative_order()
-            256
-            sage: PB,QB = E.torsion_basis(3^5)
-            sage: PB.weil_pairing(QB, 3^5).multiplicative_order()
-            243
+            sage: E = EllipticCurve(GF(2^31-1), [1767054656, 143637714])
+            sage: E.torsion_subgroup(42)
+            Additive abelian group isomorphic to Z/42 + Z/14
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1767054656*x + 143637714
+                over Finite Field of size 2147483647
+            sage: E.torsion_subgroup(42, algorithm='random')
+            Additive abelian group isomorphic to Z/42 + Z/14
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1767054656*x + 143637714
+                over Finite Field of size 2147483647
+            sage: E.torsion_subgroup(42, algorithm='divpoly')
+            Additive abelian group isomorphic to Z/42 + Z/14
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1767054656*x + 143637714
+                over Finite Field of size 2147483647
+            sage: E.torsion_subgroup(42, algorithm='structure')
+            Additive abelian group isomorphic to Z/42 + Z/14
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1767054656*x + 143637714
+                over Finite Field of size 2147483647
+            sage: E.torsion_subgroup(42, extend=True)
+            Additive abelian group isomorphic to Z/42 + Z/42
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1767054656*x + 143637714
+                over Finite Field in t of size 2147483647^3
+            sage: E.torsion_subgroup(42, extend=True, algorithm='random')
+            Additive abelian group isomorphic to Z/42 + Z/42
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1767054656*x + 143637714
+                over Finite Field in t of size 2147483647^3
+            sage: E.torsion_subgroup(42, extend=True, algorithm='divpoly')
+            Additive abelian group isomorphic to Z/42 + Z/14
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1767054656*x + 143637714
+                over Finite Field of size 2147483647
+            sage: E.torsion_subgroup(42, extend=True, algorithm='structure')
+            Additive abelian group isomorphic to Z/42 + Z/42
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1767054656*x + 143637714
+                over Finite Field in t of size 2147483647^3
 
         ::
 
-            sage: E = EllipticCurve(GF(101), [4,4])
-            sage: E.torsion_basis(23)
-            Traceback (most recent call last):
-            ...
-            ValueError: curve does not have full rational 23-torsion, or very unlikely event
-            sage: F = E.division_field(23); F
-            Finite Field in t of size 101^11
-            sage: EE = E.change_ring(F)
-            sage: P, Q = EE.torsion_basis(23)
-            sage: P  # random
-            (89*z11^10 + 51*z11^9 + 96*z11^8 + 8*z11^7 + 67*z11^6
-             + 31*z11^5 + 55*z11^4 + 59*z11^3 + 28*z11^2 + 8*z11 + 88
-             : 40*z11^10 + 33*z11^9 + 80*z11^8 + 87*z11^7 + 97*z11^6
-             + 69*z11^5 + 56*z11^4 + 17*z11^3 + 26*z11^2 + 69*z11 + 11
-             : 1)
-            sage: Q  # random
-            (25*z11^10 + 61*z11^9 + 49*z11^8 + 17*z11^7 + 80*z11^6
-             + 20*z11^5 + 49*z11^4 + 52*z11^3 + 61*z11^2 + 27*z11 + 61
-             : 60*z11^10 + 91*z11^9 + 89*z11^8 + 7*z11^7 + 63*z11^6
-             + 55*z11^5 + 23*z11^4 + 17*z11^3 + 90*z11^2 + 91*z11 + 68
-             : 1)
+            sage: E = EllipticCurve(GF(2^127-1), [1, 0])
+            sage: E.torsion_subgroup(2^99)
+            Additive abelian group isomorphic to Z/633825300114114700748351602688
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+                over Finite Field of size 170141183460469231731687303715884105727
+            sage: E.torsion_subgroup(2^99, algorithm='random')
+            Additive abelian group isomorphic to Z/633825300114114700748351602688
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+                over Finite Field of size 170141183460469231731687303715884105727
+            sage: E.torsion_subgroup(2^99, algorithm='divpoly')
+            Additive abelian group isomorphic to Z/633825300114114700748351602688
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+                over Finite Field of size 170141183460469231731687303715884105727
+            sage: E.torsion_subgroup(2^99, algorithm='structure')
+            Additive abelian group isomorphic to Z/633825300114114700748351602688
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+                over Finite Field of size 170141183460469231731687303715884105727
+            sage: EE = E.change_ring(E.base_field().extension(2,'t'))
+            sage: EE.torsion_subgroup(2^99)
+            Additive abelian group isomorphic to Z/633825300114114700748351602688 + Z/633825300114114700748351602688
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+                over Finite Field in t of size 170141183460469231731687303715884105727^2
+            sage: EE.torsion_subgroup(2^99, algorithm='random')
+            Additive abelian group isomorphic to Z/633825300114114700748351602688 + Z/633825300114114700748351602688
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+                over Finite Field in t of size 170141183460469231731687303715884105727^2
+            sage: EE.torsion_subgroup(2^99, algorithm='divpoly')
+            Additive abelian group isomorphic to Z/633825300114114700748351602688 + Z/633825300114114700748351602688
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+                over Finite Field in t of size 170141183460469231731687303715884105727^2
+            sage: EE.torsion_subgroup(2^99, algorithm='structure')
+            Additive abelian group isomorphic to Z/633825300114114700748351602688 + Z/633825300114114700748351602688
+              embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
+                over Finite Field in t of size 170141183460469231731687303715884105727^2
 
         TESTS:
 
         Check on random curves that all three algorithms return
         equivalent results::
 
-            sage: while True:
-            ....:     p = random_prime(100)
-            ....:     e = randrange(1,4)
-            ....:     E = choice(EllipticCurve(j=GF((p,e)).random_element()).twists())
-            ....:     ds = E.abelian_group().invariants()
-            ....:     if len(ds) < 2:
-            ....:         continue
-            ....:     ns = set(gcd(ds).divisors()) - {1}
-            ....:     if ns: break
-            sage: n = choice(list(ns))
-            sage: assert n >= 2
-            sage: P1, Q1 = E.torsion_basis(n, algorithm='random')
-            sage: A1 = AdditiveAbelianGroupWrapper.from_generators([P1, Q1])
-            sage: P2, Q2 = E.torsion_basis(n, algorithm='structure')
-            sage: A2 = AdditiveAbelianGroupWrapper.from_generators([P2, Q2])
-            sage: P3, Q3 = E.torsion_basis(n, algorithm='divpoly')
-            sage: A3 = AdditiveAbelianGroupWrapper.from_generators([P3, Q3])
-            sage: assert A1 == A2
-            sage: assert A1 == A3
-            sage: assert A2 == A3
+            sage: p = random_prime(100)
+            sage: e = randrange(1,4)
+            sage: E = choice(EllipticCurve(j=GF((p,e)).random_element()).twists())
+            sage: n = ZZ(randrange(2, 50))
+            sage: A1 = E.torsion_subgroup(n, algorithm='random')
+            sage: A2 = E.torsion_subgroup(n, algorithm='structure')
+            sage: A3 = E.torsion_subgroup(n, algorithm='divpoly')
+            sage: assert A1 == A2 == A3
 
         .. SEEALSO::
 
@@ -1228,15 +1260,15 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
 
         ALGORITHM:
 
-        If ``algorithm`` is ``"random"``, this method repeatedly
-        samples random points on the curve and distills a basis of the
-        `n`-torsion from them. This requires point counting.
+        If ``algorithm`` is ``"random"``, this method repeatedly samples
+        random points on the curve and distills a generating set of the
+        `n`-torsion from them. This involves point counting.
 
         If ``algorithm`` is ``divpoly``, this method uses division
-        polynomials to construct a basis of the `n`-torsion. The
-        complexity of this approach scales with the size of the prime
-        factors of `n`. This algorithm is usually much slower than
-        the others, but there might be situations in which it is
+        polynomials to construct a generating set of the `n`-torsion.
+        The complexity of this approach scales with the size of the
+        prime factors of `n`. This algorithm is usually much slower
+        than the others, but there might be situations in which it is
         useful.
 
         If ``algorithm`` is ``"structure"``, this method calls
@@ -1249,11 +1281,8 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
         practice.
         """
         n = ZZ(n)
-        if n < 2:
-            raise ValueError('computing an n-torsion basis only makes sense for n >= 2')
-
-        if self.base_field().characteristic().divides(n):
-            raise ValueError(f'curve does not have 2-dimensional rational {n}-torsion')
+        if n <= 0:
+            raise ValueError('n must be a positive integer')
 
         if algorithm is None:
             if self.abelian_group.is_in_cache():
@@ -1261,12 +1290,18 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
             else:
                 algorithm = 'random'
 
+        E = self
+        if extend:
+            E = E.change_ring(E.division_field(n))
+
         if algorithm == 'random':
             # similar to AdditiveAbelianGroupWrapper.from_generators()
             from sage.arith.misc import xlcm
 
-            N = self.cardinality()
-            P = Q = self.zero()
+            N = E.cardinality()
+            M = N // N.prime_to_m_part(n)
+
+            P = Q = E.zero()
             P._order = ZZ(1)
 
             for step in range(999):
@@ -1276,11 +1311,16 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
 
                 if Q._order == n:
                     P *= P._order // n
-                    assert hasattr(P, '_order')
                     break
 
-                cof = N.prime_to_m_part(n // Q._order)
-                T = cof * self.random_point()
+                if P._order * Q._order == M:
+                    if P._order > n:
+                        assert n.divides(P._order)
+                        P *= P._order // n
+                    break
+
+                cof = N.prime_to_m_part(n)
+                T = cof * E.random_point()
                 T.set_order(multiple=N//cof, check=False)
 
                 # extend P using T as much as possible
@@ -1313,20 +1353,19 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
                 Q.set_order(multiple=P._order, check=False)
 
             else:
-                raise ValueError(f'curve does not have full rational {n}-torsion, or very unlikely event')
+                raise RuntimeError(f'overwhelmingly unlikely event, or (more likely) a bug in EllipticCurve_finite_field.torsion_subgroup()')
 
-#            assert generic.has_order(P.weil_pairing(Q, n), n, operation='*')
-
-            return P, Q
+            assert hasattr(P, '_order')
+            assert hasattr(Q, '_order')
+            gens = list(filter(bool, [P, Q]))
+            return AdditiveAbelianGroupWrapper(E.point_homset(), gens, [pt._order for pt in gens])
 
         elif algorithm == 'divpoly':
-            return super().torsion_basis(n, algorithm=algorithm)
+            # NB: we already handled extend= above
+            return super().torsion_subgroup(n, extend=False, algorithm='divpoly')
 
         elif algorithm == 'structure':
-            T = self.abelian_group().torsion_subgroup(n)
-            if T.invariants() != (n, n):
-                raise ValueError(f'curve does not have full rational {n}-torsion')
-            return tuple(P.element() for P in T.gens())
+            return E.abelian_group().torsion_subgroup(n)
 
         raise ValueError(f'unknown algorithm {algorithm!r}')
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1142,10 +1142,19 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
         self.gens.set_cache(gens)
         return AdditiveAbelianGroupWrapper(self.point_homset(), gens, orders)
 
-    def torsion_basis(self, n):
+    def torsion_basis(self, n, *, algorithm=None):
         r"""
         Return a basis of the `n`-torsion subgroup of this elliptic curve,
-        assuming it is fully rational.
+        assuming it is isomorphic to `\ZZ/n\times\ZZ/n` and fully rational.
+
+        INPUT:
+
+        - ``n`` -- integer
+
+        - ``algorithm`` -- string (default: ``None``).
+          Currently available choices are ``"random"``, ``"structure"``,
+          and ``"divpoly"``. If ``algorithm`` is ``None``, the method
+          attempts to select the most suitable algorithm automatically.
 
         EXAMPLES::
 
@@ -1168,7 +1177,7 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
             sage: E.torsion_basis(23)
             Traceback (most recent call last):
             ...
-            ValueError: curve does not have full rational 23-torsion
+            ValueError: curve does not have full rational 23-torsion, or very unlikely event
             sage: F = E.division_field(23); F
             Finite Field in t of size 101^11
             sage: EE = E.change_ring(F)
@@ -1186,25 +1195,140 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
              + 55*z11^5 + 23*z11^4 + 17*z11^3 + 90*z11^2 + 91*z11 + 68
              : 1)
 
+        TESTS:
+
+        Check on random curves that all three algorithms return
+        equivalent results::
+
+            sage: while True:
+            ....:     p = random_prime(100)
+            ....:     e = randrange(1,4)
+            ....:     E = choice(EllipticCurve(j=GF((p,e)).random_element()).twists())
+            ....:     ds = E.abelian_group().invariants()
+            ....:     if len(ds) < 2:
+            ....:         continue
+            ....:     ns = set(gcd(ds).divisors()) - {1}
+            ....:     if ns: break
+            sage: n = choice(list(ns))
+            sage: assert n >= 2
+            sage: P1, Q1 = E.torsion_basis(n, algorithm='random')
+            sage: A1 = AdditiveAbelianGroupWrapper.from_generators([P1, Q1])
+            sage: P2, Q2 = E.torsion_basis(n, algorithm='structure')
+            sage: A2 = AdditiveAbelianGroupWrapper.from_generators([P2, Q2])
+            sage: P3, Q3 = E.torsion_basis(n, algorithm='divpoly')
+            sage: A3 = AdditiveAbelianGroupWrapper.from_generators([P3, Q3])
+            sage: assert A1 == A2
+            sage: assert A1 == A3
+            sage: assert A2 == A3
+
         .. SEEALSO::
 
             Use :meth:`~sage.schemes.elliptic_curves.ell_field.EllipticCurve_field.division_field`
-            to determine a field extension containing the full `\ell`-torsion subgroup.
+            to determine a field extension containing the full `n`-torsion subgroup.
 
         ALGORITHM:
 
-        This method currently uses :meth:`abelian_group` and
+        If ``algorithm`` is ``"random"``, this method repeatedly
+        samples random points on the curve and distills a basis of the
+        `n`-torsion from them. This requires point counting.
+
+        If ``algorithm`` is ``divpoly``, this method uses division
+        polynomials to construct a basis of the `n`-torsion. The
+        complexity of this approach scales with the size of the prime
+        factors of `n`. This algorithm is usually much slower than
+        the others, but there might be situations in which it is
+        useful.
+
+        If ``algorithm`` is ``"structure"``, this method calls
+        :meth:`abelian_group` and
         :meth:`AdditiveAbelianGroupWrapper.torsion_subgroup`.
+        Theoretically, this involves performing a superset of the work
+        of the ``"random"`` method, so it should never be the best
+        choice, but due to implementation details (PARI vs. Sage) this
+        approach can be faster than the ``"random"`` algorithm in
+        practice.
         """
-        # TODO: In many cases this is not the fastest algorithm.
-        # Alternatives include factoring division polynomials and
-        # random sampling (like PARI's ellgroup, but with a milder
-        # termination condition). We should implement these too
-        # and figure out when to use which.
-        T = self.abelian_group().torsion_subgroup(n)
-        if T.invariants() != (n, n):
-            raise ValueError(f'curve does not have full rational {n}-torsion')
-        return tuple(P.element() for P in T.gens())
+        n = ZZ(n)
+        if n < 2:
+            raise ValueError('computing an n-torsion basis only makes sense for n >= 2')
+
+        if self.base_field().characteristic().divides(n):
+            raise ValueError(f'curve does not have 2-dimensional rational {n}-torsion')
+
+        if algorithm is None:
+            if self.abelian_group.is_in_cache():
+                algorithm = 'structure'
+            else:
+                algorithm = 'random'
+
+        if algorithm == 'random':
+            # similar to AdditiveAbelianGroupWrapper.from_generators()
+            from sage.arith.misc import xlcm
+
+            N = self.cardinality()
+            P = Q = self.zero()
+            P._order = ZZ(1)
+
+            for step in range(999):
+                # check P,Q is a basis of the subgroup <P,Q> with ord(Q) | ord(P)
+                assert Q._order.divides(P._order)
+#                assert generic.has_order(P.weil_pairing(Q, P._order), Q._order, operation='*')
+
+                if Q._order == n:
+                    P *= P._order // n
+                    assert hasattr(P, '_order')
+                    break
+
+                cof = N.prime_to_m_part(n // Q._order)
+                T = cof * self.random_point()
+                T.set_order(multiple=N//cof, check=False)
+
+                # extend P using T as much as possible
+                m, k1, k2 = xlcm(P._order, T._order)
+                m1 = P._order // k1
+                m2 = T._order // k2
+                P = m1 * P + m2 * T
+                P._order = m
+
+                if not step:
+                    continue
+
+                # remove the P component from T
+                l = generic.order_from_multiple(P.weil_pairing(T, P._order), P._order, operation='*')
+                x = (l * T).log(l * P)
+                T -= x * P
+                T.set_order(multiple=P._order, check=False)
+
+                # for Q we only need the n-torsion part of T
+                T *= T._order // n.gcd(T._order)
+
+                # extend Q as much as possible
+                Q, m = generic.merge_points((Q, Q._order), (T, T._order))
+                Q._order = m
+
+                # remove the P component from Q
+                l = generic.order_from_multiple(P.weil_pairing(Q, P._order), P._order, operation='*')
+                y = (l * Q).log(l * P)
+                Q -= y * P
+                Q.set_order(multiple=P._order, check=False)
+
+            else:
+                raise ValueError(f'curve does not have full rational {n}-torsion, or very unlikely event')
+
+#            assert generic.has_order(P.weil_pairing(Q, n), n, operation='*')
+
+            return P, Q
+
+        elif algorithm == 'divpoly':
+            return super().torsion_basis(n, algorithm=algorithm)
+
+        elif algorithm == 'structure':
+            T = self.abelian_group().torsion_subgroup(n)
+            if T.invariants() != (n, n):
+                raise ValueError(f'curve does not have full rational {n}-torsion')
+            return tuple(P.element() for P in T.gens())
+
+        raise ValueError(f'unknown algorithm {algorithm!r}')
 
     def is_isogenous(self, other, field=None, proof=True):
         """

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1230,7 +1230,7 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
             Additive abelian group isomorphic to Z/633825300114114700748351602688 + Z/633825300114114700748351602688
               embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
                 over Finite Field in t of size 170141183460469231731687303715884105727^2
-            sage: EE.torsion_subgroup(2^99, algorithm='divpoly')
+            sage: EE.torsion_subgroup(2^99, algorithm='divpoly')  # long time -- 6s
             Additive abelian group isomorphic to Z/633825300114114700748351602688 + Z/633825300114114700748351602688
               embedded in Abelian group of points on Elliptic Curve defined by y^2 = x^3 + x
                 over Finite Field in t of size 170141183460469231731687303715884105727^2

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -1951,15 +1951,48 @@ class EllipticCurve_number_field(EllipticCurve_field):
         Fv = OK.residue_field(place)
         return self.change_ring(Fv)
 
-    @cached_method
-    def torsion_subgroup(self):
+    def torsion_subgroup(self, n=None, **kwds):
         r"""
-        Return the torsion subgroup of this elliptic curve.
+        Return the torsion subgroup of this elliptic curve
+        if ``n`` is ``None``, or the `n`-torsion subgroup
+        if `n` is an integer. In the latter case, if ``extend``
+        is set to ``True``, the base field is extended as
+        needed to find all `n`-torsion points that exist over
+        the algebraic closure.
 
-        OUTPUT: the :class:`EllipticCurveTorsionSubgroup` associated to this elliptic
-        curve.
+        OUTPUT: the :class:`EllipticCurveTorsionSubgroup` associated
+        to this elliptic curve in case ``n`` is ``None``, or an
+        :class:`AdditiveAbelianGroupWrapper` object representing
+        the `n`-torsion subgroup.
 
         EXAMPLES::
+
+            sage: EllipticCurve('11a').torsion_subgroup()
+            Torsion Subgroup isomorphic to Z/5 associated to the
+             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
+            sage: EllipticCurve('37b').torsion_subgroup()
+            Torsion Subgroup isomorphic to Z/3 associated to the
+             Elliptic Curve defined by y^2 + y = x^3 + x^2 - 23*x - 50 over Rational Field
+
+        ::
+
+            sage: e = EllipticCurve([-1386747,368636886]); e
+            Elliptic Curve defined by y^2 = x^3 - 1386747*x + 368636886 over Rational Field
+            sage: G = e.torsion_subgroup(); G
+            Torsion Subgroup isomorphic to Z/8 + Z/2 associated to the
+             Elliptic Curve defined by y^2 = x^3 - 1386747*x + 368636886 over
+             Rational Field
+            sage: G.0*3 + G.1
+            (1227 : 22680 : 1)
+            sage: G.1
+            (282 : 0 : 1)
+            sage: list(G)
+            [(0 : 1 : 0), (147 : -12960 : 1), (2307 : -97200 : 1), (-933 : -29160 : 1),
+             (1011 : 0 : 1), (-933 : 29160 : 1), (2307 : 97200 : 1), (147 : 12960 : 1),
+             (-1293 : 0 : 1), (1227 : 22680 : 1), (-285 : 27216 : 1), (8787 : 816480 : 1),
+             (282 : 0 : 1), (8787 : -816480 : 1), (-285 : -27216 : 1), (1227 : -22680 : 1)]
+
+        ::
 
             sage: E = EllipticCurve('11a1')
             sage: x = polygen(ZZ, 'x')
@@ -2006,9 +2039,18 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
             Use :meth:`~sage.schemes.elliptic_curves.ell_field.EllipticCurve_field.division_field`
             to determine the field of definition of the `\ell`-torsion subgroup.
+
+        ALGORITHM: If ``n`` is ``None``, constructs and returns the
+        :class:`EllipticCurveTorsionSubgroup` of this curve. If ``n``
+        is an integer, calls :meth:`EllipticCurve_field.torsion_subgroup`.
         """
-        from .ell_torsion import EllipticCurveTorsionSubgroup
-        return EllipticCurveTorsionSubgroup(self)
+        if n is None:
+            if not hasattr(self, '_cached_torsion_subgroup'):
+                from .ell_torsion import EllipticCurveTorsionSubgroup
+                self._cached_torsion_subgroup = EllipticCurveTorsionSubgroup(self)
+            return self._cached_torsion_subgroup
+
+        return super().torsion_subgroup(n, **kwds)
 
     @cached_method
     def torsion_order(self):

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -4036,11 +4036,12 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: type(e.torsion_order())
             <... 'sage.rings.integer.Integer'>
         """
-        try:
-            return self.__torsion_order
-        except AttributeError:
-            self.__torsion_order = self.torsion_subgroup().order()
-            return self.__torsion_order
+        if not hasattr(self, '_cached_torsion_subgroup'):
+            try:
+                return self.__torsion_order
+            except AttributeError:
+                pass
+        return self.torsion_subgroup().order()
 
     def _torsion_bound(self, number_of_places=20):
         r"""

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -4076,54 +4076,6 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             k += 1
         return bound
 
-    @cached_method
-    def torsion_subgroup(self):
-        r"""
-        Return the torsion subgroup of this elliptic curve.
-
-        OUTPUT: the EllipticCurveTorsionSubgroup instance associated to
-        this elliptic curve.
-
-        .. NOTE::
-
-            To see the torsion points as a list, use :meth:`.torsion_points`.
-
-        EXAMPLES::
-
-            sage: EllipticCurve('11a').torsion_subgroup()
-            Torsion Subgroup isomorphic to Z/5 associated to the
-             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
-            sage: EllipticCurve('37b').torsion_subgroup()
-            Torsion Subgroup isomorphic to Z/3 associated to the
-             Elliptic Curve defined by y^2 + y = x^3 + x^2 - 23*x - 50 over Rational Field
-
-        ::
-
-            sage: e = EllipticCurve([-1386747,368636886]); e
-            Elliptic Curve defined by y^2 = x^3 - 1386747*x + 368636886 over Rational Field
-            sage: G = e.torsion_subgroup(); G
-            Torsion Subgroup isomorphic to Z/8 + Z/2 associated to the
-             Elliptic Curve defined by y^2 = x^3 - 1386747*x + 368636886 over
-             Rational Field
-            sage: G.0*3 + G.1
-            (1227 : 22680 : 1)
-            sage: G.1
-            (282 : 0 : 1)
-            sage: list(G)
-            [(0 : 1 : 0), (147 : -12960 : 1), (2307 : -97200 : 1), (-933 : -29160 : 1),
-             (1011 : 0 : 1), (-933 : 29160 : 1), (2307 : 97200 : 1), (147 : 12960 : 1),
-             (-1293 : 0 : 1), (1227 : 22680 : 1), (-285 : 27216 : 1), (8787 : 816480 : 1),
-             (282 : 0 : 1), (8787 : -816480 : 1), (-285 : -27216 : 1), (1227 : -22680 : 1)]
-        """
-        try:
-            G = self.__torsion_subgroup
-        except AttributeError:
-            G = ell_torsion.EllipticCurveTorsionSubgroup(self)
-            self.__torsion_subgroup = G
-
-        self.__torsion_order = G.order()
-        return self.__torsion_subgroup
-
     def torsion_points(self):
         r"""
         Return the torsion points of this elliptic curve as a sorted list.

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -4076,6 +4076,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             k += 1
         return bound
 
+    @cached_method
     def torsion_subgroup(self):
         r"""
         Return the torsion subgroup of this elliptic curve.


### PR DESCRIPTION
This patch adds an implementation of the method for general fields (including number fields), as well as adding new algorithms for the method over finite fields. With this, we address the comment
```
        # TODO: In many cases this is not the fastest algorithm.
        # Alternatives include factoring division polynomials and
        # random sampling (like PARI's ellgroup, but with a milder
        # termination condition). We should implement these too
        # and figure out when to use which.
```
in `src/sage/schemes/elliptic_curves/ell_finite_field.py`.

The purpose of the "random" algorithm is to address the issue that the current implementation often wastes a lot of time (sometimes exponential) on computing the entire structure of the group of rational points, when in reality only a small subgroup is needed. Here's an example that showcases this problem:

```sage
sage: F.<t> = GF((2^127-1, 4))
sage: E = EllipticCurve(F, [1,0])
sage: %time _ = E.torsion_basis(2^128, algorithm='random')
sage: %time _ = E.torsion_basis(2^128, algorithm='structure')
```
Output:
```
CPU times: user 133 ms, sys: 0 ns, total: 133 ms
Wall time: 134 ms
CPU times: user 6.72 s, sys: 0 ns, total: 6.72 s
Wall time: 6.73 s
```