### PR TITLE
Eliminate remaining 32- and 64-bit doctest output tags

### DIFF
--- a/src/doc/en/developer/coding_basics.rst
+++ b/src/doc/en/developer/coding_basics.rst
@@ -1357,6 +1357,15 @@ framework. Here is a comprehensive list:
        the doctests in this file will be skipped unless the
        appropriate conditions are met.
 
+  - **32-bit** or **64-bit:** for tests that behave differently on 32-bit or
+    64-bit machines, the ``32_bit`` feature can be used::
+
+        sage: h = hash(2^31 + 2^13)
+        sage: h  # needs 32_bit
+        8193
+        sage: h  # needs !32_bit
+        2147491840
+
 - **indirect doctest:** in the docstring of a function ``A(...)``, a line
   calling ``A`` and in which the name ``A`` does not appear should have this
   flag. This prevents ``sage --coverage <file>`` from reporting the docstring as
@@ -1373,14 +1382,6 @@ framework. Here is a comprehensive list:
 
           sage: 1+1 # indirect doctest
           2
-
-- **32-bit** or **64-bit:** for tests that behave differently on 32-bit or
-  64-bit machines. Note that this particular flag is to be applied on the
-  **output** lines, not the input lines::
-
-      sage: hash(2^31 + 2^13)
-      8193                      # 32-bit
-      2147491840                # 64-bit
 
 Per coding style (:ref:`section-coding-python`), the magic comment
 should be separated by at least 2 spaces.

--- a/src/doc/en/developer/coding_basics.rst
+++ b/src/doc/en/developer/coding_basics.rst
@@ -1380,7 +1380,7 @@ framework. Here is a comprehensive list:
       This is the docstring of an ``__add__`` method. The following
       example tests it, but ``__add__`` is not written anywhere::
 
-          sage: 1+1 # indirect doctest
+          sage: 1+1  # indirect doctest
           2
 
 Per coding style (:ref:`section-coding-python`), the magic comment

--- a/src/sage/arith/long.pxd
+++ b/src/sage/arith/long.pxd
@@ -271,15 +271,18 @@ cdef inline bint integer_check_long_py(x, long* value, int* err) noexcept:
         sage: L += [-x for x in L] + [0, long_min()]
         sage: for v in L:
         ....:     assert check_long_py(int(v)) == v
-        sage: check_long_py(int(2^60))
-        1152921504606846976                 # 64-bit
-        'Overflow (...)'                    # 32-bit
-        sage: check_long_py(int(2^61))
-        2305843009213693952                 # 64-bit
-        'Overflow (...)'                    # 32-bit
-        sage: check_long_py(int(2^62))
-        4611686018427387904                 # 64-bit
-        'Overflow (...)'                    # 32-bit
+        sage: check_long_py(int(2^60))  # needs 32_bit
+        'Overflow (...)'
+        sage: check_long_py(int(2^60))  # needs !32_bit
+        1152921504606846976
+        sage: check_long_py(int(2^61))  # needs 32_bit
+        'Overflow (...)'
+        sage: check_long_py(int(2^61))  # needs !32_bit
+        2305843009213693952
+        sage: check_long_py(int(2^62))  # needs 32_bit
+        'Overflow (...)'
+        sage: check_long_py(int(2^62))  # needs !32_bit
+        4611686018427387904
         sage: check_long_py(int(2^63))
         'Overflow (...)'
         sage: check_long_py(int(2^100))

--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -773,19 +773,6 @@ class FileDocTestSource(DocTestSource):
 
         TESTS:
 
-        We check that we correctly process results that depend on 32
-        vs 64 bit architecture::
-
-            sage: import sys
-            sage: bitness = '64' if sys.maxsize > (1 << 32) else '32'
-            sage: sys.maxsize == 2^63 - 1
-            False # 32-bit
-            True  # 64-bit
-            sage: ex = doctests[20].examples[11]
-            sage: ((bitness == '64' and ex.want == 'True  \n')
-            ....:  or (bitness == '32' and ex.want == 'False \n'))
-            True
-
         We check that lines starting with a # aren't doctested::
 
             #sage: raise RuntimeError

--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -58,8 +58,6 @@ double_colon = re.compile(r"^(\s*).*::\s*$")
 code_block = re.compile(r"^(\s*)[.][.]\s*code-block\s*::.*$")
 
 whitespace = re.compile(r"\s*")
