### PR TITLE
Fix the bug in limit_valuation

### DIFF
--- a/src/sage/rings/valuation/inductive_valuation.py
+++ b/src/sage/rings/valuation/inductive_valuation.py
@@ -43,6 +43,18 @@ from sage.misc.cachefunc import cached_method
 from sage.misc.abstract_method import abstract_method
 
 
+class EquivalenceDecompositionTooSmall(Exception):
+    r"""
+    Raised by :meth:`InductiveValuation.mac_lane_step` when the
+    equivalence-decomposition of ``G`` is empty because the requested
+    ``principal_part_bound`` is too small to see a non-trivial decomposition.
+
+    Callers that pass a ``principal_part_bound`` may catch this exception and
+    retry without the bound.
+    """
+    pass
+
+
 class InductiveValuation(DevelopingValuation):
     r"""
     Abstract base class for iterated :mod:`augmented valuations <sage.rings.valuation.augmented_valuation>` on top of a :mod:`Gauss valuation <sage.rings.valuation.gauss_valuation>`.
@@ -789,7 +801,10 @@ class NonFinalInductiveValuation(FiniteInductiveValuation, DiscreteValuation):
         ret = []
 
         F = self.equivalence_decomposition(G, assume_not_equivalence_unit=True, coefficients=coefficients, valuations=valuations, compute_unit=False, degree_bound=principal_part_bound)
-        assert len(F), "%s equivalence-decomposes as an equivalence-unit %s" % (G, F)
+        message = "%s equivalence-decomposes as an equivalence-unit %s" % (G, F)
+        if not len(F) and principal_part_bound is not None:
+            raise EquivalenceDecompositionTooSmall(message)
+        assert len(F), message
         if len(F) == 1 and F[0][1] == 1 and F[0][0].degree() == G.degree():
             assert self.is_key(G, assume_equivalence_irreducible=assume_equivalence_irreducible)
             ret.append((self.augmentation(G, infinity, check=False), G.degree(), principal_part_bound, None, None))

--- a/src/sage/rings/valuation/inductive_valuation.py
+++ b/src/sage/rings/valuation/inductive_valuation.py
@@ -45,7 +45,7 @@ from sage.misc.abstract_method import abstract_method
 
 class EquivalenceDecompositionTooSmall(Exception):
     r"""
-    Raised by :meth:`InductiveValuation.mac_lane_step` when the
+    Raised by ``InductiveValuation.mac_lane_step`` when the
     equivalence-decomposition of ``G`` is empty because the requested
     ``principal_part_bound`` is too small to see a non-trivial decomposition.
 

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -665,6 +665,21 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, G)) == (v == w)
             ....:         assert (valuations.LimitValuation(w, G) >= valuations.LimitValuation(v, F)) == (v == w)
 
+        An example with several valuations that correspond to factors of F over Q2 that are not rational::
+
+            sage: R.<x> = QQ[]
+            sage: F = (x^2 - 17) * (x^2 - 25) * (x^7 - 1)
+            sage: G = (x^2 - 25) * (x^7 - 1)
+            sage: V = QQ.valuation(2).mac_lane_approximants(F, require_incomparability=True)
+
+            sage: for v in V:
+            ....:     for w in V:
+            ....:         print(v,w)
+            ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, F)) == (v == w)
+            ....:         if valuations.LimitValuation(w, F)(G) != oo: continue
+            ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, G)) == (v == w)
+            ....:         assert (valuations.LimitValuation(w, G) >= valuations.LimitValuation(v, F)) == (v == w)
+
         """
         if other.is_trivial():
             return other.is_discrete_valuation()

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -655,10 +655,16 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: V = QQ.valuation(2).mac_lane_approximants(F, require_incomparability=True)
             sage: valuations.LimitValuation(V[0], F) >= valuations.LimitValuation(V[1], F)
             False
-            sage: valuations.LimitValuation(V[1], F) >= valuations.LimitValuation(V[1], G)
-            True
-            sage: valuations.LimitValuation(V[2], F) >= valuations.LimitValuation(V[2], G)
-            True
+
+        TESTS::
+
+            sage: for v in V:
+            ....:     for w in V:
+            ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, F)) == (v == w)
+            ....:         if valuations.LimitValuation(w, F)(G) != oo: continue
+            ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, G)) == (v == w)
+            ....:         assert (valuations.LimitValuation(w, G) >= valuations.LimitValuation(v, F)) == (v == w)
+
         """
         if other.is_trivial():
             return other.is_discrete_valuation()

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -78,8 +78,99 @@ overview can also be found in Section 4.6 of [Rüt2014]_.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 from sage.misc.abstract_method import abstract_method
+from sage.misc.cachefunc import cached_method
 from .valuation import DiscretePseudoValuation, InfiniteDiscretePseudoValuation
 from sage.structure.factory import UniqueFactory
+
+
+def _normalize_polynomial(G):
+    r"""
+    Return a canonical representative for ``G`` up to scalar multiple.
+
+    Some base rings do not allow division by the leading coefficient. In that
+    case, leave ``G`` unchanged.
+
+    EXAMPLES::
+
+        sage: from sage.rings.valuation.limit_valuation import _normalize_polynomial
+        sage: R.<x> = QQ[]
+        sage: _normalize_polynomial(2*x + 4)
+        x + 2
+        sage: _normalize_polynomial(R.zero())
+        0
+
+    Over a ring whose leading coefficient is not invertible, the polynomial
+    is returned unchanged::
+
+        sage: S.<y> = Zmod(6)[]
+        sage: _normalize_polynomial(3*y + 4)
+        3*y + 4
+    """
+    if G == 0:
+        return G
+    try:
+        return G.monic()
+    except (ArithmeticError, NotImplementedError, TypeError,
+            ValueError, ZeroDivisionError):
+        return G
+
+
+def _normalize_key_polynomial(base_valuation, G):
+    r"""
+    Remove factors of ``G`` that cannot vanish in the corresponding limit.
+
+    The polynomial ``G`` is part of the unique factory key for limit
+    valuations. If some factors of ``G`` are equivalence-units for the initial
+    approximation, then the limit valuation sending ``G`` to infinity is the
+    same as the one defined by the complementary factor.
+
+    EXAMPLES::
+
+        sage: from sage.rings.valuation.limit_valuation import _normalize_key_polynomial
+        sage: R.<x> = QQ[]
+        sage: F = (x^2 + 7) * (x^2 + 9)
+        sage: V = QQ.valuation(2).mac_lane_approximants(F, require_incomparability=True)        # needs sage.geometry.polyhedron
+        sage: _normalize_key_polynomial(V[1], F) in [x^2 + 7, x^2 + 9]                          # needs sage.geometry.polyhedron
+        True
+        sage: _normalize_key_polynomial(V[1], F) != F                                           # needs sage.geometry.polyhedron
+        True
+
+    A constant or equivalence-unit factor alone is rejected::
+
+        sage: v = GaussValuation(R, QQ.valuation(2))
+        sage: _normalize_key_polynomial(v, R.one() + 2)
+        Traceback (most recent call last):
+        ...
+        ValueError: G must have a non-equivalence-unit factor for base_valuation
+
+    The zero polynomial is returned unchanged (the factory rejects it
+    separately)::
+
+        sage: _normalize_key_polynomial(v, R.zero())
+        0
+    """
+    if G == 0:
+        return G
+
+    try:
+        factors = G.factor()
+    except (ArithmeticError, AttributeError, NotImplementedError, TypeError,
+            ValueError):
+        return G
+
+    H = G.parent().one()
+    try:
+        for factor, exponent in factors:
+            factor = _normalize_polynomial(factor)
+            if (not factor.is_constant()
+                    and not base_valuation.is_equivalence_unit(factor)):
+                H *= factor
+    except (ArithmeticError, NotImplementedError, TypeError, ValueError):
+        return G
+
+    if H.is_one():
+        raise ValueError("G must have a non-equivalence-unit factor for base_valuation")
+    return _normalize_polynomial(H)
 
 
 class LimitValuationFactory(UniqueFactory):
@@ -110,8 +201,8 @@ class LimitValuationFactory(UniqueFactory):
 
         EXAMPLES:
 
-        Note that this does not normalize ``base_valuation`` in any way. It is
-        easily possible to create the same limit in two different ways::
+        This normalizes scalar multiples of ``G`` and an already infinite
+        final augmentation of ``base_valuation``::
 
             sage: R.<x> = QQ[]
             sage: v = GaussValuation(R, QQ.valuation(2))
@@ -119,14 +210,72 @@ class LimitValuationFactory(UniqueFactory):
             sage: v = v.augmentation(x, infinity)
             sage: u = valuations.LimitValuation(v, x)
             sage: u == w
-            False
+            True
+            sage: u is w
+            True
+            sage: valuations.LimitValuation(v._base_valuation, 2*x) is w
+            True
+            sage: valuations.LimitValuation(v, x*(x + 1)) is w
+            True
 
-        The point here is that this is not meant to be invoked from user code.
-        But mostly from other factories which have made sure that the
-        parameters are normalized already.
+        Factors of ``G`` that are equivalence-units for ``base_valuation`` are
+        also removed from the factory key::
+
+            sage: R.<x> = QQ[]
+            sage: F = (x^2 + 7) * (x^2 + 9)
+            sage: G = x^2 + 7
+            sage: V = QQ.valuation(2).mac_lane_approximants(F, require_incomparability=True)
+            sage: w = valuations.LimitValuation(V[1], F)                                  # needs sage.geometry.polyhedron
+            sage: u = valuations.LimitValuation(V[1], G)                                  # needs sage.geometry.polyhedron
+            sage: w is u                                                                  # needs sage.geometry.polyhedron
+            True
+
+        If every factor of ``G`` is already an equivalence-unit for
+        ``base_valuation``, then there is no limit over this branch that sends
+        ``G`` to infinity::
+
+            sage: v = next(v for v in V if valuations.LimitValuation(v, F)(G) != oo)       # needs sage.geometry.polyhedron
+            sage: valuations.LimitValuation(v, G)                                         # needs sage.geometry.polyhedron
+            Traceback (most recent call last):
+            ...
+            ValueError: G must have a non-equivalence-unit factor for base_valuation
+
+        The defining polynomial must be nonzero and nonconstant::
+
+            sage: valuations.LimitValuation(v, 0)
+            Traceback (most recent call last):
+            ...
+            ValueError: G must be nonzero
+            sage: valuations.LimitValuation(v, 1)
+            Traceback (most recent call last):
+            ...
+            ValueError: G must be nonconstant
+
+        Apart from this, the point here is that this is not meant to be invoked
+        from user code, but mostly from other factories which have made sure
+        that the parameters are normalized already.
         """
+        G = base_valuation.domain().coerce(G)
+        G = _normalize_polynomial(G)
+        if G == 0:
+            raise ValueError("G must be nonzero")
+        if G.is_constant():
+            raise ValueError("G must be nonconstant")
+
         if not base_valuation.restriction(G.parent().base_ring()).is_discrete_valuation():
             raise ValueError("base_valuation must be discrete on the coefficient ring.")
+
+        from .augmented_valuation import AugmentedValuation_base
+        if isinstance(base_valuation, AugmentedValuation_base):
+            from sage.rings.infinity import infinity
+            if base_valuation.mu() is infinity:
+                phi = base_valuation.phi()
+                if not phi.divides(G):
+                    raise ValueError("the infinite key polynomial of base_valuation must divide G")
+                return self.create_key(base_valuation._base_valuation, phi)
+
+        G = _normalize_key_polynomial(base_valuation, G)
+
         return base_valuation, G
 
     def create_object(self, version, key):
@@ -331,6 +480,15 @@ class LimitValuation_generic(DiscretePseudoValuation):
             sage: w = v.extension(L)
             sage: w._base_valuation # indirect doctest
             [ Gauss valuation induced by 2-adic valuation, v(t + 1) = 1/2 , … ]
+
+        When the initial approximation is already a Gauss valuation (not an
+        augmented valuation), it is printed as is::
+
+            sage: R.<x> = QQ[]
+            sage: v = GaussValuation(R, QQ.valuation(2))
+            sage: u = valuations.LimitValuation(v, x)
+            sage: u  # indirect doctest
+            Gauss valuation induced by 2-adic valuation
         """
         from sage.rings.infinity import infinity
         from .augmented_valuation import AugmentedValuation_base
