### PR TITLE
src/sage/symbolic: remove remaining "needs sage.foo" tags

### DIFF
--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -1193,7 +1193,7 @@ cdef class Expression(Expression_abc):
 
         EXAMPLES::
 
-            sage: gap(e + pi^2 + x^3)                                                   # needs sage.libs.gap
+            sage: gap(e + pi^2 + x^3)
             x^3 + pi^2 + e
         """
         return f'"{repr(self)}"'
@@ -1204,7 +1204,7 @@ cdef class Expression(Expression_abc):
 
         EXAMPLES::
 
-            sage: singular(e + pi^2 + x^3)                                              # needs sage.libs.singular
+            sage: singular(e + pi^2 + x^3)
             x^3 + pi^2 + e
         """
         return f'"{repr(self)}"'
@@ -8945,7 +8945,7 @@ cdef class Expression(Expression_abc):
             1/3*pi
             sage: SR(0.4).arccos()
             1.15927948072741
-            sage: plot(lambda x: SR(x).arccos(), -1,1)                                  # needs sage.plot
+            sage: plot(lambda x: SR(x).arccos(), -1,1)
             Graphics object consisting of 1 graphics primitive
 
         To prevent automatic evaluation use the ``hold`` argument::
@@ -8996,7 +8996,7 @@ cdef class Expression(Expression_abc):
             arctan(1/2)
             sage: SR(0.5).arctan()
             0.463647609000806
-            sage: plot(lambda x: SR(x).arctan(), -20,20)                                # needs sage.plot
+            sage: plot(lambda x: SR(x).arctan(), -20,20)
             Graphics object consisting of 1 graphics primitive
 
         To prevent automatic evaluation use the ``hold`` argument::
@@ -9266,7 +9266,7 @@ cdef class Expression(Expression_abc):
             0.761594155955765
             sage: maxima('tanh(1.0)')
             0.7615941559557649
-            sage: plot(lambda x: SR(x).tanh(), -1, 1)                                   # needs sage.plot
+            sage: plot(lambda x: SR(x).tanh(), -1, 1)
             Graphics object consisting of 1 graphics primitive
 
         To prevent automatic evaluation use the ``hold`` argument::
@@ -9542,7 +9542,7 @@ cdef class Expression(Expression_abc):
             0.500000000000000
             sage: math.log(0.5)
             -0.6931471805599453
-            sage: plot(lambda x: SR(x).log(), 0.1,10)                                   # needs sage.plot
+            sage: plot(lambda x: SR(x).log(), 0.1,10)
             Graphics object consisting of 1 graphics primitive
 
         To prevent automatic evaluation use the ``hold`` argument::
@@ -9591,11 +9591,11 @@ cdef class Expression(Expression_abc):
             1/6*pi^2
             sage: SR(3).zeta()
             zeta(3)
-            sage: SR(CDF(0,1)).zeta()  # abs tol 1e-16                                  # needs sage.libs.pari
+            sage: SR(CDF(0,1)).zeta()  # abs tol 1e-16
             0.003300223685324103 - 0.4181554491413217*I
-            sage: CDF(0,1).zeta()  # abs tol 1e-16                                      # needs sage.libs.pari
+            sage: CDF(0,1).zeta()  # abs tol 1e-16
             0.003300223685324103 - 0.4181554491413217*I
-            sage: plot(lambda x: SR(x).zeta(), -10,10).show(ymin=-3, ymax=3)            # needs sage.plot
+            sage: plot(lambda x: SR(x).zeta(), -10,10).show(ymin=-3, ymax=3)
 
         To prevent automatic evaluation use the ``hold`` argument::
 
@@ -9761,7 +9761,7 @@ cdef class Expression(Expression_abc):
 
         We plot the familiar plot of this log-convex function::
 
-            sage: plot(gamma(x), -6, 4).show(ymin=-3, ymax=3)                           # needs sage.plot
+            sage: plot(gamma(x), -6, 4).show(ymin=-3, ymax=3)
 
         To prevent automatic evaluation use the ``hold`` argument::
 
