### PR TITLE
Add restriction in random_cone parameters in examples

### DIFF
--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6924,6 +6924,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
     Or one that isn't strictly convex::
 
         sage: K = random_cone(min_ambient_dim=5, min_rays=2,
+        ....:                 max_ambient_dim=8, max_rays=10,
         ....:                 strictly_convex=False)
         sage: K.is_strictly_convex()
         False

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3477,7 +3477,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         responses.) By testing it here, we "guarantee" that it is a
         safe assumption to make in user code::
 
-            sage: K = random_cone(max_ambient_dim=6, max_rays=8)
+            sage: K = random_cone(max_ambient_dim=12)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3488,8 +3488,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
             sage: K = random_cone(strictly_convex=False,
             ....:                 min_ambient_dim=4,
-            ....:                 max_ambient_dim=6,
-            ....:                 max_rays=8)
+            ....:                 max_ambient_dim=12)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3500,9 +3499,8 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
             sage: K = random_cone(strictly_convex=False,
             ....:                 min_ambient_dim=4,
-            ....:                 max_ambient_dim=8,
-            ....:                 min_rays=4,
-            ....:                 max_rays=10)
+            ....:                 max_ambient_dim=12,
+            ....:                 min_rays=4)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3489,7 +3489,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K = random_cone(strictly_convex=False,
             ....:                 min_ambient_dim=4,
             ....:                 max_ambient_dim=12,
-            ....:                 max_rays=10)
+            ....:                 max_rays=15)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3499,7 +3499,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             True
 
             sage: K = random_cone(strictly_convex=False,
-            ....:                 min_ambient_dim=4,
+            ....:                 min_ambient_dim=8,
             ....:                 max_ambient_dim=12,
             ....:                 min_rays=4, max_rays=10)
             sage: V = K.lattice().vector_space()

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3477,7 +3477,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         responses.) By testing it here, we "guarantee" that it is a
         safe assumption to make in user code::
 
-            sage: K = random_cone()
+            sage: K = random_cone(max_ambient_dim=6, max_rays=8)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3487,7 +3487,9 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             True
 
             sage: K = random_cone(strictly_convex=False,
-            ....:                 min_ambient_dim=4)
+            ....:                 min_ambient_dim=4,
+            ....:                 max_ambient_dim=6,
+            ....:                 max_rays=8)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3497,8 +3499,10 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             True
 
             sage: K = random_cone(strictly_convex=False,
-            ....:                 min_ambient_dim=8,
-            ....:                 min_rays=4)
+            ....:                 min_ambient_dim=4,
+            ....:                 max_ambient_dim=8,
+            ....:                 min_rays=4,
+            ....:                 max_rays=10)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3487,8 +3487,9 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             True
 
             sage: K = random_cone(strictly_convex=False,
-            ....:                 min_ambient_dim=4, max_rays=10,
-            ....:                 max_ambient_dim=12)
+            ....:                 min_ambient_dim=4,
+            ....:                 max_ambient_dim=12,
+            ....:                 max_rays=10)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3501,7 +3501,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K = random_cone(strictly_convex=False,
             ....:                 min_ambient_dim=8,
             ....:                 max_ambient_dim=12,
-            ....:                 min_rays=4, max_rays=10)
+            ....:                 min_rays=4, max_rays=15)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3477,7 +3477,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         responses.) By testing it here, we "guarantee" that it is a
         safe assumption to make in user code::
 
-            sage: K = random_cone(max_ambient_dim=12)
+            sage: K = random_cone(max_ambient_dim=12, max_rays=10)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3487,7 +3487,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             True
 
             sage: K = random_cone(strictly_convex=False,
-            ....:                 min_ambient_dim=4,
+            ....:                 min_ambient_dim=4, max_rays=10,
             ....:                 max_ambient_dim=12)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
