### PR TITLE
matroids: use `Py_hash_t` for hashes

### DIFF
--- a/src/sage/matroids/basis_exchange_matroid.pxd
+++ b/src/sage/matroids/basis_exchange_matroid.pxd
@@ -11,7 +11,7 @@ cdef class BasisExchangeMatroid(Matroid):
     cdef frozenset _groundset
 
     cdef _bcount
-    cdef _weak_invariant_var, _strong_invariant_var, _heuristic_invariant_var
+    cdef Py_hash_t _weak_invariant_var, _strong_invariant_var, _heuristic_invariant_var
     cdef SetSystem _weak_partition_var, _strong_partition_var, _heuristic_partition_var
 
     cdef _relabel(self, mapping)
@@ -75,14 +75,14 @@ cdef class BasisExchangeMatroid(Matroid):
     cpdef SetSystem cocircuits(self)
     cpdef SetSystem circuits(self, k=*)
 
-    cpdef _characteristic_setsystem(self)
-    cpdef _weak_invariant(self)
-    cpdef _weak_partition(self)
-    cpdef _strong_invariant(self)
-    cpdef _strong_partition(self)
-    cpdef _heuristic_invariant(self)
-    cpdef _heuristic_partition(self)
-    cdef _flush(self)
+    cpdef SetSystem _characteristic_setsystem(self)
+    cpdef Py_hash_t _weak_invariant(self) noexcept
+    cpdef SetSystem _weak_partition(self)
+    cpdef Py_hash_t _strong_invariant(self) noexcept
+    cpdef SetSystem _strong_partition(self)
+    cpdef Py_hash_t _heuristic_invariant(self) noexcept
+    cpdef SetSystem _heuristic_partition(self)
+    cdef _flush_invariants(self)
 
     cpdef _equitable_partition(self, P=*)
     cpdef _is_isomorphic(self, other, certificate=*)

--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -180,6 +180,8 @@ cdef class BasisExchangeMatroid(Matroid):
         if basis is not None:
             self._pack(self._current_basis, frozenset(basis))
 
+        self._flush_invariants()
+
     def __dealloc__(self):
         bitset_free(self._current_basis)
         bitset_free(self._inside)
@@ -1814,7 +1816,7 @@ cdef class BasisExchangeMatroid(Matroid):
 
     # isomorphism
 
-    cpdef _characteristic_setsystem(self):
+    cpdef SetSystem _characteristic_setsystem(self):
         r"""
         Return a characteristic set-system for this matroid, on the same
         groundset.
@@ -1834,7 +1836,7 @@ cdef class BasisExchangeMatroid(Matroid):
         else:
             return self.noncospanning_cocircuits()
 
-    cpdef _weak_invariant(self):
+    cpdef Py_hash_t _weak_invariant(self) noexcept:
         """
         Return an isomorphism invariant of the matroid.
 
@@ -1853,7 +1855,7 @@ cdef class BasisExchangeMatroid(Matroid):
             False
         """
         from sage.matroids.utilities import cmp_elements_key
-        if self._weak_invariant_var is None:
+        if self._weak_invariant_var == -1:
             if self.full_rank() == 0 or self.full_corank() == 0:
                 self._weak_invariant_var = 0
                 self._weak_partition_var = SetSystem(self._E, [self.groundset()])
@@ -1864,7 +1866,7 @@ cdef class BasisExchangeMatroid(Matroid):
                 self._weak_partition_var = SetSystem(self._E, [fie[f] for f in sorted(fie, key=cmp_elements_key)])
         return self._weak_invariant_var
 
-    cpdef _weak_partition(self):
+    cpdef SetSystem _weak_partition(self):
         """
         Return an ordered partition based on the incidences of elements with
         low-dimensional flats.
@@ -1878,7 +1880,7 @@ cdef class BasisExchangeMatroid(Matroid):
         self._weak_invariant()
         return self._weak_partition_var
 
-    cpdef _strong_invariant(self):
+    cpdef Py_hash_t _strong_invariant(self) noexcept:
         """
         Return an isomorphism invariant of the matroid.
 
@@ -1896,13 +1898,13 @@ cdef class BasisExchangeMatroid(Matroid):
             sage: M._strong_invariant() == N._strong_invariant()
             False
         """
-        if self._strong_invariant_var is None:
+        if self._strong_invariant_var == -1:
             CP = self._characteristic_setsystem()._equitable_partition(self._weak_partition())
             self._strong_partition_var = CP[0]
             self._strong_invariant_var = CP[2]
         return self._strong_invariant_var
 
-    cpdef _strong_partition(self):
+    cpdef SetSystem _strong_partition(self):
         """
         Return an equitable partition which refines ``_weak_partition()``.
 
@@ -1916,7 +1918,7 @@ cdef class BasisExchangeMatroid(Matroid):
         self._strong_invariant()
         return self._strong_partition_var
 
-    cpdef _heuristic_invariant(self):
+    cpdef Py_hash_t _heuristic_invariant(self) noexcept:
         """
         Return a number characteristic for the construction of
         ``_heuristic_partition()``.
