### PR TITLE
remove and deprecate the auld class CommutativeRing

### DIFF
--- a/src/doc/en/thematic_tutorials/coercion_and_categories.rst
+++ b/src/doc/en/thematic_tutorials/coercion_and_categories.rst
@@ -111,7 +111,6 @@ as this base class still provides a few more methods than a general parent::
      '__xor__',
      '_coerce_c',
      '_coerce_impl',
-     '_default_category',
      '_gens',
      '_latex_names',
      '_list',

--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -107,12 +107,6 @@ class CommutativeRings(CategoryWithAxiom):
 
             TESTS::
 
-                sage: R = CommutativeRing(ZZ)
-                sage: R.krull_dimension()
-                Traceback (most recent call last):
-                ...
-                NotImplementedError
-
                 sage: R = GF(9).galois_group().algebra(QQ)
                 sage: R.krull_dimension()
                 Traceback (most recent call last):

--- a/src/sage/categories/rings.py
+++ b/src/sage/categories/rings.py
@@ -1434,8 +1434,8 @@ class Rings(CategoryWithAxiom):
                 Multivariate Power Series Ring in x, T over Integer Ring
 
             Use :func:`~sage.rings.fraction_field.Frac` or
-            :meth:`~sage.rings.ring.CommutativeRing.fraction_field` to obtain
-            the fields of rational functions and Laurent series::
+            :meth:`~sage.categories.commutative_rings.CommutativeRings.fraction_field`
+            to obtain the fields of rational functions and Laurent series::
 
                 sage: Frac(QQ['t'])
                 Fraction Field of Univariate Polynomial Ring in t over Rational Field

--- a/src/sage/rings/abc.pxd
+++ b/src/sage/rings/abc.pxd
@@ -1,4 +1,4 @@
-from sage.rings.ring cimport CommutativeRing, Field
+from sage.rings.ring cimport Ring, Field
 
 cdef class RealField(Field):
 

--- a/src/sage/rings/abc.pyx
+++ b/src/sage/rings/abc.pyx
@@ -418,7 +418,7 @@ class Order:
     pass
 
 
-class pAdicRing(CommutativeRing):
+class pAdicRing(Ring):
     r"""
     Abstract base class for :class:`~sage.rings.padics.generic_nodes.pAdicRingGeneric`.
 

--- a/src/sage/rings/algebraic_closure_finite_field.py
+++ b/src/sage/rings/algebraic_closure_finite_field.py
@@ -554,7 +554,7 @@ class AlgebraicClosureFiniteField_generic(Field):
             sage: F
             Algebraic closure of Finite Field of size 5
         """
-        Field.__init__(self, base_ring=base_ring, names=name,
+        Field.__init__(self, base_ring, names=name,
                        normalize=False, category=category)
 
     def __eq__(self, other):

--- a/src/sage/rings/complex_arb.pyx
+++ b/src/sage/rings/complex_arb.pyx
@@ -410,8 +410,8 @@ class ComplexBallField(UniqueRepresentation, sage.rings.abc.ComplexBallField):
         self._prec = precision
         real_field = RealBallField(self._prec)
         Field.__init__(self,
-                base_ring=real_field,
-                category=sage.categories.fields.Fields().Infinite())
+                       real_field,
+                       category=sage.categories.fields.Fields().Infinite())
         from sage.rings.rational_field import QQ
         self._populate_coercion_lists_([ZZ, QQ], convert_method_name='_acb_')
 

--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -73,7 +73,7 @@ cdef class FiniteField(Field):
         """
         if category is None:
             category = FiniteFields()
-        Field.__init__(self, base, names, normalize, category)
+        Field.__init__(self, base, names, normalize, category=category)
 
     # The methods __hash__ and __richcmp__ below were copied from
     # sage.misc.fast_methods.WithEqualityById; we cannot inherit from

--- a/src/sage/rings/infinity.py
+++ b/src/sage/rings/infinity.py
@@ -222,7 +222,7 @@ from sage.categories.rings import Rings
 from sage.categories.semirings import Semirings
 from sage.misc.fast_methods import Singleton
 from sage.misc.lazy_import import lazy_import
-from sage.rings.ring import CommutativeRing
+from sage.rings.ring import Ring
 from sage.structure.element import InfinityElement, RingElement
 from sage.structure.parent import Parent
 from sage.structure.richcmp import rich_to_bool, richcmp
@@ -972,7 +972,7 @@ class SignError(ArithmeticError):
     pass
 
 
-class InfinityRing_class(Singleton, CommutativeRing):
+class InfinityRing_class(Singleton, Ring):
     def __init__(self) -> None:
         """
         Initialize ``self``.
