### PR TITLE
Fix: incorrect conversion of finite-field elements

### DIFF
--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -340,6 +340,26 @@ cdef class Cache_givaro(Cache_base):
             ...
             TypeError: unable to coerce from a finite field other than the prime subfield
 
+        Incompatible extension degrees (no field embedding when the source
+        extension degree does not divide the target degree)::
+
+            sage: GF(101^2)(GF(101^3).gen())
+            Traceback (most recent call last):
+            ...
+            TypeError: cannot coerce element: source field is not a subfield of the target field
+
+            sage: L = GF(101^2, implementation='givaro')
+            sage: K = GF(101^3, implementation='pari_ffelt')
+            sage: L(K.gen())
+            Traceback (most recent call last):
+            ...
+            TypeError: cannot coerce element: source field is not a subfield of the target field
+
+        A subfield embeds into a larger field with compatible degrees::
+
+            sage: GF(5^4)(GF(5^2)(1))
+            1
+
         For more examples, see
         ``finite_field_givaro.FiniteField_givaro._element_constructor_``
         """
@@ -411,7 +431,14 @@ cdef class Cache_givaro(Cache_base):
             pass  # handle this in next if clause
 
         elif isinstance(e, FiniteFieldElement_pari_ffelt):
-            # Reduce to pari
+            # Reduce to PARI only when a field embedding of the source into
+            # ``self.parent`` exists: GF(p^m) -> GF(p^n) iff m | n.  Otherwise
+            # FF_to_FpXQ below silently builds an unrelated element.
+            F = self.parent
+            E = e.parent()
+            if E.degree() > 1 and F.degree() > 1 and not E.degree().divides(F.degree()):
+                raise TypeError(
+                    "cannot coerce element: source field is not a subfield of the target field")
             e = e.__pari__()
 
         elif isinstance(e, GapElement):

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -340,8 +340,8 @@ cdef class Cache_givaro(Cache_base):
             ...
             TypeError: unable to coerce from a finite field other than the prime subfield
 
-        Incompatible extension degrees (no field embedding when the source
-        extension degree does not divide the target degree)::
+        Incompatible extension degrees (no field embedding exists when the source
+        extension degree does not divide the target degree; see :issue:`41899`)::
 
             sage: GF(101^2)(GF(101^3).gen())
             Traceback (most recent call last):

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -436,7 +436,7 @@ cdef class Cache_givaro(Cache_base):
             # FF_to_FpXQ below silently builds an unrelated element.
             F = self.parent
             E = e.parent()
-            if E.degree() > 1 and F.degree() > 1 and not E.degree().divides(F.degree()):
+            if not E.degree().divides(F.degree()):
                 raise TypeError(
                     "cannot coerce element: source field is not a subfield of the target field")
             e = e.__pari__()

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -357,8 +357,10 @@ cdef class Cache_givaro(Cache_base):
 
         A subfield embeds into a larger field with compatible degrees::
 
-            sage: GF(5^4)(GF(5^2)(1))
-            1
+            sage: L = GF(5^4)
+            sage: K, inc = L.subfield(2, map=True)
+            sage: inc(K.gen()).parent() is L
+            True
 
         For more examples, see
         ``finite_field_givaro.FiniteField_givaro._element_constructor_``

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -342,7 +342,7 @@ cdef class Cache_ntl_gf2e(Cache_base):
             # Require a field embedding GF(p^m) -> GF(p^n), i.e. m | n (same as Givaro).
             F = self._parent
             E = e.parent()
-            if E.degree() > 1 and F.degree() > 1 and not E.degree().divides(F.degree()):
+            if not E.degree().divides(F.degree()):
                 raise TypeError(
                     "cannot coerce element: source field is not a subfield of the target field")
             e = e.__pari__()

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -269,7 +269,7 @@ cdef class Cache_ntl_gf2e(Cache_base):
             sage: K(c^20)
             a^6 + a^3 + a^2 + a
 
-        But not between extensions of incompatible degrees::
+        But not between extensions of incompatible degrees (see :issue:`41899`)::
 
             sage: L = GF(2^2, implementation='ntl')
             sage: P = GF(2^3, implementation='pari_ffelt')

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -268,6 +268,15 @@ cdef class Cache_ntl_gf2e(Cache_base):
             sage: M.<c> = GF(2^19, implementation="pari_ffelt")
             sage: K(c^20)
             a^6 + a^3 + a^2 + a
+
+        But not between extensions of incompatible degrees::
+
+            sage: L = GF(2^2, implementation='ntl')
+            sage: P = GF(2^3, implementation='pari_ffelt')
+            sage: L(P.gen())
+            Traceback (most recent call last):
+            ...
+            TypeError: cannot coerce element: source field is not a subfield of the target field
         """
         if isinstance(e, FiniteField_ntl_gf2eElement) and e.parent() is self._parent: return e
         cdef FiniteField_ntl_gf2eElement res = self._new()
@@ -330,7 +339,12 @@ cdef class Cache_ntl_gf2e(Cache_base):
             pass # handle this in next if clause
 
         elif isinstance(e, FiniteFieldElement_pari_ffelt):
-            # Reduce to pari
+            # Require a field embedding GF(p^m) -> GF(p^n), i.e. m | n (same as Givaro).
+            F = self._parent
+            E = e.parent()
+            if E.degree() > 1 and F.degree() > 1 and not E.degree().divides(F.degree()):
+                raise TypeError(
+                    "cannot coerce element: source field is not a subfield of the target field")
             e = e.__pari__()
 
         elif isinstance(e, GapElement):


### PR DESCRIPTION
Fix #41899

In element_givaro.pyx and element_ntl_gf2e.pyx, before e = e.__pari__(), require:

if both degrees are > 1, then E.degree().divides(F.degree())
(where E is the parent of the PARI element and F is the target field),
otherwise raise:

TypeError: cannot coerce element: source field is not a subfield of the target field

Prime fields are unchanged: the new check is skipped when F.degree() == 1 or E.degree() == 1, so the existing PARI handling for those cases is unchanged.

