### PR TITLE
Move references from combinat/rsk.py to master bibliography 

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -996,6 +996,11 @@ REFERENCES:
             Invent. Math. *178* (2009), no. 3, 451-484.
             :mathscinet:`MR2551762`
 
+.. [BKSTY06] \A. Buch, A. Kresch, M. Shimozono, H. Tamvakis, and A. Yong.
+             *Stable Grothendieck polynomials and* `K`-*theoretic factor sequences*.
+             Math. Ann. **340** Issue 2, (2008), pp. 359--382.
+             :arxiv:`math/0601514v1`.        
+
 .. [BK2009] \J. Brundan and A. Kleshchev.
             *Graded decomposition numbers for cyclotomic Hecke algebras*.
             Adv. Math. **222** (2009), 1883-1942.
@@ -2600,6 +2605,11 @@ REFERENCES:
              Journal of Combinatorial Theory, Series A, Volume 31, Issue 2,
              1981, Pages 108-125. :doi:`10.1016/0097-3165(81)90007-8`.
 
+.. [EG1987] Paul Edelman, Curtis Greene.
+            *Balanced Tableaux*.
+            Advances in Mathematics 63 (1987), pp. 42-99.
+            :doi:`10.1016/0001-8708(87)90063-6`             
+
 .. [EGNO2015] Pavel Etingof, Shlomo Gelaki, Dmitri Nikshych and Victor Ostrik,
                *Tensor Categories*, AMS Mathematical Surveys and Monographs 205 (2015).
 
@@ -3227,6 +3237,11 @@ REFERENCES:
 .. [GR2013] Darij Grinberg, Tom Roby. *Iterative properties of
             birational rowmotion*.
             http://www.cip.ifi.lmu.de/~grinberg/algebra/skeletal.pdf
+
+.. [GR2018v5sol] Darij Grinberg, Victor Reiner.
+                 *Hopf Algebras In Combinatorics*,
+                 :arxiv:`1409.8356v5`, available with solutions at
+                 https://arxiv.org/src/1409.8356v5/anc/HopfComb-v73-with-solutions.pdf            
 
 .. [Gri2005] \G. Grigorov, Kato's Euler System and the Main Conjecture,
              Harvard Ph.D. Thesis (2005).
@@ -4195,6 +4210,11 @@ REFERENCES:
              \J. Phys. A, **44** (2011), no. 10.
 
 .. [KnotAtlas] The Knot atlas. http://katlas.org/wiki/Main_Page
+
+.. [Knu1970] Donald E. Knuth.
+             *Permutations, matrices, and generalized Young tableaux*.
+             Pacific J. Math. Volume 34, Number 3 (1970), pp. 709-727.
+             http://projecteuclid.org/euclid.pjm/1102971948
 
 .. [Knu1995] Donald E. Knuth, *Overlapping Pfaffians*,
              :arxiv:`math/9503234v1`.

--- a/src/sage/combinat/rsk.py
+++ b/src/sage/combinat/rsk.py
@@ -127,31 +127,8 @@ the input is preserved::
     [0 0 1 0 0]
     [0 1 0 0 0]
     sage: p
-    [1, 4, 5, 3, 2]
-
-REFERENCES:
-
-.. [Knu1970] Donald E. Knuth.
-   *Permutations, matrices, and generalized Young tableaux*.
-   Pacific J. Math. Volume 34, Number 3 (1970), pp. 709-727.
-   http://projecteuclid.org/euclid.pjm/1102971948
-
-.. [EG1987] Paul Edelman, Curtis Greene.
-   *Balanced Tableaux*.
-   Advances in Mathematics 63 (1987), pp. 42-99.
-   :doi:`10.1016/0001-8708(87)90063-6`
-
-.. [BKSTY06] \A. Buch, A. Kresch, M. Shimozono, H. Tamvakis, and A. Yong.
-   *Stable Grothendieck polynomials and* `K`-*theoretic factor sequences*.
-   Math. Ann. **340** Issue 2, (2008), pp. 359--382.
-   :arxiv:`math/0601514v1`.
-
-.. [GR2018v5sol] Darij Grinberg, Victor Reiner.
-   *Hopf Algebras In Combinatorics*,
-   :arxiv:`1409.8356v5`, available with solutions at
-   https://arxiv.org/src/1409.8356v5/anc/HopfComb-v73-with-solutions.pdf
+    [1, 4, 5, 3, 2] 
 """
-
 # *****************************************************************************
 #       Copyright (C) 2012,2019 Travis Scrimshaw <tcscrims at gmail.com>
 #                          2019 Chaman Agrawal <chaman.ag at gmail.com>

--- a/src/sage/combinat/rsk.py
+++ b/src/sage/combinat/rsk.py
@@ -127,7 +127,7 @@ the input is preserved::
     [0 0 1 0 0]
     [0 1 0 0 0]
     sage: p
-    [1, 4, 5, 3, 2] 
+    [1, 4, 5, 3, 2]
 """
 # *****************************************************************************
 #       Copyright (C) 2012,2019 Travis Scrimshaw <tcscrims at gmail.com>


### PR DESCRIPTION
Part of #28445

Moved the following references from `src/sage/combinat/rsk.py` 
to the master bibliography `src/doc/en/reference/references/index.rst`:

- [Knu1970]
- [EG1987]
- [BKSTY06]
- [GR2018v5sol]

