### PR TITLE
Fix #41566: Khoca interface missing exports

### DIFF
--- a/src/sage/interfaces/khoca.py
+++ b/src/sage/interfaces/khoca.py
@@ -213,3 +213,6 @@ def khoca_raw_data(link, ring, red_typ=True, **kwds):
         else:
             raise TypeError('reduced must be a boolean')
     return raw_data['unred']
+
+Khoca = khoca_interface
+khoca = Khoca


### PR DESCRIPTION
This PR fixes an AttributeError when importing the Khoca interface.

Currently, `sage.interfaces.all` performs

    lazy_import('sage.interfaces.khoca', ['khoca', 'Khoca'])

but `sage.interfaces.khoca` does not export either `Khoca` or `khoca`.
This causes:

    AttributeError: module 'sage.interfaces.khoca' has no attribute 'Khoca'

This patch adds simple aliases at the end of `khoca.py`:

    Khoca = khoca_interface
    khoca = Khoca

so both names are available and the lazy import works correctly.

Fixes #41566

