### PR TITLE
Move references from finite_state_machine, rigged_configurations, tutorial, words to master bibliography

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -83,6 +83,10 @@ REFERENCES:
              Combinatorica vol 27, num 3, p253--267, 2007.
              :doi:`10.1007/s00493-007-2086-y`.
 
+.. [AC03] \B. Adamczewski, J. Cassaigne, On the transcendence of real
+          numbers with a regular expansion, J. Number Theory 103 (2003)
+          27--37.
+
 .. [AC1994] \R.J.R. Abel and Y.W. Cheng,
             Some new MOLS of order 2np for p a prime power,
             The Australasian Journal of Combinatorics, vol 10 (1994)
@@ -594,6 +598,13 @@ REFERENCES:
             Springer, 2012,
             http://homepages.cwi.nl/~aeb/math/ipm/ipm.pdf
             :doi:`10.1007/978-1-4614-1939-6`
+
+.. [BmBGL07] \A. Blondin-Massé, S. Brlek, A. Glen, and S. Labbé. On the
+             critical exponent of generalized Thue-Morse words. *Discrete Math.
+             Theor. Comput.  Sci.* 9 (1):293--304, 2007.
+
+.. [BmBGL09] \A. Blondin-Massé, S. Brlek, A. Garon, and S. Labbé. Christoffel
+             and Fibonacci Tiles, DGCI 2009, Montreal, to appear in LNCS.
 
 .. [BMFPR2011] \M. Bousquet-Mélou, É. Fusy, L.-F. Préville-Ratelle,
                 *The number of intervals in the m-Tamari lattices*.
@@ -1890,6 +1901,11 @@ REFERENCES:
              of the Advanced Encryption Standard*; Springer Verlag
              2006
 
+.. [CMS2012] Alexandre Casamayou, Nathann Cohen, Guillaume Connan, Thierry
+             Dumont, Laurent Fousse, François Maltey, Matthias Meulien, Marc Mezzarobba,
+             Clément Pernet, Nicolas M. Thiéry, Paul Zimmermann *Calcul Mathématique avec
+             Sage* https://www.sagemath.org/sagebook/french.html
+
 .. [CMT2003] \A. M. Cohen, S. H. Murray, D. E. Talyor.
              *Computing in groups of Lie type*.
              Mathematics of Computation. **73** (2003), no 247. pp. 1477--1498.
@@ -2809,6 +2825,9 @@ REFERENCES:
              Springer Verlag. V. Berthé, S. Ferenczi, C. Mauduit
              and A. Siegel, Eds.  (2002).
 
+.. [Fogg] Pytheas Fogg,
+          https://www.lirmm.fr/arith/wiki/PytheasFogg/S-adiques.
+
 .. [Fom1994] Sergey V. Fomin, *Duality of graded graphs*. Journal of
              Algebraic Combinatorics Volume 3, Number 4 (1994),
              pp. 357-404.
@@ -3475,6 +3494,16 @@ REFERENCES:
 .. [HKP2010] \T. J. Haines, R. E. Kottwitz, A. Prasad, Iwahori-Hecke
              Algebras, J. Ramanujan Math. Soc., 25 (2010),
              113--145. :arxiv:`0309168v3` :mathscinet:`MR2642451`
+
+.. [HKP2015] Clemens Heuberger, Sara Kropf, and Helmut Prodinger,
+             *Output sum of transducers: Limiting distribution and periodic
+             fluctuation*,
+             `Electron. J. Combin. 22 (2015), #P2.19 <http://www.combinatorics.org/ojs/index.php/eljc/article/view/v22i2p19>`_.
+
+.. [HKW2015] Clemens Heuberger, Sara Kropf and Stephan Wagner,
+             *Variances and Covariances in the Central Limit Theorem for the Output
+             of a Transducer*, European J. Combin. 49 (2015), 167-187,
+             :doi:`10.1016/j.ejc.2015.03.004`.
 
 .. [HL1999] \L. Heath and N. Loehr (1999).  New algorithms for
             generating Conway polynomials over finite fields.
@@ -4715,6 +4744,10 @@ REFERENCES:
 .. [Lot2005] \M. Lothaire, *Applied combinatorics on
              words*. Cambridge University Press (2005).
 