@@ -989,7 +989,7 @@ class InfinityRing_class(Singleton, CommutativeRing):
             sage: InfinityRing == UnsignedInfinityRing
             False
         """
-        CommutativeRing.__init__(self, self, names=('oo',), normalize=False)
+        Ring.__init__(self, self, names=('oo',), normalize=False)
 
     def fraction_field(self):
         """

--- a/src/sage/rings/infinity.py
+++ b/src/sage/rings/infinity.py
@@ -989,7 +989,8 @@ class InfinityRing_class(Singleton, Ring):
             sage: InfinityRing == UnsignedInfinityRing
             False
         """
-        Ring.__init__(self, self, names=('oo',), normalize=False)
+        Ring.__init__(self, self, names=('oo',),
+                      normalize=False, category=Rings().Commutative())
 
     def fraction_field(self):
         """

--- a/src/sage/rings/integer_ring.pxd
+++ b/src/sage/rings/integer_ring.pxd
@@ -1,6 +1,6 @@
-from sage.rings.ring cimport CommutativeRing
+from sage.rings.ring cimport Ring
 from sage.libs.gmp.types cimport mpz_t
 
-cdef class IntegerRing_class(CommutativeRing):
+cdef class IntegerRing_class(Ring):
     cdef int _randomize_mpz(self, mpz_t value, x, y, distribution) except -1
     cdef object _zero

--- a/src/sage/rings/integer_ring.pyi
+++ b/src/sage/rings/integer_ring.pyi
@@ -1,13 +1,13 @@
 from typing import Any, Optional, Union
 
-from sage.rings.ring import CommutativeRing
+from sage.rings.ring import Ring
 from sage.rings.integer import Integer
 from sage.libs.gmp.types import mpz_t
 
 def is_IntegerRing(x: Any) -> bool:
     ...
 
-class IntegerRing_class(CommutativeRing):
+class IntegerRing_class(Ring):
     def __init__(self) -> None:
         ...
 

--- a/src/sage/rings/integer_ring.pyx
+++ b/src/sage/rings/integer_ring.pyx
@@ -87,7 +87,7 @@ cdef int number_of_integer_rings = 0
 _prev_discrete_gaussian_integer_sampler = (None, None)
 
 
-cdef class IntegerRing_class(CommutativeRing):
+cdef class IntegerRing_class(Ring):
     r"""
     The ring of integers.
 
@@ -405,7 +405,7 @@ cdef class IntegerRing_class(CommutativeRing):
             K, _ = parent(x).subfield(x)
             return K.order(K.gen())
 
-        return CommutativeRing.__getitem__(self, x)
+        return Ring.__getitem__(self, x)
 
     def range(self, start, end=None, step=None):
         """

--- a/src/sage/rings/polynomial/infinite_polynomial_ring.py
+++ b/src/sage/rings/polynomial/infinite_polynomial_ring.py
@@ -261,7 +261,7 @@ import operator
 import re
 from functools import reduce
 
-from sage.rings.ring import CommutativeRing
+from sage.rings.ring import Ring
 from sage.categories.rings import Rings
 from sage.structure.sage_object import SageObject
 from sage.structure.element import parent
@@ -620,7 +620,7 @@ class GenDictWithBasering:
 ##############################################################
 #  The sparse implementation
 