@@ -378,9 +536,15 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         # This valuation sends an irreducible factor of _G to infinity.
         # We update _G when we find a smaller factor of _G with that property, e.g.,
         # when we determine the irreducible factor that is sent to infinity.
-        from sage.rings.all import infinity
+        from sage.rings.infinity import infinity
+        # ``G`` is normalized by the LimitValuation factory; this call is a
+        # safety net for direct internal callers (e.g., ``extensions``) which
+        # bypass the factory.
+        G = _normalize_polynomial(G)
         if self._approximation.mu() is infinity:
-            # TODO: Should this be here or should this be part of the calling contract?
+            # The factory already collapses ``G`` to ``phi`` in this case via
+            # its recursion through ``create_key``; this branch is the
+            # corresponding safety net for direct callers.
             assert self._approximation.phi().divides(G)
             G = self._approximation.phi()
         self._G = G
@@ -397,6 +561,11 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: u = v._base_valuation
             sage: u.extensions(QQ['x'])
             [[ Gauss valuation induced by 2-adic valuation, v(x + 1) = 1/2 , … ]]
+
+        Extending to the same ring is a no-op::
+
+            sage: u.extensions(u.domain()) == [u]
+            True
         """
         if self.domain() is ring:
             return [self]
@@ -427,6 +596,11 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             u1
             sage: w.lift(s)  # indirect doctest
             y
+
+        Zero in the residue ring lifts to zero in the domain::
+
+            sage: w.lift(w.residue_ring().zero())
+            0
         """
         F = self.residue_ring().coerce(F)
         return self._initial_approximation.lift(F)
@@ -467,6 +641,16 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: w = valuations.LimitValuation(V[2], f)
             sage: w((x^2 + 7) * (x + 3))
             +Infinity
+
+        The zero element always has infinite valuation::
+
+            sage: w(R.zero())
+            +Infinity
+
+        Constants are evaluated by the underlying coefficient valuation::
+
+            sage: w(R(8))
+            3
         """
         self._improve_approximation_for_call(f)
         if self._G.divides(f):
@@ -498,18 +682,63 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: u._improve_approximation()                                            # needs sage.rings.number_field
             sage: u._approximation                                                      # needs sage.rings.number_field
             [ Gauss valuation induced by 2-adic valuation, v(t + 1) = 1/2, v(t^2 + 1) = +Infinity ]
+
+        If the approximation is already infinite but ``_G`` has not yet been
+        refined to the corresponding key polynomial, this method updates
+        ``_G``::
+
+            sage: R.<x> = QQ[]
+            sage: v = GaussValuation(R, QQ.valuation(2))
+            sage: u = valuations.LimitValuation(v, x)
+            sage: u._approximation = v.augmentation(x, infinity)
+            sage: u._G = x*(x + 1)
+            sage: u._improve_approximation()
+            sage: u._G
+            x
+
+        Sometimes the bounded principal part is too short to see the
+        non-trivial equivalence decomposition. In that case, this method falls
+        back to the full Mac Lane step::
+
+            sage: # needs sage.rings.function_field
+            sage: from sage.rings.valuation.gauss_valuation import GaussValuation
+            sage: K.<x> = FunctionField(QQ)
+            sage: R.<y> = K[]
+            sage: v = K.valuation(0)
+            sage: u = valuations.LimitValuation(GaussValuation(R, v), y^2 - x + 1)
+            sage: u._improve_approximation()
+            sage: u._approximation
+            [ Gauss valuation induced by (x)-adic valuation, v(y^2 - x + 1) = +Infinity ]
         """
         from sage.rings.infinity import infinity
         if self._approximation(self._G) is infinity:
+            if self._approximation.mu() is infinity:
+                phi = self._approximation.phi()
+                assert phi.divides(self._G)
+                self._G = phi
             # an infinite valuation can not be improved further
             return
 
-        approximations = self._approximation.mac_lane_step(self._G,
-                          assume_squarefree=True,
-                          assume_equivalence_irreducible=True,
-                          check=False,
-                          principal_part_bound=1 if self._approximation.E() * self._approximation.F() == self._approximation.phi().degree() else None,
-                          report_degree_bounds_and_caches=True)
+        principal_part_bound = (1 if self._approximation.E() * self._approximation.F()
+                                == self._approximation.phi().degree() else None)
+        from .inductive_valuation import EquivalenceDecompositionTooSmall
+        try:
+            approximations = self._approximation.mac_lane_step(self._G,
+                              assume_squarefree=True,
+                              assume_equivalence_irreducible=True,
+                              check=False,
+                              principal_part_bound=principal_part_bound,
+                              report_degree_bounds_and_caches=True)
+        except EquivalenceDecompositionTooSmall:
+            # The bounded principal part is too short to see the non-trivial
+            # equivalence decomposition; fall back to the full Mac Lane step.
+            assert principal_part_bound is not None
+            approximations = self._approximation.mac_lane_step(self._G,
+                              assume_squarefree=True,
+                              assume_equivalence_irreducible=True,
+                              check=False,
+                              principal_part_bound=None,
+                              report_degree_bounds_and_caches=True)
         assert (len(approximations) == 1)
         self._approximation, _, _, self._next_coefficients, self._next_valuations = approximations[0]
 
@@ -521,10 +750,12 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         Replace our approximation with a sufficiently precise approximation to
         correctly compute the valuation of ``f``.
 
-        TODO: Explain what this means when f goes to infinity, i.e., the
-        approximation is still finite in that case.
-
-        TODO: Explain that G | f if f goes to infinity afterwards.
+        After this call, ``self._approximation(f)`` agrees with the limit
+        valuation of ``f`` whenever the limit valuation of ``f`` is finite.
+        If the limit valuation of ``f`` is infinite, ``self._G`` is updated
+        so that ``self._G`` divides ``f`` (and ``_call_`` then returns
+        infinity by checking divisibility); ``self._approximation`` itself
+        may still be finite in that case.
 
         EXAMPLES:
 
@@ -573,23 +804,40 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             for all future computations.)
         """
         if f == 0:
-            # zero always has infinite valuation (actually, this might
-            # not be desirable for inexact zero elements with leading
-            # zero coefficients.)
-            # TODO: Explain that this is also a performance improvement
+            # Zero always has infinite valuation. Returning early also avoids
+            # the gcd and equivalence-unit work below, which is a noticeable
+            # performance win for the common case of simplifications passing
+            # through this method.
+            # (For inexact zero elements with leading zero coefficients the
+            # "true" valuation may be finite; we follow Sage's convention
+            # that ``f == 0`` means the exact zero element.)
             return
 
         from sage.rings.infinity import infinity
         if self._approximation.mu() is infinity:
-            # an infinite valuation can not be improved further
-            # TODO: Explain that this is just a performance improvement.
+            phi = self._approximation.phi()
+            assert phi.divides(self._G)
+            self._G = phi
+            # An infinite approximation cannot be improved further; ``_call_``
+            # will use ``self._G`` (now equal to ``phi``) to detect whether
+            # ``f`` has infinite valuation. Returning early avoids the
+            # ``is_equivalence_unit`` and gcd work below; this is a pure
+            # performance optimization.
             return
 
         if self._approximation.is_equivalence_unit(f):
-            # TODO: Explain that we now know the valuation of f.
+            # By the ALGORITHM section above (strict triangle inequality on
+            # the phi-expansion of ``f``), the valuation of ``f`` in the
+            # limit equals ``self._approximation(f)``. So no further
+            # improvement is needed.
             return
 
-        # TODO: I doubt that this gcd and the below division really works reliably over inexact fields
+        # NOTE: This gcd and the divisions below assume that polynomial
+        # arithmetic in ``self.domain()`` is exact. Limit valuations are
+        # designed to be used over exact base rings; over inexact base rings
+        # (e.g., p-adic coefficients with finite precision) the gcd and
+        # division may yield approximate results and the dispatch below may
+        # misclassify factors. Such usage is currently unsupported.
         s = self._G.gcd(f)
         if s.is_constant():
             # G and f are coprime. The valuation of f is finite. After finitely
@@ -647,6 +895,7 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             return
         self._improve_approximation_for_call(f)
 
+    @cached_method
     def residue_ring(self):
         r"""
         Return the residue ring of this valuation, which is always a field.
@@ -660,9 +909,32 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: w = v.extension(L)
             sage: w.residue_ring()
             Finite Field of size 2
