### PR TITLE
Add example to term() method docstring"

### DIFF
--- a/src/sage/combinat/free_module.py
+++ b/src/sage/combinat/free_module.py
@@ -1098,6 +1098,10 @@ class CombinatorialFreeModule(UniqueRepresentation, Module, IndexedGenerators):
             sage: F.term('a')
             B['a']
 
+            sage: F = CombinatorialFreeModule(QQ, ['a','b'])
+            sage: F.term('b',5)
+            5*B['b']
+
         Design: should this do coercion on the coefficient ring?
         """
         if coeff is None:


### PR DESCRIPTION
additional doctest examples for CombinatorialFreeModule.term().

This PR improves the documentation by including an example that explicitly shows how to construct a basis element with a specified coefficient using term().

The new example demonstrates:

creating a free module with a named basis

constructing a term using term(index, coeff)

the resulting module element

These examples help clarify the intended usage of term() for users working with combinatorial free modules.

All doctests pass locally.
