### PR TITLE
gh-42105: fix two-sided ideal normal form in letterplace FreeAlgebra

### DIFF
--- a/src/sage/algebras/letterplace/free_algebra_element_letterplace.pyx
+++ b/src/sage/algebras/letterplace/free_algebra_element_letterplace.pyx
@@ -19,6 +19,7 @@ AUTHOR:
 from sage.groups.perm_gps.permgroup_named import CyclicPermutationGroup
 from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
 from cpython.object cimport PyObject_RichCompare
+from sage.algebras.letterplace.free_algebra_letterplace cimport FreeAlgebra_letterplace_libsingular
 
 #####################
 # Free algebra elements
@@ -642,7 +643,8 @@ cdef class FreeAlgebraElement_letterplace(AlgebraElement):
 
             This may not be the normal form of this element, unless
             the argument is a twosided Groebner basis up to the degree
-            of this element.
+            of this element.  If a commutative polynomial ideal is given,
+            then the caller is responsible for providing suitable reductors.
 
         EXAMPLES::
 
@@ -672,6 +674,18 @@ cdef class FreeAlgebraElement_letterplace(AlgebraElement):
             y*y*z*z*z + y*z*y*z*z - y*z*z*y*z + y*z*z*z*z
             sage: p.reduce(I) != p.reduce(G) != p.normal_form(I) != p.reduce(I)
             True
+
+        Check that reduction by a two-sided Groebner basis does not rely on
+        the shifted commutative reductors, which are not always a Groebner
+        basis (see :issue:`42105`)::
+
+            sage: A.<x,y> = FreeAlgebra(QQ, 2, implementation='letterplace')
+            sage: f = x*y*x + y*y*x - y*x*x - y*x*y
+            sage: I = A*f*A
+            sage: g = f*y*x
+            sage: G = I.groebner_basis(degbound=g.degree())
+            sage: g.reduce(G)
+            0
         """
         cdef FreeAlgebra_letterplace P = self._parent
         if not isinstance(G, (list, tuple)):
@@ -679,12 +693,103 @@ cdef class FreeAlgebraElement_letterplace(AlgebraElement):
                 return P.zero()
             if not (isinstance(G, MPolynomialIdeal) and G.ring() == P._current_ring):
                 G = G.gens()
-        C = P.current_ring()
-        cdef int selfdeg = self._poly.degree()
         if isinstance(G, MPolynomialIdeal):
+            C = P.current_ring()
             gI = G
-        else:
-            gI = P._reductor_(G, selfdeg)  # C.ideal(g,coerce=False)
+            from sage.libs.singular.option import LibSingularOptions
+            libsingular_options = LibSingularOptions()
+            bck = (libsingular_options['redTail'], libsingular_options['redSB'])
+            libsingular_options['redTail'] = True
+            libsingular_options['redSB'] = True
+            from sage.libs.singular.function import singular_function
+            poly_reduce = singular_function("NF")
+            try:
+                poly = poly_reduce(C(self._poly), gI, ring=C,
+                                   attributes={gI: {"isSB": 1}})
+            finally:
+                libsingular_options['redTail'] = bck[0]
+                libsingular_options['redSB'] = bck[1]
+            return FreeAlgebraElement_letterplace(P, poly, check=False)
+        return self._letterplace_normal_form(G, self._poly.degree())
+
+    def _letterplace_normal_form(self, G, degbound):
+        """
+        Return the normal form of ``self`` modulo ``G`` computed in
+        Singular's letterplace ring.
+
+        INPUT:
+
+        - ``G`` -- a list or tuple of weighted homogeneous elements of the
+          parent free algebra, to be interpreted as a (partial) two-sided
+          Groebner basis up to degree ``degbound``
+        - ``degbound`` -- nonnegative integer; an upper bound on the degree
+          of the reductions to be performed.  Singular's letterplace ring
+          requires a degree bound of at least 2, so smaller values are
+          silently raised to 2.
+
+        OUTPUT:
+
+        The two-sided normal form of ``self`` modulo ``G``, as an element
+        of the parent free algebra.
+
+        .. NOTE::
+
+            This is an internal helper used by :meth:`reduce` and
+            :meth:`normal_form`. It bypasses the shifted commutative
+            reductor approach (see
+            :meth:`~sage.algebras.letterplace.free_algebra_letterplace.FreeAlgebra_letterplace._reductor_`),
+            which only yields a commutative Groebner basis when the
+            generators are of degree 1, and routes the reduction through
+            Singular's actual letterplace ring instead (see
+            :issue:`42105`).
+
+        EXAMPLES:
+
+        A reduction by a two-sided Groebner basis (returns 0)::
+
+            sage: A.<x,y> = FreeAlgebra(QQ, 2, implementation='letterplace')
+            sage: f = x*y*x + y*y*x - y*x*x - y*x*y
+            sage: I = A*f*A
+            sage: g = f*y*x
+            sage: G = I.groebner_basis(degbound=g.degree()).gens()
+            sage: g._letterplace_normal_form(G, g.degree())
+            0
+
+        Reduction by an empty list returns ``self``::
+
+            sage: x._letterplace_normal_form([], 1)
+            x
+
+        Reduction with a degree bound below 2 is silently raised to 2,
+        so that Singular's letterplace ring can be constructed::
+
+            sage: x._letterplace_normal_form([y], 0)
+            x
+
+        Reduction in an algebra with non-trivial degree weights::
+
+            sage: F.<p,q,r> = FreeAlgebra(QQ, implementation='letterplace', degrees=[1,2,3])
+            sage: J = F*[p*q+r-q*p, p*q*r-p^6+q^3]*F
+            sage: G = J.groebner_basis(Infinity).gens()
+            sage: (r*J.0 - J.1)._letterplace_normal_form(G, 6)
+            0
+        """
+        degbound = max(degbound, 2)
+        cdef FreeAlgebra_letterplace A = self._parent
+        A.set_degbound(degbound)
+        P = A._current_ring
+        if not G:
+            return FreeAlgebraElement_letterplace(A, P(self._poly), check=False)
+        cdef FreeAlgebra_letterplace_libsingular lp_ring = \
+            FreeAlgebra_letterplace_libsingular(A._commutative_ring, A.degbound())
+        L = lp_ring._lp_ring_internal
+        to_L = P.hom(L.gens(), L, check=False)
+        from_L = L.hom(P.gens(), P, check=False)
+        cdef FreeAlgebraElement_letterplace gen
+        gens_in_L = []
+        for gen in G:
+            gens_in_L.append(to_L(gen._poly))
+        gI = L.ideal(gens_in_L)
         from sage.libs.singular.option import LibSingularOptions
         libsingular_options = LibSingularOptions()
         bck = (libsingular_options['redTail'], libsingular_options['redSB'])
@@ -692,11 +797,13 @@ cdef class FreeAlgebraElement_letterplace(AlgebraElement):
         libsingular_options['redSB'] = True
         from sage.libs.singular.function import singular_function
         poly_reduce = singular_function("NF")
-        poly = poly_reduce(C(self._poly), gI, ring=C,
-                           attributes={gI: {"isSB": 1}})
-        libsingular_options['redTail'] = bck[0]
-        libsingular_options['redSB'] = bck[1]
-        return FreeAlgebraElement_letterplace(P, poly, check=False)
+        try:
+            nf = poly_reduce(to_L(P(self._poly)), gI, ring=L,
+                             attributes={gI: {"isSB": 1}})
+        finally:
+            libsingular_options['redTail'] = bck[0]
+            libsingular_options['redSB'] = bck[1]
+        return FreeAlgebraElement_letterplace(A, P(from_L(nf)), check=False)
 
     def normal_form(self, I):
         """
