### PR TITLE
Added explicit series methods for ChainSpecies

### DIFF
--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -1855,7 +1855,7 @@ class ChainSpecies(LazyCombinatorialSpeciesElement, UniqueRepresentation,
 
             sage: L.<X> = LazyCombinatorialSpecies(QQ)
             sage: L.Chains().generating_series().truncate(7)
-            1 + X + 1/2*X^2 + 1/2*X^3 + 1/2*X^4 + 1/2*X^5 + 1/2*X^6 
+            1 + X + 1/2*X^2 + 1/2*X^3 + 1/2*X^4 + 1/2*X^5 + 1/2*X^6
         """
         P = self.parent()
         L = LazyPowerSeriesRing(P.base_ring().fraction_field(),

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -1844,6 +1844,72 @@ class ChainSpecies(LazyCombinatorialSpeciesElement, UniqueRepresentation,
                 for pi in itertools.permutations(rest):
                     yield (a,) + pi + (b,)
 
+    def generating_series(self):
+        r"""
+        Return the (exponential) generating series of the
+        species of chains.
+
+        This is `(1/(1-x) + 1 + x)/2`.
+
+        EXAMPLES::
+
+            sage: L.<X> = LazyCombinatorialSpecies(QQ)
+            sage: L.Chains().generating_series().truncate(7)
+            1 + X + 1/2*X^2 + 1/2*X^3 + 1/2*X^4 + 1/2*X^5 + 1/2*X^6 
+        """
+        P = self.parent()
+        L = LazyPowerSeriesRing(P.base_ring().fraction_field(),
+                                P._laurent_poly_ring._indices._indices.variable_names())
+        x = L.gen()
+        return (1 / (1 - x) + 1 + x) / 2
+
+    def isotype_generating_series(self):
+        r"""
+        Return the isotype generating series of the species of
+        chains.
+
+        This is the geometric series '1/(1-x)'.
+
+        EXAMPLES::
+
+            sage: L.<X> = LazyCombinatorialSpecies(QQ)
+            sage: L.Chains().isotype_generating_series().truncate(4)
+            1 + X + X^2 + X^3
+        """
+        P = self.parent()
+        L = LazyPowerSeriesRing(P.base_ring().fraction_field(),
+                                P._laurent_poly_ring._indices._indices.variable_names())
+        return L(constant=1)
+
+    def cycle_index_series(self):
+        r"""
+        Return the cycle index series of the species of chains.
+
+        EXAMPLES::
+
+            sage: L.<X> = LazyCombinatorialSpecies(QQ)
+            sage: L.Chains().cycle_index_series()[3]
+            1/2*p[1, 1, 1] + 1/2*p[2, 1]
+            sage: L.Chains().cycle_index_series()[4]
+            1/2*p[1, 1, 1, 1] + 1/2*p[2, 2]
+        """
+        P = self.parent()
+        p = SymmetricFunctions(P.base_ring().fraction_field()).p()
+        L = LazySymmetricFunctions(p)
+
+        def coefficient(n):
+            if not n:
+                return p.one()
+            if n == 1:
+                return p[1]
+            identity = p[[1] * n]
+            if n % 2 == 0:
+                reversal = p[[2] * (n // 2)]
+            else:
+                reversal = p[[2] * ((n - 1) // 2) + [1]]
+            return (identity + reversal) / 2
+
+        return L(coefficient)
 
 class GraphSpecies(LazyCombinatorialSpeciesElementGeneratingSeriesMixin,
                    LazyCombinatorialSpeciesElement, UniqueRepresentation,


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

I have added generating_series(), isotype_generating_series(), and cycle_index_series() methods for ChainSpecies in lazy_species.py. All three methods admit neat formulas which are given by

- exponential generating series: (1/(1-x) + 1 + x)/2,
- isotype generating series: 1/(1-x),
- the cycle index coefficients are obtained by averaging the identity and the reversal involution.

I  have also added doctests for these methods.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ x] The title is concise and informative.
- [ x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

None


