### PR TITLE
Fix tests with giac 2.0.0.19

### DIFF
--- a/src/sage/calculus/calculus.py
+++ b/src/sage/calculus/calculus.py
@@ -1873,14 +1873,9 @@ def laplace(ex, t, s, algorithm='maxima'):
         (t, s)
         sage: laplace(5*cos(3*t-2)*heaviside(t-2), t, s, algorithm='giac')
         5*(s*cos(4)*e^(-2*s) - 3*e^(-2*s)*sin(4))/(s^2 + 9)
-
-    Check unevaluated expression from Giac (it is locale-dependent, see
-    :issue:`22833`)::
-
-        sage: # needs giac
         sage: n = SR.var('n')
         sage: laplace(t^n, t, s, algorithm='giac')
-        laplace(t^n, t, s)
+        s^(-n - 1)*gamma(n + 1)
 
     Testing SymPy::
 

--- a/src/sage/calculus/functional.py
+++ b/src/sage/calculus/functional.py
@@ -259,7 +259,8 @@ def integral(f, *args, **kwds):
 
     Sage cannot do this elliptic integral (yet)::
 
-        sage: integral(1/sqrt(2*t^4 - 3*t^2 - 2), t, 2, 3)
+        sage: ans = integral(1/sqrt(2*t^4 - 3*t^2 - 2), t, 2, 3)  # random - ignore giac stderr output
+        sage: ans
         integrate(1/(sqrt(2*t^2 + 1)*sqrt(t^2 - 2)), t, 2, 3)
 
     A double integral::

--- a/src/sage/calculus/tests.py
+++ b/src/sage/calculus/tests.py
@@ -204,8 +204,9 @@ Maple documentation::
     sage: f = exp(-x^2)*log(x)
     sage: f.nintegral(x, 0, 999)
     (-0.87005772672831..., 7.5584...e-10, 567, 0)
-    sage: integral(1/sqrt(2*t^4 - 3*t^2 - 2), t, 2, 3)     # long time  # todo: maple can do this
-    integrate(1/(sqrt(2*t^2 + 1)*sqrt(t^2 - 2)), t, 2, 3)
+    sage: ans = integral(1/sqrt(2*t^4 - 3*t^2 - 2), t, 2, 3)     # long time  # random - ignore giac stderr output # todo: maple can do this
+    sage: ans  # long time
+    integrate(1/(sqrt(2*t^2 + 1)*sqrt(t^2 - 2)), t, 2, 3)    integrate(1/(sqrt(2*t^2 + 1)*sqrt(t^2 - 2)), t, 2, 3)
     sage: integral(integral(x*y^2, x, 0, y), y, -2, 2)
     32/5
 

--- a/src/sage/calculus/tests.py
+++ b/src/sage/calculus/tests.py
@@ -206,7 +206,7 @@ Maple documentation::
     (-0.87005772672831..., 7.5584...e-10, 567, 0)
     sage: ans = integral(1/sqrt(2*t^4 - 3*t^2 - 2), t, 2, 3)     # long time  # random - ignore giac stderr output # todo: maple can do this
     sage: ans  # long time
-    integrate(1/(sqrt(2*t^2 + 1)*sqrt(t^2 - 2)), t, 2, 3)    integrate(1/(sqrt(2*t^2 + 1)*sqrt(t^2 - 2)), t, 2, 3)
+    integrate(1/(sqrt(2*t^2 + 1)*sqrt(t^2 - 2)), t, 2, 3)
     sage: integral(integral(x*y^2, x, 0, y), y, -2, 2)
     32/5
 

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -13160,7 +13160,8 @@ cdef class Expression(Expression_abc):
             integrate(log(4/5*sin(x) + 1), x, -3.14150000000000,
             3.14150000000000)
             sage: # needs sage.libs.giac
