### PR TITLE
gh-40301: Fix incorrect containment test for submodule 

### DIFF
--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -1002,15 +1002,16 @@ class Module_free_ambient(Module):
                     return x.__copy__()
                 return x
             x = x.list()
-        if check and self.coordinate_ring().is_exact():
-            # Check entries are in the base ring
-            try:
-                R = self.base_ring()
-                for d in x:
-                    if d not in R:
-                        raise ArithmeticError
-            except ArithmeticError:
-                raise TypeError("element {!r} is not in free module".format(x))
+        if check:
+            if self.coordinate_ring().is_exact():
+                # Check entries are in the base ring
+                try:
+                    R = self.base_ring()
+                    for d in x:
+                        if d not in R:
+                            raise ArithmeticError
+                except ArithmeticError:
+                    raise TypeError("element {!r} is not in free module".format(x))
             # Additional membership check (e.g., submodule membership)
             self._check_element_membership(x)
         return self.element_class(self, x, coerce, copy)

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -338,21 +338,18 @@ class Submodule_free_ambient(Module_free_ambient):
         except (TypeError, NotImplementedError, ValueError):
             pass
 
-        names = cover_ring.variable_names()
-        # Use a prefix unlikely to clash with user-chosen variable names.
-        # The loop is a safety net in the rare event of a collision.
-        module_names = tuple("sage_free_module_e{}".format(i) for i in range(n))
-        while set(names).intersection(module_names):
-            module_names = tuple("_{}".format(name) for name in module_names)
-
+        num_coeff_variables = cover_ring.ngens()
         poly_ring = PolynomialRing(cover_ring.base_ring(),
-                                   names=names + module_names)
-        module_variables = poly_ring.gens()[len(names):]
+                                   num_coeff_variables + n, 't')
+        # Map coefficients by position, so auxiliary variable names are private.
+        coeff_map = cover_ring.hom(poly_ring.gens()[:num_coeff_variables],
+                                   poly_ring)
+        module_variables = poly_ring.gens()[num_coeff_variables:]
 
         def lift_coefficient(c):
             if do_lift:
                 c = c.lift()
-            return poly_ring(c)
+            return coeff_map(c)
 
         def encode(row):
             row = list(row)
@@ -367,7 +364,7 @@ class Submodule_free_ambient(Module_free_ambient):
 
         gens = [encode(g) for g in self.gens()]
         for f in ideal_gens:
-            f = poly_ring(f)
+            f = coeff_map(f)
             gens.extend(f * e for e in module_variables)
 
         if not gens:

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -129,16 +129,73 @@ class Submodule_free_ambient(Module_free_ambient):
         w = [C(self, x.list(), coerce=False, copy=False) for x in gens if x]
         self.__gens = basis_seq(self, w)
 
