### PR TITLE
graphs: factor shared immutable backend initialization

### DIFF
--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -177,7 +177,7 @@ from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 from itertools import product
 import sage.graphs.generic_graph_pyx as generic_graph_pyx
-from sage.graphs.generic_graph import GenericGraph
+from sage.graphs.generic_graph import GenericGraph, _initialize_graph_backend
 from sage.graphs.dot2tex_utils import have_dot2tex
 from sage.graphs.views import EdgesView
 
@@ -506,6 +506,13 @@ class DiGraph(GenericGraph):
         True
         sage: type(J_imm._backend) == type(G_imm._backend)                              # needs networkx
         True
+        sage: D = DiGraph({0: [1, 2], 2: [3]})
+        sage: D_imm = DiGraph(D, immutable=True)
+        sage: D_static = DiGraph(D, data_structure='static_sparse')
+        sage: D_imm == D_static == D
+        True
+        sage: type(D_imm._backend) == type(D_static._backend)
+        True
 
     From a list of vertices and a list of edges::
 
@@ -641,32 +648,20 @@ class DiGraph(GenericGraph):
         GenericGraph.__init__(self)
         from sage.structure.element import Matrix
 
-        if sparse is False:
-            if data_structure != "sparse":
-                raise ValueError("the 'sparse' argument is an alias for "
-                                 "'data_structure', please do not define both")
-            data_structure = "dense"
-
-        if multiedges or weighted:
-            if data_structure == "dense":
-                raise RuntimeError("multiedge and weighted c_graphs must be sparse")
-
-        if immutable:
-            data_structure = 'static_sparse'
-
         # If the data structure is static_sparse, we first build a graph
         # using the sparse data structure, then re-encode the resulting graph
         # as a static sparse graph.
-        from sage.graphs.base.sparse_graph import SparseGraphBackend
-        from sage.graphs.base.dense_graph import DenseGraphBackend
-        if data_structure in ["sparse", "static_sparse"]:
-            CGB = SparseGraphBackend
-        elif data_structure == "dense":
-            CGB = DenseGraphBackend
-        else:
-            raise ValueError("data_structure must be equal to 'sparse', "
-                             "'static_sparse' or 'dense'")
-        self._backend = CGB(0, directed=True)
+        data_structure, self._backend = _initialize_graph_backend(
+            data_structure=data_structure,
+            sparse=sparse,
+            immutable=immutable,
+            multiedges=multiedges,
+            weighted=weighted,
+            directed=True,
+            sparse_alias_error=("the 'sparse' argument is an alias for "
+                                "'data_structure', please do not define both"),
+            dense_multiedge_error="multiedge and weighted c_graphs must be sparse",
+        )
 
         if format is None and isinstance(data, str):
             format = 'dig6'

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -469,6 +469,79 @@ lazy_import('sage.matrix.constructor', 'matrix')
 
 to_hex = LazyImport('matplotlib.colors', 'to_hex')
 
