### PR TITLE
Do not invoke maxima/ECL when cross-compiling

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -15,6 +15,13 @@ option(
   description: 'Semicolon-separated GAP root paths; empty uses the Sage defaults and appends detected system GAP paths when available',
 )
 
+option(
+  'MAXIMA_FAS',
+  type: 'string',
+  value: '',
+  description: 'Location of maxima.fas; empty to locate this file automatically if possible',
+)
+
 #
 # Boolean options
 #

--- a/meson.options
+++ b/meson.options
@@ -8,6 +8,13 @@ option(
   description: 'Path to SAGE_LOCAL directory (only used for compatibility with the old Sage-the-Distro',
 )
 
+option(
+  'GAP_ROOT_PATHS',
+  type: 'string',
+  value: '',
+  description: 'Semicolon-separated GAP root paths; empty uses the Sage defaults and appends detected system GAP paths when available',
+)
+
 #
 # Boolean options
 #

--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -15,38 +15,67 @@ if not ecl.found() and not is_windows
 endif
 ecl_bin = find_program('ecl', required: false)
 if ecl_bin.found()
-  maxima_check = run_command(
-    ecl_bin,
-    '--eval',
-    '(require \'maxima)',
-    '--eval',
-    '(quit)',
-    check: false,
-  )
-  if maxima_check.returncode() == 0
-    # ecl does not have any problems with Maxima, so nothing needs to be set here:
-    conf_data.set('SAGE_MAXIMA_FAS', '')
-  else
-    # Try Sage's custom maxima location
-    sage_maxima = join_paths(
-      get_option('SAGE_LOCAL'),
-      'lib',
-      'ecl',
-      'maxima.fas',
-    )
-    maxima_check = run_command(
-      ecl_bin,
-      '--eval',
-      '(require \'maxima "' + sage_maxima + '")',
-      '--eval',
-      '(quit)',
-      check: false,
-    )
-    conf_data.set('SAGE_MAXIMA_FAS', sage_maxima)
-  endif
-
   maxima_bin = find_program('maxima', required: false, disabler: true)
-  maxima_present = maxima_check.returncode() == 0 and maxima_bin.found()
+  if maxima_bin.found()
+    maxima_fas = get_option('MAXIMA_FAS')
+
+    # Try to run maxima with the configured MAXIMA_FAS
+    if maxima_fas != ''
+      if meson.can_run_host_binaries()
+        maxima_check = run_command(
+          ecl_bin,
+          '--eval',
+          '(require \'maxima "' + maxima_fas + '")',
+          '--eval',
+          '(quit)',
+          check: false,
+        )
+        maxima_present = maxima_check.returncode() == 0
+      else
+        # We cannot execute ecl so we assume that maxima is functional
+        maxima_present = true
+      endif
+    else
+      if meson.can_run_host_binaries()
+        maxima_check = run_command(
+          ecl_bin,
+          '--eval',
+          '(require \'maxima)',
+          '--eval',
+          '(quit)',
+          check: false,
+        )
+        if maxima_check.returncode() == 0
+          # ecl does not have any problems with Maxima, so nothing needs to be set here:
+          maxima_present = true
+        else
+          # try the custom SageMath maxima.fas location
+          maxima_fas = join_paths(
+            get_option('SAGE_LOCAL'),
+            'lib',
+            'ecl',
+            'maxima.fas',
+          )
+          maxima_check = run_command(
+            ecl_bin,
+            '--eval',
+            '(require \'maxima "' + maxima_fas + '")',
+            '--eval',
+            '(quit)',
+            check: false,
+          )
+          maxima_present = maxima_check.returncode() == 0
+        endif
+      else
+        # We cannot execute ecl so we assume that maxima is functional without any special setup
+        maxima_present = true
+      endif
+    endif
+
+    conf_data.set('SAGE_MAXIMA_FAS', maxima_fas)
+  else
+    maxima_present = false
+  endif
 else
   maxima_present = false
 endif

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -36,17 +36,28 @@ if openmp.found()
 endif
 gap_exe = find_program('gap', required: not is_windows, disabler: true)
 if gap_exe.found()
-  gaprun = run_command(
-    gap_exe,
-    '-r',
-    '-q',
-    '--bare',
-    '--nointeract',
-    '-c',
-    'Display(JoinStringsWithSeparator(GAPInfo.RootPaths,";"));',
-    check: true,
-  )
-  gap_root_paths = gaprun.stdout().strip()
+  gap_root_paths = get_option('GAP_ROOT_PATHS')
+  if gap_root_paths == ''
+    if meson.can_run_host_binaries()
+      gaprun = run_command(
+        gap_exe,
+        '-r',
+        '-q',
+        '--bare',
+        '--nointeract',
+        '-c',
+        'Display(JoinStringsWithSeparator(GAPInfo.RootPaths,";"));',
+        check: true,
+      )
+      gap_root_paths = gaprun.stdout().strip()
+    else
+      gap_root_paths = '${prefix}/lib/gap;${prefix}/share/gap'
+      message(
+        'Warning: Unable to determine system GAP root paths because host binaries cannot be run. '
+        + 'Using the default GAP_ROOT_PATHS=' + gap_root_paths + '.',
+      )
+    endif
+  endif
   conf_data.set('GAP_ROOT_PATHS', gap_root_paths)
 endif
 ecm_bin = find_program(

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -53,8 +53,7 @@ if gap_exe.found()
     else
       gap_root_paths = '${prefix}/lib/gap;${prefix}/share/gap'
       message(
-        'Warning: Unable to determine system GAP root paths because host binaries cannot be run. '
-        + 'Using the default GAP_ROOT_PATHS=' + gap_root_paths + '.',
+        'Warning: Unable to determine system GAP root paths because host binaries cannot be run. ' + 'Using the default GAP_ROOT_PATHS=' + gap_root_paths + '.',
       )
     endif
   endif


### PR DESCRIPTION
When cross-compiling, it might not be possible to run the host's maxima and ecl during meson configuration.

Here we make running these host binaries optional and provide some manual overrides for meson if needed.

This is e.g. needed to build SageMath for Silicon on conda-forge, see https://github.com/conda-forge/sagelib-feedstock/pull/211.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes. No, I don't know how to check this.
- [x] I have updated the documentation and checked the documentation preview. No, I don't know if there's a special place where this should be documented. It's probably too obscure to document this.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->

#42005 which adds similar flags; it's a "dependency" because it touches the same file
