### PR TITLE
various new quaternion functionality

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -21,6 +21,10 @@ AUTHORS:
 
 - Eloi Torrents (2024): construct quaternion algebras over number fields from ramification
 
+- Lorenz Panny (2026): :meth:`QuaternionOrder.random_ideal`,
+  :meth:`QuaternionFractionalIdeal_rational.reduce_equiv`,
+  :meth:`QuaternionFractionalIdeal_rational.gens_two`
+
 TESTS:
 
 Pickling test::
@@ -2565,6 +2569,180 @@ class QuaternionOrder(Parent):
             raise NotImplementedError("ideal only implemented for quaternion algebras over QQ")
         return QuaternionFractionalIdeal_rational(self.quaternion_algebra(), self.basis(), left_order=self, right_order=self, check=False)
 
+    def random_ideal(self, side='left', norm=None, *, reduce=None):
+        r"""
+        Sample a random *primitive* integral left or right ideal of this order.
+
+        If ``norm`` is given, the distribution *should* be approximately
+        uniform on the set of primitive ideals of that norm.
+        When ``norm`` is not given, its value is chosen automatically in a way
+        that *should* render the distribution of the ideal *classes* sampled by
+        this method approximately uniform.
+        In both cases, no strict guarantees are given about the distribution.
+
+        This method is only implemented for definite quaternion algebras.
+
+        INPUT:
+
+        - ``side`` (``"left"`` or ``"right"``): Sample a left or right
+          ideal of this order.
+
+        - ``norm`` (positive integer or ``None``): Sample a random ideal
+          of the given norm. Must be coprime to the discriminant.
+
+        - ``reduce`` (boolean or (default) ``None``): Reduce the ideal using
+          :meth:`reduce_equiv` prior to returning it or not. Note that the
+          norm of the ideal is only preserved when this is ``False``; thus,
+          the default is ``False`` when ``norm`` is explicitly given and
+          ``True`` otherwise.
+
+        EXAMPLES::
+
+            sage: q = 31
+            sage: p = 7753
+            sage: B.<i,j,k> = QuaternionAlgebra(-q, -p)
+            sage: O0 = B.maximal_order(); O0
+            Order of Quaternion Algebra (-31, -7753) with base ring Rational Field
+              with basis (1/2 + 1/2*i, 1/2*j - 1/2*k, -1/31*i + 14/31*k, -k)
+            sage: I = O0.random_ideal(); I  # random
+            Fractional ideal (28, 7 + 7*i, 1/2 + 9/2*i + 2*j, 13 + 21/31*i + 1/2*j + 1/62*k)
+            sage: I.is_integral()
+            True
+            sage: I.left_order() == O0
+            True
+
+        ::
+
+            sage: O1 = I.right_order(); O1  # random
+            Order of Quaternion Algebra (-31, -7753) with base ring Rational Field
+              with basis (1/2 + 1/8*j + 103/8*k, 1/434*i + 3/56*j + 38043/1736*k, 1/4*j + 103/4*k, 28*k)
+            sage: J = O1.random_ideal(); J  # random
+            Fractional ideal (36, 252*i, 55/2 + 191/2*i + 2*j, 13/2 + 25247/217*i + 9/56*j + 1/1736*k)
+            sage: J.is_integral()
+            True
+            sage: J.left_order() == O1
+            True
+
+        ::
+
+            sage: J = O0.random_ideal('right'); J  # random
+            Fractional ideal (34, 51/2 + 17/2*i, 19/2 + 1/2*i + 2*j, 5/2 + 445/62*i + 1/2*j + 1/62*k)
+            sage: J.is_integral()
+            True
+            sage: J.right_order() == O0
+            True
+
+        We can pass a target norm, too::
+
+            sage: I = O0.random_ideal(norm=42); I  # random
+            Fractional ideal (42, 63/2 + 21/2*i, 17 + i + 2*j, 23 + 269/31*i + 3/2*j + 1/62*k)
+            sage: I.is_integral()
+            True
+            sage: I.left_order() == O0
+            True
+            sage: I.norm()
+            42
+
+        If ``reduce`` is set, the target norm is respected during sampling,
+        but the returned ideal is reduced and will often have a different
+        norm::
+
+            sage: J = O0.random_ideal('right', norm=2^99, reduce=True); J  # random
+            Fractional ideal (13, 13/2 + 13/2*i, 9 + i + j, 23/2 + 321/62*i + 1/2*j + 1/62*k)
+            sage: J.is_integral()
+            True
+            sage: J.right_order() == O0
+            True
+            sage: J.norm()  # random
+            13
+
+        ALGORITHM: Reduce to prime powers `\ell^e` using CRT; then sample
+        a random element whose norm is divisible by `\ell^e` but which is
+        not itself divisible by `\ell`.
+
+        TESTS:
+
+        Some random testing::
+
+            sage: while True:
+            ....:     norm = ZZ(randrange(1, 2^99))
+            ....:     if norm.gcd(O0.discriminant()) == 1:
+            ....:         break
+            sage: I = O0.random_ideal(norm=norm)
+            sage: I.is_integral()
+            True
+            sage: I.left_order() == O0
+            True
+            sage: I.norm() == norm
+            True
+        """
+        if side == 'left':
+            idl = self.left_ideal
+        elif side == 'right':
+            idl = self.right_ideal
+        else:
+            raise ValueError('side must be "left" or "right"')
+
+        if reduce is None:
+            reduce = norm is None
+
+        if norm is None:
+            from sage.arith.misc import next_prime
+            l = ZZ(3)
+            while l.divides(self.discriminant()):
+                l = next_prime(l)
+            norm = l ** ZZ(RR(abs(self.discriminant()) << 128).log(l).ceil())
+        else:
+            norm = ZZ(norm)
+            if norm <= 0:
+                raise ValueError('requested norm must be positive')
+            if not norm.gcd(self.discriminant()).is_one():
+                raise ValueError('requested norm must be coprime to the discriminant')
+
+        from sage.misc.prandom import randrange, choice
+        from sage.rings.finite_rings.integer_mod_ring import Zmod
+
+        B = self.quaternion_algebra()
+        O = self.unit_ideal()
+        gram = O.gram_matrix() / 4
+        x = polygen(ZZ)
+        vecs, mods = [], []
+        for l,e in norm.factor():
+            mod = l**e
+            extra = l**(e + 1 + (l == 2))
+            for _ in range(999):
+                vec = vector([x] + [randrange(mod) for _ in range(3)])
+                nf = vec * gram * vec
+                if (rs := (nf - mod).roots(ring=Zmod(extra), multiplicities=False)):
+                    r = ZZ(choice(rs))
+#                    assert (mod**2).gcd(nf(r)) == mod
+                    break
+            else:
+                raise RuntimeError('overwhelmingly unlikely event, or (more likely) a bug in QuaternionOrder.random_ideal()')
+
+            vec[0] = r
+            vec = vec.change_ring(ZZ)
+
+#            if __debug__:
+#                elt = B.sum(c*g for c,g in zip(vec, O.gens()))
+#                assert elt.reduced_norm() == nf(r)
+
+            vecs.append(vec)
+            mods.append(extra)
+
+        from sage.arith.misc import CRT_vectors
+        vec = vector(ZZ, CRT_vectors(vecs, mods))
+        elt = B.sum(c*g for c,g in zip(vec, O.gens()))
+#        assert (norm**2).gcd(elt.reduced_norm()) == norm
+
+        I = idl((norm, elt))
+#        assert I.norm() == norm
+
+        if reduce:
+            I = I.reduce_equiv(side)
+
+        return I
+
     def basis_matrix(self):
         r"""
         Return the basis matrix of this quaternion order, for the
@@ -3223,6 +3401,76 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         if self.__right_order is None:
             self.__right_order = self._compute_order(side='right')
         return self.__right_order
+
+    def gens_two(self):
+        r"""
+        Return a pair of elements `N,\alpha` of this quaternion fractional ideal
+        such that the ideal equals `O_L N + O_L\alpha` and `N O_R + \alpha O_R`,
+        where `O_L, O_R` denote the ideal's left and right orders respectively.
+
+        If the ideal is integral, it is guaranteed that `N \in \ZZ` and that
+        this value equals the norm of the ideal.
+
+        (The implementation of this method is currently deterministic, but there
+        is no guarantee that it will remain so in future releases of Sage.)
+
+        EXAMPLES::
+
+            sage: B.<i,j,k> = QuaternionAlgebra(-31, -7753)
+            sage: I = B.ideal([32, 352*i, 23/2 + 545/2*i + 2*j, 14 + 6133/682*i + 7/88*j + 1/2728*k])
+            sage: I.gens_two()
+            (32, -23/2 - 545/2*i - 2*j)
+
+        .. SEEALSO::
+
+            To test whether the ideal is principal, and to compute a generator
+            in that case, use :meth:`is_principal`.
+
+        .. SEEALSO::
+
+            There exist analogous methods for ideals in number fields; see
+            :meth:`sage.rings.number_field.number_field_ideal.NumberFieldIdeal.gens_two`
+            and
+            :meth:`sage.rings.number_field.order_ideal.NumberFieldOrderIdeal_quadratic.gens_two`.
+
+        TESTS:
+
+        Random testing::
+
+            sage: B.<i,j,k> = QuaternionAlgebra(-31, -7753)
+            sage: O0 = B.maximal_order()
+            sage: O1 = O0.random_ideal().right_order()
+            sage: I = O1.random_ideal()
+            sage: O2 = I.right_order()
+            sage: N,a = I.gens_two()
+            sage: assert N == I.norm()
+            sage: assert I == O1*N + O1*a
+            sage: assert I == N*O2 + a*O2
+
+        ::
+
+            sage: s = choice((-1,+1)) * ZZ(randrange(1,100)) / randrange(1,100)
+            sage: J = O1 * s * O2
+            sage: assert J.left_order() == O1
+            sage: assert J.right_order() == O2
+            sage: N,a = J.gens_two()
+            sage: assert J == O1*N + O1*a
+            sage: assert J == N*O2 + a*O2
+        """
+        denom = self.left_order().basis_matrix().solve_left(self.basis_matrix()).denominator()
+        I = denom * self
+        N = ZZ(I.norm())
+        Q = I.quadratic_form()
+        for v in ZZ**4:
+            if -v < v:  # enumerate up to sign  #TODO this should be a method of free modules
+                continue
+            if N.gcd(Q(v)) == 1:
+                break
+        else:
+            raise RuntimeError('bug in QuaternionFractionalIdeal_rational.gens_two()')
+        B = self.quaternion_algebra()
+        a = B.sum(c * g for c, g in zip(v, I.basis()))
+        return N/denom, a/denom
 
     def __repr__(self) -> str:
         r"""