-            sage: integrate(f, x, -3.1415, 3.1415)  # tol 10e-6
+            sage: ans = integrate(f, x, -3.1415, 3.1415)  # random
+            sage: ans  # tol 10e-6
             -1.40205228301000
         """
         from sage.symbolic.integration.integral import \

--- a/src/sage/symbolic/integration/integral.py
+++ b/src/sage/symbolic/integration/integral.py
@@ -210,10 +210,10 @@ class DefiniteIntegral(BuiltinFunction):
 
             sage: # needs sage.libs.giac
             sage: ex = 1/max_symbolic(x, 1)**2
-            sage: integral(ex, x, 0, 2, algorithm='giac')
+            sage: result = integral(ex, x, 0, 2, algorithm='giac') # random
+            sage: result
             3/2
-            sage: result = integral(1/max_symbolic(x, 1)**2, x, 0, oo, algorithm='giac')
-            ...
+            sage: result = integral(1/max_symbolic(x, 1)**2, x, 0, oo, algorithm='giac') # random
             sage: result
             2
         """
@@ -354,7 +354,8 @@ class DefiniteIntegral(BuiltinFunction):
             sage: f = function('f')
             sage: print_latex(f(x),x,0,1)
             '\\int_{0}^{1} f\\left(x\\right)\\,{d x}'
-            sage: latex(integrate(tan(x)/x, x, 0, 1))
+            sage: ans = latex(integrate(tan(x)/x, x, 0, 1)) # random - ignore giac stderr output
+            sage: ans
             \int_{0}^{1} \frac{\tan\left(x\right)}{x}\,{d x}
         """
         from sage.misc.latex import latex
@@ -689,7 +690,9 @@ def integrate(expression, v=None, a=None, b=None, algorithm=None, hold=False):
 
     but is nevertheless computed::
 
-        sage: integrate(f(x), x, 1, 2)  # long time
+        sage: # long time
+        sage: ans = integrate(f(x), x, 1, 2)  # random - ignore giac stderr output
+        sage: ans
         -1/2*pi + arctan(8) + arctan(5) + arctan(2) + arctan(1/2)
 
     Both fricas and sympy give the correct result::

--- a/src/sage/tests/books/computational_mathematics_with_sagemath/integration_doctest.py
+++ b/src/sage/tests/books/computational_mathematics_with_sagemath/integration_doctest.py
@@ -43,7 +43,8 @@ Sage example in ./integration.tex, line 162::
 
 Sage example in ./integration.tex, line 522::
 
-    sage: N(integrate(cos(log(cos(x))), x, 0, pi/4))  # rel tol 2e-12
+    sage: ans = N(integrate(cos(log(cos(x))), x, 0, pi/4))  # random - ignore giac stderr output
+    sage: ans  # rel tol 2e-12
     0.7766520331543109
 
 Sage example in ./integration.tex, line 536::
@@ -67,12 +68,14 @@ Sage example in ./integration.tex, line 600::
 
 Sage example in ./integration.tex, line 612::
 
-    sage: integrate(cos(log(cos(x))), x, 0, pi/4)
+    sage: ans = integrate(cos(log(cos(x))), x, 0, pi/4)  # random - ignore giac stderr output
+    sage: ans
     integrate(cos(log(cos(x))), x, 0, 1/4*pi)
 
 Sage example in ./integration.tex, line 622::
 
-    sage: N(integrate(cos(log(cos(x))), x, 0, pi/4), digits=60) # abs tol 2e-12
+    sage: ans = N(integrate(cos(log(cos(x))), x, 0, pi/4), digits=60)  # random - ignore giac stderr output
+    sage: ans  # abs tol 2e-12
     0.7766520331543109
 
 Sage example in ./integration.tex, line 628::


### PR DESCRIPTION
giac tends to print random chatter to stderr, which occasionally breaks doctests. In 2.0.0.19, the approximate float value is printed when computing an exact integral. Guard tests against this by separating the computing from the answer display.

We also update a test to account for `laplace(t^n, t, s)` now being correctly solved by giac.
