### PR TITLE
remove pre-isomorphisms from EllipticCurveIsogeny

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -2841,6 +2841,23 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: phi = EllipticCurveIsogeny(E, [0,3,0,1])
             sage: phi.kernel_polynomial()
             x^3 + 3*x
+
+        TESTS:
+
+        Check that :issue:`41495` is fixed::
+
+            sage: E = EllipticCurve(GF(101), [5,5])
+            sage: P = E.gens()[0] * 17
+            sage: assert P.order() == 7
+            sage: h = E.isogeny(P).kernel_polynomial()
+            sage: phi = E.isogeny(h)
+            sage: assert phi._EllipticCurveIsogeny__algorithm == 'kohel'
+            sage: iso = phi.domain().isomorphism(42)
+            sage: psi = phi * ~iso * iso
+            sage: psi == phi
+            True
+            sage: psi.domain().isogeny(psi.kernel_polynomial()) == psi
+            True
         """
         if self.__kernel_polynomial is None:
             self.__init_kernel_polynomial()

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -931,12 +931,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
     __check = None
 
     #
-    # pre-isomorphism
-    #
-    __pre_isomorphism = None
-    __prei_ratl_maps = None
-
-    #
     # post-isomorphism
     #
     __post_isomorphism = None
@@ -966,8 +960,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
     __kernel_list = None  # list of elements in the kernel
 
     __kernel_polynomial = None # polynomial with roots at x values for x-coordinate of points in the kernel
-
-    __inner_kernel_polynomial = None # the inner kernel polynomial (ignoring preisomorphism)
 
     #
     # member variables common to Velu's formula
@@ -1043,13 +1035,11 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             # the first condition assures that [1,1] is treated as x+1
             kernel = [kernel]
 
-        # if the kernel is None and the codomain isn't
-        # calculate the kernel polynomial
-        pre_isom = None
-        post_isom = None
-
         self.__check = check
 
+        self.__init_algebraic_structs(E)
+
+        # if the kernel is None and the codomain isn't, calculate the kernel polynomial
         if kernel is None and codomain is not None:
 
             if degree is None:
@@ -1058,17 +1048,14 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             # save the codomain: really used now (trac #7096)
             old_codomain = codomain
 
-            pre_isom, post_isom, E, codomain, kernel = compute_sequence_of_maps(E, codomain, degree)
+            pre_isom, _, _, _, kernel = compute_sequence_of_maps(E, codomain, degree)
+            kernel = kernel(self.__poly_ring(pre_isom.x_rational_map()))
 
-        self.__init_algebraic_structs(E)
+        self.__algorithm = _isogeny_determine_algorithm(E, kernel)
 
-        algorithm = _isogeny_determine_algorithm(E, kernel)
-
-        self.__algorithm = algorithm
-
-        if algorithm == 'velu':
+        if self.__algorithm == 'velu':
             self.__init_from_kernel_gens(kernel)
-        elif algorithm == 'kohel':
+        elif self.__algorithm == 'kohel':
             self.__init_from_kernel_polynomial(kernel)
         else:
             raise NotImplementedError
@@ -1077,13 +1064,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         self.__setup_post_isomorphism(codomain, model)
 
-        if pre_isom is not None:
-            self._set_pre_isomorphism(pre_isom)
-
-        if post_isom is not None:
-            self.__set_post_isomorphism(old_codomain, post_isom)   #(trac #7096)
-
-        # Inheritance house keeping
         self.__perform_inheritance_housekeeping()
 
     def _eval(self, P):
@@ -1126,9 +1106,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             return self._codomain(0).change_ring(k)
 
         Q = P.xy()
-
-        if self.__pre_isomorphism is not None:
-            Q = baseWI.__call__(self.__pre_isomorphism, Q)
 
         if self.__algorithm == "velu":
             compute = self.__compute_via_velu
@@ -1251,11 +1228,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             return self._codomain(0)
 
         xP, yP = P.xy()
-
-        # if there is a pre-isomorphism, apply it
-        if self.__pre_isomorphism is not None:
-            yP = self.__prei_ratl_maps[1](xP, yP)
-            xP = self.__prei_ratl_maps[0](xP)
 
         if self.__algorithm == 'velu':
             outP = self.__compute_via_velu_numeric(xP, yP)
@@ -1530,8 +1502,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: post_isom = WeierstrassIsomorphism(E2, (41, 37, 31, 29))
             sage: phi._set_post_isomorphism(post_isom)
             sage: E1pr = WeierstrassIsomorphism(E, (-1, 2, -3, 4)).codomain()
-            sage: pre_isom = E1pr.isomorphism_to(E)
-            sage: phi._set_pre_isomorphism(pre_isom)
         """
         EllipticCurveHom.__init__(self, self._domain, self._codomain)
 
@@ -1678,11 +1648,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             X_map = self.__poly_ring(X_map.numerator()) \
                     / self.__poly_ring(X_map.denominator())
 
-        if self.__prei_ratl_maps is not None:
-            prei_X_map, prei_Y_map = self.__prei_ratl_maps
-            X_map = X_map(prei_X_map)
-            Y_map = Y_map([prei_X_map, prei_Y_map])
-
         if self.__posti_ratl_maps is not None:
             posti_X_map, posti_Y_map = self.__posti_ratl_maps
             # Do not reverse the order here!
@@ -1710,48 +1675,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
                 self.__init_kernel_polynomial_velu()
             else:
                 assert False, "the kernel polynomial should already be defined!"
