### PR TITLE
use the upstream (linbox) patch

### DIFF
--- a/build/pkgs/linbox/patches/fix-ntl-lzz_px-ambiguous-conversion.patch
+++ b/build/pkgs/linbox/patches/fix-ntl-lzz_px-ambiguous-conversion.patch
@@ -1,20 +1,26 @@
---- a/linbox/ring/ntl/ntl-lzz_px.h	2025-10-21 14:28:23.362837229 +0800
-+++ b/linbox/ring/ntl/ntl-lzz_px.h	2025-10-21 14:28:35.770836212 +0800
-@@ -195,9 +195,15 @@
-       template <class E>
- 		Element& init( Element& p, const std::vector<E>& v ) const
+Description: Restrict NTL_zz_pX::init to Coeff vector
+ The previous template allowed initializing a polynomial from any
+ vector type, but on some platforms (e.g., i386) this caused ambiguous
+ conversions when E is Givaro::Integer, because NTL::SetCoeff expects
+ a long. This patch removes the generic template overload and keeps
+ the overload specifically for std::vector<Coeff>, avoiding type
+ conversion errors.
+Author: Jean-Guillaume Dumas <Jean-Guillaume.Dumas@imag.fr>
+Origin: https://github.com/linbox-team/linbox/commit/9555c5b
+Bug: https://github.com/linbox-team/linbox/issues/328
+Last-Update: 2025-09-11
+
+
+--- a/linbox/ring/ntl/ntl-lzz_px.h
++++ b/linbox/ring/ntl/ntl-lzz_px.h
+@@ -191,9 +191,7 @@
+ 		 * of the vector corresponds to the leading coefficients.  That is,
+ 		 * v[i] = coefficient of x^i.
+ 		 */
+-		//Element& init( Element& p, const std::vector<Coeff>& v ) const
+-      template <class E>
+-		Element& init( Element& p, const std::vector<E>& v ) const
++		Element& init( Element& p, const std::vector<Coeff>& v ) const
  		{
-+			// Ensure coefficients are converted via the coefficient field to
-+			// avoid ambiguous implicit conversions (e.g., from Givaro::Integer
-+			// to long) when E is not NTL::zz_p. This fixes clang/libc++ builds.
  			p = 0;
--			for( long i = 0; i < (long)v.size(); ++i )
--				NTL::SetCoeff( p, i, v[ (size_t) i ] );
-+			Coeff temp;
-+			for( long i = 0; i < (long)v.size(); ++i ) {
-+				_CField.init( temp, v[ (size_t) i ] );
-+				NTL::SetCoeff( p, i, temp );
-+			}
- 			return p;
- 		}
- 
+ 			for( long i = 0; i < (long)v.size(); ++i )


### PR DESCRIPTION
in #41044 we used a non-official patch. Here we replace it with the one from upstream
(a shorter version of https://github.com/linbox-team/linbox/commit/9555c5b22a0018ae721839f21fa2d2c3af66de02 from Debian, https://sources.debian.org/data/main/l/linbox/1.7.1-2/debian/patches/ntl-zz-px.patch)

It turns out it's also needed on the latest macOS toolchain, see https://github.com/Macaulay2/homebrew-tap/issues/318

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