-class InfinitePolynomialRing_sparse(CommutativeRing):
+class InfinitePolynomialRing_sparse(Ring):
     r"""
     Sparse implementation of Infinite Polynomial Rings.
 
@@ -754,7 +754,7 @@ class InfinitePolynomialRing_sparse(CommutativeRing):
         from sage.categories.cartesian_product import cartesian_product
         from sage.combinat.free_module import CombinatorialFreeModule
         category = polynomial_default_category(R.category(), Infinity)
-        CommutativeRing.__init__(self, R, category=category)
+        Ring.__init__(self, R, category=category)
         self._indices = cartesian_product([CombinatorialFreeModule(ZZ,
                                                                    basis_keys=NN,
                                                                    prefix=v)

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pxd
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pxd
@@ -1,7 +1,7 @@
-from sage.rings.ring cimport CommutativeRing, Ring
+from sage.rings.ring cimport Ring
 from sage.structure.parent cimport Parent
 
-cdef class MPolynomialRing_base(CommutativeRing):
+cdef class MPolynomialRing_base(Ring):
     cdef object _ngens
     cdef object _term_order
     cdef public object _indices

--- a/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_ring_base.pyx
@@ -29,7 +29,7 @@ from sage.rings.polynomial.polynomial_ring_constructor import (PolynomialRing,
 from sage.rings.polynomial.polydict cimport ETuple
 
 
-cdef class MPolynomialRing_base(CommutativeRing):
+cdef class MPolynomialRing_base(Ring):
     def __init__(self, base_ring, n, names, order):
         """
         Create a polynomial ring in several variables over a commutative ring.

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -50,7 +50,7 @@ from sage.rings.polynomial.polynomial_quotient_ring_element import (
 )
 from sage.rings.polynomial.polynomial_ring import PolynomialRing_commutative
 from sage.rings.quotient_ring import QuotientRing_generic
-from sage.rings.ring import CommutativeRing, Field
+from sage.rings.ring import Ring, Field
 from sage.structure.category_object import normalize_names
 from sage.structure.coerce_maps import DefaultConvertMap_unique
 from sage.structure.factory import UniqueFactory
@@ -580,7 +580,7 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
     #
 
     retract = _coerce_impl
-    ambient = CommutativeRing.base
+    ambient = Ring.base
 
     def lift(self, x):
         """
@@ -2202,7 +2202,7 @@ class PolynomialQuotientRing_coercion(DefaultConvertMap_unique):
         return richcmp(self.parent(), other.parent(), op)
 
 
-class PolynomialQuotientRing_domain(PolynomialQuotientRing_generic, CommutativeRing):
+class PolynomialQuotientRing_domain(PolynomialQuotientRing_generic, Ring):
     """
     EXAMPLES::
 

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -149,7 +149,7 @@ from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 from sage.rings.number_field.number_field_base import NumberField
 from sage.rings.rational_field import QQ
-from sage.rings.ring import CommutativeRing, Ring
+from sage.rings.ring import Ring
 from sage.structure.category_object import check_default_category
 from sage.structure.element import Element, RingElement
 
@@ -1890,9 +1890,9 @@ class PolynomialRing_commutative(PolynomialRing_generic):
         return roots
 
 
-class PolynomialRing_integral_domain(PolynomialRing_commutative, PolynomialRing_singular_repr, CommutativeRing):
+class PolynomialRing_integral_domain(PolynomialRing_commutative, PolynomialRing_singular_repr, Ring):
     def __init__(self, base_ring, name='x', sparse=False, implementation=None,
-            element_class=None, category=None):
+                 element_class=None, category=None):
         """
         TESTS::
 

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -375,7 +375,7 @@ class QuotientRing_nc(Parent):
         sage: j^3
         -j*k*i - j*k*j - j*k*k
 
-    For rings that *do* inherit from :class:`~sage.rings.ring.CommutativeRing`,
+    For rings that *do* inherit from :class:`~sage.rings.ring.Ring`,
     we provide a subclass :class:`QuotientRing_generic`, for backwards
     compatibility.
 
@@ -1331,7 +1331,7 @@ class QuotientRing_nc(Parent):
         return self.retract(self.cover_ring().random_element())
 
 
-class QuotientRing_generic(QuotientRing_nc, ring.CommutativeRing):
+class QuotientRing_generic(QuotientRing_nc, ring.Ring):
     r"""
     Create a quotient ring of a *commutative* ring `R` by the ideal `I`.
 
