### PR TITLE
Move references from 5 combinat files to master bibliography

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -5424,8 +5424,9 @@ REFERENCES:
             Communications Laboratory, Helsinki University of Technology,
             Espoo, Finland, Tech. Rep. T48, 2003.
 
-.. [NS] \T. Nakanishi, S. Stella, Wonder of sine-Gordon Y-systems,
-        to appear in Trans. Amer. Math. Soc., :arxiv:`1212.6853`
+.. [NS] \T. Nakanishi, S. Stella, *Wonder of sine-Gordon Y-systems*,
+        Transactions of the AMS, **368** (2016), 6835-6886.
+        :arxiv:`1212.6853`
 
 .. [Normaliz] Winfried Bruns, Bogdan Ichim, and Christof Soeger,
               Normaliz,

--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -2686,6 +2686,9 @@ REFERENCES:
 .. [EZ1950] \S. Eilenberg and J. Zilber, *Semi-Simplicial Complexes
             and Singular Homology*, Ann. Math. (2) 51 (1950), 499-513.
 
+.. [EilLan53] On the groups `H(\pi, n)`, I, Samuel Eilenberg and Saunders Mac Lane,
+              1953.
+
 .. [EPW14] Ben Elias, Nicholas Proudfoot, and Max Wakefield.
            *The Kazhdan-Lusztig polynomial of a matroid*. 2014.
            :arxiv:`1412.7408`.
@@ -4204,6 +4207,8 @@ REFERENCES:
 .. [Knu2011] Donald E. Knuth, *The Art of Computer Programming. Volume 4A.
              Combinatorial Algorithms, Part 1*.
 
+.. [Knuth1] Knuth, Donald (2000). "Dancing links". :arxiv:`cs/0011047`.
+
 .. [Knu2005] Lars R. Knudsen, *SMASH - A Cryptographic Hash Function*; in
              FSE'05, (2005), pp. 228-242.
 
@@ -5419,6 +5424,9 @@ REFERENCES:
             Communications Laboratory, Helsinki University of Technology,
             Espoo, Finland, Tech. Rep. T48, 2003.
 
+.. [NS] \T. Nakanishi, S. Stella, Wonder of sine-Gordon Y-systems,
+        to appear in Trans. Amer. Math. Soc., :arxiv:`1212.6853`
+
 .. [Normaliz] Winfried Bruns, Bogdan Ichim, and Christof Soeger,
               Normaliz,
               http://www.mathematik.uni-osnabrueck.de/normaliz/
@@ -5968,6 +5976,9 @@ REFERENCES:
              cubic graphs*, Journal of Combinatorial Theory, Series B, vol. 138,
              (2019), pages: 219 -- 285, ISSN: 0095 -- 8956,
              :doi:`10.1016/j.jctb.2019.02.002`.
+
+.. [RSW2004] Reiner, Stanton, White - *The cyclic sieving phenomenon*,
+             Journal of Combinatorial Theory A 108 (2004).
 
 .. [RSW2011] Victor Reiner, Franco Saliola, Volkmar Welker.
              *Spectra of Symmetrized Shuffling Operators*.
@@ -6905,6 +6916,11 @@ REFERENCES:
 
 .. [VW1994] Leonard Van Wyk. *Graph groups are biautomatic*. J. Pure
             Appl. Alg. **94** (1994). no. 3, 341-352.
+
+.. [vanLeeuwen91] Marc. A. A. van Leeuwen, *Edge sequences,
+       ribbon tableaux, and an action of affine permutations*.
+       Europe J. Combinatorics. **20** (1999).
+       http://wwwmathlabo.univ-poitiers.fr/~maavl/pdf/edgeseqs.pdf
 
 .. _ref-W:
 

--- a/src/sage/combinat/cyclic_sieving_phenomenon.py
+++ b/src/sage/combinat/cyclic_sieving_phenomenon.py
@@ -13,10 +13,6 @@ AUTHORS:
 
 - Christian Stump
 
