### PR TITLE
Fix a deprecation function in sphinx

### DIFF
--- a/src/sage_docbuild/conf.py
+++ b/src/sage_docbuild/conf.py
@@ -359,7 +359,7 @@ def set_intersphinx_mappings(app, config):
             dst = os.path.join(invpath, directory, 'objects.inv')
             app.config.intersphinx_mapping[directory] = (src, dst)
 
-    intersphinx.normalize_intersphinx_mapping(app, config)
+    intersphinx.validate_intersphinx_mapping(app, config)
 
 
 # By default document is master.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
```
/home/runner/work/sage/sage/src/sage_docbuild/conf.py:362: RemovedInSphinx10Warning: The alias 'sphinx.ext.intersphinx.normalize_intersphinx_mapping' is deprecated, use 'sphinx.ext.intersphinx.validate_intersphinx_mapping' instead. Check CHANGES for Sphinx API modifications.
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