-bitness_marker = re.compile('#.*(32|64)-bit')
-bitness_value = '64' if sys.maxsize > (1 << 32) else '32'  # cf. sage.features.bitness
 
 # For neutralizing doctests
 find_prompt = re.compile(r"^(\s*)(>>>|sage:)(.*)")
@@ -336,13 +334,6 @@ class DocTestSource:
                     self._process_doc(doctests, doc, namespace, start)
                     unparsed_doc = False
                 else:
-                    bitness = bitness_marker.search(line)
-                    if bitness:
-                        if bitness.groups()[0] != bitness_value:
-                            self.line_shift += 1
-                            continue
-                        else:
-                            line = line[:bitness.start()] + "\n"
                     if self.line_shift and (m := sagestart.match(line)):
                         # We insert empty doctest lines to make up for the removed lines
                         indent_and_prompt = m.group(1)

--- a/src/sage/doctest/tests/longtime.rst
+++ b/src/sage/doctest/tests/longtime.rst
@@ -1,5 +1,6 @@
 Test combining various modifiers::
 
-    sage: sys.maxsize  # long time, abs tol 0.001
-    2147483646.999            # 32-bit
-    9223372036854775806.999   # 64-bit
+    sage: sys.maxsize  # long time, abs tol 0.001, needs 32_bit
+    2147483646.999
+    sage: sys.maxsize  # long time, abs tol 0.001, needs !32_bit
+    9223372036854775806.999

--- a/src/sage/libs/singular/singular.pyx
+++ b/src/sage/libs/singular/singular.pyx
@@ -1772,14 +1772,23 @@ cdef int overflow_check(unsigned long e, ring *_ring) except -1:
     which in both cases makes a maximal default exponent of
     2^16-1.
 
-    EXAMPLES::
+    EXAMPLES:
+
+    This overflows only on 32-bit systems::
 
         sage: P.<x,y> = QQ[]
-        sage: y^(2^30)
-        Traceback (most recent call last):             # 32-bit
-        ...                                            # 32-bit
-        OverflowError: exponent overflow (1073741824)  # 32-bit
-        y^1073741824  # 64-bit
+        sage: try:
+        ....:     result = y^(2^30)
+        ....: except OverflowError as e:
+        ....:     # 32 bit
+        ....:     result = e
+        sage: isinstance(result, OverflowError)  # needs 32_bit
+        True
+        sage: result  # needs !32_bit
+        y^1073741824
+
+    This one always overflows::
+
         sage: y^2^32
         Traceback (most recent call last):
         ...

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -3176,17 +3176,25 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
         TESTS:
 
-        Overflow::
+        This example always overflows::
 
             sage: prod(primes_first_n(64)).divisors()                                   # needs sage.libs.pari
             Traceback (most recent call last):
             ...
             OverflowError: value too large
