### PR TITLE
Fix memory leak in FinitePoset 

### DIFF
--- a/src/sage/combinat/posets/elements.py
+++ b/src/sage/combinat/posets/elements.py
@@ -18,7 +18,7 @@ Elements of posets, lattices, semilattices, etc.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 from sage.misc.latex import latex
-from sage.structure.element import Element, have_same_parent
+from sage.structure.element import Element
 
 
 class PosetElement(Element):
@@ -108,11 +108,14 @@ class PosetElement(Element):
             False
             sage: PosetElement(P,0,"b") == PosetElement(P,0,"c")
             False
+            sage: R = Poset([["a","b"],["d"],["c"],["d"],[]], facade = False)
+            sage: P(0) == R(0)
+            True
 
-        .. warning:: as an optimization, this only compares the parent
-           and vertex, using the invariant that, in a proper poset
-           element, ``self.element == other.element`` if and only
-           ``self.vertex == other.vertex``::
+        If the parent is identical, this only compares the vertex, using
+        the invariant that, in a proper poset element,
+        ``self.element == other.element`` if and only
+        ``self.vertex == other.vertex``::
 
             sage: PosetElement(P,1,"c") == PosetElement(P,0,"c")
             True
@@ -122,11 +125,11 @@ class PosetElement(Element):
             sage: P(0) == int(0)
             False
         """
-        # This should instead exploit unique representation, using
-        # self is other, or best inherit __eq__ from there. But there
-        # are issues around pickling and rich comparison functions.
-        return have_same_parent(self, other) \
-            and self.vertex == other.vertex
+        if not isinstance(other, PosetElement):
+            return False
+        if self.parent() is other.parent():
+            return self.vertex == other.vertex
+        return self.parent() == other.parent() and self.element == other.element
 
     def __ne__(self, other):
         r"""

--- a/src/sage/combinat/posets/linear_extensions.py
+++ b/src/sage/combinat/posets/linear_extensions.py
@@ -494,7 +494,7 @@ class LinearExtensionsOfPoset(UniqueRepresentation, Parent):
     """
 
     @staticmethod
-    def __classcall_private__(cls, poset, facade=False):
+    def __classcall_private__(cls, poset, facade=False, _poset_cache_id=None):
         r"""
         Straighten arguments before unique representation.
 
@@ -508,9 +508,12 @@ class LinearExtensionsOfPoset(UniqueRepresentation, Parent):
             sage: L is LinearExtensionsOfPoset(P,facade=False)
             True
         """
-        return super().__classcall__(cls, poset, facade=facade)
+        if _poset_cache_id is None:
+            _poset_cache_id = id(poset)
+        return super().__classcall__(cls, poset, facade=facade,
+                                     _poset_cache_id=_poset_cache_id)
 
-    def __init__(self, poset, facade) -> None:
+    def __init__(self, poset, facade, _poset_cache_id=None) -> None:
         """
         TESTS::
 

--- a/src/sage/combinat/posets/linear_extensions.py
+++ b/src/sage/combinat/posets/linear_extensions.py
@@ -18,7 +18,6 @@ Linear extensions of posets
 
 from sage.misc.lazy_import import lazy_import
 from sage.rings.rational_field import QQ