-
-    def __set_pre_isomorphism(self, domain, isomorphism):
-        r"""
-        Private function to set the pre-isomorphism and domain (and
-        keep track of the domain of the isogeny).
-
-        EXAMPLES::
-
-            sage: E = EllipticCurve(GF(43), [2,3,5,7,11])
-            sage: R.<x> = GF(43)[]; f = x + 42
-            sage: phi = EllipticCurveIsogeny(E, f)
-            sage: phi._EllipticCurveIsogeny__perform_inheritance_housekeeping()
-            sage: from sage.schemes.elliptic_curves.weierstrass_morphism import WeierstrassIsomorphism
-            sage: E1pr = WeierstrassIsomorphism(E, (-1, 2, -3, 4)).codomain()
-            sage: pre_isom = E1pr.isomorphism_to(E)
-            sage: phi._set_pre_isomorphism(pre_isom)
-            sage: phi._EllipticCurveIsogeny__set_pre_isomorphism(E, WeierstrassIsomorphism(E, (-1, 3, -3, 4)))
-            sage: E == phi.domain()
-            True
-        """
-        self._domain = domain
-        self.__pre_isomorphism = isomorphism
-
-        # calculate the isomorphism as a rational map.
-
-        u, r, s, t = (self.__base_field(c) for c in isomorphism.tuple())
-        uinv = 1/u
-        uinv2 = uinv**2
-        uinv3 = uinv*uinv2
-
-        x = self.__poly_ring.gen()
-        y = self.__xyfield.gen(1) # not mpoly_ring.gen(1) else we end
-                                  # up in K(x)[y] and trouble ensues
-
-        self.__prei_ratl_maps = (x - r) * uinv2, (y - s*(x-r) - t) * uinv3
-
-        if self.__kernel_polynomial is not None:
-            ker_poly = self.__kernel_polynomial
-            ker_poly = ker_poly(self.__prei_ratl_maps[0])
-            self.__kernel_polynomial = ker_poly.monic()
-
-        self.__perform_inheritance_housekeeping()
 
     def __set_post_isomorphism(self, codomain, isomorphism):
         r"""
@@ -2182,10 +2105,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: eqs[1](fx,fy).numerator() % eqs[0]
             0
         """
-        if self.__pre_isomorphism is None:
-            E = self._domain
-        else:
-            E = self.__pre_isomorphism.codomain()
+        E = self._domain
 
         a1 = E.a1()
         a3 = E.a3()
@@ -2238,14 +2158,8 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         """
         poly_ring, x = self.__poly_ring.objgen()
 
-        if self.__pre_isomorphism is not None:
-            pre_isom = self.__pre_isomorphism
-            invX = pre_isom.u**2 * x + pre_isom.r
-        else:
-            invX = x
-
         from sage.misc.misc_c import prod
-        psi = prod([x - invX(xQ) for xQ in self.__kernel_mod_sign.keys()])  # building the list is not redundant; this is slightly faster
+        psi = prod([x - xQ for xQ in self.__kernel_mod_sign.keys()])  # building the list is not redundant; this is slightly faster
 
         self.__kernel_polynomial = poly_ring(psi)
 
@@ -2314,7 +2228,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         #
 
         self.__kernel_polynomial = psi
-        self.__inner_kernel_polynomial = psi
 
         self._degree = Integer(d)  # degree of the isogeny
 
@@ -2731,7 +2644,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             ()
         """
         # first check if the point is in the kernel
-        if self.__inner_kernel_polynomial(xP) == 0:
+        if self.__kernel_polynomial(xP) == 0:
             return ()
 
         return self.__compute_via_kohel(xP, yP)
@@ -2895,13 +2808,10 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: phi.scaling_factor().parent()                                         # needs sage.rings.finite_rings
             Finite Field in z2 of size 257^2
 
-        ALGORITHM: The "inner" isogeny is normalized by construction,
-        so we only need to account for the scaling factors of a pre-
-        and post-isomorphism.
+        ALGORITHM: The "inner" isogeny is normalized by construction, so we
+        only need to account for the scaling factor of a post-isomorphism.
         """
         sc = self.__base_field.one()
-        if self.__pre_isomorphism is not None:
-            sc *= self.__pre_isomorphism.scaling_factor()
         if self.__post_isomorphism is not None:
             sc *= self.__post_isomorphism.scaling_factor()
         return sc
@@ -2949,94 +2859,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             1
         """
         return Integer(1)