@@ -1929,13 +1931,13 @@ cdef class BasisExchangeMatroid(Matroid):
             sage: M._heuristic_invariant() == N._heuristic_invariant()
             True
         """
-        if self._heuristic_invariant_var is None:
+        if self._heuristic_invariant_var == -1:
             CP = self._characteristic_setsystem()._heuristic_partition(self._strong_partition())
             self._heuristic_partition_var = CP[0]
             self._heuristic_invariant_var = CP[2]
         return self._heuristic_invariant_var
 
-    cpdef _heuristic_partition(self):
+    cpdef SetSystem _heuristic_partition(self):
         """
         Return an ordered partition into singletons which refines an equitable
         partition of the matroid.
@@ -1959,13 +1961,13 @@ cdef class BasisExchangeMatroid(Matroid):
         self._heuristic_invariant()
         return self._heuristic_partition_var
 
-    cdef _flush(self):
+    cdef _flush_invariants(self):
         """
         Delete all invariants.
         """
-        self._weak_invariant_var = None
-        self._strong_invariant_var = None
-        self._heuristic_invariant_var = None
+        self._weak_invariant_var = -1
+        self._strong_invariant_var = -1
+        self._heuristic_invariant_var = -1
 
     cpdef _equitable_partition(self, P=None):
         """

--- a/src/sage/matroids/basis_matroid.pxd
+++ b/src/sage/matroids/basis_matroid.pxd
@@ -6,11 +6,11 @@ cdef class BasisMatroid(BasisExchangeMatroid):
     cdef bitset_t _bb
     cdef bitset_t _b
     cdef SetSystem _nonbases
-    cdef _bases_invariant_var
+    cdef Py_hash_t _bases_invariant_var
     cdef SetSystem _bases_partition_var
-    cdef _bases_invariant2_var
+    cdef Py_hash_t _bases_invariant2_var
     cdef SetSystem _bases_partition2_var
-    cdef _bases_invariant3_var
+    cdef Py_hash_t _bases_invariant3_var
     cdef SetSystem _bases_partition3_var
 
     cdef reset_current_basis(self)
@@ -26,12 +26,12 @@ cdef class BasisMatroid(BasisExchangeMatroid):
     cpdef _with_coloop(self, e)
     # cpdef relabel(self, mapping)
 
-    cpdef _bases_invariant(self)
-    cpdef _bases_partition(self)
-    cpdef _bases_invariant2(self)
-    cpdef _bases_partition2(self)
-    cpdef _bases_invariant3(self)
-    cpdef _bases_partition3(self)
+    cpdef Py_hash_t _bases_invariant(self) noexcept
+    cpdef SetSystem _bases_partition(self)
+    cpdef Py_hash_t _bases_invariant2(self) noexcept
+    cpdef SetSystem _bases_partition2(self)
+    cpdef Py_hash_t _bases_invariant3(self) noexcept
+    cpdef SetSystem _bases_partition3(self)
     cdef _reset_invariants(self)
     cpdef  bint is_distinguished(self, e) noexcept
     cpdef _is_relaxation(self, M, morphism)

--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -158,6 +158,8 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         cdef long i
         cdef mp_bitcnt_t bc
 
+        self._reset_invariants()
+
         if isinstance(M, BasisMatroid):
             BasisExchangeMatroid.__init__(self, groundset=(<BasisMatroid>M)._E, rank=(<BasisMatroid>M)._matroid_rank)
             bitset_init(self._bb, binom[(<BasisMatroid>M)._groundset_size][(<BasisMatroid>M)._matroid_rank])
@@ -637,7 +639,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
 
     # isomorphism test
 
-    cpdef _bases_invariant(self):
+    cpdef Py_hash_t _bases_invariant(self) noexcept:
         """
         Return an isomorphism invariant based on the incidences of groundset
         elements with bases.
@@ -652,7 +654,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             sage: M._bases_invariant() == N._bases_invariant()
             True
         """
-        if self._bases_invariant_var is not None:
+        if self._bases_invariant_var != -1:
             return self._bases_invariant_var
         cdef long i, j
         cdef list bc
@@ -675,7 +677,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         self._bases_partition_var = SetSystem(self._E, [[self._E[e] for e in bi[c]] for c in sorted(bi, key=cmp_elements_key)])
         return self._bases_invariant_var
 
-    cpdef _bases_partition(self):
+    cpdef SetSystem _bases_partition(self):
         """
         Return an ordered partition based on the incidences of groundset
         elements with bases.
@@ -690,7 +692,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         self._bases_invariant()
         return self._bases_partition_var
 
-    cpdef _bases_invariant2(self):
+    cpdef Py_hash_t _bases_invariant2(self) noexcept:
         """
         Return an isomorphism invariant of the matroid.
 
@@ -709,13 +711,13 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             sage: M._bases_invariant2() == N._bases_invariant2()
             False
         """
