### PR TITLE
fix #41494: guard paramset_from_Expression downcast

### DIFF
--- a/src/sage/symbolic/pynac_impl.pxi
+++ b/src/sage/symbolic/pynac_impl.pxi
@@ -211,13 +211,33 @@ cdef paramset_to_PyTuple(const_paramset_ref s):
 
 def paramset_from_Expression(Expression e):
     """
+    Return the parameter set of an unevaluated symbolic function derivative.
+
+    INPUT:
+
+    - ``e`` -- a symbolic expression representing an unevaluated
+      derivative of a symbolic function
+
+    OUTPUT: list of indices of the function arguments with respect to
+    which the function is differentiated
+
     EXAMPLES::
 
         sage: from sage.symbolic.expression import paramset_from_Expression
         sage: f = function('f')
         sage: paramset_from_Expression(f(x).diff(x))
         [0]
+
+    Invalid arguments raise an exception::
+
+        sage: paramset_from_Expression(x)
+        Traceback (most recent call last):
+        ...
+        TypeError: argument must be an unevaluated derivative of a symbolic function
     """
+    if not is_a_fderivative(e._gobj):
+        raise TypeError("argument must be an unevaluated derivative "
+                        "of a symbolic function")
     return paramset_to_PyTuple(ex_to_fderivative(e._gobj).get_parameter_set())
 
 


### PR DESCRIPTION
`paramset_from_Expression` is Python-visible and can be called with arbitrary symbolic expressions.  It previously passed the input directly to GiNaC's unsafe `ex_to<fderivative>` downcast, which is only valid after checking the expression type.  Passing a symbol such as `x` therefore reinterpreted the object as an fderivative and could segfault while copying the bogus parameter set.

Check `is_a_fderivative` before the downcast, raise TypeError for invalid expressions, and document the helper's expected input and error behavior with a regression doctest.

Fix #41494 

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


