### PR TITLE
Upload documentation tarballs to GitHub releases

### DIFF
--- a/.github/workflows/doc-build-livedoc.yml
+++ b/.github/workflows/doc-build-livedoc.yml
@@ -12,6 +12,9 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+.rc[0-9]+'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   PYTHON_VERSION: 3.12
 
@@ -92,3 +95,10 @@ jobs:
         with:
           name: livedoc
           path: livedoc.zip
+
+      - name: Upload docs to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: livedoc.zip
+          token: ${{ secrets.RELEASE_CREATION_TOKEN }}
+        if: github.ref_type == 'tag'


### PR DESCRIPTION
Add pre-built HTML and PDF documentation uploads to the release workflow. When triggered by a tag push, the workflow now creates and uploads livedoc.zip to the corresponding GitHub release.

My tests:
- https://github.com/mango-mice/sage/actions/runs/21561917179/job/62127753072
- https://github.com/mango-mice/sage/releases
- https://github.com/mango-mice/sage/releases/download/10.9.beta99/livedoc.zip

Closes https://github.com/sagemath/sage/issues/39949.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.