-from sage.structure.unique_representation import UniqueRepresentation
 from sage.structure.parent import Parent
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.graphs.digraph import DiGraph
@@ -462,7 +461,7 @@ class LinearExtensionOfPoset(ClonableArray,
         return n
 
 
-class LinearExtensionsOfPoset(UniqueRepresentation, Parent):
+class LinearExtensionsOfPoset(Parent):
     """
     The set of all linear extensions of a finite poset.
 
@@ -493,27 +492,7 @@ class LinearExtensionsOfPoset(UniqueRepresentation, Parent):
         Finite poset containing 4 elements with distinguished linear extension
     """
 
-    @staticmethod
-    def __classcall_private__(cls, poset, facade=False, _poset_cache_id=None):
-        r"""
-        Straighten arguments before unique representation.
-
-        TESTS::
-
-            sage: from sage.combinat.posets.linear_extensions import LinearExtensionsOfPoset
-            sage: P = Poset(([1,2],[[1,2]]))
-            sage: L = LinearExtensionsOfPoset(P)
-            sage: type(L)
-            <class 'sage.combinat.posets.linear_extensions.LinearExtensionsOfPoset_with_category'>
-            sage: L is LinearExtensionsOfPoset(P,facade=False)
-            True
-        """
-        if _poset_cache_id is None:
-            _poset_cache_id = id(poset)
-        return super().__classcall__(cls, poset, facade=facade,
-                                     _poset_cache_id=_poset_cache_id)
-
-    def __init__(self, poset, facade, _poset_cache_id=None) -> None:
+    def __init__(self, poset, facade=False) -> None:
         """
         TESTS::
 
@@ -521,6 +500,8 @@ class LinearExtensionsOfPoset(UniqueRepresentation, Parent):
             sage: P = Poset(([1,2,3],[[1,2],[1,3]]))
             sage: L = P.linear_extensions()
             sage: L is LinearExtensionsOfPoset(P)
+            False
+            sage: L == LinearExtensionsOfPoset(P)
             True
             sage: L._poset is P
             True
@@ -542,6 +523,41 @@ class LinearExtensionsOfPoset(UniqueRepresentation, Parent):
         if facade:
             facade = (list,)
         Parent.__init__(self, category=FiniteEnumeratedSets(), facade=facade)
+
+    def __eq__(self, other):
+        """
+        Return whether ``self`` and ``other`` enumerate the same linear
+        extensions.
+        """
+        if self is other:
+            return True
+        if not isinstance(other, LinearExtensionsOfPoset):
+            return NotImplemented
+        return (self.__class__ is other.__class__
+                and self._poset == other._poset
+                and self._is_facade == other._is_facade)
+
+    def __ne__(self, other):
+        """
+        Return whether ``self`` and ``other`` enumerate different linear
+        extensions.
+        """
+        equality = self.__eq__(other)
+        if equality is NotImplemented:
+            return NotImplemented
+        return not equality
+
+    def __hash__(self):
+        """
+        Return a hash compatible with equality.
+        """
+        return hash((self.__class__, self._poset, self._is_facade))
+
+    def __reduce__(self):
+        """
+        Return pickling data for this enumerated set.
+        """
+        return (self.__class__, (self._poset, self._is_facade))
 
     def _repr_(self) -> str:
         """

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -1003,9 +1003,12 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
         """
         Return whether ``cached`` was constructed from these exact arguments.
 
-        The graph comparison is done directly against the cached
-        :class:`HasseDiagram` (which is a :class:`DiGraph`) so that no fresh
-        :class:`HasseDiagram` needs to be constructed on every cache lookup.
+        For the ``elements is None`` branch we compare against
+        :attr:`_labeled_hasse_diagram` (a lazy attribute on ``cached``)
+        instead of relabeling on every lookup.  For the
+        ``elements is not None`` branch we relabel the *incoming* graph to
+        integer vertices once and compare against the cached internal
+        :class:`HasseDiagram` directly.
         """
         try:
             if cached._key != key:
@@ -1013,9 +1016,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             if cached._with_linear_extension != (elements is not None):
                 return False
             if elements is None:
-                cached_hasse_diagram = cached._hasse_diagram.relabel(
-                    dict(enumerate(cached._elements)), inplace=False)
-                return cached_hasse_diagram == hasse_diagram
+                return cached._labeled_hasse_diagram == hasse_diagram
 
             normalized_elements = cls._normalized_elements(elements)
             if cached._elements != normalized_elements:
@@ -1157,6 +1158,17 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
                 category = poset.category()
             if facade is None:
                 facade = poset in Sets().Facade()
+            # Fast path: when the input is already a compatible
+            # ``FinitePoset`` of the right class, avoid relabeling and
+            # re-constructing it.
+            if (isinstance(poset, cls)
+                    and key == poset._key
+                    and category == poset.category()
+                    and facade == poset._is_facade
+                    and poset._with_linear_extension == (elements is not None)
+                    and (elements is None
+                         or tuple(elements) == poset._elements)):
+                return poset
             if elements is None:
                 relabel = dict(enumerate(poset._elements))
             else:
@@ -1392,6 +1404,26 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
         self._element_to_vertex_dict = rdict
         self._is_facade = facade
         self._key = key
+
+    @lazy_attribute
+    def _labeled_hasse_diagram(self):
+        """
+        The Hasse diagram relabeled with the original element labels.
+
+        This is the value that the constructor receives as ``hasse_diagram``
+        in the ``elements is None`` path; it is cached lazily so that the
+        :meth:`_cache_match` lookup does not need to relabel on every hit.
+
+        TESTS::
+
+            sage: P = Poset(DiGraph({'a': ['b'], 'b': ['c']}))
+            sage: P._labeled_hasse_diagram
+            Hasse diagram of a poset containing 3 elements
+            sage: sorted(P._labeled_hasse_diagram.vertices())
+            ['a', 'b', 'c']
+        """
+        return self._hasse_diagram.relabel(
+            dict(enumerate(self._elements)), inplace=False)
 
     @lazy_attribute
     def _list(self):

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -289,11 +289,9 @@ from __future__ import annotations
 from collections import defaultdict
 from copy import copy
 from itertools import product
-import weakref
 
 from sage.misc.cachefunc import cached_method
 from sage.misc.classcall_metaclass import ClasscallMetaclass, typecall
-from sage.misc.fast_methods import WithEqualityById
 from sage.misc.lazy_attribute import lazy_attribute
 from sage.misc.misc_c import prod
 from sage.categories.category import Category
@@ -398,6 +396,9 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
         of ``facade = True``, unless the opposite can be deduced from the
         context (i.e. for instance if a :meth:`Poset` is built from another
         :meth:`Poset`, itself built with ``facade = False``)
+
+    - ``key`` -- ignored; accepted for backward compatibility with the
+      former unique-representation constructor
 
     OUTPUT:
 
@@ -625,11 +626,11 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
             sage: P.an_element().parent()
             Integer Ring
 
-    .. rubric:: Construction cache
+    .. rubric:: Identity
 
-    The constructor caches finite posets. Namely if two posets are
-    created from two equal data, then they are not only equal but
-    actually identical::
+    Finite posets are compared by their labeled order relation. The
+    constructor does not cache posets by their construction data, so two
+    posets created from the same data are equal but distinct parents::
 
         sage: data1 = [[1,2],[3],[3]]
         sage: data2 = [[1,2],[3],[3]]
@@ -638,25 +639,10 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
         sage: P1 == P2
         True
         sage: P1 is P2
-        True
-
-    The cache holds only weak references, so this identity is guaranteed
-    only while at least one reference to the poset is alive. Once all
-    references are dropped, the cached entry is discarded and a fresh
-    construction yields a new (but equal) object.
-
-    In situations where this behaviour is not desired, one can use the
-    ``key`` option::
-
-        sage: P1 = Poset(data1, key = "foo")
-        sage: P2 = Poset(data2, key = "bar")
-        sage: P1 is P2
-        False
-        sage: P1 == P2
         False
 
-    ``key`` can be any hashable value and is included in the cache key.
-    It is otherwise ignored by the poset constructor.
+    The ``key`` option is accepted for backward compatibility. It is
+    otherwise ignored by the poset constructor.
 
     TESTS::
 
@@ -786,7 +772,7 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
     return FinitePoset(D, elements=elements, category=category, facade=facade, key=key)
 
 
-class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
+class FinitePoset(Parent, metaclass=ClasscallMetaclass):
     r"""
     A (finite) `n`-element poset constructed from a directed acyclic graph.
 
@@ -824,7 +810,8 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
         :class:`~sage.combinat.posets.posets.FinitePoset`, itself built with
         ``facade = False``)
 
-    - ``key`` -- any hashable value (default: ``None``)
+    - ``key`` -- ignored; accepted for backward compatibility with the
+      former unique-representation constructor
 
     EXAMPLES::
 
@@ -875,8 +862,10 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
         Category of facade finite enumerated posets
         sage: parent(PQ[0]) is str
         True
-        sage: PQ is Q
+        sage: PQ == Q
         True
+        sage: PQ is Q
+        False
 
     Changing a facade poset to a non facade poset::
 
@@ -911,12 +900,16 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
 
     TESTS:
 
-    Equality is by identity. The constructor cache ensures that equal
-    construction data still give the same object::
+    Equality compares the underlying labeled posets, but independent
+    constructions from the same data give distinct parents::
 
         sage: P = Poset([[1,2],[3],[3]])
         sage: P == P
         True
+        sage: Poset([[1,2],[3],[3]]) == P
+        True
+        sage: Poset([[1,2],[3],[3]]) is P
+        False
         sage: Q = Poset([[1,2],[],[1]])
         sage: Q == P
         False
@@ -958,119 +951,51 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
     _lin_ext_type = LinearExtensionsOfPoset
     _desc = 'Finite poset'
 
-    # This cache uses reference-free fingerprint keys to choose a bucket,
-    # then validates exact equality before reusing a cached instance.  The
-    # cache dict itself is strong, but its values are short lists of
-    # ``weakref.ref`` to the cached posets, with finalizers that prune dead
-    # entries. Labels or ``key`` values which reference the poset therefore
-    # do not keep it alive through the cache (see :issue:`14356`).
-    _cache = {}
+    def _comparison_key(self):
+        """
+        Return structural data used for equality and hashing.
 
-    @staticmethod
-    def _fingerprint(obj):
+        The data is expressed in terms of the original element labels rather
+        than the internal integer labels.  A distinguished linear extension is
+        part of the structure when present.
         """
-        Return a cache fingerprint for ``obj`` without keeping ``obj`` alive.
-        """
-        try:
-            return hash(obj)
-        except TypeError:
-            return id(obj)
+        covers = frozenset((self._elements[i], self._elements[j])
+                           for i, j in self._hasse_diagram.cover_relations_iterator())
+        return (self._with_linear_extension, self._elements, covers)
 
-    @staticmethod
-    def _normalized_elements(elements):
+    def __eq__(self, other):
         """
-        Return elements with the same integer normalization as ``__init__``.
-        """
-        return tuple(Integer(i) if isinstance(i, int) else i
-                     for i in elements)
+        Return whether ``self`` and ``other`` define the same labeled poset.
 
-    @classmethod
-    def _cache_key(cls, hasse_diagram, elements, category, facade, key):
-        """
-        Return a cache key that does not strongly reference labels or ``key``.
-        """
-        hd_fp = cls._fingerprint(hasse_diagram)
-        if elements is None:
-            elements_fp = None
-        else:
-            elements_fp = (len(elements),
-                           tuple(cls._fingerprint(e) for e in elements))
-        key_fp = None if key is None else cls._fingerprint(key)
-        return (cls, hd_fp, elements_fp, category, facade, key_fp)
+        Equal posets need not be identical parents::
 
-    @classmethod
-    def _cache_match(cls, cached, hasse_diagram, elements, key):
+            sage: P = Poset([[1, 2], [3], [3]])
+            sage: Q = Poset([[1, 2], [3], [3]])
+            sage: P == Q
+            True
+            sage: P is Q
+            False
         """
-        Return whether ``cached`` was constructed from these exact arguments.
+        if self is other:
+            return True
+        if not isinstance(other, FinitePoset):
+            return NotImplemented
+        return self._comparison_key() == other._comparison_key()
 
-        For the ``elements is None`` branch we compare against
-        :attr:`_labeled_hasse_diagram` (a lazy attribute on ``cached``)
-        instead of relabeling on every lookup. For the
-        ``elements is not None`` branch we relabel the *incoming* graph to
-        integer vertices once and compare against the cached internal
-        :class:`HasseDiagram` directly.
+    def __ne__(self, other):
         """
-        try:
-            if cached._key != key:
-                return False
-            if cached._with_linear_extension != (elements is not None):
-                return False
-            if elements is None:
-                return cached._labeled_hasse_diagram == hasse_diagram
-
-            normalized_elements = cls._normalized_elements(elements)
-            if cached._elements != normalized_elements:
-                return False
-            relabel = {element: i
-                       for i, element in enumerate(normalized_elements)}
-            relabeled = hasse_diagram.relabel(relabel, inplace=False)
-            return cached._hasse_diagram == relabeled
-        except (AttributeError, TypeError, ValueError):
-            return False
-
-    @classmethod
-    def _cache_hit(cls, cache_key, hasse_diagram, elements, key):
+        Return whether ``self`` and ``other`` define different labeled posets.
         """
-        Return a matching cached poset, pruning dead entries in the bucket.
+        equality = self.__eq__(other)
+        if equality is NotImplemented:
+            return NotImplemented
+        return not equality
+
+    def __hash__(self):
         """
-        bucket = cls._cache.get(cache_key)
-        if bucket is None:
-            return None
-
-        live = []
-        match = None
-        for ref in bucket:
-            cached = ref()
-            if cached is None:
-                continue
-            live.append(ref)
-            if match is None and cls._cache_match(cached, hasse_diagram,
-                                                  elements, key):
-                match = cached
-
-        if not live:
-            cls._cache.pop(cache_key, None)
-        elif len(live) != len(bucket):
-            cls._cache[cache_key] = live
-        return match
-
-    @classmethod
-    def _cache_store(cls, cache_key, poset):
+        Return a hash compatible with structural equality.
         """
-        Store ``poset`` in the weak cache under ``cache_key``.
-        """
-        def remove(ref, cache=cls._cache, key=cache_key):
-            bucket = cache.get(key)
-            if bucket is None:
-                return
-            try:
-                bucket.remove(ref)
-            except ValueError:
-                return
-            if not bucket:
-                cache.pop(key, None)
-
-        cls._cache.setdefault(cache_key, []).append(weakref.ref(poset, remove))
+        return hash(self._comparison_key())
 
     # The parsing of the construction data (like a list of cover relations)
     #   into a :class:`DiGraph` is done in :func:`Poset`.
@@ -1087,7 +1012,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
           or ``None`` if no such default linear extension is wanted
         - ``category`` -- (optional) a subcategory of :class:`FinitePosets`
         - ``facade`` -- (optional) boolean if this is a facade parent or not
-        - ``key`` -- (optional) a key value
+        - ``key`` -- ignored; accepted for backward compatibility
 
         TESTS::
 
@@ -1133,14 +1058,13 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             sage: w() is None
             True
 
-        Identity is preserved while a reference is alive, but a fresh
-        construction after the poset has been garbage collected yields
-        a new (equal) object::
+        Independent constructions from the same data give distinct
+        parents::
 
             sage: data = [[1, 2], [3], [3]]
             sage: P = Poset(data)
             sage: Poset(data) is P
-            True
+            False
             sage: import weakref, gc
             sage: w = weakref.ref(P)
             sage: del P
@@ -1162,7 +1086,6 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             # ``FinitePoset`` of the right class, avoid relabeling and
             # re-constructing it.
             if (isinstance(poset, cls)
-                    and key == poset._key
                     and category == poset.category()
                     and facade == poset._is_facade
                     and poset._with_linear_extension == (elements is not None)
@@ -1189,16 +1112,10 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             category = category._without_axiom("Facade")
         category = Category.join([FinitePosets().or_subcategory(category), FiniteEnumeratedSets()])
 
-        cache_key = cls._cache_key(hasse_diagram, elements, category,
-                                   facade, key)
-        cached = cls._cache_hit(cache_key, hasse_diagram, elements, key)
-        if cached is not None:
-            return cached
-
         # Create the instance directly via typecall (equivalent to
-        # type.__call__), bypassing caches which would store the full
-        # constructor arguments, including element labels, as strong
-        # references. Pickling is handled by the __reduce__ override below.
+        # type.__call__). Pickling is handled by the __reduce__ override
+        # below, which recomputes construction data when needed instead of
+        # storing element labels in the instance.
         result = typecall(
             cls, hasse_diagram=hasse_diagram, elements=elements,
             category=category, facade=facade, key=key)
@@ -1206,28 +1123,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
         # FinitePoset_with_category) so that __reduce__ can
         # reconstruct through the same __classcall__ entry point.
         result._reduction_cls = cls
-
-        cls._cache_store(cache_key, result)
         return result
-
-    @classmethod
-    def _clear_cache_(cls):
-        """
-        Remove all cached instances of this class.
-
-        EXAMPLES::
-
-            sage: P = Poset({0: [1]})
-            sage: Q = Poset({0: [1]})
-            sage: P is Q
-            True
-            sage: from sage.combinat.posets.posets import FinitePoset
-            sage: FinitePoset._clear_cache_()
-            sage: R = Poset({0: [1]})
-            sage: P is R
-            False
-        """
-        cls._cache.clear()
 
     def __reduce__(self):
         """
@@ -1245,6 +1141,8 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             sage: Q = loads(dumps(P))
             sage: Q == P
             True
+            sage: Q.cover_relations() == P.cover_relations()
+            True
             sage: Q._is_facade
             False
         """
@@ -1253,10 +1151,10 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             dict(enumerate(self._elements)), inplace=False)
         hd = hd.copy(immutable=True)
         elements = self._elements if self._with_linear_extension else None
-        reduction = (self._reduction_cls, (),
+        reduction = (getattr(self, '_reduction_cls', self.__class__), (),
                      dict(hasse_diagram=hd, elements=elements,
                           category=self.category(),
-                          facade=self._is_facade, key=self._key))
+                          facade=self._is_facade))
         d = self.__getstate__()
         if d:
             return (unreduce, reduction, d)
