### PR TITLE
'Add input validation to term() method"

### DIFF
--- a/src/sage/combinat/free_module.py
+++ b/src/sage/combinat/free_module.py
@@ -1100,8 +1100,12 @@ class CombinatorialFreeModule(UniqueRepresentation, Module, IndexedGenerators):
 
         Design: should this do coercion on the coefficient ring?
         """
+        if index not in self._indices:
+            raise ValueError("index {} is not in the basis".format(index))
+
         if coeff is None:
             coeff = self.base_ring().one()
+
         return self._from_dict({index: coeff})
 
     def _monomial(self, index):


### PR DESCRIPTION
def term(self, index, coeff=None):
    if index not in self._indices:
        raise ValueError("index {} is not in the basis".format(index))

    if coeff is None:
        coeff = self.base_ring().one()

    return self._from_dict({index: coeff})


