### PR TITLE
fix (some) coercions between PolynomialQuotientRings

### DIFF
--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -409,6 +409,12 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             sage: Q1.has_coerce_map_from(Q)
             False
             sage: Q1(Q.gen())
+            doctest:warning
+            ...
+            DeprecationWarning: Converting from a polynomial quotient ring to a larger polynomial quotient ring is not mathematically well-defined and will cease to work in a future release. Use "S(x.lift())" instead of "S(x)" to emulate the current behaviour.
+            See https://github.com/sagemath/sage/issues/42028 for details.
+            xbar
+            sage: Q1(Q.gen().lift())  # recommended replacement for the functionality that was deprecated above
             xbar
 
         Here we test against several issues discussed in :issue:`8992`::
@@ -464,10 +470,23 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             True
             sage: T(u)
             v
+            sage: S.has_coerce_map_from(T)
+            False
+            sage: S(v)  # known bug -- #42028
+            Traceback (most recent call last):
+            ...
+            TypeError: unable to convert v to an element of Univariate Quotient Polynomial Ring in u over Finite Field of size 7 with modulus x^4 + x^3
         """
         if isinstance(x, PolynomialQuotientRingElement):
             if self.has_coerce_map_from(x.parent()):
                 return self.element_class(self, x.lift(), check=True)
+            from sage.misc.superseded import deprecation
+            deprecation(42028, 'Converting from a polynomial quotient ring to a larger polynomial '
+                               'quotient ring is not mathematically well-defined and will cease to '
+                               'work in a future release. Use "S(x.lift())" instead of "S(x)" to '
+                               'emulate the current behaviour.')
+            # more reasonable behaviour (after deprecation period):
+            # raise TypeError(f'unable to convert {x!r} to an element of {self}')
         if not isinstance(x, str):
             try:
                 return self.element_class(self, self.__ring(x) , check=True)

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -371,7 +371,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
     _ideal_class_ = QuotientRing_generic._ideal_class_
 
     def _element_constructor_(self, x):
-        """
+        r"""
         Convert x into this quotient ring. Anything that can be converted into
         the polynomial ring can be converted into the quotient.
 
@@ -453,7 +453,21 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
 
             sage: Q3('x*ybar^2')
             -x
+
+        Check that conversion from one polynomial quotient ring to another
+        smaller quotient works correctly; see :issue:`42027`::
+
+            sage: R.<x> = GF(7)[]
+            sage: S.<u> = R.quotient(x^4 + x^3)
+            sage: T.<v> = R.quotient(x^3 + x^2)
+            sage: T.has_coerce_map_from(S)
+            True
+            sage: T(u)
+            v
         """
+        if isinstance(x, PolynomialQuotientRingElement):
+            if self.has_coerce_map_from(x.parent()):
+                return self.element_class(self, x.lift(), check=True)
         if not isinstance(x, str):
             try:
                 return self.element_class(self, self.__ring(x) , check=True)
@@ -476,7 +490,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
         try:
             return self.element_class(self, self.__ring(x), check=False)
         except TypeError:
-            raise TypeError("unable to convert %r to an element of %s" % (x, self))
+            raise TypeError(f'unable to convert {x!r} to an element of {self}')
 
     def _coerce_map_from_(self, R):
         r"""


### PR DESCRIPTION
See #42027: The ring homomorphism $$R[x]/(f) \to R[x]/(g)$$, which makes sense whenever $$g\mid f$$, sometimes fails to work. I've also used the opportunity to deprecate conversions in the opposite direction, which are a dangerous footgun and should thus require an explicit `.lift()` call from users.

(More generally, the code that performs such conversions seems very keen to make sense even of the most garbage inputs, which causes some very strange failures; see for example #42029. A more thorough cleanup is left as an exercise for the reader.)