### PR TITLE
Docs: Add examples for max_symbolic and min_symbolic plotting #11258

### DIFF
--- a/src/sage/plot/plot.py
+++ b/src/sage/plot/plot.py
@@ -103,6 +103,13 @@ We draw a circle and a curve::
 
     g = circle((1,1), 1) + plot(x**2, (x,0,5))
     sphinx_plot(g)
+    
+We can also plot symbolic maximum and minimum functions::
+
+    sage: plot(max_symbolic(x, 2), (x, 0, 4))
+    Graphics object consisting of 1 graphics primitive
+    sage: plot(min_symbolic(x^2, x+2), (x, -2, 2))
+    Graphics object consisting of 1 graphics primitive
 
 Notice that the aspect ratio of the above plot makes the plot very tall
 because the plot adopts the default aspect ratio of the circle (to make


### PR DESCRIPTION
 This PR adds documentation examples (doctests) for plotting max_symbolic and min_symbolic functions in src/sage/plot/plot.py. These examples demonstrate how these symbolic functions behave when passed to the standard plot() command.
Changes:

Added a new section under "We can also plot symbolic maximum and minimum functions::".

Included two new doctests:

plot(max_symbolic(x, 2), (x, 0, 4)).

plot(min_symbolic(x^2, x+2), (x, -2, 2)).

Verified that both examples return a Graphics object consisting of 1 graphics primitive.

Testing performed:

Ran local doctests using ./sage -t src/sage/plot/plot.py.

Confirmed the examples render correctly in the documentation.
