### PR TITLE
Move local bibliography refs from combinat/designs files to master bibliography

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -87,6 +87,11 @@ REFERENCES:
             Some new MOLS of order 2np for p a prime power,
             The Australasian Journal of Combinatorics, vol 10 (1994)
 
+.. [AC07] \R. Julian R. Abel and Nicholas Cavenagh,
+          *Concerning eight mutually orthogonal latin squares*,
+          J. Combin. Des. 15 (2007), no. 3, 255-261,
+          :doi:`10.1002/jcd.20121`
+
 .. [ACFLSS04] \F. N. Abu-Khzam, R. L. Collins, M. R. Fellows, M. A.  Langston,
               \W. H. Suters, and C. T. Symons: Kernelization Algorithm for the
               Vertex Cover Problem: Theory and Experiments. *SIAM
@@ -283,6 +288,11 @@ REFERENCES:
 .. [AN2023] Alex Abreu and Antonio Nigro. *Splitting the cohomology of Hessenberg
             varieties and e-positivity of chromatic symmetric functions*.
             Preprint (2023). :arxiv:`2304.10644`.
+
+.. [AndHonk97] A short course in Combinatorial Designs,
+               Ian Anderson, Iiro Honkala,
+               Internet Editions, Spring 1997,
+               http://www.utu.fi/~honkala/designs.ps
 
 .. [Ang1997] \B. Anglès. 1997. *On some characteristic polynomials attached to
              finite Drinfeld modules.* manuscripta mathematica 93, 1 (01 Aug 1997),
@@ -974,6 +984,11 @@ REFERENCES:
                    \T. Peyrin, Y. Sasaki, P. Sasdrich, and S. M. Sim,
                    *The SKINNY family of block ciphers and its low-latency
                    variant MANTIS*; in CRYPTO, (2016), pp. 123-153.
+
+.. [BJL99] \T. Beth, D. Jungnickel, H. Lenz,
+           Design Theory 2ed.
+           Cambridge University Press
+           1999
 
 .. [BK1973] Coen Bron and Joep Kerbosch. *Algorithm 457:
             Finding All Cliques of an Undirected Graph*. Commun. ACM. v
@@ -1829,6 +1844,10 @@ REFERENCES:
 .. [CL2023] Xavier Caruso and Antoine Leudière.
             *Algorithms for computing norms and characteristic polynomials on general Drinfeld modules*, (2023) :arxiv:`2307.02879`.
 
+.. [ClaytonSmith] On the existence of `(v,5,1)`-BIBD.
+                  http://www.argilo.net/files/bibd.pdf
+                  Clayton Smith
+
 .. [Cle1872] Alfred Clebsch, *Theorie der binären algebraischen Formen*,
              Teubner, 1872.
 
@@ -1961,6 +1980,12 @@ REFERENCES:
 .. [Col2013] Julia Collins. *An algorithm for computing the Seifert
              matrix of a link from a braid
              representation*. (2013). https://ensaios.sbm.org.br/wp-content/uploads/sites/8/sites/8/2021/11/EM_30_Collins-1.pdf
+
+.. [ColDin01] Charles Colbourn, Jeffrey Dinitz,
+              *Mutually orthogonal latin squares: a brief survey of constructions*,
+              Volume 95, Issues 1-2, Pages 9-48,
+              Journal of Statistical Planning and Inference,
+              Springer, 1 May 2001.
 
 .. [Com2019] Camille Combe, *Réalisation cubique du poset des
              intervalles de Tamari*, preprint :arxiv:`1904.00658`
@@ -2135,6 +2160,9 @@ REFERENCES:
              and Intersection Algorithms. SIAM Journal on Computing
              1986 15:4, 948-957.
 
+- [CvL] P. Cameron, J. H. van Lint, Designs, graphs, codes and
+        their links, London Math. Soc., 1991.
+
 .. [CVV2019] Xavier Caruso, Tristan Vaccon and Thibaut Verron,
              *Gröbner bases over Tate algebras*, :arxiv:`1901.09574` (2019)
 
@@ -2251,6 +2279,11 @@ REFERENCES:
 .. [Den2012] Tom Denton. Canonical Decompositions of Affine Permutations,
              Affine Codes, and Split `k`-Schur Functions.  Electronic Journal of
              Combinatorics, 2012.
