### PR TITLE
add parameter immutable to distance regular graph generators (part 5)

### DIFF
--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -1455,9 +1455,15 @@ class BipartiteGraph(Graph):
         """
         return (self.left, self.right)
 
-    def project_left(self):
+    def project_left(self, immutable=None):
         r"""
         Project ``self`` onto left vertices. Edges are 2-paths in the original.
+
+        INPUT:
+
+        - ``immutable`` -- boolean (default: ``None``); whether to create a
+          mutable/immutable graph. ``immutable=None`` (default) means that the
+          bipartite graph and its projection will behave the same way.
 
         EXAMPLES::
 
@@ -1465,17 +1471,41 @@ class BipartiteGraph(Graph):
             sage: G = B.project_left()
             sage: G.order(), G.size()
             (10, 10)
-        """
-        G = Graph()
-        G.add_vertices(self.left)
-        for v in G:
-            for u in self.neighbor_iterator(v):
-                G.add_edges(((v, w) for w in self.neighbor_iterator(u)), loops=False)
-        return G
 
-    def project_right(self):
+        TESTS:
+
+        Check the behavior of parameter ``immutable``::
+
+            sage: B = BipartiteGraph(graphs.CycleGraph(4))
+            sage: B.project_left().is_immutable()
+            False
+            sage: B.project_left(immutable=True).is_immutable()
+            True
+            sage: B = BipartiteGraph(graphs.CycleGraph(4), immutable=True)
+            sage: B.project_left().is_immutable()
+            True
+            sage: B.project_left(immutable=False).is_immutable()
+            False
+        """
+        if immutable is None:
+            immutable = self.is_immutable()
+        edges = ((v, w)
+                 for v in self.left
+                 for u in self.neighbor_iterator(v)
+                 for w in self.neighbor_iterator(u)
+                 if v != w)
+        return Graph([self.left, edges], format="vertices_and_edges",
+                     immutable=immutable)
+
+    def project_right(self, immutable=None):
         r"""
         Project ``self`` onto right vertices. Edges are 2-paths in the original.
+
+        INPUT:
+
+        - ``immutable`` -- boolean (default: ``None``); whether to create a
+          mutable/immutable graph. ``immutable=None`` (default) means that the
+          bipartite graph and its projection will behave the same way.
 
         EXAMPLES::
 
@@ -1493,13 +1523,29 @@ class BipartiteGraph(Graph):
             [0, 2, 4]
             sage: B.project_right().vertices(sort=True)
             [1, 3, 5]
+
+        Check the behavior of parameter ``immutable``::
+
+            sage: B = BipartiteGraph(graphs.CycleGraph(4))
+            sage: B.project_right().is_immutable()
+            False
+            sage: B.project_right(immutable=True).is_immutable()
+            True
+            sage: B = BipartiteGraph(graphs.CycleGraph(4), immutable=True)
+            sage: B.project_right().is_immutable()
+            True
+            sage: B.project_right(immutable=False).is_immutable()
+            False
         """
-        G = Graph()
-        G.add_vertices(self.right)
-        for v in G:
-            for u in self.neighbor_iterator(v):
-                G.add_edges(((v, w) for w in self.neighbor_iterator(u)), loops=False)
-        return G
+        if immutable is None:
+            immutable = self.is_immutable()
+        edges = ((v, w)
+                 for v in self.right
+                 for u in self.neighbor_iterator(v)
+                 for w in self.neighbor_iterator(u)
+                 if v != w)
+        return Graph([self.right, edges], format="vertices_and_edges",
+                     immutable=immutable)
 
     def plot(self, *args, **kwds):
         r"""

--- a/src/sage/graphs/generators/distance_regular.pyx
+++ b/src/sage/graphs/generators/distance_regular.pyx
@@ -2207,7 +2207,8 @@ def is_classical_parameters_graph(list array):
     return (d, b, alpha, beta, gamma)
 
 
-def graph_with_classical_parameters(int d, int b, alpha_in, beta_in, int gamma):
+def graph_with_classical_parameters(int d, int b, alpha_in, beta_in, int gamma,
+                                    immutable=False):
     r"""
     Return the graph with the classical parameters given.
 
@@ -2224,6 +2225,9 @@ def graph_with_classical_parameters(int d, int b, alpha_in, beta_in, int gamma):
       graph; ``d`` and ``b`` must be integers
 
     - ``gamma`` -- element of the enum ``ClassicalParametersGraph``
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2287,59 +2291,59 @@ def graph_with_classical_parameters(int d, int b, alpha_in, beta_in, int gamma):
         beta = int(beta)
 
     if gamma == ClassicalParametersGraph.Johnson:
