### PR TITLE
build/make/Makefile.in: remove all documentation targets

### DIFF
--- a/build/make/Makefile.in
+++ b/build/make/Makefile.in
@@ -203,6 +203,7 @@ SAGE_I_TARGETS = sagelib
 	all-start build-start toolchain toolchain-deps base-toolchain \
 	pypi-sdists pypi-wheels wheels \
 	sagelib \
+	doc doc-html doc-pdf \
 	doc-uninstall \
 	python3_venv _clean-broken-gcc
 
@@ -309,6 +310,21 @@ SAGERUNTIME = sagelib $(inst_ipython) $(inst_pexpect)
 
 all-sageruntime: toolchain-deps
 	+$(MAKE_REC) $(SAGERUNTIME)
+
+
+###############################################################################
+# Building the documentation
+###############################################################################
+
+doc: doc-html
+
+# All doc-building is delegated to meson eventually. To avoid yet
+# another "make" invocation, we inline the commands that get run.
+doc-html:
+	meson compile -C build/sage-distro doc-html
+
+doc-pdf:
+	meson compile -C build/sage-distro doc-pdf
 
 doc-uninstall:
 	rm -rf "$(SAGE_SHARE)/doc/sage"

--- a/build/make/Makefile.in
+++ b/build/make/Makefile.in
@@ -54,11 +54,6 @@ SAGE_SPKG = sage-spkg
 # These are added to SAGE_SPKG in the call
 SAGE_SPKG_OPTIONS = @SAGE_SPKG_OPTIONS@
 
-# Where the Sage distribution installs documentation.
-# set to empty if --disable-doc is used
-SAGE_DOCS = @SAGE_DOCS@
-SAGE_DOCS_DISABLED_MESSAGE = This Sage build is configured with "configure --disable-doc", so building the documentation will not work.
-
 # Where the Sage distribution installs Python packages.
 # This can be overridden by 'make SAGE_VENV=/some/venv'.
 SAGE_VENV = @SAGE_VENV@
@@ -170,7 +165,7 @@ $(SAGE_LOCAL)/$(SPKG_INST_RELDIR)/.dummy:
 
 
 # Filtered by installation tree
-$(foreach tree,SAGE_LOCAL SAGE_VENV SAGE_DOCS, \
+$(foreach tree,SAGE_LOCAL SAGE_VENV, \
     $(eval $(tree)_INSTALLED_PACKAGE_INSTS = \
                $(foreach pkgname,$(INSTALLED_PACKAGES), \
                          $(if $(findstring $(tree),$(trees_$(pkgname))), \
@@ -201,14 +196,13 @@ endif
 # List of targets that can be run (in addition to names of packages) using `sage -i` or `sage -f`
 # These should generally have an associated -uninstall target for `sage -f` to
 # work correctly
-SAGE_I_TARGETS = sagelib doc
+SAGE_I_TARGETS = sagelib
 
 # Tell make not to look for files with these names:
 .PHONY: all all-sage all-toolchain all-build all-sageruntime \
 	all-start build-start toolchain toolchain-deps base-toolchain \
 	pypi-sdists pypi-wheels wheels \
 	sagelib \
-	doc doc-html doc-html-jsmath doc-html-mathjax doc-pdf \
 	doc-uninstall \
 	python3_venv _clean-broken-gcc
 
@@ -239,11 +233,8 @@ $(inst_python3_venv): | $(SAGE_VENV)/$(SPKG_INST_RELDIR)
 endif
 
 # Build everything and start Sage.
-# Note that we put the "doc" target first in the rule below because
-# the doc build takes the most time and should be started as soon as
-# possible.
 all-start: toolchain-deps
-	+$(MAKE_REC) all-sage-docs all-sage
+	+$(MAKE_REC) all-sage
 
 # Build everything except the documentation
 all-build: toolchain-deps
@@ -271,11 +262,6 @@ all-build-venv: toolchain-deps
 	+$(MAKE_REC) all-sage-venv
 
 all-sage-venv:  $(SAGE_VENV_INSTALLED_PACKAGE_INSTS)  $(SAGE_VENV_UNINSTALLED_PACKAGES_UNINSTALLS)
-
-all-build-docs: toolchain-deps
-	+$(MAKE_REC) all-sage-docs
-
-all-sage-docs:  $(SAGE_DOCS_INSTALLED_PACKAGE_INSTS) $(SAGE_DOCS_UNINSTALLED_PACKAGES_UNINSTALLS)
 
 # Download all packages which should be inside an sdist tarball (the -B
 # option to make forces all targets to be built unconditionally)
@@ -323,45 +309,6 @@ SAGERUNTIME = sagelib $(inst_ipython) $(inst_pexpect)
 
 all-sageruntime: toolchain-deps
 	+$(MAKE_REC) $(SAGERUNTIME)
-
-
-###############################################################################
-# Building the documentation
-###############################################################################
-
-# You can choose to have the built HTML version of the documentation link to
-# the PDF version. To do so, you need to build both the HTML and PDF versions.
-# To have the HTML version link to the PDF version, do
-#
-# $ ./sage --docbuild all html
-# $ ./sage --docbuild all pdf
-#
-# For more information on the docbuild utility, do
-#
-# $ ./sage --docbuild -H
-
-doc: doc-html
-
-# All doc-building is delegated to the script packages
-# sagemath_doc_html, sagemath_doc_pdf
-doc-html: sagemath_doc_html
-
-# 'doc-html-no-plot': build docs without building the graphics coming
-# from the '.. plot' directive, in case you want to save a few
-# megabytes of disk space. Run 'make doc-clean' first because the
-# presence of graphics is cached in the built documentation.
-doc-html-no-plot:
-	(cd $(SAGE_ROOT) && $(MAKE) doc-clean)
-	+$(MAKE_REC) SAGE_DOCBUILD_OPTS="$(SAGE_DOCBUILD_OPTS) --no-plot" doc-html
-
-# Using mathjax is actually the only options, but we keep
-# this target for backwards compatibility.
-doc-html-mathjax: doc-html
-
-# Also Keep target 'doc-html-jsmath' for backwards compatibility.
-doc-html-jsmath: doc-html-mathjax
-
-doc-pdf: sagemath_doc_pdf
 
 doc-uninstall:
 	rm -rf "$(SAGE_SHARE)/doc/sage"


### PR DESCRIPTION
The documentation is built by meson, as part of the sagelib install process. I've left the uninstall target in case it is still useful.

This eliminates one line of https://github.com/sagemath/sage/issues/41609