### PR TITLE
stopgaps for #43043 and #43045

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3538,7 +3538,13 @@ def compute_isogeny_stark(E1, E2, ell):
     K = E1.base_field()
     R, x = PolynomialRing(K, 'x').objgen()
 
-    wp1 = E1.weierstrass_p(prec=4*ell+4)  #BMSS2006 claim 2*ell is enough, but it is not M09
+    ell = Integer(ell)
+    if ell.is_one():
+        if E1 == E2:
+            return R.one()
+        raise ValueError("the two curves are not linked by a cyclic normalized isogeny of degree 1")
+
+    wp1 = E1.weierstrass_p(prec=4*ell+4)  # [BMSS2006] claim 2*ell is enough, but it is not [M09]
     wp2 = E2.weierstrass_p(prec=4*ell+4)
 
     # viewed them as power series in Z = z^2

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3461,7 +3461,7 @@ def compute_isogeny_bmss(E1, E2, l):
         raise ValueError(f"the two curves are not linked by a cyclic normalized isogeny of degree {l}")
     Q = Q.sqrt()
     ker = Rx(Q).reverse(degree=l//2)
-    return ker.monic()
+    return ker.monic().radical()
 
 
 def compute_isogeny_stark(E1, E2, ell):
@@ -3501,22 +3501,22 @@ def compute_isogeny_stark(E1, E2, ell):
         sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import compute_isogeny_stark, compute_sequence_of_maps
 
         sage: E = EllipticCurve(GF(97), [1,0,1,1,0])
-        sage: R.<x> = GF(97)[]; f = x^5 + 27*x^4 + 61*x^3 + 58*x^2 + 28*x + 21
+        sage: R.<x> = GF(97)[]
+        sage: f = x^5 + 27*x^4 + 61*x^3 + 58*x^2 + 28*x + 21
         sage: phi = EllipticCurveIsogeny(E, f)
         sage: E2 = phi.codomain()
         sage: isom1, isom2, E1pr, E2pr, ker_poly = compute_sequence_of_maps(E, E2, 11)
         sage: compute_isogeny_stark(E1pr, E2pr, 11)
-        x^10 + 37*x^9 + 53*x^8 + 66*x^7 + 66*x^6 + 17*x^5 + 57*x^4 + 6*x^3 + 89*x^2 + 53*x + 8
+        x^5 + 67*x^4 + 13*x^3 + 35*x^2 + 77*x + 69
 
         sage: E = EllipticCurve(GF(37), [0,0,0,1,8])
         sage: R.<x> = GF(37)[]
-        sage: f = (x + 14) * (x + 30)
+        sage: f = (x + 14) * (x + 30); f
+        x^2 + 7*x + 13
         sage: phi = EllipticCurveIsogeny(E, f)
         sage: E2 = phi.codomain()
         sage: compute_isogeny_stark(E, E2, 5)
-        x^4 + 14*x^3 + x^2 + 34*x + 21
-        sage: f**2
-        x^4 + 14*x^3 + x^2 + 34*x + 21
+        x^2 + 7*x + 13
 
         sage: E = EllipticCurve(QQ, [0,0,0,1,0])
         sage: R.<x> = QQ[]
@@ -3580,9 +3580,7 @@ def compute_isogeny_stark(E1, E2, ell):
 
         T = 1/T
 
-    qn = q[n]
-    qn /= qn.leading_coefficient()
-    return qn
+    return q[n].monic().radical()
 
 
 def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
@@ -3634,7 +3632,8 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
 
     TESTS:
 
-    Check that :meth:`Polynomial.radical` is doing the right thing for us::
+    Check that :meth:`Polynomial.radical` is doing the right thing for us
+    inside this method::
 
         sage: E = EllipticCurve(GF(37), [0,0,0,1,8])
         sage: R.<x> = GF(37)[]
@@ -3643,12 +3642,8 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
         sage: E2 = phi.codomain()
         sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import compute_isogeny_stark
         sage: ker_poly = compute_isogeny_stark(E, E2, 7); ker_poly
-        x^6 + 2*x^5 + 20*x^4 + 11*x^3 + 36*x^2 + 35*x + 16
-        sage: ker_poly.factor()
-        (x + 10)^2 * (x + 12)^2 * (x + 16)^2
-        sage: poly = ker_poly.radical(); poly
         x^3 + x^2 + 28*x + 33
-        sage: poly.factor()
+        sage: ker_poly.factor()
         (x + 10) * (x + 12) * (x + 16)
 
     Check that it works even when the degree is large compared to the characteristic::
@@ -3707,7 +3702,7 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
     if algorithm == 'bmss':
         return compute_isogeny_bmss(E1, E2, ell)
     if algorithm == 'stark':
-        return compute_isogeny_stark(E1, E2, ell).radical()
+        return compute_isogeny_stark(E1, E2, ell)
 
     raise NotImplementedError(f'unknown algorithm {algorithm}')
 

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3407,6 +3407,72 @@ def compute_isogeny_bmss(E1, E2, l):
         sage: E2 = EllipticCurve(GF(167), [56, 40])
         sage: compute_isogeny_bmss(E1, E2, 13)
         x^6 + 139*x^5 + 73*x^4 + 139*x^3 + 120*x^2 + 88*x
+
+    TESTS:
+
+    A large number of tests that used to fail (see :issue:`42043`)::
+
+        sage: F = GF(53)
+        sage: E1 = EllipticCurve(F, [0, 1])
+        sage: E2 = EllipticCurve(F, [38, 22])
+        sage: compute_isogeny_bmss(E1, E2, 2)
+        x + 1
+
+    ::
+
+        sage: F = GF(53)
+        sage: E1 = EllipticCurve(F, [0, 1])
+        sage: E2 = EllipticCurve(F, [24, 42])
+        sage: compute_isogeny_bmss(E1, E2, 6)
+        x^3 + 52*x^2 + 51*x
+
+    ::
+
+        sage: F = GF(53)
+        sage: E1 = EllipticCurve(F, [0, 26])
+        sage: E2 = EllipticCurve(F, [24, 42])
+        sage: compute_isogeny_bmss(E1, E2, 2)
+        x + 50
+
+    ::
+
+        sage: F = GF(53)
+        sage: E1 = EllipticCurve(F, [40, 39])
+        sage: E2 = EllipticCurve(F, [8, 29])
+        sage: compute_isogeny_bmss(E1, E2, 2)
+        x + 40
+
+    ::
+
+        sage: F = GF(53)
+        sage: E1 = EllipticCurve(F, [40, 39])
+        sage: E2 = EllipticCurve(F, [20, 40])
+        sage: compute_isogeny_bmss(E1, E2, 4)
+        x^2 + 48*x + 2
+
+    ::
+
+        sage: F = GF(53)
+        sage: E1 = EllipticCurve(F, [13, 49])
+        sage: E2 = EllipticCurve(F, [45, 31])
+        sage: compute_isogeny_bmss(E1, E2, 2)
+        x + 34
+
+    ::
+
+        sage: F = GF(53)
+        sage: E1 = EllipticCurve(F, [20, 8])
+        sage: E2 = EllipticCurve(F, [30, 41])
+        sage: compute_isogeny_bmss(E1, E2, 2)
+        x + 9
+
+    ::
+
+        sage: F = GF(61)
+        sage: E1 = EllipticCurve(F, [1, 0])
+        sage: E2 = EllipticCurve(F, [11, 29])
+        sage: compute_isogeny_bmss(E1, E2, 2)
+        x + 11
     """
     # Original author of this function: Rémy Oudompheng.
     # https://github.com/remyoudompheng/isogeny_weber/blob/64289127a337ac1bf258b711e02fea02b7df5275/isogeny_weber/isogenies.py#L272-L332
@@ -3544,6 +3610,28 @@ def compute_isogeny_stark(E1, E2, ell):
         sage: E2 = EllipticCurve([0,-27])
         sage: E1.isogeny(None, E2, degree=3)
         Isogeny of degree 3 from Elliptic Curve defined by y^2 = x^3 + 1 over Rational Field to Elliptic Curve defined by y^2 = x^3 - 27 over Rational Field
+
+    These tests used to fail (see :issue:`42045`)::
+
+        sage: E = EllipticCurve([1, 1])
+        sage: E.isogeny(None, E, 1)
+        Isogeny of degree 1 from Elliptic Curve defined by y^2 = x^3 + x + 1 over Rational Field to Elliptic Curve defined by y^2 = x^3 + x + 1 over Rational Field
+
+    ::
+
+        sage: F = GF(67)
+        sage: E1 = EllipticCurve(F, [0, 11])
+        sage: E2 = EllipticCurve(F, [0, 7])
+        sage: compute_isogeny_stark(E1, E2, 7)
+        x^3 + 65
+
+    ::
+
+        sage: F = GF(53)
+        sage: E1 = EllipticCurve(F, [43, 52])
+        sage: E2 = EllipticCurve(F, [25, 37])
+        sage: compute_isogeny_stark(E1, E2, 5)
+        x^2 + 2*x + 39
     """
     K = E1.base_field()
     R, x = PolynomialRing(K, 'x').objgen()

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3458,10 +3458,20 @@ def compute_isogeny_bmss(E1, E2, l):
     _, Q = Rx(U).rational_reconstruction(x ** (2 * l), l, l)
     Q = Q.add_bigoh((l + 1) // 2)
     if not Q.is_square():
+        if True:  #XXX stopgap for #42043; to be fixed properly eventually
+            return compute_isogeny_stark(E1, E2, l)
         raise ValueError(f"the two curves are not linked by a cyclic normalized isogeny of degree {l}")
     Q = Q.sqrt()
     ker = Rx(Q).reverse(degree=l//2)
-    return ker.monic().radical()
+
+    ker = ker.monic().radical()
+
+    if True:  #XXX stopgap for #42043; to be fixed properly eventually
+        if (E1.division_polynomial(l, x=Rx.quotient(ker).gen())
+            or not E1.isogeny_codomain(ker).is_isomorphic(E2)):
+            return compute_isogeny_stark(E1, E2, l)
+
+    return ker
 
 
 def compute_isogeny_stark(E1, E2, ell):
@@ -3575,6 +3585,8 @@ def compute_isogeny_stark(E1, E2, ell):
 
         if n == ell+1 or T == 0:
             if T == 0 or T.valuation() < 2:
+                if True:  #XXX stopgap for #42045; to be fixed properly eventually
+                    return compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm='bruteforce')
                 raise ValueError(f"the two curves are not linked by a cyclic normalized isogeny of degree {ell}")
             break
 


### PR DESCRIPTION
...to fix #42041. The workaround is to simply fall back to slower algorithms for finding an isogeny kernel polynomial, which is not great, but arguably better than crashing.