### PR TITLE
canonicalize quaternions in basis_for_quaternion_lattice() to fix #41903

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra_cython.pyx
+++ b/src/sage/algebras/quatalg/quaternion_algebra_cython.pyx
@@ -209,6 +209,18 @@ def rational_quaternions_from_integral_matrix_and_denom(A, Matrix_integer_dense 
 
         sage: f(A, matrix([[3,-4,2,-1],[4,3,2,1]]), 3, reverse=True)
         [1/3 + 2/3*i + j + 4/3*k, -1/3 + 2/3*i - 4/3*j + k]
+
+    TESTS:
+
+    Check that :issue:`41903` is fixed::
+
+        sage: from sage.algebras.quatalg.quaternion_algebra import basis_for_quaternion_lattice as bfql
+        sage: B.<i,j,k> = QuaternionAlgebra(-1,-19)
+        sage: basis = bfql([(1+i)/2, (1+j)/2, (1+k)/2, (i+j)/2])
+        sage: basis[0]
+        1
+        sage: basis[0].is_one()
+        True
     """
     #
     # This is an optimized version of the following interpreted Python code.
@@ -253,8 +265,7 @@ def rational_quaternions_from_integral_matrix_and_denom(A, Matrix_integer_dense 
             H.get_unsafe_mpz(i, 3, tmp)
             mpz_init_set(x.w, tmp)
         mpz_init_set(x.d, d.value)
-        # WARNING -- we do *not* canonicalize the entries in the quaternion.
-        # This is I think _not_ needed for quaternion_element.pyx
+        x.canonicalize()  # prevent issues like #41903
         v.append(x)
     mpz_clear(tmp)
     return v


### PR DESCRIPTION
Seems like `quaternion_algebra_element.pyx` *does* assume quaternions to be normalized (at least in some places). 🙂

Fixes #41903.