### PR TITLE
get rid of old cruft half in class_function.py

### DIFF
--- a/src/sage/groups/class_function.py
+++ b/src/sage/groups/class_function.py
@@ -4,6 +4,8 @@ Class functions of groups.
 
 This module implements a wrapper of GAP's ClassFunction function.
 
+This now goes through the libGAP library.
+
 .. NOTE::
 
     The ordering of the columns of the character table of a group
@@ -25,14 +27,13 @@ AUTHORS:
 #  Distributed under the terms of the GNU General Public License (GPL)
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+from __future__ import annotations
 
 from sage.structure.sage_object import SageObject
 from sage.structure.richcmp import richcmp, richcmp_method
-from sage.interfaces.gap import gap
 from sage.rings.integer import Integer
-from sage.libs.gap.element import GapElement
 from sage.libs.gap.libgap import libgap
-from sage.libs.gap.element import GapElement as LibGapElement
+from sage.libs.gap.element import GapElement
 from sage.misc.lazy_import import lazy_import
 
 lazy_import('sage.rings.number_field.number_field', 'CyclotomicField')
@@ -72,698 +73,7 @@ def ClassFunction(group, values):
     except AttributeError:
         pass
 
-    if isinstance(values, (LibGapElement, tuple, list)):
-        return ClassFunction_libgap(group, values)
-
-    # deprecation(36889, "please use libgap class functions instead")
-    return ClassFunction_gap(group, values)
-
-
-#####################################################################
-#
-#   GAP Interface-based Class Function
-#
-#   This is old code that should be deleted once we have transitioned
-#   everything to using the library interface to GAP.
-#
-#####################################################################
-
-@richcmp_method
-class ClassFunction_gap(SageObject):
-    """
-    A wrapper of GAP's ClassFunction function.
-
-    .. NOTE::
-
-        It is *not* checked whether the given values describes a character,
-        since GAP does not do this.
-
-    EXAMPLES::
-
-        sage: G = CyclicPermutationGroup(4)
-        sage: values  = [1, -1, 1, -1]
-        sage: chi = ClassFunction(G, values); chi
-        Character of Cyclic group of order 4 as a permutation group
-        sage: loads(dumps(chi)) == chi
-        True
-    """
-
-    def __init__(self, G, values):
-        r"""
-        Return the character of the group ``G`` with values given by the list
-        values. The order of the values must correspond to the output of
-        ``G.conjugacy_classes_representatives()``.
-
-        EXAMPLES::
-
-            sage: G = CyclicPermutationGroup(4)
-            sage: values  = [1, -1, 1, -1]
-            sage: chi = ClassFunction(G, values); chi
-            Character of Cyclic group of order 4 as a permutation group
-        """
-        self._group = G
-        if isinstance(values, GapElement) and gap.IsClassFunction(values):
-            self._gap_classfunction = values
-        else:
-            self._gap_classfunction = gap.ClassFunction(G, list(values))
-
-        e = self._gap_classfunction.Conductor()
-        self._base_ring = CyclotomicField(e)
-
-    def _gap_init_(self) -> str:
-        r"""
-        Return a string showing how to declare / initialize ``self`` in Gap.
-
-        Stored in the \code{self._gap_string} attribute.
-
-        EXAMPLES::
-
-            sage: G = CyclicPermutationGroup(4)
-            sage: values  = gap([1, -1, 1, -1])
-            sage: ClassFunction(G, values)._gap_init_()
-            'ClassFunction( CharacterTable( Group( [ (1,2,3,4) ] ) ), [ 1, -1, 1, -1 ] )'
-        """
-        return str(self._gap_classfunction)
-
-    def _gap_(self, gap=None):
-        r"""
-        Coerce ``self`` into a GAP element.
-
-        EXAMPLES::
-
-            sage: G = CyclicPermutationGroup(4)
-            sage: values  = gap([1, -1, 1, -1])
-            sage: chi = ClassFunction(G, values);  chi
-            Character of Cyclic group of order 4 as a permutation group
-            sage: type(_)
-            <class 'sage.groups.class_function.ClassFunction_gap'>
-            sage: gap(chi)
-            ClassFunction( CharacterTable( Group( [ (1,2,3,4) ] ) ), [ 1, -1, 1, -1 ] )
-            sage: type(_)
-            <class 'sage.interfaces.gap.GapElement'>
-        """
-        return self._gap_classfunction
-
-    def __repr__(self):
-        r"""
-        Return a string representation.
-
-        EXAMPLES::
-
-            sage: G = SymmetricGroup(4)
-            sage: values  = [1, -1, 1, 1, -1]
-            sage: ClassFunction(G, gap(values))
-            Character of Symmetric group of order 4! as a permutation group
-        """
-        return "Character of %s" % repr(self._group)
-
-    def __iter__(self):
-        r"""
-        Iterate through the values of ``self`` evaluated on the conjugacy
-        classes.
-
-        EXAMPLES::
-
-            sage: xi = ClassFunction(SymmetricGroup(4), gap([1, -1, 1, 1, -1]))
-            sage: list(xi)
-            [1, -1, 1, 1, -1]
-        """
-        for v in self._gap_classfunction:
-            yield self._base_ring(v)
-
-    def __richcmp__(self, other, op):
-        r"""
-        Rich comparison for class functions.
-
-        Compares groups and then the values of the class function on the
-        conjugacy classes.
-
-        EXAMPLES::
-
-            sage: G = PermutationGroup([[(1,2,3),(4,5)],[(3,4)]])
-            sage: chi = G.character([1, 1, 1, 1, 1, 1, 1])
-            sage: H = PermutationGroup([[(1,2,3),(4,5)]])
-            sage: xi = H.character([1, 1, 1, 1, 1, 1])
-            sage: chi == chi
-            True
-            sage: xi == xi
-            True
-            sage: xi == chi
-            False
-            sage: chi < xi
-            False
-            sage: xi < chi
-            True
-        """
-        if isinstance(other, ClassFunction_gap):
-            return richcmp((self._group, self.values()),
-                           (other._group, other.values()), op)
-        else:
-            return NotImplemented
-
-    def __hash__(self):
-        r"""
-        TESTS::
-
-            sage: G = SymmetricGroup(5)
-            sage: chi1 = ClassFunction(G,[1,1,1,1,1,1,1])
-            sage: d = {chi1:'trivial'}
-        """
-        return hash((self._group, tuple(self)))
-
-    def __reduce__(self):
-        r"""
-        Add pickle support.
-
-        EXAMPLES::
-
-            sage: G = PermutationGroup([[(1,2,3),(4,5)],[(3,4)]])
-            sage: chi = ClassFunction(G, gap([1, 1, 1, 1, 1, 1, 1]))
-            sage: type(chi)
-            <class 'sage.groups.class_function.ClassFunction_gap'>
-            sage: loads(dumps(chi)) == chi
-            True
-        """
-        return ClassFunction_gap, (self._group, self.values())
-
-    def domain(self):
-        r"""
-        Return the domain of the ``self``.
-
-        OUTPUT: the underlying group of the class function
-
-        EXAMPLES::
-
-            sage: ClassFunction(SymmetricGroup(4), [1,-1,1,1,-1]).domain()
-            Symmetric group of order 4! as a permutation group
-        """
-        return self._group
-
-    def __call__(self, g):
-        """
-        Evaluate the character on the group element `g`.
-
-        Return an error if `g` is not in `G`.
-
-        EXAMPLES::
-
-            sage: G = GL(2,7)
-            sage: values = G.gap().CharacterTable().Irr()[2].List().sage()
-            sage: chi = ClassFunction(G, values)
-            sage: z = G([[3,0],[0,3]]); z
-            [3 0]
-            [0 3]
-            sage: chi(z)
-            zeta3
-            sage: G = GL(2,3)
-            sage: chi = G.irreducible_characters()[3]
-            sage: g = G.conjugacy_classes_representatives()[6]
-            sage: chi(g)
-            zeta8^3 + zeta8
-
-            sage: G = SymmetricGroup(3)
-            sage: h = G((2,3))
-            sage: triv = G.trivial_character()
-            sage: triv(h)
-            1
-        """
-        return self._base_ring(gap(g)._operation("^", self._gap_classfunction))
-
-    def __add__(self, other):
-        r"""
-        Return the sum of the characters of ``self`` and ``other``.
-
-        INPUT:
-
-        - ``other`` -- a :class:`ClassFunction` of the same group as ``self``
-
-        OUTPUT: a :class:`ClassFunction`
-
-        EXAMPLES::
-
-            sage: chi = ClassFunction(SymmetricGroup(4), gap([3, 1, -1, 0, -1]))
-            sage: s = chi+chi
-            sage: s
-            Character of Symmetric group of order 4! as a permutation group
-            sage: s.values()
-            [6, 2, -2, 0, -2]
-        """
-        if not isinstance(other, ClassFunction_gap):
-            raise NotImplementedError
-        s = self._gap_classfunction + other._gap_classfunction
-        return ClassFunction(self._group, s)
-
-    def __sub__(self, other):
-        r"""
-        Return the difference of the characters ``self`` and ``other``.
-
-        INPUT:
-
-        - ``other`` -- a :class:`ClassFunction` of the same group as
-          ``self``
-
-        OUTPUT: a :class:`ClassFunction`
-
-        EXAMPLES::
-
-            sage: G = SymmetricGroup(4)
-            sage: chi1 = ClassFunction(G, [3, 1, -1, 0, -1])
-            sage: chi2 = ClassFunction(G, [1, -1, 1, 1, -1])
-            sage: s = chi1 - chi2
-            sage: s
-            Character of Symmetric group of order 4! as a permutation group
-            sage: s.values()
-            [2, 2, -2, -1, 0]
-        """
-        if not isinstance(other, ClassFunction_gap):
-            raise NotImplementedError
-        s = self._gap_classfunction - other._gap_classfunction
-        return ClassFunction(self._group, s)
-
-    def __mul__(self, other):
-        r"""
-        Return the product of the character with ``other``.
-
-        INPUT:
-
-        - ``other`` -- either a number or a :class:`ClassFunction` of
-          the same group as ``self``; a number can be anything that
-          can be converted into GAP: integers, rational, and elements
-          of certain number fields
-
-        OUTPUT: a :class:`ClassFunction`
-
-        EXAMPLES::
-
-            sage: G = SymmetricGroup(4)
-            sage: chi1 = ClassFunction(G, gap([3, 1, -1, 0, -1]))
-            sage: 3*chi1
-            Character of Symmetric group of order 4! as a permutation group
-            sage: 3*chi1 == chi1+chi1+chi1
-            True
-            sage: (3*chi1).values()
-            [9, 3, -3, 0, -3]
-
-            sage: (1/2*chi1).values()
-            [3/2, 1/2, -1/2, 0, -1/2]
-
-            sage: CF3 = CyclotomicField(3)
-            sage: CF3.inject_variables()
-            Defining zeta3
-            sage: (zeta3 * chi1).values()
-            [3*zeta3, zeta3, -zeta3, 0, -zeta3]
-
-            sage: chi2 = ClassFunction(G, gap([1, -1, 1, 1, -1]))
-            sage: p = chi1*chi2
-            sage: p
-            Character of Symmetric group of order 4! as a permutation group
-            sage: p.values()
-            [3, -1, -1, 0, 1]
-        """
-        if isinstance(other, ClassFunction_gap):
-            p = self._gap_classfunction * other._gap_classfunction
-            return ClassFunction(self._group, p)
-        else:
-            return ClassFunction(self._group, other * self._gap_classfunction)
-
-    def __rmul__(self, other):
-        r"""
-        Return the reverse multiplication of ``self`` and ``other``.
-
-        EXAMPLES::
-
-            sage: G = SymmetricGroup(4)
-            sage: chi = ClassFunction(G, [3, 1, -1, 0, -1])
-            sage: chi * 4   # calls chi.__mul__
-            Character of Symmetric group of order 4! as a permutation group
-            sage: 4 * chi   # calls chi.__rmul__
-            Character of Symmetric group of order 4! as a permutation group
-            sage: (4 * chi).values()
-            [12, 4, -4, 0, -4]
-        """
-        return self * other
-
-    def __pos__(self):
-        r"""
-        Return ``self``.
-
-        OUTPUT: a :class:`ClassFunction`
-
-        EXAMPLES::
-
-            sage: chi = ClassFunction(SymmetricGroup(4), [3, 1, -1, 0, -1])
-            sage: +chi
-            Character of Symmetric group of order 4! as a permutation group
-            sage: _.values()
-            [3, 1, -1, 0, -1]
-            sage: chi.__pos__() == +chi
-            True
-        """
-        return ClassFunction(self._group, self._gap_classfunction)
-
-    def __neg__(self):
-        r"""
-        Return the additive inverse of ``self``.
-
-        OUTPUT: a :class:`ClassFunction`
-
-        EXAMPLES::
-
-            sage: chi = ClassFunction(SymmetricGroup(4), [3, 1, -1, 0, -1])
-            sage: -chi
-            Character of Symmetric group of order 4! as a permutation group
-            sage: _.values()
-            [-3, -1, 1, 0, 1]
-            sage: chi.__neg__() == -chi
-            True
-        """
-        return ClassFunction(self._group, -self._gap_classfunction)
-
-    def __pow__(self, other):
-        r"""
-        Return the product of ``self`` with itself other times.
-
-        EXAMPLES::
-
-            sage: chi = ClassFunction(SymmetricGroup(4), [3, 1, -1, 0, -1])
-            sage: p = chi**3
-            sage: p
-            Character of Symmetric group of order 4! as a permutation group
-            sage: p.values()
-            [27, 1, -1, 0, -1]
-        """
-        if not isinstance(other, (int, Integer)):
-            raise NotImplementedError
-        return ClassFunction(self._group, self._gap_classfunction ** other)
-
-    def symmetric_power(self, n):
-        r"""
-        Return the symmetrized product of ``self`` with itself ``n`` times.
-
-        INPUT:
-
-        - ``n`` -- positive integer
-
-        OUTPUT: the ``n``-th symmetrized power of ``self`` as a :class:`ClassFunction`
-
-        EXAMPLES::
-
-            sage: chi = ClassFunction(SymmetricGroup(4), gap([3, 1, -1, 0, -1]))
-            sage: p = chi.symmetric_power(3)
-            sage: p
-            Character of Symmetric group of order 4! as a permutation group
-            sage: p.values()
-            [10, 2, -2, 1, 0]
-        """
-        n = Integer(n)
-        tbl = gap.UnderlyingCharacterTable(self)
-        return ClassFunction(self._group, gap.SymmetricParts(tbl, [self], n)[1])
-
-    def exterior_power(self, n):
-        r"""
-        Return the antisymmetrized product of ``self`` with itself `n`
-        times.
-
-        INPUT:
-
-        - ``n`` -- positive integer
-
-        OUTPUT: the `n`-th antisymmetrized power of ``self`` as a :class:`ClassFunction`
-
-        EXAMPLES::
-
-            sage: chi = ClassFunction(SymmetricGroup(4), gap([3, 1, -1, 0, -1]))
-            sage: p = chi.exterior_power(3)   # the highest antisymmetric power for a 3-d character
-            sage: p
-            Character of Symmetric group of order 4! as a permutation group
-            sage: p.values()
-            [1, -1, 1, 1, -1]
-            sage: p == chi.determinant_character()
-            True
-        """
-        n = Integer(n)
-        tbl = gap.UnderlyingCharacterTable(self)
-        return ClassFunction(self._group, gap.AntiSymmetricParts(tbl, [self], n)[1])
-
-    def scalar_product(self, other):
-        r"""
-        Return the scalar product of ``self`` with ``other``.
-
-        EXAMPLES::
-
-            sage: S4 = SymmetricGroup(4)
-            sage: irr = S4.irreducible_characters()
-            sage: [[x.scalar_product(y) for x in irr] for y in irr]
-            [[1, 0, 0, 0, 0],
-             [0, 1, 0, 0, 0],
-             [0, 0, 1, 0, 0],
-             [0, 0, 0, 1, 0],
-             [0, 0, 0, 0, 1]]
-        """
-        return self._gap_classfunction.ScalarProduct(other)
-
-    def is_irreducible(self):
-        r"""
-        Return ``True`` if ``self`` cannot be written as the sum of two nonzero
-        characters of ``self``.
-
-        EXAMPLES::
-
-            sage: S4 = SymmetricGroup(4)
-            sage: irr = S4.irreducible_characters()
-            sage: [x.is_irreducible() for x in irr]
-            [True, True, True, True, True]
-        """
-        return bool(self._gap_classfunction.IsIrreducible())
-
-    def degree(self):
-        r"""
-        Return the degree of the character ``self``.
-
-        EXAMPLES::
-
-            sage: S5 = SymmetricGroup(5)
-            sage: irr = S5.irreducible_characters()
-            sage: [x.degree() for x in irr]
-            [1, 4, 5, 6, 5, 4, 1]
-        """
-        return Integer(self._gap_classfunction.DegreeOfCharacter())
-
-    def irreducible_constituents(self):
-        r"""
-        Return a list of the characters that appear in the decomposition
-        of chi.
-
-        EXAMPLES::
-
-            sage: S5 = SymmetricGroup(5)
-            sage: chi = ClassFunction(S5, [22, -8, 2, 1, 1, 2, -3])
-            sage: irr = chi.irreducible_constituents(); irr
-            (Character of Symmetric group of order 5! as a permutation group,
-             Character of Symmetric group of order 5! as a permutation group)
-            sage: list(map(list, irr))
-            [[4, -2, 0, 1, 1, 0, -1], [5, -1, 1, -1, -1, 1, 0]]
-            sage: G = GL(2,3)
-            sage: chi = ClassFunction(G, [-1, -1, -1, -1, -1, -1, -1, -1])
-            sage: chi.irreducible_constituents()
-            (Character of General Linear Group of degree 2 over Finite Field of size 3,)
-            sage: chi = ClassFunction(G, [1, 1, 1, 1, 1, 1, 1, 1])
-            sage: chi.irreducible_constituents()
-            (Character of General Linear Group of degree 2 over Finite Field of size 3,)
-            sage: chi = ClassFunction(G, [2, 2, 2, 2, 2, 2, 2, 2])
-            sage: chi.irreducible_constituents()
-            (Character of General Linear Group of degree 2 over Finite Field of size 3,)
-            sage: chi = ClassFunction(G, [-1, -1, -1, -1, 3, -1, -1, 1])
-            sage: ic = chi.irreducible_constituents(); ic
-            (Character of General Linear Group of degree 2 over Finite Field of size 3,
-             Character of General Linear Group of degree 2 over Finite Field of size 3)
-            sage: list(map(list, ic))
-            [[2, -1, 2, -1, 2, 0, 0, 0], [3, 0, 3, 0, -1, 1, 1, -1]]
-        """
-        L = self._gap_classfunction.ConstituentsOfCharacter()
-        return tuple(ClassFunction(self._group, list(l)) for l in L)
-
-    def decompose(self) -> tuple:
-        r"""
-        Return a list of the characters appearing the decomposition of ``self``.
-
-        EXAMPLES::
-
-            sage: S5 = SymmetricGroup(5)
-            sage: chi = ClassFunction(S5, [22, -8, 2, 1, 1, 2, -3])
-            sage: chi.decompose()
-            ((3, Character of Symmetric group of order 5! as a permutation group),
-             (2, Character of Symmetric group of order 5! as a permutation group))
-        """
-        L = [(self.scalar_product(irr), irr)
-             for irr in self.irreducible_constituents()]
-        return tuple(L)
-
-    def norm(self):
-        r"""
-        Return the norm of ``self``.
-
-        EXAMPLES::
-
-            sage: A5 = AlternatingGroup(5)
-            sage: [x.norm() for x in A5.irreducible_characters()]
-            [1, 1, 1, 1, 1]
-        """
-        return self._gap_classfunction.Norm()
-
-    def values(self) -> list:
-        r"""
-        Return the list of values of ``self`` on the conjugacy classes.
-
-        EXAMPLES::
-
-            sage: G = GL(2,3)
-            sage: [x.values() for x in G.irreducible_characters()] #random
-            [[1, 1, 1, 1, 1, 1, 1, 1],
-             [1, 1, 1, 1, 1, -1, -1, -1],
-             [2, -1, 2, -1, 2, 0, 0, 0],
-             [2, 1, -2, -1, 0, -zeta8^3 - zeta8, zeta8^3 + zeta8, 0],
-             [2, 1, -2, -1, 0, zeta8^3 + zeta8, -zeta8^3 - zeta8, 0],
-             [3, 0, 3, 0, -1, -1, -1, 1],
-             [3, 0, 3, 0, -1, 1, 1, -1],
-             [4, -1, -4, 1, 0, 0, 0, 0]]
-
-        TESTS::
-
-            sage: G = GL(2,3)
-            sage: k = CyclotomicField(8)
-            sage: zeta8 = k.gen()
-            sage: v = [tuple(x.values()) for x in G.irreducible_characters()]
-            sage: set(v) == set([(1, 1, 1, 1, 1, 1, 1, 1), (1, 1, 1, 1, 1, -1, -1, -1), (2, -1, 2, -1, 2, 0, 0, 0), (2, 1, -2, -1, 0, -zeta8^3 - zeta8, zeta8^3 + zeta8, 0), (2, 1, -2, -1, 0, zeta8^3 + zeta8, -zeta8^3 - zeta8, 0), (3, 0, 3, 0, -1, -1, -1, 1), (3, 0, 3, 0, -1, 1, 1, -1), (4, -1, -4, 1, 0, 0, 0, 0)])
-            True
-        """
-        return list(self)
-
-    def central_character(self):
-        r"""
-        Return the central character of ``self``.
-
-        EXAMPLES::
-
-            sage: t = SymmetricGroup(4).trivial_character()
-            sage: t.central_character().values()
-            [1, 6, 3, 8, 6]
-        """
-        return ClassFunction(self._group, self._gap_classfunction.CentralCharacter())
-
-    def determinant_character(self):
-        r"""
-        Return the determinant character of ``self``.
-
-        EXAMPLES::
-
-            sage: t = ClassFunction(SymmetricGroup(4), [1, -1, 1, 1, -1])
-            sage: t.determinant_character().values()
-            [1, -1, 1, 1, -1]
-        """
-        return ClassFunction(self._group, self._gap_classfunction.DeterminantOfCharacter())
-
-    def tensor_product(self, other):
-        r"""
-        EXAMPLES::
-
-            sage: S3 = SymmetricGroup(3)
-            sage: chi1, chi2, chi3 = S3.irreducible_characters()
-            sage: chi1.tensor_product(chi3).values()
-            [1, -1, 1]
-        """
-        return ClassFunction(self._group, gap.Tensored([self], [other])[1])
-
-    def restrict(self, H):
-        r"""
-        Return the restricted character.
-
-        INPUT:
-
-        - ``H`` -- a subgroup of the underlying group of ``self``
-
-        OUTPUT: a :class:`ClassFunction` of ``H`` defined by restriction
-
-        EXAMPLES::
-
-            sage: G = SymmetricGroup(5)
-            sage: chi = ClassFunction(G, [3, -3, -1, 0, 0, -1, 3]); chi
-            Character of Symmetric group of order 5! as a permutation group
-            sage: H = G.subgroup([(1,2,3), (1,2), (4,5)])
-            sage: chi.restrict(H)
-            Character of Subgroup generated by [(1,2,3), (1,2), (4,5)] of
-             (Symmetric group of order 5! as a permutation group)
-            sage: chi.restrict(H).values()
-            [3, -3, -3, -1, 0, 0]
-        """
-        rest = self._gap_classfunction.RestrictedClassFunction(H._gap_())
-        return ClassFunction(H, rest)
-
-    def induct(self, G):
-        r"""
-        Return the induced character.
-
-        INPUT:
-
-        - ``G`` -- a supergroup of the underlying group of ``self``
-
-        OUTPUT:
-
-        A :class:`ClassFunction` of ``G`` defined by
-        induction. Induction is the adjoint functor to restriction,
-        see :meth:`restrict`.
-
-        EXAMPLES::
-
-            sage: G = SymmetricGroup(5)
-            sage: H = G.subgroup([(1,2,3), (1,2), (4,5)])
-            sage: xi = H.trivial_character(); xi
-            Character of Subgroup generated by [(1,2,3), (1,2), (4,5)] of
-             (Symmetric group of order 5! as a permutation group)
-            sage: xi.induct(G)
-            Character of Symmetric group of order 5! as a permutation group
-            sage: xi.induct(G).values()
-            [10, 4, 2, 1, 1, 0, 0]
-        """
-        rest = self._gap_classfunction.InducedClassFunction(G._gap_())
-        return ClassFunction(G, rest)
-
-    def adams_operation(self, k):
-        r"""
-        Return the ``k``-th Adams operation on ``self``.
-
-        Let `G` be a finite group. The `k`-th Adams operation `\Psi^k`
-        is given by
-
-        .. MATH::
-
-            \Psi^k(\chi)(g) = \chi(g^k).
-
-        The Adams operations turn the representation ring of `G`
-        into a `\lambda`-ring.
-
-        EXAMPLES::
-
-            sage: G = groups.permutation.Alternating(5)
-            sage: chars = sorted(G.irreducible_characters(), key=lambda chi:str(chi.values()))
-            sage: [chi.adams_operation(2).values() for chi in chars]
-            [[1, 1, 1, 1, 1],
-             [3, 3, 0, zeta5^3 + zeta5^2 + 1, -zeta5^3 - zeta5^2],
-             [3, 3, 0, -zeta5^3 - zeta5^2, zeta5^3 + zeta5^2 + 1],
-             [4, 4, 1, -1, -1],
-             [5, 5, -1, 0, 0]]
-            sage: chars[4].adams_operation(2).decompose()
-            ((1, Character of Alternating group of order 5!/2 as a permutation group),
-             (-1, Character of Alternating group of order 5!/2 as a permutation group),
-             (-1, Character of Alternating group of order 5!/2 as a permutation group),
-             (2, Character of Alternating group of order 5!/2 as a permutation group))
-
-        REFERENCES:
-
-        - :wikipedia:`Adams_operation`
-        """
-        reprs = self._group.conjugacy_classes_representatives()
-        return ClassFunction(self._group, [self(x**k) for x in reprs])
+    return ClassFunction_libgap(group, values)
 
 
 #####################################################################
