### PR TITLE
test parameter `immutable` for most graph generators

### DIFF
--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -1562,10 +1562,10 @@ class BipartiteGraph(Graph):
 
         EXAMPLES::
 
-            sage: g = BipartiteGraph(graphs.RandomBipartite(3, 3, .5))                  # needs numpy
-            sage: g.is_bipartite()                                                      # needs numpy
+            sage: g = BipartiteGraph(graphs.RandomBipartite(3, 3, .5))
+            sage: g.is_bipartite()
             True
-            sage: g.is_bipartite(certificate=True)  # random                            # needs numpy
+            sage: g.is_bipartite(certificate=True)  # random
             (True, {(0, 0): 0, (0, 1): 0, (0, 2): 0, (1, 0): 1, (1, 1): 1, (1, 2): 1})
 
         TESTS::
@@ -2646,7 +2646,6 @@ class BipartiteGraph(Graph):
 
         The two algorithms should return the same result::
 
-           sage: # needs networkx numpy
            sage: g = BipartiteGraph(graphs.RandomBipartite(10, 10, .5))
            sage: vc1 = g.vertex_cover(algorithm='Konig')
            sage: vc2 = g.vertex_cover(algorithm='Cliquer')

--- a/src/sage/graphs/generators/families.py
+++ b/src/sage/graphs/generators/families.py
@@ -3914,17 +3914,15 @@ def RingedTree(k, vertex_labels=True, immutable=False):
     g._pos[0] = (0, 0.2)
 
     # Relabel vertices as binary words
-    if not vertex_labels:
-        return g
+    if vertex_labels:
+        vertices = ['']
+        for i in range(k - 1):
+            for j in range(2**(i) - 1, 2**(i + 1) - 1):
+                v = vertices[j]
+                vertices.append(v + '0')
+                vertices.append(v + '1')
 
-    vertices = ['']
-    for i in range(k - 1):
-        for j in range(2**(i) - 1, 2**(i + 1) - 1):
-            v = vertices[j]
-            vertices.append(v + '0')
-            vertices.append(v + '1')
-
-    g.relabel(vertices)
+        g.relabel(vertices)
 
     return g.copy(immutable=True) if immutable else g
 

--- a/src/sage/graphs/generators/generators_test.py
+++ b/src/sage/graphs/generators/generators_test.py
@@ -1,4 +1,15 @@
 import pytest
+import sys
+
+from sage.graphs.generators.distance_regular import graph_from_GQ_spread
+from sage.graphs.generators.smallgraphs import _EllipticLinesProjectivePlaneScheme as ES
+from sage.graphs.graph_generators import graphs
+from sage.misc.randstate import current_randstate
+from sage.misc.randstate import set_random_seed
+
+# This is certainly not the right method to get the seed
+seed = int(current_randstate().long_seed() % sys.maxsize)
+print(f"random seed used for these tests: {seed}")
 
 
 @pytest.mark.longlong
@@ -33,3 +44,378 @@ def test_shortened_000_111_extended_binary_Golay_code_graph():
 
     H = shortened_000_111_extended_binary_Golay_code_graph()
     assert G == H