+
+        Repeated calls return the same object (cached)::
+
+            sage: w.residue_ring() is w.residue_ring()
+            True
+
+        When the approximation is already infinite, the residue ring is the
+        residue ring of that final augmentation::
+
+            sage: R.<x> = QQ[]
+            sage: v = GaussValuation(R, QQ.valuation(2))
+            sage: u = valuations.LimitValuation(v, x)
+            sage: u._improve_approximation()
+            sage: u._approximation.mu()
+            +Infinity
+            sage: u.residue_ring()
+            Finite Field of size 2
         """
-        R = self._initial_approximation.residue_ring()
         from sage.categories.fields import Fields
+        from sage.rings.infinity import infinity
+        if self._approximation.mu() is infinity:
+            R = self._approximation.residue_ring()
+            assert R in Fields()
+            return R
+
+        R = self._initial_approximation.residue_ring()
         if R in Fields():
             # the approximation ends in v(phi)=infty
             return R
@@ -723,13 +995,18 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                 # Gs are different but share a common factor.
                 # We therefore refine the defining Gs until they are either
                 # equal or we can otherwise decide that the valuations must be distinct.
+                from sage.rings.infinity import infinity
                 while self._G != other._G:
+                    if _normalize_polynomial(self._G) == _normalize_polynomial(other._G):
+                        break
+
                     if self._G.gcd(other._G).is_constant():
                         # The valuations cannot approximate the same factor of
                         # their defining Gs. They must be distinct.
                         return False
 
-                    from sage.rings.infinity import infinity
+                    old_self_G = self._G
+                    old_other_G = other._G
 
                     if self(other._G) is not infinity:
                         # The valuations differ on other._G, they must be different.
@@ -742,7 +1019,7 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                         # The valuations differ on self._G, they must be different.
                         return False
 
-                    # Since other send self._G to infinity, other._G divides
+                    # Since other sends self._G to infinity, other._G divides
                     # self._G, _improve_approximation_for_call. (**)
 
                     # Therefore, at least one of self._G and other._G has been
@@ -756,6 +1033,8 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                     # _improve_approximation_for_call, self._G == other._G
                     # actually should hold now but we consider this an
                     # implementation detail that we do not want to rely on.)
+                    if self._G == old_self_G and other._G == old_other_G:
+                        break
 
                 # If the valuations are comparable, they must approximate the
                 # same factor of G (see the documentation of LimitValuation:
@@ -777,6 +1056,12 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: v = QQ.valuation(2)
             sage: w = v.extension(L)
             sage: w._base_valuation.restriction(K)
+            2-adic valuation
+
+        Restricting to ``ZZ`` (also a subring of the coefficient ring) gives
+        the corresponding `p`-adic valuation on `\ZZ`::
+
+            sage: w._base_valuation.restriction(ZZ)
             2-adic valuation
         """
         if ring.is_subring(self.domain().base()):

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -675,10 +675,31 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                 # number of steps, see _improve_approximation_for_call.
                 while self._G != other._G:
                     if self._G.gcd(other._G).is_one():
+                        # The valuations cannot approximate the same factor of
+                        # their defining Gs. They must be distinct.
                         return False
 
-                    self._improve_approximation_for_call(other._G)
-                    other._improve_approximation_for_call(self._G)
+                    from sage.rings.infinity import infinity
+
+                    if self(other._G) is not infinity:
+                        # The valuations differ on other._G, they must be different.
+                        return False
+
+                    # Since self sends other._G to infinity, self._G divides other._G. (*)
+
+                    if other(self._G) is not infinity:
+                        # The valuations differ on self._G, they must be different.
+                        return False
+
+                    # Since other send self._G to infinity, other._G divides self._G. (**)
+
+                    # Therefore, at least one of self._G and other._G has been
+                    # replaced by one of its factors in this iteration of the
+                    # while loop which means that the loop is eventually going
+                    # to terminate.
+                    # Note that (*) and (**) do not imply that self._G ==
+                    # other._G since other._G might have been mutated so (*)
+                    # might not hold anymore.
 
                 # If the valuations are comparable, they must approximate the
                 # same factor of G (see the documentation of LimitValuation:

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -70,7 +70,7 @@ Limits of inductive valuations are discussed in [Mac1936I]_ and [Mac1936II]_. An
 overview can also be found in Section 4.6 of [Rüt2014]_.
 """
 # ****************************************************************************
-#       Copyright (C) 2016-2017 Julian Rüth <julian.rueth@fsfe.org>
+#       Copyright (C) 2016-2026 Julian Rüth <julian.rueth@fsfe.org>
 #
 #  Distributed under the terms of the GNU General Public License (GPL)
 #  as published by the Free Software Foundation; either version 2 of
@@ -375,6 +375,9 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         LimitValuation_generic.__init__(self, parent, approximation)
         InfiniteDiscretePseudoValuation.__init__(self, parent)
 
+        # This valuation sends an irreducible factor of _G to infinity.
+        # We update _G when we find a smaller factor of _G with that property, e.g.,
+        # when we determine the irreducible factor that is sent to infinity.
         self._G = G
         self._next_coefficients = None
         self._next_valuations = None
@@ -666,13 +669,16 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                 # v<w can hold everywhere.
                 # They are equal iff they approximate the same factor of their
                 # defining G. Note that they can be equal even if the defining
-                # G is different, so we need to make sure that this can not be
-                # the case.
-                self._improve_approximation_for_call(other._G)
-                other._improve_approximation_for_call(self._G)
-                if self._G != other._G:
-                    assert self._G.gcd(other._G).is_one()
-                    return False
+                # Gs are different but share a common factor.
+                # We therefore refine the defining Gs until they are either
+                # equal or coprime which is guaranteed to happen in a finite
+                # number of steps, see _improve_approximation_for_call.
+                while self._G != other._G:
+                    if self._G.gcd(other._G).is_one():
+                        return False
+
+                    self._improve_approximation_for_call(other._G)
+                    other._improve_approximation_for_call(self._G)
 
                 # If the valuations are comparable, they must approximate the
                 # same factor of G (see the documentation of LimitValuation:

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -78,7 +78,6 @@ overview can also be found in Section 4.6 of [Rüt2014]_.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 from sage.misc.abstract_method import abstract_method
-from sage.misc.cachefunc import cached_method
 from .valuation import DiscretePseudoValuation, InfiniteDiscretePseudoValuation
 from sage.structure.factory import UniqueFactory
 
@@ -895,7 +894,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             return
         self._improve_approximation_for_call(f)
 
-    @cached_method
     def residue_ring(self):
         r"""
         Return the residue ring of this valuation, which is always a field.
@@ -909,11 +907,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: w = v.extension(L)
             sage: w.residue_ring()
             Finite Field of size 2
-
-        Repeated calls return the same object (cached)::
-
-            sage: w.residue_ring() is w.residue_ring()
-            True
 
         When the approximation is already infinite, the residue ring is the
         residue ring of that final augmentation::

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -378,6 +378,11 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         # This valuation sends an irreducible factor of _G to infinity.
         # We update _G when we find a smaller factor of _G with that property, e.g.,
         # when we determine the irreducible factor that is sent to infinity.
+        from sage.rings.all import infinity
+        if self._approximation.mu() is infinity:
+            # TODO: Should this be here or should this be part of the calling contract?
+            assert self._approximation.phi().divides(G)
+            G = self._approximation.phi()
         self._G = G
         self._next_coefficients = None
         self._next_valuations = None
@@ -508,10 +513,18 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         assert (len(approximations) == 1)
         self._approximation, _, _, self._next_coefficients, self._next_valuations = approximations[0]
 
+        if self._approximation.mu() is infinity:
+            self._G = self._approximation.phi()
+
     def _improve_approximation_for_call(self, f):
         r"""
         Replace our approximation with a sufficiently precise approximation to
         correctly compute the valuation of ``f``.
+
+        TODO: Explain what this means when f goes to infinity, i.e., the
+        approximation is still finite in that case.
+
+        TODO: Explain that G | f if f goes to infinity afterwards.
 
         EXAMPLES:
 
@@ -559,36 +572,51 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             (and in fact replace `G` with the factor with infinite valuation
             for all future computations.)
         """
-        from sage.rings.infinity import infinity
-        if self._approximation(self._approximation.phi()) is infinity:
-            # an infinite valuation can not be improved further
-            return
-
         if f == 0:
             # zero always has infinite valuation (actually, this might
             # not be desirable for inexact zero elements with leading
             # zero coefficients.)
+            # TODO: Explain that this is also a performance improvement
             return
 
-        while not self._approximation.is_equivalence_unit(f):
-            # TODO: I doubt that this really works over inexact fields
-            s = self._G.gcd(f)
-            if s.is_constant():
+        from sage.rings.infinity import infinity
+        if self._approximation.mu() is infinity:
+            # an infinite valuation can not be improved further
+            # TODO: Explain that this is just a performance improvement.
+            return
+
+        if self._approximation.is_equivalence_unit(f):
+            # TODO: Explain that we now know the valuation of f.
+            return
+
+        # TODO: I doubt that this gcd and the below division really works reliably over inexact fields
+        s = self._G.gcd(f)
+        if s.is_constant():
+            # G and f are coprime. The valuation of f is finite. After finitely
+            # many augmentations, f will be an equivalence unit and thus the
+            # approximation will correctly determine its valuation.
+            while not self._approximation.is_equivalence_unit(f):
                 self._improve_approximation()
-            else:
-                t = self._G // s
+        elif self._G.divides(f):
+            # f has infinite valuation
+            return
+        else:
+            # Determine whether s = gcd(f,G) or its coprime part t = G//s has finite valuation.
+            t = self._G // s
 
