### PR TITLE
some code cleanup in quaternion algebras

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -318,10 +318,9 @@ class QuaternionAlgebraFactory(UniqueFactory):
         sage: ram = QuaternionAlgebra(K, [P, Q], inv_arch).ramified_places()
         sage: set(ram[0]) == set([P,Q]) and ram[1] == emb_arch
         True
-
     """
     def create_key(self, arg0, arg1=None, arg2=None, names='i,j,k'):
-        """
+        r"""
         Create a key that uniquely determines a quaternion algebra.
 
         TESTS::
@@ -437,7 +436,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
         return K, a, b, names
 
     def create_object(self, version, key, **extra_args):
-        """
+        r"""
         Create the object from the key (extra arguments are ignored). This is
         only called if the object was not found in the cache.
 
@@ -459,7 +458,7 @@ QuaternionAlgebra = QuaternionAlgebraFactory("QuaternionAlgebra")
 
 class QuaternionAlgebra_abstract(Parent):
     def _repr_(self) -> str:
-        """
+        r"""
         EXAMPLES::
 
             sage: sage.algebras.quatalg.quaternion_algebra.QuaternionAlgebra_abstract(QQ)._repr_()
@@ -468,7 +467,7 @@ class QuaternionAlgebra_abstract(Parent):
         return f"Quaternion Algebra with base ring {self.base_ring()}"
 
     def ngens(self) -> int:
-        """
+        r"""
         Return the number of generators of the quaternion algebra as a K-vector
         space, not including 1.
 
@@ -487,7 +486,7 @@ class QuaternionAlgebra_abstract(Parent):
 
     @cached_method
     def basis(self):
-        """
+        r"""
         Return the fixed basis of ``self``, which is `1`, `i`, `j`, `k`, where
         `i`, `j`, `k` are the generators of ``self``.
 
@@ -511,7 +510,7 @@ class QuaternionAlgebra_abstract(Parent):
 
     @cached_method
     def inner_product_matrix(self):
-        """
+        r"""
         Return the inner product matrix associated to ``self``.
 
         This is the
@@ -535,7 +534,7 @@ class QuaternionAlgebra_abstract(Parent):
         return M
 
     def is_division_algebra(self) -> bool:
-        """
+        r"""
         Check whether this quaternion algebra is a division algebra,
         i.e., whether every nonzero element in it is invertible.
 
@@ -576,7 +575,7 @@ class QuaternionAlgebra_abstract(Parent):
             raise NotImplementedError("base ring must be rational numbers or a number field")
 
     def is_matrix_ring(self) -> bool:
-        """
+        r"""
         Check whether this quaternion algebra is isomorphic to the
         2x2 matrix ring over the base ring.
 
@@ -617,7 +616,7 @@ class QuaternionAlgebra_abstract(Parent):
             raise NotImplementedError("base ring must be rational numbers or a number field")
 
     def is_exact(self) -> bool:
-        """
+        r"""
         Return ``True`` if elements of this quaternion algebra are represented
         exactly, i.e. there is no precision loss when doing arithmetic. A
         quaternion algebra is exact if and only if its base field is
@@ -635,7 +634,7 @@ class QuaternionAlgebra_abstract(Parent):
         return self.base_ring().is_exact()
 
     def is_field(self, proof=True) -> bool:
-        """
+        r"""
         Return ``False`` always, since all quaternion algebras are
         noncommutative and all fields are commutative.
 
@@ -648,7 +647,7 @@ class QuaternionAlgebra_abstract(Parent):
         return False
 
     def is_finite(self) -> bool:
-        """
+        r"""
         Return ``True`` if the quaternion algebra is finite as a set.
 
         Algorithm: A quaternion algebra is finite if and only if the
@@ -666,7 +665,7 @@ class QuaternionAlgebra_abstract(Parent):
         return self.base_ring().is_finite()
 
     def is_integral_domain(self, proof=True) -> bool:
-        """
+        r"""
         Return ``False`` always, since all quaternion algebras are
         noncommutative and integral domains are commutative (in Sage).
 
@@ -679,7 +678,7 @@ class QuaternionAlgebra_abstract(Parent):
         return False
 
     def is_noetherian(self) -> bool:
-        """
+        r"""
         Return ``True`` always, since any quaternion algebra is a Noetherian
         ring (because it is a finitely generated module over a field).
 
@@ -692,7 +691,7 @@ class QuaternionAlgebra_abstract(Parent):
         return True
 
     def order(self):
-        """
+        r"""
         Return the number of elements of the quaternion algebra, or
         ``+Infinity`` if the algebra is not finite.
 
@@ -708,7 +707,7 @@ class QuaternionAlgebra_abstract(Parent):
         return self.base_ring().order()**4
 
     def random_element(self, *args, **kwds):
-        """
+        r"""
         Return a random element of this quaternion algebra.
 
         The ``args`` and ``kwds`` are passed to the ``random_element`` method
@@ -743,7 +742,7 @@ class QuaternionAlgebra_abstract(Parent):
 
     @cached_method
     def free_module(self):
-        """
+        r"""
         Return the free module associated to ``self`` with inner
         product given by the reduced norm.
 
@@ -763,7 +762,7 @@ class QuaternionAlgebra_abstract(Parent):
         return FreeModule(self.base_ring(), 4, inner_product_matrix=self.inner_product_matrix())
 
     def vector_space(self):
-        """
+        r"""
         Alias for :meth:`free_module`.
 
         EXAMPLES::
@@ -780,7 +779,7 @@ class QuaternionAlgebra_abstract(Parent):
 
 
 class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
-    """
+    r"""
     A quaternion algebra of the form `(a, b)_K`.
 
     See ``QuaternionAlgebra`` for many more examples.
@@ -802,7 +801,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         Quaternion Algebra (-7, -21) with base ring Rational Field
     """
     def __init__(self, base_ring, a, b, names='i,j,k') -> None:
-        """
+        r"""
         Create the quaternion algebra with `i^2 = a`, `j^2 = b`, and
         `ij = -ji = k`.
 
@@ -1125,7 +1124,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return self.quaternion_order(e_new)
 
     def order_with_level(self, level):
-        """
+        r"""
         Return an order in this quaternion algebra with given level.
 
         INPUT:
@@ -1195,7 +1194,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return O
 
     def invariants(self):
-        """
+        r"""
         Return the structural invariants `a`, `b` of this quaternion
         algebra: ``self`` is generated by `i`, `j` subject to
         `i^2 = a`, `j^2 = b` and `ji = -ij`.
@@ -1213,7 +1212,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return self._a, self._b
 
     def __eq__(self, other) -> bool:
-        """
+        r"""
         Compare ``self`` and ``other``.
 
         EXAMPLES::
@@ -1228,7 +1227,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return (self.base_ring(), self._a, self._b) == (other.base_ring(), other._a, other._b)
 
     def __ne__(self, other) -> bool:
-        """
+        r"""
         Compare ``self`` and ``other``.
 
         EXAMPLES::
@@ -1241,7 +1240,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        """
+        r"""
         Compute the hash of ``self``.
 
         EXAMPLES::
@@ -1255,7 +1254,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return hash((self.base_ring(), self._a, self._b))
 
     def gen(self, i=0):
-        """
+        r"""
         Return the `i`-th generator of ``self``.
 
         INPUT:
@@ -1278,7 +1277,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return self._gens[i]
 
     def gens(self) -> tuple:
-        """
+        r"""
         Return the generators of ``self``.
 
         EXAMPLES::
@@ -1291,7 +1290,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return self._gens
 
     def _repr_(self):
-        """
+        r"""
         Print representation.
 
         TESTS::
@@ -1311,7 +1310,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return f"Quaternion Algebra ({self._a!r}, {self._b!r}) with base ring {self.base_ring()}"
 
     def inner_product_matrix(self):
-        """
+        r"""
         Return the inner product matrix associated to ``self``, i.e. the
         Gram matrix of the reduced norm as a quadratic form on ``self``.
         The standard basis `1`, `i`, `j`, `k` is orthogonal, so this matrix
@@ -1364,7 +1363,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return a < 0 and b < 0
 
     def is_totally_definite(self):
-        """
+        r"""
         Check whether this quaternion algebra is totally definite.
 
         A quaternion algebra defined over a number field is
@@ -1700,7 +1699,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             raise NotImplementedError("base field must be rational numbers or a number field")
 
     def _magma_init_(self, magma):
-        """
+        r"""
         Return Magma version of this quaternion algebra.
 
         EXAMPLES::
@@ -1731,7 +1730,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         return f'QuaternionAlgebra({R.name()},{self._a._magma_init_(magma)},{self._b._magma_init_(magma)})'
 
     def quaternion_order(self, basis, check=True):
-        """
+        r"""
         Return the order of this quaternion order with given basis.
 
         INPUT:
@@ -1935,7 +1934,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 # Unpickling
 ############################################################
 def unpickle_QuaternionAlgebra_v0(*key):
-    """
+    r"""
     The `0`-th version of pickling for quaternion algebras.
 
     EXAMPLES::
@@ -1954,7 +1953,7 @@ def unpickle_QuaternionAlgebra_v0(*key):
 
 @richcmp_method
 class QuaternionOrder(Parent):
-    """
+    r"""
     An order in a quaternion algebra.
 
     EXAMPLES::
