### PR TITLE
Compute GAP root paths at runtime

### DIFF
--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -10,11 +10,6 @@ VERSION = "@PACKAGE_VERSION@"
 # to it.
 SAGE_LOCAL = "@prefix@"
 
-# The semicolon-separated list of GAP root paths. This is the list of
-# locations that are searched for GAP packages. This is passed directly
-# to GAP via the -l flag.
-GAP_ROOT_PATHS = "@GAP_ROOT_PATHS@".replace("${prefix}", SAGE_LOCAL)
-
 # The path to the standalone maxima executable.
 MAXIMA = "@SAGE_MAXIMA@".replace("${prefix}", SAGE_LOCAL)
 

--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -241,12 +241,6 @@ SAGE_IMPORTALL = var("SAGE_IMPORTALL", "yes")
 SAGE_GAP_MEMORY = var('SAGE_GAP_MEMORY', None)
 SAGE_GAP_COMMAND = var('SAGE_GAP_COMMAND', None)
 
-# The semicolon-separated search path for GAP packages. It is passed
-# directly to GAP via the -l flag.
-GAP_ROOT_PATHS = var("GAP_ROOT_PATHS",
-                     ";".join([join(SAGE_LOCAL, "lib", "gap"),
-                               join(SAGE_LOCAL, "share", "gap")]))
-
 # post process
 if DOT_SAGE is not None and ' ' in DOT_SAGE:
     print("Your home directory has a space in it.  This")

--- a/src/sage/ext_data/gap/kernel-info.g
+++ b/src/sage/ext_data/gap/kernel-info.g
@@ -1,0 +1,20 @@
+# Print the GAP version, architecture, and root paths on separate
+# lines, without initializing the library. (That is, quickly.)
+#
+# Usage:
+#
+#   $ gap --systemfile kernel-info.g
+#   4.15.1
+#   riscv
+#   /home/mjo/.gap/;/usr/lib/gap/;/usr/share/gap/
+#
+KernelInfo := KERNEL_INFO();
+PRINT_TO( "*stdout*", KernelInfo.KERNEL_VERSION, "\n");
+PRINT_TO( "*stdout*", KernelInfo.GAP_ARCHITECTURE, "\n");
+p := KernelInfo.GAP_ROOT_PATHS;
+PRINT_TO( "*stdout*", p[1] );
+for i in [2 .. LENGTH(p)] do
+  PRINT_TO( "*stdout*", ";", p[i]);
+od;
+PRINT_TO( "*stdout*", "\n");
+QuitGap();

--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -206,7 +206,7 @@ import pexpect
 
 import sage.interfaces.abc
 from sage.cpython.string import bytes_to_str
