### PR TITLE
add parameter immutable to graph generators in families.py (part 4)

### DIFF
--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -2525,7 +2525,7 @@ def NKStarGraph(n, k, immutable=False):
                  immutable=immutable)
 
 
-def NStarGraph(n):
+def NStarGraph(n, immutable=False):
     r"""
     Return the `n`-star graph.
 
@@ -2536,6 +2536,9 @@ def NStarGraph(n):
     INPUT:
 
     -  ``n`` -- integer; number of symbols
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2559,18 +2562,19 @@ def NStarGraph(n):
     d = {}
     for v in Permutations(set):
         v = list(v)  # So we can easily mutate it
-        tmp_dict = {}
+        neighbors = []
         for i in range(1, n):
             if v[0] != v[i]:
                 # swap 0th and ith element
                 v[0], v[i] = v[i], v[0]
                 # convert to str and add to list
                 vert = "".join(v)
-                tmp_dict[vert] = None
+                neighbors.append(vert)
                 # swap back
                 v[0], v[i] = v[i], v[0]
-        d["".join(v)] = tmp_dict
-    return Graph(d, name=f"{n}-star")
+        d["".join(v)] = neighbors
+    return Graph(d, format="dict_of_lists", name=f"{n}-star",
+                 immutable=immutable)
 
 
 def OddGraph(n):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -2204,7 +2204,7 @@ def HararyGraph(k, n, immutable=False):
     return G.copy(immutable=True) if immutable else G
 
 
-def HyperStarGraph(n, k):
+def HyperStarGraph(n, k, immutable=False):
     r"""
     Return the hyper-star graph `HS(n, k)`.
 
@@ -2220,6 +2220,9 @@ def HyperStarGraph(n, k):
     - ``n`` -- nonnegative integer; length of the binary strings
 
     - ``k`` -- nonnegative integer; number of 1s per binary string
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2274,7 +2277,8 @@ def HyperStarGraph(n, k):
                 c[i] = one
             adj[u] = L
 
-    return Graph(adj, format='dict_of_lists', name=f"HS({n},{k})")
+    return Graph(adj, format='dict_of_lists', name=f"HS({n},{k})",
+                 immutable=immutable)
 
 
 def LCFGraph(n, shift_list, repeats):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -81,7 +81,7 @@ def JohnsonGraph(n, k, immutable=False):
                  immutable=immutable)
 
 
-def KneserGraph(n, k, immutable=False):
+def KneserGraph(n, k, immutable=False, name=None):
     r"""
     Return the Kneser Graph with parameters `n, k`.
 
@@ -101,6 +101,9 @@ def KneserGraph(n, k, immutable=False):
 
     - ``immutable`` -- boolean (default: ``False``); whether to return an
       immutable or a mutable graph
+
+    - ``name`` -- string (default: ``None``); used as the name of the returned
+      graph when set
 
     EXAMPLES::
 
@@ -127,6 +130,8 @@ def KneserGraph(n, k, immutable=False):
         raise ValueError("Parameter n should be a strictly positive integer")
     if k <= 0 or k > n:
         raise ValueError("Parameter k should be a strictly positive integer inferior to n")
+    if name is None:
+        name = f"Kneser graph with parameters {n},{k}"
 
     from sage.combinat.subset import Subsets
 
@@ -135,8 +140,7 @@ def KneserGraph(n, k, immutable=False):
     edges = ((s, t) for s in S for t in Subsets(s0.difference(s), k))
 
     return Graph([S, edges], format="vertices_and_edges",
-                 name=f"Kneser graph with parameters {n},{k}",
-                 immutable=immutable)
+                 name=name, immutable=immutable)
 
 
 def FurerGadget(k, prefix=None, immutable=False):
@@ -2577,7 +2581,7 @@ def NStarGraph(n, immutable=False):
                  immutable=immutable)
 
 
-def OddGraph(n):
+def OddGraph(n, immutable=False):
     r"""
     Return the Odd Graph with parameter `n`.
 
@@ -2590,6 +2594,13 @@ def OddGraph(n):
 
     For example, the Petersen Graph can be defined
     as the Odd Graph with parameter `3`.
