### PR TITLE
Support kernel polynomials with both 2-torsion and odd parts in Kohel's algorithm

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -49,8 +49,9 @@ The most useful methods that apply to isogenies are:
 
 .. WARNING::
 
-    This class only implements separable isogenies. When using Kohel's
-    algorithm, only cyclic isogenies can be computed (except for `[2]`).
+    This class only implements separable isogenies. The direct Kohel
+    implementation handles odd-degree kernel polynomials and kernel
+    polynomials contained in the 2-torsion.
 
     Working with other kinds of isogenies may be possible using other
     child classes of :class:`EllipticCurveHom`.
@@ -421,6 +422,16 @@ def compute_codomain_kohel(E, kernel):
         sage: compute_codomain_kohel(E, x^3 + 7*x^2 + 15*x + 12)
         Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 3*x + 15
          over Finite Field of size 19
+        sage: F = GF(419)
+        sage: E = EllipticCurve(F, [1, 0])
+        sage: R.<x> = F[]
+        sage: compute_codomain_kohel(E, x^3 - 25*x^2 + x)
+        Elliptic Curve defined by y^2 = x^3 + 141*x + 269 over Finite Field of size 419
+
+        sage: F = GF(3); R.<x> = F[]
+        sage: E = EllipticCurve(F, [1, 2, 0, 1, 0])
+        sage: compute_codomain_kohel(E, x^2 + x)
+        Elliptic Curve defined by y^2 + x*y = x^3 + 2*x^2 + x + 1 over Finite Field of size 3
 
     ALGORITHM:
 
@@ -443,7 +454,9 @@ def compute_codomain_kohel(E, kernel):
         psi_quo = psi//psi_2tor
 
         if psi_quo.degree() != 0:
-            raise NotImplementedError("Kohel's algorithm currently only supports cyclic isogenies (except for [2])")
+            phi_even = EllipticCurveIsogeny(E, psi_2tor)
+            psi_odd = phi_even.push_subgroup(psi_quo)
+            return compute_codomain_kohel(phi_even.codomain(), psi_odd)
 
         n = psi_2tor.degree()
 
@@ -521,6 +534,71 @@ def two_torsion_part(E, psi):
     return psi.gcd(psi_2)
 
 
+def _factored_isogeny_from_kernel_polynomial(E, kernel_polynomial,
+                                             codomain=None, model=None,
+                                             check=True):
+    r"""
+    Construct an isogeny from a kernel polynomial with both a nontrivial
+    2-torsion part and a nontrivial odd part, as a composite of an
+    even-degree and an odd-degree isogeny.
+
+    This handles the case where the direct Kohel implementation can compute
+    the even part and the odd quotient, but not both in a single step.
+
+    EXAMPLES::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import _factored_isogeny_from_kernel_polynomial
+        sage: F = GF(419)
+        sage: E = EllipticCurve(F, [1, 0])
+        sage: R.<x> = F[]
+        sage: phi = _factored_isogeny_from_kernel_polynomial(E, x^3 - 25*x^2 + x)
+        sage: [f.degree() for f in phi.factors()]
+        [2, 3]
+        sage: phi.codomain()
+        Elliptic Curve defined by y^2 = x^3 + 141*x + 269 over Finite Field of size 419
+
+    TESTS:
+
+    Check that a polynomial which does not define a subgroup is rejected::
+
+        sage: E.isogeny((x^3 + x) * (x^2 - 25*x + 1))
+        Traceback (most recent call last):
+        ...
+        ValueError: the polynomial x^5 + 394*x^4 + 2*x^3 + 394*x^2 + x
+        does not define a finite subgroup of
+        Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 419
+    """
+    polynomial_ring = PolynomialRing(E.base_ring(), 'x')
+    psi = polynomial_ring(kernel_polynomial)
+
+    if not psi.is_monic():
+        raise ValueError("given kernel polynomial is not monic")
+
+    psi_even = two_torsion_part(E, psi)
+    if psi_even.degree() == 0:
+        return EllipticCurveIsogeny(E, psi, codomain=codomain, model=model,
+                                    check=check)
+
+    psi_odd_preimage = psi // psi_even
+    if psi_odd_preimage.degree() == 0:
+        return EllipticCurveIsogeny(E, psi_even, codomain=codomain,
+                                    model=model, check=check)
+
+    phi_even = EllipticCurveIsogeny(E, psi_even, check=check)
+    psi_odd = phi_even.push_subgroup(psi_odd_preimage)
+    phi_odd = EllipticCurveIsogeny(phi_even.codomain(), psi_odd,
+                                   codomain=codomain, model=model,
+                                   check=check)
+
+    from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
+    factored_isogeny = EllipticCurveHom_composite.from_factors([phi_even, phi_odd])
+
+    if check and factored_isogeny.kernel_polynomial() != psi:
+        raise ValueError(f"the polynomial {psi} does not define a finite subgroup of {E}")
+
+    return factored_isogeny
+
+
 class EllipticCurveIsogeny(EllipticCurveHom):
     r"""
     This class implements separable isogenies of elliptic curves.
@@ -537,8 +615,8 @@ class EllipticCurveIsogeny(EllipticCurveHom):
       isogenies.  This algorithm is selected by giving as the
       ``kernel`` parameter a monic polynomial (or a coefficient list)
       which will define the kernel of the isogeny.
-      Kohel's algorithm is currently only implemented for cyclic
-      isogenies, with the exception of `[2]`.
+      The direct Kohel implementation handles odd-degree kernel
+      polynomials and kernel polynomials contained in the 2-torsion.
 
     INPUT:
 
@@ -2212,7 +2290,10 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             psi_quo = psi//psi_G
 
             if psi_quo.degree() != 0:
-                raise NotImplementedError("Kohel's algorithm currently only supports cyclic isogenies (except for [2])")
+                raise NotImplementedError(
+                    "the direct Kohel implementation requires kernel "
+                    "polynomials that are coprime to the 2-division "
+                    "polynomial or divide it")
 
             phi, omega, v, w, _, d = self.__init_even_kernel_polynomial(E, psi_G)
 

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -539,11 +539,12 @@ def _factored_isogeny_from_kernel_polynomial(E, kernel_polynomial,
                                              check=True):
     r"""
     Construct an isogeny from a kernel polynomial with both a nontrivial
