### PR TITLE
Explicit build-time features

### DIFF
--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -55,7 +55,8 @@ if [ "$SAGE_EDITABLE" = yes ]; then
         --config-settings=build-dir="build/sage-distro" \
         --config-settings=setup-args="--native-file=$SAGE_PKGS/../platform/meson/sage-configure-native-file.ini" \
         --config-settings=setup-args="-DSAGE_LOCAL=$SAGE_LOCAL" \
-        --config-settings=setup-args="-Dbuild-docs=$SAGE_BUILD_DOCS"
+        --config-settings=setup-args="-Dbuild-docs=$SAGE_BUILD_DOCS" \
+        --config-settings=setup-args="-Ddefer_feature_checks=true"
 
     if [ "$SAGE_WHEELS" = yes ]; then
         # Additionally build a wheel (for use in other venvs)
@@ -73,7 +74,8 @@ else
     # Compiling sage/interfaces/sagespawn.pyx because it depends on /private/var/folders/38/wnh4gf1552g_crsjnv2vmmww0000gp/T/pip-build-env-609n5985/overlay/lib/python3.10/site-packages/Cython/Includes/posix/unistd.pxd
     sdh_pip_install --no-build-isolation . --config-setting=build-dir="build/sage-distro" \
         --config-setting=setup-args="-DSAGE_LOCAL=$SAGE_LOCAL" \
-        --config-setting=setup-args="-Dbuild-docs=$SAGE_BUILD_DOCS"
+        --config-setting=setup-args="-Dbuild-docs=$SAGE_BUILD_DOCS" \
+        --config-settings=setup-args="-Ddefer_feature_checks=true"
 fi
 
 # Remove (potentially invalid) star import caches.

--- a/meson.options
+++ b/meson.options
@@ -17,6 +17,16 @@ option(
   description: 'Build the HTML / PDF documentation'
 )
 
+# Useful on binary distros, for example, to allow features to flip on as soon
+# as the package that provides it is installed. If this is disabled, a rebuild
+# of sagelib is required to toggle features on or off.
+option(
+  'defer_feature_checks',
+  type: 'boolean',
+  value: false,
+  description: 'Defer feature checks to runtime'
+)
+
 #
 # Features
 #

--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -31,6 +31,7 @@ Features
    sage/features
    sage/features/join_feature
    sage/features/all
+   sage/features/build_feature
    sage/features/sagemath
    sage/features/pkg_systems
    sage/features/bliss

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -55,6 +55,8 @@ THREEJS_DIR = SAGE_LOCAL + "/share/threejs-sage"
 OPENMP_CFLAGS = "@OPENMP_CFLAGS@"
 OPENMP_CXXFLAGS = "@OPENMP_CXXFLAGS@"
 
+# build-time feature flags
+defer_feature_checks = @DEFER_FEATURE_CHECKS@
 
 def is_editable_install() -> bool:
     """

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -57,6 +57,16 @@ OPENMP_CXXFLAGS = "@OPENMP_CXXFLAGS@"
 
 # build-time feature flags
 defer_feature_checks = @DEFER_FEATURE_CHECKS@
+bliss_enabled = @BLISS_ENABLED@
+brial_enabled = @BRIAL_ENABLED@
+coxeter3_enabled = @COXETER3_ENABLED@
+eclib_enabled = @ECLIB_ENABLED@
+libhomfly_enabled = @LIBHOMFLY_ENABLED@
+mcqd_enabled = @MCQD_ENABLED@
+meataxe_enabled = @MEATAXE_ENABLED@
+rankwidth_enabled = @RANKWIDTH_ENABLED@
+sirocco_enabled = @SIROCCO_ENABLED@
+tdlib_enabled = @TDLIB_ENABLED@
 
 def is_editable_install() -> bool:
     """

--- a/src/sage/doctest/external.py
+++ b/src/sage/doctest/external.py
@@ -498,9 +498,20 @@ class AvailableSoftware:
         """
         Return the list of names of those features for which testing their presence is allowed.
         """