@@ -1965,7 +1964,7 @@ class QuaternionOrder(Parent):
         <class 'sage.algebras.quatalg.quaternion_algebra.QuaternionOrder_with_category'>
     """
     def __init__(self, A, basis, check=True) -> None:
-        """
+        r"""
         INPUT:
 
         - ``A`` -- a quaternion algebra
@@ -2078,7 +2077,7 @@ class QuaternionOrder(Parent):
                         category=Algebras(ZZ).Facade().FiniteDimensional())
 
     def _element_constructor_(self, x):
-        """
+        r"""
         Construct an element of this quaternion order from ``x``,
         or throw an error if ``x`` is not contained in the order.
 
@@ -2109,7 +2108,7 @@ class QuaternionOrder(Parent):
         return y
 
     def one(self):
-        """
+        r"""
         Return the multiplicative unit of this quaternion order.
 
         EXAMPLES::
@@ -2120,7 +2119,7 @@ class QuaternionOrder(Parent):
         return self.quaternion_algebra().one()
 
     def gens(self) -> tuple:
-        """
+        r"""
         Return generators for ``self``.
 
         EXAMPLES::
@@ -2131,7 +2130,7 @@ class QuaternionOrder(Parent):
         return self.__basis
 
     def ngens(self):
-        """
+        r"""
         Return the number of generators (which is 4).
 
         EXAMPLES::
@@ -2142,7 +2141,7 @@ class QuaternionOrder(Parent):
         return 4
 
     def gen(self, n):
-        """
+        r"""
         Return the `n`-th generator.
 
         INPUT:
@@ -2166,7 +2165,7 @@ class QuaternionOrder(Parent):
         return self.__basis[n]
 
     def __richcmp__(self, other, op) -> bool:
-        """
+        r"""
         Compare this quaternion order to ``other``.
 
         EXAMPLES::
@@ -2218,7 +2217,7 @@ class QuaternionOrder(Parent):
         return richcmp(self.unit_ideal(), other.unit_ideal(), op)
 
     def __hash__(self) -> int:
-        """
+        r"""
         Compute the hash of ``self``.
 
         EXAMPLES::
@@ -2232,7 +2231,7 @@ class QuaternionOrder(Parent):
         return hash((self.__quaternion_algebra, self.__basis))
 
     def basis(self):
-        """
+        r"""
         Return fix choice of basis for this quaternion order.
 
         EXAMPLES::
@@ -2243,7 +2242,7 @@ class QuaternionOrder(Parent):
         return self.__basis
 
     def quaternion_algebra(self):
-        """
+        r"""
         Return ambient quaternion algebra that contains this quaternion order.
 
         EXAMPLES::
@@ -2254,7 +2253,7 @@ class QuaternionOrder(Parent):
         return self.__quaternion_algebra
 
     def _repr_(self):
-        """
+        r"""
         Return string representation of this order.
 
         EXAMPLES::
@@ -2267,7 +2266,7 @@ class QuaternionOrder(Parent):
         return f'Order of {self.quaternion_algebra()} with basis {self.basis()}'
 
     def random_element(self, *args, **kwds):
-        """
+        r"""
         Return a random element of this order.
 
         The args and kwds are passed to the random_element method of
@@ -2290,7 +2289,7 @@ class QuaternionOrder(Parent):
         return sum(ZZ.random_element(*args, **kwds) * b for b in self.basis())
 
     def intersection(self, other):
-        """
+        r"""
         Return the intersection of this order with other.
 
         INPUT:
@@ -2421,7 +2420,7 @@ class QuaternionOrder(Parent):
         return self.discriminant() == self.quaternion_algebra().discriminant()
 
     def _left_ideal_basis(self, gens):
-        """
+        r"""
         Return a basis for the left ideal of ``self`` with given generators.
 
         INPUT:
@@ -2441,7 +2440,7 @@ class QuaternionOrder(Parent):
         return basis_for_quaternion_lattice([b * g for b in self.basis() for g in gens])
 
     def _right_order_from_ideal_basis(self, basis):
-        """
+        r"""
         Given a basis for a left ideal `I`, return the right order in
         ``self`` of elements `x` such that `I x` is contained in `I`.
 
@@ -2575,7 +2574,7 @@ class QuaternionOrder(Parent):
 
     @cached_method
     def unit_ideal(self):
-        """
+        r"""
         Return the unit ideal in this quaternion order.
 
         EXAMPLES::
@@ -2625,7 +2624,7 @@ class QuaternionOrder(Parent):
         return matrix(QQ, map(list, self.__basis))
 
     def __mul__(self, other):
-        """
+        r"""
         Every order equals its own unit ideal. Overload ideal multiplication
         and scaling to orders.
 
@@ -2642,7 +2641,7 @@ class QuaternionOrder(Parent):
         return other * self.unit_ideal()
 
     def __add__(self, other):
-        """
+        r"""
         Every order equals its own unit ideal. Overload ideal addition
         to orders.
 
@@ -2656,7 +2655,7 @@ class QuaternionOrder(Parent):
         return self.unit_ideal() + other
 
     def quadratic_form(self):
-        """
+        r"""
         Return the normalized quadratic form associated to this quaternion order.
 
         OUTPUT: quadratic form
@@ -2976,7 +2975,7 @@ class QuaternionFractionalIdeal(Ideal_fractional):
 
 
 class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
-    """
+    r"""
     A fractional ideal in a rational quaternion algebra.
 
     INPUT:
@@ -2986,14 +2985,14 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
     - ``right_order`` -- a quaternion order or ``None``
 
     - ``basis`` -- tuple of length 4 of elements in of ambient
-      quaternion algebra whose `\\ZZ`-span is an ideal
+      quaternion algebra whose `\ZZ`-span is an ideal
 
     - ``check`` -- boolean (default: ``True``); if ``False``, do no type
       checking.
     """
     def __init__(self, Q, basis, left_order=None,
                  right_order=None, check=True) -> None:
-        """
+        r"""
         EXAMPLES::
 
             sage: R = QuaternionAlgebra(-11,-1).maximal_order()
@@ -3104,7 +3103,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
                        left_order=left_order, right_order=right_order)
 
     def quaternion_algebra(self):
-        """
+        r"""
         Return the ambient quaternion algebra that contains this fractional ideal.
 
         This is an alias for `self.ring()`.
@@ -3187,7 +3186,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return Q.quaternion_order(ISB)
 
     def left_order(self):
-        """
+        r"""
         Return the left order associated to this fractional ideal.
 
         OUTPUT: an order in a quaternion algebra
@@ -3212,7 +3211,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return self.__left_order
 
     def right_order(self):
-        """
+        r"""
         Return the right order associated to this fractional ideal.
 
         OUTPUT: an order in a quaternion algebra
@@ -3248,7 +3247,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return self.__right_order
 
     def __repr__(self) -> str:
-        """
+        r"""
         Return string representation of this quaternion fractional ideal.
 
         EXAMPLES::
@@ -3262,7 +3261,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return f'Fractional ideal {self.gens()}'
 
     def random_element(self, *args, **kwds):
-        """
+        r"""
         Return a random element in the rational fractional ideal ``self``.
 
         EXAMPLES::
@@ -3275,7 +3274,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return sum(ZZ.random_element(*args, **kwds) * g for g in self.gens())
 
     def basis(self):
-        """
+        r"""
         Return a basis for this fractional ideal.
 
         OUTPUT: tuple
@@ -3288,7 +3287,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return self.gens()
 
     def _richcmp_(self, right, op):
-        """
+        r"""
         Compare this fractional quaternion ideal to ``right``.
 
         EXAMPLES::
@@ -3341,7 +3340,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return self.free_module().__richcmp__(right.free_module(), op)
 
     def __hash__(self) -> int:
-        """
+        r"""
         Return the hash of ``self``.
 
         EXAMPLES::
@@ -3449,7 +3448,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
     @cached_method
     def quadratic_form(self):
-        """
+        r"""
         Return the normalized quadratic form associated to this quaternion ideal.
 
         OUTPUT: quadratic form
@@ -3577,7 +3576,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return M44(m, coerce=False)
 
     def norm(self):
-        """
+        r"""
         Return the reduced norm of this fractional ideal.
 
         OUTPUT: rational number
@@ -3616,7 +3615,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return r.sqrt()
 
     def conjugate(self):
-        """
+        r"""
         Return the ideal with generators the conjugates of the generators for ``self``.
 
         OUTPUT: a quaternionic fractional ideal
@@ -3633,7 +3632,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
                                                right_order=self.__left_order)
 
     def __mul__(self, right):
-        """
+        r"""
         Return the product of the fractional ideals ``self`` and ``right``.
 
         .. NOTE::
@@ -3664,7 +3663,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return A.ideal(basis, check=False)
 
     def __add__(self, other):
-        """
+        r"""
         Return the sum of the fractional ideals ``self`` and ``other``.
 
         EXAMPLES::
@@ -3683,7 +3682,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return self.quaternion_algebra().ideal(self.basis() + other.basis())
 
     def _acted_upon_(self, other, on_left):
-        """
+        r"""
         Scale a quaternion ideal.
 
         EXAMPLES::
@@ -3764,7 +3763,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return self.basis_matrix().row_module(ZZ)
 
     def intersection(self, J):
-        """
+        r"""
         Return the intersection of the ideals ``self`` and `J`.
 
         EXAMPLES::
@@ -3780,7 +3779,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return A.ideal(gens)
 
     def multiply_by_conjugate(self, J):
-        """
+        r"""
         Return product of ``self`` and the conjugate Jbar of `J`.
 
         INPUT:
@@ -3804,7 +3803,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return R.ideal(basis, check=False)
 
     def pushforward(self, J, side=None):
-        """
+        r"""
         Compute the ideal which is the pushforward of ``self`` through an ideal ``J``.
 
         Uses Lemma 2.1.7 of [Ler2022]_. Only works for integral ideals.
@@ -3896,7 +3895,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         raise ValueError('side must be "left", "right" or None')
 
     def pullback(self, J, side=None):
-        """
+        r"""
         Compute the ideal which is the pullback of ``self`` through an ideal ``J``.
 
         Uses Lemma 2.1.7 of [Ler2022]_. Only works for integral ideals.
@@ -4145,7 +4144,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         return True, self.minimal_element()
 
     def __contains__(self, x) -> bool:
-        """
+        r"""
         Return whether ``x`` is in ``self``.
 
         EXAMPLES::

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -1757,11 +1757,13 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         """
         return QuaternionOrder(self, basis, check=check)
 
-    def ideal(self, gens, left_order=None, right_order=None, check=True, **kwds):
+    def fractional_ideal(self, gens, left_order=None, right_order=None, check=True, **kwds):
         r"""
-        Return the quaternion ideal with given gens over `\ZZ`.
+        Return the quaternion fractional ideal with the given ``gens``,
+        which must be elements of this algebra that span a `\ZZ`-module
+        of rank `4`.
 
-        Neither a left or right order structure need be specified.
+        Neither a left or right order need be specified.
 
         INPUT:
 
@@ -1784,6 +1786,8 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             return QuaternionFractionalIdeal_rational(self, gens, left_order=left_order, right_order=right_order, check=check)
         else:
             raise NotImplementedError("ideal only implemented for quaternion algebras over QQ")
+
+    ideal = fractional_ideal  # legacy alias
 
     @cached_method
     def modp_splitting_data(self, p):

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -510,13 +510,13 @@ class QuaternionAlgebra_abstract(Parent):
     @cached_method
     def inner_product_matrix(self):
         r"""
-        Return the inner product matrix associated to ``self``.
+        Return the inner product matrix associated to this quaternion algebra,
+        i.e. the Gram matrix of the reduced norm as a quadratic form on ``self``.
 
-        This is the
-        Gram matrix of the reduced norm as a quadratic form on ``self``.
         The standard basis `1`, `i`, `j`, `k` is orthogonal, so this matrix
-        is just the diagonal matrix with diagonal entries `2`, `-2a`, `-2b`,
-        `2ab`.
+        is just the diagonal matrix with diagonal entries `2`, `-2a`, `-2b`, `2ab`.
+
+        Alias: :meth:`gram_matrix`
 
         EXAMPLES::
 
@@ -526,11 +526,22 @@ class QuaternionAlgebra_abstract(Parent):
             [  0  10   0   0]
             [  0   0  38   0]
             [  0   0   0 190]
+
+        ::
+
+            sage: R.<a,b> = QQ[]; Q.<i,j,k> = QuaternionAlgebra(Frac(R),a,b)
+            sage: Q.gram_matrix()
+            [    2     0     0     0]
+            [    0  -2*a     0     0]
+            [    0     0  -2*b     0]
+            [    0     0     0 2*a*b]
         """
         a, b = self._a, self._b
         M = diagonal_matrix(self.base_ring(), [2, -2 * a, -2 * b, 2 * a * b])
         M.set_immutable()
         return M
