### PR TITLE
refactor: collapse `M = <def>; return M` to `return <def>`

### DIFF
--- a/src/sage/matroids/basis_matroid.pyx
+++ b/src/sage/matroids/basis_matroid.pyx
@@ -542,8 +542,7 @@ cdef class BasisMatroid(BasisExchangeMatroid):
         d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset()]
         B = [[d[y] for y in x] for x in self.bases()]
-        M = BasisMatroid(groundset=E, bases=B)
-        return M
+        return BasisMatroid(groundset=E, bases=B)
 
     # enumeration
 

--- a/src/sage/matroids/circuit_closures_matroid.pyx
+++ b/src/sage/matroids/circuit_closures_matroid.pyx
@@ -550,7 +550,6 @@ cdef class CircuitClosuresMatroid(Matroid):
         CC = {}
         for i in self.circuit_closures():
             CC[i] = [[d[y] for y in x] for x in self._circuit_closures[i]]
-        M = CircuitClosuresMatroid(groundset=E, circuit_closures=CC)
-        return M
+        return CircuitClosuresMatroid(groundset=E, circuit_closures=CC)
 
 # todo: customized minor, extend methods.

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -439,8 +439,7 @@ cdef class CircuitsMatroid(Matroid):
         C = []
         for i in self._k_C:
             C += [[d[y] for y in x] for x in self._k_C[i]]
-        M = CircuitsMatroid(groundset=E, circuits=C)
-        return M
+        return CircuitsMatroid(groundset=E, circuits=C)
 
     # enumeration
 

--- a/src/sage/matroids/dual_matroid.py
+++ b/src/sage/matroids/dual_matroid.py
@@ -543,8 +543,7 @@ class DualMatroid(Matroid):
             sage: for S in powerset(M.groundset()):
             ....:     assert M.rank(S) == N.rank([f[x] for x in S])
         """
-        M = self._matroid.relabel(mapping).dual()
-        return M
+        return self._matroid.relabel(mapping).dual()
 
     def is_valid(self, certificate=False):
         """

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -405,8 +405,7 @@ cdef class FlatsMatroid(Matroid):
         for i in self._k_F:
             F[i] = []
             F[i] += [[d[y] for y in x] for x in self._k_F[i]]
-        M = FlatsMatroid(groundset=E, flats=F)
-        return M
+        return FlatsMatroid(groundset=E, flats=F)
 
     # enumeration
 

--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -3309,8 +3309,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
         """
         d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
-        M = LinearMatroid(groundset=E, matrix=self._matrix_())
-        return M
+        return LinearMatroid(groundset=E, matrix=self._matrix_())
 
 # Binary matroid
 
@@ -4344,8 +4343,7 @@ cdef class BinaryMatroid(LinearMatroid):
         """
         d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
-        M = BinaryMatroid(groundset=E, matrix=self._matrix_())
-        return M
+        return BinaryMatroid(groundset=E, matrix=self._matrix_())
 
 cdef class TernaryMatroid(LinearMatroid):
     r"""
@@ -5214,8 +5212,7 @@ cdef class TernaryMatroid(LinearMatroid):
         """
         d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
-        M = TernaryMatroid(groundset=E, matrix=self._matrix_())
-        return M
+        return TernaryMatroid(groundset=E, matrix=self._matrix_())
 
 # Quaternary Matroids
 
@@ -5922,8 +5919,7 @@ cdef class QuaternaryMatroid(LinearMatroid):
         """
         d = self._relabel_map(mapping)
         E = [d[x] for x in self.groundset_list()]
-        M = QuaternaryMatroid(groundset=E, matrix=self._matrix_())
-        return M
+        return QuaternaryMatroid(groundset=E, matrix=self._matrix_())
 
 # Regular Matroids
 

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8644,5 +8644,4 @@ cdef class Matroid(SageObject):
             X_inv = frozenset([d_inv[x] for x in X])
             return self._rank(X_inv)
 
-        M = RankMatroid(groundset=E, rank_function=f_relabel)
-        return M
+        return RankMatroid(groundset=E, rank_function=f_relabel)


### PR DESCRIPTION
This follows the change in `graphic_matroid.pyx`: https://github.com/sagemath/sage/pull/41649.