### PR TITLE
Fix power of `Integer` with modulus `0`

### DIFF
--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -2290,8 +2290,13 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
             sage: pow(5,7,13).parent()
             Integer Ring
+        
+        Test for :issue:`41692`::
+
+            sage: pow(-1, 1/2, 0)
+            I
         """
-        if modulus is not None:
+        if modulus is not None and modulus != 0:
             from sage.rings.finite_rings.integer_mod import Mod
             return (Mod(left, modulus) ** right).lift()
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
When calling `Integer.__pow__` with modulus `0`, `Mod(left, modulus)` is an Integer, instead of `IntegerMod_int`, hence no `(Mod(left, modulus) ** right).lift` method or calls the wrong `lift` method, e.g. 
```Python
pow(ZZ(-1), QQ((1, 2)), 0)  # => x, a polynomial, since it calls I.lift
pow(ZZ(3), 2, 0)  # => AttributeError: 'sage.rings.integer.Integer' object has no attribute 'lift'
```

I add a guard against `modulus == 0` so that `pow(n, ext, 0)` would be the same as `pow(n, ext)`. A related doctest is added.

Fixes #41692


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


