### PR TITLE
Fix a ginac crash

### DIFF
--- a/src/sage/functions/log.py
+++ b/src/sage/functions/log.py
@@ -163,7 +163,7 @@ class Function_exp(GinacFunction):
     Python object equal to the integer `-1`::
 
         sage: t, q = var('t, q')                                                        # needs sage.symbolic
-        sage: exp(-I*pi*q).subs(q=-I/pi*log(2*t))                                      # needs sage.symbolic
+        sage: exp(-I*pi*q).subs(q=-I/pi*log(2*t))                                       # needs sage.symbolic
         1/2/t
 
     Check that :issue:`19918` is fixed::

--- a/src/sage/functions/log.py
+++ b/src/sage/functions/log.py
@@ -158,6 +158,14 @@ class Function_exp(GinacFunction):
         sage: 2*sqrt(e)                                                                 # needs sage.symbolic
         2*e^(1/2)
 
+    Test substitution into an exponential whose argument contains ``I``.
+    During simplification the coefficient of the logarithm can be an exact
+    Python object equal to the integer `-1`::
+
+        sage: t, q = var('t, q')                                                        # needs sage.symbolic
+        sage: exp(-I*pi*q).subs(q=-I/pi*log(2*t))                                      # needs sage.symbolic
+        1/2/t
+
     Check that :issue:`19918` is fixed::
 
         sage: exp(-x^2).subs(x=oo)                                                      # needs sage.symbolic

--- a/src/sage/symbolic/ginac/numeric.cpp
+++ b/src/sage/symbolic/ginac/numeric.cpp
@@ -1782,19 +1782,28 @@ const numeric numeric::pow_intexp(const numeric &exponent) const
 {
         if (not exponent.is_integer())
                 throw std::runtime_error("numeric::pow_intexp: exponent not integer");
-	// Because Sage may have simplified a fraction to an integer,
-	// we should check whether the type is MPQ as well as MPZ
-        if (exponent.t == MPZ) {
-                if (not mpz_fits_sint_p(exponent.v._bigint))
+        switch (exponent.t) {
+        case LONG:
+                return power(exponent.v._long);
+        case MPZ:
+                if (not mpz_fits_slong_p(exponent.v._bigint))
                         throw std::runtime_error("size of exponent exceeds signed long size");
                 return power(mpz_get_si(exponent.v._bigint));
+        case MPQ:
+                // Sage may have simplified a fraction to an integer, so check
+                // MPQ as well as MPZ.
+                if (not mpz_fits_slong_p(mpq_numref(exponent.v._bigrat)))
+                        throw std::runtime_error("size of exponent exceeds signed long size");
+                return power(mpz_get_si(mpq_numref(exponent.v._bigrat)));
+        case PYOBJECT:
+                // Exact Python objects can be integer-valued, for example the
+                // Gaussian integer -1 obtained while simplifying products of I.
+                // Convert through Sage's Integer constructor before extracting
+                // the machine exponent.
+                return pow_intexp(exponent.to_bigint());
+        default:
+                stub("invalid type: pow_intexp exponent type not handled");
         }
-	if (exponent.t == MPQ) {
-		if (not mpz_fits_sint_p(mpq_numref(exponent.v._bigrat)))
-			throw std::runtime_error("size of exponent exceeds signed long size");
-		return power(mpz_get_si(mpq_numref(exponent.v._bigrat)));
-        }
-        return power(exponent.v._long);
 }
 
 /** Numerical exponentiation.

--- a/src/sage/symbolic/ginac/numeric.cpp
+++ b/src/sage/symbolic/ginac/numeric.cpp
@@ -1782,28 +1782,31 @@ const numeric numeric::pow_intexp(const numeric &exponent) const
 {
         if (not exponent.is_integer())
                 throw std::runtime_error("numeric::pow_intexp: exponent not integer");
-        switch (exponent.t) {
-        case LONG:
-                return power(exponent.v._long);
-        case MPZ:
-                if (not mpz_fits_slong_p(exponent.v._bigint))
+	// Because Sage may have simplified a fraction to an integer,
+	// we should check whether the type is MPQ as well as MPZ
+        if (exponent.t == MPZ) {
+                if (not mpz_fits_sint_p(exponent.v._bigint))
                         throw std::runtime_error("size of exponent exceeds signed long size");
                 return power(mpz_get_si(exponent.v._bigint));
-        case MPQ:
-                // Sage may have simplified a fraction to an integer, so check
-                // MPQ as well as MPZ.
-                if (not mpz_fits_slong_p(mpq_numref(exponent.v._bigrat)))
-                        throw std::runtime_error("size of exponent exceeds signed long size");
-                return power(mpz_get_si(mpq_numref(exponent.v._bigrat)));
-        case PYOBJECT:
-                // Exact Python objects can be integer-valued, for example the
-                // Gaussian integer -1 obtained while simplifying products of I.
-                // Convert through Sage's Integer constructor before extracting
-                // the machine exponent.
-                return pow_intexp(exponent.to_bigint());
-        default:
-                stub("invalid type: pow_intexp exponent type not handled");
         }
+	if (exponent.t == MPQ) {
+		if (not mpz_fits_sint_p(mpq_numref(exponent.v._bigrat)))
+			throw std::runtime_error("size of exponent exceeds signed long size");
+		return power(mpz_get_si(mpq_numref(exponent.v._bigrat)));
+        }
+        if (exponent.t == PYOBJECT) {
+                // exponent.v._long would alias the PyObject* pointer and be
+                // garbage; convert via the Python integer protocol instead.
+                // to_long() throws conversion_error if it does not fit in a
+                // signed long, which we re-raise as the same overflow message
+                // used for MPZ above.
+                try {
+                        return power(exponent.to_long());
+                } catch (const conversion_error&) {
+                        throw std::runtime_error("size of exponent exceeds signed long size");
+                }
+        }
+        return power(exponent.v._long);
 }
 
 /** Numerical exponentiation.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
In `numerical.cpp`, the function `numeric:pow_intexp` does not handle the case `PYOBJECT`.

In this case, `PYOBJECT` actually hold a `PyObject*` pointer. So you reinterpret a heap pointer's bit pattern as a signed integer.

Fix #42090


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


