### PR TITLE
Implemented the fix by specializing the vector-space homset natural map path

### DIFF
--- a/src/sage/modules/vector_space_homspace.py
+++ b/src/sage/modules/vector_space_homspace.py
@@ -367,6 +367,41 @@ class VectorSpaceHomspace(sage.modules.free_module_homspace.FreeModuleHomspace):
             raise TypeError(msg.format(A))
         return VectorSpaceMorphism(self, A, side=side)
 
+    def natural_map(self):
+        r"""
+        Return the natural morphism from the domain into the codomain.
+
+        If the codomain coerces elements of the domain (for example an
+        ambient vector space coercing from a subspace), return that coercion
+        map so the result is a matrix-based morphism with methods such as
+        :meth:`~sage.modules.matrix_morphism.MatrixMorphism_abstract.matrix`,
+        :meth:`~sage.categories.morphism.Morphism.restrict_domain`, and
+        :meth:`~sage.categories.morphism.Morphism.restrict_codomain`.
+        Otherwise fall back to the default homset implementation
+        (typically a formal coercion morphism or a :exc:`TypeError`).
+
+        EXAMPLES::
+
+            sage: from sage.modules.matrix_morphism import MatrixMorphism_abstract
+            sage: V = QQ^2
+            sage: W = V.span([V.0])
+            sage: f = W.hom(V)
+            sage: isinstance(f, MatrixMorphism_abstract)
+            True
+            sage: f.matrix()
+            [1 0]
+            sage: f.restrict_domain(W).matrix() == f.matrix()
+            True
+            sage: U = V.span([V.0])
+            sage: f.restrict_codomain(U).matrix()
+            [1]
+        """
+        C = self.codomain()
+        phi = C.coerce_map_from(self.domain())
+        if phi is not None:
+            return phi
+        return super().natural_map()
+
     def _repr_(self):
         r"""
         Text representation of a space of vector space morphisms.


### PR DESCRIPTION
Fixes #41674 
## What changed

- Updated VectorSpaceHomspace in src/sage/modules/vector_space_homspace.py.
- Added a new natural_map() override that:
      - first tries self.codomain().coerce_map_from(self.domain())
      - returns that map when available (this is the existing matrix-morphism path you wanted to reuse)
      - falls back to super().natural_map() for non-coercible cases (preserving existing behavior)

This directly affects calls like W.hom(V) (where W and V are vector spaces), since Parent.hom(...) with a parent argument delegates to Hom().natural_map().

## Why this fixes the issue

- Previously, vector-space .hom() natural maps could end up as a generic formal coercion morphism.
- Now, for vector spaces, it uses the same coercion-map mechanism as .coerce_map_from(), which gives a matrix-based           
   morphism.
- That means methods like:
      - .matrix()
      - .restrict_domain()
      - .restrict_codomain() are available and behave as expected.

## Tests added
Added doctests in VectorSpaceHomspace.natural_map():

## constructs:
- V = QQ^2
- W = V.span([V.0])
- f = W.hom(V)

checks:
- f is a MatrixMorphism_abstract
- f.matrix() works
- f.restrict_domain(W).matrix() works
- f.restrict_codomain(U).matrix() works for U = V.span([V.0])

Notes on verification
I attempted to run ./sage -t src/sage/modules/vector_space_homspace.py, but this workspace environment is not set up with the Sage Python module (ModuleNotFoundError: No module named 'sage'), so runtime doctest execution wasn’t possible here.
Static checks (ReadLints) on the modified file report no linter issues.