### PR TITLE
Add missing build deps to several python packages

### DIFF
--- a/build/pkgs/pillow/dependencies
+++ b/build/pkgs/pillow/dependencies
@@ -1,4 +1,4 @@
- freetype trove_classifiers | $(PYTHON_TOOLCHAIN) $(PYTHON)
+ freetype trove_classifiers | $(PYTHON_TOOLCHAIN) $(PYTHON) pybind11
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pyzmq/dependencies
+++ b/build/pkgs/pyzmq/dependencies
@@ -1,4 +1,4 @@
-zeromq cffi | $(PYTHON_TOOLCHAIN) $(PYTHON) cython scikit_build_core
+numpy zeromq cffi | $(PYTHON_TOOLCHAIN) $(PYTHON) cython scikit_build_core
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/pyzmq/dependencies
+++ b/build/pkgs/pyzmq/dependencies
@@ -1,4 +1,4 @@
- cython zeromq cffi scikit_build_core | $(PYTHON_TOOLCHAIN) $(PYTHON)
+zeromq cffi | $(PYTHON_TOOLCHAIN) $(PYTHON) cython scikit_build_core
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/scikit_build_core/dependencies
+++ b/build/pkgs/scikit_build_core/dependencies
@@ -1,4 +1,4 @@
-packaging pathspec | $(PYTHON_TOOLCHAIN) cmake $(PYTHON)
+packaging pathspec | $(PYTHON_TOOLCHAIN) cmake $(PYTHON) hatch_vcs
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
Add pybind11 to pillow dependencies, hatch_vcs to scikit_build_core, shuffle pyzmq deps around.

See https://groups.google.com/g/sage-release/c/7e3RjHOqFQA/m/-_DTZVFnBAAJ


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


