### PR TITLE
Use `Py_hash_t` for hashes

### DIFF
--- a/src/sage/algebras/lie_algebras/lie_algebra_element.pxd
+++ b/src/sage/algebras/lie_algebras/lie_algebra_element.pxd
@@ -29,7 +29,7 @@ cdef class UntwistedAffineLieAlgebraElement(Element):
     cdef dict _t_dict
     cdef _c_coeff
     cdef _d_coeff
-    cdef long _hash
+    cdef Py_hash_t _hash
 
     cpdef _add_(self, other)
     cpdef _sub_(self, other)
@@ -56,7 +56,7 @@ cdef class LieGenerator(LieObject):
 cdef class LieBracket(LieObject):
     cdef public LieObject _left
     cdef public LieObject _right
-    cdef long _hash
+    cdef Py_hash_t _hash
 
     cpdef lift(self, dict UEA_gens_dict)
 

--- a/src/sage/combinat/crystals/spins.pxd
+++ b/src/sage/combinat/crystals/spins.pxd
@@ -3,7 +3,7 @@ from sage.structure.element cimport Element
 cdef class Spin(Element):
     cdef bint* _value
     cdef int _n
-    cdef long _hash
+    cdef Py_hash_t _hash
 
     cdef Spin _new_c(self, bint* value)
 

--- a/src/sage/combinat/crystals/spins.pyx
+++ b/src/sage/combinat/crystals/spins.pyx
@@ -295,6 +295,7 @@ cdef class Spin(Element):
         self._value = <bint*>sig_malloc(self._n*sizeof(bint))
         for i in range(self._n):
             self._value[i] = (val[i] != 1)
+        self._hash = -1
         Element.__init__(self, parent)
 
     cdef Spin _new_c(self, bint* value):
@@ -305,7 +306,7 @@ cdef class Spin(Element):
         ret._parent = self._parent
         ret._n = self._n
         ret._value = value
-        ret._hash = 0
+        ret._hash = -1
         return ret
 
     def __dealloc__(self):
@@ -331,7 +332,7 @@ cdef class Spin(Element):
             True
         """
         cdef int i
-        if self._hash == 0:
+        if self._hash == -1:
             self._hash = hash(tuple([-1 if self._value[i] else 1 for i in range(self._n)]))
         return self._hash
 

--- a/src/sage/combinat/rigged_configurations/rigged_partition.pxd
+++ b/src/sage/combinat/rigged_configurations/rigged_partition.pxd
@@ -4,7 +4,7 @@ cdef class RiggedPartition(SageObject):
     cdef public list _list
     cdef public list vacancy_numbers
     cdef public list rigging
-    cdef long _hash
+    cdef Py_hash_t _hash
 
     cpdef get_num_cells_to_column(self, int end_column, t=*)
     cpdef insert_cell(self, int max_width)

--- a/src/sage/combinat/rigged_configurations/rigged_partition.pyx
+++ b/src/sage/combinat/rigged_configurations/rigged_partition.pyx
@@ -86,7 +86,7 @@ cdef class RiggedPartition(SageObject):
             <BLANKLINE>
             sage: TestSuite(RP).run()
         """
-        self._hash = 0
+        self._hash = -1
 
         if shape is None:
             self._list = []
@@ -287,7 +287,7 @@ cdef class RiggedPartition(SageObject):
             sage: h == hash(nu)
             False
         """
-        if self._hash == 0:
+        if self._hash == -1:
             self._hash = hash(tuple(self._list))
         return self._hash
 
@@ -421,7 +421,7 @@ cdef class RiggedPartition(SageObject):
         """
         cdef Py_ssize_t max_pos = -1
         cdef Py_ssize_t i
-        self._hash = 0  # Reset the cached hash value
+        self._hash = -1  # Reset the cached hash value
         if max_width > 0:
             for i, vac_num in enumerate(self.vacancy_numbers):
                 if self._list[i] <= max_width and vac_num == self.rigging[i]:
