### PR TITLE
Changed old docs link to the current one (../meson.html to ../source.html).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,7 @@ if test "$enable_meson_check" != no; then
   AC_MSG_CHECKING([for Arch Linux])
   if grep -qi 'arch' /etc/os-release 2>/dev/null || test -f /etc/arch-release; then
     AC_MSG_RESULT([yes])
-    AC_MSG_ERROR([Building on Arch Linux using make is not recommended. Please use Meson as described at https://doc.sagemath.org/html/en/installation/meson.html. Use --disable-meson-check to override.])
+    AC_MSG_ERROR([Building on Arch Linux using make is not recommended. Please use Meson as described at https://doc.sagemath.org/html/en/installation/source.html. Use --disable-meson-check to override.])
   else
     AC_MSG_RESULT([no])
   fi


### PR DESCRIPTION
When trying to build on Arch Linux using ``make configure`` and then ``./configure`` (as described in the README https://github.com/sagemath/sage?tab=readme-ov-file#instructions-to-build-from-source) you run into an error: "Building on Arch Linux using make is not recommended. Please use Meson as described at https://doc.sagemath.org/html/en/installation/meson.html". But this address returns 404. What I believe this was changed into is "../source.html" by comparing some (hard to find) old documentations of SageMath, found for example here: https://doc-10-7--sagemath.netlify.app/html/en/installation/meson.html .

I have changed the "configure.ac" file which, I think, is the correct place for that, although I was not able to confirm that -- the only confirmation I got is that the error message is correct with this commit. 
Regardless, the above error message has been changed to point to the more recent URL.

The change is not required for anything but it is in good fashion to point to existing urls when displaying an error message.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

c: documentation
