### PR TITLE
Fix link to source installation guide in walkthrough

### DIFF
--- a/src/doc/en/developer/walkthrough.rst
+++ b/src/doc/en/developer/walkthrough.rst
@@ -143,7 +143,7 @@ This will install Sage in the current Conda environment.
 You can then start Sage from the command line with ``sage``.
 
 For more information on building Sage we refer to the section `building
-from source <../installation/meson.html>`_ in the Sage installation guide.
+from source <../installation/source.html>`_ in the Sage installation guide.
 
 .. _section-walkthrough-branch:
 


### PR DESCRIPTION
Updated link in walkthrough to point to the correct source installation guide. In the current form (and on the current website), the link is dead.

Fixes #41617

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.