+
+    gram_matrix = inner_product_matrix  # alias
 
     def is_division_algebra(self) -> bool:
         r"""
@@ -742,8 +753,10 @@ class QuaternionAlgebra_abstract(Parent):
     @cached_method
     def free_module(self):
         r"""
-        Return the free module associated to ``self`` with inner
-        product given by the reduced norm.
+        Return the free module associated to this quaternion algebra
+        with inner product given by the :meth:`inner_product_matrix`.
+
+        Alias: :meth:`vector_space`
 
         EXAMPLES::
 
@@ -757,15 +770,6 @@ class QuaternionAlgebra_abstract(Parent):
               [0 2 0 0]
               [0 0 t 0]
               [0 0 0 t]
-        """
-        return FreeModule(self.base_ring(), 4, inner_product_matrix=self.inner_product_matrix())
-
-    def vector_space(self):
-        r"""
-        Alias for :meth:`free_module`.
-
-        EXAMPLES::
-
             sage: QuaternionAlgebra(-3,19).vector_space()
             Ambient quadratic space of dimension 4 over Rational Field
             Inner product matrix:
@@ -774,7 +778,9 @@ class QuaternionAlgebra_abstract(Parent):
               [   0    0  -38    0]
               [   0    0    0 -114]
         """
-        return self.free_module()
+        return FreeModule(self.base_ring(), 4, inner_product_matrix=self.inner_product_matrix())
+
+    vector_space = free_module  # alias
 
 
 class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
@@ -1307,32 +1313,6 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             'Quaternion Algebra (-5, -2) with base ring Rational Field'
         """
         return f"Quaternion Algebra ({self._a!r}, {self._b!r}) with base ring {self.base_ring()}"
-
-    def inner_product_matrix(self):
-        r"""
-        Return the inner product matrix associated to ``self``, i.e. the
-        Gram matrix of the reduced norm as a quadratic form on ``self``.
-        The standard basis `1`, `i`, `j`, `k` is orthogonal, so this matrix
-        is just the diagonal matrix with diagonal entries `1`, `a`, `b`, `ab`.
-
-        EXAMPLES::
-
-            sage: Q.<i,j,k> = QuaternionAlgebra(-5,-19)
-            sage: Q.inner_product_matrix()
-            [  2   0   0   0]
-            [  0  10   0   0]
-            [  0   0  38   0]
-            [  0   0   0 190]
-
-            sage: R.<a,b> = QQ[]; Q.<i,j,k> = QuaternionAlgebra(Frac(R),a,b)
-            sage: Q.inner_product_matrix()
-            [    2     0     0     0]
-            [    0  -2*a     0     0]
-            [    0     0  -2*b     0]
-            [    0     0     0 2*a*b]
-        """
-        a, b = self._a, self._b
-        return diagonal_matrix(self.base_ring(), [2, -2*a, -2*b, 2*a*b])
 
     def is_definite(self):
         r"""

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -179,7 +179,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
     ``QuaternionAlgebra(K, a, b)`` -- return the quaternion algebra
     defined by `(a, b)` over the ring `K`::
 
-        sage: QuaternionAlgebra(-7, -21)
+        sage: QuaternionAlgebra(QQ, -7, -21)
         Quaternion Algebra (-7, -21) with base ring Rational Field
         sage: QuaternionAlgebra(QQ[sqrt(2)], -2, -3)                                    # needs sage.symbolic
         Quaternion Algebra (-2, -3) with base ring Number Field in sqrt2
@@ -1740,7 +1740,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         which must be elements of this algebra that span a `\ZZ`-module
         of rank `4`.
 
-        Neither a left or right order need be specified.
+        Neither a left nor right order need be specified.
 
         INPUT:
 

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -1,7 +1,9 @@
 """
-Quaternion Algebras
+Quaternion Algebras, Orders, and Ideals
 
 AUTHORS:
+
+- This code is partly based on Sage code by David Kohel from 2005.
 
 - Jon Bobber (2009): rewrite
 
@@ -19,13 +21,11 @@ AUTHORS:
 
 - Eloi Torrents (2024): construct quaternion algebras over number fields from ramification
 
-This code is partly based on Sage code by David Kohel from 2005.
-
 TESTS:
 
 Pickling test::
 
-    sage: Q.<i,j,k> = QuaternionAlgebra(QQ,-5,-2)
+    sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -5, -2)
     sage: Q == loads(dumps(Q))
     True
 """
@@ -180,9 +180,9 @@ class QuaternionAlgebraFactory(UniqueFactory):
     ``QuaternionAlgebra(K, a, b)`` -- return the quaternion algebra
     defined by `(a, b)` over the ring `K`::
 
-        sage: QuaternionAlgebra(QQ, -7, -21)
+        sage: QuaternionAlgebra(-7, -21)
         Quaternion Algebra (-7, -21) with base ring Rational Field
-        sage: QuaternionAlgebra(QQ[sqrt(2)], -2,-3)                                     # needs sage.symbolic
+        sage: QuaternionAlgebra(QQ[sqrt(2)], -2, -3)                                    # needs sage.symbolic
         Quaternion Algebra (-2, -3) with base ring Number Field in sqrt2
          with defining polynomial x^2 - 2 with sqrt2 = 1.414213562373095?
 
@@ -202,21 +202,21 @@ class QuaternionAlgebraFactory(UniqueFactory):
     quaternion algebra over `K` with the ramification specified by
     ``primes`` and ``inv_archimedean``::
 
-        sage: QuaternionAlgebra(QQ, [(2), (3)], [0])
+        sage: QuaternionAlgebra(QQ, [2, 3], [0])
         Quaternion Algebra (-1, 3) with base ring Rational Field
-        sage: QuaternionAlgebra(QQ, [(2), (3)], [1/2])
+        sage: QuaternionAlgebra(QQ, [2, 3], [1/2])
         Traceback (most recent call last):
         ...
         ValueError: quaternion algebra over the rationals must have an even number of ramified places
 
         sage: x = polygen(ZZ, 'x')
-        sage: K.<w> = NumberField(x^2-x-1)
+        sage: K.<w> = NumberField(x^2 - x - 1)
         sage: P = K.prime_above(2)
         sage: Q = K.prime_above(3)
-        sage: A = QuaternionAlgebra(K, [P,Q], [0,0])
+        sage: A = QuaternionAlgebra(K, [P, Q], [0, 0])
         sage: A.discriminant()
         Fractional ideal (6)
-        sage: A = QuaternionAlgebra(K, [P,Q], [1/2,0])
+        sage: A = QuaternionAlgebra(K, [P, Q], [1/2, 0])
         Traceback (most recent call last):
         ...
         ValueError: quaternion algebra over a number field must have an even number of ramified places
@@ -240,7 +240,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
     The list of local invariants specifying the ramification at the
     real places may only contain `0` and `\frac{1}{2}`::
 
-        sage: QuaternionAlgebra(QuadraticField(5), [], [0,1])
+        sage: QuaternionAlgebra(QuadraticField(5), [], [0, 1])
         Traceback (most recent call last):
         ...
         ValueError: list of local invariants specifying ramification should contain only 0 and 1/2
@@ -248,7 +248,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
     Similarly, the list of finite ramified places must consist
     of primes or prime ideals of the number field `K`::
 
-        sage: QuaternionAlgebra(QuadraticField(5), ['water',2], [])
+        sage: QuaternionAlgebra(QuadraticField(5), ['water', 2], [])
         Traceback (most recent call last):
         ...
         ValueError: quaternion algebra constructor requires a list of primes specifying the ramification
@@ -257,26 +257,26 @@ class QuaternionAlgebraFactory(UniqueFactory):
     algebra are not integral, then a slower generic type is used for
     arithmetic::
 
-        sage: type(QuaternionAlgebra(-1,-3).0)
+        sage: type(QuaternionAlgebra(-1, -3).0)
         <... 'sage.algebras.quatalg.quaternion_algebra_element.QuaternionAlgebraElement_rational_field'>
-        sage: type(QuaternionAlgebra(-1,-3/2).0)
+        sage: type(QuaternionAlgebra(-1, -3/2).0)
         <... 'sage.algebras.quatalg.quaternion_algebra_element.QuaternionAlgebraElement_generic'>
 
     Make sure caching is sane::
 
-        sage: A = QuaternionAlgebra(2,3); A
+        sage: A = QuaternionAlgebra(2, 3); A
         Quaternion Algebra (2, 3) with base ring Rational Field
-        sage: B = QuaternionAlgebra(GF(5)(2),GF(5)(3)); B
+        sage: B = QuaternionAlgebra(GF(5)(2), GF(5)(3)); B
         Quaternion Algebra (2, 3) with base ring Finite Field of size 5
-        sage: A is QuaternionAlgebra(2,3)
+        sage: A is QuaternionAlgebra(2, 3)
         True
-        sage: B is QuaternionAlgebra(GF(5)(2),GF(5)(3))
+        sage: B is QuaternionAlgebra(GF(5)(2), GF(5)(3))
         True
         sage: Q = QuaternionAlgebra(2); Q
         Quaternion Algebra (-1, -1) with base ring Rational Field
-        sage: Q is QuaternionAlgebra(QQ,-1,-1)
+        sage: Q is QuaternionAlgebra(QQ, -1, -1)
         True
-        sage: Q is QuaternionAlgebra(-1,-1)
+        sage: Q is QuaternionAlgebra(-1, -1)
         True
         sage: Q.<ii,jj,kk> = QuaternionAlgebra(15); Q.variable_names()
         ('ii', 'jj', 'kk')
@@ -288,7 +288,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
     Verify that bug found when working on :issue:`12006` involving coercing
     invariants into the base field is fixed::
 
-        sage: Q = QuaternionAlgebra(-1,-1); Q
+        sage: Q = QuaternionAlgebra(-1, -1); Q
         Quaternion Algebra (-1, -1) with base ring Rational Field
         sage: parent(Q._a)
         Rational Field
@@ -315,7 +315,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
         sage: Q = K.prime_above(5)
         sage: inv_arch = [1/2, 1/2, 0, 0]
         sage: emb_arch = K.embeddings(AA)[0:2]
-        sage: ram = QuaternionAlgebra(K, [P,Q], inv_arch).ramified_places()
+        sage: ram = QuaternionAlgebra(K, [P, Q], inv_arch).ramified_places()
         sage: set(ram[0]) == set([P,Q]) and ram[1] == emb_arch
         True
 
@@ -362,7 +362,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
             K = arg0
             if K not in NumberFields():
                 raise ValueError("quaternion algebra construction via ramification only works over a number field")
-            if not set(arg2).issubset(set([0, QQ((1, 2))])):
+            if not set(arg2).issubset({0, QQ((1, 2))}):
                 raise ValueError("list of local invariants specifying ramification should contain only 0 and 1/2")
 
             # Check that the finite ramification is given by prime ideals
@@ -413,8 +413,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
                 inv_arch_pari = [arg2[i-1] for i in perm]
 
                 # Compute the correct quaternion algebra over L in PARI
-                A = L.__pari__().alginit([2, [fin_places_pari, [QQ((1, 2))] * len(fin_places_pari)],
-                                          inv_arch_pari], flag=0)
+                A = L.__pari__().alginit([2, [fin_places_pari, [QQ((1,2))] * len(fin_places_pari)], inv_arch_pari], flag=0)
 
                 # Obtain representation of A in terms of invariants in L
                 a_L = L(A.algsplittingfield().disc()[1])
@@ -430,13 +429,12 @@ class QuaternionAlgebraFactory(UniqueFactory):
             b = K(arg2)
 
         if not K(2).is_unit():
-            raise ValueError("2 is not invertible in %s" % K)
+            raise ValueError(f"2 is not invertible in {K}")
         if not (a.is_unit() and b.is_unit()):
-            raise ValueError("defining elements of quaternion algebra (%s, %s) are not invertible in %s"
-                             % (a, b, K))
+            raise ValueError(f"defining elements of quaternion algebra ({a}, {b}) are not invertible in {K}")
 
         names = normalize_names(3, names)
-        return (K, a, b, names)
+        return K, a, b, names
 
     def create_object(self, version, key, **extra_args):
         """