-        if self._bases_invariant2_var is None:
+        if self._bases_invariant2_var == -1:
             CP = self.nonbases()._equitable_partition(self._bases_partition())
             self._bases_partition2_var = CP[0]
             self._bases_invariant2_var = CP[2]
         return self._bases_invariant2_var
 
-    cpdef _bases_partition2(self):
+    cpdef SetSystem _bases_partition2(self):
         """
         Return an equitable partition which refines
         :meth:`<BasisMatroid._bases_partition2>`.
@@ -730,7 +732,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         self._bases_invariant2()
         return self._bases_partition2_var
 
-    cpdef _bases_invariant3(self):
+    cpdef Py_hash_t _bases_invariant3(self) noexcept:
         """
         Return a number characteristic for the construction of
         :meth:`<BasisMatroid._bases_partition3>`.
@@ -743,13 +745,13 @@ cdef class BasisMatroid(BasisExchangeMatroid):
             sage: M._bases_invariant3() == N._bases_invariant3()
             True
         """
-        if self._bases_invariant3_var is None:
+        if self._bases_invariant3_var == -1:
             CP = self.nonbases()._heuristic_partition(self._bases_partition2())
             self._bases_partition3_var = CP[0]
             self._bases_invariant3_var = CP[2]
         return self._bases_invariant3_var
 
-    cpdef _bases_partition3(self):
+    cpdef SetSystem _bases_partition3(self):
         """
         Return an ordered partition into singletons which refines an equitable
         partition of the matroid.
@@ -779,13 +781,13 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         """
         self._bcount = None
         self._nonbases = None
-        self._bases_invariant_var = None
+        self._bases_invariant_var = -1
         self._bases_partition_var = None
-        self._bases_invariant2_var = None
+        self._bases_invariant2_var = -1
         self._bases_partition2_var = None
-        self._bases_invariant3_var = None
+        self._bases_invariant3_var = -1
         self._bases_partition3_var = None
-        self._flush()
+        self._flush_invariants()
 
     cpdef bint is_distinguished(self, e) noexcept:
         """

--- a/src/sage/matroids/lean_matrix.pyx
+++ b/src/sage/matroids/lean_matrix.pyx
@@ -1350,7 +1350,7 @@ cdef class BinaryMatrix(LeanMatrix):
         Return the vector of intersection lengths of the rows with ``x``.
         """
         cdef long i
-        I = []
+        cdef list I = []
         for i in range(self._nrows):
             bitset_intersection(self._temp, self._M[i], x)
             I.append(bitset_len(self._temp))
@@ -1361,7 +1361,9 @@ cdef class BinaryMatrix(LeanMatrix):
         Helper method for equitable partition.
         """
         cdef BinaryMatrix Q
-        d = {}
+        cdef Py_hash_t c
+        cdef dict d = {}
+        cdef long i
         for i in range(self._nrows):
             c = hash(tuple(P._character(self._M[i])))
             if c in d:

--- a/src/sage/matroids/set_system.pxd
+++ b/src/sage/matroids/set_system.pxd
@@ -26,7 +26,7 @@ cdef class SetSystem:
     cdef _distinguish(self, Py_ssize_t v)
     cpdef is_connected(self)
 
-    cdef initial_partition(self, SetSystem P=*, E=*)
+    cdef SetSystem initial_partition(self, SetSystem P=*, E=*)
     cpdef _equitable_partition(self, SetSystem P=*, EP=*)
     cpdef _heuristic_partition(self, SetSystem P=*, EP=*)
     cpdef _isomorphism(self, SetSystem other, SetSystem SP=*, SetSystem OP=*)

--- a/src/sage/matroids/set_system.pyx
+++ b/src/sage/matroids/set_system.pyx
@@ -483,7 +483,7 @@ cdef class SetSystem:
         return S
 
     # partition functions
-    cdef initial_partition(self, SetSystem P=None, E=None):
+    cdef SetSystem initial_partition(self, SetSystem P=None, E=None):
         """
         Helper method for partition methods below.
         """
@@ -550,7 +550,7 @@ cdef class SetSystem:
             partition elements is an invariant of the isomorphism class of the
             hypergraph.
         """
-        cdef long h
+        cdef Py_hash_t h
         cdef list EP2, H
 
         if P is None:


### PR DESCRIPTION
This resolves a Windows-specific bug: 64-bit hash not fitting in Windows' 32-bit C long.
Reported in https://github.com/passagemath/passagemath/issues/2160.

Also includes Cython type declarations for functions that return hash invariants and `SetSystem`s.

Note that `-1` has been used as the sentinel (hash not computed) value. This should be safe given that `hash` never returns -1 except when there is an error. See, e.g., https://docs.python.org/3/c-api/object.html#c.PyObject_Hash and https://peps.python.org/pep-0456/#requirements-for-a-hash-function.