### PR TITLE
specialized (much faster) method to compute elliptic-curve division field over finite fields

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -5134,6 +5134,11 @@ REFERENCES:
              of graphs*, Linear Algebra and its Applications 103 (1988),
              119-131.
 
+.. [MPSW25] Travis Morrison, Lorenz Panny, Jana Sotáková, and Michael Wills:
+            *The SEA algorithm for endomorphisms of supersingular elliptic curves*
+            (2025).
+            :arxiv:`2501.16321`
+
 .. [Most2019] Jacob Mostovoy.
               *The pure cactus group is residually nilpotent*.
               Archiv der Math., **113** (2019). pp. 229-235.
@@ -6810,6 +6815,10 @@ REFERENCES:
 .. [Vai1994] \I. Vaisman, *Lectures on the Geometry of Poisson
              Manifolds*, Springer Basel AG (Basel) (1994);
              :doi:`10.1007/978-3-0348-8495-2`
+
+.. [VT2001] Adam Van Tuyl: *Computing the degree of the field of `n`‑torsion points*
+            (2001).
+            https://ms.mcmaster.ca/~vantuyl/papers/ntorsion_2001.pdf
 
 .. [Var1984] \V. S. Varadarajan. *Lie groups, Lie algebras, and their
              representations*. Reprint of the 1974 edition. Graduate Texts in

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -6816,7 +6816,7 @@ REFERENCES:
              Manifolds*, Springer Basel AG (Basel) (1994);
              :doi:`10.1007/978-3-0348-8495-2`
 
-.. [VT2001] Adam Van Tuyl: *Computing the degree of the field of `n`‑torsion points*
+.. [VT2001] Adam Van Tuyl: *Computing the degree of the field of 𝑛‑torsion points*
             (2001).
             https://ms.mcmaster.ca/~vantuyl/papers/ntorsion_2001.pdf
 

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1894,8 +1894,11 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         try:
             return sage.rings.integer.Integer(self.__pari__().znorder())
         except PariError:
-            raise ArithmeticError("multiplicative order of %s not defined since it is not a unit modulo %s" % (
-                self, self._modulus.sageInteger))
+            raise ArithmeticError(f"multiplicative order of {self} not defined since it is not a unit modulo {self._modulus.sageInteger}")
+
+        # fallback (for composite moduli): use generic-group algorithm
+        from sage.groups.generic import order_from_multiple
+        return order_from_multiple(self, self.parent().unit_group_exponent(), operation='*')
 
     def valuation(self, p):
         """

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1072,6 +1072,12 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         verbose("Adjoining X-coordinates of %s-torsion points" % n)
 
         F = self.base_ring()
+
+        # If the curve is supersingular, the p-torsion is trivial,
+        # so we may ignore the p-primary part of n right away.
+        if not F(n) and self.is_supersingular():
+            n = n.prime_to_m_part(F.characteristic())
+
         f = self.division_polynomial(n).radical()
 
         if n == 2 or f.is_constant():

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -990,6 +990,9 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         .. SEEALSO::
 
+            This method has a faster specialized implementation for finite base fields;
+            see :meth:`sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.division_field`.
+
             To compute a basis of the `n`-torsion once the base field
             has been extended, you may use
             :meth:`sage.schemes.elliptic_curves.ell_number_field.EllipticCurve_number_field.torsion_subgroup`

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -836,7 +836,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         If ``map`` is ``False``, the division field `K` as an absolute
         number field or a finite field.
         If ``map`` is ``True``, a tuple `(K, \phi)` where `\phi` is an
-        embedding of the base field in the division field `K`.
+        embedding of the base field into the division field `K`.
 
         .. WARNING::
 
@@ -962,22 +962,6 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
               To:   Number Field in b with defining polynomial x^24 ...
               Defn: i |--> -215621657062634529/183360797284413355040732*b^23 ...
 
-        Over a finite field::
-
-            sage: E = EllipticCurve(GF(431^2), [1,0])                                   # needs sage.rings.finite_rings
-            sage: E.division_field(5, map=True)                                         # needs sage.rings.finite_rings
-            (Finite Field in t of size 431^4,
-             Ring morphism:
-               From: Finite Field in z2 of size 431^2
-               To:   Finite Field in t of size 431^4
-               Defn: z2 |--> 52*t^3 + 222*t^2 + 78*t + 105)
-
-        ::
-
-            sage: E = EllipticCurve(GF(433^2), [1,0])                                   # needs sage.rings.finite_rings
-            sage: K.<v> = E.division_field(7); K                                        # needs sage.rings.finite_rings
-            Finite Field in v of size 433^16
-
         It also works for composite orders::
 
             sage: E = EllipticCurve(GF(11), [5,5])
@@ -1011,49 +995,6 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             :meth:`sage.schemes.elliptic_curves.ell_number_field.EllipticCurve_number_field.torsion_subgroup`
             or
             :meth:`sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.torsion_basis`.
-
-        TESTS:
-
-        Some random for prime orders::
-
-            sage: # needs sage.rings.finite_rings
-            sage: def check(E, l, K):
-            ....:     EE = E.change_ring(K)
-            ....:     cof = EE.order().prime_to_m_part(l)
-            ....:     pts = (cof * EE.random_point() for _ in iter(int, 1))
-            ....:     mul = lambda P: P if not l*P else mul(l*P)
-            ....:     pts = map(mul, filter(bool, pts))
-            ....:     if l == EE.base_field().characteristic():
-            ....:         if EE.is_supersingular():
-            ....:             Ps = ()
-            ....:         else:
-            ....:             assert l.divides(EE.order())
-            ....:             Ps = (next(pts),)
-            ....:     else:
-            ....:         assert l.divides(EE.order())
-            ....:         for _ in range(9999):
-            ....:             P,Q = next(pts), next(pts)
-            ....:             if P.weil_pairing(Q,l) != 1:
-            ....:                 Ps = (P,Q)
-            ....:                 break
-            ....:         else:
-            ....:             assert False
-            ....:     deg = lcm(el.minpoly().degree() for el in sum(map(list,Ps),[]))
-            ....:     assert max(deg, E.base_field().degree()) == K.degree()
-            sage: q = next_prime_power(randrange(1, 10^9))
-            sage: F.<a> = GF(q)
-            sage: while True:
-            ....:     try:
-            ....:         E = EllipticCurve([F.random_element() for _ in range(5)])
-            ....:     except ArithmeticError:
-            ....:         continue
-            ....:     break
-            sage: l = random_prime(8)
-            sage: K = E.division_field(l)
-            sage: n = E.cardinality(extension_degree=K.degree()//F.degree())
-            sage: (l^2 if q%l else 0 + E.is_ordinary()).divides(n)
-            True
-            sage: check(E, l, K)                # long time
 
         AUTHORS:
 

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -622,9 +622,8 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
         if self.is_supersingular():
             n = n.prime_to_m_part(F.characteristic()) # p-torsion is trivial
             if n.is_one():
-                return F
-
-            if n == 2:
+                ext = 1
+            elif n == 2:
                 ext = 3 if self.two_torsion_rank() == 0 else 2 if self.two_torsion_rank() == 1 else 1
             else:
                 from sage.rings.finite_rings.integer_mod import Mod

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -17,6 +17,8 @@ AUTHORS:
 - Lorenz Panny (2023): ``special_supersingular_curve()``
 
 - Martin Grenouilloux, Gareth Ma (2024-09): ``EllipticCurve_with_prime_order()``
+
+- Lorenz Panny (2026): :meth:`EllipticCurve_finite_field.division_field()``
 """
 
 # ****************************************************************************

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -250,6 +250,20 @@ class EllipticCurveHom_sum(EllipticCurveHom):
               To:   Elliptic Curve defined by y^2 + x*y = x^3 + x^2 + 180*x + 17255 over Rational Field
             sage: (m2 - m3).rational_maps()
             (x, -x - y)
