### PR TITLE
Add `random_bistochastic_matrices()` special constructor

### DIFF
--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3409,12 +3409,8 @@ def random_bistochastic_matrix(parent):
                          "numbers")
 
     B = random_unitary_matrix(parent)
-    n = B.nrows()
-    for i in range(n):
-        for j in range(n):
-            # Square every entry.
-            B[i, j] **= 2
-    return B
+    # Squaring every entry.
+    return B.elementwise_product(B)
 
 @matrix_method
 def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3403,9 +3403,8 @@ def random_bistochastic_matrix(parent):
         ...
         ValueError: base ring of parent must be a subfield of the real numbers
     """
-    from sage.rings.real_lazy import RLF
-    F = parent.base_ring()
-    if not (RLF.has_coerce_map_from(F) or F.has_coerce_map_from(RLF)):
+    from sage.rings.real_mpfr import RR
+    if not parent.base_ring().is_subring(RR):
         raise ValueError("base ring of parent must be a subfield of the real "
                          "numbers")
 

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3340,7 +3340,7 @@ def random_bistochastic_matrix(parent):
         the resulting matrix will usually fail the ``is_bistochastic()``
         check due to floating point precision.
 
-    EXAMPLES:
+    EXAMPLES::
 
     Matrices with rational entries::
 
@@ -3374,7 +3374,7 @@ def random_bistochastic_matrix(parent):
         ...
         ValueError: parent must be square
 
-    TESTS:
+    TESTS::
 
         sage: from sage.matrix.constructor import random_bistochastic_matrix
         sage: MS = MatrixSpace(QQ, 4)
@@ -3403,8 +3403,9 @@ def random_bistochastic_matrix(parent):
         ...
         ValueError: base ring of parent must be a subfield of the real numbers
     """
-    from sage.rings.real_mpfr import RR
-    if not parent.base_ring().is_subring(RR):
+    from sage.rings.real_lazy import RLF
+    F = parent.base_ring()
+    if not (RLF.has_coerce_map_from(F) or F.has_coerce_map_from(RLF)):
         raise ValueError("base ring of parent must be a subfield of the real "
                          "numbers")
 

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3358,7 +3358,7 @@ def random_bistochastic_matrix(parent):
         sage: B.is_bistochastic()  # random
         False
 
-    It only works over subfields of the real numbers::
+    It only works over subfields of the real numbers and for square matrices::
 
         sage: from sage.matrix.constructor import random_bistochastic_matrix
         sage: MS = MatrixSpace(CC, 4)
@@ -3367,6 +3367,13 @@ def random_bistochastic_matrix(parent):
         ...
         ValueError: base ring of parent must be a subfield of the real numbers
 
+        sage: from sage.matrix.constructor import random_bistochastic_matrix
+        sage: MS = MatrixSpace(QQ, 4, 3)
+        sage: B = random_bistochastic_matrix(MS)
+        Traceback (most recent call last):
+        ...
+        ValueError: parent must be square
+
     TESTS:
 
         sage: from sage.matrix.constructor import random_bistochastic_matrix
@@ -3374,6 +3381,13 @@ def random_bistochastic_matrix(parent):
         sage: B = random_bistochastic_matrix(MS)
         sage: B.is_bistochastic()
         True
+
+        sage: from sage.matrix.constructor import random_bistochastic_matrix
+        sage: MS = MatrixSpace(QQ, 4, 3)
+        sage: B = random_bistochastic_matrix(MS)
+        Traceback (most recent call last):
+        ...
+        ValueError: parent must be square
 
         sage: from sage.matrix.constructor import random_bistochastic_matrix
         sage: MS = MatrixSpace(GF(2), 4)

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3323,7 +3323,7 @@ def random_bistochastic_matrix(parent):
 
     OUTPUT:
 
-    A random unitary matrix in ``parent``. A :exc:`ValueError` is
+    A random bistochastic matrix in ``parent``. A :exc:`ValueError` is
     raised if ``parent`` is not an appropriate matrix space (is not
     square, or is not over a usable field).
 

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3340,7 +3340,7 @@ def random_bistochastic_matrix(parent):
         the resulting matrix will usually fail the ``is_bistochastic()``
         check due to floating point precision.
 
-    EXAMPLES::
+    EXAMPLES:
 
     Matrices with rational entries::
 

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -41,6 +41,7 @@ The following constructions are available:
     :meth:`~sage.matrix.special.random_subspaces_matrix`
     :meth:`~sage.matrix.special.random_unimodular_matrix`
     :meth:`~sage.matrix.special.random_unitary_matrix`
+    :meth:`~sage.matrix.special.random_bistochastic_matrix`
     :meth:`~sage.matrix.special.toeplitz`
     :meth:`~sage.matrix.special.vandermonde`
     :meth:`~sage.matrix.special.vector_on_axis_rotation_matrix`