+    def _coerce_map_from_(self, M):
+        r"""
+        Return a coercion map from ``M`` to ``self``, or ``None``.
+
+        TESTS:
+
+        Elements of the ambient quotient module should be tested using this
+        submodule's element constructor and membership check, not by trying to
+        prove that the whole ambient module coerces into the submodule::
+
+            sage: S.<x, y, z> = PolynomialRing(QQ)
+            sage: M = S**2
+            sage: N = M.submodule([vector([x - y, z]), vector([y*z, x*z])])
+            sage: Q = M.quotient_module(N)
+            sage: NQ = Q.submodule([Q([1, x])])
+            sage: Q([1, x]) in NQ
+            True
+            sage: Q([0, 1]) in NQ
+            False
+        """
+        if M is self.ambient_module():
+            return None
+        return super()._coerce_map_from_(M)
+
+    def __contains__(self, x):
+        r"""
+        Return whether ``x`` belongs to this submodule.
+
+        TESTS::
+
+            sage: R.<x, y> = QQ[]
+            sage: F = FreeModule(R, 1)
+            sage: G = F.submodule([F([0])])
+            sage: F([1]) in G
+            False
+
+        Elements of an ambient quotient module can belong to a subquotient
+        even though equality between the constructed subquotient element and
+        the original ambient quotient element is false because their parents
+        differ::
+
+            sage: S.<x, y, z> = PolynomialRing(QQ)
+            sage: M = S**2
+            sage: N = M.submodule([vector([x - y, z]), vector([y*z, x*z])])
+            sage: Q = M.quotient_module(N)
+            sage: NQ = Q.submodule([Q([1, x])])
+            sage: Q([1, x]) in NQ
+            True
+            sage: Q([0, 1]) in NQ
+            False
+        """
+        try:
+            self(x)
+        except (TypeError, ValueError):
+            return False
+        return True
+
     def _groebner_basis_contains(self, v):
         r"""
         Check membership of ``v`` in ``self`` using Gröbner bases.
 
         This works for submodules over polynomial rings and quotient rings
-        of polynomial rings. The algorithm lifts elements to the covering
-        polynomial ring (if necessary), augments the generator matrix with
-        the ideal relation generators, computes a Gröbner basis for the
-        resulting submodule of the free module over the polynomial ring,
-        and then uses Singular's ``reduce`` to test if `v` reduces to zero.
+        of polynomial rings. The algorithm first tries Singular's module
+        Gröbner basis implementation. If this is not available for the
+        polynomial ring, it encodes the ambient free module using fresh
+        polynomial variables and tests membership in the resulting
+        homogeneous ideal.
 
         INPUT:
 
@@ -167,6 +224,15 @@ class Submodule_free_ambient(Module_free_ambient):
             sage: N._groebner_basis_contains(vector([1, 0]))
             False
 
+        This also works for polynomial rings where Singular's module
+        Gröbner basis interface is not available::
+
+            sage: R.<x> = ZZ[]
+            sage: M = R**2
+            sage: N = M.submodule([M.0])
+            sage: N._groebner_basis_contains(M.1)
+            False
+
         When the ambient module is a quotient module (subquotient)::
 
             sage: S.<x,y,z> = PolynomialRing(QQ)
@@ -190,77 +256,124 @@ class Submodule_free_ambient(Module_free_ambient):
             sage: s._groebner_basis_contains(M.2)
             False
         """
-        from sage.libs.singular.function import singular_function
-        from sage.libs.singular.option import opt_verb
-        from sage.matrix.constructor import matrix
+        from sage.rings.polynomial.multi_polynomial_ring_base import MPolynomialRing_base
+        from sage.rings.polynomial.polynomial_ring import PolynomialRing_generic
+        from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
         from sage.rings.quotient_ring import QuotientRing_generic
         from sage.structure.element import Vector
 
         R = self.base_ring()
         n = self.degree()
 
-        # Determine the polynomial ring and ideal generators
+        if isinstance(v, Vector):
+            v = v.list()
+        else:
+            v = list(v)
+
+        if len(v) != n:
+            raise ArithmeticError(
+                "vector length {} does not match module degree {}".format(len(v), n)
+            )
+
         if isinstance(R, QuotientRing_generic):
-            poly_ring = R.cover_ring()
+            cover_ring = R.cover_ring()
             ideal_gens = R.defining_ideal().gens()
             do_lift = True
+        elif isinstance(R, (PolynomialRing_generic, MPolynomialRing_base)):
+            cover_ring = R
+            ideal_gens = []
+            do_lift = False
         else:
-            from sage.rings.polynomial.multi_polynomial_ring_base import \
-                MPolynomialRing_base
-            if isinstance(R, MPolynomialRing_base):
-                poly_ring = R
-                ideal_gens = []
-                do_lift = False
-            else:
-                raise NotImplementedError(
-                    "Gröbner basis membership test is not implemented for "
-                    "modules over {}".format(R)
-                )
+            raise NotImplementedError(
+                "Gröbner basis membership test is not implemented for "
+                "modules over {}".format(R)
+            )
 
