### PR TITLE
avoid isinstance(., CommutativeRing)

### DIFF
--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -2983,12 +2983,10 @@ cdef class FrobeniusEndomorphism_generic(RingHomomorphism):
             Frobenius endomorphism x |--> x^(5^2) of Power Series Ring in u
              over Finite Field of size 5
         """
-        from sage.rings.ring import CommutativeRing
         from sage.categories.commutative_rings import CommutativeRings
         from sage.categories.homset import Hom
-        if not (domain in CommutativeRings() or
-                isinstance(domain, CommutativeRing)):  # TODO: remove this line
-            raise TypeError("The base ring must be a commutative ring")
+        if domain not in CommutativeRings():
+            raise TypeError("the base ring must be a commutative ring")
         self._p = domain.characteristic()
         if not self._p.is_prime():
             raise TypeError("the characteristic of the base ring must be prime")

--- a/src/sage/schemes/weighted_projective/weighted_projective_point.py
+++ b/src/sage/schemes/weighted_projective/weighted_projective_point.py
@@ -25,6 +25,7 @@ from sage.misc.misc_c import prod
 from sage.structure.richcmp import op_EQ, op_NE, richcmp
 
 from sage.categories.fields import Fields
+from sage.categories.commutative_rings import CommutativeRings
 from sage.misc.latex import latex
 from sage.rings.fraction_field import FractionField
 from sage.schemes.generic.morphism import SchemeMorphism, SchemeMorphism_point
@@ -87,13 +88,12 @@ class SchemeMorphism_point_weighted_projective_ring(SchemeMorphism_point):
             if not isinstance(X, SchemeHomset_points_weighted_projective_ring):
                 raise TypeError(f"ambient space {X} must be a weighted projective space")
 
-            from sage.rings.ring import CommutativeRing
             d = X.codomain().ambient_space().ngens()
             if isinstance(v, SchemeMorphism):
                 v = list(v)
             else:
                 try:
-                    if isinstance(v.parent(), CommutativeRing):
+                    if v.parent() in CommutativeRings():
                         v = [v]
                 except AttributeError:
                     pass


### PR DESCRIPTION
as another little step towards getting rid of the auld class `CommutativeRing`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.

