### PR TITLE
sage/graphs/graph_database.py: compute database path only on init

### DIFF
--- a/src/sage/graphs/graph_database.py
+++ b/src/sage/graphs/graph_database.py
@@ -48,9 +48,7 @@ import re
 from . import graph
 from sage.rings.integer import Integer
 from sage.databases.sql_db import SQLDatabase, SQLQuery
-from sage.features.databases import DatabaseGraphs
 from sage.graphs.graph import Graph
-dblocation = DatabaseGraphs().absolute_filename()
 
 
 def degseq_to_data(degree_sequence):
@@ -994,6 +992,8 @@ class GraphDatabase(SQLDatabase):
                'sql': 'TEXT',
                'unique': False}}}
         """
+        from sage.features.databases import DatabaseGraphs
+        dblocation = DatabaseGraphs().absolute_filename()
         SQLDatabase.__init__(self, dblocation)
 
     def _gen_interact_func(self, display, **kwds):


### PR DESCRIPTION
Currently we compute the graphs database location when this module is imported, but the database is not guaranteed to be present. Indeed, the `sage.features.databases.DatabaseGraphs` feature exists to detect it.

I don't know whether or not this module works (passes tests) without the database, but now at least it is importable. This allows one to run `pytest --doctest --collect-only` without errors on a system where the database is not installed.