@@ -1278,7 +1176,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             sage: P.__getstate__()
             {}
             sage: loads(dumps(P)) is P
-            True
+            False
 
         Cached methods that opt into ``do_pickle=True`` are preserved
         across pickling. We simulate one by stashing a
@@ -1403,27 +1301,6 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
                                            data_structure='static_sparse')
         self._element_to_vertex_dict = rdict
         self._is_facade = facade
-        self._key = key
-
-    @lazy_attribute
-    def _labeled_hasse_diagram(self):
-        """
-        The Hasse diagram relabeled with the original element labels.
-
-        This is the value that the constructor receives as ``hasse_diagram``
-        in the ``elements is None`` path; it is cached lazily so that the
-        :meth:`_cache_match` lookup does not need to relabel on every hit.
-
-        TESTS::
-
-            sage: P = Poset(DiGraph({'a': ['b'], 'b': ['c']}))
-            sage: P._labeled_hasse_diagram
-            Hasse diagram of a poset containing 3 elements
-            sage: sorted(P._labeled_hasse_diagram.vertices())
-            ['a', 'b', 'c']
-        """
-        return self._hasse_diagram.relabel(
-            dict(enumerate(self._elements)), inplace=False)
 
     @lazy_attribute
     def _list(self):
@@ -1495,8 +1372,10 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             sage: all(P._vertex_to_element(P._element_to_vertex(x)) is x for x in P)
             True
         """
-        if isinstance(element, self.element_class) and element.parent() is self:
+        if isinstance(element, PosetElement) and element.parent() is self:
             return element.vertex
+        if isinstance(element, PosetElement) and element.parent() == self:
+            element = element.element
 
         try:
             return self._element_to_vertex_dict[element]
@@ -1647,6 +1526,8 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             sage: all(P(x) is x for x in P)
             True
         """
+        if isinstance(element, PosetElement) and element.parent() == self:
+            element = element.element
         try:
             return self._list[self._element_to_vertex_dict[element]]
         except KeyError:

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -627,7 +627,7 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
 
     .. rubric:: Construction cache
 
