### PR TITLE
use .torsion_basis() method in EllipticCurveHom_fractional

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom_fractional.py
+++ b/src/sage/schemes/elliptic_curves/hom_fractional.py
@@ -127,6 +127,21 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
               Numerator:   Scalar-multiplication endomorphism [-3]
                              of Elliptic Curve defined by y^2 = x^3 + x + 1 over Finite Field of size 11
               Denominator: 3
+
+        TESTS:
+
+        This example used to take a very long time prior to :issue:`42085`::
+
+            sage: F.<t> = GF((179, 2))
+            sage: q = 31
+            sage: E, iota = special_supersingular_curve(F, q, endomorphism=True)
+            sage: pi = E.frobenius_isogeny()
+            sage: iota * (21 + pi) / 31
+            Fractional elliptic-curve morphism of degree 20:
+              Numerator:   Composite morphism of degree 19220 = 620*31:
+              From: Elliptic Curve defined by y^2 = x^3 + x + 178 over Finite Field in t of size 179^2
+              To:   Elliptic Curve defined by y^2 = x^3 + x + 178 over Finite Field in t of size 179^2
+              Denominator: 31
         """
         if not isinstance(phi, EllipticCurveHom):
             raise TypeError('not an elliptic-curve morphism')
@@ -144,16 +159,13 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
 
             E = phi.domain()
             for l, e in d.factor():
-                F = E.division_field(l**e)
-                EE = E.change_ring(F)
+                pts = E.torsion_gens(l**e, extend=True)
 
-                psi = E.division_polynomial(l**e).radical()
-                psi //= psi.gcd(E.division_polynomial(l**(e-1)))
-                if psi.degree() < l**2//2:
-                    assert l == E.base_field().characteristic()
-                    if psi.is_one():
-                        # supersingular, hence [p] is the only p^2-isogeny up to isomorphism
-                        continue
+                assert len(pts) == 2 or l == E.base_field().characteristic()
+                if not pts:
+                    # supersingular, hence [p] is the only p^2-isogeny up to isomorphism
+                    continue
+                if len(pts) == 1:
                     # ordinary, hence [p] is Frobenius times its dual
                     insep = phi.inseparable_degree().valuation(l)
                     sep = phi.degree().valuation(l) - insep
@@ -161,9 +173,7 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
                         raise ValueError(f'{phi} is not divisible by {l**e}')
                     continue
 
-                P, Q = _torsion_gens(E, EE, l, e, psi=psi)
-
-                if phi._eval(P) or phi._eval(Q):
+                if any(phi._eval(pt) for pt in pts):
                     raise ValueError(f'{phi} is not divisible by {l**e}')
 
         self._phi = phi
@@ -305,27 +315,24 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
         ker = []
         insep = 0
         for l, e in self._phi.degree().factor():
-            F = E.division_field(l**e)
-            EE = E.change_ring(F)
+            pts = E.torsion_gens(l**e, extend=True)
 
-            psi = E.division_polynomial(l**e).radical()
-            psi //= psi.gcd(E.division_polynomial(l**(e-1)))
-            if psi.degree() < l**2//2:
-                assert l == E.base_field().characteristic()
-                if psi.is_one():
-                    # supersingular, hence [p] is the only p^2-isogeny up to isomorphism
-                    insep += 2*self._d.valuation(l)
-                else:
-                    # ordinary, hence [p] is Frobenius times its dual
-                    insep += self._d.valuation(l)
-                    ker.append(self._d.p_primary_part(l) * EE.lift_x(psi.any_root(ring=F)))
+            assert len(pts) == 2 or l == E.base_field().characteristic()
+            if not pts:
+                # supersingular, hence [p] is the only p^2-isogeny up to isomorphism
+                insep += 2*self._d.valuation(l)
+                continue
+            if len(pts) == 1:
+                # ordinary, hence [p] is Frobenius times its dual
+                insep += self._d.valuation(l)
+                ker.append(self._d.p_primary_part(l) * pts[0])
                 continue
 
-            P, Q = _torsion_gens(E, EE, l, e, psi=psi)
+            P, Q = pts
             if self.is_endomorphism():
                 RS = None
             else:
-                RS = _torsion_gens(self._codomain, self._codomain.change_ring(F), l, e)
+                RS = self._codomain.change_ring(P.curve().base_field()).torsion_basis(l**e, extend=False)
 
             mat = self._phi.matrix_on_subgroup((P, Q), RS)
             for row in filter(bool, self._d.p_primary_part(l) * mat.left_kernel_matrix()):
@@ -530,19 +537,3 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
             419
         """
         return self._phi.inseparable_degree() / self._domain.scalar_multiplication(self._d).inseparable_degree()
-
-
-def _torsion_gens(E, EE, l, e, psi=None):
-    if psi is None:
-        psi = E.division_polynomial(l**e).radical()
-        psi //= psi.gcd(E.division_polynomial(l**(e-1)))
-
-    xs = iter(psi.roots(ring=EE.base_field(), multiplicities=False))
-    P = EE.lift_x(next(xs))
-    while True:
-        Q = EE.lift_x(next(xs))
-        if not (P.weil_pairing(Q, l**e)**(l**(e-1))).is_one():
-            break
-    else:
-        assert False, f'bug in finding {l**e}-torsion basis'
-    return P, Q


### PR DESCRIPTION
...instead of a potentially much slower ad-hoc implementation from inside `hom_fractional.py`.

(See also #41530.)