### PR TITLE
refactor: fix and enforce ruff E721

### DIFF
--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -813,7 +813,7 @@ class GhLabelSynchronizer:
         r"""
         Post a comment that the given label must not be removed any more.
         """
-        if type(item) == Status:
+        if isinstance(item, Status):
             sel_list = 'status'
         else:
             sel_list = 'priority'

--- a/.github/workflows/ruff.toml
+++ b/.github/workflows/ruff.toml
@@ -10,7 +10,6 @@ extend-ignore = [
   "PLW1510", # 18 failures, should be easy to autofix 
   "PLC3002", # 3 failures
   "PLE0302", # 3 failures
-  "E721",    # 5 failures
   "PLR0124", # 7 failures
   "PLW1508", # 8 failures
   "PLR0402", # 90 failures, should be easy to autofix

--- a/src/sage/interfaces/maxima_lib.py
+++ b/src/sage/interfaces/maxima_lib.py
@@ -1642,7 +1642,7 @@ def sr_to_max(expr):
             return EclObject(l)
         if (op in special_sage_to_max):
             return EclObject(special_sage_to_max[op](*[sr_to_max(o) for o in expr.operands()]))
-        if op == tuple:
+        if op is tuple:
             return EclObject(([mlist],
                               [sr_to_max(op) for op in expr.operands()]))
         if op not in sage_op_dict:

--- a/src/sage/interfaces/regina.py
+++ b/src/sage/interfaces/regina.py
@@ -830,7 +830,7 @@ class ReginaElement(ExtraTabCompletion, InterfaceElement):
                 if operation == '*':
                     return P(sinst * oinst)
                 return P(sinst + oinst)
-            if type(sinst) == type(oinst):
+            if type(sinst) is type(oinst):
                 if hasattr(self, 'addTermsLast'):
                     new = self.__deepcopy__()
                     new.addTermsLast(other)

--- a/src/sage/misc/mrange.py
+++ b/src/sage/misc/mrange.py
@@ -321,7 +321,7 @@ class xmrange_iter:
         self.typ = typ
 
     def __repr__(self):
-        if self.typ == list:
+        if self.typ is list:
             return 'xmrange_iter(%s)' % self.iter_list
         return 'xmrange_iter(%s, %s)' % (self.iter_list, self.typ)
 
@@ -572,7 +572,7 @@ class xmrange:
         self.typ = typ
 
     def __repr__(self):
-        if self.typ == list:
+        if self.typ is list:
             return 'xmrange(%s)' % self.sizes
         return 'xmrange(%s, %s)' % (self.sizes, self.typ)
 

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -2507,7 +2507,7 @@ def sage_getsourcelines(obj):
                             B = None
                         if B is not None and B is not obj:
                             return sage_getsourcelines(B)
-                    if obj.__class__ != type:
+                    if obj.__class__ is not type:
                         return sage_getsourcelines(obj.__class__)
                     raise err
 


### PR DESCRIPTION
Fixes of the few E721 issues, with enforcement in ruff's toml file.

Reference: https://docs.astral.sh/ruff/rules/type-comparison/.