@@ -467,7 +465,7 @@ class QuaternionAlgebra_abstract(Parent):
             sage: sage.algebras.quatalg.quaternion_algebra.QuaternionAlgebra_abstract(QQ)._repr_()
             'Quaternion Algebra with base ring Rational Field'
         """
-        return "Quaternion Algebra with base ring %s" % self.base_ring()
+        return f"Quaternion Algebra with base ring {self.base_ring()}"
 
     def ngens(self) -> int:
         """
@@ -479,7 +477,7 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ,-5,-2)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-5, -2)
             sage: Q.ngens()
             3
             sage: Q.gens()
@@ -495,7 +493,7 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ,-5,-2)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-5, -2)
             sage: Q.basis()
             (1, i, j, k)
 
@@ -509,7 +507,7 @@ class QuaternionAlgebra_abstract(Parent):
             True
         """
         i, j, k = self.gens()
-        return (self.one(), i, j, k)
+        return self.one(), i, j, k
 
     @cached_method
     def inner_product_matrix(self):
@@ -539,14 +537,14 @@ class QuaternionAlgebra_abstract(Parent):
     def is_division_algebra(self) -> bool:
         """
         Check whether this quaternion algebra is a division algebra,
-        i.e. whether every nonzero element in it is invertible.
+        i.e., whether every nonzero element in it is invertible.
 
         Currently only implemented for quaternion algebras
         defined over a number field.
 
         EXAMPLES::
 
-            sage: QuaternionAlgebra(QQ,-5,-2).is_division_algebra()
+            sage: QuaternionAlgebra(-5, -2).is_division_algebra()
             True
             sage: QuaternionAlgebra(2,9).is_division_algebra()
             False
@@ -587,9 +585,9 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: QuaternionAlgebra(QQ,-5,-2).is_matrix_ring()
+            sage: QuaternionAlgebra(-5, -2).is_matrix_ring()
             False
-            sage: QuaternionAlgebra(2,9).is_matrix_ring()
+            sage: QuaternionAlgebra(2, 9).is_matrix_ring()
             True
             sage: K.<z> = QuadraticField(3)
             sage: QuaternionAlgebra(K, 1+z, 3-z).is_matrix_ring()
@@ -627,7 +625,7 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3, -7)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-3, -7)
             sage: Q.is_exact()
             True
             sage: Q.<i,j,k> = QuaternionAlgebra(Qp(7), -3, -7)
@@ -643,7 +641,7 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3, -7)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-3, -7)
             sage: Q.is_field()
             False
         """
@@ -658,7 +656,7 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3, -7)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-3, -7)
             sage: Q.is_finite()
             False
             sage: Q.<i,j,k> = QuaternionAlgebra(GF(5), -3, -7)
@@ -674,7 +672,7 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3, -7)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-3, -7)
             sage: Q.is_integral_domain()
             False
         """
@@ -687,7 +685,7 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3, -7)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-3, -7)
             sage: Q.is_noetherian()
             True
         """
@@ -700,14 +698,14 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3, -7)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-3, -7)
             sage: Q.order()
             +Infinity
             sage: Q.<i,j,k> = QuaternionAlgebra(GF(5), -3, -7)
             sage: Q.order()
             625
         """
-        return (self.base_ring().order())**4
+        return self.base_ring().order()**4
 
     def random_element(self, *args, **kwds):
         """
@@ -812,7 +810,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         Test making quaternion elements (using the element constructor)::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ,-1,-2)
+            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -1, -2)
             sage: a = Q(2/3); a
             2/3
             sage: type(a)
@@ -837,7 +835,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         Check for category::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ, -3,-7)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-3, -7)
             sage: Q.is_commutative()
             False
         """
@@ -1227,8 +1225,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
         """
         if not isinstance(other, QuaternionAlgebra_abstract):
             return False
-        return (self.base_ring() == other.base_ring() and
-                (self._a, self._b) == (other._a, other._b))
+        return (self.base_ring(), self._a, self._b) == (other.base_ring(), other._a, other._b)
 
     def __ne__(self, other) -> bool:
         """
@@ -1267,7 +1264,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         EXAMPLES::
 
-            sage: Q.<ii,jj,kk> = QuaternionAlgebra(QQ,-1,-2); Q
+            sage: Q.<ii,jj,kk> = QuaternionAlgebra(-1, -2); Q
             Quaternion Algebra (-1, -2) with base ring Rational Field
             sage: Q.gen(0)
             ii
@@ -1286,7 +1283,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         EXAMPLES::
 
-            sage: Q.<ii,jj,kk> = QuaternionAlgebra(QQ,-1,-2); Q
+            sage: Q.<ii,jj,kk> = QuaternionAlgebra(-1, -2); Q
             Quaternion Algebra (-1, -2) with base ring Rational Field
             sage: Q.gens()
             (ii, jj, kk)
@@ -1299,7 +1296,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         TESTS::
 
-            sage: Q.<i,j,k> = QuaternionAlgebra(QQ,-5,-2)
+            sage: Q.<i,j,k> = QuaternionAlgebra(-5, -2)
             sage: type(Q)
             <class 'sage.algebras.quatalg.quaternion_algebra.QuaternionAlgebra_ab_with_category'>
             sage: Q._repr_()
@@ -1311,7 +1308,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             sage: str(Q)
             'Quaternion Algebra (-5, -2) with base ring Rational Field'
         """
-        return "Quaternion Algebra (%r, %r) with base ring %s" % (self._a, self._b, self.base_ring())
+        return f"Quaternion Algebra ({self._a!r}, {self._b!r}) with base ring {self.base_ring()}"
 
     def inner_product_matrix(self):
         """
@@ -1349,7 +1346,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         EXAMPLES::
 
-            sage: QuaternionAlgebra(QQ,-5,-2).is_definite()
+            sage: QuaternionAlgebra(-5, -2).is_definite()
             True
             sage: QuaternionAlgebra(1).is_definite()
             False
@@ -1377,7 +1374,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         EXAMPLES::
 
-            sage: QuaternionAlgebra(QQ, -5, -2).is_totally_definite()
+            sage: QuaternionAlgebra(-5, -2).is_totally_definite()
             True
 
             sage: K = QuadraticField(3)
@@ -1388,7 +1385,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
             sage: x = polygen(ZZ, 'x')
             sage: F.<a> = NumberField(x^2 - x - 1)
-            sage: QuaternionAlgebra(F, 2*a, F(-1)).is_totally_definite()
+            sage: QuaternionAlgebra(F, 2*a, -1).is_totally_definite()
             False
 
         The method does not make sense over an arbitrary base ring::
@@ -1731,9 +1728,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             'QuaternionAlgebra(_sage_[...],(_sage_[...]![-1, 0]),(_sage_[...]![0, 1]))'
         """
         R = magma(self.base_ring())
-        return 'QuaternionAlgebra(%s,%s,%s)' % (R.name(),
-                                                self._a._magma_init_(magma),
-                                                self._b._magma_init_(magma))
+        return f'QuaternionAlgebra({R.name()},{self._a._magma_init_(magma)},{self._b._magma_init_(magma)})'
 
     def quaternion_order(self, basis, check=True):
         """
@@ -1865,11 +1860,11 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
             raise NotImplementedError("must be rational quaternion algebra")
         p = ZZ(p)
         if not p.is_prime():
-            raise ValueError("p (=%s) must be prime" % p)
+            raise ValueError(f"p (={p}) must be prime")
         if p == 2:
             raise NotImplementedError("p must be odd")
         if self.discriminant() % p == 0:
-            raise ValueError("p (=%s) must be an unramified prime" % p)
+            raise ValueError(f"p (={p}) must be an unramified prime")
 
         i, j, _ = self.gens()
         F = GF(p)
@@ -2189,8 +2184,7 @@ class QuaternionOrder(Parent):
 
         TESTS::
 
-            sage: B = QuaternionAlgebra(-1, -11)
-            sage: i,j,k = B.gens()
+            sage: B.<i,j,k> = QuaternionAlgebra(-1, -11)
             sage: O = B.quaternion_order([1,i,j,k])
             sage: O == O
             True
@@ -2266,7 +2260,7 @@ class QuaternionOrder(Parent):
             sage: QuaternionAlgebra(-11,-1).maximal_order()
             Order of Quaternion Algebra (-11, -1) with base ring Rational Field with basis (1/2 + 1/2*i, 1/2*j - 1/2*k, i, -k)
         """
-        return 'Order of %s with basis %s' % (self.quaternion_algebra(), self.basis())
+        return f'Order of {self.quaternion_algebra()} with basis {self.basis()}'
 
     def random_element(self, *args, **kwds):
         """
@@ -2310,14 +2304,14 @@ class QuaternionOrder(Parent):
 
         We intersect various orders in the quaternion algebra ramified at 11::
 
-            sage: B = BrandtModule(11,3)
+            sage: B = BrandtModule(11, 3)
             sage: R = B.maximal_order(); S = B.order_of_level_N()
             sage: R.intersection(S)
             Order of Quaternion Algebra (-1, -11) with base ring Rational Field
              with basis (1/2 + 1/2*j, 1/2*i + 5/2*k, j, 3*k)
             sage: R.intersection(S) == S
             True
