### PR TITLE
Fix EllipticCurveHom.kernel_subgroup() kerpoly path

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -618,6 +618,17 @@ class EllipticCurveHom(Morphism):
             Additive abelian group isomorphic to Z/7
               embedded in Abelian group of points on Elliptic Curve defined by y^2 + x*y = x^3 + 1
                 over Finite Field in t of size 2^42
+
+        When the `y`-coordinates require a second extension after splitting
+        the kernel polynomial, all accumulated and remaining `x`-coordinates
+        are mapped to the larger field::
+
+            sage: E = EllipticCurve(QQ, [0, 0, 0, 0, 2])
+            sage: x = polygen(QQ)
+            sage: phi = E.isogeny(x)
+            sage: G = (phi.dual() * phi).kernel_subgroup(extend=True, algorithm='kerpoly')
+            sage: G.invariants()
+            (3, 3)
         """
         if algorithm is None:
             if self.domain().base_ring().is_finite():
@@ -686,15 +697,13 @@ class EllipticCurveHom(Morphism):
         if algorithm != 'kerpoly':
             raise ValueError(f"invalid algorithm {algorithm}")
 
+        E = self.domain()
         f = self.kernel_polynomial()
-
-        if part:
-            f = f.gcd(E.division_polynomial(part))
 
         pts = []
 
         if not extend:
-            for x in self.kernel_polynomial().roots(multiplicities=False):
+            for x in f.roots(multiplicities=False):
                 try:
                     pts.append(E.lift_x(x))
                 except ValueError:
@@ -705,22 +714,20 @@ class EllipticCurveHom(Morphism):
                     return A
             raise ValueError('kernel subgroup has no generating points over the base field')
 
-        E = self.domain()
-        f = self.kernel_polynomial()
-
-        from sage.rings.polynomial.polynomial_ring import polygen
-
         K, to_K = f.splitting_field('u', map=True)
         EE = E.change_ring(to_K)
 
-        for x in f.change_ring(to_K).roots(multiplicities=False):
+        roots = f.change_ring(to_K).roots(multiplicities=False)
+        for i, x in enumerate(roots):
             h = EE.defining_polynomial()(x=x, z=1).univariate_polynomial()
             try:
                 y = h.any_root()
             except ValueError:
                 L, to_L = h.splitting_field('v', map=True)
                 EE = EE.change_ring(to_L)
-                pts = list(map(to_L, pts))
+                pts = [EE([to_L(c) for c in P]) for P in pts]
+                roots[i:] = [to_L(r) for r in roots[i:]]
+                x = roots[i]
                 K, to_K = L, to_L * to_K
                 y = h.change_ring(to_L).any_root()
             pts.append(EE(x, y))

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -740,7 +740,8 @@ class EllipticCurveHom(Morphism):
         EE = E.change_ring(to_K)
 
         roots = f.change_ring(to_K).roots(multiplicities=False)
-        for i, x in enumerate(roots):
+        while roots:
+            x = roots.pop(0)
             h = EE.defining_polynomial()(x=x, z=1).univariate_polynomial()
             try:
                 y = h.any_root()
@@ -750,7 +751,7 @@ class EllipticCurveHom(Morphism):
                 # everything computed so far still lives over the old field
                 pts = [P.change_ring(to_L) for P in pts]
                 x = to_L(x)
-                roots[i+1:] = [to_L(r) for r in roots[i+1:]]
+                roots = [to_L(r) for r in roots]
                 y = h.change_ring(to_L).any_root()
             pts.append(EE(x, y))
 

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -619,9 +619,18 @@ class EllipticCurveHom(Morphism):
               embedded in Abelian group of points on Elliptic Curve defined by y^2 + x*y = x^3 + 1
                 over Finite Field in t of size 2^42
 
-        When the `y`-coordinates require a second extension after splitting
-        the kernel polynomial, all accumulated and remaining `x`-coordinates
-        are mapped to the larger field::
+        Make sure :issue:`42506` is fixed; the ``'kerpoly'`` algorithm used to
+        fail immediately with a :exc:`NameError`::
+
+            sage: E = EllipticCurve(QQ, [0, 0, 0, -1, 0])
+            sage: phi = E.isogeny(E(0, 0))
+            sage: phi.kernel_subgroup(algorithm='kerpoly').invariants()
+            (2,)
+
+        When the `y`-coordinate of a root only exists over a further extension
+        `L`, both the points found so far and the roots not yet processed must
+        be mapped into `L`.  Here that extension is needed for the very first
+        root, so no point has been accumulated yet::
 
             sage: E = EllipticCurve(QQ, [0, 0, 0, 0, 2])
             sage: x = polygen(QQ)
@@ -629,6 +638,19 @@ class EllipticCurveHom(Morphism):
             sage: G = (phi.dual() * phi).kernel_subgroup(extend=True, algorithm='kerpoly')
             sage: G.invariants()
             (3, 3)
+
+        Here it is needed only after a `2`-torsion point has been accumulated,
+        so the points found so far really do have to be remapped::
+
+            sage: E = EllipticCurve(GF(11), [0, 1])
+            sage: phi3 = E.isogenies_prime_degree(3)[1]
+            sage: phi2 = phi3.codomain().isogenies_prime_degree(2)[0]
+            sage: G = (phi2 * phi3).kernel_subgroup(extend=True, algorithm='kerpoly')
+            sage: G.invariants()
+            (6,)
+            sage: G.universe()
+            Abelian group of points on Elliptic Curve defined by y^2 = x^3 + 1
+             over Finite Field in v of size 11^2
         """
         if algorithm is None:
             if self.domain().base_ring().is_finite():
