### PR TITLE
Fix PolyBoRi monoid cache leak

### DIFF
--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -203,7 +203,6 @@ from sage.structure.element cimport Element
 from sage.structure.parent cimport Parent
 from sage.structure.sequence import Sequence
 from sage.structure.element import coerce_binop
-from sage.structure.unique_representation import UniqueRepresentation
 from sage.structure.richcmp cimport richcmp, richcmp_not_equal, rich_to_bool
 
 from sage.categories.action cimport Action
@@ -213,6 +212,8 @@ from sage.monoids.monoid import Monoid_class
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 
 import sage.interfaces.abc
+
+from sage.misc.classcall_metaclass import ClasscallMetaclass, typecall
 
 
 order_dict = {"lp": pblp,
@@ -1846,7 +1847,7 @@ def get_var_mapping(ring, other):
     return var_mapping
 
 
-class BooleanMonomialMonoid(UniqueRepresentation, Monoid_class):
+class BooleanMonomialMonoid(Monoid_class, metaclass=ClasscallMetaclass):
     """
     Construct a boolean monomial monoid given a boolean polynomial
     ring.
@@ -1877,6 +1878,42 @@ class BooleanMonomialMonoid(UniqueRepresentation, Monoid_class):
         True
         sage: TestSuite(M).run()
     """
+    @staticmethod
+    def __classcall__(cls, polring):
+        """
+        Return the unique boolean monomial monoid associated with
+        ``polring``.
+
+        The monoid is cached on the ring itself (as its
+        ``_monom_monoid`` attribute), which avoids the global
+        :class:`~sage.structure.unique_representation.UniqueRepresentation`
+        cache that would otherwise keep ``polring`` alive by using it
+        as part of the cache key and defeat garbage collection of
+        boolean polynomial rings (see :issue:`3299`).
+
+        TESTS::
+
+            sage: from sage.rings.polynomial.pbori.pbori import BooleanMonomialMonoid
+            sage: B.<a,b,c> = BooleanPolynomialRing(3)
+            sage: M = BooleanMonomialMonoid(B)
+            sage: BooleanMonomialMonoid(B) is M
+            True
+            sage: loads(dumps(M)) is M
+            True
+            sage: import gc, weakref
+            sage: from sage.rings.polynomial.pbori.pbori import BooleanPolynomialRing as DirectBooleanPolynomialRing
+            sage: refs = [weakref.ref(DirectBooleanPolynomialRing(4,
+            ....:          names=[f'm{k}_{i}' for i in range(4)]))
+            ....:         for k in range(5)]
+            sage: _ = gc.collect(); _ = gc.collect()
+            sage: all(w() is None for w in refs)
+            True
+        """
+        existing = polring._monom_monoid
+        if existing is not None and isinstance(existing, cls):
+            return existing
+        return typecall(cls, polring)
+
     def __init__(self, BooleanPolynomialRing polring) -> None:
         """
         Create a new boolean polynomial ring.
@@ -1902,6 +1939,20 @@ class BooleanMonomialMonoid(UniqueRepresentation, Monoid_class):
         m = new_BM(self, polring)
         m._pbmonom = PBMonom(polring._pbring)
         self._one_element = m
+
+    def __reduce__(self):
+        """
+        Support pickling.
+
+        EXAMPLES::
+
+            sage: from sage.rings.polynomial.pbori.pbori import BooleanMonomialMonoid
+            sage: P.<x,y> = BooleanPolynomialRing(2)
+            sage: M = BooleanMonomialMonoid(P)
+            sage: loads(dumps(M)) is M
+            True
+        """
+        return (BooleanMonomialMonoid, (self._ring,))
 
     def _repr_(self):
         """


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
## Summary

Fixes #3299.

This patch fixes a long-standing memory leak in the PolyBoRi interface when repeatedly creating boolean polynomial rings.

The leak came from `BooleanMonomialMonoid` inheriting from `UniqueRepresentation`. Its global cache used the underlying `BooleanPolynomialRing` as part of the cache key, which kept a strong reference to the ring. Since the ring also kept a reference to its monoid, those rings were never reclaimed, and the underlying CUDD state stayed alive indefinitely.

## What this changes

Instead of relying on the global `UniqueRepresentation` cache, `BooleanMonomialMonoid` is now made canonical through the ring itself.

The monoid is recovered from the ring-local `_monom_monoid` cache in `__classcall__`, so we still preserve the expected one-monoid-per-ring behavior without pinning rings in a global cache.

Pickling support is kept by returning the monoid from its ring during unpickling.

## Why this fixes the leak

With the global cache removed from this path, directly constructed `BooleanPolynomialRing` objects are no longer kept alive by monomial-monoid cache keys. Once all strong references to a ring are dropped, the ring and its associated CUDD data can be collected.

## Tests

I added a regression doctest that directly constructs several boolean polynomial rings, drops all strong references, runs garbage collection, and checks that the weak references are dead. This gives a stable test for the leak without depending on RSS thresholds.

I also ran:

- `./sage -t src/sage/rings/polynomial/pbori/pbori.pyx`

## Notes

In local reproduction, repeated direct construction of PolyBoRi rings no longer shows unbounded memory growth after garbage collection.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


