### PR TITLE
Work around random baum_welch() runtime errors

### DIFF
--- a/src/sage/stats/hmm/chmm.pyx
+++ b/src/sage/stats/hmm/chmm.pyx
@@ -910,8 +910,12 @@ cdef class GaussianHiddenMarkovModel(HiddenMarkovModel):
             sage: m.emission_parameters()
             [(-0.2663018798..., 1.0), (-1.99850979..., 1.0)]
 
-        We watch the log likelihoods of the model converge, step by step::
+        We watch the log likelihoods of the model converge, step by
+        step. We set the random seed beforehand so that the output is
+        predictable (and guaranteed to avoid random floating point
+        issues)::
 
+            sage: set_random_seed(0)
             sage: m = hmm.GaussianHiddenMarkovModel([[.1,.9],[.5,.5]],
             ....:                                   [(1,.5), (-1,3)],
             ....:                                   [.1,.9])
@@ -920,7 +924,7 @@ cdef class GaussianHiddenMarkovModel(HiddenMarkovModel):
             ....:                       for _ in range(len(v))])
             sage: all(l[i] <= l[i+1] + 0.0001 for i in range(9))
             True
-            sage: l  # random
+            sage: l
             [-20.1167, -17.7611, -16.9814, -16.9364, -16.9314,
              -16.9309, -16.9309, -16.9309, -16.9309, -16.9309]
 

--- a/src/sage/stats/hmm/chmm.pyx
+++ b/src/sage/stats/hmm/chmm.pyx
@@ -928,12 +928,14 @@ cdef class GaussianHiddenMarkovModel(HiddenMarkovModel):
             [-20.1167, -17.7611, -16.9814, -16.9364, -16.9314,
              -16.9309, -16.9309, -16.9309, -16.9309, -16.9309]
 
-        We illustrate fixing emissions::
+        We illustrate fixing emissions; again the random seed is fixed
+        to ensure that the output is what we expect it to be::
 
+            sage: set_random_seed(0)
             sage: m = hmm.GaussianHiddenMarkovModel([[.1,.9],[.9,.1]],
             ....:                                   [(1,2),(-1,.5)],
             ....:                                   [.3,.7])
-            sage: set_random_seed(0); v = m.sample(100)
+            sage: v = m.sample(100)
             sage: m.baum_welch(v,fix_emissions=True)
             (-164.72944548204..., 23)
             sage: m.emission_parameters()

--- a/src/sage/stats/hmm/chmm.pyx
+++ b/src/sage/stats/hmm/chmm.pyx
@@ -948,6 +948,28 @@ cdef class GaussianHiddenMarkovModel(HiddenMarkovModel):
             sage: m.emission_parameters()  # rel tol 3e-14
             [(1.2722419172602375, 2.371368751761901),
              (-0.9486174675179113, 0.5762360385123765)]
+
+        TESTS:
+
+        If your luck is bad enough to cause a :exc:`RuntimeError`,
+        re-sampling will fix it. This is a repeat of one of the
+        examples above, without the fixed random seed, but then
+        acknowledging that the algorithm can fail in rare cases::
+
+            sage: m = hmm.GaussianHiddenMarkovModel([[.1,.9],[.5,.5]],
+            ....:                                   [(1,.5), (-1,3)],
+            ....:                                   [.1,.9])
+            sage: v = m.sample(10)
+            sage: while True:
+            ....:     try:
+            ....:         l = stats.TimeSeries([m.baum_welch(v, max_iter=1)[0]
+            ....:                               for _ in range(len(v))])
+            ....:         break
+            ....:     except RuntimeError:
+            ....:         v = m.sample(10)
+            sage: all(l[i] <= l[i+1] + 0.0001 for i in range(9))
+            True
+
         """
         if not isinstance(obs, TimeSeries):
             obs = TimeSeries(obs)


### PR DESCRIPTION
Fix https://github.com/sagemath/sage/issues/33880

In the example, use a fixed random seed so that the output is nice and predictable. In a new test, leave the seed random, but expect a `RuntimeError` to happen and deal with it.
