### PR TITLE
src/sage/algebras: remove all "needs sage.foo" tags

### DIFF
--- a/src/sage/algebras/affine_nil_temperley_lieb.py
+++ b/src/sage/algebras/affine_nil_temperley_lieb.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Affine nilTemperley Lieb Algebra of type A
 """

--- a/src/sage/algebras/askey_wilson.py
+++ b/src/sage/algebras/askey_wilson.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Askey-Wilson Algebras
 

--- a/src/sage/algebras/associated_graded.py
+++ b/src/sage/algebras/associated_graded.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Associated Graded Algebras To Filtered Algebras
 

--- a/src/sage/algebras/cellular_basis.py
+++ b/src/sage/algebras/cellular_basis.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Cellular Basis
 ==============

--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Clifford Algebras
 
@@ -1870,7 +1869,6 @@ class ExteriorAlgebra(CliffordAlgebra):
 
         Check :issue:`34694`::
 
-            sage: # needs sage.symbolic
             sage: E = ExteriorAlgebra(SR,'e',3)
             sage: E.inject_variables()
             Defining e0, e1, e2

--- a/src/sage/algebras/clifford_algebra_element.pyx
+++ b/src/sage/algebras/clifford_algebra_element.pyx
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 """
 Clifford algebra elements
 
@@ -956,7 +955,6 @@ cdef class CohomologyRAAGElement(CliffordAlgebraElement):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs sage.groups
             sage: C4 = graphs.CycleGraph(4)
             sage: A = groups.misc.RightAngledArtin(C4)
             sage: H = A.cohomology()

--- a/src/sage/algebras/cluster_algebra.py
+++ b/src/sage/algebras/cluster_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.graphs sage.modules
 r"""
 Cluster algebras
 
@@ -2378,7 +2377,7 @@ class ClusterAlgebra(Parent, UniqueRepresentation):
         EXAMPLES::
 
             sage: A = ClusterAlgebra(['A', 2])
-            sage: A.cluster_fan()                                                       # needs sage.geometry.polyhedron
+            sage: A.cluster_fan()
             Rational polyhedral fan in 2-d lattice N
         """
         seeds = self.seeds(depth=depth, mutating_F=False)

--- a/src/sage/algebras/commutative_dga.py
+++ b/src/sage/algebras/commutative_dga.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Commutative Differential Graded Algebras
 
@@ -4113,7 +4112,7 @@ class CohomologyClass(SageObject, CachedRepresentation):
         EXAMPLES::
 
             sage: from sage.algebras.commutative_dga import CohomologyClass
-            sage: CohomologyClass(x - 2)                                                # needs sage.symbolic
+            sage: CohomologyClass(x - 2)
             [x - 2]
         """
         self._x = x
@@ -4124,7 +4123,7 @@ class CohomologyClass(SageObject, CachedRepresentation):
         TESTS::
 
             sage: from sage.algebras.commutative_dga import CohomologyClass
-            sage: hash(CohomologyClass(sin)) == hash(sin)                               # needs sage.symbolic
+            sage: hash(CohomologyClass(sin)) == hash(sin)
             True
         """
         return hash(self._x)
@@ -4134,7 +4133,7 @@ class CohomologyClass(SageObject, CachedRepresentation):
         EXAMPLES::
 
             sage: from sage.algebras.commutative_dga import CohomologyClass
-            sage: CohomologyClass(sin)                                                  # needs sage.symbolic
+            sage: CohomologyClass(sin)
             [sin]
         """
         return '[{}]'.format(self._x)
@@ -4144,9 +4143,9 @@ class CohomologyClass(SageObject, CachedRepresentation):
         EXAMPLES::
 
             sage: from sage.algebras.commutative_dga import CohomologyClass
-            sage: latex(CohomologyClass(sin))                                           # needs sage.symbolic
+            sage: latex(CohomologyClass(sin))
             \left[ \sin \right]
-            sage: latex(CohomologyClass(x^2))                                           # needs sage.symbolic
+            sage: latex(CohomologyClass(x^2))
             \left[ x^{2} \right]
         """
         from sage.misc.latex import latex
@@ -4159,8 +4158,8 @@ class CohomologyClass(SageObject, CachedRepresentation):
         EXAMPLES::
 
             sage: from sage.algebras.commutative_dga import CohomologyClass
-            sage: x = CohomologyClass(sin)                                              # needs sage.symbolic
-            sage: x.representative() == sin                                             # needs sage.symbolic
+            sage: x = CohomologyClass(sin)
+            sage: x.representative() == sin
             True
         """
         return self._x

--- a/src/sage/algebras/down_up_algebra.py
+++ b/src/sage/algebras/down_up_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Down-Up Algebras
 
@@ -541,13 +540,12 @@ class VermaModule(CombinatorialFreeModule):
     construction of the irreducible representation `V(5)` (but they are
     different as `\mathfrak{gl}_2` weights)::
 
-        sage: B = crystals.Tableaux(['A',1], shape=[5])                                 # needs sage.graphs
-        sage: [b.weight() for b in B]                                                   # needs sage.graphs
+        sage: B = crystals.Tableaux(['A',1], shape=[5])
+        sage: [b.weight() for b in B]
         [(5, 0), (4, 1), (3, 2), (2, 3), (1, 4), (0, 5)]
 
     An example with periodic weights (see Theorem 2.13 of [BR1998]_)::
 
-        sage: # needs sage.rings.number_field
         sage: k.<z6> = CyclotomicField(6)
         sage: al = z6 + 1
         sage: (al - 1)^6 == 1

--- a/src/sage/algebras/exterior_algebra_groebner.pyx
+++ b/src/sage/algebras/exterior_algebra_groebner.pyx
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Exterior algebras Gröbner bases
 

--- a/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra.py
+++ b/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra.py
@@ -482,8 +482,8 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Parent):
         EXAMPLES::
 
             sage: C = FiniteDimensionalAlgebra(GF(2), [Matrix([1])])
-            sage: k.<y> = GF(4)                                                         # needs sage.rings.finite_rings
-            sage: C.base_extend(k)                                                      # needs sage.rings.finite_rings
+            sage: k.<y> = GF(4)
+            sage: C.base_extend(k)
             Finite-dimensional algebra of degree 1 over Finite Field in y of size 2^2
         """
         # Base extension of the multiplication table is done by __classcall_private__.
@@ -899,7 +899,7 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Parent):
             sage: A = FiniteDimensionalAlgebra(GF(3), [Matrix([[1, 0], [0, 1]]),
             ....:                                      Matrix([[0, 1], [0, 0]])],
             ....:                              category=cat)
-            sage: A.maximal_ideal()                                                     # needs sage.rings.finite_rings
+            sage: A.maximal_ideal()
             Ideal (0, e1) of
              Finite-dimensional algebra of degree 2 over Finite Field of size 3
 
@@ -908,7 +908,7 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Parent):
             ....:                                   Matrix([[0,1,0], [0,0,0], [0,0,0]]),
             ....:                                   Matrix([[0,0,0], [0,0,0], [0,0,1]])],
             ....:                              category=cat)
-            sage: B.maximal_ideal()                                                     # needs sage.libs.pari
+            sage: B.maximal_ideal()
             Traceback (most recent call last):
             ...
             ValueError: algebra is not local
@@ -946,7 +946,7 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Parent):
             sage: cat = CommutativeAlgebras(GF(3)).FiniteDimensional().WithBasis()
             sage: A = FiniteDimensionalAlgebra(GF(3), [Matrix([[1, 0], [0, 1]]),
             ....:                                      Matrix([[0, 1], [0, 0]])], category=cat)
-            sage: A.primary_decomposition()                                             # needs sage.rings.finite_rings
+            sage: A.primary_decomposition()
             [Morphism
               from Finite-dimensional algebra of degree 2 over Finite Field of size 3
                 to Finite-dimensional algebra of degree 2 over Finite Field of size 3
@@ -957,7 +957,7 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Parent):
             sage: B = FiniteDimensionalAlgebra(QQ, [Matrix([[1,0,0], [0,1,0], [0,0,0]]),
             ....:                                   Matrix([[0,1,0], [0,0,0], [0,0,0]]),
             ....:                                   Matrix([[0,0,0], [0,0,0], [0,0,1]])], category=cat)
