### PR TITLE
Remove rpy2 workaround in conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -121,7 +121,6 @@ class SageDoctestModule(DoctestModule):
                         # TODO: Remove this once all optional things are using Features
                         if exception.name in (
                             "valgrind",
-                            "rpy2",
                             "sage.libs.coxeter3.coxeter",
                             "sagemath_giac",
                         ):


### PR DESCRIPTION
We currently have a hack in conftest.py for (the possibly absent) rpy2 in `src/sage/interfaces/r.py`, but apparently everything is fine without it.
