### PR TITLE
src/sage/stats: remove remaining "needs sage.foo" tags

### DIFF
--- a/src/sage/stats/basic_stats.py
+++ b/src/sage/stats/basic_stats.py
@@ -66,15 +66,15 @@ def mean(v):
 
     EXAMPLES::
 
-        sage: mean([pi, e])                                                             # needs sage.symbolic
+        sage: mean([pi, e])
         doctest:warning...
         DeprecationWarning: sage.stats.basic_stats.mean is deprecated;
         use numpy.mean or numpy.nanmean instead
         See https://github.com/sagemath/sage/issues/29662 for details.
         1/2*pi + 1/2*e
-        sage: mean([])                                                                  # needs sage.symbolic
+        sage: mean([])
         NaN
-        sage: mean([I, sqrt(2), 3/5])                                                   # needs sage.symbolic
+        sage: mean([I, sqrt(2), 3/5])
         1/3*sqrt(2) + 1/3*I + 1/5
         sage: mean([RIF(1.0103,1.0103), RIF(2)])
         1.5051500000000000?
@@ -192,7 +192,6 @@ def std(v, bias=False):
 
     EXAMPLES::
 
-        sage: # needs sage.symbolic
         sage: std([1..6], bias=True)
         doctest:warning...
         DeprecationWarning: sage.stats.basic_stats.std is deprecated;
@@ -287,11 +286,11 @@ def variance(v, bias=False):
         7/2
         sage: variance([1..6], bias=True)
         35/12
-        sage: variance([e, pi])                                                         # needs sage.symbolic
+        sage: variance([e, pi])
         1/2*(pi - e)^2
         sage: variance([])
         NaN
-        sage: variance([I, sqrt(2), 3/5])                                               # needs sage.symbolic
+        sage: variance([I, sqrt(2), 3/5])
         1/450*(10*sqrt(2) - 5*I - 3)^2 + 1/450*(5*sqrt(2) - 10*I + 3)^2
         + 1/450*(5*sqrt(2) + 5*I - 6)^2
         sage: variance([RIF(1.0103, 1.0103), RIF(2)])
@@ -389,11 +388,11 @@ def median(v):
         use numpy.median or numpy.nanmedian instead
         See https://github.com/sagemath/sage/issues/29662 for details.
         3
-        sage: median([e, pi])                                                           # needs sage.symbolic
+        sage: median([e, pi])
         1/2*pi + 1/2*e
         sage: median(['sage', 'linux', 'python'])
         'python'
-        sage: median([])                                                                # needs sage.symbolic
+        sage: median([])
         NaN
         sage: class MyClass:
         ....:    def median(self):
@@ -447,7 +446,7 @@ def moving_average(v, n):
         [5/2, 7/2, 9/2, 11/2, 13/2, 15/2, 17/2]
         sage: moving_average([], 1)
         []
-        sage: moving_average([pi, e, I, sqrt(2), 3/5], 2)                               # needs sage.symbolic
+        sage: moving_average([pi, e, I, sqrt(2), 3/5], 2)
         [1/2*pi + 1/2*e, 1/2*e + 1/2*I, 1/2*sqrt(2) + 1/2*I,
          1/2*sqrt(2) + 3/10]
 

--- a/src/sage/stats/distributions/discrete_gaussian_integer.pyx
+++ b/src/sage/stats/distributions/discrete_gaussian_integer.pyx
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.symbolic
 #
 # distutils: sources = sage/stats/distributions/dgs_gauss_mp.c sage/stats/distributions/dgs_gauss_dp.c sage/stats/distributions/dgs_bern.c
 # distutils: depends = sage/stats/distributions/dgs_gauss.h sage/stats/distributions/dgs_bern.h sage/stats/distributions/dgs_misc.h

--- a/src/sage/stats/distributions/discrete_gaussian_lattice.py
+++ b/src/sage/stats/distributions/discrete_gaussian_lattice.py
@@ -142,7 +142,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
         sage: D = distributions.DiscreteGaussianDistributionLatticeSampler(identity_matrix(2), 3.0)
         sage: S = [D() for _ in range(2^12)]
         sage: l = [vector(v.list() + [S.count(v)]) for v in set(S)]
