### PR TITLE
src/sage/graphs: remove block-level "needs sage.foo" tags

### DIFF
--- a/src/sage/graphs/base/c_graph.pyx
+++ b/src/sage/graphs/base/c_graph.pyx
@@ -1567,7 +1567,6 @@ cdef class CGraphBackend(GenericGraphBackend):
 
         We check that the bug described in :issue:`8406` is gone::
 
-            sage: # needs sage.rings.finite_rings
             sage: G = Graph()
             sage: R.<a> = GF(3**3)
             sage: S.<x> = R[]

--- a/src/sage/graphs/base/static_sparse_backend.pyx
+++ b/src/sage/graphs/base/static_sparse_backend.pyx
@@ -448,7 +448,6 @@ cdef class StaticSparseBackend(CGraphBackend):
 
         ::
 
-            sage: # needs sage.combinat
             sage: g = DiGraph(digraphs.DeBruijn(4, 3), data_structure='static_sparse')
             sage: gi = DiGraph(g, data_structure='static_sparse')
             sage: gi.edges(sort=True)[0]

--- a/src/sage/graphs/base/static_sparse_graph.pyx
+++ b/src/sage/graphs/base/static_sparse_graph.pyx
@@ -1161,7 +1161,6 @@ def spectral_radius(G, prec=1e-10):
 
     A larger example::
 
-        sage: # needs sage.modules
         sage: G = DiGraph()
         sage: G.add_edges((i,i+1) for i in range(200))
         sage: G.add_edge(200,0)

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -196,7 +196,6 @@ class BipartiteGraph(Graph):
 
     #. From a reduced adjacency matrix::
 
-        sage: # needs sage.modules
         sage: M = Matrix([(1,1,1,0,0,0,0), (1,0,0,1,1,0,0),
         ....:             (0,1,0,1,0,1,0), (1,1,0,1,0,0,1)])
         sage: M
@@ -243,7 +242,6 @@ class BipartiteGraph(Graph):
 
        ::
 
-         sage: # needs sage.modules sage.rings.finite_rings
          sage: F.<a> = GF(4)
          sage: MS = MatrixSpace(F, 2, 3)
          sage: M = MS.matrix([[0, 1, a + 1], [a, 1, 1]])
@@ -329,7 +327,6 @@ class BipartiteGraph(Graph):
     Ensure that we can construct a ``BipartiteGraph`` with isolated vertices via
     the reduced adjacency matrix (:issue:`10356`)::
 
-        sage: # needs sage.modules
         sage: a = BipartiteGraph(matrix(2, 2, [1, 0, 1, 0]))
         sage: a
         Bipartite graph on 4 vertices
@@ -1563,7 +1560,6 @@ class BipartiteGraph(Graph):
 
         TESTS::
 
-            sage: # needs sage.modules
             sage: g = BipartiteGraph(matrix.ones(4, 3))
             sage: g.matching_polynomial()                                               # needs sage.libs.flint
             x^7 - 12*x^5 + 36*x^3 - 24*x
@@ -1839,7 +1835,6 @@ class BipartiteGraph(Graph):
 
         EXAMPLES::
 
-            sage: # needs sage.modules
             sage: M = Matrix([(1,1,1,0,0,0,0), (1,0,0,1,1,0,0),
             ....:             (0,1,0,1,0,1,0), (1,1,0,1,0,0,1)])
             sage: M
@@ -1957,7 +1952,6 @@ class BipartiteGraph(Graph):
         Bipartite graphs that are not weighted will return a matrix over ZZ,
         unless a base ring is specified::
 
-            sage: # needs sage.modules
             sage: M = Matrix([(1,1,1,0,0,0,0), (1,0,0,1,1,0,0),
             ....:             (0,1,0,1,0,1,0), (1,1,0,1,0,0,1)])
             sage: B = BipartiteGraph(M)
@@ -1981,7 +1975,6 @@ class BipartiteGraph(Graph):
         Multi-edge graphs also return a matrix over ZZ,
         unless a base ring is specified::
 
-            sage: # needs sage.modules
             sage: M = Matrix([(1,1,2,0,0), (0,2,1,1,1), (0,1,2,1,1)])
             sage: B = BipartiteGraph(M, multiedges=True, sparse=True)
             sage: N = B.reduced_adjacency_matrix()
@@ -1996,7 +1989,6 @@ class BipartiteGraph(Graph):
         Weighted graphs will return a matrix over the ring given by their
         (first) weights, unless a base ring is specified::
 
-            sage: # needs sage.modules sage.rings.finite_rings
             sage: F.<a> = GF(4)
             sage: MS = MatrixSpace(F, 2, 3)
             sage: M = MS.matrix([[0, 1, a+1], [a, 1, 1]])
@@ -2026,7 +2018,6 @@ class BipartiteGraph(Graph):
         An error is raised if the specified base ring is not compatible with the
         type of the weights of the bipartite graph::
 
-            sage: # needs sage.modules sage.rings.finite_rings
             sage: F.<a> = GF(4)
             sage: MS = MatrixSpace(F, 2, 3)
             sage: M = MS.matrix([[0, 1, a+1], [a, 1, 1]])

