### PR TITLE
Avoid "sage" executable in tests

### DIFF
--- a/src/sage/misc/sagedoc.py
+++ b/src/sage/misc/sagedoc.py
@@ -28,7 +28,9 @@ see :issue:`12849`::
 
 Check that sphinx is not imported at Sage start-up::
 
-    sage: os.system("sage -c \"if 'sphinx' in sys.modules: sys.exit(1)\"")
+    sage: # long time
+    sage: cmd = 'if "sphinx" in sys.modules: sys.exit(1)'
+    sage: os.system(f"python3 -m sage.cli -c '{cmd}'")
     0
 """
 # ****************************************************************************

--- a/src/sage/tests/startup.py
+++ b/src/sage/tests/startup.py
@@ -16,11 +16,12 @@ as they increase the startup time. Since :issue:`23696` those are imported
 by the doctest framework via a matplotlib import. Again the simple test
 would not work (but we don't have to avoid loading IPython)::
 
+    sage: # long time
     sage: from sage.tests import check_executable
     sage: cmd = "print('numpy' in sys.modules)\n"
-    sage: print(check_executable(["sage", "-c", cmd])[0])  # long time
+    sage: print(check_executable(["python3", "-m", "sage.cli", "-c", cmd])[0])
     False
     sage: cmd = "print('pyparsing' in sys.modules)\n"
-    sage: print(check_executable(["sage", "-c", cmd])[0])  # long time
+    sage: print(check_executable(["python3", "-m", "sage.cli", "-c", cmd])[0])
     False
 """


### PR DESCRIPTION
When sagelib is installed via meson (NOT with pip), the "sage" wrapper script is not installed; instead you must start sage with "python3 -m sage.cli". We have a few tests that try to run "sage", and naturally, they fail on such an installation. This commit replaces "sage" by "python3 -m sage.cli", which should work in every sort of installation, in those tests.