+        # Exclude build features that aren't runtime detectable from
+        # the list. Note that when defer_feature_checks is not set,
+        # *no* BuildFeatures are runtime-detectable.
+        from sage.features.build_feature import BuildFeature
+        def build_time_only(f):
+            return ( isinstance(f, BuildFeature)
+                     and
+                     not f.is_runtime_detectable() )
+
         return [feature.name
                 for feature, seen in zip(self._features, self._seen)
-                if seen >= 0 and (self._allow_external or feature not in self._external_features)]
+                if seen >= 0
+                and (self._allow_external or feature not in self._external_features)
+                and not build_time_only(feature)]
 
     def seen(self):
         """
@@ -512,9 +523,18 @@ class AvailableSoftware:
             sage: available_software.seen() # random
             ['internet', 'latex', 'magma']
         """
+        # Exclude build features that aren't runtime detectable from
+        # the list. Note that when defer_feature_checks is not set,
+        # *no* BuildFeatures are runtime-detectable.
+        from sage.features.build_feature import BuildFeature
+        def build_time_only(f):
+            return ( isinstance(f, BuildFeature)
+                     and
+                     not f.is_runtime_detectable() )
         return [feature.name
                 for feature, seen in zip(self._features, self._seen)
-                if seen > 0]
+                if seen > 0
+                and not build_time_only(feature)]
 
     def hidden(self):
         """

--- a/src/sage/features/bliss.py
+++ b/src/sage/features/bliss.py
@@ -13,9 +13,9 @@ Features for testing the presence of ``bliss``
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from . import CythonFeature, PythonModule
-from .join_feature import JoinFeature
-
+from sage.config import bliss_enabled
+from sage.features import CythonFeature, PythonModule
+from sage.features.build_feature import BuildFeature
 
 TEST_CODE = """
 # distutils: language=c++
@@ -57,16 +57,19 @@ class BlissLibrary(CythonFeature):
                                url='http://www.tcs.hut.fi/Software/bliss/')
 
 
-class Bliss(JoinFeature):
+class Bliss(BuildFeature):
     r"""
-    A :class:`~sage.features.Feature` which describes whether the :mod:`sage.graphs.bliss`
-    module is available in this installation of Sage.
+    A :class:`~sage.features.Feature` which describes whether the
+    :mod:`sage.graphs.bliss` module is available in this installation
+    of Sage.
 
     EXAMPLES::
 
         sage: from sage.features.bliss import Bliss
-        sage: Bliss().require()  # optional - bliss
+        sage: Bliss().require()  # needs bliss
     """
+    _enabled_in_build = bliss_enabled
+
     def __init__(self):
         r"""
         TESTS::
@@ -74,11 +77,27 @@ class Bliss(JoinFeature):
             sage: from sage.features.bliss import Bliss
             sage: Bliss()
             Feature('bliss')
-        """
-        JoinFeature.__init__(self, "bliss",
-                             [PythonModule("sage.graphs.bliss", spkg='bliss',
-                                           url='http://www.tcs.hut.fi/Software/bliss/')])
 
+        """
+        super().__init__("bliss",
+                         url='http://www.tcs.hut.fi/Software/bliss/')
+
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.bliss import Bliss
+            sage: result = Bliss().is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs bliss
+            FeatureTestResult('bliss', True)
+
+        """
+        result = PythonModule("sage.graphs.bliss")._is_present()
+        result.feature = self
+        return result
 
 def all_features():
     return [Bliss()]

--- a/src/sage/features/brial.py
+++ b/src/sage/features/brial.py
@@ -2,11 +2,12 @@ r"""
 Feature for testing the presence of (lib)brial
 """
 
-from sage.features.join_feature import JoinFeature
+from sage.config import brial_enabled
 from sage.features import PythonModule
+from sage.features.build_feature import BuildFeature
 
 
-class Brial(JoinFeature):
+class Brial(BuildFeature):
     r"""
     A :class:`sage.features.Feature` describing the presence of
     :mod:`sage.rings.polynomial.pbori`.
@@ -21,9 +22,11 @@ class Brial(JoinFeature):
         sage: Brial().is_present()  # needs brial
         FeatureTestResult('brial', True)
         sage: Brial().is_present()  # needs !brial
-        FeatureTestResult('sage.rings.polynomial.pbori.pbori', False)
+        FeatureTestResult('brial', False)
 
     """