-            sage: B = BrandtModule(11,5)
+            sage: B = BrandtModule(11, 5)
             sage: T = B.order_of_level_N()
             sage: S.intersection(T)
             Order of Quaternion Algebra (-1, -11) with base ring Rational Field
@@ -2377,7 +2371,7 @@ class QuaternionOrder(Parent):
 
             sage: QuaternionAlgebra(-11,-1).maximal_order().discriminant()
             11
-            sage: S = BrandtModule(11,5).order_of_level_N()
+            sage: S = BrandtModule(11, 5).order_of_level_N()
             sage: S.discriminant()
             55
             sage: type(S.discriminant())
@@ -2397,7 +2391,7 @@ class QuaternionOrder(Parent):
         EXAMPLES::
 
             sage: p = 11
-            sage: B = QuaternionAlgebra(QQ, -1, -p)
+            sage: B = QuaternionAlgebra(-1, -p)
             sage: i, j, k = B.gens()
             sage: O0_basis = (1, i, (i+j)/2, (1+i*j)/2)
             sage: O0 = B.quaternion_order(O0_basis)
@@ -2526,7 +2520,7 @@ class QuaternionOrder(Parent):
         if is_basis:
             basis = gens
         else:
-            if gens in self.quaternion_algebra():
+            if isinstance(gens, RingElement):
                 gens = [gens]
             basis = tuple(basis_for_quaternion_lattice([b * g for b in self.basis() for g in gens]))
             check = False
@@ -2569,7 +2563,7 @@ class QuaternionOrder(Parent):
         if is_basis:
             basis = gens
         else:
-            if gens in self.quaternion_algebra():
+            if isinstance(gens, RingElement):
                 gens = [gens]
             basis = tuple(basis_for_quaternion_lattice([g * b for b in self.basis() for g in gens]))
             check = False
@@ -2665,7 +2659,7 @@ class QuaternionOrder(Parent):
 
         EXAMPLES::
 
-            sage: R = BrandtModule(11,13).order_of_level_N()
+            sage: R = BrandtModule(11, 13).order_of_level_N()
             sage: Q = R.quadratic_form(); Q
             Quadratic form in 4 variables over Rational Field with coefficients:
             [ 14 253 55 286 ]
@@ -2708,7 +2702,7 @@ class QuaternionOrder(Parent):
 
         EXAMPLES::
 
-            sage: R = BrandtModule(11,13).order_of_level_N()
+            sage: R = BrandtModule(11, 13).order_of_level_N()
             sage: Q = R.ternary_quadratic_form(); Q
             Quadratic form in 3 variables over Rational Field with coefficients:
             [ 5820 1012 13156 ]
@@ -3045,8 +3039,9 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: B = BrandtModule(5,37); I = B.right_ideals()[0]
-            sage: i,j,k = B.quaternion_algebra().gens(); I
+            sage: B = BrandtModule(5, 37)
+            sage: i,j,k = B.quaternion_algebra().gens()
+            sage: I = B.right_ideals()[0]; I
             Fractional ideal (4, 148*i, 2 + 106*i + 2*j, 2 + 147*i + k)
             sage: I.scale(i)
             Fractional ideal (296, 4*i, 2 + 2*i + 2*j, 212 + 2*i + 2*k)
@@ -3204,7 +3199,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         We do a consistency check::
 
-            sage: B = BrandtModule(11,19); R = B.right_ideals()
+            sage: B = BrandtModule(11, 19); R = B.right_ideals()
             sage: [r.left_order().discriminant() for r in R]
             [209, 209, 209, 209, 209, 209, 209, 209, 209, 209, 209, 209, 209, 209, 209, 209, 209, 209]
         """
@@ -3234,7 +3229,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         corresponding left orders, then take ideals in the left orders
         and from those compute the right order again::
 
-            sage: B = BrandtModule(11,19); R = B.right_ideals()
+            sage: B = BrandtModule(11, 19); R = B.right_ideals()
             sage: O = [r.left_order() for r in R]
             sage: J = [O[i].left_ideal(R[i].basis()) for i in range(len(R))]
             sage: len(set(J))
@@ -3260,7 +3255,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
             sage: I.__repr__()
             'Fractional ideal (8, 8*i, 6 + 4*i + 2*j, 4 + 2*i + 2*k)'
         """
-        return 'Fractional ideal %s' % (self.gens(),)
+        return f'Fractional ideal {self.gens()}'
 
     def random_element(self, *args, **kwds):
         """
@@ -3315,12 +3310,11 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         TESTS::
 
-            sage: B = QuaternionAlgebra(QQ,-1,-11)
-            sage: i,j,k = B.gens()
-            sage: I = B.ideal([1,i,j,i*j])
+            sage: B.<i,j,k> = QuaternionAlgebra(-1, -11)
+            sage: I = B.ideal([1, i, j, i*j])
             sage: I == I
             True
-            sage: O = B.ideal([1,i,(i+j)/2,(1+i*j)/2])
+            sage: O = B.ideal([1, i, (i+j)/2, (1+i*j)/2])
             sage: I <= O
             True
             sage: I >= O
@@ -3394,7 +3388,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: B = BrandtModule(2,37); I = B.right_ideals()[0]
+            sage: B = BrandtModule(2, 37); I = B.right_ideals()[0]
             sage: I
             Fractional ideal (4, 148*i, 108*i + 4*j, 2 + 2*i + 2*j + 2*k)
             sage: I.reduced_basis()
@@ -3402,9 +3396,8 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
             sage: l = I.reduced_basis()
             sage: assert all(l[i].reduced_norm() <= l[i+1].reduced_norm() for i in range(len(l) - 1))
 
-            sage: B = QuaternionAlgebra(next_prime(2**50))
+            sage: B.<i,j,k> = QuaternionAlgebra(next_prime(2**50))
             sage: O = B.maximal_order()
-            sage: i,j,k = B.gens()
             sage: alpha = 1/2 - 1/2*i + 3/2*j - 7/2*k
             sage: I = O*alpha + O*3089622859
             sage: I.reduced_basis()[0]
@@ -3565,7 +3558,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: I = BrandtModule(3,5).right_ideals()[1]; I
+            sage: I = BrandtModule(3, 5).right_ideals()[1]; I
             Fractional ideal (8, 40*i, 6 + 28*i + 2*j, 4 + 18*i + 2*k)
             sage: I.gram_matrix()
             [ 256    0  192  128]
@@ -3594,25 +3587,25 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
             sage: # optional - magma
             sage: a, b = M.quaternion_algebra().invariants()
-            sage: magma.eval('A<i,j,k> := QuaternionAlgebra<Rationals() | %s, %s>' % (a,b))
+            sage: magma.eval(f'A<i,j,k> := QuaternionAlgebra<Rationals() | {a}, {b}>'
             ''
-            sage: magma.eval('O := QuaternionOrder(%s)' % str(list(C[0].right_order().basis())))
+            sage: magma.eval(f'O := QuaternionOrder({list(C[0].right_order().basis())})'')
             ''
-            sage: [ magma('rideal<O | %s>' % str(list(I.basis()))).Norm() for I in C]
+            sage: [ magma(f'rideal<O | {list(I.basis())}>' for I in C]
             [16, 32, 32]
 
             sage: A.<i,j,k> = QuaternionAlgebra(-1,-1)
-            sage: R = A.ideal([i,j,k,1/2 + 1/2*i + 1/2*j + 1/2*k])      # this is actually an order, so has reduced norm 1
+            sage: R = A.ideal([i, j, k, 1/2 + 1/2*i + 1/2*j + 1/2*k])   # this is actually an order, so has reduced norm 1
             sage: R.norm()
             1
             sage: [ J.norm() for J in R.cyclic_right_subideals(3) ]     # enumerate maximal right R-ideals of reduced norm 3, verify their norms
             [3, 3, 3, 3]
         """
-        G = self.gram_matrix() / QQ(2)
+        G = self.gram_matrix() / 2
         r = G.det().abs()
         assert r.is_square(), "first is bad!"
         r = r.sqrt()
-        # If we know either the left- or the right order, use that one to compute the norm.
+        # If we know either the left or the right order, use that one to compute the norm.
         R = self.__left_order or self.__right_order or self.left_order()
         r /= R.discriminant()
         assert r.is_square(), "second is bad!"
@@ -3626,7 +3619,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: I = BrandtModule(3,5).right_ideals()[1]; I
+            sage: I = BrandtModule(3, 5).right_ideals()[1]; I
             Fractional ideal (8, 40*i, 6 + 28*i + 2*j, 4 + 18*i + 2*k)
             sage: I.conjugate()
             Fractional ideal (2 + 2*j + 28*k, 2*i + 4*j + 34*k, 8*j + 32*k, 40*k)
@@ -3645,7 +3638,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: I = BrandtModule(3,5).right_ideals()[1]; I
+            sage: I = BrandtModule(3, 5).right_ideals()[1]; I
             Fractional ideal (8, 40*i, 6 + 28*i + 2*j, 4 + 18*i + 2*k)
             sage: I*I
             Fractional ideal (32, 160*i, 24 + 112*i + 8*j, 16 + 72*i + 8*k)
@@ -3672,9 +3665,9 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: I = BrandtModule(11,5).right_ideals()[1]; I
+            sage: I = BrandtModule(11, 5).right_ideals()[1]; I
             Fractional ideal (8, 40*i, 2 + 20*i + 2*j, 4 + 14*i + 2*k)
-            sage: J = BrandtModule(11,5).right_ideals()[2]; J
+            sage: J = BrandtModule(11, 5).right_ideals()[2]; J
             Fractional ideal (8, 40*i, 6 + 20*i + 2*j, 4 + 34*i + 2*k)
             sage: I + J
             Fractional ideal (2 + 2*j, 2*i + 6*k, 4*j, 20*k)
@@ -3714,7 +3707,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: X = BrandtModule(3,5).right_ideals()
+            sage: X = BrandtModule(3, 5).right_ideals()
             sage: X[0]
             Fractional ideal (4, 20*i, 2 + 8*i + 2*j, 18*i + 2*k)
             sage: X[0].free_module()
@@ -3741,7 +3734,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         The free module method is also useful since it allows for checking if
         one ideal is contained in another, computing quotients `I/J`, etc.::
 
-            sage: X = BrandtModule(3,17).right_ideals()
+            sage: X = BrandtModule(3, 17).right_ideals()
             sage: I = X[0].intersection(X[2]); I
             Fractional ideal (2 + 2*j + 164*k, 2*i + 4*j + 46*k, 16*j + 224*k, 272*k)
             sage: I.free_module().is_submodule(X[3].free_module())
