### PR TITLE
Add --disable-system-packages configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -469,6 +469,12 @@ AC_ARG_ENABLE([download-from-upstream-url],
     [AS_VAR_SET([enable_download_from_upstream_url], [yes])])
 
 AC_ARG_ENABLE(
+  [system-packages], [AS_HELP_STRING(
+    [--disable-system-packages],
+    [do not use any system packages; build everything from source (default: enabled)]
+  )])
+
+AC_ARG_ENABLE(
   [system-site-packages], [AS_HELP_STRING(
     [--enable-system-site-packages],
     [allow the use of python packages from the system (experimental; default: no)]

--- a/configure.ac
+++ b/configure.ac
@@ -468,11 +468,19 @@ AC_ARG_ENABLE([download-from-upstream-url],
     [disallow downloading packages from their upstream URL if they cannot be found on the Sage mirrors])], [],
     [AS_VAR_SET([enable_download_from_upstream_url], [yes])])
 
-AC_ARG_ENABLE(
-  [system-packages], [AS_HELP_STRING(
-    [--disable-system-packages],
-    [do not use any system packages; build everything from source (default: enabled)]
-  )])
+AC_ARG_WITH(
+  [system-standard-packages], [AS_HELP_STRING(
+    [--with-system-standard-packages={yes (default),no,force}],
+    [set the default for using system packages for all standard SPKGs:
+     yes = use system packages when suitable (default),
+     no = build everything from source,
+     force = require system packages (error if not found).
+     Individual --with-system-SPKG flags override this setting.]
+  )], [
+    AS_CASE([$withval],
+      [yes|no|force], [],
+      [AC_MSG_ERROR([Invalid value '$withval' for --with-system-standard-packages (use yes, no, or force)])])
+  ], [with_system_standard_packages=yes])
 
 AC_ARG_ENABLE(
   [system-site-packages], [AS_HELP_STRING(

--- a/m4/sage_spkg_configure.m4
+++ b/m4/sage_spkg_configure.m4
@@ -95,15 +95,17 @@ AC_ARG_WITH([system-]SPKG_NAME,
 
 AS_VAR_SET([sage_spkg_name], SPKG_NAME)
 
-dnl Default value for most packages
-dnl If --disable-system-packages was given, default to building from source,
-dnl but only if the package actually has source to build (checksums.ini or package-version.txt).
+dnl Default value for most packages.
+dnl If --with-system-standard-packages={no,force} was given, apply it to
+dnl standard packages that have buildable source (checksums.ini or package-version.txt).
 dnl Packages without source (like iconv) can only come from the system.
 AS_VAR_SET_IF([SPKG_USE_SYSTEM], [], [
-    AS_IF([test "$enable_system_packages" = "no" \
+    AS_IF([test "$with_system_standard_packages" != "yes" \
+           -a -f "${SAGE_ROOT}/build/pkgs/$1/type" \
+           -a x"`cat "${SAGE_ROOT}/build/pkgs/$1/type"`" = x"standard" \
            -a \( -f "${SAGE_ROOT}/build/pkgs/$1/checksums.ini" \
                  -o -f "${SAGE_ROOT}/build/pkgs/$1/package-version.txt" \)],
-        [AS_VAR_SET([SPKG_USE_SYSTEM], [no])],
+        [AS_VAR_SET([SPKG_USE_SYSTEM], [$with_system_standard_packages])],
         [AS_VAR_SET([SPKG_USE_SYSTEM], [yes])])])
 
 dnl The default is not to install a package, unless a check below finds that we should.

--- a/m4/sage_spkg_configure.m4
+++ b/m4/sage_spkg_configure.m4
@@ -96,7 +96,11 @@ AC_ARG_WITH([system-]SPKG_NAME,
 AS_VAR_SET([sage_spkg_name], SPKG_NAME)
 
 dnl Default value for most packages
-AS_VAR_SET_IF([SPKG_USE_SYSTEM], [], [AS_VAR_SET([SPKG_USE_SYSTEM], [yes])])
+dnl If --disable-system-packages was given, default to building from source
+AS_VAR_SET_IF([SPKG_USE_SYSTEM], [], [
+    AS_IF([test "$enable_system_packages" = "no"],
+        [AS_VAR_SET([SPKG_USE_SYSTEM], [no])],
+        [AS_VAR_SET([SPKG_USE_SYSTEM], [yes])])])
 
 dnl The default is not to install a package, unless a check below finds that we should.
 AS_VAR_SET(SPKG_INSTALL, [no])

--- a/m4/sage_spkg_configure.m4
+++ b/m4/sage_spkg_configure.m4
@@ -96,9 +96,13 @@ AC_ARG_WITH([system-]SPKG_NAME,
 AS_VAR_SET([sage_spkg_name], SPKG_NAME)
 
 dnl Default value for most packages
-dnl If --disable-system-packages was given, default to building from source
+dnl If --disable-system-packages was given, default to building from source,
+dnl but only if the package actually has source to build (checksums.ini or package-version.txt).
+dnl Packages without source (like iconv) can only come from the system.
 AS_VAR_SET_IF([SPKG_USE_SYSTEM], [], [
-    AS_IF([test "$enable_system_packages" = "no"],
+    AS_IF([test "$enable_system_packages" = "no" \
+           -a \( -f "${SAGE_ROOT}/build/pkgs/$1/checksums.ini" \
+                 -o -f "${SAGE_ROOT}/build/pkgs/$1/package-version.txt" \)],
         [AS_VAR_SET([SPKG_USE_SYSTEM], [no])],
         [AS_VAR_SET([SPKG_USE_SYSTEM], [yes])])])
 

--- a/src/doc/en/installation/source-distro.rst
+++ b/src/doc/en/installation/source-distro.rst
@@ -90,6 +90,17 @@ missing or have unsuitable versions. **Please read the messages that
 you can install to avoid having to build them from source. This can save a lot of
 time.
 
+If you prefer a fully self-contained installation that does not depend on
+any system packages (for example, on shared servers where system updates
+should not affect Sage), you can use::
+
+    $ ./configure --disable-system-packages
+
+This tells ``configure`` to build all dependencies from source. Individual
+packages can still be overridden, for example::
+
+    $ ./configure --disable-system-packages --with-system-gmp=yes
+
 The following sections provide the commands to install a large
 recommended set of packages on various systems, which will minimize
 the time it takes to build Sage. This is intended as a convenient

--- a/src/doc/en/installation/source-distro.rst
+++ b/src/doc/en/installation/source-distro.rst
@@ -94,12 +94,17 @@ If you prefer a fully self-contained installation that does not depend on
 any system packages (for example, on shared servers where system updates
 should not affect Sage), you can use::
 
-    $ ./configure --disable-system-packages
+    $ ./configure --with-system-standard-packages=no
 
-This tells ``configure`` to build all dependencies from source. Individual
-packages can still be overridden, for example::
+This tells ``configure`` to build all standard dependencies from source.
+Individual packages can still be overridden, for example::
 
-    $ ./configure --disable-system-packages --with-system-gmp=yes
+    $ ./configure --with-system-standard-packages=no --with-system-gmp=yes
+
+Conversely, if you want to require that all standard packages come from the
+system (and error out if any are missing), use::
+
+    $ ./configure --with-system-standard-packages=force
 
 The following sections provide the commands to install a large
 recommended set of packages on various systems, which will minimize


### PR DESCRIPTION
Add a global  --with-system-standard-packages={yes,no,force} flag to ./configure that sets the default for all --with-system-SPKG options to "yes", "no", or "yes" and fail if impossible.

This is useful for creating fully self-contained installations that are immune to system library updates (e.g., on shared servers where an apt upgrade can break a working Sage install).

Individual overrides still work, e.g.:
  ./configure --with-system-standard-packages=no --with-system-gmp=yes

Resolves https://github.com/sagemath/sage/issues/33345
### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.



