### PR TITLE
Add feature for eclib and deprecate mwrank

### DIFF
--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -44,6 +44,7 @@ Features
    sage/features/csdp
    sage/features/databases
    sage/features/dvipng
+   sage/features/eclib
    sage/features/ffmpeg
    sage/features/four_ti_2
    sage/features/gap

--- a/src/sage/features/eclib.py
+++ b/src/sage/features/eclib.py
@@ -1,0 +1,48 @@
+r"""
+Feature for eclib (the :mod:`sage.libs.eclib.mwrank` module)
+"""
+
+from sage.config import eclib_enabled
+from sage.features.build_feature import BuildModule
+
+
+class Eclib(BuildModule):
+    r"""
+    A :class:`sage.features.Feature` describing the presence of
+    :mod:`sage.libs.eclib.mwrank`.
+
+    EXAMPLES::
+
+        sage: from sage.features.eclib import Eclib
+        sage: Eclib().is_present()  # needs eclib
+        FeatureTestResult('eclib', True)
+        sage: Eclib().is_present()  # needs !eclib
+        FeatureTestResult('eclib', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !eclib`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.eclib import Eclib
+        sage: Eclib().is_present_at_runtime()  # needs eclib
+        FeatureTestResult('eclib', True)
+
+    """
+    _enabled_in_build = eclib_enabled
+
+    def __init__(self):
+        r"""
+        EXAMPLES::
+
+            sage: from sage.features.eclib import Eclib
+            sage: Eclib()
+            Feature('eclib')
+
+        """
+        module_name = "sage.libs.eclib.mwrank"
+        super().__init__("eclib", module_name, type="standard")
+
+
+def all_features():
+    return [Eclib()]

--- a/src/sage/interfaces/mwrank.py
+++ b/src/sage/interfaces/mwrank.py
@@ -1,5 +1,13 @@
 r"""
 Interface to mwrank
+
+TESTS:
+
+The module now raises a deprecation warning::
+
+    sage: import sage.interfaces.mwrank
+    ...DeprecationWarning...
+
 """
 
 # ****************************************************************************
@@ -22,6 +30,9 @@ import re
 import weakref
 
 from sage.interfaces.expect import Expect
+from sage.misc.superseded import deprecation
+
+deprecation(41990, "the pexpect interface to the mwrank program is deprecated, please use the library interface (sage.libs.eclib) instead")
 
 instances = {}
 

--- a/src/sage/libs/eclib/interface.py
+++ b/src/sage/libs/eclib/interface.py
@@ -27,7 +27,6 @@ Check that ``eclib`` is imported as needed::
 """
 import sys
 
-from sage.libs.eclib.mwrank import _Curvedata, _mw, _two_descent, parse_point_list
 from sage.rings.integer_ring import IntegerRing
 from sage.structure.sage_object import SageObject
 
@@ -116,6 +115,10 @@ class mwrank_EllipticCurve(SageObject):
         except (TypeError, ValueError):
             raise TypeError("ainvs must be a list or tuple of integers.")
         self.__ainvs = a_int
+
+        from sage.features.eclib import Eclib
+        Eclib().require()
+        from sage.libs.eclib.mwrank import _Curvedata
         self.__curve = _Curvedata(a_int[0], a_int[1], a_int[2],
                                   a_int[3], a_int[4])
 
@@ -342,6 +345,9 @@ class mwrank_EllipticCurve(SageObject):
             sage: E.two_descent(verbose=False)
             True
         """
+        from sage.features.eclib import Eclib
+        Eclib().require()
+        from sage.libs.eclib.mwrank import _two_descent
         first_limit = int(first_limit)
         second_limit = int(second_limit)
         n_aux = int(n_aux)
@@ -579,6 +585,9 @@ class mwrank_EllipticCurve(SageObject):
             sage: E.gens()
             ([0, -1, 1],)
         """
+        from sage.features.eclib import Eclib
+        Eclib().require()
+        from sage.libs.eclib.mwrank import parse_point_list
         self.saturate()
         return tuple(parse_point_list(self.__two_descent_data().getbasis()))
 
@@ -810,6 +819,10 @@ class mwrank_MordellWeil(SageObject):
             verb = 1
         else:
             verb = 0
+
+        from sage.features.eclib import Eclib
+        Eclib().require()
+        from sage.libs.eclib.mwrank import _mw
         self.__mw = _mw(curve._curve_data(), verb, pp, maxr)
 
     def __reduce__(self):

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -475,6 +475,9 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             Generator 1 is [29604565304828237474403861024284371796799791624792913256602210:-256256267988926809388776834045513089648669153204356603464786949:490078023219787588959802933995928925096061616470779979261000]; height 95.98037...
             Regulator = 95.98037...
         """
+        from sage.misc.superseded import deprecation
+        deprecation(41990, "the mwrank() method is deprecated, the same information can be obtained more efficiently using other methods that make use of the library (eclib) interface")
+
         if not options:
             from sage.interfaces.mwrank import mwrank
         else:
@@ -2418,7 +2421,14 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             obtained by calling :meth:`mwrank` with carefully chosen
             parameters.
 
-        EXAMPLES::
+        EXAMPLES:
+
+        This method is now deprecated::
+
+            sage: EllipticCurve([0,0,1,-1,0]).mwrank()
+            ...DeprecationWarning...
+
+        ::
 
             sage: E = EllipticCurve('37a1')
             sage: E.ngens()


### PR DESCRIPTION
Our meson build system makes eclib optional via `meson setup -Declib=disabled`, but if you disable it, many tests will fail. The first step towards making them pass is to create a feature for eclib. Rather than add two features (one for the library and one for the mwrank executable), we instead deprecate the interface to mwrank; the library is more efficient and provides the same features.

No `# needs` tags are added at this stage, because there are so many of them that it will be a nightmare to review (https://github.com/sagemath/sage/pull/40546). We do however convert a few of the top-level imports of sage.libs.eclib.mwrank to local imports, preceded by `Eclib().require()`. This allows `pytest --doctest --collect-only` to process `src/sage/libs/eclib/interface.py` without hacks.

**Documentation shortcuts:**
* https://doc-pr-41990--sagemath.netlify.app/html/en/reference/spkg/sage/features/eclib

**Depedencies:**
* https://github.com/sagemath/sage/pull/42389