### PR TITLE
Eliminate the valgrind workaround for pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -116,13 +116,6 @@ class SageDoctestModule(DoctestModule):
                 if self.config.getvalue("doctest_ignore_import_errors"):
                     pytest.skip("unable to import module %r" % self.path)
                 else:
-                    if isinstance(exception, ModuleNotFoundError):
-                        # Ignore some missing features/modules for now
-                        # TODO: Remove this once all optional things are using Features
-                        if exception.name == "valgrind":
-                            pytest.skip(
-                                f"unable to import module {self.path} due to missing feature {exception.name}"
-                            )
                     raise
         # Uses internal doctest module parsing mechanism.
         finder = MockAwareDocTestFinder()

--- a/src/sage/tests/memcheck/verify_no_leak.py
+++ b/src/sage/tests/memcheck/verify_no_leak.py
@@ -1,7 +1,5 @@
 from typing import Any
 from collections.abc import Callable
-import valgrind
-
 
 def verify_no_leak(callback: Callable[[], Any],
                    repeat: int = 10000,
@@ -12,6 +10,8 @@ def verify_no_leak(callback: Callable[[], Any],
 
     Raises an assertion if the callback leaks memory
     """
+    import valgrind
+
     callback()   # warm_up
     initial_blocks = (0, 0, 0, 0)
     valgrind.memcheck_do_leak_check()


### PR DESCRIPTION
We have one `.py` file that tries to `import valgrind` at the top level, causing import errors when pytest collects its doctests on a machine without valgrind. There is a workaround in `conftest.py` for this, but if we `import valgrind` inside the function that uses it, the workaround can be eliminated.