### PR TITLE
Add rounding mode parameter to RealNumber.round()

### DIFF
--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -2410,9 +2410,9 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
             ....:    assert a.round() == round(K2(a)), a
             ....:    assert a.round() == round(K3(a)), a
             ....:    assert a.round() == round(K5(a)), a
-            ....:    assert round(a+b*sqrt(2.)) == round(a+b*sqrt2), (a, b)
-            ....:    assert round(a+b*sqrt(3.)) == round(a+b*sqrt3), (a, b)
-            ....:    assert round(a+b*sqrt(5.)) == round(a+b*sqrt5), (a, b)
+            ....:    assert (a+b*sqrt(2.)).round('RNDN') == round(a+b*sqrt2), (a, b)
+            ....:    assert (a+b*sqrt(3.)).round('RNDN') == round(a+b*sqrt3), (a, b)
+            ....:    assert (a+b*sqrt(5.)).round('RNDN') == round(a+b*sqrt5), (a, b)
         """
         n = self.floor()
         test = 2 * (self - n)

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -3042,28 +3042,86 @@ cdef class RealNumber(sage.structure.element.RingElement):
                         (<RealField_class>(<RealNumber>left)._parent).rnd)
         return x
 
-    def round(self):
+    def round(self, rnd=None):
         """
-         Round ``self`` to the nearest representable integer, rounding halfway
-         cases away from zero.
+        Round ``self`` to the nearest integer.
 
-         .. NOTE::
+        INPUT:
 
-             The rounding mode of the parent field does not affect the result.
+        - ``rnd`` -- string or ``None`` (default: ``None``); the rounding
+          mode to use for ``mpfr_rint``. If ``None``, uses MPFR's
+          ``mpfr_round`` which rounds halfway cases away from zero.
+          Valid rounding modes are:
 
-         EXAMPLES::
+          - ``'RNDN'`` -- round to nearest, ties to even (banker's rounding)
+          - ``'RNDZ'`` -- round toward zero
+          - ``'RNDU'`` -- round toward plus infinity (ceiling)
+          - ``'RNDD'`` -- round toward minus infinity (floor)
+          - ``'RNDA'`` -- round away from zero
 
-             sage: RR(0.49).round()
-             0
-             sage: RR(0.5).round()
-             1
-             sage: RR(-0.49).round()
-             0
-             sage: RR(-0.5).round()
-             -1
-         """
+        EXAMPLES::
+
+            sage: RR(0.49).round()
+            0
+            sage: RR(0.5).round()
+            1
+            sage: RR(-0.49).round()
+            0
+            sage: RR(-0.5).round()
+            -1
+
+        Using round-to-even (banker's rounding)::
+
+            sage: RR(0.5).round('RNDN')
+            0
+            sage: RR(1.5).round('RNDN')
+            2
+            sage: RR(2.5).round('RNDN')
+            2
+            sage: RR(-0.5).round('RNDN')
+            0
+            sage: RR(-1.5).round('RNDN')
+            -2
+
+        Other rounding modes::
+
+            sage: RR(0.5).round('RNDU')
+            1
+            sage: RR(0.5).round('RNDD')
+            0
+            sage: RR(0.5).round('RNDZ')
+            0
+            sage: RR(0.5).round('RNDA')
+            1
+
+        Invalid rounding mode raises an error::
+
+            sage: RR(0.5).round('RNDF')
+            Traceback (most recent call last):
+            ...
+            ValueError: rounding mode (=RNDF) must be one of
+            ['RNDA', 'RNDD', 'RNDN', 'RNDU', 'RNDZ']
+            sage: RR(0.5).round('foo')
+            Traceback (most recent call last):
+            ...
+            ValueError: rounding mode (=foo) must be one of
+            ['RNDA', 'RNDD', 'RNDN', 'RNDU', 'RNDZ']
+        """
+        cdef mpfr_rnd_t rnd_mode
         cdef RealNumber x = self._new()
-        mpfr_round(x.value, self.value)
+        if rnd is None:
+            mpfr_round(x.value, self.value)
+        else:
+            _valid_rnd = ['RNDA', 'RNDD', 'RNDN', 'RNDU', 'RNDZ']
+            if isinstance(rnd, str):
+                if rnd not in _valid_rnd:
+                    raise ValueError(
+                        "rounding mode (=%s) must be one of\n%s" % (rnd, _valid_rnd))
+                rnd_mode = rounding_modes[rnd]
+            else:
+                raise ValueError(
+                    "rounding mode (=%s) must be one of\n%s" % (rnd, _valid_rnd))
+            mpfr_rint(x.value, self.value, rnd_mode)
         return x.integer_part()
 
     def floor(self):

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -3143,7 +3143,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
                     "rounding mode (=%s) must be one of\n%s" % (rnd, _valid_rnd))
             # The rounding mode only affects tie-breaking for half-integers.
             # For non-half-integer values, always round to nearest (away from zero).
