### PR TITLE
Improve control over libhomfly detection

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -49,6 +49,13 @@ option(
 )
 
 option(
+  'libhomfly',
+  type: 'feature',
+  value: 'auto',
+  description: 'libhomfly interface to the homfly polynomial of a link'
+)
+
+option(
   'mcqd',
   type: 'feature',
   value: 'auto',

--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -49,6 +49,7 @@ Features
    sage/features/kenzo
    sage/features/latex
    sage/features/latte
+   sage/features/libhomfly
    sage/features/lrs
    sage/features/mcqd
    sage/features/meataxe

--- a/src/sage/features/libhomfly.py
+++ b/src/sage/features/libhomfly.py
@@ -1,0 +1,38 @@
+r"""
+Feature for testing the presence of libhomfly
+"""
+
+from sage.features.join_feature import JoinFeature
+from sage.features import PythonModule
+
+
+class Libhomfly(JoinFeature):
+    r"""
+    A :class:`sage.features.Feature` describing the presence of
+    :mod:`sage.libs.homfly`, the interface to libhomfly.
+
+    TESTS::
+
+        sage: from sage.features.libhomfly import Libhomfly
+        sage: Libhomfly().is_present()  # needs libhomfly
+        FeatureTestResult('libhomfly', True)
+        sage: Libhomfly().is_present()  # needs !libhomfly
+        FeatureTestResult('sage.libs.homfly', False)
+
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.libhomfly import Libhomfly
+            sage: isinstance(Libhomfly(), Libhomfly)
+            True
+
+        """
+        JoinFeature.__init__(self, 'libhomfly',
+                             [PythonModule('sage.libs.homfly')],
+                             spkg='libhomfly', type='standard')
+
+
+def all_features():
+    return [Libhomfly()]

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -538,31 +538,6 @@ class sage__libs__giac(JoinFeature):
                              spkg='sagemath_giac', type='optional')
 
 