@@ -3772,7 +3765,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: X = BrandtModule(3,5).right_ideals()
+            sage: X = BrandtModule(3, 5).right_ideals()
             sage: I = X[0].intersection(X[1]); I
             Fractional ideal (2 + 6*j + 4*k, 2*i + 4*j + 34*k, 8*j + 32*k, 40*k)
         """
@@ -3794,7 +3787,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: R = BrandtModule(3,5).right_ideals()
+            sage: R = BrandtModule(3, 5).right_ideals()
             sage: R[0].multiply_by_conjugate(R[1])
             Fractional ideal (32, 160*i, 8 + 112*i + 8*j, 16 + 72*i + 8*k)
             sage: R[0]*R[1].conjugate()
@@ -3825,8 +3818,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: B = QuaternionAlgebra(419)
-            sage: i,j,k = B.gens()
+            sage: B.<i,j,k> = QuaternionAlgebra(419)
             sage: I1 = B.ideal([1/2 + 3/2*j + 2*k, 1/2*i + j + 3/2*k, 3*j, 3*k])
             sage: I2 = B.ideal([1/2 + 9/2*j, 1/2*i + 9/2*k, 5*j, 5*k])
             sage: I1.left_order() == I2.left_order()
@@ -3836,8 +3828,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         TESTS::
 
-            sage: B = QuaternionAlgebra(419)
-            sage: i,j,k = B.gens()
+            sage: B.<i,j,k> = QuaternionAlgebra(419)
             sage: O0 = B.maximal_order()
             sage: O0.unit_ideal().pushforward(O0.unit_ideal())
             Traceback (most recent call last):
@@ -3880,7 +3871,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
             Jnorm = J.norm()
             if gcd(self.norm(), Jnorm) != 1:
                 raise ValueError("self and J must have coprime norms")
-            return (1 / Jnorm) * (J.conjugate() * self.intersection(J))
+            return ~Jnorm * (J.conjugate() * self.intersection(J))
 
         if side == "right":
             if self.right_order() != J.right_order():
@@ -3919,8 +3910,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: B = QuaternionAlgebra(419)
-            sage: i,j,k = B.gens()
+            sage: B.<i,j,k> = QuaternionAlgebra(419)
             sage: I1 = B.ideal([1/2 + 3/2*j + 2*k, 1/2*i + j + 3/2*k, 3*j, 3*k])
             sage: I2 = B.ideal([1/2 + 9/2*j, 1/2*i + 9/2*k, 5*j, 5*k])
             sage: I3 = I1.pushforward(I2, side='left')
@@ -3931,8 +3921,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         TESTS::
 
-            sage: B = QuaternionAlgebra(419)
-            sage: i,j,k = B.gens()
+            sage: B.<i,j,k> = QuaternionAlgebra(419)
             sage: O0 = B.maximal_order()
             sage: O0.unit_ideal().pullback(O0.unit_ideal())
             Traceback (most recent call last):
@@ -4015,7 +4004,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: R = BrandtModule(3,5).right_ideals(); len(R)
+            sage: R = BrandtModule(3, 5).right_ideals(); len(R)
             2
             sage: OO = R[0].left_order()
             sage: S = OO.right_ideal([3*a for a in R[0].basis()])
@@ -4049,7 +4038,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: R = BrandtModule(3,5).right_ideals(); len(R)
+            sage: R = BrandtModule(3, 5).right_ideals(); len(R)
             2
             sage: R[0].is_right_equivalent(R[1])
             False
@@ -4063,8 +4052,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
             sage: -1/3*S == R[0]
             True
 
-            sage: B = QuaternionAlgebra(101)
-            sage: i,j,k = B.gens()
+            sage: B.<i,j,k> = QuaternionAlgebra(101)
             sage: I = B.maximal_order().unit_ideal()
             sage: beta = B.random_element()
             sage: while beta.is_zero():
@@ -4103,7 +4091,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         # Equivalently, we can simply call the principality test on IJbar,
         # but we rescale by 1/N(J) to make sure this test directly gives back
         # the correct alpha if a certificate is requested
-        return (1/J.norm()*IJbar).is_principal(certificate)
+        return (~J.norm() * IJbar).is_principal(certificate)
 
     def is_principal(self, certificate=False):
         r"""
@@ -4198,14 +4186,14 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: B = BrandtModule(2,37); I = B.right_ideals()[0]
+            sage: B = BrandtModule(2, 37); I = B.right_ideals()[0]
             sage: I.cyclic_right_subideals(3)
             [Fractional ideal (12, 444*i, 8 + 404*i + 4*j, 2 + 150*i + 2*j + 2*k),
              Fractional ideal (12, 444*i, 4 + 256*i + 4*j, 10 + 150*i + 2*j + 2*k),
              Fractional ideal (12, 444*i, 8 + 256*i + 4*j, 6 + 298*i + 2*j + 2*k),
              Fractional ideal (12, 444*i, 4 + 404*i + 4*j, 6 + 2*i + 2*j + 2*k)]
 