-
-    def _set_pre_isomorphism(self, preWI):
-        """
-        Modify this isogeny by pre-composing with a
-        :class:`sage.schemes.elliptic_curves.weierstrass_morphism.WeierstrassIsomorphism`.
-
-        For internal use only.
-
-        TESTS::
-
-            sage: E = EllipticCurve(GF(31), [1,1,0,1,-1])
-            sage: R.<x> = GF(31)[]
-            sage: f = x^3 + 9*x^2 + x + 30
-            sage: phi = EllipticCurveIsogeny(E, f)
-            sage: Epr = E.short_weierstrass_model()
-            sage: isom = Epr.isomorphism_to(E)
-            sage: phi._set_pre_isomorphism(isom)
-            sage: phi.rational_maps()
-            ((-6*x^4 - 3*x^3 + 12*x^2 + 10*x - 1)/(x^3 + x - 12),
-             (3*x^7 + x^6*y - 14*x^6 - 3*x^5 + 5*x^4*y + 7*x^4 + 8*x^3*y - 8*x^3 - 5*x^2*y + 5*x^2 - 14*x*y + 14*x - 6*y - 6)/(x^6 + 2*x^4 + 7*x^3 + x^2 + 7*x - 11))
-            sage: phi(Epr((0,22)))
-            (13 : 21 : 1)
-            sage: phi(Epr((3,7)))
-            (14 : 17 : 1)
-
-            sage: E = EllipticCurve(GF(29), [0,0,0,1,0])
-            sage: R.<x> = GF(29)[]
-            sage: f = x^2 + 5
-            sage: phi = EllipticCurveIsogeny(E, f)
-            sage: phi
-            Isogeny of degree 5
-             from Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 29
-               to Elliptic Curve defined by y^2 = x^3 + 20*x over Finite Field of size 29
-            sage: from sage.schemes.elliptic_curves.weierstrass_morphism import WeierstrassIsomorphism
-            sage: inv_isom = WeierstrassIsomorphism(E, (1,-2,5,10))
-            sage: Epr = inv_isom.codomain()
-            sage: isom = Epr.isomorphism_to(E)
-            sage: phi._set_pre_isomorphism(isom)
-            sage: phi
-            Isogeny of degree 5
-             from Elliptic Curve defined by y^2 + 10*x*y + 20*y = x^3 + 27*x^2 + 6 over Finite Field of size 29
-               to Elliptic Curve defined by y^2 = x^3 + 20*x over Finite Field of size 29
-            sage: phi(Epr((12,1)))
-            (26 : 0 : 1)
-            sage: phi(Epr((2,9)))
-            (0 : 0 : 1)
-            sage: phi(Epr((21,12)))
-            (3 : 0 : 1)
-            sage: phi.rational_maps()[0]
-            (x^5 - 10*x^4 - 6*x^3 - 7*x^2 - x + 3)/(x^4 - 8*x^3 + 5*x^2 - 14*x - 6)
-
-            sage: E = EllipticCurve('11a1')
-            sage: R.<x> = QQ[]
-            sage: f = x^2 - 21*x + 80
-            sage: phi = EllipticCurveIsogeny(E, f); phi
-            Isogeny of degree 5
-             from Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
-               to Elliptic Curve defined by y^2 + y = x^3 - x^2 - 7820*x - 263580 over Rational Field
-            sage: from sage.schemes.elliptic_curves.weierstrass_morphism import WeierstrassIsomorphism
-            sage: Epr = E.short_weierstrass_model()
-            sage: isom = Epr.isomorphism_to(E)
-            sage: phi._set_pre_isomorphism(isom)
-            sage: phi
-            Isogeny of degree 5
-             from Elliptic Curve defined by y^2 = x^3 - 13392*x - 1080432 over Rational Field
-               to Elliptic Curve defined by y^2 + y = x^3 - x^2 - 7820*x - 263580 over Rational Field
-            sage: phi(Epr((168,1188)))
-            (0 : 1 : 0)
-        """
-        WIdom = preWI.domain()
-        WIcod = preWI.codomain()
-
-        if not isinstance(preWI, WeierstrassIsomorphism):
-            raise ValueError("invalid parameter: isomorphism must be a WeierstrassIsomorphism")
-
-        if self._domain != WIcod:
-            raise ValueError("invalid parameter: isomorphism must have codomain curve equal to this isogenies' domain")
-
-        if self.__pre_isomorphism is None:
-            isom = preWI
-            domain = WIdom
-        else:
-            isom = self.__pre_isomorphism*preWI
-            domain = WIdom
-
-        self.__clear_cached_values()
-
-        self.__set_pre_isomorphism(domain, isom)
 
     def _set_post_isomorphism(self, postWI):
         """
@@ -3267,13 +3089,8 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         if self.__dual is not None:
             return self.__dual
 
-        # trac 7096
-        E1, E2pr, _, _ = compute_intermediate_curves(self.codomain(), self.domain())
-
         F = self.__base_field
         d = self._degree
-
-        from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
 
         if F(d) == 0:   # inseparable dual!
             p = F.characteristic()
@@ -3307,6 +3124,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             else:
                 sep = frob.codomain().isomorphism_to(self._domain)
 
+            from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
             phi_hat = EllipticCurveHom_composite.from_factors([frob, sep])
 
             from sage.schemes.elliptic_curves.hom import find_post_isomorphism
@@ -3316,27 +3134,19 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             self.__dual = corr * phi_hat
             return self.__dual
 
-        # trac 7096
-        # this should take care of the case when the isogeny is
-        # not normalized.
         u = self.scaling_factor()
-        E2 = E2pr.change_weierstrass_model(u/F(d), 0, 0, 0)
+        E1 = self._codomain
+        E2 = self._domain.change_weierstrass_model(u/F(d), 0, 0, 0)
 
         phi_hat = EllipticCurveIsogeny(E1, None, E2, d)
-        # assert phi_hat.scaling_factor() == 1
+        assert phi_hat.scaling_factor().is_one()
 
-        for pre_iso in self._codomain.isomorphisms(E1):
-            for post_iso in E2.isomorphisms(self._domain):
-                sc = u * pre_iso.scaling_factor() * post_iso.scaling_factor()
-                if sc == d:
-                    break
-            else:
-                continue
-            break
+        for post_iso in E2.isomorphisms(self._domain):
+            if d == u * post_iso.scaling_factor():
+                break
         else:
             raise RuntimeError("bug in dual()")
 
-        phi_hat._set_pre_isomorphism(pre_iso)
         phi_hat._set_post_isomorphism(post_iso)
         phi_hat.__perform_inheritance_housekeeping()
         return phi_hat
@@ -3353,19 +3163,10 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
             sage: E = EllipticCurve(GF(127), [5,2])
             sage: phi = E.isogeny(E.lift_x(47)); E2 = phi.codomain()
-            sage: iso1 = E.change_weierstrass_model(1,1,1,1).isomorphism_to(E)
-            sage: iso2 = E2.isomorphism_to(E2.change_weierstrass_model(39,0,0,0))
-            sage: phi * iso1            # indirect doctest
-            Isogeny of degree 11
-             from Elliptic Curve defined by y^2 + 2*x*y + 2*y = x^3 + 2*x^2 + 6*x + 7 over Finite Field of size 127
-               to Elliptic Curve defined by y^2 = x^3 + 37*x + 85 over Finite Field of size 127
-            sage: iso2 * phi            # indirect doctest
+            sage: iso = E2.isomorphism_to(E2.change_weierstrass_model(39,0,0,0))
+            sage: iso * phi  # indirect doctest
             Isogeny of degree 11
              from Elliptic Curve defined by y^2 = x^3 + 5*x + 2 over Finite Field of size 127
-               to Elliptic Curve defined by y^2 = x^3 + 117*x + 58 over Finite Field of size 127
-            sage: iso2 * phi * iso1     # indirect doctest
-            Isogeny of degree 11
-             from Elliptic Curve defined by y^2 + 2*x*y + 2*y = x^3 + 2*x^2 + 6*x + 7 over Finite Field of size 127
                to Elliptic Curve defined by y^2 = x^3 + 117*x + 58 over Finite Field of size 127
 
         TESTS:
@@ -3373,18 +3174,12 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         We should return ``NotImplemented`` when passed a combination of
         elliptic-curve morphism types that we don't handle here::
 
-            sage: phi._composition_impl(iso1, iso1**-1)
+            sage: phi._composition_impl(iso, iso**-1)
             NotImplemented
         """
         if isinstance(left, WeierstrassIsomorphism) and isinstance(right, EllipticCurveIsogeny):
             result = deepcopy(right)
             result._set_post_isomorphism(left)