@@ -472,7 +472,7 @@ cdef class RiggedPartition(SageObject):
             -1[ ]-1
             <BLANKLINE>
         """
-        self._hash = 0  # Reset the cached hash value
+        self._hash = -1  # Reset the cached hash value
         if row is None:
             return None
 

--- a/src/sage/matrix/matrix0.pxd
+++ b/src/sage/matrix/matrix0.pxd
@@ -30,12 +30,12 @@ cdef class Matrix(sage.structure.element.Matrix):
     cdef int _strassen_default_echelon_cutoff(self) except -2
 
     # Implementation of hash function
-    cdef long _hash_(self) except -1
+    cdef Py_hash_t _hash_(self) except -1
     cdef void get_hash_constants(self, long C[5]) noexcept
 
     # Cache
     cdef public object _cache
-    cdef long hash  # cached hash value
+    cdef Py_hash_t hash  # cached hash value
     cdef void clear_cache(self) noexcept
     cdef fetch(self, key)
     cdef cache(self, key, x)

--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -6193,11 +6193,11 @@ cdef class Matrix(sage.structure.element.Matrix):
             raise TypeError("mutable matrices are unhashable")
         if self.hash != -1:
             return self.hash
-        cdef long h = self._hash_()
+        cdef Py_hash_t h = self._hash_()
         self.hash = h
         return h
 
-    cdef long _hash_(self) except -1:
+    cdef Py_hash_t _hash_(self) except -1:
         """
         Implementation of hash function.
 
@@ -6237,7 +6237,8 @@ cdef class Matrix(sage.structure.element.Matrix):
         # The value for l in the loop below is not so important: it
         # must be zero if i == j and sufficiently complicated to avoid
         # hash collisions.
-        cdef long h = 0, k, l
+        cdef Py_hash_t h = 0
+        cdef long k, l
         cdef Py_ssize_t i, j
         for i in range(self._nrows):
             k = C[0] if i == 0 else C[1] + C[2] * i

--- a/src/sage/matrix/matrix_cyclo_dense.pyx
+++ b/src/sage/matrix/matrix_cyclo_dense.pyx
@@ -730,7 +730,7 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
         C._matrix = M
         return C
 
-    cdef long _hash_(self) except -1:
+    cdef Py_hash_t _hash_(self) except -1:
         """
         Return hash of an immutable matrix.
 

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -280,7 +280,7 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             se = <SparseEntry>t
             mzd_write_bit(self._entries, se.i, se.j, se.entry)
 
-    cdef long _hash_(self) except -1:
+    cdef Py_hash_t _hash_(self) except -1:
         r"""
         EXAMPLES::
 
@@ -328,7 +328,8 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         cdef long C[5]
         self.get_hash_constants(C)
 
-        cdef long h = 0, k, l
+        cdef Py_hash_t h = 0
+        cdef long k, l
         cdef Py_ssize_t i, j
         sig_on()
         for i in range(self._nrows):

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -595,7 +595,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             else:
                 v[se.j] = <celement>x
 
-    cdef long _hash_(self) except -1:
+    cdef Py_hash_t _hash_(self) except -1:
         """
         EXAMPLES::
 
@@ -629,7 +629,8 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
         cdef long C[5]
         self.get_hash_constants(C)
 
-        cdef long h = 0, k, l
+        cdef Py_hash_t h = 0
+        cdef long k, l
         cdef Py_ssize_t i, j
         cdef celement* row
         sig_on()

--- a/src/sage/matrix/matrix_sparse.pyx
+++ b/src/sage/matrix/matrix_sparse.pyx
@@ -104,7 +104,7 @@ cdef class Matrix_sparse(matrix.Matrix):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef long _hash_(self) except -1:
+    cdef Py_hash_t _hash_(self) except -1:
         """
         Return the hash of this matrix.
 
@@ -155,7 +155,8 @@ cdef class Matrix_sparse(matrix.Matrix):
         cdef long C[5]
         self.get_hash_constants(C)
 
-        cdef long h = 0, k, l
+        cdef Py_hash_t h = 0
+        cdef long k, l
         cdef Py_ssize_t i, j
         for ij, x in D.items():
             sig_check()

--- a/src/sage/modular/modsym/manin_symbol.pyx
+++ b/src/sage/modular/modsym/manin_symbol.pyx
@@ -242,15 +242,15 @@ cdef class ManinSymbol(Element):
 
             sage: from sage.modular.modsym.manin_symbol import ManinSymbol
             sage: from sage.modular.modsym.manin_symbol_list import ManinSymbolList_gamma0
