### PR TITLE
Do not invoke GAP when cross-compiling

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -8,6 +8,13 @@ option(
   description: 'Path to SAGE_LOCAL directory (only used for compatibility with the old Sage-the-Distro',
 )
 
+option(
+  'GAP_ROOT_PATHS',
+  type: 'string',
+  value: '',
+  description: 'Semicolon-separated GAP root paths; empty uses the Sage defaults and appends detected system GAP paths when available',
+)
+
 #
 # Boolean options
 #

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -36,17 +36,28 @@ if openmp.found()
 endif
 gap_exe = find_program('gap', required: not is_windows, disabler: true)
 if gap_exe.found()
-  gaprun = run_command(
-    gap_exe,
-    '-r',
-    '-q',
-    '--bare',
-    '--nointeract',
-    '-c',
-    'Display(JoinStringsWithSeparator(GAPInfo.RootPaths,";"));',
-    check: true,
-  )
-  gap_root_paths = gaprun.stdout().strip()
+  gap_root_paths = get_option('GAP_ROOT_PATHS')
+  if gap_root_paths == ''
+    if meson.can_run_host_binaries()
+      gaprun = run_command(
+        gap_exe,
+        '-r',
+        '-q',
+        '--bare',
+        '--nointeract',
+        '-c',
+        'Display(JoinStringsWithSeparator(GAPInfo.RootPaths,";"));',
+        check: true,
+      )
+      gap_root_paths = gaprun.stdout().strip()
+    else
+      gap_root_paths = '${prefix}/lib/gap;${prefix}/share/gap'
+      message(
+        'Warning: Unable to determine system GAP root paths because host binaries cannot be run. '
+        + 'Using the default GAP_ROOT_PATHS=' + gap_root_paths + '.',
+      )
+    endif
+  endif
   conf_data.set('GAP_ROOT_PATHS', gap_root_paths)
 endif
 ecm_bin = find_program(

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -53,8 +53,7 @@ if gap_exe.found()
     else
       gap_root_paths = '${prefix}/lib/gap;${prefix}/share/gap'
       message(
-        'Warning: Unable to determine system GAP root paths because host binaries cannot be run. '
-        + 'Using the default GAP_ROOT_PATHS=' + gap_root_paths + '.',
+        'Warning: Unable to determine system GAP root paths because host binaries cannot be run. ' + 'Using the default GAP_ROOT_PATHS=' + gap_root_paths + '.',
       )
     endif
   endif


### PR DESCRIPTION
Our meson setup invokes GAP to determine some path names. However, when cross-compiling this is not always possible.

Here we allow the relevant variables to be set manually to make it easier to cross-compile SageMath.

See also #42006 for a similar PR.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes. No, I wouldn't know how to test this with reasonable effort.
- [x] I have updated the documentation and checked the documentation preview. No, I didn't update any documentation. Do we record such somewhat obscure flags somewhere?

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