@@ -4120,6 +4368,63 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         # From this point on we know that self is principal, so it suffices to
         # find an element of minimal norm in self; see [Piz1980]_, Corollary 1.20.
         return True, self.minimal_element()
+
+    def reduce_equiv(self, side='left'):
+        r"""
+        Return a minimal ideal in the equivalence class of this ideal
+        as a left or right ideal (depending on ``side``).
+
+        Only implemented for definite quaternion algebras.
+
+        .. WARNING::
+
+            The reduced ideal computed by this method is **not** necessarily
+            a unique representative of its ideal class.
+
+        .. SEEALSO::
+
+            For the analogous method for ideals in number fields, see
+            :meth:`sage.rings.number_field.number_field_ideal.NumberFieldIdeal.reduce_equiv`.
+
+        EXAMPLES::
+
+            sage: B.<i,j,k> = QuaternionAlgebra(-23, -900001)
+            sage: I = B.ideal([777777799, 777777799/2 + 777777799/2*i, 239167896 + 128896225*i + j, 444024735 + 3546335033/23*i + 1/2*j + 1/46*k])
+
+            sage: J = I.reduce_equiv(); J  # default: side='left'
+            Fractional ideal (404, 303 + 101*i, 117/2 + 199/2*i + 2*j, 221 + 1327/23*i + 3/2*j + 1/46*k)
+            sage: J.left_order() == I.left_order()
+            True
+            sage: J.right_order() == I.right_order()
+            False
+            sage: J.right_order().isomorphism_to(I.right_order())
+            Ring morphism:
+              From: Order of Quaternion Algebra (-23, -900001) with base ring Rational Field with basis (1/2 + 1/8*j + 461/8*k, 1/4646*i + 131/808*j + 2342737/18584*k, 1/4*j + 461/4*k, 404*k)
+              To:   Order of Quaternion Algebra (-23, -900001) with base ring Rational Field with basis (1/2 + 1/35777778754*i + 286703630/777777799*j + 6908838277026128463/17888889377*k, 1/17888889377*i + 369036721/1555555598*j + 4377163512488215059/35777778754*k, 1/2*j + 1300147209/2*k, 777777799*k)
+              Defn: i |--> -1555944509277/1806777827077*i - 63443295/157111115398*j + 1912127635/3613555654154*k
+                    j |--> -1488349653720/78555557699*i - 593494326683/628444461592*j - 41222551815/628444461592*k
+                    k |--> 855677048751220/1806777827077*i - 961404429945/628444461592*j + 11644714791909/14454222616616*k
+
+            sage: K = I.reduce_equiv('right'); K
+            Fractional ideal (404, 303/2 + 78555557699/2*i, 523/2 + 51586726735/2*i + 4*j, 595/2 + 632417804121695856071/35777778754*i + 1810963987/1555555598*j + 1/35777778754*k)
+            sage: K.right_order() == I.right_order()
+            True
+            sage: K.left_order() == I.left_order()
+            False
+            sage: K.left_order().isomorphism_to(I.left_order())
+            Ring morphism:
+              From: Order of Quaternion Algebra (-23, -900001) with base ring Rational Field with basis (1/2 + 1/3613555654154*i + 46626963583/628444461592*j + 4431632142858537833956781/14454222616616*k, 1/1806777827077*i + 14698369467/628444461592*j + 4268487353014308385342305/14454222616616*k, 1/8*j + 29300147973/8*k, 314222230796*k)
+              To:   Order of Quaternion Algebra (-23, -900001) with base ring Rational Field with basis (1/2 + 1/46*i + 9/23*k, 1/23*i + 18/23*k, 1/2*j + 1/2*k, k)
+              Defn: i |--> -1555944509277/1806777827077*i - 38035560/78555557699*j + 950751220/1806777827077*k
+                    j |--> -57099028943295/3613555654154*i - 593494326683/628444461592*j - 961404429945/14454222616616*k
+                    k |--> 1720916783627635/3613555654154*i - 948118691745/628444461592*j + 11644714791909/14454222616616*k
+        """
+        gamma = self.minimal_element().conjugate() / self.norm()
+        if side == 'left':
+            return self * gamma
+        if side == 'right':
+            return gamma * self
+        raise ValueError('side must be "left" or "right"')
 
     def __contains__(self, x) -> bool:
         r"""

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -2584,17 +2584,18 @@ class QuaternionOrder(Parent):
 
         INPUT:
 
-        - ``side`` (``"left"`` or ``"right"``): Sample a left or right
-          ideal of this order.
+        - ``side`` -- either ``"left"`` (the default) or ``"right"``; specifies
+          whether to sample a left or a right ideal of this order.
 
-        - ``norm`` (positive integer or ``None``): Sample a random ideal
-          of the given norm. Must be coprime to the discriminant.
+        - ``norm`` -- positive integer or (default) ``None``; indicates to
+          sample a random ideal of the given norm. Must be coprime to the
+          discriminant.
 
-        - ``reduce`` (boolean or (default) ``None``): Reduce the ideal using
-          :meth:`reduce_equiv` prior to returning it or not. Note that the
-          norm of the ideal is only preserved when this is ``False``; thus,
-          the default is ``False`` when ``norm`` is explicitly given and
-          ``True`` otherwise.
+        - ``reduce`` -- boolean or (default) ``None``; whether to reduce
+          the ideal using :meth:`reduce_equiv` prior to returning it or not.
+          Note that the norm of the ideal is only preserved when this is
+          ``False``; thus, the default is ``False`` when ``norm`` is explicitly
+          given and ``True`` otherwise.
 
         EXAMPLES::
 
@@ -2734,7 +2735,7 @@ class QuaternionOrder(Parent):
 
         from sage.arith.misc import CRT_vectors
         vec = vector(ZZ, CRT_vectors(vecs, mods))
-        elt = B.sum(c*g for c,g in zip(vec, O.gens()))
+        elt = B.sum(c*g for c, g in zip(vec, O.gens()))
 
         I = idl((norm, elt))
 

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -2675,6 +2675,13 @@ class QuaternionOrder(Parent):
             True
             sage: I.norm() == norm
             True
+
+        Check that the ``side`` argument is validated correctly::
+
+            sage: O0.random_ideal(side='both')
+            Traceback (most recent call last):
+            ...
+            ValueError: side must be "left" or "right"
         """
         if side == 'left':
             idl = self.left_ideal
