### PR TITLE
Defer lib("freegb.lib") from module-level to point of use

### DIFF
--- a/src/sage/algebras/letterplace/free_algebra_element_letterplace.pyx
+++ b/src/sage/algebras/letterplace/free_algebra_element_letterplace.pyx
@@ -17,12 +17,8 @@ AUTHOR:
 # ****************************************************************************
 
 from sage.groups.perm_gps.permgroup_named import CyclicPermutationGroup
-from sage.libs.singular.function import lib
 from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
 from cpython.object cimport PyObject_RichCompare
-
-# Define some singular functions
-lib("freegb.lib")
 
 #####################
 # Free algebra elements

--- a/src/sage/algebras/letterplace/free_algebra_letterplace.pyx
+++ b/src/sage/algebras/letterplace/free_algebra_letterplace.pyx
@@ -121,17 +121,12 @@ TESTS::
     algebras with different term orderings, yet.
 """
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.libs.singular.function import lib
 from sage.libs.singular.function cimport RingWrap
 from sage.libs.singular.ring cimport singular_ring_delete, singular_ring_reference
 from sage.categories.algebras import Algebras
 from sage.rings.noncommutative_ideals import IdealMonoid_nc
 from sage.rings.polynomial.plural cimport new_CRing
 from sage.misc.cachefunc import cached_method
-
-#####################
-# Define some singular functions
-lib("freegb.lib")
 
 # unfortunately we cannot set Singular attributes for MPolynomialRing_libsingular
 # Hence, we must constantly work around Letterplace's sanity checks,
@@ -918,7 +913,8 @@ cdef class FreeAlgebra_letterplace_libsingular():
 
             sage: F.<x,y,z> = FreeAlgebra(QQ, implementation='letterplace')
         """
-        from sage.libs.singular.function import singular_function
+        from sage.libs.singular.function import singular_function, lib
+        lib("freegb.lib")
         freeAlgebra = singular_function("freeAlgebra")
         cdef RingWrap rw = freeAlgebra(commutative_ring, degbound)
         self._lp_ring = singular_ring_reference(rw._ring)

--- a/src/sage/algebras/letterplace/letterplace_ideal.pyx
+++ b/src/sage/algebras/letterplace/letterplace_ideal.pyx
@@ -41,14 +41,9 @@ AUTHOR:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 from sage.rings.noncommutative_ideals import Ideal_nc
-from sage.libs.singular.function import lib
 from sage.algebras.letterplace.free_algebra_letterplace cimport FreeAlgebra_letterplace, FreeAlgebra_letterplace_libsingular
 from sage.algebras.letterplace.free_algebra_element_letterplace cimport FreeAlgebraElement_letterplace
 from sage.rings.infinity import Infinity
-
-#####################
-# Define some singular functions
-lib("freegb.lib")
 
 
 class LetterplaceIdeal(Ideal_nc):

--- a/src/sage/libs/singular/function.pyx
+++ b/src/sage/libs/singular/function.pyx
@@ -1748,6 +1748,9 @@ def singular_function(name):
         return SingularLibraryFunction(name)
 
 
+_loaded_libs = set()
+
+
 def lib(name):
     """
     Load the Singular library ``name``.
@@ -1765,6 +1768,9 @@ def lib(name):
         sage: primes(2,10, ring=GF(127)['x,y,z'])
         (2, 3, 5, 7)
     """
+    if name in _loaded_libs:
+        return
+
     global si_opt_2
 
     cdef int vv = si_opt_2
@@ -1781,6 +1787,8 @@ def lib(name):
 
     if failure:
         raise NameError("Singular library {!r} not found".format(name))
+
+    _loaded_libs.add(name)
 
 
 def get_printlevel():


### PR DESCRIPTION
Move the Singular freegb.lib loading from module-level initialization to the only function that actually needs it (freeAlgebra in `FreeAlgebra_letterplace_libsingular.__cinit__`).

