### PR TITLE
src/sage/matrix: remove block-level "needs sage.foo" tags

### DIFF
--- a/src/sage/matrix/args.pyx
+++ b/src/sage/matrix/args.pyx
@@ -211,7 +211,6 @@ cdef class MatrixArgs:
         [1 2]
         [3 4]
 
-        sage: # needs sage.libs.pari
         sage: ma = MatrixArgs(QQ, entries=pari("[1,2;3,4]")); ma.finalized()
         <MatrixArgs for Full MatrixSpace of 2 by 2 dense matrices
          over Rational Field; typ=SEQ_FLAT; entries=[1, 2, 3, 4]>
@@ -274,7 +273,6 @@ cdef class MatrixArgs:
         [1.0000 2.0000]
         [3.0000 4.0000]
 
-        sage: # needs sage.graphs
         sage: ma = MatrixArgs(graphs.CycleGraph(3)); ma.finalized()
         <MatrixArgs for Full MatrixSpace of 3 by 3 dense matrices
          over Integer Ring; typ=MATRIX; entries=[0 1 1]
@@ -1091,7 +1089,6 @@ cdef class MatrixArgs:
 
         Check github issue #36065:
 
-            sage: # needs sage.rings.number_field
             sage: class MyAlgebraicNumber(sage.rings.qqbar.AlgebraicNumber):
             ....:     def __bool__(self):
             ....:         raise ValueError
@@ -1484,7 +1481,6 @@ cdef class MatrixArgs:
 
         Check that :issue:`26655` is fixed::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = GF(9)
             sage: M = MatrixSpace(F, 2, 2)
             sage: A = M([[1, a], [0, 1]])
@@ -1506,7 +1502,6 @@ cdef class MatrixArgs:
 
         Check that :issue:`38221` is fixed::
 
-            sage: # needs sage.groups
             sage: G = CyclicPermutationGroup(7)
             sage: R = GF(2)
             sage: A = G.algebra(R)

--- a/src/sage/matrix/constructor.pyx
+++ b/src/sage/matrix/constructor.pyx
@@ -606,7 +606,6 @@ def matrix(*args, **kwds):
 
     Check :issue:`24459`::
 
-        sage: # needs sage.libs.linbox
         sage: Matrix(ZZ, sys.maxsize, sys.maxsize)
         Traceback (most recent call last):
         ...

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -949,7 +949,6 @@ cdef class Matrix(sage.structure.element.Matrix):
         Check that submatrices with a specified implementation have the
         same implementation::
 
-            sage: # needs sage.libs.pari
             sage: M = MatrixSpace(GF(2), 3, 3, implementation='generic')
             sage: m = M(range(9))
             sage: type(m)
@@ -1988,7 +1987,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         Prior to :issue:`11544` this could take a full minute to run (2011). ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQ, 4, 4, [1, 2, -2, 2, 1, 0, -1, -1, 0, -1, 1, 1, -1, 2, 1/2, 0])
             sage: e = A.eigenvalues()[3]
             sage: K = (A - e).kernel()
@@ -2498,7 +2496,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: f(x,y) = x^2 + y
             sage: m = matrix([[f, f*f], [f^3, f^4]]); m
             [    (x, y) |--> x^2 + y (x, y) |--> (x^2 + y)^2]
@@ -2697,7 +2694,6 @@ cdef class Matrix(sage.structure.element.Matrix):
         Next of all, create a permutation group element and act
         on ``M`` with it::
 
-            sage: # needs sage.groups
             sage: G = PermutationGroup(['(1,2,3)(4,5)', '(1,2,3,4,5)'])
             sage: sigma, tau = G.gens()
             sage: sigma
@@ -2746,7 +2742,6 @@ cdef class Matrix(sage.structure.element.Matrix):
         Next of all, create a permutation group element and
         act on ``M``::
 
-            sage: # needs sage.groups
             sage: G = PermutationGroup(['(1,2,3)(4,5)', '(1,2,3,4,5)'])
             sage: sigma, tau = G.gens()
             sage: sigma
@@ -2878,7 +2873,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         Next of all, create a permutation group element and act on ``M``::
 
-            sage: # needs sage.groups
             sage: G = PermutationGroup(['(1,2,3)(4,5)', '(1,2,3,4,5)'])
             sage: sigma, tau = G.gens()
             sage: sigma
@@ -2926,7 +2920,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         Next of all, create a permutation group element and act on ``M``::
 
-            sage: # needs sage.groups
             sage: G = PermutationGroup(['(1,2,3)(4,5)', '(1,2,3,4,5)'])
             sage: sigma, tau = G.gens()
             sage: sigma
@@ -2983,7 +2976,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         Next of all, create a permutation group element and act on ``M``::
 
-            sage: # needs sage.groups
             sage: G = PermutationGroup(['(1,2,3)(4,5)', '(1,2,3,4,5)'])
             sage: sigma, tau = G.gens()
             sage: sigma
@@ -3027,7 +3019,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         Next of all, create a permutation group element and act on ``M``::
 
-            sage: # needs sage.groups
             sage: G = PermutationGroup(['(1,2,3)(4,5)', '(1,2,3,4,5)'])
             sage: sigma, tau = G.gens()
             sage: sigma
@@ -4197,7 +4188,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[ 1 + I,  1 - 6*I, -1 - I],
             ....:                    [-3 - I,     -4*I,     -2],
             ....:                    [-1 + I, -2 - 8*I,  2 + I]])
@@ -4210,7 +4200,6 @@ cdef class Matrix(sage.structure.element.Matrix):
         Sage has several fields besides the entire complex numbers
         where conjugation is non-trivial::
 
-            sage: # needs sage.rings.number_field
             sage: F.<b> = QuadraticField(-7)
             sage: C = matrix(F, [[-2*b - 3,  7*b - 6, -b + 3],
             ....:                [-2*b - 3, -3*b + 2,   -2*b],
@@ -4224,7 +4213,6 @@ cdef class Matrix(sage.structure.element.Matrix):
         A matrix that is nearly Hermitian, but for a non-real
         diagonal entry::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[    2,   2-I, 1+4*I],
             ....:                    [  2+I,   3+I, 2-6*I],
             ....:                    [1-4*I, 2+6*I,     5]])
@@ -4342,7 +4330,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[ 1 + I,  1 - 6*I, -1 - I],
             ....:                    [-3 - I,     -4*I,     -2],
             ....:                    [-1 + I, -2 - 8*I,  2 + I]])
@@ -4355,7 +4342,6 @@ cdef class Matrix(sage.structure.element.Matrix):
         Sage has several fields besides the entire complex numbers
         where conjugation is non-trivial. ::
 
-            sage: # needs sage.rings.number_field
             sage: F.<b> = QuadraticField(-7)
             sage: C = matrix(F, [[-2*b - 3,  7*b - 6, -b + 3],
             ....:                [-2*b - 3, -3*b + 2,   -2*b],
@@ -4369,7 +4355,6 @@ cdef class Matrix(sage.structure.element.Matrix):
         A matrix that is nearly Hermitian, but for a non-real
         diagonal entry. ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[    2,   2-I, 1+4*I],
             ....:                    [  2+I,   3+I, 2-6*I],
             ....:                    [1-4*I, 2+6*I,     5]])
@@ -4428,7 +4413,6 @@ cdef class Matrix(sage.structure.element.Matrix):
         A matrix that is nearly skew-Hermitian, but for a non-real
         diagonal entry. ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[  -I, -1, 1-I],
             ....:                    [   1,  1,  -1],
             ....:                    [-1-I,  1,  -I]])
@@ -5123,7 +5107,6 @@ cdef class Matrix(sage.structure.element.Matrix):
             sage: B.multiplicative_order()                                              # needs sage.rings.finite_rings
             1
 
-            sage: # needs sage.rings.finite_rings
             sage: M = MatrixSpace(GF(11^2, 'e'), 5)
             sage: E = M.random_element()
             sage: while E.det() == 0:
@@ -5295,7 +5278,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         Check that :issue:`8198` is fixed::
 
-            sage: # needs sage.rings.padics
             sage: R = Qp(5, 5)
             sage: x = R(5).add_bigoh(1)
             sage: I = matrix(R, [[1, 0], [0, 1]])
@@ -5329,7 +5311,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         Check that :issue:`8198` is fixed::
 
-            sage: # needs sage.rings.padics
             sage: R = Qp(5, 5)
             sage: x = R(5).add_bigoh(1)
             sage: I = matrix(R, [[1, 0], [0, 1]])
@@ -5426,7 +5407,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: R.<x,y> = FreeAlgebra(QQ, 2)
             sage: a = matrix(2, 2, [1,2,x*y,y*x])
             sage: b = matrix(2, 2, [1,2,y*x,y*x])
@@ -5449,7 +5429,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: R.<x,y> = FreeAlgebra(QQ,2)
             sage: a = matrix(2, 2, [1,2,x*y,y*x])
             sage: b = matrix(2, 2, [1,2,y*x,y*x])
@@ -5525,7 +5504,6 @@ cdef class Matrix(sage.structure.element.Matrix):
             [          x*y         x^2*y         x*y^2]
             [     -x^2*y^2 x^2*y + x*y^2 x^2*y - x*y^2]
 
-            sage: # needs sage.combinat
             sage: R.<x,y> = FreeAlgebra(ZZ,2)
             sage: a = matrix(R, 2, 3, [1,x,y, -x*y,x+y,x-y]); a
             [    1     x     y]
@@ -5559,7 +5537,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         An example in which the base ring is not commutative::
 
-            sage: # needs sage.combinat
             sage: F.<x,y> = FreeAlgebra(QQ,2)
             sage: a = matrix(2, [x,y, x^2,y^2]); a
             [  x   y]
@@ -5571,7 +5548,6 @@ cdef class Matrix(sage.structure.element.Matrix):
             [  x*y   y^2]
             [x^2*y   y^3]
 
-            sage: # needs sage.combinat
             sage: R.<x,y> = FreeAlgebra(ZZ,2)
             sage: a = matrix(R, 2, 3, [1,x,y, -x*y,x+y,x-y]); a
             [    1     x     y]
@@ -5668,7 +5644,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         EXAMPLE of matrix multiplication over a noncommutative base ring::
 
-            sage: # needs sage.combinat
             sage: R.<x,y> = FreeAlgebra(QQ, 2)
             sage: x*y - y*x
             x*y - y*x
@@ -5747,7 +5722,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         EXAMPLE of scalar multiplication in the noncommutative case::
 
-            sage: # needs sage.combinat
             sage: R.<x,y> = FreeAlgebra(ZZ, 2)
             sage: a = matrix(2, [x,y, x^2,y^2])
             sage: a * x
@@ -5885,7 +5859,6 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         Matrices over `p`-adics. See :issue:`17272` ::
 
-            sage: # needs sage.rings.padics
             sage: R = ZpCA(5, 5, print_mode='val-unit')
             sage: A = matrix(R, 3, 3, [250,2369,1147,106,927,362,90,398,2483])
             sage: A

--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -95,7 +95,6 @@ cdef class Matrix(Matrix0):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.gap
             sage: A = MatrixSpace(QQ,3,3)([0,1,2,3,4,5,6,7,8])
             sage: g = gap(A)  # indirect doctest
             sage: g
@@ -110,7 +109,6 @@ cdef class Matrix(Matrix0):
         Particularly difficult is the case of matrices over cyclotomic
         fields and general number fields. See :issue:`5618` and :issue:`8909`::
 
-            sage: # needs sage.libs.gap sage.rings.number_field
             sage: K.<zeta> = CyclotomicField(8)
             sage: A = MatrixSpace(K, 2, 2)([0, 1+zeta, 2*zeta, 3])
             sage: g = gap(A); g
@@ -120,7 +118,6 @@ cdef class Matrix(Matrix0):
             sage: g.IsMatrix()
             true
 
-            sage: # needs sage.libs.gap sage.rings.number_field
             sage: x = polygen(ZZ, 'x')
             sage: L.<tau> = NumberField(x^3 - 2)
             sage: A = MatrixSpace(L, 2, 2)([0, 1+tau, 2*tau, 3])
@@ -2504,7 +2501,6 @@ cdef class Matrix(Matrix0):
 
         ::
 
-            sage: # needs sage.rings.finite_rings
             sage: K.<a> = GF(2^4)
             sage: l = [a^2 + 1, a^3 + 1, 0, 0, a, a^3 + a + 1, a + 1,
             ....:      a + 1, a^2, a^3 + a + 1, a^3 + a, a^3 + a]
@@ -2519,7 +2515,6 @@ cdef class Matrix(Matrix0):
 
         ::
 
