### PR TITLE
Allow `hypergeometric` to pass kwargs to mpmath

### DIFF
--- a/src/sage/functions/hypergeometric.py
+++ b/src/sage/functions/hypergeometric.py
@@ -268,7 +268,7 @@ class Hypergeometric(BuiltinFunction):
                                               'sympy': 'hyper',
                                               'fricas': 'hypergeometricF'})
 
-    def __call__(self, a, b, z, **kwargs):
+    def __call__(self, a, b, z, *, hold=False, **kwargs):
         """
         Return symbolic hypergeometric function expression.
 
@@ -277,6 +277,8 @@ class Hypergeometric(BuiltinFunction):
         - ``a`` -- list or tuple of parameters
         - ``b`` -- list or tuple of parameters
         - ``z`` -- number or symbolic expression
+        - ``**kwargs`` -- other keyword arguments passed to `mpmath` when input
+            include numerical number while none is symbolic.
 
         EXAMPLES::
 
@@ -300,11 +302,16 @@ class Hypergeometric(BuiltinFunction):
 
             sage: hypergeometric([2, 3, 4], [4, 1], 1)
             hypergeometric((2, 3, 4), (4, 1), 1)
+            sage: parent(hypergeometric( # :issue:`27785`
+            ....:     [4.14 + 15*I, -3.14 + 15*I], 
+            ....:     [1. - 1.12e7*I], -500000, maxterms=1e6
+            ....: ))
+            Complex Field with 53 bits of precision
         """
         return BuiltinFunction.__call__(self,
                                         SR._force_pyobject(a),
                                         SR._force_pyobject(b),
-                                        z, **kwargs)
+                                        z, hold=hold, **kwargs)
 
     def _print_latex_(self, a, b, z):
         r"""
@@ -327,12 +334,12 @@ class Hypergeometric(BuiltinFunction):
             1
         """
         if not isinstance(a, tuple) or not isinstance(b, tuple):
-            raise TypeError("The first two parameters must be of type list")
+            raise TypeError("The first two parameters must be of type list or tuple")
 
         if not isinstance(z, Expression) and z == 0:  # Expression is excluded
             return Integer(1)                         # to avoid call to Maxima
 
-    def _evalf_try_(self, a, b, z):
+    def _evalf_try_(self, a, b, z, **kwargs):
         """
         Call :meth:`_evalf_` if one of the arguments is numerical and none
         of the arguments are symbolic.
@@ -357,16 +364,35 @@ class Hypergeometric(BuiltinFunction):
         # We need to override this for hypergeometric functions since
         # the first 2 arguments are tuples and the generic _evalf_try_
         # cannot handle that.
-        if not isinstance(a, tuple) or not isinstance(b, tuple):
+
+        # Note that a and b might be SR._force_pyobject-ed:
+        if isinstance(a, Expression) and a.operator() is tuple:
+            a = a.operands()
+        if isinstance(b, Expression) and b.operator() is tuple:
+            b = b.operands()
+        if (not isinstance(a, (tuple, list)) 
+            or not isinstance(b, (tuple, list))):
             return None
 
         args = list(a) + list(b) + [z]
-        if any(self._is_numerical(x) for x in args):
-            if not any(isinstance(x, Expression) for x in args):
-                p = get_coercion_model().common_parent(*args)
-                return self._evalf_(a, b, z, parent=p)
+        has_numeric = False
+        for i, x in enumerate(args):
+            if isinstance(x, Expression):
+                try:  # possibly coerced from a numerical number
+                    x = x.pyobject()
+                    args[i] = x
+                except TypeError:
+                    return None
 
-    def _evalf_(self, a, b, z, parent, algorithm=None):
+            x_is_numerical = self._is_numerical(x)
+            if x_is_numerical:
+                has_numeric = True
+
+        if has_numeric:
+            p = get_coercion_model().common_parent(*args)
+            return self._evalf_(tuple(a), tuple(b), z, parent=p, **kwargs)
+
+    def _evalf_(self, a, b, z, parent, algorithm=None, **kwargs):
         """
         TESTS::
 
@@ -376,10 +402,10 @@ class Hypergeometric(BuiltinFunction):
             2.7182818284590452353602874714
         """
         if not isinstance(a, tuple) or not isinstance(b, tuple):
-            raise TypeError("The first two parameters must be of type list")
+            raise TypeError("The first two parameters must be of type list or tuple")
         aa = [rational_param_as_tuple(c) for c in a]
         bb = [rational_param_as_tuple(c) for c in b]
-        return _mpmath_utils_call(_mpmath_hyper, aa, bb, z, parent=parent)
+        return _mpmath_utils_call(_mpmath_hyper, aa, bb, z, parent=parent, **kwargs)
 
     def _tderivative_(self, a, b, z, *args, **kwargs):
         """
@@ -1001,14 +1027,14 @@ class Hypergeometric_M(BuiltinFunction):
             return Integer(1)
         return
 
-    def _evalf_(self, a, b, z, parent, algorithm=None):
+    def _evalf_(self, a, b, z, parent, algorithm=None, **kwargs):
         """
         TESTS::
 
             sage: hypergeometric_M(1,1,1).n()                                           # needs mpmath sage.symbolic
             2.71828182845905
         """
