### PR TITLE
Random octonions and Jordan algebra elements

### DIFF
--- a/src/sage/algebras/jordan_algebra.py
+++ b/src/sage/algebras/jordan_algebra.py
@@ -146,6 +146,15 @@ class JordanAlgebra(UniqueRepresentation, Parent):
         [-2  3]
         [ 3  4]
 
+    TESTS:
+
+    Random elements work::
+
+        sage: m = matrix([[-2,3],[3,4]])
+        sage: J.<a,b,c> = JordanAlgebra(m, QQ)
+        sage: J.random_element() in J
+        True
+
     REFERENCES:
 
     - :wikipedia:`Jordan_algebra`

--- a/src/sage/algebras/octonion_algebra.pyx
+++ b/src/sage/algebras/octonion_algebra.pyx
@@ -699,6 +699,14 @@ class OctonionAlgebra(UniqueRepresentation, Parent):
         sage: (1 + l) * (1 + l).conjugate()
         0
 
+    TESTS:
+
+    Random elements work::
+
+        sage: O = OctonionAlgebra(QQ)
+        sage: O.random_element() in O
+        True
+
     REFERENCES:
 
     - [Scha1996]_

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -1430,13 +1430,13 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 True
             """
             indices = self.basis().keys()
+            if not indices:
+                return self.zero()
+
             if isinstance(indices, list):
                 # If keys() is a list, it won't have random_element().
                 from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
                 indices = FiniteEnumeratedSet(indices)
-
-            if indices.is_empty():
-                return self.zero()
 
             return self.sum(
                 self.term(indices.random_element(),

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -1430,6 +1430,11 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 True
             """
             indices = self.basis().keys()
+            if isinstance(indices, list):
+                # If keys() is a list, it won't have random_element().
+                from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
+                indices = FiniteEnumeratedSet(indices)
+
             if indices.is_empty():
                 return self.zero()
 

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -1433,13 +1433,16 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
             if not indices:
                 return self.zero()
 
-            if isinstance(indices, list):
-                # If keys() is a list, it won't have random_element().
-                from sage.sets.finite_enumerated_set import FiniteEnumeratedSet
-                indices = FiniteEnumeratedSet(indices)
+            # Some container types (list, tuple, etc.) won't have
+            # a random_element() method.
+            if hasattr(indices, "random_element"):
+                random_element = lambda c: c.random_element()
+            else:
+                from random import choice
+                random_element = choice
 
             return self.sum(
-                self.term(indices.random_element(),
+                self.term(random_element(indices),
                           self.base_ring().random_element())
                 for _ in range(n)
             )

--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -1430,12 +1430,15 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
                 True
             """
             indices = self.basis().keys()
-            a = self.zero()
-            if not indices.is_empty():
-                for i in range(n):
-                    a += self.term(indices.random_element(),
-                                   self.base_ring().random_element())
-            return a
+            if indices.is_empty():
+                return self.zero()
+
+            return self.sum(
+                self.term(indices.random_element(),
+                          self.base_ring().random_element())
+                for _ in range(n)
+            )
+
 
     class ElementMethods:
         # TODO: Define the appropriate element methods here (instead of in


### PR DESCRIPTION
Fix `random_element()` for octonion and Jordan algebras:

1. Refactor the module-with-basis `random_element()` to use a list comprehension (not strictly necessary)
2. Add a special case for when the basis `keys()` is a list
3. Add two tests

The special case could probably be made faster if we swapped out the `random_element()` method call on `indices` with `random.choice()`, but converting to a `FiniteEnumeratedSet` is consistent with what happens when the class defines `_indices` and `monomial()` but _not_ `basis()`.