### PR TITLE
Rename the BRiAl feature

### DIFF
--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -34,6 +34,7 @@ Features
    sage/features/sagemath
    sage/features/pkg_systems
    sage/features/bliss
+   sage/features/brial
    sage/features/csdp
    sage/features/databases
    sage/features/dvipng

--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -16,7 +16,7 @@ EXAMPLES::
     Boolean function with 8 variables
     sage: B.nonlinearity()
     112
-    sage: B.algebraic_immunity()                                                        # needs sage.rings.polynomial.pbori
+    sage: B.algebraic_immunity()                                                        # needs brial
     4
 
 AUTHOR:
@@ -88,7 +88,7 @@ cdef long yellow_code(unsigned long a) noexcept:
 
     EXAMPLES::
 
-        sage: # needs sage.rings.polynomial.pbori
+        sage: # needs brial
         sage: from sage.crypto.boolean_function import BooleanFunction
         sage: R.<x,y,z> = BooleanPolynomialRing(3)
         sage: P = x*y
@@ -121,7 +121,7 @@ cdef reed_muller(mp_limb_t* f, int ldn):
 
     EXAMPLES::
 
-        sage: # needs sage.rings.polynomial.pbori
+        sage: # needs brial
         sage: from sage.crypto.boolean_function import BooleanFunction
         sage: R.<x,y,z> = BooleanPolynomialRing(3)
         sage: P = x*y
@@ -191,9 +191,9 @@ cdef class BooleanFunction(SageObject):
 
     from a :class:`sage.rings.polynomial.pbori.BooleanPolynomial`::
 
-        sage: R.<x,y,z> = BooleanPolynomialRing(3)                                      # needs sage.rings.polynomial.pbori
-        sage: P = x*y                                                                   # needs sage.rings.polynomial.pbori
-        sage: BooleanFunction(P)                                                        # needs sage.rings.polynomial.pbori
+        sage: R.<x,y,z> = BooleanPolynomialRing(3)                                      # needs brial
+        sage: P = x*y                                                                   # needs brial
+        sage: BooleanFunction(P)                                                        # needs brial
         Boolean function with 3 variables
 
     from a polynomial over a binary field::
@@ -260,9 +260,9 @@ cdef class BooleanFunction(SageObject):
 
         from a :class:`sage.rings.polynomial.pbori.BooleanPolynomial`::
 
-            sage: R.<x,y,z> = BooleanPolynomialRing(3)                                  # needs sage.rings.polynomial.pbori
-            sage: P = x*y                                                               # needs sage.rings.polynomial.pbori
-            sage: BooleanFunction(P)                                                    # needs sage.rings.polynomial.pbori
+            sage: R.<x,y,z> = BooleanPolynomialRing(3)                                  # needs brial
+            sage: P = x*y                                                               # needs brial
+            sage: BooleanFunction(P)                                                    # needs brial
             Boolean function with 3 variables
 
         from a polynomial over a binary field::
@@ -393,8 +393,8 @@ cdef class BooleanFunction(SageObject):
 
         it also corresponds to the addition of algebraic normal forms::
 
-            sage: S = A.algebraic_normal_form() + B.algebraic_normal_form()             # needs sage.rings.polynomial.pbori
-            sage: (A+B).algebraic_normal_form() == S                                    # needs sage.rings.polynomial.pbori
+            sage: S = A.algebraic_normal_form() + B.algebraic_normal_form()             # needs brial
+            sage: (A+B).algebraic_normal_form() == S                                    # needs brial
             True
 
         TESTS::
@@ -425,8 +425,8 @@ cdef class BooleanFunction(SageObject):
 
         it also corresponds to the multiplication of algebraic normal forms::
 
-            sage: P = A.algebraic_normal_form() * B.algebraic_normal_form()             # needs sage.rings.polynomial.pbori
-            sage: (A*B).algebraic_normal_form() == P                                    # needs sage.rings.polynomial.pbori
+            sage: P = A.algebraic_normal_form() * B.algebraic_normal_form()             # needs brial
+            sage: (A*B).algebraic_normal_form() == P                                    # needs brial
             True
 
         TESTS::
@@ -496,9 +496,9 @@ cdef class BooleanFunction(SageObject):
 
             sage: from sage.crypto.boolean_function import BooleanFunction
             sage: B = BooleanFunction([0,1,1,0,1,0,1,1])
-            sage: P = B.algebraic_normal_form(); P                                      # needs sage.rings.polynomial.pbori
+            sage: P = B.algebraic_normal_form(); P                                      # needs brial
             x0*x1*x2 + x0 + x1*x2 + x1 + x2
-            sage: [P(*ZZ(i).digits(base=2, padto=3)) for i in range(8)]                 # needs sage.rings.polynomial.pbori
+            sage: [P(*ZZ(i).digits(base=2, padto=3)) for i in range(8)]                 # needs brial
             [0, 1, 1, 0, 1, 0, 1, 1]
         """
         cdef bitset_t anf
@@ -553,7 +553,7 @@ cdef class BooleanFunction(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: from sage.crypto.boolean_function import BooleanFunction
             sage: R.<x,y,z> = BooleanPolynomialRing(3)
             sage: B = BooleanFunction(x*y*z + z + y + 1)
@@ -564,10 +564,10 @@ cdef class BooleanFunction(SageObject):
             sage: B.truth_table(format='hex')
             '43'
 
-            sage: BooleanFunction('00ab').truth_table(format='hex')                     # needs sage.rings.polynomial.pbori
+            sage: BooleanFunction('00ab').truth_table(format='hex')                     # needs brial
             '00ab'
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: H = '0abbacadabbacad0'
             sage: len(H)
             16
@@ -993,10 +993,10 @@ cdef class BooleanFunction(SageObject):
 
             sage: from sage.crypto.boolean_function import BooleanFunction
             sage: f = BooleanFunction("7969817CC5893BA6AC326E47619F5AD0")
-            sage: f.annihilator(1) is None                                              # needs sage.rings.polynomial.pbori
+            sage: f.annihilator(1) is None                                              # needs brial
             True
-            sage: g = BooleanFunction(f.annihilator(3))                                 # needs sage.rings.polynomial.pbori
-            sage: set(fi*g(i) for i,fi in enumerate(f))                                 # needs sage.rings.polynomial.pbori
+            sage: g = BooleanFunction(f.annihilator(3))                                 # needs brial
+            sage: set(fi*g(i) for i,fi in enumerate(f))                                 # needs brial
             {0}
         """
         # NOTE: this is a toy implementation