-                while True:
-                    if self._approximation.is_equivalence_unit(s):
-                        # t has infinite valuation
-                        self._G = t
-                        return self._improve_approximation_for_call(f // s)
-                    if self._approximation.is_equivalence_unit(t):
-                        # s has infinite valuation
-                        self._G = s
-                        return
+            while True:
+                if self._approximation.is_equivalence_unit(s):
+                    # s has finite valuation, hence t has infinite valuation
+                    # We recurse to determine the valuation of f which might still be infinite.
+                    self._G = t
+                    return self._improve_approximation_for_call(f)
+                if self._approximation.is_equivalence_unit(t):
+                    # t has finite valuation, hence s has infinite valuation.
+                    # Therefore, f has infinite valuation since it's divisible by s.
+                    self._G = s
+                    return
 
-                    self._improve_approximation()
+                self._improve_approximation()
 
     def _improve_approximation_for_reduce(self, f):
         r"""
@@ -658,6 +686,7 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
 
         TESTS::
 
+            sage: # needs sage.geometry.polyhedron
             sage: for v in V:
             ....:     for w in V:
             ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, F)) == (v == w)
@@ -667,14 +696,15 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
 
         An example with several valuations that correspond to factors of F over Q2 that are not rational::
 
+            sage: # needs sage.geometry.polyhedron
             sage: R.<x> = QQ[]
             sage: F = (x^2 - 17) * (x^2 - 25) * (x^7 - 1)
             sage: G = (x^2 - 25) * (x^7 - 1)
             sage: V = QQ.valuation(2).mac_lane_approximants(F, require_incomparability=True)
 
+            sage: # needs sage.geometry.polyhedron
             sage: for v in V:
             ....:     for w in V:
-            ....:         print(v,w)
             ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, F)) == (v == w)
             ....:         if valuations.LimitValuation(w, F)(G) != oo: continue
             ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, G)) == (v == w)
@@ -694,7 +724,7 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                 # We therefore refine the defining Gs until they are either
                 # equal or we can otherwise decide that the valuations must be distinct.
                 while self._G != other._G:
-                    if self._G.gcd(other._G).is_one():
+                    if self._G.gcd(other._G).is_constant():
                         # The valuations cannot approximate the same factor of
                         # their defining Gs. They must be distinct.
                         return False

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -671,8 +671,7 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                 # defining G. Note that they can be equal even if the defining
                 # Gs are different but share a common factor.
                 # We therefore refine the defining Gs until they are either
-                # equal or coprime which is guaranteed to happen in a finite
-                # number of steps, see _improve_approximation_for_call.
+                # equal or we can otherwise decide that the valuations must be distinct.
                 while self._G != other._G:
                     if self._G.gcd(other._G).is_one():
                         # The valuations cannot approximate the same factor of
@@ -685,13 +684,15 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                         # The valuations differ on other._G, they must be different.
                         return False
 
-                    # Since self sends other._G to infinity, self._G divides other._G. (*)
+                    # Since self sends other._G to infinity, self._G divides
+                    # other._G, see _improve_approximation_for_call. (*)
 
                     if other(self._G) is not infinity:
                         # The valuations differ on self._G, they must be different.
                         return False
 
-                    # Since other send self._G to infinity, other._G divides self._G. (**)
+                    # Since other send self._G to infinity, other._G divides
+                    # self._G, _improve_approximation_for_call. (**)
 
                     # Therefore, at least one of self._G and other._G has been
                     # replaced by one of its factors in this iteration of the
@@ -699,7 +700,11 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                     # to terminate.
                     # Note that (*) and (**) do not imply that self._G ==
                     # other._G since other._G might have been mutated so (*)
-                    # might not hold anymore.
+                    # might not hold anymore. (However, due to exact
+                    # construction performed by
+                    # _improve_approximation_for_call, self._G == other._G
+                    # actually should hold now but we consider this an
+                    # implementation detail that we do not want to rely on.)
 
                 # If the valuations are comparable, they must approximate the
                 # same factor of G (see the documentation of LimitValuation:

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -235,7 +235,7 @@ class LimitValuationFactory(UniqueFactory):
         ``G`` to infinity::
 
             sage: v = next(v for v in V if valuations.LimitValuation(v, F)(G) != oo)       # needs sage.geometry.polyhedron
-            sage: valuations.LimitValuation(v, G)                                         # needs sage.geometry.polyhedron
+            sage: valuations.LimitValuation(v, G)                                          # needs sage.geometry.polyhedron
             Traceback (most recent call last):
             ...
             ValueError: G must have a non-equivalence-unit factor for base_valuation

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -119,6 +119,19 @@ class LimitValuationFactory(UniqueFactory):
         Equivalent descriptions of the same limit give the same key::
 
             sage: R.<x> = QQ[]
+            sage: v = GaussValuation(R, QQ.valuation(2))
+            sage: w = valuations.LimitValuation(v, x)  # indirect doctest
+            sage: v = v.augmentation(x, infinity)
+            sage: u = valuations.LimitValuation(v, x)
+            sage: u == w
+            True
+            sage: u is w
+            True
+            sage: valuations.LimitValuation(v._base_valuation, 2*x) is w
+            True
+            sage: valuations.LimitValuation(v, x*(x + 1)) is w
+            True
+
             sage: vK = QQ.valuation(2)
             sage: v = GaussValuation(R, vK)
             sage: G = x^2 + 1
@@ -127,6 +140,16 @@ class LimitValuationFactory(UniqueFactory):
             sage: w is valuations.LimitValuation(a, 2*G)
             True
             sage: w is valuations.LimitValuation(a.augmentation(G, infinity), G)
+            True
+
+        A reducible defining polynomial is replaced by the irreducible factor
+        selected by ``base_valuation``::
+
+            sage: F = (x^2 + 7) * (x^2 + 9)
+            sage: G = x^2 + 7
+            sage: V = vK.mac_lane_approximants(F, require_incomparability=True)  # needs sage.geometry.polyhedron
+            sage: w = valuations.LimitValuation(V[1], F)                        # needs sage.geometry.polyhedron
+            sage: w is valuations.LimitValuation(V[1], G)                       # needs sage.geometry.polyhedron
             True
 
         The defining polynomial must be nonzero and nonconstant::
@@ -142,7 +165,14 @@ class LimitValuationFactory(UniqueFactory):
 
         The parameters must single out one limit valuation::
 
+            sage: bad = next(a for a in V if valuations.LimitValuation(a, F)(G) != oo)  # needs sage.geometry.polyhedron
+            sage: valuations.LimitValuation(bad, G)                              # needs sage.geometry.polyhedron
+            Traceback (most recent call last):
+            ...
+            ValueError: base_valuation must single out one irreducible factor of G
+
             sage: v = GaussValuation(R, QQ.valuation(5))
+            sage: G = x^2 + 1
             sage: valuations.LimitValuation(v, G)
             Traceback (most recent call last):
             ...
@@ -611,7 +641,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: u._improve_approximation()                                            # needs sage.rings.number_field
             sage: u._approximation                                                      # needs sage.rings.number_field
             [ Gauss valuation induced by 2-adic valuation, v(t + 1) = 1/2, v(t^2 + 1) = +Infinity ]
-
         """
         from sage.rings.infinity import infinity
         if self._approximation(self._G) is infinity:
@@ -840,7 +869,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             ....:         if valuations.LimitValuation(w, F)(G) != oo: continue
             ....:         assert (valuations.LimitValuation(v, F) >= valuations.LimitValuation(w, G)) == (v == w)
             ....:         assert (valuations.LimitValuation(w, G) >= valuations.LimitValuation(v, F)) == (v == w)
-
         """
         if other.is_trivial():
             return other.is_discrete_valuation()

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -64,6 +64,55 @@ The same phenomenon can be observed for valuations on number fields::
         [ Gauss valuation induced by Valuation at the infinite place,
             v(y) = 1/2, v(y^2 - 1/x) = +Infinity ]
 
+Canonical representatives
+-------------------------
+
+A limit valuation has many finite descriptions: one may multiply its defining
+polynomial by a unit, add factors that have finite value, or replace a Mac Lane
+approximant by a later valuation on the same branch.  The checked
+:class:`LimitValuationFactory` removes these choices before using its arguments
+as a factory key.
+
+More precisely, write the monic squarefree defining polynomial as
+`G=\prod_i P_i`, with the `P_i` irreducible.  A factor which is an
+equivalence-unit for the input approximation stays an equivalence-unit along
+the selected branch and therefore has finite limit value.  Such factors cannot
+generate the support of the limit valuation and are discarded.  There must be
+exactly one remaining factor `P`; otherwise the input does not determine a
+unique limit valuation.  This factor must be integral for the coefficient
+valuation so that the Mac Lane algorithm applies.  The stability and
+finite-refinement properties used here are recalled below with references to
+[Mac1936II]_.
+
+The extensions associated with `P` are represented by
+:meth:`Mac Lane approximants
+<sage.rings.valuation.valuation.DiscreteValuation.mac_lane_approximants>`.
+Requiring these approximants to be incomparable separates the distinct
+extensions.  The unique approximant comparable with the input valuation is
+then selected by
+:meth:`~sage.rings.valuation.valuation.DiscreteValuation.mac_lane_approximant`.
+Thus the canonical factory key is the pair consisting of this approximant and
+`P`.  This is the same normalization used for valuations on number fields and
+function fields.  Inputs for which the factor or the branch is not unique are
+rejected rather than assigned an arbitrary key.
+
+Unchecked internal constructions may retain a squarefree product in place of
+`P`, with the invariant that exactly one of its irreducible factors has
+infinite limit value.  To evaluate a polynomial `f`, put `s=\gcd(G,f)` and
+`t=G/s`.  Squarefreeness makes `s` and `t` coprime, so exactly one contains the
+support factor.  The other becomes an equivalence-unit after finitely many Mac
+Lane steps by Theorem 5.1 of [Mac1936II]_.  Refinement therefore terminates and
+shrinks `G` towards its support.
+
+Finally, two limit valuations extending the same coefficient valuation but
+having different supports or different Mac Lane branches are incomparable.
+For legacy product representations, evaluating each defining polynomial under
+the other valuation first exposes the support factors.  If the supports agree,
+the incomparable Mac Lane approximants distinguish the branches: comparable
+initial approximants describe the same branch, while incomparable ones
+describe distinct extensions.  This gives the comparison criterion used in
+this module.
+
 REFERENCES:
 
 Limits of inductive valuations are discussed in [Mac1936I]_ and [Mac1936II]_. An
@@ -89,18 +138,22 @@ class LimitValuationFactory(UniqueFactory):
 
     INPUT:
 
-    - ``base_valuation`` -- a discrete (pseudo-)valuation on a polynomial ring
-      which is a discrete valuation on the coefficient ring which can be
-      uniquely augmented (possibly only in the limit) to a pseudo-valuation
-      that sends ``G`` to infinity.
+    - ``base_valuation`` -- a discrete (pseudo-)valuation on an exact
+      polynomial ring which is a discrete valuation on the coefficient ring
+      and which can be uniquely augmented (possibly only in the limit) to a
+      pseudo-valuation that sends ``G`` to infinity
 
-    - ``G`` -- a squarefree polynomial in the domain of ``base_valuation``
+    - ``G`` -- a nonzero nonconstant squarefree polynomial in the domain of
+      ``base_valuation`` whose leading coefficient is a unit; after making it
+      monic, the factor selected by ``base_valuation`` must be integral for the
+      valuation on the coefficient ring
 
     - ``check`` -- boolean (default: ``True``); whether to validate and
       canonicalize the arguments; internal callers may set this to ``False``
-      when ``G`` is monic and squarefree and ``base_valuation`` singles out a
-      unique branch towards ``G``; unchecked calls use their arguments as the
-      factory key and therefore do not canonicalize equivalent descriptions
+      when ``G`` is monic, squarefree, and integral and ``base_valuation``
+      singles out a unique branch towards ``G``; unchecked calls use their
+      arguments as the factory key and therefore do not canonicalize
+      equivalent descriptions
 
     EXAMPLES::
 
@@ -113,6 +166,22 @@ class LimitValuationFactory(UniqueFactory):
     def create_key(self, base_valuation, G, check=True):
         r"""
         Create a key from the parameters of this valuation.
+
+        ALGORITHM:
+
+        First, normalize ``G`` to a monic polynomial and factor it exactly.
+        Factors that are equivalence-units for ``base_valuation`` have finite
+        value on every continuation of the selected branch, so they cannot be
+        the support of the limit valuation.  Require exactly one remaining
+        irreducible factor.
+
+        Next, compute mutually incomparable Mac Lane approximants for that
+        factor.  They distinguish the extensions of the coefficient
+        valuation.  The unique approximant comparable with
+        ``base_valuation`` is its canonical representative, so it and the
+        irreducible factor form a factory key independent of the original
+        presentation.  See the module-level discussion of canonical
+        representatives for the mathematical justification.
 
         EXAMPLES:
 
@@ -162,6 +231,13 @@ class LimitValuationFactory(UniqueFactory):
             Traceback (most recent call last):
             ...
             ValueError: G must be nonconstant
+
+        It must also be integral for the coefficient valuation::
+
+            sage: valuations.LimitValuation(v, x^2 + x/2 + 1)
+            Traceback (most recent call last):
+            ...
+            ValueError: G must be integral
 
         The parameters must single out one limit valuation::
 
@@ -641,6 +717,11 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: u._improve_approximation()                                            # needs sage.rings.number_field
             sage: u._approximation                                                      # needs sage.rings.number_field
             [ Gauss valuation induced by 2-adic valuation, v(t + 1) = 1/2, v(t^2 + 1) = +Infinity ]
+
+        The bound on the principal part below is only an optimization.  If it
+        is too short to exhibit a nontrivial equivalence decomposition, the
+        full Mac Lane step is repeated without the bound; this computes the
+        same next branch rather than choosing a different one.
         """
         from sage.rings.infinity import infinity
         if self._approximation(self._G) is infinity:
@@ -720,10 +801,16 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             `w(g)=v(g)`.
             Normally, the factory normalizes `G` to an irreducible polynomial.
             The unchecked internal construction also accepts a squarefree
-            `G`; in that case gcds with `f` are used to discard factors with
-            finite valuation. Any polynomial coprime to the remaining `G`
-            becomes an equivalence-unit after finitely many Mac Lane steps
-            (Theorem 5.1 in [Mac1936II]_).
+            `G`; its invariant is that exactly one irreducible factor of the
+            current `G` has infinite limit value.  Put `s=\gcd(G,f)` and
+            `t=G/s`.  Since `G` is squarefree, `s` and `t` are coprime, and
+            exactly one of them can contain that support factor.  The other
+            one has finite value and becomes an equivalence-unit after
+            finitely many Mac Lane steps (Theorem 5.1 in [Mac1936II]_).  The
+            loop below therefore terminates and replaces `G` by the side that
+            contains its support.  If that side divides `f`, the limit value
+            of `f` is infinite; otherwise the remaining finite factor is
+            removed and the argument is repeated.
         """
         if f == 0:
             return
@@ -834,6 +921,24 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         r"""
         Return whether this valuation is greater or equal than ``other``
         everywhere.
+
+        ALGORITHM:
+
+        Distinct extensions of the same coefficient valuation are
+        incomparable.  Their supports first distinguish extensions attached
+        to coprime irreducible factors.  For unchecked or legacy objects,
+        ``_G`` may still be a squarefree product; evaluating each object on
+        the other's ``_G`` invokes
+        :meth:`_improve_approximation_for_call` and refines both products to
+        their support factors.  Different supports give incomparable limit
+        valuations.
+
+        Once the supports agree, mutually incomparable canonical Mac Lane
+        approximants distinguish the branches above that support.  Hence the
+        two limit valuations agree precisely when their initial approximants
+        are comparable.  Thus this method can return ``True`` only when the
+        valuations agree, although the operation being implemented is the
+        pointwise order.
 
         EXAMPLES::
 

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -82,96 +82,6 @@ from .valuation import DiscretePseudoValuation, InfiniteDiscretePseudoValuation
 from sage.structure.factory import UniqueFactory
 
 
-def _normalize_polynomial(G):
-    r"""
-    Return a canonical representative for ``G`` up to scalar multiple.
-
-    Some base rings do not allow division by the leading coefficient. In that
-    case, leave ``G`` unchanged.
-
-    EXAMPLES::
-
-        sage: from sage.rings.valuation.limit_valuation import _normalize_polynomial
-        sage: R.<x> = QQ[]
-        sage: _normalize_polynomial(2*x + 4)
-        x + 2
-        sage: _normalize_polynomial(R.zero())
-        0
-
-    Over a ring whose leading coefficient is not invertible, the polynomial
-    is returned unchanged::
-
-        sage: S.<y> = Zmod(6)[]
-        sage: _normalize_polynomial(3*y + 4)
-        3*y + 4
-    """
-    if G == 0:
-        return G
-    try:
-        return G.monic()
-    except (ArithmeticError, NotImplementedError, TypeError,
-            ValueError, ZeroDivisionError):
-        return G
-
-
-def _normalize_key_polynomial(base_valuation, G):
-    r"""
-    Remove factors of ``G`` that cannot vanish in the corresponding limit.
-
-    The polynomial ``G`` is part of the unique factory key for limit
-    valuations. If some factors of ``G`` are equivalence-units for the initial
-    approximation, then the limit valuation sending ``G`` to infinity is the
-    same as the one defined by the complementary factor.
-
-    EXAMPLES::
-
-        sage: from sage.rings.valuation.limit_valuation import _normalize_key_polynomial
-        sage: R.<x> = QQ[]
-        sage: F = (x^2 + 7) * (x^2 + 9)
-        sage: V = QQ.valuation(2).mac_lane_approximants(F, require_incomparability=True)        # needs sage.geometry.polyhedron
-        sage: _normalize_key_polynomial(V[1], F) in [x^2 + 7, x^2 + 9]                          # needs sage.geometry.polyhedron
-        True
-        sage: _normalize_key_polynomial(V[1], F) != F                                           # needs sage.geometry.polyhedron
-        True
-
-    A constant or equivalence-unit factor alone is rejected::
-
-        sage: v = GaussValuation(R, QQ.valuation(2))
-        sage: _normalize_key_polynomial(v, R.one() + 2)
-        Traceback (most recent call last):
-        ...
-        ValueError: G must have a non-equivalence-unit factor for base_valuation
-
-    The zero polynomial is returned unchanged (the factory rejects it
-    separately)::
-
-        sage: _normalize_key_polynomial(v, R.zero())
-        0
-    """
-    if G == 0:
-        return G
-
-    try:
-        factors = G.factor()
-    except (ArithmeticError, AttributeError, NotImplementedError, TypeError,
-            ValueError):
-        return G
-
-    H = G.parent().one()
-    try:
-        for factor, exponent in factors:
-            factor = _normalize_polynomial(factor)
-            if (not factor.is_constant()
-                    and not base_valuation.is_equivalence_unit(factor)):
-                H *= factor
-    except (ArithmeticError, NotImplementedError, TypeError, ValueError):
-        return G
-
-    if H.is_one():
-        raise ValueError("G must have a non-equivalence-unit factor for base_valuation")
-    return _normalize_polynomial(H)
-
-
 class LimitValuationFactory(UniqueFactory):
     r"""
     Return a limit valuation which sends the polynomial ``G`` to infinity and
@@ -186,6 +96,12 @@ class LimitValuationFactory(UniqueFactory):
 
     - ``G`` -- a squarefree polynomial in the domain of ``base_valuation``
 
+    - ``check`` -- boolean (default: ``True``); whether to validate and
+      canonicalize the arguments; internal callers may set this to ``False``
+      when ``G`` is monic and squarefree and ``base_valuation`` singles out a
+      unique branch towards ``G``; unchecked calls use their arguments as the
+      factory key and therefore do not canonicalize equivalent descriptions
+
     EXAMPLES::
 
         sage: R.<x> = QQ[]
@@ -194,50 +110,24 @@ class LimitValuationFactory(UniqueFactory):
         sage: w(x)
         +Infinity
     """
-    def create_key(self, base_valuation, G):
+    def create_key(self, base_valuation, G, check=True):
         r"""
         Create a key from the parameters of this valuation.
 
         EXAMPLES:
 
-        This normalizes scalar multiples of ``G`` and an already infinite
-        final augmentation of ``base_valuation``::
+        Equivalent descriptions of the same limit give the same key::
 
             sage: R.<x> = QQ[]
-            sage: v = GaussValuation(R, QQ.valuation(2))
-            sage: w = valuations.LimitValuation(v, x)  # indirect doctest
-            sage: v = v.augmentation(x, infinity)
-            sage: u = valuations.LimitValuation(v, x)
-            sage: u == w
+            sage: vK = QQ.valuation(2)
+            sage: v = GaussValuation(R, vK)
+            sage: G = x^2 + 1
+            sage: a = vK.mac_lane_approximants(G, require_incomparability=True)[0]
+            sage: w = valuations.LimitValuation(v, G)
+            sage: w is valuations.LimitValuation(a, 2*G)
             True
-            sage: u is w
+            sage: w is valuations.LimitValuation(a.augmentation(G, infinity), G)
             True
-            sage: valuations.LimitValuation(v._base_valuation, 2*x) is w
-            True
-            sage: valuations.LimitValuation(v, x*(x + 1)) is w
-            True
-
-        Factors of ``G`` that are equivalence-units for ``base_valuation`` are
-        also removed from the factory key::
-
-            sage: R.<x> = QQ[]
-            sage: F = (x^2 + 7) * (x^2 + 9)
-            sage: G = x^2 + 7
-            sage: V = QQ.valuation(2).mac_lane_approximants(F, require_incomparability=True)
-            sage: w = valuations.LimitValuation(V[1], F)                                  # needs sage.geometry.polyhedron
-            sage: u = valuations.LimitValuation(V[1], G)                                  # needs sage.geometry.polyhedron
-            sage: w is u                                                                  # needs sage.geometry.polyhedron
-            True
-
-        If every factor of ``G`` is already an equivalence-unit for
-        ``base_valuation``, then there is no limit over this branch that sends
-        ``G`` to infinity::
-
-            sage: v = next(v for v in V if valuations.LimitValuation(v, F)(G) != oo)       # needs sage.geometry.polyhedron
-            sage: valuations.LimitValuation(v, G)                                          # needs sage.geometry.polyhedron
-            Traceback (most recent call last):
-            ...
-            ValueError: G must have a non-equivalence-unit factor for base_valuation
 
         The defining polynomial must be nonzero and nonconstant::
 
@@ -250,31 +140,48 @@ class LimitValuationFactory(UniqueFactory):
             ...
             ValueError: G must be nonconstant
 
-        Apart from this, the point here is that this is not meant to be invoked
-        from user code, but mostly from other factories which have made sure
-        that the parameters are normalized already.
+        The parameters must single out one limit valuation::
+
+            sage: v = GaussValuation(R, QQ.valuation(5))
+            sage: valuations.LimitValuation(v, G)
+            Traceback (most recent call last):
+            ...
+            ValueError: ... does not approximate a unique extension ...
         """
-        G = base_valuation.domain().coerce(G)
-        G = _normalize_polynomial(G)
+        domain = base_valuation.domain()
+        G = domain.coerce(G)
+        if not check:
+            return base_valuation, G
+
+        if not domain.is_exact():
+            raise NotImplementedError("limit valuations over inexact rings are not supported")
         if G == 0:
             raise ValueError("G must be nonzero")
         if G.is_constant():
             raise ValueError("G must be nonconstant")
 
-        if not base_valuation.restriction(G.parent().base_ring()).is_discrete_valuation():
+        leading_coefficient = G.leading_coefficient()
+        if not leading_coefficient.is_unit():
+            raise ValueError("the leading coefficient of G must be a unit")
+        G //= leading_coefficient
+        if not G.is_squarefree():
+            raise ValueError("G must be squarefree")
+
+        vK = base_valuation.restriction(domain.base_ring())
+        if not vK.is_discrete_valuation():
             raise ValueError("base_valuation must be discrete on the coefficient ring.")
 
-        from .augmented_valuation import AugmentedValuation_base
-        if isinstance(base_valuation, AugmentedValuation_base):
-            from sage.rings.infinity import infinity
-            if base_valuation.mu() is infinity:
-                phi = base_valuation.phi()
-                if not phi.divides(G):
-                    raise ValueError("the infinite key polynomial of base_valuation must divide G")
-                return self.create_key(base_valuation._base_valuation, phi)
-
-        G = _normalize_key_polynomial(base_valuation, G)
-
+        factors = [factor.monic() for factor, _ in G.factor()]
+        factors = [factor for factor in factors
+                   if not base_valuation.is_equivalence_unit(factor)]
+        if len(factors) != 1:
+            raise ValueError(
+                "base_valuation must single out one irreducible factor of G")
+        G = factors[0]
+        approximants = vK.mac_lane_approximants(
+            G, assume_squarefree=True, require_incomparability=True)
+        base_valuation = vK.mac_lane_approximant(
+            G, base_valuation, approximants=approximants)
         return base_valuation, G
 
     def create_object(self, version, key):
@@ -305,6 +212,9 @@ class LimitValuationFactory(UniqueFactory):
             True
         """
         base_valuation, G = key
+        leading_coefficient = G.leading_coefficient()
+        if leading_coefficient.is_unit():
+            G //= leading_coefficient
         from .valuation_space import DiscretePseudoValuationSpace
         parent = DiscretePseudoValuationSpace(base_valuation.domain())
         return parent.__make_element_class__(MacLaneLimitValuation)(parent, base_valuation, G)
@@ -549,20 +459,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         LimitValuation_generic.__init__(self, parent, approximation)
         InfiniteDiscretePseudoValuation.__init__(self, parent)
 
-        # This valuation sends an irreducible factor of _G to infinity.
-        # We update _G when we find a smaller factor of _G with that property, e.g.,
-        # when we determine the irreducible factor that is sent to infinity.
-        from sage.rings.infinity import infinity
-        # ``G`` is normalized by the LimitValuation factory; this call is a
-        # safety net for direct internal callers (e.g., ``extensions``) which
-        # bypass the factory.
-        G = _normalize_polynomial(G)
-        if self._approximation.mu() is infinity:
-            # The factory already collapses ``G`` to ``phi`` in this case via
-            # its recursion through ``create_key``; this branch is the
-            # corresponding safety net for direct callers.
-            assert self._approximation.phi().divides(G)
-            G = self._approximation.phi()
         self._G = G
         self._next_coefficients = None
         self._next_valuations = None
@@ -625,7 +521,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: v = GaussValuation(R, QQ.valuation(2))
             sage: G = (x^2 + x + 1)^2 + 2
             sage: u = valuations.LimitValuation(v, G)
-            sage: u._improve_approximation()
             sage: u._approximation.mu()
             1/2
             sage: k = u.residue_ring(); k                                      # needs sage.rings.finite_rings
@@ -717,32 +612,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             sage: u._approximation                                                      # needs sage.rings.number_field
             [ Gauss valuation induced by 2-adic valuation, v(t + 1) = 1/2, v(t^2 + 1) = +Infinity ]
 
-        If the approximation is already infinite but ``_G`` has not yet been
-        refined to the corresponding key polynomial, this method updates
-        ``_G``::
-
-            sage: R.<x> = QQ[]
-            sage: v = GaussValuation(R, QQ.valuation(2))
-            sage: u = valuations.LimitValuation(v, x)
-            sage: u._approximation = v.augmentation(x, infinity)
-            sage: u._G = x*(x + 1)
-            sage: u._improve_approximation()
-            sage: u._G
-            x
-
-        Sometimes the bounded principal part is too short to see the
-        non-trivial equivalence decomposition. In that case, this method falls
-        back to the full Mac Lane step::
-
-            sage: # needs sage.rings.function_field
-            sage: from sage.rings.valuation.gauss_valuation import GaussValuation
-            sage: K.<x> = FunctionField(QQ)
-            sage: R.<y> = K[]
-            sage: v = K.valuation(0)
-            sage: u = valuations.LimitValuation(GaussValuation(R, v), y^2 - x + 1)
-            sage: u._improve_approximation()
-            sage: u._approximation
-            [ Gauss valuation induced by (x)-adic valuation, v(y^2 - x + 1) = +Infinity ]
         """
         from sage.rings.infinity import infinity
         if self._approximation(self._G) is infinity:
@@ -761,27 +630,23 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
 
         principal_part_bound = (1 if self._approximation.E() * self._approximation.F()
                                 == self._approximation.phi().degree() else None)
+        options = {
+            'assume_squarefree': True,
+            'assume_equivalence_irreducible': True,
+            'check': False,
+            'report_degree_bounds_and_caches': True,
+        }
         from .inductive_valuation import EquivalenceDecompositionTooSmall
         try:
-            approximations = self._approximation.mac_lane_step(self._G,
-                              assume_squarefree=True,
-                              assume_equivalence_irreducible=True,
-                              check=False,
-                              principal_part_bound=principal_part_bound,
-                              report_degree_bounds_and_caches=True)
+            approximations = self._approximation.mac_lane_step(
+                self._G, principal_part_bound=principal_part_bound, **options)
         except EquivalenceDecompositionTooSmall:
-            # The bounded principal part is too short to see the non-trivial
-            # equivalence decomposition; fall back to the full Mac Lane step.
             assert principal_part_bound is not None
-            approximations = self._approximation.mac_lane_step(self._G,
-                              assume_squarefree=True,
-                              assume_equivalence_irreducible=True,
-                              check=False,
-                              principal_part_bound=None,
-                              report_degree_bounds_and_caches=True)
+            approximations = self._approximation.mac_lane_step(
+                self._G, principal_part_bound=None, **options)
         assert (len(approximations) == 1)
-        self._approximation, _, _, self._next_coefficients, self._next_valuations = approximations[0]
-
+        (self._approximation, _, _, self._next_coefficients,
+         self._next_valuations) = approximations[0]
         if self._approximation.mu() is infinity:
             self._G = self._approximation.phi()
 
@@ -789,13 +654,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         r"""
         Replace our approximation with a sufficiently precise approximation to
         correctly compute the valuation of ``f``.
-
-        After this call, ``self._approximation(f)`` agrees with the limit
-        valuation of ``f`` whenever the limit valuation of ``f`` is finite.
-        If the limit valuation of ``f`` is infinite, ``self._G`` is updated
-        so that ``self._G`` divides ``f`` (and ``_call_`` then returns
-        infinity by checking divisibility); ``self._approximation`` itself
-        may still be finite in that case.
 
         EXAMPLES:
 
@@ -831,26 +689,14 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             valuation of key polynomials does not change during augmentations
             (Theorem 6.4 in [Mac1936II]_.) By the strict triangle inequality,
             `w(g)=v(g)`.
-            Note that any `g` which is coprime to `G` is an equivalence-unit
-            after finitely many steps of the Mac Lane algorithm. Indeed,
-            otherwise the valuation of `g` would be infinite (follows from
-            Theorem 5.1 in [Mac1936II]_) since the valuation of the key
-            polynomials increases.
-            When `f` is not coprime to `G`, consider `s=gcd(f,G)` and write
-            `G=st`. Since `G` is squarefree, either `s` or `t` have finite
-            valuation. With the above algorithm, this can be decided in
-            finitely many steps. From this we can deduce the valuation of `s`
-            (and in fact replace `G` with the factor with infinite valuation
-            for all future computations.)
+            Normally, the factory normalizes `G` to an irreducible polynomial.
+            The unchecked internal construction also accepts a squarefree
+            `G`; in that case gcds with `f` are used to discard factors with
+            finite valuation. Any polynomial coprime to the remaining `G`
+            becomes an equivalence-unit after finitely many Mac Lane steps
+            (Theorem 5.1 in [Mac1936II]_).
         """
         if f == 0:
-            # Zero always has infinite valuation. Returning early also avoids
-            # the gcd and equivalence-unit work below, which is a noticeable
-            # performance win for the common case of simplifications passing
-            # through this method.
-            # (For inexact zero elements with leading zero coefficients the
-            # "true" valuation may be finite; we follow Sage's convention
-            # that ``f == 0`` means the exact zero element.)
             return
 
         from sage.rings.infinity import infinity
@@ -858,53 +704,26 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
             phi = self._approximation.phi()
             assert phi.divides(self._G)
             self._G = phi
-            # An infinite approximation cannot be improved further; ``_call_``
-            # will use ``self._G`` (now equal to ``phi``) to detect whether
-            # ``f`` has infinite valuation. Returning early avoids the
-            # ``is_equivalence_unit`` and gcd work below; this is a pure
-            # performance optimization.
             return
 
         if self._approximation.is_equivalence_unit(f):
-            # By the ALGORITHM section above (strict triangle inequality on
-            # the phi-expansion of ``f``), the valuation of ``f`` in the
-            # limit equals ``self._approximation(f)``. So no further
-            # improvement is needed.
             return
 
-        # NOTE: This gcd and the divisions below assume that polynomial
-        # arithmetic in ``self.domain()`` is exact. Limit valuations are
-        # designed to be used over exact base rings; over inexact base rings
-        # (e.g., p-adic coefficients with finite precision) the gcd and
-        # division may yield approximate results and the dispatch below may
-        # misclassify factors. Such usage is currently unsupported.
         s = self._G.gcd(f)
         if s.is_constant():
-            # G and f are coprime. The valuation of f is finite. After finitely
-            # many augmentations, f will be an equivalence unit and thus the
-            # approximation will correctly determine its valuation.
             while not self._approximation.is_equivalence_unit(f):
                 self._improve_approximation()
-        elif self._G.divides(f):
-            # f has infinite valuation
             return
-        else:
-            # Determine whether s = gcd(f,G) or its coprime part t = G//s has finite valuation.
-            t = self._G // s
 
-            while True:
-                if self._approximation.is_equivalence_unit(s):
-                    # s has finite valuation, hence t has infinite valuation
-                    # We recurse to determine the valuation of f which might still be infinite.
-                    self._G = t
-                    return self._improve_approximation_for_call(f)
-                if self._approximation.is_equivalence_unit(t):
-                    # t has finite valuation, hence s has infinite valuation.
-                    # Therefore, f has infinite valuation since it's divisible by s.
-                    self._G = s
-                    return
-
-                self._improve_approximation()
+        t = self._G // s
+        while True:
+            if self._approximation.is_equivalence_unit(s):
+                self._G = t
+                return self._improve_approximation_for_call(f // s)
+            if self._approximation.is_equivalence_unit(t):
+                self._G = s
+                return
+            self._improve_approximation()
 
     def _improve_approximation_for_reduce(self, f):
         r"""
@@ -968,7 +787,6 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                 self._G, infinity, check=False)
             if final_approximation.psi().degree() > 1:
                 self._approximation = final_approximation
