### PR TITLE
src/sage/geometry: remove block-level "needs sage.foo" tags

### DIFF
--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -128,7 +128,6 @@ You can also perform these checks::
 
 You can work with subcones that form faces of other cones::
 
-    sage: # needs sage.graphs
     sage: face = four_rays.faces(dim=2)[0]
     sage: face
     2-d face of 3-d cone in 3-d lattice N
@@ -145,7 +144,6 @@ You can work with subcones that form faces of other cones::
 
 If you need to know inclusion relations between faces, you can use ::
 
-    sage: # needs sage.graphs
     sage: L = four_rays.face_lattice()
     sage: [len(s) for s in L.level_sets()]
     [1, 4, 4, 1]
@@ -2045,7 +2043,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: octant = Cone([(1,0,0), (0,1,0), (0,0,1)])
             sage: octant.adjacent()
             ()
@@ -2126,7 +2123,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: cone.ambient() is cone
             True
 
-            sage: # needs sage.graphs
             sage: face = cone.faces(1)[0]
             sage: face
             1-d face of 3-d cone in 3-d lattice N
@@ -2324,7 +2320,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         If we want to operate with this ray as a face of the cone, we need to
         embed it first::
 
-            sage: # needs sage.graphs
             sage: e_ray = c.embed(ray)
             sage: e_ray
             1-d face of 3-d cone in 3-d lattice N
@@ -2440,7 +2435,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         However, you can achieve some of this functionality using
         :meth:`facets`, :meth:`facet_of`, and :meth:`adjacent` methods::
 
-            sage: # needs sage.graphs
             sage: face = quadrant.faces(1)[0]
             sage: face
             1-d face of 2-d cone in 2-d lattice N
@@ -2460,7 +2454,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         Note that if ``cone`` is a face of ``supercone``, then the face
         lattice of ``cone`` consists of (appropriate) faces of ``supercone``::
 
-            sage: # needs sage.combinat sage.graphs
             sage: supercone = Cone([(1,2,3,4), (5,6,7,8),
             ....:                   (1,2,4,8), (1,3,9,7)])
             sage: supercone.face_lattice()
@@ -2665,7 +2658,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         In the case of non-strictly convex cones even faces of small
         nonnegative dimension may be missing::
 
-            sage: # needs sage.graphs
             sage: halfplane = Cone([(1,0), (0,1), (-1,0)])
             sage: halfplane.faces(0)
             ()
@@ -2849,7 +2841,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: octant = Cone([(1,0,0), (0,1,0), (0,0,1)])
             sage: octant.facet_of()
             ()
@@ -3196,7 +3187,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         We check that :issue:`18613` is fixed::
 
-            sage: # needs sage.graphs sage.groups
             sage: K = cones.trivial(0)
             sage: K.is_isomorphic(K)
             True
@@ -3839,7 +3829,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: C2_Z2 = Cone([(1,0), (1,2)])     # C^2/Z_2
             sage: c1, c2 = C2_Z2.facets()
             sage: c2.sublattice_quotient()
@@ -4122,7 +4111,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: rho = Cone([(1,1,1,3), (1,-1,1,3), (-1,-1,1,3), (-1,1,1,3)])
             sage: rho.orthogonal_sublattice()
             Sublattice <M(0, 0, 3, -1)>
@@ -4140,7 +4128,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         Different codimension::
 
-            sage: # needs sage.graphs
             sage: rho = Cone([[1,-1,1,3],[-1,-1,1,3]])
             sage: sigma = rho.facets()[0]
             sage: sigma.orthogonal_sublattice()
@@ -5663,7 +5650,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         The positive operators on a permuted cone can be obtained by
         conjugation::
 
-            sage: # needs sage.groups
             sage: K = random_cone(max_ambient_dim=3)
             sage: L = ToricLattice(K.lattice_dim()**2)
             sage: p = SymmetricGroup(K.lattice_dim()).random_element().matrix()
@@ -5987,7 +5973,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         The cross-positive operators of a permuted cone can be obtained by
         conjugation::
 
-            sage: # needs sage.groups
             sage: K = random_cone(max_ambient_dim=3)
             sage: L = ToricLattice(K.lattice_dim()**2)
             sage: p = SymmetricGroup(K.lattice_dim()).random_element().matrix()

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -758,7 +758,6 @@ def schur(ambient_dim=None, lattice=None):
     generators of the Schur cone and the nonnegative orthant in
     dimension five is `\left(3/4\right)\pi`::
 
-        sage: # needs sage.rings.number_fields
         sage: P = cones.schur(5)
         sage: Q = cones.nonnegative_orthant(5)
         sage: G = ( g.change_ring(QQbar).normalized() for g in P )

--- a/src/sage/geometry/hyperplane_arrangement/arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/arrangement.py
@@ -65,7 +65,6 @@ supported::
 
 Number fields are also possible::
 
-    sage: # needs sage.rings.number_field
     sage: x = polygen(QQ, 'x')
     sage: NF.<a> = NumberField(x**4 - 5*x**2 + 5, embedding=1.90)
     sage: H.<y,z> = HyperplaneArrangements(NF)
@@ -107,7 +106,6 @@ Notation (v): from the bounding hyperplanes of a polyhedron::
 
 New arrangements from old::
 
-    sage: # needs sage.graphs
     sage: a = hyperplane_arrangements.braid(3)
     sage: b = a.add_hyperplane([4, 1, 2, 3])
     sage: b
@@ -116,7 +114,6 @@ New arrangements from old::
     sage: a == c
     True
 
-    sage: # needs sage.combinat sage.graphs
     sage: a = hyperplane_arrangements.braid(3)
     sage: b = a.union(hyperplane_arrangements.semiorder(3))
     sage: b == a | hyperplane_arrangements.semiorder(3)    # alternate syntax
@@ -141,7 +138,6 @@ The essentialization is formed by intersecting the hyperplanes by this
 normal space (actually, it is a bit more complicated over finite
 fields)::
 
-    sage: # needs sage.graphs
     sage: a = hyperplane_arrangements.braid(4);  a
     Arrangement of 6 hyperplanes of dimension 4 and rank 3
     sage: a.is_essential()
@@ -206,7 +202,6 @@ in `\RR^n` are called the *regions* of the arrangement::
 The distance between regions is defined as the number of hyperplanes
 separating them. For example::
 
-    sage: # needs sage.combinat
     sage: r1 = b.regions()[0]
     sage: r2 = b.regions()[1]
     sage: b.distance_between_regions(r1, r2)
@@ -227,7 +222,6 @@ of all nonempty intersections of hyperplanes in the arrangement,
 ordered by reverse inclusion.  It includes the ambient space of the
 arrangement (as the intersection over the empty set)::
 
-    sage: # needs sage.graphs
     sage: a = hyperplane_arrangements.braid(3)
     sage: p = a.intersection_poset()
     sage: p.is_ranked()
@@ -398,7 +392,6 @@ class HyperplaneArrangementElement(Element):
 
         It is possible to specify a backend for polyhedral computations::
 
-            sage: # needs sage.rings.number_field
             sage: R.<sqrt5> = QuadraticField(5)
             sage: H = HyperplaneArrangements(R, names='xyz')
             sage: x, y, z = H.gens()
@@ -563,7 +556,6 @@ class HyperplaneArrangementElement(Element):
             sage: A.rank()
             2
 
