### PR TITLE
Fix hang in hom.py

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -619,9 +619,15 @@ class EllipticCurveHom(Morphism):
               embedded in Abelian group of points on Elliptic Curve defined by y^2 + x*y = x^3 + 1
                 over Finite Field in t of size 2^42
         """
+        n = self.separable_degree()
         if algorithm is None:
             if self.domain().base_ring().is_finite():
-                algorithm = 'structure'
+                # For prime-degree kernels, extend=True only needs the
+                # cyclic kernel, not the full n-torsion.
+                if extend and n.is_prime():
+                    algorithm = 'kerpoly'
+                else:
+                    algorithm = 'structure'
             else:
                 algorithm = 'kerpoly'
 
@@ -635,12 +641,11 @@ class EllipticCurveHom(Morphism):
         except AttributeError:
             pass
 
-        if self.separable_degree().is_one():
+        if n.is_one():
             # purely inseparable
             return AdditiveAbelianGroupWrapper(self.domain().point_homset(), [], [])
 
         if algorithm == 'structure':
-            n = self.separable_degree()
             T1 = self.domain().torsion_subgroup(n, extend=extend)
             F = T1.universe().codomain().base_field()
             T2 = self.codomain().change_ring(F).torsion_subgroup(n)
@@ -653,52 +658,16 @@ class EllipticCurveHom(Morphism):
             o = T2.exponent()
             for imP in imPs:
                 imP.set_order(multiple=o)
-            T2gens = list(T2.gens())
-            Rgens = [g.element() for g in T2gens]
-            T2orders = [g.order() for g in T2gens]
-            # For small exponent, compute the discrete logarithms by
-            # brute-force table lookup. Calling ``pt.log(...)`` dispatches
-            # to ``pari.elllog``, which may internally reduce the elliptic
-            # curve DLP to a discrete logarithm in the multiplicative group
-            # of the underlying finite field; the latter can become
-            # unexpectedly slow (or effectively hang) when ``q^k - 1``
-            # has a large hard-to-factor part, even though ``o`` itself is
-            # small.
-            if o <= 256:
-                Z = Rgens[0].curve().zero() if Rgens else None
-                table = {}
-                if len(Rgens) == 1:
-                    R, = Rgens
-                    oR, = map(int, T2orders)
-                    cur = Z
-                    for a in range(oR):
-                        table[cur] = (a,)
-                        cur = cur + R
-                    mylog = lambda pt: table[pt]
-                elif len(Rgens) == 2:
-                    R, S = Rgens
-                    oR, oS = map(int, T2orders)
-                    rowR = Z
-                    for a in range(oR):
-                        cur = rowR
-                        for b in range(oS):
-                            table[cur] = (a, b)
-                            cur = cur + S
-                        rowR = rowR + R
-                    mylog = lambda pt: table[pt]
-                else:
-                    # no generators (trivial T2); mylog returns empty tuple
-                    mylog = lambda pt: ()
-            elif len(T2.invariants()) == 1:
-                R, = Rgens
+            if len(T2.invariants()) == 1:
+                R, = (g.element() for g in T2.gens())
                 mylog = lambda pt: (pt.log(R),)
             else:
-                R, S = Rgens
-                mylog = lambda pt: pt.log([R, S])
+                R, S = (g.element() for g in T2.gens())
+                mylog = lambda pt: pt.log([R,S])
 
             from sage.matrix.constructor import matrix
             from sage.matrix.special import diagonal_matrix
-            M = matrix(ZZ, map(mylog, imPs)).stack(diagonal_matrix(T2orders))
+            M = matrix(ZZ, map(mylog, imPs)).stack(diagonal_matrix([elt.order() for elt in T2.gens()]))
             K = M.left_kernel_matrix()[:,:len(Ps)]
 
             V = K.row_space(ZZ) / diagonal_matrix([P.order() for P in Ps]).row_space(ZZ)
@@ -714,37 +683,30 @@ class EllipticCurveHom(Morphism):
                 gens.append(Q)
 
             A = AdditiveAbelianGroupWrapper(T1.universe(), gens, [pt._order for pt in gens])
-            assert A.order().divides(self.separable_degree())
-            if A.order() != self.separable_degree():
+            assert A.order().divides(n)
+            if A.order() != n:
                 raise ValueError('kernel subgroup has no generating points over the base field')
             return A
 
         if algorithm != 'kerpoly':
             raise ValueError(f"invalid algorithm {algorithm}")
 
+        E = self.domain()
         f = self.kernel_polynomial()
-
-        if part:
-            f = f.gcd(E.division_polynomial(part))
 
         pts = []
 
         if not extend:
-            for x in self.kernel_polynomial().roots(multiplicities=False):
+            for x in f.roots(multiplicities=False):
                 try:
                     pts.append(E.lift_x(x))
                 except ValueError:
                     continue
                 A = AdditiveAbelianGroupWrapper.from_generators(pts)
                 pts = [g.element() for g in A.gens()]
-                if A.order() == self.separable_degree():
+                if A.order() == n:
                     return A
             raise ValueError('kernel subgroup has no generating points over the base field')
-
-        E = self.domain()
-        f = self.kernel_polynomial()
-
-        from sage.rings.polynomial.polynomial_ring import polygen
 
         K, to_K = f.splitting_field('u', map=True)
         EE = E.change_ring(to_K)
@@ -763,7 +725,7 @@ class EllipticCurveHom(Morphism):
 
             A = AdditiveAbelianGroupWrapper.from_generators(pts)
             pts = [g.element() for g in A.gens()]
-            if A.order() == self.separable_degree():
+            if A.order() == n:
                 break
 
         return A

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -653,7 +653,9 @@ class EllipticCurveHom(Morphism):
             o = T2.exponent()
             for imP in imPs:
                 imP.set_order(multiple=o)
-            Rgens = [g.element() for g in T2.gens()]
+            T2gens = list(T2.gens())
+            Rgens = [g.element() for g in T2gens]
+            T2orders = [g.order() for g in T2gens]
             # For small exponent, compute the discrete logarithms by
             # brute-force table lookup. Calling ``pt.log(...)`` dispatches
             # to ``pari.elllog``, which may internally reduce the elliptic
@@ -667,17 +669,19 @@ class EllipticCurveHom(Morphism):
                 table = {}
                 if len(Rgens) == 1:
                     R, = Rgens
+                    oR, = map(int, T2orders)
                     cur = Z
-                    for a in range(int(o)):
+                    for a in range(oR):
                         table[cur] = (a,)
                         cur = cur + R
                     mylog = lambda pt: table[pt]
                 elif len(Rgens) == 2:
                     R, S = Rgens
+                    oR, oS = map(int, T2orders)
                     rowR = Z
-                    for a in range(int(o)):
+                    for a in range(oR):
                         cur = rowR
-                        for b in range(int(o)):
+                        for b in range(oS):
                             table[cur] = (a, b)
                             cur = cur + S
                         rowR = rowR + R
@@ -694,7 +698,7 @@ class EllipticCurveHom(Morphism):
 
             from sage.matrix.constructor import matrix
             from sage.matrix.special import diagonal_matrix
-            M = matrix(ZZ, map(mylog, imPs)).stack(diagonal_matrix([elt.order() for elt in T2.gens()]))
+            M = matrix(ZZ, map(mylog, imPs)).stack(diagonal_matrix(T2orders))
             K = M.left_kernel_matrix()[:,:len(Ps)]
 
             V = K.row_space(ZZ) / diagonal_matrix([P.order() for P in Ps]).row_space(ZZ)

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -614,7 +614,7 @@ class EllipticCurveHom(Morphism):
             sage: E = EllipticCurve(GF(2), [1,0,0,0,1])
             sage: x = polygen(GF(2))
             sage: phi = E.isogeny(x^3 + x^2 + 1)
-            sage: phi.kernel_subgroup(extend=True)
+            sage: phi.kernel_subgroup(extend=True, algorithm='structure')
             Additive abelian group isomorphic to Z/7
               embedded in Abelian group of points on Elliptic Curve defined by y^2 + x*y = x^3 + 1
                 over Finite Field in t of size 2^42

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -653,12 +653,44 @@ class EllipticCurveHom(Morphism):
             o = T2.exponent()
             for imP in imPs:
                 imP.set_order(multiple=o)
-            if len(T2.invariants()) == 1:
-                R, = (g.element() for g in T2.gens())
+            Rgens = [g.element() for g in T2.gens()]
+            # For small exponent, compute the discrete logarithms by
+            # brute-force table lookup. Calling ``pt.log(...)`` dispatches
+            # to ``pari.elllog``, which may internally reduce the elliptic
+            # curve DLP to a discrete logarithm in the multiplicative group
+            # of the underlying finite field; the latter can become
+            # unexpectedly slow (or effectively hang) when ``q^k - 1``
+            # has a large hard-to-factor part, even though ``o`` itself is
+            # small.
+            if o <= 256:
+                Z = Rgens[0].curve().zero() if Rgens else None
+                table = {}
+                if len(Rgens) == 1:
+                    R, = Rgens
+                    cur = Z
+                    for a in range(int(o)):
+                        table[cur] = (a,)
+                        cur = cur + R
+                    mylog = lambda pt: table[pt]
+                elif len(Rgens) == 2:
+                    R, S = Rgens
+                    rowR = Z
+                    for a in range(int(o)):
+                        cur = rowR
+                        for b in range(int(o)):
+                            table[cur] = (a, b)
+                            cur = cur + S
+                        rowR = rowR + R
+                    mylog = lambda pt: table[pt]
+                else:
+                    # no generators (trivial T2); mylog returns empty tuple
+                    mylog = lambda pt: ()
+            elif len(T2.invariants()) == 1:
+                R, = Rgens
                 mylog = lambda pt: (pt.log(R),)
             else:
-                R, S = (g.element() for g in T2.gens())
-                mylog = lambda pt: pt.log([R,S])
+                R, S = Rgens
+                mylog = lambda pt: pt.log([R, S])
 
             from sage.matrix.constructor import matrix
             from sage.matrix.special import diagonal_matrix

--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -2425,57 +2425,6 @@ def is_kernel_polynomial(E, m, f):
     return True
 
 
-def _safe_factor(f):
-    r"""
-    Factor the univariate polynomial ``f`` robustly.
-
-    Over finite fields of non-prime order, the default PARI-based
-    factorization routine can (in some cases) enter an extremely slow
-    code path involving a finite-field discrete logarithm; this can
-    effectively hang for polynomials that are trivial to factor via
-    other backends.  This helper falls back to Singular whenever the
-    base ring is a finite non-prime field, which is reliable and
-    efficient for the division polynomials encountered here.
-
-    EXAMPLES::
-
-        sage: from sage.schemes.elliptic_curves.isogeny_small_degree import _safe_factor
-        sage: R.<x> = GF(4,'z2')[]
-        sage: _safe_factor(x^3 + 2*x + 1)
-        (x + 1) * (x + z2) * (x + z2 + 1)
-
-    TESTS::
-
-        sage: from sage.schemes.elliptic_curves.isogeny_small_degree import _safe_factor
-        sage: R.<x> = GF(4,'z2')[]
-        sage: _safe_factor(x^3 + x + 1)
-        x^3 + x + 1
-    """
-    R = f.parent().base_ring()
-    from sage.rings.finite_rings.finite_field_base import FiniteField
-    if isinstance(R, FiniteField) and not R.is_prime_field():
-        from sage.structure.factorization import Factorization
-        try:
-            P = f.parent()
-            P._singular_().set_ring()
-            S = f._singular_().factorize()
-            fac_list = S[1]
-            exp_list = S[2]
-            unit = P.one()
-            pairs = []
-            for i in range(len(fac_list)):
-                g = P(fac_list[i + 1])
-                e = ZZ(exp_list[i + 1])
-                if g.is_unit():
-                    unit = unit * g**e
-                else:
-                    pairs.append((g, e))
-            return Factorization(pairs, unit=unit)
-        except (TypeError, AttributeError, NotImplementedError):
-            pass
-    return f.factor()
-
-
 def isogenies_prime_degree_general(E, l, minimal_models=True):
     """
     Return all separable ``l``-isogenies with domain ``E``.