-    2-torsion part and a nontrivial odd part, as a composite of an
-    even-degree and an odd-degree isogeny.
+    2-torsion part and another component, recursively extracting
+    2-torsion factors.
 
     This handles the case where the direct Kohel implementation can compute
-    the even part and the odd quotient, but not both in a single step.
+    each 2-torsion factor and the final residual kernel, but not the full
+    kernel polynomial in a single step.
 
     EXAMPLES::
 
@@ -556,6 +557,17 @@ def _factored_isogeny_from_kernel_polynomial(E, kernel_polynomial,
         [2, 3]
         sage: phi.codomain()
         Elliptic Curve defined by y^2 = x^3 + 141*x + 269 over Finite Field of size 419
+
+    The pushed-forward quotient can still have a nontrivial 2-torsion
+    part, in which case the construction recurses::
+
+        sage: h = (x^6 + 336*x^5 + 252*x^4 + 167*x^3
+        ....:      + 83*x^2 + 418*x)
+        sage: phi = E.isogeny(h)
+        sage: [f.degree() for f in phi.factors()]
+        [2, 2, 3]
+        sage: phi.kernel_polynomial() == h
+        True
 
     TESTS:
 
@@ -574,24 +586,22 @@ def _factored_isogeny_from_kernel_polynomial(E, kernel_polynomial,
     if not psi.is_monic():
         raise ValueError("given kernel polynomial is not monic")
 
-    psi_even = two_torsion_part(E, psi)
-    if psi_even.degree() == 0:
+    psi_2tor = two_torsion_part(E, psi)
+    if psi_2tor.degree() == 0:
         return EllipticCurveIsogeny(E, psi, codomain=codomain, model=model,
                                     check=check)
 
-    psi_odd_preimage = psi // psi_even
-    if psi_odd_preimage.degree() == 0:
-        return EllipticCurveIsogeny(E, psi_even, codomain=codomain,
+    psi_quotient = psi // psi_2tor
+    if psi_quotient.degree() == 0:
+        return EllipticCurveIsogeny(E, psi_2tor, codomain=codomain,
                                     model=model, check=check)
 
-    phi_even = EllipticCurveIsogeny(E, psi_even, check=check)
-    psi_odd = phi_even.push_subgroup(psi_odd_preimage)
-    phi_odd = EllipticCurveIsogeny(phi_even.codomain(), psi_odd,
-                                   codomain=codomain, model=model,
-                                   check=check)
-
-    from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
-    factored_isogeny = EllipticCurveHom_composite.from_factors([phi_even, phi_odd])
+    phi_2tor = EllipticCurveIsogeny(E, psi_2tor, check=check)
+    psi_image = phi_2tor.push_subgroup(psi_quotient)
+    phi_quotient = _factored_isogeny_from_kernel_polynomial(
+        phi_2tor.codomain(), psi_image, codomain=codomain, model=model,
+        check=check)
+    factored_isogeny = phi_quotient * phi_2tor
 
     if check and factored_isogeny.kernel_polynomial() != psi:
         raise ValueError(f"the polynomial {psi} does not define a finite subgroup of {E}")

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1609,8 +1609,11 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
           isogenies.  This algorithm is selected by giving as the
           ``kernel`` parameter a monic polynomial (or a coefficient list
           in little endian) which will define the kernel of the isogeny.
-          Kohel's algorithm is currently only implemented for cyclic
-          isogenies, with the exception of `[2]`.
+          The direct implementation handles odd-degree kernel polynomials
+          and kernel polynomials contained in the 2-torsion; kernel
+          polynomials with both a nontrivial 2-torsion part and a
+          nontrivial odd part are decomposed into a composite of an
+          even-degree and an odd-degree isogeny.
 
         - √élu Algorithm (see
           :mod:`~sage.schemes.elliptic_curves.hom_velusqrt`):
@@ -1789,6 +1792,21 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
               From: Elliptic Curve defined by y^2 + x*y = x^3 + x + 2 over Finite Field of size 31
               To:   Elliptic Curve defined by y^2 + x*y = x^3 + 2*x + 26 over Finite Field of size 31
 
+        Kernel polynomials with both a nontrivial 2-torsion part and a
+        nontrivial odd part are decomposed without constructing kernel
+        points (:issue:`42023`)::
+
+            sage: F = GF(419)
+            sage: E = EllipticCurve(F, [1, 0])
+            sage: R.<x> = F[]
+            sage: phi = E.isogeny(x^3 - 25*x^2 + x)
+            sage: [f.degree() for f in phi.factors()]
+            [2, 3]
+            sage: phi.codomain()
+            Elliptic Curve defined by y^2 = x^3 + 141*x + 269 over Finite Field of size 419
+            sage: phi.kernel_polynomial()
+            x^3 + 394*x^2 + x
+
         Multiple ways to set the ``velu_sqrt_bound``::
 
             sage: E = EllipticCurve_from_j(GF(97)(42))
@@ -1912,6 +1930,17 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                     return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
         try:
             return EllipticCurveIsogeny(self, kernel, codomain, degree, model, check=check)
+        except NotImplementedError as err:
+            if kernel is None:
+                raise err
+            try:
+                from .ell_curve_isogeny import _factored_isogeny_from_kernel_polynomial
+                return _factored_isogeny_from_kernel_polynomial(self, kernel,
+                                                               codomain=codomain,
+                                                               model=model,
+                                                               check=check)
+            except NotImplementedError:
+                raise err
         except AttributeError as e:
             raise RuntimeError("Unable to construct isogeny: %s" % e)
 

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -1840,16 +1840,25 @@ class EllipticCurveHom(Morphism):
             sage: f = phi.minimal_polynomial()
             sage: psi.push_subgroup(f)
             1
+
+        The image subgroup may have zero as its `x`-coordinate::
+
+            sage: F.<a> = GF(2^2)
+            sage: E = EllipticCurve(F, [0, 0, a, 0, 0])
+            sage: phi = E.isogeny(E(0, a))
+            sage: R.<x> = F[]
+            sage: phi.push_subgroup(x^3 + a + 1)
+            x
         """
         g = self.x_rational_map()
         g1, g2 = g.numerator(), g.denominator()
         gker = g2.gcd(f)
         f1 = f // gker
         R = f1.parent()
+        if f1.degree() == 0:
+            return R.one()
         S = R.quotient_ring(f1)
         alpha = S(g1 * g2.inverse_mod(f1))
-        if not alpha:
-            return R.one()
         return alpha.minpoly()
 
     def xEVAL(self, xP):


### PR DESCRIPTION
## Summary

This fixes construction of isogenies from kernel polynomials containing both a nontrivial 2-torsion part and a nontrivial odd-degree part.

Previously, the direct Kohel implementation rejected these cases because it only handled odd-degree kernel polynomials or kernel polynomials fully contained in the 2-torsion. This change decomposes the isogeny into:

1. the degree 2 or 4 isogeny defined by the 2-torsion part;
2. the odd-degree isogeny defined by the pushforward of the remaining kernel polynomial.

This follows Kohel's thesis, §2.4, where separable isogenies are decomposed into even and odd parts, with the resulting codomain independent of the chosen decomposition.

## Details

- Adds `_factored_isogeny_from_kernel_polynomial`, used as a fallback from `EllipticCurve_field.isogeny` when the direct Kohel implementation raises `NotImplementedError`.
- Lets `compute_codomain_kohel` handle such kernel polynomials by recursing on the pushforward of the odd part.
- Fixes `EllipticCurveHom.push_subgroup` to return the correct kernel polynomial when the image subgroup has `x`-coordinate zero; the previous test conflated that case with a trivial image subgroup.
- Updates documentation to clarify that the direct Kohel implementation handles odd-degree and pure 2-torsion kernel polynomials, while the mixed case is decomposed.
- Adds doctests for the motivating kernel polynomial from #42023.

Fix #42023

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.