@@ -9823,10 +9823,10 @@ cdef class Expression(Expression_abc):
             log(24)
             sage: from sage.misc.verbose import set_verbose
             sage: set_verbose(-1)
-            sage: plot(lambda x: SR(x).log_gamma(), -7,8, plot_points=1000).show()      # needs sage.plot
+            sage: plot(lambda x: SR(x).log_gamma(), -7,8, plot_points=1000).show()
             sage: math.exp(0.5)
             1.6487212707001282
-            sage: plot(lambda x: (SR(x).exp() - SR(-x).exp())/2 - SR(x).sinh(), -1, 1)  # needs sage.plot
+            sage: plot(lambda x: (SR(x).exp() - SR(-x).exp())/2 - SR(x).sinh(), -1, 1)
             Graphics object consisting of 1 graphics primitive
 
         To prevent automatic evaluation use the ``hold`` argument::
@@ -12190,7 +12190,7 @@ cdef class Expression(Expression_abc):
 
         Root finding over finite fields::
 
-            sage: f.roots(ring=GF(7^2, 'a'))                                            # needs sage.rings.finite_rings
+            sage: f.roots(ring=GF(7^2, 'a'))
             [(3, 1), (4*a + 6, 2), (3*a + 3, 2)]
 
         TESTS::
@@ -12505,7 +12505,7 @@ cdef class Expression(Expression_abc):
         zero very close to the origin::
 
             sage: a = .004*(8*e^(-(300*t)) - 8*e^(-(1200*t)))*(720000*e^(-(300*t)) - 11520000*e^(-(1200*t))) +.004*(9600*e^(-(1200*t)) - 2400*e^(-(300*t)))^2
-            sage: show(plot(a, 0, .002), xmin=0, xmax=.002)                             # needs sage.plot
+            sage: show(plot(a, 0, .002), xmin=0, xmax=.002)
 
         It is easy to approximate with ``find_root``::
 
@@ -12650,7 +12650,7 @@ cdef class Expression(Expression_abc):
             (-3.288371361890..., 3.4257507903...)
             sage: f.find_local_minimum(1, 5, tol=1e-2, maxfun=10)
             (-3.288370845983..., 3.4250840220...)
-            sage: show(f.plot(0, 20))                                                   # needs sage.plot
+            sage: show(f.plot(0, 20))
             sage: f.find_local_minimum(1, 15)
             (-9.477294259479..., 9.5293344109...)
 
@@ -12759,46 +12759,48 @@ cdef class Expression(Expression_abc):
 
         This displays a straight line::
 
-            sage: sin(2).plot((x,0,3))                                                  # needs sage.plot
+            sage: sin(2).plot((x,0,3))
             Graphics object consisting of 1 graphics primitive
 
         This draws a red oscillatory curve::
 
-            sage: sin(x^2).plot((x,0,2*pi), rgbcolor=(1,0,0))                           # needs sage.plot
+            sage: sin(x^2).plot((x,0,2*pi), rgbcolor=(1,0,0))
             Graphics object consisting of 1 graphics primitive
 
         Another plot using the variable theta::
 
             sage: var('theta')
             theta
-            sage: (cos(theta) - erf(theta)).plot((theta,-2*pi,2*pi))                    # needs sage.plot
+            sage: (cos(theta) - erf(theta)).plot((theta,-2*pi,2*pi))
             Graphics object consisting of 1 graphics primitive
 
         A very thick green plot with a frame::
 