-            sage: # needs sage.graphs
             sage: B = hyperplane_arrangements.braid(3)
             sage: B.hyperplanes()
             (Hyperplane 0*t0 + t1 - t2 + 0,
@@ -711,7 +703,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: a.<x,y,z> = hyperplane_arrangements.semiorder(3)
             sage: b = a.cone()
             sage: a.characteristic_polynomial().factor()
@@ -782,7 +773,6 @@ class HyperplaneArrangementElement(Element):
 
         ::
 
-            sage: # needs sage.combinat
             sage: A = hyperplane_arrangements.semiorder(3)
             sage: L = A.intersection_poset(); L
             Finite poset containing 19 elements
@@ -1070,7 +1060,6 @@ class HyperplaneArrangementElement(Element):
 
         We verify Equation (4) in [BHS2023]_ on some examples::
 
-            sage: # needs sage.graphs
             sage: R.<x> = ZZ[]
             sage: Arr = [hyperplane_arrangements.braid(n) for n in range(2,6)]
             sage: all(R(A.cocharacteristic_polynomial()(1/(x-1)) * (x-1)^A.dimension())
@@ -1079,7 +1068,6 @@ class HyperplaneArrangementElement(Element):
 
         We compute types `H_3` and `F_4` in Table 1 of [BHS2023]_::
 
-            sage: # needs sage.libs.gap
             sage: W = CoxeterGroup(['H',3], implementation='matrix')
             sage: A = HyperplaneArrangements(W.base_ring(), tuple(f'x{s}' for s in range(W.rank())))
             sage: H = A([[0] + list(r) for r in W.positive_roots()])
@@ -1109,7 +1097,6 @@ class HyperplaneArrangementElement(Element):
         general, the graphical arrangement of a cycle graph corresponds
         to the arrangements in Example 9.4)::
 
-            sage: # needs sage.graphs
             sage: H = hyperplane_arrangements.graphical(graphs.CycleGraph(5))
             sage: pep = H.primitive_eulerian_polynomial(); pep
             z^4 + 6*z^3 - 4*z^2 + z
@@ -1221,7 +1208,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: A.<u,x,y,z> = hyperplane_arrangements.braid(4);  A
             Arrangement of 6 hyperplanes of dimension 4 and rank 3
             sage: H = A[0];  H
@@ -1359,7 +1345,6 @@ class HyperplaneArrangementElement(Element):
 
         Check that :issue:`30749` is fixed::
 
-            sage: # needs sage.rings.number_field
             sage: R.<y> = QQ[]
             sage: v1 = AA.polynomial_root(AA.common_polynomial(y^2 - 3),
             ....:                         RIF(RR(1.7320508075688772), RR(1.7320508075688774)))
@@ -1432,7 +1417,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: a = hyperplane_arrangements.semiorder(3)
             sage: a.has_good_reduction(5)
             True
@@ -1878,7 +1862,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: A = hyperplane_arrangements.Shi(3).essentialization()
             sage: A.dimension()
             2
@@ -2035,7 +2018,6 @@ class HyperplaneArrangementElement(Element):
 
         It is possible to specify the backend::
 
-            sage: # needs sage.rings.number_field
             sage: K.<q> = CyclotomicField(9)
             sage: L.<r9> = NumberField((q + q**(-1)).minpoly(),
             ....:                      embedding=AA(q + q**-1))
@@ -2161,7 +2143,6 @@ class HyperplaneArrangementElement(Element):
             sage: A.poset_of_regions()                                                  # needs sage.combinat
             Finite poset containing 4 elements
 
-            sage: # needs sage.combinat sage.graphs
             sage: A = hyperplane_arrangements.braid(3)
             sage: A.poset_of_regions()
             Finite poset containing 6 elements
@@ -2280,7 +2261,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: a = hyperplane_arrangements.braid(2)
             sage: a.hyperplanes()
             (Hyperplane t0 - t1 + 0,)
@@ -2330,7 +2310,6 @@ class HyperplaneArrangementElement(Element):
              ((-1, -1), A 2-dimensional polyhedron in QQ^2 defined
                         as the convex hull of 1 vertex and 2 rays,  (-1, -2))]
 