@@ -793,7 +103,7 @@ class ClassFunction_libgap(SageObject):
         True
     """
 
-    def __init__(self, G, values):
+    def __init__(self, G, values) -> None:
         r"""
         Return the character of the group ``G`` with values given by the list
         values. The order of the values must correspond to the output of
@@ -807,7 +117,7 @@ class ClassFunction_libgap(SageObject):
             Character of Cyclic group of order 4 as a permutation group
         """
         self._group = G
-        if isinstance(values, LibGapElement) and values.IsClassFunction():
+        if isinstance(values, GapElement) and values.IsClassFunction():
             self._gap_classfunction = values
         else:
             self._gap_classfunction = libgap.ClassFunction(G, list(values))
@@ -835,7 +145,7 @@ class ClassFunction_libgap(SageObject):
 
     gap = _libgap_
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         r"""
         Return a string representation.
 
@@ -848,7 +158,7 @@ class ClassFunction_libgap(SageObject):
         """
         return "Character of %s" % repr(self._group)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         r"""
         TESTS::
 
@@ -875,7 +185,7 @@ class ClassFunction_libgap(SageObject):
         for v in self._gap_classfunction.List():
             yield v.sage(ring=self._base_ring)
 
-    def __richcmp__(self, other, op):
+    def __richcmp__(self, other, op) -> bool:
         r"""
         Rich comparison for class functions.
 
@@ -902,10 +212,9 @@ class ClassFunction_libgap(SageObject):
         if isinstance(other, ClassFunction_libgap):
             return richcmp((self._group, self.values()),
                            (other._group, other.values()), op)
-        else:
-            return NotImplemented
+        return NotImplemented
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple:
         r"""
         Add pickle support.
 
