### PR TITLE
src/sage/rings/qqbar.py: Add EXAMPLES block to ANBinaryExpr.exactify

### DIFF
--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -625,7 +625,6 @@ from sage.structure.richcmp import (
 )
 from sage.structure.sage_object import SageObject
 
-
 class AlgebraicField_common(sage.rings.abc.AlgebraicField_common):
     r"""
     Common base class for the classes :class:`~AlgebraicRealField` and
@@ -8660,25 +8659,34 @@ class ANBinaryExpr(ANDescr):
 
     def exactify(self):
         """
-        Trigger exact computation for this binary expression, combining
-        the exact fields of both operands into a single number field.
+        Return an exact representation of this binary expression.
 
+        This method recursively calls ``exactify()`` on both operands. The 
+        resulting number fields are then combined into a single field containing 
+        the result of the binary operation.
+    
         EXAMPLES::
 
-            sage: rt2 = AA(sqrt(2)); rt3 = AA(sqrt(3))
-            sage: x = rt2 + rt3 - rt3
-            sage: x.exactify()
-            sage: x
-            1.414213562373095?
+            We create a binary expression by adding two algebraic numbers. Initially, 
+            the result is a deferred expression (ANBinaryExpr). Calling exactify()
+            computes the minimal polynomial and interval enclosure::
+
+                sage: a = QQbar(sqrt(2)) + QQbar(sqrt(3))
+                sage: type(a.as_number())  # This triggers a binary expression
+                <class 'sage.rings.qqbar.ANBinaryExpr'>
+                sage: a.exactify()
+                sage: a
+                3.146264369941973?
 
         TESTS::
 
-            sage: rt2c = QQbar.zeta(3) + AA(sqrt(2)) - QQbar.zeta(3)                    
-            sage: rt2c.exactify()                                                      
+            sage: rt2c = QQbar.zeta(3) + AA(sqrt(2)) - QQbar.zeta(3)                    # needs sage.symbolic
+            sage: rt2c.exactify()                                                       # needs sage.symbolic
 
-        To ensure this method still works: Increase the recursion level at each step and
-        decrease it before return.
-        Lower the recursion limit for this test to allow
+        We check to make sure that this method still works even. We
+        do this by increasing the recursion level at each step and
+        decrease it before we return.
+        We lower the recursion limit for this test to allow
         a test in reasonable time::
 
             sage: import sys

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -8671,7 +8671,7 @@ class ANBinaryExpr(ANDescr):
 
             We resolve a deferred addition of two algebraic numbers::
 
-                sage: a = AA(2)**(1/2) + AA(3)**(1/2)
+                sage: a = AA(2)**(1/2) + AA(3)**(1/2) # needs sage.symbolic
                 sage: type(a.as_number())
                 <class 'sage.rings.qqbar.ANBinaryExpr'>
                 sage: a.exactify()

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -8660,12 +8660,17 @@ class ANBinaryExpr(ANDescr):
     def exactify(self):
         """
         Force the resolution of this deferred binary expression into an exact representation.
+
         This method performs two primary steps to resolve the expression:
         1. Recursively calls ``exactify()`` on the left and right operands to ensure both are fully resolved into exact algebraic numbers.
         2. Combines the resulting number fields from both operands into a single common field and performs the binary operation within that unified field.
+
         If the expression is already exact, this method does nothing.
+
         EXAMPLES::
+
             We resolve a deferred addition of two algebraic numbers::
+
                 sage: a = AA(2)**(1/2) + AA(3)**(1/2)
                 sage: type(a.as_number())
                 <class 'sage.rings.qqbar.ANBinaryExpr'>

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -8660,15 +8660,25 @@ class ANBinaryExpr(ANDescr):
 
     def exactify(self):
         """
+        Trigger exact computation for this binary expression, combining
+        the exact fields of both operands into a single number field.
+
+        EXAMPLES::
+
+            sage: rt2 = AA(sqrt(2)); rt3 = AA(sqrt(3))
+            sage: x = rt2 + rt3 - rt3
+            sage: x.exactify()
+            sage: x
+            1.414213562373095?
+
         TESTS::
 
-            sage: rt2c = QQbar.zeta(3) + AA(sqrt(2)) - QQbar.zeta(3)                    # needs sage.symbolic
-            sage: rt2c.exactify()                                                       # needs sage.symbolic
+            sage: rt2c = QQbar.zeta(3) + AA(sqrt(2)) - QQbar.zeta(3)                    
+            sage: rt2c.exactify()                                                      
 
-        We check to make sure that this method still works even. We
-        do this by increasing the recursion level at each step and
-        decrease it before we return.
-        We lower the recursion limit for this test to allow
+        To ensure this method still works: Increase the recursion level at each step and
+        decrease it before return.
+        Lower the recursion limit for this test to allow
         a test in reasonable time::
 
             sage: import sys

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -8659,36 +8659,24 @@ class ANBinaryExpr(ANDescr):
 
     def exactify(self):
         """
-        Return an exact representation of this binary expression.
-
-        This method recursively calls ``exactify()`` on both operands. The 
-        resulting number fields are then combined into a single field containing 
-        the result of the binary operation.
-    
+        Force the resolution of this deferred binary expression into an exact representation.
+        This method performs two primary steps to resolve the expression:
+        1. Recursively calls ``exactify()`` on the left and right operands to ensure both are fully resolved into exact algebraic numbers.
+        2. Combines the resulting number fields from both operands into a single common field and performs the binary operation within that unified field.
+        If the expression is already exact, this method does nothing.
         EXAMPLES::
-
-            We create a binary expression by adding two algebraic numbers. Initially, 
-            the result is a deferred expression (ANBinaryExpr). Calling exactify()
-            computes the minimal polynomial and interval enclosure::
-
-                sage: a = QQbar(sqrt(2)) + QQbar(sqrt(3))
-                sage: type(a.as_number())  # This triggers a binary expression
+            We resolve a deferred addition of two algebraic numbers::
+                sage: a = AA(2)**(1/2) + AA(3)**(1/2)
+                sage: type(a.as_number())
                 <class 'sage.rings.qqbar.ANBinaryExpr'>
                 sage: a.exactify()
                 sage: a
                 3.146264369941973?
-
         TESTS::
-
-            sage: rt2c = QQbar.zeta(3) + AA(sqrt(2)) - QQbar.zeta(3)                    # needs sage.symbolic
-            sage: rt2c.exactify()                                                       # needs sage.symbolic
-
-        We check to make sure that this method still works even. We
-        do this by increasing the recursion level at each step and
-        decrease it before we return.
-        We lower the recursion limit for this test to allow
-        a test in reasonable time::
-
+            sage: rt2c = QQbar.zeta(3) + AA(sqrt(2)) - QQbar.zeta(3) # needs sage.symbolic
+            sage: rt2c.exactify() # needs sage.symbolic
+        We check to make sure that this method still works even. We do this by increasing the recursion level at each step and decrease it before we return.
+        We lower the recursion limit for this test to allow a test in reasonable time::
             sage: import sys
             sage: old_recursion_limit = sys.getrecursionlimit()
             sage: sys.setrecursionlimit(1000)


### PR DESCRIPTION
This PR adds an EXAMPLES:: block to the documentation of ANBinaryExpr.exactify.
Previously, the method only had a TESTS:: block with no user-facing examples.

The new examples demonstrate the basic use case: a deferred binary expression (sum of two algebraic numbers) is resolved to an exact representation after calling. exactify().

This is a small contribution aimed at familiarizing myself with the QQbar codebase in the context of Issue #30222.