-            return result
-
-        if isinstance(left, EllipticCurveIsogeny) and isinstance(right, WeierstrassIsomorphism):
-            assert isinstance(left, EllipticCurveIsogeny)
-            result = deepcopy(left)
-            result._set_pre_isomorphism(right)
             return result
 
         return NotImplemented

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2254,10 +2254,10 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             sage: E.isogenies_prime_degree(13)
             [Isogeny of degree 13
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
-                to Elliptic Curve defined by y^2 = x^3 + 878063*x + 845666 over Finite Field of size 1000003,
+                to Elliptic Curve defined by y^2 = x^3 + 626451*x + 440563 over Finite Field of size 1000003,
              Isogeny of degree 13
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
-                to Elliptic Curve defined by y^2 = x^3 + 375648*x + 342776 over Finite Field of size 1000003]
+                to Elliptic Curve defined by y^2 = x^3 + 37327*x + 182964 over Finite Field of size 1000003]
             sage: E.isogenies_prime_degree(max_l=13)
             [Isogeny of degree 2
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
@@ -2270,10 +2270,10 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                 to Elliptic Curve defined by y^2 = x^3 + 999960*x + 78 over Finite Field of size 1000003,
              Isogeny of degree 13
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
-                to Elliptic Curve defined by y^2 = x^3 + 878063*x + 845666 over Finite Field of size 1000003,
+                to Elliptic Curve defined by y^2 = x^3 + 626451*x + 440563 over Finite Field of size 1000003,
              Isogeny of degree 13
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
-                to Elliptic Curve defined by y^2 = x^3 + 375648*x + 342776 over Finite Field of size 1000003]
+                to Elliptic Curve defined by y^2 = x^3 + 37327*x + 182964 over Finite Field of size 1000003]
             sage: E.isogenies_prime_degree()  # Default limit of 31
             [Isogeny of degree 2
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
@@ -2286,10 +2286,10 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                 to Elliptic Curve defined by y^2 = x^3 + 999960*x + 78 over Finite Field of size 1000003,
              Isogeny of degree 13
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
-                to Elliptic Curve defined by y^2 = x^3 + 878063*x + 845666 over Finite Field of size 1000003,
+                to Elliptic Curve defined by y^2 = x^3 + 626451*x + 440563 over Finite Field of size 1000003,
              Isogeny of degree 13
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
-                to Elliptic Curve defined by y^2 = x^3 + 375648*x + 342776 over Finite Field of size 1000003,
+                to Elliptic Curve defined by y^2 = x^3 + 37327*x + 182964 over Finite Field of size 1000003,
              Isogeny of degree 17
               from Elliptic Curve defined by y^2 = x^3 + 7*x + 8 over Finite Field of size 1000003
                 to Elliptic Curve defined by y^2 = x^3 + 347438*x + 594729 over Finite Field of size 1000003,

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -3122,7 +3122,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
               To:   Projective Plane Curve over Finite Field of size 257
                     defined by -x^3 + 8*x^2*z - 127*y^2*z - x*z^2
               Defn: Defined on coordinates by sending (x : y : z) to
-                    (x + 116*z : -y : -85*z)
+                    (x + 116*z : y : -85*z)
             sage: g = f.inverse(); g
             Scheme morphism:
               From: Projective Plane Curve over Finite Field of size 257
@@ -3130,7 +3130,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
               To:   Elliptic Curve defined by y^2 = x^3 + 10*x + 10
                     over Finite Field of size 257
               Defn: Defined on coordinates by sending (x : y : z) to
-                    (-85*x - 116*z : 85*y : z)
+                    (-85*x - 116*z : -85*y : z)
             sage: P = C(70, 8)
             sage: Q = C(17, 17)
             sage: P + Q             # this doesn't work...

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -2662,8 +2662,10 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
     def isomorphism_to(self, other):
         """
-        Given another weierstrass model ``other`` of ``self``, return an
+        Given another Weierstrass model ``other`` of ``self``, return an
         isomorphism from ``self`` to ``other``.
+
+        If possible, this method returns a normalized isomorphism.
 
         INPUT:
 
@@ -2671,7 +2673,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         OUTPUT:
 
-        (Weierstrassmorphism) An isomorphism from ``self`` to ``other``.
+        (:class:`~wm.WeierstrassIsomorphism`) An isomorphism from ``self`` to ``other``.
 
         .. NOTE::
 

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -114,11 +114,12 @@ class EllipticCurveHom(Morphism):
 
         EXAMPLES::
 
-            sage: E = EllipticCurve(GF(19), [1,0])
-            sage: phi = E.isogeny(E(0,0))
-            sage: iso = E.change_weierstrass_model(5,0,0,0).isomorphism_to(E)
-            sage: phi * iso
-            Isogeny of degree 2 from Elliptic Curve defined by y^2 = x^3 + 9*x over Finite Field of size 19 to Elliptic Curve defined by y^2 = x^3 + 15*x over Finite Field of size 19
+            sage: E1 = EllipticCurve(GF(19), [1,0])
+            sage: phi = E1.isogeny(E1(0,0))
+            sage: E2 = phi.codomain()
+            sage: iso = E2.change_weierstrass_model(5,0,0,0).isomorphism_to(E2)
+            sage: ~iso * phi
+            Isogeny of degree 2 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 19 to Elliptic Curve defined by y^2 = x^3 + 2*x over Finite Field of size 19
             sage: phi.dual() * phi
             Composite morphism of degree 4 = 2^2:
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 19
@@ -366,7 +367,7 @@ class EllipticCurveHom(Morphism):
             71
             sage: tau = E.isogeny(P, codomain=E)
             sage: tau.trace()
-            -1
+            1
 
         TESTS:
 
@@ -375,19 +376,19 @@ class EllipticCurveHom(Morphism):
 
             sage: aut = E.automorphisms()[1]  # [-1]
             sage: (aut * tau).trace()
-            1
+            -1
 
         It also works for more complicated :class:`EllipticCurveHom`
         children::
 
             sage: tau = E.isogeny(P, codomain=E, algorithm='velusqrt')
             sage: tau.trace()
-            -1
+            1
 
         Check that negation commutes with taking the trace::
 
             sage: (-tau).trace()
-            1
+            -1
 
         The trace is only defined for endomorphisms. If this method is called
         on an isogeny that is not an endomorphism a ``ValueError`` will be raised.

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -151,8 +151,8 @@ class EllipticCurveHom(Morphism):
             sage: phi + phi  # indirect doctest
             Sum morphism:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
-              To:   Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
-              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101)
+              To:   Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101
+              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101)
         """
         from sage.schemes.elliptic_curves.hom_sum import EllipticCurveHom_sum
         phis = []
@@ -182,8 +182,8 @@ class EllipticCurveHom(Morphism):
             sage: phi - phi  # indirect doctest
             Sum morphism:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
-              To:   Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
-              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101)
+              To:   Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101
+              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101)
         """
         return self + (-other)
 

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -658,21 +658,19 @@ class EllipticCurveHom_composite(EllipticCurveHom):
               To:   Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-4)*x + (-6*I)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
             sage: phi * iso1                # indirect doctest
-            Composite morphism of degree 4 = 2^2:
+            Composite morphism of degree 4 = 1*2^2:
               From: Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-4)*x + (-6*I)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
               To:   Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (480*I-694)*x + (-7778*I+5556)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
             sage: iso2 * psi * phi * iso1   # indirect doctest
-            Composite morphism of degree 16 = 2^2*4:
+            Composite morphism of degree 16 = 1*2^2*4:
               From: Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-4)*x + (-6*I)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
               To:   Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-4)*x + (-6*I)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
         """
         if isinstance(left, EllipticCurveHom_composite):
