### PR TITLE
Fix ``harmonic_number(oo, m)`` and ``hurwitz_zeta(s, oo)`` evaluation

### DIFF
--- a/src/sage/functions/log.py
+++ b/src/sage/functions/log.py
@@ -12,6 +12,7 @@ from sage.misc.functional import log
 from sage.misc.lazy_import import lazy_import
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
+from sage.rings.infinity import infinity, unsigned_infinity
 from sage.rings.rational_field import QQ
 from sage.rings.real_double import RDF
 from sage.structure.element import Expression, parent as s_parent
@@ -1109,6 +1110,23 @@ class Function_harmonic_number_generalized(BuiltinFunction):
         1
         sage: harmonic_number(x, 1)                                                     # needs sage.symbolic
         harmonic_number(x)
+
+    The limit at infinity converges only for ``Re(m) > 1``::
+
+        sage: harmonic_number(oo, 2)                                                    # needs sage.symbolic
+        1/6*pi^2
+        sage: harmonic_number(oo, 1)                                                    # needs sage.symbolic
+        +Infinity
+        sage: harmonic_number(oo, 1/2)                                                  # needs sage.symbolic
+        +Infinity
+
+    For complex exponents, divergence at ``Re(m) <= 1`` is reported as
+    unsigned infinity::
+
+        sage: harmonic_number(oo, 1 + 2*I)                                               # needs sage.symbolic
+        Infinity
+        sage: harmonic_number(oo, 2 + 2*I)                                               # needs sage.symbolic
+        zeta(2*I + 2)
     """
 
     def __init__(self):
@@ -1171,6 +1189,30 @@ class Function_harmonic_number_generalized(BuiltinFunction):
             sage: harmonic_number(int(3), int(3))                                       # needs sage.symbolic
             1.162037037037037
         """
+        if z == infinity:
+            if m == 0:
+                return z
+            if m == 1:
+                return infinity
+            if m in QQ:
+                if m <= 1:
+                    return infinity
+                return zeta(m)
+
+            # Handle symbolic numeric constants with exact real/imag parts.
+            # (Example: 1 + 2*I has Re(m)=1, so the defining series diverges.)
+            try:
+                re = m.real()
+                im = m.imag()
+            except AttributeError:
+                re = im = None
+            if re in QQ and im in QQ:
+                if re <= 1:
+                    if im == 0:
+                        return infinity
+                    return unsigned_infinity
+                return zeta(m)
+
         if m == 0:
             return z
         elif m == 1:
@@ -1199,6 +1241,42 @@ class Function_harmonic_number_generalized(BuiltinFunction):
             return parent(z)
         elif m == 1:
             return harmonic_m1._evalf_(z, parent, algorithm)
+
+        if z == infinity:
+            # For z = +Infinity, H_{z,m} is the limit of sum_{k=1}^z k^{-m},
+            # which converges iff Re(m) > 1.
+            try:
+                real_part = m.real()
+            except AttributeError:
+                real_part = None
+
+            real_value = None
+            if real_part is not None:
+                try:
+                    real_value = float(real_part)
+                except TypeError:
+                    pass
+
+            if real_value is not None and real_value <= 1:
+                try:
+                    imag_part = m.imag()
+                except AttributeError:
+                    imag_part = None
+
+                imag_value = 0
+                if imag_part is not None:
+                    try:
+                        imag_value = float(imag_part)
+                    except TypeError:
+                        # If we cannot reliably determine whether Im(m)=0,
+                        # fall back to unsigned infinity (divergence in magnitude).
+                        return unsigned_infinity
+
+                if imag_value == 0:
+                    return infinity
+                return unsigned_infinity
+
+            return zeta(m)
 
         return zeta(m) - hurwitz_zeta(m, z + 1)
 

--- a/src/sage/functions/transcendental.py
+++ b/src/sage/functions/transcendental.py
@@ -20,6 +20,7 @@ import math
 from sage.misc.lazy_import import lazy_import
 from sage.misc.misc import increase_recursion_limit
 from sage.rings.integer_ring import ZZ
+from sage.rings.infinity import infinity, minus_infinity, unsigned_infinity
 from sage.symbolic.function import GinacFunction, BuiltinFunction
 
 lazy_import('sage.functions.gamma', 'psi')
@@ -31,6 +32,7 @@ lazy_import('sage.rings.complex_mpfr', ['ComplexField', 'ComplexNumber'])
 lazy_import('sage.rings.polynomial.polynomial_real_mpfr_dense', 'PolynomialRealDense')
 lazy_import('sage.rings.real_double', 'RDF')
 lazy_import('sage.rings.real_mpfr', ['RR', 'RealField', 'RealNumber'])
