### PR TITLE
src/sage/typeset: remove all "needs sage.foo" tags

### DIFF
--- a/src/sage/typeset/ascii_art.py
+++ b/src/sage/typeset/ascii_art.py
@@ -14,7 +14,6 @@ AUTHOR:
 
 EXAMPLES::
 
-    sage: # needs sage.symbolic
     sage: n = var('n')
     sage: integrate(n^2/x, x)
     n^2*log(x)
@@ -27,7 +26,7 @@ EXAMPLES::
     ---------
         pi
 
-    sage: ascii_art(list(Partitions(6)))                                                # needs sage.combinat sage.libs.flint
+    sage: ascii_art(list(Partitions(6)))
     [                                                       * ]
     [                                                   **  * ]
     [                                      ***      **  *   * ]
@@ -41,19 +40,19 @@ manager activated by the magic function: ``%display ascii_art``::
     sage: from sage.repl.interpreter import get_test_shell
     sage: shell = get_test_shell()
     sage: shell.run_cell('%display ascii_art')
-    sage: shell.run_cell("i = var('i')")                                                # needs sage.symbolic
-    sage: shell.run_cell('sum(factorial(i)*x^i, i, 0, 10)')                             # needs sage.symbolic
+    sage: shell.run_cell("i = var('i')")
+    sage: shell.run_cell('sum(factorial(i)*x^i, i, 0, 10)')
              10           9          8         7        6        5       4      3...
     3628800*x   + 362880*x  + 40320*x  + 5040*x  + 720*x  + 120*x  + 24*x  + 6*x...
     <BLANKLINE>
     ...2
     ...+ 2*x  + x + 1
 
-    sage: shell.run_cell('3/(7*x)')                                                     # needs sage.symbolic
+    sage: shell.run_cell('3/(7*x)')
      3
     ---
     7*x
