### PR TITLE
gh-42142: fix affine_hull to respect ZZ base ring

### DIFF
--- a/src/sage/geometry/polyhedron/backend_ppl.py
+++ b/src/sage/geometry/polyhedron/backend_ppl.py
@@ -295,10 +295,10 @@ class Polyhedron_ppl(Polyhedron_mutable):
             sage: p._ppl_polyhedron.minimized_generators()
             Generator_System {point(0/2, 1/2), point(2/1, 0/1), point(24/6, 5/6)}
 
-        PPL may choose a non-integral point to represent an integral
-        affine space modulo its lineality.  In the ``ZZ`` backend, we
-        replace it by an integral representative when one exists
-        (:issue:`42142`)::
+        PPL may choose a non-integral point generator even when its
+        class modulo the lineality has an integral representative.  In
+        the ``ZZ`` backend, we replace it by such a representative when
+        one exists (:issue:`42142`)::
 
             sage: P = Polyhedron(eqns=[(-1, 1, 1, 1, -2)], base_ring=ZZ)
             sage: P.Vrepresentation()
@@ -350,9 +350,9 @@ class Polyhedron_ppl(Polyhedron_mutable):
         r"""
         Return an integral point equivalent to ``point`` modulo ``lines``.
 
-        PPL represents a polyhedron with lineality by a point modulo the
-        line space.  Even when the corresponding ``ZZ`` polyhedron has
-        integral vertices, PPL may choose a non-integral representative.
+        This helper only changes the representative of the affine flat
+        ``point + span(lines)``.  Even when this flat contains integral
+        points, PPL may choose a non-integral point generator.
         """
         line_matrix = matrix(ZZ, lines)
         equations = line_matrix.right_kernel_matrix()

--- a/src/sage/geometry/polyhedron/backend_ppl.py
+++ b/src/sage/geometry/polyhedron/backend_ppl.py
@@ -7,6 +7,8 @@ from sage.rings.integer_ring import ZZ
 from sage.rings.integer import Integer
 from sage.arith.functions import LCM_list
 from sage.misc.functional import denominator
+from sage.matrix.constructor import matrix
+from sage.modules.free_module_element import vector
 from .base_mutable import Polyhedron_mutable
 from .base_QQ import Polyhedron_QQ
 from .base_ZZ import Polyhedron_ZZ
@@ -292,12 +294,38 @@ class Polyhedron_ppl(Polyhedron_mutable):
             (A vertex at (0, 1/2), A vertex at (2, 0), A vertex at (4, 5/6))
             sage: p._ppl_polyhedron.minimized_generators()
             Generator_System {point(0/2, 1/2), point(2/1, 0/1), point(24/6, 5/6)}
