### PR TITLE
register coercion for tower of field extensions in EllipticCurveHom_fractional._eval()

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom_fractional.py
+++ b/src/sage/schemes/elliptic_curves/hom_fractional.py
@@ -219,6 +219,21 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
             (9*z3^2 + 6*z3 + 6 : 4*z3^2 + 9*z3 + 3 : 1)
             sage: phi._eval(Q)
             (z3^2 + 9*z3 : 10*z3^2 + 6*z3 + 10 : 1)
+
+        TESTS:
+
+        Check for :issue:`41902`::
+
+            sage: F.<t> = GF((1019, 2))
+            sage: E = EllipticCurve(F, [1, 0])
+            sage: P = E.lift_x(675*t + 800)
+            sage: i = E.automorphisms()[-1]
+            sage: j = E.frobenius_isogeny()
+            sage: f = End(E)(6) / 6
+            sage: P
+            (675*t + 800 : 518*t + 493 : 1)
+            sage: f(P)
+            (675*t + 800 : 518*t + 493 : 1)
         """
         if self._domain.defining_polynomial()(*P):
             raise ValueError(f'{P} not on {self._domain}')

--- a/src/sage/schemes/elliptic_curves/hom_fractional.py
+++ b/src/sage/schemes/elliptic_curves/hom_fractional.py
@@ -233,6 +233,7 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
         n = P.order()
         m = self._d.prime_to_m_part(n)
         P *= m.inverse_mod(n)
+        coercion = k.hom(k)
         for q, e in (self._d//m).factor():
             for _ in range(e):
                 f = P.division_points(q, poly_only=True)
@@ -240,9 +241,13 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
                     f.any_root(assume_squarefree=True)
                 except ValueError:
                     g = f.factor()[0][0]
-                    F = F.extension(g.degree())
-                    g.any_root(ring=F)
+                    F, emb = F.extension(g.degree(), 'W', map=True)
+                    coercion = emb * coercion
                 P = P.change_ring(F).division_points(q)[0]
+        try:
+            F.register_coercion(coercion)
+        except AssertionError:  # coercion already exists
+            pass
 
         Q = self._phi._eval(P).change_ring(k)
 


### PR DESCRIPTION
The following code currently (Sage 10.8) crashes:
```sage
F.<t> = GF((1019, 2))
E = EllipticCurve(F, [1, 0])
P = E.lift_x(675*t + 800)
i = E.automorphisms()[-1]
j = E.frobenius_isogeny()
f = End(E)(6) / 6
print(P)
print(f(P))
```

Error message:
```
TypeError: no common canonical parent for objects with parents: 'Finite Field in t of size 1019^2' and 'Finite Field in z12 of size 1019^12'
```