@@ -747,4 +854,11 @@ cdef class FreeAlgebraElement_letterplace(AlgebraElement):
         if self._parent != I.ring():
             raise ValueError("cannot compute normal form wrt an ideal that does not belong to %s" % self._parent)
         sdeg = self._poly.degree()
-        return self.reduce(self._parent._reductor_(I.groebner_basis(degbound=sdeg).gens(), sdeg))
+        degbound = max(sdeg, 2)
+        # Compute the normal form using Singular's letterplace ring
+        # directly. This avoids relying on the shifts of generators (as
+        # produced by ``_reductor_``) being a commutative Groebner basis,
+        # which is not always the case (see :issue:`42105`).
+        # Singular's letterplace ring requires a degree bound of at least 2.
+        return self._letterplace_normal_form(I.groebner_basis(degbound=degbound).gens(),
+                                             degbound)

--- a/src/sage/algebras/letterplace/letterplace_ideal.pyx
+++ b/src/sage/algebras/letterplace/letterplace_ideal.pyx
@@ -341,6 +341,14 @@ class LetterplaceIdeal(Ideal_nc):
             True
             sage: 1 in I
             False
+
+        Check that :issue:`42105` is fixed::
+
+            sage: A.<x,y> = FreeAlgebra(QQ, 2, implementation='letterplace')
+            sage: f = x*y*x + y*y*x - y*x*x - y*x*y
+            sage: J = A*f*A
+            sage: f*y*x in J
+            True
         """
         R = self.ring()
         return (x in R) and R(x).normal_form(self).is_zero()
@@ -375,6 +383,18 @@ class LetterplaceIdeal(Ideal_nc):
             Twosided Ideal (y*z, x*x - y*x - y*y) of Free Associative Unital Algebra on 3 generators (x, y, z) over Rational Field
             sage: I.reduce(F*[x^2+x*y,y^2+y*z]*F)
             Twosided Ideal (x*y + y*z, -y*x + y*z) of Free Associative Unital Algebra on 3 generators (x, y, z) over Rational Field
+
+        Check that reduction does not rely on the shifted commutative
+        reductors, which are not always a Groebner basis (see
+        :issue:`42105`)::
+
+            sage: A.<x,y> = FreeAlgebra(QQ, 2, implementation='letterplace')
+            sage: f = x*y*x + y*y*x - y*x*x - y*x*y
+            sage: J = A*f*A
+            sage: g = f*y*x
+            sage: K = A*g*A
+            sage: K.reduce(J.groebner_basis(degbound=g.degree()).gens())
+            Twosided Ideal (0) of Free Associative Unital Algebra on 2 generators (x, y) over Rational Field
         """
         P = self.ring()
         if not isinstance(G, (list, tuple)):