-class sage__libs__homfly(JoinFeature):
-    r"""
-    A :class:`sage.features.Feature` describing the presence of :mod:`sage.libs.homfly`.
-
-    In addition to the modularization purposes that this tag serves,
-    it also provides attribution to the upstream project.
-
-    TESTS::
-
-        sage: from sage.features.sagemath import sage__libs__homfly
-        sage: sage__libs__homfly().is_present()                                         # needs sage.libs.homfly
-        FeatureTestResult('sage.libs.homfly', True)
-    """
-    def __init__(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features.sagemath import sage__libs__homfly
-            sage: isinstance(sage__libs__homfly(), sage__libs__homfly)
-            True
-        """
-        JoinFeature.__init__(self, 'sage.libs.homfly',
-                             [PythonModule('sage.libs.homfly')],
-                             spkg='sagemath_homfly', type='standard')
-
 
 class sage__libs__pari(JoinFeature):
     r"""
@@ -1134,7 +1109,6 @@ def all_features():
         sage__libs__flint(),
         sage__libs__gap(),
         sage__libs__giac(),
-        sage__libs__homfly(),
         sage__libs__linbox(),
         sage__libs__m4ri(),
         sage__libs__ntl(),

--- a/src/sage/knots/free_knotinfo_monoid.py
+++ b/src/sage/knots/free_knotinfo_monoid.py
@@ -221,6 +221,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: K = KnotInfo.K5_1.link().mirror_image()
@@ -301,6 +302,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: FKIM.inject_variables(select=3)
@@ -368,6 +370,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: K = KnotInfo.K5_1.link().mirror_image()
@@ -396,6 +399,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: K = KnotInfo.K5_1.link().mirror_image()

--- a/src/sage/knots/knot.py
+++ b/src/sage/knots/knot.py
@@ -442,7 +442,7 @@ class Knot(Link, Element, metaclass=InheritComparisonClasscallMetaclass):
             [(4, 1), (2, 5), (6, 3), (10, 7), (8, 11), (12, 9)]
             sage: K2.dowker_notation()
             [(4, 1), (2, 5), (6, 3), (7, 10), (11, 8), (9, 12)]
-            sage: K.homfly_polynomial() == K2.homfly_polynomial()
+            sage: K.homfly_polynomial() == K2.homfly_polynomial()  # needs libhomfly
             False
 
         TESTS::

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -128,6 +128,7 @@ types::
 
 Obtaining the HOMFLY-PT polynomial::
 
+    sage: # needs libhomfly
     sage: L.homfly_polynomial()
     -v^-1*z - v^-3*z - v^-3*z^-1 + v^-5*z^-1
     sage: _ == l.homfly_polynomial(normalization='vz')
@@ -200,6 +201,7 @@ will be reduced to proper links with 7 crossings.
 Finally there is a method :meth:`Link.get_knotinfo` of class :class:`Link` to find an instance
 in the KnotInfo database::
 
+    sage: # needs libhomfly
     sage: L = Link([[3,1,2,4], [8,9,1,7], [5,6,7,3], [4,18,6,5],
     ....:           [17,19,8,18], [9,10,11,14], [10,12,13,11],
     ....:           [12,19,15,13], [20,16,14,15], [16,20,17,2]])
@@ -614,6 +616,7 @@ class KnotInfoBase(Enum):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: L = KnotInfo.L4a1_1
             sage: L._homfly_pol_ring('u', 'v')
             Multivariate Laurent Polynomial Ring in u, v over Integer Ring
@@ -1385,6 +1388,7 @@ class KnotInfoBase(Enum):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: K3_1 = KnotInfo.K3_1
             sage: PK3_1 = K3_1.homfly_polynomial(); PK3_1
             -v^4 + v^2*z^2 + 2*v^2
@@ -1395,6 +1399,7 @@ class KnotInfoBase(Enum):
 
         for proper links::
 
+            sage: # needs libhomfly
             sage: L4a1_1 = KnotInfo.L4a1_1
             sage: PL4a1_1 = L4a1_1.homfly_polynomial(var1='x', var2='y'); PL4a1_1
             -x^5*y + x^3*y^3 - x^5*y^-1 + 3*x^3*y + x^3*y^-1
@@ -1404,6 +1409,7 @@ class KnotInfoBase(Enum):
         check the skein-relation from the KnotInfo description page (applied to one
         of the positive crossings of the right-handed trefoil)::
 
+            sage: # needs libhomfly
             sage: R = PK3_1.parent()
             sage: PO = R.one()
             sage: L2a1_1 = KnotInfo.L2a1_1
@@ -1414,6 +1420,7 @@ class KnotInfoBase(Enum):
 
         TESTS::
 
+            sage: # needs libhomfly
             sage: H = KnotInfo.L11n459_1_1_1.homfly_polynomial()   # optional - database_knotinfo
             sage: all(L.homfly_polynomial() == L.link().homfly_polynomial(normalization='vz')\
             ....:     for L in KnotInfo if L.crossing_number() < 7)
@@ -2246,6 +2253,7 @@ class KnotInfoBase(Enum):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: KnotInfo.L4a1_0.is_unique()
             True
             sage: KnotInfo.L5a1_0.is_unique()
@@ -2299,6 +2307,7 @@ class KnotInfoBase(Enum):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: KnotInfo.L4a1_0.inject()
             Defining L4a1_0
             sage: L4a1_0.is_recoverable()
@@ -2812,6 +2821,7 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: KnotInfo.L4a1_0.series().inject()
             Defining L4a
             sage: L4a.is_recoverable()

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -4313,6 +4313,7 @@ class Link(SageObject):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: KnotInfo.L4a1_0.inject()
             Defining L4a1_0
             sage: L4a1_0.link()._knotinfo_matching_dict()
@@ -4423,7 +4424,7 @@ class Link(SageObject):
             sage: b, = BraidGroup(2).gens()
             sage: Link(b**13).get_knotinfo()    # optional - database_knotinfo
             KnotInfo['K13a_4878']
-            sage: Link(b**14).get_knotinfo()
+            sage: Link(b**14).get_knotinfo()    # needs libhomfly
             Traceback (most recent call last):
             ...
             NotImplementedError: this link having more than 11 crossings cannot be determined
@@ -4438,6 +4439,7 @@ class Link(SageObject):
 
         Lets identify the monster unknot::
 
+            sage: # needs libhomfly
             sage: L = Link([[3,1,2,4], [8,9,1,7], [5,6,7,3], [4,18,6,5],
             ....:           [17,19,8,18], [9,10,11,14], [10,12,13,11],
             ....:           [12,19,15,13], [20,16,14,15], [16,20,17,2]])
@@ -4446,6 +4448,7 @@ class Link(SageObject):
 
         Usage of option ``mirror_version``::
 
+            sage: # needs libhomfly
             sage: L.get_knotinfo(mirror_version=False) == KnotInfo.K0_1
             True
 
@@ -4488,6 +4491,7 @@ class Link(SageObject):
         the same unoriented name (according to the note above) the option can be
         used to achieve more detailed information::
 
+            sage: # needs libhomfly
             sage: L2a1 = Link(b**2)
             sage: L2a1.get_knotinfo()
             (Series of links L2a1, <SymmetryMutant.mixed: 'x'>)
@@ -4495,6 +4499,7 @@ class Link(SageObject):
             [(<KnotInfo.L2a1_0: 'L2a1{0}'>, <SymmetryMutant.mirror_image: 'm'>),
              (<KnotInfo.L2a1_1: 'L2a1{1}'>, <SymmetryMutant.itself: 's'>)]
 
+            sage: # needs libhomfly
             sage: KnotInfo.L5a1_0.inject()
             Defining L5a1_0
             sage: l5 = Link(L5a1_0.braid())
@@ -4560,6 +4565,7 @@ class Link(SageObject):
 
         Non prime knots can be detected, as well::
 
+            sage: # needs libhomfly
             sage: b = BraidGroup(4)((1, 2, 2, 2, -1, 2, 2, 2, -3, -3, -3))
             sage: Kb = Knot(b)
             sage: Kb.get_knotinfo()
@@ -4593,6 +4599,7 @@ class Link(SageObject):
              (<KnotInfo.L10a151_1_0: 'L10a151{1,0}'>, <SymmetryMutant.unknown: '?'>),
              (<KnotInfo.L10a151_1_1: 'L10a151{1,1}'>, <SymmetryMutant.unknown: '?'>)]
 