+
+.. [Denniston69] \R. H. F. Denniston,
+                 Some maximal arcs in finite projective planes.
+                 Journal of Combinatorial Theory 6, no. 3 (1969): 317-319.
+                 :doi:`10.1016/S0021-9800(69)80095-5`
 
 .. [Deo1987a] \V. Deodhar, A splitting criterion for the Bruhat
               orderings on Coxeter groups. Comm. Algebra,
@@ -3706,6 +3739,9 @@ REFERENCES:
 .. [Humphreys08] James E. Humphreys. *Representations of Semisimple Lie
                  Algebras in the BGG Category* `\mathcal{O}`.
                  Graduate Studies in Mathematics. Amer. Math. Soc., 2008.
+
+.. [Hu57] Daniel R. Hughes, "A class of non-Desarguesian projective planes",
+          The Canadian Journal of Mathematics (1957), http://cms.math.ca/cjm/v9/p378
 
 .. [Hutz2007] \B. Hutz. Arithmetic *Dynamics on Varieties of dimension greater
               than one*. Ph.D. Thesis, Brown University 2007
@@ -5824,6 +5860,11 @@ REFERENCES:
               Congressus numerantium, 1994.
               Pages 97--110
 
+.. [RCW71] \D. K. Ray-Chaudhuri, R. M. Wilson,
+           Solution of Kirkman's schoolgirl problem,
+           Volume 19, Pages 187-203,
+           Proceedings of Symposia in Pure Mathematics
+
 .. [Rea1968] Ronald C. Read,
              An improved method for computing the chromatic polynomials of sparse graphs,
              Research Report CORR 87-20, C & O Dept. Univ. of Waterloo, 1987.
@@ -6494,6 +6535,16 @@ REFERENCES:
 .. [Sti2006] Douglas R. Stinson. *Cryptography: Theory and
              Practice*. 3rd edition, Chapman \& Hall/CRC, 2006.
 
+.. [Stinson91] \D.R. Stinson,
+               A survey of Kirkman triple systems and related designs,
+               Volume 92, Issues 1-3, 17 November 1991, Pages 371-393,
+               Discrete Mathematics,
+               :doi:`10.1016/0012-365X(91)90294-C`
+
+.. [Stinson2004] Douglas R. Stinson,
+                 *Combinatorial designs: construction and analysis*,
+                 Springer, 2004.
+
 .. [Stokes1990] Timothy Stokes. *Gröbner bases in exterior algebra*.
                 J. Automat. Reason. **6** (1990) 233-250.
 
@@ -6983,6 +7034,9 @@ REFERENCES:
 .. [WC2007] \R.A. Walker II, and C.J. Colbourn, *Perfect Hash Families:
              Constructions and Existence*. J. Math. Crypt. 1 (2007),
              pp.125-150
+
+.. [We07] Charles Weibel, "Survey of Non-Desarguesian planes" (2007), notices of
+          the AMS, vol. 54 num. 10, pages 1294--1303
 
 .. [Web2007] James Webb. *Game theory: decisions, interaction and
              Evolution*. Springer Science & Business Media, 2007.

--- a/src/sage/combinat/designs/bibd.py
+++ b/src/sage/combinat/designs/bibd.py
@@ -40,12 +40,6 @@ possible cases of `(v,4,1)`-BIBD.
 
 Decompositions of `K_v` into `K_4` (i.e. `(v,4,1)`-BIBD) are built following
 Clayton Smith's construction [ClaytonSmith]_.
-
-.. [ClaytonSmith] On the existence of `(v,5,1)`-BIBD.
-  http://www.argilo.net/files/bibd.pdf
-  Clayton Smith
-
-
 Functions
 ---------
 """
@@ -479,13 +473,6 @@ def steiner_triple_system(n):
         Traceback (most recent call last):
         ...
         EmptySetError: Steiner triple systems only exist for n = 1 mod 6 or n = 3 mod 6
-
-    REFERENCE:
-
-    .. [AndHonk97] A short course in Combinatorial Designs,
-      Ian Anderson, Iiro Honkala,
-      Internet Editions, Spring 1997,
-      http://www.utu.fi/~honkala/designs.ps
     """
 
     name = "Steiner Triple System on "+str(n)+" elements"