@@ -1197,7 +506,7 @@ class ClassFunction_libgap(SageObject):
         """
         return self._gap_classfunction.ScalarProduct(other).sage()
 
-    def is_irreducible(self):
+    def is_irreducible(self) -> bool:
         r"""
         Return ``True`` if ``self`` cannot be written as the sum of two nonzero
         characters of ``self``.
@@ -1224,7 +533,7 @@ class ClassFunction_libgap(SageObject):
         """
         return self._gap_classfunction.DegreeOfCharacter().sage()
 
-    def irreducible_constituents(self):
+    def irreducible_constituents(self) -> tuple:
         r"""
         Return a list of the characters that appear in the decomposition
         of ``self``.
@@ -1257,7 +566,7 @@ class ClassFunction_libgap(SageObject):
             [[2, -1, 2, -1, 2, 0, 0, 0], [3, 0, 3, 0, -1, 1, 1, -1]]
         """
         L = self._gap_classfunction.ConstituentsOfCharacter()
-        return tuple(ClassFunction_libgap(self._group, l) for l in L)
+        return tuple(ClassFunction_libgap(self._group, ell) for ell in L)
 
     def decompose(self) -> tuple:
         r"""
@@ -1287,7 +596,7 @@ class ClassFunction_libgap(SageObject):
         """
         return self._gap_classfunction.Norm().sage()
 
-    def values(self):
+    def values(self) -> list:
         r"""
         Return the list of values of ``self`` on the conjugacy classes.
 