+            sage: # needs libhomfly
             sage: L = KnotInfo.L6a2_0
             sage: L1 = L.link()
             sage: L2 = L.link(L.items.braid_notation)
@@ -4768,6 +4775,7 @@ class Link(SageObject):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: l1 = Link([[2, 9, 3, 10], [4, 13, 5, 14], [6, 11, 7, 12],
             ....:            [8, 1, 9, 2], [10, 7, 11, 8], [12, 5, 13, 6],
             ....:            [14, 3, 1, 4]])
@@ -4777,6 +4785,7 @@ class Link(SageObject):
             sage: l1.is_isotopic(l2)
             True
 
+            sage: # needs libhomfly
             sage: l3 = l2.mirror_image()
             sage: l1.is_isotopic(l3)
             False
@@ -4799,6 +4808,7 @@ class Link(SageObject):
 
         Using verbosity::
 
+            sage: # needs libhomfly
             sage: set_verbose(1)
             sage: l1.is_isotopic(l2)
             verbose 1 (... link.py, is_isotopic) identified by KnotInfo (KnotInfo.K7_2, SymmetryMutant.mirror_image)
@@ -4816,7 +4826,7 @@ class Link(SageObject):
             sage: L1 = L.link()
             sage: L2 = L.link(L.items.braid_notation)
             sage: set_verbose(1)
-            sage: L1.is_isotopic(L2)
+            sage: L1.is_isotopic(L2)  # needs libhomfly
             verbose 1 (... link.py, is_isotopic) identified by KnotInfo uniquely (KnotInfo.L6a2_0, SymmetryMutant.itself)
             True
             sage: KnotInfo.K0_1.link().is_isotopic(KnotInfo.L2a1_0.link())

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -3185,13 +3185,13 @@ class Link(SageObject):
 
             sage: g = BraidGroup(2).gen(0)
             sage: K = Knot(g^5)