+
+
+# ****************************************************************************
+# Methods for testing the behavior of parameter immutable
+# ****************************************************************************
+
+graph_constructors = [
+    # basic.py
+    (graphs.BullGraph, (), {}),
+    (graphs.ButterflyGraph, (), {}),
+    (graphs.CircularLadderGraph, (3,), {}),
+    (graphs.ClawGraph, (), {}),
+    (graphs.CompleteBipartiteGraph, (2, 3), {'set_position': False}),
+    (graphs.CompleteGraph, (4,), {}),
+    (graphs.CompleteMultipartiteGraph, ([2, 2, 3],), {}),
+    (graphs.CorrelationGraph, ([[1,2,3], [4,5,6], [7,8,9999]], 0.9, False), {}),
+    (graphs.CycleGraph, (4,), {}),
+    (graphs.DartGraph, (), {}),
+    (graphs.DiamondGraph, (), {}),
+    (graphs.EmptyGraph, (), {}),
+    (graphs.ForkGraph, (), {}),
+    (graphs.GemGraph, (), {}),
+    (graphs.Grid2dGraph, (2, 3), {'set_positions': False}),
+    (graphs.GridGraph, ([2, 2, 3],), {}),
+    (graphs.HouseGraph, (), {}),
+    (graphs.HouseXGraph, (), {}),
+    (graphs.LadderGraph, (3,), {}),
+    (graphs.MoebiusLadderGraph, (3,), {}),
+    (graphs.PathGraph, (3,), {}),
+    (graphs.StarGraph, (3,), {}),
+    (graphs.Toroidal6RegularGrid2dGraph, (4, 4), {}),
+    (graphs.ToroidalGrid2dGraph, (3, 3), {}),
+    # chessboard.py
+    (graphs.BishopGraph, ([2, 2],), {}),
+    (graphs.KingGraph, ([2, 2],), {}),
+    (graphs.KnightGraph, ([2, 2],), {}),
+    (graphs.QueenGraph, ([2, 2],), {'relabel': True}),
+    (graphs.RookGraph, ([2, 2],), {}),
+    # degree_sequence.py
+    (graphs.DegreeSequence, ([3,3,3,3],), {}),
+    (graphs.DegreeSequenceBipartite, ([1, 1, 2, 3, 3], [2, 4, 4]), {}),
+    (graphs.DegreeSequenceConfigurationModel, ([2, 2, 2],), {}),
+    (graphs.DegreeSequenceExpected, ([1,2,3,2,3],), {}),
+    (graphs.DegreeSequenceTree, ([3,1,3,3,1,1,1,2,1],), {}),
+    # distance_regular.py
+    (graph_from_GQ_spread, (2, 4), {}),
+    (graphs.AlternatingFormsGraph, (2, 2), {}),
+    (graphs.BilinearFormsGraph, (1, 1, 2), {}),
+    (graphs.ConwaySmith_for_3S7, (), {}),
+    (graphs.DoubleGrassmannGraph, (2, 0), {}),
+    (graphs.DoubleOddGraph, (1,), {}),
+    (graphs.DoublyTruncatedWittGraph, (), {}),
+    (graphs.FosterGraph3S6, (), {}),
+    (graphs.GeneralisedHexagonGraph, (1, 2), {}),
+    (graphs.GeneralisedOctagonGraph, (1, 1), {}),
+    (graphs.GrassmannGraph, (2, 3, 1), {}),
+    (graphs.HalfCube, (2,), {}),
+    (graphs.HermitianFormsGraph, (1, 2), {}),
+    (graphs.LargeWittGraph, (), {}),
+    (graphs.LeonardGraph, (), {}),
+    (graphs.TruncatedWittGraph, (), {}),
+    (graphs.UstimenkoGraph, (2, 2), {}),
+    (graphs.cocliques_HoffmannSingleton, (), {}),
+    (graphs.distance_3_doubly_truncated_Golay_code_graph, (), {}),
+    (graphs.shortened_000_111_extended_binary_Golay_code_graph, (), {}),
+    (graphs.shortened_00_11_binary_Golay_code_graph, (), {}),
+    (graphs.vanLintSchrijverGraph, (), {}),
+    # (graphs.GeneralisedDodecagonGraph, (1, 2), {}),           # optional - internet gap_package_atlasrep
+    # (graphs.graph_3O73, (), {}),                              # optional - internet gap_package_atlasrep
+    # (graphs.IvanovIvanovFaradjevGraph, (), {}),               # optional - internet gap_package_atlasrep
+    # (graphs.J2Graph, (), {}),                                 # optional - internet gap_package_atlasrep
+    # (graphs.locally_GQ42_distance_transitive_graph, (), {}),  # optional - internet gap_package_atlasrep
+    # families.py
+    (graphs.AztecDiamondGraph, (2,), {}),
+    (graphs.BarbellGraph, (3, 2), {}),
+    (graphs.BiwheelGraph, (4,), {}),
+    (graphs.BubbleSortGraph, (2,), {}),
+    (graphs.CirculantGraph, (5, 2), {}),
+    (graphs.CubeConnectedCycle, (3,), {}),
+    (graphs.CubeGraph, (2,), {'embedding': 0}),
+    (graphs.DipoleGraph, (1,), {}),
+    (graphs.DorogovtsevGoltsevMendesGraph, (0,), {}),
+    (graphs.DoubleGeneralizedPetersenGraph, (5, 2), {}),
+    (graphs.EgawaGraph, (1, 2), {}),
+    (graphs.FoldedCubeGraph, (2,), {}),
+    (graphs.FriendshipGraph, (2,), {}),
+    (graphs.FuzzyBallGraph, ([3, 1], 2), {}),
+    (graphs.GeneralizedPetersenGraph, (5, 2), {}),
+    (graphs.GeneralizedSierpinskiGraph, (graphs.CycleGraph(3), 2), {'stretch': 1}),
+    (graphs.GoethalsSeidelGraph, (2, 3), {}),
+    (graphs.HammingGraph, (1, 2), {}),
+    (graphs.HanoiTowerGraph, (2, 3), {'labels': False, 'positions': False}),
+    (graphs.HararyGraph, (3, 5), {}),
+    (graphs.HyperStarGraph, (3, 2), {}),
+    (graphs.IGraph, (5, 1, 2), {}),
+    (graphs.JohnsonGraph, (5, 2), {}),
+    (graphs.KneserGraph, (5, 2), {}),
+    (graphs.LCFGraph, (4, [2,-2], 2), {}),
+    (graphs.LollipopGraph, (3, 3), {}),
+    (graphs.MathonPseudocyclicMergingGraph, (ES(3), 0), {}),
+    (graphs.MathonPseudocyclicStronglyRegularGraph, (1,), {}),
+    (graphs.MuzychukS6Graph, (4, 2), {}),
+    (graphs.MycielskiGraph, (), {'k': 3, 'relabel': False}),
+    (graphs.MycielskiStep, (graphs.CycleGraph(3),), {}),
+    (graphs.NKStarGraph, (2, 1), {}),
+    (graphs.NStarGraph, (2,), {}),
+    (graphs.OddGraph, (2,), {}),
+    (graphs.PaleyGraph, (5,), {}),
+    (graphs.PasechnikGraph, (2,), {}),
+    (graphs.RingedTree, (2,), {'vertex_labels': False}),
+    (graphs.RingedTree, (2,), {'vertex_labels': True}),
+    (graphs.RoseWindowGraph, (3, 2, 1), {}),
+    (graphs.SierpinskiGasketGraph, (1,), {}),
+    (graphs.SquaredSkewHadamardMatrixGraph, (1,), {}),
+    (graphs.StaircaseGraph, (3,), {}),
+    (graphs.SwitchedSquaredSkewHadamardMatrixGraph, (1,), {}),
+    (graphs.TabacjnGraph, (3, 1, 2, 1), {}),
+    (graphs.TadpoleGraph, (3, 1), {}),
+    (graphs.TruncatedBiwheelGraph, (3,), {}),
+    (graphs.TuranGraph, (2, 1), {}),
+    (graphs.WheelGraph, (4,), {}),
+    (graphs.WindmillGraph, (3, 3), {}),
+    # intersection.py
+    (graphs.IntersectionGraph, ([(1, 2), (2, 3)],), {}),
+    (graphs.IntervalGraph, ([(1, 2), (1, 2), (2, 3)],), {}),
+    (graphs.OrthogonalArrayBlockGraph, (2, 2), {}),
+    (graphs.PermutationGraph, ([3, 4, 5, 1, 2],), {}),
+    (graphs.ToleranceGraph, ([(1, 4, 3), (1, 2, 1)], ), {}),
+    # platonic_solids.py
+    (graphs.DodecahedralGraph, (), {}),
+    (graphs.HexahedralGraph, (), {}),
+    (graphs.IcosahedralGraph, (), {}),
+    (graphs.OctahedralGraph, (), {}),
+    (graphs.TetrahedralGraph, (), {}),
+    # random.py
+    (graphs.RandomBarabasiAlbert, (6, 2), {}),
+    (graphs.RandomBicubicPlanar, (6,), {}),
+    (graphs.RandomBipartite, (5, 2, .5), {}),
+    (graphs.RandomBlockGraph, (6, 4), {}),
+    (graphs.RandomBoundedToleranceGraph, (6,), {}),
+    (graphs.RandomChordalGraph, (5,), {}),
+    (graphs.RandomGNM, (3, 2), {'dense': False}),
+    (graphs.RandomGNM, (3, 2), {'dense': True}),
+    (graphs.RandomGNP, (6, .4), {'algorithm': 'Sage'}),
+    (graphs.RandomGNP, (6, .4), {'algorithm': 'networkx'}),
+    (graphs.RandomHolmeKim, (6, 2, .3), {}),
+    (graphs.RandomIntervalGraph, (5,), {}),
+    (graphs.RandomKTree, (8, 3), {}),
+    (graphs.RandomNewmanWattsStrogatz, (7, 2, .2), {}),
+    (graphs.RandomPartialKTree, (5, 2, 1), {}),
+    (graphs.RandomProperIntervalGraph, (5,), {}),
+    (graphs.RandomRegular, (3, 8), {}),
+    (graphs.RandomRegularBipartite, (1, 2, 2), {}),
+    (graphs.RandomShell, ([(10, 20, 0.8), (20, 40, 0.8)], ), {}),
+    (graphs.RandomToleranceGraph, (8,), {}),
+    (graphs.RandomTriangulation, (6,), {}),
+    (graphs.RandomUnitDiskGraph, (6,), {}),
+    # smallgraphs.py
+    (graphs.Balaban10Cage, (), {'embedding': 2}),
+    (graphs.Balaban11Cage, (), {'embedding': 3}),
+    (graphs.BidiakisCube, (), {}),
+    (graphs.BiggsSmithGraph, (), {'embedding': 2}),
+    (graphs.BlanusaFirstSnarkGraph, (), {}),
+    (graphs.BlanusaSecondSnarkGraph, (), {}),
+    (graphs.BrinkmannGraph, (), {}),
+    (graphs.BrouwerHaemersGraph, (), {}),
+    (graphs.BuckyBall, (), {}),
+    (graphs.CameronGraph, (), {}),
+    (graphs.Cell120, (), {}),
+    (graphs.Cell600, (), {'embedding': 2}),
+    (graphs.ChvatalGraph, (), {}),
+    (graphs.ClebschGraph, (), {}),
+    (graphs.CoxeterGraph, (), {}),
+    (graphs.CubeplexGraph, (), {'embedding': 'NT'}),
+    (graphs.DejterGraph, (), {}),
+    (graphs.DesarguesGraph, (), {}),
+    (graphs.DoubleStarSnark, (), {}),
+    (graphs.DurerGraph, (), {}),
+    (graphs.DyckGraph, (), {}),
+    (graphs.EllinghamHorton54Graph, (), {}),
+    (graphs.EllinghamHorton78Graph, (), {}),
+    (graphs.ErreraGraph, (), {}),
+    (graphs.F26AGraph, (), {}),
+    (graphs.FlowerSnark, (), {}),
+    (graphs.FolkmanGraph, (), {}),
+    (graphs.FosterGraph, (), {}),
+    (graphs.FranklinGraph, (), {}),
+    (graphs.FruchtGraph, (), {}),
+    (graphs.GoldnerHararyGraph, (), {}),
+    (graphs.GolombGraph, (), {}),
+    (graphs.GossetGraph, (), {}),
+    (graphs.GrayGraph, (), {'embedding': 2}),
+    (graphs.GritsenkoGraph, (), {}),
+    (graphs.GrotzschGraph, (), {}),
+    (graphs.HallJankoGraph, (), {'from_string': True}),
+    (graphs.HarborthGraph, (), {}),
+    (graphs.HarriesGraph, (), {'embedding': 2}),
+    (graphs.HarriesWongGraph, (), {'embedding': 2}),
+    (graphs.HeawoodGraph, (), {}),
+    (graphs.HerschelGraph, (), {}),
+    (graphs.HigmanSimsGraph, (), {'relabel': False}),
+    (graphs.HoffmanGraph, (), {}),
+    (graphs.HoffmanSingletonGraph, (), {}),
+    (graphs.HoltGraph, (), {}),
+    (graphs.HortonGraph, (), {}),
+    (graphs.IoninKharaghani765Graph, (), {}),
+    (graphs.JankoKharaghaniGraph, (936,), {}),  # long time
+    (graphs.JankoKharaghaniTonchevGraph, (), {}),
+    (graphs.KittellGraph, (), {}),
+    (graphs.Klein3RegularGraph, (), {}),
+    (graphs.Klein7RegularGraph, (), {}),
+    (graphs.KrackhardtKiteGraph, (), {}),
+    (graphs.LjubljanaGraph, (), {'embedding': 2}),
+    (graphs.M22Graph, (), {}),
+    (graphs.MarkstroemGraph, (), {}),
+    (graphs.MathonStronglyRegularGraph, (0,), {}),
+    (graphs.McGeeGraph, (), {'embedding': 1}),
+    (graphs.MeredithGraph, (), {}),
+    (graphs.MoebiusKantorGraph, (), {}),
+    (graphs.MoserSpindle, (), {}),
+    (graphs.MurtyGraph, (), {}),
+    (graphs.NauruGraph, (), {'embedding': 2}),
+    (graphs.PappusGraph, (), {}),
+    (graphs.PerkelGraph, (), {}),
+    (graphs.PetersenGraph, (), {}),
+    (graphs.PoussinGraph, (), {}),
+    (graphs.RobertsonGraph, (), {}),
+    (graphs.SchlaefliGraph, (), {}),
+    (graphs.ShrikhandeGraph, (), {}),
+    (graphs.SimsGewirtzGraph, (), {}),
+    (graphs.SousselierGraph, (), {}),
+    (graphs.SylvesterGraph, (), {}),
+    (graphs.SzekeresSnarkGraph, (), {}),
+    (graphs.ThomsenGraph, (), {}),
+    (graphs.TietzeGraph, (), {}),
+    (graphs.TricornGraph, (), {}),
+    (graphs.TruncatedTetrahedralGraph, (), {}),
+    (graphs.Tutte12Cage, (), {}),
+    (graphs.TutteCoxeterGraph, (), {'embedding': 2}),
+    (graphs.TutteGraph, (), {}),
+    (graphs.TwinplexGraph, (), {'embedding': 'NT'}),
+    (graphs.WagnerGraph, (), {}),
+    (graphs.WatkinsSnarkGraph, (), {}),
+    (graphs.WellsGraph, (), {}),
+    (graphs.WienerArayaGraph, (), {}),
+    # (graphs.LivingstoneGraph, (), {}),      # optional - internet # not tested
+    # (graphs.LocalMcLaughlinGraph, (), {}),  # optional - gap_package_design
+    # (graphs.McLaughlinGraph, (), {}),       # optional - gap_package_design
+    # (graphs.SuzukiGraph, (), {}),           # optional internet # not tested
+    # (graphs.U42Graph216, (), {}),           # optional - gap_package
+    # (graphs.U42Graph540, (), {}),           # optional - gap_package
+    # Can not be constructed currently, due to numerical issues
+    # (graphs.TruncatedIcosidodecahedralGraph, (), {}),
+    # trees.pyx
+    (graphs.BalancedTree, (2, 1), {}),
+    (graphs.Caterpillar, ([0, 1, 1, 0], ), {}),
+    (graphs.FibonacciTree, (3,), {}),
+    (graphs.RandomLobster, (9, .6, .3), {}),
+    (graphs.RandomTree, (5,), {}),
+    (graphs.RandomTreePowerlaw, (10,), {}),
+    # world_maps.py
+    (graphs.AfricaMap, (), {'continental': False}),
+    (graphs.AfricaMap, (), {'continental': True}),
+    (graphs.EuropeMap, (), {'continental': False}),
+    (graphs.EuropeMap, (), {'continental': True}),
+    (graphs.USAMap, (), {'continental': False}),
+    (graphs.USAMap, (), {'continental': True}),
+    (graphs.WorldMap, (), {}),
+    ]
+
+
+def _compare_graphs(mu, im):
+    r"""
+    Helper method to test the behavior of parameter ``immutable``.
+
+    The tests are robust to vertex labels of different types.
+
+    INPUT:
+
+    - ``mu`` -- a mutable graph
+
+    - ``im`` -- an immutable graph
+
+    EXAMPLES::
+
+        sage: from sage.graphs.generators.generators_test import _compare_graphs
+        random seed used for these tests: ...
+        sage: mu = graphs.CycleGraph(3, immutable=False)
+        sage: im = graphs.CycleGraph(3, immutable=True)
+        sage: _compare_graphs(mu, im)
+        sage: _compare_graphs(mu, mu)
+        Traceback (most recent call last):
+        ...
+        AssertionError
+        sage: _compare_graphs(im, im)
+        Traceback (most recent call last):
+        ...
+        AssertionError
+        sage: im = graphs.CycleGraph(4, immutable=True)
+        sage: _compare_graphs(mu, im)
+        Traceback (most recent call last):
+        ...
+        AssertionError
+    """
+    assert mu.is_immutable() is False
+    assert im.is_immutable() is True
+    assert mu.order() == im.order()
+    assert mu.size() == im.size()
+    assert set(mu) == set(im)
+    edges_mu = {(frozenset((u, v)), label) for u, v, label in mu.edges()}
+    edges_im = {(frozenset((u, v)), label) for u, v, label in im.edges()}
+    assert edges_mu == edges_im
+
+
+@pytest.mark.parametrize("graph_constructor, args, kwds", graph_constructors)
+def test_parameter_immutable(graph_constructor, args, kwds):
+    r"""
+    Check the behavior of parameter ``immutable`` on input graph generator.
+
+    Check that the graphs returned by the generator when parameter ``immutable``
+    is set to ``True`` or ``False`` have the same sets of vertices and edges.
+
+    This method is applied on all entries defined in ``graph_constructors``.
+
+    INPUT:
+
+    - ``generator`` -- a graph generator
+
+    - ``args`` -- ordered list of the arguments of the generator without default
+      values
+
+    - ``kwds`` -- dictionary mapping parameters with default values to the
+      desired value
+    """
+    set_random_seed(seed)
+    Gmu = graph_constructor(*args, **kwds, immutable=False)
+    set_random_seed(seed)
+    Gim = graph_constructor(*args, **kwds, immutable=True)
+    _compare_graphs(Gmu, Gim)
+
+
+def test_parameter_immutable_other():
+    r"""
+    Check the behavior of parameter ``immutable`` on other graph generators.
+
+    This method is devoted to graph generators returning a pair of items, a list
+    of graphs or an iterator.
+    """
+    def comp1(graph_constructor, args):
+        set_random_seed(seed)
+        Gmu = graph_constructor(*args, immutable=False)[0]
+        set_random_seed(seed)
+        Gim = graph_constructor(*args, immutable=True)[0]
+        _compare_graphs(Gmu, Gim)
+
+    comp1(graphs.CaiFurerImmermanGraph, (graphs.CycleGraph(3),))
+    comp1(graphs.FurerGadget, (1,))
+
+    # Generators returning lists of graphs
+    gens = (graphs.chang_graphs, graphs.line_graph_forbidden_subgraphs,
+            graphs.p2_forbidden_minors, graphs.petersen_family)
+    for gen in gens:
+        for Gmu, Gim in zip(gen(immutable=False), gen(immutable=True)):
+            _compare_graphs(Gmu, Gim)
+
+    # Check that iterators return trees in the same order
+    gen_mu = graphs.trees(4, immutable=False)
+    gen_im = graphs.trees(4, immutable=True)
+    for Gmu, Gim in zip(gen_mu, gen_im):
+        _compare_graphs(Gmu, Gim)
+
+    gen_mu = graphs.nauty_gentreeg("4", immutable=False)
+    gen_im = graphs.nauty_gentreeg("4", immutable=True)
+    for Gmu, Gim in zip(gen_mu, gen_im):
+        _compare_graphs(Gmu, Gim)

