### PR TITLE
faster enumeration of immutable trees

### DIFF
--- a/src/sage/graphs/generators/trees.pyx
+++ b/src/sage/graphs/generators/trees.pyx
@@ -106,6 +106,7 @@ from cysignals.memory cimport check_allocarray, sig_free
 from sage.graphs.base.sparse_graph cimport SparseGraph
 from sage.graphs.base.sparse_graph cimport SparseGraphBackend
 from sage.graphs.base.static_sparse_backend import StaticSparseBackend
+from sage.graphs.base.static_sparse_backend import _direct_static_sparse_backend_from_edges
 
 from sage.graphs.graph import Graph
 from sage.misc.randstate import current_randstate
@@ -834,15 +835,20 @@ cdef class TreeIterator:
 
         cdef int i
 
-        cdef object G = Graph(self.n, sparse=True)
-        cdef SparseGraph SG = (<SparseGraphBackend?> G._backend)._cg
-
-        for i in range(1, self.n):
-            SG.add_arc_unsafe(i, self.current_level_sequence[i] - 1)
+        cdef object G = Graph(self.n, sparse=True, immutable=self.immutable)
+        cdef SparseGraph SG
 
         if self.immutable:
-            G._backend = StaticSparseBackend(G, loops=False, multiedges=False)
+            G._backend = _direct_static_sparse_backend_from_edges(
+                range(self.n),
+                ((i, self.current_level_sequence[i] - 1)
+                 for i in range(1, self.n)),
+                False, False, False, False)
             G._immutable = True
+        else:
+            SG = (<SparseGraphBackend?> G._backend)._cg
+            for i in range(1, self.n):
+                SG.add_arc_unsafe(i, self.current_level_sequence[i] - 1)
 
         return G
 


### PR DESCRIPTION
We use the new method for building immutable graphs directly from list of edges introduced in #41988 to speed up the enumeration of immutable trees

Before
```py
sage: %timeit [len(list(graphs.trees(i, immutable=False))) for i in range(15)]
21.5 ms ± 84.2 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
sage: %timeit [len(list(graphs.trees(i, immutable=True))) for i in range(15)]
125 ms ± 138 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
After
```py
sage: %timeit [len(list(graphs.trees(i, immutable=False))) for i in range(15)]
21.7 ms ± 258 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
sage: %timeit [len(list(graphs.trees(i, immutable=True))) for i in range(15)]
66.3 ms ± 551 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