-                self._G = final_approximation.phi()
 
         if self._approximation.mu() is infinity:
             R = self._approximation.residue_ring()
@@ -1027,59 +845,19 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         if other.is_trivial():
             return other.is_discrete_valuation()
         if isinstance(other, MacLaneLimitValuation):
-            if self._approximation.restriction(self._approximation.domain().base_ring()) == other._approximation.restriction(other._approximation.domain().base_ring()):
-                # Two MacLane limit valuations v,w over the same constant
-                # valuation are either equal or incomparable; neither v>w nor
-                # v<w can hold everywhere.
-                # They are equal iff they approximate the same factor of their
-                # defining G. Note that they can be equal even if the defining
-                # Gs are different but share a common factor.
-                # We therefore refine the defining Gs until they are either
-                # equal or we can otherwise decide that the valuations must be distinct.
-                from sage.rings.infinity import infinity
-                while self._G != other._G:
-                    if _normalize_polynomial(self._G) == _normalize_polynomial(other._G):
-                        break
-
+            vK = self._approximation.restriction(
+                self._approximation.domain().base_ring())
+            wK = other._approximation.restriction(
+                other._approximation.domain().base_ring())
+            if vK == wK:
+                if self._G != other._G:
                     if self._G.gcd(other._G).is_constant():
