### PR TITLE
Fix parent mismatch in positive_roots_by_height

### DIFF
--- a/src/sage/combinat/root_system/root_lattice_realizations.py
+++ b/src/sage/combinat/root_system/root_lattice_realizations.py
@@ -908,9 +908,9 @@ class RootLatticeRealizations(Category_over_base_ring):
 
                 sage: L = RootSystem(['C',2]).root_lattice()
                 sage: L.positive_roots_by_height()                                      # needs sage.graphs
-                [alpha[2], alpha[1], alpha[1] + alpha[2], 2*alpha[1] + alpha[2]]
+                [alpha[1], alpha[2], alpha[1] + alpha[2], 2*alpha[1] + alpha[2]]
                 sage: L.positive_roots_by_height(increasing=False)                      # needs sage.graphs
-                [2*alpha[1] + alpha[2], alpha[1] + alpha[2], alpha[2], alpha[1]]
+                [2*alpha[1] + alpha[2], alpha[1] + alpha[2], alpha[1], alpha[2]]
 
                 sage: L = RootSystem(['A',2,1]).root_lattice()
                 sage: L.positive_roots_by_height()                                      # needs sage.graphs
@@ -921,13 +921,10 @@ class RootLatticeRealizations(Category_over_base_ring):
 
             if not self.cartan_type().is_finite():
                 raise NotImplementedError("Only implemented for finite Cartan type")
-            ranks = self.root_poset().level_sets()
-            if not increasing:
-                ranks.reverse()
-            roots = []
-            for x in ranks:
-                roots += x
-            return [x.element for x in roots]
+            roots = sorted(self.positive_roots(),
+                           key=lambda x: x.height(),
+                           reverse=not increasing)
+            return roots
 
         @cached_method
         def positive_roots_parabolic(self, index_set=None):


### PR DESCRIPTION
The method `positive_roots_by_height()` previously computed its sorted list by calling `self.root_poset().level_sets()` and then extracting the .element attribute from each poset element.

This is incorrect because FinitePoset inherits UniqueRepresentation, which caches instances keyed by the full argument tuple.  Two root spaces whose underlying combinatorics are isomorphic - most notably the root lattice of a type-X root system and the coroot lattice of the Langlands-dual type - produce identical HasseDiagram objects and therefore map to the same cached FinitePoset instance.  Concretely,

    `RootSystem(['C',2]).root_lattice().root_poset()`
    `RootSystem(['B',2]).coroot_lattice().root_poset()`

return the exact same Python object.  Whichever root space created the poset first 'owns' the elements stored inside it, so any later caller receives elements whose .parent() points to a foreign root space.

When max_coroot_le() subsequently computes

    `gamma = self - beta.associated_coroot()`

the two operands live in different parents, and Sage's coercion model raises:
```
    TypeError: unsupported operand parent(s) for -:
        'Coroot lattice of the Root system of type ['C', 2]' and
        'Root lattice of the Root system of type ['B', 2]'
```

This manifests as a test-order-dependent failure: the three doctests in RootSpaceElement.max_quantum_element (root_space.py lines 451-455) pass when run in isolation but fail when any B2/C2 root poset has already been instantiated in the same session.

Fix: replace the root_poset()-based sorting with a direct

    `sorted(self.positive_roots(), key=lambda x: x.height(), reverse=not increasing)`

This avoids the UniqueRepresentation cache entirely.  The elements are always drawn from `self.positive_roots()` and therefore always belong to `self`.  Height is a purely arithmetic property (sum of simple-root coefficients) that does not require a poset construction.

The ordering within a single height level may differ from the old poset-based order (which was an artifact of DFS traversal through the HasseDiagram).  The docstring examples are updated accordingly.



<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