-            sage: sin(x).plot((x, -4*pi, 4*pi),                                         # needs sage.plot
+            sage: sin(x).plot((x, -4*pi, 4*pi),
             ....:             thickness=20, rgbcolor=(0,0.7,0)).show(frame=True)
 
         You can embed 2d plots in 3d space as follows::
 
-            sage: plot(sin(x^2), (x, -pi, pi), thickness=2).plot3d(z=1)         # long time, needs sage.plot
+            sage: # long time
+            sage: plot(sin(x^2), (x, -pi, pi), thickness=2).plot3d(z=1)
             Graphics3d Object
 
         A more complicated family::
 
-            sage: G = sum(plot(sin(n*x), (x, -2*pi, 2*pi)).plot3d(z=n)                  # needs sage.plot
+            sage: # long time
+            sage: G = sum(plot(sin(n*x), (x, -2*pi, 2*pi)).plot3d(z=n)
             ....:         for n in [0,0.1,..1])
-            sage: G.show(frame_aspect_ratio=[1,1,1/2])  # long time (5s on sage.math, 2012), needs sage.plot
+            sage: G.show(frame_aspect_ratio=[1,1,1/2])
 
         A plot involving the floor function::
 
-            sage: plot(1.0 - x * floor(1/x), (x,0.00001,1.0))                           # needs sage.plot
+            sage: plot(1.0 - x * floor(1/x), (x,0.00001,1.0))
             Graphics object consisting of 1 graphics primitive
 
         Sage used to allow symbolic functions with "no arguments";
         this no longer works::
 
-            sage: plot(2*sin, -4, 4)                                                    # needs sage.plot
+            sage: plot(2*sin, -4, 4)
             Traceback (most recent call last):
             ...
             TypeError: unsupported operand parent(s) for *:
@@ -12806,13 +12808,13 @@ cdef class Expression(Expression_abc):
 
         You should evaluate the function first::
 
-            sage: plot(2*sin(x), -4, 4)                                                 # needs sage.plot
+            sage: plot(2*sin(x), -4, 4)
             Graphics object consisting of 1 graphics primitive
 
         TESTS::
 
             sage: f(x) = x*(1 - x)
-            sage: plot(f, 0, 1)                                                         # needs sage.plot
+            sage: plot(f, 0, 1)
             Graphics object consisting of 1 graphics primitive
         """
         from sage.plot.plot import plot
@@ -12869,7 +12871,7 @@ cdef class Expression(Expression_abc):
             sage: f = s._plot_fast_callable(x)
             sage: abs(f(10) - abs((I*10+1)^4)) < 1e-11
             True
-            sage: plot(s)                                                               # needs sage.plot
+            sage: plot(s)
             Graphics object consisting of 1 graphics primitive
 
         Check that :issue:`15030` is fixed::
@@ -12877,7 +12879,7 @@ cdef class Expression(Expression_abc):
             sage: abs(log(x))._plot_fast_callable(x)(-0.2) # abs tol 1e-10
             3.52985761682672
             sage: f = function('f', evalf_func=lambda self,x,parent: I*x)
-            sage: plot(abs(f(x)), 0,5)                                                  # needs sage.plot
+            sage: plot(abs(f(x)), 0,5)
             Graphics object consisting of 1 graphics primitive
         """
         from sage.ext.fast_callable import fast_callable
@@ -13159,11 +13161,12 @@ cdef class Expression(Expression_abc):
         crash). If giac is available, you may even get a usable
         answer::
 
+            sage: # needs sage.libs.giac
             sage: f = ln(1+4/5*sin(x))
             sage: integrate(f, x, -3.1415, 3.1415)  # random, long time (:issue:`39569`)
             integrate(log(4/5*sin(x) + 1), x, -3.14150000000000,
             3.14150000000000)
-            sage: # needs sage.libs.giac
+            sage:
             sage: ans = integrate(f, x, -3.1415, 3.1415)  # random
             sage: ans  # tol 10e-6
             -1.40205228301000
@@ -13743,8 +13746,8 @@ cpdef new_Expression(parent, x):
         <class 'sage.symbolic.expression.Expression'>
         sage: a.parent()
         Symbolic Ring
-        sage: K.<a> = QuadraticField(-3)                                                # needs sage.rings.number_field
-        sage: a + sin(x)                                                                # needs sage.rings.number_field
+        sage: K.<a> = QuadraticField(-3)
+        sage: a + sin(x)
         I*sqrt(3) + sin(x)
         sage: x = var('x'); y0,y1 = PolynomialRing(ZZ,2,'y').gens()
         sage: x+y0/y1

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -13161,12 +13161,11 @@ cdef class Expression(Expression_abc):
         crash). If giac is available, you may even get a usable
         answer::
 