This prevents a segfault that occurs when the letterplace module is loaded as a side effect of an isinstance() check during coercion (e.g. in `FreeAlgebra_generic._coerce_map_from_`), which can trigger lib("freegb.lib") at an unsafe time for Singular.
I hope it can fix #29528
```
sage: sig_on_count() # check sig_on/off pairings (virtual doctest) ## line 112 ##
0
sage: A.<x,y,z> = FreeAlgebra(QQ, 3) ## line 157 ##
sage: H = A.g_algebra({y*x:x*y-z, z*x:x*z+2*x, z*y:y*z-2*y}) ## line 158 ##

**********************************************************************
Traceback (most recent call last):
  File "sage/structure/parent.pyx", line 893, in sage.structure.parent.Parent.__call__
  File "sage/structure/coerce_dict.pyx", line 649, in sage.structure.coerce_dict.MonoDict.get
KeyError: Free Algebra on 3 generators (x, y, z) over Rational Field

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "sage/structure/parent.pyx", line 2495, in sage.structure.parent.Parent._internal_convert_map_from
  File "sage/structure/coerce_dict.pyx", line 649, in sage.structure.coerce_dict.MonoDict.get
KeyError: Free Algebra on 3 generators (x, y, z) over Rational Field

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/sage/sage/src/sage/doctest/forker.py", line 2657, in __call__
    doctests, extras = self._run(runner, options, results)
                       ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/sage/sage/src/sage/doctest/forker.py", line 2705, in _run
    result = runner.run(test)
  File "/home/runner/work/sage/sage/src/sage/doctest/forker.py", line 926, in run
    return self._run(test, compileflags, out)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/sage/sage/src/sage/doctest/forker.py", line 734, in _run
    self.compile_and_execute(example, compiler, test.globs)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/sage/sage/src/sage/doctest/forker.py", line 1158, in compile_and_execute
    exec(compiled, globs)
    ~~~~^^^^^^^^^^^^^^^^^
  File "<doctest sage.rings.polynomial.plural.G_AlgFactory[1]>", line 1, in <module>
  File "/home/runner/work/sage/sage/src/sage/algebras/free_algebra.py", line 995, in g_algebra
    dmat[v2_ind, v1_ind] = polynomial_ring(d_poly)
                           ~~~~~~~~~~~~~~~^^^^^^^^
  File "sage/structure/parent.pyx", line 895, in sage.structure.parent.Parent.__call__
  File "sage/structure/parent.pyx", line 2497, in sage.structure.parent.Parent._internal_convert_map_from
  File "sage/structure/parent.pyx", line 2518, in sage.structure.parent.Parent.discover_convert_map_from
  File "sage/structure/parent.pyx", line 2141, in sage.structure.parent.Parent._internal_coerce_map_from
  File "sage/structure/parent.pyx", line 2233, in sage.structure.parent.Parent._internal_coerce_map_from
  File "sage/structure/parent.pyx", line 2377, in sage.structure.parent.Parent.discover_coerce_map_from
  File "sage/modules/module.pyx", line 132, in sage.modules.module.Module._coerce_map_from_
  File "/home/runner/work/sage/sage/src/sage/algebras/free_algebra.py", line 748, in _coerce_map_from_
    if isinstance(R, (FreeAlgebra_generic, FreeAlgebra_letterplace)):
       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "sage/misc/lazy_import.pyx", line 973, in sage.misc.lazy_import.LazyImport.__instancecheck__
  File "sage/misc/lazy_import.pyx", line 231, in sage.misc.lazy_import.LazyImport.get_object
  File "sage/misc/lazy_import.pyx", line 266, in sage.misc.lazy_import.LazyImport._get_object
  File "sage/algebras/letterplace/free_algebra_letterplace.pyx", line 1, in init sage.algebras.letterplace.free_algebra_letterplace
  File "sage/algebras/letterplace/free_algebra_element_letterplace.pyx", line 25, in init sage.algebras.letterplace.free_algebra_element_letterplace
  File "sage/libs/singular/function.pyx", line 1777, in sage.libs.singular.function.lib
cysignals.signals.SignalError: Segmentation fault
```
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


