### PR TITLE
Install conftest.py with meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -221,3 +221,8 @@ root = meson.current_source_dir()
 root_build = meson.current_build_dir()
 
 subdir('src')
+
+py.install_sources(
+  'conftest.py',
+  subdir: 'sage',
+)


### PR DESCRIPTION
The tests in `sage/libs/gap/gap_test.py` depend on a custom `tmpfile` pytest fixture which is defined in `conftest.py`, which is currently not installed. This breaks running tests on an installed sage tree.

