### PR TITLE
Remove exclusion of `factorial` since from `math.factorial` on `float` raises `TypeError`

### DIFF
--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -1011,14 +1011,7 @@ cdef class BuiltinFunction(Function):
                 import mpmath as module
                 custom = self._eval_mpmath_
             elif all(isinstance(arg, float) for arg in args):
-                # We do not include the factorial here as
-                # factorial(integer-valued float) is deprecated in Python 3.9.
-                # This special case should be removed when
-                # Python always raise an error for factorial(float).
-                # This case will be delegated to the gamma function.
-                # see Github issue #30764
-                if self._name != 'factorial':
-                    import math as module
+                import math as module
             elif all(isinstance(arg, complex) for arg in args):
                 import cmath as module
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Since Python 3.10, `math.factorial(float(2.0))` raises a TypeError. Python 3.9 is EOL already. 
The comment said that this case should be removed.

Related: #30764

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