@@ -1310,7 +619,7 @@ class ClassFunction_libgap(SageObject):
             sage: k = CyclotomicField(8)
             sage: zeta8 = k.gen()
             sage: v = [tuple(x.values()) for x in G.irreducible_characters()]
-            sage: set(v) == set([(1, 1, 1, 1, 1, 1, 1, 1), (1, 1, 1, 1, 1, -1, -1, -1), (2, -1, 2, -1, 2, 0, 0, 0), (2, 1, -2, -1, 0, -zeta8^3 - zeta8, zeta8^3 + zeta8, 0), (2, 1, -2, -1, 0, zeta8^3 + zeta8, -zeta8^3 - zeta8, 0), (3, 0, 3, 0, -1, -1, -1, 1), (3, 0, 3, 0, -1, 1, 1, -1), (4, -1, -4, 1, 0, 0, 0, 0)])
+            sage: set(v) == {(1, 1, 1, 1, 1, 1, 1, 1), (1, 1, 1, 1, 1, -1, -1, -1), (2, -1, 2, -1, 2, 0, 0, 0), (2, 1, -2, -1, 0, -zeta8^3 - zeta8, zeta8^3 + zeta8, 0), (2, 1, -2, -1, 0, zeta8^3 + zeta8, -zeta8^3 - zeta8, 0), (3, 0, 3, 0, -1, -1, -1, 1), (3, 0, 3, 0, -1, 1, 1, -1), (4, -1, -4, 1, 0, 0, 0, 0)}
             True
         """
         return list(self)

--- a/src/sage/groups/libgap_mixin.py
+++ b/src/sage/groups/libgap_mixin.py
@@ -17,7 +17,7 @@ from sage.libs.gap.element import GapElement
 from sage.structure.element import parent
 from sage.misc.cachefunc import cached_method
 from sage.misc.randstate import current_randstate
-from sage.groups.class_function import ClassFunction_libgap
+from sage.groups.class_function import ClassFunction
 from sage.groups.libgap_wrapper import ElementLibGAP
 
 
@@ -340,8 +340,8 @@ class GroupMixinLibGAP:
             sage: list(chi)                                                             # needs sage.rings.number_field
             [0, 1, 2, 3, 4, 5, 6, 7]
         """
