### PR TITLE
Fix dense GF(2) vectors over NTL fields

### DIFF
--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -728,6 +728,17 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             sage: image = span(image_basis)
             sage: image_basis[0] in image.basis()
             True
+
+        Dense matrix/vector products over NTL's degree-one GF(2)
+        use compatible mod-2 vector representations::
+
+            sage: F = GF(2, impl='ntl')
+            sage: m = identity_matrix(1, F)
+            sage: v = vector(F, (1,))
+            sage: m * v
+            (1)
+            sage: v * m
+            (1)
         """
         cdef mzd_t *tmp
         if (

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -739,6 +739,17 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             sage: image = span(image_basis)
             sage: image_basis[0] in image.basis()
             True
+
+        Dense matrix/vector products over NTL's degree-one GF(2)
+        use compatible mod-2 vector representations::
+
+            sage: F = GF(2, impl='ntl')
+            sage: m = identity_matrix(1, F)
+            sage: v = vector(F, (1,))
+            sage: m * v
+            (1)
+            sage: v * m
+            (1)
         """
         cdef mzd_t *tmp
         if (

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -8418,6 +8418,9 @@ def element_class(R, is_sparse):
         <class 'sage.modules.free_module_element.FreeModuleElement_generic_sparse'>
         sage: sage.modules.free_module.element_class(FF, is_sparse=False)               # needs sage.rings.finite_rings
         <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
+        sage: FFntl = GF(2, impl='ntl')                                                # needs sage.rings.finite_rings
+        sage: sage.modules.free_module.element_class(FFntl, is_sparse=False)            # needs sage.rings.finite_rings
+        <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
         sage: sage.modules.free_module.element_class(GF(7), is_sparse=False)
         <class 'sage.modules.vector_modn_dense.Vector_modn_dense'>
         sage: sage.modules.free_module.element_class(P, is_sparse=True)
@@ -8432,6 +8435,13 @@ def element_class(R, is_sparse):
     if isinstance(R, sage.rings.rational_field.RationalField) and not is_sparse:
         from sage.modules.vector_rational_dense import Vector_rational_dense
         return Vector_rational_dense
+    if isinstance(R, FiniteField) and R.order() == 2 and not is_sparse:
+        try:
+            from sage.modules.vector_mod2_dense import Vector_mod2_dense
+        except ImportError:
+            pass
+        else:
+            return Vector_mod2_dense
     if isinstance(R, sage.rings.abc.IntegerModRing) and not is_sparse:
         if R.order() == 2:
             try:

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -8418,7 +8418,7 @@ def element_class(R, is_sparse):
         <class 'sage.modules.free_module_element.FreeModuleElement_generic_sparse'>
         sage: sage.modules.free_module.element_class(FF, is_sparse=False)               # needs sage.rings.finite_rings
         <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
-        sage: FFntl = GF(2, impl='ntl')                                                # needs sage.rings.finite_rings
+        sage: FFntl = GF(2, impl='ntl')                                                 # needs sage.rings.finite_rings
         sage: sage.modules.free_module.element_class(FFntl, is_sparse=False)            # needs sage.rings.finite_rings
         <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
         sage: sage.modules.free_module.element_class(GF(7), is_sparse=False)

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -8480,6 +8480,9 @@ def element_class(R, is_sparse):
         <class 'sage.modules.free_module_element.FreeModuleElement_generic_sparse'>
         sage: sage.modules.free_module.element_class(FF, is_sparse=False)               # needs sage.rings.finite_rings
         <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
+        sage: FFntl = GF(2, impl='ntl')                                                # needs sage.rings.finite_rings
+        sage: sage.modules.free_module.element_class(FFntl, is_sparse=False)            # needs sage.rings.finite_rings
+        <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
         sage: sage.modules.free_module.element_class(GF(7), is_sparse=False)
         <class 'sage.modules.vector_modn_dense.Vector_modn_dense'>
         sage: sage.modules.free_module.element_class(P, is_sparse=True)
@@ -8494,6 +8497,13 @@ def element_class(R, is_sparse):
     if isinstance(R, sage.rings.rational_field.RationalField) and not is_sparse:
         from sage.modules.vector_rational_dense import Vector_rational_dense
         return Vector_rational_dense
+    if isinstance(R, FiniteField) and R.order() == 2 and not is_sparse:
+        try:
+            from sage.modules.vector_mod2_dense import Vector_mod2_dense
+        except ImportError:
+            pass
+        else:
+            return Vector_mod2_dense
     if isinstance(R, sage.rings.abc.IntegerModRing) and not is_sparse:
         if R.order() == 2:
             try:

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -8480,7 +8480,7 @@ def element_class(R, is_sparse):
         <class 'sage.modules.free_module_element.FreeModuleElement_generic_sparse'>
         sage: sage.modules.free_module.element_class(FF, is_sparse=False)               # needs sage.rings.finite_rings
         <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
-        sage: FFntl = GF(2, impl='ntl')                                                # needs sage.rings.finite_rings
+        sage: FFntl = GF(2, impl='ntl')                                                 # needs sage.rings.finite_rings
         sage: sage.modules.free_module.element_class(FFntl, is_sparse=False)            # needs sage.rings.finite_rings
         <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
         sage: sage.modules.free_module.element_class(GF(7), is_sparse=False)

--- a/src/sage/modules/vector_mod2_dense.pyx
+++ b/src/sage/modules/vector_mod2_dense.pyx
@@ -28,6 +28,16 @@ TESTS::
     sage: w.set_immutable()
     sage: isinstance(hash(w), int)
     True
+
+    sage: F = GF(2, impl='ntl')
+    sage: V = VectorSpace(F, 2)
+    sage: v = V([F(1), F(0)])
+    sage: type(v)
+    <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
+    sage: v * v
+    1
+    sage: (v * v).parent() is F
+    True
 """
 
 # ****************************************************************************
@@ -40,7 +50,7 @@ TESTS::
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.rings.finite_rings.integer_mod cimport IntegerMod_int, IntegerMod_abstract
+from sage.rings.finite_rings.integer_mod cimport IntegerMod_int
 from sage.rings.integer cimport Integer
 from sage.rings.rational cimport Rational
 from sage.structure.element cimport Element, Vector
@@ -49,6 +59,23 @@ cimport sage.modules.free_module_element as free_module_element
 from libc.stdint cimport uintptr_t
 
 from sage.libs.m4ri cimport mzd_add, mzd_copy, mzd_cmp, mzd_free, mzd_init, mzd_set_ui, mzd_read_bit, mzd_row, mzd_write_bit, m4ri_word
+
+
+cdef int mod2_bit(K, x) except -1:
+    """
+    Return the bit represented by ``x`` in an order-2 base ring.
+    """
+    if isinstance(x, (IntegerMod_int, int, Integer)):
+        return 1 if x % 2 else 0
+    elif isinstance(x, Rational):
+        if not (x.denominator() % 2):
+            raise ZeroDivisionError("inverse does not exist")
+        return 1 if (x.numerator() % 2) else 0
+    try:
+        return 1 if x % 2 else 0
+    except TypeError:
+        return 1 if K(x) else 0
+
 
 cdef class Vector_mod2_dense(free_module_element.FreeModuleElement):
     cdef _new_c(self):
@@ -235,16 +262,7 @@ cdef class Vector_mod2_dense(free_module_element.FreeModuleElement):
             if len(x) != self._degree:
                 raise TypeError("x must be a list of the right length")
             for i in range(len(x)):
-                xi = x[i]
-                if isinstance(xi, (IntegerMod_int, int, Integer)):
-                    # the if/else statement is because in some compilers, (-1)%2 is -1
-                    mzd_write_bit(self._entries, 0, i, 1 if xi % 2 else 0)
-                elif isinstance(xi, Rational):
-                    if not (xi.denominator() % 2):
-                        raise ZeroDivisionError("inverse does not exist")
-                    mzd_write_bit(self._entries, 0, i, 1 if (xi.numerator() % 2) else 0)
-                else:
-                    mzd_write_bit(self._entries, 0, i, xi % 2)
+                mzd_write_bit(self._entries, 0, i, mod2_bit(self._base_ring, x[i]))
         elif x != 0:
             raise TypeError("can't initialize vector from nonzero non-list")
         elif self._degree:
@@ -415,22 +433,19 @@ cdef class Vector_mod2_dense(free_module_element.FreeModuleElement):
            (0, 0)
         """
         cdef Py_ssize_t i
-        cdef IntegerMod_int n
         cdef Vector_mod2_dense r = right
         cdef m4ri_word tmp = 0
-        n = IntegerMod_int.__new__(IntegerMod_int)
-        IntegerMod_abstract.__init__(n, self.base_ring())
-        n.ivalue = 0
+        cdef int n = 0
         cdef m4ri_word *lrow = mzd_row(self._entries, 0)
         cdef m4ri_word *rrow = mzd_row(r._entries, 0)
         for i in range(self._entries.width):
             tmp ^= lrow[i] & rrow[i]
 
         for i in range(64):
-            n.ivalue ^= <int>(tmp & 1)
+            n ^= <int>(tmp & 1)
             tmp = tmp >> 1
 
-        return n
+        return self.base_ring()(n)
 
     cpdef _pairwise_product_(self, Vector right):
         """
@@ -534,13 +549,8 @@ def unpickle_v0(parent, entries, degree, immutable):
     cdef Vector_mod2_dense v
     v = Vector_mod2_dense.__new__(Vector_mod2_dense)
     v._init(degree, parent)
-    cdef int xi
 
     for i in range(degree):
-        if isinstance(entries[i], (IntegerMod_int, int, Integer)):
-            xi = entries[i]
-            mzd_write_bit(v._entries, 0, i, xi % 2)
-        else:
-            mzd_write_bit(v._entries, 0, i, entries[i] % 2)
+        mzd_write_bit(v._entries, 0, i, mod2_bit(v._base_ring, entries[i]))
     v._is_immutable = int(immutable)
     return v

--- a/src/sage/modules/vector_mod2_dense.pyx
+++ b/src/sage/modules/vector_mod2_dense.pyx
@@ -28,6 +28,16 @@ TESTS::
     sage: w.set_immutable()
     sage: isinstance(hash(w), int)
     True
+
+    sage: F = GF(2, impl='ntl')
+    sage: V = VectorSpace(F, 2)
+    sage: v = V([F(1), F(0)])
+    sage: type(v)
+    <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
+    sage: v * v
+    1
+    sage: (v * v).parent() is F
+    True
 """
 
 # ****************************************************************************
@@ -40,7 +50,7 @@ TESTS::
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.rings.finite_rings.integer_mod cimport IntegerMod_int, IntegerMod_abstract
+from sage.rings.finite_rings.integer_mod cimport IntegerMod_int
 from sage.rings.integer cimport Integer
 from sage.rings.rational cimport Rational
 from sage.structure.element cimport Element, Vector
@@ -59,6 +69,23 @@ from weakref import WeakValueDictionary
 # factory would, while still skipping the relatively expensive
 # ``FreeModule`` argument handling on the hot path (see :issue:`40482`).
 _slice_parents = WeakValueDictionary()
+
+
+cdef int mod2_bit(K, x) except -1:
+    """
+    Return the bit represented by ``x`` in an order-2 base ring.
+    """
+    if isinstance(x, (IntegerMod_int, int, Integer)):
+        return 1 if x % 2 else 0
+    elif isinstance(x, Rational):
+        if not (x.denominator() % 2):
+            raise ZeroDivisionError("inverse does not exist")
+        return 1 if (x.numerator() % 2) else 0
+    try:
+        return 1 if x % 2 else 0
+    except TypeError:
+        return 1 if K(x) else 0
+
 
 cdef class Vector_mod2_dense(free_module_element.FreeModuleElement):
     cdef _new_c(self):
@@ -245,16 +272,7 @@ cdef class Vector_mod2_dense(free_module_element.FreeModuleElement):
             if len(x) != self._degree:
                 raise TypeError("x must be a list of the right length")
             for i in range(len(x)):
-                xi = x[i]
-                if isinstance(xi, (IntegerMod_int, int, Integer)):
-                    # the if/else statement is because in some compilers, (-1)%2 is -1
-                    mzd_write_bit(self._entries, 0, i, 1 if xi % 2 else 0)
-                elif isinstance(xi, Rational):
-                    if not (xi.denominator() % 2):
-                        raise ZeroDivisionError("inverse does not exist")
-                    mzd_write_bit(self._entries, 0, i, 1 if (xi.numerator() % 2) else 0)
-                else:
-                    mzd_write_bit(self._entries, 0, i, xi % 2)
+                mzd_write_bit(self._entries, 0, i, mod2_bit(self._base_ring, x[i]))
         elif x != 0:
             raise TypeError("can't initialize vector from nonzero non-list")
         elif self._degree:
@@ -528,22 +546,19 @@ cdef class Vector_mod2_dense(free_module_element.FreeModuleElement):
            (0, 0)
         """
         cdef Py_ssize_t i
-        cdef IntegerMod_int n
         cdef Vector_mod2_dense r = right
         cdef m4ri_word tmp = 0
-        n = IntegerMod_int.__new__(IntegerMod_int)
-        IntegerMod_abstract.__init__(n, self.base_ring())
-        n.ivalue = 0
+        cdef int n = 0
         cdef m4ri_word *lrow = mzd_row(self._entries, 0)
         cdef m4ri_word *rrow = mzd_row(r._entries, 0)
         for i in range(self._entries.width):
             tmp ^= lrow[i] & rrow[i]
 
         for i in range(64):
-            n.ivalue ^= <int>(tmp & 1)
+            n ^= <int>(tmp & 1)
             tmp = tmp >> 1
 
-        return n
+        return self.base_ring()(n)
 
     cpdef _pairwise_product_(self, Vector right):
         """
@@ -647,13 +662,8 @@ def unpickle_v0(parent, entries, degree, immutable):
     cdef Vector_mod2_dense v
     v = Vector_mod2_dense.__new__(Vector_mod2_dense)
     v._init(degree, parent)
-    cdef int xi
 
     for i in range(degree):
-        if isinstance(entries[i], (IntegerMod_int, int, Integer)):
-            xi = entries[i]
-            mzd_write_bit(v._entries, 0, i, xi % 2)
-        else:
-            mzd_write_bit(v._entries, 0, i, entries[i] % 2)
+        mzd_write_bit(v._entries, 0, i, mod2_bit(v._base_ring, entries[i]))
     v._is_immutable = int(immutable)
     return v


### PR DESCRIPTION
This fixes dense matrix-vector products over `GF(2, impl='ntl')` by making dense free modules over order-2 finite fields use the same mod-2 vector representation expected by `Matrix_mod2_dense`.

It also keeps vector construction and dot products working with the actual NTL base field.

Fixes #36361.