--- a/src/sage/graphs/generators/random.py
+++ b/src/sage/graphs/generators/random.py
@@ -215,29 +215,28 @@ def RandomBipartite(n1, n2, p, set_position=False, seed=None, immutable=False):
 
     EXAMPLES::
 
-        sage: g = graphs.RandomBipartite(5, 2, 0.5)                                     # needs numpy
-        sage: g.vertices(sort=True)                                                     # needs numpy
+        sage: g = graphs.RandomBipartite(5, 2, 0.5)
+        sage: g.vertices(sort=True)
         [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (1, 0), (1, 1)]
 
     TESTS::
 
-        sage: g = graphs.RandomBipartite(5, -3, 0.5)                                    # needs numpy
+        sage: g = graphs.RandomBipartite(5, -3, 0.5)
         Traceback (most recent call last):
         ...
         ValueError: n1 and n2 should be integers strictly greater than 0
-        sage: g = graphs.RandomBipartite(5, 3, 1.5)                                     # needs numpy
+        sage: g = graphs.RandomBipartite(5, 3, 1.5)
         Traceback (most recent call last):
         ...
         ValueError: parameter p is a probability, and so should be a real value between 0 and 1
 
     :issue:`12155`::
 
-        sage: graphs.RandomBipartite(5, 6, .2).complement()                             # needs numpy
+        sage: graphs.RandomBipartite(5, 6, .2).complement()
         complement(Random bipartite graph of order 5+6 with edge probability 0.200000000000000): Graph on 11 vertices
 
     Test assigned positions::
 
