### PR TITLE
Correct a meson.build command to use the meson python instead of user python 

### DIFF
--- a/src/sage/ext/interpreters/meson.build
+++ b/src/sage/ext/interpreters/meson.build
@@ -24,7 +24,7 @@ interpreters = custom_target(
     '__init__.py',
   ],
   input: '../../../sage_setup/autogen/interpreters/internal/__init__.py',
-  command: ['../../../sage_setup/autogen/interpreters/__main__.py', '@OUTDIR@'],
+  command: [py, '../../../sage_setup/autogen/interpreters/__main__.py', '@OUTDIR@'],
   # Manually install the generated files instead of using install_sources
   # this is a workaround for https://github.com/mesonbuild/meson/issues/7372
   install: true,

--- a/src/sage/ext/interpreters/meson.build
+++ b/src/sage/ext/interpreters/meson.build
@@ -29,7 +29,6 @@ interpreters = custom_target(
     files('../../../sage_setup/autogen/interpreters/__main__.py'),
     '@OUTDIR@',
   ],
-
   # Manually install the generated files instead of using install_sources
   # this is a workaround for https://github.com/mesonbuild/meson/issues/7372
   install: true,

--- a/src/sage/ext/interpreters/meson.build
+++ b/src/sage/ext/interpreters/meson.build
@@ -24,7 +24,12 @@ interpreters = custom_target(
     '__init__.py',
   ],
   input: '../../../sage_setup/autogen/interpreters/internal/__init__.py',
-  command: [py, files('../../../sage_setup/autogen/interpreters/__main__.py'), '@OUTDIR@'],
+  command: [
+    py,
+    files('../../../sage_setup/autogen/interpreters/__main__.py'),
+    '@OUTDIR@',
+  ],
+
   # Manually install the generated files instead of using install_sources
   # this is a workaround for https://github.com/mesonbuild/meson/issues/7372
   install: true,

--- a/src/sage/ext/interpreters/meson.build
+++ b/src/sage/ext/interpreters/meson.build
@@ -24,7 +24,7 @@ interpreters = custom_target(
     '__init__.py',
   ],
   input: '../../../sage_setup/autogen/interpreters/internal/__init__.py',
-  command: [py, '../../../sage_setup/autogen/interpreters/__main__.py', '@OUTDIR@'],
+  command: [py, file('../../../sage_setup/autogen/interpreters/__main__.py'), '@OUTDIR@'],
   # Manually install the generated files instead of using install_sources
   # this is a workaround for https://github.com/mesonbuild/meson/issues/7372
   install: true,

--- a/src/sage/ext/interpreters/meson.build
+++ b/src/sage/ext/interpreters/meson.build
@@ -24,7 +24,7 @@ interpreters = custom_target(
     '__init__.py',
   ],
   input: '../../../sage_setup/autogen/interpreters/internal/__init__.py',
-  command: [py, file('../../../sage_setup/autogen/interpreters/__main__.py'), '@OUTDIR@'],
+  command: [py, files('../../../sage_setup/autogen/interpreters/__main__.py'), '@OUTDIR@'],
   # Manually install the generated files instead of using install_sources
   # this is a workaround for https://github.com/mesonbuild/meson/issues/7372
   install: true,


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
The meson build process identifies a python installation `py` with several important build requirements. One of the build files then calls a python script, which attempts to use the user python installation instead of directly using `py`. If there are multiple such installs, then this can cause the build to fail. This changes the command call in src/sage/ext/interpreters/meson.build to use meson's python `py` (and uses the meson [command](https://mesonbuild.com/Reference-manual_functions.html#files) `files` to correctly identify the target script). 

See Issue https://github.com/sagemath/sage/issues/41895

I have confirmed this change builds on my machine with a simplified nix flake. I hope CI will check that this is also correct on a more typical OS.

I note that the issue and fix were found by a Claude instance.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ x ] The title is concise and informative.
- [ x ] The description explains in detail what this PR is about.
- [ x ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
#41895: issue and proposed fix.
Fix https://github.com/sagemath/sage/issues/41895