+
+        TESTS:
+
+        This example used to take a long time (> 1min); now it is fast (< 1s)
+        thanks to the specialized
+        :meth:`sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.division_field()`
+        method::
+
+            sage: E = EllipticCurve(GF((419,2)), [1,0])
+            sage: i = E.automorphisms()[2]
+            sage: j = E.frobenius_isogeny()
+            sage: Composite morphism of degree 3772 = 4*1*23*41:
+              From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
+              To:   Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
         """
         deg = self.degree()
         if deg.is_zero():

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -261,7 +261,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: E = EllipticCurve(GF((419,2)), [1,0])
             sage: i = E.automorphisms()[2]
             sage: j = E.frobenius_isogeny()
-            sage: Composite morphism of degree 3772 = 4*1*23*41:
+            sage: (1 + 3*j).to_isogeny_chain()
+            Composite morphism of degree 3772 = 1*2^2*23*41:
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
               To:   Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
         """


### PR DESCRIPTION
The current general implementation of `.division_field()` works by constructing the splitting field of the division polynomial (and then some).

In this patch, we implement two much faster algorithms for finite base fields: One for supersingular curves, based on the fact that Frobenius acts as a scalar after taking an extension of degree `O(1)`, and one for ordinary curves, which is due to Van Tuyl.

Example (supersingular):
```sage
sage: E = EllipticCurve(GF(419), [1,0])
sage: assert E.is_supersingular()
sage: %time E.division_field(32)
```
Sage 10.8: `CPU times: user 6.73 s, sys: 1.96 ms, total: 6.73 s`
This branch: `CPU times: user 29.9 ms, sys: 1.93 ms, total: 31.8 ms`

Example (ordinary):
```sage
E = EllipticCurve(GF(101), [1,1])
assert E.is_ordinary()
%time E.division_field(13)
```
Sage 10.8: `CPU times: user 7.5 s, sys: 1.03 ms, total: 7.5 s`
This branch: `CPU times: user 126 ms, sys: 5.93 ms, total: 132 ms`

As a byproduct, this leads to massive speedups in many other algorithms where `.division_field()` is used. For example:
```sage
sage: E = EllipticCurve(GF((419,2)), [1,0])
sage: i = E.automorphisms()[2]
sage: j = E.frobenius_isogeny()
sage: %time (i + 3*j).to_isogeny_chain()
```
Sage 10.8: `CPU times: user 12.5 s, sys: 2.98 ms, total: 12.5 s`
This branch: `CPU times: user 461 ms, sys: 0 ns, total: 461 ms`