-        sage: # needs numpy
         sage: graphs.RandomBipartite(1, 2, .1, set_position=True).get_pos()
         {(0, 0): (1, 1.0), (1, 0): (0, 0), (1, 1): (2.0, 0.0)}
         sage: graphs.RandomBipartite(2, 1, .1, set_position=True).get_pos()
@@ -254,12 +253,11 @@ def RandomBipartite(n1, n2, p, set_position=False, seed=None, immutable=False):
         set_random_seed(seed)
 
     from itertools import chain
-    from numpy.random import uniform
 
     name = f"Random bipartite graph of order {n1}+{n2} with edge probability {p}"
     S1 = [(0, i) for i in range(n1)]
     S2 = [(1, i) for i in range(n2)]
-    edges = ((v, w) for w in S2 for v in S1 if uniform() <= p)
+    edges = ((v, w) for w in S2 for v in S1 if random() <= p)
     g = Graph([chain(S1, S2), edges], format="vertices_and_edges",
               name=name, immutable=immutable)
 

--- a/src/sage/graphs/generators/smallgraphs.py
+++ b/src/sage/graphs/generators/smallgraphs.py
@@ -3612,7 +3612,7 @@ def HigmanSimsGraph(relabel=True, immutable=False):
     return HS
 
 
-def HoffmanSingletonGraph(immutable=False):
+def HoffmanSingletonGraph(immutable=False, seed=None):
     r"""
     Return the Hoffman-Singleton graph.
 
@@ -3636,6 +3636,9 @@ def HoffmanSingletonGraph(immutable=False):
 
     - ``immutable`` -- boolean (default: ``False``); whether to return an
       immutable or a mutable graph
+
+    - ``seed`` -- a ``random.Random`` seed or a Python ``int`` for the random
+      number generator (default: ``None``)
 
     EXAMPLES::
 
@@ -3676,6 +3679,10 @@ def HoffmanSingletonGraph(immutable=False):
     H.name('Hoffman-Singleton graph')
     from sage.combinat.permutation import Permutations
     from sage.misc.prandom import randint
+    if seed is not None:
+        from sage.misc.randstate import set_random_seed
+        set_random_seed(seed)
+
     P = Permutations([1, 2, 3, 4])
     qpp = [0] + list(P[randint(0, 23)])
     ppp = [0] + list(P[randint(0, 23)])
@@ -3702,7 +3709,7 @@ def HoffmanSingletonGraph(immutable=False):
             s = int(v[0])
         l += 1
     if immutable:
-        H, mymap = H.relabel(inplace=False, immutable=True, return_map=True)
+        H, mymap = H.relabel(range(50), inplace=False, immutable=True, return_map=True)
     else:
         mymap = H.relabel(range(50), return_map=True)
     H._circle_embedding([mymap[d] for d in D], angle=pi/2)
@@ -4863,7 +4870,7 @@ def ShrikhandeGraph(immutable=False):
                  name="Shrikhande graph", immutable=immutable)
 
 
-def SylvesterGraph(immutable=False):
+def SylvesterGraph(immutable=False, seed=None):
     """
     Return the Sylvester Graph.
 