-        return _mpmath_utils_call(_mpmath_hyp1f1, a, b, z, parent=parent)
+        return _mpmath_utils_call(_mpmath_hyp1f1, a, b, z, parent=parent, **kwargs)
 
     def _derivative_(self, a, b, z, diff_param):
         """
@@ -1107,14 +1133,14 @@ class Hypergeometric_U(BuiltinFunction):
     def _eval_(self, a, b, z, **kwargs):
         return
 
-    def _evalf_(self, a, b, z, parent, algorithm=None):
+    def _evalf_(self, a, b, z, parent, algorithm=None, **kwargs):
         """
         TESTS::
 
             sage: hypergeometric_U(1, 1, 1).n()                                         # needs mpmath sage.symbolic
             0.596347362323194
         """
-        return _mpmath_utils_call(_mpmath_hyperu, a, b, z, parent=parent)
+        return _mpmath_utils_call(_mpmath_hyperu, a, b, z, parent=parent, **kwargs)
 
     def _derivative_(self, a, b, z, diff_param):
         """

--- a/src/sage/functions/hypergeometric.py
+++ b/src/sage/functions/hypergeometric.py
@@ -303,7 +303,7 @@ class Hypergeometric(BuiltinFunction):
             sage: hypergeometric([2, 3, 4], [4, 1], 1)
             hypergeometric((2, 3, 4), (4, 1), 1)
             sage: parent(hypergeometric( # :issue:`27785`
-            ....:     [4.14 + 15*I, -3.14 + 15*I], 
+            ....:     [4.14 + 15*I, -3.14 + 15*I],
             ....:     [1. - 1.12e7*I], -500000, maxterms=1e6
             ....: ))
             Complex Field with 53 bits of precision
@@ -370,7 +370,7 @@ class Hypergeometric(BuiltinFunction):
             a = a.operands()
         if isinstance(b, Expression) and b.operator() is tuple:
             b = b.operands()
