### PR TITLE
Updated Sage’s pip-based script generation path.

### DIFF
--- a/build/bin/sage-dist-helpers
+++ b/build/bin/sage-dist-helpers
@@ -404,6 +404,10 @@ sdh_actually_pip_install_wheel() {
     fi
     $sudo sage-pip-install "$@" || \
         sdh_die "Error installing $distname"
+    python3 "$SAGE_ROOT"/build/sage_bootstrap/shebang.py \
+        --distribution "$distname" \
+        --scripts-dir "${SAGE_DESTDIR}${SAGE_VENV}/bin" || \
+        sdh_die "Error rewriting shebangs for $distname"
 }
 
 sdh_pip_uninstall() {

--- a/build/sage_bootstrap/shebang.py
+++ b/build/sage_bootstrap/shebang.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Helpers for normalizing Python entrypoint shebangs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
+import sysconfig
+
+
+ENV_PYTHON3_SHEBANG = "#!/usr/bin/env python3"
+
+
+def _entrypoint_script_names(dist_name: str) -> set[str]:
+    try:
+        dist = distribution(dist_name)
+    except PackageNotFoundError:
+        return set()
+    return {
+        ep.name
+        for ep in dist.entry_points
+        if ep.group in ("console_scripts", "gui_scripts")
+    }
+
+
+def rewrite_distribution_entrypoint_shebangs(
+    dist_name: str,
+    scripts_dir: str | os.PathLike[str] | None = None,
+    shebang: str = ENV_PYTHON3_SHEBANG,
+) -> int:
+    """
+    Rewrite shebangs of a distribution's generated entrypoint scripts.
+
+    Only scripts with a Python shebang are modified.
+    """
+    scripts_path = Path(scripts_dir) if scripts_dir else Path(sysconfig.get_path("scripts"))
+    rewritten = 0
+    desired = shebang.encode("utf-8")
+    for script_name in _entrypoint_script_names(dist_name):
+        script_path = scripts_path / script_name
+        if not script_path.is_file():
+            continue
+        content = script_path.read_bytes()
+        if not content:
+            continue
+        lines = content.splitlines(keepends=True)
+        first = lines[0].rstrip(b"\r\n")
+        if not first.startswith(b"#!") or b"python" not in first.lower():
+            continue
+        if first == desired:
+            continue
+        newline = b"\n"
+        if lines[0].endswith(b"\r\n"):
+            newline = b"\r\n"
+        lines[0] = desired + newline
+        script_path.write_bytes(b"".join(lines))
+        rewritten += 1
+    return rewritten
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Rewrite Python entrypoint shebangs for one distribution.",
+    )
+    parser.add_argument("--distribution", required=True, help="Installed distribution name")
+    parser.add_argument(
+        "--scripts-dir",
+        default=None,
+        help="Directory containing generated scripts (default: interpreter scripts dir)",
+    )
+    parser.add_argument(
+        "--shebang",
+        default=ENV_PYTHON3_SHEBANG,
+        help=f"Replacement shebang (default: {ENV_PYTHON3_SHEBANG})",
+    )
+    args = parser.parse_args()
+    rewrite_distribution_entrypoint_shebangs(
+        dist_name=args.distribution,
+        scripts_dir=args.scripts_dir,
+        shebang=args.shebang,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/test/test_shebang.py
+++ b/build/test/test_shebang.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for entrypoint shebang rewriting.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sage_bootstrap.shebang import rewrite_distribution_entrypoint_shebangs
+
+
+class ShebangRewriteTestCase(unittest.TestCase):
+    def test_rewrite_entrypoint_shebang_to_env_python(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            scripts_dir = Path(tmp)
+            script = scripts_dir / "jupyter"
+            script.write_text(
+                "#!/Users/someone/build/venv/bin/python3\nprint('ok')\n",
+                encoding="utf-8",
+            )
+            untouched = scripts_dir / "nonpython"
+            untouched.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+
+            fake_dist = SimpleNamespace(
+                entry_points=[
+                    SimpleNamespace(group="console_scripts", name="jupyter"),
+                    SimpleNamespace(group="console_scripts", name="missing"),
+                ]
+            )
+            with patch("sage_bootstrap.shebang.distribution", return_value=fake_dist):
+                rewritten = rewrite_distribution_entrypoint_shebangs(
+                    "jupyter-core", scripts_dir=scripts_dir
+                )
+
+            self.assertEqual(rewritten, 1)
+            lines = script.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(lines[0], "#!/usr/bin/env python3")
+            self.assertNotIn("/Users/", lines[0])
+            self.assertEqual(
+                untouched.read_text(encoding="utf-8").splitlines()[0], "#!/bin/sh"
+            )

--- a/build/test/test_shebang.py
+++ b/build/test/test_shebang.py
@@ -1,4 +1,13 @@
 # -*- coding: utf-8 -*-
+##############################################################################
+# Copyright (C) 2024
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+##############################################################################
 """
 Tests for entrypoint shebang rewriting.
 """

--- a/build/test/test_shebang.py
+++ b/build/test/test_shebang.py
@@ -28,6 +28,7 @@ class ShebangRewriteTestCase(unittest.TestCase):
                 entry_points=[
                     SimpleNamespace(group="console_scripts", name="jupyter"),
                     SimpleNamespace(group="console_scripts", name="missing"),
+                    SimpleNamespace(group="console_scripts", name="nonpython"),
                 ]
             )
             with patch("sage_bootstrap.shebang.distribution", return_value=fake_dist):


### PR DESCRIPTION
fixes #41946 

Updated Sage’s pip-based script generation path so Python entrypoint scripts (including Jupyter) get a portable shebang at install time.

## What I changed

- Hooked script shebang normalization into install-time wheel handling

  - File: build/bin/sage-dist-helpers
  - In sdh_actually_pip_install_wheel, after successful sage-pip-install, I added:

    - a call to a new helper that rewrites shebangs for entrypoint scripts of the just-installed distribution.
    - target scripts directory: ${SAGE_DESTDIR}${SAGE_VENV}/bin (works for normal installs and staged installs).

- Added a dedicated shebang rewrite helper

  - File: build/sage_bootstrap/shebang.py
  - New function: rewrite_distribution_entrypoint_shebangs(...)

    - Looks up installed distribution entry points (console_scripts + gui_scripts) via importlib.metadata.
    - Rewrites Python shebangs to a dynamic portable form.
    - Leaves non-Python scripts untouched.

  - CLI entrypoint for build scripts:

    - python3 build/sage_bootstrap/shebang.py --distribution <dist> --scripts-dir <dir>

- Added regression test

  - File: build/test/test_shebang.py
  - Verifies:

    - a script with shebang #!/Users/.../python3 is rewritten to #!/usr/bin/env python3
    - resulting shebang has no /Users/...
    - non-Python shebang scripts are not changed

## Verification performed


- ReadLints on touched files: no lints.
- Test run:

  
  - - PYTHONPATH=build python3 -m unittest -q build.test.test_shebang ✅
  

- Full Sage test/doctest runner was not usable in this environment (ModuleNotFoundError: No module named 'sage'), so only targeted unit verification was run.


<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
