### PR TITLE
Fix oddity in formatting string inside `get_coercion_model().analyse()`.

### DIFF
--- a/src/sage/structure/coerce.pyx
+++ b/src/sage/structure/coerce.pyx
@@ -969,7 +969,7 @@ cdef class CoercionModel:
 
         all = []
         if xp is yp:
-            all.append("Identical parents, arithmetic performed immediately." % xp)
+            all.append("Identical parents, arithmetic performed immediately.")
             if op is truediv and isinstance(xp, Parent):
                 xp = self.division_parent(xp)
             return all, xp


### PR DESCRIPTION
The trivial code below was choking on that particular line not converting all its arguments. It's indeed visibly wrong.

```
sage: from sage.structure.element import get_coercion_model
sage: get_coercion_model().analyse(int(1), int(1))
[...]
TypeError: not all arguments converted during string formatting
```