@@ -3500,7 +3500,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K = random_cone(strictly_convex=False,
             ....:                 min_ambient_dim=4,
             ....:                 max_ambient_dim=12,
-            ....:                 min_rays=4)
+            ....:                 min_rays=4, max_rays=10)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Fix timeout problem for some bad random seeds
```
sage: V = K.lattice().vector_space() ## line 3446 ##
sage: L = [V(l) for l in K.lines()] ## line 3447 ##
sage: all( L[i].inner_product(L[j]).is_zero()
....:      for i in range(len(L))
....:      for j in range(len(L))
....:      if i != j ) ## line 3448 ##
True
sage: K = random_cone(strictly_convex=False,
....:                 min_ambient_dim=8,
....:                 min_rays=4) ## line 3454 ##
------------------------------------------------------------------------
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/cysignals/signals.cpython-312-x86_64-linux-gnu.so(+0x8697)[0x7fbde3366697]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/cysignals/signals.cpython-312-x86_64-linux-gnu.so(+0x8757)[0x7fbde3366757]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/cysignals/signals.cpython-312-x86_64-linux-gnu.so(+0x8af6)[0x7fbde3366af6]
/lib/x86_64-linux-gnu/libc.so.6(+0x45330)[0x7fbde4445330]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/sage/ext/memory.cpython-312-x86_64-linux-gnu.so(+0x5360)[0x7fbde25ec360]
/usr/share/miniconda/envs/sage-dev/lib/libgmp.so.10(__gmpz_init2+0x33)[0x7fbde1580b23]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/ppl/../../../libppl.so.14(_ZN23Parma_Polyhedra_Library10Polyhedron10conversionINS_16Generator_SystemENS_17Constraint_SystemEEEmRT_mRT0_RNS_10Bit_MatrixEm+0x18cd)[0x7fbd7576c18d]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/ppl/../../../libppl.so.14(_ZNK23Parma_Polyhedra_Library10Polyhedron18update_constraintsEv+0x501)[0x7fbd75774d71]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/ppl/../../../libppl.so.14(_ZNK23Parma_Polyhedra_Library10Polyhedron8minimizeEv+0x76)[0x7fbd75775c86]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/ppl/../../../libppl.so.14(_ZNK23Parma_Polyhedra_Library10Polyhedron20minimized_generatorsEv+0x11)[0x7fbd7577e6c1]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/ppl/polyhedron.cpython-312-x86_64-linux-gnu.so(+0x29481)[0x7fbd75522481]
python3(PyObject_Vectorcall+0x2e)[0x55b54924350e]
python3(_PyEval_EvalFrameDefault+0xa45)[0x55b54922e315]
python3(PyVectorcall_Call+0xd3)[0x55b5491e3ffd]
/usr/share/miniconda/envs/sage-dev/lib/python3.12/site-packages/sage/misc/lazy_import.cpython-312-x86_64-linux-gnu.so(+0x19f18)[0x7fbde139cf18]
python3(_PyObject_MakeTpCall+0x2bc)[0x55b549223fac]
python3(_PyEval_EvalFrameDefault+0xa45)[0x55b54922e315]
python3(PyEval_EvalCode+0x9f)[0x55b5492e675f]
python3(+0x2d51ba)[0x55b5493051ba]
python3(_PyEval_EvalFrameDefault+0x387d)[0x55b54923114d]
python3(_PyObject_FastCallDictTstate+0x273)[0x55b549226cc3]
python3(_PyObject_Call_Prepend+0x67)[0x55b54925dbc7]
python3(+0x2feda9)[0x55b54932eda9]
python3(_PyObject_MakeTpCall+0x2bc)[0x55b549223fac]
python3(_PyEval_EvalFrameDefault+0xa45)[0x55b54922e315]
python3(_PyObject_FastCallDictTstate+0x1ce)[0x55b549226c1e]
python3(+0x22d7aa)[0x55b54925d7aa]
python3(_PyObject_MakeTpCall+0x264)[0x55b549223f54]
python3(_PyEval_EvalFrameDefault+0xa45)[0x55b54922e315]
python3(PyEval_EvalCode+0x9f)[0x55b5492e675f]
python3(+0x2f24ea)[0x55b5493224ea]
python3(+0x2ed015)[0x55b54931d015]
python3(+0x2ea020)[0x55b54931a020]
python3(_PyRun_SimpleFileObject+0x1c6)[0x55b549319ce6]
python3(_PyRun_AnyFileObject+0x44)[0x55b549319a14]
python3(Py_RunMain+0x39e)[0x55b5493165ae]
python3(Py_BytesMain+0x37)[0x55b5492ce677]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7fbde442a1ca]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7fbde442a28b]
python3(+0x29e4e7)[0x55b5492ce4e7]
------------------------------------------------------------------------
Attaching gdb to process id 30135.
Cannot find gdb installed
GDB is not installed.
Install gdb for enhanced tracebacks.
------------------------------------------------------------------------
```
you can verify this use
```
src/bin/sage -t --warn-long 5.0 --random-seed=165473321169090073016534533946561390697 src/sage/geometry/cone.py  # Timed out
```

Fix #42140 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