-            sage: # needs sage.rings.finite_rings
             sage: K.<a> = GF(25)
             sage: M = Matrix(K, 2, 3, [0, 2, 3, 5, a, a^2])
             sage: M

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -149,7 +149,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: var('a,b,d,e')
             (a, b, d, e)
             sage: m = matrix([[a,b], [d,e]])
@@ -284,7 +283,6 @@ cdef class Matrix(Matrix1):
 
         Over the complex numbers::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = matrix(CDF, [[      0, -1 + 2*I,  1 - 3*I,        I],
             ....:                  [2 + 4*I, -2 + 3*I, -1 + 2*I,   -1 - I],
             ....:                  [  2 + I,    1 - I,       -1,        5],
@@ -334,7 +332,6 @@ cdef class Matrix(Matrix1):
             sage: X
             (-1, 2, 0, 0)
 
-            sage: # needs sage.libs.pari
             sage: A = Matrix(Zmod(128), 2, 3, [5, 29, 33, 64, 0, 7])
             sage: B = vector(Zmod(128), [31,39,56])
             sage: X = A.solve_left(B); X
@@ -379,7 +376,6 @@ cdef class Matrix(Matrix1):
         The vector of constants needs to be compatible with
         the base ring of the coefficient matrix::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(27)
             sage: b = vector(F, [a,a,a,a,a])
             sage: A.solve_left(b)
@@ -389,7 +385,6 @@ cdef class Matrix(Matrix1):
 
         Check that coercions work correctly (:issue:`17405`)::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = matrix(RDF, 2, range(4))
             sage: b = vector(CDF, [1+I, 2])
             sage: A.solve_left(b)                                                       # needs scipy
@@ -583,7 +578,6 @@ cdef class Matrix(Matrix1):
 
         Solving some systems over `\ZZ/n\ZZ`::
 
-            sage: # needs sage.libs.pari
             sage: A = Matrix(Zmod(6), 3, 2, [1,2,3,4,5,6])
             sage: B = vector(Zmod(6), [1,1,1])
             sage: A.solve_right(B)
@@ -610,7 +604,6 @@ cdef class Matrix(Matrix1):
 
         Solving a system over the `p`-adics::
 
-            sage: # needs sage.rings.padics
             sage: k = Qp(5, 4)
             sage: a = matrix(k, 3, [1,7,3, 2,5,4, 1,1,2]); a
             [    1 + O(5^4) 2 + 5 + O(5^4)     3 + O(5^4)]
@@ -625,7 +618,6 @@ cdef class Matrix(Matrix1):
         Solving a system of linear equations symbolically using symbolic
         matrices::
 
-            sage: # needs sage.symbolic
             sage: var('a,b,c,d,x,y')
             (a, b, c, d, x, y)
             sage: A = matrix(SR, 2, [a,b,c,d]); A
@@ -669,7 +661,6 @@ cdef class Matrix(Matrix1):
 
         Over the complex numbers::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = matrix(CDF, [[      0, -1 + 2*I,  1 - 3*I,        I],
             ....:                  [2 + 4*I, -2 + 3*I, -1 + 2*I,   -1 - I],
             ....:                  [  2 + I,    1 - I,       -1,        5],
@@ -783,7 +774,6 @@ cdef class Matrix(Matrix1):
 
         Check that coercions work correctly (:issue:`17405`)::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = matrix(RDF, 2, range(4))
             sage: b = vector(CDF, [1+I, 2])
             sage: A.solve_right(b)
@@ -834,7 +824,6 @@ cdef class Matrix(Matrix1):
 
         ::
 
-            sage: # needs sage.symbolic
             sage: SC = SR.subring(no_variables=True)
             sage: m = matrix(SC, [0])
             sage: b = vector(SC, [1])
@@ -1398,7 +1387,6 @@ cdef class Matrix(Matrix1):
 
         Non-commutative rings behave as expected.  These are the usual quaternions. ::
 
-            sage: # needs sage.combinat
             sage: R.<i,j,k> = QuaternionAlgebra(-1, -1)
             sage: A = matrix(R, 2, [1,i,j,k])
             sage: B = matrix(R, 2, [i,i,i,i])
@@ -1790,7 +1778,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: M = diagonal_matrix(CDF, [0, I, 1+I]); M
             [        0.0         0.0         0.0]
             [        0.0       1.0*I         0.0]
@@ -1831,7 +1818,6 @@ cdef class Matrix(Matrix1):
         result is symmetric for the ``exact`` algorithm or hermitian
         for the ``exactconj`` algorithm::
 
-            sage: # needs sage.rings.number_field sage.symbolic
             sage: M = matrix(QQbar, 2, 2, [1, sqrt(-3), -sqrt(-3), 3])
             sage: M * M.pseudoinverse()
             [   0.2500000000000000?  0.4330127018922193?*I]
@@ -2310,7 +2296,6 @@ cdef class Matrix(Matrix1):
 
         We verify that :issue:`10063` is resolved::
 
-            sage: # needs sage.libs.singular
             sage: A = GF(2)['x,y,z']
             sage: A.inject_variables()
             Defining x, y, z
@@ -3077,7 +3062,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.finite_rings
             sage: A = matrix(GF(9, 'c'), 4, [1,1,0,0, 0,1,0,0, 0,0,5,0, 0,0,0,5])
             sage: factor(A.minpoly())
             (x + 1) * (x + 2)^2
@@ -3243,7 +3227,6 @@ cdef class Matrix(Matrix1):
 
         Here is an example over a number field::
 
-            sage: # needs sage.rings.number_field
             sage: x = QQ['x'].gen()
             sage: K.<a> = NumberField(x^2 - 2)
             sage: m = matrix(K, [[a-1, 2], [a, a+1]])
@@ -3263,7 +3246,6 @@ cdef class Matrix(Matrix1):
         ``S`` in the following example is an integral domain.  But the
         computation of the characteristic polynomial succeeds as follows::
 
-            sage: # needs sage.libs.singular
             sage: R.<a,b> = QQ[]
             sage: S.<x,y> = R.quo((b^3))
             sage: A = matrix(S, [[x*y^2, 2*x], [2, x^10*y]]); A
@@ -3285,7 +3267,6 @@ cdef class Matrix(Matrix1):
         and crash if an empty dictionary was cached. We don't cache
         dictionaries anymore, but this test should still pass::
 
-            sage: # needs sage.rings.padics
             sage: z = Zp(p=5)
             sage: A = matrix(z, [ [3 + O(5^1), 4 + O(5^1), 4 + O(5^1)],
             ....:                 [2*5^2 + O(5^3), 2 + O(5^1), 1 + O(5^1)],
@@ -3558,7 +3539,6 @@ cdef class Matrix(Matrix1):
 
         Here's an example involving a cyclotomic field::
 
-            sage: # needs sage.rings.number_field
             sage: K.<z> = CyclotomicField(3)
             sage: M = MatrixSpace(K, 3, sparse=True)
             sage: A = M([(1+z)/3, (2+z)/3, z/3, 1, 1+z, -2, 1, 5, -1+z])
@@ -4037,7 +4017,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.pari sage.rings.number_field
             sage: Q = QuadraticField(-7)
             sage: a = Q.gen(0)
             sage: A = matrix(Q, [[    2, 5 - a,   15 - a],
@@ -4054,7 +4033,6 @@ cdef class Matrix(Matrix1):
 
         We test some trivial cases. ::
 
-            sage: # needs sage.libs.pari sage.rings.number_field
             sage: Q = QuadraticField(-7)
             sage: A = matrix(Q, 0, 2)
             sage: A._right_kernel_matrix_over_number_field()[1]
@@ -4095,7 +4073,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: C = CyclotomicField(14)
             sage: a = C.gen(0)
             sage: A = matrix(C, 3, 4, [[  1,    a,    1+a,  a^3+a^5],
@@ -4114,7 +4091,6 @@ cdef class Matrix(Matrix1):
 
         We test some trivial cases. ::
 
-            sage: # needs sage.rings.number_field
             sage: C = CyclotomicField(14)
             sage: A = matrix(C, 0, 2)
             sage: A._right_kernel_matrix_over_field()[1]
@@ -4245,7 +4221,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.pari
             sage: A = matrix(Zmod(24480), [[1,2,3,4,5], [7,7,7,7,7]])
             sage: result = A._right_kernel_matrix_over_integer_mod_ring()
             sage: result[0]
@@ -4419,7 +4394,6 @@ cdef class Matrix(Matrix1):
         basis, so the `basis` keywords 'computed' and 'pivot' will return
         the same results. ::
 
-            sage: # needs sage.rings.number_field
             sage: Q = QuadraticField(-7)
             sage: a = Q.gen(0)
             sage: A = matrix(Q, [[2, 5-a, 15-a, 16+4*a],
@@ -4444,7 +4418,6 @@ cdef class Matrix(Matrix1):
         code for matrices over any field.  The basis vectors as computed
         are in pivot format. ::
 
-            sage: # needs sage.rings.number_field
             sage: Q = QuadraticField(-7)
             sage: a = Q.gen(0)
             sage: A = matrix(Q, [[2, 5-a, 15-a, 16+4*a], [2+a, a, -7 + 5*a, -3+3*a]])
@@ -4457,7 +4430,6 @@ cdef class Matrix(Matrix1):
         We check that number fields are handled by the right routine as part of
         typical right kernel computation. ::
 
-            sage: # needs sage.rings.number_field
             sage: Q = QuadraticField(-7)
             sage: a = Q.gen(0)
             sage: A = matrix(Q, [[2, 5-a, 15-a, 16+4*a], [2+a, a, -7 + 5*a, -3+3*a]])
@@ -4545,7 +4517,6 @@ cdef class Matrix(Matrix1):
         will compute a set of basis vectors in the pivot format.
         These could be returned as a basis in echelon form.  ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(5^2)
             sage: A = matrix(F, 3, 4, [[  1,   a,     1+a,  a^3+a^5],
             ....:                      [  a, a^4,   a+a^4,  a^4+a^8],
@@ -4585,7 +4556,6 @@ cdef class Matrix(Matrix1):
         We test that the generic code is called for matrices over fields,
         lacking any more specific routine. ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(5^2)
             sage: A = matrix(F, 3, 4, [[  1,   a,     1+a,  a^3+a^5],
             ....:                      [  a, a^4,   a+a^4,  a^4+a^8],
@@ -4631,7 +4601,6 @@ cdef class Matrix(Matrix1):
             sage: A*X.transpose() == zero_matrix(ZZ, 4, 3)
             True
 
-            sage: # needs sage.libs.pari
             sage: X = A.right_kernel_matrix(algorithm='pari', basis='computed'); X
             [ 3  1 -5 -7 -2  3  2]
             [ 3  1  2  5 -5  2 -6]
@@ -5088,7 +5057,6 @@ cdef class Matrix(Matrix1):
         Over an arbitrary field, with two basis formats.  Same vector space,
         different bases.  ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(5^2)
             sage: A = matrix(F, 3, 4, [[  1,   a,     1+a,  a^3+a^5],
             ....:                      [  a, a^4,   a+a^4,  a^4+a^8],
@@ -5129,7 +5097,6 @@ cdef class Matrix(Matrix1):
         Over number fields, PARI is used by default, but general-purpose code
         can be requested.  Same vector space, same bases, different code.::
 
-            sage: # needs sage.rings.number_field
             sage: Q = QuadraticField(-7)
             sage: a = Q.gen(0)
             sage: A = matrix(Q, [[    2, 5 - a,   15 - a, 16 + 4*a],
@@ -5626,7 +5593,6 @@ cdef class Matrix(Matrix1):
 
         An example over a bigger ring::
 
-            sage: # needs sage.rings.number_field
             sage: x = polygen(ZZ, 'x')
             sage: L.<w> = NumberField(x^2 - x + 2)
             sage: OL = L.ring_of_integers()
@@ -5769,7 +5735,6 @@ cdef class Matrix(Matrix1):
             [0 1 0]
             [0 0 1]
 
-            sage: # needs sage.rings.real_mpfr sage.symbolic
             sage: W = MatrixSpace(CC, 2, 2)
             sage: B = W([1, 2 + 3*I, 4 + 5*I, 9]); B
             [                     1.00000000000000 2.00000000000000 + 3.00000000000000*I]
@@ -6035,7 +6000,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.pari
             sage: t = matrix(QQ, 3, [3, 0, -2, 0, -2, 0, 0, 0, 0]); t
             [ 3  0 -2]
             [ 0 -2  0]
@@ -6518,7 +6482,6 @@ cdef class Matrix(Matrix1):
               User basis matrix:
               [                 1 1.289897948556636? 1.579795897113272?])]
 
-            sage: # needs sage.rings.number_field
             sage: es = A.eigenspaces_left(format='galois'); es
             [(0,
               Vector space of degree 3 and dimension 1 over Rational Field
@@ -6565,7 +6528,6 @@ cdef class Matrix(Matrix1):
         `T_2` on level 43 modular symbols, both with all eigenvalues (the default)
         and with one subspace per factor. ::
 
-            sage: # needs sage.modular
             sage: A = ModularSymbols(43).T(2).matrix(); A
             [ 3  0  0  0  0  0 -1]
             [ 0 -2  1  0  0  0  0]
@@ -6625,7 +6587,6 @@ cdef class Matrix(Matrix1):
 
         Next we compute the left eigenspaces over the finite field of order 11. ::
 
-            sage: # needs sage.modular sage.rings.finite_rings
             sage: A = ModularSymbols(43, base_ring=GF(11), sign=1).T(2).matrix(); A
             [ 3  0  9  0]
             [ 0  9  0 10]
@@ -6686,7 +6647,6 @@ cdef class Matrix(Matrix1):
             [ 0.897878732...  0.278434036... -0.341010658...]
             [ 0.408248290... -0.816496580...  0.408248290...]
 
-            sage: # needs sage.symbolic
             sage: x, y = var('x y')
             sage: S = matrix([[x, y], [y, 3*x^2]])
             sage: em = S.eigenmatrix_left()
@@ -6701,7 +6661,6 @@ cdef class Matrix(Matrix1):
         possible, will raise an error.  Using the ``'galois'``
         format option is more likely to be successful.  ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<b> = FiniteField(11^2)
             sage: A = matrix(F, [[b + 1, b + 1], [10*b + 4, 5*b + 4]])
             sage: A.eigenspaces_left(format='all')                                      # needs sage.rings.number_field
@@ -6876,7 +6835,6 @@ cdef class Matrix(Matrix1):
 
         We compute the right eigenspaces of a `3\times 3` rational matrix.  ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQ, 3, 3, range(9)); A
             [0 1 2]
             [3 4 5]
@@ -6963,7 +6921,6 @@ cdef class Matrix(Matrix1):
             [ 0.505774475...  0.104205787... -0.816496580...]
             [ 0.846785134... -0.591288087...  0.408248290...]
 
-            sage: # needs sage.symbolic
             sage: x, y = var('x y')
             sage: S = matrix([[x, y], [y, 3*x^2]])
             sage: em = S.eigenmatrix_right()
@@ -7343,7 +7300,6 @@ cdef class Matrix(Matrix1):
 
         ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQ, 3, 3, range(9)); A
             [0 1 2]
             [3 4 5]
@@ -7379,7 +7335,6 @@ cdef class Matrix(Matrix1):
 
         Check :issue:`30518`::
 
-            sage: # needs sage.rings.number_field
             sage: K.<i> = QuadraticField(-1)
             sage: m = matrix(K, 4, [2,4*i,-i,0, -4*i,2,-1,0, 2*i,-2,0,0, 4*i+4, 4*i-4,1-i,-2])
             sage: assert all(m*v == e*v for e, vs, _ in m.eigenvectors_right() for v in vs)
@@ -7681,7 +7636,6 @@ cdef class Matrix(Matrix1):
 
         ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQ, 3, 3, range(9)); A
             [0 1 2]
             [3 4 5]
@@ -7750,7 +7704,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQ, 3, 3, range(9)); A
             [0 1 2]
             [3 4 5]
@@ -7780,7 +7733,6 @@ cdef class Matrix(Matrix1):
 
         ::
 
-            sage: # needs sage.rings.number_field
             sage: A = jordan_block(2, 3); A
             [2 1 0]
             [0 2 1]
@@ -7861,7 +7813,6 @@ cdef class Matrix(Matrix1):
 
         The following example shows that :issue:`20439` has been resolved::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = matrix(CDF, [[-2.53634347567,  2.04801738686, -0.0, -62.166145304],
             ....:                  [ 0.7, -0.6, 0.0, 0.0],
             ....:                  [0.547271128842, 0.0, -0.3015, -21.7532081652],
@@ -7873,7 +7824,6 @@ cdef class Matrix(Matrix1):
         The following example shows that the fix for :issue:`20439` (conjugating
         eigenvectors rather than eigenvalues) is the correct one::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = Matrix(CDF,[[I,0],[0,1]])
             sage: D, P = A.eigenmatrix_left()
             sage: (P*A - D*P).norm() < 10^(-2)
@@ -7884,7 +7834,6 @@ cdef class Matrix(Matrix1):
         the algebraic multiplicity. The following examples show that these
         cases are detected (:issue:`27842`)::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(SR, [(225/548, 0, -175/274*sqrt(193/1446)),
             ....:                 (0, 1/2, 0),
             ....:                 (-63/548*sqrt(723/386), 0, 49/548)])
@@ -7905,7 +7854,6 @@ cdef class Matrix(Matrix1):
 
         The following example shows that :issue:`12595` has been resolved::
 
-            sage: # needs sage.rings.complex_double
             sage: m = Matrix(CDF, 8, [[-1, -1, -1, -1, 1, -3, -1, -1],
             ....:                     [1, 1, 1, 1, -1, -1, 1, -3],
             ....:                     [-1, 3, -1, -1, 1, 1, -1, -1],
@@ -7977,7 +7925,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQ, 3, 3, range(9)); A
             [0 1 2]
             [3 4 5]
@@ -8007,7 +7954,6 @@ cdef class Matrix(Matrix1):
 
         ::
 
-            sage: # needs sage.rings.number_field
             sage: A = jordan_block(2, 3); A
             [2 1 0]
             [0 2 1]
@@ -8281,7 +8227,6 @@ cdef class Matrix(Matrix1):
             [ 0  4  8 12]
             [ 0  0  0  0]
 
-            sage: # needs sage.rings.number_field
             sage: x = polygen(ZZ, 'x')
             sage: L.<w> = NumberField(x^2 - x + 2)
             sage: OL = L.ring_of_integers()
@@ -8447,7 +8392,6 @@ cdef class Matrix(Matrix1):
         We check that the echelon form works for matrices over `p`-adics.
         See :issue:`17272`::
 
-            sage: # needs sage.rings.padics
             sage: R = ZpCA(5,5,print_mode='val-unit')
             sage: A = matrix(R, 3,3, [250,2369,1147, 106,927,362, 90,398,2483])
             sage: A
@@ -8663,7 +8607,6 @@ cdef class Matrix(Matrix1):
             [ 1  0 -1]
             [ 0  1  2]
 
-            sage: # needs sage.rings.padics
             sage: R = ZpCA(5, 5, print_mode='val-unit')
             sage: A = matrix(R, 3, 3, [250,2369,1147, 106,927,362, 90,398,2483]); A
             [5^3 * 2 + O(5^5)    2369 + O(5^5)    1147 + O(5^5)]
@@ -8743,7 +8686,6 @@ cdef class Matrix(Matrix1):
             [ 1  0 -1]
             [ 0  1  2]
 
-            sage: # needs sage.rings.padics
             sage: R = ZpCA(5, 5, print_mode='val-unit')
             sage: A = matrix(R,3,3,[250,2369,1147,106,927,362,90,398,2483]); A
             [5^3 * 2 + O(5^5)    2369 + O(5^5)    1147 + O(5^5)]
@@ -9118,7 +9060,6 @@ cdef class Matrix(Matrix1):
             [  6 1/4]
             [  8  -5]
 
-            sage: # needs sage.graphs
             sage: B = M.as_bipartite_graph(); B
             Bipartite graph on 5 vertices
             sage: B.edges(sort=True)
@@ -9147,7 +9088,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs sage.groups
             sage: M = matrix(ZZ,[[1,0],[1,0],[0,1]]); M
             [1 0]
             [1 0]
@@ -9238,7 +9178,6 @@ cdef class Matrix(Matrix1):
 
         TESTS::
 
-            sage: # needs sage.graphs
             sage: M = matrix(ZZ, [[3, 4, 5], [3, 4, 5], [3, 5, 4], [2, 0,1]])
             sage: M.permutation_normal_form()
             [5 4 3]
@@ -9419,7 +9358,6 @@ cdef class Matrix(Matrix1):
 
         And for when ``check`` is True::
 
-            sage: # needs sage.graphs sage.groups
             sage: N = matrix(ZZ, [[3,5,3], [2,6,4], [1,2,3]]); N
             [3 5 3]
             [2 6 4]
@@ -9644,7 +9582,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.pari
             sage: M = matrix(5, 5, prime_range(100))
             sage: M.subdivide(2,3); M
             [ 2  3  5| 7 11]
@@ -9673,7 +9610,6 @@ cdef class Matrix(Matrix1):
 
         Degenerate cases work too::
 
-            sage: # needs sage.libs.pari
             sage: M.subdivide([2,5], [0,1,3]); M
             [| 2| 3  5| 7 11]
             [|13|17 19|23 29]
@@ -10353,7 +10289,6 @@ cdef class Matrix(Matrix1):
 
         A permutation matrix is always orthogonal. ::
 
-            sage: # needs sage.combinat
             sage: sigma = Permutation([1,3,4,5,2])
             sage: P = sigma.to_matrix(); P
             [1 0 0 0 0]
@@ -10463,7 +10398,6 @@ cdef class Matrix(Matrix1):
 
         Hermitian matrices are normal.  ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(QQ, 5, 5, range(25)) + I*matrix(QQ, 5, 5, range(0, 50, 2))
             sage: B = A*A.conjugate_transpose()
             sage: B.is_hermitian()
@@ -10473,7 +10407,6 @@ cdef class Matrix(Matrix1):
 
         Circulant matrices are normal.  ::
 
-            sage: # needs sage.graphs
             sage: G = graphs.CirculantGraph(20, [3, 7])
             sage: D = digraphs.Circuit(20)
             sage: A = 3*D.adjacency_matrix() - 5*G.adjacency_matrix()
@@ -10502,7 +10435,6 @@ cdef class Matrix(Matrix1):
         Sage has several fields besides the entire complex numbers
         where conjugation is non-trivial. ::
 
-            sage: # needs sage.rings.number_field
             sage: F.<b> = QuadraticField(-7)
             sage: C = matrix(F, [[-2*b - 3,  7*b - 6, -b + 3],
             ....:                [-2*b - 3, -3*b + 2,   -2*b],
@@ -10514,7 +10446,6 @@ cdef class Matrix(Matrix1):
         A matrix that is nearly normal, but for a non-real
         diagonal entry. ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[    2,   2-I, 1+4*I],
             ....:                    [  2+I,   3+I, 2-6*I],
             ....:                    [1-4*I, 2+6*I,     5]])
@@ -10711,7 +10642,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.real_mpfr
             sage: M = random_matrix(CC, 5, 7)
             sage: for i in range(5):  M[i,i] = 0
             sage: M[4, 0] = M[0, 6] = M[4, 6] = 0
@@ -10964,7 +10894,6 @@ cdef class Matrix(Matrix1):
         Finally, an example over a general ring ``S`` that is
         not an integral domain::
 
-            sage: # needs sage.libs.singular
             sage: R.<a,b> = QQ[]
             sage: S.<x,y> = R.quo((b^3))
             sage: A = matrix(S, [[x*y^2, 2*x], [2, x^10*y]])
@@ -11076,7 +11005,6 @@ cdef class Matrix(Matrix1):
 
         For a nonsingular matrix, the QR decomposition is unique. ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[-2, 0, -4, -1, -1],
             ....:                    [-2, 1, -6, -3, -1],
             ....:                    [1, 1, 7, 4, 5],
@@ -11108,7 +11036,6 @@ cdef class Matrix(Matrix1):
         An example with complex numbers in ``QQbar``, the field of algebraic
         numbers. ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[-8, 4*I + 1, -I + 2, 2*I + 1],
             ....:                    [1, -2*I - 1, -I + 3, -I + 1],
             ....:                    [I + 7, 2*I + 1, -2*I + 7, -I + 1],
@@ -11137,7 +11064,6 @@ cdef class Matrix(Matrix1):
 
         A rank-deficient rectangular matrix, with both values of the ``full`` keyword.  ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[2, -3, 3],
             ....:                    [-1, 1, -1],
             ....:                    [-1, 3, -3],
@@ -11159,7 +11085,6 @@ cdef class Matrix(Matrix1):
             [           0.?e-18            0.?e-18 1.000000000000000?            0.?e-18]
             [           0.?e-18            0.?e-18            0.?e-18 1.000000000000000?]
 
-            sage: # needs sage.rings.number_field
             sage: Q, R = A.QR(full=False)
             sage: Q
             [ 0.3592106040535498? -0.5693261797050169?]
@@ -11176,7 +11101,6 @@ cdef class Matrix(Matrix1):
         Another rank-deficient rectangular matrix, with complex entries,
         as a reduced decomposition. ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[-3*I - 3, I - 3, -12*I + 1, -2],
             ....:                    [-I - 1, -2, 5*I - 1, -I - 2],
             ....:                    [-4*I - 4, I - 5, -7*I, -I - 4]])
@@ -11199,7 +11123,6 @@ cdef class Matrix(Matrix1):
         Results of full decompositions are cached and thus returned
         immutable.  ::
 
-            sage: # needs sage.rings.number_field
             sage: A = random_matrix(QQbar, 2, 2)
             sage: Q, R = A.QR()
             sage: Q.is_mutable()
@@ -11210,7 +11133,6 @@ cdef class Matrix(Matrix1):
         Trivial cases return trivial results of the correct size,
         and we check `Q` itself in one case.  ::
 
-            sage: # needs sage.rings.number_field
             sage: A = zero_matrix(QQbar, 0, 10)
             sage: Q, R = A.QR()
             sage: Q.nrows(), Q.ncols()
@@ -11378,7 +11300,6 @@ cdef class Matrix(Matrix1):
         so we need to check with the conjugate-transpose.  This
         example verifies that the bug on :issue:`10791` is fixed.  ::
 
-            sage: # needs sage.rings.number_field
             sage: F.<a> = QuadraticField(-5)
             sage: A = matrix(F, [[    1,   a - 3,   a - 2, a + 1],
             ....:                [    a, 2*a + 1, 3*a + 1,     1],
@@ -11600,7 +11521,6 @@ cdef class Matrix(Matrix1):
         for small cases or instruction. Now we need to use the
         ``orthonormal`` keyword.  ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[6, -8,  1],
             ....:                    [4,  1,  3],
             ....:                    [6,  3,  3],
@@ -11631,7 +11551,6 @@ cdef class Matrix(Matrix1):
         After :issue:`14047`, the matrix can also be over the algebraic reals
         ``AA``::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(AA, [[6, -8,  1],
             ....:                 [4,  1,  3],
             ....:                 [6,  3,  3],
@@ -11653,7 +11572,6 @@ cdef class Matrix(Matrix1):
         Note the use of the conjugate-transpose when checking the
         orthonormality. ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[  -2,    -I - 1, 4*I + 2,       -1],
             ....:                    [-4*I, -2*I + 17,       0,  9*I + 1],
             ....:                    [   1,  -2*I - 6, -I + 11, -5*I + 1]])
@@ -11670,7 +11588,6 @@ cdef class Matrix(Matrix1):
         result of linear dependence get eliminated, so the rows of ``G``
         are a basis for the row space of ``A``.  ::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[2, -6, 3, 8],
             ....:                    [1, -3, 2, 5],
             ....:                    [0,  0, 2, 4],
@@ -11737,7 +11654,6 @@ cdef class Matrix(Matrix1):
 
         A complex subfield of the complex numbers.  ::
 
-            sage: # needs sage.rings.number_field
             sage: C.<z> = CyclotomicField(5)
             sage: A = matrix(C,
             ....:       [[              -z^3 - 2*z,             -z^3 - 1, 2*z^3 - 2*z^2 + 2*z,             1],
@@ -11865,7 +11781,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: a = matrix(ZZ,4,[1, 0, 0, 0, 0, 1, 0, 0,
             ....:                  1, -1, 1, 0, 1, -1, 1, 2]); a
             [ 1  0  0  0]
@@ -11911,7 +11826,6 @@ cdef class Matrix(Matrix1):
         If you need the transformation matrix as well as the Jordan form of
         ``self``, then pass the option ``transformation=True``. For example::
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: m = matrix([[5,4,2,1], [0,1,-1,-1], [-1,-1,3,0], [1,1,-1,2]]); m
             [ 5  4  2  1]
             [ 0  1 -1 -1]
@@ -11954,7 +11868,6 @@ cdef class Matrix(Matrix1):
 
         ::
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: evals = [(i,i) for i in range(1,6)]
             sage: n = sum(range(1,6))
             sage: jf = block_diagonal_matrix([jordan_block(ev,size) for ev,size in evals])
@@ -11971,7 +11884,6 @@ cdef class Matrix(Matrix1):
 
         We verify that the bug from :issue:`6942` is fixed::
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: M = Matrix(GF(2), [[1,0,1,0,0,0,1], [1,0,0,1,1,1,0], [1,1,0,1,1,1,1],
             ....:                    [1,1,1,0,1,1,1], [1,1,1,0,0,1,0], [1,1,1,0,1,0,0],
             ....:                    [1,1,1,1,1,1,0]])
@@ -12003,7 +11915,6 @@ cdef class Matrix(Matrix1):
         We now go through three `10 \times 10` matrices to exhibit cases where
         there are multiple blocks of the same size::
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: A = matrix(QQ, [[15, 37/3, -16, -104/3, -29, -7/3, 0, 2/3, -29/3, -1/3], [2, 9, -1, -6, -6, 0, 0, 0, -2, 0], [24, 74/3, -41, -208/3, -58, -23/3, 0, 4/3, -58/3, -2/3], [-6, -19, 3, 21, 19, 0, 0, 0, 6, 0], [2, 6, 3, -6, -3, 1, 0, 0, -2, 0], [-96, -296/3, 176, 832/3, 232, 101/3, 0, -16/3, 232/3, 8/3], [-4, -2/3, 21, 16/3, 4, 14/3, 3, -1/3, 4/3, -25/3], [20, 26/3, -66, -199/3, -42, -41/3, 0, 13/3, -55/3, -2/3], [18, 57, -9, -54, -57, 0, 0, 0, -15, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 3]]); A
             [    15   37/3    -16 -104/3    -29   -7/3      0    2/3  -29/3   -1/3]
             [     2      9     -1     -6     -6      0      0      0     -2      0]
@@ -12036,7 +11947,6 @@ cdef class Matrix(Matrix1):
 
         ::
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: A = matrix(QQ, [[15, 37/3, -16, -14/3, -29, -7/3, 0, 2/3, 1/3, 44/3], [2, 9, -1, 0, -6, 0, 0, 0, 0, 3], [24, 74/3, -41, -28/3, -58, -23/3, 0, 4/3, 2/3, 88/3], [-6, -19, 3, 3, 19, 0, 0, 0, 0, -9], [2, 6, 3, 0, -3, 1, 0, 0, 0, 3], [-96, -296/3, 176, 112/3, 232, 101/3, 0, -16/3, -8/3, -352/3], [-4, -2/3, 21, 16/3, 4, 14/3, 3, -1/3, 4/3, -25/3], [20, 26/3, -66, -28/3, -42, -41/3, 0, 13/3, 2/3, 82/3], [18, 57, -9, 0, -57, 0, 0, 0, 3, 28], [0, 0, 0, 0, 0, 0, 0, 0, 0, 3]]); A
             [    15   37/3    -16  -14/3    -29   -7/3      0    2/3    1/3   44/3]
             [     2      9     -1      0     -6      0      0      0      0      3]
@@ -12069,7 +11979,6 @@ cdef class Matrix(Matrix1):
 
         ::
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: A = matrix(QQ, [[15, 37/3, -16, -104/3, -29, -7/3, 35, 2/3, -29/3, -1/3], [2, 9, -1, -6, -6, 0, 7, 0, -2, 0], [24, 74/3, -29, -208/3, -58, -14/3, 70, 4/3, -58/3, -2/3], [-6, -19, 3, 21, 19, 0, -21, 0, 6, 0], [2, 6, -1, -6, -3, 0, 7, 0, -2, 0], [-96, -296/3, 128, 832/3, 232, 65/3, -279, -16/3, 232/3, 8/3], [0, 0, 0, 0, 0, 0, 3, 0, 0, 0], [20, 26/3, -30, -199/3, -42, -14/3, 70, 13/3, -55/3, -2/3], [18, 57, -9, -54, -57, 0, 63, 0, -15, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 3]]); A
             [    15   37/3    -16 -104/3    -29   -7/3     35    2/3  -29/3   -1/3]
             [     2      9     -1     -6     -6      0      7      0     -2      0]
@@ -12104,7 +12013,6 @@ cdef class Matrix(Matrix1):
         Verify that we smoothly move to QQ from ZZ (:issue:`12693`), i.e.
         we work in the vector space over the field::
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: M = matrix(((2,2,2), (0,0,0), (-2,-2,-2)))
             sage: J, P = M.jordan_form(transformation=True)
             sage: J; P
@@ -12419,7 +12327,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.pari
             sage: A = matrix(QQ, 4, [-4, 6, 3, 3, -3, 5, 3, 3, 3, -6, -4, -3, -3, 6, 3, 2])
             sage: A
             [-4  6  3  3]
@@ -12439,7 +12346,6 @@ cdef class Matrix(Matrix1):
             sage: P^-1*A*P == D
             True
 
-            sage: # needs sage.libs.pari
             sage: A = matrix(QQ, 2, [0, 2, 1, 0])
             sage: A.is_diagonalizable()
             False
@@ -12630,7 +12536,6 @@ cdef class Matrix(Matrix1):
         be possible to extend their base fields to contain all
         the eigenvalues. ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<b> = FiniteField(5^2)
             sage: A = matrix(F, [[      4, 3*b + 2, 3*b + 1, 3*b + 4],
             ....:                [2*b + 1,     4*b,       0,       2],
@@ -12645,7 +12550,6 @@ cdef class Matrix(Matrix1):
             [      0       0|2*b + 1       1]
             [      0       0|      0 2*b + 1]
 
-            sage: # needs sage.rings.number_field
             sage: F.<c> = QuadraticField(-7)
             sage: A = matrix(F, [[   c + 3,   2*c - 2,   -2*c + 2,     c - 1],
             ....:                [2*c + 10, 13*c + 15, -13*c - 17, 11*c + 31],
@@ -12818,7 +12722,6 @@ cdef class Matrix(Matrix1):
             sage: A.is_similar(B)
             True
 
-            sage: # needs sage.combinat sage.libs.pari
             sage: _, T = A.is_similar(B, transformation=True)
             sage: T
             [ 1.00000000000000? + 0.?e-14*I            0.?e-14 + 0.?e-14*I            0.?e-14 + 0.?e-14*I]
@@ -12833,7 +12736,6 @@ cdef class Matrix(Matrix1):
 
         Other exact fields are supported.  ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(7^2)
             sage: A = matrix(F, [[2*a + 5, 6*a + 6,   a + 3],
             ....:                [  a + 3, 2*a + 2, 4*a + 2],
@@ -12909,7 +12811,6 @@ cdef class Matrix(Matrix1):
         design, but we are not able to resurrect a similarity
         transformation.  ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(7^2)
             sage: C = matrix(F, [[  a + 2, 5*a + 4],
             ....:                [6*a + 6, 6*a + 4]])
@@ -12932,7 +12833,6 @@ cdef class Matrix(Matrix1):
         algebraic closure of this field to find the change-of-basis
         matrix::
 
-            sage: # needs sage.combinat sage.graphs sage.rings.finite_rings
             sage: cox = posets.TamariLattice(3).coxeter_transformation()
             sage: M = cox.change_ring(GF(3))
             sage: M.is_similar(M**3, True)      # long time
@@ -13788,7 +13688,6 @@ cdef class Matrix(Matrix1):
         field of complex numbers with rational real and imaginary parts,
         allow for this computation::
 
-            sage: # needs sage.rings.number_field
             sage: C.<I> = QuadraticField(-1)
             sage: A = matrix(C, [[        23,  17*I + 3,  24*I + 25,     21*I],
             ....:                [ -17*I + 3,        38, -69*I + 89, 7*I + 15],
@@ -13809,7 +13708,6 @@ cdef class Matrix(Matrix1):
         The field of algebraic numbers is an ideal setting for this
         computation::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[        2,   4 + 2*I,   6 - 4*I],
             ....:                    [ -2*I + 4,        11, 10 - 12*I],
             ....:                    [  4*I + 6, 10 + 12*I,        37]])
@@ -13887,7 +13785,6 @@ cdef class Matrix(Matrix1):
 
         The matrix may not be positive-definite::
 
-            sage: # needs sage.rings.number_field
             sage: C.<I> = QuadraticField(-1)
             sage: B = matrix(C, [[      2, 4 - 2*I, 2 + 2*I],
             ....:                [4 + 2*I,       8,    10*I],
@@ -14122,7 +14019,6 @@ cdef class Matrix(Matrix1):
 
         A matrix containing real roots::
 
-            sage: # needs sage.rings.number_field sage.symbolic
             sage: A = matrix(AA, [ [1,       0,       sqrt(2)],
             ....:                  [0,       sqrt(3), 0      ],
             ....:                  [sqrt(2), 0,       sqrt(5)] ])
@@ -14138,7 +14034,6 @@ cdef class Matrix(Matrix1):
 
         A Hermitian (but not symmetric) matrix with complex entries::
 
-            sage: # needs sage.rings.number_field sage.symbolic
             sage: A = matrix(QQbar, [ [ 1,  0,        I  ],
             ....:                     [ 0,  sqrt(5),  0  ],
             ....:                     [-I,  0,        3  ] ])
@@ -14177,7 +14072,6 @@ cdef class Matrix(Matrix1):
         and rational one because inverting a matrix with algebraic
         entries is harder and requires smaller test cases::
 
-            sage: # needs sage.rings.number_field
             sage: from sage.misc.prandom import choice
             sage: n = ZZ.random_element(2)
             sage: ring = choice([AA, QQbar])
@@ -14470,7 +14364,6 @@ cdef class Matrix(Matrix1):
             sage: B == P*L*U
             True
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(5^2)
             sage: C = matrix(F, [[a + 3, 4*a + 4, 2, 4*a + 2],
             ....:                [3, 2*a + 4, 2*a + 4, 2*a + 1],
@@ -14571,7 +14464,6 @@ cdef class Matrix(Matrix1):
         absolute value must be handled carefully.  This tests that
         situation in the case of cyclotomic fields.  ::
 
-            sage: # needs sage.groups sage.rings.number_field
             sage: C = SymmetricGroup(5).character_table()
             sage: C.base_ring()
             Cyclotomic Field of order 1 and degree 1
@@ -14753,7 +14645,6 @@ cdef class Matrix(Matrix1):
 
         A Hermitian matrix. ::
 
-            sage: # needs sage.rings.number_field
             sage: x = polygen(ZZ)
             sage: C.<I> = NumberField(x^2 + 1)
             sage: A = matrix(C, [[        23,  17*I + 3,  24*I + 25,     21*I],
@@ -15037,7 +14928,6 @@ cdef class Matrix(Matrix1):
         with rational real and imaginary parts.  As theory
         predicts, the diagonal entries will be real numbers.  ::
 
-            sage: # needs sage.rings.number_field
             sage: C.<I> = QuadraticField(-1)
             sage: B = matrix(C, [[      2, 4 - 2*I, 2 + 2*I],
             ....:                [4 + 2*I,       8,    10*I],
@@ -15080,7 +14970,6 @@ cdef class Matrix(Matrix1):
         may be factored.  This provides a reasonable alternative
         to the Cholesky decomposition.  ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(5^3)
             sage: A = matrix(F,
             ....:     [[      a^2 + 2*a, 4*a^2 + 3*a + 4,       3*a^2 + a, 2*a^2 + 2*a + 1],
@@ -15511,7 +15400,6 @@ cdef class Matrix(Matrix1):
 
         The same is true of the following complex Hermitian matrix::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [ [ 0,I],
             ....:                     [-I,0] ])
             sage: A.block_ldlt(classical=True)
@@ -15642,7 +15530,6 @@ cdef class Matrix(Matrix1):
         Ensure that a "random" complex Hermitian matrix is factored
         correctly::
 
-            sage: # needs sage.rings.number_field
             sage: n = ZZ.random_element(6)
             sage: F = QuadraticField(-1, 'I')
             sage: A = matrix.random(F, n)
@@ -15655,7 +15542,6 @@ cdef class Matrix(Matrix1):
         factored correctly and that the resulting block-diagonal matrix
         is in fact diagonal::
 
-            sage: # needs sage.rings.number_field
             sage: n = ZZ.random_element(6)
             sage: F = QuadraticField(-1, 'I')
             sage: A = matrix.random(F, n)
@@ -15830,7 +15716,6 @@ cdef class Matrix(Matrix1):
         Any of the preceding examples are valid over inexact rings and
         with complex numbers as well::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = matrix(CDF, [ [ 2, I],
             ....:                   [-I, 2] ] )
             sage: A.is_positive_semidefinite()
@@ -15979,7 +15864,6 @@ cdef class Matrix(Matrix1):
         confirmed by the positive determinants of its leading
         principal submatrices::
 
-            sage: # needs sage.rings.number_field
             sage: x = polygen(ZZ, 'x')
             sage: C.<I> = NumberField(x^2 + 1, embedding=CC(0,1))
             sage: A = matrix(C, [[        23,  17*I + 3,  24*I + 25,     21*I],
@@ -15994,7 +15878,6 @@ cdef class Matrix(Matrix1):
         An Hermitian matrix that is not positive-definite and a vector
         ``u`` that makes the corresponding quadratic form negative::
 
-            sage: # needs sage.rings.number_field
             sage: C.<I> = QuadraticField(-1)
             sage: B = matrix(C, [[      2, 4 - 2*I, 2 + 2*I],
             ....:                [4 + 2*I,       8,    10*I],
@@ -16009,7 +15892,6 @@ cdef class Matrix(Matrix1):
         confirmed by the positive determinants of its leading
         principal submatrices::
 
-            sage: # needs sage.rings.number_field
             sage: A = matrix(QQbar, [[        2,   4 + 2*I,   6 - 4*I],
             ....:                    [ -2*I + 4,        11, 10 - 12*I],
             ....:                    [  4*I + 6, 10 + 12*I,        37]])
@@ -16024,7 +15906,6 @@ cdef class Matrix(Matrix1):
         numbers, complex numbers, or symbolic ring, then this routine
         will fail since comparison to zero is meaningless::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(5^3)
             sage: a.conjugate()
             Traceback (most recent call last):
@@ -16049,7 +15930,6 @@ cdef class Matrix(Matrix1):
         We can check positive-definiteness of matrices over
         approximate real/complex and symbolic rings::
 
-            sage: # needs sage.rings.real_mpfr
             sage: matrix.identity(RR,4).is_positive_definite()
             True
             sage: matrix.identity(CC,4).is_positive_definite()
@@ -16235,7 +16115,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = matrix(CDF, [[1+I,1],[0,2*I]])
             sage: A.conjugate()
             [1.0 - 1.0*I         1.0]
@@ -16310,7 +16189,6 @@ cdef class Matrix(Matrix1):
             [   I + 2  6*I + 9]
             [-4*I + 3     -5*I]
 
-            sage: # needs sage.rings.real_mpfr sage.symbolic
             sage: P = matrix(CC, 3, 2, [0.95-0.63*I, 0.84+0.13*I,
             ....:                       0.94+0.23*I, 0.23+0.59*I,
             ....:                       0.52-0.41*I, -0.50+0.90*I])
@@ -16339,7 +16217,6 @@ cdef class Matrix(Matrix1):
         (Matrices over quadratic number fields are another
         class of examples.) ::
 
-            sage: # needs sage.rings.number_field
             sage: C = CyclotomicField(5)
             sage: a = C.gen(); a
             zeta5
@@ -16427,7 +16304,6 @@ cdef class Matrix(Matrix1):
         Faster routines for double precision entries from `RDF` or `CDF` are provided by
         the :class:`~sage.matrix.matrix_double_dense.Matrix_double_dense` class.  ::
 
-            sage: # needs sage.rings.real_mpfr sage.symbolic
             sage: A = matrix(CC, 2, 3, [3*I,4,1-I,1,2,0])
             sage: A.norm('frob')
             5.656854249492381
@@ -16506,7 +16382,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: d = matrix([[3, 0], [0, sqrt(2)]])
             sage: b = matrix([[1, -1], [2, 2]]); e = b * d * b.inverse(); e
             [ 1/2*sqrt(2) + 3/2 -1/4*sqrt(2) + 3/4]
@@ -16619,7 +16494,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: v = vector([1,x,x^2])
             sage: v.derivative(x)
             (0, 1, 2*x)
@@ -16655,7 +16529,6 @@ cdef class Matrix(Matrix1):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: a = matrix([[1,2], [3,4]])
             sage: a.exp()
             [-1/22*((sqrt(33) - 11)*e^sqrt(33) - sqrt(33) - 11)*e^(-1/2*sqrt(33) + 5/2)              2/33*(sqrt(33)*e^sqrt(33) - sqrt(33))*e^(-1/2*sqrt(33) + 5/2)]
@@ -16807,7 +16680,6 @@ cdef class Matrix(Matrix1):
         An example over the ring of integers of a number field (of class
         number 1)::
 
-            sage: # needs sage.rings.number_field
             sage: x = polygen(ZZ, 'x')
             sage: OE.<w> = EquationOrder(x^2 - x + 2)
             sage: m = Matrix([[1, w], [w, 7]])
@@ -16861,7 +16733,6 @@ cdef class Matrix(Matrix1):
 
         Some examples over non-PID's work anyway::
 
-            sage: # needs sage.rings.number_field
             sage: R.<s> = EquationOrder(x^2 + 5)  # class number 2
             sage: A = matrix(R, 2, 2, [s - 1, -s, -s, 2*s + 1])
             sage: D, U, V = A.smith_form()
@@ -16882,7 +16753,6 @@ cdef class Matrix(Matrix1):
 
         Empty matrices are handled safely::
 
-            sage: # needs sage.rings.number_field
             sage: m = MatrixSpace(OE, 2,0)(0)
             sage: d, u, v = m.smith_form(); u * m * v == d
             True
@@ -16895,7 +16765,6 @@ cdef class Matrix(Matrix1):
 
         Some pathological cases that crashed earlier versions::
 
-            sage: # needs sage.rings.number_field
             sage: m = Matrix(OE, [[ 2*w,      2*w - 1,  -w + 1],
             ....:                 [ 2*w + 2, -2*w - 1,   w - 1],
             ....:                 [-2*w - 1, -2*w - 2, 2*w - 1]])
@@ -17319,7 +17188,6 @@ cdef class Matrix(Matrix1):
 
         We check some degenerate cases::
 
-            sage: # needs sage.rings.number_field
             sage: m = matrix(OL, 0, 0, []); r,s,p = m._echelon_form_PID()
             sage: (r,s,p)
             ([], [], [])
@@ -17349,7 +17217,6 @@ cdef class Matrix(Matrix1):
 
         A larger example::
 
-            sage: # needs sage.rings.number_field
             sage: m = matrix(OL, 3, 5, [a^2 - 3*a - 1, a^2 - 3*a + 1, a^2 + 1,
             ....:   -a^2 + 2, -3*a^2 - a - 1, -6*a - 1, a^2 - 3*a - 1,
             ....:   2*a^2 + a + 5, -2*a^2 + 5*a + 1, -a^2 + 13*a - 3,
@@ -17855,7 +17722,6 @@ cdef class Matrix(Matrix1):
         while the eigenvalues may lie outside the field, this does not impede
         the computation of the form.  ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = GF(5^4)
             sage: A = matrix(F, [[     a,      0,  0, a + 3],
             ....:                [     0,a^2 + 1,  0,     0],
@@ -18191,7 +18057,6 @@ cdef class Matrix(Matrix1):
         Rational form may be computed over any field.  The matrix below is
         an example where the eigenvalues lie outside the field.  ::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = FiniteField(7^2)
             sage: A = matrix(F,
             ....: [[5*a + 3, 4*a + 1, 6*a + 2, 2*a + 5,       6, 4*a + 5, 4*a + 5,       5,   a + 6,      5,  4*a + 4],
@@ -18444,7 +18309,6 @@ cdef class Matrix(Matrix1):
         Your matrix can be over any exact ring, for example the ring of
         univariate polynomials with rational coefficients::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = Cone([(1,0), (-1,0), (0,1), (0,-1)])
             sage: K.is_full_space()
             True
@@ -18457,7 +18321,6 @@ cdef class Matrix(Matrix1):
 
         The identity matrix is always a positive operator::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=8)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = identity_matrix(R, K.lattice_dim())
@@ -18466,7 +18329,6 @@ cdef class Matrix(Matrix1):
 
         The zero matrix is always a positive operator::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=8)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = zero_matrix(R, K.lattice_dim())
@@ -18478,7 +18340,6 @@ cdef class Matrix(Matrix1):
         the underlying ring symbolic (the usual case is tested by
         the ``positive_operators_gens`` method)::
 
-            sage: # needs sage.geometry.polyhedron sage.symbolic
             sage: K1 = random_cone(max_ambient_dim=5)
             sage: K2 = random_cone(max_ambient_dim=5)
             sage: results = ( L.change_ring(SR).is_positive_operator_on(K1, K2)
@@ -18508,7 +18369,6 @@ cdef class Matrix(Matrix1):
 
         Symbolic subrings are fine::
 
-            sage: # needs sage.geometry.polyhedron sage.symbolic
             sage: SCR = SR.subring(no_variables=True); SCR
             Symbolic Constants Subring
             sage: K = Cone([(1,2,3), (4,5,6)])
@@ -18611,7 +18471,6 @@ cdef class Matrix(Matrix1):
 
         The identity matrix is always cross-positive::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=8)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = identity_matrix(R, K.lattice_dim())
@@ -18620,7 +18479,6 @@ cdef class Matrix(Matrix1):
 
         The zero matrix is always cross-positive::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=8)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = zero_matrix(R, K.lattice_dim())
@@ -18632,7 +18490,6 @@ cdef class Matrix(Matrix1):
         symbolic (the usual case is tested by the
         ``cross_positive_operators_gens`` method)::
 
-            sage: # needs sage.geometry.polyhedron sage.symbolic
             sage: K = random_cone(max_ambient_dim=5)
             sage: results = ( L.change_ring(SR).is_cross_positive_on(K)
             ....:             for L in K.cross_positive_operators_gens() )
@@ -18661,7 +18518,6 @@ cdef class Matrix(Matrix1):
 
         Symbolic subrings are fine::
 
-            sage: # needs sage.geometry.polyhedron sage.symbolic
             sage: SCR = SR.subring(no_variables=True); SCR
             Symbolic Constants Subring
             sage: K = Cone([(1,2,3), (4,5,6)])
@@ -18753,7 +18609,6 @@ cdef class Matrix(Matrix1):
 
         The identity matrix is always a Z-operator::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=8)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = identity_matrix(R, K.lattice_dim())
@@ -18762,7 +18617,6 @@ cdef class Matrix(Matrix1):
 
         The zero matrix is always a Z-operator::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=8)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = zero_matrix(R, K.lattice_dim())
@@ -18871,7 +18725,6 @@ cdef class Matrix(Matrix1):
 
         The identity matrix is always Lyapunov-like::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=8)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = identity_matrix(R, K.lattice_dim())
@@ -18880,7 +18733,6 @@ cdef class Matrix(Matrix1):
 
         The zero matrix is always Lyapunov-like::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=8)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = zero_matrix(R, K.lattice_dim())
@@ -18919,7 +18771,6 @@ cdef class Matrix(Matrix1):
 
         Symbolic subrings are fine::
 
-            sage: # needs sage.geometry.polyhedron sage.symbolic
             sage: SCR = SR.subring(no_variables=True); SCR
             Symbolic Constants Subring
             sage: K = Cone([(1,2,3), (4,5,6)])
@@ -18930,7 +18781,6 @@ cdef class Matrix(Matrix1):
         A matrix is Lyapunov-like on a cone if and only if both the
         matrix and its negation are cross-positive on the cone::
 
-            sage: # needs sage.geometry.polyhedron
             sage: K = random_cone(max_ambient_dim=5)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = random_matrix(R, K.lattice_dim())
@@ -20545,7 +20395,6 @@ def _smith_diag(d, transformation=True):
 
     EXAMPLES::
 
-        sage: # needs sage.rings.number_field
         sage: from sage.matrix.matrix2 import _smith_diag
         sage: x = polygen(ZZ, 'x')
         sage: OE = EquationOrder(x^2 - x + 2, 'w')
@@ -20625,7 +20474,6 @@ def _generic_clear_column(m):
 
     EXAMPLES::
 
-        sage: # needs sage.rings.number_field
         sage: x = polygen(ZZ, 'x')
         sage: L.<w> = NumberField(x^2 - x + 2)
         sage: OL = L.ring_of_integers(); w = OL(w)
@@ -20736,7 +20584,6 @@ def _smith_onestep(m):
 
     EXAMPLES::
 
-        sage: # needs sage.rings.number_field
         sage: from sage.matrix.matrix2 import _smith_onestep
         sage: x = polygen(ZZ, 'x')
         sage: OE.<w> = EquationOrder(x^2 - x + 2)
@@ -20946,7 +20793,6 @@ def _matrix_power_symbolic(A, n):
 
     General power of a two by two matrix::
 
-        sage: # needs sage.symbolic
         sage: n = SR.var('n')
         sage: A = matrix(QQ, [[2, -1], [1,  0]])
         sage: B = A^n; B
@@ -20957,7 +20803,6 @@ def _matrix_power_symbolic(A, n):
 
     General power of a three by three matrix in Jordan form::
 
-        sage: # needs sage.symbolic
         sage: n = SR.var('n')
         sage: A = matrix(QQ, 3, [[2, 1, 0], [0, 2, 0], [0, 0, 3]]); A
         [2 1 0]
@@ -20972,7 +20817,6 @@ def _matrix_power_symbolic(A, n):
 
     General power of a three by three matrix not in Jordan form::
 
-        sage: # needs sage.symbolic
         sage: A = matrix([[4, 1, 2], [0, 2, -4], [0, 1, 6]]); A
         [ 4  1  2]
         [ 0  2 -4]

--- a/src/sage/matrix/matrix_cdv.pyx
+++ b/src/sage/matrix/matrix_cdv.pyx
@@ -35,7 +35,6 @@ cpdef hessenbergize_cdvf(Matrix_generic_dense H):
 
     TESTS::
 
-        sage: # needs sage.rings.padics
         sage: K = Qp(5, print_mode='digits', prec=5)
         sage: H = matrix(K, 3, 3, range(9))
         sage: H

--- a/src/sage/matrix/matrix_complex_double_dense.pyx
+++ b/src/sage/matrix/matrix_complex_double_dense.pyx
@@ -17,7 +17,6 @@ We deal with the case of zero rows or zero columns::
 
 TESTS::
 
-    sage: # needs sage.symbolic
     sage: a = matrix(CDF,2,[i+(4-i)*I for i in range(4)], sparse=False)
     sage: TestSuite(a).run()
     sage: Mat(CDF,0,0).zero_matrix().inverse()
@@ -54,7 +53,6 @@ cdef class Matrix_complex_double_dense(Matrix_double_dense):
 
     EXAMPLES::
 
-        sage: # needs sage.symbolic
         sage: m = Matrix(CDF, [[1,2*I],[3+I,4]])
         sage: m**2
         [-1.0 + 6.0*I       10.0*I]

--- a/src/sage/matrix/matrix_dense.pyx
+++ b/src/sage/matrix/matrix_dense.pyx
@@ -74,7 +74,6 @@ cdef class Matrix_dense(matrix.Matrix):
 
         Check :issue:`27629`::
 
-            sage: # needs sage.symbolic
             sage: var('x')
             x
             sage: assume(x, 'real')

--- a/src/sage/matrix/matrix_double_dense.pyx
+++ b/src/sage/matrix/matrix_double_dense.pyx
@@ -621,7 +621,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         And over the complex numbers.  ::
 
-            sage: # needs sage.symbolic
             sage: B = matrix(CDF, 2, [[1+I, 2+3*I],[3+4*I,3*I]]); B
             [1.0 + 1.0*I 2.0 + 3.0*I]
             [3.0 + 4.0*I       3.0*I]
@@ -1149,7 +1148,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         The adjacency matrix of a graph will be symmetric, and the
         eigenvalues will be real.  ::
 
-            sage: # needs sage.graphs
             sage: A = graphs.PetersenGraph().adjacency_matrix()
             sage: A = A.change_ring(RDF)
             sage: ev = A.eigenvalues(algorithm='symmetric'); ev  # tol 1e-14
@@ -1162,7 +1160,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         the eigenvalues of a Hermitian matrix are real, and the
         eigenvalues of a positive-definite matrix will be positive.  ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix([[ 4*I + 5,  8*I + 1,  7*I + 5, 3*I + 5],
             ....:             [ 7*I - 2, -4*I + 7, -2*I + 4, 8*I + 8],
             ....:             [-2*I + 1,  6*I + 6,  5*I + 5,  -I - 4],
@@ -1178,7 +1175,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         it might split too finely.  Too large, and it can go wrong very
         badly.  Use with care.  ::
 
-            sage: # needs sage.graphs
             sage: G = graphs.PetersenGraph()
             sage: G.spectrum()
             [3, 1, 1, 1, 1, 1, -2, -2, -2, -2]
@@ -1190,7 +1186,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         An (extreme) example of properly grouping similar eigenvalues.  ::
 
-            sage: # needs sage.graphs
             sage: G = graphs.HigmanSimsGraph()
             sage: A = G.adjacency_matrix().change_ring(RDF)
             sage: A.eigenvalues(algorithm='symmetric', tol=1.0e-5)  # tol 2e-15
@@ -1268,7 +1263,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         Test keyword-only arguments::
 
-            sage: # needs sage.graphs
             sage: A = graphs.PetersenGraph().adjacency_matrix().change_ring(RDF)
             sage: ev = A.eigenvalues('symmetric')
             Traceback (most recent call last):
@@ -1692,7 +1686,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         TESTS::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[1, 2], [3, 3+I]])
             sage: b = matrix(CDF, [[1, 0], [2, 1]])
             sage: x = A._solve_right_nonsingular_square(b)
@@ -1821,7 +1814,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[1+I, 3-I], [0, 2*I]])
             sage: A.conjugate()
             [1.0 - 1.0*I 3.0 + 1.0*I]
@@ -2255,7 +2247,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         The QR decomposition will produce a unitary matrix as Q and the
         SVD decomposition will create two unitary matrices, U and V. ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[   1 - I,   -3*I,  -2 + I,        1, -2 + 3*I],
             ....:                  [   1 - I, -2 + I, 1 + 4*I,        0,    2 + I],
             ....:                  [      -1, -5 + I,  -2 + I,    1 + I, -5 - 4*I],
@@ -2418,7 +2409,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[ 1 + I,  1 - 6*I, -1 - I],
             ....:                  [-3 - I,     -4*I,     -2],
             ....:                  [-1 + I, -2 - 8*I,  2 + I]])
@@ -2431,7 +2421,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         A matrix that is nearly Hermitian, but for one non-real
         diagonal entry::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[    2,   2-I, 1+4*I],
             ....:                  [  2+I,   3+I, 2-6*I],
             ....:                  [1-4*I, 2+6*I,     5]])
@@ -2455,7 +2444,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         A matrix that is skew-Hermitian::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[-I, 2.0+I], [-2.0+I, 0.0]])
             sage: A._is_hermitian_orthonormal()
             False
@@ -2543,7 +2531,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[ 1 + I,  1 - 6*I, -1 - I],
             ....:                  [-3 - I,     -4*I,     -2],
             ....:                  [-1 + I, -2 - 8*I,  2 + I]])
@@ -2560,7 +2547,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         A matrix that is nearly Hermitian, but for one non-real
         diagonal entry. ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[    2,   2-I, 1+4*I],
             ....:                  [  2+I,   3+I, 2-6*I],
             ....:                  [1-4*I, 2+6*I,     5]])
@@ -2578,7 +2564,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         of entries and may achieve the wrong result (depending on
         the system)::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[ 1 + I,  1 - 6*I, -1 - I],
             ....:                  [-3 - I,     -4*I,     -2],
             ....:                  [-1 + I, -2 - 8*I,  2 + I]])
@@ -2682,7 +2667,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         A matrix that is nearly skew-Hermitian, but for a non-real
         diagonal entry. ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[  -I, -1, 1-I],
             ....:                  [   1,  1,  -1],
             ....:                  [-1-I,  1,  -I]])
@@ -2700,7 +2684,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         be too strict about the equality of entries and may achieve
         the wrong result (depending on the system)::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[ 1 + I,  1 - 6*I, -1 - I],
             ....:                  [-3 - I,     -4*I,     -2],
             ....:                  [-1 + I, -2 - 8*I,  2 + I]])
@@ -2796,7 +2779,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         First over the complexes.  ``B`` is Hermitian, hence normal.  ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[ 1 + I,  1 - 6*I, -1 - I],
             ....:                  [-3 - I,     -4*I,     -2],
             ....:                  [-1 + I, -2 - 8*I,  2 + I]])
@@ -2815,7 +2797,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         Now over the reals.  Circulant matrices are normal.  ::
 
-            sage: # needs sage.graphs
             sage: G = graphs.CirculantGraph(20, [3, 7])
             sage: D = digraphs.Circuit(20)
             sage: A = 3*D.adjacency_matrix() - 5*G.adjacency_matrix()
@@ -2832,7 +2813,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         Skew-Hermitian matrices are normal.  ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[ 1 + I,  1 - 6*I, -1 - I],
             ....:                  [-3 - I,     -4*I,     -2],
             ....:                  [-1 + I, -2 - 8*I,  2 + I]])
@@ -2857,7 +2837,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         Sage has several fields besides the entire complex numbers
         where conjugation is non-trivial. ::
 
-            sage: # needs sage.rings.number_field
             sage: F.<b> = QuadraticField(-7)
             sage: C = matrix(F, [[-2*b - 3,  7*b - 6, -b + 3],
             ....:                [-2*b - 3, -3*b + 2,   -2*b],
@@ -2993,7 +2972,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         First over the complexes.  The similar matrix is always
         upper-triangular in this case.  ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, 4, 4, range(16)) + matrix(CDF, 4, 4,
             ....:                                           [x^3*I for x in range(0, 16)])
             sage: Q, T = A.schur()
@@ -3073,7 +3051,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         Starting with complex numbers and requesting a result over the reals
         will never happen.  ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, 2, 2, [[2+I, -1+3*I], [5-4*I, 2-7*I]])
             sage: A.schur(base_ring=RDF)
             Traceback (most recent call last):
@@ -3110,7 +3087,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         of eigenvectors of the matrix.  Here that basis is the set of
         columns of the unitary matrix.  ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[        52,   -9*I - 8,    6*I - 187,  -188*I + 2],
             ....:                  [   9*I - 8,         12,   -58*I + 59,   30*I + 42],
             ....:                  [-6*I - 187,  58*I + 59,         2677, 2264*I + 65],
@@ -3301,7 +3277,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         A complex matrix that is Hermitian and positive definite.  ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[        23,  17*I + 3,  24*I + 25,     21*I],
             ....:                  [ -17*I + 3,        38, -69*I + 89, 7*I + 15],
             ....:                  [-24*I + 25, 69*I + 89,        976, 24*I + 6],
@@ -3340,7 +3315,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             ...
             ValueError: matrix is not positive definite
 
-            sage: # needs sage.symbolic
             sage: B = matrix(CDF, [[      2, 4 - 2*I, 2 + 2*I],
             ....:                  [4 + 2*I,       8,    10*I],
             ....:                  [2 - 2*I,   -10*I,      -3]])
@@ -3372,7 +3346,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[1+I]])
             sage: A.cholesky()
             Traceback (most recent call last):
@@ -3471,7 +3444,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         A matrix over ``CDF`` that is positive definite.  ::
 
-            sage: # needs sage.symbolic
             sage: C = matrix(CDF, [[        23,  17*I + 3,  24*I + 25,     21*I],
             ....:                  [ -17*I + 3,        38, -69*I + 89, 7*I + 15],
             ....:                  [-24*I + 25, 69*I + 89,        976, 24*I + 6],
@@ -3503,7 +3475,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         A matrix over ``CDF`` that is not positive definite.  ::
 
-            sage: # needs sage.symbolic
             sage: B = matrix(CDF, [[      2, 4 - 2*I, 2 + 2*I],
             ....:                  [4 + 2*I,       8,    10*I],
             ....:                  [2 - 2*I,   -10*I,      -3]])
@@ -3548,7 +3519,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         ::
 
-            sage: # needs sage.symbolic
             sage: A = matrix(CDF, [[1+I]])
             sage: A.is_positive_definite()
             False
@@ -3698,7 +3668,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: a = matrix(CDF, [[1, 1e-4r, 1+1e-100jr], [1e-8+3j, 0, 1e-58r]])
             sage: a
             [           1.0         0.0001 1.0 + 1e-100*I]
@@ -3770,7 +3739,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: a = matrix(CDF, [[1, -2+I, 0, -3*I], [2, 2, -2, 2], [-3, -3, -3, -2]])
             sage: a
             [         1.0 -2.0 + 1.0*I          0.0       -3.0*I]
@@ -3807,7 +3775,6 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: a = matrix(CDF, [[1, 2, -3], [-2+I, 2, -3], [0, -2, -3], [-3*I, 2, -2]])
             sage: a
             [         1.0          2.0         -3.0]

--- a/src/sage/matrix/matrix_double_sparse.pyx
+++ b/src/sage/matrix/matrix_double_sparse.pyx
@@ -133,7 +133,6 @@ cdef class Matrix_double_sparse(Matrix_generic_sparse):
 
         ::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: A = matrix(CDF, [[        2,   4 + 2*I,   6 - 4*I],
             ....:                  [ -2*I + 4,        11, 10 - 12*I],
             ....:                  [  4*I + 6, 10 + 12*I,        37]])
@@ -164,7 +163,6 @@ cdef class Matrix_double_sparse(Matrix_generic_sparse):
 
         ::
 
-            sage: # needs sage.rings.complex_double sage.symbolic
             sage: n = ZZ.random_element(1,5)
             sage: A = matrix.random(CDF, n, sparse=True)
             sage: I = matrix.identity(CDF, n, sparse=True)

--- a/src/sage/matrix/matrix_gap.pyx
+++ b/src/sage/matrix/matrix_gap.pyx
@@ -48,7 +48,6 @@ cdef class Matrix_gap(Matrix_dense):
         sage: m.transpose().parent() is M
         True
 
-        sage: # needs sage.rings.number_field
         sage: UCF = UniversalCyclotomicField()
         sage: M = MatrixSpace(UCF, 3, implementation='gap')
         sage: m = M([UCF.zeta(i) for i in range(1,10)])
@@ -276,7 +275,6 @@ cdef class Matrix_gap(Matrix_dense):
             sage: m1 != m3
             True
 
-            sage: # needs sage.rings.number_field
             sage: UCF = UniversalCyclotomicField()
             sage: M = MatrixSpace(UCF, 2, implementation='gap')
             sage: m1 = M([E(2), E(3), 0, E(4)])
@@ -444,7 +442,6 @@ cdef class Matrix_gap(Matrix_dense):
             sage: parent(M(1).determinant())
             Rational Field
 
-            sage: # needs sage.rings.number_field
             sage: M = MatrixSpace(UniversalCyclotomicField(), 1, implementation='gap')
             sage: parent(M(1).determinant())
             Universal Cyclotomic Field
@@ -473,7 +470,6 @@ cdef class Matrix_gap(Matrix_dense):
             sage: parent(M(1).trace())
             Rational Field
 
-            sage: # needs sage.rings.number_field
             sage: M = MatrixSpace(UniversalCyclotomicField(), 1, implementation='gap')
             sage: parent(M(1).trace())
             Universal Cyclotomic Field

--- a/src/sage/matrix/matrix_generic_dense.pyx
+++ b/src/sage/matrix/matrix_generic_dense.pyx
@@ -69,7 +69,6 @@ cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
         We check that the problem related to :issue:`9049` is not an issue any
         more::
 
-            sage: # needs sage.rings.number_field
             sage: S.<t> = PolynomialRing(QQ)
             sage: F.<q> = QQ.extension(t^4 + 1)
             sage: R.<x,y> = PolynomialRing(F)
@@ -255,7 +254,6 @@ cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: R.<x,y> = FreeAlgebra(QQ, 2)
             sage: a = matrix(R, 2, 2, [1,2,x*y,y*x])
             sage: b = matrix(R, 2, 2, [1,2,y*x,y*x])
@@ -279,7 +277,6 @@ cdef class Matrix_generic_dense(matrix_dense.Matrix_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: R.<x,y> = FreeAlgebra(QQ, 2)
             sage: a = matrix(R, 2, 2, [1,2,x*y,y*x])
             sage: b = matrix(R, 2, 2, [1,2,y*x,y*x])

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -723,7 +723,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         And for larger modulus::
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(1009), 51, 5)
             sage: data, version = A._pickle()
             sage: B = A.parent()(0)
@@ -1131,7 +1130,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         ::
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(15991), 201, 117)
             sage: B = random_matrix(GF(15991), 117, 195)
             sage: C = random_matrix(GF(15991), 201, 117)
@@ -1708,7 +1706,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         ::
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(16007), 10, 20)
             sage: E = A.echelon_form()
             sage: A.row_space() == E.row_space()
@@ -1726,7 +1723,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         Parallel computation::
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(65521),100,200)
             sage: Parallelism().set('linbox', nproc=2)
             sage: E = A.echelon_form()
@@ -1759,7 +1755,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             [0 0 0 0 0 0 0 0 0 0]
             [0 0 0 0 0 0 0 0 0 0]
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(16007),  0, 10)
             sage: A.echelon_form()
             []
@@ -2353,7 +2348,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         ::
 
-            sage: # needs sage.rings.finite_rings
             sage: while True:
             ....:     A = random_matrix(GF(16007), 100, 100)
             ....:     if A.rank() == 100:
@@ -2379,7 +2373,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             sage: A.rank()
             0
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(16007), 0, 0)
             sage: A.rank()
             0
@@ -2426,14 +2419,12 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         ::
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(16007), 10, 10)
             sage: A.determinant().parent() is GF(16007)
             True
 
         ::
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(16007), 100, 100)
             sage: A.determinant().parent() is GF(16007)
             True
@@ -2445,7 +2436,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
 
         Parallel computation::
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(65521),200)
             sage: B = copy(A)
             sage: Parallelism().set('linbox', nproc=2)
@@ -2473,7 +2463,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             sage: A = matrix(GF(7), 5, 5); A.det()                                      # needs sage.libs.pari
             0
 
-            sage: # needs sage.rings.finite_rings
             sage: A = random_matrix(GF(16007), 0, 0); A.det()
             1
             sage: A = random_matrix(GF(16007), 0, 1); A.det()
@@ -2966,7 +2955,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             sage: A.lift().parent()
             Full MatrixSpace of 2 by 3 dense matrices over Integer Ring
 
-            sage: # needs sage.rings.finite_rings
             sage: A = matrix(GF(16007),2,3,[1..6])
             sage: A.lift()
             [1 2 3]
@@ -3433,7 +3421,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             sage: bool(A)
             False
 
-            sage: # needs sage.rings.finite_rings
             sage: A = matrix(GF(16007), 0, 0)
             sage: A.is_zero()
             True

--- a/src/sage/matrix/matrix_polynomial_dense.pyx
+++ b/src/sage/matrix/matrix_polynomial_dense.pyx
@@ -2111,7 +2111,6 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             [x + 4     6     0]
             [    5     1     0]
 
-            sage: # needs sage.combinat
             sage: P, U = M.weak_popov_form(transformation=True,
             ....:                          row_wise=False,
             ....:                          include_zero_vectors=False)
@@ -2232,7 +2231,6 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.finite_rings
             sage: F.<a> = GF(2^4, 'a')
             sage: PF.<x> = F[]
             sage: A = matrix(PF,[[1,  a*x^17 + 1 ],
@@ -2393,7 +2391,6 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             ....:     [      6*x+4,       5*x^3+5*x,       6*x^2+2*x+2],
             ....:     [4*x^2+5*x+2, x^4+5*x^2+2*x+4, 4*x^3+6*x^2+6*x+5]])
 
-            sage: # needs sage.combinat
             sage: P, U = M.popov_form(transformation=True)
             sage: P
             [            4 x^2 + 4*x + 1             3]
@@ -2406,7 +2403,6 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
 
         Demonstrating shifts and specific case of Hermite form::
 
-            sage: # needs sage.combinat
             sage: P = M.popov_form(shifts=[0,2,4]); P
             [              4*x^2 + 3*x + 4 x^4 + 3*x^3 + 5*x^2 + 5*x + 5                             0]
             [                            6               5*x^2 + 6*x + 5                             1]
@@ -2429,7 +2425,6 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             [x + 2     6     0]
             [    0     1     0]
 
-            sage: # needs sage.combinat
             sage: P, U = M.popov_form(transformation=True,
             ....:                     row_wise=False,
             ....:                     include_zero_vectors=False)
@@ -2637,7 +2632,6 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
 
         The last example shows the usage of the transformation parameter::
 
-            sage: # needs sage.rings.finite_rings
             sage: Fq.<a> = GF(2^3)
             sage: pR.<x> = Fq[]
             sage: A = matrix(pR, [[x^2+a,  x^4+a],

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -571,7 +571,6 @@ class MatrixSpace(UniqueRepresentation, Parent):
 
     Check that different implementations play together as expected::
 
-        sage: # needs sage.libs.linbox
         sage: M1 = MatrixSpace(ZZ, 2, implementation='flint')
         sage: M2 = MatrixSpace(ZZ, 2, implementation='generic')
         sage: type(M1(range(4)))
@@ -590,7 +589,6 @@ class MatrixSpace(UniqueRepresentation, Parent):
 
     Check that libgap matrices over finite fields are working properly::
 
-        sage: # needs sage.libs.gap
         sage: M2 = MatrixSpace(GF(2), 5, implementation='gap')
         sage: M2.one()
         [1 0 0 0 0]
@@ -1076,7 +1074,6 @@ class MatrixSpace(UniqueRepresentation, Parent):
             [1 2]
             [3 4]
 
-            sage: # needs sage.modular
             sage: MS = MatrixSpace(ZZ, 2)
             sage: g = Gamma0(5)([1,1,0,1])
             sage: MS(g)
@@ -2174,7 +2171,6 @@ class MatrixSpace(UniqueRepresentation, Parent):
 
         Check that :issue:`38221` is fixed::
 
-            sage: # needs sage.groups
             sage: G = CyclicPermutationGroup(7)
             sage: R = GF(2)
             sage: A = G.algebra(R)
@@ -2266,7 +2262,6 @@ class MatrixSpace(UniqueRepresentation, Parent):
             [1]
             [2]
 
-            sage: # needs sage.rings.real_mpfr
             sage: MS = MatrixSpace(CC, 2, 1)
             sage: x = polygen(ZZ, 'x')
             sage: F = NumberField(x^2 + 1, name='x')                                    # needs sage.rings.number_field
@@ -2301,7 +2296,6 @@ class MatrixSpace(UniqueRepresentation, Parent):
         One-rowed matrices over combinatorial free modules used to break
         the constructor (:issue:`17124`). Check that this is fixed::
 
-            sage: # needs sage.combinat
             sage: Sym = SymmetricFunctions(ZZ)
             sage: h = Sym.h()
             sage: MatrixSpace(h, 1,1)([h[1]])

--- a/src/sage/matrix/matrix_sparse.pyx
+++ b/src/sage/matrix/matrix_sparse.pyx
@@ -669,7 +669,6 @@ cdef class Matrix_sparse(matrix.Matrix):
 
             sage: m = matrix(ZZ, 10000, {(1,2): 17}, sparse=True)
 
-            sage: # needs sage.rings.finite_rings
             sage: k.<a> = GF(9)
             sage: f = lambda x: k(x)
             sage: n = m.apply_map(f)
@@ -1186,7 +1185,6 @@ cdef class Matrix_sparse(matrix.Matrix):
 
         Check that the bug in :issue:`13854` has been fixed::
 
-            sage: # needs sage.combinat sage.libs.singular
             sage: A.<x,y> = FreeAlgebra(QQ, 2)
             sage: P.<x,y> = A.g_algebra(relations={y*x: -x*y}, order='lex')
             sage: M = Matrix([[x]], sparse=True)

--- a/src/sage/matrix/operation_table.py
+++ b/src/sage/matrix/operation_table.py
@@ -189,7 +189,6 @@ class OperationTable(SageObject):
     :meth:`~sage.matrix.operation_table.OperationTable.column_keys`
     method.  ::
 
-        sage: # needs sage.groups
         sage: from sage.matrix.operation_table import OperationTable
         sage: G = QuaternionGroup()
         sage: T = OperationTable(G, operator.mul)
@@ -307,7 +306,6 @@ class OperationTable(SageObject):
     structure, in forms that can be coerced into the structure.
     Here we demonstrate the proper use first::
 
-        sage: # needs sage.groups
         sage: from sage.matrix.operation_table import OperationTable
         sage: H = CyclicPermutationGroup(4)
         sage: H.list()
@@ -322,7 +320,6 @@ class OperationTable(SageObject):
     This can be rewritten so as to pass the actual elements of the
     group ``H``, using a simple ``for`` loop::
 
-        sage: # needs sage.groups
         sage: L = H.list()    #list of elements of the group H
         sage: elts = [L[i] for i in {0, 2}]
         sage: elts
@@ -337,7 +334,6 @@ class OperationTable(SageObject):
     In case they are not closed, the argument ``closed=False`` can be used to tell that it is not a problem
     if the result of the operation is not among ``elements`` as long as it can be coerced into ``S``. ::
 
-        sage: # needs sage.groups
         sage: elts.append(L[1])
         sage: elts
         [(), (1,3)(2,4), (1,2,3,4)]
@@ -358,7 +354,6 @@ class OperationTable(SageObject):
 
     Here are a couple of improper uses::
 
-        sage: # needs sage.groups
         sage: elts[2] = 5
         sage: OperationTable(H, operator.mul, elements=elts)
         Traceback (most recent call last):
@@ -554,7 +549,6 @@ class OperationTable(SageObject):
         and :meth:`change_names` methods.  So we just demonstrate
         the nature of the output here. ::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = SymmetricGroup(3)
             sage: T = OperationTable(G, operator.mul)
@@ -572,7 +566,6 @@ class OperationTable(SageObject):
         doctests for the :class:`OperationTable` and :meth:`change_names`
         methods that rely on this one. ::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = AlternatingGroup(3)
             sage: T = OperationTable(G, operator.mul)
@@ -668,7 +661,6 @@ class OperationTable(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = DiCyclicGroup(3)
             sage: T = OperationTable(G, operator.mul)
@@ -679,7 +671,6 @@ class OperationTable(SageObject):
 
         TESTS::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = DiCyclicGroup(3)
             sage: T = OperationTable(G, operator.mul)
@@ -727,7 +718,6 @@ class OperationTable(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = CyclicPermutationGroup(6)
             sage: H = CyclicPermutationGroup(3)
@@ -747,7 +737,6 @@ class OperationTable(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = CyclicPermutationGroup(6)
             sage: H = CyclicPermutationGroup(3)
@@ -792,7 +781,6 @@ class OperationTable(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = AlternatingGroup(3)
             sage: T = OperationTable(G, operator.mul)
@@ -808,7 +796,6 @@ class OperationTable(SageObject):
 
         TESTS::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = AlternatingGroup(3)
             sage: T = OperationTable(G, operator.mul)
@@ -940,7 +927,6 @@ class OperationTable(SageObject):
         :class:`OperationTable` since creating a new
         operation table uses the same routine. ::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: D = DihedralGroup(2)
             sage: T = OperationTable(D, operator.mul)
@@ -997,7 +983,6 @@ class OperationTable(SageObject):
         The output here is from the doctests for the old
         ``cayley_table()`` method for permutation groups. ::
 
-            sage: # needs sage.groups
             sage: from sage.matrix.operation_table import OperationTable
             sage: G = PermutationGroup(['(1,2,3)', '(2,3)'])
             sage: T = OperationTable(G, operator.mul)

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -360,7 +360,6 @@ def random_matrix(ring, nrows, ncols=None, algorithm='randomize', implementation
         ....:     A = random_matrix(*args, **kwds)
         ....:     density_sum += float(A.density())
 
-        sage: # needs sage.libs.linbox (otherwise timeout)
         sage: density_sum = 0.0
         sage: total_count = 0.0
         sage: add_sample(ZZ, 5, x=-10, y=10, density=0.75)
@@ -370,14 +369,12 @@ def random_matrix(ring, nrows, ncols=None, algorithm='randomize', implementation
         sage: while abs(density_sum/total_count - expected_density) > 0.001:
         ....:     add_sample(ZZ, 5, x=-10, y=10, density=0.75)
 
-        sage: # needs sage.libs.linbox (otherwise timeout)
         sage: density_sum = 0.0
         sage: total_count = 0.0
         sage: add_sample(ZZ, 5, x=20, y=30, density=0.75)
         sage: while abs(density_sum/total_count - expected_density) > 0.001:
         ....:     add_sample(ZZ, 5, x=20, y=30, density=0.75)
 
-        sage: # needs sage.libs.linbox (otherwise timeout)
         sage: density_sum = 0.0
         sage: total_count = 0.0
         sage: add_sample(ZZ, 100, x=20, y=30, density=0.75)
@@ -400,7 +397,6 @@ def random_matrix(ring, nrows, ncols=None, algorithm='randomize', implementation
     For algorithm testing you might want to control the number of bits,
     say 10,000 entries, each limited to 16 bits.  ::
 
-        sage: # needs sage.libs.linbox (otherwise timeout)
         sage: A = random_matrix(ZZ, 100, 100, x=2^16); A
         100 x 100 dense matrix over Integer Ring (use the '.str()' method to see the entries)
 
@@ -1019,7 +1015,6 @@ def zero_matrix(ring, nrows=None, ncols=None, sparse=False):
 
     Check that :issue:`38221` is fixed::
 
-        sage: # needs sage.groups
         sage: G = CyclicPermutationGroup(7)
         sage: R = GF(2)
         sage: A = G.algebra(R)
@@ -1315,18 +1310,15 @@ def elementary_matrix(arg0, arg1=None, **kwds):
         sage: E.parent()
         Full MatrixSpace of 4 by 4 dense matrices over Rational Field
 
-        sage: # needs sage.symbolic
         sage: E = elementary_matrix(4, row1=1, scale=I)
         sage: E.parent()
         Full MatrixSpace of 4 by 4 dense matrices over
          Number Field in I with defining polynomial x^2 + 1 with I = 1*I
 
-        sage: # needs sage.rings.complex_double sage.symbolic
         sage: E = elementary_matrix(4, row1=1, scale=CDF(I))
         sage: E.parent()
         Full MatrixSpace of 4 by 4 dense matrices over Complex Double Field
 
-        sage: # needs sage.rings.number_field sage.symbolic
         sage: E = elementary_matrix(4, row1=1, scale=QQbar(I))
         sage: E.parent()
         Full MatrixSpace of 4 by 4 dense matrices over Algebraic Field
@@ -2387,7 +2379,6 @@ def companion_matrix(poly, format='right'):
         [ 1  0 -8]
         [ 0  1  4]
 
-        sage: # needs sage.symbolic
         sage: y = var('y')
         sage: q = y^3 - 2*y + 1
         sage: companion_matrix(q)
@@ -2755,7 +2746,6 @@ def random_echelonizable_matrix(parent, rank, upper_bound=None, max_tries=100):
 
     Matrices can be generated over any exact ring. ::
 
-        sage: # needs sage.rings.finite_rings
         sage: F.<a> = GF(2^3)
         sage: B = random_matrix(F, 4, 5, algorithm='echelonizable', rank=4,
         ....:                   upper_bound=None)
@@ -3099,7 +3089,6 @@ def random_unimodular_matrix(parent, upper_bound=None, max_tries=100):
 
     A matrix over the number Field in `y` with defining polynomial `y^2-2y-2`. ::
 
-        sage: # needs sage.rings.number_field
         sage: y = polygen(ZZ, 'y')
         sage: K = NumberField(y^2 - 2*y - 2, 'y')
         sage: C = random_matrix(K, 3, algorithm='unimodular')
@@ -3356,7 +3345,6 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         sage: matrix_space = sage.matrix.matrix_space.MatrixSpace(QQ, 5)
         sage: A = random_diagonalizable_matrix(matrix_space)
 
-        sage: # needs sage.rings.number_field
         sage: eigenvalues = A.eigenvalues()
         sage: S = A.right_eigenmatrix()[1]
         sage: eigenvalues2 = (S.inverse()*A*S).diagonal()
@@ -3377,7 +3365,6 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         sage: all(x in ZZ for x in (B-(6*identity_matrix(6))).rref().list())
         True
 
-        sage: # needs sage.rings.number_field
         sage: S = B.right_eigenmatrix()[1]
         sage: eigenvalues2 = (S.inverse()*B*S).diagonal()
         sage: all(e in eigenvalues for e in eigenvalues2)
@@ -3585,7 +3572,6 @@ def vector_on_axis_rotation_matrix(v, i, ring=None):
 
     ::
 
-        sage: # needs sage.symbolic
         sage: x,y = var('x,y')
         sage: v = vector((x,y))
         sage: vector_on_axis_rotation_matrix(v, 1)
@@ -3689,7 +3675,6 @@ def ith_to_zero_rotation_matrix(v, i, ring=None):
 
     On the symbolic ring::
 
-        sage: # needs sage.symbolic
         sage: x,y,z = var('x,y,z')
         sage: v = vector((x,y,z))
         sage: ith_to_zero_rotation_matrix(v, 2)


### PR DESCRIPTION
These are just line noise at this point. No one is maintaining them, and there's no way to install Sage without these components.

The tags eventually need to be removed if we are to stop detecting the "features" over and over again while testing.
