### PR TITLE
fix docstring in `src/sage/graphs/graph.py`

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -9401,14 +9401,14 @@ class Graph(GenericGraph):
 
         - ``return_map`` -- boolean (default: ``False``); whether to return
           a map indicating one of the forbidden graph minors if in fact the
-          graph is not projective planar, or only True/False.
+          graph is not projective planar, or only ``True``/``False``.
 
         OUTPUT:
 
-        Return ``True`` if the graph is projective planar and ``False`` if not.  If the
-        parameter ``map_flag`` is ``True`` and the graph is not projective planar, then
-        the method returns ``False`` and a map from :meth:`~Graph.minor`
-        indicating one of the forbidden graph minors.
+        Return ``True`` if the graph is projective planar and ``False`` if not.
+        If the parameter ``return_map`` is ``True`` and the graph is not
+        projective planar, then the method returns ``False`` and a map from
+        :meth:`~Graph.minor` indicating one of the forbidden graph minors.
 
         EXAMPLES:
 


### PR DESCRIPTION
Improve the docstring of method `is_projective_planar` in `src/sage/graphs/graph.py`, as reported in https://github.com/passagemath/passagemath/pull/2139

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


