### PR TITLE
preparation work on L-functions of modular forms

### DIFF
--- a/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/elliptic_curves.rst
+++ b/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/elliptic_curves.rst
@@ -294,13 +294,13 @@ See Cohen's new GTM 239 for complete details.
 
 The complexity grows exponentially in the rank of the curve. We can
 do the above calculation, but with the first known curve of rank
-:math:`4`, and it finishes in about a minute (and outputs 64
+:math:`4`, and it finishes in less than 10 seconds (and outputs 64
 points).
 
 ::
 
     sage: E = elliptic_curves.rank(4)[0]
-    sage: E.integral_points(both_signs=True)   # about a minute
+    sage: E.integral_points(both_signs=True)   # about 10 seconds
     [(-10 : 3 : 1), (-10 : 7 : 1), ...
      (19405 : -2712802 : 1), (19405 : 2693397 : 1)]
 
@@ -327,8 +327,7 @@ on the complex plane using Sage (via code of Tim Dokchitser).
 ::
 
     sage: E = EllipticCurve('389a1')
-    sage: L = E.lseries()
-    sage: L
+    sage: L = E.lseries(); L
     Complex L-series of the Elliptic Curve defined by
            y^2 + y = x^3 + x^2 - 2*x over Rational Field
     sage: L(1) #random due to numerical noise
@@ -341,17 +340,15 @@ on the complex plane using Sage (via code of Tim Dokchitser).
 Taylor Series
 ~~~~~~~~~~~~~
 
-We can also compute the
-Taylor series of :math:`L` about any point, thanks to Tim
-Dokchitser's code.
-
-::
+We can also compute the Taylor series of :math:`L` about any point::
 
     sage: E = EllipticCurve('389a1')
     sage: L = E.lseries()
     sage: Ld = L.dokchitser()
     sage: Ld.taylor_series(1,4) #random due to numerical noise
     -1.28158145691931e-23 + (7.26268290635587e-24)*z + 0.759316500288427*z^2 - 0.430302337583362*z^3 + O(z^4)
+
+This is currently calling PARI's implementation.
 
 GRH
 ~~~

--- a/src/sage/lfunctions/dokchitser.py
+++ b/src/sage/lfunctions/dokchitser.py
@@ -109,7 +109,7 @@ class Dokchitser(SageObject):
         sage: L.derivative(1,2)
         0.373095594536324
         sage: L.cost()
-        50
+        205
         sage: L.taylor_series(1,4)
         0.000000000000000 + 0.305999773834052*z + 0.186547797268162*z^2 - 0.136791463097188*z^3 + O(z^4)
         sage: L.check_functional_equation()  # abs tol 1e-17
@@ -123,7 +123,7 @@ class Dokchitser(SageObject):
         sage: E = EllipticCurve('389a')
         sage: L = E.lseries().dokchitser(algorithm='pari')
         sage: L.cost()
-        163
+        666
         sage: L.derivative(1,E.rank())
         1.51863300057685
         sage: L.taylor_series(1,4)
@@ -139,7 +139,7 @@ class Dokchitser(SageObject):
         sage: L.conductor
         400
         sage: L.cost()
-        313
+        5499
         sage: L(2)
         1.10398438736918
         sage: L.taylor_series(2,3)
@@ -346,11 +346,11 @@ class Dokchitser(SageObject):
             sage: E = EllipticCurve('11a')
             sage: L = E.lseries().dokchitser(algorithm='pari')
             sage: L.cost()
-            27
+            112
             sage: E = EllipticCurve('5077a')
             sage: L = E.lseries().dokchitser(algorithm='pari')
             sage: L.cost()
-            591
+            2406
             sage: L = Dokchitser(conductor=1, gammaV=[0], weight=1, eps=1, poles=[1], residues=[-1], init='1')
             sage: L.cost()
             4

--- a/src/sage/lfunctions/pari.py
+++ b/src/sage/lfunctions/pari.py
@@ -112,7 +112,8 @@ class lfun_generic:
         self.poles = poles
         self.residues = residues
 
-        if isinstance(self.residues, (list, tuple)):
+        if (isinstance(self.poles, (list, tuple)) and
+                isinstance(self.residues, (list, tuple))):
             if len(self.poles) != len(self.residues):
                 raise ValueError("poles and residues do not match")
 
@@ -216,9 +217,13 @@ class lfun_generic:
         if pw.type() not in ('t_INT', 't_CLOSURE', 't_VEC'):
             raise TypeError("w (dual coefficients) must be a list or a function or the special value 0 or 1")
 
-        if not self.poles:
+        if isinstance(self.poles, (tuple, list)) and not self.poles:
             self._L = pari.lfuncreate([pv, pw, self.gammaV, self.weight,
                                        self.conductor, self.eps])
+        elif self.poles == 0:
+            # trying automatic pole reconstruction
+            self._L = pari.lfuncreate([pv, pw, self.gammaV, self.weight,
+                                       self.conductor, self.eps, 0])
         elif isinstance(self.residues, (list, tuple)):
             # pari expects pairs (pole, polar part as power series),
             # not residues
@@ -235,7 +240,7 @@ class lfun_generic:
                                        self.conductor, self.eps,
                                        poles])
         else:
-            # assuming a single pole
+            # assuming a single pole, given as a complex scalar
             self._L = pari.lfuncreate([pv, pw, self.gammaV, self.weight,
                                        self.conductor, self.eps,
                                        self.poles[0]])
@@ -574,7 +579,7 @@ class LFunction(SageObject):
         sage: L.derivative(1, 2)
         0.373095594536324
         sage: L.cost()
-        50
+        205
         sage: L.taylor_series(1, 4)
         0.000000000000000 + 0.305999773834052*z + 0.186547797268162*z^2
         - 0.136791463097188*z^3 + O(z^4)
@@ -589,7 +594,7 @@ class LFunction(SageObject):
         sage: E = EllipticCurve('389a')
         sage: L = E.lseries().dokchitser(algorithm='pari')
         sage: L.cost()
-        163
+        666
         sage: L.derivative(1, E.rank())
         1.51863300057685
         sage: L.taylor_series(1, 4)
@@ -605,7 +610,7 @@ class LFunction(SageObject):
         sage: L.conductor
         400
         sage: L.cost()
-        313
+        5499
         sage: L(2)
         1.10398438736918
         sage: L.taylor_series(2, 3)
@@ -645,7 +650,7 @@ class LFunction(SageObject):
             sage: lf = lfun_generic(conductor=1, gammaV=[0], weight=1, eps=1, poles=[1], residues=[-1], v=pari('k->vector(k,n,1)'))
             sage: L = LFunction(lf)
             sage: L.cost()
-            4
+            8
         """
         if isinstance(lfun, lfun_generic):
             # preparation using motivic data
@@ -659,6 +664,7 @@ class LFunction(SageObject):
 
         self._conductor = ZZ(self._L[4])
         self._weight = ZZ(self._L[3])
+        self._eps = ZZ(self._L[5])
 
         self._max_im = max_im
 
@@ -701,6 +707,18 @@ class LFunction(SageObject):
         """
         return self._conductor
 
+    def eps(self):
+        """
+        Return the epsilon factor.
+
+        EXAMPLES::
+
+            sage: from sage.lfunctions.pari import *
+            sage: L = LFunction(lfun_number_field(QQ)); L.eps()
+            1
+        """
+        return self._eps
+
     def cost(self, domain=None):
         """
         Return number of coefficients `a_n` that are needed in
@@ -721,18 +739,18 @@ class LFunction(SageObject):
             sage: E = EllipticCurve('11a')
             sage: L = E.lseries().dokchitser(algorithm='pari')
             sage: L.cost()
-            27
+            112
             sage: E = EllipticCurve('5077a')
             sage: L = E.lseries().dokchitser(algorithm='pari')
             sage: L.cost()
-            591
+            2406
 
             sage: from sage.lfunctions.pari import lfun_generic, LFunction
             sage: lf = lfun_generic(conductor=1, gammaV=[0], weight=1, eps=1,
             ....:        poles=[1], residues=[-1], v=pari('k->vector(k,n,1)'))
             sage: L = LFunction(lf)
             sage: L.cost()
-            4
+            8
         """
         # domain syntax :
         #    [center, width, height]
@@ -744,10 +762,7 @@ class LFunction(SageObject):
             domain = [self._weight / 2, self._max_im]
 
         # it could be that this precision-manipulation is useless
-        saved_prec = pari.default("realbitprecision")
-        pari.default("realbitprecision", self.prec)
-        num = ZZ(pari.lfuncost(self._L, domain)[0])
-        pari.default("realbitprecision", saved_prec)
+        num = ZZ(pari.lfuncost(self._L, domain, self.prec)[0])
 
         return num
 
@@ -956,4 +971,9 @@ class LFunction(SageObject):
             sage: L.check_functional_equation()
             16.0000000000000
         """
-        return self._RR(2)**pari.lfuncheckfeq(self._L)
+        if not self._max_im:
+            quality = pari.lfuncheckfeq(self._L, 335/339)
+        else:
+            # check by pari at 335/339 + I/7
+            quality = pari.lfuncheckfeq(self._L)
+        return self._RR(2)**quality

--- a/src/sage/lfunctions/pari.py
+++ b/src/sage/lfunctions/pari.py
@@ -707,14 +707,19 @@ class LFunction(SageObject):
         """
         return self._conductor
 
-    def eps(self):
+    def sign(self):
         """
-        Return the epsilon factor.
+        Return the sign.
+
+        This complex number is the sign of the functional equation,
+        sometimes also called the root number.
+
+        See https://www.lmfdb.org/knowledge/show/lfunction.sign
 
         EXAMPLES::
 
             sage: from sage.lfunctions.pari import *
-            sage: L = LFunction(lfun_number_field(QQ)); L.eps()
+            sage: L = LFunction(lfun_number_field(QQ)); L.sign()
             1
         """
         return self._eps


### PR DESCRIPTION
split from #41478 (that will require a pari update) because the use of non-integer conductors will require pari >= 2.18.1

some preparation work toward switching more L-functions to use pari.

including a better handling of precision

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.