### PR TITLE
Update error message for min_slope kwarg to indicate input should be nonpositive 

### DIFF
--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -6164,6 +6164,26 @@ class Partitions(UniqueRepresentation, Parent):
             Traceback (most recent call last):
             ...
             ValueError: the minimum slope must be nonpositive
+
+            sage: P = Partitions(min_slope=1)
+            Traceback (most recent call last):
+            ...
+            ValueError: the minimum slope must be nonpositive
+
+            sage: P = Partitions(5, min_slope=x^2)
+            Traceback (most recent call last):
+            ...
+            ValueError: the minimum slope must be an integer or coercible to an integer
+
+            sage: P = Partitions(3, min_slope=-1.0)
+            sage: list(P)
+            [[3], [2, 1], [1, 1, 1]]
+            sage: P = Partitions(3, min_slope=0)
+            sage: list(P)
+            [[3], [1, 1, 1]]
+            sage: P = Partitions(3, min_slope=-oo)
+            sage: P
+            Partitions of the integer 3
         """
         if n is infinity:
             raise ValueError("n cannot be infinite")
@@ -6174,6 +6194,18 @@ class Partitions(UniqueRepresentation, Parent):
             del kwargs['min_part']
         if 'max_slope' in kwargs and not kwargs['max_slope']:
             del kwargs['max_slope']
+        if 'min_slope' in kwargs:
+            if kwargs['min_slope'] == -infinity:
+                del kwargs['min_slope']
+            # ensure that min_slope is a nonpositive integer
+            else:
+                try:
+                    min_slope = ZZ(kwargs['min_slope'])
+                except (TypeError, ValueError):
+                    raise ValueError("the minimum slope must be an integer or coercible to an integer")
+                if min_slope > 0:
+                    raise ValueError("the minimum slope must be nonpositive")
+
         # preprocess for UniqueRepresentation
         if 'outer' in kwargs and not isinstance(kwargs['outer'], Partition):
             m = infinity
@@ -6269,9 +6301,6 @@ class Partitions(UniqueRepresentation, Parent):
 
             # max_slope is at most 0, and it is 0 by default
             kwargs['max_slope'] = min(0, kwargs.get('max_slope', 0))
-
-            if kwargs.get('min_slope', -float('inf')) > 0:
-                raise ValueError("the minimum slope must be nonpositive")
 
             if 'outer' in kwargs:
                 kwargs['ceiling'] = tuple(kwargs['outer'])

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -6157,6 +6157,13 @@ class Partitions(UniqueRepresentation, Parent):
             sage: P = Partitions(5, min_slope=0)
             sage: list(P)
             [[5], [1, 1, 1, 1, 1]]
+
+        Check that :issue:`21268` is fixed::
+
+            sage: P = Partitions(5, min_slope=1)
+            Traceback (most recent call last):
+            ...
+            ValueError: the minimum slope must be nonpositive
         """
         if n is infinity:
             raise ValueError("n cannot be infinite")

--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -6264,7 +6264,7 @@ class Partitions(UniqueRepresentation, Parent):
             kwargs['max_slope'] = min(0, kwargs.get('max_slope', 0))
 
             if kwargs.get('min_slope', -float('inf')) > 0:
-                raise ValueError("the minimum slope must be nonnegative")
+                raise ValueError("the minimum slope must be nonpositive")
 
             if 'outer' in kwargs:
                 kwargs['ceiling'] = tuple(kwargs['outer'])


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

I have updated the error message for the `min_slope` kwarg to indicate that the input value should be a **nonpositive** number for integer partitions. This inaccuracy was brought up in the ticket https://github.com/sagemath/sage/issues/21268

I have not changed any core functionality, only updated the error message to better reflect that the minimum slope constraints are expected to be **nonpositive**. 

This was addressed during Sage Days 130.5 with @nadialafreniere 

As reflected the ticket, if you wanted to reproduce the ValueError without the proposed changes:
```
sage: Partitions(5, min_slope=1)
Traceback (most recent call last):
ValueError: the minimum slope must be non-negative
```

I have run tests successfully for the corresponding file ```src/sage/combinat/partition.py```
Let me know if you have any feedback! 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [`x`] The title is concise and informative.
- [`x`] The description explains in detail what this PR is about.
- [`x`] I have linked a relevant issue or discussion.
- [`x`] I have created tests covering the changes.
- [`x`] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