+.. [Loth02] \M. Lothaire, Algebraic Combinatorics On Words, vol. 90 of
+            Encyclopedia of Mathematics and its Applications, Cambridge
+            University Press, U.K., 2002.
+            
 .. [Lov1979] László Lovász,
              *On the Shannon capacity of a graph*,
              IEEE Trans. Inf. Th. 25(1979), 1-7.
@@ -5560,6 +5593,10 @@ REFERENCES:
              SIAM ALENEX, 2009: 52-61
              :doi:`10.1137/1.9781611972894.5`
 
+.. [OSS13] Masato Okado, Reiho Sakamoto, and Anne Schilling.
+           *Affine crystal structure on rigged configurations of type* `D_n^{(1)}`.
+           J. Algebraic Combinatorics, **37** (2013). 571-599. :arxiv:`1109.3523`.
+
 .. [Oum2009] Sang-il Oum,
              *Computing rank-width exactly*,
              Information Processing Letters, 2009,
@@ -5823,6 +5860,10 @@ REFERENCES:
               *Alley CATs in search of good homes.*
               Congressus numerantium, 1994.
               Pages 97--110
+
+.. [RC-MLT] Ben Salisbury and Travis Scrimshaw. *Connecting marginally
+            large tableaux and rigged configurations via crystals*.
+            Preprint. :arxiv:`1505.07040`.
 
 .. [Rea1968] Ronald C. Read,
              An improved method for computing the chromatic polynomials of sparse graphs,

--- a/src/sage/combinat/finite_state_machine.py
+++ b/src/sage/combinat/finite_state_machine.py
@@ -863,6 +863,7 @@ See also methods :meth:`Automaton.process` and
 :class:`FSMTransition`, and the description and examples in
 :class:`FSMProcessIterator` for more information on processing and
 hooks.
+
 AUTHORS:
 
 - Daniel Krenn (2012-03-27): initial version

--- a/src/sage/combinat/finite_state_machine.py
+++ b/src/sage/combinat/finite_state_machine.py
@@ -863,19 +863,6 @@ See also methods :meth:`Automaton.process` and
 :class:`FSMTransition`, and the description and examples in
 :class:`FSMProcessIterator` for more information on processing and
 hooks.
-
-REFERENCES:
-
-.. [HKP2015] Clemens Heuberger, Sara Kropf, and Helmut Prodinger,
-   *Output sum of transducers: Limiting distribution and periodic
-   fluctuation*,
-   `Electron. J. Combin. 22 (2015), #P2.19 <http://www.combinatorics.org/ojs/index.php/eljc/article/view/v22i2p19>`_.
-
-.. [HKW2015] Clemens Heuberger, Sara Kropf and Stephan Wagner,
-   *Variances and Covariances in the Central Limit Theorem for the Output
-   of a Transducer*, European J. Combin. 49 (2015), 167-187,
-   :doi:`10.1016/j.ejc.2015.03.004`.
-
 AUTHORS:
 
 - Daniel Krenn (2012-03-27): initial version

--- a/src/sage/combinat/rigged_configurations/bij_infinity.py
+++ b/src/sage/combinat/rigged_configurations/bij_infinity.py
@@ -5,12 +5,6 @@ Bijection between rigged configurations for `B(\infty)` and marginally large tab
 AUTHORS:
 
 - Travis Scrimshaw (2015-07-01): Initial version