-            if isinstance(right, WeierstrassIsomorphism) and hasattr(left.factors()[0], '_set_pre_isomorphism'):    # XXX bit of a hack
-                return EllipticCurveHom_composite.from_factors((left.factors()[0] * right,) + left.factors()[1:], strict=False)
             if isinstance(right, EllipticCurveHom_composite):
                 return EllipticCurveHom_composite.from_factors(right.factors() + left.factors())
             if isinstance(right, EllipticCurveHom):
@@ -851,8 +849,9 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             sage: phi * psi == psi.domain().scalar_multiplication(psi.degree())
             True
         """
-        phis = (phi.dual() for phi in self._phis[::-1])
-        return EllipticCurveHom_composite.from_factors(phis)
+        if not self._phis:
+            return self
+        return prod(phi.dual() for phi in self._phis)
 
     def formal(self, prec=20):
         """

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -18,8 +18,8 @@ EXAMPLES::
     sage: phi + phi
     Sum morphism:
       From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
-      To:   Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
-      Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101)
+      To:   Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101
+      Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101)
     sage: phi + phi == phi * E.scalar_multiplication(2)
     True
     sage: phi + phi + phi == phi * E.scalar_multiplication(3)
@@ -76,8 +76,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: EllipticCurveHom_sum([phi, phi])
             Sum morphism:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
-              To:   Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
-              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101)
+              To:   Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101
+              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101)
 
         The zero morphism can be constructed even between non-isogenous curves::
 
@@ -130,7 +130,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: phi = E.isogenies_prime_degree(7)[0]
             sage: P = E.lift_x(0)
             sage: (phi + phi)(P)
-            (72 : 56 : 1)
+            (2 : 97 : 1)
             sage: (phi - phi)(P)
             (0 : 1 : 0)
         """
@@ -153,7 +153,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: phi = E.isogenies_prime_degree(7)[0]
             sage: P = E.change_ring(GF(101^2)).lift_x(1)
             sage: (phi + phi)._eval(P)
-            (11 : 15*z2 + 71 : 1)
+            (48 : 35*z2 + 31 : 1)
             sage: (phi - phi)._eval(P)
             (0 : 1 : 0)
         """
@@ -173,8 +173,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: phi + phi  # indirect doctest
             Sum morphism:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
-              To:   Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
-              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101)
+              To:   Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101
+              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101)
         """
         return f'Sum morphism:' \
                 f'\n  From: {self._domain}' \
@@ -212,7 +212,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: (phi + phi).to_isogeny_chain()
             Composite morphism of degree 28 = 4*1*7:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
-              To:   Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
+              To:   Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101
 
         ::
 
@@ -512,8 +512,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: E = EllipticCurve(GF(101), [5,5])
             sage: phi = E.isogenies_prime_degree(7)[0]
             sage: (phi + phi).rational_maps()
-            ((5*x^28 + 43*x^27 + 26*x^26 - ... + 7*x^2 - 23*x + 38)/(23*x^27 + 16*x^26 + 9*x^25 + ... - 43*x^2 - 22*x + 37),
-             (42*x^42*y - 44*x^41*y - 22*x^40*y + ... - 26*x^2*y - 50*x*y - 18*y)/(-24*x^42 - 47*x^41 - 12*x^40 + ... + 18*x^2 - 48*x + 18))
+            ((31*x^28 + 4*x^27 + 40*x^26 + ... + 3*x^2 + 19*x - 27)/(23*x^27 + 16*x^26 + 9*x^25 + ... - 43*x^2 - 22*x + 37),
+             (-3*x^42*y + 32*x^41*y + 16*x^40*y + ... - 27*x^2*y + 18*x*y - 42*y)/(-24*x^42 - 47*x^41 - 12*x^40 + ... + 18*x^2 - 48*x + 18))
 
         ALGORITHM: :meth:`to_isogeny_chain`.
         """
@@ -530,7 +530,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: E = EllipticCurve(GF(101), [5,5])
             sage: phi = E.isogenies_prime_degree(7)[0]
             sage: (phi + phi).x_rational_map()
