### PR TITLE
Improve license format imported from pypi

### DIFF
--- a/build/sage_bootstrap/app.py
+++ b/build/sage_bootstrap/app.py
@@ -463,7 +463,7 @@ class Application(object):
             if not description:
                 description = pypi_version.summary
             if not license:
-                license = pypi_version.license
+                license = pypi_version.license_expression or pypi_version.license
             if not upstream_contact:
                 upstream_contact = pypi_version.package_url
         if upstream_url and not tarball:

--- a/build/sage_bootstrap/pypi.py
+++ b/build/sage_bootstrap/pypi.py
@@ -101,6 +101,13 @@ class PyPiVersion(object):
         return self.json['info']['license']
 
     @property
+    def license_expression(self):
+        """
+        Return the package license expression
+        """
+        return self.json['info']['license_expression']
+
+    @property
     def summary(self):
         """
         Return the package summary


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Mirror of https://github.com/swe-productivity/sage/pull/6.

With PEP639, we can add a new json field called license_expression, which must be a valid SPDX. This change will benefit over 20 packages in build/pkgs, including anyio, argon2-cffi, argon2-cffi-bindings, attrs, bliss, cachetools, calver, cffi, cylp, and execnet. Importantly, this update will not affect the original license logic.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

