### PR TITLE
Handle symbolic matrix zeros conservatively

### DIFF
--- a/src/sage/matrix/args.pyx
+++ b/src/sage/matrix/args.pyx
@@ -913,8 +913,13 @@ cdef class MatrixArgs:
         for t in self.iter(convert, True):
             se = <SparseEntry>t
             x = se.entry
-            if x:
-                D[se.i, se.j] = x
+            try:
+                if x.is_trivial_zero():
+                    continue
+            except AttributeError:
+                if not x:
+                    continue
+            D[se.i, se.j] = x
         return D
 
     cpdef int set_column_keys(self, column_keys) except -1:

--- a/src/sage/matrix/matrix_generic_sparse.pyx
+++ b/src/sage/matrix/matrix_generic_sparse.pyx
@@ -189,7 +189,12 @@ cdef class Matrix_generic_sparse(matrix_sparse.Matrix_sparse):
         return bool(self._entries)
 
     cdef set_unsafe(self, Py_ssize_t i, Py_ssize_t j, value):
-        if not value:
+        try:
+            is_zero = value.is_trivial_zero()
+        except AttributeError:
+            is_zero = not value
+
+        if is_zero:
             try:
                 del self._entries[(i, j)]
             except KeyError:

--- a/src/sage/matrix/matrix_symbolic_dense.pyx
+++ b/src/sage/matrix/matrix_symbolic_dense.pyx
@@ -152,6 +152,17 @@ Check that :issue:`12778` is fixed::
     [                3  2.90000000000000               3/5               x^4]
     sage: parent(M)
     Full MatrixSpace of 3 by 4 dense matrices over Symbolic Ring
+
+Check that symbolic entries are not dropped from the support merely because
+assumptions make their truth value unreliable::
+
+    sage: var('a c')
+    (a, c)
+    sage: assume(c > 0)
+    sage: matrix(2, 2, [a/c, 0, 0, 1]).map_coefficients(lambda z: z + 1)
+    [a/c + 1       0]
+    [      0       2]
+    sage: forget()
 """
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.structure.factorization import Factorization
@@ -1002,13 +1013,7 @@ cdef class Matrix_symbolic_dense(Matrix_generic_dense):
             [1 1 1]
         """
         entry = self.get_unsafe(i, j)
-        # See if we can avoid the full proof machinery that the entry is 0
-        if entry.is_trivial_zero():
-            return 1
-        if entry:
-            return 0
-        else:
-            return 1
+        return entry.is_trivial_zero()
 
     def function(self, *args):
         """

--- a/src/sage/matrix/matrix_symbolic_sparse.pyx
+++ b/src/sage/matrix/matrix_symbolic_sparse.pyx
@@ -161,6 +161,22 @@ Check that :issue:`35653` is fixed::
     sage: M([[x,0],[0,x]]).inverse()
     [1/x   0]
     [  0 1/x]
+
+Check that symbolic entries are not dropped from sparse storage merely because
+assumptions make their truth value unreliable::
+
+    sage: var('a c')
+    (a, c)
+    sage: assume(c > 0)
+    sage: matrix(2, 2, [a/c, 0, 0, 1], sparse=True).map_coefficients(lambda z: z + 1)
+    [a/c + 1       0]
+    [      0       2]
+    sage: M = matrix(SR, 2, 2, sparse=True)
+    sage: M[0, 0] = a/c
+    sage: M
+    [a/c   0]
+    [  0   0]
+    sage: forget()
 """
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.structure.factorization import Factorization
@@ -1010,13 +1026,7 @@ cdef class Matrix_symbolic_sparse(Matrix_generic_sparse):
             [1 1 1]
         """
         entry = self.get_unsafe(i, j)
-        # See if we can avoid the full proof machinery that the entry is 0
-        if entry.is_trivial_zero():
-            return 1
-        if entry:
-            return 0
-        else:
-            return 1
+        return entry.is_trivial_zero()
 
     def function(self, *args):
         """


### PR DESCRIPTION
## Summary
Fix symbolic matrix support handling so entries are only dropped when they are trivially zero.
Fix #41777 Follow #41212
## What changed
- use `is_trivial_zero()` when extracting sparse matrix dictionaries in `MatrixArgs.dict()`
- use `is_trivial_zero()` when deciding whether sparse assignments should delete an entry
- make symbolic dense and sparse matrix zero checks conservative
- add regression doctests for the reported `assume(c > 0)` case

## Testing
- `./sage -t --long src/sage/matrix/matrix_symbolic_dense.pyx src/sage/matrix/matrix_symbolic_sparse.pyx`
