### PR TITLE
src/sage/**/*.py: use `delete_on_close=False` for temporary files

### DIFF
--- a/src/sage/doctest/util.py
+++ b/src/sage/doctest/util.py
@@ -164,20 +164,20 @@ class Timer:
             sage: from tempfile import NamedTemporaryFile
             sage: from os import unlink
             sage: from sage.doctest.util import Timer
-            sage: with NamedTemporaryFile(delete=False, mode="w") as f:
+            sage: with NamedTemporaryFile(mode="w", delete_on_close=False) as f:
             ....:     _ = f.write("1 2 3 4 5")
-            sage: cputime = Timer()._proc_stat_cpu_seconds(f.name)
+            ....:     f.close()
+            ....:     cputime = Timer()._proc_stat_cpu_seconds(f.name)
             Traceback (most recent call last):
             ...
             OSError: unable to parse ...
-            sage: os.unlink(f.name)
-            sage: with NamedTemporaryFile(delete=False, mode="w") as f:
+            sage: with NamedTemporaryFile(mode="w", delete_on_close=False) as f:
             ....:     _ = f.write("1 2 3 4 5 6 7 8 9 10 11 12 w x y z 17")
-            sage: cputime = Timer()._proc_stat_cpu_seconds(f.name)
+            ....:     f.close()
+            ....:     cputime = Timer()._proc_stat_cpu_seconds(f.name)
             Traceback (most recent call last):
             ...
             OSError: unable to parse ...
-            sage: os.unlink(f.name)
 
         """
         try:

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -254,15 +254,15 @@ class BipartiteGraph(Graph):
     #. From an alist file::
 
          sage: import tempfile
-         sage: with tempfile.NamedTemporaryFile(mode='w+t') as f:
+         sage: with tempfile.NamedTemporaryFile(mode='w+t', delete_on_close=False) as f:
          ....:     _ = f.write("7 4 \n 3 4 \n 3 3 1 3 1 1 1 \n\
          ....:                  3 3 3 4 \n 1 2 4 \n 1 3 4 \n 1 0 0 \n\
          ....:                  2 3 4 \n 2 0 0 \n 3 0 0 \n 4 0 0 \n\
          ....:                  1 2 3 0 \n 1 4 5 0 \n 2 4 6 0 \n\
          ....:                  1 2 4 7 \n")
-         ....:     f.flush()
+         ....:     f.close()
          ....:     B = BipartiteGraph(f.name)
-         sage: B.is_isomorphic(H)                                                       # needs sage.modules
+         sage: B.is_isomorphic(H)
          True
 
     #. From a ``graph6`` string::
@@ -1748,13 +1748,13 @@ class BipartiteGraph(Graph):
         EXAMPLES::
 
             sage: import tempfile
-            sage: with tempfile.NamedTemporaryFile(mode='w+t') as f:
+            sage: with tempfile.NamedTemporaryFile(mode='w+t', delete_on_close=False) as f:
             ....:     _ = f.write("7 4 \n 3 4 \n 3 3 1 3 1 1 1 \n\
             ....:                 3 3 3 4 \n 1 2 4 \n 1 3 4 \n\
             ....:                 1 0 0 \n 2 3 4 \n 2 0 0 \n 3 0 0 \n\
             ....:                 4 0 0 \n 1 2 3 0 \n 1 4 5 0 \n\
             ....:                 2 4 6 0 \n 1 2 4 7 \n")
-            ....:     f.flush()
+            ....:     f.close()
             ....:     B = BipartiteGraph()
             ....:     B2 = BipartiteGraph(f.name)
             ....:     B.load_afile(f.name)
@@ -1844,7 +1844,7 @@ class BipartiteGraph(Graph):
             [1 1 0 1 0 0 1]
             sage: b = BipartiteGraph(M)
             sage: import tempfile
-            sage: with tempfile.NamedTemporaryFile() as f:
+            sage: with tempfile.NamedTemporaryFile(delete_on_close=False) as f:
             ....:     b.save_afile(f.name)
             ....:     b2 = BipartiteGraph(f.name)
             sage: b.is_isomorphic(b2)
@@ -1853,27 +1853,27 @@ class BipartiteGraph(Graph):
         TESTS::
 
             sage: import tempfile
-            sage: f = tempfile.NamedTemporaryFile()
-            sage: for order in range(3, 13, 3):                                         # needs sage.combinat
-            ....:     num_chks = int(order / 3)
-            ....:     num_vars = order - num_chks
-            ....:     partition = (list(range(num_vars)), list(range(num_vars, num_vars+num_chks)))
-            ....:     for idx in range(100):
-            ....:         g = graphs.RandomGNP(order, 0.5)
-            ....:         try:
-            ....:             b = BipartiteGraph(g, partition, check=False)
-            ....:             b.save_afile(f.name)
-            ....:             b2 = BipartiteGraph(f.name)
-            ....:             if not b.is_isomorphic(b2):
-            ....:                 print("Load/save failed for code with edges:")
-            ....:                 print(b.edges(sort=True))
-            ....:                 break
-            ....:         except Exception:
-            ....:             print("Exception encountered for graph of order "+ str(order))
-            ....:             print("with edges: ")
-            ....:             g.edges(sort=True)
-            ....:             raise
-            sage: f.close()  # this removes the file
+            sage: with tempfile.NamedTemporaryFile(delete_on_close=False) as f:
+            ....:     for order in range(3, 13, 3):
+            ....:         num_chks = int(order / 3)
+            ....:         num_vars = order - num_chks
+            ....:         partition = (list(range(num_vars)), list(range(num_vars, num_vars+num_chks)))
+            ....:         for idx in range(100):
+            ....:             g = graphs.RandomGNP(order, 0.5)
+            ....:             try:
+            ....:                 b = BipartiteGraph(g, partition, check=False)
+            ....:                 b.save_afile(f.name)
+            ....:                 b2 = BipartiteGraph(f.name)
+            ....:                 if not b.is_isomorphic(b2):
+            ....:                     print("Load/save failed for code with edges:")
+            ....:                     print(b.edges(sort=True))
+            ....:                     break
+            ....:             except Exception:
+            ....:                 print("Exception encountered for graph of order "+ str(order))
+            ....:                 print("with edges: ")
+            ....:                 g.edges(sort=True)
+            ....:                 raise
+
         """
         # open the file
         try:

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -23718,7 +23718,7 @@ class GenericGraph(GenericGraph_pyx):
             ....:            2: {0: None, 1: None, 3: 'foo'}, 3: {2: 'foo'}},
             ....:           sparse=True)
             sage: import tempfile
