### PR TITLE
Build glpk as dinosaur C (-ansi)

### DIFF
--- a/build/pkgs/glpk/spkg-install.in
+++ b/build/pkgs/glpk/spkg-install.in
@@ -16,6 +16,10 @@ cp "$SAGE_ROOT"/config/config.* .
 #          (already the default):
 CPPFLAGS="-I$SAGE_LOCAL/include $CPPFLAGS"
 
+# Upstream does not belive in anything past 1990
+# https://lists.gnu.org/archive/html/bug-glpk/2025-05/msg00000.html
+CFLAGS="-ansi $CFLAGS"
+
 export CFLAGS LDFLAGS CPPFLAGS
 
 sdh_configure --with-gmp --disable-static


### PR DESCRIPTION
Boggles the mind, but upstream refuses to support modern C: https://lists.gnu.org/archive/html/bug-glpk/2025-05/msg00000.html

Glpk also bundles an outdated zlib that has been mucked with to look more like ancient C, and this fails to build with current macOS clang (`-std=gnu23`). And of course you can't configure it to use an external zlib. And the (documented) `--without-zlib` does not work. 
```
[spkg-install] /bin/bash ../libtool  --tag=CC   --mode=compile gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I..  -I. -I./amd -I./api -I./bflib -I./colamd -I./draft -I./env -I./intopt -I./minisat -I./misc -I./mpl -I./npp -I./proxy -I./simplex -I./zlib -I/Users/buildbot-sage/Sage/local/include   -g -O2 -c -o libglpk_la-adler32.lo `test -f 'zlib/adler32.c' || echo './'`zlib/adler32.c
[spkg-install] libtool: compile:  gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I.. -I. -I./amd -I./api -I./bflib -I./colamd -I./draft -I./env -I./intopt -I./minisat -I./misc -I./mpl -I./npp -I./proxy -I./simplex -I./zlib -I/Users/buildbot-sage/Sage/local/include -g -O2 -c zlib/adler32.c  -fno-common -DPIC -o .libs/libglpk_la-adler32.o
[spkg-install] zlib/adler32.c:60:23: error: unknown type name 'adler'
[spkg-install]    60 | uLong ZEXPORT adler32(adler, buf, len)
[spkg-install]       |                       ^
[spkg-install] zlib/adler32.c:60:30: error: unknown type name 'buf'
[spkg-install]    60 | uLong ZEXPORT adler32(adler, buf, len)
[spkg-install]       |                              ^
[spkg-install] zlib/adler32.c:60:35: error: unknown type name 'len'
[spkg-install]    60 | uLong ZEXPORT adler32(adler, buf, len)
[spkg-install]       |                                   ^
[spkg-install] zlib/adler32.c:60:39: error: expected ';' after top level declarator
[spkg-install]    60 | uLong ZEXPORT adler32(adler, buf, len)
[spkg-install]       |                                       ^
[spkg-install]       |                                       ;
[spkg-install] zlib/adler32.c:64:1: error: expected identifier or '('
[spkg-install]    64 | {
[spkg-install]       | ^
[spkg-install] zlib/adler32.c:131:30: error: unknown type name 'adler1'
[spkg-install]   131 | local uLong adler32_combine_(adler1, adler2, len2)
[spkg-install]       |                              ^
[spkg-install] zlib/adler32.c:131:38: error: unknown type name 'adler2'
[spkg-install]   131 | local uLong adler32_combine_(adler1, adler2, len2)
[spkg-install]       |                                      ^
[spkg-install] zlib/adler32.c:131:46: error: unknown type name 'len2'
[spkg-install]   131 | local uLong adler32_combine_(adler1, adler2, len2)
[spkg-install]       |                                              ^
[spkg-install] zlib/adler32.c:131:51: error: expected ';' after top level declarator
[spkg-install]   131 | local uLong adler32_combine_(adler1, adler2, len2)
[spkg-install]       |                                                   ^
[spkg-install]       |                                                   ;
[spkg-install] zlib/adler32.c:135:1: error: expected identifier or '('
[spkg-install]   135 | {
[spkg-install]       | ^
[spkg-install] zlib/adler32.c:155:31: error: unknown type name 'adler1'
[spkg-install]   155 | uLong ZEXPORT adler32_combine(adler1, adler2, len2)
[spkg-install]       |                               ^
[spkg-install] zlib/adler32.c:155:39: error: unknown type name 'adler2'
[spkg-install]   155 | uLong ZEXPORT adler32_combine(adler1, adler2, len2)
[spkg-install]       |                                       ^
[spkg-install] zlib/adler32.c:155:47: error: unknown type name 'len2'
[spkg-install]   155 | uLong ZEXPORT adler32_combine(adler1, adler2, len2)
[spkg-install]       |                                               ^
[spkg-install] zlib/adler32.c:155:52: error: expected ';' after top level declarator
[spkg-install]   155 | uLong ZEXPORT adler32_combine(adler1, adler2, len2)
[spkg-install]       |                                                    ^
[spkg-install]       |                                                    ;
[spkg-install] zlib/adler32.c:159:1: error: expected identifier or '('
[spkg-install]   159 | {
[spkg-install]       | ^
[spkg-install] zlib/adler32.c:163:33: error: unknown type name 'adler1'
[spkg-install]   163 | uLong ZEXPORT adler32_combine64(adler1, adler2, len2)
[spkg-install]       |                                 ^
[spkg-install] zlib/adler32.c:163:41: error: unknown type name 'adler2'
[spkg-install]   163 | uLong ZEXPORT adler32_combine64(adler1, adler2, len2)
[spkg-install]       |                                         ^
[spkg-install] zlib/adler32.c:163:49: error: unknown type name 'len2'
[spkg-install]   163 | uLong ZEXPORT adler32_combine64(adler1, adler2, len2)
[spkg-install]       |                                                 ^
[spkg-install] zlib/adler32.c:163:54: error: expected ';' after top level declarator
[spkg-install]   163 | uLong ZEXPORT adler32_combine64(adler1, adler2, len2)
[spkg-install]       |                                                      ^
[spkg-install]       |                                                      ;
[spkg-install] fatal error: too many errors emitted, stopping now [-ferror-limit=]
[spkg-install] 20 errors generated.
[spkg-install] make[7]: *** [libglpk_la-adler32.lo] Error 1
[spkg-install] make[6]: *** [all-recursive] Error 1
[spkg-install] make[5]: *** [all] Error 2
[spkg-install] ********************************************************************************
```