### PR TITLE
combinat/sf/schur: add verschiebung doctests for s([]) and s[1]

### DIFF
--- a/src/sage/combinat/sf/schur.py
+++ b/src/sage/combinat/sf/schur.py
@@ -501,6 +501,10 @@ class SymmetricFunctionAlgebra_schur(classical.SymmetricFunctionAlgebra_classica
                 s[]
                 sage: s([]).verschiebung(4)
                 s[]
+                sage: s([]).verschiebung(2)
+                s[]
+                sage: s[1].verschiebung(2)
+                0                
 
             TESTS:
 


### PR DESCRIPTION
Adds two additional doctest examples to the `verschiebung` method in `SymmetricFunctionAlgebra_schur.Element`:

- `s([]).verschiebung(2)` returns `s[]` (the empty partition is fixed by all Verschiebung operators, as it is the identity element)
- `s[1].verschiebung(2)` returns `0` (vanishes because 2 does not divide 1, consistent with the documented behaviour)

These examples complement the existing `s([]).verschiebung(1)` and `s([]).verschiebung(4)` cases and improve coverage for the base cases of the operator.

I am a GSoC 2026 applicant for the project "Add additional combinatorial (Hopf) algebras and additional bases". This is my first contribution to familiarise myself with the sage.combinat.sf codebase and the SageMath PR workflow.