### PR TITLE
Use bootstrap -s to avoid downloading configure-hash package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,12 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install $(build/bin/sage-get-system-packages debian _bootstrap _prereq)
       - name: Configure with --enable-download-from-upstream-url
         run: |
-          make configure
+          # Run "bootstrap -s" so that the configure tarball
+          # (configure-$(git rev-parse HEAD).tar.gz) is generated and saved
+          # locally to upstream/. Otherwise "make dist" below tries to
+          # download it from the Sage mirrors / GitHub release assets, which
+          # fails for unreleased commits (e.g. on workflow_dispatch / PR runs).
+          ./bootstrap -s
           ./configure
       - name: make dist (--enable-download-from-upstream-url)
         id: make_dist


### PR DESCRIPTION
In the release workflow, `make configure` only regenerates `configure`; it does
not create the matching `upstream/configure-<commit>.tar.gz` tarball.

For unreleased commits, `make dist` later expects that tarball to exist. If it
does not exist locally, Sage falls back to downloading it. Since unreleased
commit tarballs have not been uploaded to the Sage mirrors or GitHub release
assets, the download fails.

Using `./bootstrap -s` solves this because it both regenerates `configure` and
saves the matching configure tarball locally under `upstream/`.


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