-        # Suppress "_ is no standard basis" warning from Singular
-        opt_verb['not_warn_sb'] = True
+        if not isinstance(cover_ring, (PolynomialRing_generic, MPolynomialRing_base)):
+            raise NotImplementedError(
+                "Gröbner basis membership test is not implemented for "
+                "modules over {}".format(R)
+            )
 
-        std = singular_function('std')
-        reduce_func = singular_function('reduce')
+        def singular_module_contains():
+            from sage.libs.singular.function import singular_function
+            from sage.libs.singular.option import opt_verb
+            from sage.matrix.constructor import matrix
 
-        # Lift generators of self to the polynomial ring
-        gen_rows = []
-        for g in self.gens():
-            if do_lift:
-                row = [c.lift() for c in g]
-            else:
-                row = list(g)
-            gen_rows.append(row)
+            opt_verb['not_warn_sb'] = True
 
-        # Add ideal relation generators: for each ideal generator f and
-        # each standard basis vector e_j, add f * e_j as a row
-        for f in ideal_gens:
-            for j in range(n):
-                row = [poly_ring.zero()] * n
-                row[j] = f
+            std = singular_function('std')
+            reduce_func = singular_function('reduce')
+
+            gen_rows = []
+            for g in self.gens():
+                if do_lift:
+                    row = [c.lift() for c in g]
+                else:
+                    row = list(g)
                 gen_rows.append(row)
 
-        if not gen_rows:
-            # Zero submodule: only zero vector is contained
-            if isinstance(v, (list, tuple, Vector)):
+            for f in ideal_gens:
+                for j in range(n):
+                    row = [cover_ring.zero()] * n
+                    row[j] = f
+                    gen_rows.append(row)
+
+            if not gen_rows:
                 return all(c == 0 for c in v)
-            return v == 0
 
-        # Build the matrix and compute Gröbner basis
-        # Singular's std() for modules expects the matrix transposed
-        # (columns = generators)
-        gen_matrix = matrix(poly_ring, gen_rows).transpose()
-        gb = std(gen_matrix, ring=poly_ring)
+            gen_matrix = matrix(cover_ring, gen_rows).transpose()
+            gb = std(gen_matrix, ring=cover_ring)
 
-        # Lift the target vector
-        if do_lift:
-            v_lifted = matrix(poly_ring, [[c.lift() for c in v]]).transpose()
-        else:
-            v_lifted = matrix(poly_ring, [list(v)]).transpose()
+            if do_lift:
+                v_lifted = matrix(cover_ring, [[c.lift() for c in v]]).transpose()
+            else:
+                v_lifted = matrix(cover_ring, [v]).transpose()
 