-            sage: # needs sage.libs.giac
             sage: f = ln(1+4/5*sin(x))
             sage: integrate(f, x, -3.1415, 3.1415)  # random, long time (:issue:`39569`)
             integrate(log(4/5*sin(x) + 1), x, -3.14150000000000,
             3.14150000000000)
-            sage:
+            sage: # needs sage.libs.giac
             sage: ans = integrate(f, x, -3.1415, 3.1415)  # random
             sage: ans  # tol 10e-6
             -1.40205228301000

--- a/src/sage/symbolic/function.pyx
+++ b/src/sage/symbolic/function.pyx
@@ -77,9 +77,9 @@ like a symbol. Setting ``nargs=0`` allows any number of arguments::
     ....:     def _eval_(self, *args):
     ....:         pass
     sage: f = Test1()
-    sage: f()                                                                           # needs sage.symbolic
+    sage: f()
     test()
-    sage: f(1,2,3)*f(1,2,3)                                                             # needs sage.symbolic
+    sage: f(1,2,3)*f(1,2,3)
     test(1, 2, 3)^2
 
 In the following the ``sin`` function of ``CBF(0)`` is called because with
@@ -97,14 +97,14 @@ is attempted, and after that ``sin()`` which succeeds::
     sage: f = Test2()
     sage: f(0)
     5
-    sage: f(0, hold=True)                                                               # needs sage.symbolic
+    sage: f(0, hold=True)
     my_sin(0)
-    sage: f(0, hold=True).n()                                                           # needs sage.rings.real_mpfr
+    sage: f(0, hold=True).n()
     3.50000000000000
-    sage: f(CBF(0))                                                                     # needs sage.libs.flint
+    sage: f(CBF(0))
     0
 
-    sage: latex(f(0, hold=True))                                                        # needs sage.symbolic
+    sage: latex(f(0, hold=True))
     \SIN\left(0\right)
     sage: f(1,2)
     Traceback (most recent call last):
@@ -185,34 +185,34 @@ cdef class Function(SageObject):
 
         EXAMPLES::
 
