### PR TITLE
Tachyon: Use pkg-config for libpng

### DIFF
--- a/build/pkgs/tachyon/spkg-install.in
+++ b/build/pkgs/tachyon/spkg-install.in
@@ -52,8 +52,10 @@ if [ -z "$TARGET" ]; then
     sdh_die "Error: Sorry, your platform isn't supported by Tachyon and/or Sage. Exiting..."
 fi
 
-# The Makefile ignores LDFLAGS; we include it here so that rpath is set on Linux
-sdh_make "$TARGET" USEPNG=-DUSEPNG PNGLIB="$LDFLAGS -lpng -lz"
+sdh_make "$TARGET" \
+    USEPNG=-DUSEPNG \
+    PNGINC="$(pkg-config --cflags libpng)" \
+    PNGLIB="$(pkg-config --libs libpng)"
 
 echo "Installing the Tachyon binary..."
 cd "$CUR"


### PR DESCRIPTION
Just use pkg-config whenever possible instead of relying on hardcoded /usr paths
