### PR TITLE
fix issue in `to_bytes()` for finite fields

### DIFF
--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -138,7 +138,8 @@ cdef class FiniteRingElement(CommutativeRingElement):
             sage: a.to_bytes(byteorder='little')
             b'\x16"\x00'
         """
-        length = (self.parent().order().nbits() + 7) // 8
+        order = self.parent().order()
+        length = ((order - 1).nbits() + 7) // 8
         return int(self).to_bytes(length=length, byteorder=byteorder)
 
     def canonical_associate(self):
@@ -1128,8 +1129,18 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             sage: a = 136*z3^2 + 10*z3 + 125
             sage: a.to_bytes()
             b'7)\xa3'
+
+        TESTS:
+
+        Check that :issue:`41545` is fixed::
+
+            sage: F.<z2> = GF(2^8)
+            sage: a = F.from_integer(137)
+            sage: a.to_bytes()
+            b'\x89'
         """
-        length = (self.parent().order().nbits() + 7) // 8
+        order = self.parent().order()
+        length = ((order - 1).nbits() + 7) // 8
         return self.to_integer().to_bytes(length=length, byteorder=byteorder)
 
 cdef class Cache_base(SageObject):


### PR DESCRIPTION
When a field had order `2^8*n` for `n >= 1` then there was an additional byte of padding to the to_bytes encoding because of the use of `nbits` on the order. In this PR we instead set the length from the size of the largest element represented in the field: `order - 1`

Thanks ti @rasti37 for finding this.

Fixes #41545