@@ -243,6 +244,9 @@ def random_matrix(ring, nrows, ncols=None, algorithm='randomize', implementation
 
       - ``'unitary'`` -- creates a (square) unitary matrix over a
         subfield of the complex numbers
+
+      - ``'bistochastic'`` -- creates a (square) bistochastic matrix over a
+        subfield of the real numbers
 
       - ``'diagonalizable'`` -- creates a diagonalizable matrix. if the
         base ring is ``QQ`` creates a diagonalizable matrix whose eigenvectors,
@@ -670,6 +674,8 @@ def random_matrix(ring, nrows, ncols=None, algorithm='randomize', implementation
         return random_unimodular_matrix(parent, *args, **kwds)
     elif algorithm == 'unitary':
         return random_unitary_matrix(parent, *args, **kwds)
+    elif algorithm == 'bistochastic':
+        return random_bistochastic_matrix(parent, *args, **kwds)
     else:
         raise ValueError('random matrix algorithm "%s" is not recognized' % algorithm)
 
@@ -3303,6 +3309,98 @@ def random_unitary_matrix(parent):
 
     return U
 
+@matrix_method
+def random_bistochastic_matrix(parent):
+    """
+    Generate a random (square) bistochastic matrix of a given size with entries
+    in a subfield of the real numbers.
+
+    INPUT:
+
+    - ``parent`` -- :class:`sage.matrix.matrix_space.MatrixSpace`; a square
+      matrix space over a subfield of the real numbers having characteristic
+      zero.
+
+    OUTPUT:
+
+    A random unitary matrix in ``parent``. A :exc:`ValueError` is
+    raised if ``parent`` is not an appropriate matrix space (is not
+    square, or is not over a usable field).
+
+    ALGORITHM:
+
+    A unitary matrix over a subfield of the real numbers which entries are
+    squared will result in a bistochastic matrix. However, not all bistochastic
+    matrices arise in this way.
+
+    .. WARNING:
+
+        Inexact rings may violate your expectations; in particular,
+        the rings ``RR`` and ``RDF`` are accepted by this method but
+        the resulting matrix will usually fail the ``is_bistochastic()``
+        check due to floating point precision.
+
+    EXAMPLES:
+
+    Matrices with rational entries::
+
+        sage: from sage.matrix.constructor import random_bistochastic_matrix
+        sage: MS = MatrixSpace(QQ, 4)
+        sage: B = random_bistochastic_matrix(MS)
+        sage: B.is_bistochastic()
+        True
+
+    Matrices over the real field may expose approximation errors::
+
+        sage: from sage.matrix.constructor import random_bistochastic_matrix
+        sage: MS = MatrixSpace(RR, 4)
+        sage: B = random_bistochastic_matrix(MS)
+        sage: B.is_bistochastic()  # random
+        False
+
+    It only works over subfields of the real numbers::
+
+        sage: from sage.matrix.constructor import random_bistochastic_matrix
+        sage: MS = MatrixSpace(CC, 4)
+        sage: B = random_bistochastic_matrix(MS)
+        Traceback (most recent call last):
+        ...
+        ValueError: base ring of parent must be a subfield of the real numbers
+
+    TESTS:
+
+        sage: from sage.matrix.constructor import random_bistochastic_matrix
+        sage: MS = MatrixSpace(QQ, 4)
+        sage: B = random_bistochastic_matrix(MS)
+        sage: B.is_bistochastic()
+        True
+
+        sage: from sage.matrix.constructor import random_bistochastic_matrix
+        sage: MS = MatrixSpace(GF(2), 4)
+        sage: B = random_bistochastic_matrix(MS)
+        Traceback (most recent call last):
+        ...
+        ValueError: base ring of parent must be a subfield of the real numbers
+
+        sage: from sage.matrix.constructor import random_bistochastic_matrix
+        sage: MS = MatrixSpace(CC, 4)
+        sage: B = random_bistochastic_matrix(MS)
+        Traceback (most recent call last):
+        ...
+        ValueError: base ring of parent must be a subfield of the real numbers
+    """
+    from sage.rings.real_mpfr import RR
+    if not parent.base_ring().is_subring(RR):
+        raise ValueError("base ring of parent must be a subfield of the real "
+                         "numbers")
+
+    B = random_unitary_matrix(parent)
+    n = B.nrows()
+    for i in range(n):
+        for j in range(n):
+            # Square every entry.
+            B[i, j] **= 2
+    return B
 
 @matrix_method
 def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):


### PR DESCRIPTION
I add the matrix method `random_bistochastic_matrix()` that generates a random bistochastic matrix in the matrix space in input, provided that it is a subfield of the real numbers.

The method used squares each element of a random unitary matrix since it will necessarily give a bistochastic matrix.

You can call the function in two ways:
```py
sage: from sage.matrix.constructor import random_bistochastic_matrix
sage: MS = MatrixSpace(QQ, 4) 
sage: B = random_bistochastic_matrix(MS)
```

or with
```py
sage: MS = MatrixSpace(QQ, 4) 
sage: B = matrix.random_bistochastic(MS)
```

Note that over the real numbers, we have inexact matrices and `.is_bistochastic()` may fail.

```py
sage: MS = MatrixSpace(RR, 4) 
sage: B = matrix.random_bistochastic(MS)
sage: B.is_bistochastic()  # random
False
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