-from sage.env import GAP_ROOT_PATHS, SAGE_EXTCODE, SAGE_GAP_COMMAND, SAGE_GAP_MEMORY
+from sage.env import SAGE_EXTCODE, SAGE_GAP_COMMAND, SAGE_GAP_MEMORY
 from sage.interfaces.expect import (
     Expect,
     ExpectElement,
@@ -228,7 +228,7 @@ if SAGE_GAP_COMMAND is None:
     # Passing -A allows us to use a minimal GAP installation without
     # producing errors at start-up. The files sage.g and sage.gaprc are
     # used to load any additional packages that may be available.
-    gap_cmd = f'gap -A -l "{GAP_ROOT_PATHS}"'
+    gap_cmd = "gap -A"
     if SAGE_GAP_MEMORY is not None:
         gap_cmd += " -s " + SAGE_GAP_MEMORY + " -o " + SAGE_GAP_MEMORY
 else:

--- a/src/sage/interfaces/gap_workspace.py
+++ b/src/sage/interfaces/gap_workspace.py
@@ -17,7 +17,7 @@ import os
 import time
 import hashlib
 import subprocess
-from sage.env import DOT_SAGE, HOSTNAME, GAP_ROOT_PATHS
+from sage.env import DOT_SAGE, HOSTNAME
 
 
 def gap_workspace_file(system='gap', name='workspace', dir=None):
@@ -60,15 +60,9 @@ def gap_workspace_file(system='gap', name='workspace', dir=None):
     if dir is None:
         dir = os.path.join(DOT_SAGE, 'gap')
 
-    data = f'{GAP_ROOT_PATHS}'
-    for path in GAP_ROOT_PATHS.split(";"):
-        if not path:
-            # If GAP_ROOT_PATHS begins or ends with a semicolon,
-            # we'll get one empty path.
-            continue
-        sysinfo = os.path.join(path, "sysinfo.gap")
-        if os.path.exists(sysinfo):
-            data += subprocess.getoutput(f'. "{sysinfo}" && echo ":$GAP_VERSION:$GAParch"')
+    from sage.libs.gap.util import kernel_info
+    version, arch, paths = kernel_info()
+    data = ";".join(paths + [version, arch])
     h = hashlib.sha1(data.encode('utf-8')).hexdigest()
     return os.path.join(dir, f'{system}-{name}-{HOSTNAME}-{h}')
 

--- a/src/sage/interfaces/gap_workspace.py
+++ b/src/sage/interfaces/gap_workspace.py
@@ -61,8 +61,7 @@ def gap_workspace_file(system='gap', name='workspace', dir=None):
         dir = os.path.join(DOT_SAGE, 'gap')
 
     from sage.libs.gap.util import kernel_info
-    version, arch, paths = kernel_info()
-    data = ";".join(paths + [version, arch])
+    data = ";".join(kernel_info())
     h = hashlib.sha1(data.encode('utf-8')).hexdigest()
     return os.path.join(dir, f'{system}-{name}-{HOSTNAME}-{h}')
 

--- a/src/sage/libs/gap/saved_workspace.py
+++ b/src/sage/libs/gap/saved_workspace.py
@@ -31,7 +31,7 @@ def timestamp():
     from sage.libs.gap.util import kernel_info
     libgap_dir = os.path.dirname(__file__)
     libgap_files = glob.glob(os.path.join(libgap_dir, '*'))
-    gap_roots = kernel_info()[2]
+    gap_roots = kernel_info()[2].split(";")
     gap_packages = sum( (glob.glob(os.path.join(d, 'pkg', '*'))
                          for d in gap_roots),
                         [])

--- a/src/sage/libs/gap/saved_workspace.py
+++ b/src/sage/libs/gap/saved_workspace.py
@@ -8,7 +8,6 @@ workspaces.
 
 import os
 import glob
-from sage.env import GAP_ROOT_PATHS
 from sage.interfaces.gap_workspace import gap_workspace_file
 
 
@@ -29,14 +28,13 @@ def timestamp():
         sage: type(timestamp())
         <... 'float'>
     """
+    from sage.libs.gap.util import kernel_info
     libgap_dir = os.path.dirname(__file__)
     libgap_files = glob.glob(os.path.join(libgap_dir, '*'))
-    gap_packages = []
-    for d in GAP_ROOT_PATHS.split(";"):
-        if d:
-            # If GAP_ROOT_PATHS begins or ends with a semicolon,
-            # we'll get one empty d.
-            gap_packages += glob.glob(os.path.join(d, 'pkg', '*'))
+    gap_roots = kernel_info()[2]
+    gap_packages = sum( (glob.glob(os.path.join(d, 'pkg', '*'))
+                         for d in gap_roots),
+                        [])
 
     files = libgap_files + gap_packages
     if len(files) == 0:

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -36,6 +36,60 @@ from sage.interfaces.gap_workspace import prepare_workspace_dir
 ############################################################################
 
 
+def kernel_info():
+    r"""
+    Return the GAP version, architecture, and root paths in a tuple.
+
+    The first two are used as cache keys to invalidate old workspaces
+    in :func:`sage.interfaces.gap_workspace.gap_workspace_file`. The
+    root paths are used (required) to initialize libgap. In the past
+    we computed the root paths at build-time, but that may not work if
+    (say) the build and target hosts have different libdirs.
+
+    This is fast enough that it should suffice until a more reliable
+    method is available (GAP Github issue 6252).
+
+    OUTPUT:
+
+    A tuple with three elements:
+
+    1. The GAP version (str)
+    2. The GAP architecture (str)
+    3. A list of GAP's RootPaths (list of str)
+
+    TESTS:
+
+    Confirm the claims of our ``OUTPUT`` block::
+
+        sage: from sage.libs.gap.util import kernel_info
+        sage: ki = kernel_info()
+        sage: isinstance(ki, tuple)
+        True
+        sage: len(ki) == 3
+        True
+        sage: isinstance(ki[0], str)
+        True
+        sage: isinstance(ki[1], str)
+        True
+        sage: isinstance(ki[2], list)
+        True
+        sage: all( isinstance(p, str) for p in ki[2] )
+        True
+
+    """
+    import subprocess
+    from importlib.resources import files
+    systemfile = files("sage").joinpath("ext_data/gap/kernel-info.g")
+    cmd_and_args = ["gap", "--systemfile", systemfile]
+    result = subprocess.run(cmd_and_args,
+                            capture_output=True,
+                            check=True,
+                            text=True)
+    version, arch, roots = result.stdout.strip().split("\n")
+    roots = roots.split(";")
+    return (version, arch, roots)
+
+
 cdef class ObjWrapper():
     """
     Wrapper for GAP master pointers.
@@ -232,7 +286,8 @@ cdef initialize():
     argv[0] = "sage"
     argv[1] = "-A"
     argv[2] = "-l"
-    s = str_to_bytes(sage.env.GAP_ROOT_PATHS, FS_ENCODING, "surrogateescape")
+    gap_roots = kernel_info()[2]
+    s = str_to_bytes(";".join(gap_roots), FS_ENCODING, "surrogateescape")
     argv[3] = s
 
     argv[4] = "-m"

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -38,14 +38,14 @@ from sage.interfaces.gap_workspace import prepare_workspace_dir
 
 
 @cached_function
-def kernel_info():
+def kernel_info() -> tuple[str, str, str]:
     r"""
     Return the GAP version, architecture, and root paths in a tuple.
 
     The first two are used as cache keys to invalidate old workspaces
     in :func:`sage.interfaces.gap_workspace.gap_workspace_file`. The
-    root paths are used (required) to initialize libgap. In the past
-    we computed the root paths at build-time, but that may not work if
+    root paths are required to initialize libgap. In the past we
+    computed the root paths at build-time, but that may not work if
     (say) the build and target hosts have different libdirs.
 
     This is fast enough that it should suffice until a more reliable
@@ -53,11 +53,11 @@ def kernel_info():
 
     OUTPUT:
 
-    A tuple with three elements:
+    A tuple containing three strings:
 
-    1. The GAP version (str)
-    2. The GAP architecture (str)
-    3. A list of GAP's RootPaths (list of str)
+    1. The GAP version
+    2. The GAP architecture
+    3. A semicolon-delimited list of GAP's RootPaths
 
     TESTS:
 
@@ -69,13 +69,7 @@ def kernel_info():
         True
         sage: len(ki) == 3
         True
-        sage: isinstance(ki[0], str)
-        True
-        sage: isinstance(ki[1], str)
-        True
-        sage: isinstance(ki[2], list)
-        True
-        sage: all( isinstance(p, str) for p in ki[2] )
+        sage: all( isinstance(p, str) for p in ki )
         True
 
     """
@@ -88,7 +82,6 @@ def kernel_info():
                             check=True,
                             text=True)
     version, arch, roots = result.stdout.strip().split("\n")