@@ -1350,7 +1350,7 @@ class QuotientRing_generic(QuotientRing_nc, ring.CommutativeRing):
 
         INPUT:
 
-        - ``R`` -- a ring that is a :class:`~sage.rings.ring.CommutativeRing`
+        - ``R`` -- a ring that is a :class:`~sage.rings.ring.Ring`
 
         - ``I`` -- an ideal of `R`
 

--- a/src/sage/rings/real_arb.pyx
+++ b/src/sage/rings/real_arb.pyx
@@ -433,9 +433,8 @@ class RealBallField(UniqueRepresentation, sage.rings.abc.RealBallField):
         """
         if precision < 2:
             raise ValueError("precision must be at least 2")
-        Field.__init__(self,
-                base_ring=self,
-                category=sage.categories.fields.Fields().Infinite())
+        Field.__init__(self, self,
+                       category=sage.categories.fields.Fields().Infinite())
         self._prec = precision
         from sage.rings.real_lazy import RLF
         self._populate_coercion_lists_(coerce_list=[ZZ, QQ], convert_method_name='_arb_')

--- a/src/sage/rings/ring.pxd
+++ b/src/sage/rings/ring.pxd
@@ -10,20 +10,20 @@ cdef class Ring(ParentWithGens):
 cdef class CommutativeRing(Ring):
     pass
 
-cdef class IntegralDomain(CommutativeRing):
+cdef class IntegralDomain(Ring):
     pass
 
-cdef class DedekindDomain(CommutativeRing):
+cdef class DedekindDomain(Ring):
     pass
 
-cdef class PrincipalIdealDomain(CommutativeRing):
+cdef class PrincipalIdealDomain(Ring):
     pass
 
-cdef class Field(CommutativeRing):
+cdef class Field(Ring):
     pass
 
 cdef class Algebra(Ring):
     pass
 
-cdef class CommutativeAlgebra(CommutativeRing):
+cdef class CommutativeAlgebra(Ring):
     pass

--- a/src/sage/rings/ring.pyi
+++ b/src/sage/rings/ring.pyi
@@ -35,35 +35,27 @@ class Ring(ParentWithGens):
 
 class CommutativeRing(Ring):
     _default_category: Category = _CommutativeRings
+    def __init__(self, *args, **kwds) -> None: ...
 
-    def __init__(
-        self,
-        base_ring: Parent[Any] | object,
-        names: NameSpec = None,
-        normalize: bool = True,
-        category: Category | None = None,
-    ) -> None: ...
-    def fraction_field(self) -> Ring: ...
-
-class IntegralDomain(CommutativeRing):
+class IntegralDomain(Ring):
     _default_category: Category
     def __init__(self, *args, **kwds) -> None: ...
 
-class NoetherianRing(CommutativeRing):
+class NoetherianRing(Ring):
     _default_category: Category
     def __init__(self, *args, **kwds) -> None: ...
 
-class DedekindDomain(CommutativeRing):
+class DedekindDomain(Ring):
     _default_category: Category
     def __init__(self, *args, **kwds) -> None: ...
 
-class PrincipalIdealDomain(CommutativeRing):
+class PrincipalIdealDomain(Ring):
     _default_category: Category
     def __init__(self, *args, **kwds) -> None: ...
 
 def _is_Field(x: object) -> bool: ...
 
-class Field(CommutativeRing):
+class Field(Ring):
     _default_category: Category = _Fields
 
 class Algebra(Ring):
@@ -71,9 +63,7 @@ class Algebra(Ring):
         self, base_ring: Parent[Any] | object, *args: object, **kwds: object
     ) -> None: ...
 
-class CommutativeAlgebra(CommutativeRing):
+class CommutativeAlgebra(Ring):
     def __init__(
         self, base_ring: Parent[Any] | object, *args: object, **kwds: object
     ) -> None: ...
-
-def is_Ring(x: object) -> bool: ...

--- a/src/sage/rings/ring.pyi
+++ b/src/sage/rings/ring.pyi
@@ -51,6 +51,7 @@ class PrincipalIdealDomain(Ring):
 def _is_Field(x: object) -> bool: ...
 
 class Field(Ring):
+    pass
 
 class Algebra(Ring):
     def __init__(

--- a/src/sage/rings/ring.pyi
+++ b/src/sage/rings/ring.pyi
@@ -34,29 +34,23 @@ class Ring(ParentWithGens):
     def order(self) -> int: ...
 
 class CommutativeRing(Ring):
-    _default_category: Category = _CommutativeRings
     def __init__(self, *args, **kwds) -> None: ...
 
 class IntegralDomain(Ring):
-    _default_category: Category
     def __init__(self, *args, **kwds) -> None: ...
 
 class NoetherianRing(Ring):
-    _default_category: Category
     def __init__(self, *args, **kwds) -> None: ...
 
 class DedekindDomain(Ring):
-    _default_category: Category
     def __init__(self, *args, **kwds) -> None: ...
 
 class PrincipalIdealDomain(Ring):
-    _default_category: Category
     def __init__(self, *args, **kwds) -> None: ...
 
 def _is_Field(x: object) -> bool: ...
 
 class Field(Ring):
-    _default_category: Category = _Fields
 
 class Algebra(Ring):
     def __init__(

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -491,13 +491,10 @@ cdef class Ring(ParentWithGens):
 
 
 cdef class CommutativeRing(Ring):
-    """
-    Generic commutative ring.
-    """
     _default_category = _CommutativeRings
 
     def __init__(self, *args, **kwds):
-        deprecation(42153, "use the category CommutativeRing")
+        deprecation(42153, "use the category CommutativeRings")
         super().__init__(*args, **kwds)
 
 

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -8,7 +8,7 @@ specific base classes.
 .. WARNING::
 
     Those classes, except maybe for the lowest ones like
-    :class:`CommutativeRing` and :class:`Field`,
+    :class:`Field`,
     are being progressively deprecated in favor of the corresponding
     categories. which are more flexible, in particular with respect to multiple
     inheritance.
@@ -18,7 +18,7 @@ The class inheritance hierarchy is:
 - :class:`Ring` (to be deprecated)
 
   - :class:`Algebra` (deprecated and essentially removed)
-  - :class:`CommutativeRing`
+  - :class:`CommutativeRing` (deprecated and essentially removed)
 
     - :class:`NoetherianRing` (deprecated and essentially removed)
     - :class:`CommutativeAlgebra` (deprecated and essentially removed)
@@ -27,7 +27,7 @@ The class inheritance hierarchy is:
       - :class:`DedekindDomain` (deprecated and essentially removed)
       - :class:`PrincipalIdealDomain` (deprecated and essentially removed)
 
-Subclasses of :class:`CommutativeRing` are
+Other subclaasses of :class:`Ring` are
 
 - :class:`Field`
 
@@ -96,6 +96,15 @@ This is to test a deprecation::
     sage: F.category()
     Category of algebras over Rational Field
 
+    sage: from sage.rings.ring import CommutativeRing
+    sage: class Niets(CommutativeRing):
+    ....:     pass
+    sage: F = Niets()
+    ...:
+    DeprecationWarning: use the category CommutativeRings
+    See https://github.com/sagemath/sage/issues/xxxxx for details.
+    sage: F.category()
+    Category of commutative rings
 """
 
 # ****************************************************************************
