### PR TITLE
allow GCC version 16

### DIFF
--- a/build/pkgs/gcc/spkg-configure.m4
+++ b/build/pkgs/gcc/spkg-configure.m4
@@ -165,8 +165,8 @@ SAGE_SPKG_CONFIGURE_BASE([gcc], [
                     # Install our own GCC if the system-provided one is older than gcc 8.4
                     SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_VERSION, which is quite old])
                 ],
-                [1[[6-9]].*], [
-                    # Install our own GCC if the system-provided one is newer than 15.x.
+                [1[[7-9]].*], [
+                    # Install our own GCC if the system-provided one is newer than 16.x.
                     # See https://github.com/sagemath/sage/issues/29456
                     SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_VERSION, which is too recent for this version of Sage])
                 ])

--- a/build/pkgs/gfortran/spkg-configure.m4
+++ b/build/pkgs/gfortran/spkg-configure.m4
@@ -86,8 +86,8 @@ SAGE_SPKG_CONFIGURE([gfortran], [
                         # Install our own gfortran if the system-provided one is older than gcc-4.8.
                         SAGE_SHOULD_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is quite old])
                     ],
-                    [1[[6-9]].*], [
-                        # Install our own gfortran if the system-provided one is newer than 15.x.
+                    [1[[7-9]].*], [
+                        # Install our own gfortran if the system-provided one is newer than 16.x.
                         # See https://github.com/sagemath/sage/issues/29456, https://github.com/sagemath/sage/issues/31838
                         SAGE_MUST_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is too recent for this version of Sage])
                     ])


### PR DESCRIPTION
distributions start experimenting with gcc 16 (not yet realeased officially).
See https://groups.google.com/g/sage-support/c/qhKqeBs9AH8/m/8ShQ7NiXAQAJ
gcc 16 appears to be able to build Sage just fine, so there is no reason to block it.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


