### PR TITLE
add parameter immutable to graph generators in `world_map.py`

### DIFF
--- a/src/sage/graphs/generators/world_map.py
+++ b/src/sage/graphs/generators/world_map.py
@@ -106,7 +106,7 @@ def AfricaMap(continental=False, year=2018, immutable=False):
                  name=name, immutable=immutable)
 
 
-def EuropeMap(continental=False, year=2018):
+def EuropeMap(continental=False, year=2018, immutable=False):
     """
     Return European states as a graph of common border.
 
@@ -121,6 +121,9 @@ def EuropeMap(continental=False, year=2018):
 
     - ``year`` -- integer (default: 2018); reserved for future use
 
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     EXAMPLES::
 
         sage: Europe = graphs.EuropeMap(); Europe
@@ -133,6 +136,13 @@ def EuropeMap(continental=False, year=2018):
         40
         sage: 'Iceland' in cont_Europe
         False
+        sage: cont_Europe.is_connected()
+        True
+        sage: cont_Europe.is_immutable()
+        False
+        sage: cont_Europe = graphs.EuropeMap(continental=True, immutable=True)
+        sage: cont_Europe.is_immutable()
+        True
     """
     if year != 2018:
         raise ValueError("currently only year 2018 is implemented")
@@ -171,14 +181,14 @@ def EuropeMap(continental=False, year=2018):
     }
     no_land_border = ['Iceland', 'Malta']
 
-    G = Graph(common_border, format='dict_of_lists')
-
     if continental:
+        G = Graph(common_border, format='dict_of_lists',
+                  name="Continental Europe Map", immutable=immutable)
         G = G.subgraph(G.connected_component_containing_vertex('Austria', sort=False))
-        G.name(new="Continental Europe Map")
     else:
-        G.add_vertices(no_land_border)
-        G.name(new="Europe Map")
+        common_border.update((c, []) for c in no_land_border)
+        G = Graph(common_border, format='dict_of_lists',
+                  name="Europe Map", immutable=immutable)
 
     return G
 

--- a/src/sage/graphs/generators/world_map.py
+++ b/src/sage/graphs/generators/world_map.py
@@ -17,7 +17,7 @@ The methods defined here appear in :mod:`sage.graphs.graph_generators`.
 from sage.graphs.graph import Graph
 
 
-def AfricaMap(continental=False, year=2018):
+def AfricaMap(continental=False, year=2018, immutable=False):
     """
     Return African states as a graph of common border.
 
@@ -32,6 +32,9 @@ def AfricaMap(continental=False, year=2018):
 
     - ``year`` -- integer (default: 2018); reserved for future use
 
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     EXAMPLES::
 
         sage: Africa = graphs.AfricaMap(); Africa
@@ -44,6 +47,8 @@ def AfricaMap(continental=False, year=2018):
         48
         sage: 'Madagaskar' in cont_Africa
         False
+        sage: cont_Africa.is_connected()
+        True
 
     TESTS::
 
@@ -91,16 +96,14 @@ def AfricaMap(continental=False, year=2018):
     no_land_border = ['Cape Verde', 'Seychelles', 'Mauritius',
                       'São Tomé and Príncipe', 'Madagascar', 'Comoros']
 
-    G = Graph(common_border, format='dict_of_lists')
-
     if continental:
-        G = G.subgraph(G.connected_component_containing_vertex('Central Africa', sort=False))
-        G.name(new="Continental Africa Map")
+        name = "Continental Africa Map"
     else:
-        G.add_vertices(no_land_border)
-        G.name(new="Africa Map")
+        common_border.update((c, []) for c in no_land_border)
+        name = "Africa Map"
 
-    return G
+    return Graph(common_border, format='dict_of_lists',
+                 name=name, immutable=immutable)
 
 
 def EuropeMap(continental=False, year=2018):

--- a/src/sage/graphs/generators/world_map.py
+++ b/src/sage/graphs/generators/world_map.py
@@ -193,7 +193,7 @@ def EuropeMap(continental=False, year=2018, immutable=False):
     return G
 
 
-def USAMap(continental=False):
+def USAMap(continental=False, immutable=False):
     """
     Return states of USA as a graph of common border.
 
@@ -205,6 +205,9 @@ def USAMap(continental=False):
 
     - ``continental`` -- boolean (default: ``False``); whether to exclude Alaska
       and Hawaii
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -299,7 +302,7 @@ def USAMap(continental=False):
         states['Hawaii'] = []
         name = "USA Map"
 
-    return Graph(states, format='dict_of_lists', name=name)
+    return Graph(states, format='dict_of_lists', name=name, immutable=immutable)
 
 
 def WorldMap():

--- a/src/sage/graphs/generators/world_map.py
+++ b/src/sage/graphs/generators/world_map.py
@@ -305,7 +305,7 @@ def USAMap(continental=False, immutable=False):
     return Graph(states, format='dict_of_lists', name=name, immutable=immutable)
 
 
-def WorldMap():
+def WorldMap(immutable=False):
     """
     Return the Graph of all the countries, in which two countries are adjacent
     in the graph if they have a common boundary.
@@ -315,6 +315,11 @@ def WorldMap():
 
     The returned graph ``G`` has a member ``G.gps_coordinates`` equal to a
     dictionary containing the GPS coordinates of each country's capital city.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -731,9 +736,7 @@ def WorldMap():
         'Zambia': [[15, 'S'], [30, 'E']],
         'Zimbabwe': [[20, 'S'], [30, 'E']]
         }
-    g = Graph()
-    g.add_edges(edges)
-    g.add_vertices(gps_coordinates)
+    g = Graph([gps_coordinates, edges], format="vertices_and_edges",
+              name="World Map", immutable=immutable)
     g.gps_coordinates = gps_coordinates
-    g.name("World Map")
     return g


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to all generators in `src/sage/graphs/generators/world_map.py`.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