@@ -4883,6 +4890,9 @@ def SylvesterGraph(immutable=False):
     - ``immutable`` -- boolean (default: ``False``); whether to return an
       immutable or a mutable graph
 
+    - ``seed`` -- a ``random.Random`` seed or a Python ``int`` for the random
+      number generator (default: ``None``)
+
     EXAMPLES::
 
         sage: g = graphs.SylvesterGraph(); g
@@ -4894,14 +4904,14 @@ def SylvesterGraph(immutable=False):
         sage: g.is_regular(k=5)
         True
     """
-    g = HoffmanSingletonGraph()
+    g = HoffmanSingletonGraph(seed=seed)
     e = next(g.edge_iterator(labels=False))
     g.delete_vertices(g.neighbors(e[0]) + g.neighbors(e[1]))
     g.name("Sylvester Graph")
     if immutable:
-        g = g.relabel(inplace=False, immutable=True)
+        g = g.relabel(range(g.order()), inplace=False, immutable=True)
     else:
-        g.relabel()
+        g.relabel(range(g.order()))
     ordering = [0, 1, 2, 4, 5, 9, 16, 35, 15, 18, 20, 30, 22, 6, 33, 32, 14,
                 10, 28, 29, 7, 24, 23, 26, 19, 12, 13, 21, 11, 31, 3, 27, 25,
                 17, 8, 34]
@@ -4947,9 +4957,9 @@ def SimsGewirtzGraph(immutable=False):
     g.delete_vertices(g.neighbors(e[0]) + g.neighbors(e[1]))
     g.name("Sims-Gewirtz Graph")
     if immutable:
-        g = g.relabel(inplace=False, immutable=True)
+        g = g.relabel(range(g.order()), inplace=False, immutable=True)
     else:
-        g.relabel()
+        g.relabel(range(g.order()))
     ordering = [0, 2, 3, 4, 6, 7, 8, 17, 1, 41, 49, 5, 22, 26, 11, 27, 15, 47,
                 53, 52, 38, 43, 44, 18, 20, 32, 19, 42, 54, 36, 51, 30, 33, 35,
                 37, 28, 34, 12, 29, 23, 55, 25, 40, 24, 9, 14, 48, 39, 45, 16,

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -4590,7 +4590,7 @@ class GenericGraph(GenericGraph_pyx):
             True
             sage: graphs.CycleGraph(5).is_bipartite()
             False
-            sage: graphs.RandomBipartite(10, 10, 0.7).is_bipartite()                    # needs numpy
+            sage: graphs.RandomBipartite(10, 10, 0.7).is_bipartite()
             True
 
         A random graph is very rarely bipartite::
@@ -17166,8 +17166,8 @@ class GenericGraph(GenericGraph_pyx):
         Bipartite graphs have no odd cycle and consequently have
         infinite odd girth::
 
-            sage: G = graphs.RandomBipartite(6, 6, .5)                                  # needs numpy
-            sage: G.odd_girth()                                                         # needs numpy
+            sage: G = graphs.RandomBipartite(6, 6, .5)
+            sage: G.odd_girth()
             +Infinity
             sage: G = graphs.Grid2dGraph(3, 4)
             sage: G.odd_girth()

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -1211,7 +1211,8 @@ class Graph(GenericGraph):
             if data.get_pos() is not None:
                 pos = data.get_pos()
             self.name(data.name())
-            self.set_vertices(data.get_vertices())
+            if hasattr(data, '_assoc'):
+                self.set_vertices(data.get_vertices())
             data._backend.subgraph_given_vertices(self._backend, data)
 
         elif format == 'NX':
@@ -2300,13 +2301,13 @@ class Graph(GenericGraph):
         It is clear, though, that a random Bipartite Graph which is not a forest
         has an even hole::
 
-            sage: g = graphs.RandomBipartite(10, 10, .5)                                # needs numpy
-            sage: g.is_even_hole_free() and not g.is_forest()                           # needs numpy sage.modules
+            sage: g = graphs.RandomBipartite(10, 10, .5)
+            sage: g.is_even_hole_free() and not g.is_forest()                           # needs sage.modules
             False
 
         We can check the certificate returned is indeed an even cycle::
 
-            sage: if not g.is_forest():                                                 # needs numpy sage.modules
+            sage: if not g.is_forest():                                                 # needs sage.modules
             ....:    cycle = g.is_even_hole_free(certificate=True)
             ....:    if cycle.order() % 2 == 1:
             ....:        print("Error !")
@@ -2332,7 +2333,7 @@ class Graph(GenericGraph):
 
             sage: t = lambda x: (Graph(x).is_forest() or
             ....:       isinstance(Graph(x).is_even_hole_free(certificate=True), Graph))
-            sage: all(t(graphs.RandomBipartite(10, 10, .5)) for i in range(100))        # needs numpy sage.modules
+            sage: all(t(graphs.RandomBipartite(10, 10, .5)) for i in range(100))        # needs sage.modules
             True
         """
         girth = self.girth()