+    _enabled_in_build = brial_enabled
+
     def __init__(self):
         r"""
         TESTS::
@@ -32,10 +35,31 @@ class Brial(JoinFeature):
             sage: isinstance(Brial(), Brial)
             True
         """
-        JoinFeature.__init__(self, 'brial',
-                             [PythonModule('sage.rings.polynomial.pbori.pbori')],
-                             spkg='sagemath_brial', type='standard')
+        super().__init__("brial", spkg="brial", type="standard")
 
+
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.brial import Brial
+            sage: brial = Brial()
+            sage: result = brial.is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs brial
+            FeatureTestResult('brial', True)
+
+        """
+        # The build system installs the sage/rings/pbori source code
+        # even when brial support is disabled, so a naive import of
+        # that module will actually succeed. We check for a
+        # conditionally-compiled cython module instead.
+        cython_modname = "sage.rings.polynomial.pbori.pbori"
+        result = PythonModule(cython_modname)._is_present()
+        result.feature = self
+        return result
 
 def all_features():
     return [Brial()]

--- a/src/sage/features/build_feature.py
+++ b/src/sage/features/build_feature.py
@@ -1,0 +1,138 @@
+r"""
+Features that can be explicitly enabled or disabled at build time
+
+These features are unique in that, if they are enabled or disabled at
+build-time, then we usually do not want to detect them on-the-fly.
+Instead we trust the value supplied (or detected) at build-time. There
+is however an overrride to defer these checks to run-time (the classic
+behavior) for use on binary distros or anywhere it is desirable to
+enable/disable features without rebuilding sage.
+
+This is an implementation of Option 3 in `Github discussion 41067
+<https://github.com/sagemath/sage/discussions/41067>`__.
+"""
+
+from sage.features import Feature, FeatureTestResult
+
+class BuildFeature(Feature):
+    r"""
+    A class for features that can be enabled or disabled at
+    build-time.
+
+    The current implementation refers to build features that are
+    configurable in meson. For example::
+
+        option(
+          'foo',
+          type: 'feature',
+          value: 'auto',
+          description: 'support for foo'
+        )
+
+    At build time, support for this "foo" will be automatically
+    detected, and either enabled or disabled depending on whether or
+    not its requirements are met. Alternatively, users may pass either
+    ``-Dfoo=enabled`` or ``-Dfoo=disabled`` to explicitly enable or
+    disable the feature. Features may be disabled regardless of
+    whether or not they are installed, but usually features may only
+    be enabled if their dependencies are present and usable.
+
+    In any event, after ``meson setup``, support for "foo" is either
+    enabled or disabled, and a boolean variable called something like
+    ``foo_enabled`` is written to ``sage.config``. In your subclass,
+    you should set the member variable ``_enabled_in_build`` to the
+    value of that config variable.
+
+    The :meth:`_is_present` method for this class will return the
+    value of that config variable unless ``defer_feature_checks`` is
+    set to ``True`` in ``sage.config``. If checks are deferred, the
+    :meth:`_is_present` method will try to return the value of
+    :meth:`is_present_at_runtime` instead. If your feature can be
+    detected at run-time, you should implement that check in
+    :meth:`is_present_at_runtime`. Otherwise, leave it unimplemented;
+    and :meth:`_is_present` will return ``False``.
+
+    EXAMPLES::
+
+        sage: from sage.features.build_feature import BuildFeature
+        sage: BuildFeature("foo")
+        Feature('foo')
+
+    """
+
+    # Set this in subclasses.
+    _enabled_in_build = None
+
+    # Implement this method if your feature is detectable at run-time.
+    # Your test should only return True if the feature meets Sage's
+    # requirements; for example, if there are doctests for gzipped foo
+    # data files hidden behind "needs foo", then you should ensure
+    # that foo was compiled with (say) --enable-zlib in your check.
+    #
+    # def is_present_at_runtime(self):
+    #     pass
+
+    def is_runtime_detectable(self):
+        r"""
+        Return whether or not this feature can (and should) be
+        detected at runtime.
+
+        A feature is runtime detectable if both of the following hold:
+
+        - Deferred feature checks have been enabled globally by
+          passing ``-Ddefer_feature_checks=true`` to ``meson setup``.
+
+        - An ``is_present_at_runtime`` method has been implemented for
+          the feature.
+
+        EXAMPLES:
+
+        The method returns ``False`` if you have not implemented
+        ``is_present_at_runtime``::
+
+            sage: from sage.features.build_feature import BuildFeature
+            sage: bf = BuildFeature("example")
+            sage: bf.is_runtime_detectable()
+            False
+
+        """
+        from sage.config import defer_feature_checks
+        if not defer_feature_checks:
+            return False
+        elif hasattr(self, "is_present_at_runtime"):
+            return True
+        else:
+            return False
+
+    def _is_present(self):
+        r"""
+        Default presence check for build features.
+
+        If this feature :meth:`is_runtime_detectable`, we return the
+        result of that method. Otherwise, we use the value of
+        ``self._enabled_in_build``.
+
+        EXAMPLES:
+
+        When feature checks are deferred, runtime-detectable features
+        can be detected without ``self._enabled_in_build`` being set,
+        but this will fail by surprise when they are un-deferred::
+
+            sage: from sage.config import defer_feature_checks
+            sage: from sage.features.build_feature import BuildFeature
+            sage: bf = BuildFeature("example")
+            sage: const_True = lambda s: True
+            sage: bf.is_present_at_runtime = const_True.__get__(bf)
+            sage: (not defer_feature_checks) or bf.is_present().is_present
+            True
+
+        """
+        if self.is_runtime_detectable():
+            return self.is_present_at_runtime()
+        else:
+            import sage.config
+            # Wrap with bool() so that we can be lazy and use meson's
+            # set10() rather than painstakingly writing "True" and
+            # "False" to the config file.
+            result =  bool(self._enabled_in_build)
+            return FeatureTestResult(self, result)

--- a/src/sage/features/coxeter3.py
+++ b/src/sage/features/coxeter3.py
@@ -13,20 +13,24 @@ Features for testing the presence of ``coxeter3``
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from . import PythonModule
-from .join_feature import JoinFeature
+from sage.config import coxeter3_enabled
+from sage.features import PythonModule
+from sage.features.build_feature import BuildFeature
 
-
-class Coxeter3(JoinFeature):
+class Coxeter3(BuildFeature):
     r"""
