### PR TITLE
Eliminate pytest workarounds for sagemath-giac and coxeter3

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -119,10 +119,7 @@ class SageDoctestModule(DoctestModule):
                     if isinstance(exception, ModuleNotFoundError):
                         # Ignore some missing features/modules for now
                         # TODO: Remove this once all optional things are using Features
-                        if exception.name in (
-                            "valgrind",
-                            "sage.libs.coxeter3.coxeter",
-                        ):
+                        if exception.name == "valgrind":
                             pytest.skip(
                                 f"unable to import module {self.path} due to missing feature {exception.name}"
                             )

--- a/conftest.py
+++ b/conftest.py
@@ -122,7 +122,6 @@ class SageDoctestModule(DoctestModule):
                         if exception.name in (
                             "valgrind",
                             "sage.libs.coxeter3.coxeter",
-                            "sagemath_giac",
                         ):
                             pytest.skip(
                                 f"unable to import module {self.path} due to missing feature {exception.name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,9 @@ sage = "sage.cli.__main__:main"
 platforms = ['linux-64', 'linux-aarch64', 'osx-64', 'osx-arm64']
 
 [tool.pytest.ini_options]
-norecursedirs = "local prefix venv build builddir pkgs .git src/doc src/bin tools subprojects"
+# sage.libs.giac is a stub to keep the old imports working; all
+# it does is try to import sagemath_giac.
+norecursedirs = "local prefix venv build builddir pkgs .git src/doc src/bin src/sage/libs/giac tools subprojects"
 python_files = "*_test.py"
 # The "no:warnings" is to stop pytest from capturing warnings so that they are printed to the output of the doctest
 addopts = "--import-mode importlib -p no:warnings"

--- a/src/sage/algebras/iwahori_hecke_algebra.py
+++ b/src/sage/algebras/iwahori_hecke_algebra.py
@@ -2010,9 +2010,10 @@ class IwahoriHeckeAlgebra(Parent, UniqueRepresentation):
                 return
 
             # check if products can be computed directly using ``coxeter3``
-            try:
+            from sage.features.coxeter3 import Coxeter3
+            if Coxeter3().is_present():
                 from sage.libs.coxeter3.coxeter_group import CoxeterGroup as Coxeter3Group
-            except ImportError:
+            else:
                 return
 
             self._delta = v + ~v

--- a/src/sage/combinat/symmetric_group_algebra.py
+++ b/src/sage/combinat/symmetric_group_algebra.py
@@ -2622,9 +2622,13 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
         R = self.base_ring()
         one = R.one()
         # check if the KL polynomials can be computed using ``coxeter3``
-        try:
+        from sage.features.coxeter3 import Coxeter3
+        if Coxeter3().is_present():
             from sage.libs.coxeter3.coxeter_group import CoxeterGroup as Coxeter3Group
-        except ImportError:
+            self._cellular_KL = Coxeter3Group(['A', self.n + 1])
+            self._KLG = self._cellular_KL
+            polyfunc = self._cellular_KL.kazhdan_lusztig_polynomial
+        else:
             # Fallback to using the KL polynomial
             from sage.combinat.kazhdan_lusztig import KazhdanLusztigPolynomial
             from sage.groups.perm_gps.permgroup_named import SymmetricGroup
@@ -2632,10 +2636,6 @@ class SymmetricGroupAlgebra_n(GroupAlgebra_class):
             self._KLG = SymmetricGroup(self.n)
             self._cellular_KL = KazhdanLusztigPolynomial(self._KLG, q)
             polyfunc = self._cellular_KL.P
-        else:
-            self._cellular_KL = Coxeter3Group(['A', self.n + 1])
-            self._KLG = self._cellular_KL
-            polyfunc = self._cellular_KL.kazhdan_lusztig_polynomial
 
         if w.parent() is not self._KLG:
             w = self._KLG.from_reduced_word(w.reduced_word())

--- a/src/sage/libs/coxeter3/coxeter_group.py
+++ b/src/sage/libs/coxeter3/coxeter_group.py
@@ -9,7 +9,12 @@ Coxeter Groups implemented with Coxeter3
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.libs.coxeter3.coxeter import get_CoxGroup, CoxGroupElement
+from sage.features.coxeter3 import Coxeter3
+from sage.misc.lazy_import import lazy_import
+lazy_import("sage.libs.coxeter3.coxeter",
+            ["get_CoxGroup", "CoxGroupElement"],
+            feature=Coxeter3())
+
 from sage.misc.cachefunc import cached_method
 
 from sage.structure.unique_representation import UniqueRepresentation


### PR DESCRIPTION
Eliminate two special cases in our pytest configuration file, `conftest.py`:

1. We can safely ignore all of `sage.libs.giac` in `pyproject.toml` when testing. Using features might be nicer here, but I can't test. The main difference is that if you specifically run `pytest src/sage/libs/giac`, it will not be skipped (and can thus still fail).
2. Rework `sage.libs.coxeter3` to fail with a `FeatureNotFoundError` when its cython module was not built, and update the few places where we were doing this manually.

Afterwards, we do not need special cases in `conftest.py` for when these modules fail to import.