-        return JohnsonGraph(beta + d, d)
+        return JohnsonGraph(beta + d, d, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.Hamming:
-        return HammingGraph(d, beta + 1)
+        return HammingGraph(d, beta + 1, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.HalvedCube:
         a = 0 if beta == 2*d + 1 else 1
-        return HalfCube(beta + a)
+        return HalfCube(beta + a, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.UnitaryDualPolar:
-        return UnitaryDualPolarGraph(2 * d, -b)
+        return UnitaryDualPolarGraph(2 * d, -b, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.HermitianForms:
-        return HermitianFormsGraph(d, (-b)**2)
+        return HermitianFormsGraph(d, (-b)**2, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.GeneralisedHexagon:
         q = -b
-        return GeneralisedHexagonGraph(q, q**3)
+        return GeneralisedHexagonGraph(q, q**3, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.Grassmann:
         n = int(log((beta + 1) * (b - 1) + 1, b)) + d - 1
-        return GrassmannGraph(b, n, d)
+        return GrassmannGraph(b, n, d, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.OrthogonalDualPolar1:
-        return OrthogonalDualPolarGraph(1, d, b)
+        return OrthogonalDualPolarGraph(1, d, b, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.SymplecticDualPolar:
-        return SymplecticDualPolarGraph(2 * d, b)
+        return SymplecticDualPolarGraph(2 * d, b, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.OrthogonalDualPolar2:
-        return OrthogonalDualPolarGraph(-1, d, b)
+        return OrthogonalDualPolarGraph(-1, d, b, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.UnitaryDualPolar1:
         r = int(sqrt(b))
-        return UnitaryDualPolarGraph(2*d + 1, r)
+        return UnitaryDualPolarGraph(2*d + 1, r, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.UnitaryDualPolar2:
         r = int(sqrt(b))
-        return UnitaryDualPolarGraph(2 * d, r)
+        return UnitaryDualPolarGraph(2 * d, r, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.Ustimenko:
         q = int(sqrt(b))
         m = int(log((beta+1) * (q-1) + 1, q)) - 1
-        UstimenkoGraph(m, q)
+        return UstimenkoGraph(m, q, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.BilinearForms:
         e = int(log(beta + 1, b))
-        return BilinearFormsGraph(d, e, b)
+        return BilinearFormsGraph(d, e, b, immutable=immutable)
 
     elif gamma == ClassicalParametersGraph.AlternatingForms:
         q = int(sqrt(b))
         a = 0 if beta + 1 == q**(2*d - 1) else 1
-        return AlternatingFormsGraph(2*d + a, q)
+        return AlternatingFormsGraph(2*d + a, q, immutable=immutable)
 
     elif (gamma == ClassicalParametersGraph.LieE77 or
           gamma == ClassicalParametersGraph.AffineE6):
@@ -2433,7 +2437,7 @@ def is_pseudo_partition_graph(list arr):
     return False
 
 
-def pseudo_partition_graph(int m, int a):
+def pseudo_partition_graph(int m, int a, immutable=False):
     r"""
     Return a pseudo partition graph with the given parameters.
 
@@ -2446,6 +2450,9 @@ def pseudo_partition_graph(int m, int a):
     INPUT:
 
     - ``m``, ``a`` -- integers; parameters of the graph
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2487,11 +2494,11 @@ def pseudo_partition_graph(int m, int a):
     from sage.graphs.bipartite_graph import BipartiteGraph
 
     if a == 0:
-        return FoldedCubeGraph(m)
+        return FoldedCubeGraph(m, immutable=immutable)
     elif a == 1:
-        return JohnsonGraph(2 * m, m).folded_graph()
+        return JohnsonGraph(2 * m, m, immutable=immutable).folded_graph()
     elif a == 2:
-        return BipartiteGraph(FoldedCubeGraph(2 * m)).project_left()
+        return BipartiteGraph(FoldedCubeGraph(2 * m), immutable=immutable).project_left()
 
     raise ValueError("No known graph exists")
 
@@ -2650,7 +2657,7 @@ def is_near_polygon(array):
     return False
 
 
-def near_polygon_graph(family, params):
+def near_polygon_graph(family, params, immutable=False):
     r"""
     Return the near polygon graph with the given parameters.
 
@@ -2663,6 +2670,9 @@ def near_polygon_graph(family, params):
 
     - ``params`` -- integer or tuple; the parameters needed to construct a graph
       of the family ``family``
+
+    - ``immutable`` -- boolean (default: ``False``); whether to return an
+      immutable or a mutable graph
 
     EXAMPLES::
 
@@ -2690,7 +2700,7 @@ def near_polygon_graph(family, params):
         sage: near_polygon_graph((0, 12))
         Traceback (most recent call last):
         ...
-        TypeError: ...near_polygon_graph() takes exactly 2 positional arguments (1 given)
+        TypeError: ...near_polygon_graph() takes at least 2 positional arguments (1 given)
         sage: near_polygon_graph(0, 12)
         Cycle graph: Graph on 12 vertices
         sage: near_polygon_graph(*is_near_polygon([8, 7, 6, 5, 1, 2, 3, 8]))
@@ -2699,34 +2709,34 @@ def near_polygon_graph(family, params):
 
     if family == NearPolygonGraph.RegularPolygon:
         from sage.graphs.generators.basic import CycleGraph
-        return CycleGraph(params)
+        return CycleGraph(params, immutable=immutable)
 
     if family == NearPolygonGraph.GeneralisedPolygon:
         d, s, t = params
         if d == 3:
-            return GeneralisedHexagonGraph(s, t)
+            return GeneralisedHexagonGraph(s, t, immutable=immutable)
         if d == 4:
-            return GeneralisedOctagonGraph(s, t)
+            return GeneralisedOctagonGraph(s, t, immutable=immutable)
         if d == 6:
-            return GeneralisedDodecagonGraph(s, t)
+            return GeneralisedDodecagonGraph(s, t, immutable=immutable)
 
     if family == NearPolygonGraph.OddGraph:
         from sage.graphs.generators.families import OddGraph
-        return OddGraph(params)
+        return OddGraph(params, immutable=immutable)
 
     if family == NearPolygonGraph.DoubleOdd:
-        return DoubleOddGraph(params)
+        return DoubleOddGraph(params, immutable=immutable)
 
     if family == NearPolygonGraph.DoubleGrassmann:
-        return DoubleGrassmannGraph(*params)
+        return DoubleGrassmannGraph(*params, immutable=immutable)
 
     if family == NearPolygonGraph.FoldedCube:
         from sage.graphs.generators.families import FoldedCubeGraph
-        return FoldedCubeGraph(params)
+        return FoldedCubeGraph(params, immutable=immutable)
 
     if family == NearPolygonGraph.HammingGraph:
         from sage.graphs.generators.families import HammingGraph
-        return HammingGraph(*params)
+        return HammingGraph(*params, immutable=immutable)
 
     if family == NearPolygonGraph.DualPolarGraph:
         from sage.graphs.generators.classical_geometries import (
@@ -2736,15 +2746,15 @@ def near_polygon_graph(family, params):
 
         d, q, e = params
         if e == 0:
-            return OrthogonalDualPolarGraph(1, d, q)
+            return OrthogonalDualPolarGraph(1, d, q, immutable=immutable)
         if e == 0.5:
-            return UnitaryDualPolarGraph(2 * d, int(q**0.5))
+            return UnitaryDualPolarGraph(2 * d, int(q**0.5), immutable=immutable)
         if e == 1:
-            return SymplecticDualPolarGraph(2 * d, q)
+            return SymplecticDualPolarGraph(2 * d, q, immutable=immutable)
         if e == 1.5:
-            return UnitaryDualPolarGraph(2*d + 1, int(q**0.5))
+            return UnitaryDualPolarGraph(2*d + 1, int(q**0.5), immutable=immutable)
         if e == 2:
-            return OrthogonalDualPolarGraph(-1, d, q)
+            return OrthogonalDualPolarGraph(-1, d, q, immutable=immutable)
 
     raise ValueError("No known near polygons with the given parameters")
 

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -9194,7 +9194,7 @@ class Graph(GenericGraph):
         return True
 
     @doc_index("Leftovers")
-    def folded_graph(self, check=False):
+    def folded_graph(self, check=False, immutable=None):
         r"""
         Return the antipodal fold of this graph.
 
@@ -9212,6 +9212,10 @@ class Graph(GenericGraph):
         - ``check`` -- boolean (default: ``False``); whether to check if the
           graph is antipodal. If ``check`` is ``True`` and the graph is not
           antipodal, then return ``False``.
+
+        - ``immutable`` -- boolean (default: ``None``); whether to create a
+          mutable/immutable graph. ``immutable=None`` (default) means that the
+          graph and its folded graph will behave the same way.
 
         OUTPUT: this function returns a new graph and ``self`` is not touched
 
@@ -9262,6 +9266,19 @@ class Graph(GenericGraph):
             sage: G = Graph(1)
             sage: G.folded_graph()
             Folded Graph: Graph on 1 vertex
+
+        Check the bahavior of parameter ``immutable``::
+
+            sage: G = Graph(5)
+            sage: G.folded_graph().is_immutable()
+            False
+            sage: G.folded_graph(immutable=True).is_immutable()
+            True
+            sage: G = Graph(5, immutable=True)
+            sage: G.folded_graph().is_immutable()
+            True
+            sage: G.folded_graph(immutable=False).is_immutable()
+            False
         """
         G = self.antipodal_graph()
 
@@ -9287,10 +9304,11 @@ class Graph(GenericGraph):
                    itertools.product(newVertices[i], newVertices[j])):
                 edges.append((i, j))
 
-        H = Graph([range(numCliques), edges], format='vertices_and_edges')
+        if immutable is None:
+            immutable = self.is_immutable()
         name = self.name() if self.name() != "" else "Graph"
-        H.name(f"Folded {name}")
-        return H
+        return Graph([range(numCliques), edges], format='vertices_and_edges',
+                     name=f"Folded {name}", immutable=immutable)
 
     @doc_index("Leftovers")
     def antipodal_graph(self):


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to some generators in `src/sage/graphs/generators/distance_regular.pyx`.
- `graph_with_classical_parameters`, `pseudo_partition_graph`, `near_polygon_graph`

We also add parameter `immutable` to methods `project_left` and `project_right` of `BipartiteGraph` and to method `folded_graph` of `Graph`.

After that, it remains only method `distance_regular_graph` in `src/sage/graphs/generators/distance_regular.pyx`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