-            sage: K.homfly_polynomial()                                                 # needs sage.libs.homfly
+            sage: K.homfly_polynomial()                                                 # needs libhomfly
             L^-4*M^4 - 4*L^-4*M^2 + 3*L^-4 - L^-6*M^2 + 2*L^-6
 
         The Hopf link::
 
             sage: L = Link([[1,4,2,3],[4,1,3,2]])
-            sage: L.homfly_polynomial('x', 'y')                                         # needs sage.libs.homfly
+            sage: L.homfly_polynomial('x', 'y')                                         # needs libhomfly
             -x^-1*y + x^-1*y^-1 + x^-3*y^-1
 
         Another version of the Hopf link where the orientation
@@ -3199,18 +3199,18 @@ class Link(SageObject):
         and `y \mapsto M`::
 
             sage: L = Link([[1,3,2,4], [4,2,3,1]])
-            sage: L.homfly_polynomial()                                                 # needs sage.libs.homfly
+            sage: L.homfly_polynomial()                                                 # needs libhomfly
             L^3*M^-1 - L*M + L*M^-1
             sage: L = Link([[1,3,2,4], [4,2,3,1]])
-            sage: L.homfly_polynomial(normalization='az')                               # needs sage.libs.homfly
+            sage: L.homfly_polynomial(normalization='az')                               # needs libhomfly
             a^3*z^-1 - a*z - a*z^-1
 
         The figure-eight knot::
 
             sage: L = Link([[2,5,4,1], [5,3,7,6], [6,9,1,4], [9,7,3,2]])
-            sage: L.homfly_polynomial()                                                 # needs sage.libs.homfly
+            sage: L.homfly_polynomial()                                                 # needs libhomfly
             -L^2 + M^2 - 1 - L^-2
-            sage: L.homfly_polynomial('a', 'z', 'az')                                   # needs sage.libs.homfly
+            sage: L.homfly_polynomial('a', 'z', 'az')                                   # needs libhomfly
             a^2 - z^2 - 1 + a^-2
 
         The "monster" unknot::
@@ -3218,12 +3218,12 @@ class Link(SageObject):
             sage: L = Link([[3,1,2,4], [8,9,1,7], [5,6,7,3], [4,18,6,5],
             ....:           [17,19,8,18], [9,10,11,14], [10,12,13,11],
             ....:           [12,19,15,13], [20,16,14,15], [16,20,17,2]])
-            sage: L.homfly_polynomial()                                                 # needs sage.libs.homfly
+            sage: L.homfly_polynomial()                                                 # needs libhomfly
             1
 
         Comparison with KnotInfo::
 
-            sage: # needs sage.libs.homfly
+            sage: # needs libhomfly
             sage: KI =  K.get_knotinfo(mirror_version=False); KI
              <KnotInfo.K5_1: '5_1'>
             sage: K.homfly_polynomial(normalization='vz') == KI.homfly_polynomial()
@@ -3231,7 +3231,7 @@ class Link(SageObject):
 
         The knot `9_6`::
 
-            sage: # needs sage.libs.homfly
+            sage: # needs libhomfly
             sage: B = BraidGroup(3)
             sage: K = Knot(B([-1,-1,-1,-1,-1,-1,-2,1,-2,-2]))
             sage: K.homfly_polynomial()
@@ -3265,7 +3265,7 @@ class Link(SageObject):
 
         This works with isolated components::
 
-            sage: # needs sage.libs.homfly
+            sage: # needs libhomfly
             sage: L = Link([[[1, -1], [2, -2]], [1, 1]])
             sage: L2 = Link([[1, 4, 2, 3], [2, 4, 1, 3]])
             sage: L2.homfly_polynomial()  # not tested (:issue:`39544`)
@@ -3284,7 +3284,7 @@ class Link(SageObject):
         Check that :issue:`30346` is fixed::
 
             sage: L = Link([])
