### PR TITLE
src/sage/sat: remove all "needs sage.foo" tags

### DIFF
--- a/src/sage/sat/boolean_polynomials.py
+++ b/src/sage/sat/boolean_polynomials.py
@@ -1,4 +1,4 @@
-# sage.doctest: optional - pycryptosat, needs sage.modules brial
+# sage.doctest: optional - pycryptosat, needs brial
 """
 SAT Functions for Boolean Polynomials
 

--- a/src/sage/sat/solvers/dimacs.py
+++ b/src/sage/sat/solvers/dimacs.py
@@ -509,14 +509,14 @@ class DIMACS(SatSolver):
         TESTS::
 
             sage: from sage.sat.boolean_polynomials import solve as solve_sat
-            sage: sr = mq.SR(1, 1, 1, 4, gf2=True, polybori=True)                       # needs sage.rings.finite_rings brial
-            sage: while True:  # workaround (see :issue:`31891`)                         # needs sage.rings.finite_rings brial
+            sage: sr = mq.SR(1, 1, 1, 4, gf2=True, polybori=True)                       # needs brial
+            sage: while True:  # workaround (see :issue:`31891`)                         # needs brial
             ....:     try:
             ....:         F, s = sr.polynomial_system()
             ....:         break
             ....:     except ZeroDivisionError:
             ....:         pass
-            sage: solve_sat(F, solver=sage.sat.solvers.RSat)    # optional - rsat, needs sage.rings.finite_rings brial
+            sage: solve_sat(F, solver=sage.sat.solvers.RSat)    # optional - rsat, needs brial
         """
         if assumptions is not None:
             raise NotImplementedError("Assumptions are not supported for DIMACS based solvers.")

--- a/src/sage/sat/solvers/sat_lp.py
+++ b/src/sage/sat/solvers/sat_lp.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.numerical.mip
 r"""
 Solve SAT problems Integer Linear Programming
 

--- a/src/sage/sat/solvers/satsolver.pyx
+++ b/src/sage/sat/solvers/satsolver.pyx
@@ -139,9 +139,9 @@ cdef class SatSolver:
 
             sage: from io import StringIO
             sage: file_object = StringIO("c A sample .cnf file with xor clauses.\np cnf 3 3\n1 2 0\n3 0\nx1 2 3 0")
-            sage: from sage.sat.solvers.sat_lp import SatLP                             # needs sage.numerical.mip
-            sage: solver = SatLP()                                                      # needs sage.numerical.mip
-            sage: solver.read(file_object)                                              # needs sage.numerical.mip
+            sage: from sage.sat.solvers.sat_lp import SatLP
+            sage: solver = SatLP()
+            sage: solver.read(file_object)
             Traceback (most recent call last):
             ...
             NotImplementedError: the solver "an ILP-based SAT Solver" does not support xor clauses
@@ -338,7 +338,7 @@ def SAT(solver=None, *args, **kwds):
 
     EXAMPLES::
 
-        sage: SAT(solver='LP')                                                          # needs sage.numerical.mip
+        sage: SAT(solver='LP')
         an ILP-based SAT Solver
 
     TESTS::


### PR DESCRIPTION
These are unmaintained, and do nothing in upstream SageMath.