+lazy_import('sage.rings.rational_field', 'QQ')
 
 lazy_import('sage.libs.mpmath.utils', 'call', as_='_mpmath_utils_call')
 lazy_import('mpmath', 'zeta', as_='_mpmath_zeta')
@@ -248,15 +250,67 @@ class Function_HurwitzZeta(BuiltinFunction):
             sage: hurwitz_zeta(0, x)
             -x + 1/2
 
-            sage: hurwitz_zeta(3, 0.5)                                                  # needs mpmath
+            sage: # needs mpmath
+            sage: hurwitz_zeta(3, 0.5)
             8.41439832211716
+
+            sage: # needs sage.symbolic
+            sage: hurwitz_zeta(11/10, oo)
+            0
+            sage: hurwitz_zeta(11/10, unsigned_infinity)
+            0
+            sage: hurwitz_zeta(11/10, -oo)
+            0
+            sage: hurwitz_zeta(1 + 2*I, oo)
+            hurwitz_zeta(2*I + 1, +Infinity)
+
+            sage: # needs sage.symbolic
+            sage: hurwitz_zeta(0, oo)
+            -Infinity
+            sage: hurwitz_zeta(0, -oo)
+            +Infinity
+            sage: hurwitz_zeta(-4, oo)
+            -Infinity
+            sage: hurwitz_zeta(-4, -oo)
+            +Infinity
+            sage: hurwitz_zeta(-4, unsigned_infinity)
+            hurwitz_zeta(-4, Infinity)
         """
         if x == 1:
             return zeta(s)
+        if s in ZZ and s <= 0 and (x == infinity or x == minus_infinity or x == unsigned_infinity):
+            # For s <= 0, hurwitz_zeta(s, x) is a polynomial in x of degree 1 - s
+            # with leading term -(1/(1-s))*x^(1-s). At x = ±Infinity this diverges,
+            # and evaluating the full polynomial can lead to indeterminate expressions.
+            if x == unsigned_infinity:
+                return self(s, x, hold=True)
+            degree = 1 - s
+            if x == infinity:
+                return minus_infinity
+            # x == -Infinity
+            if degree % 2 == 0:
+                return minus_infinity
+            return infinity
+        if s in ZZ and s <= 0:
+            return -bernoulli_polynomial(x, -s + 1) / (-s + 1)
+        if x == infinity or x == unsigned_infinity or x == minus_infinity:
+            if s in ZZ:
+                if s > 1:
+                    return ZZ.zero()
+                return self(s, x, hold=True)
+            if s in QQ:
+                if s > 1:
+                    return ZZ.zero()
+                return self(s, x, hold=True)
+            try:
+                re = s.real()
+            except AttributeError:
+                return self(s, x, hold=True)
+            if re > 1:
+                return ZZ.zero()
+            return self(s, x, hold=True)
         if s in ZZ and s > 1:
             return ((-1) ** s) * psi(s - 1, x) / factorial(s - 1)
-        elif s in ZZ and s <= 0:
-            return -bernoulli_polynomial(x, -s + 1) / (-s + 1)
         else:
             return
 
@@ -271,6 +325,18 @@ class Function_HurwitzZeta(BuiltinFunction):
             sage: hurwitz_zeta(11/10, 1 + 1j).n()                                       # needs mpmath sage.rings.real_mpfr
             9.85014164287853 - 1.06139499403981*I
         """
+        if x == infinity or x == unsigned_infinity or x == minus_infinity:
+            # Avoid calling mpmath at infinity; return 0 only when Re(s) > 1.
+            # Keep the exact Bernoulli polynomial cases correct by letting _eval_ handle them.
+            if s in ZZ and s <= 0:
+                return None
+            try:
+                re = s.real()
+            except AttributeError:
+                return self(s, x, hold=True)
+            if re > 1:
+                return ZZ.zero()
+            return self(s, x, hold=True)
         return _mpmath_utils_call(_mpmath_zeta, s, x, parent=parent)
 
     def _derivative_(self, s, x, diff_param):
@@ -333,6 +399,14 @@ def hurwitz_zeta(s, x, **kwargs):
         8.41439832211716
         sage: hurwitz_zeta(3, 0.5)                                                      # needs mpmath
         8.41439832211716
+
+    Behavior at infinity::
+
+        sage: # needs sage.symbolic
+        sage: hurwitz_zeta(11/10, oo)
+        0
+        sage: hurwitz_zeta(0, oo)
+        -Infinity
 
     REFERENCES:
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Fix #41587
Fix a hang and incorrect/fragile behavior in evaluation at infinity for generalized harmonic numbers and Hurwitz zeta.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