-            sage: B = BrandtModule(5,389); I = B.right_ideals()[0]
+            sage: B = BrandtModule(5, 389); I = B.right_ideals()[0]
             sage: C = I.cyclic_right_subideals(3); C
             [Fractional ideal (12, 4668*i, 10 + 3426*i + 2*j, 6 + 379*i + k),
              Fractional ideal (12, 4668*i, 2 + 3426*i + 2*j, 6 + 3491*i + k),
@@ -4265,7 +4253,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
                 # Here we could replace the ideal by an *equivalent*
                 # ideal that works.  This is always possible.
                 # However, I haven't implemented that algorithm yet.
-                raise NotImplementedError("general algorithm not implemented (%s)" % msg)
+                raise NotImplementedError(f"general algorithm not implemented ({msg})")
 
         Ai = ~A.basis_matrix()
         AiB = Ai.change_ring(QQ) * IB
@@ -4320,7 +4308,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: R.<i,j,k> = QuaternionAlgebra(QQ, -1,-11)
+            sage: R.<i,j,k> = QuaternionAlgebra(-1, -11)
             sage: I = R.ideal([2 + 2*j + 140*k, 2*i + 4*j + 150*k, 8*j + 104*k, 152*k])
             sage: I.is_integral()
             True
@@ -4349,7 +4337,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: A.<i,j,k> = QuaternionAlgebra(QQ, -1,-11)
+            sage: A.<i,j,k> = QuaternionAlgebra(-1, -11)
             sage: I = A.ideal([1/2 + 1/2*i + 1/2*j + 3/2*k, i + k, j + k, 2*k])
             sage: I.primitive_decomposition()
             (Fractional ideal (1/2 + 1/2*i + 1/2*j + 3/2*k, i + k, j + k, 2*k), 1)
@@ -4406,7 +4394,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
         EXAMPLES::
 
-            sage: A.<i,j,k> = QuaternionAlgebra(QQ, -1,-11)
+            sage: A.<i,j,k> = QuaternionAlgebra(-1, -11)
             sage: I = A.ideal([1/2 + 1/2*i + 1/2*j + 3/2*k, i + k, j + k, 2*k])
             sage: I.is_primitive()
             True
@@ -4466,10 +4454,10 @@ def intersection_of_row_modules_over_ZZ(v):
 
     EXAMPLES::
 
-        sage: a = matrix(QQ,4,[-2, 0, 0, 0, 0, -1, -1, 1, 2, -1/2, 0, 0, 1, 1, -1, 0])
-        sage: b = matrix(QQ,4,[0, -1/2, 0, -1/2, 2, 1/2, -1, -1/2, 1, 2, 1, -2, 0, -1/2, -2, 0])
-        sage: c = matrix(QQ,4,[0, 1, 0, -1/2, 0, 0, 2, 2, 0, -1/2, 1/2, -1, 1, -1, -1/2, 0])
-        sage: v = [a,b,c]
+        sage: a = matrix(QQ, 4, [-2, 0, 0, 0, 0, -1, -1, 1, 2, -1/2, 0, 0, 1, 1, -1, 0])
+        sage: b = matrix(QQ, 4, [0, -1/2, 0, -1/2, 2, 1/2, -1, -1/2, 1, 2, 1, -2, 0, -1/2, -2, 0])
+        sage: c = matrix(QQ, 4, [0, 1, 0, -1/2, 0, 0, 2, 2, 0, -1/2, 1/2, -1, 1, -1, -1/2, 0])
+        sage: v = [a, b, c]
         sage: from sage.algebras.quatalg.quaternion_algebra import intersection_of_row_modules_over_ZZ
         sage: M = intersection_of_row_modules_over_ZZ(v); M
         [   2    0   -1   -1]
@@ -4667,8 +4655,8 @@ def maxord_solve_aux_eq(a, b, p):
         ....:         assert mod(y, 4) == 1 or mod(y, 4) == 3
         ....:         assert mod(1 - a*y^2 - b*z^2 + a*b*w^2, 4) == 0
     """
-    if p != ZZ(2):
-        raise NotImplementedError("algorithm only implemented over ZZ at the moment")
+    if not isinstance(p, Integer) or p != 2:
+        raise NotImplementedError("algorithm only implemented over ZZ and for p=2 at the moment")
 
     v_a = a.valuation(p)
     v_b = b.valuation(p)

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -77,7 +77,6 @@ from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 from sage.rings.number_field.number_field_base import NumberField
 from sage.rings.polynomial.polynomial_ring import polygen
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.power_series_ring import PowerSeriesRing
 from sage.rings.qqbar import AA
 from sage.rings.rational_field import QQ, RationalField
@@ -1184,7 +1183,7 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
                 # x = O.random_element((-p/2).floor(), (p/2).ceil())
                 if kronecker_symbol(D, p) == 1:
                     break
-            X = PolynomialRing(GF(p), 'x').gen()
+            X = polygen(GF(p), 'x')
             a = ZZ((X**2 - ZZ(x.reduced_trace()) * X + ZZ(x.reduced_norm())).roots()[0][0])
             I = O._left_ideal_basis([p**r, (x - a)**r])
             O = O._right_order_from_ideal_basis(I)

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -4099,14 +4099,19 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
 
     def is_principal(self, certificate=False):
         r"""
-        Check whether ``self`` is principal as a full rank quaternion ideal.
-        Requires the underlying quaternion algebra to be definite.
-        Independent of whether ``self`` is a left or a right ideal.
+        Check whether this quaternion fractional ideal is principal.
+
+        (The answer only depends on the ideal as a lattice inside its
+        ambient quaternion algebra and is independent of whether we
+        view ``self`` as a left or a right ideal.)
+
+        Only implemented if the ambient quaternion algebra is definite.
 
         INPUT:
 
-        - ``certificate`` -- if ``True`` returns a generator alpha s.t.
-          `I = \alpha O` where `O` is the right order of `I`
+        - ``certificate`` (boolean, default ``False``) -- if set to ``True``,
+          returns a generator `\alpha` such that `I = O_L\alpha = \alpha O_R`,
+          where `O_L, O_R` are the left and right orders of `I` respectively.
 
         OUTPUT: boolean, or (boolean, alpha) if ``certificate`` is ``True``
 
@@ -4118,10 +4123,11 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
             sage: while beta.is_zero():
             ....:     beta = O.random_element()
             sage: I = O*beta
-            sage: bool, alpha = I.is_principal(True)
-            sage: bool
+            sage: res, alpha = I.is_principal(True); res
             True
-            sage: I == O*alpha
+            sage: I == I.left_order() * alpha
+            True
+            sage: I == alpha * I.right_order()
             True
         """
         if not self.quaternion_algebra().is_definite():

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -295,7 +295,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
         Rational Field
 
     Check that construction via ramification yields the correct algebra,
-    i.e. that the differences between Sage and PARI are accounted for::
+    i.e., that the differences between Sage and PARI are accounted for::
 
         sage: x = polygen(ZZ, 'x')
         sage: K.<v> = NumberField(-3*x^5 - 11*x^4 - 4*x^3 + 1)
@@ -306,7 +306,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
         True
 
     Also check that the required Sage-PARI permutation is the correct way
-    around, i.e. that it does not need to be replaced by its inverse::
+    around, i.e., that it does not need to be replaced by its inverse::
 
         sage: x = polygen(ZZ, 'x')
         sage: K.<j> = NumberField(5*x^4 - 50*x^2 + 5)
@@ -511,7 +511,7 @@ class QuaternionAlgebra_abstract(Parent):
     def inner_product_matrix(self):
         r"""
         Return the inner product matrix associated to this quaternion algebra,
-        i.e. the Gram matrix of the reduced norm as a quadratic form on ``self``.
+        i.e., the Gram matrix of the reduced norm as a quadratic form on ``self``.
 
         The standard basis `1`, `i`, `j`, `k` is orthogonal, so this matrix
         is just the diagonal matrix with diagonal entries `2`, `-2a`, `-2b`, `2ab`.
@@ -628,9 +628,8 @@ class QuaternionAlgebra_abstract(Parent):
     def is_exact(self) -> bool:
         r"""
         Return ``True`` if elements of this quaternion algebra are represented
-        exactly, i.e. there is no precision loss when doing arithmetic. A
-        quaternion algebra is exact if and only if its base field is
-        exact.
+        exactly, i.e., there is no precision loss when doing arithmetic
+        A quaternion algebra is exact if and only if its base field is exact.
 
         EXAMPLES::
 
@@ -4320,7 +4319,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         Let `I` = ``self``. If `I` is an integral left `\mathcal{O}`-ideal return its decomposition
         as an equivalent primitive ideal and an integer such that their product is the initial ideal.
 
-        OUTPUTS: A primitive ideal equivalent to `I`, i.e. an equivalent ideal not contained
+        OUTPUTS: A primitive ideal equivalent to `I`, i.e., an equivalent ideal not contained
         in `n\mathcal{O}` for any `n>0`, and the smallest integer `g` such that `I \subset g\mathcal{O}`.
 
         EXAMPLES::

--- a/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
+++ b/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
@@ -438,8 +438,8 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
 
     cpdef reduced_trace(self):
         """
-        Return the reduced trace of self: if `\\theta = x + yi + zj +
-        wk`, then `\\theta` has reduced trace `2x`.
+        Return the reduced trace of self: if `\\theta = x + yi + zj + wk`,
+        then `\\theta` has reduced trace `2x`.
 
         EXAMPLES::
 
@@ -453,9 +453,8 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
 
     cpdef reduced_norm(self):
         """
-        Return the reduced norm of self: if `\\theta = x + yi + zj +
-        wk`, then `\\theta` has reduced norm `x^2 - ay^2 - bz^2 +
-        abw^2`.
+        Return the reduced norm of self: if `\\theta = x + yi + zj + wk`,
+        then `\\theta` has reduced norm `x^2 - ay^2 - bz^2 + abw^2`.
 
         EXAMPLES::
 

--- a/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
+++ b/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
@@ -55,7 +55,7 @@ cdef mpz_t T1, T2, t3, t4, t5, t6, t7, t8, s1, s2, U1, U2
 cdef fmpz_poly_t fT1, fT2, ft3, ft4, ft5, ft6, ft7, ft8, fs1, fs2, fU1, fU2
 
 cdef _clear_globals():
-    """
+    r"""
     Clear all global variables allocated for optimization of
     quaternion algebra arithmetic.
 
@@ -92,7 +92,7 @@ cdef _clear_globals():
     fmpz_poly_clear(fU2)
 
 cdef _init_globals():
-    """
+    r"""
     Initialize all global variables allocated for optimization of
     quaternion algebra arithmetic, and register a hook to eventually
     clear them.
@@ -139,7 +139,7 @@ cdef _init_globals():
 _init_globals()
 
 cdef to_quaternion(R, x):
-    """
+    r"""
     Internal function used implicitly by quaternion algebra creation.
 
     INPUT:
@@ -163,7 +163,7 @@ cdef to_quaternion(R, x):
         return R(x), R(0), R(0), R(0)
 
 cdef inline print_coeff(y, i, bint atomic):
-    """
+    r"""
     Internal function used implicitly by all quaternion algebra printing.
 
     INPUT:
@@ -221,9 +221,9 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return h
 
     cpdef bint is_constant(self) noexcept:
-        """
-        Return ``True`` if this quaternion is constant, i.e., has no `i`, `j`,
-        or `k` term.
+        r"""
+        Return ``True`` if this quaternion is constant, i.e.,
+        has no `i`, `j`, or `k` term.
 
         OUTPUT: boolean
 
@@ -240,7 +240,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return not (self[1] or self[2] or self[3])
 
     def __int__(self):
-        """
+        r"""
         Try to coerce this quaternion to a Python int.
 
         EXAMPLES::
@@ -260,7 +260,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         raise TypeError
 
     def __float__(self):
-        """
+        r"""
         Try to coerce this quaternion to a Python float.
 
         EXAMPLES::
@@ -280,7 +280,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         raise TypeError
 
     def _integer_(self, ZZ=None):
-        """
+        r"""
         Try to coerce this quaternion to an Integer.
 
         EXAMPLES::
@@ -304,7 +304,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         raise TypeError
 
     def _rational_(self):
-        """
+        r"""
         Try to coerce this quaternion to a Rational.
 
         EXAMPLES::
@@ -322,7 +322,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         raise TypeError
 
     def __bool__(self):
-        """
+        r"""
         Return ``True`` if this quaternion is nonzero.
 
         EXAMPLES::
@@ -336,7 +336,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return self[0] or self[1] or self[2] or self[3]
 
     cdef _do_print(self, x, y, z, w):
-        """
+        r"""
         Used internally by the print function.
 
         EXAMPLES::
@@ -364,7 +364,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return ' + '.join(v).replace('+ -', '- ')
 
     def _repr_(self):
-        """
+        r"""
         Return string representation of this quaternion.
 
         EXAMPLES::
@@ -385,7 +385,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return self._do_print(self[0], self[1], self[2], self[3])
 
     cpdef _richcmp_(self, right, int op):
-        """
+        r"""
         Comparing elements.
 
         TESTS::
@@ -413,9 +413,9 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return rich_to_bool(op, 0)
 
     cpdef conjugate(self):
-        """
-        Return the conjugate of the quaternion: if `\\theta = x + yi + zj + wk`,
-        return `x - yi - zj - wk`; that is, return theta.reduced_trace() - theta.
+        r"""
+        Return the conjugate of the quaternion: if `\theta = x + yi + zj + wk`,
+        return `x - yi - zj - wk`; that is, return ``theta.reduced_trace() - theta``.
 
         EXAMPLES::
 
@@ -437,9 +437,9 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return self.__class__(self._parent, (self[0], -self[1], -self[2], -self[3]), check=False)
 
     cpdef reduced_trace(self):
-        """
-        Return the reduced trace of self: if `\\theta = x + yi + zj + wk`,
-        then `\\theta` has reduced trace `2x`.
+        r"""
+        Return the reduced trace of self: if `\theta = x + yi + zj + wk`,
+        then `\theta` has reduced trace `2x`.
 
         EXAMPLES::
 
@@ -452,9 +452,9 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return 2*self[0]
 
     cpdef reduced_norm(self):
-        """
-        Return the reduced norm of self: if `\\theta = x + yi + zj + wk`,
-        then `\\theta` has reduced norm `x^2 - ay^2 - bz^2 + abw^2`.
+        r"""
+        Return the reduced norm of self: if `\theta = x + yi + zj + wk`,
+        then `\theta` has reduced norm `x^2 - ay^2 - bz^2 + abw^2`.
 
         EXAMPLES::
 
@@ -469,7 +469,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return w*w*a*b - y*y*a - z*z*b + x*x
 
     def __invert__(self):
-        """
+        r"""
         Return the inverse of ``self``.
 
         EXAMPLES::
@@ -508,7 +508,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return ~self.reduced_norm() * self.conjugate()
 
     cpdef _rmul_(self, Element left):
-        """
+        r"""
         Return left*self, where left is in the base ring.
 
         EXAMPLES::
@@ -523,7 +523,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return self.__class__(self._parent, (left*self[0], left*self[1], left*self[2], left*self[3]), check=False)
 
     cpdef _lmul_(self, Element right):
-        """
+        r"""
         Return self*right, where right is in the base ring.
 
         EXAMPLES::
@@ -538,7 +538,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return self.__class__(self._parent, (self[0]*right, self[1]*right, self[2]*right, self[3]*right), check=False)
 
     cpdef _div_(self, right):
-        """
+        r"""
         Return quotient of ``self`` by ``right``.
 
         EXAMPLES::
@@ -555,7 +555,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return self * ~right
 
     def reduced_characteristic_polynomial(self, var='x'):
-        """
+        r"""
         Return the reduced characteristic polynomial of this
         quaternion algebra element, which is `X^2 - tX + n`, where `t`
         is the reduced trace and `n` is the reduced norm.
@@ -583,7 +583,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return R([self.reduced_norm(), -self.reduced_trace(), 1])
 
     def matrix(self, action='right'):
-        """
+        r"""
         Return the matrix of right or left multiplication of ``self`` on
         the basis for the ambient quaternion algebra.
 
@@ -641,7 +641,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return matrix(self.base_ring(), 4, v)
 
     def coefficient_tuple(self):
-        """
+        r"""
         Return 4-tuple of coefficients of this quaternion.
 
         EXAMPLES::
@@ -657,7 +657,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
         return (self[0], self[1], self[2], self[3])
 
     def pair(self, right):
-        """
+        r"""
         Return the result of pairing ``self`` and ``right``, which should both
         be elements of a quaternion algebra.  The pairing is
         ``(x,y) = (x.conjugate()*y).reduced_trace()``.
@@ -707,7 +707,7 @@ cdef class QuaternionAlgebraElement_abstract(AlgebraElement):
 
 
 cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
-    """
+    r"""
     TESTS:
 
     Test operations on quaternions over a base ring that is not a field::
@@ -738,7 +738,7 @@ cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
         True
     """
     def __init__(self, parent, v, bint check=True):
-        """
+        r"""
         Create a quaternion over a general base ring.
 
         EXAMPLES::
@@ -754,7 +754,7 @@ cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
             self.x, self.y, self.z, self.w = v
 
     def __getitem__(self, int i):
-        """
+        r"""
         EXAMPLES::
 
             sage: Q.<i,j,k> = QuaternionAlgebra(Frac(QQ['x']),-5,-2)
@@ -776,7 +776,7 @@ cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
             raise IndexError("quaternion element index out of range")
 
     def __reduce__(self):
-        """
+        r"""
         Used for pickling.
 
         TESTS::
@@ -792,7 +792,7 @@ cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
                 (self._parent, (self.x, self.y, self.z, self.w)))
 
     cpdef _add_(self, _right):
