### PR TITLE
Fix doctest when `cypari2 leaked` is fixed

### DIFF
--- a/src/sage/rings/factorint_pari.pyx
+++ b/src/sage/rings/factorint_pari.pyx
@@ -53,8 +53,6 @@ def factor_using_pari(n, int_=False, debug_level=0, proof=None):
         sage: from sage.doctest.util import ensure_interruptible_after
         sage: with ensure_interruptible_after(0.5): factor(2^1000 - 1, verbose=5)
         ...
-        doctest:warning...
-        RuntimeWarning: cypari2 leaked ... bytes on the PARI stack
         sage: pari.get_debug_level()
         0
     """

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7272,10 +7272,11 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         check for reliable interrupting, see :issue:`18919`::
 
             sage: from cysignals import AlarmInterrupt
+            sage: from warnings import filterwarnings
+            sage: filterwarnings("ignore", r"cypari2 leaked \d+ bytes on the PARI stack")
             sage: for i in [1..10]:             # long time (5s)                        # needs sage.libs.pari
             ....:     with ensure_interruptible_after(i/11):
             ....:         (2^100).binomial(2^22, algorithm='pari')
-            doctest:...: RuntimeWarning: cypari2 leaked ... bytes on the PARI stack...
         """
         cdef Integer x
         cdef Integer mm


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

In https://github.com/sagemath/cypari2/pull/206 there is a fix for the
`cypari2 leaked ... on the PARI stack` warnings, that will eventually
be part of a new release of cypari2.

This PR fixes a couple of doctests in sagemath that fail with that fix.
The doctests should then pass with or without the warning.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


