### PR TITLE
make lfsr_autocorrelation match documented Golomb definition

### DIFF
--- a/src/doc/en/constructions/linear_codes.rst
+++ b/src/doc/en/constructions/linear_codes.rst
@@ -258,9 +258,9 @@ reverse of ``berlekamp_massey``).
     sage: s = lfsr_sequence(key,fill,n); s
     [1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0]
     sage: lfsr_autocorrelation(s,15,7)
-    4/15
+    -1/15
     sage: lfsr_autocorrelation(s,15,0)
-    8/15
+    1
     sage: lfsr_connection_polynomial(s)
     x^4 + x + 1
     sage: from sage.matrix.berlekamp_massey import berlekamp_massey

--- a/src/doc/zh/constructions/linear_codes.rst
+++ b/src/doc/zh/constructions/linear_codes.rst
@@ -237,9 +237,9 @@ x_n = x_{n-4} + x_{n-1},\ \ \ n\geq 4.
     sage: s = lfsr_sequence(key,fill,n); s
     [1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0]
     sage: lfsr_autocorrelation(s,15,7)
-    4/15
+    -1/15
     sage: lfsr_autocorrelation(s,15,0)
-    8/15
+    1
     sage: lfsr_connection_polynomial(s)
     x^4 + x + 1
     sage: from sage.matrix.berlekamp_massey import berlekamp_massey

--- a/src/sage/crypto/lfsr.py
+++ b/src/sage/crypto/lfsr.py
@@ -203,7 +203,7 @@ def lfsr_autocorrelation(L, p, k):
 
     - ``k`` -- integer between `0` and `p`
 
-    OUTPUT: autocorrelation sequence of `L`
+    OUTPUT: normalized periodic autocorrelation `C(k)` of `L`
 
     EXAMPLES::
 
@@ -213,18 +213,27 @@ def lfsr_autocorrelation(L, p, k):
         sage: key = [l,o,o,l]; fill = [l,l,o,l]; n = 20
         sage: s = lfsr_sequence(key,fill,n)
         sage: lfsr_autocorrelation(s,15,7)
-        4/15
+        -1/15
         sage: lfsr_autocorrelation(s,int(15),7)
-        4/15
+        -1/15
+        sage: lfsr_autocorrelation(s,15,0)
+        1
     """
     if not isinstance(L, list):
         raise TypeError("L (=%s) must be a list" % L)
     p = Integer(p)
     _p = int(p)
     k = int(k)
-    L0 = L[:_p]     # slices makes a copy
-    L0 = L0 + L0[:k]
-    return sum([int(L0[i]) * int(L0[i + k]) / p for i in range(_p)])
+    if _p <= 0:
+        raise ValueError("p must be a positive integer")
+    if len(L) < _p:
+        raise ValueError("L must have length at least p")
+    if not (0 <= k <= _p):
+        raise ValueError("k must be between 0 and p")
+
+    L0 = [int(x) % 2 for x in L[:_p]]
+    k %= _p
+    return sum(1 if L0[i] == L0[(i + k) % _p] else -1 for i in range(_p)) / p
 
 
 def lfsr_connection_polynomial(s):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Fix the inconsistency between the doc of 'sage.crypto.lfsr.lfsr_autocorrelation' and real implementation
> [LFSR doc](https://doc.sagemath.org/html/en/reference/cryptography/sage/crypto/lfsr.html)

Doc defines periodic autocorrelation (for binary sequences) as
C(k) = (1/P) * sum_{n=1..P} (-1)^(a_n + a_{n+k}),

while the previous implementation computed: 
(1/P) * sum_{n=1..P} a_n * a_{n+k}.

As a result, the outputs didn't match the expected behavior. 

### What's changed
- Implementation of `lfsr_autocorrelation` 
- Some arguments validation, format similiar to the others
- Update doctests/examples

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies
X
<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


