### PR TITLE
add parameter immutable to graph generators in `classical_geometries.py` (part 3)

### DIFF
--- a/src/sage/combinat/designs/incidence_structures.py
+++ b/src/sage/combinat/designs/incidence_structures.py
@@ -1109,7 +1109,7 @@ class IncidenceStructure(SageObject):
         gB = [[x + 1 for x in b] for b in self._blocks]
         return libgap.BlockDesign(v, gB)
 
-    def intersection_graph(self, sizes=None):
+    def intersection_graph(self, sizes=None, immutable=False):
         r"""
         Return the intersection graph of the incidence structure.
 
@@ -1122,6 +1122,9 @@ class IncidenceStructure(SageObject):
         - ``sizes`` -- list/set of integers; for convenience, setting
           ``sizes`` to ``5`` has the same effect as ``sizes=[5]``. When set to
           ``None`` (default), behaves as ``sizes=PositiveIntegers()``.
+
+        - ``immutable`` -- boolean (default: ``False``); whether to return an
+          immutable or a mutable graph
 
         EXAMPLES:
 
@@ -1143,7 +1146,8 @@ class IncidenceStructure(SageObject):
         elif sizes in PositiveIntegers():
             sizes = (sizes,)
         V = [Set(v) for v in self]
-        return Graph([V, lambda x, y: len(x & y) in sizes], loops=False)
+        return Graph([V, lambda x, y: len(x & y) in sizes], format="rule",
+                     loops=False, immutable=immutable)
 
     def incidence_matrix(self):
         r"""

--- a/src/sage/graphs/generators/classical_geometries.py
+++ b/src/sage/graphs/generators/classical_geometries.py
@@ -946,7 +946,7 @@ def TaylorTwographSRG(q):
     return G
 
 
-def AhrensSzekeresGeneralizedQuadrangleGraph(q, dual=False):
+def AhrensSzekeresGeneralizedQuadrangleGraph(q, dual=False, immutable=False):
     r"""
     Return the collinearity graph of the generalized quadrangle `AS(q)`, or of
     its dual
@@ -968,6 +968,9 @@ def AhrensSzekeresGeneralizedQuadrangleGraph(q, dual=False):
 
     - ``dual`` -- boolean (default: ``False``); whether to return the
       collinearity graph of `AS(q)` or of the dual `AS(q)` (when ``True``)
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -993,15 +996,16 @@ def AhrensSzekeresGeneralizedQuadrangleGraph(q, dual=False):
             for c in F:
                 L.append(tuple((c*s**2 - b*s + a, -2*c*s + b, s) for s in F))
     if dual:
-        G = IncidenceStructure(L).intersection_graph()
-        G.name('AS(' + str(q) + ')*; GQ' + str((q + 1, q - 1)))
+        G = IncidenceStructure(L).intersection_graph(immutable=immutable)
+        G._name = f"AS({q})*; GQ{(q + 1, q - 1)}"
     else:
-        G = IncidenceStructure(L).dual().intersection_graph()
-        G.name('AS(' + str(q) + '); GQ' + str((q - 1, q + 1)))
+        G = IncidenceStructure(L).dual().intersection_graph(immutable=immutable)
+        G._name = f"AS({q}); GQ{(q - 1, q + 1)}"
     return G
 
 
-def T2starGeneralizedQuadrangleGraph(q, dual=False, hyperoval=None, field=None, check_hyperoval=True):
+def T2starGeneralizedQuadrangleGraph(q, dual=False, hyperoval=None, field=None,
+                                     check_hyperoval=True, immutable=False):
     r"""
     Return the collinearity graph of the generalized quadrangle `T_2^*(q)`, or
     of its dual