-        if (not isinstance(a, (tuple, list)) 
+        if (not isinstance(a, (tuple, list))
             or not isinstance(b, (tuple, list))):
             return None
 

--- a/src/sage/functions/hypergeometric.py
+++ b/src/sage/functions/hypergeometric.py
@@ -278,7 +278,7 @@ class Hypergeometric(BuiltinFunction):
         - ``b`` -- list or tuple of parameters
         - ``z`` -- number or symbolic expression
         - ``**kwargs`` -- other keyword arguments passed to `mpmath` when input
-            include numerical number while none is symbolic.
+            includes numerical number while none is symbolic
 
         EXAMPLES::
 

--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -996,6 +996,17 @@ cdef class BuiltinFunction(Function):
             sage: bar = BuiltinFunction(name='bar', alt_name='foo')
             sage: bar(A())
             'foo'
+        
+        Check that the output is symbolic if ``hold=True`` (:issue:`41740`)::
+
+            sage: class Test(BuiltinFunction):
+            ....:     def __init__(self):
+            ....:         BuiltinFunction.__init__(self, 'test', nargs=1)
+            ....:     def _evalf_(self, x, **kwargs):
+            ....:         return "Should not be called when hold=True!"
+            sage: test = Test()
+            sage: test(RR(1.5), hold=True)
+            test(1.50000000000000)
         """
         res = None
         if args and not hold and not all(isinstance(arg, Element) for arg in args):
@@ -1055,11 +1066,11 @@ cdef class BuiltinFunction(Function):
                     except (TypeError, ValueError, ArithmeticError):
                         pass
 
-        if res is None:
+        if res is None and not hold:
             res = self._evalf_try_(*args)
-            if res is None:
-                res = super().__call__(
-                        *args, coerce=coerce, hold=hold)
+        if res is None:
+            res = super().__call__(
+                    *args, coerce=coerce, hold=hold)
 
         cdef Parent arg_parent
         if any(isinstance(x, Element) for x in args):

--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -277,7 +277,7 @@ cdef class Function(SageObject):
                                                    self._nargs, self._evalf_params_first,
                                                    False)
 
-    def _evalf_try_(self, *args):
+    def _evalf_try_(self, *args, **kwargs):
         """
         Call :meth:`_evalf_` if one the arguments is numerical and none
         of the arguments are symbolic.
@@ -344,7 +344,7 @@ cdef class Function(SageObject):
             if any(self._is_numerical(x) for x in args):
                 if not any(isinstance(x, Expression) for x in args):
                     p = coercion_model.common_parent(*args)
-                    return evalf(*args, parent=p)
+                    return evalf(*args, parent=p, **kwargs)
         except Exception:
             pass
 
@@ -408,7 +408,7 @@ cdef class Function(SageObject):
         except AttributeError:
             return NotImplemented
 
-    def __call__(self, *args, bint coerce=True, bint hold=False):
+    def __call__(self, *args, bint coerce=True, bint hold=False, **kwargs):
         """
         Evaluates this function at the given arguments.
 
@@ -470,6 +470,10 @@ cdef class Function(SageObject):
             sage: exp(RR(0)).parent()
             Real Field with 53 bits of precision
 
+        Other keyword arguments are passed to corresponding evaluation methods::
+
+            sage: exp(2, prec=16)
+            7.389
 
         TESTS:
 
@@ -546,7 +550,7 @@ cdef class Function(SageObject):
                 if len(args) == 1:
                     method = getattr(args[0], self._name, None)
                     if callable(method):
-                        return method()
+                        return method(**kwargs)
                 raise TypeError("cannot coerce arguments: %s" % (err))
 
         else: # coerce == False
@@ -747,7 +751,7 @@ cdef class Function(SageObject):
         args = [etb._var_number(n) for n in range(self.number_of_arguments())]
         return etb.call(self, *args)
 
-    def _eval_numpy_(self, *args):
+    def _eval_numpy_(self, *args, **kwargs):
         r"""
         Evaluates this function at the given arguments.
 
@@ -769,7 +773,7 @@ cdef class Function(SageObject):
         """
         raise NotImplementedError("The Function %s does not support numpy arrays as arguments" % self.name())
 
-    def _eval_mpmath_(self, *args):
+    def _eval_mpmath_(self, *args, **kwargs):
         r"""
         Evaluates this function for arguments of mpmath types.
 
@@ -816,7 +820,7 @@ cdef class Function(SageObject):
         args = [mpmath_to_sage(x, prec)
                 if isinstance(x, (mpmath.mpf, mpmath.mpc)) else x
                 for x in args]
-        res = self(*args)
+        res = self(*args, **kwargs)
         res = sage_to_mpmath(res, prec)
         return res
 
@@ -942,7 +946,7 @@ cdef class BuiltinFunction(Function):
         return [arg]
 
     def __call__(self, *args, bint coerce=True, bint hold=False,
-                 bint dont_call_method_on_arg=False):
+                 bint dont_call_method_on_arg=False, **kwargs):
         r"""
         Evaluate this function on the given arguments and return the result.
 
@@ -983,6 +987,19 @@ cdef class BuiltinFunction(Function):
             0.0
             sage: type(_)                                                               # needs numpy
             <class 'numpy.float64'>
+
+        One can hold the expression unevaluated by passing ``hold=True``::
+
+            sage: from sage.functions.airy import airy_ai_simple
+            sage: airy_ai_simple(0)
+            1/3*3^(1/3)/gamma(2/3)
+            sage: airy_ai_simple(0, hold=True)
+            airy_ai(0)
+
+        Other keyword arguments are passed to the relevant evaluation methods::
+
+            sage: airy_ai_simple(1000., algorithm='scipy')                               # needs scipy
+            0.000000000000000
 
         TESTS::
 
@@ -1040,12 +1057,12 @@ cdef class BuiltinFunction(Function):
 
                 if callable(func):
                     try:
-                        return func(*args)
+                        return func(*args, **kwargs)
                     except (ValueError, TypeError):
                         pass
 
             if custom is not None:
-                return custom(*args)
+                return custom(*args, **kwargs)
 
         if not hold and not dont_call_method_on_arg:
             try:
@@ -1062,15 +1079,15 @@ cdef class BuiltinFunction(Function):
 
                 if callable(method):
                     try:
-                        res = method(*method_args[1:])
+                        res = method(*method_args[1:], **kwargs)
                     except (TypeError, ValueError, ArithmeticError):
                         pass
 
         if res is None and not hold:
-            res = self._evalf_try_(*args)
+            res = self._evalf_try_(*args, **kwargs)
         if res is None:
             res = super().__call__(
-                    *args, coerce=coerce, hold=hold)
+                    *args, coerce=coerce, hold=hold, **kwargs)
 
         cdef Parent arg_parent
         if any(isinstance(x, Element) for x in args):
@@ -1157,15 +1174,15 @@ cdef class BuiltinFunction(Function):
 
         return False
 
-    def _evalf_or_eval_(self, *args):
+    def _evalf_or_eval_(self, *args, **kwargs):
         """
         First try to call :meth:`_evalf_` and return the result if it
         was not ``None``. Otherwise, call :meth:`_eval0_`, which is the
         original version of :meth:`_eval_` saved in :meth:`__init__`.
         """
-        res = self._evalf_try_(*args)
+        res = self._evalf_try_(*args, **kwargs)
         if res is None:
-            return self._eval0_(*args)
+            return self._eval0_(*args, **kwargs)
         else:
             return res
 

--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -998,7 +998,7 @@ cdef class BuiltinFunction(Function):
 
         Other keyword arguments are passed to the relevant evaluation methods::
 
-            sage: airy_ai_simple(1000., algorithm='scipy')                               # needs scipy
+            sage: airy_ai_simple(1000., algorithm='scipy')
             0.000000000000000
 
         TESTS::


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Since the `__call__` of the `Hypergeometric` class force-coerces the first two arguments by `SR._force_pyobject`, the `isinstance(a, list)` check is useless in `_evalf_try_`.

This PR unpacks the coerced tuple, and reverse the coercion of arguments if the `.pyobject()` is numeric.

Fixes #27785.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
- #41742: Needs `BuiltinFunction` to pass the kwargs around