@@ -1057,7 +1057,7 @@ cdef class BooleanFunction(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: from sage.crypto.boolean_function import BooleanFunction
             sage: R.<x0,x1,x2,x3,x4,x5> = BooleanPolynomialRing(6)
             sage: B = BooleanFunction(x0*x1 + x1*x2 + x2*x3 + x3*x4 + x4*x5)
@@ -1067,7 +1067,7 @@ cdef class BooleanFunction(SageObject):
             sage: B.algebraic_immunity()
             2
 
-            sage: # needs sage.rings.finite_rings sage.rings.polynomial.pbori
+            sage: # needs sage.rings.finite_rings brial
             sage: R.<x> = GF(2^8,'a')[]
             sage: B = BooleanFunction(x^31)
             sage: B.algebraic_immunity()
@@ -1096,7 +1096,7 @@ cdef class BooleanFunction(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: from sage.crypto.boolean_function import BooleanFunction
             sage: B.<x0, x1, x2, x3> = BooleanPolynomialRing()
             sage: f = BooleanFunction(x1*x2 + x1*x2*x3 + x1)
@@ -1116,7 +1116,7 @@ cdef class BooleanFunction(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: from sage.crypto.boolean_function import BooleanFunction
             sage: R.<x0, x1, x2, x3> = BooleanPolynomialRing()
             sage: f = BooleanFunction(x0*x1 + x2 + x3)
@@ -1279,7 +1279,7 @@ cdef class BooleanFunction(SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: from sage.crypto.boolean_function import BooleanFunction
             sage: f = BooleanFunction([0,1,0,1,0,1,0,1])
             sage: f.derivative(1).algebraic_normal_form()

--- a/src/sage/crypto/mq/sr.py
+++ b/src/sage/crypto/mq/sr.py
@@ -104,8 +104,8 @@ instances to recover all solutions to the system.::
     sage: a = K.gen()
     sage: K = [a]
     sage: P = [1]
-    sage: F,s = sr.polynomial_system(P=P, K=K)                                          # needs sage.rings.polynomial.pbori
-    sage: F.groebner_basis()                                                            # needs sage.rings.polynomial.pbori
+    sage: F,s = sr.polynomial_system(P=P, K=K)                                          # needs brial
+    sage: F.groebner_basis()                                                            # needs brial
     [k100, k101 + 1, k102, k103 + k003,
      x100 + 1, x101 + k003 + 1, x102 + k003 + 1,
      x103 + k003, w100, w101, w102 + 1, w103 + k003 + 1,
@@ -124,8 +124,8 @@ to the same ciphertext::
 
 All solutions can easily be recovered using the variety function for ideals.::
 
-   sage: I = F.ideal()                                                                  # needs sage.rings.polynomial.pbori
-   sage: for V in I.variety():                                                          # needs sage.rings.polynomial.pbori sage.symbolic
+   sage: I = F.ideal()                                                                  # needs brial
+   sage: for V in I.variety():                                                          # needs brial sage.symbolic
    ....:    for k,v in sorted(V.items()):
    ....:       print("{} {}".format(k, v))
    ....:    print("\n")
@@ -174,7 +174,7 @@ All solutions can easily be recovered using the variety function for ideals.::
 We can also verify the correctness of the variety by evaluating all
 ideal generators on all points.::
 
-   sage: for V in I.variety():                                                          # needs sage.rings.polynomial.pbori sage.symbolic
+   sage: for V in I.variety():                                                          # needs brial sage.symbolic
    ....:     for f in I.gens():
    ....:         if f.subs(V) != 0:
    ....:            print("epic fail")
@@ -1625,7 +1625,7 @@ class SR_generic(MPolynomialSystemGenerator):
              'x103': x103}
 
             sage: sr = mq.SR(1,1,1,4,gf2=True)
-            sage: sr.variable_dict()                                                    # needs sage.rings.polynomial.pbori
+            sage: sr.variable_dict()                                                    # needs brial
             {'k000': k000,
              'k001': k001,
              'k002': k002,
@@ -1972,16 +1972,16 @@ class SR_generic(MPolynomialSystemGenerator):
             sage: sr = mq.SR(1, 1, 1, 4, gf2=True, polybori=True)
             sage: P = sr.vector([0, 0, 1, 0])
             sage: K = sr.vector([1, 0, 0, 1])
-            sage: F, s = sr.polynomial_system(P, K)                                     # needs sage.rings.polynomial.pbori
+            sage: F, s = sr.polynomial_system(P, K)                                     # needs brial
 
         This returns a polynomial system::
 
-            sage: F                                                                     # needs sage.rings.polynomial.pbori
+            sage: F                                                                     # needs brial
             Polynomial Sequence with 36 Polynomials in 20 Variables
 
         and a solution::
 
-            sage: s  # random -- maybe we need a better doctest here?                   # needs sage.rings.polynomial.pbori
+            sage: s  # random -- maybe we need a better doctest here?                   # needs brial
             {k000: 1, k001: 0, k003: 1, k002: 0}
 
         This solution is not the only solution that we can learn from the
@@ -1989,25 +1989,25 @@ class SR_generic(MPolynomialSystemGenerator):
 
         ::
 
-            sage: F.groebner_basis()[-3:]                                               # needs sage.rings.polynomial.pbori
+            sage: F.groebner_basis()[-3:]                                               # needs brial
             [k000 + 1, k001, k003 + 1]
 
         In particular we have two solutions::
 
-            sage: len(F.ideal().variety())                                              # needs sage.rings.polynomial.pbori
+            sage: len(F.ideal().variety())                                              # needs brial
             2
 
         In the following example we provide ``C`` explicitly::
 
            sage: C = sr(P,K)
-           sage: F,s = sr.polynomial_system(P=P, C=C)                                   # needs sage.rings.polynomial.pbori
-           sage: F                                                                      # needs sage.rings.polynomial.pbori
+           sage: F,s = sr.polynomial_system(P=P, C=C)                                   # needs brial
+           sage: F                                                                      # needs brial
            Polynomial Sequence with 36 Polynomials in 20 Variables
 
         Alternatively, we can use symbols for the ``P`` and
         ``C``. First, we have to create a polynomial ring::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(1, 1, 1, 4, gf2=True, polybori=True)
             sage: R = sr.R
             sage: vn = sr.varstrs("P",0,1,4) + R.variable_names() + sr.varstrs("C",0,1,4)
@@ -2017,7 +2017,7 @@ class SR_generic(MPolynomialSystemGenerator):
 
         Now, we can construct the purely symbolic equation system::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: C = sr.vars("C",0); C
             (C000, C001, C002, C003)
             sage: P = sr.vars("P",0)
@@ -2032,13 +2032,13 @@ class SR_generic(MPolynomialSystemGenerator):
         We show that the (returned) key is a solution to the returned system::
 
             sage: sr = mq.SR(3,4,4,8, star=True, gf2=True, polybori=True)
-            sage: while True:  # workaround (see :issue:`31891`)                         # needs sage.rings.polynomial.pbori
+            sage: while True:  # workaround (see :issue:`31891`)                         # needs brial
             ....:     try:
             ....:         F, s = sr.polynomial_system()
             ....:         break
             ....:     except ZeroDivisionError:
             ....:         pass
-            sage: F.subs(s).groebner_basis()    # long time                             # needs sage.rings.polynomial.pbori
+            sage: F.subs(s).groebner_basis()    # long time                             # needs brial
             Polynomial Sequence with 1248 Polynomials in 1248 Variables
         """
         plaintext = P
@@ -3107,9 +3107,9 @@ class SR_gf2(SR_generic):
         EXAMPLES::
 
             sage: sr = mq.SR(1, 1, 1, 8, gf2=True)
-            sage: xi = sr.vars('x', 1)                                                  # needs sage.rings.polynomial.pbori
-            sage: wi = sr.vars('w', 1)                                                  # needs sage.rings.polynomial.pbori
-            sage: sr.inversion_polynomials(xi, wi, len(xi))[:3]                         # needs sage.rings.polynomial.pbori
+            sage: xi = sr.vars('x', 1)                                                  # needs brial
+            sage: wi = sr.vars('w', 1)                                                  # needs brial
+            sage: sr.inversion_polynomials(xi, wi, len(xi))[:3]                         # needs brial
             [x100*w100 + x100*w102 + x100*w103 + x100*w107 + x101*w101 + x101*w102 + x101*w106 + x102*w100 + x102*w101 + x102*w105 + x103*w100 + x103*w104 + x104*w103 + x105*w102 + x106*w101 + x107*w100,
              x100*w101 + x100*w103 + x100*w104 + x101*w100 + x101*w102 + x101*w103 + x101*w107 + x102*w101 + x102*w102 + x102*w106 + x103*w100 + x103*w101 + x103*w105 + x104*w100 + x104*w104 + x105*w103 + x106*w102 + x107*w101,
              x100*w102 + x100*w104 + x100*w105 + x101*w101 + x101*w103 + x101*w104 + x102*w100 + x102*w102 + x102*w103 + x102*w107 + x103*w101 + x103*w102 + x103*w106 + x104*w100 + x104*w101 + x104*w105 + x105*w100 + x105*w104 + x106*w103 + x107*w102]

--- a/src/sage/crypto/sbox.pyx
+++ b/src/sage/crypto/sbox.pyx
@@ -589,7 +589,7 @@ cdef class SBox(SageObject):
             ...
             IndexError: list index out of range
             sage: from sage.crypto.sboxes import PRESENT
-            sage: PRESENT.derivative(1).max_degree() < PRESENT.max_degree()             # needs sage.rings.polynomial.pbori
+            sage: PRESENT.derivative(1).max_degree() < PRESENT.max_degree()             # needs brial
             True
         """
         from sage.structure.element import Vector
@@ -1318,11 +1318,11 @@ cdef class SBox(SageObject):
             sage: from sage.crypto.sbox import SBox
             sage: S = SBox([7,6,0,4,2,5,1,3])
             sage: f3 = S.component_function(3)
-            sage: f3.algebraic_normal_form()                                            # needs sage.rings.polynomial.pbori
+            sage: f3.algebraic_normal_form()                                            # needs brial
             x0*x1 + x0*x2 + x0 + x2
 
             sage: f5 = S.component_function([1, 0, 1])
-            sage: f5.algebraic_normal_form()                                            # needs sage.rings.polynomial.pbori
+            sage: f5.algebraic_normal_form()                                            # needs brial
             x0*x2 + x0 + x1*x2
 
         TESTS::
@@ -1706,7 +1706,7 @@ cdef class SBox(SageObject):
 
             sage: from sage.crypto.sbox import SBox
             sage: S = SBox([12,5,6,11,9,0,10,13,3,14,15,8,4,7,1,2])
-            sage: S.max_degree()                                                        # needs sage.rings.polynomial.pbori
+            sage: S.max_degree()                                                        # needs brial
             3
         """
         ret = ZZ.zero()
@@ -1726,7 +1726,7 @@ cdef class SBox(SageObject):
 
             sage: from sage.crypto.sbox import SBox
             sage: S = SBox([12,5,6,11,9,0,10,13,3,14,15,8,4,7,1,2])
-            sage: S.min_degree()                                                        # needs sage.rings.polynomial.pbori
+            sage: S.min_degree()                                                        # needs brial
             2
         """
         ret = ZZ(self.m)

--- a/src/sage/features/brial.py
+++ b/src/sage/features/brial.py
@@ -20,6 +20,8 @@ class Brial(JoinFeature):
         sage: from sage.features.brial import Brial
         sage: Brial().is_present()  # needs brial
         FeatureTestResult('brial', True)
+        sage: Brial().is_present()  # needs !brial
+        FeatureTestResult('brial', False)
 
     """
     def __init__(self):
@@ -33,3 +35,7 @@ class Brial(JoinFeature):
         JoinFeature.__init__(self, 'brial',
                              [PythonModule('sage.rings.polynomial.pbori.pbori')],
                              spkg='sagemath_brial', type='standard')
+
+
+def all_features():
+    return [Brial()]

--- a/src/sage/features/brial.py
+++ b/src/sage/features/brial.py
@@ -1,0 +1,35 @@
+r"""
+Feature for testing the presence of (lib)brial
+"""
+
+from sage.features.join_feature import JoinFeature
+from sage.features import PythonModule
+
+
+class Brial(JoinFeature):
+    r"""
+    A :class:`sage.features.Feature` describing the presence of
+    :mod:`sage.rings.polynomial.pbori`.
+
+    The :mod:`sage.rings.polynomial.pbori` module in turn depends on
+    the presence and usability of libbrial -- a slightly more
+    modern fork of PolyBoRi, which hopefully explains the name.
+
+    TESTS::
+
+        sage: from sage.features.brial import Brial
+        sage: Brial().is_present()  # needs brial
+        FeatureTestResult('brial', True)
+
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.brial import Brial
+            sage: isinstance(Brial(), Brial)
+            True
+        """
+        JoinFeature.__init__(self, 'brial',
+                             [PythonModule('sage.rings.polynomial.pbori.pbori')],
+                             spkg='sagemath_brial', type='standard')

--- a/src/sage/features/brial.py
+++ b/src/sage/features/brial.py
@@ -21,7 +21,7 @@ class Brial(JoinFeature):
         sage: Brial().is_present()  # needs brial
         FeatureTestResult('brial', True)
         sage: Brial().is_present()  # needs !brial
-        FeatureTestResult('brial', False)
+        FeatureTestResult('sage.rings.polynomial.pbori.pbori', False)
 
     """
     def __init__(self):

--- a/src/sage/features/cddlib.py
+++ b/src/sage/features/cddlib.py
@@ -22,8 +22,11 @@ class CddExecutable(Executable):
     EXAMPLES::
 
         sage: from sage.features.cddlib import CddExecutable
-        sage: CddExecutable().is_present()
+        sage: CddExecutable().is_present()  # needs cddexec_gmp
         FeatureTestResult('cddexec_gmp', True)
+        sage: CddExecutable().is_present()  # needs !cddexec_gmp
+        FeatureTestResult('cddexec_gmp', False)
+
     """
     def __init__(self, name='cddexec_gmp'):
         r"""
@@ -35,3 +38,7 @@ class CddExecutable(Executable):
         """
         Executable.__init__(self, name=name, executable=name, spkg='cddlib',
                             url='https://github.com/cddlib/cddlib', type='standard')
+
+
+def all_features():
+    return [CddExecutable()]

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -941,28 +941,6 @@ class sage__rings__padics(JoinFeature):
                              type='standard')
 
 
-class sage__rings__polynomial__pbori(JoinFeature):
-    r"""
-    A :class:`sage.features.Feature` describing the presence of :mod:`sage.rings.polynomial.pbori`.
-
-    TESTS::
-
-        sage: from sage.features.sagemath import sage__rings__polynomial__pbori
-        sage: sage__rings__polynomial__pbori().is_present()                             # needs sage.rings.polynomial.pbori
-        FeatureTestResult('sage.rings.polynomial.pbori', True)
-    """
-    def __init__(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features.sagemath import sage__rings__polynomial__pbori
-            sage: isinstance(sage__rings__polynomial__pbori(), sage__rings__polynomial__pbori)
-            True
-        """
-        JoinFeature.__init__(self, 'sage.rings.polynomial.pbori',
-                             [PythonModule('sage.rings.polynomial.pbori.pbori')],
-                             spkg='sagemath_brial', type='standard')
-
 
 class sage__rings__real_double(PythonModule):
     r"""
@@ -1171,7 +1149,6 @@ def all_features():
         sage__rings__function_field(),
         sage__rings__number_field(),
         sage__rings__padics(),
-        sage__rings__polynomial__pbori(),
         sage__rings__real_double(),
         sage__rings__real_mpfr(),
         sage__sat(),

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -1422,8 +1422,8 @@ def sage_getargspec(obj):
         sage: sage_getargspec(bernstein_polynomial_factory_ratlist.coeffs_bitsize)                  # needs sage.modules
         FullArgSpec(args=['self'], varargs=None, varkw=None, defaults=None,
                     kwonlyargs=[], kwonlydefaults=None, annotations={})
-        sage: from sage.rings.polynomial.pbori.pbori import BooleanMonomialMonoid       # needs sage.rings.polynomial.pbori
-        sage: sage_getargspec(BooleanMonomialMonoid.gen)                                # needs sage.rings.polynomial.pbori
+        sage: from sage.rings.polynomial.pbori.pbori import BooleanMonomialMonoid       # needs brial
+        sage: sage_getargspec(BooleanMonomialMonoid.gen)                                # needs brial
         FullArgSpec(args=['self', 'i'], varargs=None, varkw=None, defaults=(0,),
                     kwonlyargs=[], kwonlydefaults=None, annotations={})
         sage: I = P*[x,y]
@@ -1775,8 +1775,8 @@ def sage_signature(obj):
         sage: from sage.rings.polynomial.real_roots import bernstein_polynomial_factory_ratlist     # needs sage.modules
         sage: sage_signature(bernstein_polynomial_factory_ratlist.coeffs_bitsize)                  # needs sage.modules
         <Signature (self)>
-        sage: from sage.rings.polynomial.pbori.pbori import BooleanMonomialMonoid       # needs sage.rings.polynomial.pbori
-        sage: sage_signature(BooleanMonomialMonoid.gen)                                # needs sage.rings.polynomial.pbori
+        sage: from sage.rings.polynomial.pbori.pbori import BooleanMonomialMonoid       # needs brial
+        sage: sage_signature(BooleanMonomialMonoid.gen)                                # needs brial
         <Signature (self, i=0)>
         sage: I = P*[x,y]
         sage: sage_signature(I.groebner_basis)                                         # needs sage.libs.singular

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -660,7 +660,7 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
 
         Coercion from boolean polynomials, also by index::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: B.<x,y,z> = BooleanPolynomialRing(3)
             sage: P.<x,y,z> = QQ[]
             sage: P(B.gen(0))

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -1860,8 +1860,8 @@ cdef class BooleanPolynomialRing_base(MPolynomialRing_base):
     EXAMPLES::
 
         sage: from sage.rings.polynomial.multi_polynomial_ring_base import BooleanPolynomialRing_base
-        sage: R.<x, y, z> = BooleanPolynomialRing()                                     # needs sage.rings.polynomial.pbori
-        sage: isinstance(R, BooleanPolynomialRing_base)                                 # needs sage.rings.polynomial.pbori
+        sage: R.<x, y, z> = BooleanPolynomialRing()                                     # needs brial
+        sage: isinstance(R, BooleanPolynomialRing_base)                                 # needs brial
         True
 
     By design, there is only one direct implementation subclass::

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -23,24 +23,24 @@ EXAMPLES:
 
 As an example consider a small scale variant of the AES::
 
-    sage: sr = mq.SR(2, 1, 2, 4, gf2=True, polybori=True)                               # needs sage.rings.polynomial.pbori
-    sage: sr                                                                            # needs sage.rings.polynomial.pbori
+    sage: sr = mq.SR(2, 1, 2, 4, gf2=True, polybori=True)                               # needs brial
+    sage: sr                                                                            # needs brial
     SR(2,1,2,4)
 
 We can construct a polynomial sequence for a random plaintext-ciphertext
 pair and study it::
 
     sage: set_random_seed(1)
-    sage: while True:  # workaround (see :issue:`31891`)                                # needs sage.rings.polynomial.pbori
+    sage: while True:  # workaround (see :issue:`31891`)                                # needs brial
     ....:     try:
     ....:         F, s = sr.polynomial_system()
     ....:         break
     ....:     except ZeroDivisionError:
     ....:         pass
-    sage: F                                                                             # needs sage.rings.polynomial.pbori
+    sage: F                                                                             # needs brial
     Polynomial Sequence with 112 Polynomials in 64 Variables
 
-    sage: r2 = F.part(2); r2                                                            # needs sage.rings.polynomial.pbori
+    sage: r2 = F.part(2); r2                                                            # needs brial
     (w200 + k100 + x100 + x102 + x103,
      w201 + k101 + x100 + x101 + x103 + 1,
      w202 + k102 + x100 + x101 + x102 + 1,
@@ -76,7 +76,7 @@ pair and study it::
 
 We separate the system in independent subsystems::
 
-    sage: C = Sequence(r2).connected_components(); C                                    # needs sage.rings.polynomial.pbori
+    sage: C = Sequence(r2).connected_components(); C                                    # needs brial
     [[w200 + k100 + x100 + x102 + x103,
       w201 + k101 + x100 + x101 + x103 + 1,
       w202 + k102 + x100 + x101 + x102 + 1,
@@ -109,27 +109,27 @@ We separate the system in independent subsystems::
       x110*w110 + x110*w111 + x110*w112 + x111*w112 + x112*w110 + x112*w111 + x112*w113 + x113*w111 + w112,
       x110*w111 + x111*w110 + x111*w112 + x112*w110 + x113*w111 + x113*w113 + w113,
       x110*w112 + x111*w111 + x112*w110 + x113*w113 + 1]]
-    sage: C[0].groebner_basis()                                                         # needs sage.rings.polynomial.pbori
+    sage: C[0].groebner_basis()                                                         # needs brial
     Polynomial Sequence with 30 Polynomials in 16 Variables
 
 and compute the coefficient matrix::
 
-    sage: A,v = Sequence(r2).coefficients_monomials()                                   # needs sage.rings.polynomial.pbori
-    sage: A.rank()                                                                      # needs sage.rings.polynomial.pbori
+    sage: A,v = Sequence(r2).coefficients_monomials()                                   # needs brial
+    sage: A.rank()                                                                      # needs brial
     32
 
 Using these building blocks we can implement a simple XL algorithm
 easily::
 
-    sage: sr = mq.SR(1,1,1,4, gf2=True, polybori=True, order='lex')                     # needs sage.rings.polynomial.pbori
-    sage: while True:  # workaround (see :issue:`31891`)                                # needs sage.rings.polynomial.pbori
+    sage: sr = mq.SR(1,1,1,4, gf2=True, polybori=True, order='lex')                     # needs brial
+    sage: while True:  # workaround (see :issue:`31891`)                                # needs brial
     ....:     try:
     ....:         F, s = sr.polynomial_system()
     ....:         break
     ....:     except ZeroDivisionError:
     ....:         pass
 
-    sage: # needs sage.rings.polynomial.pbori
+    sage: # needs brial
     sage: monomials = [a*b for a in F.variables() for b in F.variables() if a < b]
     sage: len(monomials)
     190
@@ -421,7 +421,7 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(allow_zero_inversions=True)
             sage: F,s = sr.polynomial_system()
             sage: copy(F)  # indirect doctest
@@ -437,9 +437,9 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: sr = mq.SR(allow_zero_inversions=True, gf2=True, order='block')       # needs sage.rings.polynomial.pbori
-            sage: F, s = sr.polynomial_system()                                         # needs sage.rings.polynomial.pbori
-            sage: print(F.ring().repr_long())                                           # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True, gf2=True, order='block')       # needs brial
+            sage: F, s = sr.polynomial_system()                                         # needs brial
+            sage: print(F.ring().repr_long())                                           # needs brial
             Polynomial Ring
              Base Ring : Finite Field of size 2
                   Size : 20 Variables
@@ -458,9 +458,9 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs sage.rings.polynomial.pbori
-            sage: F, s = sr.polynomial_system()                                         # needs sage.rings.polynomial.pbori
-            sage: F.nparts()                                                            # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs brial
+            sage: F, s = sr.polynomial_system()                                         # needs brial
+            sage: F.nparts()                                                            # needs brial
             4
         """
         return len(self._parts)
@@ -471,7 +471,7 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(allow_zero_inversions=True)
             sage: F, s = sr.polynomial_system()
             sage: l = F.parts()
@@ -486,7 +486,7 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(allow_zero_inversions=True)
             sage: F, s = sr.polynomial_system()
             sage: R0 = F.part(1)
@@ -501,7 +501,7 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(allow_zero_inversions=True)
             sage: F, s = sr.polynomial_system()
             sage: P = F.ring()
@@ -529,7 +529,7 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(allow_zero_inversions=True)
             sage: F, s = sr.polynomial_system()
             sage: gb = F.groebner_basis()
@@ -541,7 +541,7 @@ class PolynomialSequence_generic(Sequence_generic):
         Check that this method also works for boolean polynomials
         (:issue:`10680`)::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: B.<a,b,c,d> = BooleanPolynomialRing()
             sage: F0 = Sequence(map(lambda f: f.lm(), [a,b,c,d]))
             sage: F0.groebner_basis()
@@ -558,9 +558,9 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs sage.rings.polynomial.pbori
-            sage: F,s = sr.polynomial_system()                                          # needs sage.rings.polynomial.pbori
-            sage: len(F.monomials())                                                    # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs brial
+            sage: F,s = sr.polynomial_system()                                          # needs brial
+            sage: len(F.monomials())                                                    # needs brial
             49
         """
         M = set()
@@ -575,9 +575,9 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs sage.rings.polynomial.pbori
-            sage: F,s = sr.polynomial_system()                                          # needs sage.rings.polynomial.pbori
-            sage: F.nmonomials()                                                        # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs brial
+            sage: F,s = sr.polynomial_system()                                          # needs brial
+            sage: F.nmonomials()                                                        # needs brial
             49
         """
         return len(self.monomials())
@@ -589,9 +589,9 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs sage.rings.polynomial.pbori
-            sage: F,s = sr.polynomial_system()                                          # needs sage.rings.polynomial.pbori
-            sage: F.variables()[:10]                                                    # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs brial
+            sage: F,s = sr.polynomial_system()                                          # needs brial
+            sage: F.variables()[:10]                                                    # needs brial
             (k003, k002, k001, k000, s003, s002, s001, s000, w103, w102)
         """
         V = set()
@@ -606,9 +606,9 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs sage.rings.polynomial.pbori
-            sage: F,s = sr.polynomial_system()                                          # needs sage.rings.polynomial.pbori
-            sage: F.nvariables()                                                        # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs brial
+            sage: F,s = sr.polynomial_system()                                          # needs brial
+            sage: F.nvariables()                                                        # needs brial
             20
         """
         return len(self.variables())
@@ -1072,10 +1072,10 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs sage.rings.polynomial.pbori
-            sage: F, s = sr.polynomial_system(); F                                      # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True)                                # needs brial
+            sage: F, s = sr.polynomial_system(); F                                      # needs brial
             Polynomial Sequence with 40 Polynomials in 20 Variables
-            sage: F = F.subs(s); F                                                      # needs sage.rings.polynomial.pbori
+            sage: F = F.subs(s); F                                                      # needs brial
             Polynomial Sequence with 40 Polynomials in 16 Variables
         """
         return PolynomialSequence(self._ring, [tuple([f.subs(*args, **kwargs) for f in r]) for r in self._parts])
@@ -1108,7 +1108,7 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(allow_zero_inversions=True, gf2=True)
             sage: F,s = sr.polynomial_system()
             sage: F.set_immutable()
@@ -1149,8 +1149,8 @@ class PolynomialSequence_generic(Sequence_generic):
         If the system contains 20 or more polynomials, a short summary
         is printed::
 
-            sage: sr = mq.SR(allow_zero_inversions=True, gf2=True)                      # needs sage.rings.polynomial.pbori
-            sage: F,s = sr.polynomial_system(); F                                       # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True, gf2=True)                      # needs brial
+            sage: F,s = sr.polynomial_system(); F                                       # needs brial
             Polynomial Sequence with 36 Polynomials in 20 Variables
         """
         if self._is_short_for_repr():
@@ -1175,8 +1175,8 @@ class PolynomialSequence_generic(Sequence_generic):
         If the system contains 20 or more polynomials, a short summary
         is printed::
 
-            sage: sr = mq.SR(allow_zero_inversions=True, gf2=True)                      # needs sage.rings.polynomial.pbori
-            sage: F,s = sr.polynomial_system(); F                                       # needs sage.rings.polynomial.pbori
+            sage: sr = mq.SR(allow_zero_inversions=True, gf2=True)                      # needs brial
+            sage: F,s = sr.polynomial_system(); F                                       # needs brial
             Polynomial Sequence with 36 Polynomials in 20 Variables
         """
         if self._is_short_for_repr():
@@ -1233,7 +1233,7 @@ class PolynomialSequence_generic(Sequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: B.<x,y,z> = BooleanPolynomialRing()
             sage: F = Sequence([x*y + y + 1, z + 1])
             sage: G = F.connection_graph(); G
@@ -1246,7 +1246,7 @@ class PolynomialSequence_generic(Sequence_generic):
 
         TESTS::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: F = Sequence([], B)
             sage: F.connection_graph()
             Graph on 0 vertices
@@ -1282,7 +1282,7 @@ class PolynomialSequence_generic(Sequence_generic):
         As an example consider one part of AES, which naturally
         splits into four subsystems which are independent::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(2, 4, 4, 8, gf2=True, polybori=True)
             sage: while True:  # workaround (see :issue:`31891`)
             ....:     try:
@@ -1585,7 +1585,7 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: B.<a,b,c,d> = BooleanPolynomialRing()
             sage: F = Sequence([c + d + b + 1, a + c + d, a*b + c, b*c*d + c])
             sage: F.eliminate_linear_variables() # everything vanishes
@@ -1597,7 +1597,7 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         The list of reductors can be requested by setting ``return_reductors`` to ``True``::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: B.<a,b,c,d> = BooleanPolynomialRing()
             sage: F = Sequence([a + b + d, a + b + c])
             sage: F, R = F.eliminate_linear_variables(return_reductors=True)
@@ -1610,7 +1610,7 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
         If the input system is detected to be inconsistent then ``[1]`` is returned,
         and the list of reductors is empty::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: R.<x,y,z> = BooleanPolynomialRing()
             sage: S = Sequence([x*y*z + x*y + z*y + x*z, x + y + z + 1, x + y + z])
             sage: S.eliminate_linear_variables()
@@ -1625,23 +1625,23 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         The function should really dispose of linear equations (:issue:`13968`)::
 
-            sage: R.<x,y,z> = BooleanPolynomialRing()                                   # needs sage.rings.polynomial.pbori
-            sage: S = Sequence([x + y + z + 1, y + z])                                  # needs sage.rings.polynomial.pbori
-            sage: S.eliminate_linear_variables(return_reductors=True)                   # needs sage.rings.polynomial.pbori
+            sage: R.<x,y,z> = BooleanPolynomialRing()                                   # needs brial
+            sage: S = Sequence([x + y + z + 1, y + z])                                  # needs brial
+            sage: S.eliminate_linear_variables(return_reductors=True)                   # needs brial
             ([], [x + 1, y + z])
 
 
         The function should take care of linear variables created by previous
         substitution of linear variables ::
 
-            sage: R.<x,y,z> = BooleanPolynomialRing()                                   # needs sage.rings.polynomial.pbori
-            sage: S = Sequence([x*y*z + x*y + z*y + x*z, x + y + z + 1, x + y])         # needs sage.rings.polynomial.pbori
-            sage: S.eliminate_linear_variables(return_reductors=True)                   # needs sage.rings.polynomial.pbori
+            sage: R.<x,y,z> = BooleanPolynomialRing()                                   # needs brial
+            sage: S = Sequence([x*y*z + x*y + z*y + x*z, x + y + z + 1, x + y])         # needs brial
+            sage: S.eliminate_linear_variables(return_reductors=True)                   # needs brial
             ([], [x + y, z + 1])
 
         We test a case which would increase the degree with ``polybori=True``::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: B.<a,b,c,d> = BooleanPolynomialRing()
             sage: f = a*d + a + b*d + c*d + 1
             sage: Sequence([f, a + b*c + c+d + 1]).eliminate_linear_variables()
@@ -1738,7 +1738,7 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
             Groebner Strategy for ideal generated by 2 elements over
             Multivariate Polynomial Ring in x, y, z over Finite Field of size 2
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: P.<x,y,z> = BooleanPolynomialRing()
             sage: F = Sequence([x*y + z, y + z + 1])
             sage: F._groebner_strategy()
@@ -1797,7 +1797,7 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         Without argument, a single arbitrary solution is returned::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: R.<x,y,z> = BooleanPolynomialRing()
             sage: S = Sequence([x*y + z, y*z + x, x + y + z + 1])
             sage: sol = S.solve()
@@ -1806,39 +1806,39 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         We check that it is actually a solution::
 
-            sage: S.subs(sol[0])                                                        # needs sage.rings.polynomial.pbori
+            sage: S.subs(sol[0])                                                        # needs brial
             [0, 0, 0]
 
         We obtain all solutions::
 
-            sage: sols = S.solve(n=Infinity)                                            # needs sage.rings.polynomial.pbori
-            sage: sols                                                                  # needs sage.rings.polynomial.pbori
+            sage: sols = S.solve(n=Infinity)                                            # needs brial
+            sage: sols                                                                  # needs brial
             [{z: 0, y: 1, x: 0}, {z: 1, y: 1, x: 1}]
-            sage: [S.subs(x) for x in sols]                                             # needs sage.rings.polynomial.pbori
+            sage: [S.subs(x) for x in sols]                                             # needs brial
             [[0, 0, 0], [0, 0, 0]]
 
         We can force the use of exhaustive search if the optional
         package ``FES`` is present::
 
-            sage: sol = S.solve(algorithm='exhaustive_search')  # optional - fes        # needs sage.rings.polynomial.pbori
-            sage: sol                                           # optional - fes        # needs sage.rings.polynomial.pbori
+            sage: sol = S.solve(algorithm='exhaustive_search')  # optional - fes        # needs brial
+            sage: sol                                           # optional - fes        # needs brial
             [{z: 1, y: 1, x: 1}]
-            sage: S.subs(sol[0])                                # optional - fes        # needs sage.rings.polynomial.pbori
+            sage: S.subs(sol[0])                                # optional - fes        # needs brial
             [0, 0, 0]
 
         And we may use SAT-solvers if they are available::
 
-            sage: sol = S.solve(algorithm='sat')        # optional - pycryptosat        # needs sage.rings.polynomial.pbori
-            sage: sol                                   # optional - pycryptosat        # needs sage.rings.polynomial.pbori
+            sage: sol = S.solve(algorithm='sat')        # optional - pycryptosat        # needs brial
+            sage: sol                                   # optional - pycryptosat        # needs brial
             [{z: 0, y: 1, x: 0}]
-            sage: S.subs(sol[0])                                                        # needs sage.rings.polynomial.pbori
+            sage: S.subs(sol[0])                                                        # needs brial
             [0, 0, 0]
 
         TESTS:
 
         Make sure that variables not occurring in the equations are no problem::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: R.<x,y,z,t> = BooleanPolynomialRing()
             sage: S = Sequence([x*y + z, y*z + x, x + y + z + 1])
             sage: sols = S.solve(n=Infinity)
@@ -1847,15 +1847,15 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         Not eliminating linear variables::
 
-            sage: sols = S.solve(n=Infinity, eliminate_linear_variables=False)          # needs sage.rings.polynomial.pbori
-            sage: [S.subs(x) for x in sols]                                             # needs sage.rings.polynomial.pbori
+            sage: sols = S.solve(n=Infinity, eliminate_linear_variables=False)          # needs brial
+            sage: [S.subs(x) for x in sols]                                             # needs brial
             [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]
 
         A tricky case where the linear equations are insatisfiable::
 
-            sage: R.<x,y,z> = BooleanPolynomialRing()                                   # needs sage.rings.polynomial.pbori
-            sage: S = Sequence([x*y*z + x*y + z*y + x*z, x + y + z + 1, x + y + z])     # needs sage.rings.polynomial.pbori
-            sage: S.solve()                                                             # needs sage.rings.polynomial.pbori
+            sage: R.<x,y,z> = BooleanPolynomialRing()                                   # needs brial
+            sage: S = Sequence([x*y*z + x*y + z*y + x*z, x + y + z + 1, x + y + z])     # needs brial
+            sage: S.solve()                                                             # needs brial
             []
         """
         from sage.modules.free_module import VectorSpace
@@ -1935,7 +1935,7 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(1, 1, 1, 4, gf2=True, polybori=True)
             sage: while True:  # workaround (see :issue:`31891`)
             ....:     try:
@@ -1988,7 +1988,7 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: B.<x,y,z> = BooleanPolynomialRing()
             sage: F = Sequence([x*y + y + 1, z + 1])
             sage: A, v = F.coefficients_monomials()
@@ -2077,7 +2077,7 @@ class PolynomialSequence_gf2e(PolynomialSequence_generic):
 
         Another bigger example for a small scale AES::
 
-            sage: # needs sage.rings.polynomial.pbori
+            sage: # needs brial
             sage: sr = mq.SR(1, 1, 1, 4, gf2=False)
             sage: while True:  # workaround (see :issue:`31891`)
             ....:     try:

--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -1033,7 +1033,7 @@ def BooleanPolynomialRing_constructor(n=None, names=None, order='lex'):
 
     EXAMPLES::
 
-        sage: # needs sage.rings.polynomial.pbori
+        sage: # needs brial
         sage: R.<x, y, z> = BooleanPolynomialRing(); R  # indirect doctest
         Boolean PolynomialRing in x, y, z
         sage: p = x*y + x*z + y*z
@@ -1042,29 +1042,29 @@ def BooleanPolynomialRing_constructor(n=None, names=None, order='lex'):
         sage: R.term_order()
         Lexicographic term order
 
-        sage: R = BooleanPolynomialRing(5, 'x', order='deglex(3),deglex(2)')            # needs sage.rings.polynomial.pbori
-        sage: R.term_order()                                                            # needs sage.rings.polynomial.pbori
+        sage: R = BooleanPolynomialRing(5, 'x', order='deglex(3),deglex(2)')            # needs brial
+        sage: R.term_order()                                                            # needs brial
         Block term order with blocks:
         (Degree lexicographic term order of length 3,
          Degree lexicographic term order of length 2)
 
-        sage: R = BooleanPolynomialRing(3, 'x', order='degneglex')                      # needs sage.rings.polynomial.pbori
-        sage: R.term_order()                                                            # needs sage.rings.polynomial.pbori
+        sage: R = BooleanPolynomialRing(3, 'x', order='degneglex')                      # needs brial
+        sage: R.term_order()                                                            # needs brial
         Degree negative lexicographic term order
 
-        sage: BooleanPolynomialRing(names=('x','y'))                                    # needs sage.rings.polynomial.pbori
+        sage: BooleanPolynomialRing(names=('x','y'))                                    # needs brial
         Boolean PolynomialRing in x, y
 
-        sage: BooleanPolynomialRing(names='x,y')                                        # needs sage.rings.polynomial.pbori
+        sage: BooleanPolynomialRing(names='x,y')                                        # needs brial
         Boolean PolynomialRing in x, y
 
     TESTS::
 
-        sage: P.<x,y> = BooleanPolynomialRing(2, order='deglex')                        # needs sage.rings.polynomial.pbori
-        sage: x > y                                                                     # needs sage.rings.polynomial.pbori
+        sage: P.<x,y> = BooleanPolynomialRing(2, order='deglex')                        # needs brial
+        sage: x > y                                                                     # needs brial
         True
 
-        sage: # needs sage.rings.polynomial.pbori
+        sage: # needs brial
         sage: P.<x0, x1, x2, x3> = BooleanPolynomialRing(4, order='deglex(2),deglex(2)')
         sage: x0 > x1
         True

--- a/src/sage/sat/boolean_polynomials.py
+++ b/src/sage/sat/boolean_polynomials.py
@@ -1,4 +1,4 @@
-# sage.doctest: optional - pycryptosat, needs sage.modules sage.rings.polynomial.pbori
+# sage.doctest: optional - pycryptosat, needs sage.modules brial
 """
 SAT Functions for Boolean Polynomials
 

--- a/src/sage/sat/converters/polybori.py
+++ b/src/sage/sat/converters/polybori.py
@@ -1,4 +1,4 @@
-# sage.doctest: needs sage.rings.polynomial.pbori
+# sage.doctest: needs brial
 """
 An ANF to CNF Converter using a Dense/Sparse Strategy
 

--- a/src/sage/sat/solvers/dimacs.py
+++ b/src/sage/sat/solvers/dimacs.py
@@ -509,14 +509,14 @@ class DIMACS(SatSolver):
         TESTS::
 
             sage: from sage.sat.boolean_polynomials import solve as solve_sat
-            sage: sr = mq.SR(1, 1, 1, 4, gf2=True, polybori=True)                       # needs sage.rings.finite_rings sage.rings.polynomial.pbori
-            sage: while True:  # workaround (see :issue:`31891`)                         # needs sage.rings.finite_rings sage.rings.polynomial.pbori
+            sage: sr = mq.SR(1, 1, 1, 4, gf2=True, polybori=True)                       # needs sage.rings.finite_rings brial
+            sage: while True:  # workaround (see :issue:`31891`)                         # needs sage.rings.finite_rings brial
             ....:     try:
             ....:         F, s = sr.polynomial_system()
             ....:         break
             ....:     except ZeroDivisionError:
             ....:         pass
-            sage: solve_sat(F, solver=sage.sat.solvers.RSat)    # optional - rsat, needs sage.rings.finite_rings sage.rings.polynomial.pbori
+            sage: solve_sat(F, solver=sage.sat.solvers.RSat)    # optional - rsat, needs sage.rings.finite_rings brial
         """
         if assumptions is not None:
             raise NotImplementedError("Assumptions are not supported for DIMACS based solvers.")

--- a/src/sage/structure/category_object.pyx
+++ b/src/sage/structure/category_object.pyx
@@ -276,8 +276,8 @@ cdef class CategoryObject(SageObject):
 
         EXAMPLES::
 
-            sage: B.<a,b,c,d> = BooleanPolynomialRing()                                 # needs sage.rings.polynomial.pbori
-            sage: B.gens_dict()                                                         # needs sage.rings.polynomial.pbori
+            sage: B.<a,b,c,d> = BooleanPolynomialRing()                                 # needs brial
+            sage: B.gens_dict()                                                         # needs brial
             {'a': a, 'b': b, 'c': c, 'd': d}
 
         TESTS::


### PR DESCRIPTION
The BRiAl feature is named after the sage module that implements it (sage.rings.polynomial.pbori), and even that refers to the old library name, PolyBoRi.

Let's just rename it to "brial", so that the doctest line becomes `# needs brial`.
