### PR TITLE
make a doctest in dynamical_semigroup.py clearer

### DIFF
--- a/src/sage/dynamics/arithmetic_dynamics/dynamical_semigroup.py
+++ b/src/sage/dynamics/arithmetic_dynamics/dynamical_semigroup.py
@@ -1015,6 +1015,8 @@ class DynamicalSemigroup(Parent, metaclass=InheritComparisonClasscallMetaclass):
 
         TESTS::
 
+            sage: A.<x, y, z, w, t, u ,v> = AffineSpace(QQ, 7)
+            sage: f = DynamicalSystem([t + u, v - w, x + y, z^2, u * t, v^2 - w^2, x * y * z], A)
             sage: d = DynamicalSemigroup(f)
             sage: d*d == d^2
             True

--- a/src/sage/dynamics/arithmetic_dynamics/dynamical_semigroup.py
+++ b/src/sage/dynamics/arithmetic_dynamics/dynamical_semigroup.py
@@ -1015,28 +1015,11 @@ class DynamicalSemigroup(Parent, metaclass=InheritComparisonClasscallMetaclass):
 
         TESTS::
 
-            sage: A.<x> = AffineSpace(QQ, 1)
-            sage: f1 = DynamicalSystem(x^2 + 1, A)
-            sage: f2 = DynamicalSystem(x^3 - 1, A)
             sage: d = DynamicalSemigroup(f)
             sage: d*d == d^2
             True
-
-        ::
-
-            sage: A.<x> = AffineSpace(QQ, 1)
-            sage: f1 = DynamicalSystem(x^2 + 1, A)
-            sage: f2 = DynamicalSystem(x^3 - 1, A)
-            sage: d = DynamicalSemigroup(f)
             sage: d^3 * d^2 == d^(3 + 2)
             True
-
-        ::
-
-            sage: A.<x> = AffineSpace(QQ, 1)
-            sage: f1 = DynamicalSystem(x^2 + 1, A)
-            sage: f2 = DynamicalSystem(x^3 - 1, A)
-            sage: d = DynamicalSemigroup(f)
             sage: (d^3)^2 == d^(3 * 2)
             True
 


### PR DESCRIPTION
currently, the doctests define variables which are never used.  These definitions are repeated later, where they are used, so I believe it is a copy paste oversight.