### PR TITLE
Replace assert with explicit TypeError in _from_dict()

### DIFF
--- a/src/sage/combinat/free_module.py
+++ b/src/sage/combinat/free_module.py
@@ -1254,7 +1254,10 @@ class CombinatorialFreeModule(UniqueRepresentation, Module, IndexedGenerators):
                 sage: list(s._from_dict({part: 0}, remove_zeros=False))                 # needs sage.combinat
                 [([2, 1], 0)]
         """
-        assert isinstance(d, dict)
+        if not isinstance(d, dict):
+            raise TypeError(
+                "expected a dictionary mapping basis indices to coefficients"
+            )
         if coerce:
             R = self.base_ring()
             d = {key: R(coeff) for key, coeff in d.items()}


### PR DESCRIPTION
Currently, _from_dict() verifies that the input is a dictionary by using assert isinstance(d, dict). However, assertions can be disabled when Python is executed with optimization flags, which means this validation step may be skipped entirely.

To make the behavior more reliable, this PR replaces the assertion with an explicit TypeError. This ensures that invalid input is always rejected, regardless of how Python is run, and improves the overall robustness of the function.