-        sage: list_plot3d(l, point_list=True, interpolation='nn')                       # needs sage.plot
+        sage: list_plot3d(l, point_list=True, interpolation='nn')
         Graphics3d Object
 
     REFERENCES:
@@ -447,7 +447,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             sage: n = 2; sigma = 3.0
             sage: D = distributions.DiscreteGaussianDistributionLatticeSampler(ZZ^n, sigma)
             sage: f = D.f
-            sage: nf = D._normalisation_factor_zz(); nf                                 # needs sage.symbolic
+            sage: nf = D._normalisation_factor_zz(); nf
             56.5486677646...
 
             sage: from collections import defaultdict
@@ -461,7 +461,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             sage: v = vector(ZZ, n, (-3, -3))
             sage: v.set_immutable()
             sage: while v not in counter: add_samples(1000)
-            sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:                     # needs sage.symbolic
+            sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:
             ....:     add_samples(1000)
 
             sage: counter = defaultdict(Integer); m = 0
@@ -469,7 +469,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             sage: v.set_immutable()
             sage: while v not in counter:
             ....:     add_samples(1000)
-            sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:                     # needs sage.symbolic
+            sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:
             ....:     add_samples(1000)
 
         Spherical covariance are automatically handled::
@@ -505,7 +505,7 @@ class DiscreteGaussianDistributionLatticeSampler(SageObject):
             ....:     add_samples(1000)
             sage: sum(counter.values())  # random
             3000
-            sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:  # long time, needs sage.symbolic
+            sage: while abs(m*f(v)*1.0/nf/counter[v] - 1.0) >= 0.1:  # long time
             ....:     add_samples(1000)
 
         If the covariance provided is not positive definite, an error is thrown::

--- a/src/sage/stats/distributions/discrete_gaussian_polynomial.py
+++ b/src/sage/stats/distributions/discrete_gaussian_polynomial.py
@@ -16,9 +16,9 @@ EXAMPLES::
     sage: sigma = 3.0; n = 1000
     sage: l = [DiscreteGaussianDistributionPolynomialSampler(ZZ['x'], 64, sigma)()
     ....:      for _ in range(n)]
-    sage: l = [vector(f).norm().n() for f in l]                                         # needs sage.symbolic
+    sage: l = [vector(f).norm().n() for f in l]
     sage: from numpy import mean                                                        # needs numpy
-    sage: mean(l), sqrt(64)*sigma  # abs tol 5e-1                                       # needs numpy sage.symbolic
+    sage: mean(l), sqrt(64)*sigma  # abs tol 5e-1                                       # needs numpy
     (24.0, 24.0)
 """
 # ******************************************************************************

--- a/src/sage/stats/hmm/distributions.pyx
+++ b/src/sage/stats/hmm/distributions.pyx
@@ -127,7 +127,7 @@ cdef class Distribution:
         EXAMPLES::
 
             sage: P = hmm.GaussianMixtureDistribution([(.2,-10,.5),(.6,1,1),(.2,20,.5)])
-            sage: P.plot(-10,30)                                                        # needs sage.plot
+            sage: P.plot(-10,30)
             Graphics object consisting of 1 graphics primitive
         """
         from sage.plot.plot import plot

--- a/src/sage/stats/hmm/hmm.pyx
+++ b/src/sage/stats/hmm/hmm.pyx
@@ -1,4 +1,3 @@
-# sage.doctest: needs numpy sage.modules
 r"""
 Hidden Markov Models
 
@@ -148,11 +147,11 @@ cdef class HiddenMarkovModel:
             sage: m = hmm.DiscreteHiddenMarkovModel([[.3,0,.7],[0,0,1],[.5,.5,0]],
             ....:                                   [[.5,.5,.2]]*3,
             ....:                                   [1/3]*3)
-            sage: G = m.graph(); G                                                      # needs sage.graphs
+            sage: G = m.graph(); G
             Looped digraph on 3 vertices
-            sage: G.edges(sort=True)                                                    # needs sage.graphs
+            sage: G.edges(sort=True)
             [(0, 0, 0.3), (0, 2, 0.7), (1, 2, 1.0), (2, 0, 0.5), (2, 1, 0.5)]
-            sage: G.plot()                                                              # needs sage.graphs sage.plot
+            sage: G.plot()
             Graphics object consisting of 11 graphics primitives
         """
         cdef int i, j