-    A :class:`~sage.features.Feature` which describes whether the :mod:`sage.libs.coxeter3`
-    module is available in this installation of Sage.
+    A :class:`~sage.features.Feature` which describes whether the
+    :mod:`sage.libs.coxeter3` module is available in this installation
+    of Sage.
 
     EXAMPLES::
 
         sage: from sage.features.coxeter3 import Coxeter3
-        sage: Coxeter3().require()  # optional - coxeter3
+        sage: Coxeter3().require()  # needs coxeter3
+
     """
+    _enabled_in_build = coxeter3_enabled
+
     def __init__(self):
         r"""
         TESTS::
@@ -34,11 +38,31 @@ class Coxeter3(JoinFeature):
             sage: from sage.features.coxeter3 import Coxeter3
             sage: Coxeter3()
             Feature('coxeter3')
-        """
-        JoinFeature.__init__(self, "coxeter3",
-                             [PythonModule("sage.libs.coxeter3.coxeter",
-                                           spkg='coxeter3')])
 
+        """
+        super().__init__("coxeter3", spkg="coxeter3")
+
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.coxeter3 import Coxeter3
+            sage: result = Coxeter3().is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs coxeter3
+            FeatureTestResult('coxeter3', True)
+
+        """
+        # The build system installs the sage/libs/coxeter3 source code
+        # even when coxeter3 support is disabled, so a naive import of
+        # that module will actually succeed. We check for a
+        # conditionally-compiled cython module instead.
+        cython_modname = "sage.libs.coxeter3.coxeter"
+        result = PythonModule(cython_modname)._is_present()
+        result.feature = self
+        return result
 
 def all_features():
     return [Coxeter3()]

--- a/src/sage/features/libhomfly.py
+++ b/src/sage/features/libhomfly.py
@@ -2,11 +2,12 @@ r"""
 Feature for testing the presence of libhomfly
 """
 
-from sage.features.join_feature import JoinFeature
+from sage.config import libhomfly_enabled
 from sage.features import PythonModule
+from sage.features.build_feature import BuildFeature
 
 
-class Libhomfly(JoinFeature):
+class Libhomfly(BuildFeature):
     r"""
     A :class:`sage.features.Feature` describing the presence of
     :mod:`sage.libs.homfly`, the interface to libhomfly.
