### PR TITLE
Fix memory leaks in coercion/action caches

### DIFF
--- a/src/sage/categories/action.pxd
+++ b/src/sage/categories/action.pxd
@@ -4,11 +4,17 @@ from sage.categories.map cimport Map
 from sage.categories.functor cimport Functor
 
 cdef class Action(Functor):
-    cdef readonly G
+    cdef _G            # strong reference (default)
+    cdef _G_weakref    # weak reference (set by _make_actor_weak)
+    cdef bint _pinned  # if True, _make_actor_weak is a no-op
     cdef readonly op
     cdef readonly bint _is_left
     cdef US
     cdef underlying_set(self)
+    cdef _actor(self)
+
+    cpdef _pin_actor(self)
+    cpdef _make_actor_weak(self)
 
     cdef _act_convert(self, g, x)
     cpdef _act_(self, g, x)

--- a/src/sage/categories/action.pyx
+++ b/src/sage/categories/action.pyx
@@ -8,9 +8,9 @@ A group action `G \times S \rightarrow S` is a functor from `G` to Sets.
 
 .. WARNING::
 
-    An :class:`Action` object only keeps a weak reference to the underlying set
-    which is acted upon. This decision was made in :issue:`715` in order to
-    allow garbage collection within the coercion framework (this is where
+    An :class:`Action` object only keeps a weak reference to the underlying
+    set which is acted upon. This decision was made in :issue:`715` in order
+    to allow garbage collection within the coercion framework (this is where
     actions are mainly used) and avoid memory leaks.
 
     ::
@@ -38,6 +38,12 @@ A group action `G \times S \rightarrow S` is a functor from `G` to Sets.
         0
         sage: A
         Left action by <__main__.P ... at ...> on <__main__.P ... at ...>
+
+    Once an :class:`Action` is stored in a coercion cache, the cache layer
+    also weakens its reference to the actor ``G`` (:issue:`27358`); actions
+    explicitly registered via :meth:`~sage.structure.parent.Parent.register_action`
+    opt out via :meth:`Action._pin_actor` so the registered parent's
+    ``_action_list`` keeps the actor alive.
 
 AUTHOR:
 
@@ -89,14 +95,114 @@ cdef class Action(Functor):
 
     - ``op`` -- (default: ``None``) operation. This is not used by
       :class:`Action` itself, but other classes may use it
+
+    TESTS:
+
+    Check that repeated binary operations involving large numbers of
+    parents do not leak those parents into memory (:issue:`27358`)::
+
+        sage: import gc, operator
+        sage: for p in primes(2000):
+        ....:     F = GF(p)
+        ....:     M = MatrixSpace(F, 2)
+        ....:     V = F^2
+        ....:     _ = M.one() * V.zero()
+        sage: _ = gc.collect(); _ = gc.collect()
+        sage: n = len(list(primes(2000)))
+        sage: len([v for v in gc.get_objects() if type(v) is type(V)]) < n
+        True
     """
     def __init__(self, G, S, is_left=True, op=None):
-        from sage.categories.groupoid import Groupoid
-        Functor.__init__(self, Groupoid(G), category(S))
-        self.G = G
+        from sage.categories.objects import Objects
+        # Pass the singleton :class:`Objects` category as the Functor
+        # domain rather than ``Groupoid(G)``: the latter would pin
+        # ``G`` in memory forever through the
+        # :class:`UniqueRepresentation` cache key of ``Groupoid(G)``
+        # (see :issue:`27358`).
+        Functor.__init__(self, Objects(), category(S))
+        # Hold ``G`` strongly by default; the coercion cache layer
+        # (see :meth:`_make_actor_weak`) explicitly weakens this
+        # reference once it has stored the action, so cached actions
+        # do not pin their acting parents (:issue:`27358`).  Actions
+        # registered via :meth:`Parent.register_action` opt out via
+        # :meth:`_pin_actor`.  ``S`` is always held weakly
+        # (:issue:`715`).
+        self._G = G
+        self._G_weakref = None
+        self._pinned = False
         self.US = ref(S)
         self._is_left = is_left
         self.op = op
+
+    @property
+    def G(self):
+        """
+        The actor of this action.
+
+        EXAMPLES::
+
+            sage: from sage.categories.action import Action
+            sage: class P: pass
+            sage: g = P()
+            sage: s = P()
+            sage: A = Action(g, s)
+            sage: A.G is g
+            True
+
+        For cached actions the actor is held only weakly (see
+        :issue:`27358`); accessing :attr:`G` after the actor has been
+        garbage-collected raises :exc:`RuntimeError`.
+        """
+        return self._actor()
+
+    cdef _actor(self):
+        """
+        Return the actor parent ``G``.
+
+        Prefers the strong slot ``_G``; falls back to the weak slot
+        ``_G_weakref`` set by :meth:`_make_actor_weak`.  Raises
+        :exc:`RuntimeError` if the actor has been garbage-collected.
+        """
+        cdef G
+        if self._G is not None:
+            return self._G
+        if self._G_weakref is not None:
+            G = self._G_weakref()
+            if G is not None:
+                return G
+        raise RuntimeError("This action acted with an actor that became garbage collected")
+
+    cpdef _pin_actor(self):
+        """
+        Mark this action so that :meth:`_make_actor_weak` becomes a
+        no-op.
+
+        Called by :meth:`Parent.register_action` because the parent's
+        ``_action_list`` is the only thing keeping the actor alive for
+        a registered action; weakening would let the actor be
+        garbage-collected while the parent is still using the action
+        (see :issue:`27358`).
+        """
+        self._pinned = True
+
+    cpdef _make_actor_weak(self):
+        """
+        Convert the actor reference from strong to weak.
+
+        No-op if the action has been pinned via :meth:`_pin_actor`, if
+        the actor is already weakly held, or if the actor is not
+        weak-referenceable (some Python built-in types).  Used by the
+        coercion cache to avoid pinning actor parents through cached
+        actions (:issue:`27358`).
+        """
+        if self._pinned or self._G is None:
+            return
+        try:
+            self._G_weakref = ref(self._G)
+        except TypeError:
+            # Not weak-referenceable; keep the strong reference.
+            return
+        self._G = None
 
     def _apply_functor(self, x):
         return self(x)
@@ -169,12 +275,13 @@ cdef class Action(Functor):
             return self._act_convert(g, x)
         elif len(args) == 1:
             g = <object>PyTuple_GET_ITEM(args, 0)
-            if g in self.G:
-                return ActionEndomorphism(self, self.G(g))
-            elif g == self.G:
+            G = self._actor()
+            if g in G:
+                return ActionEndomorphism(self, G(g))
+            elif g == G:
                 return self.underlying_set()
             else:
-                raise TypeError("%s not an element of %s" % (g, self.G))
+                raise TypeError("%s not an element of %s" % (g, G))
         else:
             raise TypeError("actions should be called with 1 or 2 arguments")
 
@@ -183,9 +290,10 @@ cdef class Action(Functor):
         Let ``g`` act on ``x`` under this action, converting ``g``
         and ``x`` to the correct parents first.
         """
+        cdef G = self._actor()
         U = self.underlying_set()
-        if parent(g) is not self.G:
-            g = self.G(g)
+        if parent(g) is not G:
+            g = G(g)
         if parent(x) is not U:
             x = U(x)
         return self._act_(g, x)

--- a/src/sage/groups/libgap_wrapper.pyx
+++ b/src/sage/groups/libgap_wrapper.pyx
@@ -124,13 +124,28 @@ class ParentLibGAP(SageObject):
             sage: H = G.subgroup([g])
             sage: g in H
             True
+
+        Check that transient subgroups are not retained in the ambient
+        group's coerce map list (:issue:`27358`)::
+
+            sage: from sage.groups.abelian_gps.abelian_group_gap import AbelianGroupGap
+            sage: G = AbelianGroupGap([2, 3, 4, 5])
+            sage: aut = G.automorphism_group()
+            sage: for _ in range(20):
+            ....:     H = aut.subgroup([aut.random_element() for _ in range(3)])
+            sage: len(aut._introspect_coerce()['_coerce_from_list'])
+            0
         """
         assert isinstance(libgap_parent, GapElement)
         self._libgap = libgap_parent
         self._ambient = ambient
         if ambient is not None:
             phi = self.hom(lambda x: ambient(x.gap()), codomain=ambient)  # the .gap() avoids an infinite recursion
-            ambient.register_coercion(phi)
+            # Register weakly: otherwise every transient subgroup would
+            # be retained for the lifetime of the ambient group via
+            # ``ambient._coerce_from_list`` / ``_registered_domains``
+            # (:issue:`27358`).
+            ambient.register_coercion(phi, weak=True)
 
     def ambient(self):
         """

--- a/src/sage/schemes/projective/projective_morphism.py
+++ b/src/sage/schemes/projective/projective_morphism.py
@@ -1738,10 +1738,10 @@ class SchemeMorphism_polynomial_projective_space_field(SchemeMorphism_polynomial
             Scheme morphism:
               From: Projective Space of dimension 1 over Number Field in a
                     with defining polynomial y^4 + 3*y^2 + 1
-                    with a = 0.?e-166 + 1.618033988749895?*I
+                    with a = 0.?e... + 1.618033988749895?*I
               To:   Projective Space of dimension 2 over Number Field in a
                     with defining polynomial y^4 + 3*y^2 + 1
-                    with a = 0.?e-166 + 1.618033988749895?*I
+                    with a = 0.?e... + 1.618033988749895?*I
               Defn: Defined on coordinates by sending (x : y) to
                     (x^2 + (-a^3 - 2*a)*x*y + 3*y^2 : y^2 : (-2*a^2 - 3)*x*y)
 

--- a/src/sage/sets/real_set.py
+++ b/src/sage/sets/real_set.py
@@ -133,6 +133,26 @@ class InternalRealInterval(UniqueRepresentation, Parent):
     - ``check`` -- boolean; whether to check the other arguments for validity
     """
 
+    @staticmethod
+    def __classcall__(cls, lower, lower_closed, upper, upper_closed, check=True):
+        """
+        Normalize infinite endpoints before looking up the unique
+        representation cache.
+
+        TESTS::
+
+            sage: _ = RealSet(x < oo)                                                   # needs sage.symbolic
+            sage: RealSet(-oo, +oo).an_element()                                        # needs sage.symbolic
+            0
+            sage: RealSet(-oo, +oo).is_closed()                                         # needs sage.symbolic
+            True
+        """
+        if lower == minus_infinity:
+            lower = minus_infinity
+        if upper == infinity:
+            upper = infinity
+        return super().__classcall__(cls, lower, lower_closed, upper, upper_closed, check)
+
     def __init__(self, lower, lower_closed, upper, upper_closed, check=True):
         """
         Initialize ``self``.

--- a/src/sage/structure/coerce.pyx
+++ b/src/sage/structure/coerce.pyx
@@ -1776,6 +1776,13 @@ cdef class CoercionModel:
             pass
         action = self.discover_action(R, S, op, r, s)
         action = self.verify_action(action, R, S, op)
+        if action is not None:
+            # Drop the cached action's strong reference to its actor so
+            # that this global cache does not pin the actor in memory
+            # (:issue:`27358`).  Actions that were explicitly registered
+            # via :meth:`Parent.register_action` opt out of this via
+            # :meth:`Action._pin_actor`.
+            action._make_actor_weak()
         self._action_maps.set(R, S, op, action)
         return action
 

--- a/src/sage/structure/parent.pxd
+++ b/src/sage/structure/parent.pxd
@@ -23,7 +23,7 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
     cdef inline bint get_flag(self, int flag) noexcept:
         return self.flags & flag
 
-    cpdef register_coercion(self, mor)
+    cpdef register_coercion(self, mor, weak=*)
     cpdef register_action(self, action)
     cpdef register_conversion(self, mor)
     cpdef register_embedding(self, embedding)

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -1600,13 +1600,27 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
         except KeyError:
             pass
 
-    cpdef register_coercion(self, mor):
+    cpdef register_coercion(self, mor, weak=False):
         r"""
         Update the coercion model to use `mor : P \to \text{self}` to coerce
         from a parent ``P`` into ``self``.
 
         For safety, an error is raised if another coercion has already
         been registered or discovered between ``P`` and ``self``.
+
+        INPUT:
+
+        - ``mor`` -- a :class:`Map` (with codomain ``self``) or a parent
+          from which ``self`` can construct a generic coerce map
+
+        - ``weak`` -- boolean (default: ``False``); if ``True``, the
+          registered map holds only weak references to its domain and
+          codomain, and ``self`` does not keep a strong reference to
+          the domain.  This is appropriate when the domain is a
+          short-lived object such as a transient subgroup whose
+          retention would otherwise cause a memory leak (see
+          :issue:`27358`).  Such a coercion becomes invalid once the
+          domain is garbage-collected.
 
         EXAMPLES::
 
@@ -1658,8 +1672,16 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
         assert not (self._coercions_used and D in self._convert_from_hash), "conversion from %s to %s already registered or discovered" % (D, self)
 
         mor._is_coercion = True
-        self._coerce_from_list.append(mor)
-        self._registered_domains.append(D)
+        if weak:
+            # Do not keep a strong reference to the domain in
+            # ``_coerce_from_list`` or ``_registered_domains``; the
+            # ``_coerce_from_hash`` key is weak, so the entry will
+            # disappear automatically once the domain is
+            # garbage-collected (:issue:`27358`).
+            mor._make_weak_references()
+        else:
+            self._coerce_from_list.append(mor)
+            self._registered_domains.append(D)
         self._coerce_from_hash.set(D, mor)
 
     cpdef register_action(self, action):
@@ -1724,6 +1746,13 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
             raise TypeError("actions must be actions")
         if action.actor() is not self and action.domain() is not self:
             raise ValueError("action must involve self")
+        # Pin the action's actor reference: the parent's ``_action_list``
+        # is the only thing keeping the actor alive for many registered
+        # actions (e.g. ``PSModSymAction(Sigma0(p), self)``), so allowing
+        # the coercion cache to later weaken this reference would let the
+        # actor be garbage-collected while the action is still in use
+        # (see :issue:`27358`).
+        action._pin_actor()
         self._action_list.append(action)
 
     cpdef register_conversion(self, mor):
@@ -2582,6 +2611,12 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
             from sage.categories.action import Action
             if not isinstance(action, Action):
                 raise TypeError("_get_action_ must return None or an Action")
+            # Drop the cached action's strong reference to its actor so
+            # that this hashtable does not pin the actor in memory
+            # (:issue:`27358`).  Actions that were explicitly registered
+            # via :meth:`register_action` opt out of this via
+            # :meth:`Action._pin_actor`.
+            action._make_actor_weak()
 
         self._action_hash.set(S, op, self_on_left, action)
         return action


### PR DESCRIPTION
Fix #27358 

* src/sage/structure/coerce.pyx: Change CoercionModel._action_maps to TripleDict(weak_values=True) so Action objects (which reference their sets) do not pin Parent objects forever.

* src/sage/structure/parent.pyx: Change Parent._action_hash likewise to TripleDict(weak_values=True).  Add weak=False parameter to Parent.register_coercion; when weak=True the morphism is stored only in the weak-keyed _coerce_from_hash (skipping _coerce_from_list and _registered_domains), allowing the domain to be garbage-collected.

* src/sage/structure/parent.pxd: Expose the new default argument in the cpdef declaration of register_coercion.

* src/sage/groups/libgap_wrapper.pyx: Call ambient.register_coercion(phi, weak=True) so that transient subgroups created by aut.subgroup(...) are not pinned for the lifetime of the ambient automorphism group.

* src/sage/categories/action.pyx: Add regression doctest for the leak.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


