### PR TITLE
Fix exception handling in elliptic curve variety method

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -2247,6 +2247,7 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
             ....:     except ValueError:
             ....:         if I.dimension() == 0:
             ....:              raise
+            ....:         continue
             ....:     if not V:
             ....:         continue
             ....:     sol = choice(V)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The bug: when ValueError is raised and I.dimension() != 0, the exception is silently swallowed, V is never assigned, and the next line if not V: fails with NameError.
fix a  random error in ci
```
src/bin/sage -t --warn-long 5.0 --random-seed=125008470752069326983408742394094516986 src/sage/schemes/elliptic_curves/ell_finite_field.py
**********************************************************************
Error: Failed example:: Exception raised:
Traceback (most recent call last):
  File "/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/forker.py", line 724, in _run
    self.compile_and_execute(example, compiler, test.globs)
  File "/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/forker.py", line 1148, in compile_and_execute
    exec(compiled, globs)
  File "<doctest sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.twists[38]>", line 8, in <module>
    if not V:
           ^
NameError: name 'V' is not defined

    for _ in range(10):
        I = Ideal([eq, A + B - F.random_element()])
        try:
            V = I.variety()
        except ValueError:
            if I.dimension() == 0:
                 raise
        if not V:
            continue
        sol = choice(V)
        a, b = sol[A], sol[B]
        try:
            twists2.append(EllipticCurve([a, b]))
        except ArithmeticError:
            pass
Exception raised:
    Traceback (most recent call last):
      File "/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/forker.py", line 724, in _run
        self.compile_and_execute(example, compiler, test.globs)
      File "/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/sage/doctest/forker.py", line 1148, in compile_and_execute
        exec(compiled, globs)
      File "<doctest sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.twists[38]>", line 8, in <module>
        if not V:
               ^
    NameError: name 'V' is not defined
**********************************************************************
1 item had failures:
   1 of  41 in sage.schemes.elliptic_curves.ell_finite_field.EllipticCurve_finite_field.twists
    [545 tests, 1 failure, 11.39s wall]
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