@@ -2707,7 +2714,7 @@ class QuaternionOrder(Parent):
         gram = O.gram_matrix() / 4
         x = polygen(ZZ)
         vecs, mods = [], []
-        for l,e in norm.factor():
+        for l, e in norm.factor():
             mod = l**e
             extra = l**(e + 1 + (l == 2))
             for _ in range(999):
@@ -2715,7 +2722,6 @@ class QuaternionOrder(Parent):
                 nf = vec * gram * vec
                 if (rs := (nf - mod).roots(ring=Zmod(extra), multiplicities=False)):
                     r = ZZ(choice(rs))
-#                    assert (mod**2).gcd(nf(r)) == mod
                     break
             else:
                 raise RuntimeError('overwhelmingly unlikely event, or (more likely) a bug in QuaternionOrder.random_ideal()')
@@ -2723,20 +2729,14 @@ class QuaternionOrder(Parent):
             vec[0] = r
             vec = vec.change_ring(ZZ)
 
-#            if __debug__:
-#                elt = B.sum(c*g for c,g in zip(vec, O.gens()))
-#                assert elt.reduced_norm() == nf(r)
-
             vecs.append(vec)
             mods.append(extra)
 
         from sage.arith.misc import CRT_vectors
         vec = vector(ZZ, CRT_vectors(vecs, mods))
         elt = B.sum(c*g for c,g in zip(vec, O.gens()))
