### PR TITLE
use .trace() in degree computation for EllipticCurveHom_sum

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -2109,10 +2109,9 @@ def compute_trace_generic(phi):
     for l in Primes():
         if tr.modulus() >= M:
             break
-        try:
-            P = point_of_order(E, l)
-        except ValueError:
-            continue   # supersingular and l == p
+        if l == p:
+            continue
+        P = point_of_order(E, l)
 
         Q = phi._eval(P)
         if not Q:  # we learn nothing when P lies in the kernel

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -389,9 +389,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
         Internal method to compute and cache the degree of this sum morphism
         (and its dual).
 
-        ALGORITHM: Evaluate the composition with the dual on points of small
-        order and solve logarithms to eventually recover the degree using CRT.
-        (This is essentially Schoof's algorithm, applied to a scalar.)
+        ALGORITHM: Recursive application of the formula
+        `\deg(\varphi+\psi) = \deg(\varphi) + \deg(\psi) + \mathrm{tr}(\varphi\circ\widehat\psi)`.
 
         EXAMPLES::
 
@@ -427,25 +426,13 @@ class EllipticCurveHom_sum(EllipticCurveHom):
         else:
             #TODO In some cases it would probably be faster to simply
             # compute the kernel polynomial using the addition formulas?
-            from sage.rings.finite_rings.integer_mod import Mod
-
-            lo, hi = self._degree_bounds()
-            M = hi - lo + 1
-            rem = Mod(0,1)
-            for l in Primes():
-                if rem.modulus() >= M:
-                    break
-                try:
-                    P = point_of_order(self._domain, l)
-                except ValueError:
-                    continue   # supersingular and l == p
-
-                Q = self.dual()._eval(self._eval(P))
-                d = discrete_log(Q, P, ord=l, operation='+')
-                rem = rem.crt(Mod(d-lo, l))
-
-            self._degree = lo + rem.lift()
-            self.dual()._degree = self._degree
+            mid = (len(self._phis) + 1) // 2
+            left = EllipticCurveHom_sum(self._phis[:mid])
+            right = EllipticCurveHom_sum(self._phis[mid:])
+            pair = left * right.dual() if right.degree() < left.degree() else left.dual() * right
+            self._degree = left.degree() + right.degree() + pair.trace()
+            if self.dual.is_in_cache():
+                self.dual()._degree = self._degree
 
     @staticmethod
     def _comparison_impl(left, right, op):


### PR DESCRIPTION
Currently, `EllipticCurveHom_sum` uses an ad-hoc implementation of (a variant of) Schoof's algorithm to compute the trace. Reusing the implementation in `.trace()` reduces code duplication and, incidentally, yields a pretty large speedup thanks to the more optimized code in `.trace()`.

We can also expect future speedups in `.trace()` thanks to the algorithms from [this paper](https://eprint.iacr.org/2026/137).