-        """
+        r"""
         Return the sum of ``self`` and ``_right``.
 
         EXAMPLES::
@@ -808,7 +808,7 @@ cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
         return QuaternionAlgebraElement_generic(self._parent, (self.x + right.x, self.y + right.y, self.z + right.z, self.w + right.w), check=False)
 
     cpdef _sub_(self, _right):
-        """
+        r"""
         Return the difference of ``self`` and ``_right``.
 
         EXAMPLES::
@@ -823,7 +823,7 @@ cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
         return QuaternionAlgebraElement_generic(self._parent, (self.x - right.x, self.y - right.y, self.z - right.z, self.w - right.w), check=False)
 
     cpdef _mul_(self, _right):
-        """
+        r"""
         Return the product of ``self`` and ``_right``.
 
         EXAMPLES::
@@ -864,7 +864,7 @@ cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
         return QuaternionAlgebraElement_generic(self._parent, (x, y, z, w), check=False)
 
     def _repr_(self):
-        """
+        r"""
         Print representation of ``self``.
 
         EXAMPLES::
@@ -880,7 +880,7 @@ cdef class QuaternionAlgebraElement_generic(QuaternionAlgebraElement_abstract):
 
 
 cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abstract):
-    """
+    r"""
     TESTS:
 
     We test pickling::
@@ -903,7 +903,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
     #       i^2 = a   and   j^2 = b
 
     def __cinit__(self):
-        """
+        r"""
         Initialize C variables.
 
         EXAMPLES::
@@ -929,7 +929,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         mpz_clear(self.d)
 
     def _rational_(self):
-        """
+        r"""
         Try to coerce this quaternion to a Rational.
 
         EXAMPLES::
@@ -951,7 +951,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         raise TypeError
 
     cpdef bint is_constant(self) noexcept:
-        """
+        r"""
         Return ``True`` if this quaternion is constant, i.e., has no `i`, `j`,
         or `k` term.
 
@@ -972,7 +972,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return not (mpz_sgn(self.y) or mpz_sgn(self.z) or mpz_sgn(self.w))
 
     def __bool__(self):
-        """
+        r"""
         Return ``True`` if this quaternion is nonzero.
 
         EXAMPLES::
@@ -986,7 +986,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return bool(mpz_sgn(self.x) or mpz_sgn(self.y) or mpz_sgn(self.z) or mpz_sgn(self.w))
 
     cpdef _richcmp_(self, _right, int op):
-        """
+        r"""
         Compare two quaternions.
 
         The comparison is fairly arbitrary
@@ -1025,7 +1025,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return rich_to_bool(op, 0)
 
     def __init__(self, parent, v, bint check=True):
-        """
+        r"""
         Setup element data from parent and coordinates.
 
         EXAMPLES::
@@ -1103,7 +1103,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         mpz_clear(lcm)
 
     def __getitem__(self, int i):
-        """
+        r"""
         TESTS::
 
             sage: Q.<i,j,k> = QuaternionAlgebra(QQ,-5,-2)
@@ -1129,7 +1129,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return r
 
     def __reduce__(self):
-        """
+        r"""
         Used for pickling.
 
         TESTS::
@@ -1146,7 +1146,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
                 (self._parent, (self[0], self[1], self[2], self[3])))
 
     cpdef _add_(self, _right):
-        """
+        r"""
         EXAMPLES::
 
             sage: Q.<i,j,k> = QuaternionAlgebra(15)
@@ -1202,7 +1202,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return result
 
     cpdef _sub_(self, _right):
-        """
+        r"""
         EXAMPLES::
 
             sage: Q.<i,j,k> = QuaternionAlgebra(15)
@@ -1243,7 +1243,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return result
 
     cpdef _mul_(self, _right):
-        """
+        r"""
         EXAMPLES::
 
             sage: Q.<i,j,k> = QuaternionAlgebra(15)
@@ -1356,7 +1356,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return result
 
     cpdef reduced_norm(self):
-        """
+        r"""
         Return the reduced norm of ``self``.
 
         Given a quaternion `x+yi+zj+wk`, this is `x^2 - ay^2 - bz^2 + abw^2`.
@@ -1397,7 +1397,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return result
 
     cpdef conjugate(self):
-        """
+        r"""
         Return the conjugate of this quaternion.
 
         EXAMPLES::
@@ -1428,7 +1428,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return result
 
     cpdef reduced_trace(self):
-        """
+        r"""
         Return the reduced trace of ``self``.
 
         This is `2x` if ``self`` is `x+iy+zj+wk`.
@@ -1452,7 +1452,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return result
 
     cdef inline canonicalize(self):
-        """
+        r"""
         Put the representation of this quaternion element into
         smallest form. For `a = (1/d)(x + yi + zj + wk)` we
         divide `a`, `x`, `y`, `z`, and `w` by the gcd of all of them.
@@ -1488,9 +1488,9 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
                         mpz_divexact(self.w, self.w, U1)
 
     def denominator(self):
-        """
+        r"""
         Return the lowest common multiple of the denominators of the coefficients
-        of i, j and k for this quaternion.
+        of `i`, `j` and `k` for this quaternion.
 
         EXAMPLES::
 
@@ -1513,10 +1513,10 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return d
 
     def denominator_and_integer_coefficient_tuple(self):
-        """
-        Return 5-tuple d, x, y, z, w, where this rational quaternion
-        is equal to `(x + yi + zj + wk)/d` and x, y, z, w do not share
-        a common factor with d.
+        r"""
+        Return 5-tuple `(d, x, y, z, w)`, where this rational quaternion
+        is equal to `(x + yi + zj + wk)/d` and `x, y, z, w` do not share
+        a common factor with `d`.
 
         OUTPUT: 5-tuple of Integers
 
@@ -1541,7 +1541,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return (d, x, y, z, w)
 
     def integer_coefficient_tuple(self):
-        """
+        r"""
         Return the integer part of this quaternion, ignoring the common denominator.
 
         OUTPUT: 4-tuple of Integers
@@ -1565,7 +1565,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return (x, y, z, w)
 
     def coefficient_tuple(self):
-        """
+        r"""
         Return 4-tuple of rational numbers which are the coefficients of this quaternion.
 
         EXAMPLES::
@@ -1596,7 +1596,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return (x, y, z, w)
 
     def _multiply_by_integer(self, Integer n):
-        """
+        r"""
         Return the product of ``self`` times the integer `n`.
 
         EXAMPLES::
@@ -1633,7 +1633,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         return result
 
     def _divide_by_integer(self, Integer n):
-        """
+        r"""
         Return the quotient of ``self`` by the integer `n`.
 
         EXAMPLES::
@@ -1669,7 +1669,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
 
 cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstract):
     def __cinit__(self):
-        """
+        r"""
         Allocate memory for this quaternion over a number field.
 
         EXAMPLES::
@@ -1688,7 +1688,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         mpz_init(self.d)
 
     def __dealloc__(self):
-        """
+        r"""
         Free memory used by this quaternion over a number field.
         """
         fmpz_poly_clear(self.x)
@@ -1701,7 +1701,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         mpz_clear(self.d)
 
     def __init__(self, parent, v, bint check=True):
-        """
+        r"""
         EXAMPLES::
 
             sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K,-a,a+1)          # needs sage.symbolic
@@ -1745,7 +1745,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         fmpz_poly_set_ZZX(self.modulus, (<NumberFieldElement>x)._fld_numerator.x)  # and same for the modulus
 
     def __getitem__(self, int i):
-        """
+        r"""
         EXAMPLES::
 
             sage: # needs sage.symbolic
@@ -1787,7 +1787,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         return item
 
     def __reduce__(self):
-        """
+        r"""
         EXAMPLES::
 
             sage: # needs sage.symbolic
@@ -1804,7 +1804,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
                 (self._parent, (self[0], self[1], self[2], self[3])))
 
     cpdef _add_(self, _right):
-        """
+        r"""
         Add ``self`` and ``_right``:
 
         EXAMPLES::
@@ -1878,7 +1878,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         return result
 
     cpdef _sub_(self, _right):
-        """
+        r"""
         Subtract ``_right`` from ``self``.
 
         EXAMPLES::
@@ -1929,7 +1929,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         return result
 
     cpdef _mul_(self, _right):
-        """
+        r"""
         Multiply ``self`` and ``_right``.
 
         EXAMPLES::
@@ -2077,7 +2077,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         return result
 
     cdef inline canonicalize(self):
-        """
+        r"""
         Put the representation of this quaternion element into
         smallest form. For a = `(1/d)(x + yi + zj + wk)` we
         divide `a`, `x`, `y`, `z`, and `w` by the gcd of all of them.
@@ -2133,7 +2133,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
 #######################################################################
 
 def unpickle_QuaternionAlgebraElement_generic_v0(*args):
-    """
+    r"""
     EXAMPLES::
 
         sage: K.<X> = QQ[]
@@ -2148,7 +2148,7 @@ def unpickle_QuaternionAlgebraElement_generic_v0(*args):
 
 
 def unpickle_QuaternionAlgebraElement_rational_field_v0(*args):
-    """
+    r"""
     EXAMPLES::
 
         sage: Q.<i,j,k> = QuaternionAlgebra(-5,-19); a = 2/3 + i*5/7 - j*2/5 +19/2
@@ -2160,7 +2160,7 @@ def unpickle_QuaternionAlgebraElement_rational_field_v0(*args):
 
 
 def unpickle_QuaternionAlgebraElement_number_field_v0(*args):
-    """
+    r"""
     EXAMPLES::
 
         sage: # needs sage.symbolic


### PR DESCRIPTION
...mostly cosmetic, with some tiny non-breaking functional changes (new aliases for some methods that were inconsistently named before, such as `.inner_product_matrix()` for some quaternion classes vs. `.gram_matrix()` for some others).