### PR TITLE
src/sage/doctest/parsing.py: hide output from lto-wrapper

### DIFF
--- a/src/sage/doctest/parsing.py
+++ b/src/sage/doctest/parsing.py
@@ -1510,6 +1510,13 @@ class SageOutputChecker(doctest.OutputChecker):
             got = dup_rpath_regex.sub('', got)
             did_fixup = True
 
+        if "lto-wrapper" in got:
+            # Messages from GCC's LTO wrapper when -flto is in CFLAGS
+            # and cython() is used non-trivially. Github issue 41991.
+            lto_wrapper_regex = re.compile("lto-wrapper: (warning|note): .*")
+            got = lto_wrapper_regex.sub('', got)
+            did_fixup = True
+
         return did_fixup, want, got
 
     def output_difference(self, example, got, optionflags):


### PR DESCRIPTION
When `-flto` is in your `CFLAGS`, the lto-wrapper program can output some messages during `cython()` that will cause the doctests to fail. Similar linker output problems have been addressed in the past with tweaks to the doctest output parser, so that's what we'll do again.

Fixes https://github.com/sagemath/sage/issues/41991