--- a/src/sage/graphs/bliss.pyx
+++ b/src/sage/graphs/bliss.pyx
@@ -483,7 +483,6 @@ cpdef canonical_form(G, partition=None, return_graph=False,
     Check that it works with non hashable non sortable edge labels (relying
     on string representations of the labels)::
 
-        sage: # needs sage.modules
         sage: g1 = Graph([(0, 1, matrix(ZZ, 2)), (0, 2, RDF.pi()), (1, 2, 'a')])
         sage: g2 = Graph([(1, 2, matrix(ZZ, 2)), (2, 0, RDF.pi()), (0, 1, 'a')])
         sage: g1can = canonical_form(g1, use_edge_labels=True)              # optional - bliss

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -1634,7 +1634,6 @@ class DiGraph(GenericGraph):
 
         Loops are part of the feedback edge set (:issue:`23989`)::
 
-            sage: # needs sage.combinat
             sage: D = digraphs.DeBruijn(2, 2)
             sage: sorted(D.loops(labels=None))
             [('00', '00'), ('11', '11')]
@@ -2543,7 +2542,6 @@ class DiGraph(GenericGraph):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: G = digraphs.DeBruijn(5,4)
             sage: G.diameter()
             4
@@ -3324,7 +3322,6 @@ class DiGraph(GenericGraph):
 
         Using a different choice of sources and sinks::
 
-            sage: # needs sage.geometry.polyhedron
             sage: fl = H.flow_polytope(ends=([1], [3])); fl
             A 1-dimensional polyhedron in QQ^6 defined as the convex hull
             of 2 vertices

--- a/src/sage/graphs/digraph_generators.py
+++ b/src/sage/graphs/digraph_generators.py
@@ -395,7 +395,6 @@ class DiGraphGenerators:
         A Strongly Regular digraph satisfies the condition `AJ = JA = kJ` where
         `A` is the adjacency matrix::
 
-            sage: # needs sage.combinat sage.modules
             sage: g = digraphs.StronglyRegular(7); g
             Strongly regular digraph: Digraph on 7 vertices
             sage: A = g.adjacency_matrix()*ones_matrix(7)
@@ -1052,7 +1051,6 @@ class DiGraphGenerators:
 
         Building a de Bruijn digraph on a different alphabet::
 
-            sage: # needs sage.combinat
             sage: g = digraphs.DeBruijn(['a', 'b'], 2)
             sage: g.vertices(sort=True)
             ['aa', 'ab', 'ba', 'bb']
@@ -1311,7 +1309,6 @@ class DiGraphGenerators:
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: K = digraphs.Kautz(2, 3)
             sage: b, D = K.is_isomorphic(digraphs.ImaseItoh(12, 2), certificate=True)
             sage: b

--- a/src/sage/graphs/digraph_generators.py
+++ b/src/sage/graphs/digraph_generators.py
@@ -1042,11 +1042,11 @@ class DiGraphGenerators:
 
         de Bruijn digraph of degree 2 and diameter 2::
 
-            sage: db = digraphs.DeBruijn(2, 2); db                                      # needs sage.combinat
+            sage: db = digraphs.DeBruijn(2, 2); db
             De Bruijn digraph (k=2, n=2): Looped digraph on 4 vertices
-            sage: db.order(), db.size()                                                 # needs sage.combinat
+            sage: db.order(), db.size()
             (4, 8)
-            sage: db.diameter()                                                         # needs sage.combinat
+            sage: db.diameter()
             2
 
         Building a de Bruijn digraph on a different alphabet::
@@ -1066,20 +1066,20 @@ class DiGraphGenerators:
 
         Alphabet of null size or words of length zero::
 
-            sage: digraphs.DeBruijn(5, 0)                                               # needs sage.combinat
+            sage: digraphs.DeBruijn(5, 0)
             De Bruijn digraph (k=5, n=0): Looped multi-digraph on 1 vertex
-            sage: digraphs.DeBruijn(0, 0)                                               # needs sage.combinat
+            sage: digraphs.DeBruijn(0, 0)
             De Bruijn digraph (k=0, n=0): Looped multi-digraph on 0 vertices
 
         :issue:`22355`::
 
-            sage: db = digraphs.DeBruijn(2, 2, vertices='strings')                      # needs sage.combinat
-            sage: db.vertices(sort=True)                                                # needs sage.combinat
+            sage: db = digraphs.DeBruijn(2, 2, vertices='strings')
+            sage: db.vertices(sort=True)
             ['00', '01', '10', '11']
             sage: h = digraphs.DeBruijn(2, 2, vertices='integers')
             sage: h.vertices(sort=True)
             [0, 1, 2, 3]
-            sage: db.is_isomorphic(h)                                                   # needs sage.combinat
+            sage: db.is_isomorphic(h)
             True
             sage: digraphs.DeBruijn(0, 0, vertices='integers')
             De Bruijn digraph (k=0, n=0): Looped multi-digraph on 0 vertices

--- a/src/sage/graphs/domination.py
+++ b/src/sage/graphs/domination.py
@@ -314,7 +314,6 @@ def dominating_sets(g, k=1, independent=False, total=False, connected=False,
 
     Independent distance-`k` dominating sets of a Path graph::
 
-        sage: # needs sage.numerical.mip
         sage: G = graphs.PathGraph(6)
         sage: sorted(G.dominating_sets(k=1, independent=True))
         [[1, 4]]
@@ -326,7 +325,6 @@ def dominating_sets(g, k=1, independent=False, total=False, connected=False,
     The dominating set is calculated for both the directed and undirected graphs
     (modification introduced in :issue:`17905`)::
 
-        sage: # needs sage.numerical.mip
         sage: g = digraphs.Path(3)
         sage: g.dominating_set(value_only=True)
         2

--- a/src/sage/graphs/generators/basic.py
+++ b/src/sage/graphs/generators/basic.py
@@ -69,13 +69,11 @@ def BullGraph(immutable=False):
     `x` is a variable, `A` the adjacency matrix of the graph, and `I`
     the identity matrix of the same dimensions as `A`::
 
-        sage: # needs sage.libs.flint
         sage: chrompoly = g.chromatic_polynomial()
         sage: x = chrompoly.parent()('x')
         sage: x * (x - 2) * (x - 1)^3 == chrompoly
         True
 
-        sage: # needs sage.libs.flint sage.modules
         sage: charpoly = g.characteristic_polynomial()
         sage: M = g.adjacency_matrix(); M
         [0 1 1 0 0]
@@ -414,7 +412,6 @@ def CompleteGraph(n, immutable=False):
     We view many Complete graphs with a Sage Graphics Array, first with this
     constructor (i.e., the position dictionary filled)::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -1426,7 +1423,6 @@ def LadderGraph(n, immutable=False):
 
     Create several ladder graphs in a Sage graphics array::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -1501,7 +1497,6 @@ def MoebiusLadderGraph(n, immutable=False):
 
     Create several Möbius ladder graphs in a Sage graphics array::
 
-        sage: # needs sage.plots
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -1721,7 +1716,6 @@ def StarGraph(n, immutable=False):
 
     ::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):

--- a/src/sage/graphs/generators/classical_geometries.py
+++ b/src/sage/graphs/generators/classical_geometries.py
@@ -61,7 +61,6 @@ def SymplecticPolarGraph(d, q, algorithm=None):
         sage: G.is_strongly_regular(parameters=True)
         (40, 12, 2, 4)
 
-        sage: # needs sage.libs.gap
         sage: O = graphs.OrthogonalPolarGraph(5, 3)
         sage: O.is_strongly_regular(parameters=True)
         (40, 12, 2, 4)
@@ -156,7 +155,6 @@ def AffineOrthogonalPolarGraph(d, q, sign='+'):
     Some examples from `Brouwer's table or strongly regular graphs
     <https://www.win.tue.nl/~aeb/graphs/srg/srgtab.html>`_::
 
-        sage: # needs sage.libs.gap
         sage: g = graphs.AffineOrthogonalPolarGraph(6,2,"-"); g
         Affine Polar Graph VO^-(6,2): Graph on 64 vertices
         sage: g.is_strongly_regular(parameters=True)
@@ -168,7 +166,6 @@ def AffineOrthogonalPolarGraph(d, q, sign='+'):
 
     When ``sign is None``::
 
-        sage: # needs sage.libs.gap
         sage: g = graphs.AffineOrthogonalPolarGraph(5,2,None); g
         Affine Polar Graph VO^-(5,2): Graph on 32 vertices
         sage: g.is_strongly_regular(parameters=True)
@@ -277,7 +274,6 @@ def _orthogonal_polar_graph(m, q, sign='+', point_type=[0]):
 
     TESTS::
 
-        sage: # needs sage.libs.gap
         sage: g = _orthogonal_polar_graph(5,3,point_type=[-1])
         sage: g.is_strongly_regular(parameters=True)
         (45, 12, 3, 3)
@@ -345,7 +341,6 @@ def OrthogonalPolarGraph(m, q, sign='+'):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.gap
         sage: G = graphs.OrthogonalPolarGraph(6,3,"+"); G
         Orthogonal Polar Graph O^+(6, 3): Graph on 130 vertices
         sage: G.is_strongly_regular(parameters=True)
@@ -428,7 +423,6 @@ def NonisotropicOrthogonalPolarGraph(m, q, sign='+', perp=None):
 
     `NO^-(6,2)` and `NO^+(6,2)`::
 
-        sage: # needs sage.libs.gap
         sage: g = graphs.NonisotropicOrthogonalPolarGraph(6,2,'-')
         sage: g.is_strongly_regular(parameters=True)
         (36, 15, 6, 6)
@@ -445,7 +439,6 @@ def NonisotropicOrthogonalPolarGraph(m, q, sign='+', perp=None):
 
     Wilbrink's graphs for `q=5`::
 
-        sage: # needs sage.libs.gap
         sage: g = graphs.NonisotropicOrthogonalPolarGraph(5,5,perp=1)
         sage: g.is_strongly_regular(parameters=True)    # long time
         (325, 60, 15, 10)
@@ -455,7 +448,6 @@ def NonisotropicOrthogonalPolarGraph(m, q, sign='+', perp=None):
 
     Wilbrink's graphs::
 
-        sage: # needs sage.libs.gap
         sage: g = graphs.NonisotropicOrthogonalPolarGraph(5,4,'+')
         sage: g.is_strongly_regular(parameters=True)
         (136, 75, 42, 40)
@@ -469,7 +461,6 @@ def NonisotropicOrthogonalPolarGraph(m, q, sign='+', perp=None):
 
     TESTS::
 
-        sage: # needs sage.libs.gap
         sage: g = graphs.NonisotropicOrthogonalPolarGraph(4,2); g
         NO^+(4, 2): Graph on 6 vertices
         sage: g = graphs.NonisotropicOrthogonalPolarGraph(4,3,'-')
@@ -619,7 +610,6 @@ def UnitaryPolarGraph(m, q, algorithm='gap'):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.gap
         sage: G = graphs.UnitaryPolarGraph(4,2); G
         Unitary Polar Graph U(4, 2); GQ(4, 2): Graph on 45 vertices
         sage: G.is_strongly_regular(parameters=True)
@@ -858,7 +848,6 @@ def TaylorTwographDescendantSRG(q, clique_partition=False):
 
     EXAMPLES::
 
-        sage: # needs sage.rings.finite_rings
         sage: g = graphs.TaylorTwographDescendantSRG(3); g
         Taylor two-graph descendant SRG: Graph on 27 vertices
         sage: g.is_strongly_regular(parameters=True)
@@ -873,7 +862,6 @@ def TaylorTwographDescendantSRG(q, clique_partition=False):
 
     TESTS::
 
-        sage: # needs sage.rings.finite_rings
         sage: g,l,_ = graphs.TaylorTwographDescendantSRG(3, clique_partition=True)
         sage: all(g.is_clique(x) for x in l)
         True
@@ -1041,7 +1029,6 @@ def T2starGeneralizedQuadrangleGraph(q, dual=False, hyperoval=None, field=None, 
 
     using the built-in construction::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: g = graphs.T2starGeneralizedQuadrangleGraph(4); g
         T2*(O,4); GQ(3, 5): Graph on 64 vertices
         sage: g.is_strongly_regular(parameters=True)
@@ -1053,7 +1040,6 @@ def T2starGeneralizedQuadrangleGraph(q, dual=False, hyperoval=None, field=None, 
 
     supplying your own hyperoval::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: F = GF(4,'b')
         sage: O = [vector(F,(0,0,0,1)),vector(F,(0,0,1,0))] + [vector(F, (0,1,x^2,x))
         ....:                                                  for x in F]
@@ -1064,7 +1050,6 @@ def T2starGeneralizedQuadrangleGraph(q, dual=False, hyperoval=None, field=None, 
 
     TESTS::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: F = GF(4,'b')  # repeating a point...
         sage: O = [vector(F,(0,1,0,0)),vector(F,(0,0,1,0))]+[vector(F, (0,1,x^2,x)) for x in F]
         sage: graphs.T2starGeneralizedQuadrangleGraph(4, hyperoval=O, field=F)
@@ -1164,7 +1149,6 @@ def HaemersGraph(q, hyperoval=None, hyperoval_matching=None, field=None, check_h
 
     using the built-in constructions::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: g = graphs.HaemersGraph(4); g
         Haemers(4): Graph on 96 vertices
         sage: g.is_strongly_regular(parameters=True)
@@ -1172,7 +1156,6 @@ def HaemersGraph(q, hyperoval=None, hyperoval_matching=None, field=None, check_h
 
     supplying your own hyperoval_matching::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: g = graphs.HaemersGraph(4, hyperoval_matching=((0,5),(1,4),(2,3))); g
         Haemers(4): Graph on 96 vertices
         sage: g.is_strongly_regular(parameters=True)
@@ -1180,7 +1163,6 @@ def HaemersGraph(q, hyperoval=None, hyperoval_matching=None, field=None, check_h
 
     TESTS::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: F = GF(4,'b')  # repeating a point...
         sage: O = [vector(F,(0,1,0,0)),vector(F,(0,0,1,0))]+[vector(F, (0,1,x^2,x)) for x in F]
         sage: graphs.HaemersGraph(4, hyperoval=O, field=F)
@@ -1388,7 +1370,6 @@ def Nowhere0WordsTwoWeightCodeGraph(q, hyperoval=None, field=None, check_hyperov
 
     using the built-in construction::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: g = graphs.Nowhere0WordsTwoWeightCodeGraph(8); g
         Nowhere0WordsTwoWeightCodeGraph(8): Graph on 196 vertices
         sage: g.is_strongly_regular(parameters=True)
@@ -1399,7 +1380,6 @@ def Nowhere0WordsTwoWeightCodeGraph(q, hyperoval=None, field=None, check_hyperov
 
     supplying your own hyperoval::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: F = GF(8)
         sage: O = [vector(F,(0,0,1)),vector(F,(0,1,0))] + [vector(F, (1,x^2,x))
         ....:                                              for x in F]
@@ -1410,7 +1390,6 @@ def Nowhere0WordsTwoWeightCodeGraph(q, hyperoval=None, field=None, check_hyperov
 
     TESTS::
 
-        sage: # needs sage.combinat sage.rings.finite_rings
         sage: F = GF(8)  # repeating a point...
         sage: O = [vector(F,(1,0,0)),vector(F,(0,1,0))]+[vector(F, (1,x^2,x)) for x in F]
         sage: graphs.Nowhere0WordsTwoWeightCodeGraph(8,hyperoval=O,field=F)
@@ -1486,7 +1465,6 @@ def OrthogonalDualPolarGraph(e, d, q):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.gap
         sage: G = graphs.OrthogonalDualPolarGraph(1,3,2)
         sage: G.is_distance_regular(True)
         ([7, 6, 4, None], [None, 1, 3, 7])
@@ -1502,7 +1480,6 @@ def OrthogonalDualPolarGraph(e, d, q):
 
     TESTS::
 
-        sage: # needs sage.libs.gap
         sage: G = graphs.OrthogonalDualPolarGraph(0,3,2)
         sage: G.is_distance_regular(True)
         ([14, 12, 8, None], [None, 1, 3, 7])

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -740,7 +740,6 @@ def BilinearFormsGraph(const int d, const int e, const int q):
 
     EXAMPLES::
 
-        sage: # needs sage.modules
         sage: G = graphs.BilinearFormsGraph(3, 3, 2)
         sage: G.is_distance_regular(True)
         ([49, 36, 16, None], [None, 1, 6, 28])
@@ -758,7 +757,6 @@ def BilinearFormsGraph(const int d, const int e, const int q):
 
     TESTS::
 
-        sage: # needs sage.modules
         sage: G = graphs.BilinearFormsGraph(2,3,2)
         sage: G.is_distance_regular(True)
         ([21, 12, None], [None, 1, 6])
@@ -844,7 +842,6 @@ def AlternatingFormsGraph(const int n, const int q):
 
     TESTS::
 
-         sage: # needs sage.modules
          sage: G = graphs.AlternatingFormsGraph(6,2)    # not tested (2 min)            # needs sage.rings.finite_rings
          sage: G.order()                        # not tested (because of above)         # needs sage.rings.finite_rings
          32768
@@ -931,7 +928,6 @@ def HermitianFormsGraph(const int n, const int r):
 
     EXAMPLES::
 
-        sage: # needs sage.modules sage.rings.finite_rings
         sage: G = graphs.HermitianFormsGraph(2, 2)
         sage: G.is_distance_regular(True)
         ([5, 4, None], [None, 1, 2])
@@ -945,7 +941,6 @@ def HermitianFormsGraph(const int n, const int r):
 
     TESTS::
 
-         sage: # needs sage.modules sage.rings.finite_rings
          sage: G = graphs.HermitianFormsGraph(3, 2)
          sage: G.is_distance_regular(True)
          ([21, 20, 16, None], [None, 1, 2, 12])
@@ -1182,7 +1177,6 @@ def GrassmannGraph(const int q, const int n, const int input_e):
 
     TESTS::
 
-        sage: # needs sage.modules sage.rings.finite_rings
         sage: G = graphs.GrassmannGraph(2, 6, 3)        # long time
         sage: G.is_distance_regular(True)       # long time
         ([98, 72, 32, None], [None, 1, 9, 49])
@@ -1239,7 +1233,6 @@ def DoubleGrassmannGraph(const int q, const int e):
 
     TESTS::
 
-        sage: # needs sage.modules
         sage: G = graphs.DoubleGrassmannGraph(5,1)
         sage: G.order()
         62
@@ -1505,7 +1498,6 @@ def GeneralisedOctagonGraph(const int s, const int t):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.gap
         sage: G = graphs.GeneralisedOctagonGraph(1, 4)          # optional - database_graphs
         sage: G.is_distance_regular(True)                       # optional - database_graphs
         ([5, 4, 4, 4, None], [None, 1, 1, 1, 5])
@@ -1616,7 +1608,6 @@ def GeneralisedHexagonGraph(const int s, const int t):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.gap
         sage: G = graphs.GeneralisedHexagonGraph(5, 5)          # optional - gap_package_atlasrep internet
         sage: G.is_distance_regular(True)                       # optional - gap_package_atlasrep internet
         ([30, 25, 25, None], [None, 1, 1, 6])
@@ -1773,7 +1764,6 @@ def _extract_lines(G):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.gap
         sage: from sage.graphs.generators.distance_regular import _extract_lines
         sage: G = graphs.GeneralisedHexagonGraph(1, 8)
         sage: lines = _extract_lines(G)
@@ -1841,7 +1831,6 @@ def _line_graph_generalised_polygon(H):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.gap
         sage: from sage.graphs.generators.distance_regular import (
         ....:     _line_graph_generalised_polygon)
         sage: G = graphs.GeneralisedHexagonGraph(1, 8)
@@ -2506,7 +2495,6 @@ def is_near_polygon(array):
 
     TESTS::
 
-        sage: # needs sage.combinat sage.libs.pari
         sage: from sage.graphs.generators.distance_regular import (
         ....: is_near_polygon, near_polygon_graph)
         sage: is_near_polygon([7, 6, 6, 4, 4, 1, 1, 3, 3, 7])
@@ -2644,7 +2632,6 @@ def near_polygon_graph(family, params):
 
     TESTS::
 
-        sage: # needs sage.combinat
         sage: near_polygon_graph(12, 9)
         Traceback (most recent call last):
         ...
@@ -2818,7 +2805,6 @@ def distance_regular_graph(list arr, existence=False, check=True):
         sage: graphs.distance_regular_graph([18, 16, 16, 1, 1, 9])              # optional - internet gap_package_atlasrep
         Generalised hexagon of order (2, 8): Graph on 819 vertices
 
-        sage: # needs sage.combinat
         sage: graphs.distance_regular_graph([14, 12, 10, 8, 6, 4, 2,
         ....:                                1, 2, 3, 4, 5, 6, 7])
         Hamming Graph with parameters 7,3: Graph on 2187 vertices

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -602,7 +602,6 @@ def BarbellGraph(n1, n2, immutable=False):
         sage: K_n1 = graphs.CompleteGraph(n1)
         sage: P_n2 = graphs.PathGraph(n2)
 
-        sage: # needs sage.modules
         sage: s_K = g.subgraph_search(K_n1, induced=True)
         sage: s_P = g.subgraph_search(P_n2, induced=True)
         sage: K_n1.is_isomorphic(s_K)
@@ -1130,7 +1129,6 @@ def CirculantGraph(n, adjacency, immutable=False, name=None):
     use the ``CirculantGraph`` constructor, which fills in
     the position dictionary::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -1242,7 +1240,6 @@ def CubeGraph(n, embedding=1, immutable=False):
 
     Plot several `n`-cubes in a Sage Graphics Array::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(6):
@@ -1532,7 +1529,6 @@ def FriendshipGraph(n, immutable=False):
 
     The first few friendship graphs. ::
 
-        sage: # needs sage.plot
         sage: A = []; B = []
         sage: for i in range(9):
         ....:     g = graphs.FriendshipGraph(i + 1)
@@ -2733,7 +2729,6 @@ def SquaredSkewHadamardMatrixGraph(n):
 
     EXAMPLES::
 
-        sage: # needs sage.combinat sage.modules
         sage: G = graphs.SquaredSkewHadamardMatrixGraph(4)
         sage: G.is_strongly_regular(parameters=True)
         (225, 112, 55, 56)
@@ -2787,7 +2782,6 @@ def SwitchedSquaredSkewHadamardMatrixGraph(n):
 
     EXAMPLES::
 
-        sage: # needs sage.combinat sage.modules
         sage: g = graphs.SwitchedSquaredSkewHadamardMatrixGraph(4)
         sage: g.is_strongly_regular(parameters=True)
         (226, 105, 48, 49)
@@ -3346,7 +3340,6 @@ def SierpinskiGasketGraph(n):
 
     EXAMPLES::
 
-        sage: # needs sage.modules
         sage: s4 = graphs.SierpinskiGasketGraph(4); s4
         Graph on 42 vertices
         sage: s4.size()
@@ -3444,7 +3437,6 @@ def GeneralizedSierpinskiGraph(G, k, stretch=None):
     The generalized Sierpinski graph of dimension `k` of any graph `G` with `n`
     vertices and `m` edges has `n^k` vertices and `m\sum_{i=0}^{k-1}n^i` edges::
 
-        sage: # needs sage.modules
         sage: n = randint(2, 6)
         sage: k = randint(1, 5)
         sage: G = graphs.RandomGNP(n, .5)
@@ -3483,7 +3475,6 @@ def GeneralizedSierpinskiGraph(G, k, stretch=None):
 
     TESTS::
 
-        sage: # needs sage.modules
         sage: graphs.GeneralizedSierpinskiGraph(Graph(), 3)
         Generalized Sierpinski Graph of Graph on 0 vertices of dimension 3: Graph on 0 vertices
         sage: graphs.GeneralizedSierpinskiGraph(Graph(1), 3).vertices(sort=False)
@@ -3563,7 +3554,6 @@ def WheelGraph(n):
     We view many wheel graphs with a Sage Graphics Array, first with this
     constructor (i.e., the position dictionary filled)::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -3833,7 +3823,6 @@ def MathonPseudocyclicMergingGraph(M, t):
         ...
         AssertionError...
 
-        sage: # needs sage.libs.gap
         sage: M = ES(3)
         sage: M = [M[1],M[0],M[2],M[3]]
         sage: G = mer(M, 2)
@@ -3904,7 +3893,6 @@ def MathonPseudocyclicStronglyRegularGraph(t, G=None, L=None):
     :meth:`~sage.groups.perm_gps.permgroup.PermutationGroup_generic.normal_subgroups`
     method::
 
-        sage: # needs sage.groups sage.libs.gap sage.rings.finite_rings
         sage: G = graphs.PaleyGraph(9)
         sage: a = G.automorphism_group(partition=[sorted(G)])
         sage: it = (x for x in a.normal_subgroups() if x.order() == 9)
@@ -4123,7 +4111,6 @@ def MuzychukS6Graph(n, d, Phi='fixed', Sigma='fixed', verbose=False):
 
     EXAMPLES::
 
-        sage: # needs sage.combinat sage.modules sage.rings.finite_rings
         sage: graphs.MuzychukS6Graph(3, 3).is_strongly_regular(parameters=True)
         (378, 116, 34, 36)
         sage: phi = {(2,(0,2)):0, (1,(1,3)):1, (0,(0,3)):1, (2,(1,2)):1,
@@ -4133,7 +4120,6 @@ def MuzychukS6Graph(n, d, Phi='fixed', Sigma='fixed', verbose=False):
 
     TESTS::
 
-        sage: # needs sage.modules
         sage: graphs.MuzychukS6Graph(2,2,Phi='random',Sigma='random').is_strongly_regular(parameters=True)              # needs sage.rings.finite_rings
         (16, 5, 0, 2)
         sage: graphs.MuzychukS6Graph(3,3,Phi='random',Sigma='random').is_strongly_regular(parameters=True)              # needs sage.rings.finite_rings
@@ -4452,7 +4438,6 @@ def StaircaseGraph(n):
 
     Create several staircase graphs in a Sage graphics array::
 
-        sage: # needs sage.plots
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -4565,7 +4550,6 @@ def BiwheelGraph(n):
 
     Create several biwheel graphs in a Sage graphics array::
 
-        sage: # needs sage.plots
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -4668,7 +4652,6 @@ def TruncatedBiwheelGraph(n):
 
     Create several truncated biwheel graphs in a Sage graphics array::
 
-        sage: # needs sage.plots
         sage: g = []
         sage: j = []
         sage: for i in range(9):

--- a/src/sage/graphs/generators/intersection.py
+++ b/src/sage/graphs/generators/intersection.py
@@ -416,7 +416,6 @@ def OrthogonalArrayBlockGraph(k, n, OA=None):
 
     EXAMPLES::
 
-        sage: # needs sage.modules
         sage: G = graphs.OrthogonalArrayBlockGraph(5,5); G                              # needs sage.schemes
         OA(5,5): Graph on 25 vertices
         sage: G.is_strongly_regular(parameters=True)                                    # needs sage.schemes
@@ -428,7 +427,6 @@ def OrthogonalArrayBlockGraph(k, n, OA=None):
 
     Two graphs built from different orthogonal arrays are also different::
 
-        sage: # needs sage.modules
         sage: k = 4; n = 10
         sage: OAa = designs.orthogonal_arrays.build(k,n)
         sage: OAb = [[(x+1)%n for x in R] for R in OAa]

--- a/src/sage/graphs/generators/platonic_solids.py
+++ b/src/sage/graphs/generators/platonic_solids.py
@@ -92,7 +92,6 @@ def HexahedralGraph():
     Create several hexahedral graphs in a Sage graphics array. They will be
     drawn differently due to the use of the spring-layout algorithm::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -145,7 +144,6 @@ def OctahedralGraph():
     Create several octahedral graphs in a Sage graphics array They will be drawn
     differently due to the use of the spring-layout algorithm::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -190,7 +188,6 @@ def IcosahedralGraph():
     Create several icosahedral graphs in a Sage graphics array. They will be
     drawn differently due to the use of the spring-layout algorithm::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):
@@ -235,7 +232,6 @@ def DodecahedralGraph():
     Create several dodecahedral graphs in a Sage graphics array They will be
     drawn differently due to the use of the spring-layout algorithm::
 
-        sage: # needs sage.plot
         sage: g = []
         sage: j = []
         sage: for i in range(9):

--- a/src/sage/graphs/generators/random.py
+++ b/src/sage/graphs/generators/random.py
@@ -2302,7 +2302,6 @@ def RandomBicubicPlanar(n, seed=None):
 
     EXAMPLES::
 
-        sage: # needs sage.combinat
         sage: n = randint(200, 300)
         sage: G = graphs.RandomBicubicPlanar(n)
         sage: G.order() == 2*n

--- a/src/sage/graphs/generators/smallgraphs.py
+++ b/src/sage/graphs/generators/smallgraphs.py
@@ -1588,7 +1588,6 @@ def BuckyBall(immutable=False):
     The Bucky Ball can also be created by extracting the 1-skeleton of the Bucky
     Ball polyhedron, but this is much slower::
 
-        sage: # needs sage.geometry.polyhedron sage.groups sage.rings.number_field
         sage: g = polytopes.buckyball().vertex_graph()
         sage: g.remove_loops()
         sage: h = graphs.BuckyBall()
@@ -1960,7 +1959,6 @@ def CameronGraph(immutable=False):
 
     EXAMPLES::
 
-        sage: # needs sage.groups
         sage: g = graphs.CameronGraph()
         sage: g.order()
         231
@@ -3478,7 +3476,6 @@ def HigmanSimsGraph(relabel=True, immutable=False):
     The automorphism group contains only one nontrivial proper normal subgroup,
     which is of index 2 and is simple.  It is known as the Higman-Sims group::
 
-        sage: # needs sage.groups
         sage: H = graphs.HigmanSimsGraph()
         sage: G = H.automorphism_group()
         sage: g = G.order(); g
@@ -4066,7 +4063,6 @@ def M22Graph(immutable=False):
 
     EXAMPLES::
 
-        sage: # needs sage.groups
         sage: g = graphs.M22Graph()
         sage: g.order()
         77
@@ -4314,7 +4310,6 @@ def MoserSpindle(immutable=False):
 
     The Moser spindle is a planar graph having 7 vertices and 11 edges::
 
-        sage: # needs sage.symbolic
         sage: G = graphs.MoserSpindle(); G
         Moser spindle: Graph on 7 vertices
         sage: G.is_planar()
@@ -4326,7 +4321,6 @@ def MoserSpindle(immutable=False):
 
     It is a Hamiltonian graph with radius 2, diameter 2, and girth 3::
 
-        sage: # needs sage.symbolic
         sage: G.is_hamiltonian()                                                        # needs sage.numerical.mip
         True
         sage: G.radius()
@@ -4340,7 +4334,6 @@ def MoserSpindle(immutable=False):
     has chromatic number 4, and its automorphism group is isomorphic to
     the dihedral group `D_4`::
 
-        sage: # needs sage.symbolic
         sage: pos = G.get_pos()
         sage: all(sum((ui-vi)**2 for ui, vi in zip(pos[u], pos[v])) == 1
         ....:         for u, v in G.edge_iterator(labels=None))

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -1094,7 +1094,6 @@ class GenericGraph(GenericGraph_pyx):
 
         An example coming from ``graphviz_string`` documentation in SageMath::
 
-            sage: # needs sage.symbolic
             sage: f(x) = -1 / x
             sage: g(x) = 1 / (x + 1)
             sage: G = DiGraph()
@@ -2397,7 +2396,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Creating a module endomorphism::
 
-            sage: # needs sage.modules
             sage: D12 = posets.DivisorLattice(12).hasse_diagram()
             sage: phi = D12.adjacency_matrix(vertices=True); phi
             Generic endomorphism of
@@ -2413,7 +2411,6 @@ class GenericGraph(GenericGraph_pyx):
 
         TESTS::
 
-            sage: # needs sage.modules
             sage: graphs.CubeGraph(8).adjacency_matrix().parent()
             Full MatrixSpace of 256 by 256 dense matrices over Integer Ring
             sage: graphs.CubeGraph(9).adjacency_matrix().parent()
@@ -2648,7 +2645,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Creating a module morphism::
 
-            sage: # needs sage.modules
             sage: D12 = posets.DivisorLattice(12).hasse_diagram()
             sage: phi_VE = D12.incidence_matrix(vertices=True, edges=True); phi_VE
             Generic morphism:
@@ -2961,7 +2957,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Creating a module morphism::
 
-            sage: # needs sage.modules
             sage: G = Graph(sparse=True, weighted=True)
             sage: G.add_edges([('A', 'B', 1), ('B', 'C', 2), ('A', 'C', 3), ('A', 'D', 4)])
             sage: phi = G.weighted_adjacency_matrix(vertices=True); phi
@@ -3197,7 +3192,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Creating a module morphism::
 
-            sage: # needs sage.modules
             sage: G = Graph(sparse=True, weighted=True)
             sage: G.add_edges([('A', 'B', 1), ('B', 'C', 2), ('A', 'C', 3), ('A', 'D', 4)])
             sage: phi = G.laplacian_matrix(weighted=True, vertices=True); phi
@@ -5415,7 +5409,6 @@ class GenericGraph(GenericGraph_pyx):
 
         ::
 
-            sage: # needs sage.modules
             sage: M = matrix(3, 3, [0, 1, 0, 0, 0, 1, 1, 1, 0])
             sage: D = DiGraph(M)
             sage: D.number_of_spanning_trees()
@@ -7434,7 +7427,6 @@ class GenericGraph(GenericGraph_pyx):
         By Edmonds' theorem, a graph which is `k`-connected always has `k`
         edge-disjoint arborescences, regardless of the root we pick::
 
-            sage: # needs sage.numerical.mip
             sage: g = digraphs.RandomDirectedGNP(11, .3)  # reduced from 30 to 11, cf. #32169
             sage: k = Integer(g.edge_connectivity())
             sage: while not k:
@@ -7448,7 +7440,6 @@ class GenericGraph(GenericGraph_pyx):
 
         In the undirected case, we can only ensure half of it::
 
-            sage: # needs sage.numerical.mip
             sage: g = graphs.RandomGNP(14, .3)  # reduced from 30 to 14, see #32169
             sage: while not g.is_biconnected():
             ....:     g = graphs.RandomGNP(14, .3)
@@ -7459,7 +7450,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Check the validity of the algorithms for undirected graphs::
 
-            sage: # needs sage.numerical.mip
             sage: g = graphs.RandomGNP(12, .7)
             sage: k = Integer(g.edge_connectivity()) // 2
             sage: trees = g.edge_disjoint_spanning_trees(k, algorithm='MILP')
@@ -7490,7 +7480,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Small cases::
 
-            sage: # needs sage.numerical.mip
             sage: Graph().edge_disjoint_spanning_trees(0)
             []
             sage: Graph(1).edge_disjoint_spanning_trees(0)
@@ -7510,7 +7499,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Choice of the algorithm::
 
-            sage: # needs sage.numerical.mip
             sage: Graph().edge_disjoint_spanning_trees(0, algorithm=None)
             []
             sage: Graph().edge_disjoint_spanning_trees(0, algorithm='Roskind-Tarjan')
@@ -8215,7 +8203,6 @@ class GenericGraph(GenericGraph_pyx):
         Quite obviously, the max cut of a bipartite graph is the number of
         edges, and the two sets of vertices are the two sides::
 
-            sage: # needs sage.numerical.mip
             sage: g = graphs.CompleteBipartiteGraph(5,6)
             sage: [ value, edges, [ setA, setB ]] = g.max_cut(vertices=True)
             sage: value == 5*6
@@ -8817,7 +8804,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Empty graphs::
 
-            sage: # needs sage.numerical.mip
             sage: Graph().longest_path()
             Graph on 0 vertices
             sage: Graph().longest_path(use_edge_labels=True)
@@ -8829,7 +8815,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Trivial graphs::
 
-            sage: # needs sage.numerical.mip
             sage: G = Graph()
             sage: G.add_vertex(0)
             sage: G.longest_path()
@@ -8888,7 +8873,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Check the behavior of parameter ``immutable``::
 
-            sage: # needs sage.numerical.mip
             sage: g1 =  digraphs.RandomDirectedGNP(15, 0.2)
             sage: for u,v in g.edge_iterator(labels=False):
             ....:     g.set_edge_label(u, v, random())
@@ -9186,7 +9170,6 @@ class GenericGraph(GenericGraph_pyx):
         starting from vertex `(0, 0)` and ending at vertex `(2, 2)`, but no
         Hamiltonian path starting from `(0, 0)` and ending at `(0, 1)`::
 
-            sage: # needs sage.numerical.mip
             sage: g = graphs.Grid2dGraph(3, 3)
             sage: g.hamiltonian_path()
             Hamiltonian path from 2D Grid Graph for [3, 3]: Graph on 9 vertices
@@ -9246,7 +9229,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Check the behavior of parameter ``immutable``::
 
-            sage: # needs sage.numerical.mip
             sage: g = graphs.Grid2dGraph(3, 3)
             sage: g.hamiltonian_path().is_immutable()
             False
@@ -9519,7 +9501,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Search for a minimum and a maximum weight Hamiltonian cycle::
 
-            sage: # needs sage.numerical.mip
             sage: G = Graph([(0, 1, 1), (0, 2, 2), (0, 3, 1), (1, 2, 1), (1, 3, 2), (2, 3, 1)])
             sage: tsp = G.traveling_salesman_problem(use_edge_labels=True,
             ....:                                    maximize=False)
@@ -9569,7 +9550,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Simple tests for multiple edges and loops::
 
-            sage: # needs sage.numerical.mip
             sage: G = DiGraph(multiedges=True, loops=True)
             sage: G.is_hamiltonian()
             False
@@ -9597,7 +9577,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Graphs on 2 vertices::
 
-            sage: # needs sage.numerical.mip
             sage: Graph([(0, 1), (0, 1)], multiedges=True).is_hamiltonian()
             True
             sage: DiGraph([(0, 1), (0, 1)], multiedges=True).is_hamiltonian()
@@ -10112,7 +10091,6 @@ class GenericGraph(GenericGraph_pyx):
 
         The necessary example::
 
-            sage: # needs sage.numerical.mip
             sage: g = graphs.PetersenGraph()
             sage: fvs = g.feedback_vertex_set()
             sage: len(fvs)
@@ -10127,7 +10105,6 @@ class GenericGraph(GenericGraph_pyx):
         of its neighbors removed: a feedback vertex set is in this situation a
         vertex cover::
 
-            sage: # needs sage.numerical.mip
             sage: cycle = graphs.CycleGraph(5)
             sage: dcycle = DiGraph(cycle)
             sage: cycle.vertex_cover(value_only=True)
@@ -10680,7 +10657,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Loops and multiple edges::
 
-            sage: # needs sage.numerical.mip
             sage: g = Graph([(0, 0), (0, 0)], loops=True, multiedges=True)
             sage: g.nowhere_zero_flow().edges(sort=True)
             [(0, 0, 1), (0, 0, 1)]
@@ -12413,7 +12389,6 @@ class GenericGraph(GenericGraph_pyx):
         are first-class objects in Python, we can specify precisely the function
         from the Sage library that we wish to use as the key::
 
-            sage: # needs sage.libs.flint
             sage: t = polygen(QQ, 't')
             sage: K = Graph({5*t: [t^2], t^2: [t^2+2], t^2+2: [4*t^2-6], 4*t^2-6: [5*t]})
             sage: from sage.rings.polynomial.polynomial_rational_flint import Polynomial_rational_flint
@@ -14014,7 +13989,6 @@ class GenericGraph(GenericGraph_pyx):
         returned list is the degree of the `i`-th vertex in the list
         ``list(self)``::
 
-            sage: # needs sage.combinat
             sage: D = digraphs.DeBruijn(4, 2)
             sage: D.delete_vertex('20')
             sage: print(D.degree())
@@ -14820,7 +14794,6 @@ class GenericGraph(GenericGraph_pyx):
 
         It also contains the claw `K_{1,3}`::
 
-             sage: # needs sage.modules
              sage: h2 = g.subgraph_search(graphs.ClawGraph()); h2
              Subgraph of (Petersen graph): Graph on 4 vertices
              sage: h2.vertices(sort=True); h2.edges(sort=True, labels=False)
@@ -15664,7 +15637,6 @@ class GenericGraph(GenericGraph_pyx):
 
         TESTS::
 
-            sage: # needs sage.groups
             sage: digraphs.DeBruijn(3,1).is_circulant(certificate=True)                 # needs sage.combinat
             (True, [(3, [0, 1, 2])])
             sage: Graph(1).is_circulant(certificate=True)
@@ -20412,7 +20384,6 @@ class GenericGraph(GenericGraph_pyx):
 
         The tensor product of two DeBruijn digraphs of same diameter is a DeBruijn digraph::
 
-            sage: # needs sage.combinat
             sage: B1 = digraphs.DeBruijn(2, 3)
             sage: B2 = digraphs.DeBruijn(3, 3)
             sage: T = B1.tensor_product(B2)
@@ -21083,7 +21054,6 @@ class GenericGraph(GenericGraph_pyx):
 
         We first request the coloring as a function::
 
-            sage: # needs sage.groups
             sage: f = G._color_by_label(as_function=True)
             sage: [f(1), f(2), f(3)]
             ['#0000ff', '#ff0000', '#00ff00']
@@ -21115,7 +21085,6 @@ class GenericGraph(GenericGraph_pyx):
 
         We check what happens when several labels have the same color::
 
-            sage: # needs sage.groups
             sage: result = G._color_by_label({1: "blue", 2: "blue", 3: "green"})
             sage: sorted(result)
             ['blue', 'green']
@@ -21901,7 +21870,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Make sure that :issue:`12364` is fixed::
 
-            sage: # needs sage.combinat sage.modules
             sage: m = WordMorphism('a->abb,b->ba')
             sage: w = m.fixed_point('a')
             sage: prefix = Word(list(w[:100]))
@@ -22248,7 +22216,6 @@ class GenericGraph(GenericGraph_pyx):
         We can modify the :class:`~sage.graphs.graph_plot.GraphPlot` object.
         Notice that the changes are cumulative::
 
-            sage: # needs sage.plot
             sage: GP.set_edges(edge_style='solid')
             sage: GP.plot()
             Graphics object consisting of 22 graphics primitives
@@ -22473,7 +22440,6 @@ class GenericGraph(GenericGraph_pyx):
 
         ::
 
-            sage: # needs sage.plot
             sage: from sage.plot.colors import rainbow
             sage: C = graphs.CubeGraph(5)
             sage: R = rainbow(5)
@@ -22611,7 +22577,6 @@ class GenericGraph(GenericGraph_pyx):
 
         ::
 
-            sage: # needs sage.modular
             sage: S = SupersingularModule(389)
             sage: H = S.hecke_matrix(2)
             sage: D = DiGraph(H, sparse=True)
@@ -23198,7 +23163,6 @@ class GenericGraph(GenericGraph_pyx):
 
         A digraph using latex labels for vertices and edges::
 
-            sage: # needs sage.symbolic
             sage: f(x) = -1 / x
             sage: g(x) = 1 / (x + 1)
             sage: G = DiGraph()
@@ -23476,7 +23440,6 @@ class GenericGraph(GenericGraph_pyx):
         The following digraph has vertices with newlines in their string
         representations::
 
-            sage: # needs sage.modules
             sage: m1 = matrix(3, 3)
             sage: m2 = matrix(3, 3, 1)
             sage: m1.set_immutable()
@@ -23825,7 +23788,6 @@ class GenericGraph(GenericGraph_pyx):
         test both the Laplacian construction and the computation of
         eigenvalues. ::
 
-            sage: # needs sage.modules sage.rings.number_field
             sage: H = graphs.HoffmanSingletonGraph()
             sage: evals = H.spectrum()
             sage: lap = [7 - x for x in evals]
@@ -24206,7 +24168,6 @@ class GenericGraph(GenericGraph_pyx):
             [0 0 1]
             [1 1 0]
 
-            sage: # needs sage.groups
             sage: C5 = graphs.CycleGraph(5)
             sage: C5.relabel({u: str(u) for u in C5}, inplace=True)
             sage: ar = C5.automorphism_group().random_element()
@@ -24672,7 +24633,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Graphs::
 
-            sage: # needs sage.groups
             sage: graphs_query = GraphQuery(display_cols=['graph6'],num_vertices=4)
             sage: L = graphs_query.get_graphs_list()
             sage: graphs_list.show_graphs(L)                                            # needs sage.plot
@@ -24700,7 +24660,6 @@ class GenericGraph(GenericGraph_pyx):
 
         ::
 
-            sage: # needs sage.groups
             sage: D = graphs.DodecahedralGraph()
             sage: G = D.automorphism_group()
             sage: A5 = AlternatingGroup(5)
@@ -24743,7 +24702,6 @@ class GenericGraph(GenericGraph_pyx):
             sage: G.automorphism_group(edge_labels=True)                                # needs sage.groups
             Permutation Group with generators [(0,1)]
 
-            sage: # needs sage.groups
             sage: foo = Graph(sparse=True)
             sage: bar = Graph(sparse=True)
             sage: foo.add_edges([(0,1,1),(1,2,2), (2,3,3)])
@@ -24765,7 +24723,6 @@ class GenericGraph(GenericGraph_pyx):
 
         ::
 
-            sage: # needs sage.groups
             sage: G = graphs.PetersenGraph()
             sage: G.automorphism_group(return_group=False, orbits=True, algorithm='sage')
             [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
@@ -24801,7 +24758,6 @@ class GenericGraph(GenericGraph_pyx):
 
         Labeled automorphism group::
 
-            sage: # needs sage.combinat sage.groups
             sage: d = digraphs.DeBruijn(3,2)
             sage: A = d.automorphism_group(algorithm='sage')
             sage: A_target = PermutationGroup(["('02','10','21')('00','11','22')('01','12','20')",
@@ -24843,7 +24799,6 @@ class GenericGraph(GenericGraph_pyx):
         We check that the representations of the groups returned with ``'sage'``
         and ``'bliss'`` are the same (:issue:`27571`)::
 
-            sage: # needs sage.groups sage.libs.pari
             sage: G = graphs.PaleyGraph(9)
             sage: a1 = G.automorphism_group(algorithm='sage')
             sage: V = sorted(G, reverse=True)
@@ -25827,7 +25782,6 @@ class GenericGraph(GenericGraph_pyx):
         Graphs with loops and multiedges will have identity and repeated
         elements, respectively, among the generators::
 
-            sage: # needs sage.rings.finite_rings
             sage: g = Graph(graphs.PaleyGraph(9), loops=True, multiedges=True)
             sage: g.add_edges([(u, u) for u in g])
             sage: g.add_edges([(u, u+1) for u in g])
@@ -25852,7 +25806,6 @@ class GenericGraph(GenericGraph_pyx):
 
         A disconnected graphs may also be a Cayley graph::
 
-            sage: # needs sage.rings.finite_rings
             sage: g = graphs.PaleyGraph(9)
             sage: h = g.disjoint_union(g)
             sage: h = h.disjoint_union(h)
@@ -26169,7 +26122,6 @@ class GenericGraph(GenericGraph_pyx):
 
         TESTS::
 
-            sage: # needs sage.modules sage.rings.number_field
             sage: (graphs.CompleteGraph(4)).katz_matrix(1/4)
             [3/5 4/5 4/5 4/5]
             [4/5 3/5 4/5 4/5]
@@ -26279,7 +26231,6 @@ class GenericGraph(GenericGraph_pyx):
 
         TESTS::
 
-            sage: # needs sage.modules sage.rings.number_field
             sage: graphs.PathGraph(3).katz_centrality(1/20)
             {0: 11/199, 1: 21/199, 2: 11/199}
             sage: graphs.PathGraph(4).katz_centrality(1/20)

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -21048,8 +21048,8 @@ class GenericGraph(GenericGraph_pyx):
         We consider the Cayley graph of the symmetric group, whose edges are
         labelled by the numbers 1,2, and 3::
 
-            sage: G = SymmetricGroup(4).cayley_graph()                                  # needs sage.groups
-            sage: set(G.edge_labels())                                                  # needs sage.groups
+            sage: G = SymmetricGroup(4).cayley_graph()
+            sage: set(G.edge_labels())
             {1, 2, 3}
 
         We first request the coloring as a function::
@@ -21071,12 +21071,12 @@ class GenericGraph(GenericGraph_pyx):
 
         The default output is a dictionary assigning edges to colors::
 
-            sage: G._color_by_label()                                                   # needs sage.groups
+            sage: G._color_by_label()
             {'#0000ff': [((), (1,2), 1), ...],
              '#00ff00': [((), (3,4), 3), ...],
              '#ff0000': [((), (2,3), 2), ...]}
 
-            sage: G._color_by_label({1: "blue", 2: "red", 3: "green"})                  # needs sage.groups
+            sage: G._color_by_label({1: "blue", 2: "red", 3: "green"})
             {'blue': [((), (1,2), 1), ...],
              'green': [((), (3,4), 3), ...],
              'red': [((), (2,3), 2), ...]}
@@ -22208,9 +22208,9 @@ class GenericGraph(GenericGraph_pyx):
             sage: g = Graph({}, loops=True, multiedges=True, sparse=True)
             sage: g.add_edges([(0,0,'a'),(0,0,'b'),(0,1,'c'),(0,1,'d'),
             ....:     (0,1,'e'),(0,1,'f'),(0,1,'f'),(2,1,'g'),(2,2,'h')])
-            sage: GP = g.graphplot(edge_labels=True, color_by_label=True,               # needs sage.plot
+            sage: GP = g.graphplot(edge_labels=True, color_by_label=True,
             ....:                  edge_style='dashed')
-            sage: GP.plot()                                                             # needs sage.plot
+            sage: GP.plot()
             Graphics object consisting of 22 graphics primitives
 
         We can modify the :class:`~sage.graphs.graph_plot.GraphPlot` object.

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -151,7 +151,6 @@ covered here.
 
    ::
 
-       sage: # needs sage.modules
        sage: M = Matrix([(0,1,0,0,1,1,0,0,0,0), (1,0,1,0,0,0,1,0,0,0),
        ....:             (0,1,0,1,0,0,0,1,0,0), (0,0,1,0,1,0,0,0,1,0),
        ....:             (1,0,0,1,0,0,0,0,0,1), (1,0,0,0,0,0,0,1,1,0), (0,1,0,0,0,0,0,0,1,1),
@@ -176,7 +175,6 @@ covered here.
 
    ::
 
-       sage: # needs sage.modules
        sage: M = Matrix([(-1, 0, 0, 0, 1, 0, 0, 0, 0, 0,-1, 0, 0, 0, 0),
        ....:             ( 1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0,-1, 0, 0, 0),
        ....:             ( 0, 1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0,-1, 0, 0),
@@ -768,7 +766,6 @@ class Graph(GenericGraph):
 
         Check that :issue:`9714` is fixed::
 
-            sage: # needs sage.modules
             sage: MA = Matrix([[1,2,0], [0,2,0], [0,0,1]])
             sage: GA = Graph(MA, format='adjacency_matrix')
             sage: MI = GA.incidence_matrix(oriented=False); MI
@@ -892,7 +889,6 @@ class Graph(GenericGraph):
         ValueError: An *undirected* igraph graph was expected.
         To build a directed graph, call the DiGraph constructor.
 
-        sage: # needs sage.modules
         sage: m = matrix([[0, -1], [-1, 0]])
         sage: Graph(m, format='seidel_adjacency_matrix')
         Graph on 2 vertices
@@ -3568,7 +3564,6 @@ class Graph(GenericGraph):
             sage: are_equal_colorings(P, Q)
             True
 
-            sage: # needs sage.plot
             sage: G.plot(partition=P)
             Graphics object consisting of 16 graphics primitives
             sage: G.coloring(hex_colors=True, algorithm='MILP')
@@ -3655,7 +3650,6 @@ class Graph(GenericGraph):
         We show that given a triangle `\{e_1, e_2, e_3\}`, we have
         `X_G = X_{G - e_1} + X_{G - e_2} - X_{G - e_1 - e_2}`::
 
-            sage: # needs sage.combinat sage.modules
             sage: G = Graph([[1,2],[1,3],[2,3]])
             sage: XG = G.chromatic_symmetric_function()
             sage: G1 = copy(G)
@@ -3765,7 +3759,6 @@ class Graph(GenericGraph):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat sage.modules
             sage: G = Graph([[1,2,3], [[1,3], [2,3]]])
             sage: G.chromatic_quasisymmetric_function()
             (2*t^2+2*t+2)*M[1, 1, 1] + M[1, 2] + t^2*M[2, 1]
@@ -4049,7 +4042,6 @@ class Graph(GenericGraph):
 
         Check corner cases::
 
-            sage: # needs sage.numerical.mip
             sage: Graph().maximum_average_degree(value_only=True)
             0
             sage: Graph().maximum_average_degree(value_only=False)
@@ -4161,7 +4153,6 @@ class Graph(GenericGraph):
         partition of the set of vertices the family defined by the three copies
         of each vertex. The ISR of such a family defines a 3-coloring::
 
-            sage: # needs sage.numerical.mip
             sage: g = 3 * graphs.PetersenGraph()
             sage: n = g.order() / 3
             sage: f = [[i, i + n, i + 2*n] for i in range(n)]
@@ -4294,7 +4285,6 @@ class Graph(GenericGraph):
 
         Trying to find a minor isomorphic to `K_4` in the `4\times 4` grid::
 
-            sage: # needs sage.numerical.mip
             sage: g = graphs.GridGraph([4,4])
             sage: h = graphs.CompleteGraph(4)
             sage: L = g.minor(h)
@@ -4480,7 +4470,6 @@ class Graph(GenericGraph):
             When it is created, it builds a table of useful information to
             compute convex hulls. As a result ::
 
-                sage: # needs sage.numerical.mip
                 sage: g = graphs.PetersenGraph()
                 sage: g.convexity_properties().hull([1, 3])
                 [1, 2, 3]
@@ -4489,7 +4478,6 @@ class Graph(GenericGraph):
 
             is a terrible waste of computations, while ::
 
-                sage: # needs sage.numerical.mip
                 sage: g = graphs.PetersenGraph()
                 sage: CP = g.convexity_properties()
                 sage: CP.hull([1, 3])
@@ -7139,7 +7127,6 @@ class Graph(GenericGraph):
             sage: (graphs.FruchtGraph()).cores(with_labels=True)
             {0: 3, 1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 3, 8: 3, 9: 3, 10: 3, 11: 3}
 
-            sage: # needs sage.modules
             sage: set_random_seed(0)
             sage: a = random_matrix(ZZ, 20, x=2, sparse=True, density=.1)
             sage: b = Graph(20)
@@ -8454,7 +8441,6 @@ class Graph(GenericGraph):
 
         Effective resistances in a straight linear 2-tree on 6 vertices ::
 
-            sage: # needs sage.modules
             sage: G = Graph([(0,1),(0,2),(1,2),(1,3),(3,5),(2,4),(2,3),(3,4),(4,5)])
             sage: G.effective_resistance(0,1)
             34/55
@@ -8467,7 +8453,6 @@ class Graph(GenericGraph):
 
         Effective resistances in a fan on 6 vertices ::
 
-            sage: # needs sage.modules
             sage: H = Graph([(0,1),(0,2),(0,3),(0,4),(0,5),(0,6),(1,2),(2,3),(3,4),(4,5)])
             sage: H.effective_resistance(1,5)
             6/5
@@ -8496,7 +8481,6 @@ class Graph(GenericGraph):
 
         TESTS::
 
-            sage: # needs sage.modules
             sage: G = graphs.CompleteGraph(4)
             sage: all(G.effective_resistance(u, v) == 1/2
             ....:     for u,v in G.edge_iterator(labels=False))
@@ -8655,7 +8639,6 @@ class Graph(GenericGraph):
             in the meantime if you want to use it please disallow multiedges
             using allow_multiple_edges().
 
-            sage: # needs sage.modules
             sage: graphs.CompleteGraph(4).effective_resistance_matrix(nonedgesonly=False)
             [  0 1/2 1/2 1/2]
             [1/2   0 1/2 1/2]
@@ -8680,7 +8663,6 @@ class Graph(GenericGraph):
 
         Ask for an immutable matrix::
 
-            sage: # needs sage.modules
             sage: G = Graph([(0, 1)])
             sage: M = G.effective_resistance_matrix(immutable=False)
             sage: M.is_immutable()
@@ -8776,7 +8758,6 @@ class Graph(GenericGraph):
 
         TESTS::
 
-            sage: # needs sage.modules
             sage: graphs.CompleteGraph(4).least_effective_resistance()
             []
             sage: graphs.CompleteGraph(4).least_effective_resistance(nonedgesonly=False)
@@ -8903,7 +8884,6 @@ class Graph(GenericGraph):
 
         TESTS::
 
-            sage: # needs sage.modules
             sage: G = graphs.CompleteGraph(4)
             sage: M = G.common_neighbors_matrix()
             sage: M.is_zero()
@@ -8921,7 +8901,6 @@ class Graph(GenericGraph):
 
         Asking for an immutable matrix::
 
-            sage: # needs sage.modules
             sage: G = Graph([(0, 1)])
             sage: M = G.common_neighbors_matrix()
             sage: M.is_immutable()
@@ -8989,7 +8968,6 @@ class Graph(GenericGraph):
 
         TESTS::
 
-            sage: # needs sage.modules
             sage: G = graphs.CompleteGraph(4)
             sage: G.most_common_neighbors()
             []

--- a/src/sage/graphs/graph_coloring.pyx
+++ b/src/sage/graphs/graph_coloring.pyx
@@ -1380,7 +1380,6 @@ def edge_coloring(g, value_only=False, vizing=False, hex_colors=False, solver=No
 
     The Petersen graph has chromatic index 4::
 
-        sage: # needs sage.numerical.mip
         sage: from sage.graphs.graph_coloring import edge_coloring
         sage: g = graphs.PetersenGraph()
         sage: edge_coloring(g, value_only=True, solver='GLPK')

--- a/src/sage/graphs/graph_decompositions/vertex_separation.pyx
+++ b/src/sage/graphs/graph_decompositions/vertex_separation.pyx
@@ -805,7 +805,6 @@ def vertex_separation(G, algorithm='BAB', cut_off=None, upper_bound=None, verbos
 
         sage: from sage.graphs.graph_decompositions.vertex_separation import vertex_separation
 
-        sage: # needs sage.combinat
         sage: G = digraphs.DeBruijn(2,3)
         sage: vs,L = vertex_separation(G, algorithm='BAB'); vs
         2
@@ -1456,7 +1455,6 @@ def vertex_separation_MILP(G, integrality=False, solver=None, verbose=0,
 
     Vertex separation of a De Bruijn digraph::
 
-        sage: # needs sage.combinat
         sage: from sage.graphs.graph_decompositions import vertex_separation
         sage: G = digraphs.DeBruijn(2,3)
         sage: vs, L = vertex_separation.vertex_separation_MILP(G); vs                   # needs sage.numerical.mip

--- a/src/sage/graphs/graph_generators.py
+++ b/src/sage/graphs/graph_generators.py
@@ -1409,7 +1409,6 @@ class GraphGenerators:
 
         There are two sets of cospectral graphs on six vertices with no isolated vertices::
 
-            sage: # needs sage.modules
             sage: g = graphs.cospectral_graphs(6, graphs=lambda x: min(x.degree())>0)
             sage: sorted(sorted(g.graph6_string() for g in glist) for glist in g)
             [['Ep__', 'Er?G'], ['ExGg', 'ExoG']]
@@ -1429,7 +1428,6 @@ class GraphGenerators:
         There are two sets of cospectral graphs (with respect to the
         Laplacian matrix) on six vertices::
 
-            sage: # needs sage.modules
             sage: g = graphs.cospectral_graphs(6, matrix_function=lambda g: g.laplacian_matrix())
             sage: sorted(sorted(g.graph6_string() for g in glist) for glist in g)
             [['Edq_', 'ErcG'], ['Exoo', 'EzcG']]

--- a/src/sage/graphs/graph_latex.py
+++ b/src/sage/graphs/graph_latex.py
@@ -265,7 +265,6 @@ the possible options available through Sage's interface to the ``tkz-graph``
 package.  So it is worth viewing this in the notebook to see the effects of
 various defaults and choices.::
 
-    sage: # needs sage.symbolic
     sage: var('x y u w')
     (x, y, u, w)
     sage: G = Graph(loops=True)

--- a/src/sage/graphs/graph_plot_js.py
+++ b/src/sage/graphs/graph_plot_js.py
@@ -175,7 +175,6 @@ def gen_html_code(G,
 
         sage: graphs.DodecahedralGraph().show(method='js')                      # optional - internet
 
-        sage: # needs sage.combinat
         sage: g = digraphs.DeBruijn(2, 2)
         sage: g.allow_multiple_edges(True)
         sage: g.add_edge("10", "10", "a")

--- a/src/sage/graphs/line_graph.pyx
+++ b/src/sage/graphs/line_graph.pyx
@@ -189,7 +189,6 @@ def is_line_graph(g, certificate=False):
 
     But what is the graph whose line graph is the house ?::
 
-        sage: # needs sage.modules
         sage: is_line, R, isom = g.is_line_graph(certificate=True)
         sage: R.sparse6_string()
         ':DaHI~'

--- a/src/sage/graphs/matching_covered_graph.py
+++ b/src/sage/graphs/matching_covered_graph.py
@@ -249,7 +249,6 @@ class MatchingCoveredGraph(Graph):
         sage: sorted(H.get_matching())
         [(0, 5, None), (1, 2, None), (3, 4, None)]
 
-        sage: # needs sage.modules
         sage: M = Matrix([(0,1,0,0,1,1,0,0,0,0),
         ....:             (1,0,1,0,0,0,1,0,0,0),
         ....:             (0,1,0,1,0,0,0,1,0,0),
@@ -278,7 +277,6 @@ class MatchingCoveredGraph(Graph):
         sage: sorted(H.get_matching())
         [(0, 5, None), (1, 6, None), (2, 7, None), (3, 8, None), (4, 9, None)]
 
-        sage: # needs sage.modules
         sage: M = Matrix([(-1, 0, 0, 0, 1, 0, 0, 0, 0, 0,-1, 0, 0, 0, 0),
         ....:             ( 1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0,-1, 0, 0, 0),
         ....:             ( 0, 1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0,-1, 0, 0),
@@ -476,7 +474,6 @@ class MatchingCoveredGraph(Graph):
         ...
         ValueError: input graph is not matching covered
 
-        sage: # needs sage.modules
         sage: M = Matrix([(0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0),
         ....:             (1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         ....:             (0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
@@ -516,7 +513,6 @@ class MatchingCoveredGraph(Graph):
         ...
         ValueError: input graph is not matching covered
 
-        sage: # needs sage.modules
         sage: M = Matrix([(1, 1, 0, 0, 0, 0),
         ....:             (0, 0, 1, 1, 0, 0),
         ....:             (0, 0, 1, 0, 1, 0),

--- a/src/sage/graphs/morphisms.py
+++ b/src/sage/graphs/morphisms.py
@@ -371,7 +371,6 @@ def has_homomorphism_to(G, H, core=False, solver=None, verbose=0,
     One can compute the core of a graph (with respect to homomorphism)
     with this method::
 
-        sage: # needs sage.numerical.mip
         sage: g = graphs.CycleGraph(8)
         sage: mapping = g.has_homomorphism_to(g, core=True)
         sage: print(f"The size of the core is {len(set(mapping.values()))}")
@@ -384,7 +383,6 @@ def has_homomorphism_to(G, H, core=False, solver=None, verbose=0,
     The chromatic number of a graph is the order of the smallest clique to which
     it has an homomorphism::
 
-        sage: # needs sage.numerical.mip
         sage: g = graphs.CycleGraph(9)
         sage: g.chromatic_number()
         3

--- a/src/sage/graphs/orientations.py
+++ b/src/sage/graphs/orientations.py
@@ -1145,7 +1145,6 @@ def minimum_outdegree_orientation(G, use_edge_labels=False, solver=None, verbose
 
     Show the influence of edge labels on the solution::
 
-        sage: # needs sage.numerical.mip
         sage: g = graphs.PetersenGraph()
         sage: o = g.minimum_outdegree_orientation(use_edge_labels=False)
         sage: max(o.out_degree())

--- a/src/sage/graphs/path_enumeration.pyx
+++ b/src/sage/graphs/path_enumeration.pyx
@@ -446,7 +446,6 @@ def shortest_simple_paths(self, source, target, weight_function=None,
          [1, 6, 9, 3, 4, 5],
          [1, 6, 9, 11, 10, 5]]
 
-        sage: # needs sage.combinat
         sage: G = digraphs.DeBruijn(2, 3)
         sage: for u,v in G.edges(sort=True, labels=False):
         ....:     G.set_edge_label(u, v, 1)
@@ -478,7 +477,6 @@ def shortest_simple_paths(self, source, target, weight_function=None,
 
     Check for consistency of results of Yen's and Feng's::
 
-        sage: # needs sage.combinat
         sage: G = digraphs.DeBruijn(2, 4)
         sage: s = set()
         sage: for p in G.shortest_simple_paths('0000', '1111', by_weight=False, algorithm='Yen'):

--- a/src/sage/graphs/strongly_regular_db.pyx
+++ b/src/sage/graphs/strongly_regular_db.pyx
@@ -161,7 +161,6 @@ def is_muzychuk_S6(int v, int k, int l, int mu):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.pari
         sage: from sage.graphs.strongly_regular_db import is_muzychuk_S6
         sage: t = is_muzychuk_S6(378, 116, 34, 36)
         sage: G = t[0](*t[1:]); G
@@ -211,7 +210,6 @@ def is_orthogonal_array_block_graph(int v, int k, int l, int mu):
 
     EXAMPLES::
 
-        sage: # needs sage.combinat sage.modules
         sage: from sage.graphs.strongly_regular_db import is_orthogonal_array_block_graph
         sage: t = is_orthogonal_array_block_graph(64, 35, 18, 20); t
         (..., 5, 8)
@@ -579,7 +577,6 @@ def is_NOodd(int v, int k, int l, int mu):
 
     All of ``NO^+(2m+1,q)`` and ``NO^-(2m+1,q)`` appear::
 
-        sage: # needs sage.libs.pari
         sage: t = is_NOodd(120, 51, 18, 24); t
         (<function NonisotropicOrthogonalPolarGraph at ...>, 5, 4, '-')
         sage: t = is_NOodd(136, 75, 42, 40); t
@@ -810,7 +807,6 @@ def is_NU(int v, int k, int l, int mu):
 
     TESTS::
 
-        sage: # needs sage.libs.pari
         sage: t = is_NU(176, 135, 102, 108); t
         (<function NonisotropicUnitaryPolarGraph at ...>, 5, 2)
         sage: t = is_NU(540, 224, 88, 96); t
@@ -1011,7 +1007,6 @@ def is_polhill(int v, int k, int l, int mu):
 
     EXAMPLES::
 
-        sage: # needs sage.rings.finite_rings
         sage: from sage.graphs.strongly_regular_db import is_polhill
         sage: t = is_polhill(1024, 231,  38,  56); t
         [<cyfunction is_polhill.<locals>.<lambda> at ...>]
@@ -1283,7 +1278,6 @@ def is_unitary_polar(int v, int k, int l, int mu):
 
     All the ``U(n,q)`` appear::
 
-        sage: # needs sage.libs.pari
         sage: t = is_unitary_polar(45, 12, 3, 3); t
         (<function UnitaryPolarGraph at ...>, 4, 2)
         sage: t = is_unitary_polar(165, 36, 3, 9); t
@@ -1346,7 +1340,6 @@ def is_unitary_dual_polar(int v, int k, int l, int mu):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.pari
         sage: from sage.graphs.strongly_regular_db import is_unitary_dual_polar
         sage: t = is_unitary_dual_polar(297, 40, 7, 5); t
         (<function UnitaryDualPolarGraph at ...>, 5, 2)
@@ -1397,7 +1390,6 @@ def is_GQqmqp(int v, int k, int l, int mu):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.pari
         sage: from sage.graphs.strongly_regular_db import is_GQqmqp
         sage: t = is_GQqmqp(27,10,1,5); t
         (<function AhrensSzekeresGeneralizedQuadrangleGraph at ...>, 3, False)
@@ -1424,7 +1416,6 @@ def is_GQqmqp(int v, int k, int l, int mu):
 
     TESTS::
 
-        sage: # needs sage.libs.pari
         sage: S, T = 127, 129
         sage: t = is_GQqmqp((S+1)*(S*T+1), S*(T+1), S-1, T+1); t
         (<function T2starGeneralizedQuadrangleGraph at ...>, 128, False)
@@ -1552,7 +1543,6 @@ def is_taylor_twograph_srg(int v, int k, int l, int mu):
 
     EXAMPLES::
 
-        sage: # needs sage.libs.pari
         sage: from sage.graphs.strongly_regular_db import is_taylor_twograph_srg
         sage: t = is_taylor_twograph_srg(28, 15, 6, 10); t
         (<function TaylorTwographSRG at ...>, 3)
@@ -1814,7 +1804,6 @@ def eigenmatrix(int v, int k, int l, int mu):
     A strongly regular graph with a non-isomorphic dual coming from another
     strongly regular graph::
 
-        sage: # needs sage.modules
         sage: graphs.strongly_regular_graph(243,220,199,200, existence=True)            # needs sage.combinat
         True
         sage: graphs.strongly_regular_graph(243,110,37,60, existence=True)              # needs sage.combinat

--- a/src/sage/graphs/traversals.pyx
+++ b/src/sage/graphs/traversals.pyx
@@ -397,7 +397,6 @@ def lex_BFS(G, reverse=False, tree=False, initial_vertex=None, algorithm="fast")
 
     Different orderings for different traversals::
 
-        sage: # needs sage.combinat
         sage: G = digraphs.DeBruijn(2,3)
         sage: G.lex_BFS(initial_vertex='000', algorithm='fast')
         ['000', '001', '100', '010', '011', '110', '101', '111']
@@ -572,7 +571,6 @@ def lex_UP(G, reverse=False, tree=False, initial_vertex=None):
 
     Different orderings for different traversals::
 
-        sage: # needs sage.combinat
         sage: G = digraphs.DeBruijn(2,3)
         sage: G.lex_BFS(initial_vertex='000')
         ['000', '001', '100', '010', '011', '110', '101', '111']
@@ -645,7 +643,6 @@ def lex_DFS(G, reverse=False, tree=False, initial_vertex=None):
 
     Different orderings for different traversals::
 
-        sage: # needs sage.combinat
         sage: G = digraphs.DeBruijn(2,3)
         sage: G.lex_BFS(initial_vertex='000')
         ['000', '001', '100', '010', '011', '110', '101', '111']
@@ -718,7 +715,6 @@ def lex_DOWN(G, reverse=False, tree=False, initial_vertex=None):
 
     Different orderings for different traversals::
 
-        sage: # needs sage.combinat
         sage: G = digraphs.DeBruijn(2,3)
         sage: G.lex_BFS(initial_vertex='000')
         ['000', '001', '100', '010', '011', '110', '101', '111']


### PR DESCRIPTION
These are just line noise at this point. No one is maintaining them, and there's no way to install Sage without these components.

The tags eventually need to be removed if we are to stop detecting the "features" over and over again while testing.