-    The constructor caches finite posets.  Namely if two posets are
+    The constructor caches finite posets. Namely if two posets are
     created from two equal data, then they are not only equal but
     actually identical::
 
@@ -641,7 +641,7 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
         True
 
     The cache holds only weak references, so this identity is guaranteed
-    only while at least one reference to the poset is alive.  Once all
+    only while at least one reference to the poset is alive. Once all
     references are dropped, the cached entry is discarded and a fresh
     construction yields a new (but equal) object.
 
@@ -911,7 +911,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
 
     TESTS:
 
-    Equality is by identity.  The constructor cache ensures that equal
+    Equality is by identity. The constructor cache ensures that equal
     construction data still give the same object::
 
         sage: P = Poset([[1,2],[3],[3]])
@@ -962,7 +962,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
     # then validates exact equality before reusing a cached instance.  The
     # cache dict itself is strong, but its values are short lists of
     # ``weakref.ref`` to the cached posets, with finalizers that prune dead
-    # entries.  Labels or ``key`` values which reference the poset therefore
+    # entries. Labels or ``key`` values which reference the poset therefore
     # do not keep it alive through the cache (see :issue:`14356`).
     _cache = {}
 
@@ -1005,7 +1005,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
 
         For the ``elements is None`` branch we compare against
         :attr:`_labeled_hasse_diagram` (a lazy attribute on ``cached``)
-        instead of relabeling on every lookup.  For the
+        instead of relabeling on every lookup. For the
         ``elements is not None`` branch we relabel the *incoming* graph to
         integer vertices once and compare against the cached internal
         :class:`HasseDiagram` directly.
@@ -1198,7 +1198,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
         # Create the instance directly via typecall (equivalent to
         # type.__call__), bypassing caches which would store the full
         # constructor arguments, including element labels, as strong
-        # references.  Pickling is handled by the __reduce__ override below.
+        # references. Pickling is handled by the __reduce__ override below.
         result = typecall(
             cls, hasse_diagram=hasse_diagram, elements=elements,
             category=category, facade=facade, key=key)
@@ -1268,7 +1268,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
 
         Only cached methods that opt into ``do_pickle=True`` are preserved;
         all other state is rebuilt by :meth:`__classcall__` / :meth:`__init__`
-        when the pickle is loaded.  This keeps the pickle stream small and
+        when the pickle is loaded. This keeps the pickle stream small and
         avoids carrying strong references to element labels that could
         defeat the leak fix from :issue:`14356`.
 
@@ -1281,7 +1281,7 @@ class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
             True
 
         Cached methods that opt into ``do_pickle=True`` are preserved
-        across pickling.  We simulate one by stashing a
+        across pickling. We simulate one by stashing a
         :class:`~sage.misc.cachefunc.CachedFunction` directly into the
         instance dictionary::
 

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -1073,16 +1073,22 @@ class FinitePoset(UniqueRepresentation, Parent):
             except Exception:
                 return cached
 
-        # Create the instance via WithPicklingByInitArgs.__classcall__
-        # (bypasses CachedRepresentation's weak_cached_function cache,
-        # which would store the full arguments — including element
-        # labels — as a strong-referenced key and thereby prevent
-        # garbage collection when labels reference the poset; see
-        # :issue:`14356`).
-        from sage.structure.unique_representation import WithPicklingByInitArgs
-        result = WithPicklingByInitArgs.__classcall__(
+        # Create the instance directly via typecall (equivalent to
+        # type.__call__), bypassing both CachedRepresentation's
+        # weak_cached_function cache and WithPicklingByInitArgs's
+        # _reduction attribute.  Both would store the full arguments
+        # — including element labels — as strong references and
+        # thereby prevent garbage collection when labels reference
+        # the poset (see :issue:`14356`).  Pickling is handled by
+        # the __reduce__ override below.
+        from sage.misc.classcall_metaclass import typecall
+        result = typecall(
             cls, hasse_diagram=hasse_diagram, elements=elements,
             category=category, facade=facade, key=key)
+        # Store the "canonical" class (e.g. FinitePoset, not
+        # FinitePoset_with_category) so that __reduce__ can
+        # reconstruct through the same __classcall__ entry point.
+        result._reduction_cls = cls
 
         cls._cache[cache_key] = result
         return result
@@ -1105,6 +1111,41 @@ class FinitePoset(UniqueRepresentation, Parent):
             False
         """
         cls._cache.clear()
+
+    def __reduce__(self):
+        """
+        Return pickling data for this poset.
+
+        This overrides :meth:`WithPicklingByInitArgs.__reduce__`
+        because ``__classcall__`` no longer stores ``_reduction``
+        (to avoid the memory leak described in :issue:`14356`).
+        The constructor arguments are recomputed here at pickle time.
+
+        TESTS::
+
+            sage: P = Poset({0: [1, 2], 1: [3], 2: [3]})
+            sage: loads(dumps(P)) == P
+            True
+            sage: P = Poset(DiGraph({'a':['b'],'b':['c'],'c':['d']}), facade=False)
+            sage: Q = loads(dumps(P))
+            sage: Q == P
+            True
+            sage: Q._is_facade
+            False
+        """
+        from sage.structure.unique_representation import unreduce
+        hd = self._hasse_diagram.relabel(
+            dict(enumerate(self._elements)), inplace=False)
+        hd = hd.copy(immutable=True)
+        elements = self._elements if self._with_linear_extension else None
+        reduction = (self._reduction_cls, (),
+                     dict(hasse_diagram=hd, elements=elements,
+                          category=self.category(),
+                          facade=self._is_facade, key=self._key))
+        d = self.__getstate__()
+        if d:
+            return (unreduce, reduction, d)
+        return (unreduce, reduction)
 
     def __init__(self, hasse_diagram, elements, category, facade, key) -> None:
         r"""
@@ -1177,6 +1218,7 @@ class FinitePoset(UniqueRepresentation, Parent):
                                            data_structure='static_sparse')
         self._element_to_vertex_dict = rdict
         self._is_facade = facade
+        self._key = key
 
     @lazy_attribute
     def _list(self):

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -772,6 +772,14 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
     return FinitePoset(D, elements=elements, category=category, facade=facade, key=key)
 
 
+def _unpickle_finite_poset(cls, hasse_diagram, elements, category, facade):
+    """
+    Reconstruct a finite poset from pickled constructor data.
+    """
+    return cls(hasse_diagram=hasse_diagram, elements=elements,
+               category=category, facade=facade)
+
+
 class FinitePoset(Parent, metaclass=ClasscallMetaclass):
     r"""
     A (finite) `n`-element poset constructed from a directed acyclic graph.
@@ -1146,19 +1154,16 @@ class FinitePoset(Parent, metaclass=ClasscallMetaclass):
             sage: Q._is_facade
             False
         """
-        from sage.structure.unique_representation import unreduce
         hd = self._hasse_diagram.relabel(
             dict(enumerate(self._elements)), inplace=False)
         hd = hd.copy(immutable=True)
         elements = self._elements if self._with_linear_extension else None
-        reduction = (getattr(self, '_reduction_cls', self.__class__), (),
-                     dict(hasse_diagram=hd, elements=elements,
-                          category=self.category(),
-                          facade=self._is_facade))
+        reduction = (getattr(self, '_reduction_cls', self.__class__), hd,
+                     elements, self.category(), self._is_facade)
         d = self.__getstate__()
         if d:
