### PR TITLE
use expand_basis() in .abelian_group() for hyperelliptic jacobians

### DIFF
--- a/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
@@ -854,7 +854,8 @@ def _expand_basis_pgroup(p, alphas, vals, beta, h, rel):
     to the subgroup spanned jointly by the original subgroup and
     the new element.
 
-    Used as a subroutine in :func:`basis_from_generators`.
+    Used as a subroutine in :func:`basis_from_generators`
+    and :func:`expand_basis`.
 
     This function modifies ``alphas`` and ``vals`` in place.
 
@@ -970,6 +971,91 @@ def _expand_basis_pgroup(p, alphas, vals, beta, h, rel):
         vals.append(h)
     # assert all(a.order() == p**v for a,v in zip(alphas,vals))
 
+def expand_basis(gens, new_gen, ords=None, new_ord=None):
+    r"""
+    Given a basis of a subgroup `G` of some finite abelian
+    group (additively written), as well as another element
+    `g` of the group, compute and return a basis of the
+    subgroup `G + \langle g\rangle`.
+
+    .. NOTE::
+
+        A *basis* of a finite abelian group is a generating
+        set `\{g_1, \ldots, g_n\}` such that each element of the
+        group can be written as a unique linear combination
+        `\alpha_1 g_1 + \cdots + \alpha_n g_n` with each
+        `\alpha_i \in \{0, \ldots, \mathrm{ord}(g_i)-1\}`.
+
+    EXAMPLES:
+
+    The result of adding generators progressively using this
+    method matches the one-shot basis computation algorithm
+    in :func:`basis_from_generators`::
+
+        sage: from sage.groups.additive_abelian.additive_abelian_wrapper import expand_basis
+        sage: G = AdditiveAbelianGroup([15, 30, 45])
+        sage: gs = [G((1,2,3)), G((4,5,6)), G((7,7,7)), G((3,2,1))]
+        sage: H = AdditiveAbelianGroupWrapper.from_generators(gs); H
+        Additive abelian group isomorphic to Z/90 + Z/15 embedded in Additive abelian group isomorphic to Z/15 + Z/30 + Z/45
+        sage: basis = []
+        sage: for g in gs:
+        ....:     basis, orders = expand_basis(basis, g)
+        ....:     print(basis, orders)
+        [(1, 2, 3)] [15]
+        [(4, 5, 6), (8, 16, 24)] [30, 15]
+        [(4, 13, 7), (4, 20, 21)] [90, 15]
+        [(7, 19, 16), (2, 10, 33)] [90, 15]
+        sage: AdditiveAbelianGroupWrapper(G, basis, orders) == H
+        True
+    """
+    gens = list(gens)
+    if ords is None:
+        ords = [g.order() for g in gens]
+    else:
+        ords = Sequence(ords, ZZ)
+        if len(ords) != len(gens):
+            raise ValueError('ords must have the same length as gens')
+    if new_ord is None:
+        new_ord = new_gen.order()
+    else:
+        new_ord = ZZ(new_ord)
+
+    ps = sorted({p for o in ords for p in o.prime_factors()})
+
+    gammas, ms = [], []
+
+    coprime_ord = new_ord.prime_to_m_part(ZZ.prod(ps))
+    if not coprime_ord.is_one():
+        coprime_gen = new_ord // coprime_ord * new_gen
+        gammas.append(coprime_gen)
+        ms.append(coprime_ord)
+
+    for p in ps:
+        pgens = [(o.prime_to_m_part(p) * g, o.valuation(p))
+                 for g, o in zip(gens, ords) if not o % p]
+        assert pgens
+        pgens.sort(key=lambda tup: tup[1])
+        alphas, vals = map(list, zip(*pgens))
+
+        if p.divides(new_ord):
+            beta, h = new_ord.prime_to_m_part(p) * new_gen, new_ord.valuation(p)
+            e = _basis_relation_pgroup(p, alphas, vals, beta, h)
+            if e is None:
+                alphas.append(beta)
+                vals.append(h)
+            elif e[-1].valuation(p):
+                _expand_basis_pgroup(p, alphas, vals, beta, h, e)
+            assert all(vals)
+
+        for i, (v, a) in enumerate(sorted(zip(vals, alphas), reverse=True)):
+            if i < len(gammas):
+                gammas[i] += a
+                ms[i] *= p ** v
+            else:
+                gammas.append(a)
+                ms.append(p ** v)
+
+    return gammas, ms
 
 def basis_from_generators(gens, ords=None):
     r"""

--- a/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
@@ -50,6 +50,7 @@ AUTHORS:
 - David Loeffler (2010)
 - Lorenz Panny (2017): :meth:`AdditiveAbelianGroupWrapper.discrete_log`
 - Lorenz Panny (2023): :meth:`AdditiveAbelianGroupWrapper.from_generators`
+- Lorenz Panny (2026): :func:`expand_basis`, sums of :class:`AdditiveAbelianGroupWrapper` objects
 """
 
 # ****************************************************************************

