### PR TITLE
Add python3 to Docker runtime dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,7 +87,6 @@ RUN ln -s "$SAGE_ROOT/sage" /usr/bin/sage
 RUN ln -s /usr/bin/sage /usr/bin/sagemath
 # Sage needs the fortran libraries at run-time because we do not build gfortran
 # with Sage but use the system's.
-# Sage's virtual environment uses the system Python executable at run-time.
 # We need gcc/g++ to allow compilation of cython at run-time from the notebook.
 # We also install sudo for the sage user, see below.
 RUN apt-get -qq update \
@@ -233,7 +232,7 @@ ARG SAGE_ROOT=/home/sage/sage
 COPY --chown=sage:sage --from=make-release $SAGE_ROOT/ $SAGE_ROOT/
 # set path in bashrc to start gap, gp, maxima, ... this does not
 # affect Sage (see https://github.com/sagemath/sage/pull/38049)
-RUN echo "export PATH=$SAGE_ROOT/local/bin:$PATH" >> ~/.bashrc
+RUN echo 'export PATH='"$SAGE_ROOT"'/local/bin:$PATH' >> ~/.bashrc
 
 COPY ./docker/entrypoint.sh /usr/local/bin/sage-entrypoint
 WORKDIR $HOME

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,7 +90,7 @@ RUN ln -s /usr/bin/sage /usr/bin/sagemath
 # We need gcc/g++ to allow compilation of cython at run-time from the notebook.
 # We also install sudo for the sage user, see below.
 RUN apt-get -qq update \
-    && apt-get -qq install -y --no-install-recommends gfortran gcc g++ sudo openssl pkg-config patch libz-dev libbz2-dev bzip2 ca-certificates perl libboost-dev python3 \
+    && apt-get -qq install -y --no-install-recommends gfortran gcc g++ sudo openssl pkg-config patch libz-dev libbz2-dev bzip2 ca-certificates perl libboost-dev python3 python3-dev \
     && apt-get -qq clean \
     && rm -r /var/lib/apt/lists/*
 # Sage refuses to build as root, so we add a "sage" user that can sudo without a password.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,10 +87,11 @@ RUN ln -s "$SAGE_ROOT/sage" /usr/bin/sage
 RUN ln -s /usr/bin/sage /usr/bin/sagemath
 # Sage needs the fortran libraries at run-time because we do not build gfortran
 # with Sage but use the system's.
+# Sage's virtual environment uses the system Python executable at run-time.
 # We need gcc/g++ to allow compilation of cython at run-time from the notebook.
 # We also install sudo for the sage user, see below.
 RUN apt-get -qq update \
-    && apt-get -qq install -y --no-install-recommends gfortran gcc g++ sudo openssl pkg-config patch libz-dev libbz2-dev bzip2 ca-certificates perl libboost-dev \
+    && apt-get -qq install -y --no-install-recommends gfortran gcc g++ sudo openssl pkg-config patch libz-dev libbz2-dev bzip2 ca-certificates perl libboost-dev python3 \
     && apt-get -qq clean \
     && rm -r /var/lib/apt/lists/*
 # Sage refuses to build as root, so we add a "sage" user that can sudo without a password.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Docker image can not run
```
root@LAPTOP-A6042VHQ:~# sudo docker run -it sagemath/sagemath:latest
/usr/bin/env: ‘python3’: No such file or directory
```
Fix #42138
Fix #40867

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