-            return (unreduce, reduction, d)
-        return (unreduce, reduction)
+            return (_unpickle_finite_poset, reduction, d)
+        return (_unpickle_finite_poset, reduction)
 
     def __getstate__(self):
         """

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -289,8 +289,11 @@ from __future__ import annotations
 from collections import defaultdict
 from copy import copy
 from itertools import product
+import weakref
 
 from sage.misc.cachefunc import cached_method
+from sage.misc.classcall_metaclass import ClasscallMetaclass, typecall
+from sage.misc.fast_methods import WithEqualityById
 from sage.misc.lazy_attribute import lazy_attribute
 from sage.misc.misc_c import prod
 from sage.categories.category import Category
@@ -298,7 +301,6 @@ from sage.categories.sets_cat import Sets
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.categories.posets import Posets
 from sage.categories.finite_posets import FinitePosets
-from sage.misc.weak_dict import WeakValueDictionary
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.structure.parent import Parent
 from sage.rings.integer import Integer
@@ -623,12 +625,11 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
             sage: P.an_element().parent()
             Integer Ring
 
-    .. rubric:: Unique representation
+    .. rubric:: Construction cache
 
-    As most parents, :class:`Poset` have unique representation (see
-    :class:`UniqueRepresentation`). Namely if two posets are created
-    from two equal data, then they are not only equal but actually
-    identical::
+    The constructor caches finite posets.  Namely if two posets are
+    created from two equal data, then they are not only equal but
+    actually identical::
 
         sage: data1 = [[1,2],[3],[3]]
         sage: data2 = [[1,2],[3],[3]]
@@ -638,6 +639,11 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
         True
         sage: P1 is P2
         True
+
+    The cache holds only weak references, so this identity is guaranteed
+    only while at least one reference to the poset is alive.  Once all
+    references are dropped, the cached entry is discarded and a fresh
+    construction yields a new (but equal) object.
 
     In situations where this behaviour is not desired, one can use the
     ``key`` option::
@@ -649,9 +655,8 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
         sage: P1 == P2
         False
 
-    ``key`` can be any hashable value and is passed down to
-    :class:`UniqueRepresentation`. It is otherwise ignored by the
-    poset constructor.
+    ``key`` can be any hashable value and is included in the cache key.
+    It is otherwise ignored by the poset constructor.
 
     TESTS::
 
@@ -781,7 +786,7 @@ def Poset(data=None, element_labels=None, cover_relations=False, linear_extensio
     return FinitePoset(D, elements=elements, category=category, facade=facade, key=key)
 
 
-class FinitePoset(UniqueRepresentation, Parent):
+class FinitePoset(WithEqualityById, Parent, metaclass=ClasscallMetaclass):
     r"""
     A (finite) `n`-element poset constructed from a directed acyclic graph.
 
@@ -906,8 +911,8 @@ class FinitePoset(UniqueRepresentation, Parent):
 
     TESTS:
 
-    Equality is derived from :class:`UniqueRepresentation`. We check that this
-    gives consistent results::
+    Equality is by identity.  The constructor cache ensures that equal
+    construction data still give the same object::
 
         sage: P = Poset([[1,2],[3],[3]])
         sage: P == P
@@ -953,11 +958,118 @@ class FinitePoset(UniqueRepresentation, Parent):
     _lin_ext_type = LinearExtensionsOfPoset
     _desc = 'Finite poset'
 
-    # Custom cache using WeakValueDictionary with integer-labeled
-    # HasseDiagram keys.  This avoids a memory leak where element labels
-    # that reference back to the poset keep it alive via
-    # UniqueRepresentation's cache key (see :issue:`14356`).
-    _cache = WeakValueDictionary()
+    # This cache uses reference-free fingerprint keys to choose a bucket,
+    # then validates exact equality before reusing a cached instance.  The
+    # cache dict itself is strong, but its values are short lists of
+    # ``weakref.ref`` to the cached posets, with finalizers that prune dead
+    # entries.  Labels or ``key`` values which reference the poset therefore
+    # do not keep it alive through the cache (see :issue:`14356`).
+    _cache = {}
+
+    @staticmethod
+    def _fingerprint(obj):
+        """
+        Return a cache fingerprint for ``obj`` without keeping ``obj`` alive.
+        """
+        try:
+            return hash(obj)
+        except TypeError:
+            return id(obj)
+
+    @staticmethod
+    def _normalized_elements(elements):
+        """
+        Return elements with the same integer normalization as ``__init__``.
+        """
+        return tuple(Integer(i) if isinstance(i, int) else i
+                     for i in elements)
+
+    @classmethod
+    def _cache_key(cls, hasse_diagram, elements, category, facade, key):
+        """
+        Return a cache key that does not strongly reference labels or ``key``.
+        """
+        hd_fp = cls._fingerprint(hasse_diagram)
+        if elements is None:
+            elements_fp = None
+        else:
+            elements_fp = (len(elements),
+                           tuple(cls._fingerprint(e) for e in elements))
+        key_fp = None if key is None else cls._fingerprint(key)
+        return (cls, hd_fp, elements_fp, category, facade, key_fp)
+
+    @classmethod
+    def _cache_match(cls, cached, hasse_diagram, elements, key):
+        """
+        Return whether ``cached`` was constructed from these exact arguments.
+
+        The graph comparison is done directly against the cached
+        :class:`HasseDiagram` (which is a :class:`DiGraph`) so that no fresh
+        :class:`HasseDiagram` needs to be constructed on every cache lookup.
+        """
+        try:
+            if cached._key != key:
+                return False
+            if cached._with_linear_extension != (elements is not None):
+                return False
+            if elements is None:
+                cached_hasse_diagram = cached._hasse_diagram.relabel(
+                    dict(enumerate(cached._elements)), inplace=False)
+                return cached_hasse_diagram == hasse_diagram
+
+            normalized_elements = cls._normalized_elements(elements)
+            if cached._elements != normalized_elements:
+                return False
+            relabel = {element: i
+                       for i, element in enumerate(normalized_elements)}
+            relabeled = hasse_diagram.relabel(relabel, inplace=False)
+            return cached._hasse_diagram == relabeled
+        except (AttributeError, TypeError, ValueError):
+            return False
+
+    @classmethod
+    def _cache_hit(cls, cache_key, hasse_diagram, elements, key):
+        """
+        Return a matching cached poset, pruning dead entries in the bucket.
+        """
+        bucket = cls._cache.get(cache_key)
+        if bucket is None:
+            return None
+
+        live = []
+        match = None
+        for ref in bucket:
+            cached = ref()
+            if cached is None:
+                continue
+            live.append(ref)
+            if match is None and cls._cache_match(cached, hasse_diagram,
+                                                  elements, key):
+                match = cached
+
+        if not live:
+            cls._cache.pop(cache_key, None)
+        elif len(live) != len(bucket):
+            cls._cache[cache_key] = live
+        return match
+
+    @classmethod
+    def _cache_store(cls, cache_key, poset):
+        """
+        Store ``poset`` in the weak cache under ``cache_key``.
+        """
+        def remove(ref, cache=cls._cache, key=cache_key):
+            bucket = cache.get(key)
+            if bucket is None:
+                return
+            try:
+                bucket.remove(ref)
+            except ValueError:
+                return
+            if not bucket:
+                cache.pop(key, None)
+
+        cls._cache.setdefault(cache_key, []).append(weakref.ref(poset, remove))
 
     # The parsing of the construction data (like a list of cover relations)
     #   into a :class:`DiGraph` is done in :func:`Poset`.
@@ -1007,6 +1119,36 @@ class FinitePoset(UniqueRepresentation, Parent):
             sage: _ = gc.collect()
             sage: w() is None
             True