+
+    INPUT:
+
+    -  ``n`` -- integer; the grounset has `2n - 1` elements
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2610,9 +2621,8 @@ def OddGraph(n):
     """
     if n <= 1:
         raise ValueError("Parameter n should be an integer strictly greater than 1")
-    g = KneserGraph(2*n - 1, n - 1)
-    g.name("Odd Graph with parameter %s" % n)
-    return g
+    return KneserGraph(2*n - 1, n - 1, immutable=immutable,
+                       name=f"Odd Graph with parameter {n}")
 
 
 def PaleyGraph(q):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -1078,7 +1078,7 @@ def chang_graphs(immutable=False):
     return [g1, g2, g3]
 
 
-def CirculantGraph(n, adjacency, immutable=False):
+def CirculantGraph(n, adjacency, immutable=False, name=None):
     r"""
     Return a circulant graph with `n` nodes.
 
@@ -1093,6 +1093,9 @@ def CirculantGraph(n, adjacency, immutable=False):
 
     - ``immutable`` -- boolean (default: ``False``); whether to return an
       immutable or a mutable graph
+
+    - ``name`` -- string (default: ``None``); used as the name of the returned
+      graph when set
 
     PLOTTING: Upon construction, the position dictionary is filled to
     override the spring-layout algorithm. By convention, each circulant
@@ -1178,11 +1181,12 @@ def CirculantGraph(n, adjacency, immutable=False):
     """
     if not isinstance(adjacency, list):
         adjacency = [adjacency]
+    if name is None:
+        name = f"Circulant graph ({adjacency})"
 
     edges = ((v, (v + j) % n) for v in range(n) for j in adjacency)
     G = Graph([range(n), edges], format="vertices_and_edges",
-              name=f"Circulant graph ({adjacency})",
-              immutable=immutable)
+              name=name, immutable=immutable)
     G._circle_embedding(list(range(n)))
     return G
 
@@ -2133,7 +2137,7 @@ def TabacjnGraph(n, a, b, r, immutable=False):
     return G
 
 
-def HararyGraph(k, n):
+def HararyGraph(k, n, immutable=False):
     r"""
     Return the Harary graph on `n` vertices and connectivity `k`, where
     `2 \leq k < n`.
@@ -2146,6 +2150,15 @@ def HararyGraph(k, n):
     The construction provided uses the method CirculantGraph.  For more
     details, see the book [West2001]_ or the `MathWorld article on
     Harary graphs <http://mathworld.wolfram.com/HararyGraph.html>`_.
+
+    INPUT:
+
+    - ``k`` -- integer; connectivity of the graph
+
+    - ``n`` -- integer; number of vertices of the graph
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -2175,19 +2188,20 @@ def HararyGraph(k, n):
     if k >= n:
         raise ValueError("Number of vertices n should be greater than k.")
 
