### PR TITLE
src/sage/doctest/reporting.py: delete optional latex tag test

### DIFF
--- a/src/sage/doctest/reporting.py
+++ b/src/sage/doctest/reporting.py
@@ -149,15 +149,6 @@ class DocTestReporter(SageObject):
             sage: DTR.were_doctests_with_optional_tag_run('nice_unavailable_package')
             False
 
-        When latex is available, doctests marked with optional tag
-        ``latex`` are run by default since :issue:`32174`::
-
-            sage: # needs SAGE_SRC
-            sage: filename = os.path.join(SAGE_SRC, 'sage', 'misc', 'latex.py')
-            sage: DC = DocTestController(DocTestDefaults(), [filename])
-            sage: DTR = DocTestReporter(DC)
-            sage: DTR.were_doctests_with_optional_tag_run('latex')   # optional - latex
-            True
         """
         if self.controller.options.optional is True or tag in self.controller.options.optional:
             return True


### PR DESCRIPTION
A test in this file tries to ensure that "optional - latex" tags are processed by default, but it doesn't work, because latex was demoted to the "external" tier in https://github.com/sagemath/sage/commit/6f311b311e44def63f21ed4524d5.