-            sage: m = ManinSymbolList_gamma0(5,2)
-            sage: s = ManinSymbol(m,(2,2,3))
+            sage: m = ManinSymbolList_gamma0(5, 2)
+            sage: s = ManinSymbol(m, (2, 2, 3))
             sage: hash(s)  # random
             7331463901
         """
-        cdef unsigned long h1 = hash(self.i)
-        cdef unsigned long h2 = hash(self.u)
-        cdef unsigned long h3 = hash(self.v)
-        return <Py_hash_t>(h1 + 1247963869*h2 + 1611845387*h3)
+        cdef Py_hash_t h1 = hash(self.i)
+        cdef Py_hash_t h2 = hash(self.u)
+        cdef Py_hash_t h3 = hash(self.v)
+        return h1 + 1247963869 * h2 + 1611845387 * h3
 
     def __mul__(self, matrix):
         """

--- a/src/sage/modules/with_basis/indexed_element.pxd
+++ b/src/sage/modules/with_basis/indexed_element.pxd
@@ -2,7 +2,7 @@ from sage.structure.element cimport Element, ModuleElement
 
 cdef class IndexedFreeModuleElement(ModuleElement):
     cdef public dict _monomial_coefficients
-    cdef long _hash
+    cdef Py_hash_t _hash
     cdef bint _hash_set
 
     cpdef _add_(self, other)

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -113,7 +113,7 @@ cdef class IndexedFreeModuleElement(ModuleElement):
         deprecation(34509, "using 'index in vector' is deprecated; use 'index in vector.support()' instead")
         return x in self.support()
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> Py_hash_t:
         """
         Return the hash value for ``self``.
 

--- a/src/sage/quivers/algebra_elements.pxd
+++ b/src/sage/quivers/algebra_elements.pxd
@@ -82,7 +82,7 @@ cdef class PathAlgebraElement(RingElement):
     # This ordering has to be passed as an argument to all boilerplate
     # functions.
     cdef path_order_t cmp_terms
-    cdef long _hash
+    cdef Py_hash_t _hash
     cpdef _add_(self, other)
     cpdef _mul_(self, other)
     cpdef ssize_t degree(self) except -2

--- a/src/sage/quivers/algebra_elements.pxi
+++ b/src/sage/quivers/algebra_elements.pxi
@@ -407,8 +407,9 @@ cdef path_term_t *term_copy_recursive(path_term_t *T) except NULL:
     return first
 
 # Hash of a term; probably not a good one.
-cdef inline long term_hash(path_term_t *T) noexcept:
-    return (<long>hash(<object>T.coef)+(T.mon.l_len<<5)+(T.mon.pos<<10))^bitset_hash(T.mon.path.data)
+cdef inline Py_hash_t term_hash(path_term_t *T) noexcept:
+    return (hash(<object>T.coef) + (T.mon.l_len << 5) +
+            (T.mon.pos << 10)) ^ bitset_hash(T.mon.path.data)
 
 # Recall that a monomial a*I*b (with I a generator of a free module)
 # is encoded by a path a*s*b for some monomial s that refers to a
@@ -749,9 +750,9 @@ cdef bint poly_richcmp(path_poly_t *P1, path_poly_t *P2, path_order_t cmp_terms,
     return rich_to_bool(op, 1)
 
 # Hash of a polynomial. Probably not a very strong hash.
-cdef inline long poly_hash(path_poly_t *P) noexcept:
+cdef inline Py_hash_t poly_hash(path_poly_t *P) noexcept:
     cdef path_term_t *T = P.lead
-    cdef long out = 0
+    cdef Py_hash_t out = 0
     while T != NULL:
         out = out<<7 | (out>>(sizeof(long)-7))
         out += term_hash(T)

--- a/src/sage/structure/category_object.pxd
+++ b/src/sage/structure/category_object.pxd
@@ -19,7 +19,7 @@ cdef class CategoryObject(SageObject):
     cdef public _names
     cdef public _factory_data
     cdef object __weakref__
-    cdef long _hash_value
+    cdef Py_hash_t _hash_value
 
     cdef getattr_from_category(self, name)
 

--- a/src/sage/structure/list_clone.pxd
+++ b/src/sage/structure/list_clone.pxd
@@ -16,7 +16,7 @@ from sage.structure.element cimport Element
 cdef class ClonableElement(Element):
     cdef bint _is_immutable
     cdef bint _needs_check
-    cdef long int  _hash
+    cdef Py_hash_t _hash
 
     cpdef bint _require_mutable(self) except -2
     cpdef bint is_mutable(self) noexcept
@@ -38,7 +38,7 @@ cdef class ClonableArray(ClonableElement):
     cpdef _setitem(self, int key, value)
     cpdef int index(self, key, start=*, stop=*) except -1
     cpdef int count(self, key) except -1
-    cpdef long int _hash_(self) except? -1
+    cpdef Py_hash_t _hash_(self) except? -1
 
 cdef class ClonableList(ClonableArray):
     cpdef append(self, el)
@@ -60,5 +60,5 @@ cdef class ClonableIntArray(ClonableElement):
     cpdef object _getitem(self, int key)
     cpdef _setitem(self, int item, value)
     cpdef int index(self, int item) except -1
-    cpdef long int _hash_(self) except? -1
+    cpdef Py_hash_t _hash_(self) except? -1
     cpdef list list(self)

--- a/src/sage/structure/list_clone.pyx
+++ b/src/sage/structure/list_clone.pyx
@@ -908,7 +908,7 @@ cdef class ClonableArray(ClonableElement):
         """
         raise NotImplementedError("this should never be called, please overload the check method")
 