-            sage: prod(primes_first_n(58)).divisors()                                   # needs sage.libs.pari
-            Traceback (most recent call last):
-            ...
-            OverflowError: value too large                                 # 32-bit
-            MemoryError: failed to allocate 288230376151711744 * 24 bytes  # 64-bit
+
+        While this one overflows only on 32-bit systems. On 64-bit
+        systems, we run out of memory::
+
+            sage: # needs sage.libs.pari
+            sage: try:
+            ....:     prod(primes_first_n(58)).divisors()
+            ....: except (OverflowError, MemoryError) as e:
+            ....:     exc = e
+            sage: isinstance(exc, OverflowError)  # needs 32_bit
+            True
+            sage: isinstance(exc, MemoryError)    # needs !32_bit
+            True
 
         Check for memory leaks and ability to interrupt
         (the ``divisors`` call below allocates about 800 MB every time,

--- a/src/sage/rings/number_field/bdd_height.py
+++ b/src/sage/rings/number_field/bdd_height.py
@@ -231,13 +231,18 @@ def bdd_norm_pr_ideal_gens(K, norm_list):
         sage: bdd_norm_pr_ideal_gens(K, [1])
         {1: [1]}
 
-    ::
+    In this example the output differs slightly on 32- and 64-bit
+    machines, but in both cases the norm of `g \pm 11` is the same::
 
-        sage: from sage.rings.number_field.bdd_height import bdd_norm_pr_ideal_gens
+        sage: from sage.rings.number_field.bdd_height import (
+        ....:     bdd_norm_pr_ideal_gens
+        ....: )
         sage: K.<g> = QuadraticField(123)
-        sage: bdd_norm_pr_ideal_gens(K, range(5))
-        {0: [0], 1: [1], 2: [g + 11], 3: [], 4: [2]}  # 64-bit
-        {0: [0], 1: [1], 2: [g - 11], 3: [], 4: [2]}  # 32-bit
+        sage: d = bdd_norm_pr_ideal_gens(K, range(5))
+        sage: d  # needs 32_bit
+        {0: [0], 1: [1], 2: [g - 11], 3: [], 4: [2]}
+        sage: d  # needs !32_bit
+        {0: [0], 1: [1], 2: [g + 11], 3: [], 4: [2]}
 
     ::
 

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -4905,12 +4905,19 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             True
 
         Number fields defined by non-monic and non-integral
-        polynomials are supported (:issue:`252`)::
+        polynomials are supported (:issue:`252`). The units returned
+        below differ slightly depending on the CPU::
 
             sage: K.<a> = NumberField(2*x^2 - 1/3)
-            sage: K._S_class_group_and_units(tuple(K.primes_above(2) + K.primes_above(3)))
-            ([6*a + 2, -6*a + 3, -1, -12*a - 5], [])  # 64-bit
-            ([6*a + 2, -6*a - 3, -1, -12*a - 5], [])  # 32-bit
+            sage: ps = tuple(K.primes_above(2) + K.primes_above(3))
+            sage: units, gens = K._S_class_group_and_units(ps)
+            sage: gens
+            []
+            sage: units  # needs 32_bit
+            [6*a + 2, -6*a - 3, -1, -12*a - 5]
+            sage: units  # needs !32_bit
+            [6*a + 2, -6*a + 3, -1, -12*a - 5]
+
         """
         K_pari = self.pari_bnf(proof=proof)
         S_pari = [p.pari_prime() for p in sorted(set(S))]

--- a/src/sage/rings/number_field/totallyreal_rel.py
+++ b/src/sage/rings/number_field/totallyreal_rel.py
@@ -67,9 +67,6 @@ discriminant `\le 17 \times 10^9`.
     sage: F.<t> = NumberField(ZZx([1,-4,3,1]))
     sage: F.disc()
     49
-    sage: enumerate_totallyreal_fields_rel(F, 3, 17*10^9)  # not tested, too long time (258s on sage.math, 2013)
-    [[16240385609L, x^9 - x^8 - 9*x^7 + 4*x^6 + 26*x^5 - 2*x^4 - 25*x^3 - x^2 + 7*x + 1, xF^3 + (-t^2 - 4*t + 1)*xF^2 + (t^2 + 3*t - 5)*xF + 3*t^2 + 11*t - 5]]    # 32-bit
-    [[16240385609, x^9 - x^8 - 9*x^7 + 4*x^6 + 26*x^5 - 2*x^4 - 25*x^3 - x^2 + 7*x + 1, xF^3 + (-t^2 - 4*t + 1)*xF^2 + (t^2 + 3*t - 5)*xF + 3*t^2 + 11*t - 5]]     # 64-bit
 
 TESTS:
 

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -1587,10 +1587,6 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
             sage: P.monomial_quotient(P(3/2),P(2/3), coeff=True)
             9/4
 
-            sage: P.monomial_quotient(x,y) # Note the wrong result
-            x*y^65535*z^65535      # 32-bit
-            x*y^1048575*z^1048575  # 64-bit
-
             sage: P.monomial_quotient(x,P(1))
             x
 

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -1687,17 +1687,24 @@ cdef class NCPolynomial_plural(RingElement):
             sage: f^2
             x^6 + x^2*z + y^2
 
-        TESTS::
+        TESTS:
+
+        The exponents overflow at different points on 32- and 64-bit
+        systems::
 
             sage: A.<x,z,y> = FreeAlgebra(QQ, 3)
             sage: P = A.g_algebra(relations={y*x:-x*y + z},  order='lex')
             sage: P.inject_variables()
             Defining x, z, y
-            sage: x^(2^20-1)
-            Traceback (most recent call last):             # 32-bit
-            ...                                            # 32-bit
-            OverflowError: exponent overflow (1048575)     # 32-bit
-            x^1048575  # 64-bit
+            sage: try:
+            ....:     power = x^(2^20-1)
+            ....: except OverflowError as e:
+            ....:     # Happens on 32-bit systems
+            ....:     power = e
+            sage: isinstance(power, OverflowError)  # needs 32_bit
+            True
+            sage: power  # needs !32_bit
+            x^1048575
             sage: x^2^20
             Traceback (most recent call last):
             ....

--- a/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_ntl.pyx
@@ -158,8 +158,8 @@ cdef class Polynomial_integer_dense_ntl(Polynomial):
             sage: PolynomialRing(ZZ, 'x', implementation='NTL')({sys.maxsize>>1: 1})
             Traceback (most recent call last):
             ...
-            OverflowError: Dense NTL integer polynomials have a maximum degree of 268435455    # 32-bit
-            OverflowError: Dense NTL integer polynomials have a maximum degree of 1152921504606846975    # 64-bit
+            OverflowError: Dense NTL integer polynomials have a maximum degree of ...
+
         """
         Polynomial.__init__(self, parent, is_gen=is_gen)
 

--- a/src/sage/rings/real_arb.pyx
+++ b/src/sage/rings/real_arb.pyx
@@ -293,9 +293,22 @@ cdef int arb_to_mpfi(mpfi_t target, arb_t source, const long precision) except -
 
     EXAMPLES::
 
-        sage: RIF(RBF(2)**(2**100))
-        [5.8756537891115869e1388255822130839282 .. +infinity] # 64-bit
-        [2.098... .. +infinity]                               # 32-bit
+        sage: from sage.rings.real_arb import RealBall
+        sage: from sage.rings.real_mpfi import RealIntervalFieldElement
+        sage: arb = RBF(2)
+        sage: isinstance(arb, RealBall)
+        True
+        sage: mpfi = RIF(arb)
+        sage: isinstance(mpfi, RealIntervalFieldElement)
+        True
+
+    TESTS::
+
+        sage: RIF(RBF(2)**(2**100))  # needs 32_bit
+        [2.098... .. +infinity]
+        sage: RIF(RBF(2)**(2**100))  # needs !32_bit
+        [5.8756537891115869e1388255822130839282 .. +infinity]
+
     """
     cdef mpfr_t left
     cdef mpfr_t right

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -1861,19 +1861,27 @@ cdef class RealIntervalFieldElement(RingElement):
 
         Check that :issue:`15166` is fixed::
 
-            sage: RIF(1.84e13).exp()
-            [2.0985787164673874e323228496 .. +infinity] # 32-bit
-            6.817557048799520?e7991018467019 # 64-bit
+            sage: v = RIF(1.84e13).exp()
+            sage: v  # needs 32_bit
+            [2.0985787164673874e323228496 .. +infinity]
+            sage: v  # needs !32_bit
+            6.817557048799520?e7991018467019
             sage: from sage.rings.real_mpfr import mpfr_get_exp_min, mpfr_get_exp_max
-            sage: v = RIF(1.0 << (mpfr_get_exp_max() - 1)); v
-            1.0492893582336939?e323228496 # 32-bit
-            2.9378268945557938?e1388255822130839282 # 64-bit
-            sage: -v
-            -1.0492893582336939?e323228496 # 32-bit
-            -2.9378268945557938?e1388255822130839282 # 64-bit
-            sage: v = RIF(1.0 >> -mpfr_get_exp_min()+1); v
-            2.3825649048879511?e-323228497 # 32-bit
-            8.5096913117408362?e-1388255822130839284 # 64-bit
+            sage: v = RIF(1.0 << (mpfr_get_exp_max() - 1))
+            sage: v  # needs 32_bit
+            1.0492893582336939?e323228496
+            sage: v  # needs !32_bit
+            2.9378268945557938?e1388255822130839282
+            sage: v = -v
+            sage: v  # needs 32_bit
+            -1.0492893582336939?e323228496
+            sage: v  # needs !32_bit
+            -2.9378268945557938?e1388255822130839282
+            sage: v = RIF(1.0 >> -mpfr_get_exp_min()+1)
+            sage: v  # needs 32_bit
+            2.3825649048879511?e-323228497
+            sage: v  # needs !32_bit
+            8.5096913117408362?e-1388255822130839284
         """
         if not(mpfr_number_p(&self.value.left) and mpfr_number_p(&self.value.right)):
             raise ValueError("_str_question_style on NaN or infinity")
@@ -2479,17 +2487,22 @@ cdef class RealIntervalFieldElement(RingElement):
             2.06622879260?e6137
             sage: a.fp_rank_diameter()
             30524
-            sage: (RIF(sqrt(2)) - RIF(sqrt(2))).fp_rank_diameter()
-            9671406088542672151117826            # 32-bit
-            41538374868278620559869609387229186  # 64-bit
+            sage: d = (RIF(sqrt(2)) - RIF(sqrt(2))).fp_rank_diameter()
+            sage: diam32 = 9671406088542672151117826
+            sage: diam64 = 41538374868278620559869609387229186
+            sage: d in [diam32, diam64]
+            True
 
         Just because we have the best possible interval, doesn't mean the
         interval is actually small::
 
-            sage: a = RIF(pi)^12345678901234567890; a                                   # needs sage.symbolic
-            [2.0985787164673874e323228496 .. +infinity]            # 32-bit
-            [5.8756537891115869e1388255822130839282 .. +infinity]  # 64-bit
-            sage: a.fp_rank_diameter()                                                  # needs sage.symbolic
+            sage: # needs sage.symbolic
+            sage: a = RIF(pi)^12345678901234567890
+            sage: a  # needs 32_bit
+            [2.0985787164673874e323228496 .. +infinity]
+            sage: a  # needs !32_bit
+            [5.8756537891115869e1388255822130839282 .. +infinity]
+            sage: a.fp_rank_diameter()
             1
         """
         return self.lower().fp_rank_delta(self.upper())

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -84,9 +84,11 @@ EXAMPLES:
 
 A difficult conversion::
 
-    sage: RR(sys.maxsize)
-    9.22337203685478e18      # 64-bit
-    2.14748364700000e9       # 32-bit
+    sage: r = RR(sys.maxsize)
+    sage: r  # needs 32_bit
+    2.14748364700000e9
+    sage: r  # needs !32_bit
+    9.22337203685478e18
 
 TESTS::
 
@@ -228,10 +230,17 @@ def mpfr_prec_max():
         sage: R = RealField(2^31-257); R
         Real Field with 2147483391 bits of precision
 
-        sage: R = RealField(2^31-256)
-        Traceback (most recent call last):                     # 32-bit
-        ...                                                    # 32-bit
-        ValueError: prec (=...) must be >= 1 and <= ...        # 32-bit
+   This overflows on 32-bit, leading to an invalid argument::
+
+        sage: try:
+        ....:     R = RealField(2^31-256)
+        ....: except ValueError as e:
+        ....:     R = e
+        sage: isinstance(R, ValueError)  # needs 32_bit
+        True
+        sage: isinstance(R, ValueError)  # needs !32_bit
+        False
+
     """
     return MPFR_PREC_MAX
 
@@ -247,9 +256,11 @@ def mpfr_get_exp_min():
         sage: min64 = -4611686018427387903
         sage: mpfr_get_exp_min() in [min32, min64]
         True
-        sage: 0.5 >> (-mpfr_get_exp_min())
-        2.38256490488795e-323228497            # 32-bit
-        8.50969131174084e-1388255822130839284  # 64-bit
+        sage: x = 0.5 >> (-mpfr_get_exp_min())
+        sage: x  # needs 32_bit
+        2.38256490488795e-323228497
+        sage: x  # needs !32_bit
+        8.50969131174084e-1388255822130839284
         sage: 0.5 >> (-mpfr_get_exp_min()+1)
         0.000000000000000
     """
@@ -267,9 +278,11 @@ def mpfr_get_exp_max():
         sage: max64 = 4611686018427387903
         sage: mpfr_get_exp_max() in [max32, max64]
         True
-        sage: 0.5 << mpfr_get_exp_max()
-        1.04928935823369e323228496            # 32-bit
-        2.93782689455579e1388255822130839282  # 64-bit
+        sage: x = 0.5 << mpfr_get_exp_max()
+        sage: x  # needs 32_bit
+        1.04928935823369e323228496
+        sage: x  # needs !32_bit
+        2.93782689455579e1388255822130839282
         sage: 0.5 << (mpfr_get_exp_max()+1)
         +infinity
     """
@@ -2861,9 +2874,10 @@ cdef class RealNumber(sage.structure.element.RingElement):
         The ulp of zero is the smallest nonzero number::
 
             sage: a = RR(0).ulp()
-            sage: a
-            2.38256490488795e-323228497            # 32-bit
-            8.50969131174084e-1388255822130839284  # 64-bit
+            sage: a  # needs 32_bit
+            2.38256490488795e-323228497
+            sage: a  # needs !32_bit
+            8.50969131174084e-1388255822130839284
             sage: a.fp_rank()
             1
 
@@ -3164,9 +3178,11 @@ cdef class RealNumber(sage.structure.element.RingElement):
             '1.0000000000000002'
             sage: (1.0).nexttoward(RR('-infinity')).str()
             '0.99999999999999989'
-            sage: RR(infinity).nexttoward(0)
-            2.09857871646739e323228496            # 32-bit
-            5.87565378911159e1388255822130839282  # 64-bit
+            sage: x = RR(infinity).nexttoward(0)
+            sage: x  # needs 32_bit
+            2.09857871646739e323228496
+            sage: x  # needs !32_bit
+            5.87565378911159e1388255822130839282
             sage: RR(pi).str()                                                          # needs sage.symbolic
             '3.1415926535897931'
             sage: RR(pi).nexttoward(22/7).str()                                         # needs sage.symbolic
@@ -3193,12 +3209,16 @@ cdef class RealNumber(sage.structure.element.RingElement):
 
         EXAMPLES::
 
-            sage: RR('-infinity').nextabove()
-            -2.09857871646739e323228496            # 32-bit
-            -5.87565378911159e1388255822130839282  # 64-bit
-            sage: RR(0).nextabove()
-            2.38256490488795e-323228497            # 32-bit
-            8.50969131174084e-1388255822130839284  # 64-bit
+            sage: x = RR('-infinity').nextabove()
+            sage: x  # needs 32_bit
+            -2.09857871646739e323228496
+            sage: x  # needs !32_bit
+            -5.87565378911159e1388255822130839282
+            sage: x = RR(0).nextabove()
+            sage: x  # needs 32_bit
+            2.38256490488795e-323228497
+            sage: x  # needs !32_bit
+            8.50969131174084e-1388255822130839284
             sage: RR('+infinity').nextabove()
             +infinity
             sage: RR(-sqrt(2)).str()                                                    # needs sage.symbolic
@@ -3221,12 +3241,16 @@ cdef class RealNumber(sage.structure.element.RingElement):
 
             sage: RR('-infinity').nextbelow()
             -infinity
-            sage: RR(0).nextbelow()
-            -2.38256490488795e-323228497            # 32-bit
-            -8.50969131174084e-1388255822130839284  # 64-bit
-            sage: RR('+infinity').nextbelow()
-            2.09857871646739e323228496              # 32-bit
-            5.87565378911159e1388255822130839282    # 64-bit
+            sage: x = RR(0).nextbelow()
+            sage: x  # needs 32_bit
+            -2.38256490488795e-323228497
+            sage: x  # needs !32_bit
+            -8.50969131174084e-1388255822130839284
+            sage: x = RR('+infinity').nextbelow()
+            sage: x  # needs 32_bit
+            2.09857871646739e323228496
+            sage: x  # needs !32_bit
+            5.87565378911159e1388255822130839282
             sage: RR(-sqrt(2)).str()                                                    # needs sage.symbolic
             '-1.4142135623730951'
             sage: RR(-sqrt(2)).nextbelow().str()                                        # needs sage.symbolic

--- a/src/sage/schemes/elliptic_curves/lseries_ell.py
+++ b/src/sage/schemes/elliptic_curves/lseries_ell.py
@@ -79,8 +79,7 @@ class Lseries_ell(SageObject):
             sage: E = EllipticCurve('389a')
             sage: L = E.lseries()
             sage: L.taylor_series(series_prec=3)   # abs tol 1e-14
-            -1.27685190980159e-23 + (7.23588070754027e-24)*z + 0.759316500288427*z^2 + O(z^3)  # 32-bit
-            1.34667664606157e-19 + (-7.63157535163667e-20)*z + 0.759316500288427*z^2 + O(z^3)  # 64-bit
+            1.34667664606157e-19 + (-7.63157535163667e-20)*z + 0.759316500288427*z^2 + O(z^3)
         """
         D = self.dokchitser(prec)
         return D.taylor_series(a, series_prec, var)


### PR DESCRIPTION
Our `# 32-bit` and `# 64bit` tags, namely that they must annotate the output lines and not the input line, are non-standard. We have replacements that work on the input lines in `# needs 32_bit` or `# needs !32_bit`, but in some cases we can handle both cases simultaneously (which is preferable, in my opinion).

This PR replaces all uses of the old tags, updates the documentation to suggest `# needs 32_bit`, and removes support for the old tags from the doctest runner. The latter is a backwards-incompatible change, but it cannot break user code, only custom tests. If we were to make the old-style tags raise deprecation warnings, exactly the same tests would break, so it does not seem worthwhile to deprecate and remove later.

This is a follow-up to https://github.com/sagemath/sage/pull/41468, and supersedes https://github.com/sagemath/sage/pull/40238.

The tests pass for me on a 64-bit system, but I don't have a 32-bit one to try with.