### PR TITLE
Factor static_sparse constructor finalization

### DIFF
--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -610,6 +610,15 @@ class DiGraph(GenericGraph):
             sage: copy(g) is g    # copy is mutable again
             False
 
+        The vertex iteration order is preserved when creating an immutable digraph::
+
+            sage: D = DiGraph([['b', 'a'], []])
+            sage: list(D)
+            ['b', 'a']
+            sage: Dim = DiGraph([['b', 'a'], []], immutable=True)
+            sage: list(Dim)
+            ['b', 'a']
+
         Unknown input format::
 
             sage: DiGraph(4, format='HeyHeyHey')
@@ -862,7 +871,8 @@ class DiGraph(GenericGraph):
             from sage.graphs.base.static_sparse_backend import StaticSparseBackend
             ib = StaticSparseBackend(self,
                                      loops=self.allows_loops(),
-                                     multiedges=self.allows_multiple_edges())
+                                     multiedges=self.allows_multiple_edges(),
+                                     sort=not immutable)
             self._backend = ib
             self._immutable = True
 

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -610,7 +610,8 @@ class DiGraph(GenericGraph):
             sage: copy(g) is g    # copy is mutable again
             False
 
-        The vertex iteration order is preserved when creating an immutable digraph::
+        When the input provides an explicit vertex list, creating an immutable
+        digraph preserves this order::
 
             sage: D = DiGraph([['b', 'a'], []])
             sage: list(D)
@@ -872,7 +873,7 @@ class DiGraph(GenericGraph):
             ib = StaticSparseBackend(self,
                                      loops=self.allows_loops(),
                                      multiedges=self.allows_multiple_edges(),
-                                     sort=not immutable)
+                                     sort=(format != "vertices_and_edges"))
             self._backend = ib
             self._immutable = True
 

--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -868,14 +868,7 @@ class DiGraph(GenericGraph):
         if format != 'DiGraph' or name is not None:
             self.name(name)
 
-        if data_structure == "static_sparse":
-            from sage.graphs.base.static_sparse_backend import StaticSparseBackend
-            ib = StaticSparseBackend(self,
-                                     loops=self.allows_loops(),
-                                     multiedges=self.allows_multiple_edges(),
-                                     sort=(format != "vertices_and_edges"))
-            self._backend = ib
-            self._immutable = True
+        self._finalize_static_sparse_backend(data_structure, immutable)
 
     # Formats
 

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -499,6 +499,24 @@ class GenericGraph(GenericGraph_pyx):
             Graph on 0 vertices
         """
         self._latex_opts = None
+    def _finalize_static_sparse_backend(self, data_structure, immutable):
+        """
+        Finalize construction with a static sparse backend when requested.
+
+        This preserves the existing constructor behavior where a graph may be
+        built first with a mutable backend and then converted to
+        ``StaticSparseBackend``.
+        """
+        if data_structure != "static_sparse":
+            return
+
+        from sage.graphs.base.static_sparse_backend import StaticSparseBackend
+        ib = StaticSparseBackend(self,
+                                 loops=self.allows_loops(),
+                                 multiedges=self.allows_multiple_edges(),
+                                 sort=not immutable)
+        self._backend = ib
+        self._immutable = True
 
     def __setstate__(self, state):
         r"""

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -1010,6 +1010,15 @@ class Graph(GenericGraph):
             sage: Graph(g, immutable=True)
             Petersen graph: Graph on 10 vertices
 
+        The vertex iteration order is preserved when creating an immutable graph::
+
+            sage: G = Graph([['b', 'a'], []])
+            sage: list(G)
+            ['b', 'a']
+            sage: Gim = Graph([['b', 'a'], []], immutable=True)
+            sage: list(Gim)
+            ['b', 'a']
+
         Check error messages for graphs built from incidence matrices (see
         :issue:`18440`)::
 
@@ -1285,7 +1294,8 @@ class Graph(GenericGraph):
             from sage.graphs.base.static_sparse_backend import StaticSparseBackend
             ib = StaticSparseBackend(self,
                                      loops=self.allows_loops(),
-                                     multiedges=self.allows_multiple_edges())
+                                     multiedges=self.allows_multiple_edges(),
+                                     sort=not immutable)
             self._backend = ib
             self._immutable = True
 

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -1291,14 +1291,7 @@ class Graph(GenericGraph):
         if format != 'Graph' or name is not None:
             self.name(name)
 
-        if data_structure == "static_sparse":
-            from sage.graphs.base.static_sparse_backend import StaticSparseBackend
-            ib = StaticSparseBackend(self,
-                                     loops=self.allows_loops(),
-                                     multiedges=self.allows_multiple_edges(),
-                                     sort=(format != "vertices_and_edges"))
-            self._backend = ib
-            self._immutable = True
+        self._finalize_static_sparse_backend(data_structure, immutable)
 
     # Formats
 

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -1010,7 +1010,8 @@ class Graph(GenericGraph):
             sage: Graph(g, immutable=True)
             Petersen graph: Graph on 10 vertices
 
-        The vertex iteration order is preserved when creating an immutable graph::
+        When the input provides an explicit vertex list, creating an immutable
+        graph preserves this order::
 
             sage: G = Graph([['b', 'a'], []])
             sage: list(G)
@@ -1295,7 +1296,7 @@ class Graph(GenericGraph):
             ib = StaticSparseBackend(self,
                                      loops=self.allows_loops(),
                                      multiedges=self.allows_multiple_edges(),
-                                     sort=not immutable)
+                                     sort=(format != "vertices_and_edges"))
             self._backend = ib
             self._immutable = True
 


### PR DESCRIPTION
This PR is a refactor-only preparation step for immutable-construction work.

### What changes
- Adds `GenericGraph._finalize_static_sparse_backend(data_structure, immutable)`.
- Replaces duplicated static-sparse finalization blocks in:
  - `Graph.__init__`
  - `DiGraph.__init__`
  with a call to the shared helper.

### Why
`Graph` and `DiGraph` currently duplicate the same “finalize to `StaticSparseBackend`” logic.  
Centralizing it reduces duplication and makes upcoming constructor changes easier to review and safer to land incrementally.

### Behavior and scope
- No intended behavior change.
- Construction flow remains the same: mutable build path first, then finalization to static sparse backend when requested.
- This PR does **not** implement direct immutable construction yet; it only prepares the code structure for that follow-up.

Related issue: #41910


