### PR TITLE
src/sage/features/pkg_systems.py: adds "needs pip" for a pip test

### DIFF
--- a/src/sage/features/pkg_systems.py
+++ b/src/sage/features/pkg_systems.py
@@ -183,7 +183,7 @@ class PipPackageSystem(PackageSystem):
         EXAMPLES::
 
             sage: from sage.features.pkg_systems import PipPackageSystem
-            sage: bool(PipPackageSystem().is_present())    # indirect doctest
+            sage: bool(PipPackageSystem().is_present())    # indirect doctest, needs pip
             True
         """
         from subprocess import run, DEVNULL, CalledProcessError

--- a/src/sage/features/pkg_systems.py
+++ b/src/sage/features/pkg_systems.py
@@ -188,7 +188,14 @@ class PipPackageSystem(PackageSystem):
         """
         from subprocess import run, DEVNULL, CalledProcessError
         try:
-            run('sage -pip --version', shell=True, stdout=DEVNULL, stderr=DEVNULL, check=True)
+            # The command below is missing the arguments to pip, but
+            # when run from within the sage distribution, it will
+            # still succeed. If, on the other hand, "sage" is the
+            # script provided by a minimal sage library installation,
+            # then the command will fail regardless of whether or not
+            # pip is installed. This is fine: the PackageSystem
+            # concept is helpful only within the sage distribution.
+            run('sage -pip', shell=True, stdout=DEVNULL, stderr=DEVNULL, check=True)
             return True
         except CalledProcessError:
             return False


### PR DESCRIPTION
Pip isn't a requirement of the sage library, and (without "needs pip") this test can fail when it isn't present.

