### PR TITLE
src/sage/geometry: remove remaining "needs sage.foo" tags

### DIFF
--- a/src/sage/geometry/abc.pyx
+++ b/src/sage/geometry/abc.pyx
@@ -13,13 +13,13 @@ class LatticePolytope:
     EXAMPLES::
 
         sage: import sage.geometry.abc
-        sage: P = LatticePolytope([(1,2,3), (4,5,6)])                                   # needs sage.geometry.polyhedron
-        sage: isinstance(P, sage.geometry.abc.LatticePolytope)                          # needs sage.geometry.polyhedron
+        sage: P = LatticePolytope([(1,2,3), (4,5,6)])
+        sage: isinstance(P, sage.geometry.abc.LatticePolytope)
         True
 
     By design, there is a unique direct subclass::
 
-        sage: sage.geometry.abc.LatticePolytope.__subclasses__()                        # needs sage.geometry.polyhedron
+        sage: sage.geometry.abc.LatticePolytope.__subclasses__()
         [<class 'sage.geometry.lattice_polytope.LatticePolytopeClass'>]
 
         sage: len(sage.geometry.abc.Polyhedron.__subclasses__()) <= 1
@@ -39,13 +39,13 @@ class ConvexRationalPolyhedralCone:
     EXAMPLES::
 
         sage: import sage.geometry.abc
-        sage: C = cones.nonnegative_orthant(2)                                          # needs sage.geometry.polyhedron
-        sage: isinstance(C, sage.geometry.abc.ConvexRationalPolyhedralCone)             # needs sage.geometry.polyhedron
+        sage: C = cones.nonnegative_orthant(2)
+        sage: isinstance(C, sage.geometry.abc.ConvexRationalPolyhedralCone)
         True
 
     By design, there is a unique direct subclass::
 
-        sage: sage.geometry.abc.ConvexRationalPolyhedralCone.__subclasses__()           # needs sage.geometry.polyhedron
+        sage: sage.geometry.abc.ConvexRationalPolyhedralCone.__subclasses__()
         [<class 'sage.geometry.cone.ConvexRationalPolyhedralCone'>]
 
         sage: len(sage.geometry.abc.Polyhedron.__subclasses__()) <= 1
@@ -65,13 +65,13 @@ class Polyhedron:
     EXAMPLES::
 
         sage: import sage.geometry.abc
-        sage: P = polytopes.cube()                                                      # needs sage.geometry.polyhedron
-        sage: isinstance(P, sage.geometry.abc.Polyhedron)                               # needs sage.geometry.polyhedron
+        sage: P = polytopes.cube()
+        sage: isinstance(P, sage.geometry.abc.Polyhedron)
         True
 
     By design, there is a unique direct subclass::
 
-        sage: sage.geometry.abc.Polyhedron.__subclasses__()                             # needs sage.geometry.polyhedron
+        sage: sage.geometry.abc.Polyhedron.__subclasses__()
         [<class 'sage.geometry.polyhedron.base0.Polyhedron_base0'>]
 
         sage: len(sage.geometry.abc.Polyhedron.__subclasses__()) <= 1

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -539,9 +539,9 @@ def _ambient_space_point(body, data):
         (1, 1/3)
         sage: _ambient_space_point(c, vector(QQ,[1,1/3]))
         (1, 1/3)
-        sage: _ambient_space_point(c, [1/2, 1/sqrt(3)])                                 # needs sage.rings.number_field sage.symbolic
+        sage: _ambient_space_point(c, [1/2, 1/sqrt(3)])
         (1/2, 0.5773502691896258?)
-        sage: _ambient_space_point(c, vector(AA, [1/2, 1/sqrt(3)]))                     # needs sage.rings.number_field sage.symbolic
+        sage: _ambient_space_point(c, vector(AA, [1/2, 1/sqrt(3)]))
         (1/2, 0.5773502691896258?)
         sage: _ambient_space_point(c, [1,1,3])
         Traceback (most recent call last):
@@ -559,9 +559,9 @@ def _ambient_space_point(body, data):
 
         sage: from sage.geometry.cone import _ambient_space_point
         sage: c = Cone([(1,0), (0,1)])
-        sage: _ambient_space_point(c, [1, pi])                                          # needs sage.rings.number_field sage.symbolic
+        sage: _ambient_space_point(c, [1, pi])
         (1.00000000000000, 3.14159265358979)
-        sage: _ambient_space_point(c, vector(SR,[1, pi]))                               # needs sage.rings.number_field sage.symbolic
+        sage: _ambient_space_point(c, vector(SR,[1, pi]))
         (1.00000000000000, 3.14159265358979)
     """
     L = body.lattice()
@@ -970,7 +970,7 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
             sage: c = Cone([(1,0)])
             sage: c.ambient_vector_space()
             Vector space of dimension 2 over Rational Field
-            sage: c.ambient_vector_space(AA)                                            # needs sage.rings.number_field
+            sage: c.ambient_vector_space(AA)
             Vector space of dimension 2 over Algebraic Real Field
         """
         return self.lattice().vector_space(base_field=base_field)
@@ -1059,7 +1059,7 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
         EXAMPLES::
 
             sage: quadrant = Cone([(1,0), (0,1)])
-            sage: quadrant.plot()                                                       # needs sage.plot sage.symbolic
+            sage: quadrant.plot()
             Graphics object consisting of 9 graphics primitives
         """
         tp = ToricPlotter(options, self.lattice().degree(), self.rays())
@@ -1565,7 +1565,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         TESTS::
 
             sage: C = Cone([(1,0)])
-            sage: C.face_lattice()                                                      # needs sage.combinat sage.graphs
+            sage: C.face_lattice()
             Finite lattice containing 2 elements with distinguished linear extension
             sage: C._test_pickling()
             sage: C2 = loads(dumps(C)); C2
@@ -1638,17 +1638,17 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         We can test vectors with irrational components::
 
             sage: c = Cone([(1,0), (0,1)])
-            sage: c._contains((1, sqrt(2)))                                             # needs sage.symbolic
+            sage: c._contains((1, sqrt(2)))
             True
-            sage: c._contains(vector(SR, [1, pi]))                                      # needs sage.symbolic
+            sage: c._contains(vector(SR, [1, pi]))
             True
 
         Ensure that complex vectors are not contained in a real cone::
 
             sage: c = Cone([(1,0), (0,1)])
-            sage: c._contains((1,I))                                                    # needs sage.symbolic
+            sage: c._contains((1,I))
             False
-            sage: c._contains(vector(QQbar, [1,I]))                                     # needs sage.rings.number_field sage.symbolic
+            sage: c._contains(vector(QQbar, [1,I]))
             False
 
         And we refuse to coerce elements of another lattice into ours::
@@ -1932,7 +1932,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: quadrant = Cone([(1,0), (0,1)])
             sage: quadrant._latex_()
             '\\sigma^{2}'
-            sage: quadrant.facets()[0]._latex_()                                        # needs sage.graphs
+            sage: quadrant.facets()[0]._latex_()
             '\\sigma^{1} \\subset \\sigma^{2}'
         """
         if self.ambient() is self:
@@ -1953,7 +1953,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             '2-d cone in 2-d lattice N'
             sage: quadrant
             2-d cone in 2-d lattice N
-            sage: quadrant.facets()[0]                                                  # needs sage.graphs
+            sage: quadrant.facets()[0]
             1-d face of 2-d cone in 2-d lattice N
         """
         result = "%d-d" % self.dim()
@@ -2007,7 +2007,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
             sage: octant = Cone(identity_matrix(3).columns())
             sage: # indirect doctest
-            sage: for i, face in enumerate(octant.faces(1)):                            # needs sage.graphs
+            sage: for i, face in enumerate(octant.faces(1)):
             ....:     if face.ray(0) != octant.ray(i):
             ....:         print("Wrong order!")
         """
@@ -2065,7 +2065,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: fan = Fan(cones=[(0,1), (1,2)],
             ....:           rays=[(1,0), (0,1), (-1,0)])
             sage: cone = fan.generating_cone(0)
-            sage: len(cone.adjacent())                                                  # needs sage.graphs
+            sage: len(cone.adjacent())
             1
 
         The second generating cone is adjacent to this one. Now we create the
@@ -2074,7 +2074,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: fan = Fan(cones=[(0,1), (1,2)],
             ....:           rays=[(1,0,0), (0,1,0), (-1,0,0)])
             sage: cone = fan.generating_cone(0)
-            sage: len(cone.adjacent())                                                  # needs sage.graphs
+            sage: len(cone.adjacent())
             1
 
         The result is as before, since we still have::
@@ -2087,7 +2087,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: fan = Fan(cones=[(0,1), (1,2), (3,)],
             ....:           rays=[(1,0,0), (0,1,0), (-1,0,0), (0,0,1)])
             sage: cone = fan.generating_cone(0)
-            sage: len(cone.adjacent())                                                  # needs sage.graphs
+            sage: len(cone.adjacent())
             0
 
         Since now ``cone`` has smaller dimension than ``fan``, it and its
@@ -2149,7 +2149,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: quadrant = Cone([(1,0), (0,1)])
             sage: quadrant.ambient_ray_indices()
             (0, 1)
-            sage: quadrant.facets()[1].ambient_ray_indices()                            # needs sage.graphs
+            sage: quadrant.facets()[1].ambient_ray_indices()
             (1,)
         """
         return self._ambient_ray_indices
@@ -2188,9 +2188,9 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             False
             sage: c.contains(1)
             False
-            sage: c.contains(1/2, sqrt(3))                                              # needs sage.symbolic
+            sage: c.contains(1/2, sqrt(3))
             True
-            sage: c.contains(-1/2, sqrt(3))                                             # needs sage.symbolic
+            sage: c.contains(-1/2, sqrt(3))
             False
         """
         point = flatten(args)
@@ -2310,7 +2310,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             1-d cone in 3-d lattice N
             sage: ray.ambient_ray_indices()
             (0,)
-            sage: ray.adjacent()                                                        # needs sage.graphs
+            sage: ray.adjacent()
             ()
             sage: ray.ambient()
             1-d cone in 3-d lattice N
@@ -2343,7 +2343,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             ...
             ValueError: 1-d cone in 3-d lattice N is not a face
             of 3-d cone in 3-d lattice N!
-            sage: c.embed(Cone([(1,0,1), (-1,0,1)]))                                    # needs sage.graphs
+            sage: c.embed(Cone([(1,0,1), (-1,0,1)]))
             Traceback (most recent call last):
             ...
             ValueError: 2-d cone in 3-d lattice N is not a face
@@ -2388,13 +2388,13 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         Let's take a look at the face lattice of the first quadrant::
 
             sage: quadrant = Cone([(1,0), (0,1)])
-            sage: L = quadrant.face_lattice()                                           # needs sage.combinat sage.graphs
-            sage: L                                                                     # needs sage.combinat sage.graphs
+            sage: L = quadrant.face_lattice()
+            sage: L
             Finite lattice containing 4 elements with distinguished linear extension
 
         To see all faces arranged by dimension, you can do this::
 
-            sage: for level in L.level_sets(): print(level)                             # needs sage.combinat sage.graphs
+            sage: for level in L.level_sets(): print(level)
             [0-d face of 2-d cone in 2-d lattice N]
             [1-d face of 2-d cone in 2-d lattice N,
              1-d face of 2-d cone in 2-d lattice N]
@@ -2402,15 +2402,15 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         For a particular face you can look at its actual rays... ::
 
-            sage: face = L.level_sets()[1][0]                                           # needs sage.combinat sage.graphs
-            sage: face.rays()                                                           # needs sage.combinat sage.graphs
+            sage: face = L.level_sets()[1][0]
+            sage: face.rays()
             N(1, 0)
             in 2-d lattice N
 
         ... or you can see the index of the ray of the original cone that
         corresponds to the above one::
 
-            sage: face.ambient_ray_indices()                                            # needs sage.combinat sage.graphs
+            sage: face.ambient_ray_indices()
             (0,)
             sage: quadrant.ray(0)
             N(1, 0)
@@ -2418,15 +2418,15 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         An alternative to extracting faces from the face lattice is to use
         :meth:`faces` method::
 
-            sage: face is quadrant.faces(dim=1)[0]                                      # needs sage.combinat sage.graphs
+            sage: face is quadrant.faces(dim=1)[0]
             True
 
         The advantage of working with the face lattice directly is that you
         can (relatively easily) get faces that are related to the given one::
 
-            sage: face = L.level_sets()[1][0]                                           # needs sage.combinat sage.graphs
-            sage: D = L.hasse_diagram()                                                 # needs sage.combinat sage.graphs
-            sage: sorted(D.neighbors(face))                                             # needs sage.combinat sage.graphs
+            sage: face = L.level_sets()[1][0]
+            sage: D = L.hasse_diagram()
+            sage: sorted(D.neighbors(face))
             [0-d face of 2-d cone in 2-d lattice N,
              2-d cone in 2-d lattice N]
 
@@ -2483,19 +2483,19 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         to have non identical face lattices, even if the faces
         themselves are equal (see :issue:`10998`)::
 
-            sage: C1.face_lattice() is C2.face_lattice()                                # needs sage.combinat sage.graphs
+            sage: C1.face_lattice() is C2.face_lattice()
             False
 
-            sage: C1.facets()[0]                                                        # needs sage.graphs
+            sage: C1.facets()[0]
             0-d face of 1-d cone in 2-d lattice N
-            sage: C2.facets()[0]                                                        # needs sage.graphs
+            sage: C2.facets()[0]
             0-d face of 1-d cone in 2-d lattice N
 
-            sage: C1.facets()[0].ambient() is C1                                        # needs sage.graphs
+            sage: C1.facets()[0].ambient() is C1
             True
-            sage: C2.facets()[0].ambient() is C1                                        # needs sage.graphs
+            sage: C2.facets()[0].ambient() is C1
             False
-            sage: C2.facets()[0].ambient() is C2                                        # needs sage.graphs
+            sage: C2.facets()[0].ambient() is C2
             True
         """
         if "_face_lattice" not in self.__dict__:
@@ -2621,35 +2621,35 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         Let's take a look at the faces of the first quadrant::
 
             sage: quadrant = Cone([(1,0), (0,1)])
-            sage: quadrant.faces()                                                      # needs sage.graphs
+            sage: quadrant.faces()
             ((0-d face of 2-d cone in 2-d lattice N,),
              (1-d face of 2-d cone in 2-d lattice N,
               1-d face of 2-d cone in 2-d lattice N),
              (2-d cone in 2-d lattice N,))
-            sage: quadrant.faces(dim=1)                                                 # needs sage.graphs
+            sage: quadrant.faces(dim=1)
             (1-d face of 2-d cone in 2-d lattice N,
              1-d face of 2-d cone in 2-d lattice N)
-            sage: face = quadrant.faces(dim=1)[0]                                       # needs sage.graphs
+            sage: face = quadrant.faces(dim=1)[0]
 
         Now you can look at the actual rays of this face... ::
 
-            sage: face.rays()                                                           # needs sage.graphs
+            sage: face.rays()
             N(1, 0)
             in 2-d lattice N
 
         ... or you can see indices of the rays of the original cone that
         correspond to the above ray::
 
-            sage: face.ambient_ray_indices()                                            # needs sage.graphs
+            sage: face.ambient_ray_indices()
             (0,)
             sage: quadrant.ray(0)
             N(1, 0)
 
         Note that it is OK to ask for faces of too small or high dimension::
 
-            sage: quadrant.faces(-1)                                                    # needs sage.graphs
+            sage: quadrant.faces(-1)
             ()
-            sage: quadrant.faces(3)                                                     # needs sage.graphs
+            sage: quadrant.faces(3)
             ()
 
         In the case of non-strictly convex cones even faces of small
@@ -2673,7 +2673,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         dimension of the ambient space work as expected (see :issue:`9188`)::
 
             sage: c = Cone([(1,1,1,3),(1,-1,1,3),(-1,-1,1,3)])
-            sage: c.faces()                                                             # needs sage.graphs
+            sage: c.faces()
             ((0-d face of 3-d cone in 4-d lattice N,),
              (1-d face of 3-d cone in 4-d lattice N,
               1-d face of 3-d cone in 4-d lattice N,
@@ -2686,7 +2686,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         We also ensure that a call to this function does not break
         :meth:`facets` method (see :issue:`9780`)::
 
-            sage: # needs palp sage.graphs
+            sage: # needs palp
             sage: cone = toric_varieties.dP8().fan().generating_cone(0); cone
             2-d cone of Rational polyhedral fan in 2-d lattice N
             sage: for f in cone.facets(): print(f.rays())
@@ -2849,14 +2849,14 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         While fan is the top element of its own cone lattice, which is a
         variant of a face lattice, we do not refer to cones as its facets::
 
-            sage: fan = Fan([octant])                                                   # needs sage.graphs
-            sage: fan.generating_cone(0).facet_of()                                     # needs sage.graphs
+            sage: fan = Fan([octant])
+            sage: fan.generating_cone(0).facet_of()
             ()
 
         Subcones of generating cones work as before::
 
-            sage: one_cone = fan(1)[0]                                                  # needs sage.graphs
-            sage: len(one_cone.facet_of())                                              # needs sage.graphs
+            sage: one_cone = fan(1)[0]
+            sage: len(one_cone.facet_of())
             2
         """
         L = self._ambient._face_lattice_function()
@@ -2873,7 +2873,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         EXAMPLES::
 
             sage: quadrant = Cone([(1,0), (0,1)])
-            sage: quadrant.facets()                                                     # needs sage.graphs
+            sage: quadrant.facets()
             (1-d face of 2-d cone in 2-d lattice N,
              1-d face of 2-d cone in 2-d lattice N)
         """
@@ -3428,7 +3428,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         EXAMPLES::
 
             sage: quadrant = Cone([(1,0), (0,1)])
-            sage: quadrant.plot()                                                       # needs sage.plot sage.symbolic
+            sage: quadrant.plot()
             Graphics object consisting of 9 graphics primitives
         """
         # What to do with 3-d cones in 5-d? Use some projection method?
@@ -3829,10 +3829,10 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         EXAMPLES::
 
             sage: C2_Z2 = Cone([(1,0), (1,2)])     # C^2/Z_2
-            sage: c1, c2 = C2_Z2.facets()                                               # needs sage.graphs
-            sage: c2.sublattice()                                                       # needs sage.graphs
+            sage: c1, c2 = C2_Z2.facets()
+            sage: c2.sublattice()
             Sublattice <N(1, 2)>
-            sage: c2.sublattice_complement()                                            # needs sage.graphs
+            sage: c2.sublattice_complement()
             Sublattice <N(0, 1)>
 
         A more complicated example::

--- a/src/sage/geometry/cone_catalog.py
+++ b/src/sage/geometry/cone_catalog.py
@@ -600,8 +600,8 @@ def rearrangement(p, ambient_dim=None, lattice=None):
         sage: ambient_dim = ZZ.random_element(2,10).abs()
         sage: p = ZZ.random_element(1, ambient_dim)
         sage: K = cones.rearrangement(p, ambient_dim)
-        sage: P = SymmetricGroup(ambient_dim).random_element().matrix()                 # needs sage.groups
-        sage: all(K.contains(P*r) for r in K)                                           # needs sage.groups
+        sage: P = SymmetricGroup(ambient_dim).random_element().matrix()
+        sage: all(K.contains(P*r) for r in K)
         True
 
     The smallest ``p`` components of every element of the rearrangement

--- a/src/sage/geometry/fan.py
+++ b/src/sage/geometry/fan.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.graphs sage.combinat
 r"""
 Rational polyhedral fans
 
@@ -479,7 +478,7 @@ def Fan(cones, rays=None, lattice=None, check=True, normalize=True,
         sage: fan = Fan([c1, c2], allow_arrangement=True)
         sage: fan.n_generating_cones()
         7
-        sage: fan.plot()                                                                # needs sage.plot
+        sage: fan.plot()
         Graphics3d Object
 
     Cones of different dimension::
@@ -499,7 +498,7 @@ def Fan(cones, rays=None, lattice=None, check=True, normalize=True,
         sage: c3 = Cone([[0, 1, 1], [1, 0, 1], [0, -1, 1], [-1, 0, 1]])
         sage: c1 = Cone([[0, 0, 1]])
         sage: fan1 = Fan([c1, c3], allow_arrangement=True)
-        sage: fan1.plot()                                                               # needs sage.plot
+        sage: fan1.plot()
         Graphics3d Object
 
     A 3-d cone and two 2-d cones::
@@ -1607,9 +1606,9 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
             False
             sage: f.support_contains(0)   # 0 converts to the origin in the lattice
             True
-            sage: f.support_contains(1/2, sqrt(3))                                      # needs sage.symbolic
+            sage: f.support_contains(1/2, sqrt(3))
             True
-            sage: f.support_contains(-1/2, sqrt(3))                                     # needs sage.symbolic
+            sage: f.support_contains(-1/2, sqrt(3))
             False
         """
         if len(args) == 1:
@@ -2564,9 +2563,9 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
             [(1, 0), (1, 0), (1, 0), (1, 0)]
 
             sage: g = toric_varieties.Cube_deformation(10).fan().vertex_graph()
-            sage: g.automorphism_group().order()                                        # needs sage.groups
+            sage: g.automorphism_group().order()
             48
-            sage: g.automorphism_group(edge_labels=True).order()                        # needs sage.groups
+            sage: g.automorphism_group(edge_labels=True).order()
             4
         """
         from sage.geometry.cone import classify_cone_2d
@@ -3017,7 +3016,7 @@ class RationalPolyhedralFan(IntegralRayCollection, Callable, Container):
         EXAMPLES::
 
             sage: fan = toric_varieties.dP6().fan()                                     # needs palp
-            sage: fan.plot()                                                            # needs palp sage.plot
+            sage: fan.plot()                                                            # needs palp
             Graphics object consisting of 31 graphics primitives
         """
         tp = ToricPlotter(options, self.lattice().degree(), self.rays())

--- a/src/sage/geometry/fan_isomorphism.py
+++ b/src/sage/geometry/fan_isomorphism.py
@@ -34,10 +34,10 @@ def fan_isomorphic_necessary_conditions(fan1, fan2):
 
     EXAMPLES::
 
-        sage: fan1 = toric_varieties.P2().fan()                                         # needs palp sage.graphs
-        sage: fan2 = toric_varieties.dP8().fan()                                        # needs palp sage.graphs
+        sage: fan1 = toric_varieties.P2().fan()                                         # needs palp
+        sage: fan2 = toric_varieties.dP8().fan()                                        # needs palp
         sage: from sage.geometry.fan_isomorphism import fan_isomorphic_necessary_conditions
-        sage: fan_isomorphic_necessary_conditions(fan1, fan2)                           # needs palp sage.graphs
+        sage: fan_isomorphic_necessary_conditions(fan1, fan2)                           # needs palp
         False
     """
     if fan1.lattice_dim() != fan2.lattice_dim():
@@ -72,9 +72,9 @@ def fan_isomorphism_generator(fan1, fan2):
 
     EXAMPLES::
 
-        sage: fan = toric_varieties.P2().fan()                                          # needs palp sage.graphs
+        sage: fan = toric_varieties.P2().fan()                                          # needs palp
         sage: from sage.geometry.fan_isomorphism import fan_isomorphism_generator
-        sage: sorted(fan_isomorphism_generator(fan, fan))                               # needs palp sage.graphs
+        sage: sorted(fan_isomorphism_generator(fan, fan))                               # needs palp
         [
         [-1 -1]  [-1 -1]  [ 0  1]  [0 1]  [ 1  0]  [1 0]
         [ 0  1], [ 1  0], [-1 -1], [1 0], [-1 -1], [0 1]
@@ -87,7 +87,7 @@ def fan_isomorphism_generator(fan1, fan2):
         ....:             Cone([m1*vector([-1,-14]), m1*vector([-100, -5])])])
         sage: fan2 = Fan([Cone([m2*vector([23, 14]), m2*vector([   3,100])]),
         ....:             Cone([m2*vector([-1,-14]), m2*vector([-100, -5])])])
-        sage: sorted(fan_isomorphism_generator(fan1, fan2))                             # needs sage.graphs
+        sage: sorted(fan_isomorphism_generator(fan1, fan2))
         [
         [-12  1 -5]
         [ -4  0 -1]
@@ -105,24 +105,24 @@ def fan_isomorphism_generator(fan1, fan2):
         ....:             Cone([m1*vector([1,1]), m1*vector([0,1])])])
         sage: fan2 = Fan([Cone([m2*vector([1,0]), m2*vector([1,1])]),
         ....:             Cone([m2*vector([1,1]), m2*vector([0,1])])])
-        sage: sorted(fan_isomorphism_generator(fan0, fan0))                             # needs sage.graphs
+        sage: sorted(fan_isomorphism_generator(fan0, fan0))
         [
         [0 1]  [1 0]
         [1 0], [0 1]
         ]
-        sage: sorted(fan_isomorphism_generator(fan1, fan1))                             # needs sage.graphs
+        sage: sorted(fan_isomorphism_generator(fan1, fan1))
         [
         [ -3 -20  28]  [1 0 0]
         [ -1  -4   7]  [0 1 0]
         [ -1  -5   8], [0 0 1]
         ]
-        sage: sorted(fan_isomorphism_generator(fan1, fan2))                             # needs sage.graphs
+        sage: sorted(fan_isomorphism_generator(fan1, fan2))
         [
         [-24  -3   7]  [-12   1  -5]
         [ -7  -1   2]  [ -4   0  -1]
         [ -8  -1   2], [ -5   0  -1]
         ]
-        sage: sorted(fan_isomorphism_generator(fan2, fan1))                             # needs sage.graphs
+        sage: sorted(fan_isomorphism_generator(fan2, fan1))
         [
         [  0   1  -1]  [ 0  1 -1]
         [  1 -13   8]  [ 2 -8  1]
@@ -210,14 +210,14 @@ def find_isomorphism(fan1, fan2, check=False):
         sage: fan2 = Fan(cones, [vector(r)*m for r in rays])
 
         sage: from sage.geometry.fan_isomorphism import find_isomorphism
-        sage: find_isomorphism(fan1, fan2, check=True)                                  # needs sage.graphs
+        sage: find_isomorphism(fan1, fan2, check=True)
         Fan morphism defined by the matrix
         [-2  3]
         [ 1 -1]
         Domain fan: Rational polyhedral fan in 2-d lattice N
         Codomain fan: Rational polyhedral fan in 2-d lattice N
 
-        sage: find_isomorphism(fan1, toric_varieties.P2().fan())                        # needs palp sage.graphs
+        sage: find_isomorphism(fan1, toric_varieties.P2().fan())                        # needs palp
         Traceback (most recent call last):
         ...
         FanNotIsomorphicError
@@ -226,7 +226,7 @@ def find_isomorphism(fan1, fan2, check=False):
         ....:            rays=[(-1,-1,0),(-1,-1,3),(-1,1,-1),(-1,3,-1),(0,2,-1),(1,-1,1)])
         sage: fan2 = Fan(cones=[[0,2,3,5],[0,1,4,5],[0,1,2],[3,4,5]],
         ....:            rays=[(-1,-1,-1),(-1,-1,0),(-1,1,-1),(0,2,-1),(1,-1,1),(3,-1,-1)])
-        sage: fan1.is_isomorphic(fan2)                                                  # needs sage.graphs
+        sage: fan1.is_isomorphic(fan2)
         True
     """
     generator = fan_isomorphism_generator(fan1, fan2)
@@ -305,14 +305,14 @@ def fan_2d_echelon_forms(fan):
 
     EXAMPLES::
 
-        sage: fan = toric_varieties.P2().fan()                                          # needs palp sage.graphs
+        sage: fan = toric_varieties.P2().fan()                                          # needs palp
         sage: from sage.geometry.fan_isomorphism import fan_2d_echelon_forms
-        sage: fan_2d_echelon_forms(fan)                                                 # needs palp sage.graphs
+        sage: fan_2d_echelon_forms(fan)                                                 # needs palp
         frozenset({[ 1  0 -1]
                    [ 0  1 -1]})
 
