### PR TITLE
Fix command syntax for GCL FriCAS execution

### DIFF
--- a/src/sage/features/fricas.py
+++ b/src/sage/features/fricas.py
@@ -67,7 +67,7 @@ class FriCAS(Executable):
             sage: FriCAS().is_functional()  # optional - fricas
             FeatureTestResult('fricas', True)
         """
-        command = ['fricas -nosman -eval ")quit"']
+        command = ['fricas -nosman -- -eval ")quit"']
         try:
             lines = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
GCL 2.7.1 has built-in -eval processing in its process-some-args function (at gcl_top.lsp line 213):
```
((string-equal x "-eval") (eval (read-from-string (pop args))))
```
The -- tells GCL to stop processing its own command-line options, so -eval arguments are left for FriCAS's own evalInlineCode() to handle. This is exactly how the texmacs mode already works (line 98 of the same script). Without --, GCL's process-some-args intercepts -eval and tries to read-from-string the argument as raw Lisp, which fails on FriCAS system commands like )quit.

In sage, FriCAS with GCL hang on
```
sage: from sage.features.fricas import FriCAS
sage: FriCAS().is_functional()
```
See the suggestion from https://github.com/fricas/fricas/pull/214


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