@@ -1347,13 +1334,6 @@ def BIBD_from_arc_in_desarguesian_projective_plane(n, k, existence=False):
         Traceback (most recent call last):
         ...
         ValueError: This function cannot produce a (7,3,1)-BIBD
-
-    REFERENCE:
-
-    .. [Denniston69] \R. H. F. Denniston,
-       Some maximal arcs in finite projective planes.
-       Journal of Combinatorial Theory 6, no. 3 (1969): 317-319.
-       :doi:`10.1016/S0021-9800(69)80095-5`
     """
     q = (n-1)//(k-1)-1
     if (k % 2 or

--- a/src/sage/combinat/designs/block_design.py
+++ b/src/sage/combinat/designs/block_design.py
@@ -5,22 +5,12 @@ Block designs
 A *block design* is a set together with a family of subsets (repeated subsets
 are allowed) whose members are chosen to satisfy some set of properties that are
 deemed useful for a particular application. See :wikipedia:`Block_design`.
-
-REFERENCES:
-
 - Block design from wikipedia: :wikipedia:`Block_design`
 
 - What is a block design?,
   http://designtheory.org/library/extrep/extrep-1.1-html/node4.html (in 'The
   External Representation of Block Designs' by Peter J. Cameron, Peter
   Dobcsanyi, John P. Morgan, Leonard H. Soicher)
-
-.. [Hu57] Daniel R. Hughes, "A class of non-Desarguesian projective planes",
-   The Canadian Journal of Mathematics (1957), http://cms.math.ca/cjm/v9/p378
-
-.. [We07] Charles Weibel, "Survey of Non-Desarguesian planes" (2007), notices of
-   the AMS, vol. 54 num. 10, pages 1294--1303
-
 AUTHORS:
 
 - Quentin Honoré (2015): construction of Hughes plane :issue:`18527`
@@ -989,11 +979,6 @@ def HadamardDesign(n):
         [5 5 5 5 5 5 5 5 5 5 5]
         [5 5 5 5 5 5 5 5 5 5 5]
         [5 5 5 5 5 5 5 5 5 5 5]
-
-    REFERENCES:
-
-    - [CvL] P. Cameron, J. H. van Lint, Designs, graphs, codes and
-      their links, London Math. Soc., 1991.
     """
     from sage.combinat.matrices.hadamard_matrix import hadamard_matrix
     from sage.matrix.constructor import matrix
@@ -1050,12 +1035,6 @@ def Hadamard3Design(n):
         [2 2 0 2 2 2 2 2 2 2 2 4 2 2]
         [2 0 2 2 2 2 2 2 2 2 2 2 4 2]
         [0 2 2 2 2 2 2 2 2 2 2 2 2 4]
-
-
-    REFERENCES:
-
-    .. [CvL] \P. Cameron, J. H. van Lint, Designs, graphs, codes and
-      their links, London Math. Soc., 1991.
     """
     if n == 1 or n == 4:
         raise ValueError("The Hadamard design with n = %s does not extend to a three design." % n)

--- a/src/sage/combinat/designs/block_design.py
+++ b/src/sage/combinat/designs/block_design.py
@@ -12,6 +12,7 @@ deemed useful for a particular application. See :wikipedia:`Block_design`.
   http://designtheory.org/library/extrep/extrep-1.1-html/node4.html (in 'The
   External Representation of Block Designs' by Peter J. Cameron, Peter
   Dobcsanyi, John P. Morgan, Leonard H. Soicher)
+
 AUTHORS:
 
 - Quentin Honoré (2015): construction of Hughes plane :issue:`18527`

--- a/src/sage/combinat/designs/block_design.py
+++ b/src/sage/combinat/designs/block_design.py
@@ -5,6 +5,7 @@ Block designs
 A *block design* is a set together with a family of subsets (repeated subsets
 are allowed) whose members are chosen to satisfy some set of properties that are
 deemed useful for a particular application. See :wikipedia:`Block_design`.
+
 - Block design from wikipedia: :wikipedia:`Block_design`
 
 - What is a block design?,

--- a/src/sage/combinat/designs/latin_squares.py
+++ b/src/sage/combinat/designs/latin_squares.py
@@ -106,6 +106,7 @@ Comparison with the results from the Handbook of Combinatorial Designs (2ed)
 .. TODO::
 
     Look at [ColDin01]_.
+
 Functions
 ---------
 """