@@ -17,9 +18,11 @@ class Libhomfly(JoinFeature):
         sage: Libhomfly().is_present()  # needs libhomfly
         FeatureTestResult('libhomfly', True)
         sage: Libhomfly().is_present()  # needs !libhomfly
-        FeatureTestResult('sage.libs.homfly', False)
+        FeatureTestResult('libhomfly', False)
 
     """
+    _enabled_in_build = libhomfly_enabled
+
     def __init__(self):
         r"""
         TESTS::
@@ -29,9 +32,25 @@ class Libhomfly(JoinFeature):
             True
 
         """
-        JoinFeature.__init__(self, 'libhomfly',
-                             [PythonModule('sage.libs.homfly')],
-                             spkg='libhomfly', type='standard')
+        super().__init__('libhomfly', spkg='libhomfly', type='standard')
+
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.libhomfly import Libhomfly
+            sage: lhf = Libhomfly()
+            sage: result = lhf.is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs libhomfly
+            FeatureTestResult('libhomfly', True)
+
+        """
+        result = PythonModule("sage.libs.homfly")._is_present()
+        result.feature = self
+        return result
 
 
 def all_features():

--- a/src/sage/features/mcqd.py
+++ b/src/sage/features/mcqd.py
@@ -11,21 +11,24 @@ Features for testing the presence of ``mcqd``
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from . import PythonModule
-from .join_feature import JoinFeature
+from sage.config import mcqd_enabled
+from sage.features import PythonModule
+from sage.features.build_feature import BuildFeature
 
-
-class Mcqd(JoinFeature):
+class Mcqd(BuildFeature):
     r"""
-    A :class:`~sage.features.Feature` describing the presence of the :mod:`~sage.graphs.mcqd` module,
-    which is the SageMath interface to the :ref:`mcqd <spkg_mcqd>` library
+    A :class:`~sage.features.Feature` describing the presence of
+    the :mod:`~sage.graphs.mcqd` module, which is the SageMath
+    interface to the :ref:`mcqd <spkg_mcqd>` library
 
     EXAMPLES::
 
         sage: from sage.features.mcqd import Mcqd
-        sage: Mcqd().is_present()  # optional - mcqd
+        sage: Mcqd().is_present()  # needs mcqd
         FeatureTestResult('mcqd', True)
+
     """
+    _enabled_in_build = mcqd_enabled
 
     def __init__(self):
         """
@@ -34,11 +37,26 @@ class Mcqd(JoinFeature):
             sage: from sage.features.mcqd import Mcqd
             sage: isinstance(Mcqd(), Mcqd)
             True
-        """
-        JoinFeature.__init__(self, 'mcqd',
-                             [PythonModule('sage.graphs.mcqd',
-                                           spkg='mcqd')])
 
+        """
+        super().__init__("mcqd", spkg="mcqd")
+
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.mcqd import Mcqd
+            sage: result = Mcqd().is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs mcqd
+            FeatureTestResult('mcqd', True)
+
+        """
+        result = PythonModule("sage.graphs.mcqd")._is_present()
+        result.feature = self
+        return result
 
 def all_features():
     return [Mcqd()]

--- a/src/sage/features/meataxe.py
+++ b/src/sage/features/meataxe.py
@@ -12,22 +12,25 @@ Feature for testing the presence of ``meataxe``
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
+from sage.config import meataxe_enabled
+from sage.features import PythonModule
+from sage.features.build_feature import BuildFeature
 
