### PR TITLE
workaround for #38481: brute-force the kernel polynomial for bad characteristic-degree pairs

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3645,12 +3645,49 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
         x^3 + x^2 + 28*x + 33
         sage: poly.factor()
         (x + 10) * (x + 12) * (x + 16)
+
+    Check that it works even when the degree is larged compared to the characteristic::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import compute_isogeny_kernel_polynomial
+        sage: E1 = EllipticCurve(GF(5), [1,1])
+        sage: E2 = EllipticCurve(GF(5), [1,4])
+        sage: compute_isogeny_kernel_polynomial(E1, E2, 11)
+        x^5 + 4*x^4 + 4*x^2 + 3*x + 4
+
+    ...even for long Weierstraß curves::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import compute_isogeny_kernel_polynomial
+        sage: E1 = EllipticCurve(GF(2), [1,0,1,0,1])
+        sage: E2 = EllipticCurve(GF(2), [1,0,1,1,1])
+        sage: compute_isogeny_kernel_polynomial(E1, E2, 7)
+        x^3 + x + 1
     """
     if algorithm is None:
         char = E1.base_ring().characteristic()
-        if char != 0 and char < 4*ell + 4:
-            raise NotImplementedError(f'no algorithm for computing kernel polynomial from domain and codomain is implemented for degree {ell} and characteristic {char}')
-        algorithm = 'stark' if ell < 10 else 'bmss'
+        # This could be 4l+4 according to Stark/BMSS alone, but
+        # weierstrass_p() currently only works for p-2 >= 4l+4.
+        if char != 0 and char < 4*ell + 6:
+            # No good algorithm available... See :issue:`38481`.
+            algorithm = 'bruteforce'
+        else:
+            algorithm = 'stark' if ell < 10 else 'bmss'
+
+    if algorithm == 'bruteforce':
+        # This is a lazy workaround; there are better algorithms
+        # for most cases even when BMSS fails. See :issue:`38481`.
+        for phi in E1.isogenies_degree(ell):
+            if not any(E1.a_invariants()[:3] + E2.a_invariants()[:3]):
+                # short Weierstrass
+                u = phi.scaling_factor()
+                iso = phi.codomain().isomorphism(u)
+                if iso.codomain() == E2:
+                    return phi.kernel_polynomial()
+            else:
+                # long Weierstrass
+                for iso in phi.codomain().isomorphisms(E2):
+                    if iso.scaling_factor().is_one():
+                        return phi.kernel_polynomial()
+        raise ValueError(f"the two curves are not linked by a cyclic normalized isogeny of degree {ell}")
 
     if algorithm == 'bmss':
         return compute_isogeny_bmss(E1, E2, ell)

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3646,7 +3646,7 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
         sage: poly.factor()
         (x + 10) * (x + 12) * (x + 16)
 
-    Check that it works even when the degree is larged compared to the characteristic::
+    Check that it works even when the degree is large compared to the characteristic::
 
         sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import compute_isogeny_kernel_polynomial
         sage: E1 = EllipticCurve(GF(5), [1,1])

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3661,6 +3661,16 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
         sage: E2 = EllipticCurve(GF(2), [1,0,1,1,1])
         sage: compute_isogeny_kernel_polynomial(E1, E2, 7)
         x^3 + x + 1
+
+    Verify that it works with the ``"bruteforce"`` algorithm even when
+    :meth:`~EllipticCurve_field.isogenies_degree` returns a non-normalized
+    isogeny (see :issue:`41565`)::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import compute_isogeny_kernel_polynomial
+        sage: E1 = EllipticCurve(GF(419^2), [1,0])
+        sage: for phi in E1.isogenies_degree(5):
+        ....:     E2 = phi.codomain().isomorphism(~phi.scaling_factor()).codomain()
+        ....:     assert phi.kernel_polynomial() == compute_isogeny_kernel_polynomial(E1, E2, phi.degree(), algorithm='bruteforce')
     """
     if algorithm is None:
         char = E1.base_ring().characteristic()
@@ -3679,7 +3689,7 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
             if not any(E1.a_invariants()[:3] + E2.a_invariants()[:3]):
                 # short Weierstrass
                 u = phi.scaling_factor()
-                iso = phi.codomain().isomorphism(u)
+                iso = phi.codomain().isomorphism(~u)
                 if iso.codomain() == E2:
                     return phi.kernel_polynomial()
             else:


### PR DESCRIPTION
The issue in #38481 has been long-standing and there's no immediate fix readily available; hence, in this patch we simply resort to a brute-force search in the cases that currently cause the code to just fail.

This is (much?) slower than other approaches, but at least we get functionality to *work* that currently doesn't.