-    roots = roots.split(";")
     return (version, arch, roots)
 
 
@@ -289,7 +282,7 @@ cdef initialize():
     argv[1] = "-A"
     argv[2] = "-l"
     gap_roots = kernel_info()[2]
-    s = str_to_bytes(";".join(gap_roots), FS_ENCODING, "surrogateescape")
+    s = str_to_bytes(gap_roots, FS_ENCODING, "surrogateescape")
     argv[3] = s
 
     argv[4] = "-m"

--- a/src/sage/libs/gap/util.pyx
+++ b/src/sage/libs/gap/util.pyx
@@ -26,6 +26,7 @@ import sage.env
 
 from sage.libs.gap.gap_includes cimport *
 from sage.libs.gap.element cimport *
+from sage.misc.cachefunc import cached_function
 from sage.cpython.string import FS_ENCODING
 from sage.cpython.string cimport str_to_bytes, char_to_str
 from sage.interfaces.gap_workspace import prepare_workspace_dir
@@ -36,6 +37,7 @@ from sage.interfaces.gap_workspace import prepare_workspace_dir
 ############################################################################
 
 
+@cached_function
 def kernel_info():
     r"""
     Return the GAP version, architecture, and root paths in a tuple.

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -35,20 +35,6 @@ if openmp.found()
   conf_data.set('OPENMP_CXXFLAGS', '-fopenmp')
 endif
 gap_exe = find_program('gap', required: not is_windows, disabler: true)
-if gap_exe.found()
-  gaprun = run_command(
-    gap_exe,
-    '-r',
-    '-q',
-    '--bare',
-    '--nointeract',
-    '-c',
-    'Display(JoinStringsWithSeparator(GAPInfo.RootPaths,";"));',
-    check: true,
-  )
-  gap_root_paths = gaprun.stdout().strip()
-  conf_data.set('GAP_ROOT_PATHS', gap_root_paths)
-endif
 ecm_bin = find_program(
   ['ecm', 'gmp-ecm'],
   required: not is_windows,


### PR DESCRIPTION
Computing the GAP root paths at build-time is causing a lot of paper cuts:

* https://github.com/sagemath/sage/pull/42005
* https://github.com/sagemath/sage/pull/41236
* https://github.com/sagemath/sage/pull/37344
* https://github.com/sagemath/sage/issues/41101
* https://github.com/sagemath/sage/issues/37308

Until we can do it easily and reliably (https://github.com/gap-system/gap/issues/6252), this draft implements run-time detection. The idea is stolen from @tornaria who suggested  and opened a PR for it a long time ago.