--- a/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
@@ -713,6 +713,64 @@ class AdditiveAbelianGroupWrapper(addgp.AdditiveAbelianGroup_fixed_gens):
 
         return AdditiveAbelianGroupWrapper(self.universe(), newgens, newords)
 
+    def __add__(self, other):
+        r"""
+        Compute the (not necessarily direct) sum of this group
+        with another :class:`AdditiveAbelianGroupWrapper` over
+        the same :meth:`universe`.
+
+        EXAMPLES::
+
+            sage: from sage.groups.additive_abelian.additive_abelian_wrapper import expand_basis
+            sage: G = AdditiveAbelianGroup([15, 30, 45])
+            sage: gs = [G((1,2,3)), G((4,5,6)), G((7,7,7)), G((3,2,1))]
+            sage: H = AdditiveAbelianGroupWrapper.from_generators(gs); H
+            Additive abelian group isomorphic to Z/90 + Z/15 embedded in Additive abelian group isomorphic to Z/15 + Z/30 + Z/45
+            sage: Is = [AdditiveAbelianGroupWrapper.from_generators([g]) for g in gs]; Is
+            [Additive abelian group isomorphic to Z/15 embedded in Additive abelian group isomorphic to Z/15 + Z/30 + Z/45,
+             Additive abelian group isomorphic to Z/30 embedded in Additive abelian group isomorphic to Z/15 + Z/30 + Z/45,
+             Additive abelian group isomorphic to Z/90 embedded in Additive abelian group isomorphic to Z/15 + Z/30 + Z/45,
+             Additive abelian group isomorphic to Z/45 embedded in Additive abelian group isomorphic to Z/15 + Z/30 + Z/45]
+            sage: Is[0] + Is[1]
+            Additive abelian group isomorphic to Z/30 + Z/15 embedded in Additive abelian group isomorphic to Z/15 + Z/30 + Z/45
+            sage: sum(Is) == H
+            True
+
+        By a slight abuse of notation, we can also use the `+` operator
+        for adding single elements and sequences of elements to the set
+        of generators::
+
+            sage: Is[0] + gs[1] == Is[0] + Is[1]
+            True
+            sage: gs[0] + Is[1] == Is[0] + Is[1]
+            True
+            sage: Is[0] + gs[1:] == H
+            True
+            sage: gs[1:] + Is[0] == H
+            True
+        """
+        if other in self.universe():
+            other_gens = Sequence([other], self.universe())
+            other_ords = [None]
+        elif isinstance(other, (list, tuple)):
+            other_gens = Sequence(other, self.universe())
+            other_ords = [None] * len(other)
+        elif isinstance(other, AdditiveAbelianGroupWrapper):
+            if other.universe() != self.universe():
+                raise TypeError('groups to be added must have the same universe')
+            other_gens = list(other._gen_elements)
+            other_ords = list(other._gen_orders)
+        else:
+            return NotImplemented
+
+        gens, ords = self._gen_elements, self._gen_orders
+        for g, o in zip(other_gens, other_ords):
+            gens, ords = expand_basis(gens, g, ords, o)
+
+        return AdditiveAbelianGroupWrapper(self.universe(), gens, ords)
+
+    __radd__ = __add__
+
 
 def _discrete_log_pgroup(p, vals, aa, b):
     r"""

--- a/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
@@ -811,6 +811,42 @@ def _discrete_log_pgroup(p, vals, aa, b):
     return _rec(0, max(vals), b)
 
 
+def _basis_relation_pgroup(p, alphas, vals, beta, h):
+    r"""
+    Given a basis `g_1,...,g_r` of a `p`-subgroup of a finite abelian group
+    and an element `g_{r+1}` of `p`-power order, find a *relation*, i.e., a
+    non-negative integer vector `(v_1,...,v_{r+1})` such that
+    `v_1\cdot g_1+\cdots+v_{r+1} g_{r+1} = 0` and such that `v_{r+1}>0`
+    is of minimal `p`-adic valuation.
+
+    If no nontrivial relation exists, return ``None``.
+
+    EXAMPLES::
+
+        sage: from sage.groups.additive_abelian.additive_abelian_wrapper import _basis_relation_pgroup
+        sage: p = 5
+        sage: G = Zmod(p^10)^4
+        sage: vss = diagonal_matrix([1,3,3,7])
+        sage: alphas = [G([p^(10-v) for v in vs]) for vs in vss]
+        sage: vals = [alpha.order().valuation(p) for alpha in alphas]
+        sage: ws = [2,2,2,2]
+        sage: beta = G([p^(10-w) for w in ws])
+        sage: h = beta.order().valuation(p)
+        sage: rel = _basis_relation_pgroup(p, alphas, vals, beta, h); rel
+        [4, 100, 100, 62500, 5]
+        sage: sum(c * elt for c, elt in zip(rel, alphas + [beta]))
+        (0, 0, 0, 0)
+    """
+    beta_q = beta
+    for v in range(h):
+        if v:
+            beta_q *= p
+        try:
+            e = _discrete_log_pgroup(p, vals, alphas, -beta_q)
+        except ValueError:
+            continue
+        return list(e) + [p**v]
+
 def _expand_basis_pgroup(p, alphas, vals, beta, h, rel):
     r"""
     Given a basis of a `p`-subgroup of a finite abelian group
