### PR TITLE
Removed shutil.which() and added some features

### DIFF
--- a/src/sage/interfaces/phc.py
+++ b/src/sage/interfaces/phc.py
@@ -919,9 +919,7 @@ class PHC:
         if e:
             from sage.features import Executable
             phc_executable = Executable(name='phc', executable='phc')
-            if not phc_executable.is_present():
-                print(str(os.system('which phc')) + '  PHC needs to be installed and in your path')
-                raise RuntimeError
+            phc_executable.require()
             # todo -- why? etc.
             with open(log_filename) as f:
                 msg = f.read()

--- a/src/sage/interfaces/phc.py
+++ b/src/sage/interfaces/phc.py
@@ -917,8 +917,9 @@ class PHC:
 
         # Was there an error?
         if e:
-            from shutil import which
-            if not which('phc'):
+            from sage.features import Executable
+            phc_executable = Executable(name='phc', executable='phc')
+            if not phc_executable.is_present():
                 print(str(os.system('which phc')) + '  PHC needs to be installed and in your path')
                 raise RuntimeError
             # todo -- why? etc.

--- a/src/sage/misc/viewer.py
+++ b/src/sage/misc/viewer.py
@@ -26,6 +26,7 @@ Functions and classes
 """
 
 import platform
+from sage.features import Executable
 from sage.structure.sage_object import SageObject
 
 
@@ -55,7 +56,15 @@ def default_viewer(viewer=None):
         ValueError: Unknown type of viewer: jpg.
     """
     import os
-    from shutil import which
+
+    executable_features = {}
+
+    def executable_is_present(cmd):
+        feature = executable_features.get(cmd)
+        if feature is None:
+            feature = Executable(name=cmd, executable=cmd)
+            executable_features[cmd] = feature
+        return feature.is_present()
 
     if isinstance(viewer, str):
         viewer = viewer.lower()
@@ -74,7 +83,7 @@ def default_viewer(viewer=None):
         PDF_VIEWER = BROWSER
         PNG_VIEWER = BROWSER
 
-    elif which('xdg-open'):
+    elif executable_is_present('xdg-open'):
         # On other OS'es try xdg-open if present.
         # See http://portland.freedesktop.org/xdg-utils-1.0.
         BROWSER = 'xdg-open'
@@ -89,7 +98,7 @@ def default_viewer(viewer=None):
         except KeyError:
             BROWSER = 'less'  # silly default; lets hope it doesn't come to this!
             for cmd in ['firefox', 'konqueror', 'mozilla', 'mozilla-firefox']:
-                if which(cmd):
+                if executable_is_present(cmd):
                     BROWSER = cmd
                     break
         DVI_VIEWER = BROWSER
@@ -101,14 +110,14 @@ def default_viewer(viewer=None):
             DVI_VIEWER = os.environ['DVI_VIEWER']
         except KeyError:
             for cmd in ['xdvi', 'kdvi']:
-                if which(cmd):
+                if executable_is_present(cmd):
                     DVI_VIEWER = cmd
                     break
         try:
             PDF_VIEWER = os.environ['PDF_VIEWER']
         except KeyError:
             for cmd in ['acroread', 'xpdf']:
-                if which(cmd):
+                if executable_is_present(cmd):
                     PDF_VIEWER = cmd
                     break
 

--- a/src/sage/repl/ipython_kernel/install.py
+++ b/src/sage/repl/ipython_kernel/install.py
@@ -261,15 +261,16 @@ class SageKernelSpec:
                           'check your Jupyter configuration '
                           '(see https://docs.jupyter.org/en/latest/use/jupyter-directories.html).')
         else:
-            import shutil
             import sys
             from pathlib import Path
-            kernel_executable = shutil.which(spec.argv[0])
-            if not kernel_executable:
+            from sage.features import Executable
+            kernel_executable_feature = Executable(name=spec.argv[0], executable=spec.argv[0])
+            if not kernel_executable_feature.is_present():
                 warnings.warn(f'The kernel named {ident} does not seem to be runnable; '
                               'check your Jupyter configuration '
                               '(see https://docs.jupyter.org/en/latest/use/jupyter-directories.html).')
                 return
+            kernel_executable = kernel_executable_feature.absolute_filename()
             if Path(kernel_executable).resolve() != Path(sys.executable).resolve():
                 warnings.warn(f'The kernel named {ident} does not seem to correspond to this '
                               'installation of SageMath; check your Jupyter configuration '


### PR DESCRIPTION
## Modified files

src/sage/misc/viewer.py
src/sage/interfaces/phc.py
src/sage/repl/ipython_kernel/install.py

## What changed

- Switched checks like which("...") to Executable(name="...", executable="...").is_present(). Added from sage.features import Executable where needed.
- In default_viewer, added a small per-call cache of Executable objects so repeated command checks reuse objects instead of recreating them.
- In kernel spec validation, replaced shutil.which(spec.argv[0]) with an Executable feature object and used it for presence check + resolved executable path. 
- In PHC error handling, replaced which('phc') with Executable(...).is_present() while keeping existing error behavior/messages unchanged. Verification

fixes #41808 