-            (9*x^28 + 37*x^27 + 67*x^26 + ... + 53*x^2 + 100*x + 28)/(x^27 + 49*x^26 + 97*x^25 + ... + 64*x^2 + 21*x + 6)
+            (76*x^28 + 88*x^27 + 72*x^26 + ... + 66*x^2 + 14*x + 12)/(x^27 + 49*x^26 + 97*x^25 + ... + 64*x^2 + 21*x + 6)
+
 
         ALGORITHM: :meth:`to_isogeny_chain`.
         """
@@ -579,9 +580,9 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: E = EllipticCurve(GF(101), [5,5])
             sage: phi = E.isogenies_prime_degree(7)[0]
             sage: phi.scaling_factor()
-            84
+            1
             sage: (phi + phi).scaling_factor()
-            67
+            2
 
         ALGORITHM: The scaling factor is additive under addition
         of elliptic-curve morphisms, so we simply add together the
@@ -600,9 +601,9 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: phi = E.isogenies_prime_degree(7)[0]
             sage: (phi + phi).dual()
             Sum morphism:
-              From: Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101
+              From: Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101
               To:   Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
-              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 12*x + 98 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101)
+              Via:  (Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101, Isogeny of degree 7 from Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101 to Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101)
             sage: (phi + phi).dual() == phi.dual() + phi.dual()
             True
 

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -617,14 +617,14 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
         (0 : 1 : 0)
         sage: P = E(2, 3163*t^2 + 7293*t + 5999)
         sage: phi(P)
-        (6085*t^2 + 855*t + 8720 : 8078*t^2 + 9889*t + 6030 : 1)
+        (6085*t^2 + 855*t + 8720 : 1931*t^2 + 120*t + 3979 : 1)
         sage: Q = E(6, 5575*t^2 + 6607*t + 9991)
         sage: phi(Q)
-        (626*t^2 + 9749*t + 1291 : 5931*t^2 + 8549*t + 3111 : 1)
+        (626*t^2 + 9749*t + 1291 : 4078*t^2 + 1460*t + 6898 : 1)
         sage: phi(P + Q)
-        (983*t^2 + 4894*t + 4072 : 5047*t^2 + 9325*t + 336 : 1)
+        (983*t^2 + 4894*t + 4072 : 4962*t^2 + 684*t + 9673 : 1)
         sage: phi(P) + phi(Q)
-        (983*t^2 + 4894*t + 4072 : 5047*t^2 + 9325*t + 336 : 1)
+        (983*t^2 + 4894*t + 4072 : 4962*t^2 + 684*t + 9673 : 1)
 
     TESTS:
 
@@ -1142,7 +1142,7 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
             sage: z2 = GF(71^2).gen()
             sage: E = EllipticCurve(j=57*z2+51)
             sage: E.isogeny(3*E.lift_x(0), algorithm='velusqrt').dual()
-            Composite morphism of degree 71 = 71*1^2:
+            Composite morphism of degree 71 = 71*1:
               From: Elliptic Curve defined by y^2 = x^3 + (8*z2+70)*x + (3*z2+49) over Finite Field in z2 of size 71^2
               To:   Elliptic Curve defined by y^2 = x^3 + (41*z2+56)*x + (18*z2+42) over Finite Field in z2 of size 71^2
             sage: E.isogeny(E.lift_x(0), algorithm='velusqrt').dual()

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -1128,9 +1128,9 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
               From: Elliptic Curve defined by y^2 + x*y + y = x^3 + x^2 + x + 1 over Finite Field in z2 of size 101^2
               To:   Elliptic Curve defined by y^2 = x^3 + 39*x + 40 over Finite Field in z2 of size 101^2
             sage: phi.dual()
-            Isogeny of degree 11
-              from Elliptic Curve defined by y^2 = x^3 + 39*x + 40 over Finite Field in z2 of size 101^2
-              to Elliptic Curve defined by y^2 + x*y + y = x^3 + x^2 + x + 1 over Finite Field in z2 of size 101^2
+            Composite morphism of degree 11 = 1*11:
+              From: Elliptic Curve defined by y^2 = x^3 + 39*x + 40 over Finite Field in z2 of size 101^2
+              To:   Elliptic Curve defined by y^2 + x*y + y = x^3 + x^2 + x + 1 over Finite Field in z2 of size 101^2
             sage: phi.dual() * phi == phi.domain().scalar_multiplication(11)
             True
             sage: phi * phi.dual() == phi.codomain().scalar_multiplication(11)

--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -328,16 +328,14 @@ def isogenies_prime_degree_genus_0(E, l=None, minimal_models=True):
     jt = Fricke_module(l)
     kt = jt - 1728
     psi = Psi(l)
-    X = t
     f = R(prod([p for p,e in jt.factor() if e == 3]
              + [p for p,e in kt.factor() if e == 2]))
-
     E1 = EllipticCurve([-27*c4, -54*c6])
-    kernels = [R(psi(X * T * (j - 1728) * t0 / f(t0), t0)).monic() for t0 in t_list]
-    isogs = [E1.isogeny(ker, model=model) for ker in kernels]
 
-    w = E.isomorphism_to(E1)
-    isogs = [isog * w for isog in isogs]
+    kernels = [R(psi(t * T * (j - 1728) * t0 / f(t0), t0)) for t0 in t_list]
+
+    w = E.isomorphism_to(E1).x_rational_map().numerator()
+    isogs = [E.isogeny(ker(w).monic(), model=model) for ker in kernels]
     return isogs
 
 
@@ -711,9 +709,8 @@ def isogenies_sporadic_Q(E, l=None, minimal_models=True):
     R = PolynomialRing(F, 'x')
     n = len(f)
     ker = R([d**(n-i-1) * f[i] for i in range(n)])
-    isog = Ew.isogeny(ker, degree=l, model=model, check=False)
-    w = E.isomorphism_to(Ew)
-    isog = isog * w
+    w = E.isomorphism_to(Ew).x_rational_map().numerator()
+    isog = E.isogeny(ker(w).monic(), degree=l, model=model, check=False)
     return [isog]
 
 
@@ -916,10 +913,9 @@ def isogenies_5_0(E, minimal_models=True):
     gammas = [(beta**2 * (beta**3-140*b)) / (120*b) for beta in betas]
 
     kernels = [x**2 + beta*x + gamma for beta, gamma in zip(betas, gammas)]
-    isogs = [Ew.isogeny(ker, model=model) for ker in kernels]
 
-    w = E.isomorphism_to(Ew)
-    isogs = [isog * w for isog in isogs]
+    w = E.isomorphism_to(Ew).x_rational_map().numerator()
+    isogs = [E.isogeny(ker(w).monic(), model=model) for ker in kernels]
     return isogs
 
 
@@ -1041,9 +1037,11 @@ def isogenies_5_1728(E, minimal_models=True):
     if not square5 and not square1:
         return []
 
+    x = polygen(F)
+
     Ew = E.short_weierstrass_model()
     a = Ew.a4()
-    x = polygen(F)
+    w = E.isomorphism_to(Ew).x_rational_map().numerator()
 
     isogs = []
 
@@ -1051,17 +1049,15 @@ def isogenies_5_1728(E, minimal_models=True):
     if square1:
         i = F(-1).sqrt()
         kernels = [x**2 + a / (1+2*i), x**2 + a / (1-2*i)]
-        isogs.extend(Ew.isogeny(ker, codomain=E) for ker in kernels)
+        isogs.extend(E.isogeny(ker(w).monic(), codomain=E) for ker in kernels)
 
     # Type 2: if 5 is a square we have up to 4 (non-endomorphism) isogenies
     if square5:
         betas = sorted((x**4 + 20*a*x**2 - 80*a**2).roots(multiplicities=False))
         gammas = [(beta**2 - 2*a) / 6 for beta in betas]
         kernels = [x**2 + beta*x + gamma for beta, gamma in zip(betas, gammas)]
-        isogs.extend(Ew.isogeny(ker, model=model) for ker in kernels)
+        isogs.extend(E.isogeny(ker(w).monic(), model=model) for ker in kernels)
 
-    w = E.isomorphism_to(Ew)
-    isogs = [isog * w for isog in isogs]
     return isogs
 
 
@@ -1180,16 +1176,18 @@ def isogenies_7_0(E, minimal_models=True):
         raise NotImplementedError("not implemented when the characteristic of the base field is 2, 3 or 7")
     from sage.rings.number_field.number_field_base import NumberField
     model = "minimal" if minimal_models and isinstance(F, NumberField) else None
+
     x = polygen(F)
 
     Ew = E.short_weierstrass_model()
     b = Ew.a6()
+    w = E.isomorphism_to(Ew).x_rational_map().numerator()
 
     # there will be 2 endomorphisms if -3 is a square:
     ts = sorted(F(-3).sqrt(all=True, extend=False))
     kernels = [7*x - (2 + 6*t) for t in ts]
     kernels = [ker(x**3/b).monic() for ker in kernels]
-    isogs = [Ew.isogeny(ker, codomain=E) for ker in kernels]
+    isogs = [E.isogeny(ker(w).monic(), codomain=E) for ker in kernels]
 
     # we may have up to 6 other isogenies:
     ts = sorted(F(21).sqrt(all=True, extend=False))
@@ -1198,10 +1196,8 @@ def isogenies_7_0(E, minimal_models=True):
         ss = sorted((x**3 - s3).roots(multiplicities=False))
         ker = x**3 - 2*t0*x**2 - 4*t0*x + 4*t0 + 28
         kernels = [ker(x/s).monic() for s in ss]
-        isogs.extend(Ew.isogeny(ker, model=model) for ker in kernels)
+        isogs.extend(E.isogeny(ker(w).monic(), model=model) for ker in kernels)
 
-    w = E.isomorphism_to(Ew)
-    isogs = [isog * w for isog in isogs]
     return isogs
 
 
@@ -1284,14 +1280,16 @@ def isogenies_7_1728(E, minimal_models=True):
         raise NotImplementedError("not implemented when the characteristic of the base field is 2, 3 or 7")
     from sage.rings.number_field.number_field_base import NumberField
     model = "minimal" if minimal_models and isinstance(F, NumberField) else None
-    x = polygen(F)
 
     ts = sorted((Fricke_module(7) - 1728).numerator().roots(F, multiplicities=False))
     if not ts:
         return []
 
+    x = polygen(F)
+
     Ew = E.short_weierstrass_model()
     a = Ew.a4()
+    w = E.isomorphism_to(Ew).x_rational_map().numerator()
 
     isogs = []
     for t0 in ts:
@@ -1299,10 +1297,8 @@ def isogenies_7_1728(E, minimal_models=True):
         ss = sorted(s2.sqrt(all=True, extend=False))
         ker = 9*x**3 + (-3*t0**3 - 36*t0**2 - 123*t0)*x**2 + (-8*t0**3 - 101*t0**2 - 346*t0 + 35)*x - 7*t0**3 - 88*t0**2 - 296*t0 + 28
         kernels = [ker(x/s).monic() for s in ss]
-        isogs.extend(Ew.isogeny(ker, model=model) for ker in kernels)
+        isogs.extend(E.isogeny(ker(w).monic(), model=model) for ker in kernels)
 
-    w = E.isomorphism_to(Ew)
-    isogs = [isog * w for isog in isogs]
     return isogs
 
 
@@ -1386,8 +1382,7 @@ def isogenies_13_0(E, minimal_models=True):
             to Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field in a of size 19^2]
         sage: isogenies_13_0(E)[0].rational_maps()
         ((6*x^13 - 6*x^10 - 3*x^7 + 6*x^4 + x)/(x^12 - 5*x^9 - 9*x^6 - 7*x^3 + 5),
-         (-8*x^18*y - 9*x^15*y + 9*x^12*y - 5*x^9*y
-          + 5*x^6*y - 7*x^3*y + 7*y)/(x^18 + 2*x^15 + 3*x^12 - x^9 + 8*x^6 - 9*x^3 + 7))
+         (8*x^18*y + 9*x^15*y - 9*x^12*y + 5*x^9*y - 5*x^6*y + 7*x^3*y - 7*y)/(x^18 + 2*x^15 + 3*x^12 - x^9 + 8*x^6 - 9*x^3 + 7))
 
     A previous implementation did not work in some characteristics::
 
@@ -1427,16 +1422,18 @@ def isogenies_13_0(E, minimal_models=True):
         raise NotImplementedError("not implemented when the characteristic of the base field is 2, 3 or 13")
     from sage.rings.number_field.number_field_base import NumberField
     model = "minimal" if minimal_models and isinstance(F, NumberField) else None
+
     x = polygen(F)
 
     Ew = E.short_weierstrass_model()
     b = Ew.a6()
+    w = E.isomorphism_to(Ew).x_rational_map().numerator()
 
     # there will be 2 endomorphisms if -3 is a square:
     ts = sorted(F(-3).sqrt(all=True, extend=False))
     kernels = [13*x**2 + (78*t + 26)*x + 24*t + 40 for t in ts]
     kernels = [ker(x**3/b).monic() for ker in kernels]
-    isogs = [Ew.isogeny(ker, codomain=E) for ker in kernels]
+    isogs = [E.isogeny(ker(w).monic(), codomain=E) for ker in kernels]
 
     # we may have up to 12 other isogenies:
     ts = sorted((x**4 + 7*x**3 + 20*x**2 + 19*x + 1).roots(multiplicities=False))
@@ -1450,10 +1447,8 @@ def isogenies_13_0(E, minimal_models=True):
             + (354472*t0**3 + 1899488*t0**2 + 3971680*t0 + 215960)*x
             - 459424*t0**3 - 2461888*t0**2 - 5147648*t0 - 279904)
         kernels = [ker(x/s).monic() for s in ss]
-        isogs.extend(Ew.isogeny(ker, model=model) for ker in kernels)
+        isogs.extend(E.isogeny(ker(w).monic(), model=model) for ker in kernels)
 
-    w = E.isomorphism_to(Ew)
-    isogs = [isog * w for isog in isogs]
     return isogs
 
 
@@ -1571,16 +1566,18 @@ def isogenies_13_1728(E, minimal_models=True):
         raise NotImplementedError("not implemented when the characteristic of the base field is 2, 3 or 13")
     from sage.rings.number_field.number_field_base import NumberField
     model = "minimal" if minimal_models and isinstance(F, NumberField) else None
+
     x = polygen(F)
 
     Ew = E.short_weierstrass_model()
     a = Ew.a4()
+    w = E.isomorphism_to(Ew).x_rational_map().numerator()
 
     # we will have two endomorphisms if -1 is a square:
     ts = sorted(F(-1).sqrt(all=True, extend=False))
     kernels = [13*x**3 + (-26*i - 13)*x**2 + (-52*i - 13)*x - 2*i - 3 for i in ts]
     kernels = [ker(x**2/a).monic() for ker in kernels]
-    isogs = [Ew.isogeny(ker, codomain=E) for ker in kernels]
+    isogs = [E.isogeny(ker(w).monic(), codomain=E) for ker in kernels]
 
     # we may have up to 12 other isogenies:
     ts = sorted((x**6 + 10*x**5 + 46*x**4 + 108*x**3 + 122*x**2 + 38*x - 1).roots(multiplicities=False))
@@ -1600,10 +1597,8 @@ def isogenies_13_1728(E, minimal_models=True):
               966973468160*t0**4 - 4190156868352*t0**3 -
               8843158270336*t0**2 - 7860368751232*t0 + 196854655936)
         kernels = [ker(x/s).monic() for s in ss]
-        isogs.extend(Ew.isogeny(ker, model=model) for ker in kernels)
+        isogs.extend(E.isogeny(ker(w).monic(), model=model) for ker in kernels)
 
-    w = E.isomorphism_to(Ew)
-    isogs = [isog * w for isog in isogs]
     return isogs
 
 # List of primes l for which X_0(l) is (hyper)elliptic and X_0^+(l) has genus 0

--- a/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
+++ b/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
@@ -221,8 +221,8 @@ class baseWI:
 
 def _isomorphisms(E, F):
     r"""