@@ -990,47 +1026,29 @@ def basis_from_generators(gens, ords=None):
     if not all(o < Infinity for o in ords):
         raise ValueError('all provided generators must have finite order')
 
-    from sage.arith.functions import lcm
-    lam = lcm(ords)
-    ps = sorted(lam.prime_factors(), key=lam.valuation)
+    ps = sorted({p for o in ords for p in o.prime_factors()})
 
     gammas = []
     ms = []
     for p in ps:
-        pgens = [(o.prime_to_m_part(p) * g, o.p_primary_part(p))
+        pgens = [(o.prime_to_m_part(p) * g, o.valuation(p))
                  for g, o in zip(gens, ords) if not o % p]
         assert pgens
         pgens.sort(key=lambda tup: tup[1])
 
-        alpha, ord_alpha = pgens.pop()
-        vals = [ord_alpha.valuation(p)]
+        alpha, val_alpha = pgens.pop()
+        vals = [val_alpha]
         alphas = [alpha]
 
         while pgens:
-            beta, ord_beta = pgens.pop()
-            try:
-                _ = _discrete_log_pgroup(p, vals, alphas, beta)
-            except ValueError:
-                pass
-            else:
-                continue
-
-            # step 4
-            val_beta = ord_beta.valuation(p)
-            beta_q = beta
-            for v in range(1, val_beta):
-                beta_q *= p
-#                assert beta_q == beta * p**v
-                try:
-                    e = _discrete_log_pgroup(p, vals, alphas, -beta_q)
-                except ValueError:
-                    continue
-                _expand_basis_pgroup(p, alphas, vals, beta, val_beta, list(e) + [p**v])
-#                assert all(a.order() == p**v for a,v in zip(alphas, vals))
-                break
-            else:
+            beta, h = pgens.pop()
+            e = _basis_relation_pgroup(p, alphas, vals, beta, h)
+            if e is None:
                 alphas.append(beta)
-                vals.append(val_beta)
+                vals.append(h)
+            elif e[-1].valuation(p):
+                _expand_basis_pgroup(p, alphas, vals, beta, h, e)
+        assert all(vals)
 
         for i, (v, a) in enumerate(sorted(zip(vals, alphas), reverse=True)):
             if i < len(gammas):
@@ -1039,9 +1057,5 @@ def basis_from_generators(gens, ords=None):
             else:
                 gammas.append(a)
                 ms.append(p ** v)
-
-#    assert len({sum(i*g for i,g in zip(vec,gammas))
-#                for vec in __import__('itertools').product(*map(range,ms))}) \
-#               == __import__('sage').misc.misc_c.prod(ms)
 
     return gammas, ms

--- a/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
@@ -749,6 +749,25 @@ class AdditiveAbelianGroupWrapper(addgp.AdditiveAbelianGroup_fixed_gens):
             True
             sage: gs[1:] + Is[0] == H
             True
+
+        TESTS:
+
+        Random testing::
+
+            sage: invs = []
+            sage: while not 1 < prod(invs) < 10^4:
+            ....:     invs = [randrange(1,100) for _ in range(randrange(1,20))]
+            sage: G = AdditiveAbelianGroup(invs)
+            sage: gs = [G.random_element() for _ in range(randrange(1,10))]
+            sage: H = AdditiveAbelianGroupWrapper.from_generators(gs)
+            sage: myH = AdditiveAbelianGroupWrapper(G, [], [])
+            sage: for _ in range(999):
+            ....:     g = H.random_element().element()
+            ....:     myH += g
+            ....:     assert myH <= H
+            ....:     if myH == H:
+            ....:         break
+            sage: assert myH == H
         """
         if other in self.universe():
             other_gens = Sequence([other], self.universe())

--- a/src/sage/schemes/hyperelliptic_curves/jacobian_homset_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/jacobian_homset_generic.py
@@ -999,16 +999,15 @@ class HyperellipticJacobianHomset(SchemeHomset_points):
         """
         n = self.order()
         g = self.curve().genus()
-        from sage.groups.additive_abelian.additive_abelian_wrapper import AdditiveAbelianGroupWrapper
-        A = AdditiveAbelianGroupWrapper(self, [], [])
+        from sage.groups.additive_abelian.additive_abelian_wrapper import expand_basis, AdditiveAbelianGroupWrapper
+        gens, ords = [], []
         for fast in (True, False):
             for _ in range(99 * g):
-                assert len(A.invariants()) <= 2 * g
-                assert A.order().divides(n)
-                if A.order() == n:
-                    return A
+                assert len(ords) <= 2 * g
+                order = product(ords)
+                assert order.divides(n)
+                if order == n:
+                    return AdditiveAbelianGroupWrapper(self, gens, ords)
                 D = self.random_element(fast=fast)
-                if D in A:
-                    continue
-                A = AdditiveAbelianGroupWrapper.from_generators(A._gen_elements + (D,))
+                gens, ords = expand_basis(gens, D, ords)
         raise RuntimeError('very unlikely event, or (more likely) bug in HyperellipticJacobianHomset.abelian_group()')


### PR DESCRIPTION
Follow-up to #41998 and #42015: We can use the new function from the latter in the new method from the former.

(This branch has #42015 merged in; only the last commit is new.)

Depends on: #42015