### PR TITLE
Docs: add examples for max_symbolic and min_symbolic plotting

### DIFF
--- a/src/sage/plot/plot.py
+++ b/src/sage/plot/plot.py
@@ -1092,7 +1092,13 @@ def plot(funcs, *args, **kwds):
         P = plot(sin, (0,10))
         sphinx_plot(P)
 
-    ::
+        We illustrate the use of ``max_symbolic`` and ``min_symbolic``::
+
+           plot(x^2, (x, -2, 2), max_symbolic=10)
+
+           plot(sin(x), (x, -pi, pi), min_symbolic=5)
+
+     ::
 
         sage: P = plot(sin, (0,10), plot_points=10); print(P)
         Graphics object consisting of 1 graphics primitive


### PR DESCRIPTION
This PR adds documentation examples demonstrating the use of the
max_symbolic and min_symbolic parameters in the plot() function.