### PR TITLE
Fix bugs in miniaes.py

### DIFF
--- a/src/sage/crypto/block_cipher/miniaes.py
+++ b/src/sage/crypto/block_cipher/miniaes.py
@@ -67,8 +67,8 @@ class MiniAES(SageObject):
         [    x^3 + x^2       x^3 + x]
         [x^3 + x^2 + x   x^2 + x + 1]
         sage: C = maes.encrypt(P, key); C
-        [    x^3 + x^2 + 1 x^3 + x^2 + x + 1]
-        [                x     x^3 + x^2 + x]
+        [            x       x^2 + x]
+        [x^3 + x^2 + x       x^3 + x]
 
     Decrypt the result::
 
@@ -93,7 +93,7 @@ class MiniAES(SageObject):
         sage: P = bin.encoding("Encrypt this secret message!"); P
         01000101011011100110001101110010011110010111000001110100001000000111010001101000011010010111001100100000011100110110010101100011011100100110010101110100001000000110110101100101011100110111001101100001011001110110010100100001
         sage: C = maes(P, key, algorithm='encrypt'); C
-        11100000101000010110001101101001110110010010111011010001100111100000101000101111100110010010100001110101011100111001000010101000001111000101010011010001100111100111001100000001101100110110101001001000011100000101010110110101
+        10001101011010001111111111000011010011000101011001000010110101100101100101011110101011000101100100101000101101001010110101101001110101011001111101000010110101100010111100001000001111111100101111100110101101110000100011100010
         sage: plaintxt = maes(C, key, algorithm='decrypt')
         sage: plaintxt == P
         True
@@ -111,7 +111,7 @@ class MiniAES(SageObject):
         sage: key = maes.integer_to_binary(key); key
         0010001110110000
         sage: C = maes(P, key, algorithm='encrypt'); C
-        0011101000101110010011000101010100011101010000111000100100011010
+        1100010111111100111010001000000001010110010000010001110100110110
         sage: plaintxt = maes(C, key, algorithm='decrypt')
         sage: plaintxt == P
         True
@@ -294,10 +294,15 @@ class MiniAES(SageObject):
             sage: P = bin.encoding("Encrypt this secret message!"); P
             01000101011011100110001101110010011110010111000001110100001000000111010001101000011010010111001100100000011100110110010101100011011100100110010101110100001000000110110101100101011100110111001101100001011001110110010100100001
             sage: C = maes(P, key, algorithm='encrypt'); C
-            11100000101000010110001101101001110110010010111011010001100111100000101000101111100110010010100001110101011100111001000010101000001111000101010011010001100111100111001100000001101100110110101001001000011100000101010110110101
+            10001101011010001111111111000011010011000101011001000010110101100101100101011110101011000101100100101000101101001010110101101001110101011001111101000010110101100010111100001000001111111100101111100110101101110000100011100010
             sage: plaintxt = maes(C, key, algorithm='decrypt')
             sage: plaintxt == P
             True
+
+            sage: P = bin("1001110001100011")
+            sage: key = bin("1100001111110000")
+            sage: maes(P, key, algorithm='encrypt')
+            0111001011000110
 
         TESTS:
 
@@ -362,15 +367,15 @@ class MiniAES(SageObject):
         MS = MatrixSpace(FiniteField(self._key_size, "x"), 2, 2)
         bin = BinaryStrings()
         S = ""
+        matK = MS(self.binary_to_GF(key)).transpose()
         if algorithm == "encrypt":
             # encrypt each 16-bit block in succession
             for i in range(N):
                 # here 16 is the number of bits per encryption block
                 block = B[i*16 : (i+1)*16]
-                matB = MS(self.binary_to_GF(block))
-                matK = MS(self.binary_to_GF(key))
+                matB = MS(self.binary_to_GF(block)).transpose()
                 e = self.encrypt(matB, matK)
-                e = self.GF_to_binary(e)
+                e = self.GF_to_binary(e.transpose())
                 S = "".join([S, str(e)])
             return bin(S)
         if algorithm == "decrypt":
@@ -378,10 +383,9 @@ class MiniAES(SageObject):
             for i in range(N):
                 # here 16 is the number of bits per encryption block
                 block = B[i*16 : (i+1)*16]
-                matB = MS(self.binary_to_GF(block))
-                matK = MS(self.binary_to_GF(key))
+                matB = MS(self.binary_to_GF(block)).transpose()
                 e = self.decrypt(matB, matK)
-                e = self.GF_to_binary(e)
+                e = self.GF_to_binary(e.transpose())
                 S = "".join([S, str(e)])
             return bin(S)
         raise ValueError("algorithm must be either 'encrypt' or 'decrypt'")
@@ -609,8 +613,8 @@ class MiniAES(SageObject):
             [        x^3 + x^2 x^3 + x^2 + x + 1]
             [            x + 1                 0]
             sage: C = maes.encrypt(P, key); C
-            [            x + 1           x^2 + 1]
-            [x^3 + x^2 + x + 1               x^2]
+            [x^2 + x + 1   x^3 + x^2]
+            [          x     x^2 + x]
             sage: plaintxt = maes.decrypt(C, key)
             sage: plaintxt; P
             <BLANKLINE>
@@ -777,8 +781,8 @@ class MiniAES(SageObject):
             [        x^3 + x^2 x^3 + x^2 + x + 1]
             [            x + 1                 0]
             sage: maes.encrypt(P, key)