-from . import PythonModule
-from .join_feature import JoinFeature
-
-
-class Meataxe(JoinFeature):
+class Meataxe(BuildFeature):
     r"""
-    A :class:`~sage.features.Feature` describing the presence of the Sage modules
-    that depend on the :ref:`meataxe <spkg_meataxe>` library.
+    A :class:`~sage.features.Feature` describing the presence of
+    the Sage modules that depend on the :ref:`meataxe <spkg_meataxe>`
+    library.
 
     EXAMPLES::
 
         sage: from sage.features.meataxe import Meataxe
-        sage: Meataxe().is_present()  # optional - meataxe
+        sage: Meataxe().is_present()  # needs meataxe
         FeatureTestResult('meataxe', True)
+
     """
+    _enabled_in_build = meataxe_enabled
+
     def __init__(self):
         r"""
         TESTS::
@@ -35,11 +38,27 @@ class Meataxe(JoinFeature):
             sage: from sage.features.meataxe import Meataxe
             sage: isinstance(Meataxe(), Meataxe)
             True
-        """
-        JoinFeature.__init__(self, 'meataxe',
-                             [PythonModule('sage.matrix.matrix_gfpn_dense',
-                                           spkg='meataxe')])
 
+        """
+        super().__init__("meataxe", spkg="meataxe")
+
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.meataxe import Meataxe
+            sage: result = Meataxe().is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs meataxe
+            FeatureTestResult('meataxe', True)
+
+        """
+        modname = "sage.matrix.matrix_gfpn_dense"
+        result = PythonModule(modname)._is_present()
+        result.feature = self
+        return result
 
 def all_features():
     return [Meataxe()]

--- a/src/sage/features/rankwidth.py
+++ b/src/sage/features/rankwidth.py
@@ -12,11 +12,12 @@ Feature for the rank-width graph decomposition
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
+from sage.config import rankwidth_enabled
 from sage.features import PythonModule
-from sage.features.join_feature import JoinFeature
+from sage.features.build_feature import BuildFeature
 
 
-class RankWidth(JoinFeature):
+class RankWidth(BuildFeature):
     r"""
     A :class:`~sage.features.Feature` indicating whether or not the
     rank-width graph decomposition is available.
@@ -32,9 +33,11 @@ class RankWidth(JoinFeature):
         sage: RankWidth().is_present()  # needs rankwidth
         FeatureTestResult('rankwidth', True)
         sage: RankWidth().is_present()  # needs !rankwidth
-        FeatureTestResult('sage.graphs.graph_decompositions.rankwidth', False)
+        FeatureTestResult('rankwidth', False)
 
     """
+    _enabled_in_build = rankwidth_enabled
+
     def __init__(self):
         r"""
         EXAMPLES::
@@ -44,9 +47,26 @@ class RankWidth(JoinFeature):
             Feature('rankwidth')
 
         """
-        f = PythonModule("sage.graphs.graph_decompositions.rankwidth")
-        JoinFeature.__init__(self, "rankwidth", [f], spkg="rw", type="standard")
+        super().__init__("rankwidth", spkg="rw", type="standard")
 
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.rankwidth import RankWidth
+            sage: rw = RankWidth()
+            sage: result = rw.is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs rankwidth
+            FeatureTestResult('rankwidth', True)
+
+        """
+        cython_modname = "sage.graphs.graph_decompositions.rankwidth"
+        result = PythonModule(cython_modname)._is_present()
+        result.feature = self
+        return result
 
 def all_features():
     return [RankWidth()]

--- a/src/sage/features/sirocco.py
+++ b/src/sage/features/sirocco.py
@@ -13,20 +13,24 @@ Features for testing the presence of ``sirocco``
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from . import PythonModule
-from .join_feature import JoinFeature
+from sage.config import sirocco_enabled
+from sage.features import PythonModule
+from sage.features.build_feature import BuildFeature
 
-
-class Sirocco(JoinFeature):
+class Sirocco(BuildFeature):
     r"""
