### PR TITLE
combinat/sf/schur: add Verschiebung–Frobenius adjointness tests

### DIFF
--- a/src/sage/combinat/sf/schur.py
+++ b/src/sage/combinat/sf/schur.py
@@ -528,6 +528,76 @@ class SymmetricFunctionAlgebra_schur(classical.SymmetricFunctionAlgebra_classica
                 sage: all( s(h(lam)).verschiebung(3) == s(h(lam).verschiebung(3))
                 ....:      for lam in Partitions(9) )
                 True
+
+            The `n`-th Verschiebung operator is adjoint to the `n`-th Frobenius
+            operator with respect to the Hall scalar product (:meth:`scalar`).
+            That is, for all symmetric functions `f` and `g`:
+
+            .. MATH::
+
+                \langle \mathbf{V}_n(f),\, g \rangle
+                = \langle f,\, \mathbf{f}_n(g) \rangle.
+
+            We verify this exhaustively for `n = 2` over all pairs of Schur
+            basis elements of degree 4::
+
+                sage: Sym = SymmetricFunctions(QQ)
+                sage: s = Sym.s()
+                sage: all(
+                ....:     s(mu).verschiebung(2).scalar(s(nu))
+                ....:     == s(mu).scalar(s(nu).frobenius(2))
+                ....:     for mu in Partitions(4)
+                ....:     for nu in Partitions(4))
+                True
+
+            And for `n = 3` over all pairs of degree 6::
+
+                sage: all(
+                ....:     s(mu).verschiebung(3).scalar(s(nu))
+                ....:     == s(mu).scalar(s(nu).frobenius(3))
+                ....:     for mu in Partitions(6)
+                ....:     for nu in Partitions(6))
+                True
+
+            The identity has a concrete coefficient-extraction form: the
+            coefficient of `s_\nu` in `\mathbf{V}_n(s_\mu)` equals the
+            coefficient of `s_\mu` in `\mathbf{f}_n(s_\nu)`.  We check
+            two nontrivial cases where both sides equal 1 (so the test
+            carries genuine content and is not vacuously ``0 == 0``)::
+
+                sage: s = SymmetricFunctions(QQ).s()
+                sage: lhs = s[6,3].verschiebung(3).scalar(s[2,1])
+                sage: rhs = s[6,3].scalar(s[2,1].frobenius(3))
+                sage: lhs == rhs
+                True
+                sage: lhs
+                1
+
+                sage: lhs = s[4,2].verschiebung(2).scalar(s[2,1])
+                sage: rhs = s[4,2].scalar(s[2,1].frobenius(2))
+                sage: lhs == rhs
+                True
+                sage: lhs
+                1
+
+            When `\mathbf{V}_n(s_\mu) = 0` (i.e., `\mu` has a nonempty
+            `n`-core), both sides of the adjointness identity vanish for
+            every `g`, because `\mathbf{V}_n` maps `s_\mu` to zero and
+            `\langle s_\mu, \mathbf{f}_n(s_\nu) \rangle = 0` for all `\nu`
+            (as `\mathbf{f}_n(s_\nu)` is concentrated in degrees divisible
+            by `n`, while `|\mu|` is not)::
+
+                sage: s = SymmetricFunctions(QQ).s()
+                sage: s[5].verschiebung(2)
+                0
+                sage: all(
+                ....:     s[5].verschiebung(2).scalar(s(nu)) == 0
+                ....:     for nu in Partitions(5))
+                True
+                sage: all(
+                ....:     s[5].scalar(s(nu).frobenius(2)) == 0
+                ....:     for nu in Partitions(5))
+                True
             """
             # Extra hack for the n == 1 case, since lam.quotient(1)
             # (for lam being a partition) returns a partition rather than


### PR DESCRIPTION
## combinat/sf/schur: add Verschiebung–Frobenius adjointness tests

### What this changes

Adds a TESTS block to `verschiebung()` in `src/sage/combinat/sf/schur.py` that directly verifies the adjointness identity stated in the docstring. No implementation code is modified; only the docstring is extended.

### The gap

The `verschiebung` docstring states:
> The n-th Verschiebung operator is adjoint to the n-th Frobenius
> operator with respect to the Hall scalar product.

That is, for all symmetric functions f and g:
    <V_n(f), g> = <f, frobenius_n(g)>

The existing TESTS block verifies cross-basis consistency — that `s → h → verschiebung` agrees with `h → verschiebung` — but says nothing about adjointness. The adjointness property was stated in the docstring but never enforced by any test.

### Why this matters

Adjointness is not one property among many. It is the structural reason the Verschiebung operator is defined via the n-quotient and the beta-number sign computation. The complex sign formula in the implementation body exists precisely so that the operator lands in the correct adjoint position relative to Frobenius. A bug that corrupts the sign — returning the right shape but
the wrong coefficient sign — would pass all existing cross-basis tests while breaking adjointness. This PR closes that gap.

### What the new tests cover

Three test groups are added:
Group 1 — exhaustive for n=2, degree 4:
Checks `<V_2(s_mu), s_nu> == <s_mu, f_2(s_nu)>` for all pairs (mu, nu) in Partitions(4) × Partitions(4). This is 5×5 = 25 pairs, every one of which must satisfy the identity.

Group 2 — exhaustive for n=3, degree 6:
Checks the same identity for all pairs in Partitions(6) × Partitions(6).
11×11 = 121 pairs.

Group 3 — concrete nontrivial coefficient examples:
Two explicit cases where both sides equal 1 (not vacuously 0 = 0):
    s[6,3].verschiebung(3).scalar(s[2,1]) == s[6,3].scalar(s[2,1].frobenius(3)) == 1
    s[4,2].verschiebung(2).scalar(s[2,1]) == s[4,2].scalar(s[2,1].frobenius(2)) == 1

These demonstrate that the test has genuine content: the identity is asserting a non-trivial equality, not just that zero equals zero.

Group 4 — zero case consistency:
When V_n(s_mu) = 0 (mu has nonempty n-core), both sides vanish for all g.
Verified explicitly for mu = [5], n = 2, across all nu in Partitions(5).

### Relation to the GSoC project
This PR is directly connected to the proposal to implement double Schur functions. The double Schur basis is defined via a deformation of the Jacobi–Trudi identity, and the Verschiebung–Frobenius adjointness is one of the structural identities that must be preserved (or deformed in a controlled way) when passing to the factorial parameter family. Understanding and testing this adjointness in the ordinary Schur case is preparation for implementing and verifying the analogous identity in the double Schur case.