@@ -487,27 +496,12 @@ cdef class CommutativeRing(Ring):
     """
     _default_category = _CommutativeRings
 
-    def __init__(self, base_ring, names=None, normalize=True, category=None):
-        """
-        Initialize ``self``.
-
-        EXAMPLES::
-
-            sage: Integers(389)['x,y']
-            Multivariate Polynomial Ring in x, y over Ring of integers modulo 389
-        """
-        if base_ring is not self and base_ring not in _CommutativeRings:
-            raise TypeError("base ring %s is no commutative ring" % base_ring)
-
-        # This is a low-level class. For performance, we trust that
-        # the category is fine, if it is provided. If it isn't, we use
-        # the category of commutative rings.
-        category = check_default_category(self._default_category, category)
-        Ring.__init__(self, base_ring, names=names, normalize=normalize,
-                      category=category)
+    def __init__(self, *args, **kwds):
+        deprecation(xxxxx, "use the category CommutativeRing")
+        super().__init__(*args, **kwds)
 
 
-cdef class IntegralDomain(CommutativeRing):
+cdef class IntegralDomain(Ring):
     _default_category = IntegralDomains()
 
     def __init__(self, *args, **kwds):
@@ -515,7 +509,7 @@ cdef class IntegralDomain(CommutativeRing):
         super().__init__(*args, **kwds)
 
 
-cdef class NoetherianRing(CommutativeRing):
+cdef class NoetherianRing(Ring):
     _default_category = NoetherianRings()
 
     def __init__(self, *args, **kwds):
@@ -523,7 +517,7 @@ cdef class NoetherianRing(CommutativeRing):
         super().__init__(*args, **kwds)
 
 
-cdef class DedekindDomain(CommutativeRing):
+cdef class DedekindDomain(Ring):
     _default_category = DedekindDomains()
 
     def __init__(self, *args, **kwds):
@@ -531,7 +525,7 @@ cdef class DedekindDomain(CommutativeRing):
         super().__init__(*args, **kwds)
 
 
-cdef class PrincipalIdealDomain(CommutativeRing):
+cdef class PrincipalIdealDomain(Ring):
     _default_category = PrincipalIdealDomains()
 
     def __init__(self, *args, **kwds):
@@ -575,7 +569,7 @@ from sage.categories.commutative_algebras import CommutativeAlgebras
 from sage.categories.fields import Fields
 _Fields = Fields()
 
-cdef class Field(CommutativeRing):
+cdef class Field(Ring):
     """
     Generic field
 
