### PR TITLE
CI Linux fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,8 @@ jobs:
           - debian:forky
           - ghcr.io/void-linux/void-glibc-full
           - archlinux
-          #- ubuntu:22.04 - gap is outdated there (only 4.11)
-          - ubuntu:24.04
           - ubuntu:25.04
+          - ubuntu:26.04
     container:
       image: ${{ matrix.container }}
 
@@ -46,10 +45,6 @@ jobs:
             # The archlinux container is configured to not install docs by default
             # but we need the maxima help to be in place
             sed -i '/^NoExtract/d' /etc/pacman.conf
-          fi
-          if [ "${{ matrix.container }}" = "ubuntu:22.04" ]; then
-            apt-get update
-            apt-get install -y git
           fi
 
       - name: Checkout code
@@ -91,7 +86,9 @@ jobs:
       - name: Build
         run: |
           # Install build dependencies manually as workaround for https://github.com/astral-sh/uv/issues/1516
-          uv sync --frozen --inexact --no-install-project -v
+          # Rebuild cypari2 from source to link against the system PARI library,
+          # avoiding a conflict between the system PARI and the one bundled in the cypari2 wheel
+          uv sync --frozen --inexact --no-install-project --no-binary-package cypari2 -v
           uv sync --frozen --inexact --no-build-isolation -v
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           - debian:forky
           - ghcr.io/void-linux/void-glibc-full
           - archlinux
-          - ubuntu:25.04
+          - ubuntu:25.10
           - ubuntu:26.04
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,8 @@ jobs:
           # Install build dependencies manually as workaround for https://github.com/astral-sh/uv/issues/1516
           # Rebuild cypari2 from source to link against the system PARI library,
           # avoiding a conflict between the system PARI and the one bundled in the cypari2 wheel
-          uv sync --frozen --inexact --no-install-project --no-binary-package cypari2 -v
-          uv sync --frozen --inexact --no-build-isolation -v
+          uv sync --frozen --inexact --no-install-project --no-binary-package cypari2 --extra extra -v
+          uv sync --frozen --inexact --no-build-isolation --extra extra -v
 
       - name: Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,10 @@ jobs:
           # Install build dependencies manually as workaround for https://github.com/astral-sh/uv/issues/1516
           # Rebuild cypari2 from source to link against the system PARI library,
           # avoiding a conflict between the system PARI and the one bundled in the cypari2 wheel
-          uv sync --frozen --inexact --no-install-project --no-binary-package cypari2 --extra extra -v
-          uv sync --frozen --inexact --no-build-isolation --extra extra -v
+          uv sync --frozen --inexact --no-install-project --no-binary-package cypari2 -v
+          uv sync --frozen --inexact --no-build-isolation -v
+          # Install optional packages that are needed for tests but not in the default dependency group
+          uv pip install lrcalc
 
       - name: Test
         run: |


### PR DESCRIPTION
- Replace ubuntu:24.04 with ubuntu:26.04 in the CI matrix
- Remove obsolete ubuntu:22.04 prepare-container block
- Rebuild cypari2 from source (--no-binary-package cypari2) so it links against the system PARI library, avoiding segfaults caused by having two separate PARI library instances in the same process (bundled vs system libpari)

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