-REFERENCES:
-
-.. [RSW2004] Reiner, Stanton, White - *The cyclic sieving phenomenon*,
-             Journal of Combinatorial Theory A 108 (2004)
 """
 # ****************************************************************************
 #       Copyright (C) 2010 Christian Stump christian.stump@univie.ac.at

--- a/src/sage/combinat/cyclic_sieving_phenomenon.py
+++ b/src/sage/combinat/cyclic_sieving_phenomenon.py
@@ -12,7 +12,6 @@ unique polynomial ``P(q)`` of order < `n` such that the triple (`S`,
 AUTHORS:
 
 - Christian Stump
-
 """
 # ****************************************************************************
 #       Copyright (C) 2010 Christian Stump christian.stump@univie.ac.at

--- a/src/sage/combinat/ribbon_tableau.py
+++ b/src/sage/combinat/ribbon_tableau.py
@@ -195,12 +195,6 @@ class RibbonTableaux(UniqueRepresentation, Parent):
           2  0  0
         <BLANKLINE>
 
-    REFERENCES:
-
-    .. [vanLeeuwen91] Marc. A. A. van Leeuwen, *Edge sequences,
-       ribbon tableaux, and an action of affine permutations*.
-       Europe J. Combinatorics. **20** (1999).
-       http://wwwmathlabo.univ-poitiers.fr/~maavl/pdf/edgeseqs.pdf
     """
     @staticmethod
     def __classcall_private__(cls, shape=None, weight=None, length=None):

--- a/src/sage/combinat/ribbon_tableau.py
+++ b/src/sage/combinat/ribbon_tableau.py
@@ -194,7 +194,6 @@ class RibbonTableaux(UniqueRepresentation, Parent):
           .  1  0  1
           2  0  0
         <BLANKLINE>
-
     """
     @staticmethod
     def __classcall_private__(cls, shape=None, weight=None, length=None):

--- a/src/sage/combinat/shuffle.py
+++ b/src/sage/combinat/shuffle.py
@@ -33,13 +33,6 @@ EXAMPLES::
      ['a', 1, 'b', 'c', 2],
      [1, 'a', 'b', 'c', 2]]
 
-References:
-
-.. [EilLan53] On the groups `H(\pi, n)`, I,
-    Samuel Eilenberg and
-    Saunders Mac Lane,
-    1953.
-
 Author:
 
 - Jean-Baptiste Priez

--- a/src/sage/combinat/sine_gordon.py
+++ b/src/sage/combinat/sine_gordon.py
@@ -25,11 +25,6 @@ The same integer tuple but for the non-reduced case::
 .. TODO::
 
     The code for plotting is extremely slow.
-
-REFERENCES:
-
-.. [NS] \T. Nakanishi, S. Stella, Wonder of sine-Gordon Y-systems,
-   to appear in Trans. Amer. Math. Soc., :arxiv:`1212.6853`
 """
 # ****************************************************************************
 #       Copyright (C) 2014 Salvatore Stella <sstella@ncsu.edu>

--- a/src/sage/combinat/tiling.py
+++ b/src/sage/combinat/tiling.py
@@ -272,10 +272,6 @@ rectangles. Obviously, there is one solution::
      [25], [26], [27], [28], [29], [30], [31]]
     sage: T.number_of_solutions()                       # long time (fast)
     1
-
-REFERENCES:
-
-.. [Knuth1] Knuth, Donald (2000). "Dancing links". :arxiv:`cs/0011047`.
 """
 # ****************************************************************************
 #       Copyright (C) 2011-2015 Sébastien Labbé <slabqc@gmail.com>


### PR DESCRIPTION
Part of #28445

Moved references to master bibliography from:
- cyclic_sieving_phenomenon.py: [RSW2004]
- ribbon_tableau.py: [vanLeeuwen91]
- shuffle.py: [EilLan53]
- sine_gordon.py: [NS]
- tiling.py: [Knuth1]