-            [            x + 1           x^2 + 1]
-            [x^3 + x^2 + x + 1               x^2]
+            [x^2 + x + 1   x^3 + x^2]
+            [          x     x^2 + x]
 
         But we can also work with binary strings::
 
@@ -1297,12 +1301,11 @@ class MiniAES(SageObject):
             [        x^3 + x^2 x^3 + x^2 + x + 1]
             [            x + 1                 0]
             sage: maes.round_key(key, 1)
-            [x^3 + x x^2 + x]
-            [x^3 + 1 x^2 + x]
+            [            x + 1 x^3 + x^2 + x + 1]
+            [                0 x^3 + x^2 + x + 1]
             sage: maes.round_key(key, 2)
-            <BLANKLINE>
-            [  x^2 + 1   x^3 + x]
-            [x^3 + x^2 x^3 + x^2]
+            [x^2 + x x^3 + 1]
+            [x^2 + x x^2 + x]
 
         TESTS:
 
@@ -1353,7 +1356,9 @@ class MiniAES(SageObject):
         # round 1
         if n == 1:
             round_constant_1 = K("1")
-            w4 = key[0][0] + self._sboxE[key[1][1]] + round_constant_1
+            sbox = self._sboxE[self._GF_to_int[key[1][1]]]
+            subkey = self._int_to_GF[sbox]
+            w4 = key[0][0] + subkey + round_constant_1
             w5 = key[1][0] + w4
             w6 = key[0][1] + w5
             w7 = key[1][1] + w6
@@ -1362,7 +1367,9 @@ class MiniAES(SageObject):
         if n == 2:
             round_constant_2 = K("x")
             key1 = self.round_key(key, 1)
-            w8 = key1[0][0] + self._sboxE[key1[1][1]] + round_constant_2
+            sbox = self._sboxE[self._GF_to_int[key1[1][1]]]
+            subkey = self._int_to_GF[sbox]
+            w8 = key1[0][0] + subkey + round_constant_2
             w9 = key1[1][0] + w8
             w10 = key1[0][1] + w9
             w11 = key1[1][1] + w10


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Reference paper: Raphael Chung-Wei Phan, *"Mini Advanced Encryption Standard (Mini-AES): A Testbed for Cryptanalysis Students"*, *Cryptologia* XXVI(4), 2002.

---

## Bug 1: Wrong matrix fill order in `__call__` (column-major vs row-major)

### What the paper says

Section 3.1, Figure 2 of the paper defines the 2×2 matrix representation of a 16-bit block
`P = (p0, p1, p2, p3)` (each `pi` being a 4-bit nibble) as **column-major**:

```
P = | p0  p2 |
    | p1  p3 |
```

So nibble `p0` goes to position `(0,0)`, `p1` to `(1,0)`, `p2` to `(0,1)`, `p3` to `(1,1)`.

### What the old code did

`binary_to_GF` converts a 16-bit binary string to a flat list of four GF(16) elements
`[p0, p1, p2, p3]`. Passing that list directly to `MatrixSpace(GF(16), 2, 2)(...)` **fills
the matrix row by row**:

```
| p0  p1 |     # wrong — row-major fill
| p2  p3 |
```

This is the **transpose** of what the paper requires.

### What the fix does

After building the matrix with `MS(self.binary_to_GF(block))`, apply `.transpose()` to
obtain the correct column-major layout:

```python
# old
matB = MS(self.binary_to_GF(block))
matK = MS(self.binary_to_GF(key))

# new
matB = MS(self.binary_to_GF(block)).transpose()
matK = MS(self.binary_to_GF(key)).transpose()   # computed once, outside the loop
```

When converting back from a matrix to a binary string the same `.transpose()` is applied
before `GF_to_binary` so the serialisation round-trips correctly:

```python
# old
e = self.GF_to_binary(e)

# new
e = self.GF_to_binary(e.transpose())
```

Because the key matrix was rebuilt from scratch on every block iteration, it was also
moved outside the loop as a minor clean-up.

---

## Bug 2: GF element passed directly as SBox index in `round_key`

### What the paper says

Section 3.6, Table 2 defines the key schedule. For round 1:

```
w4 = w0 ⊕ NibbleSub(w3) ⊕ rcon(1)
```

`NibbleSub` (the S-box) takes an **integer** index (0–15) and returns an **integer** (0–15);
the GF(16) encoding/decoding is separate.

### What the old code did

```python
w4 = key[0][0] + self._sboxE[key[1][1]] + round_constant_1
```

`key[1][1]` is a **GF(16) element** (a polynomial such as `x^3 + x^2`). The `SBox` object's
`__getitem__` also accepts integers, but once Bug 1 is fixed the element at position `[1][1]`
changes (it is now `w3` in the paper's notation rather than a different nibble), and the
implicit coercion of a GF element to an integer index is fragile and semantically wrong.
Furthermore, the **return value** of `self._sboxE[gf_element]` is an integer, not a GF
element, so adding it to the GF element `key[0][0]` with `+` silently coerced types rather
than performing a proper GF addition.

### What the fix does

Explicitly convert through the lookup tables:

```python
# old
w4 = key[0][0] + self._sboxE[key[1][1]] + round_constant_1

# new
sbox   = self._sboxE[self._GF_to_int[key[1][1]]]   # GF element → int → SBox → int
subkey = self._int_to_GF[sbox]                      # int → GF element
w4     = key[0][0] + subkey + round_constant_1      # all operands are GF elements
```
Fix #40069 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


