### PR TITLE
allow flint 3.5 from the system

### DIFF
--- a/build/pkgs/flint/spkg-configure.m4
+++ b/build/pkgs/flint/spkg-configure.m4
@@ -3,12 +3,12 @@ SAGE_SPKG_CONFIGURE([flint], [
         AC_CHECK_HEADERS([flint/flint.h flint/padic.h], [dnl
           dnl gr_get_fexpr appears in Flint 3.0
           AC_SEARCH_LIBS([gr_get_fexpr], [flint], [dnl
-            dnl Assume Flint 3.5 is too new
-            AC_MSG_CHECKING([whether FLINT version is >= 3.5.0])
+            dnl Assume Flint 3.6 is too new
+            AC_MSG_CHECKING([whether FLINT version is >= 3.6.0])
             AC_COMPILE_IFELSE([dnl
               AC_LANG_PROGRAM([[#include <flint/flint.h>
-                                #if __FLINT_RELEASE > 30499
-                                # error "FLINT 3.5 is too new"
+                                #if __FLINT_RELEASE > 30599
+                                # error "FLINT 3.6 is too new"
                                 #endif
                               ]])
             ], [dnl


### PR DESCRIPTION
flint 3.5.0 is out, and already available on e.g. Homebrew

So we clear it for using

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


