### PR TITLE
factor static_sparse constructor finalization

### DIFF
--- a/src/sage/graphs/digraph.py
+++ b/src/sage/graphs/digraph.py
@@ -858,13 +858,7 @@ class DiGraph(GenericGraph):
         if format != 'DiGraph' or name is not None:
             self.name(name)
 
-        if data_structure == "static_sparse":
-            from sage.graphs.base.static_sparse_backend import StaticSparseBackend
-            ib = StaticSparseBackend(self,
-                                     loops=self.allows_loops(),
-                                     multiedges=self.allows_multiple_edges())
-            self._backend = ib
-            self._immutable = True
+        self._finalize_static_sparse_backend(data_structure, immutable)
 
     # Formats
 

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -514,8 +514,7 @@ class GenericGraph(GenericGraph_pyx):
         from sage.graphs.base.static_sparse_backend import StaticSparseBackend
         ib = StaticSparseBackend(self,
                                  loops=self.allows_loops(),
-                                 multiedges=self.allows_multiple_edges(),
-                                 sort=not immutable)
+                                 multiedges=self.allows_multiple_edges())
         self._backend = ib
         self._immutable = True
 

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -500,6 +500,25 @@ class GenericGraph(GenericGraph_pyx):
         """
         self._latex_opts = None
 
+    def _finalize_static_sparse_backend(self, data_structure, immutable):
+        """
+        Finalize construction with a static sparse backend when requested.
+
+        This preserves the existing constructor behavior where a graph may be
+        built first with a mutable backend and then converted to
+        ``StaticSparseBackend``.
+        """
+        if data_structure != "static_sparse":
+            return
+
+        from sage.graphs.base.static_sparse_backend import StaticSparseBackend
+        ib = StaticSparseBackend(self,
+                                 loops=self.allows_loops(),
+                                 multiedges=self.allows_multiple_edges(),
+                                 sort=not immutable)
+        self._backend = ib
+        self._immutable = True
+
     def __setstate__(self, state):
         r"""
         Set the state from a pickle dict.

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -1281,13 +1281,7 @@ class Graph(GenericGraph):
         if format != 'Graph' or name is not None:
             self.name(name)
 
-        if data_structure == "static_sparse":
-            from sage.graphs.base.static_sparse_backend import StaticSparseBackend
-            ib = StaticSparseBackend(self,
-                                     loops=self.allows_loops(),
-                                     multiedges=self.allows_multiple_edges())
-            self._backend = ib
-            self._immutable = True
+        self._finalize_static_sparse_backend(data_structure, immutable)
 
     # Formats
 


### PR DESCRIPTION
This PR is a refactor-only preparation step for immutable-construction work.

### What changes
- Adds `GenericGraph._finalize_static_sparse_backend(data_structure, immutable)`.
- Replaces duplicated static-sparse finalization blocks in:
  - `Graph.__init__`
  - `DiGraph.__init__`
  with a call to the shared helper.

### Why
`Graph` and `DiGraph` currently duplicate the same “finalize to `StaticSparseBackend`” logic.  
Centralizing it reduces duplication and makes upcoming constructor changes easier to review and safer to land incrementally.

### Behavior and scope
- No intended behavior change.
- Construction flow remains the same: mutable build path first, then finalization to static sparse backend when requested.
- This PR does **not** implement direct immutable construction yet; it only prepares the code structure for that follow-up.

Related issue: #41910