-    A :class:`~sage.features.Feature` which describes whether the :mod:`sage.libs.sirocco`
-    module is available in this installation of Sage.
+    A :class:`~sage.features.Feature` which describes whether the
+    :mod:`sage.libs.sirocco` module is available in this installation
+    of Sage.
 
     EXAMPLES::
 
         sage: from sage.features.sirocco import Sirocco
-        sage: Sirocco().require()  # optional - sirocco
+        sage: Sirocco().require()  # needs sirocco
+
     """
+    _enabled_in_build = sirocco_enabled
+
     def __init__(self):
         r"""
         TESTS::
@@ -34,11 +38,26 @@ class Sirocco(JoinFeature):
             sage: from sage.features.sirocco import Sirocco
             sage: Sirocco()
             Feature('sirocco')
-        """
-        JoinFeature.__init__(self, "sirocco",
-                             [PythonModule("sage.libs.sirocco",
-                                           spkg='sirocco')])
 
+        """
+        super().__init__("sirocco", spkg="sirocco")
+
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.sirocco import Sirocco
+            sage: result = Sirocco().is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs sirocco
+            FeatureTestResult('sirocco', True)
+
+        """
+        result = PythonModule("sage.libs.sirocco")._is_present()
+        result.feature = self
+        return result
 
 def all_features():
     return [Sirocco()]

--- a/src/sage/features/tdlib.py
+++ b/src/sage/features/tdlib.py
@@ -12,14 +12,17 @@ Features for testing the presence of ``tdlib``
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
-from . import PythonModule
-from .join_feature import JoinFeature
+from sage.config import tdlib_enabled
+from sage.features import PythonModule
+from sage.features.build_feature import BuildFeature
 
-
-class Tdlib(JoinFeature):
+class Tdlib(BuildFeature):
     r"""
-    A :class:`~sage.features.Feature` describing the presence of the SageMath interface to the :ref:`tdlib <spkg_tdlib>` library.
+    A :class:`~sage.features.Feature` describing the presence of
+    the SageMath interface to the :ref:`tdlib <spkg_tdlib>` library.
     """
+    _enabled_in_build = tdlib_enabled
+
     def __init__(self):
         r"""
         TESTS::
@@ -27,11 +30,27 @@ class Tdlib(JoinFeature):
             sage: from sage.features.tdlib import Tdlib
             sage: isinstance(Tdlib(), Tdlib)
             True
