### PR TITLE
Fix PresentationComplex not working for certain groups

### DIFF
--- a/src/sage/topology/simplicial_set_examples.py
+++ b/src/sage/topology/simplicial_set_examples.py
@@ -853,8 +853,8 @@ def PresentationComplex(G):
     """
     O = AbstractSimplex(0)
     SO = O.apply_degeneracies(0)
-    edges = {i + 1: AbstractSimplex(1, name=str(g)) for (i,g) in enumerate(G.gens())}
-    inverseedges = {-i - 1: AbstractSimplex(1, name=str(g.inverse())) for (i,g) in enumerate(G.gens())}
+    edges = {i + 1: AbstractSimplex(1, name=str(g)) for (i, g) in enumerate(G.gens())}
+    inverseedges = {-i - 1: AbstractSimplex(1, name=str(g.inverse())) for (i, g) in enumerate(G.gens())}
     all_edges = {}
     all_edges.update(edges)
     all_edges.update(inverseedges)

--- a/src/sage/topology/simplicial_set_examples.py
+++ b/src/sage/topology/simplicial_set_examples.py
@@ -859,7 +859,7 @@ def PresentationComplex(G):
     all_edges.update(edges)
     all_edges.update(inverseedges)
     triangles = {i + 1 : AbstractSimplex(2, name='T' + str(g)) for (i, g) in enumerate(G.gens())}
-    face_maps = {O : None}
+    face_maps = {O: None}
     face_maps.update({g: [O, O] for g in all_edges.values()})
     face_maps.update({triangles[t]: [all_edges[t], SO, all_edges[-t]] for t in triangles})
     for r in G.relations():

--- a/src/sage/topology/simplicial_set_examples.py
+++ b/src/sage/topology/simplicial_set_examples.py
@@ -832,28 +832,52 @@ def PresentationComplex(G):
          a^2: (a, s_0 Delta^0, a)}
         sage: S.fundamental_group()
         Finitely presented group < e0 | e0^2 >
+
+    TESTS::
+
+        sage: # needs sage.groups
+        sage: S = simplicial_sets.PresentationComplex(FreeGroup(0) / [])
+        sage: S
+        Simplicial set with 1 non-degenerate simplex
+        sage: S.face_data()
+        {Delta^0: None}
+
+    ::
+
+        sage: F = FreeGroup(2)
+        sage: G = F / [[2, 1, -2, -1, 2]]
+        sage: S = simplicial_sets.PresentationComplex(G)
+        sage: S
+        Simplicial set with 12 non-degenerate simplices
+
     """
     O = AbstractSimplex(0)
     SO = O.apply_degeneracies(0)
-    edges = {g: AbstractSimplex(1, name=str(g)) for g in G.gens()}
-    inverseedges = {g.inverse(): AbstractSimplex(1, name=str(g.inverse())) for g in G.gens()}
+    edges = {i + 1: AbstractSimplex(1, name=str(g)) for (i,g) in enumerate(G.gens())}
+    inverseedges = {-i - 1: AbstractSimplex(1, name=str(g.inverse())) for (i,g) in enumerate(G.gens())}
     all_edges = {}
     all_edges.update(edges)
     all_edges.update(inverseedges)
-    triangles = {g: AbstractSimplex(2, name='T' + str(g)) for g in G.gens()}
-    face_maps = {g: [O, O] for g in all_edges.values()}
-    face_maps.update({triangles[t]: [all_edges[t], SO, all_edges[t.inverse()]] for t in triangles})
+    triangles = {i + 1 : AbstractSimplex(2, name='T' + str(g)) for (i, g) in enumerate(G.gens())}
+    face_maps = {O : None}
+    face_maps.update({g: [O, O] for g in all_edges.values()})
+    face_maps.update({triangles[t]: [all_edges[t], SO, all_edges[-t]] for t in triangles})
     for r in G.relations():
-        if len(r.Tietze()) == 1:
-            pass
+        if len(r.Tietze()) == 0:
+            T = AbstractSimplex(2, name=str(r))
+            face_maps[T] = [SO, SO, SO]
+        elif len(r.Tietze()) == 1:
+            T = AbstractSimplex(2, name=str(r))
+            a = all_edges[r.Tietze()[0]]
+            face_maps[T] = [a, SO, SO]
         elif len(r.Tietze()) == 2:
-            a = all_edges[G([r.Tietze()[0]])]
-            b = all_edges[G([r.Tietze()[1]])]
+            a = all_edges[r.Tietze()[0]]
+            b = all_edges[r.Tietze()[1]]
             T = AbstractSimplex(2, name=str(r))
             face_maps[T] = [a, SO, b]
         else:
-            words = [all_edges[G([a])] for a in r.Tietze()]
-            words[-1] = all_edges[G([-r.Tietze()[-1]])]
+            words = [all_edges[a] for a in r.Tietze()]
+            words[-1] = all_edges[-r.Tietze()[-1]]
             while len(words) > 3:
                 auxedge = AbstractSimplex(1)
                 face_maps[auxedge] = [O, O]


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

`simplicial_sets.PresentationComplex` does not work if gap can't solve the word problem in the group. This is because group elements are used as keys in dictionaries.

This PR solves this using integer indexes instead.

It also fixes some corner cases such as trivial relations, no relations or no generators.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

