### PR TITLE
Implement SVD-based rank for RDF and CDF matrices

### DIFF
--- a/src/sage/matrix/matrix_double_dense.pyx
+++ b/src/sage/matrix/matrix_double_dense.pyx
@@ -1735,6 +1735,33 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
         X._matrix_numpy = arr
         return X
 
+    def rank(self, eps='auto'):
+        r"""
+        Return the numerical rank of this matrix.
+
+        The rank is computed using the Singular Value Decomposition (SVD),
+        which is much more stable for floating-point numbers than 
+        Gaussian elimination.
+
+        INPUT:
+
+        - ``eps`` -- (default: ``'auto'``) a threshold below which 
+          singular values are considered zero. 
+
+        EXAMPLES::
+
+            sage: # This matrix is mathematically rank 1
+            sage: m = matrix(RDF, [[1.5, 1.75], [1.5, 1.75]])
+            sage: m.rank()
+            1
+        """
+        # We use the singular_values method already defined in this file.
+        # It already handles the 'auto' logic and NumPy conversion.
+        sv = self.singular_values(eps=eps)
+        
+        # Count how many singular values are NOT zero
+        return len([s for s in sv if s > 0])
+
     def determinant(self):
         """
         Return the determinant of ``self``.


### PR DESCRIPTION
This PR implements a dedicated `rank` method for `Matrix_double_dense` (Real Double Field and Complex Double Field matrices).

Currently, the rank of these matrices is often calculated via Gaussian elimination, which is numerically unstable for floating-point arithmetic. This leads to incorrect results where nearly-singular matrices are reported as full rank due to precision errors.

Key Changes:

Added a new `rank` method to `src/sage/matrix/matrix_double_dense.pyx`.

The method utilizes the existing `singular_values()` function (based on NumPy/SciPy SVD).

It includes an `eps='auto'` parameter to allow for a tolerance threshold when determining which singular values are effectively zero.

Why is this change required?
Floating-point matrices require a tolerance-based approach to rank. SVD is the industry-standard method for this because it provides a reliable spectrum of the matrix's "energy." Using SVD ensures that SageMath provides accurate results for numerical linear algebra tasks, matching the behavior of other mature systems like MATLAB or NumPy.

Fixes #7392