@@ -1036,6 +1040,9 @@ def T2starGeneralizedQuadrangleGraph(q, dual=False, hyperoval=None, field=None, 
 
     - ``check_hyperoval`` -- boolean (default: ``True``); whether to check
       ``hyperoval`` for correctness or not
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES:
 
@@ -1111,11 +1118,11 @@ def T2starGeneralizedQuadrangleGraph(q, dual=False, hyperoval=None, field=None, 
          for z in Theta.blocks() if len(HO.intersection(z)) == 1]
 
     if dual:
-        G = IncidenceStructure(L).intersection_graph()
-        G.name('T2*(O,' + str(q) + ')*; GQ' + str((q + 1, q - 1)))
+        G = IncidenceStructure(L).intersection_graph(immutable=immutable)
+        G._name = f"T2*(O,{q})*; GQ{(q + 1, q - 1)}"
     else:
-        G = IncidenceStructure(L).dual().intersection_graph()
-        G.name('T2*(O,' + str(q) + '); GQ' + str((q - 1, q + 1)))
+        G = IncidenceStructure(L).dual().intersection_graph(immutable=immutable)
+        G._name = f"T2*(O,{q}); GQ{(q - 1, q + 1)}"
     return G
 
 

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -1355,7 +1355,7 @@ def is_from_GQ_spread(list arr):
     return (s, t)
 
 
-def graph_from_GQ_spread(const int s, const int t):
+def graph_from_GQ_spread(const int s, const int t, immutable=False):
     r"""
     Return the point graph of the generalised quadrangle with
     order `(s, t)` after removing one of its spreads.
@@ -1366,6 +1366,9 @@ def graph_from_GQ_spread(const int s, const int t):
     INPUT:
 
     - ``s``, ``t`` -- integers; order of the generalised quadrangle
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -1402,7 +1405,7 @@ def graph_from_GQ_spread(const int s, const int t):
             sig_check()
             edges.append((p1, p2))
 
-    return Graph(edges, format='list_of_edges')
+    return Graph(edges, format='list_of_edges', immutable=immutable)
 
 
 def GeneralisedDodecagonGraph(const int s, const int t):

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -1223,7 +1223,7 @@ def GrassmannGraph(const int q, const int n, const int input_e,
     return G
 
 
-def DoubleGrassmannGraph(const int q, const int e):
+def DoubleGrassmannGraph(const int q, const int e, immutable=False):
     r"""
     Return the bipartite double of the distance-`e` graph of the Grassmann graph `J_q(n,e)`.
 
@@ -1237,7 +1237,11 @@ def DoubleGrassmannGraph(const int q, const int e):
     INPUT:
 
     - ``q`` -- a prime power
+
     - ``e`` -- integer
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -1277,9 +1281,8 @@ def DoubleGrassmannGraph(const int q, const int e):
             Ubasis = frozenset(U.basis())
             edges.append((Wbasis, Ubasis))
 
-    G = Graph(edges, format='list_of_edges')
-    G.name("Double Grassmann graph (%d, %d, %d)" % (n, e, q))
-    return G
+    return Graph(edges, format='list_of_edges', immutable=immutable,
+                 name=f"Double Grassmann graph ({n}, {e}, {q})")
 
 
 def is_from_GQ_spread(list arr):

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -1163,7 +1163,8 @@ def HalfCube(const int n, immutable=False):
     return G
 
 
-def GrassmannGraph(const int q, const int n, const int input_e):
+def GrassmannGraph(const int q, const int n, const int input_e,
+                   immutable=False):
     r"""
     Return the Grassmann graph with parameters `(q, n, e)`.
 
@@ -1178,7 +1179,11 @@ def GrassmannGraph(const int q, const int n, const int input_e):
     INPUT:
 
     - ``q`` -- a prime power
+
     - ``n``, ``e`` -- integers with `n > e+1`
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -1213,8 +1218,8 @@ def GrassmannGraph(const int q, const int n, const int input_e):
     # we want the intersection graph
     # the size of the intersection must be (q^{e-1} - 1) / (q-1)
     size = (q**(e - 1) - 1) // (q - 1)
-    G = PG.intersection_graph([size])
-    G.name("Grassmann graph J_%d(%d, %d)" % (q, n, e))
+    G = PG.intersection_graph([size], immutable=immutable)
+    G._name = f"Grassmann graph J_{q}({n}, {e})"
     return G
 
 

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -1021,7 +1021,7 @@ def HermitianFormsGraph(const int n, const int r, immutable=False):
                  name=f"Hermitian forms graph on (F_{q})^{n}")
 
 
-def DoubleOddGraph(const int n):
+def DoubleOddGraph(const int n, immutable=False):
     r"""
     Return the double odd graph on `2n+1` points.
 
@@ -1034,6 +1034,9 @@ def DoubleOddGraph(const int n):
     INPUT:
 
     - ``n`` -- integer; must be greater than 0
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -1068,23 +1071,24 @@ def DoubleOddGraph(const int n):
     if n < 1:
         raise ValueError("n must be >= 1")
 
-    cdef list edges, s1
+    cdef list edges, s2
+    cdef tuple s1
     cdef int i
+    cdef int k = 2*n + 1
 
     # a binary vector of size 2n + 1 represents a set
     edges = []
-    for s in IntegerVectors(n, k=2*n + 1, max_part=1):
-        s1 = list(s)
+    for s in IntegerVectors(n, k=k, max_part=1):
+        s1 = tuple(s)
         for i in range(2*n + 1):
             sig_check()
             if s1[i] == 0:
                 s2 = list(s)  # duplicate list
                 s2[i] = 1
-                edges.append((tuple(s1), tuple(s2)))
+                edges.append((s1, tuple(s2)))
 
-    G = Graph(edges, format='list_of_edges')
-    G.name("Bipartite double of Odd graph on a set of %d elements" % (2*n + 1))
-    return G
+    return Graph(edges, format='list_of_edges', immutable=immutable,
+                 name=f"Bipartite double of Odd graph on a set of {k} elements")
 
 
 def HalfCube(const int n):

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -913,7 +913,7 @@ def AlternatingFormsGraph(const int n, const int q):
     return G
 
 
-def HermitianFormsGraph(const int n, const int r):
+def HermitianFormsGraph(const int n, const int r, immutable=False):
     r"""
     Return the Hermitian forms graph with the given parameters.
 
@@ -927,7 +927,11 @@ def HermitianFormsGraph(const int n, const int r):
     INPUT:
 
     - ``n`` -- integer
+
     - ``r`` -- a prime power
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -1013,9 +1017,8 @@ def HermitianFormsGraph(const int n, const int r):
             N = tuple([M[i] + R[i] for i in range((n * (n+1)) // 2)])
             edges.append((M, N))
 
-    G = Graph(edges, format='list_of_edges')
-    G.name(f"Hermitian forms graph on (F_{q})^{n}")
-    return G
+    return Graph(edges, format='list_of_edges', immutable=immutable,
+                 name=f"Hermitian forms graph on (F_{q})^{n}")
 
 
 def DoubleOddGraph(const int n):

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -1091,7 +1091,7 @@ def DoubleOddGraph(const int n, immutable=False):
                  name=f"Bipartite double of Odd graph on a set of {k} elements")
 
 
-def HalfCube(const int n):
+def HalfCube(const int n, immutable=False):
     r"""
     Return the halved cube in `n` dimensions.
 
@@ -1101,6 +1101,9 @@ def HalfCube(const int n):
     INPUT:
 
     - ``n`` -- integer; must be greater than 2
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -1154,9 +1157,9 @@ def HalfCube(const int n):
                 if u < v:
                     E.append((u, v))
 
-    G = Graph([range(2**(n - 1)), E], format='vertices_and_edges')
+    G = Graph([range(2**(n - 1)), E], format='vertices_and_edges',
+              name=f"Half {n} Cube", immutable=immutable)
     G.set_pos(pos)
-    G.name("Half %d Cube" % n)
     return G
 
 


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to some generators in `src/sage/graphs/generators/classical_geometries.py`.
- `AhrensSzekeresGeneralizedQuadrangleGraph`,  `T2starGeneralizedQuadrangleGraph`

This PR concludes the work on `classical_geometries.py`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

#41724: adds in particular parameter `immutable` to method `intersection_graph` of `sage.combinat.designs.incidence_structures.IncidenceStructure`