@@ -595,31 +589,8 @@ cdef class Algebra(Ring):
         super().__init__(base_ring, *args, **kwds)
 
 
-cdef class CommutativeAlgebra(CommutativeRing):
+cdef class CommutativeAlgebra(Ring):
     def __init__(self, base_ring, *args, **kwds):
         self._default_category = CommutativeAlgebras(base_ring)
         deprecation(37999, "use the category CommutativeAlgebras")
         super().__init__(base_ring, *args, **kwds)
-
-
-def is_Ring(x):
-    """
-    Return ``True`` if ``x`` is a ring.
-
-    EXAMPLES::
-
-        sage: from sage.rings.ring import is_Ring
-        sage: is_Ring(ZZ)
-        doctest:warning...
-        DeprecationWarning: The function is_Ring is deprecated; use '... in Rings()' instead
-        See https://github.com/sagemath/sage/issues/38288 for details.
-        True
-        sage: MS = MatrixSpace(QQ, 2)                                                   # needs sage.modules
-        sage: is_Ring(MS)                                                               # needs sage.modules
-        True
-    """
-    from sage.misc.superseded import deprecation_cython
-    deprecation_cython(38288,
-                       "The function is_Ring is deprecated; "
-                       "use '... in Rings()' instead")
-    return x in _Rings

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -102,7 +102,7 @@ This is to test a deprecation::
     sage: F = Niets()
     ...:
     DeprecationWarning: use the category CommutativeRings
-    See https://github.com/sagemath/sage/issues/xxxxx for details.
+    See https://github.com/sagemath/sage/issues/42153 for details.
     sage: F.category()
     Category of commutative rings
 """
@@ -497,7 +497,7 @@ cdef class CommutativeRing(Ring):
     _default_category = _CommutativeRings
 
     def __init__(self, *args, **kwds):
-        deprecation(xxxxx, "use the category CommutativeRing")
+        deprecation(42153, "use the category CommutativeRing")
         super().__init__(*args, **kwds)
 
 

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -241,7 +241,7 @@ cdef class Ring(ParentWithGens):
         sage: QQ.cardinality()
         +Infinity
      """