@@ -714,7 +736,7 @@ class EllipticCurveHom(Morphism):
                     return A
             raise ValueError('kernel subgroup has no generating points over the base field')
 
-        K, to_K = f.splitting_field('u', map=True)
+        _, to_K = f.splitting_field('u', map=True)
         EE = E.change_ring(to_K)
 
         roots = f.change_ring(to_K).roots(multiplicities=False)
@@ -725,10 +747,10 @@ class EllipticCurveHom(Morphism):
             except ValueError:
                 L, to_L = h.splitting_field('v', map=True)
                 EE = EE.change_ring(to_L)
-                pts = [EE([to_L(c) for c in P]) for P in pts]
-                roots[i:] = [to_L(r) for r in roots[i:]]
-                x = roots[i]
-                K, to_K = L, to_L * to_K
+                # everything computed so far still lives over the old field
+                pts = [P.change_ring(to_L) for P in pts]
+                x = to_L(x)
+                roots[i+1:] = [to_L(r) for r in roots[i+1:]]
                 y = h.change_ring(to_L).any_root()
             pts.append(EE(x, y))
 


### PR DESCRIPTION
This is the **bugfix half** of #42158, split out as requested by the reviewer so it can be reviewed and merged quickly, independently of the algorithmic improvements.

### What this fixes

`EllipticCurveHom.kernel_subgroup()` had two problems in its `kerpoly` code path:

1. **`NameError` on every `kerpoly` call** (`part` is not defined). The `kerpoly`
   branch still referenced the removed `part` argument:
   ```python
   if part:
       f = f.gcd(E.division_polynomial(part))
   ```
   so any call with `algorithm='kerpoly'` crashed (this is #42506).

2. **Wrong result when the `y`-coordinates need a second field extension.**
   After splitting the kernel polynomial, when a root's `y`-coordinate only
   exists over a further extension `L`, the code remapped the already-accumulated
   points with `pts = list(map(to_L, pts))` (mapping the *point objects* through
   the field embedding) and left the remaining `x`-coordinate roots in the
   smaller field. Both are wrong once that branch is taken. We now map all
   projective coordinates of the accumulated points and the remaining roots into
   `L`:
   ```python
   pts = [EE([to_L(c) for c in P]) for P in pts]
   roots[i:] = [to_L(r) for r in roots[i:]]
   ```

A regression test over `QQ` (which exercises exactly the second-extension path)
is added.

### Relation to #42507

@yyyyx4's #42507 fixes the `NameError` (1) as well, but not the
second-extension bug (2). This PR is a self-contained fix for both; feel free to
take whichever you prefer for the `NameError` part.

Fixes #42506.

### :hourglass: Follow-up

The algorithmic improvements from the original #42158 (prefer `kerpoly` over
`structure` for separable maps over finite fields, and avoid PARI's slow
factorization of division polynomials over finite fields) are split into a
separate PR stacked on top of this one.