+
+        PPL may choose a non-integral point to represent an integral
+        affine space modulo its lineality.  In the ``ZZ`` backend, we
+        replace it by an integral representative when one exists
+        (:issue:`42142`)::
+
+            sage: P = Polyhedron(eqns=[(-1, 1, 1, 1, -2)], base_ring=ZZ)
+            sage: P.Vrepresentation()
+            (A line in the direction (0, 0, 2, 1),
+             A line in the direction (2, 0, 0, 1),
+             A line in the direction (0, 2, 0, 1),
+             A vertex at (1, 0, 0, 0))
+
+        If no integral representative exists, construction still fails::
+
+            sage: Polyhedron(eqns=[(-1, 2)], base_ring=ZZ)
+            Traceback (most recent call last):
+            ...
+            TypeError: no conversion of this rational to integer
+            sage: Polyhedron(eqns=[(-1, 2, 2)], base_ring=ZZ)
+            Traceback (most recent call last):
+            ...
+            TypeError: no conversion of this rational to integer
         """
         if not self._is_mutable:
             raise TypeError("Vrepresentation of mutable polyhedra cannot be recomputed")
-        self._Vrepresentation = []
         gs = self._ppl_polyhedron.minimized_generators()
+        gs = tuple(gs)
         parent = self.parent()
+        lines = [[Integer(mpz) for mpz in g.coefficients()]
+                 for g in gs if g.is_line()]
+        self._Vrepresentation = []
         for g in gs:
             coefficients = [Integer(mpz) for mpz in g.coefficients()]
             if g.is_point():
@@ -305,7 +333,10 @@ class Polyhedron_ppl(Polyhedron_mutable):
                 if d.is_one():
                     parent._make_Vertex(self, coefficients)
                 else:
-                    parent._make_Vertex(self, [x/d for x in coefficients])
+                    point = [x/d for x in coefficients]
+                    if parent.base_ring() is ZZ and lines:
+                        point = self._integral_representative_mod_lines(point, lines)
+                    parent._make_Vertex(self, point)
             elif g.is_ray():
                 parent._make_Ray(self, coefficients)
             elif g.is_line():
@@ -313,6 +344,41 @@ class Polyhedron_ppl(Polyhedron_mutable):
             else:
                 assert False
         self._Vrepresentation = tuple(self._Vrepresentation)
+
+    @staticmethod
+    def _integral_representative_mod_lines(point, lines):
+        r"""
+        Return an integral point equivalent to ``point`` modulo ``lines``.
+
+        PPL represents a polyhedron with lineality by a point modulo the
+        line space.  Even when the corresponding ``ZZ`` polyhedron has
+        integral vertices, PPL may choose a non-integral representative.
+        """
+        line_matrix = matrix(ZZ, lines)
+        equations = line_matrix.right_kernel_matrix()
+        if not equations.nrows():
+            return [ZZ.zero()] * len(point)
+
+        point = vector(point)
+        rhs = equations.change_ring(point.base_ring()) * point
+        if any(denominator(x) != 1 for x in rhs):
+            return point
+
+        hermite_transpose, transformation_transpose = equations.transpose().hermite_form(
+            transformation=True)
+        hermite = hermite_transpose.transpose()
+        transformation = transformation_transpose.transpose()
+        rhs = vector(ZZ, rhs)
+        coordinates = vector(ZZ, equations.ncols())
+        for i in range(hermite.nrows()):
+            residual = rhs[i] - sum(hermite[i, j] * coordinates[j] for j in range(i))
+            if not residual:
+                continue
+            d = hermite[i, i]
+            if not d or residual % d:
+                return point
+            coordinates[i] = residual // d
+        return transformation * coordinates
 
     def _init_Hrepresentation_from_ppl(self, minimize):
         """

--- a/src/sage/geometry/polyhedron/backend_ppl.py
+++ b/src/sage/geometry/polyhedron/backend_ppl.py
@@ -307,6 +307,19 @@ class Polyhedron_ppl(Polyhedron_mutable):
              A line in the direction (0, 2, 0, 1),
              A vertex at (1, 0, 0, 0))
 
+        Point generators are treated independently.  Here PPL produces
+        two non-integral point generators, both of which have integral
+        representatives modulo the lineality::
+
+            sage: P = Polyhedron(ieqs=[(-1, 1, -2), (3, -1, 2)],
+            ....:                base_ring=ZZ, backend='ppl')
+            sage: P._ppl_polyhedron.minimized_generators()
+            Generator_System {line(2, 1), point(0/2, -3/2), point(0/2, -1/2)}
+            sage: P.n_vertices()
+            2
+            sage: all(v.vector() in ZZ^2 for v in P.vertices())
+            True
+
         If no integral representative exists, construction still fails::
 
             sage: Polyhedron(eqns=[(-1, 2)], base_ring=ZZ)
@@ -314,6 +327,21 @@ class Polyhedron_ppl(Polyhedron_mutable):
             ...
             TypeError: no conversion of this rational to integer
             sage: Polyhedron(eqns=[(-1, 2, 2)], base_ring=ZZ)
+            Traceback (most recent call last):
+            ...
+            TypeError: no conversion of this rational to integer
+
+        Merely containing an integral point is not sufficient.  Every
+        point-generator class modulo the lineality must have an integral
+        representative.  The following strip contains ``(1, 0)`` in its
+        interior, but neither boundary class has an integral representative::
+
+            sage: P = Polyhedron(ieqs=[(-1, 2, 0), (3, -2, 0)],
+            ....:                base_ring=QQ, backend='ppl')
+            sage: P.interior_contains((1, 0))
+            True
+            sage: Polyhedron(ieqs=[(-1, 2, 0), (3, -2, 0)],
+            ....:            base_ring=ZZ, backend='ppl')
             Traceback (most recent call last):
             ...
             TypeError: no conversion of this rational to integer
