### PR TITLE
Fix link to building Sage from source

### DIFF
--- a/src/doc/en/developer/walkthrough.rst
+++ b/src/doc/en/developer/walkthrough.rst
@@ -147,7 +147,7 @@ This will install Sage in the current Conda environment.
 You can then start Sage from the command line with ``sage``.
 
 For more information on building Sage we refer to the section `building
-from source <../installation/source.html>`_ in the Sage installation guide.
+from source <../installation/source.rst>`_ in the Sage installation guide.
 
 .. _section-walkthrough-branch:
 


### PR DESCRIPTION
Updated link to the Sage installation guide for building from source. It is actually an rst file

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