-        """
-        JoinFeature.__init__(self, 'tdlib',
-                             [PythonModule('sage.graphs.graph_decompositions.tdlib',
-                                           spkg='tdlib')])
 
+        """
+        super().__init__("tdlib", spkg="tdlib")
+
+    def is_present_at_runtime(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features import FeatureTestResult
+            sage: from sage.features.tdlib import Tdlib
+            sage: result = Tdlib().is_present_at_runtime()
+            sage: isinstance(result, FeatureTestResult)
+            True
+            sage: result  # needs tdlib
+            FeatureTestResult('tdlib', True)
+
+        """
+        modname = "sage.graphs.graph_decompositions.tdlib"
+        result = PythonModule(modname)._is_present()
+        result.feature = self
+        return result
 
 def all_features():
     return [Tdlib()]

--- a/src/sage/graphs/graph_decompositions/meson.build
+++ b/src/sage/graphs/graph_decompositions/meson.build
@@ -83,3 +83,7 @@ py.extension_module(
   dependencies: [py_dep, cysignals, tdlib],
 )
 
+# Record in the config file whether or not optional packages were
+# found, so that we don't have to look for them at runtime.
+conf_data.set10('RANKWIDTH_ENABLED', rw.found())
+conf_data.set10('TDLIB_ENABLED', tdlib.found())

--- a/src/sage/graphs/meson.build
+++ b/src/sage/graphs/meson.build
@@ -183,6 +183,11 @@ py.extension_module(
   dependencies: [py_dep, cysignals, mcqd],
 )
 
+# Record in the config file whether or not optional packages were
+# found, so that we don't have to look for them at runtime.
+conf_data.set10('BLISS_ENABLED', bliss.found())
+conf_data.set10('MCQD_ENABLED', mcqd.found())
+
 subdir('base')
 subdir('generators')
 subdir('graph_decompositions')

--- a/src/sage/libs/coxeter3/meson.build
+++ b/src/sage/libs/coxeter3/meson.build
@@ -25,3 +25,7 @@ foreach name, pyx : extension_data_cpp
     dependencies: [py_dep, cysignals, coxeter3],
   )
 endforeach
+
+# Record in the config file whether or not optional packages were
+# found, so that we don't have to look for them at runtime.
+conf_data.set10('COXETER3_ENABLED', coxeter3.found())

--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -169,6 +169,12 @@ foreach name, pyx : extension_data_cpp
   )
 endforeach
 
+# Record in the config file whether or not optional packages were
+# found, so that we don't have to look for them at runtime.
+conf_data.set10('LIBHOMFLY_ENABLED', homfly.found())
+conf_data.set10('MEATAXE_ENABLED', mtx.found())
+conf_data.set10('SIROCCO_ENABLED', sirocco.found())
+
 subdir('arb')
 subdir('coxeter3')
 install_subdir('cremona', install_dir: sage_install_dir / 'libs')

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -163,6 +163,7 @@ configure_file(
 # enabled or disabled, and whether or not we should defer detection to
 # runtime.
 conf_data.set10('DEFER_FEATURE_CHECKS', get_option('defer_feature_checks'))
+conf_data.set10('ECLIB_ENABLED', ec.found())
 
 # Write config file
 # Should be last so that subdir calls can modify the config data

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -159,6 +159,11 @@ configure_file(
   configuration: kernel_data,
 )
 
+# Record what build-time features (e.g. external package support) were
+# enabled or disabled, and whether or not we should defer detection to
+# runtime.
+conf_data.set10('DEFER_FEATURE_CHECKS', get_option('defer_feature_checks'))
+
 # Write config file
 # Should be last so that subdir calls can modify the config data
 config_file = configure_file(

--- a/src/sage/rings/polynomial/pbori/meson.build
+++ b/src/sage/rings/polynomial/pbori/meson.build
@@ -62,3 +62,6 @@ foreach name, pyx : extension_data_cpp
   )
 endforeach
 
+# Record in the config file whether or not optional packages were
+# found, so that we don't have to look for them at runtime.
+conf_data.set10('BRIAL_ENABLED', brial.found() and brial_groebner.found())


### PR DESCRIPTION
Implement Option 3 from https://github.com/sagemath/sage/discussions/41067.

1. Add a new meson option `defer_feature_checks` that defaults to false in meson, and true in the sage distro (for backwards compatibility). Record its value in `sage/config.py`.
2. For all of the existing features in `meson.options`, define variables in `sage/config.py` stating whether or not they were enabled in the build.
3. Add a new `BuildFeature` class to handle the processing.
4. Subclass the new `BuildFeature` for the optional packages in `meson.options` (except eclib, which is still lacking feature detection).
5. Avoid spamming build-only features in the output from `sage -t`. 

All permutations of the options should work, but for an example using the meson build, `meson setup -Dauto_features=disabled ...` will disable everything at build-time, and not check for it again at run-time. You should be able to see the values `foo_enabled = 0` in `sage/config.py`. The feature objects (`BuildFeature` subclasses) will consult these variables to determine if the feature is enabled.

To test the deferred runtime detection, rebuild with `meson setup -Ddefer_feature_checks=true ...`. All of the existing features supported by this PR are linked to various python modules at build time, so it's not so obvious how to add or remove them at runtime, but one option is to uninstall the library that the feature uses (say, rw, for the `RankWidth` feature). This will cause the import test of the associated cython module to fail at runtime, leading to the feature being disabled. Reinstall rw and the feature should re-enable itself.

Relevant docs:

* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/bliss
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/brial
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/build_feature
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/coxeter3
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/libhomfly
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/mcqd
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/meataxe
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/rankwidth
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/sirocco
* https://doc-pr-41550--sagemath.netlify.app/html/en/reference/spkg/sage/features/tdlib
