### PR TITLE
Fix the release trigger workflow name.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+.rc[0-9]+'
   pull_request:
     paths:
-      - '.github/workflows/dist.yml'
+      - '.github/workflows/release.yml'
   workflow_dispatch:
     # Allow to run manually
 


### PR DESCRIPTION
In https://github.com/sagemath/sage/commit/3a269979e08464e9964af4d52e396e0b6fc1d1de, dist.yml was renamed to release.yml, but the filename reference inside the yml file itself was not updated accordingly.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

