### PR TITLE
Add free module sign iterator

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -49,7 +49,6 @@ Pickling test::
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
-from itertools import islice
 from operator import itemgetter
 
 from sage.algebras.quatalg import quaternion_algebra_cython
@@ -3642,6 +3641,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         I = denom * self
         N = ZZ(I.norm())
         Q = I.quadratic_form()
+        from itertools import islice
         for v in islice((ZZ**4).iter_up_to_sign(), 1, None):
             if N.gcd(Q(v)) == 1:
                 break

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -3616,6 +3616,17 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
             sage: assert I == O1*N + O1*a
             sage: assert I == N*O2 + a*O2
 
+        The second generator is nonzero even when the ideal has norm one::
+
+            sage: I = O1.unit_ideal()
+            sage: N,a = I.gens_two()
+            sage: N
+            1
+            sage: a.is_zero()
+            False
+            sage: assert I == O1*N + O1*a
+            sage: assert I == N*O1 + a*O1
+
         ::
 
             sage: s = choice((-1,+1)) * ZZ(randrange(1,100)) / randrange(1,100)
@@ -3630,9 +3641,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         I = denom * self
         N = ZZ(I.norm())
         Q = I.quadratic_form()
-        for v in ZZ**4:
-            if -v < v:  # enumerate up to sign  #TODO this should be a method of free modules
-                continue
+        for v in (ZZ**4).iter_up_to_sign(include_zero=False):
             if N.gcd(Q(v)) == 1:
                 break
         else:

--- a/src/sage/algebras/quatalg/quaternion_algebra.py
+++ b/src/sage/algebras/quatalg/quaternion_algebra.py
@@ -49,6 +49,7 @@ Pickling test::
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+from itertools import islice
 from operator import itemgetter
 
 from sage.algebras.quatalg import quaternion_algebra_cython
@@ -3641,7 +3642,7 @@ class QuaternionFractionalIdeal_rational(QuaternionFractionalIdeal):
         I = denom * self
         N = ZZ(I.norm())
         Q = I.quadratic_form()
-        for v in (ZZ**4).iter_up_to_sign(include_zero=False):
+        for v in islice((ZZ**4).iter_up_to_sign(), 1, None):
             if N.gcd(Q(v)) == 1:
                 break
         else:

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -2592,6 +2592,59 @@ class FreeModule_generic(Module_free_ambient):
                 v[n] = zero
                 n += 1
 
+    def iter_up_to_sign(self, include_zero=True):
+        r"""
+        Return an iterator over the elements of ``self`` up to sign.
+
+        This yields one representative from each pair `\{v, -v\}`,
+        choosing the smaller one with respect to the module element ordering.
+        The order of the representatives is inherited from the usual iterator
+        for ``self``.
+
+        INPUT:
+
+        - ``include_zero`` -- boolean (default: ``True``); whether to include
+          the zero element
+
+        EXAMPLES::
+
+            sage: it = (ZZ^2).iter_up_to_sign()
+            sage: [next(it) for _ in range(10)]
+            [(0, 0), (-1, 0), (0, -1), (-1, 1), (-1, -1),
+             (-2, 0), (0, -2), (-2, 1), (-2, -1), (-1, 2)]
+            sage: it = (ZZ^2).iter_up_to_sign(include_zero=False)
+            sage: [next(it) for _ in range(5)]
+            [(-1, 0), (0, -1), (-1, 1), (-1, -1), (-2, 0)]
+
+        In characteristic two, negation acts trivially, so all elements are
+        returned::
+
+            sage: list(VectorSpace(GF(2), 2).iter_up_to_sign())                         # needs sage.rings.finite_rings
+            [(0, 0), (1, 0), (0, 1), (1, 1)]
+
+        TESTS::
+
+            sage: V = ZZ^3
+            sage: it = V.iter_up_to_sign()
+            sage: vs = [next(it) for _ in range(1000)]
+            sage: _ = [v.set_immutable() for v in vs]
+            sage: len(set(vs)) == 1000
+            True
+            sage: all(-v not in vs or v.is_zero() for v in vs)
+            True
+
+            sage: list((ZZ^0).iter_up_to_sign())
+            [()]
+            sage: list((ZZ^0).iter_up_to_sign(include_zero=False))
+            []
+        """
+        for v in self:
+            if not include_zero and v.is_zero():
+                continue
+            if -v < v:
+                continue
+            yield v
+
     def cardinality(self):
         r"""
         Return the cardinality of the free module.

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -2592,19 +2592,14 @@ class FreeModule_generic(Module_free_ambient):
                 v[n] = zero
                 n += 1
 
-    def iter_up_to_sign(self, include_zero=True):
+    def iter_up_to_sign(self):
         r"""
         Return an iterator over the elements of ``self`` up to sign.
 
         This yields one representative from each pair `\{v, -v\}`,
         choosing the smaller one with respect to the module element ordering.
         The order of the representatives is inherited from the usual iterator
-        for ``self``.
-
-        INPUT:
-
-        - ``include_zero`` -- boolean (default: ``True``); whether to include
-          the zero element
+        for ``self``; in particular, the zero element is returned first.
 
         EXAMPLES::
 
@@ -2612,7 +2607,11 @@ class FreeModule_generic(Module_free_ambient):
             sage: [next(it) for _ in range(10)]
             [(0, 0), (-1, 0), (0, -1), (-1, 1), (-1, -1),
              (-2, 0), (0, -2), (-2, 1), (-2, -1), (-1, 2)]
-            sage: it = (ZZ^2).iter_up_to_sign(include_zero=False)
+
+        To skip the zero element, skip the first element of the iterator::
+
+            sage: from itertools import islice
+            sage: it = islice((ZZ^2).iter_up_to_sign(), 1, None)
             sage: [next(it) for _ in range(5)]
             [(-1, 0), (0, -1), (-1, 1), (-1, -1), (-2, 0)]
 
@@ -2625,6 +2624,8 @@ class FreeModule_generic(Module_free_ambient):
         TESTS::
 
             sage: V = ZZ^3
+            sage: next(V.iter_up_to_sign()) == V.zero()
+            True
             sage: it = V.iter_up_to_sign()
             sage: vs = [next(it) for _ in range(1000)]
             sage: _ = [v.set_immutable() for v in vs]
@@ -2635,12 +2636,10 @@ class FreeModule_generic(Module_free_ambient):
 
             sage: list((ZZ^0).iter_up_to_sign())
             [()]
-            sage: list((ZZ^0).iter_up_to_sign(include_zero=False))
+            sage: list(islice((ZZ^0).iter_up_to_sign(), 1, None))
             []
         """
         for v in self:
-            if not include_zero and v.is_zero():
-                continue
             if -v < v:
                 continue
             yield v


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
- Add `FreeModule_generic.iter_up_to_sign(include_zero=True)` to iterate over one representative from each pair `{v, -v}`.
- Use the new helper in `QuaternionFractionalIdeal_rational.gens_two()` instead of an inline sign filter.
- Skip the zero vector in `gens_two()` so norm-one ideals do not return a zero second generator.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


