### PR TITLE
Drop obsolete test that fails with ipython 9.10

### DIFF
--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -119,8 +119,7 @@ line::
     sage: from sage.repl.interpreter import get_test_shell
     sage: shell = get_test_shell()
     sage: shell.run_cell('sage: a = 123')              # single line
-    sage: shell.run_cell('sage: a = [\n... 123]')      # old-style multi-line
-    sage: shell.run_cell('sage: a = [\n....: 123]')    # new-style multi-line
+    sage: shell.run_cell('sage: a = [\n....: 123]')    # multi-line
 
 We test that :issue:`16196` is resolved::
 


### PR DESCRIPTION
This test for the old multi-line prompt is no longer relevant and fails with ipython 9.10

