### PR TITLE
Keep the fraction method consistent

### DIFF
--- a/src/sage/functions/other.py
+++ b/src/sage/functions/other.py
@@ -741,6 +741,27 @@ class Function_frac(BuiltinFunction):
                                  conversions=dict(sympy='frac'),
                                  latex_name=r"\operatorname{frac}")
 
+    def __call__(self, *args, **kwds):
+        r"""
+        Evaluate the fractional part function.
+
+        TESTS:
+
+        Check that ``frac(x)`` does not use methods implementing the signed
+        fractional part with respect to ``trunc`` (:issue:`40418`)::
+
+            sage: frac(-2.3) == (-2.3) - floor(-2.3)                                   # needs sage.rings.real_mpfr
+            True
+            sage: frac(RR(-2.3)) == RR(-2.3) - floor(RR(-2.3))                         # needs sage.rings.real_mpfr
+            True
+            sage: frac(RDF(-2.3)) == RDF(-2.3) - floor(RDF(-2.3))
+            True
+            sage: frac(RIF(-2.3)).endpoints()                                          # needs sage.rings.real_mpfi
+            (0.700000000000000, 0.700000000000001)
+        """
+        kwds["dont_call_method_on_arg"] = True
+        return BuiltinFunction.__call__(self, *args, **kwds)
+
     def _evalf_(self, x, **kwds):
         """
         EXAMPLES::


### PR DESCRIPTION
Implement `__call__` method for the frac function to evaluate the fractional part correctly, including tests for various input types.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Fix #40418 


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