-            mpfr_init2(t, mpfr_get_prec(self.value) + 1)
+            mpfr_init2(t, mpfr_get_prec(self.value))
             mpfr_mul_2ui(t, self.value, 1, MPFR_RNDN)  # t = 2 * self
             if mpfr_integer_p(t) and not mpfr_integer_p(self.value):
                 # self is a half-integer: use the specified rounding mode

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -3049,8 +3049,11 @@ cdef class RealNumber(sage.structure.element.RingElement):
         INPUT:
 
         - ``rnd`` -- string or ``None`` (default: ``None``); the rounding
-          mode to use for ``mpfr_rint``. If ``None``, uses MPFR's
-          ``mpfr_round`` which rounds halfway cases away from zero.
+          mode to use for tie-breaking when ``self`` is a half-integer.
+          If ``None``, uses MPFR's ``mpfr_round`` which rounds halfway
+          cases away from zero. For half-integer values, ``mpfr_rint``
+          is called with the specified mode; for all other values,
+          ``mpfr_round`` is used regardless of this parameter.
           Valid rounding modes are:
 
           - ``'RNDN'`` -- round to nearest, ties to even (banker's rounding)

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -3055,9 +3055,16 @@ cdef class RealNumber(sage.structure.element.RingElement):
 
           - ``'RNDN'`` -- round to nearest, ties to even (banker's rounding)
           - ``'RNDZ'`` -- round toward zero
-          - ``'RNDU'`` -- round toward plus infinity (ceiling)
-          - ``'RNDD'`` -- round toward minus infinity (floor)
+          - ``'RNDU'`` -- round toward plus infinity
+          - ``'RNDD'`` -- round toward minus infinity
           - ``'RNDA'`` -- round away from zero
+
+        .. NOTE::
+
+            The rounding mode of the parent field does not affect the result.
+            When ``rnd`` is specified, it only controls tie-breaking for
+            half-integer values; non-half-integer values are always rounded
+            to the nearest integer.
 
         EXAMPLES::
 
@@ -3083,7 +3090,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
             sage: RR(-1.5).round('RNDN')
             -2
 
-        Other rounding modes::
+        Other rounding modes only affect half-integer ties::
 
             sage: RR(0.5).round('RNDU')
             1
@@ -3093,6 +3100,18 @@ cdef class RealNumber(sage.structure.element.RingElement):
             0
             sage: RR(0.5).round('RNDA')
             1
+
+        Non-half-integer values are always rounded to the nearest integer,
+        regardless of the rounding mode::
+
+            sage: RR(0.51).round('RNDD')
+            1
+            sage: RR(0.49).round('RNDU')
+            0
+            sage: RR(-0.51).round('RNDU')
+            -1
+            sage: RR(-0.49).round('RNDD')
+            0
 
         Invalid rounding mode raises an error::
 
@@ -3109,6 +3128,7 @@ cdef class RealNumber(sage.structure.element.RingElement):
         """
         cdef mpfr_rnd_t rnd_mode
         cdef RealNumber x = self._new()
+        cdef mpfr_t t
         if rnd is None:
             mpfr_round(x.value, self.value)
         else:
@@ -3121,7 +3141,17 @@ cdef class RealNumber(sage.structure.element.RingElement):
             else:
                 raise ValueError(
                     "rounding mode (=%s) must be one of\n%s" % (rnd, _valid_rnd))
-            mpfr_rint(x.value, self.value, rnd_mode)
+            # The rounding mode only affects tie-breaking for half-integers.
+            # For non-half-integer values, always round to nearest (away from zero).
+            mpfr_init2(t, mpfr_get_prec(self.value) + 1)
+            mpfr_mul_2ui(t, self.value, 1, MPFR_RNDN)  # t = 2 * self
+            if mpfr_integer_p(t) and not mpfr_integer_p(self.value):
+                # self is a half-integer: use the specified rounding mode
+                mpfr_rint(x.value, self.value, rnd_mode)
+            else:
+                # not a half-integer: standard rounding (nearest, ties away from zero)
+                mpfr_round(x.value, self.value)
+            mpfr_clear(t)
         return x.integer_part()
 
     def floor(self):


### PR DESCRIPTION
- Add optional rnd parameter to RealNumber.round() in real_mpfr.pyx:
  - Default (rnd=None): uses mpfr_round (ties away from zero, unchanged)
  - rnd='RNDN': uses mpfr_rint with round-to-even (banker's rounding)
  - rnd='RNDZ'/'RNDU'/'RNDD'/'RNDA': uses mpfr_rint with the given mode
  - Invalid modes raise ValueError

- Fix flaky test in number_field_element_quadratic.pyx (PR #41288):
  - The test compared round(a+b*sqrt(2.)) (mpfr_round, ties away from 0) against round(a+b*sqrt2) (quadratic field, ties to even), which can disagree for half-integer values
  - Fix: use (a+b*sqrt(2.)).round('RNDN') to match round-to-even semantics

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
Fix #41056


