### PR TITLE
Deprecate sage.misc.sage_ostools.have_program()

### DIFF
--- a/src/sage/interfaces/phc.py
+++ b/src/sage/interfaces/phc.py
@@ -917,8 +917,8 @@ class PHC:
 
         # Was there an error?
         if e:
-            from sage.misc.sage_ostools import have_program
-            if not have_program('phc'):
+            from shutil import which
+            if not which('phc'):
                 print(str(os.system('which phc')) + '  PHC needs to be installed and in your path')
                 raise RuntimeError
             # todo -- why? etc.

--- a/src/sage/misc/sage_ostools.pyx
+++ b/src/sage/misc/sage_ostools.pyx
@@ -28,6 +28,10 @@ def have_program(program, path=None) -> bool:
 
         sage: from sage.misc.sage_ostools import have_program
         sage: have_program('ls')
+        doctest:warning
+        ...
+        DeprecationWarning: have_program is deprecated; use shutil.which instead
+        See https://github.com/sagemath/sage/issues/32957 for details.
         True
         sage: have_program('there_is_not_a_program_with_this_name')
         False
@@ -38,6 +42,8 @@ def have_program(program, path=None) -> bool:
         sage: have_program('there_is_not_a_program_with_this_name', "/bin")
         False
     """
+    from sage.misc.superseded import deprecation
+    deprecation(32957, "have_program is deprecated; use shutil.which instead")
     if path is None:
         path = os.environ.get('PATH', "")
     for p in path.split(os.pathsep):

--- a/src/sage/misc/viewer.py
+++ b/src/sage/misc/viewer.py
@@ -55,7 +55,7 @@ def default_viewer(viewer=None):
         ValueError: Unknown type of viewer: jpg.
     """
     import os
-    from sage.misc.sage_ostools import have_program
+    from shutil import which
 
     if isinstance(viewer, str):
         viewer = viewer.lower()
@@ -74,7 +74,7 @@ def default_viewer(viewer=None):
         PDF_VIEWER = BROWSER
         PNG_VIEWER = BROWSER
 
-    elif have_program('xdg-open'):
+    elif which('xdg-open'):
         # On other OS'es try xdg-open if present.
         # See http://portland.freedesktop.org/xdg-utils-1.0.
         BROWSER = 'xdg-open'
@@ -89,7 +89,7 @@ def default_viewer(viewer=None):
         except KeyError:
             BROWSER = 'less'  # silly default; lets hope it doesn't come to this!
             for cmd in ['firefox', 'konqueror', 'mozilla', 'mozilla-firefox']:
-                if have_program(cmd):
+                if which(cmd):
                     BROWSER = cmd
                     break
         DVI_VIEWER = BROWSER
@@ -101,14 +101,14 @@ def default_viewer(viewer=None):
             DVI_VIEWER = os.environ['DVI_VIEWER']
         except KeyError:
             for cmd in ['xdvi', 'kdvi']:
-                if have_program(cmd):
+                if which(cmd):
                     DVI_VIEWER = cmd
                     break
         try:
             PDF_VIEWER = os.environ['PDF_VIEWER']
         except KeyError:
             for cmd in ['acroread', 'xpdf']:
-                if have_program(cmd):
+                if which(cmd):
                     PDF_VIEWER = cmd
                     break
 


### PR DESCRIPTION
Deprecate `have_program()` in favor of `shutil.which()`, and replace the two remaining uses in the sage library cf. https://github.com/sagemath/sage/issues/32957

When this is done, I'll open a new issue to replace `shutil.which` with features, since we still should not be randomly guessing at this stuff at runtime.