-#        assert (norm**2).gcd(elt.reduced_norm()) == norm
 
         I = idl((norm, elt))
-#        assert I.norm() == norm
 
         if reduce:
             I = I.reduce_equiv(side)
@@ -3411,8 +3411,10 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         If the ideal is integral, it is guaranteed that `N \in \ZZ` and that
         this value equals the norm of the ideal.
 
-        (The implementation of this method is currently deterministic, but there
-        is no guarantee that it will remain so in future releases of Sage.)
+        .. NOTE::
+
+            The implementation of this method is currently deterministic, but there
+            is no guarantee that it will remain so in future releases of Sage.
 
         EXAMPLES::
 
@@ -4418,6 +4420,17 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
               Defn: i |--> -1555944509277/1806777827077*i - 38035560/78555557699*j + 950751220/1806777827077*k
                     j |--> -57099028943295/3613555654154*i - 593494326683/628444461592*j - 961404429945/14454222616616*k
                     k |--> 1720916783627635/3613555654154*i - 948118691745/628444461592*j + 11644714791909/14454222616616*k
+
+        TESTS:
+
+        Check that the ``side`` argument is validated correctly::
+
+            sage: B.<i,j,k> = QuaternionAlgebra(-23, -900001)
+            sage: I = B.ideal([777777799, 777777799/2 + 777777799/2*i, 239167896 + 128896225*i + j, 444024735 + 3546335033/23*i + 1/2*j + 1/46*k])
+            sage: I.reduce_equiv(side='both')
+            Traceback (most recent call last):
+            ...
+            ValueError: side must be "left" or "right"
         """
         gamma = self.minimal_element().conjugate() / self.norm()
         if side == 'left':


### PR DESCRIPTION
In this patch, we implement three new methods for (definite) quaternion algebras:
- `.random_ideal()` for quaternion orders.
- `.reduce_equiv()` for quaternion ideals.
- `.gens_two()` for quaternion ideals.

All of these are needed rather frequently for applications in isogeny-based cryptography.