### PR TITLE
add parameter immutable to graph generators in `smallgraphs.py` (part 13)

### DIFF
--- a/src/sage/graphs/generators/smallgraphs.py
+++ b/src/sage/graphs/generators/smallgraphs.py
@@ -2336,11 +2336,16 @@ def DejterGraph(immutable=False):
     return g
 
 
-def DesarguesGraph():
+def DesarguesGraph(immutable=False):
     """
     Return the Desargues graph.
 
     PLOTTING: The layout chosen is the same as on the cover of [Har1969]_.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2351,16 +2356,20 @@ def DesarguesGraph():
         sage: D.show()                          # long time                             # needs sage.plot
     """
     from sage.graphs.generators.families import GeneralizedPetersenGraph
-    G = GeneralizedPetersenGraph(10, 3)
-    G.name("Desargues Graph")
-    return G
+    return GeneralizedPetersenGraph(10, 3, immutable=immutable,
+                                    name="Desargues Graph")
 
 
-def DurerGraph():
+def DurerGraph(immutable=False):
     r"""
     Return the Dürer graph.
 
     For more information, see the :wikipedia:`D%C3%BCrer_graph`.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -2392,9 +2401,8 @@ def DurerGraph():
         True
     """
     from sage.graphs.generators.families import GeneralizedPetersenGraph
-    G = GeneralizedPetersenGraph(6, 2)
-    G.name("Durer graph")
-    return G
+    return GeneralizedPetersenGraph(6, 2, immutable=immutable,
+                                    name="Durer graph")
 
 
 def DyckGraph(immutable=False):
@@ -4297,7 +4305,7 @@ def McLaughlinGraph(immutable=False):
     return g
 
 
-def MoebiusKantorGraph():
+def MoebiusKantorGraph(immutable=False):
     """
     Return a Möbius-Kantor Graph.
 
@@ -4311,6 +4319,11 @@ def MoebiusKantorGraph():
 
     PLOTTING: See the plotting section for the generalized Petersen graphs.
 
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     EXAMPLES::
 
         sage: MK = graphs.MoebiusKantorGraph()
@@ -4321,9 +4334,8 @@ def MoebiusKantorGraph():
         sage: (graphs.MoebiusKantorGraph()).show()      # long time                     # needs sage.plot
     """
     from sage.graphs.generators.families import GeneralizedPetersenGraph
-    G = GeneralizedPetersenGraph(8, 3)
-    G.name("Moebius-Kantor Graph")
-    return G
+    return GeneralizedPetersenGraph(8, 3, immutable=immutable,
+                                    name="Moebius-Kantor Graph")
 
 
 def MoserSpindle(immutable=False):
@@ -4482,7 +4494,7 @@ def MurtyGraph(immutable=False):
                  name="Murty Graph", immutable=immutable)
 
 
-def NauruGraph(embedding=2):
+def NauruGraph(embedding=2, immutable=False):
     """
     Return the Nauru Graph.
 
@@ -4492,6 +4504,9 @@ def NauruGraph(embedding=2):
 
     - ``embedding`` -- integer (default: `2`); two embeddings are available,
       and can be selected by setting ``embedding`` to 1 or 2
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -4516,19 +4531,15 @@ def NauruGraph(embedding=2):
         sage: graphs.NauruGraph(embedding=1).is_isomorphic(g)
         True
     """
-
     if embedding == 1:
         from sage.graphs.generators.families import LCFGraph
-        g = LCFGraph(24, [5, -9, 7, -7, 9, -5], 4)
-        g.name('Nauru Graph')
-        return g
-    elif embedding == 2:
+        return LCFGraph(24, [5, -9, 7, -7, 9, -5], 4,
+                        immutable=immutable, name="Nauru Graph")
+    if embedding == 2:
         from sage.graphs.generators.families import GeneralizedPetersenGraph
-        g = GeneralizedPetersenGraph(12, 5)
-        g.name("Nauru Graph")
-        return g
-    else:
-        raise ValueError("the value of embedding must be 1 or 2")
+        return GeneralizedPetersenGraph(12, 5, immutable=immutable,
+                                        name="Nauru Graph")
+    raise ValueError("the value of embedding must be 1 or 2")
 
 
 def PappusGraph(immutable=False):
@@ -5797,13 +5808,16 @@ def _EllipticLinesProjectivePlaneScheme(k):
             for x in mats]
 
 
-def MathonStronglyRegularGraph(t):
+def MathonStronglyRegularGraph(t, immutable=False):
     r"""
     Return one of Mathon's graphs on 784 vertices.
 
     INPUT:
 
     - ``t`` -- integer; the number of the graph, from 0 to 2
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -5825,7 +5839,7 @@ def MathonStronglyRegularGraph(t):
     """
     from sage.graphs.generators.families import MathonPseudocyclicMergingGraph
     ES = _EllipticLinesProjectivePlaneScheme(3)
-    return MathonPseudocyclicMergingGraph(ES, t)
+    return MathonPseudocyclicMergingGraph(ES, t, immutable=immutable)
 
 
 def JankoKharaghaniGraph(v, immutable=False):


### PR DESCRIPTION
Following discussions in #39177, and now that #41573, #41597 and #41599 have been merged, we add the option to return immutable graphs to the remaining generators in `src/sage/graphs/generators/smallgraphs.py`.
- `DesarguesGraph`, `DurerGraph`, `MoebiusKantorGraph`, `NauruGraph`, `MathonStronglyRegularGraph`

This concludes the work for `smallgraphs.py`.

The next step will be to add in `pytest` a generic test on all graph generators (see https://github.com/sagemath/sage/pull/41501#issuecomment-3805054033).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


