### PR TITLE
Add --enable-march-native configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -392,6 +392,21 @@ AX_PROG_PERL_VERSION([5.8.0],[],[
 
 # Save compiler flags as configured by the user.
 # We have to redo this, because otherwise `AC_PROG_CC` will just overwrite them.
+
+AC_ARG_ENABLE(
+  [march-native], [AS_HELP_STRING(
+    [--enable-march-native],
+    [compile with -march=native to optimize for the current CPU (default: disabled)]
+  )])
+
+AS_IF([test "$enable_march_native" = "yes"], [
+    CFLAGS="${CFLAGS} -march=native"
+    CXXFLAGS="${CXXFLAGS} -march=native"
+    FCFLAGS="${FCFLAGS} -march=native"
+    F77FLAGS="${F77FLAGS} -march=native"
+    AC_MSG_NOTICE([Compiling with -march=native])
+])
+
 AC_SUBST(CFLAGS, "$CFLAGS")
 AC_SUBST(CXXFLAGS, "$CXXFLAGS")
 AC_SUBST(FCFLAGS, "$FCFLAGS")


### PR DESCRIPTION
Add a convenience flag to compile Sage and all its dependencies with -march=native, optimizing for the build machine's CPU (e.g., AVX-512).

This appends -march=native to CFLAGS, CXXFLAGS, FCFLAGS, and F77FLAGS before any compiler checks, so it applies to all SPKGs built from source.

This is equivalent to manually setting:
  CFLAGS="-march=native" CXXFLAGS="-march=native" ./configure
but more discoverable and less error-prone.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