+
+        Same check when only ``key`` references the poset's owner
+        (default integer labels, no ``element_labels``)::
+
+            sage: foo = Foo()
+            sage: foo.poset = Poset(DiGraph({0: [1, 2], 1: [3], 2: [3]}),
+            ....:                   key=foo)
+            sage: w = weakref.ref(foo.poset)
+            sage: del foo
+            sage: _ = gc.collect()
+            sage: w() is None
+            True
+
+        Identity is preserved while a reference is alive, but a fresh
+        construction after the poset has been garbage collected yields
+        a new (equal) object::
+
+            sage: data = [[1, 2], [3], [3]]
+            sage: P = Poset(data)
+            sage: Poset(data) is P
+            True
+            sage: import weakref, gc
+            sage: w = weakref.ref(P)
+            sage: del P
+            sage: _ = gc.collect()
+            sage: w() is None
+            True
+            sage: Q = Poset(data)
+            sage: Q == Poset(data)
+            True
         """
         assert isinstance(hasse_diagram, (FinitePoset, DiGraph))
         if isinstance(hasse_diagram, FinitePoset):
@@ -1035,53 +1177,16 @@ class FinitePoset(UniqueRepresentation, Parent):
             category = category._without_axiom("Facade")
         category = Category.join([FinitePosets().or_subcategory(category), FiniteEnumeratedSets()])
 
-        # Build a reference-free cache key from the hash of the labeled
-        # hasse_diagram.  Using hashes (integers) avoids holding strong
-        # references to element objects in the cache key, which prevents
-        # a memory leak when element labels reference the poset itself
-        # (see :issue:`14356`).
-        try:
-            _hd_hash = hash(hasse_diagram)
-        except TypeError:
-            _hd_hash = id(hasse_diagram)
-        if elements is None:
-            _elts_hash = 0
-        else:
-            try:
-                _elts_hash = hash(elements)
-            except TypeError:
-                _elts_hash = hash(tuple(id(e) for e in elements))
-
-        cache_key = (cls, _hd_hash, _elts_hash,
-                     elements is not None, category, facade, key)
-
-        cached = cls._cache.get(cache_key)
+        cache_key = cls._cache_key(hasse_diagram, elements, category,
+                                   facade, key)
+        cached = cls._cache_hit(cache_key, hasse_diagram, elements, key)
         if cached is not None:
-            # Validate the cached instance against the incoming data
-            # to guard against hash collisions.  Two structurally-
-            # isomorphic posets whose vertex labels have pairwise equal
-            # hashes but different parents (e.g. root lattice of C2 vs.
-            # coroot lattice of B2) will collide in the hash-based key.
-            # Reconstruct the labeled vertex list from the cached instance
-            # and compare with the incoming hasse_diagram's vertices.
-            try:
-                cached_verts = set(cached._hasse_diagram.relabel(
-                    dict(enumerate(cached._elements)), inplace=False).vertices())
-                incoming_verts = set(hasse_diagram.vertices())
-                if cached_verts == incoming_verts:
-                    return cached
-            except Exception:
-                return cached
+            return cached
 
         # Create the instance directly via typecall (equivalent to
-        # type.__call__), bypassing both CachedRepresentation's
-        # weak_cached_function cache and WithPicklingByInitArgs's
-        # _reduction attribute.  Both would store the full arguments
-        # — including element labels — as strong references and
-        # thereby prevent garbage collection when labels reference
-        # the poset (see :issue:`14356`).  Pickling is handled by
-        # the __reduce__ override below.
-        from sage.misc.classcall_metaclass import typecall
+        # type.__call__), bypassing caches which would store the full
+        # constructor arguments, including element labels, as strong
+        # references.  Pickling is handled by the __reduce__ override below.
         result = typecall(
             cls, hasse_diagram=hasse_diagram, elements=elements,
             category=category, facade=facade, key=key)
@@ -1090,7 +1195,7 @@ class FinitePoset(UniqueRepresentation, Parent):
         # reconstruct through the same __classcall__ entry point.
         result._reduction_cls = cls
 
-        cls._cache[cache_key] = result
+        cls._cache_store(cache_key, result)
         return result
 
     @classmethod
@@ -1116,10 +1221,8 @@ class FinitePoset(UniqueRepresentation, Parent):
         """
         Return pickling data for this poset.
 
-        This overrides :meth:`WithPicklingByInitArgs.__reduce__`
-        because ``__classcall__`` no longer stores ``_reduction``
-        (to avoid the memory leak described in :issue:`14356`).
-        The constructor arguments are recomputed here at pickle time.
+        The constructor arguments are recomputed here at pickle time instead
+        of being stored as strong references when the poset is created.
 
         TESTS::
 
@@ -1146,6 +1249,76 @@ class FinitePoset(UniqueRepresentation, Parent):
         if d:
             return (unreduce, reduction, d)
         return (unreduce, reduction)
+
+    def __getstate__(self):
+        """
+        Return the state to pickle for this poset.
+
+        Only cached methods that opt into ``do_pickle=True`` are preserved;
+        all other state is rebuilt by :meth:`__classcall__` / :meth:`__init__`
+        when the pickle is loaded.  This keeps the pickle stream small and
+        avoids carrying strong references to element labels that could
+        defeat the leak fix from :issue:`14356`.
+
+        TESTS::
+
+            sage: P = Poset({0: [1, 2], 1: [3], 2: [3]})
+            sage: P.__getstate__()
+            {}
+            sage: loads(dumps(P)) is P
+            True
+
+        Cached methods that opt into ``do_pickle=True`` are preserved
+        across pickling.  We simulate one by stashing a
+        :class:`~sage.misc.cachefunc.CachedFunction` directly into the
+        instance dictionary::
+
+            sage: from sage.misc.cachefunc import cached_function
+            sage: @cached_function(do_pickle=True)
+            ....: def f(x):
+            ....:     return x
+            sage: P.cached = f
+            sage: state = P.__getstate__()
+            sage: list(state) == ['cached']
+            True
+            sage: state['cached'] is f
+            True
+            sage: del P.cached
+        """
+        from sage.misc.cachefunc import CachedFunction
+        return {key: value for key, value in self.__dict__.items()
+                if isinstance(value, CachedFunction)
+                and value.is_pickled_with_cache()}
+
+    def __setstate__(self, d):
+        """
+        Restore the pickled state of this poset.
+
+        See :meth:`__getstate__` for what is preserved across pickling.
+        """
+        self.__dict__.update(d)
+
+    def __copy__(self):
+        """
+        Return ``self`` as a semantic copy.
+
+        Finite posets are immutable parents identified by identity, so
+        ``copy(P) is P``::
+
+            sage: from copy import copy, deepcopy
+            sage: P = Poset({0: [1, 2], 1: [3], 2: [3]})
+            sage: copy(P) is P
+            True
+            sage: deepcopy(P) is P
+            True
+        """
+        return self
+
+    def __deepcopy__(self, memo):
+        """
+        Return ``self`` as a semantic deep copy.  See :meth:`__copy__`.
+        """
+        return self
 
     def __init__(self, hasse_diagram, elements, category, facade, key) -> None:
         r"""

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -969,7 +969,13 @@ class FinitePoset(Parent, metaclass=ClasscallMetaclass):
         """
         covers = frozenset((self._elements[i], self._elements[j])
                            for i, j in self._hasse_diagram.cover_relations_iterator())