-        # Reduce v modulo the Gröbner basis; zero result means v is in the submodule
-        remainder = reduce_func(v_lifted, gb, ring=poly_ring)
-        return matrix(remainder).is_zero()
+            remainder = reduce_func(v_lifted, gb, ring=cover_ring)
+            return matrix(remainder).is_zero()
+
+        try:
+            return singular_module_contains()
+        except (TypeError, NotImplementedError, ValueError):
+            pass
+
+        names = cover_ring.variable_names()
+        # Use a prefix unlikely to clash with user-chosen variable names.
+        # The loop is a safety net in the rare event of a collision.
+        module_names = tuple("sage_free_module_e{}".format(i) for i in range(n))
+        while set(names).intersection(module_names):
+            module_names = tuple("_{}".format(name) for name in module_names)
+
+        poly_ring = PolynomialRing(cover_ring.base_ring(),
+                                   names=names + module_names)
+        module_variables = poly_ring.gens()[len(names):]
+
+        def lift_coefficient(c):
+            if do_lift:
+                c = c.lift()
+            return poly_ring(c)
+
+        def encode(row):
+            row = list(row)
+            if len(row) != n:
+                raise ArithmeticError(
+                    "row length {} does not match module degree {}".format(len(row), n)
+                )
+            total = poly_ring.zero()
+            for c, e in zip(row, module_variables):
+                total += lift_coefficient(c) * e
+            return total
+
+        gens = [encode(g) for g in self.gens()]
+        for f in ideal_gens:
+            f = poly_ring(f)
+            gens.extend(f * e for e in module_variables)
+
+        if not gens:
+            return encode(v).is_zero()
+
+        return encode(v) in poly_ring.ideal(gens)
 
     def _check_element_membership(self, x):
         r"""
@@ -281,6 +394,30 @@ class Submodule_free_ambient(Module_free_ambient):
             Traceback (most recent call last):
             ...
             TypeError: element (0, 1, 0, 0, 0, 0, 0, 0, 0, 0) is not in this submodule
+
+        Check that :issue:`40301` is fixed, including over inexact
+        coefficient rings::
+
+            sage: R.<x, y> = QQ[]
+            sage: F = FreeModule(R, 1)
+            sage: G = F.submodule([F([0])])
+            sage: F([1]) in G
+            False
+
+            sage: # needs sage.rings.real_mpfr
+            sage: R.<x, y> = CC[]
+            sage: F = FreeModule(R, 1)
+            sage: G = F.submodule([F([0])])
+            sage: F([1]) in G
+            False
+
+        The same issue affected non-PID univariate polynomial rings::
+
+            sage: R.<x> = ZZ[]
+            sage: F = FreeModule(R, 2)
+            sage: G = F.submodule([F.0])
+            sage: F.1 in G
+            False
         """
         try:
             if not self._groebner_basis_contains(x):

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -415,8 +415,8 @@ class Submodule_free_ambient(Module_free_ambient):
 
             sage: R.<x> = ZZ[]
             sage: F = FreeModule(R, 2)
-            sage: G = F.submodule([F.0])
-            sage: F.1 in G
+            sage: G = F.submodule([F.gen(0)])
+            sage: F.gen(1) in G
             False
         """
         try:


### PR DESCRIPTION
Fixes #40301.

Before this fix, testing membership in a submodule of a free module over a
multivariate polynomial ring (or any non-PID ring handled by
`Submodule_free_ambient`) returned incorrect results:

```python
sage: R.<x, y> = QQ[]
sage: F = FreeModule(R, 1)
sage: G = F.submodule([F([0])])
sage: F([1]) in G
True   # WRONG — should be False
```

The same bug affected non-PID univariate polynomial rings such as `ZZ[x]`, and
any coefficient ring for which `is_exact()` returns `False` (e.g. `CC[x,y]`).

## Root cause

`Submodule_free_ambient` (used for modules over rings that are not PIDs) did not
override `__contains__`; it therefore fell back to the default Sage coercion
mechanism.  The default path calls `G(vec)` and checks `G(vec) == vec`.

The ambient free module `F` coerces into `G` (same base ring, same degree), so
`G(vec)` silently succeeded and returned a copy of `vec` — making `G(vec) == vec`
trivially `True` regardless of whether `vec` is actually in the submodule.

- Add `_coerce_map_from_` to Submodule_free_ambient to prevent the ambient module from being considered as coercing into a submodule, which caused the element constructor to silently accept out-of-submodule vectors.

- Add `__contains__` to Submodule_free_ambient that delegates to the element constructor (and thus to _check_element_membership) instead of relying on coercion equality.

- Refactor `_groebner_basis_contains` to fall back from Singular's module Gröbner basis interface (unavailable for e.g. ZZ[x]) to an ideal-encoding approach that introduces fresh module variables and tests membership in the resulting polynomial ideal.

- Fix `_element_constructor_` in Module_free_ambient so that _check_element_membership is called even for inexact coefficient rings (e.g. CC[x,y]).


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