-        sage: fan = toric_varieties.dP7().fan()                                         # needs palp sage.graphs
-        sage: sorted(fan_2d_echelon_forms(fan))                                         # needs palp sage.graphs
+        sage: fan = toric_varieties.dP7().fan()                                         # needs palp
+        sage: sorted(fan_2d_echelon_forms(fan))                                         # needs palp
         [
         [ 1  0 -1 -1  0]  [ 1  0 -1 -1  0]  [ 1  0 -1 -1  1]  [ 1  0 -1  0  1]
         [ 0  1  0 -1 -1], [ 0  1  1  0 -1], [ 0  1  1  0 -1], [ 0  1  0 -1 -1],
@@ -328,10 +328,10 @@ def fan_2d_echelon_forms(fan):
         sage: fan1 = Fan(cones, rays)
         sage: from sage.geometry.fan_isomorphism import fan_2d_echelon_form, fan_2d_echelon_forms
         sage: echelon_forms = fan_2d_echelon_forms(fan1)
-        sage: S4 = CyclicPermutationGroup(4)                                            # needs sage.groups
+        sage: S4 = CyclicPermutationGroup(4)
         sage: rays.reverse()
         sage: cones = [(3,1), (1,2), (2,0), (0,3)]
-        sage: for i in range(100):                                                      # needs sage.groups
+        sage: for i in range(100):
         ....:     m = random_matrix(ZZ,2,2)
         ....:     if abs(det(m)) != 1: continue
         ....:     perm = S4.random_element()
@@ -376,9 +376,9 @@ def fan_2d_echelon_form(fan):
 
     EXAMPLES::
 
-        sage: fan = toric_varieties.P2().fan()                                          # needs palp sage.graphs
+        sage: fan = toric_varieties.P2().fan()                                          # needs palp
         sage: from sage.geometry.fan_isomorphism import fan_2d_echelon_form
-        sage: fan_2d_echelon_form(fan)                                                  # needs palp sage.graphs
+        sage: fan_2d_echelon_form(fan)                                                  # needs palp
         [ 1  0 -1]
         [ 0  1 -1]
     """

--- a/src/sage/geometry/fan_morphism.py
+++ b/src/sage/geometry/fan_morphism.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat sage.graphs
 r"""
 Morphisms between toric lattices compatible with fans
 

--- a/src/sage/geometry/hasse_diagram.py
+++ b/src/sage/geometry/hasse_diagram.py
@@ -104,9 +104,9 @@ def lattice_from_incidences(atom_to_coatoms, coatom_to_atoms,
     and we can compute the lattice as ::
 
         sage: from sage.geometry.cone import lattice_from_incidences
-        sage: L = lattice_from_incidences(atom_to_coatoms, coatom_to_atoms); L          # needs sage.graphs
+        sage: L = lattice_from_incidences(atom_to_coatoms, coatom_to_atoms); L
         Finite lattice containing 8 elements with distinguished linear extension
-        sage: for level in L.level_sets(): print(level)                                 # needs sage.graphs
+        sage: for level in L.level_sets(): print(level)
         [((), (0, 1, 2))]
         [((0,), (0, 1)), ((1,), (0, 2)), ((2,), (1, 2))]
         [((0, 1), (0,)), ((0, 2), (1,)), ((1, 2), (2,))]

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_geodesic.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_geodesic.py
@@ -24,7 +24,7 @@ in this example we will show the axis.
 
 ::
 
-    sage: g.plot(axes=True)                                                             # needs sage.plot
+    sage: g.plot(axes=True)
     Graphics object consisting of 2 graphics primitives
 
 .. PLOT::
@@ -37,7 +37,7 @@ in this example we will show the axis.
     sage: g = HyperbolicPlane().UHP().get_geodesic(I, 3 + I)
     sage: g.length()
     arccosh(11/2)
-    sage: g.plot(axes=True)                                                             # needs sage.plot
+    sage: g.plot(axes=True)
     Graphics object consisting of 2 graphics primitives
 
 .. PLOT::
@@ -49,7 +49,7 @@ Geodesics of both types in UHP are supported::
     sage: g = HyperbolicPlane().UHP().get_geodesic(I, 3*I)
     sage: g
     Geodesic in UHP from I to 3*I
-    sage: g.plot()                                                                      # needs sage.plot
+    sage: g.plot()
     Graphics object consisting of 2 graphics primitives
 
 .. PLOT::
@@ -1090,7 +1090,7 @@ class HyperbolicGeodesicUHP(HyperbolicGeodesic):
         EXAMPLES::
 
             sage: UHP = HyperbolicPlane().UHP()
-            sage: UHP.get_geodesic(0, 1).plot()                                         # needs sage.plot
+            sage: UHP.get_geodesic(0, 1).plot()
             Graphics object consisting of 2 graphics primitives
 
         .. PLOT::
@@ -1101,7 +1101,7 @@ class HyperbolicGeodesicUHP(HyperbolicGeodesic):
 
         ::
 
-            sage: UHP.get_geodesic(I, 3+4*I).plot(linestyle='dashed', color='brown')    # needs sage.plot
+            sage: UHP.get_geodesic(I, 3+4*I).plot(linestyle='dashed', color='brown')
             Graphics object consisting of 2 graphics primitives
 
         .. PLOT::
@@ -1112,7 +1112,7 @@ class HyperbolicGeodesicUHP(HyperbolicGeodesic):
 
         ::
 
-            sage: UHP.get_geodesic(1, infinity).plot(color='orange')                    # needs sage.plot
+            sage: UHP.get_geodesic(1, infinity).plot(color='orange')
             Graphics object consisting of 2 graphics primitives
 
         .. PLOT::
@@ -1126,25 +1126,25 @@ class HyperbolicGeodesicUHP(HyperbolicGeodesic):
         Plotting a line with ``boundary=True``. ::
 
             sage: g = HyperbolicPlane().UHP().get_geodesic(0, I)
-            sage: g.plot()                                                              # needs sage.plot
+            sage: g.plot()
             Graphics object consisting of 2 graphics primitives
 
         Plotting a line with ``boundary=False``. ::
 
             sage: g = HyperbolicPlane().UHP().get_geodesic(0, I)
-            sage: g.plot(boundary=False)                                                # needs sage.plot
+            sage: g.plot(boundary=False)
             Graphics object consisting of 1 graphics primitive
 
         Plotting a circle with ``boundary=True``. ::
 
             sage: g = HyperbolicPlane().UHP().get_geodesic(-3, 19)
-            sage: g.plot()                                                              # needs sage.plot
+            sage: g.plot()
             Graphics object consisting of 2 graphics primitives
 
         Plotting a circle with ``boundary=False``. ::
 
             sage: g = HyperbolicPlane().UHP().get_geodesic(3, 4)
-            sage: g.plot(boundary=False)                                                # needs sage.plot
+            sage: g.plot(boundary=False)
             Graphics object consisting of 1 graphics primitive
         """
 
@@ -2148,7 +2148,7 @@ class HyperbolicGeodesicPD(HyperbolicGeodesic):
         First some lines::
 
             sage: PD = HyperbolicPlane().PD()
-            sage: PD.get_geodesic(0, 1).plot()                                          # needs sage.plot
+            sage: PD.get_geodesic(0, 1).plot()
             Graphics object consisting of 2 graphics primitives
 
         .. PLOT::
@@ -2157,7 +2157,7 @@ class HyperbolicGeodesicPD(HyperbolicGeodesic):
 
         ::
 
-            sage: PD.get_geodesic(0, 0.3+0.8*I).plot()                                  # needs sage.plot
+            sage: PD.get_geodesic(0, 0.3+0.8*I).plot()
             Graphics object consisting of 2 graphics primitives
 
         .. PLOT::
@@ -2167,15 +2167,15 @@ class HyperbolicGeodesicPD(HyperbolicGeodesic):
 
         Then some generic geodesics::
 
-            sage: PD.get_geodesic(-0.5, 0.3+0.4*I).plot()                               # needs sage.plot
+            sage: PD.get_geodesic(-0.5, 0.3+0.4*I).plot()
             Graphics object consisting of 2 graphics primitives
             sage: g = PD.get_geodesic(-1, exp(3*I*pi/7))
-            sage: G = g.plot(linestyle='dashed',color='red'); G                         # needs sage.plot
+            sage: G = g.plot(linestyle='dashed',color='red'); G
             Graphics object consisting of 2 graphics primitives
             sage: h = PD.get_geodesic(exp(2*I*pi/11), exp(1*I*pi/11))
-            sage: H = h.plot(thickness=6, color='orange'); H                            # needs sage.plot
+            sage: H = h.plot(thickness=6, color='orange'); H
             Graphics object consisting of 2 graphics primitives
-            sage: show(G+H)                                                             # needs sage.plot
+            sage: show(G+H)
 
         .. PLOT::
 
@@ -2238,7 +2238,7 @@ class HyperbolicGeodesicKM(HyperbolicGeodesic):
         sage: KM = HyperbolicPlane().KM()
         sage: g = KM.get_geodesic((0.1,0.9),(-0.1,-0.9))
         sage: h = KM.get_geodesic((-0.707106781,-0.707106781),(0.707106781,-0.707106781))
-        sage: P = g.plot(color='orange')+h.plot(); P                                    # needs sage.plot
+        sage: P = g.plot(color='orange')+h.plot(); P
         Graphics object consisting of 4 graphics primitives
 
     .. PLOT::
@@ -2257,7 +2257,7 @@ class HyperbolicGeodesicKM(HyperbolicGeodesic):
 
         EXAMPLES::
 
-            sage: HyperbolicPlane().KM().get_geodesic(0, 1).plot()                      # needs sage.plot
+            sage: HyperbolicPlane().KM().get_geodesic(0, 1).plot()
             Graphics object consisting of 2 graphics primitives
 
         .. PLOT::
@@ -2323,7 +2323,7 @@ class HyperbolicGeodesicHM(HyperbolicGeodesic):
             sage: p1 = HM.get_point((4, -4, sqrt(33)))
             sage: p2 = HM.get_point((-3,-3,sqrt(19)))
             sage: g = HM.get_geodesic(p1, p2)
-            sage: g._plot_vertices(5)                                                   # needs sage.plot
+            sage: g._plot_vertices(5)
             [(4.0, -4.0, 5.744562...),
              (1.363213..., -1.637073..., 2.353372...),
              (0.138568..., -0.969980..., 1.400022...),
@@ -2368,7 +2368,7 @@ class HyperbolicGeodesicHM(HyperbolicGeodesic):
             sage: from sage.geometry.hyperbolic_space.hyperbolic_geodesic \
             ....:    import *
             sage: g = HyperbolicPlane().HM().random_geodesic()
-            sage: g.plot()                                                              # needs sage.plot
+            sage: g.plot()
             Graphics3d Object
 
         .. PLOT::

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_model.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_model.py
@@ -920,7 +920,7 @@ class HyperbolicModelUHP(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: hp = HyperbolicPlane().UHP().get_background_graphic()                 # needs sage.plot
+            sage: hp = HyperbolicPlane().UHP().get_background_graphic()
         """
         from sage.plot.line import line
         bd_min = bdry_options.get('bd_min', -5)
@@ -1254,7 +1254,7 @@ class HyperbolicModelPD(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: circ = HyperbolicPlane().PD().get_background_graphic()                # needs sage.plot
+            sage: circ = HyperbolicPlane().PD().get_background_graphic()
         """
         from sage.plot.circle import circle
         return circle((0, 0), 1, axes=False, color='black')
@@ -1378,7 +1378,7 @@ class HyperbolicModelKM(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: circ = HyperbolicPlane().KM().get_background_graphic()                # needs sage.plot
+            sage: circ = HyperbolicPlane().KM().get_background_graphic()
         """
         from sage.plot.circle import circle
         return circle((0, 0), 1, axes=False, color='black')
@@ -1487,7 +1487,7 @@ class HyperbolicModelHM(HyperbolicModel):
 
         EXAMPLES::
 
-            sage: H = HyperbolicPlane().HM().get_background_graphic()                   # needs sage.plot
+            sage: H = HyperbolicPlane().HM().get_background_graphic()
         """
         from sage.plot.plot3d.all import plot3d
         from sage.symbolic.ring import SR

--- a/src/sage/geometry/hyperbolic_space/hyperbolic_point.py
+++ b/src/sage/geometry/hyperbolic_space/hyperbolic_point.py
@@ -508,11 +508,11 @@ class HyperbolicPoint(Element):
 
         EXAMPLES::
 
-            sage: HyperbolicPlane().PD().get_point(0).show()                            # needs sage.plot
+            sage: HyperbolicPlane().PD().get_point(0).show()
             Graphics object consisting of 2 graphics primitives
-            sage: HyperbolicPlane().KM().get_point((0,0)).show()                        # needs sage.plot
+            sage: HyperbolicPlane().KM().get_point((0,0)).show()
             Graphics object consisting of 2 graphics primitives
-            sage: HyperbolicPlane().HM().get_point((0,0,1)).show()                      # needs sage.plot
+            sage: HyperbolicPlane().HM().get_point((0,0,1)).show()
             Graphics3d Object
         """
         p = self.coordinates()
@@ -587,7 +587,7 @@ class HyperbolicPointUHP(HyperbolicPoint):
 
             sage: HyperbolicPlane().UHP().get_point(I).show()
             Graphics object consisting of 2 graphics primitives
-            sage: HyperbolicPlane().UHP().get_point(0).show()                           # needs sage.plot
+            sage: HyperbolicPlane().UHP().get_point(0).show()
             Graphics object consisting of 2 graphics primitives
             sage: HyperbolicPlane().UHP().get_point(infinity).show()
             Traceback (most recent call last):

--- a/src/sage/geometry/hyperplane_arrangement/arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/arrangement.py
@@ -88,11 +88,11 @@ Notation (iii): a list or tuple of hyperplanes::
 
 Notation (iv): using the library of arrangements::
 
-    sage: hyperplane_arrangements.braid(4)                                              # needs sage.graphs
+    sage: hyperplane_arrangements.braid(4)
     Arrangement of 6 hyperplanes of dimension 4 and rank 3
     sage: hyperplane_arrangements.semiorder(3)
     Arrangement of 6 hyperplanes of dimension 3 and rank 2
-    sage: hyperplane_arrangements.graphical(graphs.PetersenGraph())                     # needs sage.graphs
+    sage: hyperplane_arrangements.graphical(graphs.PetersenGraph())
     Arrangement of 15 hyperplanes of dimension 10 and rank 9
     sage: hyperplane_arrangements.Ish(5)
     Arrangement of 20 hyperplanes of dimension 5 and rank 4
@@ -263,16 +263,16 @@ For finer invariants derived from the intersection poset, see
 Miscellaneous methods (see documentation for an explanation)::
 
     sage: a = hyperplane_arrangements.semiorder(3)
-    sage: a.has_good_reduction(5)                                                       # needs sage.rings.finite_rings
+    sage: a.has_good_reduction(5)
     True
     sage: b = a.change_ring(GF(5))
-    sage: pa = a.intersection_poset()                                                   # needs sage.graphs
-    sage: pb = b.intersection_poset()                                                   # needs sage.rings.finite_rings
-    sage: pa.is_isomorphic(pb)                                                          # needs sage.graphs sage.rings.finite_rings
+    sage: pa = a.intersection_poset()
+    sage: pb = b.intersection_poset()
+    sage: pa.is_isomorphic(pb)
     True
-    sage: a.face_vector()                                                               # needs sage.graphs
+    sage: a.face_vector()
     (0, 12, 30, 19)
-    sage: a.face_vector()                                                               # needs sage.graphs
+    sage: a.face_vector()
     (0, 12, 30, 19)
     sage: a.is_central()
     False
@@ -420,8 +420,8 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: a.<x,y,z> = hyperplane_arrangements.braid(3)   # indirect doctest     # needs sage.graphs
-            sage: (x, y) == a._first_ngens(2)                                           # needs sage.graphs
+            sage: a.<x,y,z> = hyperplane_arrangements.braid(3)   # indirect doctest
+            sage: (x, y) == a._first_ngens(2)
             True
         """
         return self.parent()._first_ngens(n)
@@ -670,7 +670,7 @@ class HyperplaneArrangementElement(Element):
         EXAMPLES::
 
             sage: L.<x, y> = HyperplaneArrangements(QQ)
-            sage: L(x, y, x+y-2).plot()                                                 # needs sage.plot
+            sage: L(x, y, x+y-2).plot()
             Graphics object consisting of 3 graphics primitives
         """
         from sage.geometry.hyperplane_arrangement.plot import plot
@@ -764,11 +764,11 @@ class HyperplaneArrangementElement(Element):
         of hyperplanes of the arrangement. ::
 
             sage: A = hyperplane_arrangements.coordinate(2)
-            sage: L = A.intersection_poset(); L                                         # needs sage.combinat
+            sage: L = A.intersection_poset(); L
             Finite poset containing 4 elements
-            sage: sorted(L)                                                             # needs sage.combinat
+            sage: sorted(L)
             [0, 1, 2, 3]
-            sage: L.level_sets()                                                        # needs sage.combinat
+            sage: L.level_sets()
             [[0], [1, 2], [3]]
 
         ::
@@ -787,8 +787,8 @@ class HyperplaneArrangementElement(Element):
         index in ``self.hyperplanes()``. ::
 
             sage: A = hyperplane_arrangements.semiorder(3)
-            sage: L = A.intersection_poset(element_label='subset')                      # needs sage.combinat
-            sage: [sorted(level, key=sorted) for level in L.level_sets()]               # needs sage.combinat
+            sage: L = A.intersection_poset(element_label='subset')
+            sage: [sorted(level, key=sorted) for level in L.level_sets()]
             [[{}],
              [{0}, {1}, {2}, {3}, {4}, {5}],
              [{0, 2}, {0, 3}, {0, 4}, {0, 5}, {1, 2}, {1, 3}, {1, 4}, {1, 5}, {2, 4}, {2, 5}, {3, 4}, {3, 5}]]
@@ -797,17 +797,17 @@ class HyperplaneArrangementElement(Element):
 
             sage: H.<x,y> = HyperplaneArrangements(QQ)
             sage: A = H((y, y-1, y+1, x-y, x+y))
-            sage: L = A.intersection_poset(element_label='subset')                      # needs sage.combinat
-            sage: sorted(L, key=sorted)                                                 # needs sage.combinat
+            sage: L = A.intersection_poset(element_label='subset')
+            sage: sorted(L, key=sorted)
             [{}, {0}, {0, 3}, {0, 4}, {1}, {1, 3, 4}, {2}, {2, 3}, {2, 4}, {3}, {4}]
 
         One can instead use affine subspaces as elements,
         which is what is used to compute the poset in the first place::
 
             sage: A = hyperplane_arrangements.coordinate(2)
-            sage: L = A.intersection_poset(element_label='subspace'); L                 # needs sage.combinat
+            sage: L = A.intersection_poset(element_label='subspace'); L
             Finite poset containing 4 elements
-            sage: sorted(L, key=lambda S: (S.dimension(),                               # needs sage.combinat
+            sage: sorted(L, key=lambda S: (S.dimension(),
             ....:                          S.linear_part().basis_matrix()))
             [Affine space p + W where:
                p = (0, 0)
@@ -888,7 +888,7 @@ class HyperplaneArrangementElement(Element):
         EXAMPLES::
 
             sage: a = hyperplane_arrangements.coordinate(2)
-            sage: a._slow_characteristic_polynomial()                                   # needs sage.combinat
+            sage: a._slow_characteristic_polynomial()
             x^2 - 2*x + 1
         """
         from sage.rings.polynomial.polynomial_ring import polygen
@@ -983,10 +983,10 @@ class HyperplaneArrangementElement(Element):
         EXAMPLES::
 
             sage: A = hyperplane_arrangements.coordinate(2)
-            sage: A.cocharacteristic_polynomial()                                       # needs sage.graphs
+            sage: A.cocharacteristic_polynomial()
             z^2 + 2*z + 1
             sage: B = hyperplane_arrangements.braid(3)
-            sage: B.cocharacteristic_polynomial()                                       # needs sage.graphs
+            sage: B.cocharacteristic_polynomial()
             2*z^3 + 3*z^2 + z
 
         TESTS::
@@ -1031,26 +1031,26 @@ class HyperplaneArrangementElement(Element):
         EXAMPLES::
 
             sage: A = hyperplane_arrangements.coordinate(2)
-            sage: A.primitive_eulerian_polynomial()                                     # needs sage.graphs
+            sage: A.primitive_eulerian_polynomial()
             z^2
             sage: B = hyperplane_arrangements.braid(3)
-            sage: B.primitive_eulerian_polynomial()                                     # needs sage.graphs
+            sage: B.primitive_eulerian_polynomial()
             z^2 + z
 
             sage: H = hyperplane_arrangements.Shi(['B',2]).cone()
             sage: H.is_simplicial()
             False
-            sage: H.primitive_eulerian_polynomial()                                     # needs sage.graphs
+            sage: H.primitive_eulerian_polynomial()
             z^3 + 11*z^2 + 4*z
 
             sage: H = hyperplane_arrangements.graphical(graphs.CycleGraph(4))
-            sage: H.primitive_eulerian_polynomial()                                     # needs sage.graphs
+            sage: H.primitive_eulerian_polynomial()
             z^3 + 3*z^2 - z
 
         We verify Example 2.4 in [BHS2023]_ for `k = 2,3,4,5`::
 
             sage: R.<x,y> = HyperplaneArrangements(QQ)
-            sage: for k in range(2,6):                                                  # needs sage.graphs
+            sage: for k in range(2,6):
             ....:     H = R([x+j*y for j in range(k)])
             ....:     H.primitive_eulerian_polynomial()
             z^2
@@ -1071,7 +1071,7 @@ class HyperplaneArrangementElement(Element):
             sage: W = CoxeterGroup(['H',3], implementation='matrix')
             sage: A = HyperplaneArrangements(W.base_ring(), tuple(f'x{s}' for s in range(W.rank())))
             sage: H = A([[0] + list(r) for r in W.positive_roots()])
-            sage: H.is_simplicial()                                                     # needs sage.graphs
+            sage: H.is_simplicial()
             True
             sage: H.primitive_eulerian_polynomial()
             z^3 + 28*z^2 + 16*z
@@ -1079,7 +1079,7 @@ class HyperplaneArrangementElement(Element):
             sage: W = CoxeterGroup(['F',4], implementation='permutation')
             sage: A = HyperplaneArrangements(QQ, tuple(f'x{s}' for s in range(W.rank())))
             sage: H = A([[0] + list(r) for r in W.positive_roots()])
-            sage: H.primitive_eulerian_polynomial()     # long time                     # needs sage.graphs
+            sage: H.primitive_eulerian_polynomial()     # long time
             z^4 + 116*z^3 + 220*z^2 + 48*z
 
         We verify Proposition 2.5 in [BHS2023]_ on the braid arrangement
@@ -1088,7 +1088,7 @@ class HyperplaneArrangementElement(Element):
             sage: B = [hyperplane_arrangements.braid(k) for k in range(2,6)]
             sage: all(H.is_simplicial() for H in B)
             True
-            sage: all(c > 0 for H in B                                                  # needs sage.graphs
+            sage: all(c > 0 for H in B
             ....:     for c in H.primitive_eulerian_polynomial().coefficients())
             True
 
@@ -1449,8 +1449,8 @@ class HyperplaneArrangementElement(Element):
             sage: a = hyperplane_arrangements.semiorder(3)
             sage: a.is_linear()
             False
-            sage: b = hyperplane_arrangements.braid(3)                                  # needs sage.graphs
-            sage: b.is_linear()                                                         # needs sage.graphs
+            sage: b = hyperplane_arrangements.braid(3)
+            sage: b.is_linear()
             True
 
             sage: H.<x,y> = HyperplaneArrangements(QQ)
@@ -1508,8 +1508,8 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: a = hyperplane_arrangements.braid(2)                                  # needs sage.graphs
-            sage: a.is_central()                                                        # needs sage.graphs
+            sage: a = hyperplane_arrangements.braid(2)
+            sage: a.is_central()
             True
 
         The Catalan arrangement in dimension 3 is not central::
@@ -1586,8 +1586,8 @@ class HyperplaneArrangementElement(Element):
         The Braid arrangement in dimension 3 has a center that is neither
         empty nor full-dimensional::
 
-            sage: A = hyperplane_arrangements.braid(3)                                  # needs sage.combinat
-            sage: A.center()                                                            # needs sage.combinat
+            sage: A = hyperplane_arrangements.braid(3)
+            sage: A.center()
             A 1-dimensional polyhedron in QQ^3 defined as the convex hull of 1 vertex and 1 line
         """
         return self.is_central(certificate=True)[1]
@@ -1615,7 +1615,7 @@ class HyperplaneArrangementElement(Element):
             sage: A = H([[0,1,1,1], [0,1,2,3], [0,1,3,2], [0,2,1,3]])
             sage: A.is_simplicial()
             False
-            sage: hyperplane_arrangements.braid(3).is_simplicial()                      # needs sage.graphs
+            sage: hyperplane_arrangements.braid(3).is_simplicial()
             True
         """
         # if the arr is not essential, grab the essential version and check there.
@@ -1642,10 +1642,10 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: a = hyperplane_arrangements.braid(3)                                  # needs sage.graphs
-            sage: a.is_essential()                                                      # needs sage.graphs
+            sage: a = hyperplane_arrangements.braid(3)
+            sage: a.is_essential()
             False
-            sage: a.essentialization()                                                  # needs sage.graphs
+            sage: a.essentialization()
             Arrangement <t1 - t2 | t1 + 2*t2 | 2*t1 + t2>
 
             sage: H.<x,y> = HyperplaneArrangements(QQ)
@@ -1778,7 +1778,7 @@ class HyperplaneArrangementElement(Element):
         EXAMPLES::
 
             sage: A = hyperplane_arrangements.Shi(3)
-            sage: A.face_vector()                                                       # needs sage.combinat
+            sage: A.face_vector()
             (0, 6, 21, 16)
         """
         m = self.whitney_data()[0]
@@ -1866,7 +1866,7 @@ class HyperplaneArrangementElement(Element):
             (6, 21, 16)
             sage: A.vertices()
             ((-2/3, 1/3), (-1/3, -1/3), (0, -1), (0, 0), (1/3, -2/3), (2/3, -1/3))
-            sage: point2d(A.vertices(), size=20) + A.plot()                             # needs sage.plot
+            sage: point2d(A.vertices(), size=20) + A.plot()
             Graphics object consisting of 7 graphics primitives
 
             sage: H.<x,y> = HyperplaneArrangements(QQ)
@@ -1960,8 +1960,8 @@ class HyperplaneArrangementElement(Element):
 
         EXAMPLES::
 
-            sage: a = hyperplane_arrangements.braid(2)                                  # needs sage.graphs
-            sage: a.regions()                                                           # needs sage.graphs
+            sage: a = hyperplane_arrangements.braid(2)
+            sage: a.regions()
             (A 2-dimensional polyhedron in QQ^2 defined
                  as the convex hull of 1 vertex, 1 ray, 1 line,
              A 2-dimensional polyhedron in QQ^2 defined
@@ -2136,7 +2136,7 @@ class HyperplaneArrangementElement(Element):
 
             sage: H.<x,y,z> = HyperplaneArrangements(QQ)
             sage: A = H([[0,1,1,1], [0,1,2,3]])
-            sage: A.poset_of_regions()                                                  # needs sage.combinat
+            sage: A.poset_of_regions()
             Finite poset containing 4 elements
 
             sage: A = hyperplane_arrangements.braid(3)
@@ -2152,7 +2152,7 @@ class HyperplaneArrangementElement(Element):
             sage: A = H([[0,1,1,1], [0,1,2,3], [0,1,3,2], [0,2,1,3]])
             sage: R = A.regions()
             sage: base_region = R[3]
-            sage: A.poset_of_regions(B=base_region)                                     # needs sage.combinat
+            sage: A.poset_of_regions(B=base_region)
             Finite poset containing 14 elements
         """
         from sage.combinat.posets.posets import Poset
@@ -2348,10 +2348,10 @@ class HyperplaneArrangementElement(Element):
             ....:     LHS = Qx.sum(x ** F[1].dim() for F in a.closed_faces())
             ....:     return LHS == RHS
             sage: a = hyperplane_arrangements.Catalan(2)
-            sage: test_number(a)                                                        # needs sage.combinat
+            sage: test_number(a)
             True
             sage: a = hyperplane_arrangements.Shi(3)
-            sage: test_number(a)                # long time                             # needs sage.combinat
+            sage: test_number(a)                # long time
             True
 
         TESTS:
@@ -2622,7 +2622,7 @@ class HyperplaneArrangementElement(Element):
             sage: (e3 + 2*e4) * (e1 - e7)
             e4 - e6
 
-            sage: U3 = a.face_semigroup_algebra(field=GF(3)); U3                        # needs sage.graphs sage.rings.finite_rings
+            sage: U3 = a.face_semigroup_algebra(field=GF(3)); U3
             Finite-dimensional algebra of degree 13 over Finite Field of size 3
 
         TESTS:
@@ -3161,8 +3161,8 @@ class HyperplaneArrangementElement(Element):
         intersection lattice::
 
             sage: f = sum([list(M.flats(i)) for i in range(M.rank() + 1)], [])
-            sage: PF = Poset([f, lambda x, y: x < y])                                   # needs sage.combinat
-            sage: PF.is_isomorphic(A.intersection_poset())                              # needs sage.combinat
+            sage: PF = Poset([f, lambda x, y: x < y])
+            sage: PF.is_isomorphic(A.intersection_poset())
             True
         """
         if not self.is_central():
@@ -3416,8 +3416,8 @@ class HyperplaneArrangementElement(Element):
         For type `A` arrangements, chordality is equivalent to freeness.
         We verify that in type `A_3`::
 
-            sage: W = WeylGroup(['A', 3], prefix='s')                                   # needs sage.combinat sage.groups
-            sage: for x in W:                                                           # needs sage.combinat sage.groups
+            sage: W = WeylGroup(['A', 3], prefix='s')
+            sage: for x in W:
             ....:    A = x.inversion_arrangement()
             ....:    assert A.matroid().is_chordal() == A.is_free()
 
@@ -3425,8 +3425,8 @@ class HyperplaneArrangementElement(Element):
 
         We check that the algorithms agree::
 
-            sage: W = WeylGroup(['B', 3], prefix='s')                                   # needs sage.combinat sage.groups
-            sage: for x in W:                   # long time                             # needs sage.combinat sage.groups
+            sage: W = WeylGroup(['B', 3], prefix='s')
+            sage: for x in W:                   # long time
             ....:    A = x.inversion_arrangement()
             ....:    assert (A.is_free(algorithm='BC')
             ....:            == A.is_free(algorithm='singular'))
@@ -3503,10 +3503,10 @@ class HyperplaneArrangementElement(Element):
 
         We check the algorithms produce a basis with the same exponents::
 
-            sage: W = WeylGroup(['A', 2], prefix='s')                                   # needs sage.combinat sage.groups
+            sage: W = WeylGroup(['A', 2], prefix='s')
             sage: def exponents(B):
             ....:     return sorted([max(x.degree() for x in b) for b in B])
-            sage: for x in W:                   # long time                             # needs sage.combinat sage.groups
+            sage: for x in W:                   # long time
             ....:     A = x.inversion_arrangement()
             ....:     B = A.derivation_module_basis(algorithm='singular')
             ....:     Bp = A.derivation_module_basis(algorithm='BC')

--- a/src/sage/geometry/hyperplane_arrangement/check_freeness.py
+++ b/src/sage/geometry/hyperplane_arrangement/check_freeness.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.libs.singular
 r"""
 Helper Functions For Freeness Of Hyperplane Arrangements
 

--- a/src/sage/geometry/hyperplane_arrangement/hyperplane.py
+++ b/src/sage/geometry/hyperplane_arrangement/hyperplane.py
@@ -617,7 +617,7 @@ class Hyperplane(LinearExpression):
         EXAMPLES::
 
             sage: L.<x, y> = HyperplaneArrangements(QQ)
-            sage: (x + y - 2).plot()                                                    # needs sage.plot
+            sage: (x + y - 2).plot()
             Graphics object consisting of 2 graphics primitives
         """
         from sage.geometry.hyperplane_arrangement.plot import plot_hyperplane

--- a/src/sage/geometry/hyperplane_arrangement/library.py
+++ b/src/sage/geometry/hyperplane_arrangement/library.py
@@ -84,7 +84,7 @@ class HyperplaneArrangementLibrary:
 
         EXAMPLES::
 
-            sage: hyperplane_arrangements.braid(4)                                      # needs sage.graphs
+            sage: hyperplane_arrangements.braid(4)
             Arrangement of 6 hyperplanes of dimension 4 and rank 3
         """
         from sage.graphs.graph_generators import graphs
@@ -285,7 +285,7 @@ class HyperplaneArrangementLibrary:
         If the Cartan type is not crystallographic, the Coxeter arrangement
         is not implemented yet::
 
-            sage: hyperplane_arrangements.Coxeter("H3")                                 # needs sage.libs.gap
+            sage: hyperplane_arrangements.Coxeter("H3")
             Traceback (most recent call last):
             ...
             NotImplementedError: Coxeter arrangements are not implemented
@@ -487,8 +487,8 @@ class HyperplaneArrangementLibrary:
 
         TESTS::
 
-            sage: a.characteristic_polynomial.clear_cache()     # long time             # needs sage.combinat
-            sage: a.characteristic_polynomial()         # long time                     # needs sage.combinat
+            sage: a.characteristic_polynomial.clear_cache()     # long time
+            sage: a.characteristic_polynomial()         # long time
             x^3 - 6*x^2 + 9*x
 
         REFERENCES:
@@ -545,7 +545,7 @@ class HyperplaneArrangementLibrary:
              Hyperplane t0 + 0*t1 + 0,
              Hyperplane t0 + 0*t1 + 1,
              Hyperplane t0 + t1 + 0)
-            sage: a.cone().is_free()                                                    # needs sage.libs.singular
+            sage: a.cone().is_free()
             True
 
         .. PLOT::

--- a/src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/ordered_arrangement.py
@@ -382,7 +382,7 @@ class OrderedHyperplaneArrangementElement(HyperplaneArrangementElement):
             sage: H.projective_fundamental_group()
             Finitely presented group < x0, x1 |  >
 
-            sage: # needs sirocco sage.graphs
+            sage: # needs sirocco
             sage: A3.<x, y, z> = OrderedHyperplaneArrangements(QQ)
             sage: H = A3(hyperplane_arrangements.braid(4).essentialization())
             sage: G3 = H.projective_fundamental_group(); G3.sorted_presentation()
@@ -482,7 +482,7 @@ class OrderedHyperplaneArrangementElement(HyperplaneArrangementElement):
             sage: H.projective_meridians()
             {0: x0, 1: x1, 2: [x1^-1*x0^-1]}
 
-            sage: # needs sirocco sage.graphs
+            sage: # needs sirocco
             sage: A3.<x, y, z> = OrderedHyperplaneArrangements(QQ)
             sage: H = A3(hyperplane_arrangements.braid(4).essentialization())
             sage: H.projective_meridians()

--- a/src/sage/geometry/hyperplane_arrangement/plot.py
+++ b/src/sage/geometry/hyperplane_arrangement/plot.py
@@ -56,26 +56,26 @@ EXAMPLES::
 
     sage: H3.<x,y,z> = HyperplaneArrangements(QQ)
     sage: A = H3([(1,0,0), 0], [(0,0,1), 5])
-    sage: A.plot(hyperplane_opacities=0.5, hyperplane_labels=True,                      # needs sage.plot
+    sage: A.plot(hyperplane_opacities=0.5, hyperplane_labels=True,
     ....:        hyperplane_legend=False)
     Graphics3d Object
 
     sage: c = H3([(1,0,0),0], [(0,0,1),5])
-    sage: c.plot(ranges=10)                                                             # needs sage.plot
+    sage: c.plot(ranges=10)
     Graphics3d Object
-    sage: c.plot(ranges=[[9.5,10], [-3,3]])                                             # needs sage.plot
+    sage: c.plot(ranges=[[9.5,10], [-3,3]])
     Graphics3d Object
-    sage: c.plot(ranges=[[[9.5,10], [-3,3]], [[-6,6], [-5,5]]])                         # needs sage.plot
+    sage: c.plot(ranges=[[[9.5,10], [-3,3]], [[-6,6], [-5,5]]])
     Graphics3d Object
 
 
     sage: H2.<s,t> = HyperplaneArrangements(QQ)
     sage: h = H2([(1,1),0], [(1,-1),0], [(0,1),2])
-    sage: h.plot(ranges=20)                                                             # needs sage.plot
+    sage: h.plot(ranges=20)
     Graphics object consisting of 3 graphics primitives
-    sage: h.plot(ranges=[-1, 10])                                                       # needs sage.plot
+    sage: h.plot(ranges=[-1, 10])
     Graphics object consisting of 3 graphics primitives
-    sage: h.plot(ranges=[[-1, 1], [-5, 5], [-1, 10]])                                   # needs sage.plot
+    sage: h.plot(ranges=[[-1, 1], [-5, 5], [-1, 10]])
     Graphics object consisting of 3 graphics primitives
 
     sage: a = hyperplane_arrangements.coordinate(3)
@@ -84,24 +84,24 @@ EXAMPLES::
     sage: opts['label_offsets'] = [(0,2,2), (2,0,2), (2,2,0)]
     sage: opts['hyperplane_legend'] = False
     sage: opts['hyperplane_opacities'] = 0.7
-    sage: a.plot(**opts)                                                                # needs sage.plot
+    sage: a.plot(**opts)
     Graphics3d Object
     sage: opts['hyperplane_labels'] = 'short'
-    sage: a.plot(**opts)                                                                # needs sage.plot
+    sage: a.plot(**opts)
     Graphics3d Object
 
     sage: H.<u> = HyperplaneArrangements(QQ)
     sage: pts = H(3*u+4, 2*u+5, 7*u+1)
-    sage: pts.plot(hyperplane_colors=['yellow','black','blue'])                         # needs sage.plot
+    sage: pts.plot(hyperplane_colors=['yellow','black','blue'])
     Graphics object consisting of 3 graphics primitives
-    sage: pts.plot(point_sizes=[50,100,200], hyperplane_colors='blue')                  # needs sage.plot
+    sage: pts.plot(point_sizes=[50,100,200], hyperplane_colors='blue')
     Graphics object consisting of 3 graphics primitives
 
     sage: H.<x,y,z> = HyperplaneArrangements(QQ)
     sage: a = H(x, y+1, y+2)
-    sage: a.plot(hyperplane_labels=True, label_colors='blue', label_fontsize=18)        # needs sage.plot
+    sage: a.plot(hyperplane_labels=True, label_colors='blue', label_fontsize=18)
     Graphics3d Object
-    sage: a.plot(hyperplane_labels=True, label_colors=['red','green','black'])          # needs sage.plot
+    sage: a.plot(hyperplane_labels=True, label_colors=['red','green','black'])
     Graphics3d Object
 """
 from copy import copy
@@ -143,7 +143,7 @@ def plot(hyperplane_arrangement, **kwds):
     EXAMPLES::
 
         sage: B = hyperplane_arrangements.semiorder(4)
-        sage: B.plot()                                                                  # needs sage.combinat sage.plot
+        sage: B.plot()
         Displaying the essentialization.
         Graphics3d Object
     """
@@ -325,20 +325,20 @@ def plot_hyperplane(hyperplane, **kwds):
 
         sage: H1.<x> = HyperplaneArrangements(QQ)
         sage: a = 3*x + 4
-        sage: a.plot()    # indirect doctest                                            # needs sage.plot
+        sage: a.plot()    # indirect doctest
         Graphics object consisting of 3 graphics primitives
-        sage: a.plot(point_size=100, hyperplane_label='hello')                          # needs sage.plot
+        sage: a.plot(point_size=100, hyperplane_label='hello')
         Graphics object consisting of 3 graphics primitives
 
         sage: H2.<x,y> = HyperplaneArrangements(QQ)
         sage: b = 3*x + 4*y + 5
-        sage: b.plot()                                                                  # needs sage.plot
+        sage: b.plot()
         Graphics object consisting of 2 graphics primitives
-        sage: b.plot(ranges=(1,5), label_offset=(2,-1))                                 # needs sage.plot
+        sage: b.plot(ranges=(1,5), label_offset=(2,-1))
         Graphics object consisting of 2 graphics primitives
         sage: opts = {'hyperplane_label': True, 'label_color': 'green',
         ....:         'label_fontsize': 24, 'label_offset': (0,1.5)}
-        sage: b.plot(**opts)                                                            # needs sage.plot
+        sage: b.plot(**opts)
         Graphics object consisting of 2 graphics primitives
 
         sage: H3.<x,y,z> = HyperplaneArrangements(QQ)
@@ -482,20 +482,20 @@ def legend_3d(hyperplane_arrangement, hyperplane_colors, length):
 
         sage: a = hyperplane_arrangements.semiorder(3)
         sage: from sage.geometry.hyperplane_arrangement.plot import legend_3d
-        sage: legend_3d(a, list(colors.values())[:6], length='long')                    # needs sage.combinat sage.plot
+        sage: legend_3d(a, list(colors.values())[:6], length='long')
         Graphics object consisting of 6 graphics primitives
 
         sage: b = hyperplane_arrangements.semiorder(4)
         sage: c = b.essentialization()
-        sage: legend_3d(c, list(colors.values())[:12], length='long')                   # needs sage.combinat sage.plot
+        sage: legend_3d(c, list(colors.values())[:12], length='long')
         Graphics object consisting of 12 graphics primitives
 
-        sage: legend_3d(c, list(colors.values())[:12], length='short')                  # needs sage.combinat sage.plot
+        sage: legend_3d(c, list(colors.values())[:12], length='short')
         Graphics object consisting of 12 graphics primitives
 
-        sage: p = legend_3d(c, list(colors.values())[:12], length='short')              # needs sage.combinat sage.plot
-        sage: p.set_legend_options(ncol=4)                                              # needs sage.combinat sage.plot
-        sage: type(p)                                                                   # needs sage.combinat sage.plot
+        sage: p = legend_3d(c, list(colors.values())[:12], length='short')
+        sage: p.set_legend_options(ncol=4)
+        sage: type(p)
         <class 'sage.plot.graphics.Graphics'>
     """
     if hyperplane_arrangement.dimension() != 3:

--- a/src/sage/geometry/integral_points.pxi
+++ b/src/sage/geometry/integral_points.pxi
@@ -471,8 +471,8 @@ cpdef rectangular_box_points(list box_min, list box_max,
 
     Long ints and non-integral polyhedra are explicitly allowed::
 
-        sage: polytope = Polyhedron([[1], [10*pi.n()]], base_ring=RDF)                  # needs sage.symbolic
-        sage: len(rectangular_box_points([-100], [100], polytope))                      # needs sage.symbolic
+        sage: polytope = Polyhedron([[1], [10*pi.n()]], base_ring=RDF)
+        sage: len(rectangular_box_points([-100], [100], polytope))
         31
 
         sage: halfplane = Polyhedron(ieqs=[(-1,1,0)])
@@ -739,7 +739,7 @@ cdef class Inequality_generic:
     EXAMPLES::
 
         sage: from sage.geometry.integral_points import Inequality_generic
-        sage: Inequality_generic([2 * pi, sqrt(3), 7/2], -5.5)                          # needs sage.symbolic
+        sage: Inequality_generic([2 * pi, sqrt(3), 7/2], -5.5)
         generic: (2*pi, sqrt(3), 7/2) x + -5.50000000000000 >= 0
     """
 
@@ -761,7 +761,7 @@ cdef class Inequality_generic:
         EXAMPLES::
 
             sage: from sage.geometry.integral_points import Inequality_generic
-            sage: Inequality_generic([2 * pi, sqrt(3), 7/2], -5.5)                      # needs sage.symbolic
+            sage: Inequality_generic([2 * pi, sqrt(3), 7/2], -5.5)
             generic: (2*pi, sqrt(3), 7/2) x + -5.50000000000000 >= 0
         """
         self.A = A
@@ -1182,8 +1182,8 @@ cdef class InequalityCollection:
         Check that :issue:`21037` is fixed::
 
             sage: P = Polyhedron(vertices=((0, 0), (17,3)))
-            sage: P += 1/1000*polytopes.regular_polygon(5)                              # needs sage.rings.number_field
-            sage: P.integral_points()                                                   # needs sage.rings.number_field
+            sage: P += 1/1000*polytopes.regular_polygon(5)
+            sage: P.integral_points()
             ((0, 0), (17, 3))
         """
         cdef list A

--- a/src/sage/geometry/lattice_polytope.py
+++ b/src/sage/geometry/lattice_polytope.py
@@ -224,7 +224,7 @@ def LatticePolytope(data, compute_vertices=True, n=0, lattice=None):
 
     We draw a pretty picture of the polytope in 3-dimensional space::
 
-        sage: p.plot3d().show()                                                         # needs palp sage.plot
+        sage: p.plot3d().show()                                                         # needs palp
 
     Now we add an extra point, which is in the interior of the
     polytope...
@@ -280,7 +280,7 @@ def LatticePolytope(data, compute_vertices=True, n=0, lattice=None):
         sage: p.points()
         Empty collection
         in 3-d lattice M
-        sage: p.faces()                                                                 # needs sage.graphs
+        sage: p.faces()
         ((-1-d lattice polytope in 3-d lattice M,),)
     """
     parent = LatticePolytopes()
@@ -1309,7 +1309,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
             sage: o = lattice_polytope.cross_polytope(3)
             sage: # indirect doctest
-            sage: for i, face in enumerate(o.faces(0)):                                 # needs sage.graphs
+            sage: for i, face in enumerate(o.faces(0)):
             ....:     if face.vertex(0) != o.vertex(i):
             ....:         print("Wrong order!")
         """
@@ -1354,10 +1354,10 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES::
 
             sage: o = lattice_polytope.cross_polytope(3)
-            sage: o.adjacent()                                                          # needs sage.graphs
+            sage: o.adjacent()
             ()
-            sage: face = o.faces(1)[0]                                                  # needs sage.graphs
-            sage: face.adjacent()                                                       # needs sage.graphs
+            sage: face = o.faces(1)[0]
+            sage: face.adjacent()
             (1-d face of 3-d reflexive polytope in 3-d lattice M,
              1-d face of 3-d reflexive polytope in 3-d lattice M,
              1-d face of 3-d reflexive polytope in 3-d lattice M,
@@ -1555,10 +1555,10 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES::
 
             sage: cube = lattice_polytope.cross_polytope(3).polar()
-            sage: face = cube.facets()[0]                                               # needs sage.graphs
-            sage: face.ambient_point_indices()                                          # needs palp sage.graphs
+            sage: face = cube.facets()[0]
+            sage: face.ambient_point_indices()                                          # needs palp
             (4, 5, 6, 7, 8, 9, 10, 11, 12)
-            sage: cube.points(face.ambient_point_indices()) == face.points()            # needs palp sage.graphs
+            sage: cube.points(face.ambient_point_indices()) == face.points()            # needs palp
             True
         """
         if self._ambient is self:
@@ -1581,10 +1581,10 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES::
 
             sage: cube = lattice_polytope.cross_polytope(3).polar()
-            sage: face = cube.facets()[0]                                               # needs sage.graphs
-            sage: face.ambient_ordered_point_indices()                                  # needs palp sage.graphs
+            sage: face = cube.facets()[0]
+            sage: face.ambient_ordered_point_indices()                                  # needs palp
             (5, 8, 4, 9, 10, 11, 6, 12, 7)
-            sage: cube.points(face.ambient_ordered_point_indices())                     # needs palp sage.graphs
+            sage: cube.points(face.ambient_ordered_point_indices())                     # needs palp
             N(-1, -1, -1),
             N(-1, -1,  0),
             N(-1, -1,  1),
@@ -1613,8 +1613,8 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             sage: o = lattice_polytope.cross_polytope(3)
             sage: o.ambient_vertex_indices()
             (0, 1, 2, 3, 4, 5)
-            sage: face = o.faces(1)[0]                                                  # needs sage.graphs
-            sage: face.ambient_vertex_indices()                                         # needs sage.graphs
+            sage: face = o.faces(1)[0]
+            sage: face.ambient_vertex_indices()
             (0, 1)
         """
         return self._ambient_vertex_indices
@@ -1647,13 +1647,13 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         For an edge the boundary is formed by the end points::
 
-            sage: face = square.edges()[0]                                              # needs sage.graphs
-            sage: face.points()                                                         # needs sage.graphs
+            sage: face = square.edges()[0]
+            sage: face.points()
             N(-1, -1),
             N(-1,  1),
             N(-1,  0)
             in 2-d lattice N
-            sage: face.boundary_point_indices()                                         # needs sage.graphs
+            sage: face.boundary_point_indices()
             (0, 1)
         """
         return tuple(i
@@ -1684,8 +1684,8 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         For an edge the boundary is formed by the end points::
 
-            sage: face = square.edges()[0]                                              # needs sage.graphs
-            sage: face.boundary_points()                                                # needs sage.graphs
+            sage: face = square.edges()[0]
+            sage: face.boundary_points()
             N(-1, -1),
             N(-1,  1)
             in 2-d lattice N
@@ -1782,7 +1782,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
             sage: o.distances([1,2,3/2])
             (-3/2, 5/2, 11/2, 3/2, -1/2, -7/2, 1/2, 7/2)
-            sage: o.distances([1,2,sqrt(2)])                                            # needs sage.symbolic
+            sage: o.distances([1,2,sqrt(2)])
             Traceback (most recent call last):
             ...
             TypeError: unable to convert sqrt(2) to an element of Rational Field
@@ -1879,11 +1879,11 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES::
 
             sage: o = lattice_polytope.cross_polytope(3)
-            sage: o.edges()                                                             # needs sage.graphs
+            sage: o.edges()
             (1-d face of 3-d reflexive polytope in 3-d lattice M,
             ...
              1-d face of 3-d reflexive polytope in 3-d lattice M)
-            sage: len(o.edges())                                                        # needs sage.graphs
+            sage: len(o.edges())
             12
         """
         return self.faces(dim=1)
@@ -1906,12 +1906,12 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         Let's take a look at the face lattice of a square::
 
             sage: square = LatticePolytope([(0,0), (1,0), (1,1), (0,1)])
-            sage: L = square.face_lattice(); L                                          # needs sage.graphs
+            sage: L = square.face_lattice(); L
             Finite lattice containing 10 elements with distinguished linear extension
 
         To see all faces arranged by dimension, you can do this::
 
-            sage: for level in L.level_sets(): print(level)                             # needs sage.graphs
+            sage: for level in L.level_sets(): print(level)
             [-1-d face of 2-d lattice polytope in 2-d lattice M]
             [0-d face of 2-d lattice polytope in 2-d lattice M,
              0-d face of 2-d lattice polytope in 2-d lattice M,
@@ -1925,15 +1925,15 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         For a particular face you can look at its actual vertices... ::
 
-            sage: face = L.level_sets()[1][0]                                           # needs sage.graphs
-            sage: face.vertices()                                                       # needs sage.graphs
+            sage: face = L.level_sets()[1][0]
+            sage: face.vertices()
             M(0, 0)
             in 2-d lattice M
 
         ... or you can see the index of the vertex of the original polytope that
         corresponds to the above one::
 
-            sage: face.ambient_vertex_indices()                                         # needs sage.graphs
+            sage: face.ambient_vertex_indices()
             (0,)
             sage: square.vertex(0)
             M(0, 0)
@@ -1941,15 +1941,15 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         An alternative to extracting faces from the face lattice is to use
         :meth:`faces` method::
 
-            sage: face is square.faces(dim=0)[0]                                        # needs sage.graphs
+            sage: face is square.faces(dim=0)[0]
             True
 
         The advantage of working with the face lattice directly is that you
         can (relatively easily) get faces that are related to the given one::
 
-            sage: face = L.level_sets()[1][0]                                           # needs sage.graphs
-            sage: D = L.hasse_diagram()                                                 # needs sage.graphs
-            sage: sorted(D.neighbors(face))                                             # needs sage.graphs
+            sage: face = L.level_sets()[1][0]
+            sage: D = L.hasse_diagram()
+            sage: sorted(D.neighbors(face))
             [-1-d face of 2-d lattice polytope in 2-d lattice M,
              1-d face of 2-d lattice polytope in 2-d lattice M,
              1-d face of 2-d lattice polytope in 2-d lattice M]
@@ -2084,7 +2084,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         Let's take a look at the faces of a square::
 
             sage: square = LatticePolytope([(0,0), (1,0), (1,1), (0,1)])
-            sage: square.faces()                                                        # needs sage.graphs
+            sage: square.faces()
             ((-1-d face of 2-d lattice polytope in 2-d lattice M,),
              (0-d face of 2-d lattice polytope in 2-d lattice M,
               0-d face of 2-d lattice polytope in 2-d lattice M,
@@ -2098,7 +2098,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         Its faces of dimension one (i.e., edges)::
 
-            sage: square.faces(dim=1)                                                   # needs sage.graphs
+            sage: square.faces(dim=1)
             (1-d face of 2-d lattice polytope in 2-d lattice M,
              1-d face of 2-d lattice polytope in 2-d lattice M,
              1-d face of 2-d lattice polytope in 2-d lattice M,
@@ -2106,16 +2106,16 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         Its faces of codimension one are the same (also edges)::
 
-            sage: square.faces(codim=1) is square.faces(dim=1)                          # needs sage.graphs
+            sage: square.faces(codim=1) is square.faces(dim=1)
             True
 
         Let's pick a particular face::
 
-            sage: face = square.faces(dim=1)[0]                                         # needs sage.graphs
+            sage: face = square.faces(dim=1)[0]
 
         Now you can look at the actual vertices of this face... ::
 
-            sage: face.vertices()                                                       # needs sage.graphs
+            sage: face.vertices()
             M(0, 0),
             M(0, 1)
             in 2-d lattice M
@@ -2123,9 +2123,9 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         ... or you can see indices of the vertices of the original polytope that
         correspond to the above ones::
 
-            sage: face.ambient_vertex_indices()                                         # needs sage.graphs
+            sage: face.ambient_vertex_indices()
             (0, 3)
-            sage: square.vertices(face.ambient_vertex_indices())                        # needs sage.graphs
+            sage: square.vertices(face.ambient_vertex_indices())
             M(0, 0),
             M(0, 1)
             in 2-d lattice M
@@ -2363,11 +2363,11 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES::
 
             sage: o = lattice_polytope.cross_polytope(3)
-            sage: o.facets()                                                            # needs sage.graphs
+            sage: o.facets()
             (2-d face of 3-d reflexive polytope in 3-d lattice M,
             ...
              2-d face of 3-d reflexive polytope in 3-d lattice M)
-            sage: len(o.facets())                                                       # needs sage.graphs
+            sage: len(o.facets())
             8
         """
         return self.faces(codim=1)
@@ -2395,14 +2395,14 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             [0 1 1 0]
             [1 1 0 0]
             [1 0 0 1]
-            sage: o.faces(1)[0].incidence_matrix()                                      # needs sage.graphs
+            sage: o.faces(1)[0].incidence_matrix()
             [1 0]
             [0 1]
 
             sage: o = lattice_polytope.cross_polytope(4)
             sage: o.incidence_matrix().column(3).nonzero_positions()
             [3, 4, 5, 6]
-            sage: o.facets()[3].ambient_vertex_indices()                                # needs sage.graphs
+            sage: o.facets()[3].ambient_vertex_indices()
             (3, 4, 5, 6)
 
         TESTS::
@@ -2468,13 +2468,13 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         But they are in the same `GL(\ZZ^n)` orbit and have the same
         normal form::
 
-            sage: d.normal_form()                                                       # needs sage.groups
+            sage: d.normal_form()
             M( 1,  0),
             M( 0,  1),
             M( 0, -1),
             M(-1,  0)
             in 2-d lattice M
-            sage: lattice_polytope.ReflexivePolytope(2,3).normal_form()                 # needs sage.groups
+            sage: lattice_polytope.ReflexivePolytope(2,3).normal_form()
             M( 1,  0),
             M( 0,  1),
             M( 0, -1),
@@ -2521,13 +2521,13 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         Its edges also have a single interior point each::
 
-            sage: face = square.edges()[0]                                              # needs sage.graphs
-            sage: face.points()                                                         # needs sage.graphs
+            sage: face = square.edges()[0]
+            sage: face.points()
             N(-1, -1),
             N(-1,  1),
             N(-1,  0)
             in 2-d lattice N
-            sage: face.interior_point_indices()                                         # needs sage.graphs
+            sage: face.interior_point_indices()
             (2,)
         """
         return tuple(i
@@ -2551,8 +2551,8 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
         Its edges also have a single interior point each::
 
-            sage: face = square.edges()[0]                                              # needs sage.graphs
-            sage: face.interior_points()                                                # needs sage.graphs
+            sage: face = square.edges()[0]
+            sage: face.interior_points()
             N(-1, 0)
             in 2-d lattice N
         """
@@ -2693,7 +2693,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             sage: p = LatticePolytope([(1,0)])
             sage: p.ambient_vector_space()
             Vector space of dimension 2 over Rational Field
-            sage: p.ambient_vector_space(AA)                                            # needs sage.rings.number_field
+            sage: p.ambient_vector_space(AA)
             Vector space of dimension 2 over Algebraic Real Field
         """
         return self.lattice().vector_space(base_field=base_field)
@@ -2974,7 +2974,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             M(-1,  0),
             M( 0, -1)
             in 2-d lattice M
-            sage: d.normal_form()                                                       # needs sage.groups
+            sage: d.normal_form()
             M( 1,  0),
             M( 0,  1),
             M( 0, -1),
@@ -3010,7 +3010,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         We can perform the same examples using other algorithms::
 
             sage: o = lattice_polytope.cross_polytope(2)
-            sage: o.normal_form(algorithm='palp_native')                                # needs sage.groups
+            sage: o.normal_form(algorithm='palp_native')
             M( 1,  0),
             M( 0,  1),
             M( 0, -1),
@@ -3018,7 +3018,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             in 2-d lattice M
 
             sage: o = lattice_polytope.cross_polytope(2)
-            sage: o.normal_form(algorithm='palp_modified')                              # needs sage.groups
+            sage: o.normal_form(algorithm='palp_modified')
             M( 1,  0),
             M( 0,  1),
             M( 0, -1),
@@ -3086,7 +3086,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             RuntimeError: Error executing ... for a polytope sequence!
             Output:
             b'*** stack smashing detected ***: terminated\nAborted\n'
-            sage: P.normal_form(algorithm='palp_native')                                # needs sage.groups
+            sage: P.normal_form(algorithm='palp_native')
             M(  6,  0,  0,  0,  0),
             M( -6,  0,  0,  0,  0),
             M(  0,  1,  0,  0,  0),
@@ -3128,7 +3128,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             M( 12, -1, -9, -6,  6),
             M( 12, -1, -6, -3,  3)
             in 5-d lattice M
-            sage: P.normal_form(algorithm='palp_modified')      # not tested (22s; MemoryError on 32 bit), needs sage.groups
+            sage: P.normal_form(algorithm='palp_modified')      # not tested (22s; MemoryError on 32 bit)
             M(  6,  0,  0,  0,  0),
             M( -6,  0,  0,  0,  0),
             M(  0,  1,  0,  0,  0),
@@ -3231,13 +3231,13 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             M(-1,  0),
             M( 0, -1)
             in 2-d lattice M
-            sage: o._palp_modified_normal_form()                                        # needs sage.graphs sage.groups
+            sage: o._palp_modified_normal_form()
             M( 1,  0),
             M( 0,  1),
             M( 0, -1),
             M(-1,  0)
             in 2-d lattice M
-            sage: o._palp_modified_normal_form(permutation=True)                        # needs sage.graphs sage.groups
+            sage: o._palp_modified_normal_form(permutation=True)
             (M( 1,  0),
             M( 0,  1),
             M( 0, -1),
@@ -3280,13 +3280,13 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
             M(-1,  0),
             M( 0, -1)
             in 2-d lattice M
-            sage: o._palp_native_normal_form()                                          # needs sage.groups
+            sage: o._palp_native_normal_form()
             M( 1,  0),
             M( 0,  1),
             M( 0, -1),
             M(-1,  0)
             in 2-d lattice M
-            sage: o._palp_native_normal_form(permutation=True)                          # needs sage.groups
+            sage: o._palp_native_normal_form(permutation=True)
             (M( 1,  0),
             M( 0,  1),
             M( 0, -1),
@@ -3330,23 +3330,23 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
             sage: o = lattice_polytope.cross_polytope(2)
             sage: PM = o.vertex_facet_pairing_matrix()
-            sage: PM_max = PM.permutation_normal_form()                                 # needs sage.graphs
-            sage: PM_max == o._palp_PM_max()                                            # needs sage.graphs sage.groups
+            sage: PM_max = PM.permutation_normal_form()
+            sage: PM_max == o._palp_PM_max()
             True
             sage: P2 = ReflexivePolytope(2, 0)
-            sage: PM_max, permutations = P2._palp_PM_max(check=True)                    # needs sage.groups
-            sage: PM_max                                                                # needs sage.graphs
+            sage: PM_max, permutations = P2._palp_PM_max(check=True)
+            sage: PM_max
             [3 0 0]
             [0 3 0]
             [0 0 3]
-            sage: list(permutations.values())                                           # needs sage.groups
+            sage: list(permutations.values())
             [[(1,2,3), (1,2,3)],
              [(1,3,2), (1,3,2)],
              [(1,3), (1,3)],
              [(1,2), (1,2)],
              [(), ()],
              [(2,3), (2,3)]]
-            sage: PM_max.automorphisms_of_rows_and_columns()                            # needs sage.graphs sage.groups
+            sage: PM_max.automorphisms_of_rows_and_columns()
             [((), ()),
              ((1,2,3), (1,2,3)),
              ((1,3,2), (1,3,2)),
@@ -3558,30 +3558,30 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES: The default plot of a cube::
 
             sage: c = lattice_polytope.cross_polytope(3).polar()
-            sage: c.plot3d()                                                            # needs palp sage.plot
+            sage: c.plot3d()                                                            # needs palp
             Graphics3d Object
 
         Plot without facets and points, shown without the frame::
 
-            sage: c.plot3d(show_facets=false,                                           # needs palp sage.plot
+            sage: c.plot3d(show_facets=false,                                           # needs palp
             ....:          show_points=false).show(frame=False)
 
         Plot with facets of different colors::
 
-            sage: c.plot3d(facet_colors=rainbow(c.n_facets(), 'rgbtuple'))               # needs palp sage.plot
+            sage: c.plot3d(facet_colors=rainbow(c.n_facets(), 'rgbtuple'))               # needs palp
             Graphics3d Object
 
         It is also possible to plot lower dimensional polytops in 3D (let's
         also change labels of vertices)::
 
             sage: c2 = lattice_polytope.cross_polytope(2)
-            sage: c2.plot3d(vlabels=["A", "B", "C", "D"])                               # needs palp sage.plot
+            sage: c2.plot3d(vlabels=["A", "B", "C", "D"])                               # needs palp
             Graphics3d Object
 
         TESTS::
 
             sage: p = LatticePolytope([[0,0,0],[0,1,1],[1,0,1],[1,1,0]])
-            sage: p.plot3d()                                                            # needs palp sage.plot
+            sage: p.plot3d()                                                            # needs palp
             Graphics3d Object
         """
         dim = self.dim()
@@ -3681,7 +3681,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES::
 
             sage: o = lattice_polytope.cross_polytope(3)
-            sage: o.show3d()                                                            # needs palp sage.plot
+            sage: o.show3d()                                                            # needs palp
         """
         self.plot3d().show(axis=False, frame=False)
 
@@ -4028,9 +4028,9 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES::
 
             sage: d = lattice_polytope.cross_polytope(2)
-            sage: g = d.skeleton(); g                                                   # needs palp sage.graphs
+            sage: g = d.skeleton(); g                                                   # needs palp
             Graph on 4 vertices
-            sage: g.edges(sort=True)                                                    # needs palp sage.graphs
+            sage: g.edges(sort=True)                                                    # needs palp
             [(0, 1, None), (0, 3, None), (1, 2, None), (2, 3, None)]
         """
         from sage.graphs.graph import Graph
@@ -4051,22 +4051,22 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
 
             sage: o = lattice_polytope.cross_polytope(3)
             sage: c = o.polar()
-            sage: c.skeleton_points()                                                   # needs palp sage.graphs
+            sage: c.skeleton_points()                                                   # needs palp
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 15, 19, 21, 22, 23, 25, 26]
 
         The default was 1-skeleton::
 
-            sage: c.skeleton_points(k=1)                                                # needs palp sage.graphs
+            sage: c.skeleton_points(k=1)                                                # needs palp
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 15, 19, 21, 22, 23, 25, 26]
 
         0-skeleton just lists all vertices::
 
-            sage: c.skeleton_points(k=0)                                                # needs palp sage.graphs
+            sage: c.skeleton_points(k=0)                                                # needs palp
             [0, 1, 2, 3, 4, 5, 6, 7]
 
         2-skeleton lists all points except for the origin (point #17)::
 
-            sage: c.skeleton_points(k=2)                                                # needs palp sage.graphs
+            sage: c.skeleton_points(k=2)                                                # needs palp
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
              18, 19, 20, 21, 22, 23, 24, 25, 26]
 
@@ -4103,7 +4103,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES: Show a pretty picture of the octahedron::
 
             sage: o = lattice_polytope.cross_polytope(3)
-            sage: o.skeleton_show([1,2,4])                                              # needs palp sage.plot
+            sage: o.skeleton_show([1,2,4])                                              # needs palp
 
         Does not work for a diamond at the moment::
 
@@ -4133,7 +4133,7 @@ class LatticePolytopeClass(Element, ConvexSet_compact,
         EXAMPLES::
 
             sage: p = lattice_polytope.cross_polytope(2).polar()
-            sage: p.traverse_boundary()                                                 # needs sage.graphs
+            sage: p.traverse_boundary()
             [3, 0, 1, 2]
         """
         if self.dim() != 2:
@@ -5194,9 +5194,9 @@ def _palp_canonical_order(V, PM_max, permutations) -> tuple:
 
         sage: L = lattice_polytope.cross_polytope(2)
         sage: V = L.vertices()
-        sage: PM_max, permutations = L._palp_PM_max(check=True)                         # needs sage.groups
+        sage: PM_max, permutations = L._palp_PM_max(check=True)
         sage: from sage.geometry.lattice_polytope import _palp_canonical_order
-        sage: _palp_canonical_order(V, PM_max, permutations)                            # needs sage.groups
+        sage: _palp_canonical_order(V, PM_max, permutations)
         (M( 1,  0),
          M( 0,  1),
          M( 0, -1),
@@ -5231,9 +5231,9 @@ def _palp_convert_permutation(permutation):
     EXAMPLES::
 
         sage: from sage.geometry.lattice_polytope import _palp_convert_permutation
-        sage: _palp_convert_permutation('1023')                                         # needs sage.groups
+        sage: _palp_convert_permutation('1023')
         (1,2)
-        sage: _palp_convert_permutation('0123456789bac')                                # needs sage.groups
+        sage: _palp_convert_permutation('0123456789bac')
         (11,12)
     """
     def from_palp_index(i):

--- a/src/sage/geometry/linear_expression.py
+++ b/src/sage/geometry/linear_expression.py
@@ -430,7 +430,7 @@ class LinearExpression(ModuleElement):
             9
             sage: ex([1,1])    # syntactic sugar
             9
-            sage: ex([pi, e])                                                           # needs sage.symbolic
+            sage: ex([pi, e])
             2*pi + 3*e + 4
         """
         try:

--- a/src/sage/geometry/newton_polygon.py
+++ b/src/sage/geometry/newton_polygon.py
@@ -459,7 +459,7 @@ class NewtonPolygon_element(Element):
 
             sage: from sage.geometry.newton_polygon import NewtonPolygon
             sage: NP = NewtonPolygon([ (0,0), (1,1), (2,6) ])
-            sage: polygon = NP.plot()                                                   # needs sage.plot
+            sage: polygon = NP.plot()
         """
         vertices = self.vertices()
         if len(vertices) == 0:

--- a/src/sage/geometry/palp_normal_form.pyx
+++ b/src/sage/geometry/palp_normal_form.pyx
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.groups
 r"""
 PALP normal form of vertices of a lattice polytope
 """

--- a/src/sage/geometry/polyhedral_complex.py
+++ b/src/sage/geometry/polyhedral_complex.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.graphs
 r"""
 Finite polyhedral complexes
 
@@ -208,7 +207,7 @@ class PolyhedralComplex(GenericCellComplex):
          (A vertex at (0, 1/4),),
          (A vertex at (1/7, 2/7),),
          (A vertex at (1/3, 1/3),)]
-        sage: pc.plot()                                                                 # needs sage.plot
+        sage: pc.plot()
         Graphics object consisting of 10 graphics primitives
         sage: pc.is_pure()
         True
@@ -755,17 +754,17 @@ class PolyhedralComplex(GenericCellComplex):
             sage: p3 = Polyhedron(vertices=[(0, 0), (0, 2), (-1, 1)])
             sage: pc1 = PolyhedralComplex([p1, p2, p3, -p1, -p2, -p3])
             sage: bb = dict(xmin=-2, xmax=2, ymin=-3, ymax=3, axes=False)
-            sage: g0 = pc1.plot(color='rainbow', **bb)                                  # needs sage.plot
-            sage: g1 = pc1.plot(explosion_factor=0.5, **bb)                             # needs sage.plot
-            sage: g2 = pc1.plot(explosion_factor=1, color='rainbow', alpha=0.5, **bb)   # needs sage.plot
+            sage: g0 = pc1.plot(color='rainbow', **bb)
+            sage: g1 = pc1.plot(explosion_factor=0.5, **bb)
+            sage: g2 = pc1.plot(explosion_factor=1, color='rainbow', alpha=0.5, **bb)
             sage: graphics_array([g0, g1, g2]).show(axes=False)                        # not tested
 
             sage: pc2 = PolyhedralComplex([polytopes.hypercube(3)])
             sage: pc3 = pc2.subdivide(new_vertices=[(0, 0, 0)])
-            sage: g3 = pc3.plot(explosion_factor=1, color='rainbow',                    # needs sage.plot
+            sage: g3 = pc3.plot(explosion_factor=1, color='rainbow',
             ....:               alpha=0.5, axes=False, online=True)
             sage: pc4 = pc2.subdivide(make_simplicial=True)
-            sage: g4 = pc4.plot(explosion_factor=1, center=(1, -1, 1), fill='blue',     # needs sage.plot
+            sage: g4 = pc4.plot(explosion_factor=1, center=(1, -1, 1), fill='blue',
             ....:              wireframe='white', point={'color':'red', 'size':10},
             ....:              alpha=0.6, online=True)
             sage: pc5 = PolyhedralComplex([
@@ -776,7 +775,7 @@ class PolyhedralComplex(GenericCellComplex):
             ....:         Polyhedron(rays=[[-1,0,0], [0,-1,0], [0,0,1]]),
             ....:         Polyhedron(rays=[[-1,0,0], [0,1,0], [0,0,-1]]),
             ....:         Polyhedron(rays=[[-1,0,0], [0,1,0], [0,0,1]])])
-            sage: g5 = pc5.plot(explosion_factor=0.3, color='rainbow', alpha=0.8,       # needs sage.plot
+            sage: g5 = pc5.plot(explosion_factor=0.3, color='rainbow', alpha=0.8,
             ....:               point={'size': 20}, axes=False, online=True)
         """
         if self.dimension() > 3:
@@ -1007,7 +1006,7 @@ class PolyhedralComplex(GenericCellComplex):
             sage: poset
             Finite poset containing 11 elements
             sage: d = {i: i.vertices_matrix() for i in poset}
-            sage: poset.plot(element_labels=d)                                          # needs sage.plot
+            sage: poset.plot(element_labels=d)
             Graphics object consisting of 28 graphics primitives
 
         For a nonbounded polyhedral complex::
@@ -2552,11 +2551,11 @@ def exploded_plot(polyhedra, *,
         sage: p1 = Polyhedron(vertices=[(1, 1), (0, 0), (1, 2)])
         sage: p2 = Polyhedron(vertices=[(1, 2), (0, 0), (0, 2)])
         sage: p3 = Polyhedron(vertices=[(0, 0), (1, 1), (2, 0)])
-        sage: exploded_plot([p1, p2, p3])                                               # needs sage.plot
+        sage: exploded_plot([p1, p2, p3])
         Graphics object consisting of 20 graphics primitives
-        sage: exploded_plot([p1, p2, p3], center=(1, 1))                                # needs sage.plot
+        sage: exploded_plot([p1, p2, p3], center=(1, 1))
         Graphics object consisting of 19 graphics primitives
-        sage: exploded_plot([p1, p2, p3], center=(1, 1), sticky_vertices=True)          # needs sage.plot
+        sage: exploded_plot([p1, p2, p3], center=(1, 1), sticky_vertices=True)
         Graphics object consisting of 23 graphics primitives
     """
     from sage.plot.colors import rainbow

--- a/src/sage/geometry/polyhedron/backend_field.py
+++ b/src/sage/geometry/polyhedron/backend_field.py
@@ -46,15 +46,15 @@ class Polyhedron_field(Polyhedron_base):
 
     EXAMPLES::
 
-        sage: p = Polyhedron(vertices=[(0,0),(AA(2).sqrt(),0),(0,AA(3).sqrt())],        # needs sage.rings.number_field
+        sage: p = Polyhedron(vertices=[(0,0),(AA(2).sqrt(),0),(0,AA(3).sqrt())],
         ....:                rays=[(1,1)], lines=[], backend='field', base_ring=AA)
-        sage: TestSuite(p).run()                                                        # needs sage.rings.number_field
+        sage: TestSuite(p).run()
 
     TESTS::
 
-        sage: K.<sqrt3> = QuadraticField(3)                                             # needs sage.rings.number_field
-        sage: p = Polyhedron([(0,0), (1,0), (1/2, sqrt3/2)])                            # needs sage.rings.number_field
-        sage: TestSuite(p).run()                                                        # needs sage.rings.number_field
+        sage: K.<sqrt3> = QuadraticField(3)
+        sage: p = Polyhedron([(0,0), (1,0), (1/2, sqrt3/2)])
+        sage: TestSuite(p).run()
 
     Check that :issue:`19013` is fixed::
 
@@ -83,10 +83,10 @@ class Polyhedron_field(Polyhedron_base):
 
         EXAMPLES::
 
-            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)                     # needs sage.rings.number_field sage.symbolic
-            sage: p._is_zero(0)                                                         # needs sage.rings.number_field sage.symbolic
+            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)
+            sage: p._is_zero(0)
             True
-            sage: p._is_zero(1/100000)                                                  # needs sage.rings.number_field sage.symbolic
+            sage: p._is_zero(1/100000)
             False
         """
         return x == 0
@@ -103,10 +103,10 @@ class Polyhedron_field(Polyhedron_base):
 
         EXAMPLES::
 
-            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)                     # needs sage.rings.number_field sage.symbolic
-            sage: p._is_nonneg(1)                                                       # needs sage.rings.number_field sage.symbolic
+            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)
+            sage: p._is_nonneg(1)
             True
-            sage: p._is_nonneg(-1/100000)                                               # needs sage.rings.number_field sage.symbolic
+            sage: p._is_nonneg(-1/100000)
             False
         """
         return x >= 0
@@ -123,10 +123,10 @@ class Polyhedron_field(Polyhedron_base):
 
         EXAMPLES::
 
-            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)                     # needs sage.rings.number_field sage.symbolic
-            sage: p._is_positive(1)                                                     # needs sage.rings.number_field sage.symbolic
+            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)
+            sage: p._is_positive(1)
             True
-            sage: p._is_positive(0)                                                     # needs sage.rings.number_field sage.symbolic
+            sage: p._is_positive(0)
             False
         """
         return x > 0
@@ -146,12 +146,12 @@ class Polyhedron_field(Polyhedron_base):
 
             sage: from sage.geometry.polyhedron.parent import Polyhedra_field
             sage: from sage.geometry.polyhedron.backend_field import Polyhedron_field
-            sage: parent = Polyhedra_field(AA, 1, 'field')                              # needs sage.rings.number_field
+            sage: parent = Polyhedra_field(AA, 1, 'field')
             sage: Vrep = [[[0], [1]], [], []]
             sage: Hrep = [[[0, 1], [1, -1]], []]
-            sage: p = Polyhedron_field(parent, Vrep, Hrep,  # indirect doctest          # needs sage.rings.number_field
+            sage: p = Polyhedron_field(parent, Vrep, Hrep,  # indirect doctest
             ....:                      Vrep_minimal=True, Hrep_minimal=True)
-            sage: p                                                                     # needs sage.rings.number_field
+            sage: p
             A 1-dimensional polyhedron in AA^1 defined as the convex hull of 2 vertices
         """
         self._init_Vrepresentation(*Vrep)
@@ -240,13 +240,13 @@ class Polyhedron_field(Polyhedron_base):
 
             sage: from sage.geometry.polyhedron.parent import Polyhedra_field
             sage: from sage.geometry.polyhedron.backend_field import Polyhedron_field
-            sage: parent = Polyhedra_field(AA, 1, 'field')                              # needs sage.rings.number_field
+            sage: parent = Polyhedra_field(AA, 1, 'field')
             sage: Vrep = [[[0], [1]], [], []]
             sage: Hrep = [[[0, 1], [1, -1]], []]
-            sage: p = Polyhedron_field(parent, Vrep, Hrep,  # indirect doctest          # needs sage.rings.number_field
+            sage: p = Polyhedron_field(parent, Vrep, Hrep,  # indirect doctest
             ....:                      Vrep_minimal=True,
             ....:                      Hrep_minimal=True)
-            sage: p.vertices_list()                                                     # needs sage.rings.number_field
+            sage: p.vertices_list()
             [[0], [1]]
         """
         self._Vrepresentation = []
@@ -265,15 +265,15 @@ class Polyhedron_field(Polyhedron_base):
 
         EXAMPLES::
 
-            sage: p = Polyhedron(vertices=[(0, 1/sqrt(2)),  # indirect doctest          # needs sage.rings.number_field sage.symbolic
+            sage: p = Polyhedron(vertices=[(0, 1/sqrt(2)),  # indirect doctest
             ....:                          (sqrt(2), 0),
             ....:                          (4, sqrt(5)/6)],
             ....:                base_ring=AA, backend='field')
-            sage: p.Hrepresentation()                                                   # needs sage.rings.number_field sage.symbolic
+            sage: p.Hrepresentation()
             (An inequality (-0.1582178750233332?, 1.097777812326429?) x + 0.2237538646678492? >= 0,
              An inequality (-0.1419794359520263?, -1.698172434277148?) x + 1.200789243901438? >= 0,
              An inequality (0.3001973109753594?, 0.600394621950719?) x - 0.4245431085692869? >= 0)
-            sage: p.Vrepresentation()                                                   # needs sage.rings.number_field sage.symbolic
+            sage: p.Vrepresentation()
             (A vertex at (0.?e-16, 0.7071067811865475?),
              A vertex at (1.414213562373095?, 0),
              A vertex at (4.000000000000000?, 0.372677996249965?))
@@ -288,12 +288,12 @@ class Polyhedron_field(Polyhedron_base):
 
             sage: from sage.geometry.polyhedron.parent import Polyhedra_field
             sage: from sage.geometry.polyhedron.backend_field import Polyhedron_field
-            sage: parent = Polyhedra_field(AA, 1, 'field')                              # needs sage.rings.number_field
+            sage: parent = Polyhedra_field(AA, 1, 'field')
             sage: Vrep = [[[0], [1]], [], []]
             sage: Hrep = [[[0, 1], [1, -1]], []]
-            sage: p = Polyhedron_field(parent, Vrep, Hrep,  # indirect doctest          # needs sage.rings.number_field
+            sage: p = Polyhedron_field(parent, Vrep, Hrep,  # indirect doctest
             ....:                      Vrep_minimal=True, Hrep_minimal=True)
-            sage: p.inequalities_list()                                                 # needs sage.rings.number_field
+            sage: p.inequalities_list()
             [[0, 1], [1, -1]]
         """
         self._Hrepresentation = []
@@ -310,15 +310,15 @@ class Polyhedron_field(Polyhedron_base):
 
         EXAMPLES::
 
-            sage: p = Polyhedron(vertices=[(0, 1/sqrt(2)),  # indirect doctest          # needs sage.rings.number_field sage.symbolic
+            sage: p = Polyhedron(vertices=[(0, 1/sqrt(2)),  # indirect doctest
             ....:                          (sqrt(2), 0),
             ....:                          (4, sqrt(5)/6)],
             ....:                base_ring=AA, backend='field')
-            sage: p.Hrepresentation()                                                   # needs sage.rings.number_field sage.symbolic
+            sage: p.Hrepresentation()
             (An inequality (-0.1582178750233332?, 1.097777812326429?) x + 0.2237538646678492? >= 0,
              An inequality (-0.1419794359520263?, -1.698172434277148?) x + 1.200789243901438? >= 0,
              An inequality (0.3001973109753594?, 0.600394621950719?) x - 0.4245431085692869? >= 0)
-            sage: p.Vrepresentation()                                                   # needs sage.rings.number_field sage.symbolic
+            sage: p.Vrepresentation()
             (A vertex at (0.?e-16, 0.7071067811865475?),
              A vertex at (1.414213562373095?, 0),
              A vertex at (4.000000000000000?, 0.372677996249965?))
@@ -331,11 +331,11 @@ class Polyhedron_field(Polyhedron_base):
 
         TESTS::
 
-            sage: empty = Polyhedron(backend='field', base_ring=AA); empty              # needs sage.rings.number_field
+            sage: empty = Polyhedron(backend='field', base_ring=AA); empty
             The empty polyhedron in AA^0
-            sage: empty.Vrepresentation()                                               # needs sage.rings.number_field
+            sage: empty.Vrepresentation()
             ()
-            sage: empty.Hrepresentation()                                               # needs sage.rings.number_field
+            sage: empty.Hrepresentation()
             (An equation -1 == 0,)
             sage: Polyhedron(vertices=[], backend='field')
             The empty polyhedron in QQ^0

--- a/src/sage/geometry/polyhedron/backend_normaliz.py
+++ b/src/sage/geometry/polyhedron/backend_normaliz.py
@@ -156,7 +156,7 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
 
     Algebraic polyhedra::
 
-        sage: P = Polyhedron(vertices=[[1], [sqrt(2)]],                                 # needs sage.rings.number_field sage.symbolic
+        sage: P = Polyhedron(vertices=[[1], [sqrt(2)]],
         ....:                backend='normaliz', verbose=True)
         # ----8<---- Equivalent Normaliz input file ----8<----
         amb_space 1
@@ -168,13 +168,13 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
          (a) 1
         # ----8<-------------------8<-------------------8<----
         # Calling PyNormaliz.NmzCone(cone=[], number_field=['a^2 - 2', 'a', '[1.414213562373095 +/- 2.99e-16]'], subspace=[], vertices=[[1, 1], [[[0, 1], [1, 1]], 1]])
-        sage: P                                                                         # needs sage.rings.number_field sage.symbolic
+        sage: P
         A 1-dimensional polyhedron in (Symbolic Ring)^1 defined as
          the convex hull of 2 vertices
-        sage: P.vertices()                                                              # needs sage.rings.number_field sage.symbolic
+        sage: P.vertices()
         (A vertex at (1), A vertex at (sqrt(2)))
 
-        sage: P = polytopes.icosahedron(exact=True,                                     # needs sage.rings.number_field
+        sage: P = polytopes.icosahedron(exact=True,
         ....:                           backend='normaliz'); P
         A 3-dimensional polyhedron in
          (Number Field in sqrt5 with defining polynomial x^2 - 5
@@ -182,7 +182,7 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
          defined as the convex hull of 12 vertices
 
         sage: x = polygen(ZZ)
-        sage: P = Polyhedron(vertices=[[sqrt(2)],                                       # needs sage.rings.number_field sage.symbolic
+        sage: P = Polyhedron(vertices=[[sqrt(2)],
         ....:                          [AA.polynomial_root(x^3 - 2, RIF(0,3))]],
         ....:                backend='normaliz', verbose=True)
         # ----8<---- Equivalent Normaliz input file ----8<----
@@ -195,10 +195,10 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
          (a^2) 1
         # ----8<-------------------8<-------------------8<----
         # Calling PyNormaliz.NmzCone(cone=[], number_field=['a^6 - 2', 'a', '[1.122462048309373 +/- 5.38e-16]'], subspace=[], vertices=[[[[0, 1], [0, 1], [0, 1], [1, 1], [0, 1], [0, 1]], 1], [[[0, 1], [0, 1], [1, 1], [0, 1], [0, 1], [0, 1]], 1]])
-        sage: P                                                                         # needs sage.rings.number_field sage.symbolic
+        sage: P
         A 1-dimensional polyhedron in (Symbolic Ring)^1 defined as
          the convex hull of 2 vertices
-        sage: P.vertices()                                                              # needs sage.rings.number_field sage.symbolic
+        sage: P.vertices()
         (A vertex at (2^(1/3)), A vertex at (sqrt(2)))
     """
     def __init__(self, parent, Vrep, Hrep, normaliz_cone=None, normaliz_data=None, internal_base_ring=None, **kwds):
@@ -308,7 +308,7 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
 
         TESTS::
 
-            sage: K.<sqrt2> = QuadraticField(2)                                         # needs sage.rings.number_field
+            sage: K.<sqrt2> = QuadraticField(2)
             sage: from sage.geometry.polyhedron.backend_normaliz import Polyhedron_normaliz as Pn
             sage: Pn._convert_to_pynormaliz(17)
             17
@@ -320,9 +320,9 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
             [[28, 5]]
             sage: Pn._convert_to_pynormaliz(28901824309821093821093812093810928309183091832091/5234573685674784567853456543456456786543456765)
             [[28901824309821093821093812093810928309183091832091, 5234573685674784567853456543456456786543456765]]
-            sage: Pn._convert_to_pynormaliz(7 + sqrt2)                                  # needs sage.rings.number_field
+            sage: Pn._convert_to_pynormaliz(7 + sqrt2)
             [[7, 1], [1, 1]]
-            sage: Pn._convert_to_pynormaliz(7/2 + sqrt2)                                # needs sage.rings.number_field
+            sage: Pn._convert_to_pynormaliz(7/2 + sqrt2)
             [[7, 2], [1, 1]]
             sage: Pn._convert_to_pynormaliz([[1, 2], (3, 4)])
             [[1, 2], [3, 4]]
@@ -330,8 +330,8 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
         Check that :issue:`29836` is fixed::
 
             sage: P = polytopes.simplex(backend='normaliz')
-            sage: K.<sqrt2> = QuadraticField(2)                                         # needs sage.rings.number_field
-            sage: P.dilation(sqrt2)                                                     # needs sage.rings.number_field
+            sage: K.<sqrt2> = QuadraticField(2)
+            sage: P.dilation(sqrt2)
             A 3-dimensional polyhedron in
              (Number Field in sqrt2 with defining polynomial x^2 - 2 with sqrt2 = 1.41...)^4
              defined as the convex hull of 4 vertices
@@ -367,17 +367,17 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
             [[0, -1, 2], [0, 2, -1]]
 
             sage: from sage.geometry.polyhedron.backend_normaliz import Polyhedron_normaliz
-            sage: from sage.rings.qqbar import AA                                       # needs sage.rings.number_field
-            sage: from sage.rings.number_field.number_field import QuadraticField       # needs sage.rings.number_field
+            sage: from sage.rings.qqbar import AA
+            sage: from sage.rings.number_field.number_field import QuadraticField
             sage: data = {'number_field': ['a^2 - 2', 'a', '[1.4 +/- 0.1]'],
             ....: 'inhom_inequalities': [[-1, 2, 0], [0, 0, 1], [2, -1, 0]]}
             sage: from sage.geometry.polyhedron.parent import Polyhedra_normaliz
-            sage: parent = Polyhedra_normaliz(AA, 2, 'normaliz')                        # needs sage.rings.number_field
-            sage: Polyhedron_normaliz(parent, None, None,                               # needs sage.rings.number_field
+            sage: parent = Polyhedra_normaliz(AA, 2, 'normaliz')
+            sage: Polyhedron_normaliz(parent, None, None,
             ....:                     normaliz_data=data,
             ....:                     internal_base_ring=QuadraticField(2))
             A 2-dimensional polyhedron in AA^2 defined as the convex hull of 1 vertex and 2 rays
-            sage: _.inequalities_list()                                                 # needs sage.rings.number_field
+            sage: _.inequalities_list()
             [[0, -1/2, 1], [0, 2, -1]]
         """
         if internal_base_ring is None:
@@ -430,10 +430,10 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
 
         EXAMPLES::
 
-            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)                     # needs sage.rings.number_field sage.symbolic
-            sage: p._is_zero(0)                                                         # needs sage.rings.number_field sage.symbolic
+            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)
+            sage: p._is_zero(0)
             True
-            sage: p._is_zero(1/100000)                                                  # needs sage.rings.number_field sage.symbolic
+            sage: p._is_zero(1/100000)
             False
         """
         return x == 0
@@ -450,10 +450,10 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
 
         EXAMPLES::
 
-            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)                     # needs sage.rings.number_field sage.symbolic
-            sage: p._is_nonneg(1)                                                       # needs sage.rings.number_field sage.symbolic
+            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)
+            sage: p._is_nonneg(1)
             True
-            sage: p._is_nonneg(-1/100000)                                               # needs sage.rings.number_field sage.symbolic
+            sage: p._is_nonneg(-1/100000)
             False
         """
         return x >= 0
@@ -470,10 +470,10 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
 
         EXAMPLES::
 
-            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)                     # needs sage.rings.number_field sage.symbolic
-            sage: p._is_positive(1)                                                     # needs sage.rings.number_field sage.symbolic
+            sage: p = Polyhedron([(sqrt(3),sqrt(2))], base_ring=AA)
+            sage: p._is_positive(1)
             True
-            sage: p._is_positive(0)                                                     # needs sage.rings.number_field sage.symbolic
+            sage: p._is_positive(0)
             False
         """
         return x > 0
@@ -580,9 +580,9 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
 
         TESTS::
 
-            sage: K.<a> = QuadraticField(2)                                             # needs sage.rings.number_field
-            sage: p = Polyhedron(ieqs=[(1, a, 0)], backend='normaliz')                  # needs sage.rings.number_field
-            sage: p & p == p                                                            # needs sage.rings.number_field
+            sage: K.<a> = QuadraticField(2)
+            sage: p = Polyhedron(ieqs=[(1, a, 0)], backend='normaliz')
+            sage: p & p == p
             True
 
         Check that :issue:`30248` is fixed, that maps as input works::
@@ -725,7 +725,7 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
             ....:                for arg in args)
             sage: test_poly(polytopes.simplex(backend='normaliz'))
             True
-            sage: test_poly(polytopes.dodecahedron(backend='normaliz'))                 # needs sage.rings.number_field
+            sage: test_poly(polytopes.dodecahedron(backend='normaliz'))
             True
             sage: test_poly(Polyhedron(vertices=[[1,0], [0,1]], rays=[[1,1]],
             ....:                      backend='normaliz'))
@@ -1011,7 +1011,7 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
             sage: from sage.geometry.polyhedron.backend_normaliz import Polyhedron_normaliz as Pn
             sage: Pn._number_field_triple(QQ) is None
             True
-            sage: Pn._number_field_triple(QuadraticField(5))                            # needs sage.rings.number_field
+            sage: Pn._number_field_triple(QuadraticField(5))
             ['a^2 - 5', 'a', '[2.236067977499789 +/- 8.06e-16]']
         """
         R = internal_base_ring
@@ -1308,7 +1308,7 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
             sage: P = Polyhedron(ieqs=[[1, 0, 2], [3, 0, -2], [3, 2, -2]],
             ....:                backend='normaliz')
             sage: PI = P.integral_hull()
-            sage: P.plot(color='yellow') + PI.plot(color='green')                       # needs sage.plot
+            sage: P.plot(color='yellow') + PI.plot(color='green')
             Graphics object consisting of 10 graphics primitives
             sage: PI.Vrepresentation()
             (A vertex at (-1, 0),
@@ -1436,8 +1436,8 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
 
         Check that :issue:`28872` is fixed::
 
-            sage: P = polytopes.dodecahedron(backend='normaliz')                        # needs sage.rings.number_field
-            sage: P.volume(measure='induced_lattice')                                   # needs sage.rings.number_field
+            sage: P = polytopes.dodecahedron(backend='normaliz')
+            sage: P.volume(measure='induced_lattice')
             -1056*sqrt5 + 2400
 
         Some sanity checks that the ambient volume works correctly::
@@ -1449,12 +1449,12 @@ class Polyhedron_normaliz(Polyhedron_base_number_field):
             sage: s._volume_normaliz(measure='ambient')
             0
 
-            sage: P = polytopes.regular_polygon(3, backend='normaliz')                  # needs sage.rings.number_field
-            sage: P._volume_normaliz('ambient') == P.volume(engine='internal')          # needs sage.rings.number_field
+            sage: P = polytopes.regular_polygon(3, backend='normaliz')
+            sage: P._volume_normaliz('ambient') == P.volume(engine='internal')
             True
 
-            sage: P = polytopes.dodecahedron(backend='normaliz')                        # needs sage.rings.number_field
-            sage: P._volume_normaliz('ambient') == P.volume(engine='internal')          # needs sage.rings.number_field
+            sage: P = polytopes.dodecahedron(backend='normaliz')
+            sage: P._volume_normaliz('ambient') == P.volume(engine='internal')
             True
 
             sage: P = Polyhedron(rays=[[1]], backend='normaliz')
@@ -2251,7 +2251,7 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
 
         Then we calculate the rational function `H^*(t)`::
 
-            sage: Hst = P._Hstar_function_normaliz(G); Hst                              # needs sage.groups
+            sage: Hst = P._Hstar_function_normaliz(G); Hst
             (chi_0*t^4 + (3*chi_0 + 3*chi_1)*t^3
               + (8*chi_0 + 2*chi_1)*t^2 + (3*chi_0 + 3*chi_1)*t + chi_0)/(t + 1)
 
@@ -2259,7 +2259,7 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
         ``'Hstar_as_lin_comb'``. The first coordinate is the coefficient of the
         trivial character; the second is the coefficient of the sign character::
 
-            sage: lin = P._Hstar_function_normaliz(G, output='Hstar_as_lin_comb'); lin  # needs sage.groups
+            sage: lin = P._Hstar_function_normaliz(G, output='Hstar_as_lin_comb'); lin
             ((t^4 + 3*t^3 + 8*t^2 + 3*t + 1)/(t + 1), (3*t^3 + 2*t^2 + 3*t)/(t + 1))
         """
         from sage.groups.conjugacy_classes import ConjugacyClassGAP
@@ -2370,14 +2370,14 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
 
             sage: simplex = Polyhedron(vertices=[[0,0,0], [1,0,0],
             ....:                                [0,1,0], [0,0,1]], backend='normaliz')
-            sage: Hstar = simplex.Hstar_function(); Hstar  # indirect doctest           # needs sage.rings.number_field
+            sage: Hstar = simplex.Hstar_function(); Hstar  # indirect doctest
             chi_4
 
         The polynomial is `\chi_4 \cdot t^0`. We can see which irreducible
         representation `\chi_4` corresponds to by looking at the character table::
 
-            sage: G = simplex.restricted_automorphism_group(output='permutation')       # needs sage.groups
-            sage: char = G.character_table(); char                                      # needs sage.groups
+            sage: G = simplex.restricted_automorphism_group(output='permutation')
+            sage: char = G.character_table(); char
             [ 1 -1  1  1 -1]
             [ 3 -1  0 -1  1]
             [ 2  0 -1  2  0]
@@ -2391,14 +2391,14 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
 
             sage: square = Polyhedron(vertices=[[1,1], [-1,1], [-1,-1], [1,-1]],
             ....:                     backend='normaliz')
-            sage: Hstar = square.Hstar_function(); Hstar                                # needs sage.rings.number_field
+            sage: Hstar = square.Hstar_function(); Hstar
             chi_0*t^2 + (2*chi_0 + chi_2 + chi_3 + chi_4)*t + chi_0
 
         Plugging in the values from the first column of the character table below
         yields the `h^*`-polynomial of the square, `t^2+6t+1`::
 
-            sage: G = square.restricted_automorphism_group(output='permutation')        # needs sage.groups
-            sage: G.character_table()                                                   # needs sage.groups
+            sage: G = square.restricted_automorphism_group(output='permutation')
+            sage: G.character_table()
             [ 1  1  1  1  1]
             [ 1 -1 -1  1  1]
             [ 1 -1  1 -1  1]
@@ -2449,9 +2449,9 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
             sage: S3 = G.subgroup(gens=[reflection12, reflection23])
             sage: S3.is_isomorphic(SymmetricGroup(3))
             True
-            sage: Hstar = p3.Hstar_function(S3)                                         # needs sage.rings.number_field
-            sage: Hlin  = p3.Hstar_function(S3, output='Hstar_as_lin_comb')             # needs sage.rings.number_field
-            sage: p3._is_effective_normaliz(Hstar, Hlin)                                # needs sage.rings.number_field
+            sage: Hstar = p3.Hstar_function(S3)
+            sage: Hlin  = p3.Hstar_function(S3, output='Hstar_as_lin_comb')
+            sage: p3._is_effective_normaliz(Hstar, Hlin)
             True
 
         If the `H^*`-series is not polynomial, then it is not effective::
@@ -2461,11 +2461,11 @@ class Polyhedron_QQ_normaliz(Polyhedron_normaliz, Polyhedron_QQ):
             ....:                backend='normaliz')
             sage: G = P.restricted_automorphism_group(output='permutation')
             sage: H = G.subgroup(gens = [G([(0,2),(1,3),(4,6),(5,7)])])
-            sage: Hstar = P.Hstar_function(H); Hstar                                    # needs sage.rings.number_field
+            sage: Hstar = P.Hstar_function(H); Hstar
             (chi_0*t^4 + (3*chi_0 + 3*chi_1)*t^3
               + (8*chi_0 + 2*chi_1)*t^2 + (3*chi_0 + 3*chi_1)*t + chi_0)/(t + 1)
-            sage: Hstar_lin = P.Hstar_function(H, output='Hstar_as_lin_comb')           # needs sage.rings.number_field
-            sage: P._is_effective_normaliz(Hstar, Hstar_lin)                            # needs sage.rings.number_field
+            sage: Hstar_lin = P.Hstar_function(H, output='Hstar_as_lin_comb')
+            sage: P._is_effective_normaliz(Hstar, Hstar_lin)
             False
         """
         if not Hstar.denominator().is_unit():

--- a/src/sage/geometry/polyhedron/backend_number_field.py
+++ b/src/sage/geometry/polyhedron/backend_number_field.py
@@ -39,26 +39,26 @@ class Polyhedron_number_field(Polyhedron_field, Polyhedron_base_number_field):
 
     EXAMPLES::
 
-        sage: P = Polyhedron(vertices=[[1], [sqrt(2)]], backend='number_field'); P      # needs sage.rings.number_field sage.symbolic
+        sage: P = Polyhedron(vertices=[[1], [sqrt(2)]], backend='number_field'); P
         A 1-dimensional polyhedron
          in (Symbolic Ring)^1 defined as the convex hull of 2 vertices
-        sage: P.vertices()                                                              # needs sage.rings.number_field sage.symbolic
+        sage: P.vertices()
         (A vertex at (1), A vertex at (sqrt(2)))
 
-        sage: P = polytopes.icosahedron(exact=True, backend='number_field')             # needs sage.rings.number_field
-        sage: P                                                                         # needs sage.rings.number_field
+        sage: P = polytopes.icosahedron(exact=True, backend='number_field')
+        sage: P
         A 3-dimensional polyhedron
          in (Number Field in sqrt5 with defining polynomial x^2 - 5
              with sqrt5 = 2.236067977499790?)^3
          defined as the convex hull of 12 vertices
 
-        sage: x = polygen(ZZ); P = Polyhedron(                                          # needs sage.rings.number_field sage.symbolic
+        sage: x = polygen(ZZ); P = Polyhedron(
         ....:     vertices=[[sqrt(2)], [AA.polynomial_root(x^3-2, RIF(0,3))]],
         ....:     backend='number_field')
-        sage: P                                                                         # needs sage.rings.number_field sage.symbolic
+        sage: P
         A 1-dimensional polyhedron
          in (Symbolic Ring)^1 defined as the convex hull of 2 vertices
-        sage: P.vertices()                                                              # needs sage.rings.number_field sage.symbolic
+        sage: P.vertices()
         (A vertex at (sqrt(2)), A vertex at (2^(1/3)))
 
     TESTS:
@@ -66,14 +66,14 @@ class Polyhedron_number_field(Polyhedron_field, Polyhedron_base_number_field):
     Tests from :class:`~sage.geometry.polyhedron.backend_field.Polyhedron_field` --
     here the data are already either in a number field or in ``AA``::
 
-        sage: p = Polyhedron(vertices=[(0,0),(AA(2).sqrt(),0),(0,AA(3).sqrt())],        # needs sage.rings.number_field
+        sage: p = Polyhedron(vertices=[(0,0),(AA(2).sqrt(),0),(0,AA(3).sqrt())],
         ....:                rays=[(1,1)], lines=[], backend='number_field',
         ....:                base_ring=AA)
-        sage: TestSuite(p).run()                                                        # needs sage.rings.number_field
+        sage: TestSuite(p).run()
 
-        sage: K.<sqrt3> = QuadraticField(3)                                             # needs sage.rings.number_field
-        sage: p = Polyhedron([(0,0), (1,0), (1/2, sqrt3/2)], backend='number_field')    # needs sage.rings.number_field
-        sage: TestSuite(p).run()                                                        # needs sage.rings.number_field
+        sage: K.<sqrt3> = QuadraticField(3)
+        sage: p = Polyhedron([(0,0), (1,0), (1/2, sqrt3/2)], backend='number_field')
+        sage: TestSuite(p).run()
 
         sage: x = polygen(ZZ, 'x')
         sage: K.<phi> = NumberField(x^2 - x - 1, embedding=1.618)
@@ -120,9 +120,9 @@ class Polyhedron_number_field(Polyhedron_field, Polyhedron_base_number_field):
 
         Check that the coordinates of a vertex get simplified in the Symbolic Ring::
 
-            sage: p = Polyhedron(ambient_dim=2, base_ring=SR, backend='number_field')   # needs sage.symbolic
+            sage: p = Polyhedron(ambient_dim=2, base_ring=SR, backend='number_field')
             sage: from sage.geometry.polyhedron.backend_number_field import Polyhedron_number_field
-            sage: Polyhedron_number_field._init_from_Vrepresentation(p, [(0,1/2),(sqrt(2),0),(4,5/6)], [], []); p       # needs sage.symbolic
+            sage: Polyhedron_number_field._init_from_Vrepresentation(p, [(0,1/2),(sqrt(2),0),(4,5/6)], [], []); p
             A 2-dimensional polyhedron in (Symbolic Ring)^2 defined as the convex hull of 3 vertices
             sage: p.vertices()[0][0]
             0

--- a/src/sage/geometry/polyhedron/backend_polymake.py
+++ b/src/sage/geometry/polyhedron/backend_polymake.py
@@ -96,8 +96,8 @@ class Polyhedron_polymake(Polyhedron_base):
 
     Quadratic fields work::
 
-        sage: V = polytopes.dodecahedron().vertices_list()                              # needs sage.groups sage.rings.number_field
-        sage: Polyhedron(vertices=V, backend='polymake')        # optional - jupymake, needs sage.groups sage.rings.number_field
+        sage: V = polytopes.dodecahedron().vertices_list()
+        sage: Polyhedron(vertices=V, backend='polymake')        # optional - jupymake
         A 3-dimensional polyhedron
          in (Number Field in sqrt5 with defining polynomial x^2 - 5
              with sqrt5 = 2.236067977499790?)^3
@@ -657,7 +657,7 @@ class Polyhedron_polymake(Polyhedron_base):
             sage: P2 = Polyhedron_polymake(P1.parent(), None, None, P1._polymake_polytope)
             sage: P._test_polymake_pickling(other=P2)
 
-            sage: # optional - jupymake, needs sage.rings.number_field
+            sage: # optional - jupymake
             sage: print("Possible output"); P = polytopes.dodecahedron(backend='polymake')
             Possible output...
             sage: P1 = loads(dumps(P))

--- a/src/sage/geometry/polyhedron/base.py
+++ b/src/sage/geometry/polyhedron/base.py
@@ -98,7 +98,7 @@ class Polyhedron_base(Polyhedron_base7):
 
     ::
 
-        sage: p = polytopes.flow_polytope(digraphs.DeBruijn(3,2))                       # needs sage.combinat sage.graphs
+        sage: p = polytopes.flow_polytope(digraphs.DeBruijn(3,2))
         sage: TestSuite(p).run()
 
     ::
@@ -238,14 +238,14 @@ class Polyhedron_base(Polyhedron_base7):
 
         TESTS::
 
-            sage: p = polytopes.flow_polytope(digraphs.DeBruijn(3,2)); p                # needs sage.combinat sage.graphs
+            sage: p = polytopes.flow_polytope(digraphs.DeBruijn(3,2)); p
             A 19-dimensional polyhedron in QQ^27
              defined as the convex hull of 1 vertex and 148 rays
             sage: p.to_linear_program().polyhedron() == p
             True
 
-            sage: p = polytopes.icosahedron()                                           # needs sage.groups sage.rings.number_field
-            sage: p.to_linear_program(solver='PPL')                                     # needs sage.groups sage.rings.number_field
+            sage: p = polytopes.icosahedron()
+            sage: p.to_linear_program(solver='PPL')
             Traceback (most recent call last):
             ...
             TypeError: The PPL backend only supports rational data.
@@ -292,11 +292,11 @@ class Polyhedron_base(Polyhedron_base7):
 
             sage: oc = polytopes.octahedron()
             sage: sc_oc = oc.boundary_complex()
-            sage: fl_oc = oc.face_lattice()                                             # needs sage.combinat
-            sage: fl_sc = sc_oc.face_poset()                                            # needs sage.combinat
-            sage: [len(x) for x in fl_oc.level_sets()]                                  # needs sage.combinat
+            sage: fl_oc = oc.face_lattice()
+            sage: fl_sc = sc_oc.face_poset()
+            sage: [len(x) for x in fl_oc.level_sets()]
             [1, 6, 12, 8, 1]
-            sage: [len(x) for x in fl_sc.level_sets()]                                  # needs sage.combinat
+            sage: [len(x) for x in fl_sc.level_sets()]
             [6, 12, 8]
             sage: sc_oc.euler_characteristic()
             2
@@ -647,10 +647,10 @@ class Polyhedron_base(Polyhedron_base7):
             ...
             ValueError: the normal fan is only defined for full-dimensional polytopes
 
-            sage: R = Polyhedron(vertices=[[0, 0],                                      # needs sage.rings.number_field sage.symbolic
+            sage: R = Polyhedron(vertices=[[0, 0],
             ....:                          [AA(sqrt(2)), 0],
             ....:                          [0, AA(sqrt(2))]])
-            sage: R.normal_fan()                                                        # needs sage.rings.number_field sage.symbolic
+            sage: R.normal_fan()
             Traceback (most recent call last):
             ...
             NotImplementedError: normal fan handles only polytopes over the rationals
@@ -730,8 +730,8 @@ class Polyhedron_base(Polyhedron_base7):
 
         The polytope has to have rational coordinates::
 
-            sage: S = polytopes.dodecahedron()                                          # needs sage.groups sage.rings.number_field
-            sage: S.face_fan()                                                          # needs sage.groups sage.rings.number_field
+            sage: S = polytopes.dodecahedron()
+            sage: S.face_fan()
             Traceback (most recent call last):
             ...
             NotImplementedError: face fan handles only polytopes over the rationals
@@ -818,8 +818,8 @@ class Polyhedron_base(Polyhedron_base7):
             sage: P.barycentric_subdivision()
             A 2-dimensional polyhedron in QQ^3 defined as the convex hull
             of 6 vertices
-            sage: P = polytopes.regular_polygon(4, base_ring=QQ)                        # needs sage.rings.number_field
-            sage: P.barycentric_subdivision()                                           # needs sage.rings.number_field
+            sage: P = polytopes.regular_polygon(4, base_ring=QQ)
+            sage: P.barycentric_subdivision()
             A 2-dimensional polyhedron in QQ^2 defined as the convex hull of 8
             vertices
 
@@ -931,7 +931,7 @@ class Polyhedron_base(Polyhedron_base7):
         `\pm 1` 2-dimensional square. The permutations are written in terms
         of the vertices of the square::
 
-            sage: # optional - pynormaliz, needs sage.groups
+            sage: # optional - pynormaliz
             sage: square = Polyhedron(vertices=[[1,1], [-1,1],
             ....:                               [-1,-1], [1,-1]],
             ....:                     backend='normaliz')
@@ -1026,7 +1026,7 @@ class Polyhedron_base(Polyhedron_base7):
             (None, None)
             sage: Polyhedron([(1/3,2/3), (3/3, 4/3)]).bounding_box(integral_hull=True)
             ((1, 1), (1, 1))
-            sage: polytopes.buckyball(exact=False).bounding_box()                       # needs sage.groups
+            sage: polytopes.buckyball(exact=False).bounding_box()
             ((-0.8090169944, -0.8090169944, -0.8090169944),
              (0.8090169944, 0.8090169944, 0.8090169944))
 
@@ -1133,7 +1133,7 @@ class Polyhedron_base(Polyhedron_base7):
 
         Floating-point polyhedron::
 
-            sage: # optional - jupymake, needs sage.groups
+            sage: # optional - jupymake
             sage: P = polytopes.dodecahedron(exact=False); P
             A 3-dimensional polyhedron in RDF^3 defined as the convex hull of 20 vertices
             sage: print("There may be a recompilation warning"); PP = polymake(P); PP

--- a/src/sage/geometry/polyhedron/base0.py
+++ b/src/sage/geometry/polyhedron/base0.py
@@ -84,10 +84,10 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
 
             sage: from sage.geometry.polyhedron.backend_field import Polyhedron_field
             sage: from sage.geometry.polyhedron.parent import Polyhedra_field
-            sage: parent = Polyhedra_field(AA, 1, 'field')                              # needs sage.rings.number_field
+            sage: parent = Polyhedra_field(AA, 1, 'field')
             sage: Vrep = [[[0], [1/2], [1]], [], []]
             sage: Hrep = [[[0, 1], [1, -1]], []]
-            sage: p = Polyhedron_field(parent, Vrep, Hrep,                              # needs sage.rings.number_field
+            sage: p = Polyhedron_field(parent, Vrep, Hrep,
             ....:                      Vrep_minimal=False, Hrep_minimal=True)
             Traceback (most recent call last):
             ...
@@ -403,13 +403,13 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
             ...
             TypeError: cannot change the base ring to the Integer Ring
 
-            sage: P = polytopes.regular_polygon(3); P                                   # needs sage.rings.number_field
+            sage: P = polytopes.regular_polygon(3); P
             A 2-dimensional polyhedron in AA^2 defined as the convex hull of 3 vertices
-            sage: P.vertices()                                                          # needs sage.rings.number_field
+            sage: P.vertices()
             (A vertex at (0.?e-16, 1.000000000000000?),
              A vertex at (0.866025403784439?, -0.500000000000000?),
              A vertex at (-0.866025403784439?, -0.500000000000000?))
-            sage: P.change_ring(QQ)                                                     # needs sage.rings.number_field
+            sage: P.change_ring(QQ)
             Traceback (most recent call last):
             ...
             TypeError: cannot change the base ring to the Rational Field
@@ -422,11 +422,11 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
             base ring from an exact ring into ``RDF`` may cause a
             loss of data::
 
-                sage: P = Polyhedron([[2/3,0],[6666666666666667/10^16,0]], base_ring=AA); P         # needs sage.rings.number_field
+                sage: P = Polyhedron([[2/3,0],[6666666666666667/10^16,0]], base_ring=AA); P
                 A 1-dimensional polyhedron in AA^2 defined as the convex hull of 2 vertices
-                sage: Q = P.change_ring(RDF); Q                                         # needs sage.rings.number_field
+                sage: Q = P.change_ring(RDF); Q
                 A 0-dimensional polyhedron in RDF^2 defined as the convex hull of 1 vertex
-                sage: P.n_vertices() == Q.n_vertices()                                  # needs sage.rings.number_field
+                sage: P.n_vertices() == Q.n_vertices()
                 False
         """
         from sage.categories.rings import Rings
@@ -576,8 +576,8 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
 
         EXAMPLES::
 
-            sage: p = polytopes.icosahedron()                                           # needs sage.groups sage.rings.number_field
-            sage: p.is_compact()                                                        # needs sage.groups sage.rings.number_field
+            sage: p = polytopes.icosahedron()
+            sage: p.is_compact()
             True
             sage: p = Polyhedron(ieqs=[[0,1,0,0],[0,0,1,0],[0,0,0,1],[1,-1,0,0]])
             sage: p.is_compact()
@@ -1290,8 +1290,8 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
             sage: triangle = Polyhedron(vertices=[[1, 0], [0, 1], [1, 1]])
             sage: triangle.backend()
             'ppl'
-            sage: D = polytopes.dodecahedron()                                          # needs sage.groups sage.rings.number_field
-            sage: D.backend()                                                           # needs sage.groups sage.rings.number_field
+            sage: D = polytopes.dodecahedron()
+            sage: D.backend()
             'field'
             sage: P = Polyhedron([[1.23]])
             sage: P.backend()
@@ -1325,10 +1325,10 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
             end
             <BLANKLINE>
 
-            sage: triangle = Polyhedron(vertices=[[1,0], [0,1], [1,1]], base_ring=AA)   # needs sage.rings.number_field
-            sage: triangle.base_ring()                                                  # needs sage.rings.number_field
+            sage: triangle = Polyhedron(vertices=[[1,0], [0,1], [1,1]], base_ring=AA)
+            sage: triangle.base_ring()
             Algebraic Real Field
-            sage: triangle.cdd_Hrepresentation()                                        # needs sage.rings.number_field
+            sage: triangle.cdd_Hrepresentation()
             Traceback (most recent call last):
             ...
             TypeError: the base ring must be ZZ, QQ, or RDF

--- a/src/sage/geometry/polyhedron/base1.py
+++ b/src/sage/geometry/polyhedron/base1.py
@@ -388,11 +388,11 @@ class Polyhedron_base1(Polyhedron_base0, ConvexSet_closed):
             sage: poly_test.ambient_vector_space() is poly_test.ambient()
             True
 
-            sage: poly_test.ambient_vector_space(AA)                                    # needs sage.rings.number_field
+            sage: poly_test.ambient_vector_space(AA)
             Vector space of dimension 4 over Algebraic Real Field
             sage: poly_test.ambient_vector_space(RDF)
             Vector space of dimension 4 over Real Double Field
-            sage: poly_test.ambient_vector_space(SR)                                    # needs sage.symbolic
+            sage: poly_test.ambient_vector_space(SR)
             Vector space of dimension 4 over Symbolic Ring
         """
         return self.Vrepresentation_space().vector_space(base_field=base_field)

--- a/src/sage/geometry/polyhedron/base2.py
+++ b/src/sage/geometry/polyhedron/base2.py
@@ -96,7 +96,7 @@ class Polyhedron_base2(Polyhedron_base1):
 
             sage: polytopes.cross_polytope(3).is_lattice_polytope()
             True
-            sage: polytopes.regular_polygon(5).is_lattice_polytope()                    # needs sage.rings.number_field
+            sage: polytopes.regular_polygon(5).is_lattice_polytope()
             False
         """
         if not self.is_compact():
@@ -296,8 +296,8 @@ class Polyhedron_base2(Polyhedron_base1):
             ...
             TypeError: The h_star vector is only defined for lattice polytopes
 
-            sage: t2 = Polyhedron(vertices=[[AA(sqrt(2))], [1/2]])                      # needs sage.rings.number_field sage.symbolic
-            sage: t2.h_star_vector()                                                    # needs sage.rings.number_field sage.symbolic
+            sage: t2 = Polyhedron(vertices=[[AA(sqrt(2))], [1/2]])
+            sage: t2.h_star_vector()
             Traceback (most recent call last):
             ...
             TypeError: The h_star vector is only defined for lattice polytopes

--- a/src/sage/geometry/polyhedron/base3.py
+++ b/src/sage/geometry/polyhedron/base3.py
@@ -156,7 +156,7 @@ class Polyhedron_base3(Polyhedron_base2):
 
             sage: Polyhedron().slack_matrix()
             []
-            sage: Polyhedron(base_ring=QuadraticField(2)).slack_matrix().base_ring()    # needs sage.rings.number_field
+            sage: Polyhedron(base_ring=QuadraticField(2)).slack_matrix().base_ring()
             Number Field in a with defining polynomial x^2 - 2 with a = 1.41...
         """
         if not self.n_Vrepresentation() or not self.n_Hrepresentation():
@@ -277,7 +277,7 @@ class Polyhedron_base3(Polyhedron_base2):
 
             sage: P = polytopes.twenty_four_cell()
             sage: M = P.incidence_matrix()
-            sage: sum(sum(x) for x in M) == P.flag_f_vector(0, 3)                       # needs sage.combinat
+            sage: sum(sum(x) for x in M) == P.flag_f_vector(0, 3)
             True
 
         TESTS:
@@ -983,8 +983,8 @@ class Polyhedron_base3(Polyhedron_base2):
             sage: M = Q.vertex_adjacency_matrix()
             sage: sum(M)
             (4, 4, 3, 3, 4, 4, 4, 3, 3)
-            sage: G = Q.vertex_graph()                                                  # needs sage.graphs
-            sage: G.degree()                                                            # needs sage.graphs
+            sage: G = Q.vertex_graph()
+            sage: G.degree()
             [4, 4, 3, 3, 4, 4, 4, 3, 3]
 
         TESTS:
@@ -1266,8 +1266,8 @@ class Polyhedron_base3(Polyhedron_base2):
             True
             sage: P.is_pyramid(certificate=True)
             (True, A vertex at (1, 0, 0, 0))
-            sage: egyptian_pyramid = polytopes.regular_polygon(4).pyramid()             # needs sage.rings.number_field
-            sage: egyptian_pyramid.is_pyramid()                                         # needs sage.rings.number_field
+            sage: egyptian_pyramid = polytopes.regular_polygon(4).pyramid()
+            sage: egyptian_pyramid.is_pyramid()
             True
             sage: Q = polytopes.octahedron()
             sage: Q.is_pyramid()
@@ -1437,8 +1437,8 @@ class Polyhedron_base3(Polyhedron_base2):
             sage: L.is_lattice_polytope()
             True
 
-            sage: egyptian_pyramid = polytopes.regular_polygon(4).pyramid()             # needs sage.number_field
-            sage: egyptian_pyramid.is_lawrence_polytope()                               # needs sage.number_field
+            sage: egyptian_pyramid = polytopes.regular_polygon(4).pyramid()
+            sage: egyptian_pyramid.is_lawrence_polytope()
             True
 
             sage: polytopes.octahedron().is_lawrence_polytope()

--- a/src/sage/geometry/polyhedron/base4.py
+++ b/src/sage/geometry/polyhedron/base4.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.graphs
 r"""
 Base class for polyhedra: Graph-theoretic methods
 
@@ -111,18 +110,18 @@ class Polyhedron_base4(Polyhedron_base3):
              An inequality (0, 0, 1) x + 1 >= 0,
              An inequality (0, 1, 0) x + 1 >= 0,
              An inequality (1, 0, 0) x + 1 >= 0]
-            sage: G.automorphism_group().is_isomorphic(P.hasse_diagram().automorphism_group())      # needs sage.groups
+            sage: G.automorphism_group().is_isomorphic(P.hasse_diagram().automorphism_group())
             True
             sage: O = polytopes.octahedron(); O
             A 3-dimensional polyhedron in ZZ^3 defined as the convex hull of 6 vertices
             sage: O.vertex_facet_graph()
             Digraph on 14 vertices
             sage: H = O.vertex_facet_graph()
-            sage: G.is_isomorphic(H)                                                                # needs sage.groups
+            sage: G.is_isomorphic(H)
             False
             sage: G2 = copy(G)
             sage: G2.reverse_edges(G2.edges(sort=True))
-            sage: G2.is_isomorphic(H)                                                               # needs sage.groups
+            sage: G2.is_isomorphic(H)
             True
 
         TESTS:
@@ -170,7 +169,7 @@ class Polyhedron_base4(Polyhedron_base3):
 
             sage: g3 = polytopes.hypercube(3).vertex_graph(); g3
             Graph on 8 vertices
-            sage: g3.automorphism_group().cardinality()                                             # needs sage.groups
+            sage: g3.automorphism_group().cardinality()
             48
             sage: s4 = polytopes.simplex(4).vertex_graph(); s4
             Graph on 5 vertices
@@ -354,7 +353,7 @@ class Polyhedron_base4(Polyhedron_base3):
             sage: c5_20_fl = c5_20.face_lattice() # long time
             sage: [len(x) for x in c5_20_fl.level_sets()] # long time
             [1, 20, 190, 580, 680, 272, 1]
-            sage: polytopes.hypercube(2).face_lattice().plot()                          # needs sage.plot
+            sage: polytopes.hypercube(2).face_lattice().plot()
             Graphics object consisting of 27 graphics primitives
             sage: level_sets = polytopes.cross_polytope(2).face_lattice().level_sets()
             sage: level_sets[0][0].ambient_V_indices(), level_sets[-1][0].ambient_V_indices()
@@ -641,16 +640,16 @@ class Polyhedron_base4(Polyhedron_base3):
         EXAMPLES::
 
             sage: quadrangle = Polyhedron(vertices=[(0,0),(1,0),(0,1),(2,3)])
-            sage: quadrangle.combinatorial_automorphism_group().is_isomorphic(          # needs sage.groups
+            sage: quadrangle.combinatorial_automorphism_group().is_isomorphic(
             ....:     groups.permutation.Dihedral(4))
             True
-            sage: quadrangle.restricted_automorphism_group()                            # needs sage.groups
+            sage: quadrangle.restricted_automorphism_group()
             Permutation Group with generators [()]
 
         Permutations of the vertex graph only exchange vertices with vertices::
 
             sage: P = Polyhedron(vertices=[(1,0), (1,1)], rays=[(1,0)])
-            sage: P.combinatorial_automorphism_group(vertex_graph_only=True)            # needs sage.groups
+            sage: P.combinatorial_automorphism_group(vertex_graph_only=True)
             Permutation Group with generators [(A vertex at (1,0),A vertex at (1,1))]
 
         This shows an example of two polytopes whose vertex-edge graphs are isomorphic,
@@ -896,7 +895,7 @@ class Polyhedron_base4(Polyhedron_base3):
 
             sage: P = Polyhedron(vertices=[(1/3,0,0,1),(0,1/4,0,1),(0,0,1/5,1)],
             ....:                base_ring=RDF)
-            sage: P.restricted_automorphism_group()                                     # needs sage.groups
+            sage: P.restricted_automorphism_group()
             Permutation Group with generators [(2,3), (1,2)]
             sage: len(P.restricted_automorphism_group(output='matrixlist'))
             6
@@ -904,7 +903,7 @@ class Polyhedron_base4(Polyhedron_base3):
         TESTS::
 
             sage: P = Polyhedron(vertices=[(1,0), (1,1)], rays=[(1,0)])
-            sage: P.restricted_automorphism_group(output='permutation')                 # needs sage.groups
+            sage: P.restricted_automorphism_group(output='permutation')
             Permutation Group with generators [(1,2)]
             sage: P.restricted_automorphism_group(output='matrix')
             Matrix group over Rational Field with 1 generators (
@@ -1084,10 +1083,10 @@ class Polyhedron_base4(Polyhedron_base3):
         All the faces of the 3-dimensional permutahedron are either
         combinatorially isomorphic to a square or a hexagon::
 
-            sage: H = polytopes.regular_polygon(6)                                      # needs sage.rings.number_field
+            sage: H = polytopes.regular_polygon(6)
             sage: S = polytopes.hypercube(2)
             sage: P = polytopes.permutahedron(4)
-            sage: all(F.as_polyhedron().is_combinatorially_isomorphic(S)                # needs sage.rings.number_field
+            sage: all(F.as_polyhedron().is_combinatorially_isomorphic(S)
             ....:       or F.as_polyhedron().is_combinatorially_isomorphic(H)
             ....:     for F in P.faces(2))
             True
@@ -1106,7 +1105,7 @@ class Polyhedron_base4(Polyhedron_base3):
             ....:    return C.intersection(H)
             sage: [simplex_intersection(k).is_combinatorially_isomorphic(cube_intersection(k)) for k in range(2,5)]
             [True, True, True]
-            sage: simplex_intersection(2).is_combinatorially_isomorphic(polytopes.regular_polygon(6))                   # needs sage.rings.number_field
+            sage: simplex_intersection(2).is_combinatorially_isomorphic(polytopes.regular_polygon(6))
             True
             sage: simplex_intersection(3).is_combinatorially_isomorphic(polytopes.octahedron())
             True
@@ -1227,7 +1226,7 @@ class Polyhedron_base4(Polyhedron_base3):
             True
             sage: polytopes.cube().is_self_dual()
             False
-            sage: polytopes.hypersimplex(5,2).is_self_dual()                            # needs sage.combinat
+            sage: polytopes.hypersimplex(5,2).is_self_dual()
             False
             sage: P = Polyhedron(vertices=[[1/2, 1/3]], rays=[[1, 1]]).is_self_dual()
             Traceback (most recent call last):

--- a/src/sage/geometry/polyhedron/base5.py
+++ b/src/sage/geometry/polyhedron/base5.py
@@ -325,7 +325,7 @@ class Polyhedron_base5(Polyhedron_base4):
 
         TESTS:
 
-            sage: polytopes.regular_polygon(4)._test_pyramid()                          # needs sage.rings.number_field
+            sage: polytopes.regular_polygon(4)._test_pyramid()
         """
         if tester is None:
             tester = self._tester(**options)
@@ -1119,7 +1119,7 @@ class Polyhedron_base5(Polyhedron_base4):
 
             sage: C = polytopes.hypercube(5)
             sage: S = Polyhedron([[1]])
-            sage: C.join(S).is_combinatorially_isomorphic(C.pyramid())                  # needs sage.graphs
+            sage: C.join(S).is_combinatorially_isomorphic(C.pyramid())
             True
 
             sage: P = polytopes.simplex(backend='cdd')
@@ -1803,7 +1803,7 @@ class Polyhedron_base5(Polyhedron_base4):
 
         Linear transformation without specified new base ring fails in this case::
 
-            sage: M*P                                                                   # needs sage.rings.number_field
+            sage: M*P
             Traceback (most recent call last):
             ...
             TypeError: unsupported operand parent(s) for *:
@@ -1836,7 +1836,7 @@ class Polyhedron_base5(Polyhedron_base4):
             A 3-dimensional polyhedron in RDF^4 defined as the convex hull of 5 vertices
             sage: (1/1 * proj_mat) * b3
             A 3-dimensional polyhedron in QQ^4 defined as the convex hull of 5 vertices
-            sage: (AA(2).sqrt() * proj_mat) * b3                                        # needs sage.rings.number_field
+            sage: (AA(2).sqrt() * proj_mat) * b3
             A 3-dimensional polyhedron in AA^4 defined as the convex hull of 5 vertices
 
         Check that zero-matrices act correctly::
@@ -2094,7 +2094,7 @@ class Polyhedron_base5(Polyhedron_base4):
               A vertex at (-1/3, 1, 1),
               A vertex at (-1/3, 1, -1),
               A vertex at (-1/3, -1, -1))
-             sage: face_trunc.face_lattice().is_isomorphic(Cube.face_lattice())         # needs sage.combinat sage.graphs
+             sage: face_trunc.face_lattice().is_isomorphic(Cube.face_lattice())
              True
 
         TESTS:
@@ -2199,7 +2199,7 @@ class Polyhedron_base5(Polyhedron_base4):
             sage: stacked_hexaprism.f_vector()
             (1, 13, 22, 11, 1)
 
-            sage: hexaprism.stack(square_face, position=4)                              # needs sage.rings.number_field
+            sage: hexaprism.stack(square_face, position=4)
             Traceback (most recent call last):
             ...
             ValueError: the chosen position is too large
@@ -2323,7 +2323,7 @@ class Polyhedron_base5(Polyhedron_base4):
             sage: W1 = P_4.wedge(P_4.faces(1)[0]); W1
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 6 vertices
             sage: triangular_prism = polytopes.regular_polygon(3).prism()
-            sage: W1.is_combinatorially_isomorphic(triangular_prism)                    # needs sage.graphs
+            sage: W1.is_combinatorially_isomorphic(triangular_prism)
             True
 
             sage: Q = polytopes.hypersimplex(4,2)
@@ -2355,9 +2355,9 @@ class Polyhedron_base5(Polyhedron_base4):
              A vertex at (0, 1, 1, 0, -1))
 
             sage: C_3_7 = polytopes.cyclic_polytope(3,7)
-            sage: P_6 = polytopes.regular_polygon(6)                                    # needs sage.rings.number_field
-            sage: W4 = P_6.wedge(P_6.faces(1)[0])                                       # needs sage.rings.number_field
-            sage: W4.is_combinatorially_isomorphic(C_3_7.polar())                       # needs sage.graphs sage.rings.number_field
+            sage: P_6 = polytopes.regular_polygon(6)
+            sage: W4 = P_6.wedge(P_6.faces(1)[0])
+            sage: W4.is_combinatorially_isomorphic(C_3_7.polar())
             True
 
         REFERENCES:
@@ -2529,7 +2529,7 @@ class Polyhedron_base5(Polyhedron_base4):
 
         Check that :issue:`28725` is fixed::
 
-            sage: polytopes.regular_polygon(3)._test_lawrence()                         # needs sage.rings.number_field
+            sage: polytopes.regular_polygon(3)._test_lawrence()
 
         Check that :issue:`30293` is fixed::
 

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -46,9 +46,9 @@ class Polyhedron_base6(Polyhedron_base5):
 
         sage: from sage.geometry.polyhedron.base6 import Polyhedron_base6
         sage: P = polytopes.cube()
-        sage: Polyhedron_base6.plot(P)                                                  # needs sage.plot
+        sage: Polyhedron_base6.plot(P)
         Graphics3d Object
-        sage: print(Polyhedron_base6.tikz(P, output_type='TikzPicture'))                # needs sage.plot
+        sage: print(Polyhedron_base6.tikz(P, output_type='TikzPicture'))
         \RequirePackage{luatex85}
         \documentclass[tikz]{standalone}
         \begin{document}
@@ -131,7 +131,7 @@ class Polyhedron_base6(Polyhedron_base5):
         \end{document}
 
         sage: Q = polytopes.hypercube(4)
-        sage: Polyhedron_base6.show(Q)                                                  # needs sage.plot
+        sage: Polyhedron_base6.show(Q)
         sage: Polyhedron_base6.schlegel_projection(Q)
         The projection of a polyhedron into 3 dimensions
 
@@ -252,32 +252,32 @@ class Polyhedron_base6(Polyhedron_base5):
             sage: hcube = polytopes.hypercube(5)
             sage: facet = hcube.facets()[0].as_polyhedron(); facet
             A 4-dimensional polyhedron in ZZ^5 defined as the convex hull of 16 vertices
-            sage: facet.plot()                                                          # needs sage.plot
+            sage: facet.plot()
             Graphics3d Object
 
         For a 3d plot, we may draw the polygons with rainbow colors, using any of the following ways::
 
-            sage: cube.plot(polygon='rainbow')                                          # needs sage.plot
+            sage: cube.plot(polygon='rainbow')
             Graphics3d Object
-            sage: cube.plot(polygon={'color':'rainbow'})                                # needs sage.plot
+            sage: cube.plot(polygon={'color':'rainbow'})
             Graphics3d Object
-            sage: cube.plot(fill='rainbow')                                             # needs sage.plot
+            sage: cube.plot(fill='rainbow')
             Graphics3d Object
 
         For a 3d plot, the size of a point, the thickness of a line and the width of an arrow
         are controlled by the respective parameters::
 
             sage: prism = Polyhedron(vertices=[[0,0,0],[1,0,0],[0,1,0]], rays=[[0,0,1]])
-            sage: prism.plot(size=20, thickness=30, width=1)                            # needs sage.plot
+            sage: prism.plot(size=20, thickness=30, width=1)
             Graphics3d Object
-            sage: prism.plot(point={'size':20, 'color':'black'},                        # needs sage.plot
+            sage: prism.plot(point={'size':20, 'color':'black'},
             ....:            line={'thickness':30, 'width':1, 'color':'black'},
             ....:            polygon='rainbow')
             Graphics3d Object
 
         TESTS::
 
-            sage: for p in square.plot():                                               # needs sage.plot
+            sage: for p in square.plot():
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             blue Point set defined by 4 point(s)
             blue Line defined by 2 points
@@ -286,18 +286,18 @@ class Polyhedron_base6(Polyhedron_base5):
             blue Line defined by 2 points
             green Polygon defined by 4 points
 
-            sage: for p in line.plot():                                                 # needs sage.plot
+            sage: for p in line.plot():
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             blue Point set defined by 2 point(s)
             green Line defined by 2 points
 
-            sage: for p in point.plot():                                                # needs sage.plot
+            sage: for p in point.plot():
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             green Point set defined by 1 point(s)
 
         Draw the lines in red and nothing else::
 
-            sage: for p in square.plot(point=False, line='red', polygon=False):         # needs sage.plot
+            sage: for p in square.plot(point=False, line='red', polygon=False):
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             red Line defined by 2 points
             red Line defined by 2 points
@@ -306,30 +306,30 @@ class Polyhedron_base6(Polyhedron_base5):
 
         Draw vertices in red, no lines, and a blue polygon::
 
-            sage: for p in square.plot(point={'color':'red'}, line=False, polygon=(0,0,1)):         # needs sage.plot
+            sage: for p in square.plot(point={'color':'red'}, line=False, polygon=(0,0,1)):
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             red Point set defined by 4 point(s)
             (0, 0, 1) Polygon defined by 4 points
 
-            sage: for p in line.plot(point={'color':'red'}, line=False, polygon=(0,0,1)):           # needs sage.plot
+            sage: for p in line.plot(point={'color':'red'}, line=False, polygon=(0,0,1)):
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             red Point set defined by 2 point(s)
 
-            sage: for p in point.plot(point={'color':'red'}, line=False, polygon=(0,0,1)):          # needs sage.plot
+            sage: for p in point.plot(point={'color':'red'}, line=False, polygon=(0,0,1)):
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             red Point set defined by 1 point(s)
 
         Draw in red without wireframe::
 
-            sage: for p in square.plot(wireframe=False, fill='red'):                    # needs sage.plot
+            sage: for p in square.plot(wireframe=False, fill='red'):
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             red Polygon defined by 4 points
 
-            sage: for p in line.plot(wireframe=False, fill='red'):                      # needs sage.plot
+            sage: for p in line.plot(wireframe=False, fill='red'):
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             red Line defined by 2 points
 
-            sage: for p in point.plot(wireframe=False, fill='red'):                     # needs sage.plot
+            sage: for p in point.plot(wireframe=False, fill='red'):
             ....:     print("{} {}".format(p.options()['rgbcolor'], p))
             red Point set defined by 1 point(s)
 
@@ -346,7 +346,7 @@ class Polyhedron_base6(Polyhedron_base5):
 
         In 4d a projection to 3d is used::
 
-            sage: type(polytopes.hypercube(4).plot())                                   # needs sage.plot
+            sage: type(polytopes.hypercube(4).plot())
             <class 'sage.plot.plot3d.base.Graphics3dGroup'>
             sage: type(polytopes.hypercube(5).plot())
             Traceback (most recent call last):
@@ -401,10 +401,10 @@ class Polyhedron_base6(Polyhedron_base5):
             Graphics3d Object
 
             sage: cylinder = Polyhedron(vertices=[(0, 0, 0), (1, 0, 0), (0, 1, 0)], lines=[(0, 0, 1)])
-            sage: cylinder.plot(fill='red')  # check it is not all black                # needs sage.plot
+            sage: cylinder.plot(fill='red')  # check it is not all black
             Graphics3d Object
             sage: quarter = Polyhedron(rays=[(-1, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)])
-            sage: quarter.plot(fill='rainbow')  # check it is not all black nor with too many colors                    # needs sage.plot
+            sage: quarter.plot(fill='rainbow')  # check it is not all black nor with too many colors
             Graphics3d Object
         """
         def merge_options(*opts):
@@ -471,7 +471,7 @@ class Polyhedron_base6(Polyhedron_base5):
         EXAMPLES::
 
             sage: square = polytopes.hypercube(2)
-            sage: square.show(point='red')                                              # needs sage.plot
+            sage: square.show(point='red')
         """
         self.plot(**kwds).show()
 
@@ -688,8 +688,8 @@ class Polyhedron_base6(Polyhedron_base5):
 
         Check that :issue:`29073` is fixed::
 
-            sage: P = polytopes.icosahedron(exact=False)                                # needs sage.groups
-            sage: sum(P.gale_transform()).norm() < 1e-15                                # needs sage.groups
+            sage: P = polytopes.icosahedron(exact=False)
+            sage: sum(P.gale_transform()).norm() < 1e-15
             True
         """
         if not self.is_compact():
@@ -780,8 +780,8 @@ class Polyhedron_base6(Polyhedron_base5):
         EXAMPLES::
 
             sage: p = polytopes.hypercube(3)
-            sage: p_solid = p.render_solid(opacity=.7)                                  # needs sage.plot
-            sage: type(p_solid)                                                         # needs sage.plot
+            sage: p_solid = p.render_solid(opacity=.7)
+            sage: type(p_solid)
             <class 'sage.plot.plot3d.index_face_set.IndexFaceSet'>
         """
         proj = self.projection()
@@ -799,8 +799,8 @@ class Polyhedron_base6(Polyhedron_base5):
         EXAMPLES::
 
             sage: p = Polyhedron([[1,2,],[1,1],[0,0]])
-            sage: p_wireframe = p.render_wireframe()                                    # needs sage.plot
-            sage: p_wireframe._objects                                                  # needs sage.plot
+            sage: p_wireframe = p.render_wireframe()
+            sage: p_wireframe._objects
             [Line defined by 2 points, Line defined by 2 points, Line defined by 2 points]
         """
         proj = self.projection()
@@ -847,24 +847,24 @@ class Polyhedron_base6(Polyhedron_base5):
             sage: tfcube.facets()[-1]
             A 3-dimensional face of a Polyhedron in QQ^4 defined as the convex hull of 8 vertices
             sage: sp = tfcube.schlegel_projection(tfcube.facets()[-1])
-            sage: sp.plot()                                                             # needs sage.plot
+            sage: sp.plot()
             Graphics3d Object
 
         The same truncated cube but see inside the tetrahedral facet::
 
             sage: tfcube.facets()[4]
             A 3-dimensional face of a Polyhedron in QQ^4 defined as the convex hull of 4 vertices
-            sage: sp = tfcube.schlegel_projection(tfcube.facets()[4])                   # needs sage.symbolic
-            sage: sp.plot()                                                             # needs sage.plot sage.symbolic
+            sage: sp = tfcube.schlegel_projection(tfcube.facets()[4])
+            sage: sp.plot()
             Graphics3d Object
 
         A different values of ``position`` changes the projection::
 
             sage: sp = tfcube.schlegel_projection(tfcube.facets()[4], 1/2)
-            sage: sp.plot()                                                             # needs sage.plot
+            sage: sp.plot()
             Graphics3d Object
             sage: sp = tfcube.schlegel_projection(tfcube.facets()[4], 4)
-            sage: sp.plot()                                                             # needs sage.plot
+            sage: sp.plot()
             Graphics3d Object
 
         A value which is too large give a projection point that sees more than
@@ -960,11 +960,11 @@ class Polyhedron_base6(Polyhedron_base5):
             sage: P = Polyhedron(V)
             sage: P.affine_hull_projection()
             A 4-dimensional polyhedron in ZZ^4 defined as the convex hull of 6 vertices
-            sage: P.affine_hull_projection(orthonormal=True)                            # needs sage.symbolic
+            sage: P.affine_hull_projection(orthonormal=True)
             Traceback (most recent call last):
             ...
             ValueError: the base ring needs to be extended; try with "extend=True"
-            sage: P.affine_hull_projection(orthonormal=True, extend=True)               # needs sage.rings.number_field
+            sage: P.affine_hull_projection(orthonormal=True, extend=True)
             A 4-dimensional polyhedron in AA^4 defined as the convex hull of 6 vertices
         """
         result = AffineHullProjectionData()
@@ -1180,13 +1180,13 @@ class Polyhedron_base6(Polyhedron_base5):
             A 1-dimensional polyhedron in QQ^1 defined as the convex hull of 2 vertices
             sage: A.vertices()
             (A vertex at (0), A vertex at (2))
-            sage: A = L.affine_hull_projection(orthonormal=True)                        # needs sage.rings.number_field
+            sage: A = L.affine_hull_projection(orthonormal=True)
             Traceback (most recent call last):
             ...
             ValueError: the base ring needs to be extended; try with "extend=True"
-            sage: A = L.affine_hull_projection(orthonormal=True, extend=True); A        # needs sage.rings.number_field
+            sage: A = L.affine_hull_projection(orthonormal=True, extend=True); A
             A 1-dimensional polyhedron in AA^1 defined as the convex hull of 2 vertices
-            sage: A.vertices()                                                          # needs sage.rings.number_field
+            sage: A.vertices()
             (A vertex at (1.414213562373095?), A vertex at (0.?e-18))
 
         More generally::
@@ -1212,9 +1212,9 @@ class Polyhedron_base6(Polyhedron_base5):
              A vertex at (2, 0, 0),
              A vertex at (1, 3/2, 0),
              A vertex at (1, 1/2, 4/3))
-            sage: A = S.affine_hull_projection(orthonormal=True, extend=True); A        # needs sage.rings.number_field
+            sage: A = S.affine_hull_projection(orthonormal=True, extend=True); A
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 4 vertices
-            sage: A.vertices()                                                          # needs sage.rings.number_field
+            sage: A.vertices()
             (A vertex at (0.7071067811865475?, 0.4082482904638630?, 1.154700538379252?),
              A vertex at (0.7071067811865475?, 1.224744871391589?, 0.?e-18),
              A vertex at (1.414213562373095?, 0.?e-18, 0.?e-18),
@@ -1236,11 +1236,11 @@ class Polyhedron_base6(Polyhedron_base5):
 
             sage: P = polytopes.permutahedron(3); P
             A 2-dimensional polyhedron in ZZ^3 defined as the convex hull of 6 vertices
-            sage: set([F.as_polyhedron().affine_hull_projection(                        # needs sage.combinat sage.rings.number_field
+            sage: set([F.as_polyhedron().affine_hull_projection(
             ....:          orthonormal=True, extend=True).volume()
             ....:     for F in P.affine_hull_projection().faces(1)]) == {1, sqrt(AA(2))}
             True
-            sage: set([F.as_polyhedron().affine_hull_projection(                        # needs sage.combinat sage.rings.number_field
+            sage: set([F.as_polyhedron().affine_hull_projection(
             ....:          orthonormal=True, extend=True).volume()
             ....:     for F in P.affine_hull_projection(
             ....:             orthonormal=True, extend=True).faces(1)]) == {sqrt(AA(2))}
@@ -1293,12 +1293,12 @@ class Polyhedron_base6(Polyhedron_base5):
 
         The affine hull is combinatorially equivalent to the input::
 
-            sage: P.is_combinatorially_isomorphic(P.affine_hull_projection())           # needs sage.rings.number_field
+            sage: P.is_combinatorially_isomorphic(P.affine_hull_projection())
             True
-            sage: P.is_combinatorially_isomorphic(P.affine_hull_projection(             # needs sage.rings.number_field
+            sage: P.is_combinatorially_isomorphic(P.affine_hull_projection(
             ....:     orthogonal=True))
             True
-            sage: P.is_combinatorially_isomorphic(P.affine_hull_projection(             # needs sage.rings.number_field
+            sage: P.is_combinatorially_isomorphic(P.affine_hull_projection(
             ....:     orthonormal=True, extend=True))
             True
 
@@ -1498,8 +1498,8 @@ class Polyhedron_base6(Polyhedron_base5):
 
         TESTS::
 
-            sage: D = polytopes.dodecahedron()                                          # needs sage.rings.number_field
-            sage: D.facets()[0].as_polyhedron()._test_affine_hull_projection()          # needs sage.rings.number_field
+            sage: D = polytopes.dodecahedron()
+            sage: D.facets()[0].as_polyhedron()._test_affine_hull_projection()
         """
         if tester is None:
             tester = self._tester(**options)
@@ -1613,13 +1613,13 @@ class Polyhedron_base6(Polyhedron_base5):
 
         Orthogonal version::
 
-            sage: A = triangle.affine_hull_manifold(name='A', orthogonal=True); A       # needs sage.symbolic
+            sage: A = triangle.affine_hull_manifold(name='A', orthogonal=True); A
             2-dimensional Riemannian submanifold A embedded in the Euclidean space E^3
-            sage: A.embedding().display()                                               # needs sage.symbolic
+            sage: A.embedding().display()
             A → E^3
                (x0, x1) ↦ (x, y, z) = (t0 - 1/2*x0 - 1/3*x1 + 1,
                                        t0 + 1/2*x0 - 1/3*x1, t0 + 2/3*x1)
-            sage: A.embedding().inverse().display()                                     # needs sage.symbolic
+            sage: A.embedding().inverse().display()
             E^3 → A
                (x, y, z) ↦ (x0, x1) = (-x + y + 1, -1/2*x - 1/2*y + z + 1/2)
 
@@ -1631,7 +1631,7 @@ class Polyhedron_base6(Polyhedron_base5):
             ....:     F.as_polyhedron().affine_hull_manifold(name=f'F{i}',
             ....:                                            orthogonal=True, ambient_space=E3)
             ....:     for i, F in enumerate(D.facets())]
-            sage: sum(FM.plot({},               # long time, not tested                 # needs sage.plot
+            sage: sum(FM.plot({},               # long time, not tested
             ....:             srange(-2, 2, 0.1), srange(-2, 2, 0.1),
             ....:             opacity=0.2)
             ....:     for FM in submanifolds) + D.plot()
@@ -1641,7 +1641,7 @@ class Polyhedron_base6(Polyhedron_base5):
 
             sage: cube = polytopes.cube(); cube
             A 3-dimensional polyhedron in ZZ^3 defined as the convex hull of 8 vertices
-            sage: cube.affine_hull_manifold()                                           # needs sage.symbolic
+            sage: cube.affine_hull_manifold()
             Euclidean space E^3
         """
         if ambient_space is None:

--- a/src/sage/geometry/polyhedron/base7.py
+++ b/src/sage/geometry/polyhedron/base7.py
@@ -92,8 +92,8 @@ class Polyhedron_base7(Polyhedron_base6):
             sage: P.centroid()
             (1/4, 0, 0)
 
-            sage: P = polytopes.associahedron(['A', 2])                                 # needs sage.combinat
-            sage: P.centroid()                                                          # needs sage.combinat
+            sage: P = polytopes.associahedron(['A', 2])
+            sage: P.centroid()
             (2/21, 2/21)
 
             sage: P = polytopes.permutahedron(4, backend='normaliz')    # optional - pynormaliz
@@ -513,13 +513,13 @@ class Polyhedron_base7(Polyhedron_base6):
 
         If the base ring is exact, the answer is exact::
 
-            sage: P5 = polytopes.regular_polygon(5)                                     # needs sage.rings.number_field
-            sage: P5.volume()                                                           # needs sage.rings.number_field
+            sage: P5 = polytopes.regular_polygon(5)
+            sage: P5.volume()
             2.377641290737884?
 
-            sage: polytopes.icosahedron().volume()                                      # needs sage.groups sage.rings.number_field
+            sage: polytopes.icosahedron().volume()
             5/12*sqrt5 + 5/4
-            sage: numerical_approx(_)  # abs tol 1e9                                    # needs sage.groups sage.rings.number_field
+            sage: numerical_approx(_)  # abs tol 1e9
             2.18169499062491
 
         When considering lower-dimensional polytopes, we can ask for the
@@ -532,7 +532,7 @@ class Polyhedron_base7(Polyhedron_base6):
             sage: P = Polyhedron([[0, 0], [1, 1]])
             sage: P.volume()
             0
-            sage: P.volume(measure='induced')                                           # needs sage.rings.number_field
+            sage: P.volume(measure='induced')
             1.414213562373095?
             sage: P.volume(measure='induced_rational')                  # optional - latte_int
             1
@@ -553,7 +553,7 @@ class Polyhedron_base7(Polyhedron_base6):
             ....:                          [-1,1,1], [-1,2,0]])
             sage: P.volume()
             0
-            sage: P.volume(measure='induced')                                           # needs sage.rings.number_field
+            sage: P.volume(measure='induced')
             2.598076211353316?
             sage: P.volume(measure='induced', engine='normaliz')
             2.598076211353316
@@ -587,19 +587,19 @@ class Polyhedron_base7(Polyhedron_base6):
             sage: RDF(w)    # abs tol 1e-9
             1.5340627082974878
 
-            sage: all(polytopes.simplex(d).volume(measure='induced')                    # needs sage.rings.number_field sage.symbolic
+            sage: all(polytopes.simplex(d).volume(measure='induced')
             ....:        == sqrt(d+1)/factorial(d)
             ....:     for d in range(1,5))
             True
 
             sage: I = Polyhedron([[-3, 0], [0, 9]])
-            sage: I.volume(measure='induced')                                           # needs sage.rings.number_field
+            sage: I.volume(measure='induced')
             9.48683298050514?
             sage: I.volume(measure='induced_rational')                  # optional - latte_int
             3
 
             sage: T = Polyhedron([[3, 0, 0], [0, 4, 0], [0, 0, 5]])
-            sage: T.volume(measure='induced')                                           # needs sage.rings.number_field
+            sage: T.volume(measure='induced')
             13.86542462386205?
             sage: T.volume(measure='induced_rational')                  # optional - latte_int
             1/2
@@ -833,21 +833,21 @@ class Polyhedron_base7(Polyhedron_base6):
 
             sage: R.<x, y, z> = QQ[]
             sage: P = polytopes.simplex(2)
-            sage: V = AA(P.volume(measure='induced'))                                   # needs sage.rings.number_field
-            sage: V.radical_expression()                                                # needs sage.rings.number_field sage.symbolic
+            sage: V = AA(P.volume(measure='induced'))
+            sage: V.radical_expression()
             1/2*sqrt(3)
-            sage: P.integrate(R(1), measure='induced') == V             # optional - latte_int, needs sage.rings.number_field sage.symbolic
+            sage: P.integrate(R(1), measure='induced') == V             # optional - latte_int
             True
 
         Computing the mass center::
 
-            sage: (P.integrate(x, measure='induced')                    # optional - latte_int, needs sage.rings.number_field sage.symbolic
+            sage: (P.integrate(x, measure='induced')                    # optional - latte_int
             ....:     / V).radical_expression()
             1/3
-            sage: (P.integrate(y, measure='induced')                    # optional - latte_int, needs sage.rings.number_field sage.symbolic
+            sage: (P.integrate(y, measure='induced')                    # optional - latte_int
             ....:     / V).radical_expression()
             1/3
-            sage: (P.integrate(z, measure='induced')                    # optional - latte_int, needs sage.rings.number_field sage.symbolic
+            sage: (P.integrate(z, measure='induced')                    # optional - latte_int
             ....:     / V).radical_expression()
             1/3
 
@@ -862,8 +862,8 @@ class Polyhedron_base7(Polyhedron_base6):
 
         Testing a polytope with non-rational vertices::
 
-            sage: P = polytopes.icosahedron()                                           # needs sage.groups sage.rings.number_field
-            sage: P.integrate(x^2*y^2*z^2)                              # optional - latte_int, needs sage.groups sage.rings.number_field
+            sage: P = polytopes.icosahedron()
+            sage: P.integrate(x^2*y^2*z^2)                              # optional - latte_int
             Traceback (most recent call last):
             ...
             TypeError: the base ring must be ZZ, QQ, or RDF

--- a/src/sage/geometry/polyhedron/base_QQ.py
+++ b/src/sage/geometry/polyhedron/base_QQ.py
@@ -150,7 +150,7 @@ class Polyhedron_QQ(Polyhedron_base):
             ....:     x = lp.new_variable(nonnegative=True)
             ....:     lp.add_constraint(lp.sum(fibonacci(i+3)*x[i] for i in range(d)) <= b)
             ....:     return lp.polyhedron(backend=backend)
-            sage: fibonacci_knapsack(20, 12).integral_points_count()  # does not finish with preprocess=False           # needs sage.combinat
+            sage: fibonacci_knapsack(20, 12).integral_points_count()  # does not finish with preprocess=False
             33
 
         TESTS:
@@ -947,7 +947,7 @@ class Polyhedron_QQ(Polyhedron_base):
 
         Here is an example for the square::
 
-            sage: # optional - pynormaliz, needs sage.groups
+            sage: # optional - pynormaliz
             sage: p = polytopes.hypercube(2, backend='normaliz'); p
             A 2-dimensional polyhedron in ZZ^2 defined as the convex hull of 4 vertices
             sage: aut_p = p.restricted_automorphism_group(
@@ -962,9 +962,9 @@ class Polyhedron_QQ(Polyhedron_base):
         TESTS::
 
             sage: P = Polyhedron(vertices=[[1, 1]], rays=[[1, 1]])
-            sage: aut_P = P.restricted_automorphism_group(output='permutation')         # needs sage.groups
-            sage: conj_list = aut_P.conjugacy_classes_representatives()                 # needs sage.groups
-            sage: P.fixed_subpolytopes(conj_list)                                       # needs sage.groups
+            sage: aut_P = P.restricted_automorphism_group(output='permutation')
+            sage: conj_list = aut_P.conjugacy_classes_representatives()
+            sage: P.fixed_subpolytopes(conj_list)
             Traceback (most recent call last):
             ...
             NotImplementedError: unbounded polyhedra are not supported

--- a/src/sage/geometry/polyhedron/base_ZZ.py
+++ b/src/sage/geometry/polyhedron/base_ZZ.py
@@ -85,7 +85,7 @@ class Polyhedron_ZZ(Polyhedron_QQ):
 
             sage: polytopes.cross_polytope(3).is_lattice_polytope()
             True
-            sage: polytopes.regular_polygon(5).is_lattice_polytope()                    # needs sage.rings.number_field
+            sage: polytopes.regular_polygon(5).is_lattice_polytope()
             False
 
         TESTS:
@@ -664,8 +664,8 @@ class Polyhedron_ZZ(Polyhedron_QQ):
 
         EXAMPLES::
 
-            sage: P = Polyhedron(toric_varieties.P4_11169().fan().rays(), base_ring=ZZ)             # needs palp sage.graphs
-            sage: list(P.fibration_generator(2))                                        # needs palp sage.graphs
+            sage: P = Polyhedron(toric_varieties.P4_11169().fan().rays(), base_ring=ZZ)             # needs palp
+            sage: list(P.fibration_generator(2))                                        # needs palp
             [A 2-dimensional polyhedron in ZZ^4 defined as the convex hull of 3 vertices]
         """
         from sage.combinat.combination import Combinations
@@ -893,9 +893,9 @@ class Polyhedron_ZZ(Polyhedron_QQ):
              A vertex at (0, -1),
              A vertex at (0, 1),
              A vertex at (1, 0))
-            sage: d.normal_form()                                                       # needs sage.groups
+            sage: d.normal_form()
             [(1, 0), (0, 1), (0, -1), (-1, 0)]
-            sage: d.lattice_polytope().normal_form("palp_native")                       # needs sage.groups
+            sage: d.lattice_polytope().normal_form("palp_native")
             M( 1,  0),
             M( 0,  1),
             M( 0, -1),
@@ -904,7 +904,7 @@ class Polyhedron_ZZ(Polyhedron_QQ):
 
         Using ``permutation=True``::
 
-            sage: d.normal_form(permutation=True)                                       # needs sage.groups
+            sage: d.normal_form(permutation=True)
             ([(1, 0), (0, 1), (0, -1), (-1, 0)], ())
 
         It is not possible to compute normal forms for polytopes which do not

--- a/src/sage/geometry/polyhedron/base_number_field.py
+++ b/src/sage/geometry/polyhedron/base_number_field.py
@@ -32,12 +32,12 @@ def _number_field_elements_from_algebraics_list_of_lists_of_lists(listss, **kwds
 
     EXAMPLES::
 
-        sage: rt2 = AA(sqrt(2)); rt2                                                    # needs sage.rings.number_field sage.symbolic
+        sage: rt2 = AA(sqrt(2)); rt2
         1.414213562373095?
-        sage: rt3 = AA(sqrt(3)); rt3                                                    # needs sage.rings.number_field sage.symbolic
+        sage: rt3 = AA(sqrt(3)); rt3
         1.732050807568878?
         sage: from sage.geometry.polyhedron.base_number_field import _number_field_elements_from_algebraics_list_of_lists_of_lists
-        sage: K, results, hom = _number_field_elements_from_algebraics_list_of_lists_of_lists([[[rt2], [1]], [[rt3]], [[1], []]]); results                      # needs sage.rings.number_field sage.symbolic
+        sage: K, results, hom = _number_field_elements_from_algebraics_list_of_lists_of_lists([[[rt2], [1]], [[rt3]], [[1], []]]); results
         [[[-a^3 + 3*a], [1]], [[a^2 - 2]], [[1], []]]
     """
     from sage.rings.qqbar import number_field_elements_from_algebraics
@@ -58,7 +58,7 @@ class Polyhedron_base_number_field(Polyhedron_base):
 
         EXAMPLES::
 
-            sage: # optional - pynormaliz, needs sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: p = Polyhedron(vertices=[(0,1/2), (2,0), (4,5/6)],
             ....:                base_ring=AA, backend='normaliz')
             sage: def convert_QQ(ieqs, eqs):
@@ -79,8 +79,8 @@ class Polyhedron_base_number_field(Polyhedron_base):
 
         TESTS::
 
-            sage: K.<a> = QuadraticField(-5)                                            # needs sage.rings.number_field
-            sage: p = Polyhedron(base_ring=K,       # indirect doctest  # optional - pynormaliz, needs sage.rings.number_field
+            sage: K.<a> = QuadraticField(-5)
+            sage: p = Polyhedron(base_ring=K,       # indirect doctest  # optional - pynormaliz
             ....:                backend='normaliz',
             ....:                vertices=[(a,1/2), (2,0), (4,5/6)])
             Traceback (most recent call last):
@@ -89,11 +89,11 @@ class Polyhedron_base_number_field(Polyhedron_base):
 
         Checks that :issue:`30248` is fixed::
 
-            sage: q = Polyhedron(base_ring=AA,      # indirect doctest  # optional - pynormaliz, needs sage.rings.number_field
+            sage: q = Polyhedron(base_ring=AA,      # indirect doctest  # optional - pynormaliz
             ....:                backend='normaliz',
             ....:                rays=[(0, 0, 1), (0, 1, -1), (1, 0, -1)]); q
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 1 vertex and 3 rays
-            sage: -q                                                    # optional - pynormaliz, needs sage.rings.number_field
+            sage: -q                                                    # optional - pynormaliz
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 1 vertex and 3 rays
         """
         from sage.categories.number_fields import NumberFields

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/base.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/base.pyx
@@ -49,14 +49,14 @@ Obtaining edges and ridges::
 
 Vertex-graph and facet-graph::
 
-    sage: C.vertex_graph()                                                              # needs sage.graphs
+    sage: C.vertex_graph()
     Graph on 16 vertices
-    sage: C.facet_graph()                                                               # needs sage.graphs
+    sage: C.facet_graph()
     Graph on 8 vertices
 
 Face lattice::
 
-    sage: C.face_lattice()                                                              # needs sage.combinat
+    sage: C.face_lattice()
     Finite lattice containing 82 elements
 
 Face iterator::
@@ -327,7 +327,7 @@ cdef class CombinatorialPolyhedron(SageObject):
             Traceback (most recent call last):
             ...
             ValueError: the combinatorial polyhedron was not initialized
-            sage: C.face_lattice()                                                      # needs sage.combinat
+            sage: C.face_lattice()
             Traceback (most recent call last):
             ...
             ValueError: the combinatorial polyhedron was not initialized
@@ -1278,14 +1278,14 @@ cdef class CombinatorialPolyhedron(SageObject):
 
             sage: P = polytopes.cyclic_polytope(3,5)
             sage: C = CombinatorialPolyhedron(P)
-            sage: G = C.vertex_graph(); G                                               # needs sage.graphs
+            sage: G = C.vertex_graph(); G
             Graph on 5 vertices
-            sage: sorted(G.degree())                                                    # needs sage.graphs
+            sage: sorted(G.degree())
             [3, 3, 4, 4, 4]
 
             sage: P = Polyhedron(rays=[[1]])
             sage: C = CombinatorialPolyhedron(P)
-            sage: C.graph()                                                             # needs sage.graphs
+            sage: C.graph()
             Graph on 1 vertex
         """
         vertices = self.vertices(names=names)
@@ -1545,25 +1545,25 @@ cdef class CombinatorialPolyhedron(SageObject):
 
             sage: P = polytopes.cyclic_polytope(4,6)
             sage: C = CombinatorialPolyhedron(P)
-            sage: C.facet_graph()                                                       # needs sage.graphs
+            sage: C.facet_graph()
             Graph on 9 vertices
 
         TESTS::
 
             sage: P = Polyhedron(ieqs=[[1,-1,0],[1,1,0]])
-            sage: CombinatorialPolyhedron(P).facet_graph()                              # needs sage.graphs
+            sage: CombinatorialPolyhedron(P).facet_graph()
             Graph on 2 vertices
 
         Checking that :issue:`28604` is fixed::
 
             sage: C = CombinatorialPolyhedron(polytopes.cube()); C
             A 3-dimensional combinatorial polyhedron with 6 facets
-            sage: C.facet_graph(names=False)                                            # needs sage.graphs
+            sage: C.facet_graph(names=False)
             Graph on 6 vertices
 
             sage: C = CombinatorialPolyhedron(polytopes.hypersimplex(5,2)); C
             A 4-dimensional combinatorial polyhedron with 10 facets
-            sage: C.facet_graph()                                                       # needs sage.combinat sage.graphs
+            sage: C.facet_graph()
             Graph on 10 vertices
         """
         face_iter = self.face_iter(self.dimension() - 1, algorithm='primal')
@@ -1601,7 +1601,7 @@ cdef class CombinatorialPolyhedron(SageObject):
 
             sage: P = polytopes.hypercube(2).pyramid()
             sage: C = CombinatorialPolyhedron(P)
-            sage: G = C.vertex_facet_graph(); G                                         # needs sage.graphs
+            sage: G = C.vertex_facet_graph(); G
             Digraph on 10 vertices
             sage: C.Vrepresentation()
             (A vertex at (0, -1, -1),
@@ -1609,7 +1609,7 @@ cdef class CombinatorialPolyhedron(SageObject):
              A vertex at (0, 1, -1),
              A vertex at (0, 1, 1),
              A vertex at (1, 0, 0))
-            sage: sorted(G.neighbors_out(C.Vrepresentation()[4]))                       # needs sage.graphs
+            sage: sorted(G.neighbors_out(C.Vrepresentation()[4]))
             [An inequality (-1, -1, 0) x + 1 >= 0,
              An inequality (-1, 0, -1) x + 1 >= 0,
              An inequality (-1, 0, 1) x + 1 >= 0,
@@ -1622,7 +1622,7 @@ cdef class CombinatorialPolyhedron(SageObject):
         with a string 'H' or 'V'::
 
             sage: C = CombinatorialPolyhedron(P.incidence_matrix())
-            sage: C.vertex_facet_graph().vertices(sort=True)                            # needs sage.graphs
+            sage: C.vertex_facet_graph().vertices(sort=True)
             [('H', 0),
              ('H', 1),
              ('H', 2),
@@ -1636,18 +1636,18 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         If ``names`` is ``False`` then the vertices of the graph are given by integers::
 
-            sage: C.vertex_facet_graph(names=False).vertices(sort=True)                 # needs sage.graphs
+            sage: C.vertex_facet_graph(names=False).vertices(sort=True)
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
         TESTS:
 
         Test that :issue:`29898` is fixed::
 
-            sage: Polyhedron().vertex_facet_graph()                                     # needs sage.graphs
+            sage: Polyhedron().vertex_facet_graph()
             Digraph on 0 vertices
-            sage: Polyhedron([[0]]).vertex_facet_graph()                                # needs sage.graphs
+            sage: Polyhedron([[0]]).vertex_facet_graph()
             Digraph on 1 vertex
-            sage: Polyhedron([[0]]).vertex_facet_graph(False)                           # needs sage.graphs
+            sage: Polyhedron([[0]]).vertex_facet_graph(False)
             Digraph on 1 vertex
         """
         from sage.graphs.digraph import DiGraph
@@ -1788,7 +1788,7 @@ cdef class CombinatorialPolyhedron(SageObject):
         Obtain the entire flag-f-vector::
 
             sage: C = polytopes.hypercube(4).combinatorial_polyhedron()
-            sage: C.flag_f_vector()                                                     # needs sage.combinat
+            sage: C.flag_f_vector()
                 {(-1,): 1,
                  (0,): 16,
                  (0, 1): 64,
@@ -1809,39 +1809,39 @@ cdef class CombinatorialPolyhedron(SageObject):
 
         Specify an entry::
 
-            sage: C.flag_f_vector(0,3)                                                  # needs sage.combinat
+            sage: C.flag_f_vector(0,3)
             64
-            sage: C.flag_f_vector(2)                                                    # needs sage.combinat
+            sage: C.flag_f_vector(2)
             24
 
         Leading ``-1`` and trailing entry of dimension are allowed::
 
-            sage: C.flag_f_vector(-1,0,3)                                               # needs sage.combinat
+            sage: C.flag_f_vector(-1,0,3)
             64
-            sage: C.flag_f_vector(-1,0,3,4)                                             # needs sage.combinat
+            sage: C.flag_f_vector(-1,0,3,4)
             64
 
         One can get the number of trivial faces::
 
-            sage: C.flag_f_vector(-1)                                                   # needs sage.combinat
+            sage: C.flag_f_vector(-1)
             1
-            sage: C.flag_f_vector(4)                                                    # needs sage.combinat
+            sage: C.flag_f_vector(4)
             1
 
         Polyhedra with lines, have ``0`` entries accordingly::
 
             sage: C = (Polyhedron(lines=[[1]]) * polytopes.hypercube(2)).combinatorial_polyhedron()
-            sage: C.flag_f_vector()                                                     # needs sage.combinat
+            sage: C.flag_f_vector()
             {(-1,): 1, (0, 1): 0, (0, 2): 0, (0,): 0, (1, 2): 8, (1,): 4, (2,): 4, 3: 1}
 
         If the arguments are not strictly increasing or out of range,
         a key error is raised::
 
-            sage: C.flag_f_vector(-1,0,3,5)                                             # needs sage.combinat
+            sage: C.flag_f_vector(-1,0,3,5)
             Traceback (most recent call last):
             ...
             KeyError: (0, 3, 5)
-            sage: C.flag_f_vector(-1,3,0)                                               # needs sage.combinat
+            sage: C.flag_f_vector(-1,3,0)
             Traceback (most recent call last):
             ...
             KeyError: (3, 0)
@@ -1869,7 +1869,7 @@ cdef class CombinatorialPolyhedron(SageObject):
         TESTS::
 
             sage: C = CombinatorialPolyhedron(3)
-            sage: C._flag_f_vector()                                                    # needs sage.combinat
+            sage: C._flag_f_vector()
             {(-1,): 1, (0, 1): 0, (0, 2): 0, (0,): 0, (1, 2): 0, (1,): 0, (2,): 0, 3: 1}
         """
         poly = self.face_lattice().flag_f_polynomial()
@@ -2792,31 +2792,31 @@ cdef class CombinatorialPolyhedron(SageObject):
 
             sage: P = Polyhedron(rays=[[1,0],[0,1]])
             sage: C = CombinatorialPolyhedron(P)
-            sage: C.face_lattice()                                                      # needs sage.combinat
+            sage: C.face_lattice()
             Finite lattice containing 5 elements
 
             sage: P = Polyhedron(rays=[[1,0,0], [-1,0,0], [0,-1,0], [0,1,0]])
             sage: C = CombinatorialPolyhedron(P)
             sage: P1 = Polyhedron(rays=[[1,0], [-1,0]])
             sage: C1 = CombinatorialPolyhedron(P1)
-            sage: C.face_lattice().is_isomorphic(C1.face_lattice())                     # needs sage.combinat
+            sage: C.face_lattice().is_isomorphic(C1.face_lattice())
             True
 
             sage: P = polytopes.permutahedron(5)
             sage: C = CombinatorialPolyhedron(P)
-            sage: C.face_lattice()                                                      # needs sage.combinat
+            sage: C.face_lattice()
             Finite lattice containing 542 elements
 
         TESTS::
 
             sage: P = polytopes.cyclic_polytope(4,10)
             sage: C = CombinatorialPolyhedron(P)
-            sage: C.face_lattice().is_isomorphic(P.face_lattice())                      # needs sage.combinat
+            sage: C.face_lattice().is_isomorphic(P.face_lattice())
             True
 
             sage: P = polytopes.permutahedron(4)
             sage: C = CombinatorialPolyhedron(P)
-            sage: C.face_lattice().is_isomorphic(P.face_lattice())                      # needs sage.combinat
+            sage: C.face_lattice().is_isomorphic(P.face_lattice())
             True
         """
         from sage.combinat.posets.lattices import FiniteLatticePoset
@@ -2888,12 +2888,12 @@ cdef class CombinatorialPolyhedron(SageObject):
 
             sage: P = polytopes.cube()
             sage: C = CombinatorialPolyhedron(P)
-            sage: F = C.face_lattice()                                                  # needs sage.combinat
+            sage: F = C.face_lattice()
             sage: def f(i):
             ....:     return (i, C._face_lattice_dimension(i))
             ....:
-            sage: G = F.relabel(f)                                                      # needs sage.combinat
-            sage: set(G._elements)                                                      # needs sage.combinat
+            sage: G = F.relabel(f)
+            sage: set(G._elements)
             {(0, -1),
              (1, 0),
              (2, 0),
@@ -2960,9 +2960,9 @@ cdef class CombinatorialPolyhedron(SageObject):
 
             sage: P = Polyhedron(rays=[[0,1], [1,0]])
             sage: C = CombinatorialPolyhedron(P)
-            sage: F = C.face_lattice()                                                  # needs sage.combinat
-            sage: G = F.relabel(C.face_by_face_lattice_index)                           # needs sage.combinat
-            sage: G._elements                                                           # needs sage.combinat
+            sage: F = C.face_lattice()
+            sage: G = F.relabel(C.face_by_face_lattice_index)
+            sage: G._elements
             (A -1-dimensional face of a 2-dimensional combinatorial polyhedron,
               A 0-dimensional face of a 2-dimensional combinatorial polyhedron,
               A 1-dimensional face of a 2-dimensional combinatorial polyhedron,
@@ -2970,8 +2970,8 @@ cdef class CombinatorialPolyhedron(SageObject):
               A 2-dimensional face of a 2-dimensional combinatorial polyhedron)
 
             sage: def f(i): return C.face_by_face_lattice_index(i).ambient_V_indices()
-            sage: G = F.relabel(f)                                                      # needs sage.combinat
-            sage: G._elements                                                           # needs sage.combinat
+            sage: G = F.relabel(f)
+            sage: G._elements
             ((), (0,), (0, 1), (0, 2), (0, 1, 2))
         """
         self._record_all_faces()                            # Initialize ``_all_faces``, if not done yet.
@@ -3312,7 +3312,7 @@ cdef class CombinatorialPolyhedron(SageObject):
             sage: D.f_vector()
             (1, 6, 12, 8, 1)
             sage: D1 = P.polar().combinatorial_polyhedron()
-            sage: D1.face_lattice().is_isomorphic(D.face_lattice())                     # needs sage.combinat
+            sage: D1.face_lattice().is_isomorphic(D.face_lattice())
             True
 
         Polar is an alias to be consistent with :class:`~sage.geometry.polyhedron.base.Polyhedron_base`::
@@ -3362,7 +3362,7 @@ cdef class CombinatorialPolyhedron(SageObject):
             sage: C1 = C.pyramid()
             sage: P1 = P.pyramid()
             sage: C2 = P1.combinatorial_polyhedron()
-            sage: C2.vertex_facet_graph().is_isomorphic(C1.vertex_facet_graph())        # needs sage.combinat
+            sage: C2.vertex_facet_graph().is_isomorphic(C1.vertex_facet_graph())
             True
 
         One can specify a name for the new vertex::

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/combinatorial_face.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/combinatorial_face.pyx
@@ -22,7 +22,7 @@ Obtain a face from a face lattice index::
 
     sage: P = polytopes.simplex(2)
     sage: C = CombinatorialPolyhedron(P)
-    sage: sorted(C.face_lattice()._elements)                                            # needs sage.combinat
+    sage: sorted(C.face_lattice()._elements)
     [0, 1, 2, 3, 4, 5, 6, 7]
     sage: face = C.face_by_face_lattice_index(0); face
     A -1-dimensional face of a 2-dimensional combinatorial polyhedron
@@ -97,8 +97,8 @@ cdef class CombinatorialFace(SageObject):
 
     Obtain a combinatorial face from an index of the face lattice::
 
-        sage: F = C.face_lattice()                                                      # needs sage.combinat
-        sage: F._elements[3]                                                            # needs sage.combinat
+        sage: F = C.face_lattice()
+        sage: F._elements[3]
         34
         sage: C.face_by_face_lattice_index(29)
         A 1-dimensional face of a 5-dimensional combinatorial polyhedron
@@ -325,8 +325,8 @@ cdef class CombinatorialFace(SageObject):
 
             sage: P = polytopes.cyclic_polytope(4,10)
             sage: C = CombinatorialPolyhedron(P)
-            sage: F = C.face_lattice()                                                  # needs sage.combinat
-            sage: G = F.relabel(C.face_by_face_lattice_index)                           # needs sage.combinat
+            sage: F = C.face_lattice()
+            sage: G = F.relabel(C.face_by_face_lattice_index)
         """
         return self._hash_index
 
@@ -509,7 +509,7 @@ cdef class CombinatorialFace(SageObject):
 
         ``dim`` is an alias::
 
-            sage: face.dim()                                                            # needs sage.combinat
+            sage: face.dim()
             2
         """
         if self._dual:
@@ -757,9 +757,9 @@ cdef class CombinatorialFace(SageObject):
 
         Add the indices of the equation::
 
-            sage: face.ambient_H_indices(add_equations=True)                            # needs sage.combinat
+            sage: face.ambient_H_indices(add_equations=True)
             (28, 29, 30)
-            sage: face2.ambient_H_indices(add_equations=True)                           # needs sage.combinat
+            sage: face2.ambient_H_indices(add_equations=True)
             (25, 29, 30)
 
         Another example::
@@ -873,7 +873,7 @@ cdef class CombinatorialFace(SageObject):
             sage: F.f_vector()
             (1, 5, 10, 10, 5, 1)
             sage: F_alt = polytopes.cyclic_polytope(4,5).combinatorial_polyhedron()
-            sage: F_alt.vertex_facet_graph().is_isomorphic(F.vertex_facet_graph())      # needs sage.graphs
+            sage: F_alt.vertex_facet_graph().is_isomorphic(F.vertex_facet_graph())
             True
 
         Obtaining the quotient::

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/face_iterator.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/face_iterator.pyx
@@ -1575,12 +1575,12 @@ cdef class FaceIterator(FaceIterator_base):
         r"""
         EXAMPLES::
 
-            sage: P = polytopes.associahedron(['A',3])                                  # needs sage.combinat
-            sage: C = CombinatorialPolyhedron(P)                                        # needs sage.combinat
-            sage: C.face_generator()                                                    # needs sage.combinat
+            sage: P = polytopes.associahedron(['A',3])
+            sage: C = CombinatorialPolyhedron(P)
+            sage: C.face_generator()
             Iterator over the proper faces of a 3-dimensional combinatorial polyhedron
 
-            sage: C.face_generator(1)                                                   # needs sage.combinat
+            sage: C.face_generator(1)
             Iterator over the 1-faces of a 3-dimensional combinatorial polyhedron
         """
         if self.structure.output_dimension != -2:
@@ -1846,11 +1846,11 @@ cdef class FaceIterator_geom(FaceIterator_base):
         r"""
         EXAMPLES::
 
-            sage: P = polytopes.associahedron(['A',3])                                  # needs sage.combinat
-            sage: P.face_generator()                                                    # needs sage.combinat
+            sage: P = polytopes.associahedron(['A',3])
+            sage: P.face_generator()
             Iterator over the faces of a 3-dimensional polyhedron in QQ^3
 
-            sage: P.face_generator(1)                                                   # needs sage.combinat
+            sage: P.face_generator(1)
             Iterator over the 1-faces of a 3-dimensional polyhedron in QQ^3
         """
         if self._requested_dim is not None:

--- a/src/sage/geometry/polyhedron/combinatorial_polyhedron/polyhedron_face_lattice.pyx
+++ b/src/sage/geometry/polyhedron/combinatorial_polyhedron/polyhedron_face_lattice.pyx
@@ -99,7 +99,7 @@ cdef class PolyhedronFaceLattice:
         sage: P = polytopes.Birkhoff_polytope(3)
         sage: C = CombinatorialPolyhedron(P)
         sage: C._record_all_faces()  # indirect doctests
-        sage: C.face_lattice()                                                          # needs sage.combinat
+        sage: C.face_lattice()
         Finite lattice containing 50 elements
 
     ALGORITHM:
@@ -213,7 +213,7 @@ cdef class PolyhedronFaceLattice:
             sage: P = polytopes.cube()
             sage: C = CombinatorialPolyhedron(P)
             sage: C._record_all_faces() # indirect doctests
-            sage: C.face_lattice()                                                      # needs sage.combinat
+            sage: C.face_lattice()
             Finite lattice containing 28 elements
 
             sage: TestSuite(sage.geometry.polyhedron.combinatorial_polyhedron.polyhedron_face_lattice.PolyhedronFaceLattice).run()

--- a/src/sage/geometry/polyhedron/constructor.py
+++ b/src/sage/geometry/polyhedron/constructor.py
@@ -176,8 +176,8 @@ equilateral triangle whose vertex coordinates involve `\sqrt{3}`. An
 exact way to work with roots in Sage is the
 :mod:`Algebraic Real Field <sage.rings.qqbar>` ::
 
-    sage: triangle = Polyhedron([(0,0), (1,0), (1/2, sqrt(3)/2)], base_ring=AA)         # needs sage.rings.number_field sage.symbolic
-    sage: triangle.Hrepresentation()                                                    # needs sage.rings.number_field sage.symbolic
+    sage: triangle = Polyhedron([(0,0), (1,0), (1/2, sqrt(3)/2)], base_ring=AA)
+    sage: triangle.Hrepresentation()
     (An inequality (-1, -0.5773502691896258?) x + 1 >= 0,
      An inequality (1, -0.5773502691896258?) x + 0 >= 0,
      An inequality (0, 1.154700538379252?) x + 0 >= 0)
@@ -186,12 +186,12 @@ Without specifying the ``base_ring``, the ``sqrt(3)`` would be a
 symbolic ring element and, therefore, the polyhedron defined over the
 symbolic ring. This is currently not supported as SR is not exact::
 
-    sage: Polyhedron([(0,0), (1,0), (1/2, sqrt(3)/2)])                                  # needs sage.symbolic
+    sage: Polyhedron([(0,0), (1,0), (1/2, sqrt(3)/2)])
     Traceback (most recent call last):
     ...
     ValueError: no default backend for computations with Symbolic Ring
 
-    sage: SR.is_exact()                                                                 # needs sage.symbolic
+    sage: SR.is_exact()
     False
 
 Even faster than all algebraic real numbers (the field ``AA``) is
@@ -199,8 +199,8 @@ to take the smallest extension field. For the equilateral
 triangle, that would be::
 
     sage: x = polygen(ZZ, 'x')
-    sage: K.<sqrt3> = NumberField(x^2 - 3, embedding=AA(3)**(1/2))                      # needs sage.rings.number_field
-    sage: Polyhedron([(0,0), (1,0), (1/2, sqrt3/2)])                                    # needs sage.rings.number_field
+    sage: K.<sqrt3> = NumberField(x^2 - 3, embedding=AA(3)**(1/2))
+    sage: Polyhedron([(0,0), (1,0), (1/2, sqrt3/2)])
     A 2-dimensional polyhedron in
      (Number Field in sqrt3 with defining polynomial x^2 - 3 with sqrt3 = 1.732050807568878?)^2
      defined as the convex hull of 3 vertices
@@ -220,7 +220,7 @@ triangle, that would be::
         A 0-dimensional polyhedron in RDF^2 defined as the convex hull of 1 vertex
         sage: Polyhedron(vertices = [[1.12345678901234, 2.123456789012345]])
         A 0-dimensional polyhedron in RDF^2 defined as the convex hull of 1 vertex
-        sage: Polyhedron(vertices = [[1.123456789012345, 2.123456789012345]])           # needs sage.rings.real_mpfr
+        sage: Polyhedron(vertices = [[1.123456789012345, 2.123456789012345]])
         Traceback (most recent call last):
         ...
         ValueError: the only allowed inexact ring is 'RDF' with backend 'cdd'
@@ -454,10 +454,10 @@ def Polyhedron(vertices=None, rays=None, lines=None,
         sage: gold = (1+r1)/2
         sage: v = [[0, 1, gold], [0, 1, -gold], [0, -1, gold], [0, -1, -gold]]
         sage: pp = Permutation((1, 2, 3))
-        sage: icosah = Polyhedron(                                                      # needs sage.combinat
+        sage: icosah = Polyhedron(
         ....:    [(pp^2).action(w) for w in v] + [pp.action(w) for w in v] + v,
         ....:    base_ring=R1)
-        sage: len(icosah.faces(2))                                                      # needs sage.combinat
+        sage: len(icosah.faces(2))
         20
 
     When the input contains elements of a Number Field, they require an
@@ -564,7 +564,7 @@ def Polyhedron(vertices=None, rays=None, lines=None,
     Check that input with too many bits of precision returns an error (see
     :issue:`22552`)::
 
-        sage: Polyhedron(vertices=[(8.3319544851638732, 7.0567045956967727),            # needs sage.rings.real_mpfr
+        sage: Polyhedron(vertices=[(8.3319544851638732, 7.0567045956967727),
         ....:                      (6.4876921900819049, 4.8435898415984129)])
         Traceback (most recent call last):
         ...
@@ -572,11 +572,11 @@ def Polyhedron(vertices=None, rays=None, lines=None,
 
     Check that setting ``base_ring`` to a ``RealField`` returns an error (see :issue:`22552`)::
 
-        sage: Polyhedron(vertices=[(8.3, 7.0), (6.4, 4.8)], base_ring=RealField(40))    # needs sage.rings.real_mpfr
+        sage: Polyhedron(vertices=[(8.3, 7.0), (6.4, 4.8)], base_ring=RealField(40))
         Traceback (most recent call last):
         ...
         ValueError: no default backend for computations with Real Field with 40 bits of precision
-        sage: Polyhedron(vertices=[(8.3, 7.0), (6.4, 4.8)], base_ring=RealField(53))    # needs sage.rings.real_mpfr
+        sage: Polyhedron(vertices=[(8.3, 7.0), (6.4, 4.8)], base_ring=RealField(53))
         Traceback (most recent call last):
         ...
         ValueError: no default backend for computations with Real Field with 53 bits of precision

--- a/src/sage/geometry/polyhedron/double_description.py
+++ b/src/sage/geometry/polyhedron/double_description.py
@@ -28,10 +28,10 @@ The implementation works over any exact field that is embedded in
 `\RR`, for example::
 
     sage: from sage.geometry.polyhedron.double_description import StandardAlgorithm
-    sage: A = matrix(AA, [(1,0,1), (0,1,1), (-AA(2).sqrt(),-AA(3).sqrt(),1),            # needs sage.rings.number_field
+    sage: A = matrix(AA, [(1,0,1), (0,1,1), (-AA(2).sqrt(),-AA(3).sqrt(),1),
     ....:                 (-AA(3).sqrt(),-AA(2).sqrt(),1)])
     sage: alg = StandardAlgorithm(A)
-    sage: alg.run().R                                                                   # needs sage.rings.number_field
+    sage: alg.run().R
     [(-0.4177376677004119?, 0.5822623322995881?, 0.4177376677004119?),
      (-0.2411809548974793?, -0.2411809548974793?, 0.2411809548974793?),
      (0.07665629029830300?, 0.07665629029830300?, 0.2411809548974793?),
@@ -585,9 +585,9 @@ class Problem:
 
         EXAMPLES::
 
-            sage: A = matrix(AA, [(1, 1), (-1, 1)])                                     # needs sage.rings.number_field
+            sage: A = matrix(AA, [(1, 1), (-1, 1)])
             sage: from sage.geometry.polyhedron.double_description import Problem
-            sage: Problem(A).base_ring()                                                # needs sage.rings.number_field
+            sage: Problem(A).base_ring()
             Algebraic Real Field
         """
         return self._field

--- a/src/sage/geometry/polyhedron/face.py
+++ b/src/sage/geometry/polyhedron/face.py
@@ -35,7 +35,7 @@ the faces in a particular dimension, use the
 or :meth:`~sage.geometry.polyhedron.base4.Polyhedron_base4.face_lattice` to get the
 whole face lattice as a poset::
 
-    sage: P.face_lattice()                                                              # needs sage.combinat
+    sage: P.face_lattice()
     Finite lattice containing 28 elements
 
 The faces are printed in shorthand notation where each integer is the
@@ -389,7 +389,7 @@ class PolyhedronFace(ConvexSet_closed):
         EXAMPLES::
 
             sage: square = polytopes.hypercube(2)
-            sage: for face in square.face_lattice():                                    # needs sage.combinat
+            sage: for face in square.face_lattice():
             ....:     print(face.ambient_Hrepresentation())
             (An inequality (-1, 0) x + 1 >= 0, An inequality (0, -1) x + 1 >= 0,
              An inequality (1, 0) x + 1 >= 0, An inequality (0, 1) x + 1 >= 0)
@@ -428,7 +428,7 @@ class PolyhedronFace(ConvexSet_closed):
         EXAMPLES::
 
             sage: square = polytopes.hypercube(2)
-            sage: for fl in square.face_lattice():                                      # needs sage.combinat
+            sage: for fl in square.face_lattice():
             ....:     print(fl.ambient_Vrepresentation())
             ()
             (A vertex at (1, -1),)
@@ -458,14 +458,14 @@ class PolyhedronFace(ConvexSet_closed):
         EXAMPLES::
 
             sage: p = polytopes.cross_polytope(4)
-            sage: face = p.face_lattice()[5]; face                                      # needs sage.combinat
+            sage: face = p.face_lattice()[5]; face
             A 1-dimensional face of a Polyhedron in ZZ^4 defined as the convex hull of 2 vertices
-            sage: face.ambient_Hrepresentation()                                        # needs sage.combinat
+            sage: face.ambient_Hrepresentation()
             (An inequality (1, -1, 1, -1) x + 1 >= 0,
              An inequality (1, 1, 1, 1) x + 1 >= 0,
              An inequality (1, 1, 1, -1) x + 1 >= 0,
              An inequality (1, -1, 1, 1) x + 1 >= 0)
-            sage: face.n_ambient_Hrepresentation()                                      # needs sage.combinat
+            sage: face.n_ambient_Hrepresentation()
             4
         """
         return len(self.ambient_Hrepresentation())
@@ -482,11 +482,11 @@ class PolyhedronFace(ConvexSet_closed):
         EXAMPLES::
 
             sage: p = polytopes.cross_polytope(4)
-            sage: face = p.face_lattice()[5]; face                                      # needs sage.combinat
+            sage: face = p.face_lattice()[5]; face
             A 1-dimensional face of a Polyhedron in ZZ^4 defined as the convex hull of 2 vertices
-            sage: face.ambient_Vrepresentation()                                        # needs sage.combinat
+            sage: face.ambient_Vrepresentation()
             (A vertex at (-1, 0, 0, 0), A vertex at (0, 0, -1, 0))
-            sage: face.n_ambient_Vrepresentation()                                      # needs sage.combinat
+            sage: face.n_ambient_Vrepresentation()
             2
         """
         return len(self.ambient_Vrepresentation())
@@ -565,8 +565,8 @@ class PolyhedronFace(ConvexSet_closed):
 
         EXAMPLES::
 
-            sage: fl = polytopes.dodecahedron().face_lattice()                          # needs sage.combinat sage.rings.number_field
-            sage: sorted(x.dim() for x in fl)                                           # needs sage.combinat sage.rings.number_field
+            sage: fl = polytopes.dodecahedron().face_lattice()
+            sage: sorted(x.dim() for x in fl)
             [-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
               1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
               1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3]
@@ -597,8 +597,8 @@ class PolyhedronFace(ConvexSet_closed):
         EXAMPLES::
 
             sage: square = polytopes.hypercube(2)
-            sage: a_face = list( square.face_lattice() )[8]                             # needs sage.combinat
-            sage: a_face.__repr__()                                                     # needs sage.combinat
+            sage: a_face = list( square.face_lattice() )[8]
+            sage: a_face.__repr__()
             'A 1-dimensional face of a Polyhedron in ZZ^2 defined as the convex hull of 2 vertices'
         """
         desc = ''
@@ -674,7 +674,7 @@ class PolyhedronFace(ConvexSet_closed):
              Polyhedron in QQ^2 defined as the convex hull of 1 vertex and 1 line
             sage: line.ambient_vector_space()
             Vector space of dimension 2 over Rational Field
-            sage: line.ambient_vector_space(AA)                                         # needs sage.rings.number_field
+            sage: line.ambient_vector_space(AA)
             Vector space of dimension 2 over Algebraic Real Field
         """
         return self.polyhedron().ambient_vector_space(base_field=base_field)

--- a/src/sage/geometry/polyhedron/generating_function.py
+++ b/src/sage/geometry/polyhedron/generating_function.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.combinat
 r"""
 Generating Function of Polyhedron's Integral Points
 

--- a/src/sage/geometry/polyhedron/library.py
+++ b/src/sage/geometry/polyhedron/library.py
@@ -121,7 +121,7 @@ def zero_sum_projection(d, base_ring=None):
 
     Exact computation in :class:`AA <sage.rings.qqbar.AlgebraicRealField>`::
 
-        sage: zero_sum_projection(3, base_ring=AA)                                      # needs sage.rings.number_field
+        sage: zero_sum_projection(3, base_ring=AA)
         [ 0.7071067811865475? -0.7071067811865475?                    0]
         [ 0.4082482904638630?  0.4082482904638630? -0.8164965809277260?]
     """
@@ -176,15 +176,15 @@ def project_points(*points, **kwds):
 
         sage: V = list(map(vector, IntegerVectors(n=5, length=3)))
         sage: P = project_points(*V)
-        sage: for i in range(21):                                                       # needs sage.combinat
+        sage: for i in range(21):
         ....:     for j in range(21):
         ....:         assert abs((V[i]-V[j]).norm() - (P[i]-P[j]).norm()) < 0.00001
 
     Example with exact computation::
 
         sage: V = [ vector(v) for v in IntegerVectors(n=4, length=2) ]
-        sage: P = project_points(*V, base_ring=AA)                                      # needs sage.combinat sage.rings.number_field
-        sage: for i in range(len(V)):                                                   # needs sage.combinat sage.rings.number_field
+        sage: P = project_points(*V, base_ring=AA)
+        sage: for i in range(len(V)):
         ....:     for j in range(len(V)):
         ....:         assert (V[i]-V[j]).norm() == (P[i]-P[j]).norm()
     """
@@ -540,7 +540,7 @@ class Polytopes:
 
         TESTS::
 
-            sage: # optional - pynormaliz, needs sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: octagon = polytopes.regular_polygon(8, backend='normaliz')
             sage: octagon
             A 2-dimensional polyhedron in AA^2 defined as the convex hull of 8 vertices
@@ -683,8 +683,8 @@ class Polytopes:
 
         Computation in algebraic reals::
 
-            sage: s3 = polytopes.simplex(3, project=True, base_ring=AA)                 # needs sage.rings.number_field
-            sage: s3.volume() == sqrt(3+1) / factorial(3)                               # needs sage.rings.number_field
+            sage: s3 = polytopes.simplex(3, project=True, base_ring=AA)
+            sage: s3.volume() == sqrt(3+1) / factorial(3)
             True
 
         TESTS::
@@ -721,39 +721,39 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: ico = polytopes.icosahedron()                                         # needs sage.rings.number_field
-            sage: ico.f_vector()                                                        # needs sage.rings.number_field
+            sage: ico = polytopes.icosahedron()
+            sage: ico.f_vector()
             (1, 12, 30, 20, 1)
-            sage: ico.volume()                                                          # needs sage.rings.number_field
+            sage: ico.volume()
             5/12*sqrt5 + 5/4
 
         Its non exact version::
 
-            sage: ico = polytopes.icosahedron(exact=False)                              # needs sage.groups
-            sage: ico.base_ring()                                                       # needs sage.groups
+            sage: ico = polytopes.icosahedron(exact=False)
+            sage: ico.base_ring()
             Real Double Field
-            sage: ico.volume()                  # known bug                             # needs sage.groups
+            sage: ico.volume()                  # known bug
             2.181694990...
 
         A version using `AA <sage.rings.qqbar.AlgebraicRealField>`::
 
-            sage: ico = polytopes.icosahedron(base_ring=AA)     # long time             # needs sage.groups sage.rings.number_field
-            sage: ico.base_ring()                               # long time             # needs sage.groups sage.rings.number_field
+            sage: ico = polytopes.icosahedron(base_ring=AA)     # long time
+            sage: ico.base_ring()                               # long time
             Algebraic Real Field
-            sage: ico.volume()                                  # long time             # needs sage.groups sage.rings.number_field
+            sage: ico.volume()                                  # long time
             2.181694990624913?
 
         Note that if base ring is provided it must contain the square root of
         `5`. Otherwise you will get an error::
 
-            sage: polytopes.icosahedron(base_ring=QQ)                                   # needs sage.symbolic
+            sage: polytopes.icosahedron(base_ring=QQ)
             Traceback (most recent call last):
             ...
             TypeError: unable to convert 1/4*sqrt(5) + 1/4 to a rational
 
         TESTS::
 
-            sage: # optional - pynormaliz, needs sage.groups sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: ico = polytopes.icosahedron(backend='normaliz')
             sage: ico.f_vector()
             (1, 12, 30, 20, 1)
@@ -761,8 +761,8 @@ class Polytopes:
             5/12*sqrt5 + 5/4
             sage: TestSuite(ico).run()
 
-            sage: ico = polytopes.icosahedron(exact=False)                              # needs sage.groups
-            sage: TestSuite(ico).run(skip='_test_lawrence')                             # needs sage.groups
+            sage: ico = polytopes.icosahedron(exact=False)
+            sage: TestSuite(ico).run(skip='_test_lawrence')
         """
         if base_ring is None and exact:
             from sage.rings.number_field.number_field import QuadraticField
@@ -811,23 +811,23 @@ class Polytopes:
             sage: numerical_approx(_)
             6.45203596003699
 
-            sage: d12 = polytopes.dodecahedron(exact=False)                             # needs sage.groups
-            sage: d12.base_ring()                                                       # needs sage.groups
+            sage: d12 = polytopes.dodecahedron(exact=False)
+            sage: d12.base_ring()
             Real Double Field
 
         Here is an error with a field that does not contain `\sqrt(5)`::
 
-            sage: polytopes.dodecahedron(base_ring=QQ)                                  # needs sage.groups sage.symbolic
+            sage: polytopes.dodecahedron(base_ring=QQ)
             Traceback (most recent call last):
             ...
             TypeError: unable to convert 1/4*sqrt(5) + 1/4 to a rational
 
         TESTS::
 
-            sage: d12 = polytopes.dodecahedron(backend='normaliz')      # optional - pynormaliz, needs sage.groups sage.rings.number_field
-            sage: d12.f_vector()                                        # optional - pynormaliz, needs sage.groups sage.rings.number_field
+            sage: d12 = polytopes.dodecahedron(backend='normaliz')      # optional - pynormaliz
+            sage: d12.f_vector()                                        # optional - pynormaliz
             (1, 20, 30, 12, 1)
-            sage: TestSuite(d12).run()                                  # optional - pynormaliz, needs sage.groups sage.rings.number_field
+            sage: TestSuite(d12).run()                                  # optional - pynormaliz
         """
         return self.icosahedron(exact=exact, base_ring=base_ring, backend=backend).polar()
 
@@ -852,17 +852,17 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: sr = polytopes.small_rhombicuboctahedron()                            # needs sage.rings.number_field
-            sage: sr.f_vector()                                                         # needs sage.rings.number_field
+            sage: sr = polytopes.small_rhombicuboctahedron()
+            sage: sr.f_vector()
             (1, 24, 48, 26, 1)
-            sage: sr.volume()                                                           # needs sage.rings.number_field
+            sage: sr.volume()
             80/3*sqrt2 + 32
 
         The faces are `8` equilateral triangles and `18` squares::
 
-            sage: sum(1 for f in sr.facets() if len(f.vertices()) == 3)                 # needs sage.rings.number_field
+            sage: sum(1 for f in sr.facets() if len(f.vertices()) == 3)
             8
-            sage: sum(1 for f in sr.facets() if len(f.vertices()) == 4)                 # needs sage.rings.number_field
+            sage: sum(1 for f in sr.facets() if len(f.vertices()) == 4)
             18
 
         Its non exact version::
@@ -876,7 +876,7 @@ class Polytopes:
 
         TESTS::
 
-            sage: # optional - pynormaliz, needs sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: sr = polytopes.small_rhombicuboctahedron(backend='normaliz')
             sage: sr.f_vector()
             (1, 24, 48, 26, 1)
@@ -924,8 +924,8 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: gr = polytopes.great_rhombicuboctahedron()    # long time             # needs sage.rings.number_field
-            sage: gr.f_vector()                 # long time                             # needs sage.rings.number_field
+            sage: gr = polytopes.great_rhombicuboctahedron()    # long time
+            sage: gr.f_vector()                 # long time
             (1, 48, 72, 26, 1)
 
         A faster implementation is obtained by setting ``exact=False``::
@@ -1078,28 +1078,28 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: co = polytopes.truncated_cube()                                       # needs sage.rings.number_field
-            sage: co.f_vector()                                                         # needs sage.rings.number_field
+            sage: co = polytopes.truncated_cube()
+            sage: co.f_vector()
             (1, 24, 36, 14, 1)
 
         Its facets are 8 triangles and 6 octogons::
 
-            sage: sum(1 for f in co.facets() if len(f.vertices()) == 3)                 # needs sage.rings.number_field
+            sage: sum(1 for f in co.facets() if len(f.vertices()) == 3)
             8
-            sage: sum(1 for f in co.facets() if len(f.vertices()) == 8)                 # needs sage.rings.number_field
+            sage: sum(1 for f in co.facets() if len(f.vertices()) == 8)
             6
 
         Some more computation::
 
-            sage: co.volume()                                                           # needs sage.rings.number_field
+            sage: co.volume()
             56/3*sqrt2 - 56/3
 
         TESTS::
 
-            sage: co = polytopes.truncated_cube(backend='normaliz')     # optional - pynormaliz, needs sage.rings.number_field
-            sage: co.f_vector()                 # optional - pynormaliz                 # needs sage.rings.number_field
+            sage: co = polytopes.truncated_cube(backend='normaliz')     # optional - pynormaliz
+            sage: co.f_vector()                 # optional - pynormaliz
             (1, 24, 36, 14, 1)
-            sage: TestSuite(co).run()           # optional - pynormaliz                 # needs sage.rings.number_field
+            sage: TestSuite(co).run()           # optional - pynormaliz
         """
         if base_ring is None and exact:
             from sage.rings.number_field.number_field import QuadraticField
@@ -1238,13 +1238,13 @@ class Polytopes:
 
             sage: co.volume()
             32
-            sage: co.ehrhart_polynomial()       # optional - latte_int                  # needs sage.combinat
+            sage: co.ehrhart_polynomial()       # optional - latte_int
             32*t^3 + 18*t^2 + 6*t + 1
 
         TESTS::
 
-            sage: to_norm = polytopes.truncated_octahedron(backend='normaliz')  # optional - pynormaliz, needs sage.combinat
-            sage: TestSuite(to_norm).run()                                      # optional - pynormaliz, needs sage.combinat
+            sage: to_norm = polytopes.truncated_octahedron(backend='normaliz')  # optional - pynormaliz
+            sage: TestSuite(to_norm).run()                                      # optional - pynormaliz
         """
         v = [(0, e, f) for e in [-1, 1] for f in [-2, 2]]
         v = [(xyz[sigma(1) - 1], xyz[sigma(2) - 1], xyz[sigma(3) - 1])
@@ -1323,7 +1323,7 @@ class Polytopes:
             sage: sc_inexact.f_vector()
             (1, 24, 60, 38, 1)
 
-            sage: # long time, needs sage.groups sage.rings.number_field
+            sage: # long time
             sage: sc_exact = polytopes.snub_cube(exact=True)
             sage: sc_exact.f_vector()
             (1, 24, 60, 38, 1)
@@ -1357,8 +1357,8 @@ class Polytopes:
 
         TESTS::
 
-            sage: sc = polytopes.snub_cube(exact=True, backend='normaliz')      # optional - pynormaliz, needs sage.groups sage.rings.number_field
-            sage: sc.f_vector()                                                 # optional - pynormaliz, needs sage.groups sage.rings.number_field
+            sage: sc = polytopes.snub_cube(exact=True, backend='normaliz')      # optional - pynormaliz
+            sage: sc.f_vector()                                                 # optional - pynormaliz
             (1, 24, 60, 38, 1)
         """
         def construct_z(field):
@@ -1422,31 +1422,31 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: bb = polytopes.buckyball()    # long time                             # needs sage.groups sage.rings.number_field
-            sage: bb.f_vector()                 # long time                             # needs sage.groups sage.rings.number_field
+            sage: bb = polytopes.buckyball()    # long time
+            sage: bb.f_vector()                 # long time
             (1, 60, 90, 32, 1)
-            sage: bb.base_ring()                # long time                             # needs sage.groups sage.rings.number_field
+            sage: bb.base_ring()                # long time
             Number Field in sqrt5 with defining polynomial x^2 - 5
              with sqrt5 = 2.236067977499790?
 
         A much faster implementation using floating point approximations::
 
-            sage: bb = polytopes.buckyball(exact=False)                                 # needs sage.groups
-            sage: bb.f_vector()                                                         # needs sage.groups
+            sage: bb = polytopes.buckyball(exact=False)
+            sage: bb.f_vector()
             (1, 60, 90, 32, 1)
-            sage: bb.base_ring()                                                        # needs sage.groups
+            sage: bb.base_ring()
             Real Double Field
 
         Its facets are 5 regular pentagons and 6 regular hexagons::
 
-            sage: sum(1 for f in bb.facets() if len(f.vertices()) == 5)                 # needs sage.groups
+            sage: sum(1 for f in bb.facets() if len(f.vertices()) == 5)
             12
-            sage: sum(1 for f in bb.facets() if len(f.vertices()) == 6)                 # needs sage.groups
+            sage: sum(1 for f in bb.facets() if len(f.vertices()) == 6)
             20
 
         TESTS::
 
-            sage: # optional - pynormaliz, needs sage.groups sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: bb = polytopes.buckyball(backend='normaliz')
             sage: bb.f_vector()
             (1, 60, 90, 32, 1)
@@ -1473,20 +1473,20 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: id = polytopes.icosidodecahedron()                                    # needs sage.groups sage.rings.number_field
-            sage: id.f_vector()                                                         # needs sage.groups sage.rings.number_field
+            sage: id = polytopes.icosidodecahedron()
+            sage: id.f_vector()
             (1, 30, 60, 32, 1)
 
         TESTS::
 
-            sage: id = polytopes.icosidodecahedron(exact=False); id                     # needs sage.groups sage.rings.number_field
+            sage: id = polytopes.icosidodecahedron(exact=False); id
             A 3-dimensional polyhedron in RDF^3 defined as the convex hull of 30 vertices
-            sage: TestSuite(id).run(skip=["_test_is_combinatorially_isomorphic",        # needs sage.groups sage.rings.number_field
+            sage: TestSuite(id).run(skip=["_test_is_combinatorially_isomorphic",
             ....:                         "_test_product",
             ....:                         "_test_pyramid",
             ....:                         "_test_lawrence"])
 
-            sage: # optional - pynormaliz, needs sage.groups sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: id = polytopes.icosidodecahedron(backend='normaliz')
             sage: id.f_vector()
             (1, 30, 60, 32, 1)
@@ -1612,18 +1612,18 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: td = polytopes.truncated_dodecahedron()                               # needs sage.rings.number_field
-            sage: td.f_vector()                                                         # needs sage.rings.number_field
+            sage: td = polytopes.truncated_dodecahedron()
+            sage: td.f_vector()
             (1, 60, 90, 32, 1)
-            sage: td.base_ring()                                                        # needs sage.rings.number_field
+            sage: td.base_ring()
             Number Field in sqrt5 with defining polynomial x^2 - 5
              with sqrt5 = 2.236067977499790?
 
         Its facets are 20 triangles and 12 regular decagons::
 
-            sage: sum(1 for f in td.facets() if len(f.vertices()) == 3)                 # needs sage.rings.number_field
+            sage: sum(1 for f in td.facets() if len(f.vertices()) == 3)
             20
-            sage: sum(1 for f in td.facets() if len(f.vertices()) == 10)                # needs sage.rings.number_field
+            sage: sum(1 for f in td.facets() if len(f.vertices()) == 10)
             12
 
         The faster implementation using floating point approximations does not
@@ -1646,7 +1646,7 @@ class Polytopes:
 
         TESTS::
 
-            sage: # optional - pynormaliz, needs sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: td = polytopes.truncated_dodecahedron(backend='normaliz')
             sage: td.f_vector()
             (1, 60, 90, 32, 1)
@@ -1708,15 +1708,15 @@ class Polytopes:
 
         A much faster implementation is obtained when setting ``exact=False``::
 
-            sage: pd = polytopes.pentakis_dodecahedron(exact=False)                     # needs sage.groups
-            sage: pd.n_vertices()                                                       # needs sage.groups
+            sage: pd = polytopes.pentakis_dodecahedron(exact=False)
+            sage: pd.n_vertices()
             32
-            sage: pd.n_inequalities()                                                   # needs sage.groups
+            sage: pd.n_inequalities()
             60
 
         The 60 are triangles::
 
-            sage: all(len(f.vertices()) == 3 for f in pd.facets())                      # needs sage.groups
+            sage: all(len(f.vertices()) == 3 for f in pd.facets())
             True
         """
         return self.buckyball(exact=exact, base_ring=base_ring, backend=backend).polar()
@@ -2247,20 +2247,20 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: p600 = polytopes.six_hundred_cell(); p600                             # needs sage.groups
+            sage: p600 = polytopes.six_hundred_cell(); p600
             A 4-dimensional polyhedron in RDF^4 defined as the convex hull of 120 vertices
-            sage: p600.f_vector()               # long time (~2sec)                     # needs sage.groups
+            sage: p600.f_vector()               # long time (~2sec)
             (1, 120, 720, 1200, 600, 1)
 
         Computation with exact coordinates is currently too long to be useful::
 
-            sage: p600 = polytopes.six_hundred_cell(exact=True)         # long time, not tested, needs sage.groups
-            sage: len(list(p600.bounded_edges()))                       # long time, not tested, needs sage.groups
+            sage: p600 = polytopes.six_hundred_cell(exact=True)         # long time, not tested
+            sage: len(list(p600.bounded_edges()))                       # long time, not tested
             720
 
         TESTS::
 
-            sage: # optional - pynormaliz, needs sage.groups sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: p600 = polytopes.six_hundred_cell(exact=True,
             ....:                                   backend='normaliz')
             sage: len(list(p600.bounded_edges()))                       # long time
@@ -2319,8 +2319,8 @@ class Polytopes:
 
         Computation with the backend ``'normaliz'`` is instantaneous::
 
-            sage: gap_norm = polytopes.grand_antiprism(backend='normaliz')      # optional - pynormaliz, needs sage.rings.number_field
-            sage: gap_norm                                                      # optional - pynormaliz, needs sage.rings.number_field
+            sage: gap_norm = polytopes.grand_antiprism(backend='normaliz')      # optional - pynormaliz
+            sage: gap_norm                                                      # optional - pynormaliz
             A 4-dimensional polyhedron in (Number Field in sqrt5 with defining
             polynomial x^2 - 5 with sqrt5 = 2.236067977499790?)^4 defined as
             the convex hull of 100 vertices
@@ -2545,9 +2545,9 @@ class Polytopes:
             sage: perm4 = polytopes.permutahedron(4, project=True)
             sage: perm4
             A 3-dimensional polyhedron in RDF^3 defined as the convex hull of 24 vertices
-            sage: perm4.plot()                                                          # needs sage.plot
+            sage: perm4.plot()
             Graphics3d Object
-            sage: perm4.graph().is_isomorphic(graphs.BubbleSortGraph(4))                # needs sage.graphs
+            sage: perm4.graph().is_isomorphic(graphs.BubbleSortGraph(4))
             True
 
         As both Hrepresentation and Vrepresentation are known, the permutahedron can be set
@@ -2624,7 +2624,7 @@ class Polytopes:
 
         EXAMPLES::
 
-            sage: perm_a3 = polytopes.generalized_permutahedron(['A',3]); perm_a3       # needs sage.combinat
+            sage: perm_a3 = polytopes.generalized_permutahedron(['A',3]); perm_a3
             A 3-dimensional polyhedron in QQ^3 defined as the convex hull of 24 vertices
 
         You can put the starting point along the hyperplane of the first
@@ -2651,8 +2651,8 @@ class Polytopes:
         The usual output does not necessarily give a polyhedron with isometric
         vertex figures::
 
-            sage: perm_a2 = polytopes.generalized_permutahedron(['A',2])                # needs sage.combinat
-            sage: perm_a2.vertices()                                                    # needs sage.combinat
+            sage: perm_a2 = polytopes.generalized_permutahedron(['A',2])
+            sage: perm_a2.vertices()
             (A vertex at (-1, -1),
              A vertex at (-1, 0),
              A vertex at (0, -1),
@@ -2662,8 +2662,8 @@ class Polytopes:
 
         It works also with Coxeter types that lead to non-rational coordinates::
 
-            sage: perm_b3 = polytopes.generalized_permutahedron(['B',3])        # long time, needs sage.combinat sage.rings.number_field
-            sage: perm_b3                                                       # long time, needs sage.combinat sage.rings.number_field
+            sage: perm_b3 = polytopes.generalized_permutahedron(['B',3])        # long time
+            sage: perm_b3                                                       # long time
             A 3-dimensional polyhedron in
              (Number Field in a with defining polynomial x^2 - 2 with a = 1.414213562373095?)^3
              defined as the convex hull of 48 vertices
@@ -2673,9 +2673,9 @@ class Polytopes:
         rational coordinates. We first do the computations using floating point
         approximations (``RDF``)::
 
-            sage: perm_a2_inexact = polytopes.generalized_permutahedron(                # needs sage.combinat
+            sage: perm_a2_inexact = polytopes.generalized_permutahedron(
             ....:     ['A',2], exact=False)
-            sage: sorted(perm_a2_inexact.vertices())                                    # needs sage.combinat
+            sage: sorted(perm_a2_inexact.vertices())
             [A vertex at (-1.0, -1.0),
              A vertex at (-1.0, 0.0),
              A vertex at (0.0, -1.0),
@@ -2683,9 +2683,9 @@ class Polytopes:
              A vertex at (1.0, 0.0),
              A vertex at (1.0, 1.0)]
 
-            sage: perm_a2_inexact_reg = polytopes.generalized_permutahedron(            # needs sage.combinat
+            sage: perm_a2_inexact_reg = polytopes.generalized_permutahedron(
             ....:     ['A',2], exact=False, regular=True)
-            sage: sorted(perm_a2_inexact_reg.vertices())                                # needs sage.combinat
+            sage: sorted(perm_a2_inexact_reg.vertices())
             [A vertex at (-1.0, 0.0),
              A vertex at (-0.5, -0.8660254038),
              A vertex at (-0.5, 0.8660254038),
@@ -2695,9 +2695,9 @@ class Polytopes:
 
         We can do the same computation using exact arithmetic with the field ``AA``::
 
-            sage: perm_a2_reg = polytopes.generalized_permutahedron(                    # needs sage.combinat sage.rings.number_field
+            sage: perm_a2_reg = polytopes.generalized_permutahedron(
             ....:     ['A',2], regular=True)
-            sage: V = sorted(perm_a2_reg.vertices()); V  # random                       # needs sage.combinat sage.rings.number_field
+            sage: V = sorted(perm_a2_reg.vertices()); V  # random
             [A vertex at (-1, 0),
              A vertex at (-1/2, -0.866025403784439?),
              A vertex at (-1/2, 0.866025403784439?),
@@ -2708,17 +2708,17 @@ class Polytopes:
         Even though the numbers look like floating point approximations, the computation is
         actually exact. We can clean up the display a bit using ``exactify``::
 
-            sage: for v in V:                                                           # needs sage.combinat sage.rings.number_field
+            sage: for v in V:
             ....:     for x in v:
             ....:         x.exactify()
-            sage: V                                                                     # needs sage.combinat sage.rings.number_field
+            sage: V
             [A vertex at (-1, 0),
              A vertex at (-1/2, -0.866025403784439?),
              A vertex at (-1/2, 0.866025403784439?),
              A vertex at (1/2, -0.866025403784439?),
              A vertex at (1/2, 0.866025403784439?),
              A vertex at (1, 0)]
-            sage: perm_a2_reg.is_inscribed()                                            # needs sage.combinat sage.rings.number_field
+            sage: perm_a2_reg.is_inscribed()
             True
 
         Larger examples take longer::
@@ -2746,7 +2746,7 @@ class Polytopes:
 
         It is even faster with the backend ``'normaliz'``::
 
-            sage: # optional - pynormaliz, needs sage.combinat sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: perm_a3_reg_norm = polytopes.generalized_permutahedron(
             ....:    ['A',3], regular=True, backend='normaliz'); perm_a3_reg_norm
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 24 vertices
@@ -2758,7 +2758,7 @@ class Polytopes:
 
         The speedups from using backend ``'normaliz'`` allow us to go even further::
 
-            sage: # optional - pynormaliz, needs sage.combinat sage.rings.number_field
+            sage: # optional - pynormaliz
             sage: perm_h3 = polytopes.generalized_permutahedron(
             ....:     ['H',3], backend='normaliz'); perm_h3
             A 3-dimensional polyhedron in
@@ -2777,7 +2777,7 @@ class Polytopes:
 
         TESTS::
 
-            sage: TestSuite(perm_h3).run()      # optional - pynormaliz                 # needs sage.combinat sage.rings.number_field
+            sage: TestSuite(perm_h3).run()      # optional - pynormaliz
         """
         from sage.combinat.root_system.coxeter_group import CoxeterGroup
         try:
@@ -3319,7 +3319,7 @@ class Polytopes:
 
             sage: P = polytopes.hypercube(2, [[1/2, 2], [0, 1]])
             sage: P = polytopes.hypercube(2, [[1/2, 2], [0, 1.0]])
-            sage: P = polytopes.hypercube(2, [[1/2, 2], [0, AA(2).sqrt()]])             # needs sage.rings.number_field
+            sage: P = polytopes.hypercube(2, [[1/2, 2], [0, AA(2).sqrt()]])
             sage: P = polytopes.hypercube(2, [[1/2, 2], [0, 1.0]], backend='ppl')       # needs pplpy
             Traceback (most recent call last):
             ...
@@ -3424,7 +3424,7 @@ class Polytopes:
             (1, 8, 12, 6, 1)
             sage: c.volume()
             8
-            sage: c.plot()                                                              # needs sage.plot
+            sage: c.plot()
             Graphics3d Object
 
         Return the `0/1`-cube::
@@ -3508,16 +3508,16 @@ class Polytopes:
             sage: polytopes.parallelotope([[1,2,3,4], [0,1,0,7], [3,1,0,2], [0,0,1,0]])
             A 4-dimensional polyhedron in ZZ^4 defined as the convex hull of 16 vertices
 
-            sage: K = QuadraticField(2, 'sqrt2')                                        # needs sage.rings.number_field
-            sage: sqrt2 = K.gen()                                                       # needs sage.rings.number_field
-            sage: P = polytopes.parallelotope([(1, sqrt2), (1, -1)]); P                 # needs sage.rings.number_field
+            sage: K = QuadraticField(2, 'sqrt2')
+            sage: sqrt2 = K.gen()
+            sage: P = polytopes.parallelotope([(1, sqrt2), (1, -1)]); P
             A 2-dimensional polyhedron in (Number Field in sqrt2 with defining
             polynomial x^2 - 2 with sqrt2 = 1.414213562373095?)^2 defined as
             the convex hull of 4 vertices
 
         TESTS::
 
-            sage: TestSuite(P).run()                                                    # needs sage.rings.number_field
+            sage: TestSuite(P).run()
         """
         from sage.modules.free_module_element import vector
         generators = [vector(v) for v in generators]

--- a/src/sage/geometry/polyhedron/palp_database.py
+++ b/src/sage/geometry/polyhedron/palp_database.py
@@ -5,7 +5,7 @@ Access the PALP database(s) of reflexive lattice polytopes
 EXAMPLES::
 
     sage: from sage.geometry.polyhedron.palp_database import PALPreader
-    sage: for lp in PALPreader(2):                                                      # needs sage.graphs
+    sage: for lp in PALPreader(2):
     ....:     cone = Cone([(1,r[0],r[1]) for r in lp.vertices()])
     ....:     fan = Fan([cone])
     ....:     X = ToricVariety(fan)

--- a/src/sage/geometry/polyhedron/parent.py
+++ b/src/sage/geometry/polyhedron/parent.py
@@ -65,7 +65,7 @@ def Polyhedra(ambient_space_or_base_ring=None, ambient_dim=None, backend=None, *
     EXAMPLES::
 
         sage: from sage.geometry.polyhedron.parent import Polyhedra
-        sage: Polyhedra(AA, 3)                                                          # needs sage.rings.number_field
+        sage: Polyhedra(AA, 3)
         Polyhedra in AA^3
         sage: Polyhedra(ZZ, 3)
         Polyhedra in ZZ^3
@@ -97,34 +97,34 @@ def Polyhedra(ambient_space_or_base_ring=None, ambient_dim=None, backend=None, *
 
     TESTS::
 
-        sage: Polyhedra(RR, 3, backend='field')                                         # needs sage.rings.real_mpfr
+        sage: Polyhedra(RR, 3, backend='field')
         Traceback (most recent call last):
         ...
         ValueError: the 'field' backend for polyhedron cannot be used with non-exact fields
-        sage: Polyhedra(RR, 3)                                                          # needs sage.rings.real_mpfr
+        sage: Polyhedra(RR, 3)
         Traceback (most recent call last):
         ...
         ValueError: no default backend for computations with Real Field with 53 bits of precision
-        sage: Polyhedra(QQ[I], 2)                                                       # needs sage.rings.number_field
+        sage: Polyhedra(QQ[I], 2)
         Traceback (most recent call last):
         ...
         ValueError: invalid base ring: Number Field in I
         with defining polynomial x^2 + 1 with I = 1*I
         cannot be coerced to a real field
-        sage: Polyhedra(AA, 3, backend='polymake')      # optional - jupymake           # needs sage.rings.number_field
+        sage: Polyhedra(AA, 3, backend='polymake')      # optional - jupymake
         Traceback (most recent call last):
         ...
         ValueError: the 'polymake' backend for polyhedron cannot be used with Algebraic Real Field
 
         sage: Polyhedra(QQ, 2, backend='normaliz')
         Polyhedra in QQ^2
-        sage: Polyhedra(SR, 2, backend='normaliz')      # optional - pynormaliz         # needs sage.symbolic
+        sage: Polyhedra(SR, 2, backend='normaliz')      # optional - pynormaliz
         Polyhedra in (Symbolic Ring)^2
-        sage: SCR = SR.subring(no_variables=True)                                       # needs sage.symbolic
-        sage: Polyhedra(SCR, 2, backend='normaliz')     # optional - pynormaliz         # needs sage.symbolic
+        sage: SCR = SR.subring(no_variables=True)
+        sage: Polyhedra(SCR, 2, backend='normaliz')     # optional - pynormaliz
         Polyhedra in (Symbolic Constants Subring)^2
 
-        sage: Polyhedra(SCR, 2, backend='number_field')                                 # needs sage.symbolic
+        sage: Polyhedra(SCR, 2, backend='number_field')
         Polyhedra in (Symbolic Constants Subring)^2
     """
     if ambient_space_or_base_ring is not None:
@@ -510,8 +510,8 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             sage: Polyhedra(QQ, 3)._repr_base_ring()
             'QQ'
             sage: x = polygen(ZZ, 'x')
-            sage: K.<sqrt3> = NumberField(x^2 - 3, embedding=AA(3).sqrt())              # needs sage.rings.number_field
-            sage: Polyhedra(K, 4)._repr_base_ring()                                     # needs sage.rings.number_field
+            sage: K.<sqrt3> = NumberField(x^2 - 3, embedding=AA(3).sqrt())
+            sage: Polyhedra(K, 4)._repr_base_ring()
             '(Number Field in sqrt3 with defining polynomial x^2 - 3 with sqrt3 = 1.732050807568878?)'
         """
         if self.base_ring() is ZZ:
@@ -542,8 +542,8 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             sage: Polyhedra(QQ, 3)._repr_ambient_module()
             'QQ^3'
             sage: x = polygen(ZZ, 'x')
-            sage: K.<sqrt3> = NumberField(x^2 - 3, embedding=AA(3).sqrt())              # needs sage.rings.number_field
-            sage: Polyhedra(K, 4)._repr_ambient_module()                                # needs sage.rings.number_field
+            sage: K.<sqrt3> = NumberField(x^2 - 3, embedding=AA(3).sqrt())
+            sage: Polyhedra(K, 4)._repr_ambient_module()
             '(Number Field in sqrt3 with defining polynomial x^2 - 3 with sqrt3 = 1.732050807568878?)^4'
         """
         s = self._repr_base_ring()
@@ -601,7 +601,7 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             sage: lp.set_objective(x[0] + x[1])
             sage: b = lp.get_backend()
             sage: P = b.interactive_lp_problem()
-            sage: p = P.plot()                                                          # needs sage.plot
+            sage: p = P.plot()
 
             sage: Q = Polyhedron(ieqs=[[-499999, 1000000], [1499999, -1000000]])
             sage: P = Polyhedron(ieqs=[[0, 1.0], [1.0, -1.0]], base_ring=RDF)
@@ -714,10 +714,10 @@ class Polyhedra_base(UniqueRepresentation, Parent):
             sage: P(p)
             A 3-dimensional polyhedron in QQ^3 defined as the convex hull of 4 vertices
 
-            sage: P = Polyhedra(AA, 3, backend='field')                                 # needs sage.rings.number_field
+            sage: P = Polyhedra(AA, 3, backend='field')
             sage: vertices = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
             sage: p = Polyhedron(vertices=vertices)
-            sage: P(p)                                                                  # needs sage.rings.number_field
+            sage: P(p)
             A 3-dimensional polyhedron in AA^3 defined as the convex hull of 4 vertices
         """
         Vrep = None
@@ -854,15 +854,15 @@ class Polyhedra_base(UniqueRepresentation, Parent):
         Test that :issue:`28770` is fixed::
 
             sage: z = QQ['z'].0
-            sage: K = NumberField(z^2 - 2, 's')                                         # needs sage.rings.number_field
-            sage: triangle_QQ._coerce_base_ring(K)                                      # needs sage.rings.number_field
+            sage: K = NumberField(z^2 - 2, 's')
+            sage: triangle_QQ._coerce_base_ring(K)
             Number Field in s with defining polynomial z^2 - 2
-            sage: triangle_QQ._coerce_base_ring(K.gen())                                # needs sage.rings.number_field
+            sage: triangle_QQ._coerce_base_ring(K.gen())
             Number Field in s with defining polynomial z^2 - 2
 
             sage: z = QQ['z'].0
-            sage: K = NumberField(z^2 - 2, 's')                                         # needs sage.rings.number_field
-            sage: K.gen() * polytopes.simplex(backend='field')                          # needs sage.rings.number_field
+            sage: K = NumberField(z^2 - 2, 's')
+            sage: K.gen() * polytopes.simplex(backend='field')
             A 3-dimensional polyhedron in
              (Number Field in s with defining polynomial z^2 - 2)^4
              defined as the convex hull of 4 vertices
@@ -1254,9 +1254,9 @@ def does_backend_handle_base_ring(base_ring, backend):
         sage: from sage.geometry.polyhedron.parent import does_backend_handle_base_ring
         sage: does_backend_handle_base_ring(QQ, 'ppl')
         True
-        sage: does_backend_handle_base_ring(QQ[sqrt(5)], 'ppl')                         # needs sage.rings.number_field sage.symbolic
+        sage: does_backend_handle_base_ring(QQ[sqrt(5)], 'ppl')
         False
-        sage: does_backend_handle_base_ring(QQ[sqrt(5)], 'field')                       # needs sage.rings.number_field sage.symbolic
+        sage: does_backend_handle_base_ring(QQ[sqrt(5)], 'field')
         True
     """
     try:

--- a/src/sage/geometry/polyhedron/plot.py
+++ b/src/sage/geometry/polyhedron/plot.py
@@ -355,12 +355,12 @@ class Projection(SageObject):
             The projection of a polyhedron into 2 dimensions
             sage: Projection(p,  lambda x: [x[1],x[2]] )   # another way of doing the same projection
             The projection of a polyhedron into 2 dimensions
-            sage: _.plot()   # plot of the projected icosahedron in 2d                  # needs sage.plot
+            sage: _.plot()   # plot of the projected icosahedron in 2d
             Graphics object consisting of 51 graphics primitives
             sage: proj = Projection(p)
             sage: proj.stereographic([1,2,3])
             The projection of a polyhedron into 2 dimensions
-            sage: proj.plot()                                                           # needs sage.plot
+            sage: proj.plot()
             Graphics object consisting of 51 graphics primitives
             sage: TestSuite(proj).run(skip='_test_pickling')
         """
@@ -458,7 +458,7 @@ class Projection(SageObject):
             sage: from sage.geometry.polyhedron.plot import Projection
             sage: proj = Projection(polytopes.buckyball()); proj  # long time
             The projection of a polyhedron into 3 dimensions
-            sage: proj.stereographic([5,2,3]).plot()    # long time                     # needs sage.plot
+            sage: proj.stereographic([5,2,3]).plot()    # long time
             Graphics object consisting of 123 graphics primitives
             sage: Projection(polytopes.twenty_four_cell()).stereographic([2,0,0,0])
             The projection of a polyhedron into 3 dimensions
@@ -495,7 +495,7 @@ class Projection(SageObject):
             sage: from sage.geometry.polyhedron.plot import Projection
             sage: Projection(cube4).schlegel()
             The projection of a polyhedron into 3 dimensions
-            sage: _.plot()                                                              # needs sage.plot
+            sage: _.plot()
             Graphics3d Object
 
         The 4-cube with a truncated vertex seen into the resulting tetrahedron
@@ -504,14 +504,14 @@ class Projection(SageObject):
             sage: tcube4 = cube4.face_truncation(cube4.faces(0)[0])
             sage: tcube4.facets()[4]
             A 3-dimensional face of a Polyhedron in QQ^4 defined as the convex hull of 4 vertices
-            sage: into_tetra = Projection(tcube4).schlegel(tcube4.facets()[4])          # needs sage.symbolic
-            sage: into_tetra.plot()                                                     # needs sage.plot sage.symbolic
+            sage: into_tetra = Projection(tcube4).schlegel(tcube4.facets()[4])
+            sage: into_tetra.plot()
             Graphics3d Object
 
         Taking a larger value for the position changes the image::
 
-            sage: into_tetra_far = Projection(tcube4).schlegel(tcube4.facets()[4], 4)   # needs sage.symbolic
-            sage: into_tetra_far.plot()                                                 # needs sage.plot sage.symbolic
+            sage: into_tetra_far = Projection(tcube4).schlegel(tcube4.facets()[4], 4)
+            sage: into_tetra_far.plot()
             Graphics3d Object
 
         A value which is too large or negative give a projection point that
@@ -914,8 +914,8 @@ class Projection(SageObject):
 
             sage: cube1 = polytopes.hypercube(1)
             sage: proj = cube1.projection()
-            sage: points = proj.render_points_1d()                                      # needs sage.plot
-            sage: points._objects                                                       # needs sage.plot
+            sage: points = proj.render_points_1d()
+            sage: points._objects
             [Point set defined by 2 point(s)]
         """
         return point2d([c + [0] for c in self.coordinates_of(self.points)], **kwds)
@@ -933,8 +933,8 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: outline = polytopes.hypercube(1).projection().render_line_1d()        # needs sage.plot
-            sage: outline._objects[0]                                                   # needs sage.plot
+            sage: outline = polytopes.hypercube(1).projection().render_line_1d()
+            sage: outline._objects[0]
             Line defined by 2 points
         """
         if len(self.lines) == 0:
@@ -952,8 +952,8 @@ class Projection(SageObject):
 
             sage: hex = polytopes.regular_polygon(6)
             sage: proj = hex.projection()
-            sage: hex_points = proj.render_points_2d()                                  # needs sage.plot
-            sage: hex_points._objects                                                   # needs sage.plot
+            sage: hex_points = proj.render_points_2d()
+            sage: hex_points._objects
             [Point set defined by 6 point(s)]
         """
         return point2d(self.coordinates_of(self.points), **kwds)
@@ -964,9 +964,9 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: penta = polytopes.regular_polygon(5)                                  # needs sage.rings.number_field
-            sage: outline = penta.projection().render_outline_2d()                      # needs sage.plot sage.rings.number_field
-            sage: outline._objects[0]                                                   # needs sage.plot sage.rings.number_field
+            sage: penta = polytopes.regular_polygon(5)
+            sage: outline = penta.projection().render_outline_2d()
+            sage: outline._objects[0]
             Line defined by 2 points
         """
         wireframe = []
@@ -987,8 +987,8 @@ class Projection(SageObject):
             sage: cps = [i^3 for i in srange(-2, 2, 1/5)]
             sage: p = Polyhedron(vertices=[[(t^2-1)/(t^2+1), 2*t/(t^2+1)] for t in cps])
             sage: proj = p.projection()
-            sage: filled_poly = proj.render_fill_2d()                                   # needs sage.plot
-            sage: filled_poly.axes_width()                                              # needs sage.plot
+            sage: filled_poly = proj.render_fill_2d()
+            sage: filled_poly.axes_width()
             0.8
         """
         poly = [polygon2d(self.coordinates_of(p), **kwds)
@@ -1003,8 +1003,8 @@ class Projection(SageObject):
 
             sage: p = polytopes.cross_polytope(3)
             sage: proj = p.projection()
-            sage: verts = proj.render_vertices_3d()                                     # needs sage.plot
-            sage: verts.bounding_box()                                                  # needs sage.plot
+            sage: verts = proj.render_vertices_3d()
+            sage: verts.bounding_box()
             ((-1.0, -1.0, -1.0), (1.0, 1.0, 1.0))
         """
         return point3d(self.coordinates_of(self.points), **kwds)
@@ -1017,8 +1017,8 @@ class Projection(SageObject):
 
             sage: cube = polytopes.hypercube(3)
             sage: cube_proj = cube.projection()
-            sage: wire = cube_proj.render_wireframe_3d()                                # needs sage.plot
-            sage: print(wire.tachyon().split('\n')[77])  # for testing                  # needs sage.plot
+            sage: wire = cube_proj.render_wireframe_3d()
+            sage: print(wire.tachyon().split('\n')[77])  # for testing
             FCylinder base 1.0 1.0 -1.0 apex -1.0 1.0 -1.0 rad 0.005 texture...
         """
         wireframe = []
@@ -1037,8 +1037,8 @@ class Projection(SageObject):
         EXAMPLES::
 
             sage: p = polytopes.hypercube(3).projection()
-            sage: p_solid = p.render_solid_3d(opacity=.7)                               # needs sage.plot
-            sage: type(p_solid)                                                         # needs sage.plot
+            sage: p_solid = p.render_solid_3d(opacity=.7)
+            sage: type(p_solid)
             <class 'sage.plot.plot3d.index_face_set.IndexFaceSet'>
         """
         polys = self.polygons
@@ -1065,10 +1065,10 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: print(Polyhedron([]).projection().render_0d().description())          # needs sage.plot
+            sage: print(Polyhedron([]).projection().render_0d().description())
             <BLANKLINE>
             sage: P = Polyhedron(ieqs=[(1,)])
-            sage: print(P.projection().render_0d().description())                       # needs sage.plot
+            sage: print(P.projection().render_0d().description())
             Point set defined by 1 point(s):    [(0.0, 0.0)]
         """
         if point_opts is None:
@@ -1094,7 +1094,7 @@ class Projection(SageObject):
 
         EXAMPLES::
 
-            sage: Polyhedron([(0,), (1,)]).projection().render_1d()                     # needs sage.plot
+            sage: Polyhedron([(0,), (1,)]).projection().render_1d()
             Graphics object consisting of 2 graphics primitives
         """
         plt = Graphics()
@@ -1126,7 +1126,7 @@ class Projection(SageObject):
             sage: q3 = p3.projection()
             sage: p4 = Polyhedron(vertices=[[2,0]], rays=[[1,-1]], lines=[[1,1]])
             sage: q4 = p4.projection()
-            sage: q1.plot() + q2.plot() + q3.plot() + q4.plot()                         # needs sage.plot
+            sage: q1.plot() + q2.plot() + q3.plot() + q4.plot()
             Graphics object consisting of 18 graphics primitives
         """
         plt = Graphics()
@@ -1159,7 +1159,7 @@ class Projection(SageObject):
             sage: p2 = Polyhedron(vertices=[[2,0,0], [0,2,0], [0,0,2]])
             sage: p3 = Polyhedron(vertices=[[1,0,0], [0,1,0], [0,0,1]],
             ....:                 rays=[[-1,-1,-1]])
-            sage: (p1.projection().plot() + p2.projection().plot()                      # needs sage.plot
+            sage: (p1.projection().plot() + p2.projection().plot()
             ....:   + p3.projection().plot())
             Graphics3d Object
 
@@ -1191,13 +1191,13 @@ class Projection(SageObject):
             sage: Q = Polyhedron([[100],[101]])
             sage: P = Q*Q*Q; P
             A 3-dimensional polyhedron in ZZ^3 defined as the convex hull of 8 vertices
-            sage: p = P.plot()                                                          # needs sage.plot
-            sage: p.bounding_box()                                                      # needs sage.plot
+            sage: p = P.plot()
+            sage: p.bounding_box()
             ((100.0, 100.0, 100.0), (101.0, 101.0, 101.0))
 
         Plot 3d polytope with rainbow colors::
 
-            sage: polytopes.hypercube(3).plot(polygon='rainbow', alpha=0.4)             # needs sage.plot
+            sage: polytopes.hypercube(3).plot(polygon='rainbow', alpha=0.4)
             Graphics3d Object
         """
         pplt = None
@@ -1620,8 +1620,8 @@ class Projection(SageObject):
 
             sage: p = Polyhedron(vertices=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
             sage: proj = p.projection()
-            sage: Img = proj.tikz([1, 1, 1], 130, axis=True, output_type='LatexExpr')   # needs sage.plot
-            sage: print('\n'.join(Img.splitlines()[12:21]))                             # needs sage.plot
+            sage: Img = proj.tikz([1, 1, 1], 130, axis=True, output_type='LatexExpr')
+            sage: print('\n'.join(Img.splitlines()[12:21]))
             %% with the command: ._tikz_2d_in_3d and parameters:
             %% view = [1, 1, 1]
             %% angle = 130

--- a/src/sage/geometry/polyhedron/ppl_lattice_polygon.py
+++ b/src/sage/geometry/polyhedron/ppl_lattice_polygon.py
@@ -403,11 +403,11 @@ class LatticePolygon_PPL_class(LatticePolytope_PPL_class):
 
             sage: from sage.geometry.polyhedron.ppl_lattice_polytope import LatticePolytope_PPL
             sage: P = LatticePolytope_PPL((1,0), (0,1), (0,0), (2,2))
-            sage: P.plot()                                                              # needs sage.plot
+            sage: P.plot()
             Graphics object consisting of 6 graphics primitives
-            sage: LatticePolytope_PPL([0], [1]).plot()                                  # needs sage.plot
+            sage: LatticePolytope_PPL([0], [1]).plot()
             Graphics object consisting of 3 graphics primitives
-            sage: LatticePolytope_PPL([0]).plot()                                       # needs sage.plot
+            sage: LatticePolytope_PPL([0]).plot()
             Graphics object consisting of 2 graphics primitives
         """
         from sage.plot.point import point2d

--- a/src/sage/geometry/polyhedron/ppl_lattice_polytope.py
+++ b/src/sage/geometry/polyhedron/ppl_lattice_polytope.py
@@ -48,7 +48,7 @@ only differ by a lattice automorphism::
     sage: square = LatticePolytope_PPL((-1,-1), (-1,1), (1,-1), (1,1))
     sage: fibers = [ f.vertices() for f in square.fibration_generator(1) ];  fibers
     [((1, 0), (-1, 0)), ((0, 1), (0, -1)), ((-1, -1), (1, 1)), ((-1, 1), (1, -1))]
-    sage: square.pointsets_mod_automorphism(fibers)                                     # needs sage.groups
+    sage: square.pointsets_mod_automorphism(fibers)
     (frozenset({(-1, -1), (1, 1)}), frozenset({(-1, 0), (1, 0)}))
 
 AUTHORS:
@@ -638,7 +638,7 @@ class LatticePolytope_PPL_class(C_Polyhedron):
             sage: from sage.geometry.polyhedron.ppl_lattice_polytope import LatticePolytope_PPL
             sage: square = LatticePolytope_PPL((-1,-1), (-1,1), (1,-1), (1,1))
             sage: fibers = [f.vertices() for f in square.fibration_generator(1)]
-            sage: square.pointsets_mod_automorphism(fibers)                             # needs sage.graphs sage.groups
+            sage: square.pointsets_mod_automorphism(fibers)
             (frozenset({(-1, -1), (1, 1)}), frozenset({(-1, 0), (1, 0)}))
 
             sage: cell24 = LatticePolytope_PPL(
@@ -647,7 +647,7 @@ class LatticePolytope_PPL_class(C_Polyhedron):
             ....:     (1,-1,-1,0), (0,0,-1,0), (0,-1,0,0), (-1,0,0,0), (1,-1,0,0), (1,0,-1,0),
             ....:     (0,1,1,-1), (-1,1,1,0), (-1,1,0,0), (-1,0,1,0), (0,-1,-1,1), (0,0,0,-1))
             sage: fibers = [f.vertices() for f in cell24.fibration_generator(2)]
-            sage: cell24.pointsets_mod_automorphism(fibers)     # long time             # needs sage.graphs sage.groups
+            sage: cell24.pointsets_mod_automorphism(fibers)     # long time
             (frozenset({(-1, 0, 0, 0),
                         (-1, 0, 0, 1),
                         (0, 0, 0, -1),
@@ -1033,25 +1033,25 @@ class LatticePolytope_PPL_class(C_Polyhedron):
 
             sage: from sage.geometry.polyhedron.ppl_lattice_polytope import LatticePolytope_PPL
             sage: Z3square = LatticePolytope_PPL((0,0), (1,2), (2,1), (3,3))
-            sage: Z3square.lattice_automorphism_group()                                 # needs sage.graphs sage.groups
+            sage: Z3square.lattice_automorphism_group()
             Permutation Group with generators [(), ((1,2),(2,1)),
             ((0,0),(3,3)), ((0,0),(3,3))((1,2),(2,1))]
 
-            sage: G1 = Z3square.lattice_automorphism_group(point_labels=(1,2,3,4))      # needs sage.graphs sage.groups
-            sage: G1                                                                    # needs sage.graphs sage.groups
+            sage: G1 = Z3square.lattice_automorphism_group(point_labels=(1,2,3,4))
+            sage: G1
             Permutation Group with generators [(), (2,3), (1,4), (1,4)(2,3)]
-            sage: G1.cardinality()                                                      # needs sage.graphs sage.groups
+            sage: G1.cardinality()
             4
 
-            sage: G2 = Z3square.restricted_automorphism_group(vertex_labels=(1,2,3,4))  # needs sage.graphs sage.groups
-            sage: G2 == PermutationGroup([[(2,3)], [(1,2),(3,4)], [(1,4)]])             # needs sage.graphs sage.groups
+            sage: G2 = Z3square.restricted_automorphism_group(vertex_labels=(1,2,3,4))
+            sage: G2 == PermutationGroup([[(2,3)], [(1,2),(3,4)], [(1,4)]])
             True
-            sage: G2.cardinality()                                                      # needs sage.graphs sage.groups
+            sage: G2.cardinality()
             8
 
             sage: points = Z3square.integral_points(); points
             ((0, 0), (1, 1), (1, 2), (2, 1), (2, 2), (3, 3))
-            sage: Z3square.lattice_automorphism_group(points,                           # needs sage.graphs sage.groups
+            sage: Z3square.lattice_automorphism_group(points,
             ....:                                     point_labels=(1,2,3,4,5,6))
             Permutation Group with generators [(), (3,4), (1,6)(2,5), (1,6)(2,5)(3,4)]
 
@@ -1060,7 +1060,7 @@ class LatticePolytope_PPL_class(C_Polyhedron):
 
             sage: from sage.geometry.polyhedron.ppl_lattice_polytope import LatticePolytope_PPL
             sage: lp = LatticePolytope_PPL((1,0,0), (0,1,0), (-1,-1,0))
-            sage: lp.lattice_automorphism_group(point_labels=(0,1,2))                   # needs sage.graphs sage.groups
+            sage: lp.lattice_automorphism_group(point_labels=(0,1,2))
             Permutation Group with generators [(), (1,2), (0,1), (0,1,2), (0,2,1), (0,2)]
         """
         if not self.is_full_dimensional():

--- a/src/sage/geometry/polyhedron/representation.py
+++ b/src/sage/geometry/polyhedron/representation.py
@@ -785,7 +785,7 @@ class Inequality(Hrepresentation):
             sage: Q = Polyhedron(ieqs=[[0,2,0,3]])
             sage: Q.inequalities()[0].is_facet_defining_inequality(P)
             True
-            sage: Q = Polyhedron(ieqs=[[0,AA(2).sqrt(),0,3]])                           # needs sage.rings.number_field
+            sage: Q = Polyhedron(ieqs=[[0,AA(2).sqrt(),0,3]])
             sage: Q.inequalities()[0].is_facet_defining_inequality(P)
             True
             sage: Q = Polyhedron(ieqs=[[1,1,0,0]])
@@ -888,9 +888,9 @@ class Inequality(Hrepresentation):
         Test that :issue:`21105` has been fixed::
 
             sage: x = polygen(ZZ, 'x')
-            sage: K.<cbrt2> = NumberField(x^3 - 2, 'a', embedding=1.26)                 # needs sage.rings.number_field
-            sage: P = Polyhedron(vertices=[(1,1,cbrt2),(cbrt2,1,1)])                    # needs sage.rings.number_field
-            sage: P.inequalities()                                                      # needs sage.rings.number_field
+            sage: K.<cbrt2> = NumberField(x^3 - 2, 'a', embedding=1.26)
+            sage: P = Polyhedron(vertices=[(1,1,cbrt2),(cbrt2,1,1)])
+            sage: P.inequalities()
             (An inequality (-cbrt2^2 - cbrt2 - 1, 0, 0) x + cbrt2^2 + cbrt2 + 2 >= 0,
              An inequality (cbrt2^2 + cbrt2 + 1, 0, 0) x - cbrt2^2 + cbrt2 + 1 >= 0)
         """

--- a/src/sage/geometry/pseudolines.py
+++ b/src/sage/geometry/pseudolines.py
@@ -49,7 +49,7 @@ ones.
     sage: p = PseudolineArrangement(permutations)
     sage: p
     Arrangement of pseudolines of size 4
-    sage: p.show()                                                                      # needs sage.plot
+    sage: p.show()
 
 **Sequence of transpositions**
 
@@ -67,7 +67,7 @@ from left to right (see the :meth:`show
     sage: p = PseudolineArrangement(transpositions)
     sage: p
     Arrangement of pseudolines of size 4
-    sage: p.show()                                                                      # needs sage.plot
+    sage: p.show()
 
 
 Note that this ordering is not necessarily unique.
@@ -131,7 +131,7 @@ avoid a common crossing of three lines by adding a random noise to `b`::
     sage: n = 20
     sage: l = sorted(zip(Subsets(20*n, n).random_element(),
     ....:                [randint(0, 20*n) + random() for i in range(n)]))
-    sage: print(l[:5])                          # not tested                            # needs sage.combinat
+    sage: print(l[:5])                          # not tested
     [(96, 278.0130613051349), (74, 332.92512282478714), (13, 155.65820951249867),
      (209, 34.753946221755307), (147, 193.51376457741441)]
 
@@ -149,7 +149,7 @@ And finally build the line arrangement::
     sage: p = PseudolineArrangement(permutations)
     sage: print(p)
     Arrangement of pseudolines of size 20
-    sage: p.show(figsize=[20,8])                                                        # needs sage.combinat sage.plot
+    sage: p.show(figsize=[20,8])
 
 Author
 ^^^^^^
@@ -419,14 +419,14 @@ class PseudolineArrangement:
             sage: from sage.geometry.pseudolines import PseudolineArrangement
             sage: permutations = [[3, 2, 1], [3, 2, 0], [3, 1, 0], [2, 1, 0]]
             sage: p = PseudolineArrangement(permutations)
-            sage: p.show(figsize=[7,5])                                                 # needs sage.plot
+            sage: p.show(figsize=[7,5])
 
         TESTS::
 
             sage: from sage.geometry.pseudolines import PseudolineArrangement
             sage: permutations = [[3, 2, 1], [3, 2, 0], [3, 0, 1], [2, 0, 1]]
             sage: p = PseudolineArrangement(permutations)
-            sage: p.show()                                                              # needs sage.plot
+            sage: p.show()
             Traceback (most recent call last):
             ...
             ValueError: There has been a problem while plotting the figure...

--- a/src/sage/geometry/relative_interior.py
+++ b/src/sage/geometry/relative_interior.py
@@ -320,11 +320,11 @@ class RelativeInterior(ConvexSet_relatively_open):
             sage: ri_segment = segment.relative_interior(); ri_segment
             Relative interior of
              a 1-dimensional polyhedron in ZZ^2 defined as the convex hull of 2 vertices
-            sage: segment2 = Polyhedron([[1, 2], [3, 4]], base_ring=AA)                 # needs sage.rings.number_field
-            sage: ri_segment2 = segment2.relative_interior(); ri_segment2               # needs sage.rings.number_field
+            sage: segment2 = Polyhedron([[1, 2], [3, 4]], base_ring=AA)
+            sage: ri_segment2 = segment2.relative_interior(); ri_segment2
             Relative interior of
              a 1-dimensional polyhedron in AA^2 defined as the convex hull of 2 vertices
-            sage: ri_segment == ri_segment2                                             # needs sage.rings.number_field
+            sage: ri_segment == ri_segment2
             True
 
         TESTS::
@@ -351,11 +351,11 @@ class RelativeInterior(ConvexSet_relatively_open):
             sage: ri_segment = segment.relative_interior(); ri_segment
             Relative interior of
              a 1-dimensional polyhedron in ZZ^2 defined as the convex hull of 2 vertices
-            sage: segment2 = Polyhedron([[1, 2], [3, 4]], base_ring=AA)                 # needs sage.rings.number_field
-            sage: ri_segment2 = segment2.relative_interior(); ri_segment2               # needs sage.rings.number_field
+            sage: segment2 = Polyhedron([[1, 2], [3, 4]], base_ring=AA)
+            sage: ri_segment2 = segment2.relative_interior(); ri_segment2
             Relative interior of
              a 1-dimensional polyhedron in AA^2 defined as the convex hull of 2 vertices
-            sage: ri_segment != ri_segment2                                             # needs sage.rings.number_field
+            sage: ri_segment != ri_segment2
             False
         """
         return not (self == other)

--- a/src/sage/geometry/riemannian_manifolds/parametrized_surface3d.py
+++ b/src/sage/geometry/riemannian_manifolds/parametrized_surface3d.py
@@ -95,7 +95,7 @@ class ParametrizedSurface3D(SageObject):
         sage: ellipsoid = ParametrizedSurface3D(ellipsoid_eq, coords, 'ellipsoid'); ellipsoid
         Parametrized surface ('ellipsoid') with equation
         (cos(u1)*cos(u2), 2*cos(u2)*sin(u1), 3*sin(u2))
-        sage: ellipsoid.plot()                                                          # needs sage.plot
+        sage: ellipsoid.plot()
         Graphics3d Object
 
     Standard surfaces can be constructed using the ``surfaces`` generator::
@@ -123,7 +123,7 @@ class ParametrizedSurface3D(SageObject):
         sage: enneper = surfaces.Enneper(); enneper
         Parametrized surface ('Enneper's surface') with equation
         (-1/9*(u^2 - 3*v^2 - 3)*u, -1/9*(3*u^2 - v^2 + 3)*v, 1/3*u^2 - 1/3*v^2)
-        sage: enneper.plot(aspect_ratio='automatic')                                    # needs sage.plot
+        sage: enneper.plot(aspect_ratio='automatic')
         Graphics3d Object
 
     We construct an ellipsoid whose axes are given by symbolic variables `a`,
@@ -277,11 +277,11 @@ class ParametrizedSurface3D(SageObject):
         sage: points_array = [ellipsoid_equation(u_array[counter][0],
         ....:                                    u_array[counter][1])
         ....:                 for counter in range(len(u_array))]
-        sage: curvature_ellipsoid_plot = sum(point([xx                                  # needs sage.plot
+        sage: curvature_ellipsoid_plot = sum(point([xx
         ....:                                       for xx in points_array[counter]],
         ....:                                      color=hue(cc_array[counter]/2))
         ....:                                for counter in range(len(u_array)))
-        sage: curvature_ellipsoid_plot.show(aspect_ratio=1)                             # needs sage.plot
+        sage: curvature_ellipsoid_plot.show(aspect_ratio=1)
 
     We can find the principal curvatures and principal directions of the
     elliptic paraboloid::
@@ -338,7 +338,7 @@ class ParametrizedSurface3D(SageObject):
         sage: g3 = [c[-1] for c in S.geodesics_numerical((0,0),
         ....:                                            (cos(2*pi/3),sin(2*pi/3)),
         ....:                                            (0,2*pi,100))]
-        sage: (S.plot(opacity=0.3) + line3d(g1, color='red')                            # needs sage.plot
+        sage: (S.plot(opacity=0.3) + line3d(g1, color='red')
         ....:     + line3d(g2, color='red') + line3d(g3, color='red')).show()
     """
 
@@ -501,7 +501,7 @@ class ParametrizedSurface3D(SageObject):
             sage: u, v = var('u, v', domain='real')
             sage: eq = (3*u + 3*u*v^2 - u^3, 3*v + 3*u^2*v - v^3, 3*(u^2-v^2))
             sage: enneper = ParametrizedSurface3D(eq, (u, v), 'Enneper Surface')
-            sage: enneper.plot((-5, 5), (-5, 5))                                        # needs sage.plot
+            sage: enneper.plot((-5, 5), (-5, 5))
             Graphics3d Object
         """
 

--- a/src/sage/geometry/riemannian_manifolds/surface3d_generators.py
+++ b/src/sage/geometry/riemannian_manifolds/surface3d_generators.py
@@ -52,7 +52,7 @@ class SurfaceGenerators:
 
             sage: cat = surfaces.Catenoid(); cat
             Parametrized surface ('Catenoid') with equation (cos(u)*cosh(v), cosh(v)*sin(u), v)
-            sage: cat.plot()                                                            # needs sage.plot
+            sage: cat.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -85,7 +85,7 @@ class SurfaceGenerators:
 
             sage: crosscap = surfaces.Crosscap(); crosscap
             Parametrized surface ('Crosscap') with equation ((cos(v) + 1)*cos(u), (cos(v) + 1)*sin(u), -sin(v)*tanh(-pi + u))
-            sage: crosscap.plot()                                                       # needs sage.plot
+            sage: crosscap.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -119,7 +119,7 @@ class SurfaceGenerators:
 
             sage: dini = surfaces.Dini(a=3, b=4); dini
             Parametrized surface ('Dini's surface') with equation (3*cos(u)*sin(v), 3*sin(u)*sin(v), 4*u + 3*cos(v) + 3*log(tan(1/2*v)))
-            sage: dini.plot()                                                           # needs sage.plot
+            sage: dini.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -157,7 +157,7 @@ class SurfaceGenerators:
 
             sage: ell = surfaces.Ellipsoid(axes=(1, 2, 3)); ell
             Parametrized surface ('Ellipsoid') with equation (cos(u)*cos(v), 2*cos(v)*sin(u), 3*sin(v))
-            sage: ell.plot()                                                            # needs sage.plot
+            sage: ell.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -192,7 +192,7 @@ class SurfaceGenerators:
 
             sage: enn = surfaces.Enneper(); enn
             Parametrized surface ('Enneper's surface') with equation (-1/9*(u^2 - 3*v^2 - 3)*u, -1/9*(3*u^2 - v^2 + 3)*v, 1/3*u^2 - 1/3*v^2)
-            sage: enn.plot()                                                            # needs sage.plot
+            sage: enn.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -226,7 +226,7 @@ class SurfaceGenerators:
 
             sage: helicoid = surfaces.Helicoid(h=2); helicoid
             Parametrized surface ('Helicoid') with equation (rho*cos(theta), rho*sin(theta), theta/pi)
-            sage: helicoid.plot()                                                       # needs sage.plot
+            sage: helicoid.plot()
             Graphics3d Object
         """
         rho, theta = var('rho, theta')
@@ -259,7 +259,7 @@ class SurfaceGenerators:
 
             sage: klein = surfaces.Klein(); klein
             Parametrized surface ('Klein bottle') with equation (-(sin(1/2*u)*sin(2*v) - cos(1/2*u)*sin(v) - 1)*cos(u), -(sin(1/2*u)*sin(2*v) - cos(1/2*u)*sin(v) - 1)*sin(u), cos(1/2*u)*sin(2*v) + sin(1/2*u)*sin(v))
-            sage: klein.plot()                                                          # needs sage.plot
+            sage: klein.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -290,7 +290,7 @@ class SurfaceGenerators:
 
             sage: saddle = surfaces.MonkeySaddle(); saddle
             Parametrized surface ('Monkey saddle') with equation (u, v, u^3 - 3*u*v^2)
-            sage: saddle.plot()                                                         # needs sage.plot
+            sage: saddle.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -326,12 +326,12 @@ class SurfaceGenerators:
 
             sage: epar = surfaces.Paraboloid(1, 3, 2); epar
             Parametrized surface ('Elliptic paraboloid') with equation (u, v, 2*u^2 + 2/9*v^2)
-            sage: epar.plot()                                                           # needs sage.plot
+            sage: epar.plot()
             Graphics3d Object
 
             sage: hpar = surfaces.Paraboloid(2, 3, 1, elliptic=False); hpar
             Parametrized surface ('Hyperbolic paraboloid') with equation (u, v, -1/4*u^2 + 1/9*v^2)
-            sage: hpar.plot()                                                           # needs sage.plot
+            sage: hpar.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -371,7 +371,7 @@ class SurfaceGenerators:
 
             sage: sphere = surfaces.Sphere(center=(0, 1, -1), R=2); sphere
             Parametrized surface ('Sphere') with equation (2*cos(u)*cos(v), 2*cos(v)*sin(u) + 1, 2*sin(v) - 1)
-            sage: sphere.plot()                                                         # needs sage.plot
+            sage: sphere.plot()
             Graphics3d Object
 
         Note that the radius of the sphere can be negative. The surface thus
@@ -381,14 +381,14 @@ class SurfaceGenerators:
 
             sage: octant1 = surfaces.Sphere(R=1); octant1
             Parametrized surface ('Sphere') with equation (cos(u)*cos(v), cos(v)*sin(u), sin(v))
-            sage: octant1.plot((0, pi/2), (0, pi/2))                                    # needs sage.plot
+            sage: octant1.plot((0, pi/2), (0, pi/2))
             Graphics3d Object
 
         with the first octant of the unit sphere with negative radius::
 
             sage: octant2 = surfaces.Sphere(R=-1); octant2
             Parametrized surface ('Sphere') with equation (-cos(u)*cos(v), -cos(v)*sin(u), -sin(v))
-            sage: octant2.plot((0, pi/2), (0, pi/2))                                    # needs sage.plot
+            sage: octant2.plot((0, pi/2), (0, pi/2))
             Graphics3d Object
         """
         return SurfaceGenerators.Ellipsoid(center, (R, R, R), name)
@@ -420,7 +420,7 @@ class SurfaceGenerators:
 
             sage: torus = surfaces.Torus(); torus
             Parametrized surface ('Torus') with equation ((2*cos(v) + 3)*cos(u), (2*cos(v) + 3)*sin(u), 2*sin(v))
-            sage: torus.plot()                                                          # needs sage.plot
+            sage: torus.plot()
             Graphics3d Object
         """
         u, v = var('u, v')
@@ -447,7 +447,7 @@ class SurfaceGenerators:
 
             sage: whitney = surfaces.WhitneyUmbrella(); whitney
             Parametrized surface ('Whitney's umbrella') with equation (u*v, u, v^2)
-            sage: whitney.plot()                                                        # needs sage.plot
+            sage: whitney.plot()
             Graphics3d Object
         """
         u, v = var('u, v')

--- a/src/sage/geometry/toric_lattice.py
+++ b/src/sage/geometry/toric_lattice.py
@@ -982,7 +982,7 @@ class ToricLattice_ambient(ToricLattice_generic, FreeModule_ambient_pid):
         EXAMPLES::
 
             sage: N = ToricLattice(3)
-            sage: N.plot()                                                              # needs sage.plot
+            sage: N.plot()
             Graphics3d Object
         """
         if "show_lattice" not in options:
@@ -1114,12 +1114,12 @@ class ToricLattice_sublattice_with_basis(ToricLattice_generic,
 
             sage: N = ToricLattice(3)
             sage: sublattice = N.submodule_with_basis([(1,1,0), (3,2,1)])
-            sage: sublattice.plot()                                                     # needs sage.plot
+            sage: sublattice.plot()
             Graphics3d Object
 
         Now we plot both the ambient lattice and its sublattice::
 
-            sage: N.plot() + sublattice.plot(point_color='red')                         # needs sage.plot
+            sage: N.plot() + sublattice.plot(point_color='red')
             Graphics3d Object
         """
         if "show_lattice" not in options:

--- a/src/sage/geometry/toric_lattice_element.pyx
+++ b/src/sage/geometry/toric_lattice_element.pyx
@@ -352,7 +352,7 @@ cdef class ToricLatticeElement(Vector_integer_dense):
 
             sage: N = ToricLattice(3)
             sage: n = N(1,2,3)
-            sage: n.plot()                                                              # needs sage.plot
+            sage: n.plot()
             Graphics3d Object
         """
         from sage.geometry.toric_plotter import ToricPlotter

--- a/src/sage/geometry/toric_plotter.py
+++ b/src/sage/geometry/toric_plotter.py
@@ -15,8 +15,8 @@ EXAMPLES:
 
 In most cases, this module is used indirectly, e.g. ::
 
-    sage: fan = toric_varieties.dP6().fan()                                             # needs palp sage.graphs
-    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot
+    sage: fan = toric_varieties.dP6().fan()                                             # needs palp
+    sage: fan.plot()                                                                    # needs palp
     Graphics object consisting of 31 graphics primitives
 
 You may change default plotting options as follows::
@@ -26,12 +26,12 @@ You may change default plotting options as follows::
     sage: toric_plotter.options(show_rays=False)
     sage: toric_plotter.options("show_rays")
     False
-    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot
+    sage: fan.plot()                                                                    # needs palp
     Graphics object consisting of 19 graphics primitives
     sage: toric_plotter.reset_options()
     sage: toric_plotter.options("show_rays")
     True
-    sage: fan.plot()                                                                    # needs palp sage.graphs sage.plot
+    sage: fan.plot()                                                                    # needs palp
     Graphics object consisting of 31 graphics primitives
 """
 
@@ -134,10 +134,10 @@ class ToricPlotter(SageObject):
     directly. Instead, use plotting method of the object which you want to
     plot, e.g. ::
 
-        sage: fan = toric_varieties.dP6().fan()                                         # needs palp sage.graphs
-        sage: fan.plot()                                                                # needs palp sage.graphs sage.plot
+        sage: fan = toric_varieties.dP6().fan()                                         # needs palp
+        sage: fan.plot()                                                                # needs palp
         Graphics object consisting of 31 graphics primitives
-        sage: print(fan.plot())                                                         # needs palp sage.graphs sage.plot
+        sage: print(fan.plot())                                                         # needs palp
         Graphics object consisting of 31 graphics primitives
 
     If you do want to create your own plotting function for some toric
@@ -163,7 +163,7 @@ class ToricPlotter(SageObject):
     For example, the plot from the previous example can be obtained as
     follows::
 
-        sage: # needs palp sage.graphs sage.plot
+        sage: # needs palp
         sage: from sage.geometry.toric_plotter import ToricPlotter
         sage: options = dict()  # use default for everything
         sage: tp = ToricPlotter(options, fan.lattice().degree())
@@ -181,7 +181,7 @@ class ToricPlotter(SageObject):
     this case they can be passed to the constructor as an optional argument.
     In the example above, the toric plotter can be completely set up using ::
 
-        sage: tp = ToricPlotter(options, fan.lattice().degree(), fan.rays())            # needs palp sage.graphs sage.plot
+        sage: tp = ToricPlotter(options, fan.lattice().degree(), fan.rays())            # needs palp
 
     All options are exposed as attributes of toric plotters and can be modified
     after constructions, however you will have to manually call
@@ -380,7 +380,7 @@ class ToricPlotter(SageObject):
 
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2, [(3,4)])
-            sage: tp.plot_generators()                                                  # needs sage.plot
+            sage: tp.plot_generators()
             Graphics object consisting of 1 graphics primitive
         """
         generators = self.generators
@@ -429,7 +429,7 @@ class ToricPlotter(SageObject):
 
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2)
-            sage: tp.plot_labels("u", [(1.5,0)])                                        # needs sage.plot
+            sage: tp.plot_labels("u", [(1.5,0)])
             Graphics object consisting of 1 graphics primitive
         """
         result = Graphics()
@@ -461,7 +461,7 @@ class ToricPlotter(SageObject):
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2)
             sage: tp.adjust_options()
-            sage: tp.plot_lattice()                                                     # needs sage.plot
+            sage: tp.plot_lattice()
             Graphics object consisting of 1 graphics primitive
         """
         if not self.show_lattice:
@@ -503,7 +503,7 @@ class ToricPlotter(SageObject):
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2)
             sage: tp.adjust_options()
-            sage: tp.plot_points([(1,0), (0,1)])                                        # needs sage.plot
+            sage: tp.plot_points([(1,0), (0,1)])
             Graphics object consisting of 1 graphics primitive
         """
         return point(points, color=self.point_color, size=self.point_size,
@@ -525,7 +525,7 @@ class ToricPlotter(SageObject):
 
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2, [(3,4)])
-            sage: tp.plot_ray_labels()                                                  # needs sage.plot
+            sage: tp.plot_ray_labels()
             Graphics object consisting of 1 graphics primitive
         """
         return self.plot_labels(self.ray_label,
@@ -544,7 +544,7 @@ class ToricPlotter(SageObject):
 
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2, [(3,4)])
-            sage: tp.plot_rays()                                                        # needs sage.plot
+            sage: tp.plot_rays()
             Graphics object consisting of 2 graphics primitives
         """
         result = Graphics()
@@ -584,14 +584,14 @@ class ToricPlotter(SageObject):
             sage: quadrant = Cone([(1,0), (0,1)])
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2, quadrant.rays())
-            sage: tp.plot_walls([quadrant])                                             # needs sage.plot
+            sage: tp.plot_walls([quadrant])
             Graphics object consisting of 2 graphics primitives
 
         Let's also check that the truncating polyhedron is functioning
         correctly::
 
             sage: tp = ToricPlotter({"mode": "box"}, 2, quadrant.rays())
-            sage: tp.plot_walls([quadrant])                                             # needs sage.plot
+            sage: tp.plot_walls([quadrant])
             Graphics object consisting of 2 graphics primitives
         """
         result = Graphics()
@@ -679,12 +679,12 @@ class ToricPlotter(SageObject):
             sage: from sage.geometry.toric_plotter import ToricPlotter
             sage: tp = ToricPlotter(dict(), 2)
             sage: tp.adjust_options()
-            sage: tp.plot_rays()                                                        # needs sage.plot
+            sage: tp.plot_rays()
             Traceback (most recent call last):
             ...
             AttributeError: 'ToricPlotter' object has no attribute 'rays'...
             sage: tp.set_rays([(0,1)])
-            sage: tp.plot_rays()                                                        # needs sage.plot
+            sage: tp.plot_rays()
             Graphics object consisting of 2 graphics primitives
         """
         d = self.dimension
@@ -1071,9 +1071,9 @@ def sector(ray1, ray2, **extra_options):
     EXAMPLES::
 
         sage: from sage.geometry.toric_plotter import sector
-        sage: sector((1,0), (0,1))                                                      # needs sage.symbolic
+        sage: sector((1,0), (0,1))
         Graphics object consisting of 1 graphics primitive
-        sage: sector((3,2,1), (1,2,3))                                                  # needs sage.plot
+        sage: sector((3,2,1), (1,2,3))
         Graphics3d Object
     """
     from sage.functions.trig import acos as arccos

--- a/src/sage/geometry/triangulation/element.py
+++ b/src/sage/geometry/triangulation/element.py
@@ -23,7 +23,7 @@ Here is a simple example of how to triangulate a point configuration::
     sage: points = PointConfiguration(p)
     sage: triang = points.triangulate();  triang
     (<0,1,2,5>, <0,1,3,5>, <1,3,4,5>)
-    sage: triang.plot(axes=False)                                                       # needs sage.plot
+    sage: triang.plot(axes=False)
     Graphics3d Object
 
 See :mod:`sage.geometry.triangulation.point_configuration` for more details.
@@ -65,7 +65,7 @@ def triangulation_render_2d(triangulation, **kwds):
 
         sage: points = PointConfiguration([[0,0],[0,1],[1,0],[1,1],[-1,-1]])
         sage: triang = points.triangulate()
-        sage: triang.plot(axes=False, aspect_ratio=1)   # indirect doctest              # needs sage.plot
+        sage: triang.plot(axes=False, aspect_ratio=1)   # indirect doctest
         Graphics object consisting of 12 graphics primitives
     """
     from sage.plot.point import point2d
@@ -127,7 +127,7 @@ def triangulation_render_3d(triangulation, **kwds):
         sage: p = [[0,-1,-1],[0,0,1],[0,1,0], [1,-1,-1],[1,0,1],[1,1,0]]
         sage: points = PointConfiguration(p)
         sage: triang = points.triangulate()
-        sage: triang.plot(axes=False)     # indirect doctest                            # needs sage.plot
+        sage: triang.plot(axes=False)     # indirect doctest
         Graphics3d Object
     """
     from sage.plot.plot3d.all import point3d, line3d, polygon3d
@@ -403,7 +403,7 @@ class Triangulation(Element):
             sage: triangulation = p.triangulate()
             sage: triangulation
             (<1,3,4>, <2,3,4>)
-            sage: triangulation.plot(axes=False)                                        # needs sage.plot
+            sage: triangulation.plot(axes=False)
             Graphics object consisting of 12 graphics primitives
         """
         dim = self.point_configuration().dim()
@@ -516,7 +516,7 @@ class Triangulation(Element):
             sage: triangulation = pc.triangulate()
             sage: fan = triangulation.fan(); fan
             Rational polyhedral fan in 2-d lattice N
-            sage: fan.is_equivalent(toric_varieties.P2().fan())                         # needs palp sage.graphs
+            sage: fan.is_equivalent(toric_varieties.P2().fan())                         # needs palp
             True
 
         Toric diagrams (the `\ZZ_5` hyperconifold)::
@@ -557,12 +557,12 @@ class Triangulation(Element):
         EXAMPLES::
 
             sage: p = polytopes.cuboctahedron()
-            sage: sc = p.triangulate(engine='internal').simplicial_complex(); sc        # needs sage.graphs
+            sage: sc = p.triangulate(engine='internal').simplicial_complex(); sc
             Simplicial complex with 12 vertices and 16 facets
 
         Any convex set is contractable, so its reduced homology groups vanish::
 
-            sage: sc.homology()                                                         # needs sage.graphs
+            sage: sc.homology()
             {0: 0, 1: 0, 2: 0, 3: 0}
         """
         from sage.topology.simplicial_complex import SimplicialComplex
@@ -658,19 +658,19 @@ class Triangulation(Element):
 
             sage: p = polytopes.cuboctahedron()
             sage: triangulation = p.triangulate(engine='internal')
-            sage: bd_sc = triangulation.boundary_simplicial_complex(); bd_sc            # needs sage.graphs
+            sage: bd_sc = triangulation.boundary_simplicial_complex(); bd_sc
             Simplicial complex with 12 vertices and 20 facets
 
         The boundary of every convex set is a topological sphere, so it has
         spherical homology::
 
-            sage: bd_sc.homology()                                                      # needs sage.graphs
+            sage: bd_sc.homology()
             {0: 0, 1: 0, 2: Z}
 
         It is a subcomplex of ``self`` as a :meth:`simplicial_complex`::
 
-            sage: sc = triangulation.simplicial_complex()                               # needs sage.graphs
-            sage: all(f in sc for f in bd_sc.maximal_faces())                           # needs sage.graphs
+            sage: sc = triangulation.simplicial_complex()
+            sage: all(f in sc for f in bd_sc.maximal_faces())
             True
         """
         from sage.topology.simplicial_complex import SimplicialComplex
@@ -727,9 +727,9 @@ class Triangulation(Element):
             sage: pc = PointConfiguration(P.vertices())
             sage: T = pc.placing_triangulation(); T
             (<0,1,2,7>, <0,1,5,7>, <0,2,3,7>, <0,3,4,7>, <0,4,5,7>, <1,5,6,7>)
-            sage: C = T.polyhedral_complex(); C                                         # needs sage.graphs
+            sage: C = T.polyhedral_complex(); C
             Polyhedral complex with 6 maximal cells
-            sage: [P.vertices_list() for P in C.maximal_cells_sorted()]                 # needs sage.graphs
+            sage: [P.vertices_list() for P in C.maximal_cells_sorted()]
             [[[-1, -1, -1], [-1, -1, 1], [-1, 1, 1], [1, -1, -1]],
              [[-1, -1, -1], [-1, 1, -1], [-1, 1, 1], [1, 1, -1]],
              [[-1, -1, -1], [-1, 1, 1], [1, -1, -1], [1, 1, -1]],
@@ -763,9 +763,9 @@ class Triangulation(Element):
             sage: pc = PointConfiguration(P.vertices())
             sage: T = pc.placing_triangulation(); T
             (<0,1,2,7>, <0,1,5,7>, <0,2,3,7>, <0,3,4,7>, <0,4,5,7>, <1,5,6,7>)
-            sage: bd_C = T.boundary_polyhedral_complex(); bd_C                          # needs sage.graphs
+            sage: bd_C = T.boundary_polyhedral_complex(); bd_C
             Polyhedral complex with 12 maximal cells
-            sage: [P.vertices_list() for P in bd_C.maximal_cells_sorted()]              # needs sage.graphs
+            sage: [P.vertices_list() for P in bd_C.maximal_cells_sorted()]
             [[[-1, -1, -1], [-1, -1, 1], [-1, 1, 1]],
              [[-1, -1, -1], [-1, -1, 1], [1, -1, -1]],
              [[-1, -1, -1], [-1, 1, -1], [-1, 1, 1]],
@@ -781,8 +781,8 @@ class Triangulation(Element):
 
         It is a subcomplex of ``self`` as a :meth:`polyhedral_complex`::
 
-            sage: C = T.polyhedral_complex()                                            # needs sage.graphs
-            sage: bd_C.is_subcomplex(C)                                                 # needs sage.graphs
+            sage: C = T.polyhedral_complex()
+            sage: bd_C.is_subcomplex(C)
             True
         """
         from sage.geometry.polyhedral_complex import PolyhedralComplex
@@ -906,7 +906,7 @@ class Triangulation(Element):
             sage: p = PointConfiguration([[1,0,0], [0,1,0], [0,0,1], [-1,0,1],
             ....:                         [1,0,-1], [-1,0,0], [0,-1,0], [0,0,-1]])
             sage: t = p.triangulate()
-            sage: t.adjacency_graph()                                                   # needs sage.graphs
+            sage: t.adjacency_graph()
             Graph on 8 vertices
         """
         vertices = [Set(_) for _ in list(self)]

--- a/src/sage/geometry/triangulation/point_configuration.py
+++ b/src/sage/geometry/triangulation/point_configuration.py
@@ -61,7 +61,7 @@ A triangulation of it::
     (2, 3, 4)
     sage: list(t)
     [(1, 3, 4), (2, 3, 4)]
-    sage: t.plot(axes=False)                                                       # needs sage.plot
+    sage: t.plot(axes=False)
     Graphics object consisting of 12 graphics primitives
 
 .. PLOT::
@@ -91,7 +91,7 @@ A 3-dimensional point configuration::
     sage: p = [[0,-1,-1], [0,0,1], [0,1,0], [1,-1,-1], [1,0,1], [1,1,0]]
     sage: points = PointConfiguration(p)
     sage: triang = points.triangulate()
-    sage: triang.plot(axes=False)                                                 # needs sage.plot
+    sage: triang.plot(axes=False)
     Graphics3d Object
 
 .. PLOT::
@@ -116,7 +116,7 @@ The standard example of a non-regular triangulation (requires TOPCOM)::
     16
     sage: len(nonregular)
     2
-    sage: nonregular[0].plot(aspect_ratio=1, axes=False)                          # needs sage.plot
+    sage: nonregular[0].plot(aspect_ratio=1, axes=False)
     Graphics object consisting of 25 graphics primitives
     sage: PointConfiguration.set_engine('internal')   # to make doctests independent of TOPCOM
 
@@ -1126,10 +1126,10 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
 
             sage: pyramid = PointConfiguration([[1,0,0], [0,1,1], [0,1,-1],
             ....:                               [0,-1,-1], [0,-1,1]])
-            sage: G = pyramid.restricted_automorphism_group()                      # needs sage.graphs sage.groups
-            sage: G == PermutationGroup([[(3,5)], [(2,3),(4,5)], [(2,4)]])         # needs sage.graphs sage.groups
+            sage: G = pyramid.restricted_automorphism_group()
+            sage: G == PermutationGroup([[(3,5)], [(2,3),(4,5)], [(2,4)]])
             True
-            sage: DihedralGroup(4).is_isomorphic(G)                                # needs sage.graphs sage.groups
+            sage: DihedralGroup(4).is_isomorphic(G)
             True
 
         The square with an off-center point in the middle. Note that
@@ -1137,9 +1137,9 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         `D_4` of the convex hull::
 
             sage: square = PointConfiguration([(3/4,3/4), (1,1), (1,-1), (-1,-1), (-1,1)])
-            sage: square.restricted_automorphism_group()                           # needs sage.graphs sage.groups
+            sage: square.restricted_automorphism_group()
             Permutation Group with generators [(3,5)]
-            sage: DihedralGroup(1).is_isomorphic(_)                                # needs sage.graphs sage.groups
+            sage: DihedralGroup(1).is_isomorphic(_)
             True
         """
         v_list = [ vector(p.projective()) for p in self ]
@@ -1527,9 +1527,9 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
             sage: pc.bistellar_flips()
             (((<0,1,3>, <0,2,3>), (<0,1,2>, <1,2,3>)),)
             sage: Tpos, Tneg = pc.bistellar_flips()[0]
-            sage: Tpos.plot(axes=False)                                            # needs sage.plot
+            sage: Tpos.plot(axes=False)
             Graphics object consisting of 11 graphics primitives
-            sage: Tneg.plot(axes=False)                                            # needs sage.plot
+            sage: Tneg.plot(axes=False)
             Graphics object consisting of 11 graphics primitives
 
         The 3d analog::
@@ -1544,7 +1544,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
             sage: pc.bistellar_flips()
             (((<0,1,3>, <0,2,3>), (<0,1,2>, <1,2,3>)),)
             sage: Tpos, Tneg = pc.bistellar_flips()[0]
-            sage: Tpos.plot(axes=False)                                            # needs sage.plot
+            sage: Tpos.plot(axes=False)
             Graphics3d Object
         """
         flips = []
@@ -2238,7 +2238,7 @@ class PointConfiguration(UniqueRepresentation, PointConfiguration_base):
         EXAMPLES::
 
             sage: p = PointConfiguration([[0,0], [0,1], [1,0], [1,1], [-1,-1]])
-            sage: p.plot(axes=False)                                                    # needs sage.plot
+            sage: p.plot(axes=False)
             Graphics object consisting of 5 graphics primitives
 
         .. PLOT::

--- a/src/sage/geometry/voronoi_diagram.py
+++ b/src/sage/geometry/voronoi_diagram.py
@@ -47,19 +47,19 @@ class VoronoiDiagram(SageObject):
     Get the Voronoi diagram of a regular pentagon in ``AA^2``.
     All cells meet at the origin::
 
-        sage: DV = VoronoiDiagram([[AA(c) for c in v]                                   # needs sage.rings.number_field
+        sage: DV = VoronoiDiagram([[AA(c) for c in v]
         ....:                      for v in polytopes.regular_polygon(5).vertices_list()]); DV
         The Voronoi diagram of 5 points of dimension 2 in the Algebraic Real Field
-        sage: all(P.contains([0, 0]) for P in DV.regions().values())                    # needs sage.rings.number_field
+        sage: all(P.contains([0, 0]) for P in DV.regions().values())
         True
-        sage: any(P.interior_contains([0, 0]) for P in DV.regions().values())           # needs sage.rings.number_field
+        sage: any(P.interior_contains([0, 0]) for P in DV.regions().values())
         False
 
     If the vertices are not converted to ``AA`` before, the method throws an error::
 
-        sage: polytopes.dodecahedron().vertices_list()[0][0].parent()                   # needs sage.groups sage.rings.number_field
+        sage: polytopes.dodecahedron().vertices_list()[0][0].parent()
         Number Field in sqrt5 with defining polynomial x^2 - 5 with sqrt5 = 2.236067977499790?
-        sage: VoronoiDiagram(polytopes.dodecahedron().vertices_list())                  # needs sage.groups sage.rings.number_field
+        sage: VoronoiDiagram(polytopes.dodecahedron().vertices_list())
         Traceback (most recent call last):
         ...
         NotImplementedError: Base ring of the Voronoi diagram must be
@@ -227,7 +227,7 @@ class VoronoiDiagram(SageObject):
 
         EXAMPLES::
 
-            sage: V = VoronoiDiagram(polytopes.regular_polygon(3).vertices()); V        # needs sage.rings.number_field
+            sage: V = VoronoiDiagram(polytopes.regular_polygon(3).vertices()); V
             The Voronoi diagram of 3 points of dimension 2 in the Algebraic Real Field
             sage: VoronoiDiagram([])
             The empty Voronoi diagram.
@@ -273,7 +273,7 @@ class VoronoiDiagram(SageObject):
         Trying to plot a Voronoi diagram of dimension other than 2 gives an
         error::
 
-            sage: VoronoiDiagram([[1, 2, 3], [6, 5, 4]]).plot()                         # needs sage.plot
+            sage: VoronoiDiagram([[1, 2, 3], [6, 5, 4]]).plot()
             Traceback (most recent call last):
             ...
             NotImplementedError: Plotting of 3-dimensional Voronoi diagrams not


### PR DESCRIPTION
These are unmaintained, and serve no purpose in the upstream Sage library.