-        from sage.groups.class_function import ClassFunction_libgap
-        return ClassFunction_libgap(self, values)
+        from sage.groups.class_function import ClassFunction
+        return ClassFunction(self, values)
 
     @cached_method
     def center(self):
@@ -668,7 +668,7 @@ class GroupMixinLibGAP:
         if not self.is_finite():
             raise NotImplementedError("only implemented for finite groups")
         Irr = self.gap().Irr()
-        L = [ClassFunction_libgap(self, irr) for irr in Irr]
+        L = [ClassFunction(self, irr) for irr in Irr]
         return tuple(L)
 
     def character(self, values):
@@ -699,7 +699,7 @@ class GroupMixinLibGAP:
         """
         if not self.is_finite():
             raise NotImplementedError("only implemented for finite groups")
-        return ClassFunction_libgap(self, values)
+        return ClassFunction(self, values)
 
     def trivial_character(self):
         r"""

--- a/src/sage/groups/perm_gps/permgroup.py
+++ b/src/sage/groups/perm_gps/permgroup.py
@@ -148,7 +148,7 @@ from sage.groups.perm_gps.permgroup_element import PermutationGroupElement
 from sage.groups.perm_gps.constructor import PermutationGroupElement as PermutationConstructor, standardize_generator
 from sage.groups.abelian_gps.abelian_group import AbelianGroup
 from sage.misc.cachefunc import cached_method
