### PR TITLE
doc: alert pexpect GAP interface to libgap library interface

### DIFF
--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -23,7 +23,7 @@ The interface offers two pieces of functionality:
     This interface is based on pexpect and communicates with GAP via a
     subprocess. For most purposes, the library-based interface
     :mod:`~sage.libs.gap.libgap` is preferred, as it is faster and
-    more robust. See :mod:`sage.libs.gap.libgap` for details.  
+    more robust. See :mod:`sage.libs.gap.libgap` for details.
 
 First Examples
 --------------

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -23,7 +23,7 @@ The interface offers two pieces of functionality:
     This interface is based on pexpect and communicates with GAP via a
     subprocess. For most purposes, the library-based interface
     :mod:`~sage.libs.gap.libgap` is preferred, as it is faster and
-    more robust. See :mod:`sage.libs.gap.libgap` for details.   
+    more robust. See :mod:`sage.libs.gap.libgap` for details.  
 
 First Examples
 --------------

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -18,6 +18,12 @@ The interface offers two pieces of functionality:
    ``f.Factors()`` returns the prime factorization of
    `10` computed using GAP.
 
+.. NOTE::
+
+    This interface is based on pexpect and communicates with GAP via a
+    subprocess. For most purposes, the library-based interface
+    :mod:`~sage.libs.gap.libgap` is preferred, as it is faster and
+    more robust. See :mod:`sage.libs.gap.libgap` for details.   
 
 First Examples
 --------------


### PR DESCRIPTION
Fixes #22680

Added a `.. NOTE::` directive to `src/sage/interfaces/gap.py` 
pointing users to the faster library-based interface 
`sage.libs.gap.libgap`.