-                        # The valuations cannot approximate the same factor of
-                        # their defining Gs. They must be distinct.
                         return False
-
-                    old_self_G = self._G
-                    old_other_G = other._G
-
-                    if self(other._G) is not infinity:
-                        # The valuations differ on other._G, they must be different.
+                    from sage.rings.infinity import infinity
+                    if (self(other._G) is not infinity
+                            or other(self._G) is not infinity
+                            or self._G != other._G):
                         return False
-
-                    # Since self sends other._G to infinity, self._G divides
-                    # other._G, see _improve_approximation_for_call. (*)
-
-                    if other(self._G) is not infinity:
-                        # The valuations differ on self._G, they must be different.
-                        return False
-
-                    # Since other sends self._G to infinity, other._G divides
-                    # self._G, _improve_approximation_for_call. (**)
-
-                    # Therefore, at least one of self._G and other._G has been
-                    # replaced by one of its factors in this iteration of the
-                    # while loop which means that the loop is eventually going
-                    # to terminate.
-                    # Note that (*) and (**) do not imply that self._G ==
-                    # other._G since other._G might have been mutated so (*)
-                    # might not hold anymore. (However, due to exact
-                    # construction performed by
-                    # _improve_approximation_for_call, self._G == other._G
-                    # actually should hold now but we consider this an
-                    # implementation detail that we do not want to rely on.)
-                    if self._G == old_self_G and other._G == old_other_G:
-                        break
-
-                # If the valuations are comparable, they must approximate the
-                # same factor of G (see the documentation of LimitValuation:
-                # the approximation must *uniquely* single out a valuation.)
                 return (self._initial_approximation >= other._initial_approximation
                         or self._initial_approximation <= other._initial_approximation)
 

