### PR TITLE
Indentation fix in gens documentation for #42001

### DIFF
--- a/src/sage/structure/gens_py.py
+++ b/src/sage/structure/gens_py.py
@@ -57,8 +57,8 @@ def multiplicative_iterator(M):
 
     - elements of ``M`` in a deterministic order
 
-   If not all generators have finite multiplicative order, an
-   ``ArithmeticError`` is raised.
+    If not all generators have finite multiplicative order, an
+    ``ArithmeticError`` is raised.
     """
     from sage.rings.infinity import infinity
 
@@ -117,8 +117,8 @@ def abelian_iterator(M):
 
     - elements of ``M`` in a deterministic order
 
-   If not all generators have finite additive order, an
-   ``ArithmeticError`` is raised.
+    If not all generators have finite additive order, an
+    ``ArithmeticError`` is raised.
     """
     from sage.rings.infinity import infinity
 


### PR DESCRIPTION
Applied changes suggested by @tscrim in PR #42001 

This is a follow up PR for: 
The documentation which was not properly indented in PR #42001 is fixed here.