@@ -350,9 +378,16 @@ class Polyhedron_ppl(Polyhedron_mutable):
         r"""
         Return an integral point equivalent to ``point`` modulo ``lines``.
 
-        This helper only changes the representative of the affine flat
-        ``point + span(lines)``.  Even when this flat contains integral
-        points, PPL may choose a non-integral point generator.
+        A minimized PPL generator system represents a polyhedron as
+        ``conv(points) + cone(rays) + span(lines)``.  Replacing any point
+        generator ``p`` independently by a point in ``p + span(lines)``
+        leaves the represented polyhedron unchanged.
+
+        Modulo the lineality, the point generators are the vertices of the
+        quotient polyhedron.  Consequently, an integral V-representation
+        exists only if every one of these classes has an integral
+        representative; an integral point elsewhere in the polyhedron is
+        not sufficient.
         """
         line_matrix = matrix(ZZ, lines)
         equations = line_matrix.right_kernel_matrix()

--- a/src/sage/geometry/polyhedron/backend_ppl.py
+++ b/src/sage/geometry/polyhedron/backend_ppl.py
@@ -320,7 +320,7 @@ class Polyhedron_ppl(Polyhedron_mutable):
             sage: all(v.vector() in ZZ^2 for v in P.vertices())
             True
 
-        If no integral representative exists, construction still fails::
+        If no integral representative exists, construction fails::
 
             sage: Polyhedron(eqns=[(-1, 2)], base_ring=ZZ)
             Traceback (most recent call last):

--- a/src/sage/geometry/polyhedron/base6.py
+++ b/src/sage/geometry/polyhedron/base6.py
@@ -890,13 +890,52 @@ class Polyhedron_base6(Polyhedron_base5):
 
             sage: polytopes.cube().affine_hull().is_universe()
             True