@@ -2655,14 +2656,14 @@ class Graph(GenericGraph):
 
         A Bipartite Graph is always perfect ::
 
-            sage: g = graphs.RandomBipartite(8,4,.5)                                    # needs numpy
-            sage: g.is_perfect()                                                        # needs numpy sage.modules
+            sage: g = graphs.RandomBipartite(8,4,.5)
+            sage: g.is_perfect()                                                        # needs sage.modules
             True
 
         So is the line graph of a bipartite graph::
 
-            sage: g = graphs.RandomBipartite(4,3,0.7)                                   # needs numpy
-            sage: g.line_graph().is_perfect()   # long time                             # needs numpy sage.modules
+            sage: g = graphs.RandomBipartite(4,3,0.7)
+            sage: g.line_graph().is_perfect()   # long time                             # needs sage.modules
             True
 
         As well as the Cartesian product of two complete graphs::
@@ -3530,7 +3531,7 @@ class Graph(GenericGraph):
 
         A bipartite graph has (by definition) chromatic number 2::
 
-            sage: graphs.RandomBipartite(50,50,0.7).chromatic_number()                  # needs numpy
+            sage: graphs.RandomBipartite(50,50,0.7).chromatic_number()
             2
 
         A complete multipartite graph with `k` parts has chromatic number `k`::

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -563,8 +563,8 @@ def is_factor_critical(G, matching=None, algorithm='Edmonds', solver=None, verbo
 
     Bipartite graphs are not factor-critical::
 
-        sage: G = graphs.RandomBipartite(randint(1, 10), randint(1, 10), .5)        # needs numpy
-        sage: G.is_factor_critical()                                                # needs numpy
+        sage: G = graphs.RandomBipartite(randint(1, 10), randint(1, 10), .5)
+        sage: G.is_factor_critical()
         False
 
     Graphs with even order are not factor critical::


### PR DESCRIPTION
As discussed in https://github.com/sagemath/sage/pull/41501#issuecomment-3805054033, we add tests for checking the behavior of parameter `immutable` on many graph generators.
Tests for distance regular graphs will be added when #41723 and #41725 will be merged and some final work is done on this file. Tests for trees will be added after #41714.

On the way, we take parameter `immutable` into account in `RingedTree` when `vertex_labels` is `False`.

For each graph constructor, we compare the graphs obtained with parameter immutable set to `True` and `False`. We check that these graphs have the same set of vertices and edges. This is faster than graph isomorphism and certainly sufficient. The tests we use support graphs with different types of vertex labels.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

#42767
<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