--- a/src/sage/rings/valuation/limit_valuation.py
+++ b/src/sage/rings/valuation/limit_valuation.py
@@ -286,6 +286,23 @@ class LimitValuationFactory(UniqueFactory):
             sage: R.<x> = QQ[]
             sage: v = GaussValuation(R, QQ.valuation(2))
             sage: w = valuations.LimitValuation(v, x^2 + 1)  # indirect doctest
+
+        If the defining polynomial is already a key polynomial, its final
+        augmentation is restored when needed.  In particular, this preserves
+        a nontrivial residue field extension::
+
+            sage: G = x^2 + x + 1
+            sage: w = valuations.LimitValuation(v, G)
+            sage: w.residue_ring()                                              # needs sage.rings.finite_rings
+            Finite Field in u1 of size 2^2
+            sage: w._approximation.mu()
+            +Infinity
+            sage: a = w.residue_ring().gen()                                    # needs sage.rings.finite_rings
+            sage: w.reduce(w.lift(a)) == a                                      # needs sage.rings.finite_rings
+            True
+            sage: u = valuations.LimitValuation(v.augmentation(G, infinity), G)
+            sage: u is w
+            True
         """
         base_valuation, G = key
         from .valuation_space import DiscretePseudoValuationSpace
@@ -600,9 +617,27 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
 
             sage: w.lift(w.residue_ring().zero())
             0
+
+        When improving the approximation produces a nontrivial residue field
+        extension, lifting uses that final approximation::
+
+            sage: R.<x> = QQ[]
+            sage: v = GaussValuation(R, QQ.valuation(2))
+            sage: G = (x^2 + x + 1)^2 + 2
+            sage: u = valuations.LimitValuation(v, G)
+            sage: u._improve_approximation()
+            sage: u._approximation.mu()
+            1/2
+            sage: k = u.residue_ring(); k                                      # needs sage.rings.finite_rings
+            Finite Field in u1 of size 2^2
+            sage: a = k.gen()                                                   # needs sage.rings.finite_rings
+            sage: u.reduce(u.lift(a)) == a                                      # needs sage.rings.finite_rings
+            True
+            sage: u.lift(k.zero())                                              # needs sage.rings.finite_rings
+            0
         """
         F = self.residue_ring().coerce(F)
-        return self._initial_approximation.lift(F)
+        return self._approximation.lift(F)
 
     def uniformizer(self):
         r"""
@@ -716,6 +751,12 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
                 assert phi.divides(self._G)
                 self._G = phi
             # an infinite valuation can not be improved further
+            return
+
+        if self._approximation.is_key(self._G):
+            self._approximation = self._approximation.augmentation(
+                self._G, infinity, check=False)
+            self._G = self._approximation.phi()
             return
 
         principal_part_bound = (1 if self._approximation.E() * self._approximation.F()
@@ -922,12 +963,19 @@ class MacLaneLimitValuation(LimitValuation_generic, InfiniteDiscretePseudoValuat
         """
         from sage.categories.fields import Fields
         from sage.rings.infinity import infinity
+        if self._approximation.mu() is not infinity and self._approximation.is_key(self._G):
+            final_approximation = self._approximation.augmentation(
+                self._G, infinity, check=False)
+            if final_approximation.psi().degree() > 1:
+                self._approximation = final_approximation
+                self._G = final_approximation.phi()
+
         if self._approximation.mu() is infinity:
             R = self._approximation.residue_ring()
             assert R in Fields()
             return R
 
-        R = self._initial_approximation.residue_ring()
+        R = self._approximation.residue_ring()
         if R in Fields():
             # the approximation ends in v(phi)=infty
             return R

--- a/src/sage/rings/valuation/limit_valuation_test.py
+++ b/src/sage/rings/valuation/limit_valuation_test.py
@@ -22,7 +22,7 @@ def test_equivalent_approximations_have_the_same_limit():
     a = gauss.augmentation(x, 1)
     b = gauss.augmentation(x + 2, 1)
     assert a is not b
-    assert a >= b and b >= a
+    assert a >= b >= a
     assert LimitValuation(a, x) is LimitValuation(b, x)
 
     G = x**2 + 1
@@ -149,7 +149,7 @@ def test_unchecked_composite_polynomial_is_refined_on_demand():
     current = LimitValuation(approximant, G)
     assert unchecked._G == G
     assert unchecked is not current
-    assert unchecked >= current and current >= unchecked
+    assert unchecked >= current >= unchecked
     assert unchecked._G == current._G
 
 
@@ -192,7 +192,7 @@ def test_legacy_keys_with_shared_support_compare_by_branch():
             (1, i, 0), (approximant, left_polynomial), {})
         right = LimitValuation.get_object(
             (1, i, 1), (approximant, right_polynomial), {})
-        assert left >= right and right >= left
+        assert left >= right >= left
         assert left._G == right._G == support
         limits.append(left)
 