+
+        The base ring is preserved when an integral affine hull admits an
+        integral point (:issue:`42142`)::
+
+            sage: pp = Polyhedron(vertices=[[-1, -1, 1, -1], [-1, -1, 5, 1],
+            ....:                           [-1, 5, -1, 1], [5, -1, -1, 1]])
+            sage: ah = pp.affine_hull()
+            sage: ah.base_ring()
+            Integer Ring
+            sage: ah.Hrepresentation()
+            (An equation (1, 1, 1, -2) x - 1 == 0,)
+            sage: ah.base_extend(QQ) == pp.base_extend(QQ).affine_hull()
+            True
+
+        Rays and lines contribute to the affine hull as directions::
+
+            sage: P = Polyhedron(vertices=[[1, 0, 0]], rays=[[1, 1, 0], [1, -1, 0]])
+            sage: P.affine_hull().Hrepresentation()
+            (An equation (0, 0, 1) x + 0 == 0,)
+            sage: P = Polyhedron(vertices=[[2, 3, 0]], lines=[[1, 1, 0]])
+            sage: P.affine_hull().Hrepresentation()
+            (An equation (1, -1, 0) x + 1 == 0, An equation (0, 0, 1) x + 0 == 0)
+
+        PPL may choose a non-integral point for an integral affine space.
+        Sage replaces it by an integral representative::
+
+            sage: P = Polyhedron(vertices=[[0, 3, -3], [-2, -2, -3]],
+            ....:                rays=[[2, -3, -1]], base_ring=ZZ)
+            sage: P.affine_hull()
+            A 2-dimensional polyhedron in ZZ^3 defined as
+             the convex hull of 1 vertex and 2 lines
+            sage: P.affine_hull().Hrepresentation()
+            (An equation (5, -2, 16) x + 54 == 0,)
         """
         if args or kwds:
             raise TypeError("the method 'affine_hull' does not take any parameters; perhaps you meant 'affine_hull_projection'")
         if not self.inequalities():
             return self
-        self_as_face = self.faces(self.dimension())[0]
-        return self_as_face.affine_tangent_cone()
+
+        verts = self.vertices()
+        v0 = verts[0].vector()
+        directions = [v.vector() - v0 for v in verts[1:]]
+        directions.extend(r.vector() for r in self.rays())
+        directions.extend(l.vector() for l in self.lines())
+        parent = self.parent()
+        return parent.element_class(parent, [[v0], [], directions], None)
 
     @cached_method
     def _affine_hull_projection(self, *,

--- a/src/sage/geometry/polyhedron/constructor.py
+++ b/src/sage/geometry/polyhedron/constructor.py
@@ -551,8 +551,9 @@ def Polyhedron(vertices=None, rays=None, lines=None,
         sage: Q.base_ring()
         Rational Field
 
-    Enforcing base ring ``ZZ`` for this example succeeds because an integral
-    representative of the affine hull exists (see :issue:`42142`)::
+    Enforcing base ring ``ZZ`` for this example succeeds because the PPL
+    point generator can be replaced by an integral representative modulo
+    the lineality (see :issue:`42142`)::
 
         sage: Q = Polyhedron(vertices=[(1, 2, 3), (1, 3, 2), (2, 1, 3),
         ....:                          (2, 3, 1), (3, 1, 2), (3, 2, 1)],

--- a/src/sage/geometry/polyhedron/constructor.py
+++ b/src/sage/geometry/polyhedron/constructor.py
@@ -551,15 +551,17 @@ def Polyhedron(vertices=None, rays=None, lines=None,
         sage: Q.base_ring()
         Rational Field
 
-    Check that enforcing base ring `ZZ` for this example gives an error::
+    Enforcing base ring ``ZZ`` for this example succeeds because an integral
+    representative of the affine hull exists (see :issue:`42142`)::
 
         sage: Q = Polyhedron(vertices=[(1, 2, 3), (1, 3, 2), (2, 1, 3),
         ....:                          (2, 3, 1), (3, 1, 2), (3, 2, 1)],
         ....:                rays=[[1, 1, 1]], lines=[[1, 2, 3]], backend='ppl',
         ....:                base_ring=ZZ)
-        Traceback (most recent call last):
-        ...
-        TypeError: no conversion of this rational to integer
+        sage: Q.base_ring()
+        Integer Ring
+        sage: Q.dimension()
+        3
 
     Check that input with too many bits of precision returns an error (see
     :issue:`22552`)::


### PR DESCRIPTION
Fixes #42142.

## Problem

Calling `.affine_hull()` on a `ZZ`-polyhedron that lives inside an affine
hyperplane could raise a `TypeError`:

```python
sage: pp = Polyhedron(vertices=[[-1,-1,1,-1],[-1,-1,5,1],[-1,5,-1,1],[5,-1,-1,1]])
sage: pp.affine_hull()
# TypeError: no conversion of this rational to integer
```

The root cause was a two-layer issue:

1. **`backend_ppl.py`** — PPL's `minimized_generators()` represents a
   polyhedron with lineality as `{p/d} + span(lines)`.  Even when the affine
   flat contains integer points, PPL may choose a non-integer representative
   `p/d`.  Converting that fraction directly to `ZZ` raises a `TypeError`.

2. **`base6.py`** — `affine_hull()` was implemented by taking the top-
   dimensional face and calling `.affine_tangent_cone()`, which internally
   uses the PPL generator described above, inheriting the same problem.

## Fix

### `backend_ppl.py` — find an integral representative via Smith normal form

When the `ZZ` backend encounters a non-integral PPL point and there are lines
present, a new static method `_integral_representative_mod_lines` searches for
an integral point in the same affine flat:

1. Compute `E = right_kernel_matrix(lines)` over `ZZ` — the rows of `E` span
   the orthogonal complement of the line space, giving the constraint system
   `E·q = E·p` that any equivalent point must satisfy.
2. Check whether `E·p` is already integral; if not, no integer solution can
   exist and the original (fractional) point is returned unchanged, preserving
   the existing `TypeError` for genuinely non-integral polyhedra.
3. Solve `E·q = rhs` over `ZZ` via Smith normal form (`D = U·E·V`), reducing
   to a diagonal system and back-substituting to obtain an integral `q = V·y`.
4. Return `q`; if any divisibility condition fails, return the original point.

### `base6.py` — reimplement `affine_hull()` directly from Vrep

Replace the face/tangent-cone round-trip with a direct construction:

```python
verts = self.vertices()
v0 = verts[0].vector()
directions = [v.vector() - v0 for v in verts[1:]]
directions.extend(r.vector() for r in self.rays())
directions.extend(l.vector() for l in self.lines())
parent = self.parent()
return parent.element_class(parent, [[v0], [], directions], None)
```

This builds `v0 + span(directions)` entirely from integral Vrep data, so the
base ring is preserved automatically. It also correctly handles rays and lines
as direction vectors contributing to the affine hull.

### `constructor.py` — update obsolete doctest

An existing doctest documented that building the polyhedron
```python
Polyhedron(vertices=[(1,2,3),(1,3,2),(2,1,3),(2,3,1),(3,1,2),(3,2,1)],
           rays=[[1,1,1]], lines=[[1,2,3]], backend='ppl', base_ring=ZZ)
```
raises `TypeError`.  This is precisely the behaviour the fix corrects, so the
doctest is updated to assert it succeeds with `base_ring == ZZ`.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


