### PR TITLE
mathics.sage(): Fix ValueError for global variable names with backticks

### DIFF
--- a/src/sage/interfaces/mathics.py
+++ b/src/sage/interfaces/mathics.py
@@ -427,6 +427,8 @@ def _mathics_sympysage_symbol(self):
                 return True
             if name == mathics._false_symbol():
                 return False
+        elif '`' in name:
+            name = name.split('`')[-1]
         return SR.var(name)
     except ValueError:
         # sympy sometimes returns dummy variables


### PR DESCRIPTION
addressing issue #41877 
## Summary
Fix `_mathics_sympysage_symbol` to handle Mathics global variable names
that contain backticks (e.g., `_uGlobal`x`).
## Description
When calling `.sage()` on a Mathics expression involving global variables,
Mathics returns symbol names like `_uGlobal`x`` which are not valid Python
identifiers. The function `_mathics_sympysage_symbol` only handled the
`_Mathics_User_` prefix, causing a ValueError for other namespace prefixes.
The fix extracts the variable name from the last part after splitting on
backticks, consistent with how `_Mathics_User_` names are already handled.
## Steps to reproduce
from sage.interfaces.mathics import mathics
mobj = mathics(x^2 - 1)
mobj.sage()  # Previously raised ValueError
## Files changed
- `src/sage/interfaces/mathics.py`: Added handling for backtick-separated
  global variable names in `_mathics_sympysage_symbol`.