### PR TITLE
improved efficiency

### DIFF
--- a/src/sage/topology/simplicial_complex.py
+++ b/src/sage/topology/simplicial_complex.py
@@ -3957,10 +3957,14 @@ class SimplicialComplex(Parent, GenericCellComplex):
         face_sets = {f: f.set() for f in faces}
         # Track nonempty intersections incrementally to avoid recomputing all
         # intersections from scratch in every pass.
-        intersections = {f: {inter for a_set in new_facet_sets
-                             for inter in [a_set.intersection(face_sets[f])]
-                             if inter}
-                         for f in faces}
+        intersections = {
+            f: {
+                inter
+                for a_set in new_facet_sets
+                if (inter := a_set.intersection(face_sets[f]))
+            }
+            for f in faces
+        }
         # Cache contractibility tests for repeated intersection complexes.
         contractible_intersections = {}
         while not done:

--- a/src/sage/topology/simplicial_complex.py
+++ b/src/sage/topology/simplicial_complex.py
@@ -3953,25 +3953,52 @@ class SimplicialComplex(Parent, GenericCellComplex):
         faces = sorted(faces, key=str)
         done = False
         new_facets = sorted(subcomplex._facets, key=str)
+        new_facet_sets = [f.set() for f in new_facets]
+        face_sets = {f: f.set() for f in faces}
+        # Track nonempty intersections incrementally to avoid recomputing all
+        # intersections from scratch in every pass.
+        intersections = {f: {inter for a_set in new_facet_sets
+                             for inter in [a_set.intersection(face_sets[f])]
+                             if inter}
+                         for f in faces}
+        # Cache contractibility tests for repeated intersection complexes.
+        contractible_intersections = {}
         while not done:
             done = True
             remove_these = []
             if verbose:
                 print(f"  looping through {len(faces)} facets")
             for f in faces:
-                f_set = f.set()
-                int_facets = {a.set().intersection(f_set) for a in new_facets}
-                intersection = SimplicialComplex(int_facets)
-                if not intersection._facets[0].is_empty():
-                    if (len(intersection._facets) == 1 or
-                            intersection == intersection._contractible_subcomplex()):
+                int_facets = intersections[f]
+                if int_facets:
+                    if len(int_facets) == 1:
+                        is_contractible = True
+                    else:
+                        key = frozenset(int_facets)
+                        is_contractible = contractible_intersections.get(key)
+                        if is_contractible is None:
+                            intersection = SimplicialComplex(int_facets)
+                            is_contractible = (intersection == intersection._contractible_subcomplex())
+                            contractible_intersections[key] = is_contractible
+                    if is_contractible:
                         new_facets.append(f)
+                        f_set = face_sets[f]
+                        new_facet_sets.append(f_set)
                         remove_these.append(f)
                         done = False
+                        for g in faces:
+                            if g != f:
+                                inter = face_sets[g].intersection(f_set)
+                                if inter:
+                                    intersections[g].add(inter)
             if verbose and not done:
                 print("    added %s facets" % len(remove_these))
-            for f in remove_these:
-                faces.remove(f)
+            if remove_these:
+                remove_set = set(remove_these)
+                faces = [f for f in faces if f not in remove_set]
+                for f in remove_set:
+                    intersections.pop(f, None)
+                    face_sets.pop(f, None)
         if verbose:
             print("  now constructing a simplicial complex with {} vertices and {} facets".format(len(self.vertices()), len(new_facets)))
         L = SimplicialComplex(new_facets, maximality_check=False,


### PR DESCRIPTION
What changed
Precomputed set() views for existing and candidate facets (new_facet_sets, face_sets) instead of rebuilding them repeatedly. Added an incremental intersections cache per remaining facet, so we no longer recompute all intersections from scratch each pass. Added contractible_intersections memoization keyed by intersection facet sets, avoiding repeated recursive contractibility checks for the same intersection complex. Replaced repeated faces.remove(f) calls with a single filtered rebuild per pass (remove_set), which is cheaper for many removals. Kept the deterministic processing order (sorted(..., key=str)) and core acceptance criterion unchanged.

 Why this should be faster
The original algorithm repeatedly did:
full intersection recomputation for every facet on every pass repeated temporary simplicial-complex construction/contractibility checks for identical intersections quadratic-ish removals from Python lists
The new version reuses intersection state and memoized contractibility results, cutting redundant work significantly on larger complexes.

Please asign this to me.