-        return (self._with_linear_extension, self._elements, covers)
+        if self._with_linear_extension:
+            elements = self._elements
+        else:
+            # Without a distinguished linear extension, ``_elements`` is an
+            # internal topological sort and its order is not part of the poset.
+            elements = frozenset(self._elements)
+        return (self._with_linear_extension, elements, covers)
 
     def __eq__(self, other):
         """

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -1052,34 +1052,26 @@ class FinitePoset(UniqueRepresentation, Parent):
             except TypeError:
                 _elts_hash = hash(tuple(id(e) for e in elements))
 
-        # Guard against hash collisions between structurally-isomorphic
-        # posets whose vertex labels come from *different* parent spaces.
-        # For example, RootSystem(['C',2]).root_lattice().root_poset() and
-        # RootSystem(['B',2]).coroot_lattice().root_poset() produce graphs
-        # with the same topology; their vertex labels (roots vs. coroots)
-        # have identical Python hashes yet live in different parents and
-        # are not equal.  Without this extra discriminator the cache would
-        # return the *first* poset for both callers, causing the elements
-        # of the second poset to carry the wrong parent.
-        #
-        # Use id(parent) of the first Sage element vertex — an integer,
-        # holding *no* strong references — so that two posets whose vertex
-        # labels belong to different parent objects get distinct cache keys.
-        _vertex_parent_id = None
-        try:
-            for _v in hasse_diagram.vertices():
-                if hasattr(_v, 'parent'):
-                    _vertex_parent_id = id(_v.parent())
-                break
-        except (AttributeError, TypeError):
-            pass
-
-        cache_key = (cls, _hd_hash, _elts_hash, _vertex_parent_id,
+        cache_key = (cls, _hd_hash, _elts_hash,
                      elements is not None, category, facade, key)
 
         cached = cls._cache.get(cache_key)
         if cached is not None:
-            return cached
+            # Validate the cached instance against the incoming data
+            # to guard against hash collisions.  Two structurally-
+            # isomorphic posets whose vertex labels have pairwise equal
+            # hashes but different parents (e.g. root lattice of C2 vs.
+            # coroot lattice of B2) will collide in the hash-based key.
+            # Reconstruct the labeled vertex list from the cached instance
+            # and compare with the incoming hasse_diagram's vertices.
+            try:
+                cached_verts = set(cached._hasse_diagram.relabel(
+                    dict(enumerate(cached._elements)), inplace=False).vertices())
+                incoming_verts = set(hasse_diagram.vertices())
+                if cached_verts == incoming_verts:
+                    return cached
+            except Exception:
+                return cached
 
         # Create the instance via WithPicklingByInitArgs.__classcall__
         # (bypasses CachedRepresentation's weak_cached_function cache,

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -298,7 +298,6 @@ from sage.categories.sets_cat import Sets
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.categories.posets import Posets
 from sage.categories.finite_posets import FinitePosets
-from sage.misc.classcall_metaclass import typecall
 from sage.misc.weak_dict import WeakValueDictionary
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.structure.parent import Parent
@@ -996,7 +995,6 @@ class FinitePoset(UniqueRepresentation, Parent):
         poset can be garbage collected (:issue:`14356`)::
 
             sage: import gc, weakref
-            sage: from sage.combinat.posets.posets import FinitePoset
             sage: class Foo:
             ....:     pass
             sage: foo = Foo()
@@ -1005,14 +1003,10 @@ class FinitePoset(UniqueRepresentation, Parent):
             ....:     element_labels=[(i, foo) for i in range(4)],
             ....:     key=id(foo))
             sage: w = weakref.ref(foo.poset)
-            sage: pid = id(foo.poset)
             sage: del foo
             sage: _ = gc.collect()
             sage: w() is None
             True
-            sage: [x for x in gc.get_objects()
-            ....:  if isinstance(x, FinitePoset) and id(x) == pid]
-            []
         """
         assert isinstance(hasse_diagram, (FinitePoset, DiGraph))
         if isinstance(hasse_diagram, FinitePoset):
@@ -1050,41 +1044,32 @@ class FinitePoset(UniqueRepresentation, Parent):
             _hd_hash = hash(hasse_diagram)
         except TypeError:
             _hd_hash = id(hasse_diagram)
-        try:
-            _elts_hash = hash(elements) if elements is not None else 0
-        except TypeError:
+        if elements is None:
             _elts_hash = 0
+        else:
+            try:
+                _elts_hash = hash(elements)
+            except TypeError:
+                _elts_hash = hash(tuple(id(e) for e in elements))
         cache_key = (cls, _hd_hash, _elts_hash,
                      elements is not None, category, facade, key)
 
-        cached = FinitePoset._cache.get(cache_key)
+        cached = cls._cache.get(cache_key)
         if cached is not None:
-            try:
-                # Verify it is really the same poset (hash collision guard):
-                # reconstruct the labeled graph from the cached instance
-                # and compare with the input.
-                _relabel = dict(enumerate(cached._elements))
-                _cached_hd = cached._hasse_diagram.relabel(_relabel,
-                                                           inplace=False)
-                if _cached_hd == hasse_diagram:
-                    if elements is None or cached._elements == tuple(
-                            Integer(i) if isinstance(i, int) else i
-                            for i in elements):
-                        return cached
-            except Exception:
-                pass
+            return cached
 
-        # Create the instance via typecall (bypasses
-        # CachedRepresentation's weak_cached_function cache, which
-        # would store the full arguments — including element labels —
-        # as a strong-referenced key and thereby prevent garbage
-        # collection when labels reference the poset; see :issue:`14356`).
+        # Create the instance via WithPicklingByInitArgs.__classcall__
+        # (bypasses CachedRepresentation's weak_cached_function cache,
+        # which would store the full arguments — including element
+        # labels — as a strong-referenced key and thereby prevent
+        # garbage collection when labels reference the poset; see
+        # :issue:`14356`).
         from sage.structure.unique_representation import WithPicklingByInitArgs
         result = WithPicklingByInitArgs.__classcall__(
             cls, hasse_diagram=hasse_diagram, elements=elements,
             category=category, facade=facade, key=key)
 
-        FinitePoset._cache[cache_key] = result
+        cls._cache[cache_key] = result
         return result
 
     @classmethod
@@ -1104,7 +1089,7 @@ class FinitePoset(UniqueRepresentation, Parent):
             sage: P is R
             False
         """
-        FinitePoset._cache.clear()
+        cls._cache.clear()
 
     def __init__(self, hasse_diagram, elements, category, facade, key) -> None:
         r"""

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -298,6 +298,8 @@ from sage.categories.sets_cat import Sets
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.categories.posets import Posets
 from sage.categories.finite_posets import FinitePosets
+from sage.misc.classcall_metaclass import typecall
+from sage.misc.weak_dict import WeakValueDictionary
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.structure.parent import Parent
 from sage.rings.integer import Integer
@@ -952,6 +954,12 @@ class FinitePoset(UniqueRepresentation, Parent):
     _lin_ext_type = LinearExtensionsOfPoset
     _desc = 'Finite poset'
 
+    # Custom cache using WeakValueDictionary with integer-labeled
+    # HasseDiagram keys.  This avoids a memory leak where element labels
+    # that reference back to the poset keep it alive via
+    # UniqueRepresentation's cache key (see :issue:`14356`).
+    _cache = WeakValueDictionary()
+
     # The parsing of the construction data (like a list of cover relations)
     #   into a :class:`DiGraph` is done in :func:`Poset`.
     @staticmethod
@@ -983,6 +991,28 @@ class FinitePoset(UniqueRepresentation, Parent):
             sage: p = Poset()
             sage: p is Poset(p, category=p.category())
             True