-            sage: f = function('f', nargs=1,  # indirect doctest                        # needs sage.symbolic
+            sage: f = function('f', nargs=1,  # indirect doctest
             ....:              conjugate_func=lambda self, x: 2r*x)
-            sage: f(2)                                                                  # needs sage.symbolic
+            sage: f(2)
             f(2)
-            sage: f(2).conjugate()                                                      # needs sage.symbolic
+            sage: f(2).conjugate()
             4
 
         TESTS::
 
             # eval_func raises exception
             sage: def ef(self, x): raise RuntimeError("foo")
-            sage: bar = function("bar", nargs=1, eval_func=ef)                          # needs sage.symbolic
-            sage: bar(x)                                                                # needs sage.symbolic
+            sage: bar = function("bar", nargs=1, eval_func=ef)
+            sage: bar(x)
             Traceback (most recent call last):
             ...
             RuntimeError: foo
 
             # eval_func returns non coercible
             sage: def ef(self, x): return ZZ
-            sage: bar = function("bar", nargs=1, eval_func=ef)                          # needs sage.symbolic
-            sage: bar(x)                                                                # needs sage.symbolic
+            sage: bar = function("bar", nargs=1, eval_func=ef)
+            sage: bar(x)
             Traceback (most recent call last):
             ...
             TypeError: function did not return a symbolic expression
             or an element that can be coerced into a symbolic expression
 
             # eval_func is not callable
-            sage: bar = function("bar", nargs=1, eval_func=5)                           # needs sage.symbolic
+            sage: bar = function("bar", nargs=1, eval_func=5)
             Traceback (most recent call last):
             ...
             ValueError: eval_func parameter must be callable
@@ -290,9 +290,9 @@ cdef class Function(SageObject):
 
         TESTS::
 
-            sage: coth(5)  # indirect doctest                                           # needs sage.symbolic
+            sage: coth(5)  # indirect doctest
             coth(5)
-            sage: coth(0.5)                                                             # needs sage.rings.real_mpfr
+            sage: coth(0.5)
             2.16395341373865
             sage: from sage.symbolic.function import BuiltinFunction
             sage: class Test(BuiltinFunction):
@@ -309,15 +309,15 @@ cdef class Function(SageObject):
             ....:         else:
             ....:             return
             sage: test = Test()
-            sage: test(1.3, 4)                                                          # needs sage.rings.real_mpfr
+            sage: test(1.3, 4)
             2.30000000000000
-            sage: test(pi, 4)                                                           # needs sage.symbolic
+            sage: test(pi, 4)
             test(pi, 4)
-            sage: test(2, x)                                                            # needs sage.symbolic
+            sage: test(2, x)
             3
-            sage: test(2., 4)                                                           # needs sage.rings.real_mpfr
+            sage: test(2., 4)
             3.00000000000000
-            sage: test(1 + 1.0*I, 2)                                                    # needs sage.symbolic
+            sage: test(1 + 1.0*I, 2)
             2.00000000000000 + 1.00000000000000*I
             sage: class Test2(BuiltinFunction):
             ....:     def __init__(self):
@@ -331,9 +331,9 @@ cdef class Function(SageObject):
             ....:         else:
             ....:             return 3
             sage: test2 = Test2()
-            sage: test2(1.3)                                                            # needs sage.rings.real_mpfr
+            sage: test2(1.3)
             0.500000000000000
-            sage: test2(pi)                                                             # needs sage.symbolic
+            sage: test2(pi)
             3
         """
         # If any of the inputs is numerical and none is symbolic,
@@ -351,10 +351,10 @@ cdef class Function(SageObject):
         """
         EXAMPLES::
 
-            sage: f = function('f', nargs=1, conjugate_func=lambda self, x: 2r*x)       # needs sage.symbolic
-            sage: f.__hash__()    # random                                              # needs sage.symbolic
+            sage: f = function('f', nargs=1, conjugate_func=lambda self, x: 2r*x)
+            sage: f.__hash__()    # random
             -2224334885124003860
-            sage: hash(f(2))      # random                                              # needs sage.symbolic
+            sage: hash(f(2))      # random
             4168614485
         """
         return hash(self._name)*(self._nargs+1)*self._serial
@@ -363,7 +363,7 @@ cdef class Function(SageObject):
         """
         EXAMPLES::
 
-            sage: foo = function("foo", nargs=2); foo                                   # needs sage.symbolic
+            sage: foo = function("foo", nargs=2); foo
             foo
         """
         return self._name
@@ -432,9 +432,9 @@ cdef class Function(SageObject):
 
         The `hold` argument prevents automatic evaluation of the function::
 
-            sage: exp(log(x))                                                           # needs sage.symbolic
+            sage: exp(log(x))
             x
-            sage: exp(log(x), hold=True)                                                # needs sage.symbolic
+            sage: exp(log(x), hold=True)
             e^log(x)
 
         We can also handle numpy types::
@@ -446,18 +446,18 @@ cdef class Function(SageObject):
         Symbolic functions evaluate non-exact input numerically, and return
         symbolic expressions on exact input, or if any input is symbolic::
 
-            sage: arctan(1)                                                             # needs sage.symbolic
+            sage: arctan(1)
             1/4*pi
-            sage: arctan(float(1))                                                      # needs sage.rings.complex_double
+            sage: arctan(float(1))
             0.7853981633974483
-            sage: type(lambert_w(SR(0)))                                                # needs sage.symbolic
+            sage: type(lambert_w(SR(0)))
             <class 'sage.symbolic.expression.Expression'>
 
         Precision of the result depends on the precision of the input::
 
-            sage: arctan(RR(1))                                                         # needs sage.rings.real_mpfr
+            sage: arctan(RR(1))
             0.785398163397448
-            sage: arctan(RealField(100)(1))                                             # needs sage.rings.real_mpfr
+            sage: arctan(RealField(100)(1))
             0.78539816339744830961566084582
 
         Return types for non-exact input depends on the input type::
@@ -472,18 +472,18 @@ cdef class Function(SageObject):
 
         Test coercion::
 
-            sage: bar(ZZ)                                                               # needs sage.symbolic
+            sage: bar(ZZ)
             Traceback (most recent call last):
             ...
             TypeError: cannot coerce arguments: ...
-            sage: exp(QQbar(I))                                                         # needs sage.rings.number_field sage.symbolic
+            sage: exp(QQbar(I))
             e^I
 
         For functions with single argument, if coercion fails we try to call
         a method with the name of the function on the object::
 
-            sage: M = matrix(SR, 2, 2, [x, 0, 0, I*pi])                                 # needs sage.modules sage.symbolic
-            sage: exp(M)                                                                # needs sage.modules sage.symbolic
+            sage: M = matrix(SR, 2, 2, [x, 0, 0, I*pi])
+            sage: exp(M)
             [e^x   0]
             [  0  -1]
 
@@ -511,7 +511,7 @@ cdef class Function(SageObject):
 
         Check that ``real_part`` and ``imag_part`` still works after :issue:`21216`::
 
-            sage: # needs numpy sage.symbolic
+            sage: # needs numpy
             sage: import numpy
             sage: a = numpy.array([1+2*I, -2-3*I], dtype=complex)
             sage: real_part(a)
@@ -560,8 +560,8 @@ cdef class Function(SageObject):
 
         EXAMPLES::
 
-            sage: foo = function("foo", nargs=2)                                        # needs sage.symbolic
-            sage: foo.name()                                                            # needs sage.symbolic
+            sage: foo = function("foo", nargs=2)
+            sage: foo.name()
             'foo'
         """
         return self._name
@@ -601,7 +601,7 @@ cdef class Function(SageObject):
 
         EXAMPLES::
 
-            sage: sin.default_variable()                                                # needs sage.symbolic
+            sage: sin.default_variable()
             x
         """
         from sage.symbolic.ring import SR
@@ -621,9 +621,9 @@ cdef class Function(SageObject):
 
             sage: [sin._is_numerical(a) for a in [5., 5.4r]]
             [True, True]
-            sage: [sin._is_numerical(a) for a in [5, pi]]                               # needs sage.symbolic
+            sage: [sin._is_numerical(a) for a in [5, pi]]
             [False, False]
-            sage: [sin._is_numerical(R(1)) for R in [RIF, CIF, RBF, CBF]]               # needs sage.libs.flint
+            sage: [sin._is_numerical(R(1)) for R in [RIF, CIF, RBF, CBF]]
             [False, False, False, False]
 
         The following calls used to yield incorrect results because intervals
@@ -643,7 +643,7 @@ cdef class Function(SageObject):
 
             sage: airy_ai(iv)
             airy_ai(1.0001?)
-            sage: airy_ai(CIF(iv))                                                      # needs sage.rings.complex_interval_field
+            sage: airy_ai(CIF(iv))
             airy_ai(1.0001?)
         """
         if isinstance(x, (float, complex)):
@@ -657,7 +657,7 @@ cdef class Function(SageObject):
         """
         EXAMPLES::
 
-             sage: sin._interface_init_(maxima)                                         # needs sage.symbolic
+             sage: sin._interface_init_(maxima)
              'sin'
         """
         if I is None:
@@ -672,7 +672,7 @@ cdef class Function(SageObject):
              'Sin'
              sage: exp._mathematica_init_()
              'Exp'
-             sage: (exp(x) + sin(x) + tan(x))._mathematica_init_()                      # needs sage.symbolic
+             sage: (exp(x) + sin(x) + tan(x))._mathematica_init_()
              '(Exp[x])+(Sin[x])+(Tan[x])'
         """
         s = self._conversions.get('mathematica', None)
@@ -688,7 +688,7 @@ cdef class Function(SageObject):
             sage: g = SymbolicFunction('g', conversions=dict(sympy='gg'))
             sage: g._sympy_init_()
             'gg'
-            sage: g(x)._sympy_()                                                        # needs sage.symbolic
+            sage: g(x)._sympy_()
             gg(x)
         """
         return self._conversions.get('sympy', self._name)
@@ -834,11 +834,11 @@ cdef class GinacFunction(BuiltinFunction):
 
             sage: from sage.functions.trig import Function_sin
             sage: s = Function_sin()  # indirect doctest
-            sage: s(0)                                                                  # needs sage.symbolic
+            sage: s(0)
             0
-            sage: s(pi)                                                                 # needs sage.symbolic
+            sage: s(pi)
             0
-            sage: s(pi/2)                                                               # needs sage.symbolic
+            sage: s(pi/2)
             1
         """
         self._ginac_name = ginac_name
@@ -885,7 +885,7 @@ cdef class BuiltinFunction(Function):
 
             sage: from sage.functions.trig import Function_cot
             sage: c = Function_cot()  # indirect doctest
-            sage: c(pi/2)                                                               # needs sage.symbolic
+            sage: c(pi/2)
             0
         """
         self._preserved_arg = 0 if preserved_arg is None else preserved_arg
@@ -942,7 +942,7 @@ cdef class BuiltinFunction(Function):
 
         EXAMPLES::
 
-            sage: exp(5)                                                                # needs sage.symbolic
+            sage: exp(5)
             e^5
             sage: gamma(15)
             87178291200
@@ -1117,10 +1117,10 @@ cdef class BuiltinFunction(Function):
             ....:       def _eval_(self, arg):
             ....:               return arg**self.exponent
             sage: p2 = AFunction('p2', 2)
-            sage: p2(x)                                                                 # needs sage.symbolic
+            sage: p2(x)
             x^2
             sage: p3 = AFunction('p3', 3)
-            sage: p3(x)                                                                 # needs sage.symbolic
+            sage: p3(x)
             x^3
             sage: loads(dumps(cot)) == cot  # Issue #15138
             True
@@ -1164,7 +1164,7 @@ cdef class BuiltinFunction(Function):
             (<class 'sage.functions.trig.Function_cot'>, ())
 
             sage: f = loads(dumps(cot)) #indirect doctest
-            sage: f(pi/2)                                                               # needs sage.symbolic
+            sage: f(pi/2)
             0
         """
         return self.__class__, tuple()
@@ -1211,11 +1211,11 @@ cdef class SymbolicFunction(Function):
             sage: foo = my_function()
             sage: foo
             foo
-            sage: foo(2, 3)                                                             # needs sage.symbolic
+            sage: foo(2, 3)
             foo(2, 3)
-            sage: foo(2, 3).n()                                                         # needs sage.rings.real_mpfr
+            sage: foo(2, 3).n()
             12.0000000000000
-            sage: foo(2, 3).conjugate()                                                 # needs sage.symbolic
+            sage: foo(2, 3).conjugate()
             2
         """
         self.__hinit = False
@@ -1255,13 +1255,13 @@ cdef class SymbolicFunction(Function):
         """
         TESTS::
 
-            sage: foo = function("foo", nargs=2)                                        # needs sage.symbolic
-            sage: hash(foo)      # random output                                        # needs sage.symbolic
+            sage: foo = function("foo", nargs=2)
+            sage: hash(foo)      # random output
             -6859868030555295348
 
             sage: def ev(self, x): return 2*x
-            sage: foo = function("foo", nargs=2, eval_func=ev)                          # needs sage.symbolic
-            sage: hash(foo)      # random output                                        # needs sage.symbolic
+            sage: foo = function("foo", nargs=2, eval_func=ev)
+            sage: hash(foo)      # random output
             -6859868030555295348
         """
         return self._serial*self._hash_()
@@ -1314,8 +1314,8 @@ cdef class SymbolicFunction(Function):
             foo(x, y)
 
             sage: def ev(self, x, y): return 2*x
-            sage: foo = function("foo", nargs=2, eval_func=ev)                          # needs sage.symbolic
-            sage: foo.__getstate__()                                                    # needs sage.symbolic
+            sage: foo = function("foo", nargs=2, eval_func=ev)
+            sage: foo.__getstate__()
             (2, 'foo', 2, None, {}, True,
              [..., None, None, None, None, None, None, None, None, None, None])
 
@@ -1328,8 +1328,8 @@ cdef class SymbolicFunction(Function):
             2*y
 
             sage: def evalf_f(self, x, **kwds): return int(6)
-            sage: foo = function("foo", nargs=1, evalf_func=evalf_f)                    # needs sage.symbolic
-            sage: foo.__getstate__()                                                    # needs sage.symbolic
+            sage: foo = function("foo", nargs=1, evalf_func=evalf_f)
+            sage: foo.__getstate__()
             (2, 'foo', 1, None, {}, True,
              [None, ..., None, None, None, None, None, None, None, None, None])
 
@@ -1345,11 +1345,11 @@ cdef class SymbolicFunction(Function):
 
         Test pickling expressions with symbolic functions::
 
-            sage: u = loads(dumps(foo(x)^2 + foo(y) + x^y)); u                          # needs sage.symbolic
+            sage: u = loads(dumps(foo(x)^2 + foo(y) + x^y)); u
             foo(x)^2 + x^y + foo(y)
-            sage: u.subs(y=0)                                                           # needs sage.symbolic
+            sage: u.subs(y=0)
             foo(x)^2 + foo(0) + 1
-            sage: u.subs(y=0).n()                                                       # needs sage.symbolic
+            sage: u.subs(y=0).n()
             43.0000000000000
 
         Check that :issue:`40292` is fixed::
@@ -1396,9 +1396,9 @@ cdef class SymbolicFunction(Function):
         Note that the other direction doesn't work here, since ``foo._hash_()``
         hash already been initialized.::
 
-            sage: bar                                                                   # needs sage.symbolic
+            sage: bar
             foo
-            sage: bar(x, y)                                                             # needs sage.symbolic
+            sage: bar(x, y)
             foo(x, y)
         """
         # check input

--- a/src/sage/symbolic/pynac.pxi
+++ b/src/sage/symbolic/pynac.pxi
@@ -3,7 +3,7 @@ Declarations for pynac, a Python frontend for ginac
 
 Check that we can externally cimport this (:issue:`18825`)::
 
-    sage: cython(                                                                       # needs sage.misc.cython
+    sage: cython(
     ....: '''
     ....: cimport sage.symbolic.expression
     ....: ''')

--- a/src/sage/symbolic/symbols.py
+++ b/src/sage/symbolic/symbols.py
@@ -34,8 +34,8 @@ def register_symbol(obj, conversions, nargs=None):
     EXAMPLES::
 
         sage: from sage.symbolic.symbols import register_symbol as rs
-        sage: rs(SR(5), {'maxima': 'five'})                                             # needs sage.symbolic
-        sage: SR(maxima_calculus('five'))                                               # needs sage.symbolic
+        sage: rs(SR(5), {'maxima': 'five'})
+        sage: SR(maxima_calculus('five'))
         5
     """
     conversions = dict(conversions)


### PR DESCRIPTION
These are unmaintained and do nothing for the upstream Sage library. We leave sage.libs.giac since it tests for the presence of the sagemath-giac package.
