### PR TITLE
Restore support for SAGE_DOCBUILD_OPTS

### DIFF
--- a/src/doc/en/installation/source-distro.rst
+++ b/src/doc/en/installation/source-distro.rst
@@ -987,9 +987,9 @@ Environment variables controlling the documentation build
 
 .. envvar:: SAGE_DOCBUILD_OPTS
 
-  The value of this variable is passed as an
-  argument to ``sage --docbuild all html`` or ``sage --docbuild all pdf`` when
-  you run ``make``, ``make doc``, or ``make doc-pdf``.  For example:
+  The contents of this variable are passed as additional arguments to
+  the documentation builder when you run ``make``, ``make doc``, or
+  ``make doc-pdf``.  For example:
 
   - add ``--no-plot`` to this variable to avoid building the graphics coming from
     the ``.. PLOT`` directive within the documentation,
@@ -997,7 +997,8 @@ Environment variables controlling the documentation build
   - add ``--include-tests-blocks`` to include all "TESTS" blocks in the reference
     manual.
 
-  Run ``sage --docbuild help`` to see the full list of options.
+  A full list of valid options can be found at the top of
+  ``src/sage_docbuild/__main__.py``.
 
 .. envvar:: SAGE_SPKG_INSTALL_DOCS
 

--- a/src/sage_docbuild/__main__.py
+++ b/src/sage_docbuild/__main__.py
@@ -444,9 +444,23 @@ class IntersphinxCache:
 
 
 def main():
+    # Before parsing the command line, insert SAGE_DOCBUILD_OPTS into
+    # the list of arguments.
+    docbuild_opts = os.getenv("SAGE_DOCBUILD_OPTS", "")
+
+    # Handle the empty strings that arise when SAGE_DOCBUILD_OPTS is
+    # unset, or when multiple spaces appear between e.g. --foo  --bar.
+    docbuild_args = [arg for arg in docbuild_opts.split(" ") if arg]
+
+    # Insert the SAGE_DOCBUILD_OPTS before the remaining args. This
+    # ensures that they are actually processed as options. Note: when
+    # the args passed to parse_args() are not implicit, they shouldn't
+    # include sys.argv[0].
+    all_args = docbuild_args + sys.argv[1:]
+
     # Parse the command-line.
     parser = setup_parser()
-    args: BuildOptions = parser.parse_args() # type: ignore
+    args: BuildOptions = parser.parse_args(all_args) # type: ignore
 
     # Check that the docs source directory exists
     if args.source_dir is None:


### PR DESCRIPTION
In the past, `SAGE_DOCBUILD_OPTS` was included on the command-line in most scenarios where the documentation build was invoked. At some point, this got lost. In an ideal future it will no longer be necessary, but right now, supporting it makes it easy for the CI to include TESTS blocks in the documentation.

In the docbuild's `main()`, we now prepend `SAGE_DOCBUILD_OPTS` to `sys.argv[1:]` before calling `parse_args()`. To convert the variable (a string) to a list, we split on whitespace. This isn't great, but it gets the job done in typical use cases. The "easy" way to accomplish this goal would be to insert `SAGE_DOCBUILD_OPTS` into the docbuild command in `src/doc/meson.build`, but the meson people feel rather strongly that you shouldn't be able to access environment variables within the build.

Closes: https://github.com/sagemath/sage/issues/41609

The main issue (for me) that this solves is the absence of the `TESTS` blocks in the documentation previews. A random documentation page where `TESTS` are visible:

* https://doc-pr-41776--sagemath.netlify.app/html/en/reference/quat_algebras/sage/algebras/quatalg/quaternion_algebra

And its counterpart in another open PR, with no `TESTS`:

* https://doc-pr-41768--sagemath.netlify.app/html/en/reference/quat_algebras/sage/algebras/quatalg/quaternion_algebra