-    sage: shell.run_cell('list(Compositions(5))')                                       # needs sage.combinat
+    sage: shell.run_cell('list(Compositions(5))')
     [ *
     [ *  **   *        *                   *
     [ *  *   **  ***   *   **    *         *   **    *          *
@@ -175,8 +174,8 @@ class AsciiArt(CharacterArt):
 
     EXAMPLES::
 
-        sage: i = var('i')                                                              # needs sage.symbolic
-        sage: ascii_art(sum(pi^i/factorial(i)*x^i, i, 0, oo))                           # needs sage.symbolic
+        sage: i = var('i')
+        sage: ascii_art(sum(pi^i/factorial(i)*x^i, i, 0, oo))
          pi*x
         e
     """
@@ -215,9 +214,9 @@ def ascii_art(*obj, **kwds):
 
     EXAMPLES::
 
-        sage: result = ascii_art(integral(exp(x+x^2)/(x+1), x))                         # needs sage.symbolic
+        sage: result = ascii_art(integral(exp(x+x^2)/(x+1), x))
         ...
-        sage: result                                                                    # needs sage.symbolic
+        sage: result
             /
            |
            |   2
@@ -231,21 +230,21 @@ def ascii_art(*obj, **kwds):
     We can specify a separator object::
 
         sage: ident = lambda n: identity_matrix(ZZ, n)
-        sage: ascii_art(ident(1), ident(2), ident(3), sep=' : ')                        # needs sage.modules
+        sage: ascii_art(ident(1), ident(2), ident(3), sep=' : ')
                       [1 0 0]
               [1 0]   [0 1 0]
         [1] : [0 1] : [0 0 1]
 
     We can specify the baseline::
 
-        sage: ascii_art(ident(2), baseline=-1) + ascii_art(ident(3))                    # needs sage.modules
+        sage: ascii_art(ident(2), baseline=-1) + ascii_art(ident(3))
         [1 0][1 0 0]
         [0 1][0 1 0]
              [0 0 1]
 
     We can determine the baseline of the separator::
 
-        sage: ascii_art(ident(1), ident(2), ident(3), sep=' -- ', sep_baseline=-1)      # needs sage.modules
+        sage: ascii_art(ident(1), ident(2), ident(3), sep=' -- ', sep_baseline=-1)
                         [1 0 0]
             -- [1 0] -- [0 1 0]
         [1]    [0 1]    [0 0 1]
@@ -254,7 +253,7 @@ def ascii_art(*obj, **kwds):
     an ascii art separator::
 
         sage: sep_line = ascii_art('\n'.join(' | ' for _ in range(6)), baseline=6)
-        sage: ascii_art(*Partitions(6), separator=sep_line, sep_baseline=0)             # needs sage.combinat sage.libs.flint
+        sage: ascii_art(*Partitions(6), separator=sep_line, sep_baseline=0)
                |       |      |      |     |     |     |    |    |    | *
                |       |      |      |     |     |     |    |    | ** | *
                |       |      |      |     |     | *** |    | ** | *  | *
@@ -264,14 +263,14 @@ def ascii_art(*obj, **kwds):
 
     TESTS::
 
-        sage: n = var('n')                                                              # needs sage.symbolic
-        sage: ascii_art(sum(binomial(2 * n, n + 1) * x^n, n, 0, oo))                    # needs sage.symbolic
+        sage: n = var('n')
+        sage: ascii_art(sum(binomial(2 * n, n + 1) * x^n, n, 0, oo))
          /        _________    \
         -\2*x + \/ 1 - 4*x  - 1/
         -------------------------
                    _________
              2*x*\/ 1 - 4*x
-        sage: ascii_art(list(DyckWords(3)))                                             # needs sage.combinat
+        sage: ascii_art(list(DyckWords(3)))
         [                                   /\   ]
         [            /\    /\      /\/\    /  \  ]
         [ /\/\/\, /\/  \, /  \/\, /    \, /    \ ]

--- a/src/sage/typeset/character_art.py
+++ b/src/sage/typeset/character_art.py
@@ -57,8 +57,8 @@ class CharacterArt(SageObject):
 
         EXAMPLES::
 
-            sage: i = var('i')                                                          # needs sage.symbolic
-            sage: ascii_art(sum(pi^i/factorial(i)*x^i, i, 0, oo))                       # needs sage.symbolic
+            sage: i = var('i')
+            sage: ascii_art(sum(pi^i/factorial(i)*x^i, i, 0, oo))
              pi*x
             e
 
@@ -158,10 +158,10 @@ class CharacterArt(SageObject):
 
         EXAMPLES::
 
-            sage: M = matrix([[1,2],[3,4]])                                             # needs sage.modules
-            sage: format(ascii_art(M))                                                  # needs sage.modules
+            sage: M = matrix([[1,2],[3,4]])
+            sage: format(ascii_art(M))
             '[1 2]\n[3 4]'
-            sage: format(unicode_art(M))                                                # needs sage.modules
+            sage: format(unicode_art(M))
             '\u239b1 2\u239e\n\u239d3 4\u23a0'
         """
         return format(str(self), fmt)

--- a/src/sage/typeset/character_art_factory.py
+++ b/src/sage/typeset/character_art_factory.py
@@ -78,9 +78,9 @@ class CharacterArtFactory(SageObject):
 
         EXAMPLES::
 
-            sage: result = ascii_art(integral(exp(x+x^2)/(x+1), x))                     # needs sage.symbolic
+            sage: result = ascii_art(integral(exp(x+x^2)/(x+1), x))
             ...
-            sage: result                                                                # needs sage.symbolic
+            sage: result
                 /
                |
                |   2
@@ -93,14 +93,14 @@ class CharacterArtFactory(SageObject):
 
         TESTS::
 
-            sage: n = var('n')                                                          # needs sage.symbolic
-            sage: ascii_art(sum(binomial(2 * n, n + 1) * x^n, n, 0, oo))                # needs sage.symbolic
+            sage: n = var('n')
+            sage: ascii_art(sum(binomial(2 * n, n + 1) * x^n, n, 0, oo))
              /        _________    \
             -\2*x + \/ 1 - 4*x  - 1/
             -------------------------
                        _________
                  2*x*\/ 1 - 4*x
-            sage: ascii_art(list(DyckWords(3)))                                         # needs sage.combinat
+            sage: ascii_art(list(DyckWords(3)))
             [                                   /\   ]
             [            /\    /\      /\/\    /  \  ]
             [ /\/\/\, /\/  \, /  \/\, /    \, /    \ ]
@@ -150,10 +150,10 @@ class CharacterArtFactory(SageObject):
         EXAMPLES::
 
             sage: from sage.typeset.ascii_art import _ascii_art_factory as factory
-            sage: out = factory.build_from_magic_method(identity_matrix(2));  out       # needs sage.modules
+            sage: out = factory.build_from_magic_method(identity_matrix(2));  out
             [1 0]
             [0 1]
-            sage: type(out)                                                             # needs sage.modules
+            sage: type(out)
             <class 'sage.typeset.ascii_art.AsciiArt'>
         """
         magic_method = getattr(obj, self.magic_method_name)
@@ -228,12 +228,12 @@ class CharacterArtFactory(SageObject):
 
         TESTS::
 
-            sage: l = ascii_art(list(DyckWords(3)))  # indirect doctest                 # needs sage.combinat
-            sage: l                                                                     # needs sage.combinat
+            sage: l = ascii_art(list(DyckWords(3)))  # indirect doctest
+            sage: l
             [                                   /\   ]
             [            /\    /\      /\/\    /  \  ]
             [ /\/\/\, /\/  \, /  \/\, /    \, /    \ ]
-            sage: l._breakpoints                                                        # needs sage.combinat
+            sage: l._breakpoints
             [9, 17, 25, 33]
 
         Check that zero-height strings are handled (:issue:`28527`)::
@@ -274,7 +274,7 @@ class CharacterArtFactory(SageObject):
         iteration over sets is non-deterministic so too is the results of this
         test::
 
-            sage: ascii_art(set(DyckWords(3)))  # indirect doctest random               # needs sage.combinat
+            sage: ascii_art(set(DyckWords(3)))  # indirect doctest random
             {                                   /\   }
             {  /\      /\/\              /\    /  \  }
             { /  \/\, /    \, /\/\/\, /\/  \, /    \ }
@@ -283,7 +283,7 @@ class CharacterArtFactory(SageObject):
         a set, but still obtain the same output formatting::
 
             sage: from sage.typeset.ascii_art import _ascii_art_factory as factory
-            sage: factory.build_set(sorted(set(DyckWords(3))))                          # needs sage.combinat
+            sage: factory.build_set(sorted(set(DyckWords(3))))
             {                                   /\   }
             {            /\    /\      /\/\    /  \  }
             { /\/\/\, /\/  \, /  \/\, /    \, /    \ }
@@ -300,7 +300,6 @@ class CharacterArtFactory(SageObject):
 
         TESTS::
 
-            sage: # needs sage.combinat
             sage: from collections import OrderedDict
             sage: d = OrderedDict(enumerate(DyckWords(3)))
             sage: art = ascii_art(d)  # indirect doctest
@@ -343,18 +342,18 @@ class CharacterArtFactory(SageObject):
 
         TESTS::
 
-            sage: l = ascii_art(list(DyckWords(3)))  # indirect doctest                 # needs sage.combinat
-            sage: l                                                                     # needs sage.combinat
+            sage: l = ascii_art(list(DyckWords(3)))  # indirect doctest
+            sage: l
             [                                   /\   ]
             [            /\    /\      /\/\    /  \  ]
             [ /\/\/\, /\/  \, /  \/\, /    \, /    \ ]
-            sage: l._breakpoints                                                        # needs sage.combinat
+            sage: l._breakpoints
             [9, 17, 25, 33]
 
         The breakpoints of the object are used as breakpoints::
 
-            sage: l = ascii_art([DyckWords(2).list(), DyckWords(2).list()])             # needs sage.combinat
-            sage: l._breakpoints                                                        # needs sage.combinat
+            sage: l = ascii_art([DyckWords(2).list(), DyckWords(2).list()])
+            sage: l._breakpoints
             [(2, [7]), 17, (18, [7])]
 
         The parentheses only stretch as high as the content (:issue:`28527`)::
@@ -385,7 +384,7 @@ class CharacterArtFactory(SageObject):
 
         TESTS::
 
-            sage: ascii_art(tuple(DyckWords(3)))  # indirect doctest                    # needs sage.combinat
+            sage: ascii_art(tuple(DyckWords(3)))  # indirect doctest
             (                                   /\   )
             (            /\    /\      /\/\    /  \  )
             ( /\/\/\, /\/  \, /  \/\, /    \, /    \ )
@@ -426,8 +425,8 @@ class CharacterArtFactory(SageObject):
 
         EXAMPLES::
 
-            sage: i2 = identity_matrix(2)                                               # needs sage.modules
-            sage: ascii_art(i2, i2, i2, sep=ascii_art(1/x))                             # needs sage.modules sage.symbolic
+            sage: i2 = identity_matrix(2)
+            sage: ascii_art(i2, i2, i2, sep=ascii_art(1/x))
                  1     1
             [1 0]-[1 0]-[1 0]
             [0 1]x[0 1]x[0 1]

--- a/src/sage/typeset/unicode_art.py
+++ b/src/sage/typeset/unicode_art.py
@@ -43,8 +43,8 @@ class UnicodeArt(CharacterArt):
 
     EXAMPLES::
 
-        sage: i = var('i')                                                              # needs sage.symbolic
-        sage: unicode_art(sum(pi^i/factorial(i)*x^i, i, 0, oo))                         # needs sage.symbolic
+        sage: i = var('i')
+        sage: unicode_art(sum(pi^i/factorial(i)*x^i, i, 0, oo))
          π⋅x
         ℯ
     """
@@ -83,9 +83,9 @@ def unicode_art(*obj, **kwds):
 
     EXAMPLES::
 
-        sage: result = unicode_art(integral(exp(sqrt(x))/(x+pi), x))                    # needs sage.symbolic
+        sage: result = unicode_art(integral(exp(sqrt(x))/(x+pi), x))
         ...
-        sage: result                                                                    # needs sage.symbolic
+        sage: result
             ⌠
             ⎮   √x
             ⎮  ℯ
@@ -93,7 +93,7 @@ def unicode_art(*obj, **kwds):
             ⎮ x + π
             ⌡
         sage: ident = lambda n: identity_matrix(ZZ, n)
-        sage: unicode_art(ident(1), ident(2), ident(3), sep=' : ')                      # needs sage.modules
+        sage: unicode_art(ident(1), ident(2), ident(3), sep=' : ')
                       ⎛1 0 0⎞
               ⎛1 0⎞   ⎜0 1 0⎟
         (1) : ⎝0 1⎠ : ⎝0 0 1⎠
@@ -102,7 +102,7 @@ def unicode_art(*obj, **kwds):
     an unicode art separator::
 
         sage: sep_line = unicode_art('\n'.join(' ⎟ ' for _ in range(5)), baseline=5)
-        sage: unicode_art(*AlternatingSignMatrices(3),                                  # needs sage.combinat sage.modules
+        sage: unicode_art(*AlternatingSignMatrices(3),
         ....:             separator=sep_line, sep_baseline=1)
                 ⎟         ⎟         ⎟            ⎟         ⎟         ⎟
         ⎛1 0 0⎞ ⎟ ⎛0 1 0⎞ ⎟ ⎛1 0 0⎞ ⎟ ⎛ 0  1  0⎞ ⎟ ⎛0 0 1⎞ ⎟ ⎛0 1 0⎞ ⎟ ⎛0 0 1⎞
@@ -112,14 +112,14 @@ def unicode_art(*obj, **kwds):
 
     TESTS::
 
-        sage: n = var('n')                                                              # needs sage.symbolic
-        sage: unicode_art(sum(binomial(2 * n, n + 1) * x^n, n, 0, oo))                  # needs sage.symbolic
+        sage: n = var('n')
+        sage: unicode_art(sum(binomial(2 * n, n + 1) * x^n, n, 0, oo))
          ⎛        _________    ⎞
         -⎝2⋅x + ╲╱ 1 - 4⋅x  - 1⎠
         ─────────────────────────
                    _________
              2⋅x⋅╲╱ 1 - 4⋅x
-        sage: unicode_art(list(DyckWords(3)))                                           # needs sage.combinat
+        sage: unicode_art(list(DyckWords(3)))
         ⎡                                   ╱╲   ⎤
         ⎢            ╱╲    ╱╲      ╱╲╱╲    ╱  ╲  ⎥
         ⎣ ╱╲╱╲╱╲, ╱╲╱  ╲, ╱  ╲╱╲, ╱    ╲, ╱    ╲ ⎦


### PR DESCRIPTION
These are unmaintained, and do nothing in the upstream SageMath.
