### PR TITLE
fix doctest warning in `src/sage/rings/finite_rings/element_base.pyx`

### DIFF
--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -747,7 +747,7 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             sage: (a**2).is_square()                                                    # needs sage.libs.ntl
             True
             sage: k.<a> = FiniteField(17^5, implementation='pari_ffelt', modulus='primitive')     # needs sage.libs.pari
-            sage: a.is_square()
+            sage: a.is_square()                                                         # needs sage.libs.pari
             False
             sage: (a**2).is_square()                                                    # needs sage.libs.pari
             True


### PR DESCRIPTION
Add missing tag to fix doctest warning reported by some bots, for instance
```
 Check warning on line 750 in src/sage/rings/finite_rings/element_base.pyx
 
GitHub Actions / Conda (macos, Python 3.13, all)

Warning: Variable 'a' referenced here was set only in doctest marked '# needs sage.libs.linbox sage.rings.finite_rings'; '# needs sage.libs.ntl sage.rings.finite_rings'; '# needs sage.libs.pari sage.rings.finite_rings'
Variable 'a' referenced here was set only in doctest marked '# needs sage.libs.linbox sage.rings.finite_rings'; '# needs sage.libs.ntl sage.rings.finite_rings'; '# needs sage.libs.pari sage.rings.finite_rings'
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


