### PR TITLE
remove a few traces of long-gone cmp

### DIFF
--- a/src/sage/combinat/crystals/letters.pyx
+++ b/src/sage/combinat/crystals/letters.pyx
@@ -133,7 +133,7 @@ class ClassicalCrystalOfLetters(UniqueRepresentation, Parent):
     used intensively as building blocks. Therefore, we explicitly build
     in memory the list of all elements, the crystal graph and its
     transitive closure, so as to make the following operations constant
-    time: ``list``, ``cmp``, (todo: ``phi``, ``epsilon``, ``e``, and
+    time: ``list``, ``richcmp``, (todo: ``phi``, ``epsilon``, ``e``, and
     ``f`` with caching)
     """
     def __init__(self, cartan_type, element_class,
@@ -271,7 +271,7 @@ class ClassicalCrystalOfLetters(UniqueRepresentation, Parent):
         """
         return self.digraph().transitive_closure()
 
-    def __contains__(self, x):
+    def __contains__(self, x) -> bool:
         """
         EXAMPLES::
 
@@ -283,7 +283,7 @@ class ClassicalCrystalOfLetters(UniqueRepresentation, Parent):
         """
         return x in self._list
 
-    def lt_elements(self, x, y):
+    def lt_elements(self, x, y) -> bool:
         r"""
         Return ``True`` if and only if there is a path from ``x`` to ``y`` in
         the crystal graph, when ``x`` is not equal to ``y``.

--- a/src/sage/libs/linkages/padics/Polynomial_shared.pxi
+++ b/src/sage/libs/linkages/padics/Polynomial_shared.pxi
@@ -75,14 +75,8 @@ cdef inline int ccmp(celement a, celement b, long prec, bint reduce_a, bint redu
     r"""
     Return the comparison of ``a`` and ``b``.
 
-    This function returns -1, 0, or 1 for use with ``cmp`` of Python 2. In
-    particular, this function return 0 if ``a`` and ``b`` differ by an element
-    of valuation at least ``prec``.
-
-    .. NOTE::
-
-        You should not rely on whether this function returns -1 or 1 as this
-        might not be consistent.
+    This function returns 0 or 1. This function returns 0 if ``a`` and
+    ``b`` differ by an element of valuation at least ``prec``.
 
     INPUT:
 
@@ -101,11 +95,12 @@ cdef inline int ccmp(celement a, celement b, long prec, bint reduce_a, bint redu
     """
     if not (reduce_a or reduce_b):
         return 0 if a == b else 1
+
     csub(prime_pow.tmp_ccmp_a, a, b, prec, prime_pow)
     coeffs = prime_pow.tmp_ccmp_a._coeffs
     cdef long i, coeff_prec, break_pt
     if prime_pow.e == 1:
-        for i in range(prime_pow.tmp_ccmp_a.degree()+1):
+        for i in range(prime_pow.tmp_ccmp_a.degree() + 1):
             if coeffs[i] and coeffs[i].valuation() < prec:
                 return 1
     else:

--- a/src/sage/modules/with_basis/indexed_element.pyx
+++ b/src/sage/modules/with_basis/indexed_element.pyx
@@ -659,8 +659,8 @@ cdef class IndexedFreeModuleElement(ModuleElement):
         equality testing costly. It may be removed at some point.
 
         Equality testing can be a bit tricky when the order of terms
-        can vary because their indices are incomparable with
-        ``cmp``. The following test did fail before :issue:`12489` ::
+        can vary because their indices are incomparable.
+        The following test did fail before :issue:`12489` ::
 
             sage: # needs sage.combinat
             sage: F = CombinatorialFreeModule(QQ, Subsets([1,2,3]))

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -874,9 +874,9 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             return (<Integer>x)._xor(y)
         return coercion_model.bin_op(x, y, operator.xor)
 
-    def __richcmp__(left, right, int op):
+    def __richcmp__(left, right, int op) -> bool:
         """
-        ``cmp`` for integers.
+        ``richcmp`` for integers.
 
         EXAMPLES::
 

--- a/src/sage/rings/real_mpfi.pyx
+++ b/src/sage/rings/real_mpfi.pyx
@@ -173,11 +173,6 @@ The bad:
 
     Intervals ``a`` and ``b`` overlap iff ``not(a != b)``.
 
-.. WARNING::
-
-    The ``cmp(a, b)`` function should not be used to compare real
-    intervals. Note that ``cmp`` will disappear in Python3.
-
 EXAMPLES::
 
     sage: 0 < RIF(1, 2)
@@ -849,7 +844,7 @@ cdef class RealIntervalField_class(sage.rings.abc.RealIntervalField):
             return self._convert_method_map(S, "_real_mpfi_")
         return None
 
-    def __richcmp__(self, other, int op):
+    def __richcmp__(self, other, int op) -> bool:
         """
         Compare ``self`` to ``other``.
 


### PR DESCRIPTION
This was still remaining from good old python2 times.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.