### PR TITLE
New RankWidth feature

### DIFF
--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -57,6 +57,7 @@ Features
    sage/features/pandoc
    sage/features/pdf2svg
    sage/features/polymake
+   sage/features/rankwidth
    sage/features/rubiks
    sage/features/tdlib
    sage/features/topcom

--- a/src/sage/features/rankwidth.py
+++ b/src/sage/features/rankwidth.py
@@ -1,0 +1,42 @@
+r"""
+Feature for the rank-width graph decomposition
+"""
+
+from sage.features import PythonModule
+from sage.features.join_feature import JoinFeature
+
+
+class RankWidth(JoinFeature):
+    r"""
+    A :class:`~sage.features.Feature` indicating whether or not the
+    rank-width graph decomposition is available.
+
+    This is a proxy for the build-time availability of the rankwidth
+    (librw) library from the "rw" package; the associated module
+    :mod:`sage.graphs.graph_decompositions.rankwidth` is built if and
+    only if the library is detected, usable, and enabled.
+
+    EXAMPLES::
+
+        sage: from sage.features.rankwidth import RankWidth
+        sage: RankWidth().is_present()  # needs rankwidth
+        FeatureTestResult('rankwidth', True)
+        sage: RankWidth().is_present()  # needs !rankwidth
+        FeatureTestResult('sage.graphs.graph_decompositions.rankwidth', False)
+
+    """
+    def __init__(self):
+        r"""
+        EXAMPLES::
+
+            sage: from sage.features.rankwidth import RankWidth
+            sage: RankWidth()
+            Feature('rankwidth')
+
+        """
+        f = PythonModule("sage.graphs.graph_decompositions.rankwidth")
+        JoinFeature.__init__(self, "rankwidth", [f], spkg="rw", type="standard")
+
+
+def all_features():
+    return [RankWidth()]

--- a/src/sage/features/rankwidth.py
+++ b/src/sage/features/rankwidth.py
@@ -2,6 +2,16 @@ r"""
 Feature for the rank-width graph decomposition
 """
 
+# ****************************************************************************
+#       Copyright (C) 2026 Michael Orlitzky <michael@orlitzky.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
+
 from sage.features import PythonModule
 from sage.features.join_feature import JoinFeature
 

--- a/src/sage/graphs/graph_decompositions/rankwidth.pyx
+++ b/src/sage/graphs/graph_decompositions/rankwidth.pyx
@@ -46,6 +46,7 @@ i.e. singletons.
 
 ::
 
+    sage: # needs rankwidth
     sage: g = graphs.PetersenGraph()
     sage: rw, tree = g.rank_decomposition()
     sage: all(len(v)==1 for v in tree if tree.degree(v) == 1)
@@ -58,6 +59,7 @@ from the smaller of the two and its complement.
 
 ::
 
+    sage: # needs rankwidth
     sage: g = graphs.PetersenGraph()
     sage: rw, tree = g.rank_decomposition()
     sage: u = Set([8, 9, 3, 7])
@@ -80,6 +82,7 @@ from the smaller of the two and its complement.
 
 EXAMPLES::
 
+        sage: # needs rankwidth
         sage: g = graphs.PetersenGraph()
         sage: g.rank_decomposition()
         (3, Graph on 19 vertices)
@@ -137,6 +140,7 @@ def rank_decomposition(G, verbose=False, immutable=None):
 
     EXAMPLES::
 
+        sage: # needs rankwidth
         sage: from sage.graphs.graph_decompositions.rankwidth import rank_decomposition
         sage: g = graphs.PetersenGraph()
         sage: rank_decomposition(g)
@@ -144,6 +148,7 @@ def rank_decomposition(G, verbose=False, immutable=None):
 
     On more than 32 vertices::
 
+        sage: # needs rankwidth
         sage: g = graphs.RandomGNP(40, .5)
         sage: rank_decomposition(g)
         Traceback (most recent call last):
@@ -152,12 +157,14 @@ def rank_decomposition(G, verbose=False, immutable=None):
 
     The empty graph::
 
+        sage: # needs rankwidth
         sage: g = Graph()
         sage: rank_decomposition(g)
         (0, Graph on 0 vertices)
 
     Check the behavior of parameter ``immutable``::
 
+        sage: # needs rankwidth
         sage: G = Graph()
         sage: rank_decomposition(G)[1].is_immutable()
         False
@@ -302,6 +309,7 @@ def mkgraph(int num_vertices):
 
     EXAMPLES::
 
+        sage: # needs rankwidth
         sage: from sage.graphs.graph_decompositions.rankwidth import rank_decomposition
         sage: g = graphs.PetersenGraph()
         sage: rank_decomposition(g)


### PR DESCRIPTION
Add a new `sage.features.rankwidth.RankWidth` feature. This tries to import an optional cython module that can be disabled at build-time with `meson setup -Drankwidth=disabled`. Afterwards, we add the new module to the documentation, and add the relevant "needs rankwidth" tags to the cython module's doctests. The end result is that the tests (at least, _these_ tests) should pass on a no-rankwidth build of sagelib.

Split from https://github.com/sagemath/sage/pull/41550 to minimize the irrelevant changes there.

**Documentation shortcut:**
* https://doc-pr-41987--sagemath.netlify.app/html/en/reference/spkg/sage/features/rankwidth
