### PR TITLE
fix random doctest failure in #41999

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -599,7 +599,8 @@ class EllipticCurveHom(Morphism):
             True
             sage: E.scalar_multiplication(-1).inverse_image(P) == -P
             True
-            sage: f.inverse_image(f.codomain().0)
+            sage: Ts = [pt for pt in f.codomain() if pt.weil_pairing(f(Q), f(Q).order())**3 != 1]
+            sage: f.inverse_image(choice(Ts))
             Traceback (most recent call last):
             ...
             ValueError: ...


### PR DESCRIPTION
The codomain here has group structure $$\mathbb Z/6\times\mathbb Z/6$$, so this `.0` invocation results in a random choice of order‑6 point. Some of them do have a preimage under $$f$$. Fixes #41999.