+
+        Check that posets whose element labels reference back to the
+        poset can be garbage collected (:issue:`14356`)::
+
+            sage: import gc, weakref
+            sage: from sage.combinat.posets.posets import FinitePoset
+            sage: class Foo:
+            ....:     pass
+            sage: foo = Foo()
+            sage: foo.dag = DiGraph({0: [1, 2], 1: [3], 2: [3]})
+            sage: foo.poset = Poset(foo.dag,
+            ....:     element_labels=[(i, foo) for i in range(4)],
+            ....:     key=id(foo))
+            sage: w = weakref.ref(foo.poset)
+            sage: pid = id(foo.poset)
+            sage: del foo
+            sage: _ = gc.collect()
+            sage: w() is None
+            True
+            sage: [x for x in gc.get_objects()
+            ....:  if isinstance(x, FinitePoset) and id(x) == pid]
+            []
         """
         assert isinstance(hasse_diagram, (FinitePoset, DiGraph))
         if isinstance(hasse_diagram, FinitePoset):
@@ -999,7 +1029,8 @@ class FinitePoset(UniqueRepresentation, Parent):
             hasse_diagram = poset._hasse_diagram.relabel(relabel, inplace=False)
             hasse_diagram = hasse_diagram.copy(immutable=True)
         else:
-            hasse_diagram = HasseDiagram(hasse_diagram, data_structure='static_sparse')
+            if not isinstance(hasse_diagram, HasseDiagram):
+                hasse_diagram = HasseDiagram(hasse_diagram, data_structure='static_sparse')
             if facade is None:
                 facade = True
             if elements is not None:
@@ -1009,10 +1040,71 @@ class FinitePoset(UniqueRepresentation, Parent):
         if category is not None and category.is_subcategory(Sets().Facade()):
             category = category._without_axiom("Facade")
         category = Category.join([FinitePosets().or_subcategory(category), FiniteEnumeratedSets()])
-        return super().__classcall__(cls, hasse_diagram=hasse_diagram,
-                                     elements=elements,
-                                     category=category, facade=facade,
-                                     key=key)
+
+        # Build a reference-free cache key from the hash of the labeled
+        # hasse_diagram.  Using hashes (integers) avoids holding strong
+        # references to element objects in the cache key, which prevents
+        # a memory leak when element labels reference the poset itself
+        # (see :issue:`14356`).
+        try:
+            _hd_hash = hash(hasse_diagram)
+        except TypeError:
+            _hd_hash = id(hasse_diagram)
+        try:
+            _elts_hash = hash(elements) if elements is not None else 0
+        except TypeError:
+            _elts_hash = 0
+        cache_key = (cls, _hd_hash, _elts_hash,
+                     elements is not None, category, facade, key)
+
+        cached = FinitePoset._cache.get(cache_key)
+        if cached is not None:
+            try:
+                # Verify it is really the same poset (hash collision guard):
+                # reconstruct the labeled graph from the cached instance
+                # and compare with the input.
+                _relabel = dict(enumerate(cached._elements))
+                _cached_hd = cached._hasse_diagram.relabel(_relabel,
+                                                           inplace=False)
+                if _cached_hd == hasse_diagram:
+                    if elements is None or cached._elements == tuple(
+                            Integer(i) if isinstance(i, int) else i
+                            for i in elements):
+                        return cached
+            except Exception:
+                pass
+
+        # Create the instance via typecall (bypasses
+        # CachedRepresentation's weak_cached_function cache, which
+        # would store the full arguments — including element labels —
+        # as a strong-referenced key and thereby prevent garbage
+        # collection when labels reference the poset; see :issue:`14356`).
+        from sage.structure.unique_representation import WithPicklingByInitArgs
+        result = WithPicklingByInitArgs.__classcall__(
+            cls, hasse_diagram=hasse_diagram, elements=elements,
+            category=category, facade=facade, key=key)
+
+        FinitePoset._cache[cache_key] = result
+        return result
+
+    @classmethod
+    def _clear_cache_(cls):
+        """
+        Remove all cached instances of this class.
+
+        EXAMPLES::
+
+            sage: P = Poset({0: [1]})
+            sage: Q = Poset({0: [1]})
+            sage: P is Q
+            True
+            sage: from sage.combinat.posets.posets import FinitePoset
+            sage: FinitePoset._clear_cache_()
+            sage: R = Poset({0: [1]})
+            sage: P is R
+            False
+        """
+        FinitePoset._cache.clear()
 
     def __init__(self, hasse_diagram, elements, category, facade, key) -> None:
         r"""

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -1051,7 +1051,30 @@ class FinitePoset(UniqueRepresentation, Parent):
                 _elts_hash = hash(elements)
             except TypeError:
                 _elts_hash = hash(tuple(id(e) for e in elements))
-        cache_key = (cls, _hd_hash, _elts_hash,
+
+        # Guard against hash collisions between structurally-isomorphic
+        # posets whose vertex labels come from *different* parent spaces.
+        # For example, RootSystem(['C',2]).root_lattice().root_poset() and
+        # RootSystem(['B',2]).coroot_lattice().root_poset() produce graphs
+        # with the same topology; their vertex labels (roots vs. coroots)
+        # have identical Python hashes yet live in different parents and
+        # are not equal.  Without this extra discriminator the cache would
+        # return the *first* poset for both callers, causing the elements
+        # of the second poset to carry the wrong parent.
+        #
+        # Use id(parent) of the first Sage element vertex — an integer,
+        # holding *no* strong references — so that two posets whose vertex
+        # labels belong to different parent objects get distinct cache keys.
+        _vertex_parent_id = None
+        try:
+            for _v in hasse_diagram.vertices():
+                if hasattr(_v, 'parent'):
+                    _vertex_parent_id = id(_v.parent())
+                break
+        except (AttributeError, TypeError):
+            pass
+
+        cache_key = (cls, _hd_hash, _elts_hash, _vertex_parent_id,
                      elements is not None, category, facade, key)
 
         cached = cls._cache.get(cache_key)

--- a/src/sage/modular/modform_hecketriangle/analytic_type.py
+++ b/src/sage/modular/modform_hecketriangle/analytic_type.py
@@ -363,6 +363,24 @@ class AnalyticType(FiniteLatticePoset):
             cls._singleton_instance = instance
         return instance
 
+    def __reduce__(self):
+        r"""
+        Return pickling data for the singleton instance.
+
+        TESTS::
+
+            sage: from sage.modular.modform_hecketriangle.analytic_type import AnalyticType
+            sage: AT = AnalyticType()
+            sage: loads(dumps(AT)) is AT
+            True
+            sage: el = AT(["quasi", "weak"])
+            sage: loads(dumps(el)) == el
+            True
+            sage: loads(dumps(el)).parent() is AT
+            True
+        """
+        return (AnalyticType, ())
+
     def __init__(self):
         r"""
         Container for all possible analytic types of forms and/or spaces.

--- a/src/sage/modular/modform_hecketriangle/analytic_type.py
+++ b/src/sage/modular/modform_hecketriangle/analytic_type.py
@@ -342,12 +342,11 @@ class AnalyticType(FiniteLatticePoset):
     @staticmethod
     def __classcall__(cls):
         r"""
-        Directly return the classcall of UniqueRepresentation
-        (skipping the classcalls of the other superclasses).
+        Return the singleton instance of ``cls``.
 
-        That's because ``self`` is supposed to be used as a Singleton.
-        It initializes the FinitelatticePoset with the proper arguments
-        by itself in ``self.__init__()``.
+        Skips :meth:`FinitePoset.__classcall__` (which expects a Hasse
+        diagram argument); ``self.__init__()`` initializes the underlying
+        :class:`FiniteLatticePoset` with the proper arguments by itself.
 
         EXAMPLES::
 
@@ -357,7 +356,12 @@ class AnalyticType(FiniteLatticePoset):
             sage: AT is AT2
             True
         """
-        return super(FinitePoset, cls).__classcall__(cls)
+        from sage.misc.classcall_metaclass import typecall
+        instance = cls.__dict__.get('_singleton_instance')
+        if instance is None:
+            instance = typecall(cls)
+            cls._singleton_instance = instance
+        return instance
 
     def __init__(self):
         r"""


### PR DESCRIPTION
Posets whose element labels hold a reference to the poset's parent object (e.g. cones of a fan labelling a face lattice in toric varieties) are never garbage collected.  The root cause is that UniqueRepresentation caches instances via @weak_cached_function(cache=128) whose *keys* are stored with strong references.  The key tuple includes the full hasse_diagram (with element labels as vertices), so when those labels contain a reference chain back to the FinitePoset instance the poset is kept alive indefinitely.

Fix: replace UniqueRepresentation's weak_cached_function cache with a custom WeakValueDictionary on FinitePoset._cache.  The cache key uses only *hashes* of the labeled HasseDiagram and elements (plain integers), so no strong references to element objects are held.  On a cache hit the entry is validated by reconstructing the labeled graph from the cached instance's integer-labeled internal HasseDiagram and comparing it with the input (guards against hash collisions).  Instances are created via WithPicklingByInitArgs.__classcall__ to preserve the existing pickle protocol.

Also add FinitePoset._clear_cache_() classmethod (mirrors UniqueRepresentation._clear_cache_()) and a regression test that verifies the poset is collected after 'del foo' using both a weakref and gc.get_objects().

Fixes #14356

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


