### PR TITLE
add FiniteRingElement.minpoly_over() as a workaround for #34907

### DIFF
--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -166,6 +166,83 @@ cdef class FiniteRingElement(CommutativeRingElement):
             return (R.one(), self)
         return NotImplemented
 
+    def minpoly_over(self, F, var='x'):
+        r"""
+        Return the minimal polynomial of this finite-field element over
+        the given base field, which must be a subfield of the parent of
+        this element.
+
+        EXAMPLES::
+
+            sage: f = GF(101^2).gen().minpoly_over(GF(101^2)); f
+            x + 100*z2
+            sage: f.parent()
+            Univariate Polynomial Ring in x over Finite Field in z2 of size 101^2
+
+        ::
+
+            sage: f = GF(101^4).gen().minpoly_over(GF(101^2)); f
+            x^2 + (31*z2 + 39)*x + z2
+            sage: f.parent()
+            Univariate Polynomial Ring in x over Finite Field in z2 of size 101^2
+
+        ::
+
+            sage: GF(101^3).gen().minpoly_over(GF(101^2))
+            Traceback (most recent call last):
+            ...
+            ValueError: Finite Field in z2 of size 101^2 does not embed into Finite Field in z3 of size 101^3
+
+        ::
+
+            sage: f = GF(101)(42).minpoly_over(GF(101)); f
+            x + 59
+            sage: f.parent()
+            Univariate Polynomial Ring in x over Finite Field of size 101
+
+        ::
+
+            sage: GF(101)(42).minpoly_over(GF(101^2))
+            Traceback (most recent call last):
+            ...
+            ValueError: Finite Field in z2 of size 101^2 does not embed into Finite Field of size 101
+
+        ::
+
+            sage: f = (GF(101^2).gen()^102).minpoly_over(GF(101^2)); f
+            x + 99
+            sage: f.parent()
+            Univariate Polynomial Ring in x over Finite Field in z2 of size 101^2
+
+        ::
+
+            sage: f = (GF(101^2).gen()^102).minpoly_over(GF(101)); f
+            x + 99
+            sage: f.parent()
+            Univariate Polynomial Ring in x over Finite Field of size 101
+
+        ::
+
+            sage: f = (GF(101^2).gen()^100).minpoly_over(GF(101)); f
+            x^2 + 95*x + 1
+            sage: f.parent()
+            Univariate Polynomial Ring in x over Finite Field of size 101
+        """
+        # workaround for #34907: if this element lies in F, then .minpoly() for extensions is buggy
+        try:
+            emb = F.hom(self.parent())
+        except TypeError:
+            raise ValueError(f'{F} does not embed into {self.parent()}')
+        try:
+            a = emb.section()(self)
+        except ValueError:
+            ext = self.parent().over(F)
+            return ext(self).minpoly(var=var)
+        else:
+            from sage.rings.polynomial.polynomial_ring import polygen
+            return polygen(F, var) - a
+
+
 
 cdef class FinitePolyExtElement(FiniteRingElement):
     """

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2077,9 +2077,8 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                 raise ValueError('algorithm "minpoly" only supports odd prime-power degrees')
 
             xx = P.xy()[0]
-            ext = xx.parent().over(self.base_ring())
-            mu = ext(xx).minpoly()
-            assert mu.base_ring() == self.base_ring()
+            mu = xx.minpoly_over(self.base_ring())
+            assert mu.base_ring() == self.base_ring()  # just to be sure -- see #34907
 
             return self.kernel_polynomial_from_divisor(mu, P.order(), check=False)
 

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2029,6 +2029,34 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             sage: set(isogs) == set(E.isogenies_prime_degree(11))
             True
 
+        TESTS:
+
+        Check that it works correctly for points defined over the base field (see :issue:`41900`)::
+
+            sage: E = EllipticCurve(GF(419), [1,0])
+            sage: P = E.lift_x(343)
+            sage: P.order()
+            7
+            sage: E.kernel_polynomial_from_point(P, algorithm='minpoly')
+            x^3 + 274*x^2 + 350*x + 6
+
+        ::
+
+            sage: F.<i> = GF((419,2), modulus=[1,0,1])
+            sage: EE = EllipticCurve(F, [1,0])
+            sage: Q = EE.lift_x(83*i + 16)
+            sage: Q.order()
+            7
+            sage: EE.kernel_polynomial_from_point(Q, algorithm='minpoly')
+            x^3 + (389*i + 98)*x^2 + (36*i + 186)*x + 69*i + 282
+
+        ::
+            sage: R = EE.lift_x(76)
+            sage: R.order()
+            7
+            sage: E.kernel_polynomial_from_point(R, algorithm='minpoly')
+            x^3 + 145*x^2 + 350*x + 413
+
         ALGORITHM:
 
         - The ``'basic'`` algorithm is to multiply together all the linear

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -2088,7 +2088,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         if algorithm is None:
             if R in FiniteFields():
                 # In this case the minpoly approach is likely to be faster.
-                if l & 1 and l.is_prime_power():
+                if l & 1 and l.is_prime():
                     algorithm = 'minpoly'
             if algorithm is None:
                 algorithm = 'basic'
@@ -2101,8 +2101,8 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             return f.change_ring(R)
 
         if algorithm == 'minpoly':
-            if not l & 1 or not l.is_prime_power():
-                raise ValueError('algorithm "minpoly" only supports odd prime-power degrees')
+            if not l & 1 or not l.is_prime():
+                raise ValueError('algorithm "minpoly" only supports odd prime degrees')
 
             xx = P.xy()[0]
             mu = xx.minpoly_over(self.base_ring())


### PR DESCRIPTION
Due to #34907, the method `EllipticCurve_field.kernel_polynomial_from_point()` currently (Sage 10.8) fails with the `"minpoly"` algorithm when the given point is rational. In this patch, we add a workaround by introducing a `.minpoly_over()` method for finite-field elements that handles this case correctly.