-from sage.groups.class_function import ClassFunction_libgap
+from sage.groups.class_function import ClassFunction
 from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.groups.conjugacy_classes import ConjugacyClassGAP
@@ -3597,7 +3597,7 @@ class PermutationGroup_generic(FiniteGroup):
             sage: [x.values() for x in irr]                                             # needs sage.rings.number_field
             [[1, -1, 1], [2, 0, -1], [1, 1, 1]]
         """
-        return [ClassFunction_libgap(self, irr) for irr in self._libgap_().Irr()]
+        return [ClassFunction(self, irr) for irr in self._libgap_().Irr()]
 
     def trivial_character(self):
         r"""
@@ -3624,7 +3624,7 @@ class PermutationGroup_generic(FiniteGroup):
             sage: G.character([1]*n)                                                    # needs sage.rings.number_field
             Character of Alternating group of order 4!/2 as a permutation group
         """
-        return ClassFunction_libgap(self, values)
+        return ClassFunction(self, values)
 
     def conjugacy_classes_representatives(self):
         """

--- a/src/sage/modules/with_basis/invariant.py
+++ b/src/sage/modules/with_basis/invariant.py
@@ -807,11 +807,11 @@ class FiniteDimensionalTwistedInvariantModule(SubmoduleWithBasis):
             ...
             ValueError: chi must be a list/tuple or a class function of the group G
         """
-        from sage.groups.class_function import ClassFunction, ClassFunction_libgap
+        from sage.groups.class_function import ClassFunction
 
         if isinstance(chi, (list, tuple)):
             chi = ClassFunction(G, libgap(chi))
-        elif not isinstance(chi, ClassFunction_libgap):
+        elif not isinstance(chi, ClassFunction):
             raise ValueError("chi must be a list/tuple or a class function of the group G")
 
         try:


### PR DESCRIPTION
keeping only the libgap interface

This is removing half of the modified file. Every method of the old class was checked to exist in the kept class.

As another small step towards getting rid of pexpect interface to gap.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.

