### PR TITLE
Remove "needs sage.foo" tags in sage.{sandpiles,probability}

### DIFF
--- a/src/sage/probability/probability_distribution.pyx
+++ b/src/sage/probability/probability_distribution.pyx
@@ -116,8 +116,8 @@ cdef class ProbabilityDistribution:
             sage: from sage.probability.probability_distribution import GeneralDiscreteDistribution
             sage: P = [0.3, 0.4, 0.3]
             sage: X = GeneralDiscreteDistribution(P)
-            sage: h, b = X.generate_histogram_data(bins=10)                             # needs sage.plot
-            sage: h  # rel tol 1e-08                                                    # needs sage.plot
+            sage: h, b = X.generate_histogram_data(bins=10)
+            sage: h  # rel tol 1e-08
             [1.6299999999999999,
              0.0,
              0.0,
@@ -128,7 +128,7 @@ cdef class ProbabilityDistribution:
              0.0,
              0.0,
              1.4650000000000003]
-            sage: b                                                                     # needs sage.plot
+            sage: b
             [0.0,
              0.2,
              0.4,
@@ -172,7 +172,7 @@ cdef class ProbabilityDistribution:
             sage: import tempfile
             sage: P = [0.3, 0.4, 0.3]
             sage: X = GeneralDiscreteDistribution(P)
-            sage: with tempfile.NamedTemporaryFile() as f:                              # needs sage.plot
+            sage: with tempfile.NamedTemporaryFile() as f:
             ....:     X.generate_histogram_plot(f.name)
         """
         import pylab
@@ -1025,7 +1025,7 @@ cdef class RealDistribution(ProbabilityDistribution):
         EXAMPLES::
 
             sage: T = RealDistribution('uniform', [0, 2])
-            sage: P = T.plot()                                                          # needs sage.plot
+            sage: P = T.plot()
         """
         from sage.plot.plot import plot
         return plot(self.distribution_function, *args, **kwds)

--- a/src/sage/probability/random_variable.py
+++ b/src/sage/probability/random_variable.py
@@ -310,7 +310,7 @@ class DiscreteProbabilitySpace(ProbabilitySpace_generic,DiscreteRandomVariable):
             (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
             sage: X.set()
             {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-            sage: X.entropy().n()                                                       # needs sage.libs.pari
+            sage: X.entropy().n()
             1.99993896484375
 
         A probability space can be defined on any list of elements::
@@ -321,7 +321,7 @@ class DiscreteProbabilitySpace(ProbabilitySpace_generic,DiscreteRandomVariable):
             sage: X = DiscreteProbabilitySpace(S,P)
             sage: X
             Discrete probability space defined by {'A': 1/2, 'B': 1/4, 'C': 1/4}
-            sage: X.entropy().n()                                                       # needs sage.libs.pari
+            sage: X.entropy().n()
             1.50000000000000
         """
         if codomain is None:

--- a/src/sage/sandpiles/examples.py
+++ b/src/sage/sandpiles/examples.py
@@ -138,10 +138,10 @@ class SandpileExamples:
         EXAMPLES::
 
             sage: f = sandpiles.Fan(10)
-            sage: f.group_order() == fibonacci(18)                                      # needs sage.libs.pari
+            sage: f.group_order() == fibonacci(18)
             True
             sage: f = sandpiles.Fan(10,True)  # all nonsink vertices have deg 3
-            sage: f.group_order() == fibonacci(20)                                      # needs sage.libs.pari
+            sage: f.group_order() == fibonacci(20)
             True
         """
         f = graphs.WheelGraph(n)

--- a/src/sage/sandpiles/sandpile.py
+++ b/src/sage/sandpiles/sandpile.py
@@ -83,7 +83,7 @@ Or just::
 
 A picture of the graph::
 
-    sage: S.show()                              # long time                             # needs sage.plot
+    sage: S.show()                              # long time
 
 The relevant Laplacian matrices::
 
@@ -205,19 +205,19 @@ The number of superstable configurations of each degree::
 
 the saturated homogeneous toppling ideal::
 
-    sage: S.ideal()                                                                     # needs sage.libs.singular
+    sage: S.ideal()
     Ideal (x1 - x0, x3*x2 - x0^2, x4^2 - x0^2, x2^3 - x4*x3*x0,
            x4*x2^2 - x3^2*x0, x3^3 - x4*x2*x0, x4*x3^2 - x2^2*x0) of
      Multivariate Polynomial Ring in x4, x3, x2, x1, x0 over Rational Field
 
 its minimal free resolution::
 
-    sage: S.resolution()                                                                # needs sage.libs.singular
+    sage: S.resolution()
     'R^1 <-- R^7 <-- R^15 <-- R^13 <-- R^4'
 
 and its Betti numbers::
 
-    sage: S.betti()                                                                     # needs sage.libs.singular
+    sage: S.betti()
                0     1     2     3     4
     ------------------------------------
         0:     1     1     -     -     -
@@ -253,7 +253,6 @@ Distribution of avalanche sizes::
     ....:     m, f = m.stabilize(True)
     ....:     a.append(sum(f.values()))
 
-    sage: # needs sage.plot
     sage: p = list_plot([[log(i + 1), log(a.count(i))]
     ....:                for i in [0..max(a)] if a.count(i)])
     sage: p.axes_labels(['log(N)', 'log(D(N))'])
@@ -281,7 +280,6 @@ Working with sandpile divisors::
     sage: D.rank()
     2
 
-    sage: # needs sage.geometry.polyhedron
     sage: sorted(D.effective_div(), key=str)
     [{0: 0, 1: 0, 2: 0, 3: 5},
      {0: 0, 1: 0, 2: 4, 3: 1},
@@ -792,8 +790,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = Sandpile({0:[], 1:[0,3,4], 2:[0,3,5], 3:[2,5], 4:[1,1], 5:[2,4]})
-            sage: S.show()                                                              # needs sage.plot
-            sage: S.show(graph_border=True, edge_labels=True)                           # needs sage.plot
+            sage: S.show()
+            sage: S.show(graph_border=True, edge_labels=True)
         """
         if self.is_undirected():
             Graph(self).show(**kwds)
@@ -812,7 +810,7 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = sandpiles.House()
-            sage: S.show3d()                    # long time                             # needs sage.plot
+            sage: S.show3d()                    # long time
         """
 
         if self.is_undirected():
@@ -1350,7 +1348,7 @@ class Sandpile(DiGraph):
             [{1: 2, 2: 3, 3: 3, 4: 1},
              {1: 1, 2: 3, 3: 3, 4: 0},
              {1: 1, 2: 3, 3: 3, 4: 1}]
-            sage: sandpiles.Complete(4).recurrents(False)                               # needs sage.combinat
+            sage: sandpiles.Complete(4).recurrents(False)
             [[2, 2, 2],
              [2, 2, 1],
              [2, 1, 2],
@@ -1408,7 +1406,7 @@ class Sandpile(DiGraph):
             [{1: 0, 2: 0, 3: 0, 4: 0},
              {1: 1, 2: 0, 3: 0, 4: 1},
              {1: 1, 2: 0, 3: 0, 4: 0}]
-            sage: sandpiles.Complete(4).superstables(False)                             # needs sage.combinat
+            sage: sandpiles.Complete(4).superstables(False)
             [[0, 0, 0],
              [0, 0, 1],
              [0, 1, 0],
@@ -1529,8 +1527,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: s = sandpiles.Complete(4)
-            sage: s._set_min_recurrents()                                               # needs sage.combinat
-            sage: '_min_recurrents' in s.__dict__                                       # needs sage.combinat
+            sage: s._set_min_recurrents()
+            sage: '_min_recurrents' in s.__dict__
             True
         """
         if self.is_undirected():
@@ -1628,7 +1626,7 @@ class Sandpile(DiGraph):
             x^3 + y^3 + 3*x^2 + 4*x*y + 3*y^2 + 2*x + 2*y
             sage: s.tutte_polynomial().subs(x=1)
             y^3 + 3*y^2 + 6*y + 6
-            sage: s.tutte_polynomial().subs(x=1).coefficients() == s.h_vector()         # needs sage.combinat
+            sage: s.tutte_polynomial().subs(x=1).coefficients() == s.h_vector()
             True
         """
         if self.is_undirected():
@@ -1642,8 +1640,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: s = sandpiles.Complete(4)
-            sage: s._set_avalanche_polynomial()                                         # needs sage.combinat
-            sage: '_avalanche_polynomial' in s.__dict__                                 # needs sage.combinat
+            sage: s._set_avalanche_polynomial()
+            sage: '_avalanche_polynomial' in s.__dict__
             True
         """
         n = self.n_vertices() - 1
@@ -1673,9 +1671,9 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: s = sandpiles.Complete(4)
-            sage: s.avalanche_polynomial()                                              # needs sage.combinat
+            sage: s.avalanche_polynomial()
             9*x0*x1*x2 + 2*x0*x1 + 2*x0*x2 + 2*x1*x2 + 3*x0 + 3*x1 + 3*x2 + 24
-            sage: s.avalanche_polynomial(False)                                         # needs sage.combinat
+            sage: s.avalanche_polynomial(False)
             9*x0^3 + 6*x0^2 + 9*x0 + 24
 
         .. NOTE::
@@ -1710,13 +1708,12 @@ class Sandpile(DiGraph):
 
         EXAMPLES::
 
-            sage: # needs sage.combinat
             sage: S = sandpiles.Complete(4)
             sage: ns = S.nonspecial_divisors()
             sage: D = ns[0]
-            sage: D.values()                                                            # needs sage.symbolic
+            sage: D.values()
             [-1, 0, 1, 2]
-            sage: D.deg()                                                               # needs sage.symbolic
+            sage: D.deg()
             2
             sage: [i.effective_div() for i in ns]
             [[], [], [], [], [], []]
@@ -1867,7 +1864,7 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: s = sandpiles.Complete(4)
-            sage: s.postulation()                                                       # needs sage.combinat
+            sage: s.postulation()
             3
         """
         return self._postulation
@@ -1949,8 +1946,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: s = sandpiles.Complete(3)
-            sage: s._set_jacobian_representatives()                                     # needs sage.combinat
-            sage: '_jacobian_representatives' in s.__dict__                             # needs sage.combinat
+            sage: s._set_jacobian_representatives()
+            sage: '_jacobian_representatives' in s.__dict__
             True
         """
         if self.is_undirected():
@@ -2002,9 +1999,9 @@ class Sandpile(DiGraph):
         representatives for the Jacobian group.::
 
             sage: s = sandpiles.Complete(3)
-            sage: s.superstables(False)                                                 # needs sage.combinat
+            sage: s.superstables(False)
             [[0, 0], [0, 1], [1, 0]]
-            sage: s.jacobian_representatives(False)                                     # needs sage.combinat
+            sage: s.jacobian_representatives(False)
             [[0, 0, 0], [-1, 0, 1], [-1, 1, 0]]
 
         If the graph is directed, the representatives described above may by
@@ -2013,7 +2010,7 @@ class Sandpile(DiGraph):
             sage: s = Sandpile({0: {1: 1, 2: 2}, 1: {0: 2, 2: 4}, 2: {0: 4, 1: 2}},0)
             sage: s.group_order()
             28
-            sage: s.jacobian_representatives()                                          # needs sage.symbolic
+            sage: s.jacobian_representatives()
             [{0: -5, 1: 3, 2: 2}, {0: -4, 1: 3, 2: 1}]
 
         Let `\tau` be the nonnegative generator of the kernel of the transpose of
@@ -2053,11 +2050,11 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: s = sandpiles.Complete(3)
-            sage: s.superstables(False)                                                 # needs sage.combinat
+            sage: s.superstables(False)
             [[0, 0], [0, 1], [1, 0]]
-            sage: s.jacobian_representatives(False)                                     # needs sage.combinat
+            sage: s.jacobian_representatives(False)
             [[0, 0, 0], [-1, 0, 1], [-1, 1, 0]]
-            sage: s.picard_representatives(3,False)                                     # needs sage.combinat
+            sage: s.picard_representatives(3,False)
             [[3, 0, 0], [2, 0, 1], [2, 1, 0]]
         """
         D = self.zero_div()
@@ -2087,12 +2084,12 @@ class Sandpile(DiGraph):
 
             sage: s = sandpiles.Complete(3)
             sage: a = s.stable_configs()
-            sage: next(a)                                                               # needs sage.combinat
+            sage: next(a)
             {1: 0, 2: 0}
-            sage: [i.values() for i in a]                                               # needs sage.combinat
+            sage: [i.values() for i in a]
             [[0, 1], [1, 0], [1, 1]]
             sage: b = s.stable_configs([1,0])
-            sage: list(b)                                                               # needs sage.combinat
+            sage: list(b)
             [{1: 0, 2: 0}, {1: 1, 2: 0}]
         """
         if smax is None:
@@ -2267,7 +2264,6 @@ class Sandpile(DiGraph):
             sage: s.stationary_density()
             10/9
 
-            sage: # needs sage.combinat
             sage: s = Sandpile(digraphs.DeBruijn(2,2),'00')
             sage: s.stationary_density()
             9/8
@@ -2325,8 +2321,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = Sandpile({0:{},1:{0: 1, 2: 1, 3: 4},2:{3: 5},3:{1: 1, 2: 1}},0)
-            sage: S._set_betti_complexes()                                              # needs sage.geometry.polyhedron
-            sage: '_betti_complexes' in S.__dict__                                      # needs sage.geometry.polyhedron
+            sage: S._set_betti_complexes()
+            sage: '_betti_complexes' in S.__dict__
             True
         """
         results = []
@@ -2357,15 +2353,14 @@ class Sandpile(DiGraph):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron
             sage: S = Sandpile({0:{},1:{0: 1, 2: 1, 3: 4},2:{3: 5},3:{1: 1, 2: 1}},0)
             sage: p = S.betti_complexes()
             sage: p[0]
             [{0: -8, 1: 5, 2: 4, 3: 1},
              Simplicial complex with vertex set (1, 2, 3) and facets {(3,), (1, 2)}]
-            sage: S.resolution()                                                        # needs sage.libs.singular
+            sage: S.resolution()
             'R^1 <-- R^5 <-- R^5 <-- R^1'
-            sage: S.betti()                                                             # needs sage.libs.singular
+            sage: S.betti()
                        0     1     2     3
             ------------------------------
                 0:     1     -     -     -
@@ -2436,8 +2431,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = sandpiles.Diamond()
-            sage: S._set_ideal()                                                        # needs sage.libs.singular
-            sage: '_ideal' in S.__dict__                                                # needs sage.libs.singular
+            sage: S._set_ideal()
+            sage: '_ideal' in S.__dict__
             True
         """
         from sage.libs.singular.function_factory import ff
@@ -2461,7 +2456,7 @@ class Sandpile(DiGraph):
             sage: S = sandpiles.Diamond()
             sage: S.unsaturated_ideal().gens()
             [x1^3 - x3*x2*x0, x2^3 - x3*x1*x0, x3^2 - x2*x1]
-            sage: S.ideal().gens()                                                      # needs sage.libs.singular
+            sage: S.ideal().gens()
             [x2*x1 - x0^2, x3^2 - x0^2, x1^3 - x3*x2*x0,
              x3*x1^2 - x2^2*x0, x2^3 - x3*x1*x0, x3*x2^2 - x1^2*x0]
         """
@@ -2481,14 +2476,14 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = sandpiles.Diamond()
-            sage: S.ideal()                                                             # needs sage.libs.singular
+            sage: S.ideal()
             Ideal (x2*x1 - x0^2, x3^2 - x0^2, x1^3 - x3*x2*x0,
                    x3*x1^2 - x2^2*x0, x2^3 - x3*x1*x0, x3*x2^2 - x1^2*x0)
              of Multivariate Polynomial Ring in x3, x2, x1, x0 over Rational Field
-            sage: S.ideal(True)                                                         # needs sage.libs.singular
+            sage: S.ideal(True)
             [x2*x1 - x0^2, x3^2 - x0^2, x1^3 - x3*x2*x0,
              x3*x1^2 - x2^2*x0, x2^3 - x3*x1*x0, x3*x2^2 - x1^2*x0]
-            sage: S.ideal().gens()  # another way to get the generators                 # needs sage.libs.singular
+            sage: S.ideal().gens()  # another way to get the generators
             [x2*x1 - x0^2, x3^2 - x0^2, x1^3 - x3*x2*x0,
              x3*x1^2 - x2^2*x0, x2^3 - x3*x1*x0, x3*x2^2 - x1^2*x0]
         """
@@ -2527,8 +2522,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = sandpiles.Diamond()
-            sage: S._set_resolution()                                                   # needs sage.libs.singular
-            sage: '_resolution' in S.__dict__                                           # needs sage.libs.singular
+            sage: S._set_resolution()
+            sage: '_resolution' in S.__dict__
             True
         """
         # get the resolution in singular form
@@ -2576,7 +2571,6 @@ class Sandpile(DiGraph):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.singular
             sage: S = Sandpile({0: {}, 1: {0: 1, 2: 1, 3: 4}, 2: {3: 5}, 3: {1: 1, 2: 1}},0)
             sage: S.resolution()  # a Gorenstein sandpile graph
             'R^1 <-- R^5 <-- R^5 <-- R^1'
@@ -2614,8 +2608,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = sandpiles.Diamond()
-            sage: S._set_groebner()                                                     # needs sage.libs.singular
-            sage: '_groebner' in S.__dict__                                             # needs sage.libs.singular
+            sage: S._set_groebner()
+            sage: '_groebner' in S.__dict__
             True
         """
         self._groebner = self._ideal.groebner_basis()
@@ -2632,7 +2626,7 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = sandpiles.Diamond()
-            sage: S.groebner()                                                          # needs sage.libs.singular
+            sage: S.groebner()
             [x3*x2^2 - x1^2*x0, x2^3 - x3*x1*x0, x3*x1^2 - x2^2*x0,
              x1^3 - x3*x2*x0, x3^2 - x0^2, x2*x1 - x0^2]
         """
@@ -2654,7 +2648,7 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = sandpiles.Diamond()
-            sage: S.betti()                                                             # needs sage.libs.singular
+            sage: S.betti()
                        0     1     2     3
             ------------------------------
                 0:     1     -     -     -
@@ -2662,7 +2656,7 @@ class Sandpile(DiGraph):
                 2:     -     4     9     4
             ------------------------------
             total:     1     6     9     4
-            sage: S.betti(False)                                                        # needs sage.libs.singular
+            sage: S.betti(False)
             [1, 6, 9, 4]
         """
         if verbose:
@@ -2681,7 +2675,7 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = Sandpile({0: {}, 1: {2: 2}, 2: {0: 4, 1: 1}}, 0)
-            sage: Z = S.solve(); Z                                                      # needs sage.libs.singular
+            sage: Z = S.solve(); Z
             [[-0.707107000000000 + 0.707107000000000*I,
               0.707107000000000 - 0.707107000000000*I],
              [-0.707107000000000 - 0.707107000000000*I,
@@ -2694,7 +2688,7 @@ class Sandpile(DiGraph):
               -0.707107000000000 + 0.707107000000000*I],
              [1, 1],
              [-1, -1]]
-            sage: len(Z)                                                                # needs sage.libs.singular
+            sage: len(Z)
             8
             sage: S.group_order()
             8
@@ -2727,8 +2721,8 @@ class Sandpile(DiGraph):
         EXAMPLES::
 
             sage: S = sandpiles.Diamond()
-            sage: S._set_points()                                                       # needs sage.symbolic
-            sage: '_points' in S.__dict__                                               # needs sage.symbolic
+            sage: S._set_points()
+            sage: '_points' in S.__dict__
             True
         """
         L = self._reduced_laplacian.transpose().dense_matrix()
@@ -2757,7 +2751,7 @@ class Sandpile(DiGraph):
         ::
 
             sage: S = sandpiles.Complete(4)
-            sage: S.points()                                                            # needs sage.symbolic
+            sage: S.points()
             [[-I, I, 1], [-I, 1, I]]
         """
         return self._points
@@ -3659,7 +3653,6 @@ class SandpileConfig(dict):
             ....:     m, f = m.stabilize(True)
             ....:     a.append(sum(f.values()))
 
-            sage: # needs sage.plot
             sage: p = list_plot([[log(i + 1), log(a.count(i))]
             ....:                for i in [0..max(a)] if a.count(i)])
             sage: p.axes_labels(['log(N)', 'log(D(N))'])
@@ -4016,9 +4009,9 @@ class SandpileConfig(dict):
 
             sage: S = sandpiles.Diamond()
             sage: c = S.identity()
-            sage: c.show()                                                              # needs sage.plot
-            sage: c.show(directed=False)                                                # needs sage.plot
-            sage: c.show(sink=False, colors=False, heights=True)                        # needs sage.plot
+            sage: c.show()
+            sage: c.show(directed=False)
+            sage: c.show(sink=False, colors=False, heights=True)
         """
         if directed:
             T = DiGraph(self.sandpile())
@@ -4190,8 +4183,8 @@ class SandpileDivisor(dict):
 
             sage: S = sandpiles.Cycle(3)
             sage: D = SandpileDivisor(S,[0,1,1])
-            sage: eff = D.effective_div()                                               # needs sage.geometry.polyhedron
-            sage: D.__dict__                                                            # needs sage.geometry.polyhedron
+            sage: eff = D.effective_div()
+            sage: D.__dict__
             {'_effective_div': [{0: 0, 1: 1, 2: 1}, {0: 2, 1: 0, 2: 0}],
              '_polytope': A 2-dimensional polyhedron in QQ^2 defined as the convex hull of 3 vertices,
              '_polytope_integer_pts': ((0, 0), (1, 1)),
@@ -5017,8 +5010,8 @@ class SandpileDivisor(dict):
 
             sage: s = sandpiles.Complete(4)
             sage: D = SandpileDivisor(s,[4,2,0,0])
-            sage: D._set_polytope()                                                     # needs sage.geometry.polyhedron
-            sage: '_polytope' in D.__dict__                                             # needs sage.geometry.polyhedron
+            sage: D._set_polytope()
+            sage: '_polytope' in D.__dict__
             True
         """
         S = self.sandpile()
@@ -5034,7 +5027,6 @@ class SandpileDivisor(dict):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron
             sage: s = sandpiles.Complete(4)
             sage: D = SandpileDivisor(s,[4,2,0,0])
             sage: p = D.polytope()
@@ -5067,8 +5059,8 @@ class SandpileDivisor(dict):
 
             sage: s = sandpiles.Complete(4)
             sage: D = SandpileDivisor(s,[4,2,0,0])
-            sage: D._set_polytope_integer_pts()                                         # needs sage.geometry.polyhedron
-            sage: '_polytope_integer_pts' in D.__dict__                                 # needs sage.geometry.polyhedron
+            sage: D._set_polytope_integer_pts()
+            sage: '_polytope_integer_pts' in D.__dict__
             True
         """
         self._polytope_integer_pts = self._polytope.integral_points()
@@ -5087,7 +5079,7 @@ class SandpileDivisor(dict):
 
             sage: s = sandpiles.Complete(4)
             sage: D = SandpileDivisor(s,[4,2,0,0])
-            sage: sorted(D.polytope_integer_pts())                                      # needs sage.geometry.polyhedron
+            sage: sorted(D.polytope_integer_pts())
             [(-2, -1, -1),
              (-1, -2, -1),
              (-1, -1, -2),
@@ -5095,7 +5087,7 @@ class SandpileDivisor(dict):
              (0, -1, -1),
              (0, 0, 0)]
             sage: D = SandpileDivisor(s,[-1,0,0,0])
-            sage: D.polytope_integer_pts()                                              # needs sage.geometry.polyhedron
+            sage: D.polytope_integer_pts()
             ()
         """
         return deepcopy(self._polytope_integer_pts)
@@ -5108,8 +5100,8 @@ class SandpileDivisor(dict):
 
             sage: s = sandpiles.Complete(4)
             sage: D = SandpileDivisor(s,[4,2,0,0])
-            sage: D._set_effective_div()                                                # needs sage.geometry.polyhedron
-            sage: '_effective_div' in D.__dict__                                        # needs sage.geometry.polyhedron
+            sage: D._set_effective_div()
+            sage: '_effective_div' in D.__dict__
             True
         """
         S = self.sandpile()
@@ -5138,7 +5130,6 @@ class SandpileDivisor(dict):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron
             sage: s = sandpiles.Complete(4)
             sage: D = SandpileDivisor(s,[4,2,0,0])
             sage: sorted(D.effective_div(), key=str)
@@ -5215,8 +5206,8 @@ class SandpileDivisor(dict):
             True
             sage: '_rank_witness' in D.__dict__
             False
-            sage: D._set_rank(True)                                                     # needs sage.geometry.polyhedron
-            sage: '_rank_witness' in D.__dict__                                         # needs sage.geometry.polyhedron
+            sage: D._set_rank(True)
+            sage: '_rank_witness' in D.__dict__
             True
             sage: D = SandpileDivisor(s,[1,0,0,0])
             sage: D._set_rank()
@@ -5283,7 +5274,6 @@ class SandpileDivisor(dict):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron
             sage: S = sandpiles.Complete(4)
             sage: D = SandpileDivisor(S,[4,2,0,0])
             sage: D.rank()
@@ -5291,18 +5281,16 @@ class SandpileDivisor(dict):
             sage: D.rank(True)
             (3, {0: 3, 1: 0, 2: 1, 3: 0})
             sage: E = _[1]
-            sage: (D - E).rank()                                                        # needs sage.rings.number_field
+            sage: (D - E).rank()
             -1
 
          Riemann-Roch theorem::
 
-            sage: # needs sage.geometry.polyhedron
             sage: D.rank() - (S.canonical_divisor()-D).rank() == D.deg() + 1 - S.genus()
             True
 
          Riemann-Roch theorem::
 
-            sage: # needs sage.geometry.polyhedron
             sage: D.rank() - (S.canonical_divisor()-D).rank() == D.deg() + 1 - S.genus()
             True
             sage: S = Sandpile({0:[1,1,1,2],1:[0,0,0,1,1,1,2,2],2:[2,2,1,1,0]},0)  # multigraph with loops
@@ -5318,7 +5306,7 @@ class SandpileDivisor(dict):
             sage: D.rank(True)
             (0, {0: 0, 1: 0, 2: 1})
             sage: E = D.rank(True)[1]
-            sage: (D - E).effective_div()                                               # needs sage.rings.number_field
+            sage: (D - E).effective_div()
             []
 
         .. NOTE::
@@ -5397,7 +5385,7 @@ class SandpileDivisor(dict):
 
             sage: s = sandpiles.House()
             sage: K = s.canonical_divisor()
-            sage: [K.weierstrass_rank_seq(v) for v in s.vertices(sort=True)]            # needs sage.geometry.polyhedron
+            sage: [K.weierstrass_rank_seq(v) for v in s.vertices(sort=True)]
             [(1, 0, -1), (1, 0, -1), (1, 0, -1), (1, 0, -1), (1, 0, 0, -1)]
         """
         s = self.sandpile()
@@ -5435,7 +5423,6 @@ class SandpileDivisor(dict):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron
             sage: s = sandpiles.Cycle(4)
             sage: D = SandpileDivisor(s,[2,0,0,0])
             sage: [D.weierstrass_gap_seq(v,False) for v in s.vertices(sort=True)]
@@ -5476,7 +5463,6 @@ class SandpileDivisor(dict):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron
             sage: s = sandpiles.House()
             sage: K = s.canonical_divisor()
             sage: K.weierstrass_rank_seq()  # sequence at the sink vertex, 0
@@ -5504,8 +5490,8 @@ class SandpileDivisor(dict):
 
             sage: s = sandpiles.Diamond()
             sage: D = SandpileDivisor(s, [2,1,0,0])
-            sage: D._set_weierstrass_pts()                                              # needs sage.geometry.polyhedron
-            sage: '_weierstrass_pts' in D.__dict__                                      # needs sage.geometry.polyhedron
+            sage: D._set_weierstrass_pts()
+            sage: '_weierstrass_pts' in D.__dict__
             True
         """
         self._weierstrass_pts = tuple([v for v in self.sandpile().vertices(sort=True)
@@ -5526,9 +5512,9 @@ class SandpileDivisor(dict):
 
             sage: s = sandpiles.House()
             sage: K = s.canonical_divisor()
-            sage: K.weierstrass_pts()                                                   # needs sage.geometry.polyhedron
+            sage: K.weierstrass_pts()
             (4,)
-            sage: K.weierstrass_pts(True)                                               # needs sage.geometry.polyhedron
+            sage: K.weierstrass_pts(True)
             [(4, (1, 0, 0, -1))]
 
         .. NOTE::
@@ -5558,12 +5544,12 @@ class SandpileDivisor(dict):
 
             sage: s = sandpiles.Diamond()
             sage: D = SandpileDivisor(s,[4,2,1,0])
-            sage: [D.weierstrass_rank_seq(v) for v in s]                                # needs sage.geometry.polyhedron
+            sage: [D.weierstrass_rank_seq(v) for v in s]
             [(5, 4, 3, 2, 1, 0, 0, -1),
              (5, 4, 3, 2, 1, 0, -1),
              (5, 4, 3, 2, 1, 0, 0, 0, -1),
              (5, 4, 3, 2, 1, 0, 0, -1)]
-            sage: D.weierstrass_div()                                                   # needs sage.geometry.polyhedron
+            sage: D.weierstrass_div()
             {0: 1, 1: 0, 2: 2, 3: 1}
             sage: k5 = sandpiles.Complete(5)
             sage: K = k5.canonical_divisor()
@@ -5604,8 +5590,8 @@ class SandpileDivisor(dict):
 
             sage: S = sandpiles.Complete(4)
             sage: D = SandpileDivisor(S, [0,0,1,1])
-            sage: D._set_Dcomplex()                                                     # needs sage.geometry.polyhedron
-            sage: '_Dcomplex' in D.__dict__                                             # needs sage.geometry.polyhedron
+            sage: D._set_Dcomplex()
+            sage: '_Dcomplex' in D.__dict__
             True
         """
         simp = []
@@ -5639,7 +5625,6 @@ class SandpileDivisor(dict):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron
             sage: S = sandpiles.House()
             sage: p = SandpileDivisor(S, [1,2,1,0,0]).Dcomplex()
             sage: p.homology()
@@ -5666,7 +5651,7 @@ class SandpileDivisor(dict):
 
             sage: S = sandpiles.Cycle(3)
             sage: D = SandpileDivisor(S, [2,0,1])
-            sage: D.betti()                                                             # needs sage.geometry.polyhedron
+            sage: D.betti()
             {0: 1, 1: 1}
 
         .. NOTE::
@@ -5854,7 +5839,7 @@ class SandpileDivisor(dict):
 
             sage: S = sandpiles.Diamond()
             sage: D = SandpileDivisor(S, [1,-2,0,2])
-            sage: D.show(graph_border=True, vertex_size=700, directed=False)            # needs sage.plot
+            sage: D.show(graph_border=True, vertex_size=700, directed=False)
         """
         if directed:
             T = DiGraph(self.sandpile())
@@ -5903,7 +5888,7 @@ def sandlib(selector=None):
                  riemann-roch1 : directed graph with postulation 9 and 3 maximal weight superstables
                  riemann-roch2 : directed graph with a superstable not majorized by a maximal superstable
             sage: S = sandlib('gor')
-            sage: S.resolution()                                                        # needs sage.libs.singular
+            sage: S.resolution()
             'R^1 <-- R^5 <-- R^5 <-- R^1'
     """
     # The convention is for the sink to be zero.
@@ -6088,7 +6073,7 @@ def glue_graphs(g, h, glue_g, glue_h):
         sage: S = Sandpile(z,'sink')
         sage: S.h_vector()
         [1, 6, 17, 31, 41, 41, 31, 17, 6, 1]
-        sage: S.resolution()                                                            # needs sage.libs.singular
+        sage: S.resolution()
         'R^1 <-- R^7 <-- R^21 <-- R^35 <-- R^35 <-- R^21 <-- R^7 <-- R^1'
 
     .. NOTE::
@@ -6158,8 +6143,8 @@ def firing_graph(S, eff):
 
         sage: S = sandpiles.Cycle(6)
         sage: D = SandpileDivisor(S, [1,1,1,1,2,0])
-        sage: eff = D.effective_div()                                                   # needs sage.geometry.polyhedron
-        sage: firing_graph(S, eff).show3d(edge_size=.005,               # long time, needs sage.geometry.polyhedron sage.plot
+        sage: eff = D.effective_div()
+        sage: firing_graph(S, eff).show3d(edge_size=.005,               # long time
         ....:                             vertex_size=0.01)
     """
     g = DiGraph()
@@ -6193,8 +6178,8 @@ def parallel_firing_graph(S, eff):
 
         sage: S = sandpiles.Cycle(6)
         sage: D = SandpileDivisor(S, [1,1,1,1,2,0])
-        sage: eff = D.effective_div()                                                   # needs sage.geometry.polyhedron
-        sage: parallel_firing_graph(S, eff).show3d(edge_size=.005,      # long time, needs sage.geometry.polyhedron sage.plot
+        sage: eff = D.effective_div()
+        sage: parallel_firing_graph(S, eff).show3d(edge_size=.005,      # long time
         ....:                                      vertex_size=0.01)
     """
     g = DiGraph()
@@ -6231,8 +6216,8 @@ def admissible_partitions(S, k):
         sage: from sage.sandpiles.sandpile import admissible_partitions
         sage: from sage.sandpiles.sandpile import partition_sandpile
         sage: S = sandpiles.Cycle(4)
-        sage: P = [list(admissible_partitions(S, i)) for i in [2,3,4]]                  # needs sage.combinat
-        sage: P                                                                         # needs sage.combinat
+        sage: P = [list(admissible_partitions(S, i)) for i in [2,3,4]]
+        sage: P
         [[{{0, 2, 3}, {1}},
           {{0, 3}, {1, 2}},
           {{0, 1, 3}, {2}},
@@ -6244,12 +6229,12 @@ def admissible_partitions(S, k):
           {{0}, {1, 2}, {3}},
           {{0, 1}, {2}, {3}}],
          [{{0}, {1}, {2}, {3}}]]
-        sage: for p in P:                                                               # needs sage.combinat
+        sage: for p in P:
         ....:  sum([partition_sandpile(S, i).betti(verbose=False)[-1] for i in p])
         6
         8
         3
-        sage: S.betti()                                                                 # needs sage.libs.singular
+        sage: S.betti()
                    0     1     2     3
         ------------------------------
             0:     1     -     -     -
@@ -6282,13 +6267,13 @@ def partition_sandpile(S, p) -> Sandpile:
 
         sage: from sage.sandpiles.sandpile import admissible_partitions, partition_sandpile
         sage: S = sandpiles.Cycle(4)
-        sage: P = [list(admissible_partitions(S, i)) for i in [2,3,4]]                  # needs sage.combinat
-        sage: for p in P:                                                               # needs sage.combinat
+        sage: P = [list(admissible_partitions(S, i)) for i in [2,3,4]]
+        sage: for p in P:
         ....:  sum([partition_sandpile(S, i).betti(verbose=False)[-1] for i in p])
         6
         8
         3
-        sage: S.betti()                                                                 # needs sage.libs.singular
+        sage: S.betti()
                    0     1     2     3
         ------------------------------
             0:     1     -     -     -


### PR DESCRIPTION
These aren't being used or maintain in upstream SageMath. Eventually it would be nice to stop detecting these "features" over and over again at runtime, but first we have to eliminate all of the tags.

Note: I removed both the block-level and per-line tags this time around, to avoid warnings about variables being declared behind one or the other.