@@ -313,7 +312,7 @@ cdef class DiscreteHiddenMarkovModel(HiddenMarkovModel):
         Initial probabilities: [0.0000, 1.0000]
         sage: m.sample(10)
         [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
-        sage: m.graph().plot()                                                          # needs sage.plot
+        sage: m.graph().plot()
         Graphics object consisting of 6 graphics primitives
 
     A 3-state model that happens to always outputs 'b'::

--- a/src/sage/stats/intlist.pyx
+++ b/src/sage/stats/intlist.pyx
@@ -516,9 +516,9 @@ cdef class IntList:
 
         EXAMPLES::
 
-            sage: stats.IntList([3,7,19,-2]).plot()                                     # needs sage.plot
+            sage: stats.IntList([3,7,19,-2]).plot()
             Graphics object consisting of 1 graphics primitive
-            sage: stats.IntList([3,7,19,-2]).plot(color='red',                          # needs sage.plot
+            sage: stats.IntList([3,7,19,-2]).plot(color='red',
             ....:                                 pointsize=50, points=True)
             Graphics object consisting of 1 graphics primitive
         """
@@ -534,7 +534,7 @@ cdef class IntList:
 
         EXAMPLES::
 
-            sage: stats.IntList([1..15]).plot_histogram()                               # needs sage.plot
+            sage: stats.IntList([1..15]).plot_histogram()
             Graphics object consisting of 50 graphics primitives
         """
         return self.time_series().plot_histogram(*args, **kwds)

--- a/src/sage/stats/time_series.pyx
+++ b/src/sage/stats/time_series.pyx
@@ -97,7 +97,7 @@ cdef class TimeSeries:
 
         This implicitly calls init::
 
-            sage: stats.TimeSeries([pi, 3, 18.2])                                       # needs sage.symbolic
+            sage: stats.TimeSeries([pi, 3, 18.2])
             [3.1416, 3.0000, 18.2000]
 
         Conversion from a NumPy 1-D array, which is very fast::
@@ -1003,7 +1003,7 @@ cdef class TimeSeries:
 
         Draw a plot of a time series::
 
-            sage: stats.TimeSeries([1..10]).show()                                      # needs sage.plot
+            sage: stats.TimeSeries([1..10]).show()
             Graphics object consisting of 1 graphics primitive
         """
         return self.plot(*args, **kwds)
@@ -1029,7 +1029,6 @@ cdef class TimeSeries:
 
         EXAMPLES::
 
-            sage: # needs sage.plot
             sage: v = stats.TimeSeries([5,4,1.3,2,8,10,3,-5]); v
             [5.0000, 4.0000, 1.3000, 2.0000, 8.0000, 10.0000, 3.0000, -5.0000]
             sage: v.plot()
@@ -1903,12 +1902,12 @@ cdef class TimeSeries:
         EXAMPLES::
 
             sage: v = stats.TimeSeries([1..50])
-            sage: v.plot_histogram(bins=10)                                             # needs sage.plot
+            sage: v.plot_histogram(bins=10)
             Graphics object consisting of 10 graphics primitives
 
         ::
 
-            sage: v.plot_histogram(bins=3,normalize=False,aspect_ratio=1)               # needs sage.plot
+            sage: v.plot_histogram(bins=3,normalize=False,aspect_ratio=1)
             Graphics object consisting of 3 graphics primitives
         """
         from sage.plot.polygon import polygon
@@ -1945,7 +1944,7 @@ cdef class TimeSeries:
         Here we look at the candlestick plot for Brownian motion::
 
             sage: v = stats.TimeSeries(1000).randomize()
-            sage: v.plot_candlestick(bins=20)                                           # needs sage.plot
+            sage: v.plot_candlestick(bins=20)
             Graphics object consisting of 40 graphics primitives
         """
         from sage.plot.line import line
@@ -2308,7 +2307,7 @@ cdef class TimeSeries:
             sage: v = stats.TimeSeries(10^6)
             sage: v.randomize('lognormal').mean()
             1.647351973...
-            sage: exp(0.5)                                                              # needs sage.symbolic
+            sage: exp(0.5)
             1.648721270...
 
         A log-normal distribution can be simply thought of as the logarithm


### PR DESCRIPTION
These are unmaintained, and don't do anything in the upstream SageMath library.
