### PR TITLE
Set ruff format quote-style to preserve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,6 +261,9 @@ exclude = [
   "build/",
 ]
 
+[tool.ruff.format]
+quote-style = "preserve"
+
 [tool.ruff.lint]
 
 # Rules that we deliberately do not attempt to follow,  either because we


### PR DESCRIPTION
We have not adopted a strict rule throughout the project on using `'` versus `"` for quotes. This PR changes our ruff configuration to leave quotes alone, so that developers can use `ruff format` without creating large diffs that mostly just change `'` to `"`. If we ever decide to enforce either single or double quotes, we can just change this config option then.

Hopefully this makes it easier to use `ruff format` more often when developing Sage without cluttering diffs.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