@@ -2648,7 +2597,7 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
 
     psi_l = E.division_polynomial(l)
 
-    factors = [h for h,_ in _safe_factor(psi_l) if h.degree().divides(l//2)]
+    factors = [h for h,_ in psi_l.factor() if h.degree().divides(l//2)]
 
     kernels = []  # will store all kernel polynomials found
 

--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -2425,6 +2425,41 @@ def is_kernel_polynomial(E, m, f):
     return True
 
 
+def _factor_division_polynomial_with_singular(f):
+    r"""
+    Return the factorization of a division polynomial.
+
+    Use Singular for extension finite fields: PARI's finite-field
+    factorization can be very slow on some binary extension fields.
+
+    TESTS::
+
+        sage: from sage.schemes.elliptic_curves.isogeny_small_degree import _factor_division_polynomial_with_singular
+        sage: F.<a> = GF(8)
+        sage: E = EllipticCurve(F, [1, 0, 0, 0, a^2 + a])
+        sage: psi = E.division_polynomial(19)
+        sage: factorization = _factor_division_polynomial_with_singular(psi)
+        sage: [g.degree() for g, _ in factorization]
+        [9, 9, 18, 18, 18, 18, 18, 18, 18, 18, 18]
+    """
+    R = f.base_ring()
+    if R.is_finite() and hasattr(R, 'is_prime_field') and not R.is_prime_field():
+        P = f.parent()
+        if P._has_singular:
+            P._singular_().set_ring()
+            S = f._singular_().factorize()
+            factors = S[1]
+            exponents = S[2]
+            result = []
+            for i in range(len(factors)):
+                factor = P(factors[i + 1])
+                if not factor.is_unit():
+                    result.append((factor, ZZ(exponents[i + 1])))
+            return sorted(result)
+
+    return list(f.factor())
+
+
 def isogenies_prime_degree_general(E, l, minimal_models=True):
     """
     Return all separable ``l``-isogenies with domain ``E``.
@@ -2587,6 +2622,14 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
         ....:  for phi in E.isogenies_prime_degree(37)]
         [(0, 0, 0, 840*i + 1081, 0),
          (0, 0, 0, -840*i + 1081, 0)]
+
+    Check a binary extension field where PARI factorization of the
+    division polynomial can be very slow::
+
+        sage: F.<a> = GF(8)
+        sage: E = EllipticCurve(F, [1, 0, 0, 0, a^2 + a])
+        sage: [phi.degree() for phi in isogenies_prime_degree_general(E, 19)]
+        [19, 19]
     """
     if not l.is_prime():
         raise ValueError(f"{l} is not prime")
@@ -2597,7 +2640,8 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
 
     psi_l = E.division_polynomial(l)
 
-    factors = [h for h,_ in psi_l.factor() if h.degree().divides(l//2)]
+    factors = [h for h, _ in _factor_division_polynomial_with_singular(psi_l)
+               if h.degree().divides(l//2)]
 
     kernels = []  # will store all kernel polynomials found
 

--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -2425,6 +2425,57 @@ def is_kernel_polynomial(E, m, f):
     return True
 
 
+def _safe_factor(f):
+    r"""
+    Factor the univariate polynomial ``f`` robustly.
+
+    Over finite fields of non-prime order, the default PARI-based
+    factorization routine can (in some cases) enter an extremely slow
+    code path involving a finite-field discrete logarithm; this can
+    effectively hang for polynomials that are trivial to factor via
+    other backends.  This helper falls back to Singular whenever the
+    base ring is a finite non-prime field, which is reliable and
+    efficient for the division polynomials encountered here.
+
+    EXAMPLES::
+
+        sage: from sage.schemes.elliptic_curves.isogeny_small_degree import _safe_factor
+        sage: R.<x> = GF(4,'z2')[]
+        sage: _safe_factor(x^3 + 2*x + 1)
+        (x + 1) * (x + z2) * (x + z2 + 1)
+
+    TESTS::
+
+        sage: from sage.schemes.elliptic_curves.isogeny_small_degree import _safe_factor
+        sage: R.<x> = GF(4,'z2')[]
+        sage: _safe_factor(x^3 + x + 1)
+        x^3 + x + 1
+    """
+    R = f.parent().base_ring()
+    from sage.rings.finite_rings.finite_field_base import FiniteField
+    if isinstance(R, FiniteField) and not R.is_prime_field():
+        from sage.structure.factorization import Factorization
+        try:
+            P = f.parent()
+            P._singular_().set_ring()
+            S = f._singular_().factorize()
+            fac_list = S[1]
+            exp_list = S[2]
+            unit = P.one()
+            pairs = []
+            for i in range(len(fac_list)):
+                g = P(fac_list[i + 1])
+                e = ZZ(exp_list[i + 1])
+                if g.is_unit():
+                    unit = unit * g**e
+                else:
+                    pairs.append((g, e))
+            return Factorization(pairs, unit=unit)
+        except (TypeError, AttributeError, NotImplementedError):
+            pass
+    return f.factor()
+
+
 def isogenies_prime_degree_general(E, l, minimal_models=True):
     """
     Return all separable ``l``-isogenies with domain ``E``.
@@ -2597,7 +2648,7 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
 
     psi_l = E.division_polynomial(l)
 
-    factors = [h for h,_ in psi_l.factor() if h.degree().divides(l//2)]
+    factors = [h for h,_ in _safe_factor(psi_l) if h.degree().divides(l//2)]
 
     kernels = []  # will store all kernel polynomials found
 


### PR DESCRIPTION
for `extend=True` prime-degree kernels over finite fields, `kernel_subgroup()` defaulted to the "structure" algorithm, which constructs the full n-torsion field. With the bad seed this hit a degree-17 case over `GF(29^2)` and stalled before producing the kernel. The "kerpoly" path is the right tool for prime-degree kernels, but it had stale broken code (part undefined, E used too late), so it was not usable.

Fix:
For finite fields, `extend=True` and prime separable degree now default to "kerpoly" instead of full torsion structure.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->
#42049 