@@ -383,20 +403,11 @@ class LetterplaceIdeal(Ideal_nc):
             if G in P:
                 return G.normal_form(self)
             G = G.gens()
-        C = P.current_ring()
-        sI = C.ideal([C(X.letterplace_polynomial()) for X in self.gens()],
-                     coerce=False)
-        selfdeg = max([x.degree() for x in sI.gens()])
-        gI = P._reductor_(G, selfdeg)
-        from sage.libs.singular.option import LibSingularOptions
-        libsingular_options = LibSingularOptions()
-        bck = (libsingular_options['redTail'], libsingular_options['redSB'])
-        libsingular_options['redTail'] = True
-        libsingular_options['redSB'] = True
-        from sage.libs.singular.function import singular_function
-        poly_reduce = singular_function("NF")
-        sI = poly_reduce(sI, gI, ring=C, attributes={gI: {"isSB": 1}})
-        libsingular_options['redTail'] = bck[0]
-        libsingular_options['redSB'] = bck[1]
-        return P.ideal([FreeAlgebraElement_letterplace(P, x, check=False)
-                        for x in sI], coerce=False)
+        # Reduce each generator of ``self`` by ``G`` via the letterplace
+        # ring path.  This avoids relying on the shifts of generators
+        # (as produced by ``_reductor_``) being a commutative Groebner
+        # basis, which is not always the case (see :issue:`42105`).
+        selfdeg = max(x.degree() for x in self.gens())
+        reduced = [x._letterplace_normal_form(G, selfdeg)
+                   for x in self.gens()]
+        return P.ideal(reduced, coerce=False)

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -264,9 +264,9 @@ def QuotientRing(R, I, names=None, **kwds):
          over Rational Field by the ideal
          (-y*y*z - y*z*x - 2*y*z*z, x*y + y*z, x*x + x*y - y*x - y*y)
         sage: i^3
-        -j*k*i - j*k*j - j*k*k
+        j*j*k - j*k*j + j*k*k
         sage: j^3
-        -j*k*i - j*k*j - j*k*k
+        j*j*k - j*k*j + j*k*k
 
     Check that :issue:`5978` is fixed by if we quotient by the zero ideal `(0)`
     then we just return ``R``::
@@ -371,9 +371,9 @@ class QuotientRing_nc(Parent):
          Free Associative Unital Algebra on 3 generators (x, y, z) over Rational Field
          by the ideal (-y*y*z - y*z*x - 2*y*z*z, x*y + y*z, x*x + x*y - y*x - y*y)
         sage: i^3
-        -j*k*i - j*k*j - j*k*k
+        j*j*k - j*k*j + j*k*k
         sage: j^3
-        -j*k*i - j*k*j - j*k*k
+        j*j*k - j*k*j + j*k*k
 
     For rings that *do* inherit from :class:`~sage.rings.ring.Ring`,
     we provide a subclass :class:`QuotientRing_generic`, for backwards


### PR DESCRIPTION
The previous implementation computed normal forms by reducing modulo the commutative ideal generated by all shifts of the generators (via `_reductor_`) and asserted isSB:1. For generators of degree >= 2 with overlapping shifts, this is not actually a Groebner basis, so Singular silently produced incorrect reductions and 'g in I' returned False even when g was in I.

Route the normal form through Singular's letterplace ring (the same path already used by groebner_basis), which performs the correct two-sided reduction.

Fix #42105 


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