-            sage: # needs sage.graphs
             sage: a = hyperplane_arrangements.braid(3)
             sage: a.hyperplanes()
             (Hyperplane 0*t0 + t1 - t2 + 0,
@@ -2512,7 +2491,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: a = hyperplane_arrangements.braid(3)
             sage: a.hyperplanes()
             (Hyperplane 0*t0 + t1 - t2 + 0,
@@ -2608,7 +2586,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: a = hyperplane_arrangements.braid(3)
             sage: [(i, F[0]) for i, F in enumerate(a.closed_faces())]
             [(0, (0, 0, 0)),
@@ -2657,7 +2634,6 @@ class HyperplaneArrangementElement(Element):
 
         The ``names`` keyword works::
 
-            sage: # needs sage.graphs
             sage: a = hyperplane_arrangements.braid(3)
             sage: U = a.face_semigroup_algebra(names='x'); U
             Finite-dimensional algebra of degree 13 over Rational Field
@@ -2797,7 +2773,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: A = hyperplane_arrangements.semiorder(3)
             sage: A.bounded_regions()
             (A 3-dimensional polyhedron in QQ^3 defined
@@ -2837,7 +2812,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: A = hyperplane_arrangements.semiorder(3)
             sage: B = A.essentialization()
             sage: B.n_regions() - B.n_bounded_regions()
@@ -2890,7 +2864,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: A = hyperplane_arrangements.Shi(3)
             sage: A.whitney_data()
             (
@@ -2941,7 +2914,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: A = hyperplane_arrangements.Shi(3)
             sage: A.doubly_indexed_whitney_number(0, 2)
             9
@@ -2992,7 +2964,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: A = hyperplane_arrangements.Shi(3)
             sage: A.whitney_number(0)
             1
@@ -3286,7 +3257,6 @@ class HyperplaneArrangementElement(Element):
 
         Check that :issue:`26705` is fixed::
 
-            sage: # needs sage.combinat sage.groups
             sage: w = WeylGroup(['A', 4]).from_reduced_word([3, 4, 2, 1])
             sage: I = w.inversion_arrangement()
             sage: I
@@ -3375,7 +3345,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat sage.groups
             sage: W = WeylGroup(['A',3], prefix='s')
             sage: A = W.long_element().inversion_arrangement()
             sage: for M in A.derivation_module_free_chain(): print("%s\n"%M)
@@ -3531,7 +3500,6 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat sage.groups
             sage: W = WeylGroup(['A', 2], prefix='s')
             sage: A = W.long_element().inversion_arrangement()
             sage: A.derivation_module_basis()

--- a/src/sage/geometry/hyperplane_arrangement/hyperplane.py
+++ b/src/sage/geometry/hyperplane_arrangement/hyperplane.py
@@ -383,7 +383,6 @@ class Hyperplane(LinearExpression):
             sage: h.point() in h
             True
 
-            sage: # needs sage.rings.finite_rings
             sage: H.<x,y,z> = HyperplaneArrangements(GF(3))
             sage: h = 2*x + y + z + 1
             sage: h.point()
@@ -534,7 +533,6 @@ class Hyperplane(LinearExpression):
 
         Check that :issue:`30078` is fixed::
 
-            sage: # needs sage.rings.number_field
             sage: R.<sqrt2> = QuadraticField(2)
             sage: H.<x,y> = HyperplaneArrangements(base_ring=R)
             sage: B = H([1,1,0], [2,2,0], [sqrt2,sqrt2,0])
@@ -543,7 +541,6 @@ class Hyperplane(LinearExpression):
 
         Check that :issue:`30749` is fixed::
 
-            sage: # needs sage.rings.number_field
             sage: tau = (1+AA(5).sqrt()) / 2
             sage: ncn = [[2*tau+1,2*tau,tau],[2*tau+2,2*tau+1,tau+1]]
             sage: ncn += [[tau+1,tau+1,tau],[2*tau,2*tau,tau],[tau+1,tau+1,1]]

--- a/src/sage/geometry/hyperplane_arrangement/library.py
+++ b/src/sage/geometry/hyperplane_arrangement/library.py
@@ -120,7 +120,6 @@ class HyperplaneArrangementLibrary:
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: G = graphs.CycleGraph(4)
             sage: G.edges(sort=True)
             [(0, 1, None), (0, 3, None), (1, 2, None), (2, 3, None)]
@@ -276,7 +275,6 @@ class HyperplaneArrangementLibrary:
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: hyperplane_arrangements.Coxeter(4)
             Arrangement of 6 hyperplanes of dimension 4 and rank 3
             sage: hyperplane_arrangements.Coxeter("B4")
@@ -296,7 +294,6 @@ class HyperplaneArrangementLibrary:
         The characteristic polynomial is pre-computed using the results
         of Terao, see [Ath2000]_::
 
-            sage: # needs sage.combinat
             sage: hyperplane_arrangements.Coxeter("A3").characteristic_polynomial()
             x^3 - 6*x^2 + 11*x - 6
         """
@@ -347,7 +344,6 @@ class HyperplaneArrangementLibrary:
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: G = graphs.CompleteGraph(5)
             sage: hyperplane_arrangements.G_semiorder(G)
             Arrangement of 20 hyperplanes of dimension 5 and rank 4
@@ -384,7 +380,6 @@ class HyperplaneArrangementLibrary:
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: G = graphs.CompleteGraph(5)
             sage: hyperplane_arrangements.G_Shi(G)
             Arrangement of 20 hyperplanes of dimension 5 and rank 4
@@ -427,7 +422,6 @@ class HyperplaneArrangementLibrary:
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: G = graphs.CompleteGraph(5)
             sage: hyperplane_arrangements.graphical(G)
             Arrangement of 10 hyperplanes of dimension 5 and rank 4
@@ -437,7 +431,6 @@ class HyperplaneArrangementLibrary:
 
         TESTS::
 
-            sage: # needs sage.graphs
             sage: h = hyperplane_arrangements.graphical(g)
             sage: h.characteristic_polynomial()
             x^5 - 6*x^4 + 14*x^3 - 15*x^2 + 6*x
@@ -484,7 +477,6 @@ class HyperplaneArrangementLibrary:
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: a = hyperplane_arrangements.Ish(3); a
             Arrangement of 6 hyperplanes of dimension 3 and rank 2
             sage: a.characteristic_polynomial()
@@ -668,7 +660,6 @@ class HyperplaneArrangementLibrary:
 
         TESTS::
 
-            sage: # needs sage.combinat
             sage: h = hyperplane_arrangements.semiorder(5)
             sage: h.characteristic_polynomial()
             x^5 - 20*x^4 + 180*x^3 - 790*x^2 + 1380*x
@@ -727,7 +718,6 @@ class HyperplaneArrangementLibrary:
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: hyperplane_arrangements.Shi(4)
             Arrangement of 12 hyperplanes of dimension 4 and rank 3
             sage: hyperplane_arrangements.Shi("A3")
@@ -758,7 +748,6 @@ class HyperplaneArrangementLibrary:
         The characteristic polynomial is pre-computed using the results
         of [Ath1996]_::
 
-            sage: # needs sage.combinat
             sage: hyperplane_arrangements.Shi("A3").characteristic_polynomial()
             x^4 - 12*x^3 + 48*x^2 - 64*x
             sage: hyperplane_arrangements.Shi("A3", m=2).characteristic_polynomial()
@@ -772,7 +761,6 @@ class HyperplaneArrangementLibrary:
 
         TESTS::
 
-            sage: # needs sage.combinat
             sage: h = hyperplane_arrangements.Shi(4)
             sage: h.characteristic_polynomial()
             x^4 - 12*x^3 + 48*x^2 - 64*x

--- a/src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py
@@ -44,7 +44,6 @@ We see the differences in :meth:`~sage.geometry.hyperplane_arrangement.arrangeme
 
 Also in meth:`~sage.geometry.hyperplane_arrangement.arrangement.HyperplaneArrangementElement.cone`::
 
-    sage: # needs sage.combinat
     sage: a.<x,y,z> = hyperplane_arrangements.semiorder(3)
     sage: H.<x,y,z> = OrderedHyperplaneArrangements(QQ)
     sage: a1 = H(a)
@@ -54,7 +53,6 @@ Also in meth:`~sage.geometry.hyperplane_arrangement.arrangement.HyperplaneArrang
 
 And in :meth:`~sage.geometry.hyperplane_arrangement.arrangement.HyperplaneArrangementElement.restriction`::
 
-    sage: # needs sage.graphs
     sage: A.<u, x, y, z> = hyperplane_arrangements.braid(4)
     sage: L.<u, x, y, z> = OrderedHyperplaneArrangements(QQ)
     sage: A1 = L(A)
@@ -158,7 +156,6 @@ class OrderedHyperplaneArrangementElement(HyperplaneArrangementElement):
             ...
             TypeError: the arrangement is not projective
 
-            sage: # needs sage.graphs
             sage: A0.<u,x,y,z> = hyperplane_arrangements.braid(4); A0
             Arrangement of 6 hyperplanes of dimension 4 and rank 3
             sage: L.<u,x,y,z> = OrderedHyperplaneArrangements(QQ)
@@ -177,7 +174,6 @@ class OrderedHyperplaneArrangementElement(HyperplaneArrangementElement):
             sage: T1.isomorphism(M2)
             {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}
 
-            sage: # needs sage.combinat
             sage: a0 = hyperplane_arrangements.semiorder(3); a0
             Arrangement of 6 hyperplanes of dimension 3 and rank 2
             sage: L.<t0, t1, t2> = OrderedHyperplaneArrangements(QQ)

--- a/src/sage/geometry/hyperplane_arrangement/plot.py
+++ b/src/sage/geometry/hyperplane_arrangement/plot.py
@@ -342,7 +342,6 @@ def plot_hyperplane(hyperplane, **kwds):
         sage: b.plot(**opts)                                                            # needs sage.plot
         Graphics object consisting of 2 graphics primitives
 
-        sage: # needs sage.plot
         sage: H3.<x,y,z> = HyperplaneArrangements(QQ)
         sage: c = 2*x + 3*y + 4*z + 5
         sage: c.plot()

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -729,7 +729,6 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         Check that :issue:`28741` is fixed::
 
-            sage: # needs sage.graphs
             sage: p = LatticePolytope([], lattice=ToricLattice(3).dual()); p
             -1-d lattice polytope in 3-d lattice M
             sage: a = p.faces()[0][0]
@@ -1479,7 +1478,6 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             sage: o.ambient() is o
             True
 
-            sage: # needs sage.graphs
             sage: face = o.faces(1)[0]
             sage: face
             1-d face of 3-d reflexive polytope in 3-d lattice M
@@ -1506,7 +1504,6 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         But each of its other faces is contained in one or more facets::
 
-            sage: # needs sage.graphs
             sage: face = o.faces(1)[0]
             sage: face.ambient_facet_indices()
             (4, 5)
@@ -1809,7 +1806,6 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: o = lattice_polytope.cross_polytope(4)
             sage: e = o.edges()[0]; e
             1-d face of 4-d reflexive polytope in 4-d lattice M
@@ -1938,7 +1934,6 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         However, you can achieve some of this functionality using
         :meth:`facets`, :meth:`facet_of`, and :meth:`adjacent` methods::
 
-            sage: # needs sage.graphs
             sage: face = square.faces(0)[0]
             sage: face
             0-d face of 2-d lattice polytope in 2-d lattice M
@@ -1960,7 +1955,6 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         Note that if ``p`` is a face of ``superp``, then the face
         lattice of ``p`` consists of (appropriate) faces of ``superp``::
 
-            sage: # needs sage.graphs
             sage: superp = LatticePolytope([(1,2,3,4), (5,6,7,8),
             ....:                           (1,2,4,8), (1,3,9,7)])
             sage: superp.face_lattice()
@@ -2326,7 +2320,6 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         EXAMPLES::
 
-            sage: # needs sage.graphs
             sage: square = LatticePolytope([(0,0), (1,0), (1,1), (0,1)])
             sage: square.facet_of()
             ()

--- a/src/sage/geometry/polyhedron/backend_cdd_rdf.py
+++ b/src/sage/geometry/polyhedron/backend_cdd_rdf.py
@@ -134,7 +134,6 @@ class Polyhedron_RDF_cdd(Polyhedron_cdd, Polyhedron_RDF):
 
         Test that :issue:`29568` is fixed::
 
-            sage: # needs sage.groups
             sage: P = polytopes.buckyball(exact=False)
             sage: Q = P + P.center()
             sage: P.is_combinatorially_isomorphic(Q)

--- a/src/sage/geometry/polyhedron/backend_field.py
+++ b/src/sage/geometry/polyhedron/backend_field.py
@@ -7,7 +7,6 @@ allows you to define polyhedra.
 
 EXAMPLES::
 
-    sage: # needs sage.rings.number_field
     sage: p0 = (0, 0)
     sage: p1 = (1, 0)
     sage: p2 = (1/2, AA(3).sqrt()/2)
@@ -59,7 +58,6 @@ class Polyhedron_field(Polyhedron_base):
 
     Check that :issue:`19013` is fixed::
 
-        sage: # needs sage.rings.number_field
         sage: x = polygen(ZZ, 'x')
         sage: K.<phi> = NumberField(x^2 - x - 1, embedding=1.618)
         sage: P1 = Polyhedron([[0,1], [1,1], [1,-phi+1]])

--- a/src/sage/geometry/polyhedron/backend_normaliz.py
+++ b/src/sage/geometry/polyhedron/backend_normaliz.py
@@ -247,7 +247,6 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
             ...
             NormalizError: Some error in the normaliz input data detected: Unknown ConeProperty...
 
-            sage: # needs sage.rings.number_field
             sage: x = polygen(QQ, 'x')
             sage: K.<a> = NumberField(x^3 - 3, embedding=AA(3)**(1/3))
             sage: p = Polyhedron(vertices=[(0, 0), (1, 1), (a, 3), (-1, a**2)],
@@ -588,7 +587,6 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
 
         Check that :issue:`30248` is fixed, that maps as input works::
 
-            sage: # needs sage.rings.number_field
             sage: q = Polyhedron(backend='normaliz', base_ring=AA,
             ....:                rays=[(0, 0, 1), (0, 1, -1), (1, 0, -1)])
             sage: def make_new_Hrep(h):
@@ -1253,7 +1251,6 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
             sage: P2 == P
             True
 
-            sage: # needs sage.rings.number_field
             sage: P = polytopes.dodecahedron(backend='normaliz')
             sage: P1 = loads(dumps(P))
             sage: P2 = Polyhedron_normaliz(P1.parent(), None, None, P1._normaliz_cone,
@@ -2208,7 +2205,6 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
         is equal to 1 = `\chi_{trivial}` (Prop 6.1 [Stap2011]_).
         Here is the computation for the 3-dimensional standard simplex::
 
-            sage: # needs sage.groups
             sage: S = polytopes.simplex(3, backend='normaliz'); S
             A 3-dimensional polyhedron in ZZ^4 defined as the convex hull of 4 vertices
             sage: G = S.restricted_automorphism_group(output='permutation')
@@ -2230,7 +2226,6 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
         `\pm(0,0,1),\pm(1,0,1), \pm(0,1,1), \pm(1,1,1)` and let
         G = `\Zmod{2}` act on P as follows::
 
-            sage: # needs sage.groups
             sage: P = Polyhedron(vertices=[[0,0,1], [0,0,-1], [1,0,1], [-1,0,-1],
             ....:                          [0,1,1], [0,-1,-1], [1,1,1], [-1,-1,-1]],
             ....:                backend='normaliz')
@@ -2444,7 +2439,6 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
         The `H^*` series of the two-dimensional permutahedron under the action
         of the symmetric group is effective::
 
-            sage: # needs sage.groups
             sage: p3 = polytopes.permutahedron(3, backend='normaliz')
             sage: G = p3.restricted_automorphism_group(output='permutation')
             sage: reflection12 = G([(0,2),(1,4),(3,5)])
@@ -2459,7 +2453,6 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
 
         If the `H^*`-series is not polynomial, then it is not effective::
 
-            sage: # needs sage.groups
             sage: P = Polyhedron(vertices=[[0,0,1], [0,0,-1], [1,0,1], [-1,0,-1],
             ....:                          [0,1,1], [0,-1,-1], [1,1,1], [-1,-1,-1]],
             ....:                backend='normaliz')

--- a/src/sage/geometry/polyhedron/backend_number_field.py
+++ b/src/sage/geometry/polyhedron/backend_number_field.py
@@ -75,7 +75,6 @@ class Polyhedron_number_field(Polyhedron_field, Polyhedron_base_number_field):
         sage: p = Polyhedron([(0,0), (1,0), (1/2, sqrt3/2)], backend='number_field')    # needs sage.rings.number_field
         sage: TestSuite(p).run()                                                        # needs sage.rings.number_field
 
-        sage: # needs sage.rings.number_field
         sage: x = polygen(ZZ, 'x')
         sage: K.<phi> = NumberField(x^2 - x - 1, embedding=1.618)
         sage: P1 = Polyhedron([[0,1], [1,1], [1,-phi+1]], backend='number_field')

--- a/src/sage/geometry/polyhedron/base.py
+++ b/src/sage/geometry/polyhedron/base.py
@@ -208,7 +208,6 @@ class Polyhedron_base(Polyhedron_base7):
 
         Irrational algebraic linear program over an embedded number field::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: p = polytopes.icosahedron()
             sage: lp, x = p.to_linear_program(return_variable=True)
             sage: lp.set_objective(x[0] + x[1] + x[2])
@@ -217,7 +216,6 @@ class Polyhedron_base(Polyhedron_base7):
 
         Same example with floating point::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: lp, x = p.to_linear_program(return_variable=True, base_ring=RDF)
             sage: lp.set_objective(x[0] + x[1] + x[2])
             sage: lp.solve()                                               # tol 1e-5
@@ -225,7 +223,6 @@ class Polyhedron_base(Polyhedron_base7):
 
         Same example with a specific floating point solver::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: lp, x = p.to_linear_program(return_variable=True, solver='GLPK')
             sage: lp.set_objective(x[0] + x[1] + x[2])
             sage: lp.solve()                                               # tol 1e-8
@@ -233,7 +230,6 @@ class Polyhedron_base(Polyhedron_base7):
 
         Irrational algebraic linear program over `AA`::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: p = polytopes.icosahedron(base_ring=AA)
             sage: lp, x = p.to_linear_program(return_variable=True)
             sage: lp.set_objective(x[0] + x[1] + x[2])
@@ -295,7 +291,6 @@ class Polyhedron_base(Polyhedron_base7):
 
         The boundary complex of the octahedron::
 
-            sage: # needs sage.graphs
             sage: oc = polytopes.octahedron()
             sage: sc_oc = oc.boundary_complex()
             sage: fl_oc = oc.face_lattice()                                             # needs sage.combinat
@@ -964,7 +959,6 @@ class Polyhedron_base(Polyhedron_base7):
 
         This example tests the functionality for additional elements::
 
-            sage: # needs sage.groups sage.rings.real_mpfr
             sage: C = polytopes.cross_polytope(2)
             sage: G = C.restricted_automorphism_group(output='permutation')
             sage: conj_reps = G.conjugacy_classes_representatives()
@@ -1132,7 +1126,6 @@ class Polyhedron_base(Polyhedron_base7):
 
         Algebraic polyhedron::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: P = polytopes.dodecahedron(); P
             A 3-dimensional polyhedron
              in (Number Field in sqrt5 with defining polynomial x^2 - 5

--- a/src/sage/geometry/polyhedron/base0.py
+++ b/src/sage/geometry/polyhedron/base0.py
@@ -878,7 +878,6 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
              An inequality (0, 1, 0) x + 0 >= 0,
              An inequality (0, 0, 1) x + 0 >= 0)
 
-            sage: # needs sage.combinat
             sage: p3 = Polyhedron(vertices=Permutations([1, 2, 3, 4]))
             sage: ieqs = p3.inequalities()
             sage: ieqs[0]
@@ -904,7 +903,6 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
             sage: p.inequalities_list()[0:3]
             [[0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
 
-            sage: # needs sage.combinat
             sage: p3 = Polyhedron(vertices=Permutations([1, 2, 3, 4]))
             sage: ieqs = p3.inequalities_list()
             sage: ieqs[0]

--- a/src/sage/geometry/polyhedron/base1.py
+++ b/src/sage/geometry/polyhedron/base1.py
@@ -95,7 +95,6 @@ class Polyhedron_base1(Polyhedron_base0, ConvexSet_closed):
         r"""
         TESTS::
 
-            sage: # needs sage.rings.number_field
             sage: K.<a> = QuadraticField(2)
             sage: p = Polyhedron(vertices=[(0, 1, a), (3, a, 5)],
             ....:                rays=[(a, 2, 3), (0, 0, 1)],
@@ -607,7 +606,6 @@ class Polyhedron_base1(Polyhedron_base0, ConvexSet_closed):
         The point need not have coordinates in the same field as the
         polyhedron::
 
-            sage: # needs sage.symbolic
             sage: ray = Polyhedron(vertices=[(0,0)], rays=[(1,0)], base_ring=QQ)
             sage: ray.contains([sqrt(2)/3,0])        # irrational coordinates are ok
             True

--- a/src/sage/geometry/polyhedron/base2.py
+++ b/src/sage/geometry/polyhedron/base2.py
@@ -776,7 +776,6 @@ class Polyhedron_base2(Polyhedron_base1):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P2 = (Polyhedron(ieqs=[(0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, -1)]),
             ....:       Polyhedron(ieqs=[(0, -1, 0, 1), (0, 1, 0, 0), (0, 0, 1, 0)]))
             sage: P2[0].generating_function_of_integral_points(sort_factors=True)
@@ -793,7 +792,6 @@ class Polyhedron_base2(Polyhedron_base1):
         The number of integer partitions
         `1 \leq r_0 \leq r_1 \leq r_2 \leq r_3 \leq r_4`::
 
-            sage: # needs sage.combinat
             sage: P = Polyhedron(ieqs=[(-1, 1, 0, 0, 0, 0), (0, -1, 1, 0, 0, 0),
             ....:                      (0, 0, -1, 1, 0, 0), (0, 0, 0, -1, 1, 0),
             ....:                      (0, 0, 0, 0, -1, 1)])

--- a/src/sage/geometry/polyhedron/base3.py
+++ b/src/sage/geometry/polyhedron/base3.py
@@ -136,7 +136,6 @@ class Polyhedron_base3(Polyhedron_base2):
             [1 0 1 0 0 1]
             [1 0 0 0 1 1]
 
-            sage: # needs sage.rings.number_field
             sage: P = polytopes.dodecahedron().faces(2)[0].as_polyhedron()
             sage: P.slack_matrix()
             [1/2*sqrt5 - 1/2               0               0               1 1/2*sqrt5 - 1/2               0]
@@ -289,7 +288,6 @@ class Polyhedron_base3(Polyhedron_base2):
         Test that this method works for inexact base ring
         (``cdd`` sets the cache already)::
 
-            sage: # needs sage.groups
             sage: P = polytopes.dodecahedron(exact=False)
             sage: M = P.incidence_matrix.cache
             sage: P.incidence_matrix.clear_cache()

--- a/src/sage/geometry/polyhedron/base4.py
+++ b/src/sage/geometry/polyhedron/base4.py
@@ -399,7 +399,6 @@ class Polyhedron_base4(Polyhedron_base3):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: P = polytopes.regular_polygon(4).pyramid()
             sage: D = P.hasse_diagram(); D
             Digraph on 20 vertices
@@ -409,7 +408,6 @@ class Polyhedron_base4(Polyhedron_base3):
         Faces of a mutable polyhedron are not hashable. Hence those are not suitable as
         vertices of the hasse diagram. Use the combinatorial polyhedron instead::
 
-            sage: # needs sage.rings.number_field
             sage: P = polytopes.regular_polygon(4).pyramid()
             sage: parent = P.parent()
             sage: parent = parent.change_ring(QQ, backend='ppl')
@@ -659,7 +657,6 @@ class Polyhedron_base4(Polyhedron_base3):
         This shows an example of two polytopes whose vertex-edge graphs are isomorphic,
         but their face lattices are not isomorphic::
 
-            sage: # needs sage.groups
             sage: Q = Polyhedron([[-123984206864/2768850730773, -101701330976/922950243591, -64154618668/2768850730773, -2748446474675/2768850730773],
             ....:                 [-11083969050/98314591817, -4717557075/98314591817, -32618537490/98314591817, -91960210208/98314591817],
             ....:                 [-9690950/554883199, -73651220/554883199, 1823050/554883199, -549885101/554883199],
@@ -680,7 +677,6 @@ class Polyhedron_base4(Polyhedron_base3):
 
         The automorphism group of the face lattice is isomorphic to the combinatorial automorphism group::
 
-            sage: # needs sage.groups
             sage: CG = C.hasse_diagram().automorphism_group()
             sage: C.combinatorial_automorphism_group().is_isomorphic(CG)
             True
@@ -799,7 +795,6 @@ class Polyhedron_base4(Polyhedron_base3):
 
         A cross-polytope example::
 
-            sage: # needs sage.groups
             sage: P = polytopes.cross_polytope(3)
             sage: P.restricted_automorphism_group() == PermutationGroup([[(3,4)], [(2,3),(4,5)],[(2,5)],[(1,2),(5,6)],[(1,6)]])
             True
@@ -809,7 +804,6 @@ class Polyhedron_base4(Polyhedron_base3):
 
         We test groups for equality in a fool-proof way; they can have different generators, etc::
 
-            sage: # needs sage.groups
             sage: poly_g = P.restricted_automorphism_group(output='matrix')
             sage: matrix_g = MatrixGroup([matrix(QQ,t) for t in mgens])
             sage: all(t.matrix() in poly_g for t in matrix_g.gens())
@@ -819,7 +813,6 @@ class Polyhedron_base4(Polyhedron_base3):
 
         24-cell example::
 
-            sage: # needs sage.groups
             sage: P24 = polytopes.twenty_four_cell()
             sage: AutP24 = P24.restricted_automorphism_group()
             sage: PermutationGroup([
@@ -832,7 +825,6 @@ class Polyhedron_base4(Polyhedron_base3):
 
         Here is the quadrant example mentioned in the beginning::
 
-            sage: # needs sage.groups
             sage: P = Polyhedron(rays=[(1,0),(0,1)])
             sage: P.Vrepresentation()
             (A vertex at (0, 0), A ray in the direction (0, 1), A ray in the direction (1, 0))
@@ -841,7 +833,6 @@ class Polyhedron_base4(Polyhedron_base3):
 
         Also, the polyhedron need not be full-dimensional::
 
-            sage: # needs sage.groups
             sage: P = Polyhedron(vertices=[(1,2,3,4,5),(7,8,9,10,11)])
             sage: P.restricted_automorphism_group()
             Permutation Group with generators [(1,2)]
@@ -876,7 +867,6 @@ class Polyhedron_base4(Polyhedron_base3):
         dihedral group with 6 elements, `D_6`, as its automorphism
         group::
 
-            sage: # needs sage.groups
             sage: initial_points = [vector([1,0]), vector([0,1]), vector([-2,-1])]
             sage: points = initial_points
             sage: Polyhedron(vertices=points).restricted_automorphism_group()
@@ -894,7 +884,6 @@ class Polyhedron_base4(Polyhedron_base3):
         The ``output="matrixlist"`` can be used over fields without a
         complete implementation of matrix groups::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: P = polytopes.dodecahedron(); P
             A 3-dimensional polyhedron in (Number Field in sqrt5 with defining
              polynomial x^2 - 5 with sqrt5 = 2.236067977499790?)^3

--- a/src/sage/geometry/polyhedron/base5.py
+++ b/src/sage/geometry/polyhedron/base5.py
@@ -1414,7 +1414,6 @@ class Polyhedron_base5(Polyhedron_base4):
 
         Check that :issue:`19012` is fixed::
 
-            sage: # needs sage.rings.number_field
             sage: K.<a> = QuadraticField(5)
             sage: P = Polyhedron([[0, 0], [0, a], [1, 1]])
             sage: Q = Polyhedron(ieqs=[[-1, a, 1]])
@@ -1777,7 +1776,6 @@ class Polyhedron_base5(Polyhedron_base4):
             sage: b3_proj = proj_mat * b3; b3_proj
             A 3-dimensional polyhedron in ZZ^4 defined as the convex hull of 5 vertices
 
-            sage: # needs sage.rings.number_field
             sage: square = polytopes.regular_polygon(4)
             sage: square.vertices_list()
             [[0, -1], [1, 0], [-1, 0], [0, 1]]
@@ -1790,7 +1788,6 @@ class Polyhedron_base5(Polyhedron_base4):
 
         Specifying the new base ring may avoid coercion failure::
 
-            sage: # needs sage.rings.number_field
             sage: K.<sqrt2> = QuadraticField(2)
             sage: L.<sqrt3> = QuadraticField(3)
             sage: P = polytopes.cube()*sqrt2
@@ -2191,7 +2188,6 @@ class Polyhedron_base5(Polyhedron_base4):
             (1, 9, 16, 9, 1)
             sage: stacked_square_large = cube.stack(square_face, position=10)
 
-            sage: # needs sage.rings.number_field
             sage: hexaprism = polytopes.regular_polygon(6).prism()
             sage: hexaprism.f_vector()
             (1, 12, 18, 8, 1)
@@ -2320,7 +2316,6 @@ class Polyhedron_base5(Polyhedron_base4):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: P_4 = polytopes.regular_polygon(4)
             sage: W1 = P_4.wedge(P_4.faces(1)[0]); W1
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 6 vertices
@@ -2443,7 +2438,6 @@ class Polyhedron_base5(Polyhedron_base4):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: pentagon  = polytopes.regular_polygon(5)
             sage: f = pentagon.faces(1)[0]
             sage: fsplit_pentagon = pentagon.face_split(f)
@@ -2641,7 +2635,6 @@ class Polyhedron_base5(Polyhedron_base4):
             sage: ops_cube.f_vector()
             (1, 9, 24, 24, 9, 1)
 
-            sage: # needs sage.rings.number_field
             sage: pentagon  = polytopes.regular_polygon(5)
             sage: v = pentagon.vertices()[0]
             sage: ops_pentagon = pentagon.one_point_suspension(v)

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -195,7 +195,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         By default, the wireframe is rendered in blue and the fill in green::
 
-            sage: # needs sage.plot
             sage: square.plot()
             Graphics object consisting of 6 graphics primitives
             sage: point.plot()
@@ -209,7 +208,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         Draw the lines in red and nothing else::
 
-            sage: # needs sage.plot
             sage: square.plot(point=False, line='red', polygon=False)
             Graphics object consisting of 4 graphics primitives
             sage: point.plot(point=False, line='red', polygon=False)
@@ -223,7 +221,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         Draw points in red, no lines, and a blue polygon::
 
-            sage: # needs sage.plot
             sage: square.plot(point={'color':'red'}, line=False, polygon=(0,0,1))
             Graphics object consisting of 2 graphics primitives
             sage: point.plot(point={'color':'red'}, line=False, polygon=(0,0,1))
@@ -238,7 +235,6 @@ class Polyhedron_base6(Polyhedron_base5):
         If we instead use the ``fill`` and ``wireframe`` options, the
         coloring depends on the dimension of the object::
 
-            sage: # needs sage.plot
             sage: square.plot(fill='green', wireframe='red')
             Graphics object consisting of 6 graphics primitives
             sage: point.plot(fill='green', wireframe='red')
@@ -339,7 +335,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         We try to draw the polytope in 2 or 3 dimensions::
 
-            sage: # needs sage.plot
             sage: type(Polyhedron(ieqs=[(1,)]).plot())
             <class 'sage.plot.graphics.Graphics'>
             sage: type(polytopes.hypercube(1).plot())
@@ -360,7 +355,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         If the polyhedron is not full-dimensional, the :meth:`affine_hull_projection` is used if necessary::
 
-            sage: # needs sage.plot
             sage: type(Polyhedron([(0,), (1,)]).plot())
             <class 'sage.plot.graphics.Graphics'>
             sage: type(Polyhedron([(0,0), (1,1)]).plot())
@@ -389,7 +383,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         Check that :issue:`31802` is fixed::
 
-            sage: # needs sage.plot
             sage: halfspace = Polyhedron(rays=[(0, 0, 1)], lines=[(1, 0, 0), (0, 1, 0)])
             sage: len(halfspace.projection().arrows)
             5
@@ -551,7 +544,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         EXAMPLES::
 
-            sage: # needs sage.plot
             sage: co = polytopes.cuboctahedron()
             sage: Img = co.tikz([0, 0, 1], 0, output_type='TikzPicture')
             sage: Img
@@ -589,7 +581,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         When output type is a :class:`sage.misc.latex_standalone.TikzPicture`::
 
-            sage: # needs sage.plot
             sage: co = polytopes.cuboctahedron()
             sage: t = co.tikz([674, 108, -731], 112, output_type='TikzPicture'); t
             \documentclass[tikz]{standalone}
@@ -871,7 +862,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         A different values of ``position`` changes the projection::
 
-            sage: # needs sage.symbolic
             sage: sp = tfcube.schlegel_projection(tfcube.facets()[4], 1/2)
             sage: sp.plot()                                                             # needs sage.plot
             Graphics3d Object
@@ -1234,7 +1224,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         With the parameter ``minimal`` one can get a minimal base ring::
 
-            sage: # needs sage.rings.number_field
             sage: s = polytopes.simplex(3)
             sage: s_AA = s.affine_hull_projection(orthonormal=True, extend=True)
             sage: s_AA.base_ring()
@@ -1259,7 +1248,6 @@ class Polyhedron_base6(Polyhedron_base5):
             ....:             orthonormal=True, extend=True).faces(1)]) == {sqrt(AA(2))}
             True
 
-            sage: # needs sage.rings.number_field
             sage: D = polytopes.dodecahedron()
             sage: F = D.faces(2)[0].as_polyhedron()
             sage: F.affine_hull_projection(orthogonal=True)
@@ -1270,7 +1258,6 @@ class Polyhedron_base6(Polyhedron_base5):
             sage: F.affine_hull_projection(orthonormal=True, extend=True)
             A 2-dimensional polyhedron in AA^2 defined as the convex hull of 5 vertices
 
-            sage: # needs sage.rings.number_field
             sage: K.<sqrt2> = QuadraticField(2)
             sage: P = Polyhedron([2*[K.zero()],2*[sqrt2]]); P
             A 1-dimensional polyhedron in
@@ -1287,7 +1274,6 @@ class Polyhedron_base6(Polyhedron_base5):
             sage: A.vertices()
             (A vertex at (0), A vertex at (2))
 
-            sage: # needs sage.rings.number_field
             sage: K.<sqrt3> = QuadraticField(3)
             sage: P = Polyhedron([2*[K.zero()], 2*[sqrt3]]); P
             A 1-dimensional polyhedron in
@@ -1321,7 +1307,6 @@ class Polyhedron_base6(Polyhedron_base5):
         The ``orthonormal=True`` parameter preserves volumes;
         it provides an isometric copy of the polyhedron::
 
-            sage: # needs sage.rings.number_field
             sage: Pentagon = polytopes.dodecahedron().faces(2)[0].as_polyhedron()
             sage: P = Pentagon.affine_hull_projection(orthonormal=True, extend=True)
             sage: _, c= P.is_inscribed(certificate=True)
@@ -1343,7 +1328,6 @@ class Polyhedron_base6(Polyhedron_base5):
         by the square root of the determinant of the linear part of the
         affine transformation times its transpose::
 
-            sage: # needs sage.rings.number_field
             sage: Pentagon = polytopes.dodecahedron().faces(2)[0].as_polyhedron()
             sage: Pnormal = Pentagon.affine_hull_projection(orthonormal=True,
             ....:                                           extend=True)
@@ -1362,7 +1346,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         Another example with ``as_affine_map=True``::
 
-            sage: # needs sage.combinat sage.rings.number_field
             sage: P = polytopes.permutahedron(4)
             sage: Q    = P.affine_hull_projection(orthonormal=True, extend=True)
             sage: A, b = P.affine_hull_projection(orthonormal=True, extend=True,
@@ -1609,7 +1592,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: triangle = Polyhedron([(1, 0, 0), (0, 1, 0), (0, 0, 1)]);  triangle
             A 2-dimensional polyhedron in ZZ^3 defined as the convex hull of 3 vertices
             sage: A = triangle.affine_hull_manifold(name='A'); A
@@ -1645,7 +1627,6 @@ class Polyhedron_base6(Polyhedron_base5):
 
         Arrangement of affine hull of facets::
 
-            sage: # needs sage.rings.number_field sage.symbolic
             sage: D = polytopes.dodecahedron()
             sage: E3 = EuclideanSpace(3)
             sage: submanifolds = [              # long time

--- a/src/sage/geometry/polyhedron/base7.py
+++ b/src/sage/geometry/polyhedron/base7.py
@@ -44,7 +44,6 @@ class Polyhedron_base7(Polyhedron_base6):
 
     TESTS::
 
-        sage: # needs sage.combinat
         sage: from sage.geometry.polyhedron.base7 import Polyhedron_base7
         sage: P = polytopes.associahedron(['A', 3])
         sage: Polyhedron_base7.centroid(P)
@@ -539,7 +538,6 @@ class Polyhedron_base7(Polyhedron_base6):
             sage: P.volume(measure='induced_rational')                  # optional - latte_int
             1
 
-            sage: # needs sage.rings.number_field
             sage: S = polytopes.regular_polygon(6); S
             A 2-dimensional polyhedron in AA^2 defined as the convex hull of 6 vertices
             sage: edge = S.faces(1)[4].as_polyhedron()
@@ -574,7 +572,6 @@ class Polyhedron_base7(Polyhedron_base6):
             sage: P.volume(measure='induced_lattice', engine='latte')   # optional - latte_int
             3
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: Dexact = polytopes.dodecahedron()
             sage: F0 = Dexact.faces(2)[0].as_polyhedron()
             sage: v = F0.volume(measure='induced', engine='internal'); v
@@ -585,7 +582,6 @@ class Polyhedron_base7(Polyhedron_base6):
             sage: RDF(v)    # abs tol 1e-9
             1.53406271079044
 
-            sage: # needs sage.groups
             sage: Dinexact = polytopes.dodecahedron(exact=False)
             sage: F2 = Dinexact.faces(2)[2].as_polyhedron()
             sage: w = F2.volume(measure='induced', engine='internal')

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/base.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/base.pyx
@@ -638,7 +638,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         TESTS::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(4)
             sage: C = CombinatorialPolyhedron(P)
             sage: C1 = loads(C.dumps())
@@ -1103,7 +1102,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         ::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(5, backend='field')
             sage: C = P.combinatorial_polyhedron()
             sage: C.incidence_matrix.clear_cache()
@@ -1392,7 +1390,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(2)
             sage: C = CombinatorialPolyhedron(P)
             sage: C.ridges()
@@ -2617,7 +2614,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(4)
             sage: C = CombinatorialPolyhedron(P)
             sage: C.join_of_Vrep(0,1)
@@ -2641,7 +2637,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: P = polytopes.dodecahedron()
             sage: C = CombinatorialPolyhedron(P)
             sage: C.meet_of_Hrep(0)
@@ -2683,7 +2678,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(5)
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator(dimension=2)
@@ -2857,7 +2851,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs sage.rings.number_field
             sage: P = polytopes.regular_polygon(4).pyramid()
             sage: C = CombinatorialPolyhedron(P)
             sage: D = C.hasse_diagram(); D
@@ -2954,7 +2947,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.cube()
             sage: C = CombinatorialPolyhedron(P)
             sage: F = C.face_lattice()
@@ -3029,7 +3021,6 @@ cdef class CombinatorialPolyhedron(SageObject):
             sage: [face.ambient_V_indices() for face in chain]
             [(15,), (6, 15), (5, 6, 14, 15), (0, 5, 6, 7, 8, 9, 14, 15)]
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(4)
             sage: C = P.combinatorial_polyhedron()
             sage: chain = C.a_maximal_chain(); chain
@@ -3395,7 +3386,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         One can specify a name for the new facets::
 
-            sage: # needs sage.rings.number_field
             sage: P = polytopes.regular_polygon(4)
             sage: C = P.combinatorial_polyhedron()
             sage: C1 = C.pyramid(new_facet='base')
@@ -3781,7 +3771,6 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         TESTS::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(4)
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator()

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/combinatorial_face.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/combinatorial_face.pyx
@@ -260,7 +260,6 @@ cdef class CombinatorialFace(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(6)
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator(dimension=3, algorithm='primal')
@@ -319,7 +318,6 @@ cdef class CombinatorialFace(SageObject):
 
         TESTS::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(5)
             sage: C = CombinatorialPolyhedron(P)
             sage: F = C.face_lattice()
@@ -503,7 +501,6 @@ cdef class CombinatorialFace(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.associahedron(['A', 3])
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator()
@@ -548,7 +545,6 @@ cdef class CombinatorialFace(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(5)
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator(dimension=2)
@@ -613,7 +609,6 @@ cdef class CombinatorialFace(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(5)
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator(dimension=2)
@@ -693,7 +688,6 @@ cdef class CombinatorialFace(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(5)
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator(2)
@@ -754,7 +748,6 @@ cdef class CombinatorialFace(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(5)
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator(2)
@@ -835,7 +828,6 @@ cdef class CombinatorialFace(SageObject):
 
         Specifying whether to count the equations or not::
 
-            sage: # needs sage.combinat
             sage: P = polytopes.permutahedron(5)
             sage: C = CombinatorialPolyhedron(P)
             sage: it = C.face_generator(2)

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/conversions.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/conversions.pyx
@@ -31,7 +31,6 @@ Obtain the facets of a polyhedron as :class:`~sage.geometry.polyhedron.combinato
 Obtain the Vrepresentation of a polyhedron as facet-incidences stored in
 :class:`~sage.geometry.polyhedron.combinatorial_polyhedron.list_of_faces.ListOfFaces`::
 
-    sage: # needs sage.combinat
     sage: from sage.geometry.polyhedron.combinatorial_polyhedron.conversions \
     ....:         import incidence_matrix_to_bit_rep_of_Vrep
     sage: P = polytopes.associahedron(['A',4])

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/face_iterator.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/face_iterator.pyx
@@ -639,7 +639,6 @@ cdef class FaceIterator_base(SageObject):
 
         If the iterator has already been used, it must be reset before::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: P = polytopes.dodecahedron()
             sage: it = P.face_generator()
             sage: _ = next(it), next(it)
@@ -725,7 +724,6 @@ cdef class FaceIterator_base(SageObject):
 
         If the iterator has already been used, it must be reset before::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: P = polytopes.dodecahedron()
             sage: it = P.face_generator()
             sage: _ = next(it), next(it)
@@ -850,7 +848,6 @@ cdef class FaceIterator_base(SageObject):
 
         The face iterator must not have the output dimension specified::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: P = polytopes.dodecahedron()
             sage: it = P.face_generator(2)
             sage: it._meet_of_coatoms(1,2)
@@ -960,7 +957,6 @@ cdef class FaceIterator_base(SageObject):
 
         If the iterator has already been used, it must be reset before::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: P = polytopes.dodecahedron()
             sage: it = P.face_generator()
             sage: _ = next(it), next(it)
@@ -976,7 +972,6 @@ cdef class FaceIterator_base(SageObject):
 
         The face iterator must not have the output dimension specified::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: P = polytopes.dodecahedron()
             sage: it = P.face_generator(2)
             sage: it._join_of_atoms(1,2)

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/list_of_faces.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/list_of_faces.pyx
@@ -39,7 +39,6 @@ Obtain the facets of a polyhedron::
 
 Obtain the Vrepresentation of a polyhedron as facet-incidences::
 
-    sage: # needs sage.combinat
     sage: from sage.geometry.polyhedron.combinatorial_polyhedron.conversions \
     ....:         import incidence_matrix_to_bit_rep_of_Vrep
     sage: P = polytopes.associahedron(['A',3])

--- a/src/sage/geometry/polyhedron/constructor.py
+++ b/src/sage/geometry/polyhedron/constructor.py
@@ -448,7 +448,6 @@ def Polyhedron(vertices=None, rays=None, lines=None,
     by the cyclic shifts of `(0, \pm 1, \pm (1+\sqrt(5))/2)`, cf.
     :wikipedia:`Regular_icosahedron`. It needs a number field::
 
-        sage: # needs sage.rings.number_field
         sage: R0.<r0> = QQ[]
         sage: R1.<r1> = NumberField(r0^2-5, embedding=AA(5)**(1/2))
         sage: gold = (1+r1)/2
@@ -463,7 +462,6 @@ def Polyhedron(vertices=None, rays=None, lines=None,
     When the input contains elements of a Number Field, they require an
     embedding::
 
-        sage: # needs sage.rings.number_field
         sage: x = polygen(ZZ, 'x')
         sage: K = NumberField(x^2 - 2,'s')
         sage: s = K.0
@@ -506,7 +504,6 @@ def Polyhedron(vertices=None, rays=None, lines=None,
         sage: Polyhedron(p)
         A 2-dimensional polyhedron in QQ^2 defined as the convex hull of 4 vertices
 
-        sage: # needs sage.combinat
         sage: H.<x,y> = HyperplaneArrangements(QQ)
         sage: h = x + y - 1; h
         Hyperplane x + y - 1

--- a/src/sage/geometry/polyhedron/double_description.py
+++ b/src/sage/geometry/polyhedron/double_description.py
@@ -405,7 +405,6 @@ class DoubleDescriptionPair:
             sage: DD.matrix_space(3,2)
             Full MatrixSpace of 3 by 2 dense matrices over Rational Field
 
-            sage: # needs sage.rings.number_field
             sage: K.<sqrt2> = QuadraticField(2)
             sage: A = matrix([[1,sqrt2],[2,0]])
             sage: DD, _  = Problem(A).initial_pair()

--- a/src/sage/geometry/polyhedron/library.py
+++ b/src/sage/geometry/polyhedron/library.py
@@ -518,7 +518,6 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: octagon = polytopes.regular_polygon(8)
             sage: octagon
             A 2-dimensional polyhedron in AA^2 defined as the convex hull of 8 vertices
@@ -804,7 +803,6 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: d12 = polytopes.dodecahedron()
             sage: d12.f_vector()
             (1, 20, 30, 12, 1)
@@ -1320,7 +1318,6 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: sc_inexact = polytopes.snub_cube(exact=False); sc_inexact
             A 3-dimensional polyhedron in RDF^3 defined as the convex hull of 24 vertices
             sage: sc_inexact.f_vector()
@@ -2489,7 +2486,6 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: h_4_2 = polytopes.hypersimplex(4, 2)
             sage: h_4_2
             A 3-dimensional polyhedron in ZZ^4 defined as the convex hull of 6 vertices
@@ -2499,7 +2495,6 @@ class Polytopes:
             2/3*t^3 + 2*t^2 + 7/3*t + 1
             sage: TestSuite(h_4_2).run()
 
-            sage: # needs sage.combinat
             sage: h_7_3 = polytopes.hypersimplex(7, 3, project=True)
             sage: h_7_3
             A 6-dimensional polyhedron in RDF^6 defined as the convex hull of 35 vertices
@@ -2637,7 +2632,6 @@ class Polytopes:
         You can put the starting point along the hyperplane of the first
         generator::
 
-            sage: # needs sage.combinat
             sage: perm_a3_011 = polytopes.generalized_permutahedron(['A',3], [0,1,1])
             sage: perm_a3_011
             A 3-dimensional polyhedron in QQ^3 defined as the convex hull of 12 vertices
@@ -2731,7 +2725,6 @@ class Polytopes:
 
         Larger examples take longer::
 
-            sage: # needs sage.combinat sage.rings.number_field
             sage: perm_a3_reg = polytopes.generalized_permutahedron(    # long time
             ....:     ['A',3], regular=True); perm_a3_reg
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 24 vertices
@@ -2744,7 +2737,6 @@ class Polytopes:
         It is faster with the backend ``'number_field'``, which internally uses an embedded
         number field instead of doing the computations directly with the base ring (``AA``)::
 
-            sage: # needs sage.combinat sage.rings.number_field
             sage: perm_a3_reg_nf = polytopes.generalized_permutahedron(
             ....:    ['A',3], regular=True, backend='number_field'); perm_a3_reg_nf
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 24 vertices

--- a/src/sage/geometry/polyhedron/parent.py
+++ b/src/sage/geometry/polyhedron/parent.py
@@ -271,7 +271,6 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             sage: P.cardinality()
             +Infinity
 
-            sage: # needs sage.rings.number_field
             sage: P = Polyhedra(AA, 0)
             sage: P.category()
             Category of finite enumerated polyhedral sets over Algebraic Real Field
@@ -595,7 +594,6 @@ class Polyhedra_base(UniqueRepresentation, Parent):
 
         Check that :issue:`21270` is fixed::
 
-            sage: # needs sage.rings.number_field
             sage: poly = polytopes.regular_polygon(7)
             sage: lp, x = poly.to_linear_program(solver='InteractiveLP',
             ....:                                return_variable=True)
@@ -624,7 +622,6 @@ class Polyhedra_base(UniqueRepresentation, Parent):
 
         When the parent of the object is not ``self``, the default is not to copy::
 
-            sage: # needs sage.rings.number_field
             sage: Q = P.base_extend(AA)
             sage: q = Q._element_constructor_(p)
             sage: q is p

--- a/src/sage/geometry/polyhedron/plot.py
+++ b/src/sage/geometry/polyhedron/plot.py
@@ -346,7 +346,6 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: p = polytopes.icosahedron(exact=False)
             sage: from sage.geometry.polyhedron.plot import Projection
             sage: Projection(p)
@@ -412,7 +411,6 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: p = polytopes.icosahedron(exact=False)
             sage: from sage.geometry.polyhedron.plot import Projection
             sage: pproj = Projection(p)
@@ -437,7 +435,6 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: p = polytopes.icosahedron(exact=False)
             sage: from sage.geometry.polyhedron.plot import Projection
             sage: pproj = Projection(p)
@@ -954,7 +951,6 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: hex = polytopes.regular_polygon(6)
             sage: proj = hex.projection()
             sage: hex_points = proj.render_points_2d()                                  # needs sage.plot
@@ -1172,7 +1168,6 @@ class Projection(SageObject):
 
         It correctly handles various degenerate cases::
 
-            sage: # needs sage.plot
             sage: Polyhedron(lines=[[1,0,0], [0,1,0], [0,0,1]]).plot()  # whole space
             Graphics3d Object
             sage: Polyhedron(vertices=[[1,1,1]], rays=[[1,0,0]],
@@ -1294,7 +1289,6 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.plot sage.rings.number_field
             sage: P1 = polytopes.small_rhombicuboctahedron()
             sage: Image1 = P1.projection().tikz([1,3,5], 175, scale=4,
             ....:                               output_type='TikzPicture')
@@ -1349,7 +1343,6 @@ class Projection(SageObject):
 
         The second example using a LatexExpr as output type::
 
-            sage: # needs sage.plot
             sage: Image2 = P2.projection().tikz(scale=3, edge_color='blue!95!black',
             ....:                               facet_color='orange!95!black', opacity=0.4,
             ....:                               vertex_color='yellow', axis=True,
@@ -1366,7 +1359,6 @@ class Projection(SageObject):
 
         A third example::
 
-            sage: # needs sage.plot
             sage: P3 = Polyhedron(vertices=[[-1, -1, 2], [-1, 2, -1], [2, -1, -1]]); P3
             A 2-dimensional polyhedron in ZZ^3 defined as the convex hull of 3 vertices
             sage: Image3 = P3.projection().tikz([0.5, -1, -0.1], 55, scale=3,
@@ -1612,7 +1604,6 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.plot
             sage: P = Polyhedron(vertices=[[-1, -1, 2], [-1, 2, -1], [2, -1, -1]]); P
             A 2-dimensional polyhedron in ZZ^3 defined as the convex hull of 3 vertices
             sage: Image = P.projection()._tikz_2d_in_3d(view=[0.5, -1, -0.5], angle=55, scale=3,
@@ -1764,7 +1755,6 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.plot sage.rings.number_field
             sage: P = polytopes.small_rhombicuboctahedron()
             sage: Image = P.projection()._tikz_3d_in_3d([3, 7, 5], 100, scale=3,
             ....:                                       edge_color='blue', facet_color='orange',
@@ -1781,7 +1771,6 @@ class Projection(SageObject):
 
         ::
 
-            sage: # needs sage.plot
             sage: Associahedron = Polyhedron(vertices=[[1, 0, 1], [1, 0, 0], [1, 1, 0],
             ....:                                      [0, 0, -1], [0, 1, 0], [-1, 0, 0],
             ....:                                      [0, 1, 1], [0, 0, 1], [0, -1, 0]]).polar()
@@ -1942,7 +1931,6 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.plot sage.rings.number_field
             sage: P = polytopes.small_rhombicuboctahedron()
             sage: from sage.geometry.polyhedron.plot import Projection
             sage: proj = Projection(P)

--- a/src/sage/geometry/polyhedron/ppl_lattice_polytope.py
+++ b/src/sage/geometry/polyhedron/ppl_lattice_polytope.py
@@ -959,7 +959,6 @@ class LatticePolytope_PPL_class(C_Polyhedron):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs sage.groups
             sage: from sage.geometry.polyhedron.ppl_lattice_polytope import LatticePolytope_PPL
             sage: Z3square = LatticePolytope_PPL((0,0), (1,2), (2,1), (3,3))
             sage: G1234 = Z3square.restricted_automorphism_group(

--- a/src/sage/geometry/toric_plotter.py
+++ b/src/sage/geometry/toric_plotter.py
@@ -752,7 +752,6 @@ def color_list(color, n):
 
     EXAMPLES::
 
-        sage: # needs sage.plot
         sage: from sage.geometry.toric_plotter import color_list
         sage: color_list("grey", 1)
         [RGB color (0.5019607843137255, 0.5019607843137255, 0.5019607843137255)]

--- a/src/sage/geometry/voronoi_diagram.py
+++ b/src/sage/geometry/voronoi_diagram.py
@@ -255,7 +255,6 @@ class VoronoiDiagram(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.plot
             sage: P = [[0.671, 0.650], [0.258, 0.767], [0.562, 0.406],
             ....:      [0.254, 0.709], [0.493, 0.879]]
             sage: V = VoronoiDiagram(P); S=V.plot()


### PR DESCRIPTION
These are just line noise at this point. No one is maintaining them, and there's no way to install Sage without these components.
