### PR TITLE
Add is_pointed() method for convex cones

### DIFF
--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3332,6 +3332,58 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
                 return False
         return True
 
+    def is_pointed(self) -> bool:
+        r"""
+        Check if ``self`` is pointed.
+
+        A convex cone is said to be pointed if (and only if) it
+        contains no lines. For a closed convex cone, this is
+        equivalent to saying that the origin is the only point
+        contained in both the cone and its negation.
+
+        This is an alias for :meth:`is_strictly_convex`. The "pointed"
+        terminology is however standard in many settings, and for
+        example is consistent with the ``isPointed()`` function in
+        Macaulay2.
+
+        OUTPUT:
+
+        ``True`` if :meth:`lineality` is zero, and ``False`` otherwise.
+
+        .. SEEALSO::
+
+            :meth:`is_strictly_convex`,
+            :meth:`is_solid`,
+            :meth:`is_proper`
+
+        EXAMPLES:
+
+        The Barker-Foran cone must be pointed, because it is self-dual
+        under the canonical dual space identification::
+
+            sage: cones.barker_foran().is_pointed()
+            True
+
+        The nonnegative orthant and trivial cone are always pointed::
+
+            sage: n = ZZ.random_element(10)
+            sage: L = ToricLattice(n)
+            sage: cones.nonnegative_orthant(n, lattice=L).is_pointed()
+            True
+            sage: cones.trivial(lattice=L).is_pointed()
+            True
+
+        TESTS:
+
+        Random test for the claim made in the ``OUTPUT`` block::
+
+            sage: K = random_cone(max_ambient_dim = 8)
+            sage: K.is_pointed() == K.lineality().is_zero()
+            True
+
+        """
+        return self.is_strictly_convex()
+
     @cached_method
     def linear_subspace(self):
         r"""

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3340,7 +3340,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         r"""
         Check if ``self`` is pointed.
 
-        A convex cone is said to be pointed if (and only if) it
+        A convex cone is said to be *pointed* if (and only if) it
         contains no lines. For a closed convex cone, this is
         equivalent to saying that the origin is the only point
         contained in both the cone and its negation.

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3318,6 +3318,10 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         OUTPUT: ``True`` if ``self`` is strictly convex, ``False`` otherwise
 
+        .. SEEALSO::
+
+            :meth:`is_pointed`
+
         EXAMPLES::
 
             sage: cone1 = Cone([(1,0), (0, 1)])
@@ -4671,7 +4675,9 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         .. SEEALSO::
 
-            :meth:`is_strictly_convex`, :meth:`is_solid`
+            :meth:`is_strictly_convex`,
+            :meth:`is_pointed`,
+            :meth:`is_solid`
 
         EXAMPLES:
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3309,6 +3309,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
     is_compact = is_trivial
 
+    @cached_method
     def is_strictly_convex(self) -> bool:
         r"""
         Check if ``self`` is strictly convex.
@@ -3326,14 +3327,10 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: cone2.is_strictly_convex()
             False
         """
-        if "_is_strictly_convex" not in self.__dict__:
-            convex = True
-            for gs in self._PPL_cone().minimized_generators():
-                if gs.is_line():
-                    convex = False
-                    break
-            self._is_strictly_convex = convex
-        return self._is_strictly_convex
+        for gs in self._PPL_cone().minimized_generators():
+            if gs.is_line():
+                return False
+        return True
 
     @cached_method
     def linear_subspace(self):

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3331,10 +3331,8 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: cone2.is_strictly_convex()
             False
         """
-        for gs in self._PPL_cone().minimized_generators():
-            if gs.is_line():
-                return False
-        return True
+        return all(not gs.is_line()
+                   for gs in self._PPL_cone().minimized_generators())
 
     def is_pointed(self) -> bool:
         r"""


### PR DESCRIPTION
I've written a few papers and have given many presentations using this property, and I'm tired of explaining why you have to write `is_strictly_convex()` instead of `is_pointed()`.

Docs: https://doc-pr-41665--sagemath.netlify.app/html/en/reference/discrete_geometry/sage/geometry/cone#sage.geometry.cone.ConvexRationalPolyhedralCone.is_pointed