-    def __init__(self, base=None, names=None, normalize=True, category=None):
+    def __init__(self, base, names=None, normalize=True, category=None):
         """
         Initialize ``self``.
 

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -568,6 +568,7 @@ from sage.categories.commutative_algebras import CommutativeAlgebras
 from sage.categories.fields import Fields
 _Fields = Fields()
 
+
 cdef class Field(Ring):
     """
     Generic field
@@ -577,7 +578,10 @@ cdef class Field(Ring):
         sage: QQ.is_noetherian()
         True
     """
-    _default_category = _Fields
+    def __init__(self, *args, **kwds):
+        if 'category' not in kwds:
+            kwds['category'] = _Fields
+        super().__init__(*args, **kwds)
 
 
 cdef class Algebra(Ring):

--- a/src/sage/rings/ring.pyx
+++ b/src/sage/rings/ring.pyx
@@ -99,7 +99,7 @@ This is to test a deprecation::
     sage: from sage.rings.ring import CommutativeRing
     sage: class Niets(CommutativeRing):
     ....:     pass
-    sage: F = Niets()
+    sage: F = Niets(ZZ)
     ...:
     DeprecationWarning: use the category CommutativeRings
     See https://github.com/sagemath/sage/issues/42153 for details.
@@ -241,7 +241,7 @@ cdef class Ring(ParentWithGens):
         sage: QQ.cardinality()
         +Infinity
      """
-    def __init__(self, base, names=None, normalize=True, category=None):
+    def __init__(self, base=None, names=None, normalize=True, category=None):
         """
         Initialize ``self``.
 
@@ -260,6 +260,8 @@ cdef class Ring(ParentWithGens):
         #
         # This is a low-level class. For performance, we trust that the category
         # is fine, if it is provided. If it isn't, we use the category of rings.
+        if base is None:
+            raise TypeError('a ring must have a base ring')
         if category is None:
             category = check_default_category(_Rings, category)
         Parent.__init__(self, base=base, names=names, normalize=normalize,
@@ -491,41 +493,41 @@ cdef class Ring(ParentWithGens):
 
 
 cdef class CommutativeRing(Ring):
-    _default_category = _CommutativeRings
-
     def __init__(self, *args, **kwds):
+        if "category" not in kwds:
+            kwds["category"] = _CommutativeRings
         deprecation(42153, "use the category CommutativeRings")
         super().__init__(*args, **kwds)
 
 
 cdef class IntegralDomain(Ring):
-    _default_category = IntegralDomains()
-
     def __init__(self, *args, **kwds):
+        if "category" not in kwds:
+            kwds["category"] = IntegralDomains()
         deprecation(39227, "use the category IntegralDomains")
         super().__init__(*args, **kwds)
 
 
 cdef class NoetherianRing(Ring):
-    _default_category = NoetherianRings()
-
     def __init__(self, *args, **kwds):
+        if "category" not in kwds:
+            kwds["category"] = NoetherianRings()
         deprecation(37234, "use the category NoetherianRings")
         super().__init__(*args, **kwds)
 
 
 cdef class DedekindDomain(Ring):
-    _default_category = DedekindDomains()
-
     def __init__(self, *args, **kwds):
+        if "category" not in kwds:
+            kwds["category"] = DedekindDomains()
         deprecation(37234, "use the category DedekindDomains")
         super().__init__(*args, **kwds)
 
 
 cdef class PrincipalIdealDomain(Ring):
-    _default_category = PrincipalIdealDomains()
-
     def __init__(self, *args, **kwds):
+        if "category" not in kwds:
+            kwds["category"] = PrincipalIdealDomains()
         deprecation(37719, "use the category PrincipalIdealDomains")
         super().__init__(*args, **kwds)
 
@@ -588,6 +590,7 @@ cdef class Algebra(Ring):
 
 cdef class CommutativeAlgebra(Ring):
     def __init__(self, base_ring, *args, **kwds):
-        self._default_category = CommutativeAlgebras(base_ring)
+        if "category" not in kwds:
+            kwds["category"] = CommutativeAlgebras(base_ring)
         deprecation(37999, "use the category CommutativeAlgebras")
         super().__init__(base_ring, *args, **kwds)


### PR DESCRIPTION
as another little step towards getting rid of the auld way of doing things, before categories

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.