-    Enumerate all isomorphisms between two elliptic curves,
-    as a generator object.
+    Enumerate all isomorphisms between two elliptic curves, as a generator.
+    Normalized isomorphisms are output before any non-normalized ones.
 
     INPUT:
 
@@ -312,10 +312,12 @@ def _isomorphisms(E, F):
 
     char = K.characteristic()
 
+    one_first = lambda vs: [K.one()] * (K.one() in vs) + [v for v in vs if not v.is_one()]
+
     if char == 2:
         if j == 0:
             ulist = (x**3 - a3E/a3F).roots(multiplicities=False)
-            for u in ulist:
+            for u in one_first(ulist):
                 slist = (x**4 + a3E*x + (a2F**2 + a4F)*u**4 + a2E**2 + a4E).roots(multiplicities=False)
                 for s in slist:
                     r = s**2 + a2E + a2F*u**2
@@ -337,7 +339,7 @@ def _isomorphisms(E, F):
     if char == 3:
         if j == 0:
             ulist = (x**4 - b4E/b4F).roots(multiplicities=False)
-            for u in ulist:
+            for u in one_first(ulist):
                 s = a1E - a1F*u
                 t = a3E - a3F*u**3
                 rlist = (x**3 - b4E*x + b6E - b6F*u**6).roots(multiplicities=False)
