### PR TITLE
Sort divisor points

### DIFF
--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -1634,7 +1634,7 @@ class ProjectiveCurve_field(ProjectiveCurve, AlgebraicScheme_subscheme_projectiv
 
             sage: P2.<x,y,z> = ProjectiveSpace(QQ, 2)
             sage: C = Curve(x^2 + y^2)
-            sage: C.genus()  # indirect test
+            sage: C.genus()  # indirect doctest
             -1
         """
         return self.defining_ideal().genus()
@@ -2131,6 +2131,19 @@ class ProjectivePlaneCurve_finite_field(ProjectivePlaneCurve_field):
             sage: D = C.divisor([ (3, pts[0]), (-1,pts[1]), (10, pts[5]) ])
             sage: C.riemann_roch_basis(D)
             [(-2*x + y)/(x + y), (-x + z)/(x + y)]
+
+        TESTS:
+
+        We check that issue:`41793` is fixed:
+
+            sage: F = GF(13)
+            sage: PP.<X,Y,Z> = PolynomialRing(F,3)
+            sage: F = Y^2*Z - X^3 - X*Z^2
+            sage: C = Curve(F)
+            sage: Points = C.rational_points()
+            sage: G = C.divisor([(1, Points[0]), (3, Points[0])])
+            sage: C.riemann_roch_basis(G)
+            [1, Z/X, Y*Z/X^2, Z^2/X^2]
 
         .. NOTE::
 

--- a/src/sage/schemes/generic/divisor.py
+++ b/src/sage/schemes/generic/divisor.py
@@ -339,7 +339,13 @@ class Divisor_curve(Divisor_generic):
 
         if know_points:
             self._points = points
-            self._sort_points()
+        else:
+            # TODO: in the next line, we should probably replace
+            # rational_points() with irreducible_components()
+            # once Sage can deal with divisors that are not only
+            # rational points (see trac #16225)
+            self._points = [(m, self.scheme().ambient_space().subscheme(p).rational_points()[0]) for (m, p) in self]
+        self._sort_points()
 
     def _repr_(self):
         r"""
@@ -427,17 +433,7 @@ class Divisor_curve(Divisor_generic):
         try:
             return self._support
         except AttributeError:
-            try:
-                pts = self._points
-            except AttributeError:
-                # TODO: in the next line, we should probably replace
-                # rational_points() with irreducible_components()
-                # once Sage can deal with divisors that are not only
-                # rational points (see trac #16225)
-                self._points = [(m, self.scheme().ambient_space().subscheme(p).rational_points()[0]) for (m, p) in self]
-                self._sort_points()
-                pts = self._points
-            self._support = [s[1] for s in pts]
+            self._support = [s[1] for s in self._points]
             return self._support
 
     def coefficient(self, P):

--- a/src/sage/schemes/generic/divisor.py
+++ b/src/sage/schemes/generic/divisor.py
@@ -41,6 +41,8 @@ EXAMPLES::
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
+from bisect import bisect_left
+
 from sage.misc.latex import latex
 from sage.misc.lazy_import import lazy_import
 from sage.misc.repr import repr_lincomb
@@ -337,6 +339,7 @@ class Divisor_curve(Divisor_generic):
 
         if know_points:
             self._points = points
+            self._sort_points()
 
     def _repr_(self):
         r"""
@@ -351,6 +354,40 @@ class Divisor_curve(Divisor_generic):
             '(x, y)'
         """
         return repr_lincomb([(tuple(I.gens()), c) for c, I in self])
+
+    def _sort_points(self):
+        """
+        Sort the list of the points of this divisor, and combine duplicates if
+        needed.
+
+        EXAMPLES::
+
+            sage: F = GF(13)
+            sage: PP.<X,Y,Z> = PolynomialRing(F,3)
+            sage: F = Y^2*Z - X^3 - X*Z^2
+            sage: C = Curve(F)
+            sage: Points = C.rational_points()
+            sage: G = C.divisor([(1, Points[0]), (3, Points[0])])
+            sage: G.support()  # indirect doctest
+            [(0 : 0 : 1)]
+            sage: G = C.divisor([(3, Points[1]), (1, Points[0])])
+            sage: G.support()  # indirect doctest
+            [(0 : 0 : 1), (0 : 1 : 0)]
+        """
+        sorted_points = []
+        for coefficient, point in self._points:
+            try:
+                position = bisect_left(sorted_points, point, key=lambda l: l[1])
+            except TypeError:
+                # Some sets of points cannot be sorted, ignore
+                return
+            if position == len(sorted_points):
+                sorted_points.append([coefficient, point])
+            elif sorted_points[position][1] != point:
+                sorted_points.insert(position, [coefficient, point])
+            else:
+                sorted_points[position][0] += coefficient
+        self._points = [tuple(l) for l in sorted_points]
 
     def support(self) -> list:
         """
@@ -398,6 +435,7 @@ class Divisor_curve(Divisor_generic):
                 # once Sage can deal with divisors that are not only
                 # rational points (see trac #16225)
                 self._points = [(m, self.scheme().ambient_space().subscheme(p).rational_points()[0]) for (m, p) in self]
+                self._sort_points()
                 pts = self._points
             self._support = [s[1] for s in pts]
             return self._support
@@ -421,6 +459,15 @@ class Divisor_curve(Divisor_generic):
             3
             sage: D.coefficient(pts[1])
             -1
+
+            sage: F = GF(13)
+            sage: PP.<X,Y,Z> = PolynomialRing(F,3)
+            sage: F = Y^2*Z - X^3 - X*Z^2
+            sage: C = Curve(F)
+            sage: Points = C.rational_points()
+            sage: G = C.divisor([(1, Points[0]), (3, Points[0])])
+            sage: G.coefficient(Points[0])
+            4
         """
         P = self.parent().scheme()(P)
         if P not in self.support():

--- a/src/sage/schemes/generic/divisor.py
+++ b/src/sage/schemes/generic/divisor.py
@@ -468,12 +468,15 @@ class Divisor_curve(Divisor_generic):
             sage: G = C.divisor([(1, Points[0]), (3, Points[0])])
             sage: G.coefficient(Points[0])
             4
+            sage: G.coefficient(Points[1])
+            0
         """
         P = self.parent().scheme()(P)
         if P not in self.support():
             return self.base_ring().zero()
         t, i = search(self.support(), P)
-        assert t
+        if not t:
+            return Integer(0)
         try:
             return self._points[i][0]
         except AttributeError:


### PR DESCRIPTION
Fixes #41793.

In the aforementioned bug, an error is raised when one wants to access to the coefficient of a divisor on a curve. This happens because the method to get this coefficient assumes that the list is sorted, but it is not always the case.

It turns out that not sorting the list of points led to other unwanted behaviours, such as the following one:
```
F = GF(13)

PP.<X,Y,Z> = PolynomialRing(F,3)
F = Y^2*Z - X^3 - X*Z^2
C = Curve(F)
Points = C.rational_points()

G = C.divisor([(1, Points[0]), (3,Points[0])])

print(G.coefficient(Points[0])) # Prints 1
```

This PR fixes all of these bugs, assuming the set of points can be sorted.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.