-            sage: with tempfile.NamedTemporaryFile(mode='a+t') as f:
+            sage: with tempfile.NamedTemporaryFile(mode='a+t', delete_on_close=False) as f:
             ....:     G.graphviz_to_file_named(f.name, edge_labels=True)
             ....:     print(f.read())
             graph {

--- a/src/sage/rings/polynomial/msolve.py
+++ b/src/sage/rings/polynomial/msolve.py
@@ -48,19 +48,19 @@ def _run_msolve(ideal, options):
 
     drlpolring = ideal.ring().change_ring(order='degrevlex')
     polys = ideal.change_ring(drlpolring).gens()
-    msolve_in = tempfile.NamedTemporaryFile(mode='w',
-                                            encoding='ascii', delete=False)
-    command = [msolve().absolute_filename(), "-f", msolve_in.name] + options
-    try:
+    with tempfile.NamedTemporaryFile(mode='w',
+                                     encoding='ascii',
+                                     delete_on_close=False) as msolve_in:
         print(",".join(drlpolring.variable_names()), file=msolve_in)
         print(base.characteristic(), file=msolve_in)
         print(*(pol._repr_().replace(" ", "") for pol in polys),
                 sep=',\n', file=msolve_in)
         msolve_in.close()
-        msolve_out = subprocess.run(command, capture_output=True, text=True)
-    finally:
-        os.unlink(msolve_in.name)
-    msolve_out.check_returncode()
+        command = [msolve().absolute_filename(), "-f", msolve_in.name] + options
+        msolve_out = subprocess.run(command,
+                                    capture_output=True,
+                                    text=True)
+        msolve_out.check_returncode()
 
     return msolve_out.stdout
 


### PR DESCRIPTION
Python 3.12, which is now our minimum required version, introduced the `delete_on_close=False` parameter for [named temporary files](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile). We add it in a few places, and replace `delete=False` by it in a few others. This should increase portability and readability:

* Reopening a tempfile on Windows is not guaranteed to work, but with `delete=True` (the default) and `delete_on_close=False`, we can just close the file before reopening it. In earlier pythons, there was no way to do this without deleting the file.
* In general this allows us to write/close/reopen a tempfile all within a context manager, rather than by setting delete=False and doing the cleanup ourselves.

This certainly isn't all of the places that could benefit from such a change, but these are the ones that I've been made aware of or were amenable to grep.