-            sage: B.primary_decomposition()                                             # needs sage.libs.pari
+            sage: B.primary_decomposition()
             [Morphism
               from Finite-dimensional algebra of degree 3 over Rational Field
                 to Finite-dimensional algebra of degree 1 over Rational Field
@@ -1019,7 +1019,7 @@ class FiniteDimensionalAlgebra(UniqueRepresentation, Parent):
             sage: cat = Algebras(GF(3)).FiniteDimensional().WithBasis()
             sage: A = FiniteDimensionalAlgebra(GF(3), [Matrix([[1, 0], [0, 1]]),
             ....:                                      Matrix([[0, 1], [0, 0]])], category=cat)
-            sage: A.maximal_ideals()                                                    # needs sage.rings.finite_rings
+            sage: A.maximal_ideals()
             [Ideal (e1) of Finite-dimensional algebra of degree 2 over Finite Field of size 3]
 
             sage: cat = Algebras(QQ).FiniteDimensional().WithBasis()

--- a/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra_element.pyx
+++ b/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra_element.pyx
@@ -663,12 +663,12 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
             sage: B = FiniteDimensionalAlgebra(QQ, [Matrix([[1,0,0], [0,1,0], [0,0,0]]),
             ....:                                   Matrix([[0,1,0], [0,0,0], [0,0,0]]),
             ....:                                   Matrix([[0,0,0], [0,0,0], [0,0,1]])])
-            sage: B(0).minimal_polynomial()                                             # needs sage.libs.pari
+            sage: B(0).minimal_polynomial()
             x
             sage: b = B.random_element()
-            sage: f = b.minimal_polynomial(); f  # random                               # needs sage.libs.pari
+            sage: f = b.minimal_polynomial(); f  # random
             x^3 + 1/2*x^2 - 7/16*x + 1/16
-            sage: f(b) == 0                                                             # needs sage.libs.pari
+            sage: f(b) == 0
             True
         """
         A = self.parent()
@@ -694,12 +694,12 @@ cdef class FiniteDimensionalAlgebraElement(AlgebraElement):
             sage: B = FiniteDimensionalAlgebra(QQ, [Matrix([[1,0,0], [0,1,0], [0,0,0]]),
             ....:                                   Matrix([[0,1,0], [0,0,0], [0,0,0]]),
             ....:                                   Matrix([[0,0,0], [0,0,0], [0,0,1]])])
-            sage: B(0).characteristic_polynomial()                                      # needs sage.libs.pari
+            sage: B(0).characteristic_polynomial()
             x^3
             sage: b = B.random_element()
-            sage: f = b.characteristic_polynomial(); f  # random                        # needs sage.libs.pari
+            sage: f = b.characteristic_polynomial(); f  # random
             x^3 - 8*x^2 + 16*x
-            sage: f(b) == 0                                                             # needs sage.libs.pari
+            sage: f(b) == 0
             True
         """
         return self.matrix().characteristic_polynomial()

--- a/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra_ideal.py
+++ b/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra_ideal.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.rings.finite_rings (because all doctests use GF)
 """
 Ideals of Finite Dimensional Algebras
 

--- a/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra_morphism.py
+++ b/src/sage/algebras/finite_dimensional_algebras/finite_dimensional_algebra_morphism.py
@@ -88,9 +88,9 @@ class FiniteDimensionalAlgebraMorphism(RingHomomorphism_im_gens):
             sage: A = FiniteDimensionalAlgebra(QQ, [Matrix([[1, 0], [0, 1]]),
             ....:                                   Matrix([[0, 1], [0, 0]])],
             ....:                              category=cat)
-            sage: I = A.maximal_ideal()                                                 # needs sage.libs.pari
-            sage: q = A.quotient_map(I)                                                 # needs sage.libs.pari
-            sage: q._repr_()                                                            # needs sage.libs.pari
+            sage: I = A.maximal_ideal()
+            sage: q = A.quotient_map(I)
+            sage: q._repr_()
             'Morphism from Finite-dimensional algebra of degree 2 over Rational Field to Finite-dimensional algebra of degree 1 over Rational Field given by matrix\n[1]\n[0]'
         """
         return "Morphism from {} to {} given by matrix\n{}".format(
@@ -104,9 +104,9 @@ class FiniteDimensionalAlgebraMorphism(RingHomomorphism_im_gens):
             sage: A = FiniteDimensionalAlgebra(QQ, [Matrix([[1, 0], [0, 1]]),
             ....:                                   Matrix([[0, 1], [0, 0]])],
             ....:                              category=cat)
-            sage: I = A.maximal_ideal()                                                 # needs sage.libs.pari
-            sage: q = A.quotient_map(I)                                                 # needs sage.libs.pari
-            sage: q(0) == 0 and q(1) == 1                                               # needs sage.libs.pari
+            sage: I = A.maximal_ideal()
+            sage: q = A.quotient_map(I)
+            sage: q(0) == 0 and q(1) == 1
             True
         """
         x = self.domain()(x)
@@ -186,10 +186,10 @@ class FiniteDimensionalAlgebraMorphism(RingHomomorphism_im_gens):
             sage: A = FiniteDimensionalAlgebra(QQ, [Matrix([[1, 0], [0, 1]]),
             ....:                                   Matrix([[0, 1], [0, 0]])],
             ....:                              category=cat)
-            sage: I = A.maximal_ideal()                                                 # needs sage.libs.pari
-            sage: q = A.quotient_map(I)                                                 # needs sage.libs.pari
-            sage: B = q.codomain()                                                      # needs sage.libs.pari
-            sage: q.inverse_image(B.zero_ideal()) == I                                  # needs sage.libs.pari
+            sage: I = A.maximal_ideal()
+            sage: q = A.quotient_map(I)
+            sage: B = q.codomain()
+            sage: q.inverse_image(B.zero_ideal()) == I
             True
         """
         coker_I = I.basis_matrix().transpose().kernel().basis_matrix().transpose()

--- a/src/sage/algebras/finite_gca.py
+++ b/src/sage/algebras/finite_gca.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Finite dimensional graded commutative algebras
 

--- a/src/sage/algebras/free_algebra.py
+++ b/src/sage/algebras/free_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Free algebras
 
@@ -35,7 +34,6 @@ arithmetic is much faster than in the generic implementation.
 Moreover, we can compute Groebner bases with degree bound for its
 two-sided ideals, and thus provide ideal containment tests::
 
-    sage: # needs sage.libs.singular
     sage: F.<x,y,z> = FreeAlgebra(QQ, implementation='letterplace'); F
     Free Associative Unital Algebra on 3 generators (x, y, z) over Rational Field
     sage: I = F*[x*y+y*z,x^2+x*y-y*x-y^2]*F
@@ -55,7 +53,6 @@ two-sided ideals, and thus provide ideal containment tests::
 Positive integral degree weights for the letterplace implementation
 was introduced in :issue:`7797`::
 
-    sage: # needs sage.libs.singular
     sage: F.<x,y,z> = FreeAlgebra(QQ, implementation='letterplace', degrees=[2,1,3])
     sage: x.degree()
     2
@@ -76,7 +73,6 @@ TESTS::
     sage: F is loads(dumps(F))
     True
 
-    sage: # needs sage.libs.singular
     sage: F = FreeAlgebra(GF(5),3,'x', implementation='letterplace')
     sage: TestSuite(F).run()
     sage: F is loads(dumps(F))
@@ -89,7 +85,6 @@ TESTS::
     sage: F is loads(dumps(F))
     True
 
-    sage: # needs sage.libs.singular
     sage: F.<x,y,z> = FreeAlgebra(GF(5),3, implementation='letterplace')
     sage: TestSuite(F).run()
     sage: F is loads(dumps(F))
@@ -102,7 +97,6 @@ TESTS::
     sage: F is loads(dumps(F))
     True
 
-    sage: # needs sage.libs.singular
     sage: F = FreeAlgebra(GF(5),3, ['xx', 'zba', 'Y'], implementation='letterplace')
     sage: TestSuite(F).run()
     sage: F is loads(dumps(F))
@@ -115,7 +109,6 @@ TESTS::
     sage: F is loads(dumps(F))
     True
 
-    sage: # needs sage.libs.singular
     sage: F = FreeAlgebra(GF(5),3, 'abc', implementation='letterplace')
     sage: TestSuite(F).run()
     sage: F is loads(dumps(F))
@@ -131,7 +124,7 @@ TESTS::
 Note that the letterplace implementation can only be used if the corresponding
 (multivariate) polynomial ring has an implementation in Singular::
 
-    sage: FreeAlgebra(FreeAlgebra(ZZ,2,'ab'), 2, 'x', implementation='letterplace')     # needs sage.libs.singular
+    sage: FreeAlgebra(FreeAlgebra(ZZ,2,'ab'), 2, 'x', implementation='letterplace')
     Traceback (most recent call last):
     ...
     NotImplementedError: polynomials over Free Algebra on 2 generators (a, b)
@@ -230,7 +223,6 @@ class FreeAlgebraFactory(UniqueFactory):
     elements are supported. Of course, isomorphic algebras in different
     implementations are not identical::
 
-        sage: # needs sage.libs.singular
         sage: G = FreeAlgebra(GF(5),['x','y','z'], implementation='letterplace')
         sage: F == G
         False
@@ -242,7 +234,6 @@ class FreeAlgebraFactory(UniqueFactory):
 
     ::
 
-        sage: # needs sage.libs.singular
         sage: H = FreeAlgebra(GF(5), ['x','y','z'], implementation='letterplace',
         ....:                 degrees=[1,2,3])
         sage: F != H != G
@@ -287,7 +278,6 @@ class FreeAlgebraFactory(UniqueFactory):
             sage: FreeAlgebra.create_key(GF(5),3,'xyz')
             (Finite Field of size 5, ('x', 'y', 'z'))
 
-            sage: # needs sage.libs.singular
             sage: FreeAlgebra.create_key(GF(5),['x','y','z'],
             ....:                        implementation='letterplace')
             (Multivariate Polynomial Ring in x, y, z over Finite Field of size 5,)
@@ -584,7 +574,6 @@ class FreeAlgebra_generic(CombinatorialFreeModule):
 
         TESTS::
 
-            sage: # needs sage.libs.singular
             sage: F.<x,y,z> = FreeAlgebra(GF(5),3)
             sage: L.<x,y,z> = FreeAlgebra(ZZ,3,implementation='letterplace')
             sage: F(x)     # indirect doctest
@@ -596,7 +585,6 @@ class FreeAlgebra_generic(CombinatorialFreeModule):
 
         ::
 
-            sage: # needs sage.libs.singular sage.rings.finite_rings
             sage: K.<z> = GF(25)
             sage: F.<a,b,c> = FreeAlgebra(K,3)
             sage: L.<a,b,c> = FreeAlgebra(K,3, implementation='letterplace')
@@ -721,7 +709,6 @@ class FreeAlgebra_generic(CombinatorialFreeModule):
             sage: F.has_coerce_map_from(PolynomialRing(ZZ, 3, 'x,y,z'))
             False
 
-            sage: # needs sage.rings.finite_rings
             sage: K.<z> = GF(25)
             sage: F.<a,b,c> = FreeAlgebra(K,3)
             sage: F._coerce_map_from_(ZZ)
@@ -737,8 +724,8 @@ class FreeAlgebra_generic(CombinatorialFreeModule):
             True
             sage: G._coerce_map_from_(F)
             False
-            sage: L.<a,b,c> = FreeAlgebra(K,3, implementation='letterplace')            # needs sage.libs.singular
-            sage: F.1 + (z+1) * L.2                                                     # needs sage.libs.singular
+            sage: L.<a,b,c> = FreeAlgebra(K,3, implementation='letterplace')
+            sage: F.1 + (z+1) * L.2
             b + (z+1)*c
         """
         if self._indices.has_coerce_map_from(R):
@@ -928,7 +915,6 @@ class FreeAlgebra_generic(CombinatorialFreeModule):
 
         EXAMPLES::
 
-            sage: # needs sage.libs.singular
             sage: A.<x,y,z> = FreeAlgebra(QQ,3)
             sage: G = A.g_algebra({y*x: -x*y})
             sage: (x,y,z) = G.gens()

--- a/src/sage/algebras/free_algebra_element.py
+++ b/src/sage/algebras/free_algebra_element.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Free algebra elements
 

--- a/src/sage/algebras/free_algebra_quotient.py
+++ b/src/sage/algebras/free_algebra_quotient.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Finite dimensional free algebra quotients
 

--- a/src/sage/algebras/free_algebra_quotient_element.py
+++ b/src/sage/algebras/free_algebra_quotient_element.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Free algebra quotient elements
 

--- a/src/sage/algebras/free_zinbiel_algebra.py
+++ b/src/sage/algebras/free_zinbiel_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Free Zinbiel Algebras
 

--- a/src/sage/algebras/group_algebra.py
+++ b/src/sage/algebras/group_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.groups sage.modules
 r"""
 Group algebras
 

--- a/src/sage/algebras/hall_algebra.py
+++ b/src/sage/algebras/hall_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Hall Algebras
 

--- a/src/sage/algebras/hecke_algebras/ariki_koike_algebra.py
+++ b/src/sage/algebras/hecke_algebras/ariki_koike_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Ariki-Koike Algebras
 
@@ -239,7 +238,6 @@ class ArikiKoikeAlgebra(Parent, UniqueRepresentation):
     We construct an Ariki-Koike algebra with `u = (1, \zeta_3, \zeta_3^2)`,
     where `\zeta_3` is a primitive third root of unity::
 
-        sage: # needs sage.rings.number_field
         sage: F = CyclotomicField(3)
         sage: zeta3 = F.gen()
         sage: R.<q> = LaurentPolynomialRing(F)
@@ -254,7 +252,6 @@ class ArikiKoikeAlgebra(Parent, UniqueRepresentation):
     Next, we additionally take `q = 1` to obtain the group algebra
     of `G(r, 1, n)`::
 
-        sage: # needs sage.rings.number_field
         sage: F = CyclotomicField(3)
         sage: zeta3 = F.gen()
         sage: H = algebras.ArikiKoike(3, 4, q=1, u=[1, zeta3, zeta3^2], R=F)

--- a/src/sage/algebras/hecke_algebras/cubic_hecke_algebra.py
+++ b/src/sage/algebras/hecke_algebras/cubic_hecke_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.groups sage.modules
 r"""
 Cubic Hecke Algebras
 

--- a/src/sage/algebras/hecke_algebras/cubic_hecke_base_ring.py
+++ b/src/sage/algebras/hecke_algebras/cubic_hecke_base_ring.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.libs.pari (for factorization)
 r"""
 Cubic Hecke Base Rings
 

--- a/src/sage/algebras/hecke_algebras/cubic_hecke_matrix_rep.py
+++ b/src/sage/algebras/hecke_algebras/cubic_hecke_matrix_rep.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Cubic Hecke matrix representations
 

--- a/src/sage/algebras/iwahori_hecke_algebra.py
+++ b/src/sage/algebras/iwahori_hecke_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.graphs sage.modules
 r"""
 Iwahori-Hecke Algebras
 

--- a/src/sage/algebras/jordan_algebra.py
+++ b/src/sage/algebras/jordan_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Jordan Algebras
 

--- a/src/sage/algebras/lie_algebras/lie_algebra_element.pyx
+++ b/src/sage/algebras/lie_algebras/lie_algebra_element.pyx
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat
 """
 Lie Algebra Elements
 

--- a/src/sage/algebras/lie_algebras/morphism.py
+++ b/src/sage/algebras/lie_algebras/morphism.py
@@ -461,8 +461,8 @@ class LieAlgebraMorphism_from_generators(LieAlgebraHomomorphism_im_gens):
 
     A quotient type Lie algebra morphism::
 
-        sage: K.<A,B> = LieAlgebra(SR, abelian=True)                                    # needs sage.symbolic
-        sage: L.morphism({X: A, Y: B})                                                  # needs sage.symbolic
+        sage: K.<A,B> = LieAlgebra(SR, abelian=True)
+        sage: L.morphism({X: A, Y: B})
         Lie algebra morphism:
           From: Lie algebra on 4 generators (X, Y, Z, W) over Rational Field
           To:   Abelian Lie algebra on 2 generators (A, B) over Symbolic Ring
@@ -623,17 +623,17 @@ class LieAlgebraMorphism_from_generators(LieAlgebraHomomorphism_im_gens):
         EXAMPLES::
 
             sage: L.<X,Y,Z,W> = LieAlgebra(QQ, {('X','Y'): {'Z':1}, ('X','Z'): {'W':1}})
-            sage: K.<A,B> = LieAlgebra(SR, abelian=True)                                # needs sage.symbolic
-            sage: phi = L.morphism({X: A, Y: B})                                        # needs sage.symbolic
-            sage: phi(X)                                                                # needs sage.symbolic
+            sage: K.<A,B> = LieAlgebra(SR, abelian=True)
+            sage: phi = L.morphism({X: A, Y: B})
+            sage: phi(X)
             A
-            sage: phi(Y)                                                                # needs sage.symbolic
+            sage: phi(Y)
             B
-            sage: phi(Z)                                                                # needs sage.symbolic
+            sage: phi(Z)
             0
-            sage: phi(W)                                                                # needs sage.symbolic
+            sage: phi(W)
             0
-            sage: phi(-X + 3*Y)                                                         # needs sage.symbolic
+            sage: phi(-X + 3*Y)
             -A + 3*B
 
             sage: K.<A,B,C> = LieAlgebra(QQ, {('A','B'): {'C':2}})

--- a/src/sage/algebras/lie_algebras/quotient.py
+++ b/src/sage/algebras/lie_algebras/quotient.py
@@ -254,7 +254,6 @@ class LieQuotient_finite_dimensional_with_basis(LieAlgebraWithStructureCoefficie
 
         TESTS::
 
-            sage: # needs sage.symbolic
             sage: L.<x,y,z> = LieAlgebra(SR, {('x','y'): {'x':1}})
             sage: K = L.quotient(y)
             sage: K.dimension()

--- a/src/sage/algebras/lie_algebras/structure_coefficients.py
+++ b/src/sage/algebras/lie_algebras/structure_coefficients.py
@@ -412,8 +412,8 @@ class LieAlgebraWithStructureCoefficients(FinitelyGeneratedLieAlgebra, IndexedGe
             sage: LQQ = L.change_ring(QQ)
             sage: LQQ.structure_coefficients()
             Finite family {('x', 'y'): z}
-            sage: LSR = LQQ.change_ring(SR)                                             # needs sage.symbolic
-            sage: LSR.structure_coefficients()                                          # needs sage.symbolic
+            sage: LSR = LQQ.change_ring(SR)
+            sage: LSR.structure_coefficients()
             Finite family {('x', 'y'): z}
         """
         return LieAlgebraWithStructureCoefficients(

--- a/src/sage/algebras/lie_algebras/subalgebra.py
+++ b/src/sage/algebras/lie_algebras/subalgebra.py
@@ -79,7 +79,6 @@ class LieSubalgebra_finite_dimensional_with_basis(Parent, UniqueRepresentation):
     Elements of the ambient Lie algebra can be reduced modulo an
     ideal or subalgebra::
 
-        sage: # needs sage.symbolic
         sage: L.<X,Y,Z> = LieAlgebra(SR, {('X','Y'): {'Z': 1}})
         sage: I = L.ideal(Y)
         sage: I.reduce(X + 2*Y + 3*Z)
@@ -92,7 +91,6 @@ class LieSubalgebra_finite_dimensional_with_basis(Parent, UniqueRepresentation):
     When the base ring is a field, the complementary subspace is spanned by
     those basis elements which are not leading supports of the basis::
 
-        sage: # needs sage.symbolic
         sage: I =  L.ideal(X + Y)
         sage: I.basis()
         Finite family {'Y': X + Y, 'Z': Z}
@@ -103,10 +101,10 @@ class LieSubalgebra_finite_dimensional_with_basis(Parent, UniqueRepresentation):
 
     Giving a different ``order`` may change the reduction of elements::
 
-        sage: I =  L.ideal(X + Y, order=lambda s: ['Z','Y','X'].index(s))               # needs sage.symbolic
-        sage: I.basis()                                                                 # needs sage.symbolic
+        sage: I =  L.ideal(X + Y, order=lambda s: ['Z','Y','X'].index(s))
+        sage: I.basis()
         Finite family {'Z': Z, 'X': X + Y}
-        sage: I.reduce(el)                                                              # needs sage.symbolic
+        sage: I.reduce(el)
         (-x+y)*Y
 
     A subalgebra of a subalgebra is a subalgebra of the original::

--- a/src/sage/algebras/lie_conformal_algebras/abelian_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/abelian_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Abelian Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/affine_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/affine_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Affine Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/bosonic_ghosts_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/bosonic_ghosts_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Bosonic Ghosts Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/fermionic_ghosts_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/fermionic_ghosts_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Fermionic Ghosts Super Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/finitely_freely_generated_lca.py
+++ b/src/sage/algebras/lie_conformal_algebras/finitely_freely_generated_lca.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Finitely and Freely Generated Lie Conformal Algebras.
 

--- a/src/sage/algebras/lie_conformal_algebras/free_bosons_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/free_bosons_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Free Bosons Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/free_fermions_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/free_fermions_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Free Fermions Super Lie Conformal Algebra.
 

--- a/src/sage/algebras/lie_conformal_algebras/freely_generated_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/freely_generated_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Freely Generated Lie Conformal Algebras
 

--- a/src/sage/algebras/lie_conformal_algebras/graded_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/graded_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Graded Lie Conformal Algebras
 

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_element.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_element.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Lie Conformal Algebra Element
 

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_basis.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_basis.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Lie Conformal Algebras With Basis
 

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Lie Conformal Algebras With Structure Coefficients
 

--- a/src/sage/algebras/lie_conformal_algebras/n2_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/n2_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules sage.rings.number_field
 r"""
 N=2 Super Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/neveu_schwarz_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/neveu_schwarz_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Neveu-Schwarz Super Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/virasoro_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/virasoro_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Virasoro Lie Conformal Algebra
 

--- a/src/sage/algebras/lie_conformal_algebras/weyl_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/weyl_lie_conformal_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Weyl Lie Conformal Algebra
 

--- a/src/sage/algebras/nil_coxeter_algebra.py
+++ b/src/sage/algebras/nil_coxeter_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Nil-Coxeter Algebra
 """

--- a/src/sage/algebras/octonion_algebra.pyx
+++ b/src/sage/algebras/octonion_algebra.pyx
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 """
 Octonion Algebras
 
@@ -416,7 +415,7 @@ cdef class Octonion_generic(AlgebraElement):
 
             sage: O = OctonionAlgebra(QQ, 1, 3, 7)
             sage: elt = sum(i * b for i, b in enumerate(O.basis(), start=2))
-            sage: elt.norm()                                                            # needs sage.symbolic
+            sage: elt.norm()
             2*sqrt(-61)
             sage: elt = sum(O.basis())
             sage: elt.norm()
@@ -439,7 +438,7 @@ cdef class Octonion_generic(AlgebraElement):
 
             sage: O = OctonionAlgebra(QQ, 1, 3, 7)
             sage: elt = sum(i * b for i, b in enumerate(O.basis(), start=2))
-            sage: elt.abs()                                                             # needs sage.symbolic
+            sage: elt.abs()
             2*sqrt(-61)
             sage: elt = sum(O.basis())
             sage: elt.abs()
@@ -573,10 +572,10 @@ cdef class Octonion(Octonion_generic):
 
             sage: O = OctonionAlgebra(QQ)
             sage: elt = sum(i * b for i, b in enumerate(O.basis(), start=2))
-            sage: elt.norm()                                                            # needs sage.symbolic
+            sage: elt.norm()
             2*sqrt(71)
             sage: elt = sum(O.basis())
-            sage: elt.norm()                                                            # needs sage.symbolic
+            sage: elt.norm()
             2*sqrt(2)
         """
         return self.vec.norm()
@@ -747,7 +746,7 @@ class OctonionAlgebra(UniqueRepresentation, Parent):
         EXAMPLES::
 
             sage: O = OctonionAlgebra(QQ)
-            sage: TestSuite(O).run()                                                    # needs sage.symbolic
+            sage: TestSuite(O).run()
 
             sage: O = OctonionAlgebra(QQ, 1, 3, 7)
             sage: TestSuite(O).run()

--- a/src/sage/algebras/orlik_solomon.py
+++ b/src/sage/algebras/orlik_solomon.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Orlik-Solomon Algebras
 """
@@ -117,7 +116,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
         We check on the matroid associated to the graph with 3 vertices and
         2 edges between each vertex::
 
-            sage: # needs sage.graphs
             sage: G = Graph([[1,2],[1,2],[2,3],[2,3],[1,3],[1,3]], multiedges=True)
             sage: MG = Matroid(G)
             sage: OS = MG.orlik_solomon_algebra(QQ)
@@ -257,7 +255,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
         Let us check that `e_{s_1} e_{s_2} \cdots e_{s_k} = e_S` for any
         subset `S = \{ s_1 < s_2 < \cdots < s_k \}` of the groundset::
 
-            sage: # needs sage.graphs
             sage: G = Graph([[1,2],[1,2],[2,3],[3,4],[4,2]], multiedges=True)
             sage: MG = Matroid(G).regular_matroid()
             sage: E = MG.groundset_list()
@@ -331,7 +328,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
             ([2, 5], -OS{0, 2} + OS{0, 5})
             ([4, 5], -OS{3, 4} + OS{3, 5})
 
-            sage: # needs sage.graphs
             sage: M4 = matroids.CompleteGraphic(4)
             sage: OSM4 = M4.orlik_solomon_algebra(QQ)
             sage: OSM4.subset_image(frozenset({2,3,4}))
@@ -339,7 +335,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
 
         An example of a custom ordering::
 
-            sage: # needs sage.graphs
             sage: G = Graph([[3, 4], [4, 1], [1, 2], [2, 3], [3, 5], [5, 6], [6, 3]])
             sage: MG = Matroid(G)
             sage: s = [(5, 6), (1, 2), (3, 5), (2, 3), (1, 4), (3, 6), (3, 4)]
@@ -367,7 +362,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
 
         TESTS::
 
-            sage: # needs sage.graphs
             sage: G = Graph([[1,2],[1,2],[2,3],[2,3],[1,3],[1,3]], multiedges=True)
             sage: MG = Matroid(G)
             sage: sorted([sorted(c) for c in MG.circuits()])
@@ -388,7 +382,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
             sage: OSMG.subset_image(frozenset([1, 5]))
             OS{0, 4}
 
-            sage: # needs sage.graphs
             sage: G = Graph([[1,2],[1,2],[2,3],[3,4],[4,2]], multiedges=True)
             sage: MG = Matroid(G)
             sage: sorted([sorted(c) for c in MG.circuits()])
@@ -461,7 +454,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron sage.graphs
             sage: H = hyperplane_arrangements.braid(3)
             sage: O = H.orlik_solomon_algebra(QQ)
             sage: O.as_gca()
@@ -472,7 +464,7 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
 
             sage: N = matroids.catalog.Fano()
             sage: O = N.orlik_solomon_algebra(QQ)
-            sage: O.as_gca()                                                            # needs sage.libs.singular
+            sage: O.as_gca()
             Graded Commutative Algebra with generators ('e0', 'e1', 'e2', 'e3', 'e4', 'e5', 'e6')
              in degrees (1, 1, 1, 1, 1, 1, 1) with relations
              [e1*e2 - e1*e3 + e2*e3, e0*e1*e3 - e0*e1*e4 + e0*e3*e4 - e1*e3*e4,
@@ -486,7 +478,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
 
         TESTS::
 
-            sage: # needs sage.geometry.polyhedron
             sage: H = hyperplane_arrangements.Catalan(3,QQ).cone()
             sage: O = H.orlik_solomon_algebra(QQ)
             sage: A = O.as_gca()
@@ -525,7 +516,6 @@ class OrlikSolomonAlgebra(CombinatorialFreeModule):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron sage.graphs
             sage: H = hyperplane_arrangements.braid(3)
             sage: O = H.orlik_solomon_algebra(QQ)
             sage: O.as_cdga()
@@ -626,11 +616,10 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
 
     Lets start with the action of `S_3` on the rank `2` braid matroid::
 
-        sage: # needs sage.graphs
         sage: M = matroids.CompleteGraphic(3)
         sage: M.groundset()
         frozenset({0, 1, 2})
-        sage: G = SymmetricGroup(3)                                                     # needs sage.groups
+        sage: G = SymmetricGroup(3)
 
     Calling elements ``g`` of ``G`` on an element `i` of `\{1, 2, 3\}`
     defines the action we want, but since the groundset is `\{0, 1, 2\}`
@@ -642,7 +631,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
     Now that we have defined an action we can create the invariant, and
     get its basis::
 
-        sage: # needs sage.graphs sage.groups
         sage: OSG = M.orlik_solomon_algebra(QQ, invariant=(G, on_groundset))
         sage: OSG.basis()
         Finite family {0: B[0], 1: B[1]}
@@ -651,7 +639,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
 
     Since it is invariant, the action of any ``g`` in ``G`` is trivial::
 
-        sage: # needs sage.graphs sage.groups
         sage: x = OSG.an_element(); x
         2*B[0] + 2*B[1]
         sage: g = G.an_element(); g
@@ -659,7 +646,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
         sage: g * x
         2*B[0] + 2*B[1]
 
-        sage: # needs sage.graphs sage.groups
         sage: x = OSG.random_element()
         sage: g = G.random_element()
         sage: g * x == x
@@ -668,7 +654,7 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
     The underlying ambient module is the Orlik-Solomon algebra,
     which is accessible via :meth:`ambient()`::
 
-        sage: M.orlik_solomon_algebra(QQ) is OSG.ambient()                              # needs sage.graphs sage.groups
+        sage: M.orlik_solomon_algebra(QQ) is OSG.ambient()
         True
 
     There is not much structure here, so lets look at a bigger example.
@@ -676,7 +662,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
     easier, we'll start the indexing at `1` so that the `S_6` action
     on the groundset is simply calling `g`::
 
-        sage: # needs sage.graphs sage.groups
         sage: M = matroids.CompleteGraphic(4); M.groundset()
         frozenset({0, 1, 2, 3, 4, 5})
         sage: new_bases = [frozenset(i+1 for i in j) for j in M.bases()]
@@ -696,7 +681,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
     Next, we look at the same matroid but with an `S_3 \times S_3` action
     (here realized as a Young subgroup of `S_6`)::
 
-        sage: # needs sage.graphs sage.groups
         sage: H = G.young_subgroup([3, 3])
         sage: OSH = M.orlik_solomon_algebra(QQ, invariant=H)
         sage: OSH.basis()
@@ -706,7 +690,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
 
     We implement an `S_4` action on the vertices::
 
-        sage: # needs sage.graphs sage.groups
         sage: M = matroids.CompleteGraphic(4)
         sage: G = SymmetricGroup(4)
         sage: edge_map = {i: M.groundset_to_edges([i])[0][:2]
@@ -722,7 +705,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
 
     We use this to describe the Young subgroup `S_2 \times S_2` action::
 
-        sage: # needs sage.graphs sage.groups
         sage: H = G.young_subgroup([2,2])
         sage: OSH = M.orlik_solomon_algebra(QQ, invariant=(H, vert_action))
         sage: B = OSH.basis()
@@ -734,7 +716,7 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
 
     We demonstrate the algebra structure::
 
-        sage: matrix([[b*bp for b in B] for bp in B])                                   # needs sage.graphs sage.groups
+        sage: matrix([[b*bp for b in B] for bp in B])
         [   B[0]    B[1]    B[2]    B[3]    B[4]    B[5]    B[6]    B[7]]
         [   B[1]       0  2*B[4]    B[5]       0       0  2*B[7]       0]
         [   B[2] -2*B[4]       0    B[6]       0 -2*B[7]       0       0]
@@ -757,7 +739,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs sage.groups
             sage: M = matroids.CompleteGraphic(4)
             sage: new_bases = [frozenset(i+1 for i in j) for j in M.bases()]
             sage: M = Matroid(bases=new_bases)
@@ -846,7 +827,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         EXAMPLES::
 
-            sage: # needs sage.graphs sage.groups
             sage: M = matroids.CompleteGraphic(3)
             sage: M.groundset()
             frozenset({0, 1, 2})
@@ -866,7 +846,6 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         We also check that the ordering is respected::
 
-            sage: # needs sage.graphs sage.groups
             sage: fset = frozenset({1,2})
             sage: OS1 = M.orlik_solomon_algebra(QQ)
             sage: OS1.subset_image(fset)
@@ -883,9 +862,9 @@ class OrlikSolomonInvariantAlgebra(FiniteDimensionalInvariantModule):
         This choice of ``g`` acting on this choice of ``fset`` reverses
         the sign::
 
-            sage: OSG._basis_action(g, fset)                                            # needs sage.graphs sage.groups
+            sage: OSG._basis_action(g, fset)
             OS{0, 1} - OS{0, 2}
-            sage: OSG2._basis_action(g, fset)                                           # needs sage.graphs sage.groups
+            sage: OSG2._basis_action(g, fset)
             -OS{1, 2}
         """
         OS = self._ambient

--- a/src/sage/algebras/orlik_terao.py
+++ b/src/sage/algebras/orlik_terao.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Orlik-Terao Algebras
 """
@@ -131,12 +130,10 @@ class OrlikTeraoAlgebra(CombinatorialFreeModule):
             sage: OT = M.orlik_terao_algebra(QQ)
             sage: TestSuite(OT).run(elements=OT.basis())
 
-            sage: # needs sage.graphs
             sage: M = matroids.CompleteGraphic(4).ternary_matroid()
             sage: OT = M.orlik_terao_algebra(GF(3)['t'])
             sage: TestSuite(OT).run(elements=OT.basis())
 
-            sage: # needs sage.geometry.polyhedron
             sage: H = hyperplane_arrangements.Catalan(4).cone()
             sage: M = H.matroid()
             sage: OT = M.orlik_terao_algebra()
@@ -147,7 +144,6 @@ class OrlikTeraoAlgebra(CombinatorialFreeModule):
         We check on the matroid associated to the graph with 3 vertices and
         2 edges between each vertex::
 
-            sage: # needs sage.graphs
             sage: G = Graph([[1,2],[1,2],[2,3],[2,3],[1,3],[1,3]], multiedges=True)
             sage: M = Matroid(G).regular_matroid()
             sage: OT = M.orlik_terao_algebra(QQ)
@@ -325,7 +321,6 @@ class OrlikTeraoAlgebra(CombinatorialFreeModule):
         Let us check that `e_{s_1} e_{s_2} \cdots e_{s_k} = e_S` for any
         subset `S = \{ s_1 < s_2 < \cdots < s_k \}` of the groundset::
 
-            sage: # needs sage.graphs
             sage: G = Graph([[1,2],[1,2],[2,3],[3,4],[4,2]], multiedges=True)
             sage: M = Matroid(G).regular_matroid()
             sage: E = M.groundset_list()
@@ -375,7 +370,6 @@ class OrlikTeraoAlgebra(CombinatorialFreeModule):
             ([2, 5], -OT{0, 2} + OT{0, 5})
             ([4, 5], -OT{3, 4} - OT{3, 5})
 
-            sage: # needs sage.graphs
             sage: M4 = matroids.CompleteGraphic(4).ternary_matroid()
             sage: OT = M4.orlik_terao_algebra()
             sage: OT.subset_image(frozenset({2,3,4}))
@@ -383,7 +377,6 @@ class OrlikTeraoAlgebra(CombinatorialFreeModule):
 
         An example of a custom ordering::
 
-            sage: # needs sage.graphs
             sage: G = Graph([[3, 4], [4, 1], [1, 2], [2, 3], [3, 5], [5, 6], [6, 3]])
             sage: M = Matroid(G).regular_matroid()
             sage: s = [(5, 6), (1, 2), (3, 5), (2, 3), (1, 4), (3, 6), (3, 4)]
@@ -411,7 +404,6 @@ class OrlikTeraoAlgebra(CombinatorialFreeModule):
 
         TESTS::
 
-            sage: # needs sage.graphs
             sage: G = Graph([[1,2],[1,2],[2,3],[2,3],[1,3],[1,3]], multiedges=True)
             sage: M = Matroid(G).regular_matroid()
             sage: sorted([sorted(c) for c in M.circuits()])
@@ -432,7 +424,6 @@ class OrlikTeraoAlgebra(CombinatorialFreeModule):
             sage: OT.subset_image(frozenset([1, 5]))
             OT{0, 4}
 
-            sage: # needs sage.graphs
             sage: G = Graph([[1,2],[1,2],[2,3],[3,4],[4,2]], multiedges=True)
             sage: M = Matroid(G).regular_matroid()
             sage: sorted([sorted(c) for c in M.circuits()])
@@ -507,7 +498,6 @@ class OrlikTeraoAlgebra(CombinatorialFreeModule):
 
         EXAMPLES::
 
-            sage: # needs sage.geometry.polyhedron
             sage: H = hyperplane_arrangements.Catalan(2).cone()
             sage: M = H.matroid()
             sage: OT = M.orlik_terao_algebra()
@@ -551,7 +541,7 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
         sage: M = Matroid(A)
         sage: M.groundset()
         frozenset({0, 1, 2})
-        sage: G = SymmetricGroup(3)                                                     # needs sage.groups
+        sage: G = SymmetricGroup(3)
 
     Calling elements ``g`` of ``G`` on an element `i` of `\{1,2,3\}`
     defines the action we want, but since the groundset is `\{0,1,2\}`
@@ -563,7 +553,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
     Now that we have defined an action we can create the invariant, and
     get its basis::
 
-        sage: # needs sage.groups
         sage: OTG = M.orlik_terao_algebra(QQ, invariant=(G, on_groundset))
         sage: OTG.basis()
         Finite family {0: B[0], 1: B[1]}
@@ -572,7 +561,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
 
     Since it is invariant, the action of any ``g`` in ``G`` is trivial::
 
-        sage: # needs sage.groups
         sage: x = OTG.an_element(); x
         2*B[0] + 2*B[1]
         sage: g = G.an_element(); g
@@ -580,7 +568,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
         sage: g*x
         2*B[0] + 2*B[1]
 
-        sage: # needs sage.groups
         sage: x = OTG.random_element()
         sage: g = G.random_element()
         sage: g*x == x
@@ -589,12 +576,11 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
     The underlying ambient module is the Orlik-Terao algebra,
     which is accessible via :meth:`ambient()`::
 
-        sage: M.orlik_terao_algebra(QQ) is OTG.ambient()                                # needs sage.groups
+        sage: M.orlik_terao_algebra(QQ) is OTG.ambient()
         True
 
     For a bigger example, here we will look at the rank-`3` braid matroid::
 
-        sage: # needs sage.groups
         sage: A = matrix([[1,1,1,0,0,0],[-1,0,0,1,1,0],
         ....:             [0,-1,0,-1,0,1],[0,0,-1,0,-1,-1]]); A
         [ 1  1  1  0  0  0]
@@ -620,7 +606,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: A = matrix([[1,1,1,0,0,0],[-1,0,0,1,1,0],[0,-1,0,-1,0,1],
             ....:             [0,0,-1,0,-1,-1]])
             sage: M = Matroid(A);
@@ -683,7 +668,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         TESTS::
 
-            sage: # needs sage.groups
             sage: A = matrix([[1,1,0],[-1,0,1],[0,-1,-1]])
             sage: M = Matroid(A)
             sage: G = SymmetricGroup(3)
@@ -712,7 +696,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         EXAMPLES::
 
-            sage: # needs sage.groups
             sage: A = matrix([[1,1,0],[-1,0,1],[0,-1,-1]])
             sage: M = Matroid(A)
             sage: M.groundset()
@@ -735,7 +718,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         We also check that the ordering is respected::
 
-            sage: # needs sage.groups
             sage: fset = frozenset({1,2})
             sage: OT1 = M.orlik_terao_algebra(QQ)
             sage: OT1.subset_image(fset)
@@ -744,7 +726,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
             sage: OT2.subset_image(fset)
             OT{1, 2}
 
-            sage: # needs sage.groups
             sage: OTG2 = M.orlik_terao_algebra(QQ,
             ....:                              invariant=(G,on_groundset),
             ....:                              ordering=range(2,-1,-1))
@@ -753,7 +734,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         This choice of ``g`` fixes these elements::
 
-            sage: # needs sage.groups
             sage: OTG._basis_action(g, fset)
             -OT{0, 1} + OT{0, 2}
             sage: OTG2._basis_action(g, fset)
@@ -761,7 +741,6 @@ class OrlikTeraoInvariantAlgebra(FiniteDimensionalInvariantModule):
 
         TESTS::
 
-            sage: # needs sage.groups
             sage: [on_groundset(g, e) for e in M.groundset()]
             [0, 2, 1]
             sage: [OTG._groundset_action(g,e) for e in M.groundset()]

--- a/src/sage/algebras/q_commuting_polynomials.py
+++ b/src/sage/algebras/q_commuting_polynomials.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.groups sage.modules
 r"""
 `q`-Commuting Polynomials
 

--- a/src/sage/algebras/q_system.py
+++ b/src/sage/algebras/q_system.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.graphs sage.modules
 r"""
 Q-Systems
 

--- a/src/sage/algebras/quantum_clifford.py
+++ b/src/sage/algebras/quantum_clifford.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 r"""
 Quantum Clifford Algebras
 

--- a/src/sage/algebras/quantum_groups/ace_quantum_onsager.py
+++ b/src/sage/algebras/quantum_groups/ace_quantum_onsager.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Alternating Central Extension Quantum Onsager Algebra
 

--- a/src/sage/algebras/quantum_groups/fock_space.py
+++ b/src/sage/algebras/quantum_groups/fock_space.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Fock Space
 

--- a/src/sage/algebras/quantum_groups/representations.py
+++ b/src/sage/algebras/quantum_groups/representations.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.graphs sage.modules
 r"""
 Quantum Group Representations
 

--- a/src/sage/algebras/quantum_matrix_coordinate_algebra.py
+++ b/src/sage/algebras/quantum_matrix_coordinate_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Quantum Matrix Coordinate Algebras
 

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -142,10 +142,10 @@ class QuaternionAlgebraFactory(UniqueFactory):
         Quaternion Algebra (2, 3) with base ring Finite Field of size 5
         sage: QuaternionAlgebra(2, GF(5)(3))
         Quaternion Algebra (2, 3) with base ring Finite Field of size 5
-        sage: QuaternionAlgebra(QQ[sqrt(2)](-1), -5)                                    # needs sage.symbolic
+        sage: QuaternionAlgebra(QQ[sqrt(2)](-1), -5)
         Quaternion Algebra (-1, -5) with base ring Number Field in sqrt2
          with defining polynomial x^2 - 2 with sqrt2 = 1.414213562373095?
-        sage: QuaternionAlgebra(sqrt(-1), sqrt(-3))                                     # needs sage.symbolic
+        sage: QuaternionAlgebra(sqrt(-1), sqrt(-3))
         Quaternion Algebra (I, sqrt(-3)) with base ring Symbolic Ring
         sage: QuaternionAlgebra(1r,1)
         Quaternion Algebra (1, 1) with base ring Rational Field
@@ -185,7 +185,7 @@ class QuaternionAlgebraFactory(UniqueFactory):
 
         sage: QuaternionAlgebra(QQ, -7, -21)
         Quaternion Algebra (-7, -21) with base ring Rational Field
-        sage: QuaternionAlgebra(QQ[sqrt(2)], -2, -3)                                    # needs sage.symbolic
+        sage: QuaternionAlgebra(QQ[sqrt(2)], -2, -3)
         Quaternion Algebra (-2, -3) with base ring Number Field in sqrt2
          with defining polynomial x^2 - 2 with sqrt2 = 1.414213562373095?
 
@@ -728,8 +728,8 @@ class QuaternionAlgebra_abstract(Parent):
 
         EXAMPLES::
 
-            sage: g = QuaternionAlgebra(QQ[sqrt(2)], -3, 7).random_element()            # needs sage.symbolic
-            sage: g.parent() is QuaternionAlgebra(QQ[sqrt(2)], -3, 7)                   # needs sage.symbolic
+            sage: g = QuaternionAlgebra(QQ[sqrt(2)], -3, 7).random_element()
+            sage: g.parent() is QuaternionAlgebra(QQ[sqrt(2)], -3, 7)
             True
             sage: g = QuaternionAlgebra(-3, 19).random_element()
             sage: g.parent() is QuaternionAlgebra(-3, 19)
@@ -1699,13 +1699,13 @@ class QuaternionAlgebra_ab(QuaternionAlgebra_abstract):
 
         A more complicated example involving a quaternion algebra over a number field::
 
-            sage: K.<a> = QQ[sqrt(2)]; Q = QuaternionAlgebra(K,-1,a); Q                 # needs sage.symbolic
+            sage: K.<a> = QQ[sqrt(2)]; Q = QuaternionAlgebra(K,-1,a); Q
             Quaternion Algebra (-1, sqrt2) with base ring Number Field in sqrt2
              with defining polynomial x^2 - 2 with sqrt2 = 1.414213562373095?
-            sage: magma(Q)                                              # optional - magma, needs sage.symbolic
+            sage: magma(Q)                                              # optional - magma
             Quaternion Algebra with base ring Number Field with defining polynomial
              x^2 - 2 over the Rational Field, defined by i^2 = -1, j^2 = sqrt2
-            sage: Q._magma_init_(magma)                                 # optional - magma, needs sage.symbolic
+            sage: Q._magma_init_(magma)                                 # optional - magma
             'QuaternionAlgebra(_sage_[...],(_sage_[...]![-1, 0]),(_sage_[...]![0, 1]))'
         """
         R = magma(self.base_ring())

--- a/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
+++ b/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
@@ -1675,8 +1675,8 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
 
         EXAMPLES::
 
-            sage: K.<a> = QQ[2^(1/5)]; Q.<i,j,k> = QuaternionAlgebra(K,-a,a*17/3)       # needs sage.symbolic
-            sage: Q([a,-2/3,a^2-1/2,a*2])           # implicit doctest                  # needs sage.symbolic
+            sage: K.<a> = QQ[2^(1/5)]; Q.<i,j,k> = QuaternionAlgebra(K,-a,a*17/3)
+            sage: Q([a,-2/3,a^2-1/2,a*2])           # implicit doctest
             a + (-2/3)*i + (a^2 - 1/2)*j + 2*a*k
         """
         fmpz_poly_init(self.x)
@@ -1705,8 +1705,8 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         r"""
         EXAMPLES::
 
-            sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K,-a,a+1)          # needs sage.symbolic
-            sage: Q([a,-2/3,a^2-1/2,a*2])           # implicit doctest                  # needs sage.symbolic
+            sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K,-a,a+1)
+            sage: Q([a,-2/3,a^2-1/2,a*2])           # implicit doctest
             a + (-2/3)*i + (a^2 - 1/2)*j + 2*a*k
         """
         self._parent = parent
@@ -1749,7 +1749,6 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         r"""
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K,-a,a+1)
             sage: Q([a,-2/3,a^2-1/2,a*2])
             a + (-2/3)*i + (a^2 - 1/2)*j + 2*a*k
@@ -1791,7 +1790,6 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         r"""
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K, -3, a)
             sage: z = (i+j+k+a)^2; z
             a^2 + 4*a - 3 + 2*a*i + 2*a*j + 2*a*k
@@ -1810,7 +1808,6 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K, -3, a)
             sage: z = a + i + (2/3)*a^3*j + (1+a)*k
             sage: w = a - i - (2/3)*a^3*j + (1/3+a)*k
@@ -1884,7 +1881,6 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K, -3, a)
             sage: z = a + i + (2/3)*a^3*j + (1+a)*k
             sage: w = a - i - (2/3)*a^3*j + (1/3+a)*k
@@ -1935,7 +1931,6 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
             sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K, -3, a)
             sage: z = a + i + (2/3)*a^3*j + (1+a)*k
             sage: w = a - i - (2/3)*a^3*j + (1/3+a)*k
@@ -2085,7 +2080,6 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
 
         TESTS::
 
-            sage: # needs sage.symbolic
             sage: F = QQ[3^(1/3)]
             sage: a = F.gen()
             sage: K.<i,j,k> = QuaternionAlgebra(F, -10 + a, -7 - a)
@@ -2164,7 +2158,6 @@ def unpickle_QuaternionAlgebraElement_number_field_v0(*args):
     r"""
     EXAMPLES::
 
-        sage: # needs sage.symbolic
         sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K, -3, a); z = i + j
         sage: f, t = z.__reduce__()
         sage: sage.algebras.quatalg.quaternion_algebra_element.unpickle_QuaternionAlgebraElement_number_field_v0(*t)

--- a/src/sage/algebras/quaternion_algebra.py
+++ b/src/sage/algebras/quaternion_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 
 ############################################################
 # Backwards compatible unpickling

--- a/src/sage/algebras/quaternion_algebra_element.py
+++ b/src/sage/algebras/quaternion_algebra_element.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 
 #######################################################################
 # Backward compatible unpickle functions
@@ -44,7 +43,6 @@ def unpickle_QuaternionAlgebraElement_number_field_v0(*args):
     """
     EXAMPLES::
 
-        sage: # needs sage.symbolic
         sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K, -3, a); z = i + j
         sage: f, t = z.__reduce__()
         sage: import sage.algebras.quaternion_algebra_element

--- a/src/sage/algebras/rational_cherednik_algebra.py
+++ b/src/sage/algebras/rational_cherednik_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 """
 Rational Cherednik Algebras
 """

--- a/src/sage/algebras/schur_algebra.py
+++ b/src/sage/algebras/schur_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.groups sage.modules
 r"""
 Schur algebras for `GL_n`
 

--- a/src/sage/algebras/shuffle_algebra.py
+++ b/src/sage/algebras/shuffle_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Shuffle algebras
 

--- a/src/sage/algebras/splitting_algebra.py
+++ b/src/sage/algebras/splitting_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.libs.pari sage.modules
 r"""
 Splitting Algebras
 

--- a/src/sage/algebras/steenrod/steenrod_algebra.py
+++ b/src/sage/algebras/steenrod/steenrod_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 The Steenrod algebra
 
@@ -764,8 +763,8 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             mod 3 Steenrod algebra, milnor basis
             sage: SteenrodAlgebra(2, basis='adem')
             mod 2 Steenrod algebra, serre-cartan basis
-            sage: B = SteenrodAlgebra(2003)                                             # needs sage.rings.finite_rings
-            sage: B._repr_()                                                            # needs sage.rings.finite_rings
+            sage: B = SteenrodAlgebra(2003)
+            sage: B._repr_()
             'mod 2003 Steenrod algebra, milnor basis'
             sage: SteenrodAlgebra(generic=True, basis='adem')
             generic mod 2 Steenrod algebra, serre-cartan basis

--- a/src/sage/algebras/steenrod/steenrod_algebra_bases.py
+++ b/src/sage/algebras/steenrod/steenrod_algebra_bases.py
@@ -132,7 +132,6 @@ def convert_to_milnor_matrix(n, basis, p=2, generic='auto'):
 
     EXAMPLES::
 
-        sage: # needs sage.modules
         sage: from sage.algebras.steenrod.steenrod_algebra_bases import convert_to_milnor_matrix
         sage: convert_to_milnor_matrix(5, 'adem')  # indirect doctest
         [0 1]
@@ -151,7 +150,6 @@ def convert_to_milnor_matrix(n, basis, p=2, generic='auto'):
     The function takes an optional argument, the prime `p` over
     which to work::
 
-        sage: # needs sage.modules
         sage: convert_to_milnor_matrix(17, 'adem', 3)
         [0 0 1 1]
         [0 0 0 1]
@@ -208,7 +206,6 @@ def convert_from_milnor_matrix(n, basis, p=2, generic='auto'):
 
     EXAMPLES::
 
-        sage: # needs sage.modules
         sage: from sage.algebras.steenrod.steenrod_algebra_bases import convert_from_milnor_matrix, convert_to_milnor_matrix
         sage: convert_from_milnor_matrix(12, 'wall')
         [1 0 0 1 0 0 0]
@@ -244,7 +241,7 @@ def convert_from_milnor_matrix(n, basis, p=2, generic='auto'):
     The function takes an optional argument, the prime `p` over
     which to work::
 
-        sage: convert_from_milnor_matrix(17, 'adem', 3)                                 # needs sage.modules
+        sage: convert_from_milnor_matrix(17, 'adem', 3)
         [2 1 1 2]
         [0 2 0 1]
         [1 2 0 0]

--- a/src/sage/algebras/steenrod/steenrod_algebra_mult.py
+++ b/src/sage/algebras/steenrod/steenrod_algebra_mult.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.rings.finite_rings
 r"""
 Multiplication for elements of the Steenrod algebra
 

--- a/src/sage/algebras/tensor_algebra.py
+++ b/src/sage/algebras/tensor_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Tensor Algebras
 

--- a/src/sage/algebras/weyl_algebra.py
+++ b/src/sage/algebras/weyl_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Weyl Algebras
 
@@ -56,12 +55,12 @@ def repr_from_monomials(monomials, term_repr, use_latex=False) -> str:
 
         sage: from sage.algebras.weyl_algebra import repr_from_monomials
         sage: R.<x,y,z> = QQ[]
-        sage: d = [(z, 4/7), (y, sqrt(2)), (x, -5)]                                     # needs sage.symbolic
-        sage: repr_from_monomials(d, lambda m: repr(m))                                 # needs sage.symbolic
+        sage: d = [(z, 4/7), (y, sqrt(2)), (x, -5)]
+        sage: repr_from_monomials(d, lambda m: repr(m))
         '4/7*z + sqrt(2)*y - 5*x'
-        sage: a = repr_from_monomials(d, lambda m: latex(m), True); a                   # needs sage.symbolic
+        sage: a = repr_from_monomials(d, lambda m: latex(m), True); a
         \frac{4}{7} z + \sqrt{2} y - 5 x
-        sage: type(a)                                                                   # needs sage.symbolic
+        sage: type(a)
         <class 'sage.misc.latex.LatexExpr'>
 
     The zero element::
@@ -93,7 +92,6 @@ def repr_from_monomials(monomials, term_repr, use_latex=False) -> str:
 
     Leading minus signs are dealt with appropriately::
 
-        sage: # needs sage.symbolic
         sage: d = [(z, -4/7), (y, -sqrt(2)), (x, -5)]
         sage: repr_from_monomials(d, lambda m: repr(m))
         '-4/7*z - sqrt(2)*y - 5*x'

--- a/src/sage/algebras/yangian.py
+++ b/src/sage/algebras/yangian.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.modules
 r"""
 Yangians
 

--- a/src/sage/algebras/yokonuma_hecke_algebra.py
+++ b/src/sage/algebras/yokonuma_hecke_algebra.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.modules
 """
 Yokonuma-Hecke Algebras
 


### PR DESCRIPTION
No one is maintaining or testing these in SageMath, and they make everything less readable.
