### PR TITLE
add parameter immutable to graph generators in `platonic_solids.py`

### DIFF
--- a/src/sage/graphs/generators/platonic_solids.py
+++ b/src/sage/graphs/generators/platonic_solids.py
@@ -18,7 +18,7 @@ from sage.graphs.graph import Graph
 from math import sin, cos, pi
 
 
-def TetrahedralGraph():
+def TetrahedralGraph(immutable=False):
     """
     Return a tetrahedral graph (with 4 nodes).
 
@@ -31,6 +31,11 @@ def TetrahedralGraph():
     to use a planar embedding of the graph. We hope to add rotatable,
     3-dimensional viewing in the future. In such a case, an argument will be
     added to select the desired layout.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -61,12 +66,13 @@ def TetrahedralGraph():
         sage: G = graphics_array(j)
         sage: G.show()                          # long time
     """
-    edges = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+    edges = ((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3))
     pos = {0: (0, 0),
            1: (0, 1),
            2: (cos(3.5*pi/3), sin(3.5*pi/3)),
            3: (cos(5.5*pi/3), sin(5.5*pi/3))}
-    return Graph(edges, name='Tetrahedron', pos=pos)
+    return Graph([range(4), edges], format="vertices_and_edges",
+                 name='Tetrahedron', pos=pos, immutable=immutable)
 
 
 def HexahedralGraph():

--- a/src/sage/graphs/generators/platonic_solids.py
+++ b/src/sage/graphs/generators/platonic_solids.py
@@ -184,7 +184,7 @@ def OctahedralGraph(immutable=False):
     return G
 
 
-def IcosahedralGraph():
+def IcosahedralGraph(immutable=False):
     """
     Return an Icosahedral graph (with 12 nodes).
 
@@ -197,6 +197,11 @@ def IcosahedralGraph():
     to use a planar embedding of the graph. We hope to add rotatable,
     3-dimensional viewing in the future. In such a case, an argument will be
     added to select the desired layout.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -225,7 +230,8 @@ def IcosahedralGraph():
     adj = {0: [1, 5, 7, 8, 11], 1: [2, 5, 6, 8], 2: [3, 6, 8, 9],
            3: [4, 6, 9, 10], 4: [5, 6, 10, 11], 5: [6, 11],
            7: [8, 9, 10, 11], 8: [9], 9: [10], 10: [11]}
-    G = Graph(adj, format='dict_of_lists', name='Icosahedron')
+    G = Graph(adj, format='dict_of_lists', name='Icosahedron',
+              immutable=immutable)
     G._circle_embedding([2, 8, 7, 11, 4, 6], radius=5, angle=pi/6)
     G._circle_embedding([1, 9, 0, 10, 5, 3], radius=2, angle=pi/6)
     return G

--- a/src/sage/graphs/generators/platonic_solids.py
+++ b/src/sage/graphs/generators/platonic_solids.py
@@ -75,7 +75,7 @@ def TetrahedralGraph(immutable=False):
                  name='Tetrahedron', pos=pos, immutable=immutable)
 
 
-def HexahedralGraph():
+def HexahedralGraph(immutable=False):
     """
     Return a hexahedral graph (with 8 nodes).
 
@@ -87,6 +87,11 @@ def HexahedralGraph():
     to use a planar embedding of the graph. We hope to add rotatable,
     3-dimensional viewing in the future. In such a case, an argument will be
     added to select the desired layout.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -123,7 +128,8 @@ def HexahedralGraph():
         7: (.5, 1.5),
         6: (1.5, 1.5)
         }
-    return Graph(adj, name='Hexahedron', pos=pos)
+    return Graph(adj, format="dict_of_lists", name='Hexahedron', pos=pos,
+                 immutable=immutable)
 
 
 def OctahedralGraph():

--- a/src/sage/graphs/generators/platonic_solids.py
+++ b/src/sage/graphs/generators/platonic_solids.py
@@ -132,7 +132,7 @@ def HexahedralGraph(immutable=False):
                  immutable=immutable)
 
 
-def OctahedralGraph():
+def OctahedralGraph(immutable=False):
     """
     Return an Octahedral graph (with 6 nodes).
 
@@ -146,6 +146,11 @@ def OctahedralGraph():
     to use a planar embedding of the graph. We hope to add rotatable,
     3-dimensional viewing in the future. In such a case, an argument will be
     added to select the desired layout.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -172,7 +177,8 @@ def OctahedralGraph():
         sage: G.show()                          # long time
     """
     adj = {0: [1, 2, 3, 4], 1: [2, 3, 5], 2: [4, 5], 3: [4, 5], 4: [5]}
-    G = Graph(adj, format='dict_of_lists', name='Octahedron')
+    G = Graph(adj, format='dict_of_lists', name='Octahedron',
+              immutable=immutable)
     G._circle_embedding([0, 1, 2], radius=5, angle=pi/2)
     G._circle_embedding([4, 3, 5], radius=1, angle=pi/6)
     return G

--- a/src/sage/graphs/generators/platonic_solids.py
+++ b/src/sage/graphs/generators/platonic_solids.py
@@ -237,7 +237,7 @@ def IcosahedralGraph(immutable=False):
     return G
 
 
-def DodecahedralGraph():
+def DodecahedralGraph(immutable=False):
     """
     Return a Dodecahedral graph (with 20 nodes).
 
@@ -248,6 +248,11 @@ def DodecahedralGraph():
     choose to use a planar embedding of the graph. We hope to add rotatable,
     3-dimensional viewing in the future. In such a case, an argument will be
     added to select the desired layout.
+
+    INPUT:
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -277,7 +282,8 @@ def DodecahedralGraph():
            5: [6, 15], 6: [7], 7: [8, 14], 8: [9], 9: [10, 13], 10: [11],
            11: [12, 18], 12: [13, 16], 13: [14], 14: [15], 15: [16], 16: [17],
            17: [18], 18: [19]}
-    G = Graph(adj, format='dict_of_lists', name='Dodecahedron')
+    G = Graph(adj, format='dict_of_lists', name='Dodecahedron',
+              immutable=immutable)
     G._circle_embedding([19, 0, 1, 2, 3], radius=7, angle=pi/10)
     G._circle_embedding([18, 10, 8, 6, 4], radius=4.7, angle=pi/10)
     G._circle_embedding([11, 9, 7, 5, 17], radius=3.8, angle=3*pi/10)


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to all generators in `src/sage/graphs/generators/platonic_solids.py`.




### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


