### PR TITLE
Fix FiniteField_ntl_gf2eElement.log 

### DIFF
--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -1276,6 +1276,19 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
 
         TESTS:
 
+        Check that logarithms to a base whose order is a proper divisor of
+        the unit group order are handled correctly::
+
+            sage: F.<a> = GF(2^10, impl='ntl')
+            sage: b = a^3
+            sage: b.multiplicative_order()
+            341
+            sage: x = (b^37).log(b)
+            sage: x
+            37
+            sage: b^x == b^37
+            True
+
         Check that non-existence is correctly detected::
 
             sage: g = GF(2^50).gen()

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -1319,9 +1319,15 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
             raise ValueError(f'no logarithm of {self} exists to base {base}')
 
         # Let's pass the known factorization of the order to PARI.
+        # Filter out primes that do not divide ``base_order``: PARI's
+        # ``fflog`` rejects a factorization matrix containing zero
+        # valuations (cf. the error ``incorrect type in generic
+        # discrete logarithm (order factorization)``).
         fs, = self._parent.factored_unit_order()  # cached
-        ps = pari.Col(p for p,_ in fs)
-        vs = pari.Col(base_order.valuation(p) for p,_ in fs)
+        pvs = [(p, base_order.valuation(p)) for p, _ in fs]
+        pvs = [(p, v) for p, v in pvs if v]
+        ps = pari.Col([p for p, _ in pvs])
+        vs = pari.Col([v for _, v in pvs])
         fac = pari.matconcat((ps, vs))
 
         x = pari.fflog(self, base, (base_order, fac))


### PR DESCRIPTION


PARI's fflog rejects a factorisation matrix that contains zero exponents. When base_order is a proper divisor of the field's unit-group order (2^n-1), some primes in factored_unit_order() have valuation 0 w.r.t. base_order. These are now filtered out before building the matrix, matching what fflog actually needs: only the primes that divide base_order.

Fixes: PariError 'incorrect type in generic discrete logarithm (order factorization) (t_VEC)' triggered via EllipticCurveHom.kernel_subgroup.

fixes 
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

fix #42058 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