--- a/src/sage/rings/valuation/limit_valuation_test.py
+++ b/src/sage/rings/valuation/limit_valuation_test.py
@@ -1,0 +1,255 @@
+import pytest
+
+
+def _polynomial_ring():
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    from sage.rings.rational_field import QQ
+
+    return PolynomialRing(QQ, 'x')
+
+
+def test_equivalent_approximations_have_the_same_limit():
+    from sage.rings.infinity import infinity
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.gauss_valuation import GaussValuation
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+    vK = QQ.valuation(2)
+    gauss = GaussValuation(R, vK)
+
+    a = gauss.augmentation(x, 1)
+    b = gauss.augmentation(x + 2, 1)
+    assert a is not b
+    assert a >= b and b >= a
+    assert LimitValuation(a, x) is LimitValuation(b, x)
+
+    G = x**2 + 1
+    approximant = vK.mac_lane_approximants(
+        G, require_incomparability=True)[0]
+    limit = LimitValuation(gauss, G)
+    assert limit is LimitValuation(approximant, G)
+    assert limit is LimitValuation(
+        approximant.augmentation(G, infinity), G)
+
+
+def test_later_approximation_of_an_infinite_chain_has_the_same_limit():
+    from sage.rings.function_field.constructor import FunctionField
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    K = FunctionField(QQ, 't')
+    t = K.gen()
+    R = PolynomialRing(K, 'y')
+    y = R.gen()
+    G = y**2 - t
+    vK = K.valuation(t)
+    approximant = vK.mac_lane_approximants(
+        G, require_incomparability=True)[0]
+    later = approximant.mac_lane_step(G)[0]
+
+    assert LimitValuation(approximant, G) is LimitValuation(later, G)
+
+
+def test_composite_polynomial_has_a_canonical_support():
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+    vK = QQ.valuation(2)
+    G = (x**2 + 7) * (x**2 + 9)
+    approximants = vK.mac_lane_approximants(
+        G, require_incomparability=True)
+    limits = [LimitValuation(v, G) for v in approximants]
+
+    for v, limit in zip(approximants, limits):
+        support, = [factor.monic() for factor, _ in G.factor()
+                    if not v.is_equivalence_unit(factor)]
+        assert limit._G == support
+        assert limit is LimitValuation(v, support)
+
+    assert all(limits[i] is not limits[j]
+               for i in range(len(limits))
+               for j in range(i))
+
+
+def test_canonical_support_uses_incomparable_approximants():
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.gauss_valuation import GaussValuation
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+    vK = QQ.valuation(2)
+    base = GaussValuation(R, vK).augmentation(x - 3, 3)
+    support = x**2 + 7
+    G = (x + 1) * support
+    approximants = vK.mac_lane_approximants(
+        support, require_incomparability=True)
+
+    limit = LimitValuation(base, G)
+    assert limit._G == support
+    assert limit._initial_approximation is vK.mac_lane_approximant(
+        support, base, approximants=approximants)
+    limits = [LimitValuation(approximant, support)
+              for approximant in approximants]
+    for i, left in enumerate(limits):
+        for j, right in enumerate(limits):
+            assert (left >= right) == (i == j)
+
+
+def test_ambiguous_approximation_is_rejected():
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.gauss_valuation import GaussValuation
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+
+    gauss = GaussValuation(R, QQ.valuation(2))
+    G = (x**2 + 7) * (x**2 + 9)
+    with pytest.raises(ValueError, match="single out one irreducible factor"):
+        LimitValuation(gauss, G)
+
+    gauss = GaussValuation(R, QQ.valuation(5))
+    with pytest.raises(ValueError, match="does not approximate a unique extension"):
+        LimitValuation(gauss, x**2 + 1)
+
+
+def test_unchecked_canonical_key_uses_the_same_cache_entry():
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+    vK = QQ.valuation(2)
+
+    G = x**3 + 2
+    approximant = vK.mac_lane_approximants(
+        G, require_incomparability=True)[0]
+    unchecked = LimitValuation(approximant, G, check=False)
+    assert LimitValuation(approximant, G) is unchecked
+
+
+def test_unchecked_composite_polynomial_is_refined_on_demand():
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+    vK = QQ.valuation(2)
+    G = (x**2 + 7) * (x**2 + 9)
+    approximant = vK.mac_lane_approximants(
+        G, require_incomparability=True)[0]
+
+    unchecked = LimitValuation(approximant, G, check=False)
+    current = LimitValuation(approximant, G)
+    assert unchecked._G == G
+    assert unchecked is not current
+    assert unchecked >= current and current >= unchecked
+    assert unchecked._G == current._G
+
+
+def test_legacy_factory_key_is_refined_on_demand():
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+    vK = QQ.valuation(2)
+    G = (x**2 + 7) * (x**2 + 9)
+    approximant = vK.mac_lane_approximants(
+        G, require_incomparability=True)[0]
+    current = LimitValuation(approximant, G)
+    legacy = LimitValuation.get_object((0,), (approximant, 2*G), {})
+
+    assert legacy._G == G
+    assert legacy(approximant.phi()) == current(approximant.phi())
+    assert legacy(current._G) == current(current._G)
+    assert legacy._G == current._G
+
+
+def test_legacy_keys_with_shared_support_compare_by_branch():
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+    support = x**2 + 7
+    left_polynomial = support * (x**2 + 9)
+    right_polynomial = support * x
+    approximants = QQ.valuation(2).mac_lane_approximants(
+        left_polynomial, require_incomparability=True)
+    approximants = [v for v in approximants
+                    if not v.is_equivalence_unit(support)]
+
+    limits = []
+    for i, approximant in enumerate(approximants):
+        left = LimitValuation.get_object(
+            (1, i, 0), (approximant, left_polynomial), {})
+        right = LimitValuation.get_object(
+            (1, i, 1), (approximant, right_polynomial), {})
+        assert left >= right and right >= left
+        assert left._G == right._G == support
+        limits.append(left)
+
+    assert len(limits) == 2
+    assert not (limits[0] >= limits[1])
+    assert not (limits[1] >= limits[0])
+
+
+def test_bounded_mac_lane_step_can_need_the_full_principal_part():
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.gauss_valuation import GaussValuation
+    from sage.rings.valuation.inductive_valuation import (
+        EquivalenceDecompositionTooSmall,
+    )
+
+    R = _polynomial_ring()
+    x = R.gen()
+    valuation = GaussValuation(R, QQ.valuation(2))
+    G = x**2 - 2*x - 1
+    options = {
+        'assume_squarefree': True,
+        'assume_equivalence_irreducible': True,
+        'check': False,
+        'report_degree_bounds_and_caches': True,
+    }
+
+    with pytest.raises(EquivalenceDecompositionTooSmall):
+        valuation.mac_lane_step(G, principal_part_bound=1, **options)
+    steps = valuation.mac_lane_step(
+        G, principal_part_bound=None, **options)
+    assert len(steps) == 1
+    assert steps[0][0].mu() == QQ(1) / 2
+
+
+def test_invalid_polynomial_is_rejected():
+    from sage.rings.integer_ring import ZZ
+    from sage.rings.padics.factory import Qp
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    from sage.rings.rational_field import QQ
+    from sage.rings.valuation.gauss_valuation import GaussValuation
+    from sage.rings.valuation.limit_valuation import LimitValuation
+
+    R = _polynomial_ring()
+    x = R.gen()
+    gauss = GaussValuation(R, QQ.valuation(2))
+    with pytest.raises(ValueError, match="squarefree"):
+        LimitValuation(gauss, x**2)
+
+    S = PolynomialRing(ZZ, 'y')
+    y = S.gen()
+    gauss = GaussValuation(S, ZZ.valuation(2))
+    assert LimitValuation(gauss, -y) is LimitValuation(gauss, y)
+    with pytest.raises(ValueError, match="leading coefficient"):
+        LimitValuation(gauss, 2*y**2 + y + 2)
+
+    K = Qp(5)
+    T = PolynomialRing(K, 'z')
+    gauss = GaussValuation(T, K.valuation())
+    with pytest.raises(NotImplementedError, match="inexact rings"):
+        LimitValuation(gauss, T.gen())

--- a/src/sage/rings/valuation/mapped_valuation.py
+++ b/src/sage/rings/valuation/mapped_valuation.py
@@ -592,8 +592,20 @@ class FiniteExtensionFromLimitValuation(FiniteExtensionFromInfiniteValuation):
         # this valuation nicely, dropping any unnecessary information
         self._approximants = approximants
 
-        from .limit_valuation import LimitValuation
-        limit = LimitValuation(approximant, G)
+        from sage.rings.infinity import infinity
+        if approximant.mu() is infinity:
+            # Preserve an already-infinite approximant. The public
+            # LimitValuation factory canonicalizes it to its finite base
+            # valuation, but _repr_ below needs to locate the original
+            # approximant among self._approximants.
+            from .limit_valuation import MacLaneLimitValuation
+            from .valuation_space import DiscretePseudoValuationSpace
+            limit_parent = DiscretePseudoValuationSpace(approximant.domain())
+            limit = limit_parent.__make_element_class__(MacLaneLimitValuation)(
+                limit_parent, approximant, G)
+        else:
+            from .limit_valuation import LimitValuation
+            limit = LimitValuation(approximant, G)
         FiniteExtensionFromInfiniteValuation.__init__(self, parent, limit)
 
     def _repr_(self):

--- a/src/sage/rings/valuation/mapped_valuation.py
+++ b/src/sage/rings/valuation/mapped_valuation.py
@@ -569,7 +569,6 @@ class FiniteExtensionFromLimitValuation(FiniteExtensionFromInfiniteValuation):
         sage: w = v.extensions(L); w
         [[ (x - 1)-adic valuation, v(y + 1) = 1 ]-adic valuation,
          [ (x - 1)-adic valuation, v(y - 1) = 1 ]-adic valuation]
-
     """
     def __init__(self, parent, approximant, G, approximants):
         r"""

--- a/src/sage/rings/valuation/mapped_valuation.py
+++ b/src/sage/rings/valuation/mapped_valuation.py
@@ -592,20 +592,10 @@ class FiniteExtensionFromLimitValuation(FiniteExtensionFromInfiniteValuation):
         # this valuation nicely, dropping any unnecessary information
         self._approximants = approximants
 
-        from sage.rings.infinity import infinity
-        if approximant.mu() is infinity:
-            # Preserve an already-infinite approximant. The public
-            # LimitValuation factory canonicalizes it to its finite base
-            # valuation, but _repr_ below needs to locate the original
-            # approximant among self._approximants.
-            from .limit_valuation import MacLaneLimitValuation
-            from .valuation_space import DiscretePseudoValuationSpace
-            limit_parent = DiscretePseudoValuationSpace(approximant.domain())
-            limit = limit_parent.__make_element_class__(MacLaneLimitValuation)(
-                limit_parent, approximant, G)
-        else:
-            from .limit_valuation import LimitValuation
-            limit = LimitValuation(approximant, G)
+        from .limit_valuation import LimitValuation
+        # The outer factory canonicalized the approximant, and G defines a
+        # field extension, so no work remains for the inner factory.
+        limit = LimitValuation(approximant, G, check=False)
         FiniteExtensionFromInfiniteValuation.__init__(self, parent, limit)
 
     def _repr_(self):

--- a/src/sage/rings/valuation/mapped_valuation_test.py
+++ b/src/sage/rings/valuation/mapped_valuation_test.py
@@ -31,3 +31,23 @@ def test_finite_extension_from_limit_valuation_w(w, idx):
     TestSuite(w[idx]).run(verbose=True,
                           raise_on_failure=True,
                           max_runs=512)
+
+
+def test_finite_extension_preserves_an_infinite_approximant():
+    from sage.rings.function_field.constructor import FunctionField
+    from sage.rings.integer import Integer
+    from sage.rings.infinity import infinity
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    from sage.rings.rational_field import QQ
+
+    K = FunctionField(QQ, 'x')
+    x = K.gen()
+    R = PolynomialRing(K, 'y')
+    y = R.gen()
+    L = K.extension(y**2 - x)
+    valuation = K.valuation(Integer(2)).extension(L)
+    limit = valuation._base_valuation
+
+    assert limit._initial_approximation.mu() is infinity
+    assert limit._initial_approximation in valuation._approximants
+    assert repr(valuation) == '(x - 2)-adic valuation'


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Follow #41896 

This fixes comparison and equality issues for Mac Lane limit valuations by making the `LimitValuation` factory normalize its input data more carefully.

In particular, the factory now canonicalizes scalar multiples of `G`, handles already-infinite approximants correctly, and removes factors of `G` that are equivalence-units for the starting approximation. This prevents situations where two limit valuations define the same valuation and are mutually comparable, but still compare unequal because they were created from different factory keys.

The change also tightens a few edge cases:

- reject zero and constant defining polynomials;
- update `_G` when the approximation has already become infinite;
- retry a Mac Lane step without a bounded principal part when the bound is too small to see the relevant decomposition;
- use the refined infinite approximation’s residue ring when appropriate.

Tests were added for the normalization behavior, the already-infinite `_G` refinement case, the bounded-principal-part fallback, and comparison examples involving composite defining polynomials.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