-    if k % 2 == 0:
-        G = CirculantGraph(n, list(range(1, k//2 + 1)))
-    else:
-        if n % 2 == 0:
-            G = CirculantGraph(n, list(range(1, (k - 1)//2 + 1)))
-            for i in range(n):
-                G.add_edge(i, (i + n//2) % n)
-        else:
-            G = HararyGraph(k - 1, n)
-            for i in range((n - 1)//2 + 1):
-                G.add_edge(i, (i + (n - 1)//2) % n)
-    G.name('Harary graph {0}, {1}'.format(k, n))
-    return G
+    name = f"Harary graph {k}, {n}"
+    if not k % 2:
+        return CirculantGraph(n, list(range(1, k//2 + 1)),
+                              immutable=immutable, name=name)
+    if not n % 2:
+        shift_list = list(range(1, (k - 1)//2 + 1))
+        shift_list.append(n//2)
+        return CirculantGraph(n, shift_list,
+                              immutable=immutable, name=name)
+    G = CirculantGraph(n, list(range(1, (k - 1)//2 + 1)),
+                       immutable=False, name=name)
+    for i in range((n - 1)//2 + 1):
+        G.add_edge(i, (i + (n - 1)//2) % n)
+    return G.copy(immutable=True) if immutable else G
 
 
 def HyperStarGraph(n, k):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -2597,7 +2597,7 @@ def OddGraph(n, immutable=False):
 
     INPUT:
 
-    -  ``n`` -- integer; the grounset has `2n - 1` elements
+    -  ``n`` -- integer; the groundset has `2n - 1` elements
 
     - ``immutable`` -- boolean (default: ``False``); whether to return an
       immutable or a mutable graph
@@ -2617,10 +2617,10 @@ def OddGraph(n, immutable=False):
         sage: KG = graphs.OddGraph(1)
         Traceback (most recent call last):
         ...
-        ValueError: Parameter n should be an integer strictly greater than 1
+        ValueError: parameter n should be an integer strictly greater than 1
     """
     if n <= 1:
-        raise ValueError("Parameter n should be an integer strictly greater than 1")
+        raise ValueError("parameter n should be an integer strictly greater than 1")
     return KneserGraph(2*n - 1, n - 1, immutable=immutable,
                        name=f"Odd Graph with parameter {n}")
 

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -2458,7 +2458,7 @@ def MycielskiStep(g):
     return gg
 
 
-def NKStarGraph(n, k):
+def NKStarGraph(n, k, immutable=False):
     r"""
     Return the `(n,k)`-star graph.
 
@@ -2475,6 +2475,9 @@ def NKStarGraph(n, k):
     -  ``n`` -- integer; number of symbols
 
     -  ``k`` -- integer; length of the labels of the vertices
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2497,14 +2500,14 @@ def NKStarGraph(n, k):
     d = {}
     for v in Arrangements(set, k):
         v = list(v)  # So we can easily mutate it
-        tmp_dict = {}
+        neighbors = []
         # add edges of dimension i
         for i in range(1, k):
             # swap 0th and ith element
             v[0], v[i] = v[i], v[0]
             # convert to str and add to list
             vert = "".join(v)
-            tmp_dict[vert] = None
+            neighbors.append(vert)
             # swap back
             v[0], v[i] = v[i], v[0]
         # add other edges
@@ -2515,10 +2518,11 @@ def NKStarGraph(n, k):
                 v[0] = i
                 # add edge
                 vert = "".join(v)
-                tmp_dict[vert] = None
+                neighbors.append(vert)
             v[0] = tmp_bit
-        d["".join(v)] = tmp_dict
-    return Graph(d, name=f"({n},{k})-star")
+        d["".join(v)] = neighbors
+    return Graph(d, format="dict_of_lists", name=f"({n},{k})-star",
+                 immutable=immutable)
 
 
 def NStarGraph(n):

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -2625,12 +2625,19 @@ def OddGraph(n, immutable=False):
                        name=f"Odd Graph with parameter {n}")
 
 
-def PaleyGraph(q):
+def PaleyGraph(q, immutable=False):
     r"""
     Paley graph with `q` vertices.
 
     Parameter `q` must be the power of a prime number and congruent
     to 1 mod 4.
+
+    INPUT:
+
+    - ``q`` -- integer; number of vertices
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2664,9 +2671,9 @@ def PaleyGraph(q):
         raise ValueError("parameter q must be a prime power")
     if not mod(q, 4) == 1:
         raise ValueError("parameter q must be congruent to 1 mod 4")
-    g = Graph([FiniteField(q, 'a'), lambda i, j: (i - j).is_square()],
-              loops=False, name=f"Paley graph with parameter {q}")
-    return g
+    return Graph([FiniteField(q, 'a'), lambda i, j: (i - j).is_square()],
+                 format="rule", immutable=immutable,
+                 loops=False, name=f"Paley graph with parameter {q}")
 
 
 def PasechnikGraph(n):


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to some generators in `src/sage/graphs/generators/families.py`.
- `HararyGraph`, `HyperStarGraph`, `NKStarGraph`, `NStarGraph`, `OddGraph`, `PaleyGraph`

To simplify the work, we add parameter `name` to `KneserGraph` and `CirculantGraph`

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