@@ -345,7 +347,7 @@ def _isomorphisms(E, F):
                     yield (u, r, s, t + r*a1E)
         else:
             ulist = (x**2 - b2E/b2F).roots(multiplicities=False)
-            for u in ulist:
+            for u in one_first(ulist):
                 r = (b4F * u**4 - b4E) / b2E
                 s = a1E - a1F * u
                 t = a3E - a3F * u**3 + a1E * r
@@ -364,7 +366,7 @@ def _isomorphisms(E, F):
     else:
         m, um = 2, (c6E*c4F)/(c6F*c4E)
     ulist = (x**m - um).roots(multiplicities=False)
-    for u in ulist:
+    for u in one_first(ulist):
         s = (a1F*u - a1E)/2
         r = (a2F*u**2 + a1E*s + s**2 - a2E)/3
         t = (a3F*u**3 - a1E*r - a3E)/2
@@ -736,6 +738,12 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
                 raise ValueError("Domain of first argument must equal codomain of second")
             w = baseWI.__mul__(left, right)
             return WeierstrassIsomorphism(right._domain, w.tuple(), left._codomain)
+
+        if isinstance(left, WeierstrassIsomorphism) and left.is_identity():
+            return right
+
+        if isinstance(right, WeierstrassIsomorphism) and right.is_identity():
+            return left
 
         return NotImplemented
 

--- a/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
+++ b/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
@@ -990,7 +990,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
             sage: p = 97
             sage: Fp = GF(p)
             sage: E = EllipticCurve(Fp, [1, 28])
-            sage: ws = WeierstrassIsomorphism(E, None, E)
+            sage: ws = E.automorphisms()[1]
             sage: ws.is_identity()
             False
 
@@ -1000,7 +1000,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
             sage: p = 97
             sage: Fp = GF(p)
             sage: E = EllipticCurve(Fp, [1, 28])
-            sage: ws = WeierstrassIsomorphism(E, (1, 0, 0, 0), None)
+            sage: ws = E.automorphisms()[0]
             sage: ws.is_identity()
             True
         """
@@ -1020,7 +1020,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
             sage: p = 97
             sage: Fp = GF(p)
             sage: E = EllipticCurve(Fp, [1, 28])
-            sage: ws = WeierstrassIsomorphism(E, None, E)
+            sage: ws = E.automorphisms()[1]
             sage: ws.order()
             2
 
@@ -1030,7 +1030,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
             sage: p = 97
             sage: Fp = GF(p)
             sage: E = EllipticCurve(Fp, [1, 28])
-            sage: ws = WeierstrassIsomorphism(E, None, E)
+            sage: ws = E.automorphisms()[1]
             sage: ws.order()
             2
             sage: E1 = EllipticCurve(Fp, [1, 69])
@@ -1051,7 +1051,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
             3
             sage: F2_bar = GF(2).algebraic_closure()
             sage: E = EllipticCurve_from_j(F2_bar(0))
-            sage: ws = WeierstrassIsomorphism(E, None, E)
+            sage: ws = E.automorphisms()[8]
             sage: ws.order()
             3
         """


### PR DESCRIPTION
The existence of these (as well as post-isomorphisms, but that's a topic for later) is superseded by the existence of `EllipticCurveHom_composite`, which supports arbitrary compositions of pre- and post-isomorphisms.

The main motivation at this time is to fix #41495. It also dramatically simplifies a lot of the code in `EllipticCurveIsogeny`, and it increases the consistency of `EllipticCurveIsogeny` with other `EllipticCurveHom` implementations.