### PR TITLE
meson: Fix to `Could not run pari version` build error (macOS)

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -89,12 +89,11 @@ except Exception:
   if pari.found() and not meson.is_cross_build()
     # Verify PARI version
     pari_version_code = '''
-    #include <stdio.h>
     #include <pari/pari.h>
     int main(void) {
       pari_init(1000000, 2);
       GEN v = pari_version(), M = gel(v,1), m = gel(v,2), p = gel(v,3);
-      printf("%ld.%ld.%ld", itos(M), itos(m), itos(p));
+      pari_printf("%ld.%ld.%ld", itos(M), itos(m), itos(p));
       pari_close();
       return 0;
     }


### PR DESCRIPTION
The issue was a linkage issue to `printf`. I asked Claude for an alternative and it told me about `pari_printf`. This simple change seems to fix the issue.

Resolves https://github.com/sagemath/sage/issues/41921.
