### PR TITLE
Fix a test failure on distro packages after #41548

### DIFF
--- a/src/sage/misc/lazy_import.pyx
+++ b/src/sage/misc/lazy_import.pyx
@@ -1112,7 +1112,6 @@ def lazy_import(module, names, as_=None, *,
         Failed lazy import:
         foo is not available.
         Importing not_there failed: No module named 'foo'...
-        No equivalent system packages for ... are known to Sage...
     """
     if as_ is None:
         as_ = names


### PR DESCRIPTION
There is no insallation hint displayed on distros because there are no `package_systems()` available.

This used to pass before #41548 becasue `PipPackageSystem` was wrongly considered available in `package_systems()`


