### PR TITLE
Fix race condition in package pari_seadata_small

### DIFF
--- a/build/pkgs/pari_elldata/dependencies
+++ b/build/pkgs/pari_elldata/dependencies
@@ -1,4 +1,4 @@
-# no dependencies
+pari_seadata_small
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pari_galdata/dependencies
+++ b/build/pkgs/pari_galdata/dependencies
@@ -1,4 +1,4 @@
-# no dependencies
+pari_seadata_small
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pari_galpol/dependencies
+++ b/build/pkgs/pari_galpol/dependencies
@@ -1,4 +1,4 @@
-# no dependencies
+pari_seadata_small
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pari_nftables/dependencies
+++ b/build/pkgs/pari_nftables/dependencies
@@ -1,4 +1,4 @@
-# no dependencies
+pari_seadata_small
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pari_seadata/dependencies
+++ b/build/pkgs/pari_seadata/dependencies
@@ -1,4 +1,4 @@
-# no dependencies
+pari_seadata_small
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
```
[pari_galdata-20080411.p0] error installing, exit status 1. Log file:
  [pari_galdata-20080411.p0]   Attempting to download package pari_galdata-20080411.tar.bz2 from mirrors
  [pari_galdata-20080411.p0]   https://github.com/sagemath/sage/releases/download/10.9/pari_galdata-20080411.tar.bz2
  [pari_galdata-20080411.p0]   [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]
  [pari_galdata-20080411.p0]   ERROR [transfer|run:137]: HTTP Error 404: Not Found
  [pari_galdata-20080411.p0]   https://github.com/sagemath/sage/releases/download/10.8/pari_galdata-20080411.tar.bz2
  [pari_galdata-20080411.p0]   [......................................................................]
  [pari_galdata-20080411.p0]   Setting up build directory /sage/local/var/tmp/sage/build/pari_galdata-20080411.p0
  [pari_galdata-20080411.p0]   No patch files found in ../patches
  [pari_galdata-20080411.p0]   Host system: Linux buildkitsandbox 6.14.0-1017-azure #17~24.04.1-Ubuntu SMP Mon Dec  1 20:10:50 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
  [pari_galdata-20080411.p0]   C compiler: gcc, Using built-in specs., COLLECT_GCC=gcc, COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-linux-gnu/13/lto-wrapper, OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa, OFFLOAD_TARGET_DEFAULT=1, Target: x86_64-linux-gnu, Configured with: ../src/configure -v --with-pkgversion='Ubuntu 13.3.0-6ubuntu2~24.04.1' --with-bugurl=file:///usr/share/doc/gcc-13/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-13 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/libexec --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-libstdcxx-backtrace --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --enable-cet --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-13-EldibY/gcc-13-13.3.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/gcc-13-EldibY/gcc-13-13.3.0/debian/tmp-gcn/usr --enable-offload-defaulted --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu --with-build-config=bootstrap-lto-lean --enable-link-serialization=2, Thread model: posix, Supported LTO compression algorithms: zlib zstd, gcc version 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)
  [pari_galdata-20080411.p0]   No stamp file for package 'pari_galdata' in /sage/local/var/lib/sage/installed
  [pari_galdata-20080411.p0]   No spkg-legacy-uninstall script; nothing to do
  [pari_galdata-20080411.p0]   ::group::.log
  [pari_galdata-20080411.p0]   [spkg-install] src/galdata -> /sage/local/var/tmp/sage/build/pari_galdata-20080411.p0/inst/sage/local/share/pari
  [pari_galdata-20080411.p0]   ::endgroup::
  [pari_galdata-20080411.p0]   Moving package files from temporary location /sage/local/var/tmp/sage/build/pari_galdata-20080411.p0/inst to /sage/local
  [pari_galdata-20080411.p0]   cp: cannot create directory '/sage/local/./share/pari': File exists
  [pari_galdata-20080411.p0]   ************************************************************************
  [pari_galdata-20080411.p0]   Error moving files for pari_galdata-20080411.p0.
  [pari_galdata-20080411.p0]   ************************************************************************
  [pari_galdata-20080411.p0]   Please email sage-devel (http://groups.google.com/group/sage-devel)
  [pari_galdata-20080411.p0]   explaining the problem and including the log files
  [pari_galdata-20080411.p0]     /sage/logs/pkgs/pari_galdata-20080411.p0.log
  [pari_galdata-20080411.p0]   and
  [pari_galdata-20080411.p0]     /sage/config.log
  [pari_galdata-20080411.p0]   Describe your computer, operating system, etc.
  [pari_galdata-20080411.p0]   ************************************************************************
make[2]: *** [Makefile:3308: pari_galdata-SAGE_LOCAL-no-deps] Error 1
make[1]: *** [Makefile:3308: /sage/local/var/lib/sage/installed/pari_galdata-20080411.p0] Error 2
make --no-print-directory lrcalc-SAGE_LOCAL-no-deps
  [pari_seadata_small-20090618.p0] successfully installed.
```
It is a race condition caused by `cp -Rp` because two processes both find the folder is not exist. they both use `mkdir` to create.  So it causes one fails and one successes


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


