### PR TITLE
add parameter immutable to graph generators in `degree_sequence.py`

### DIFF
--- a/src/sage/graphs/generators/degree_sequence.py
+++ b/src/sage/graphs/generators/degree_sequence.py
@@ -21,7 +21,7 @@ from sage.graphs.graph import Graph
 from sage.misc.randstate import current_randstate
 
 
-def DegreeSequence(deg_sequence):
+def DegreeSequence(deg_sequence, immutable=False):
     """
     Return a graph with the given degree sequence.
 
@@ -37,6 +37,9 @@ def DegreeSequence(deg_sequence):
 
     - ``deg_sequence`` -- list of integers with each entry corresponding to the
       degree of a different vertex
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -61,10 +64,11 @@ def DegreeSequence(deg_sequence):
         sage: G.show()                          # long time                             # needs networkx sage.plot
     """
     import networkx
-    return Graph(networkx.havel_hakimi_graph([int(i) for i in deg_sequence]))
+    return Graph(networkx.havel_hakimi_graph([int(i) for i in deg_sequence]),
+                 immutable=immutable)
 
 
-def DegreeSequenceBipartite(s1, s2):
+def DegreeSequenceBipartite(s1, s2, immutable=False):
     r"""
     Return a bipartite graph whose two sets have the given degree sequences.
 
@@ -75,11 +79,14 @@ def DegreeSequenceBipartite(s1, s2):
 
     INPUT:
 
-    - ``s_1`` -- list of integers corresponding to the degree sequence of the
+    - ``s1`` -- list of integers corresponding to the degree sequence of the
       first set of vertices
 
-    - ``s_2`` -- list of integers corresponding to the degree sequence of the
+    - ``s2`` -- list of integers corresponding to the degree sequence of the
       second set of vertices
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     ALGORITHM:
 
@@ -123,10 +130,10 @@ def DegreeSequenceBipartite(s1, s2):
     if m is False:
         raise ValueError("there exists no bipartite graph corresponding to "
                          "the given degree sequences")
-    return Graph(BipartiteGraph(m))
+    return Graph(BipartiteGraph(m), immutable=immutable)
 
 
-def DegreeSequenceConfigurationModel(deg_sequence, seed=None):
+def DegreeSequenceConfigurationModel(deg_sequence, seed=None, immutable=False):
     """
     Return a random pseudograph with the given degree sequence.
 
@@ -143,6 +150,9 @@ def DegreeSequenceConfigurationModel(deg_sequence, seed=None):
 
     - ``seed`` -- (optional) a ``random.Random`` seed or a Python ``int`` for
       the random number generator
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -171,10 +181,10 @@ def DegreeSequenceConfigurationModel(deg_sequence, seed=None):
     import networkx
     deg_sequence = [int(i) for i in deg_sequence]
     return Graph(networkx.configuration_model(deg_sequence, seed=seed),
-                 loops=True, multiedges=True, sparse=True)
+                 loops=True, multiedges=True, sparse=True, immutable=immutable)
 
 
-def DegreeSequenceTree(deg_sequence):
+def DegreeSequenceTree(deg_sequence, immutable=False):
     """
     Return a tree with the given degree sequence.
 
@@ -189,6 +199,9 @@ def DegreeSequenceTree(deg_sequence):
     - ``deg_sequence`` -- list of integers with each entry corresponding to the
       expected degree of a different vertex
 
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     EXAMPLES::
 
         sage: G = graphs.DegreeSequenceTree([3,1,3,3,1,1,1,2,1]); G                     # needs networkx
@@ -196,10 +209,11 @@ def DegreeSequenceTree(deg_sequence):
         sage: G.show()                          # long time                             # needs networkx sage.plot
     """
     import networkx
-    return Graph(networkx.degree_sequence_tree([int(i) for i in deg_sequence]))
+    return Graph(networkx.degree_sequence_tree([int(i) for i in deg_sequence]),
+                 immutable=immutable)
 
 
-def DegreeSequenceExpected(deg_sequence, seed=None):
+def DegreeSequenceExpected(deg_sequence, seed=None, immutable=False):
     """
     Return a random graph with expected given degree sequence.
 
@@ -217,6 +231,9 @@ def DegreeSequenceExpected(deg_sequence, seed=None):
     - ``seed`` -- (optional) a ``random.Random`` seed or a Python ``int`` for
       the random number generator
 
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
+
     EXAMPLES::
 
         sage: G = graphs.DegreeSequenceExpected([1,2,3,2,3]); G                         # needs networkx
@@ -231,4 +248,5 @@ def DegreeSequenceExpected(deg_sequence, seed=None):
         seed = int(current_randstate().long_seed() % sys.maxsize)
     import networkx
     deg_sequence = [int(i) for i in deg_sequence]
-    return Graph(networkx.expected_degree_graph(deg_sequence, seed=seed), loops=True)
+    return Graph(networkx.expected_degree_graph(deg_sequence, seed=seed),
+                 loops=True, immutable=immutable)


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to all generators in `src/sage/graphs/generators/degree_sequence.py `.

A set of tests for checking the behavior of parameter `immutable` will be added to `generators_test.py` for all generators in a follow-up PR.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