-    cpdef long _hash_(self) except? -1:
+    cpdef Py_hash_t _hash_(self) except? -1:
         """
         Return the hash value of ``self``.
 
@@ -1699,7 +1699,7 @@ cdef class ClonableIntArray(ClonableElement):
         """
         raise NotImplementedError("this should never be called, please overload the check method")
 
-    cpdef long _hash_(self) except? -1:
+    cpdef Py_hash_t _hash_(self) except? -1:
         """
         Return the hash value of ``self``.
 
@@ -1712,7 +1712,7 @@ cdef class ClonableIntArray(ClonableElement):
             sage: type(el._hash_()) == int
             True
         """
-        cdef long hv
+        cdef Py_hash_t hv
         if self._list == NULL:
             hv = hash(None)
         else:

--- a/src/sage/symbolic/function.pxd
+++ b/src/sage/symbolic/function.pxd
@@ -22,7 +22,7 @@ cdef class GinacFunction(BuiltinFunction):
 
 cdef class SymbolicFunction(Function):
     # cache hash value
-    cdef long _hash_(self) except -1
+    cdef Py_hash_t _hash_(self) except -1
     cdef bint __hinit
-    cdef long __hcache
+    cdef Py_hash_t __hcache
     cdef _is_registered(self)

--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -1227,7 +1227,7 @@ cdef class SymbolicFunction(Function):
     cdef _is_registered(SymbolicFunction self):
         from .expression import get_sfunction_from_hash
         # see if there is already a SymbolicFunction with the same state
-        cdef long myhash = self._hash_()
+        cdef Py_hash_t myhash = self._hash_()
         cdef SymbolicFunction sfunc = get_sfunction_from_hash(myhash)
         if sfunc is not None:
             # found one, set self._serial to be a copy
@@ -1238,7 +1238,7 @@ cdef class SymbolicFunction(Function):
     # cache the hash value of this function
     # this is used very often while unpickling to see if there is already
     # a function with the same properties
-    cdef long _hash_(self) except -1:
+    cdef Py_hash_t _hash_(self) except -1:
         if not self.__hinit:
             # create a string representation of this SymbolicFunction
             slist = [self._nargs, self._name, str(self._latex_name),


### PR DESCRIPTION
This resolves various occurences of a Windows-specific bug: 64-bit hash not fitting in Windows' 32-bit C long.
I hunted them down using the regex search `long.*hash`. There may be more however.

Reported in https://github.com/passagemath/passagemath/issues/2220.
Follow-up of similar PR: https://github.com/sagemath/sage/pull/41630.