### PR TITLE
√élu: minor typo in docstring, plus Velu→Vélu

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -139,8 +139,8 @@ from .hom import EllipticCurveHom, compare_via_evaluation
 class _VeluBoundObj:
     """
     Helper object to define the point in which isogeny
-    computation should start using square-roor Velu formulae
-    instead of Velu.
+    computation should start using square-root Vélu formulae
+    instead of Vélu.
 
     EXAMPLES ::
 


### PR DESCRIPTION
Thanks to Tomoki Moriya for finding the typo "square-roor".