-            sage: L.homfly_polynomial()                                                 # needs sage.libs.homfly
+            sage: L.homfly_polynomial()                                                 # needs libhomfly
             1
 
         REFERENCES:
@@ -4219,9 +4219,9 @@ class Link(SageObject):
 
             sage: KnotInfo.L5a1_0.inject()
             Defining L5a1_0
-            sage: ML = L5a1_0.link()._knotinfo_matching_list(); ML                      # needs sage.libs.homfly
+            sage: ML = L5a1_0.link()._knotinfo_matching_list(); ML                      # needs libhomfly
             ([<KnotInfo.L5a1_0: 'L5a1{0}'>, <KnotInfo.L5a1_1: 'L5a1{1}'>], True)
-            sage: ML == Link(L5a1_0.braid())._knotinfo_matching_list()                  # needs sage.libs.homfly
+            sage: ML == Link(L5a1_0.braid())._knotinfo_matching_list()                  # needs libhomfly
             True
 
         Care is needed for links having non irreducible HOMFLY-PT polynomials::
@@ -4229,7 +4229,7 @@ class Link(SageObject):
             sage: k4_1 = KnotInfo.K4_1.link()
             sage: k5_2 = KnotInfo.K5_2.link()
             sage: k = k4_1.connected_sum(k5_2)
-            sage: k._knotinfo_matching_list()   # optional - database_knotinfo          # needs sage.libs.homfly
+            sage: k._knotinfo_matching_list()   # optional - database_knotinfo          # needs libhomfly
             ([<KnotInfo.K9_12: '9_12'>], False)
         """
         from sage.knots.knotinfo import KnotInfoSeries
@@ -4431,7 +4431,7 @@ class Link(SageObject):
             sage: Link([[1, 4, 2, 5], [3, 8, 4, 1], [5, 2, 6, 3],
             ....:       [6, 10, 7, 9], [10, 8, 9, 7]])
             Link with 2 components represented by 5 crossings
-            sage: _.get_knotinfo()                                                      # needs sage.libs.homfly
+            sage: _.get_knotinfo()                                                      # needs libhomfly
             Traceback (most recent call last):
             ...
             NotImplementedError: this (possibly non prime) link cannot be determined

--- a/src/sage/libs/homfly.pyx
+++ b/src/sage/libs/homfly.pyx
@@ -63,6 +63,7 @@ def homfly_polynomial_string(link):
 
     EXAMPLES::
 
+        sage: # needs libhomfly
         sage: from sage.libs.homfly import homfly_polynomial_string
         sage: trefoil = '1 6 0 1  1 -1  2 1  0 -1  1 1  2 -1 0 1 1 1 2 1'
         sage: homfly_polynomial_string(trefoil)
@@ -85,6 +86,7 @@ def homfly_polynomial_dict(link):
 
     EXAMPLES::
 
+        sage: # needs libhomfly
         sage: from sage.libs.homfly import homfly_polynomial_dict
         sage: trefoil = '1 6 0 1  1 -1  2 1  0 -1  1 1  2 -1 0 1 1 1 2 1'
         sage: homfly_polynomial_dict(trefoil)

--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -91,7 +91,7 @@ if not homfly.found()
   homfly = cc.find_library(
     'homfly',
     has_headers: ['homfly.h'],
-    required: false,
+    required: get_option('libhomfly'),
     disabler: true,
   )
 endif


### PR DESCRIPTION
While deleting `needs sage.foo` tags, I noticed that `sage.libs.homfly`, unlike most others, refers to a single optional leaf node in the sage library. Its presence (or lack thereof) only affects `sage.knots`, making it a good candidate for modularization. In fact, as far as meson is concerned, libhomfly is already optional -- you just can't force it on or off.

This commit does four things:

1. Add a `-Dlibhomfly={enabled,disabled,auto}` option to `meson.options`.
2. Rename the existing `sage.libs.homfly` feature to `libhomfly`.
3. Update any existing "needs" tags to use the new name.
4. Add additional "needs" tags under `src/sage/knots` to get the tests passing with `-Dlibhomfly=disabled`.