+def _initialize_graph_backend(data_structure, sparse, immutable,
+                              multiedges, weighted, directed,
+                              sparse_alias_error, dense_multiedge_error):
+    """
+    Normalize backend options and construct the initial backend.
+
+    INPUT:
+
+    - ``data_structure`` -- string
+    - ``sparse`` -- boolean
+    - ``immutable`` -- boolean
+    - ``multiedges`` -- boolean or ``None``
+    - ``weighted`` -- boolean or ``None``
+    - ``directed`` -- boolean
+    - ``sparse_alias_error`` -- error message for conflicting ``sparse`` /
+      ``data_structure`` arguments
+    - ``dense_multiedge_error`` -- error message for invalid dense backend use
+
+    OUTPUT:
+
+    A pair ``(data_structure, backend)`` where ``data_structure`` is the
+    normalized backend name and ``backend`` is an initialized backend object.
+
+    TESTS::
+
+        sage: from sage.graphs.generic_graph import _initialize_graph_backend
+        sage: ds, B = _initialize_graph_backend(
+        ....:     'sparse', True, False, False, False, False,
+        ....:     "bad sparse alias", "bad dense backend")
+        sage: ds
+        'sparse'
+        sage: B is not None
+        True
+
+        sage: ds, B = _initialize_graph_backend(
+        ....:     'sparse', True, True, False, False, True,
+        ....:     "bad sparse alias", "bad dense backend")
+        sage: ds
+        'static_sparse'
+        sage: B is not None
+        True
+
+        sage: _initialize_graph_backend(
+        ....:     'dense', True, False, True, False, False,
+        ....:     "bad sparse alias", "bad dense backend")
+        Traceback (most recent call last):
+        ...
+        RuntimeError: bad dense backend
+    """
+    if sparse is False:
+        if data_structure != "sparse":
+            raise ValueError(sparse_alias_error)
+        data_structure = "dense"
+
+    if multiedges or weighted:
+        if data_structure == "dense":
+            raise RuntimeError(dense_multiedge_error)
+
+    if immutable:
+        data_structure = "static_sparse"
+
+    from sage.graphs.base.sparse_graph import SparseGraphBackend
+    from sage.graphs.base.dense_graph import DenseGraphBackend
+
+    if data_structure in ["sparse", "static_sparse"]:
+        backend_class = SparseGraphBackend
+    elif data_structure == "dense":
+        backend_class = DenseGraphBackend
+    else:
+        raise ValueError("data_structure must be equal to 'sparse', "
+                         "'static_sparse' or 'dense'")
+
+    return data_structure, backend_class(0, directed=directed)
 
 class GenericGraph(GenericGraph_pyx):
     """

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -418,7 +418,7 @@ from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 import sage.graphs.generic_graph_pyx as generic_graph_pyx
-from sage.graphs.generic_graph import GenericGraph
+from sage.graphs.generic_graph import GenericGraph, _initialize_graph_backend
 from sage.graphs.independent_sets import IndependentSets
 from sage.misc.rest_index_of_methods import doc_index, gen_thematic_rest_table_index
 from sage.graphs.views import EdgesView
@@ -875,6 +875,14 @@ class Graph(GenericGraph):
           True
           sage: {G_imm:1}[H_imm]
           1
+          sage: G = graphs.PetersenGraph()
+          sage: G_imm = Graph(G, immutable=True)
+          sage: G_static = Graph(G, data_structure='static_sparse')
+          sage: G_imm == G_static == G
+          True
+          sage: type(G_imm._backend) == type(G_static._backend)
+          True
+
 
     TESTS::
 
@@ -1036,34 +1044,22 @@ class Graph(GenericGraph):
             {0: 'foo'}
         """
         GenericGraph.__init__(self)
-
         from sage.structure.element import Matrix
-
-        if sparse is False:
-            if data_structure != "sparse":
-                raise ValueError("The 'sparse' argument is an alias for "
-                                 "'data_structure'. Please do not define both.")
-            data_structure = "dense"
-
-        if multiedges or weighted:
-            if data_structure == "dense":
-                raise RuntimeError("Multiedge and weighted c_graphs must be sparse.")
-        if immutable:
-            data_structure = 'static_sparse'
 
         # If the data structure is static_sparse, we first build a graph
         # using the sparse data structure, then re-encode the resulting graph
         # as a static sparse graph.
-        from sage.graphs.base.sparse_graph import SparseGraphBackend
-        from sage.graphs.base.dense_graph import DenseGraphBackend
-        if data_structure in ["sparse", "static_sparse"]:
-            CGB = SparseGraphBackend
-        elif data_structure == "dense":
-            CGB = DenseGraphBackend
-        else:
-            raise ValueError("data_structure must be equal to 'sparse', "
-                             "'static_sparse' or 'dense'")
-        self._backend = CGB(0, directed=False)
+        data_structure, self._backend = _initialize_graph_backend(
+            data_structure=data_structure,
+            sparse=sparse,
+            immutable=immutable,
+            multiedges=multiedges,
+            weighted=weighted,
+            directed=False,
+            sparse_alias_error=("The 'sparse' argument is an alias for "
+                                "'data_structure'. Please do not define both."),
+            dense_multiedge_error="Multiedge and weighted c_graphs must be sparse.",
+        )
 
         if format is None and isinstance(data, str):
             if data.startswith(">>graph6<<"):


### PR DESCRIPTION
Graph and DiGraph currently duplicate the logic that normalizes
`sparse` / `data_structure`, maps `immutable=True` to `static_sparse`,
and initializes the sparse or dense backend.

This PR factors that shared logic into a private helper in
`sage.graphs.generic_graph`.

Behavior is unchanged. Additional doctests verify that immutable
construction still agrees with `data_structure='static_sparse'`
for both Graph and DiGraph.

Local testing:
- `./sage -t src/sage/graphs/digraph.py` passed
- `./sage -t src/sage/graphs/generic_graph.py` and `./sage -t src/sage/graphs/graph.py` were blocked locally by unrelated optional `database_graphs` doctests in `GraphQuery` examples