### PR TITLE
fix "bruteforce" method in compute_isogeny_kernel_polynomial()

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3685,17 +3685,9 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
         # This is a lazy workaround; there are better algorithms
         # for most cases even when BMSS fails. See :issue:`38481`.
         for phi in E1.isogenies_degree(ell):
-            if not any(E1.a_invariants()[:3] + E2.a_invariants()[:3]):
-                # short Weierstrass
-                u = phi.scaling_factor()
-                iso = phi.codomain().isomorphism(~u)
-                if iso.codomain() == E2:
+            for iso in phi.codomain().isomorphisms(E2):
+                if (iso * phi).scaling_factor().is_one():
                     return phi.kernel_polynomial()
-            else:
-                # long Weierstrass
-                for iso in phi.codomain().isomorphisms(E2):
-                    if iso.scaling_factor().is_one():
-                        return phi.kernel_polynomial()
         raise ValueError(f"the two curves are not linked by a cyclic normalized isogeny of degree {ell}")
 
     if algorithm == 'bmss':

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3670,6 +3670,19 @@ def compute_isogeny_kernel_polynomial(E1, E2, ell, algorithm=None):
         sage: for phi in E1.isogenies_degree(5):
         ....:     E2 = phi.codomain().isomorphism(~phi.scaling_factor()).codomain()
         ....:     assert phi.kernel_polynomial() == compute_isogeny_kernel_polynomial(E1, E2, phi.degree(), algorithm='bruteforce')
+
+    Verify that it works with the ``"bruteforce"`` algorithm even when
+    the Weierstrass isomorphism from the model of the codomain curve
+    chosen by :meth:`~EllipticCurve_field.isogenies_degree` to ``E2``
+    has `\{r,s,t\}\neq\{0\}`; see :issue:`42051`::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import compute_isogeny_kernel_polynomial
+        sage: E1 = EllipticCurve([-3483, 121014])
+        sage: E2 = EllipticCurve([-275643, -61114986])
+        sage: [(phi.codomain().isomorphism_to(E2) * phi).scaling_factor() for phi in E1.isogenies_prime_degree(7)]
+        [1]
+        sage: compute_isogeny_kernel_polynomial(E1, E2, 7, algorithm='bruteforce')
+        x^3 - 81*x^2 - 2997*x + 120285
     """
     if algorithm is None:
         char = E1.base_ring().characteristic()


### PR DESCRIPTION
The brute-force search silently assumed that the isomorphism we're looking for is of the form $$(u,0,0,0)$$. That is not necessarily true, as indicated by the test added in this patch.