### PR TITLE
Fix #36662: add fricas to default integrator priority list

### DIFF
--- a/src/sage/symbolic/integration/integral.py
+++ b/src/sage/symbolic/integration/integral.py
@@ -89,6 +89,7 @@ class IndefiniteIntegral(BuiltinFunction):
         # (unevaluated) answer if libgiac is unavailable. This essentially
         # causes it to be skipped.
         self.integrators = [external.maxima_integrator,
+                            external.fricas_integrator,
                             external.libgiac_integrator,
                             external.sympy_integrator]
 
@@ -222,6 +223,7 @@ class DefiniteIntegral(BuiltinFunction):
         # a global variable in this module to enable customization by
         # creating a subclasses which define a different set of integrators
         self.integrators = [external.maxima_integrator,
+                            external.fricas_integrator,
                             external.libgiac_integrator,
                             external.sympy_integrator]
 


### PR DESCRIPTION
FriCAS was not included in the default integrator list, causing
integral() to run for a long time without returning an output.

Note: this commit does not address the simplification of the 
complex output that integral() still returns. That remains 
a separate issue to be fixed.