### PR TITLE
Add sirocco and coxeter3 features to docs

### DIFF
--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -35,6 +35,7 @@ Features
    sage/features/pkg_systems
    sage/features/bliss
    sage/features/brial
+   sage/features/coxeter3
    sage/features/csdp
    sage/features/databases
    sage/features/dvipng

--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -59,6 +59,7 @@ Features
    sage/features/pdf2svg
    sage/features/polymake
    sage/features/rubiks
+   sage/features/sirocco
    sage/features/tdlib
    sage/features/topcom
 


### PR DESCRIPTION
Trivial, must've been overlooked.

Doc preview:

* https://doc-pr-42135--sagemath.netlify.app/html/en/reference/spkg/sage/features/coxeter3
* https://doc-pr-42135--sagemath.netlify.app/html/en/reference/spkg/sage/features/sirocco