--- a/src/sage/combinat/designs/latin_squares.py
+++ b/src/sage/combinat/designs/latin_squares.py
@@ -106,19 +106,6 @@ Comparison with the results from the Handbook of Combinatorial Designs (2ed)
 .. TODO::
 
     Look at [ColDin01]_.
-
-REFERENCES:
-
-.. [Stinson2004] Douglas R. Stinson,
-  *Combinatorial designs: construction and analysis*,
-  Springer, 2004.
-
-.. [ColDin01] Charles Colbourn, Jeffrey Dinitz,
-  *Mutually orthogonal latin squares: a brief survey of constructions*,
-  Volume 95, Issues 1-2, Pages 9-48,
-  Journal of Statistical Planning and Inference,
-  Springer, 1 May 2001.
-
 Functions
 ---------
 """

--- a/src/sage/combinat/designs/orthogonal_arrays_find_recursive.pyx
+++ b/src/sage/combinat/designs/orthogonal_arrays_find_recursive.pyx
@@ -33,15 +33,6 @@ obtain an `OA(k,n)`.
     :func:`find_three_factor_product` | Find `n_1n_2n_3=n` to obtain an `OA(k,n)` by the three-factor product from [DukesLing14]_
     :func:`find_brouwer_separable_design` | Find `t(q^2+q+1)+x=n` to obtain an `OA(k,n)` by Brouwer's separable design construction.
     :func:`find_brouwer_van_rees_with_one_truncated_column` | Find `rm+x_1+...+x_c=n` such that the Brouwer-van Rees constructions yields a `OA(k,n)`.
-
-REFERENCES:
-
-.. [AC07] Concerning eight mutually orthogonal latin squares
-  Julian R. Abel, Nicholas Cavenagh
-  Journal of Combinatorial Designs
-  Vol. 15, n.3, pp. 255-261
-  2007
-
 Functions
 ---------
 """

--- a/src/sage/combinat/designs/resolvable_bibd.py
+++ b/src/sage/combinat/designs/resolvable_bibd.py
@@ -26,6 +26,7 @@ The main function of this module is
     :func:`v_4_1_rbibd` | Return a `(v,4,1)`-RBIBD
     :func:`PBD_4_7` | Return a `(v,\{4,7\})`-PBD
     :func:`PBD_4_7_from_Y` | Return a `(3v+1,\{4,7\})`-PBD from a `(v,\{4,5,7\},\NN-\{3,6,10\})`-GDD.
+
 Functions
 ---------
 """

--- a/src/sage/combinat/designs/resolvable_bibd.py
+++ b/src/sage/combinat/designs/resolvable_bibd.py
@@ -26,25 +26,6 @@ The main function of this module is
     :func:`v_4_1_rbibd` | Return a `(v,4,1)`-RBIBD
     :func:`PBD_4_7` | Return a `(v,\{4,7\})`-PBD
     :func:`PBD_4_7_from_Y` | Return a `(3v+1,\{4,7\})`-PBD from a `(v,\{4,5,7\},\NN-\{3,6,10\})`-GDD.
-
-References:
-
-.. [Stinson91] \D.R. Stinson,
-   A survey of Kirkman triple systems and related designs,
-   Volume 92, Issues 1-3, 17 November 1991, Pages 371-393,
-   Discrete Mathematics,
-   :doi:`10.1016/0012-365X(91)90294-C`
-
-.. [RCW71] \D. K. Ray-Chaudhuri, R. M. Wilson,
-   Solution of Kirkman's schoolgirl problem,
-   Volume 19, Pages 187-203,
-   Proceedings of Symposia in Pure Mathematics
-
-.. [BJL99] \T. Beth, D. Jungnickel, H. Lenz,
-   Design Theory 2ed.
-   Cambridge University Press
-   1999
-
 Functions
 ---------
 """


### PR DESCRIPTION
Part of #28445. Moves locally-defined bibliography references from:
- src/sage/combinat/designs/bibd.py
- src/sage/combinat/designs/block_design.py
- src/sage/combinat/designs/latin_squares.py
- src/sage/combinat/designs/orthogonal_arrays_find_recursive.pyx
- src/sage/combinat/designs/resolvable_bibd.py

into the centralized master bibliography at src/doc/en/reference/references/index.rst.