-
-REFERENCES:
-
-.. [RC-MLT] Ben Salisbury and Travis Scrimshaw. *Connecting marginally
-   large tableaux and rigged configurations via crystals*.
-   Preprint. :arxiv:`1505.07040`.
 """
 
 # ****************************************************************************

--- a/src/sage/combinat/rigged_configurations/kr_tableaux.py
+++ b/src/sage/combinat/rigged_configurations/kr_tableaux.py
@@ -12,13 +12,6 @@ rigged configurations [RigConBijection]_.
 
 For more information, see :class:`~sage.combinat.rigged_configurations.kr_tableaux.KirillovReshetikhinTableaux`
 and :class:`~sage.combinat.rigged_configurations.tensor_product_kr_tableaux.TensorProductOfKirillovReshetikhinTableaux`.
-
-REFERENCES:
-
-.. [OSS13] Masato Okado, Reiho Sakamoto, and Anne Schilling.
-   *Affine crystal structure on rigged configurations of type* `D_n^{(1)}`.
-   J. Algebraic Combinatorics, **37** (2013). 571-599. :arxiv:`1109.3523`.
-
 AUTHORS:
 
 - Travis Scrimshaw (2012-01-03): initial version

--- a/src/sage/combinat/rigged_configurations/kr_tableaux.py
+++ b/src/sage/combinat/rigged_configurations/kr_tableaux.py
@@ -12,6 +12,7 @@ rigged configurations [RigConBijection]_.
 
 For more information, see :class:`~sage.combinat.rigged_configurations.kr_tableaux.KirillovReshetikhinTableaux`
 and :class:`~sage.combinat.rigged_configurations.tensor_product_kr_tableaux.TensorProductOfKirillovReshetikhinTableaux`.
+
 AUTHORS:
 
 - Travis Scrimshaw (2012-01-03): initial version

--- a/src/sage/combinat/tutorial.py
+++ b/src/sage/combinat/tutorial.py
@@ -1836,7 +1836,7 @@ etc. This can be applied to generate:
 -  lattices (not implemented in ``Sage``), via the bijection with the
    meet semi-lattice obtained by deleting the maximal vertex; in this
    case an augmentation by vertices rather than by edges is used.
-   
+
 .. [1]
    Or at least that should be the case; there are still many corners to
    clean up.

--- a/src/sage/combinat/tutorial.py
+++ b/src/sage/combinat/tutorial.py
@@ -1836,14 +1836,6 @@ etc. This can be applied to generate:
 -  lattices (not implemented in ``Sage``), via the bijection with the
    meet semi-lattice obtained by deleting the maximal vertex; in this
    case an augmentation by vertices rather than by edges is used.
-
-REFERENCES:
-
-.. [CMS2012] Alexandre Casamayou, Nathann Cohen, Guillaume Connan, Thierry
-   Dumont, Laurent Fousse, François Maltey, Matthias Meulien, Marc Mezzarobba,
-   Clément Pernet, Nicolas M. Thiéry, Paul Zimmermann *Calcul Mathématique avec
-   Sage* https://www.sagemath.org/sagebook/french.html
-
 .. [1]
    Or at least that should be the case; there are still many corners to
    clean up.

--- a/src/sage/combinat/tutorial.py
+++ b/src/sage/combinat/tutorial.py
@@ -1836,6 +1836,7 @@ etc. This can be applied to generate:
 -  lattices (not implemented in ``Sage``), via the bijection with the
    meet semi-lattice obtained by deleting the maximal vertex; in this
    case an augmentation by vertices rather than by edges is used.
+   
 .. [1]
    Or at least that should be the case; there are still many corners to
    clean up.

--- a/src/sage/combinat/words/word_generators.py
+++ b/src/sage/combinat/words/word_generators.py
@@ -14,27 +14,6 @@ USE:
 To see a list of all word constructors, type ``words.`` and then press
 the :kbd:`Tab` key. The documentation for each constructor includes
 information about each word, which provides a useful reference.
-
-REFERENCES:
-
-.. [AC03] \B. Adamczewski, J. Cassaigne, On the transcendence of real
-   numbers with a regular expansion, J. Number Theory 103 (2003)
-   27--37.
-
-.. [BmBGL07] \A. Blondin-Massé, S. Brlek, A. Glen, and S. Labbé. On the
-   critical exponent of generalized Thue-Morse words. *Discrete Math.
-   Theor. Comput.  Sci.* 9 (1):293--304, 2007.
-
-.. [BmBGL09] \A. Blondin-Massé, S. Brlek, A. Garon, and S. Labbé. Christoffel
-   and Fibonacci Tiles, DGCI 2009, Montreal, to appear in LNCS.
-
-.. [Loth02] \M. Lothaire, Algebraic Combinatorics On Words, vol. 90 of
-   Encyclopedia of Mathematics and its Applications, Cambridge
-   University Press, U.K., 2002.
-
-.. [Fogg] Pytheas Fogg,
-   https://www.lirmm.fr/arith/wiki/PytheasFogg/S-adiques.
-
 EXAMPLES::
 
     sage: t = words.ThueMorseWord(); t


### PR DESCRIPTION
"Move references from combinat files to master bibliography

Migrates local references from tutorial.py, finite_state_machine.py,
words/word_generators.py, rigged_configurations/bij_infinity.py,
and rigged_configurations/kr_tableaux.py.

Part of sagemath#28445"