### PR TITLE
Group repeated eigenvalues in random_diagonalizable_matrix

### DIFF
--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3442,7 +3442,7 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     EXAMPLES:
 
-    A diagonalizable matrix, size 5. ::
+    A diagonalizable matrix, size 5::
 
         sage: from sage.matrix.constructor import random_diagonalizable_matrix
         sage: matrix_space = sage.matrix.matrix_space.MatrixSpace(QQ, 5)
@@ -3456,9 +3456,9 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     A diagonalizable matrix with eigenvalues and dimensions designated,
     with a check that if eigenvectors were calculated by hand
-    entries would all be integers. ::
+    entries would all be integers::
 
-        sage: eigenvalues = [ZZ.random_element() for _ in range(3)]
+        sage: eigenvalues = [-12, 4, 6]
         sage: B = random_matrix(QQ, 6, algorithm='diagonalizable',
         ....:                   eigenvalues=eigenvalues, dimensions=[2,3,1])
         sage: all(x in ZZ for x in (B-(-12*identity_matrix(6))).rref().list())
@@ -3471,6 +3471,15 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         sage: S = B.right_eigenmatrix()[1]
         sage: eigenvalues2 = (S.inverse()*B*S).diagonal()
         sage: all(e in eigenvalues for e in eigenvalues2)
+        True
+
+    Repeated eigenvalues are merged into a single eigenspace::
+
+        sage: B = random_matrix(QQ, 6, algorithm='diagonalizable',
+        ....:                   eigenvalues=[-5, 4, 4], dimensions=[2, 3, 1])
+        sage: (B - 4*identity_matrix(6)).right_kernel().dimension()
+        4
+        sage: all(x in ZZ for x in (B - 4*identity_matrix(6)).rref().list())
         True
 
     Matrices over finite fields are also supported::
@@ -3488,7 +3497,7 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     TESTS:
 
-    Eigenvalues must all be elements of the ring. ::
+    Eigenvalues must all be elements of the ring::
 
         sage: random_matrix(QQ, 3, algorithm='diagonalizable',                          # needs sage.symbolic
         ....:               eigenvalues=[2+I, 2-I, 2], dimensions=[1,1,1])
@@ -3496,49 +3505,49 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         ...
         TypeError: eigenvalues must be elements of the corresponding ring.
 
-    Diagonal matrices must be square. ::
+    Diagonal matrices must be square::
 
         sage: random_matrix(QQ, 5, 7, algorithm='diagonalizable', eigenvalues=[-5,2,-3], dimensions=[1,1,3])
         Traceback (most recent call last):
         ...
         TypeError: a diagonalizable matrix must be square.
 
-    A list of eigenvalues must be accompanied with a list of dimensions. ::
+    A list of eigenvalues must be accompanied with a list of dimensions::
 
         sage: random_matrix(QQ,10,algorithm='diagonalizable',eigenvalues=[4,8])
         Traceback (most recent call last):
         ...
         ValueError: the list of eigenvalues must have a list of dimensions corresponding to each eigenvalue.
 
-    A list of dimensions must be accompanied with a list of eigenvalues. ::
+    A list of dimensions must be accompanied with a list of eigenvalues::
 
         sage: random_matrix(QQ, 10,algorithm='diagonalizable',dimensions=[2,2,4,2])
         Traceback (most recent call last):
         ...
         ValueError: the list of dimensions must have a list of corresponding eigenvalues.
 
-    The sum of the eigenvalue dimensions must equal the size of the matrix. ::
+    The sum of the eigenvalue dimensions must equal the size of the matrix::
 
         sage: random_matrix(QQ,12,algorithm='diagonalizable',eigenvalues=[4,2,6,-1],dimensions=[2,3,5,1])
         Traceback (most recent call last):
         ...
         ValueError: the size of the matrix must equal the sum of the dimensions.
 
-    Each eigenspace dimension must be at least 1. ::
+    Each eigenspace dimension must be at least 1::
 
         sage: random_matrix(QQ,9,algorithm='diagonalizable',eigenvalues=[-15,22,8,-4,90,12],dimensions=[4,2,2,4,-3,0])
         Traceback (most recent call last):
         ...
         ValueError: eigenspaces must have a dimension of at least 1.
 
-    Each eigenvalue must have a corresponding eigenspace dimension. ::
+    Each eigenvalue must have a corresponding eigenspace dimension::
 
         sage: random_matrix(QQ,12,algorithm='diagonalizable',eigenvalues=[4,2,6,-1],dimensions=[4,3,5])
         Traceback (most recent call last):
         ...
         ValueError: each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue.
 
-    Each dimension must have an eigenvalue paired to it. ::
+    Each dimension must have an eigenvalue paired to it::
 
         sage: random_matrix(QQ,12,algorithm='diagonalizable',eigenvalues=[4,2,6],dimensions=[2,3,5,2])
         Traceback (most recent call last):
@@ -3591,6 +3600,17 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         raise ValueError("eigenspaces must have a dimension of at least 1.")
     if len(eigenvalues) != len(dimensions):
         raise ValueError("each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue.")
+    eigenvalue_dimensions = []
+    for eigenvalue, dimension in zip(eigenvalues, dimensions):
+        eigenvalue = ring(eigenvalue)
+        for i, (value, old_dimension) in enumerate(eigenvalue_dimensions):
+            if eigenvalue == value:
+                eigenvalue_dimensions[i] = (value, old_dimension + dimension)
+                break
+        else:
+            eigenvalue_dimensions.append((eigenvalue, dimension))
+    eigenvalues = [x[0] for x in eigenvalue_dimensions]
+    dimensions = [x[1] for x in eigenvalue_dimensions]
     # sort the dimensions in order of increasing size, and sort the eigenvalues list in an identical fashion, to maintain corresponding values.
     dimensions_sort = sorted(zip(dimensions, eigenvalues))
     dimensions = [x[0] for x in dimensions_sort]

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3544,13 +3544,13 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         ...
         TypeError: unhashable type: 'sage.rings.padics.qadic_flint_CR.qAdicCappedRelativeElement'
 
-    Eigenvalues must all be elements of the ring::
+    Eigenvalues must be coercible into the ring::
 
         sage: random_matrix(QQ, 3, algorithm='diagonalizable',                          # needs sage.symbolic
         ....:               eigenvalues=[2+I, 2-I, 2], dimensions=[1,1,1])
         Traceback (most recent call last):
         ...
-        TypeError: eigenvalues must be elements of the corresponding ring
+        TypeError: Unable to coerce I + 2 to a rational
 
     Diagonal matrices must be square::
 
@@ -3626,8 +3626,6 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         eigenvalues = [ring(randint(-10, 10)) for _ in range(size)]
         dimensions = [1] * size
 
-    if not all(x in ring for x in eigenvalues):
-        raise TypeError("eigenvalues must be elements of the corresponding ring")
     if size != sum(dimensions):
         raise ValueError("the size of the matrix must equal the sum of the dimensions")
     if min(dimensions) < 1:

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3534,14 +3534,14 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         ....:               dimensions=[1, 2, 1])
         Traceback (most recent call last):
         ...
-        TypeError: unhashable type: 'sage.rings.padics.qadic_flint_CR.qAdicCappedRelativeElement'
+        TypeError: ...unhashable type: 'sage.rings.padics.qadic_flint_CR.qAdicCappedRelativeElement'...
 
     This applies to randomly generated eigenvalues as well::
 
         sage: random_matrix(K, 4, algorithm='diagonalizable')
         Traceback (most recent call last):
         ...
-        TypeError: unhashable type: 'sage.rings.padics.qadic_flint_CR.qAdicCappedRelativeElement'
+        TypeError: ...unhashable type: 'sage.rings.padics.qadic_flint_CR.qAdicCappedRelativeElement'...
 
     Eigenvalues must be coercible into the ring::
 

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3446,7 +3446,7 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     EXAMPLES:
 
-    A diagonalizable matrix, size 5. ::
+    A diagonalizable matrix, size 5::
 
         sage: from sage.matrix.constructor import random_diagonalizable_matrix
         sage: matrix_space = sage.matrix.matrix_space.MatrixSpace(QQ, 5)
@@ -3460,11 +3460,13 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     A diagonalizable matrix with eigenvalues and dimensions designated,
     with a check that if eigenvectors were calculated by hand
-    entries would all be integers. ::
+    entries would all be integers::
 
-        sage: eigenvalues = [-12, 4, 6]
-        sage: B = random_matrix(QQ, 6, algorithm='diagonalizable',
-        ....:                   eigenvalues=eigenvalues, dimensions=[2, 3, 1])
+        sage: N = randint(5, 15)
+        sage: dimensions = Compositions(N).random_element()
+        sage: eigenvalues = [ZZ.random_element() for _ in dimensions]
+        sage: B = random_matrix(QQ, N, algorithm='diagonalizable',
+        ....:                   eigenvalues=eigenvalues, dimensions=dimensions)
         sage: all(x in ZZ for eigenvalue in eigenvalues
         ....:                    for x in (B - eigenvalue).rref().list())
         True
@@ -3522,62 +3524,62 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     TESTS:
 
-    Eigenvalues must all be elements of the ring. ::
+    Eigenvalues must all be elements of the ring::
 
         sage: random_matrix(QQ, 3, algorithm='diagonalizable',                          # needs sage.symbolic
         ....:               eigenvalues=[2+I, 2-I, 2], dimensions=[1,1,1])
         Traceback (most recent call last):
         ...
-        TypeError: eigenvalues must be elements of the corresponding ring.
+        TypeError: eigenvalues must be elements of the corresponding ring
 
-    Diagonal matrices must be square. ::
+    Diagonal matrices must be square::
 
         sage: random_matrix(QQ, 5, 7, algorithm='diagonalizable', eigenvalues=[-5,2,-3], dimensions=[1,1,3])
         Traceback (most recent call last):
         ...
-        TypeError: a diagonalizable matrix must be square.
+        TypeError: a diagonalizable matrix must be square
 
-    A list of eigenvalues must be accompanied with a list of dimensions. ::
+    A list of eigenvalues must be accompanied with a list of dimensions::
 
         sage: random_matrix(QQ,10,algorithm='diagonalizable',eigenvalues=[4,8])
         Traceback (most recent call last):
         ...
-        ValueError: the list of eigenvalues must have a list of dimensions corresponding to each eigenvalue.
+        ValueError: the list of eigenvalues must have a list of dimensions corresponding to each eigenvalue
 
-    A list of dimensions must be accompanied with a list of eigenvalues. ::
+    A list of dimensions must be accompanied with a list of eigenvalues::
 
         sage: random_matrix(QQ, 10,algorithm='diagonalizable',dimensions=[2,2,4,2])
         Traceback (most recent call last):
         ...
-        ValueError: the list of dimensions must have a list of corresponding eigenvalues.
+        ValueError: the list of dimensions must have a list of corresponding eigenvalues
 
-    The sum of the eigenvalue dimensions must equal the size of the matrix. ::
+    The sum of the eigenvalue dimensions must equal the size of the matrix::
 
         sage: random_matrix(QQ,12,algorithm='diagonalizable',eigenvalues=[4,2,6,-1],dimensions=[2,3,5,1])
         Traceback (most recent call last):
         ...
-        ValueError: the size of the matrix must equal the sum of the dimensions.
+        ValueError: the size of the matrix must equal the sum of the dimensions
 
-    Each eigenspace dimension must be at least 1. ::
+    Each eigenspace dimension must be at least 1::
 
         sage: random_matrix(QQ,9,algorithm='diagonalizable',eigenvalues=[-15,22,8,-4,90,12],dimensions=[4,2,2,4,-3,0])
         Traceback (most recent call last):
         ...
-        ValueError: eigenspaces must have a dimension of at least 1.
+        ValueError: eigenspaces must have a dimension of at least 1
 
-    Each eigenvalue must have a corresponding eigenspace dimension. ::
+    Each eigenvalue must have a corresponding eigenspace dimension::
 
         sage: random_matrix(QQ,12,algorithm='diagonalizable',eigenvalues=[4,2,6,-1],dimensions=[4,3,5])
         Traceback (most recent call last):
         ...
-        ValueError: each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue.
+        ValueError: each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue
 
-    Each dimension must have an eigenvalue paired to it. ::
+    Each dimension must have an eigenvalue paired to it::
 
         sage: random_matrix(QQ,12,algorithm='diagonalizable',eigenvalues=[4,2,6],dimensions=[2,3,5,2])
         Traceback (most recent call last):
         ...
-        ValueError: each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue.
+        ValueError: each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue
 
     .. TODO::
 
@@ -3593,38 +3595,36 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
     size = parent.nrows()
     ring = parent.base_ring()
     if parent.nrows() != parent.ncols():
-        raise TypeError("a diagonalizable matrix must be square.")
+        raise TypeError("a diagonalizable matrix must be square")
     if eigenvalues is not None and dimensions is None:
-        raise ValueError("the list of eigenvalues must have a list of dimensions corresponding to each eigenvalue.")
+        raise ValueError("the list of eigenvalues must have a list of dimensions corresponding to each eigenvalue")
     if eigenvalues is None and dimensions is not None:
-        raise ValueError("the list of dimensions must have a list of corresponding eigenvalues.")
+        raise ValueError("the list of dimensions must have a list of corresponding eigenvalues")
     if eigenvalues is None and dimensions is None:
-        values = []
-        # create a list with "size" number of entries
-        for eigen_index in range(size):
-            eigenvalue = ring(randint(-10, 10))
-            values.append(eigenvalue)
-        values.sort()
-        dimensions = []
-        eigenvalues = []
-        # create a list with no duplicate values to be the eigenvalues
-        for eigenvalue in range(size):
-            if values[eigenvalue] not in eigenvalues:
-                eigenvalues.append(values[eigenvalue])
-        for dimension in range(len(eigenvalues)):
-            # dimension is equal to how many times an eigenvalue was generated in the 'values' list
-            dimensions.append(values.count(eigenvalues[dimension]))
-    size_check = 0
-    for check in range(len(dimensions)):
-        size_check = size_check + dimensions[check]
+        from collections import Counter
+        values = [ring(randint(-10, 10)) for _ in range(size)]
+        try:
+            value_frequencies = list(Counter(values).items())
+        except TypeError:  # Some ring elements are unhashable.
+            value_frequencies = []
+            for value in values:
+                for i, (old_value, frequency) in enumerate(value_frequencies):
+                    if value == old_value:
+                        value_frequencies[i] = (old_value, frequency + 1)
+                        break
+                else:
+                    value_frequencies.append((value, 1))
+        eigenvalues = [value for value, _ in value_frequencies]
+        dimensions = [frequency for _, frequency in value_frequencies]
+
     if not all(x in ring for x in eigenvalues):
-        raise TypeError("eigenvalues must be elements of the corresponding ring.")
-    if size != size_check:
-        raise ValueError("the size of the matrix must equal the sum of the dimensions.")
+        raise TypeError("eigenvalues must be elements of the corresponding ring")
+    if size != sum(dimensions):
+        raise ValueError("the size of the matrix must equal the sum of the dimensions")
     if min(dimensions) < 1:
-        raise ValueError("eigenspaces must have a dimension of at least 1.")
+        raise ValueError("eigenspaces must have a dimension of at least 1")
     if len(eigenvalues) != len(dimensions):
-        raise ValueError("each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue.")
+        raise ValueError("each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue")
     # Merge equal eigenvalues after coercion into the base ring.
     eigenvalue_dimensions = []
     for raw_eigenvalue, dimension in zip(eigenvalues, dimensions):
@@ -3639,42 +3639,24 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
     eigenvalues = [pair[0] for pair in eigenvalue_dimensions]
     dimensions = [pair[1] for pair in eigenvalue_dimensions]
     # Create the matrix of eigenvalues on the diagonal.  Use a lower limit and upper limit determined by the eigenvalue dimensions.
-    diagonal_matrix = matrix(ring, size)
-    up_bound = 0
-    low_bound = 0
-    for row_index in range(len(dimensions)):
-        up_bound = up_bound + dimensions[row_index]
-        for entry in range(low_bound, up_bound):
-            diagonal_matrix[entry, entry] = eigenvalues[row_index]
-        low_bound = low_bound+dimensions[row_index]
+    diag_matrix = diagonal_matrix(ring, [e for d, e in zip(dimensions, eigenvalues) for _ in range(d)])
     # Create a matrix to hold each of the eigenvectors as its columns, begin with an identity matrix so that after row and column
     # operations the resulting matrix will be unimodular.
     eigenvector_matrix = matrix.identity(ring, size)
-    upper_limit = 0
-    lower_limit = 0
-    # run the routine over the necessary number of columns corresponding eigenvalue dimension.
-    for dimension_index in range(len(dimensions)-1):
-        upper_limit = upper_limit+dimensions[dimension_index]
-        lowest_index_row_with_one = size-dimensions[dimension_index]
-        # assign a one to the row that is the eigenvalue dimension rows up from the bottom row then assign ones diagonally down to the right.
-        for eigen_ones in range(lower_limit, upper_limit):
-            eigenvector_matrix[lowest_index_row_with_one, eigen_ones] = 1
-            lowest_index_row_with_one += 1
-        lower_limit = lower_limit+dimensions[dimension_index]
+    cur_sum = 0
+    for dim in dimensions[:-1]:
+        for idx in range(dim):
+            eigenvector_matrix[-dim + idx, cur_sum + idx] = 1
+        cur_sum += dim
     # Create a list to give the eigenvalue dimension corresponding to each column.
-    dimension_check = []
-    for i in range(len(dimensions)):
-        for k in range(dimensions[i]):
-            dimension_check.append(dimensions[i])
+    dimension_check = [dim for dim in dimensions for _ in range(dim)]
     # run routine over the rows that are in the range of the protected ones.  Use addition of column multiples to fill entries.
     for dimension_multiplicity in range(max(dimensions), min(dimensions), -1):
         highest_one_row = size-dimension_multiplicity
-        highest_one_column = 0
         # find the column with the protected one in the lowest indexed row.
-        while eigenvector_matrix[highest_one_row, highest_one_column] == 0:
-            highest_one_column += 1
+        highest_one_column = min(col for col in range(size) if eigenvector_matrix[highest_one_row, col] != 0)
         # dimension_check determines if column has a low enough eigenvalue dimension to take a column multiple.
-        for bottom_entry_filler in range(len(dimension_check)):
+        for bottom_entry_filler in range(size):
             if dimension_check[bottom_entry_filler] < dimension_multiplicity and eigenvector_matrix[highest_one_row, bottom_entry_filler] == 0:
                 # randint range determined experimentally to keep entries manageable.
                 eigenvector_matrix.add_multiple_of_column(bottom_entry_filler, highest_one_column, randint(-4, 4))
@@ -3683,7 +3665,7 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         for upper_row in range(size-max(dimensions)):
             # range of multiplier determined experimentally so that entries stay manageable for small matrices
             eigenvector_matrix.add_multiple_of_row(upper_row, row, randint(-4, 4))
-    return eigenvector_matrix*diagonal_matrix*(eigenvector_matrix.inverse())
+    return eigenvector_matrix*diag_matrix*eigenvector_matrix.inverse()
 
 
 @matrix_method

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3524,6 +3524,20 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     TESTS:
 
+    Eigenvalues are grouped even when the base ring has unhashable elements::
+
+        sage: K = Qq(9, names='a')
+        sage: set_random_seed(42)
+        sage: M = random_matrix(K, 4, algorithm='diagonalizable',
+        ....:                   eigenvalues=[K(2), K(2), K(5)],
+        ....:                   dimensions=[1, 2, 1])
+        sage: set_random_seed(42)
+        sage: M_normalized = random_matrix(K, 4, algorithm='diagonalizable',
+        ....:                              eigenvalues=[K(2), K(5)],
+        ....:                              dimensions=[3, 1])
+        sage: M == M_normalized
+        True
+
     Eigenvalues must all be elements of the ring::
 
         sage: random_matrix(QQ, 3, algorithm='diagonalizable',                          # needs sage.symbolic
@@ -3590,6 +3604,8 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
     Billy Wonderly (2010-07)
     """
 
+    from collections import defaultdict
+
     from sage.misc.prandom import randint
 
     size = parent.nrows()
@@ -3601,21 +3617,8 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
     if eigenvalues is None and dimensions is not None:
         raise ValueError("the list of dimensions must have a list of corresponding eigenvalues")
     if eigenvalues is None and dimensions is None:
-        from collections import Counter
-        values = [ring(randint(-10, 10)) for _ in range(size)]
-        try:
-            value_frequencies = list(Counter(values).items())
-        except TypeError:  # Some ring elements are unhashable.
-            value_frequencies = []
-            for value in values:
-                for i, (old_value, frequency) in enumerate(value_frequencies):
-                    if value == old_value:
-                        value_frequencies[i] = (old_value, frequency + 1)
-                        break
-                else:
-                    value_frequencies.append((value, 1))
-        eigenvalues = [value for value, _ in value_frequencies]
-        dimensions = [frequency for _, frequency in value_frequencies]
+        eigenvalues = [ring(randint(-10, 10)) for _ in range(size)]
+        dimensions = [1] * size
 
     if not all(x in ring for x in eigenvalues):
         raise TypeError("eigenvalues must be elements of the corresponding ring")
@@ -3626,23 +3629,28 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
     if len(eigenvalues) != len(dimensions):
         raise ValueError("each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue")
     # Merge equal eigenvalues after coercion into the base ring.
-    eigenvalue_dimensions = []
-    for raw_eigenvalue, dimension in zip(eigenvalues, dimensions):
-        eigenvalue = ring(raw_eigenvalue)
-        for i, (value, old_dimension) in enumerate(eigenvalue_dimensions):
-            if eigenvalue == value:
-                eigenvalue_dimensions[i] = (value, old_dimension + dimension)
-                break
-        else:
-            eigenvalue_dimensions.append((eigenvalue, dimension))
+    eigenvalues = [ring(eigenvalue) for eigenvalue in eigenvalues]
+    try:
+        grouped = defaultdict(int)
+        for eigenvalue, dimension in zip(eigenvalues, dimensions):
+            grouped[eigenvalue] += dimension
+        eigenvalue_dimensions = list(grouped.items())
+    except TypeError:  # e.g. Qq(9) has unhashable elements
+        eigenvalue_dimensions = []
+        for eigenvalue, dimension in zip(eigenvalues, dimensions):
+            for i, (old_eigenvalue, old_dimension) in enumerate(eigenvalue_dimensions):
+                if eigenvalue == old_eigenvalue:
+                    eigenvalue_dimensions[i] = (old_eigenvalue, old_dimension + dimension)
+                    break
+            else:
+                eigenvalue_dimensions.append((eigenvalue, dimension))
     eigenvalue_dimensions.sort(key=lambda pair: pair[1])
-    eigenvalues = [pair[0] for pair in eigenvalue_dimensions]
-    dimensions = [pair[1] for pair in eigenvalue_dimensions]
-    # Create the matrix of eigenvalues on the diagonal.  Use a lower limit and upper limit determined by the eigenvalue dimensions.
-    diag_matrix = diagonal_matrix(ring, [e for d, e in zip(dimensions, eigenvalues) for _ in range(d)])
+    dimensions = [dimension for _, dimension in eigenvalue_dimensions]
+    # Create the matrix of eigenvalues on the diagonal, each repeated according to its dimension.
+    diag_matrix = diagonal_matrix(ring, [e for e, d in eigenvalue_dimensions for _ in range(d)])
     # Create a matrix to hold each of the eigenvectors as its columns, begin with an identity matrix so that after row and column
     # operations the resulting matrix will be unimodular.
-    eigenvector_matrix = matrix.identity(ring, size)
+    eigenvector_matrix = identity_matrix(ring, size)
     cur_sum = 0
     for dim in dimensions[:-1]:
         for idx in range(dim):

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3526,8 +3526,7 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     Grouping equal eigenvalues requires the elements of the base ring to be
     hashable.  Rings whose elements are unhashable, such as unramified
-    `p`-adic extensions, are therefore not supported; grouping them by
-    equality would rely on inexact comparisons::
+    `p`-adic extensions, are therefore not supported::
 
         sage: K = Qq(9, names='a')
         sage: random_matrix(K, 4, algorithm='diagonalizable',
@@ -3632,10 +3631,11 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         raise ValueError("eigenspaces must have a dimension of at least 1")
     if len(eigenvalues) != len(dimensions):
         raise ValueError("each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue")
-    # Merge equal eigenvalues after coercion into the base ring.  Grouping by
-    # hash is deliberate: grouping by equality instead would compare inexact
-    # elements (of p-adic rings, say), which is unreliable, so rings with
-    # unhashable elements raise a TypeError here.
+    # Merge equal eigenvalues after coercion into the base ring.  The dict
+    # groups by equality (hash only selects the bucket), so this still relies
+    # on the ring having meaningful equality; rings that signal otherwise by
+    # making their elements unhashable (p-adic extensions, say) raise a
+    # TypeError here instead of being grouped unreliably.
     grouped = defaultdict(int)
     for eigenvalue, dimension in zip(eigenvalues, dimensions):
         grouped[ring(eigenvalue)] += dimension

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3462,19 +3462,32 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
     with a check that if eigenvectors were calculated by hand
     entries would all be integers. ::
 
-        sage: eigenvalues = [ZZ.random_element() for _ in range(3)]
+        sage: eigenvalues = [-12, 4, 6]
         sage: B = random_matrix(QQ, 6, algorithm='diagonalizable',
-        ....:                   eigenvalues=eigenvalues, dimensions=[2,3,1])
-        sage: all(x in ZZ for x in (B-(-12*identity_matrix(6))).rref().list())
-        True
-        sage: all(x in ZZ for x in (B-(4*identity_matrix(6))).rref().list())
-        True
-        sage: all(x in ZZ for x in (B-(6*identity_matrix(6))).rref().list())
+        ....:                   eigenvalues=eigenvalues, dimensions=[2, 3, 1])
+        sage: all(x in ZZ for eigenvalue in eigenvalues
+        ....:                    for x in (B - eigenvalue).rref().list())
         True
 
         sage: S = B.right_eigenmatrix()[1]
         sage: eigenvalues2 = (S.inverse()*B*S).diagonal()
         sage: all(e in eigenvalues for e in eigenvalues2)
+        True
+
+    Repeated eigenvalues describe a single eigenspace, so their dimensions
+    are added before constructing the matrix::
+
+        sage: set_random_seed(42)
+        sage: B = random_matrix(QQ, 4, algorithm='diagonalizable',
+        ....:                   eigenvalues=[0, 0, 1], dimensions=[1, 1, 2])
+        sage: set_random_seed(42)
+        sage: B_normalized = random_matrix(QQ, 4, algorithm='diagonalizable',
+        ....:                              eigenvalues=[0, 1], dimensions=[2, 2])
+        sage: B == B_normalized
+        True
+        sage: B.right_kernel().dimension()
+        2
+        sage: all(x in ZZ for x in B.rref().list())
         True
 
     Matrices over finite fields are also supported::
@@ -3489,6 +3502,23 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         [0 0 1]
         [2 1 1]
         [1 0 0]
+
+    Eigenvalues are compared after coercion into the base ring::
+
+        sage: K(0) == K(3)
+        True
+        sage: set_random_seed(42)
+        sage: M = random_matrix(K, 4, algorithm='diagonalizable',
+        ....:                   eigenvalues=[0, 3, 1], dimensions=[1, 2, 1])
+        sage: set_random_seed(42)
+        sage: M_normalized = random_matrix(K, 4, algorithm='diagonalizable',
+        ....:                              eigenvalues=[0, 1], dimensions=[3, 1])
+        sage: M == M_normalized
+        True
+        sage: M.base_ring() == K
+        True
+        sage: M.right_kernel().dimension()
+        3
 
     TESTS:
 
@@ -3595,10 +3625,19 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         raise ValueError("eigenspaces must have a dimension of at least 1.")
     if len(eigenvalues) != len(dimensions):
         raise ValueError("each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue.")
-    # sort the dimensions in order of increasing size, and sort the eigenvalues list in an identical fashion, to maintain corresponding values.
-    dimensions_sort = sorted(zip(dimensions, eigenvalues))
-    dimensions = [x[0] for x in dimensions_sort]
-    eigenvalues = [x[1] for x in dimensions_sort]
+    # Merge equal eigenvalues after coercion into the base ring.
+    eigenvalue_dimensions = []
+    for raw_eigenvalue, dimension in zip(eigenvalues, dimensions):
+        eigenvalue = ring(raw_eigenvalue)
+        for i, (value, old_dimension) in enumerate(eigenvalue_dimensions):
+            if eigenvalue == value:
+                eigenvalue_dimensions[i] = (value, old_dimension + dimension)
+                break
+        else:
+            eigenvalue_dimensions.append((eigenvalue, dimension))
+    eigenvalue_dimensions.sort(key=lambda pair: pair[1])
+    eigenvalues = [pair[0] for pair in eigenvalue_dimensions]
+    dimensions = [pair[1] for pair in eigenvalue_dimensions]
     # Create the matrix of eigenvalues on the diagonal.  Use a lower limit and upper limit determined by the eigenvalue dimensions.
     diagonal_matrix = matrix(ring, size)
     up_bound = 0

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3524,19 +3524,25 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
     TESTS:
 
-    Eigenvalues are grouped even when the base ring has unhashable elements::
+    Grouping equal eigenvalues requires the elements of the base ring to be
+    hashable.  Rings whose elements are unhashable, such as unramified
+    `p`-adic extensions, are therefore not supported; grouping them by
+    equality would rely on inexact comparisons::
 
         sage: K = Qq(9, names='a')
-        sage: set_random_seed(42)
-        sage: M = random_matrix(K, 4, algorithm='diagonalizable',
-        ....:                   eigenvalues=[K(2), K(2), K(5)],
-        ....:                   dimensions=[1, 2, 1])
-        sage: set_random_seed(42)
-        sage: M_normalized = random_matrix(K, 4, algorithm='diagonalizable',
-        ....:                              eigenvalues=[K(2), K(5)],
-        ....:                              dimensions=[3, 1])
-        sage: M == M_normalized
-        True
+        sage: random_matrix(K, 4, algorithm='diagonalizable',
+        ....:               eigenvalues=[K(2), K(2), K(5)],
+        ....:               dimensions=[1, 2, 1])
+        Traceback (most recent call last):
+        ...
+        TypeError: unhashable type: 'sage.rings.padics.qadic_flint_CR.qAdicCappedRelativeElement'
+
+    This applies to randomly generated eigenvalues as well::
+
+        sage: random_matrix(K, 4, algorithm='diagonalizable')
+        Traceback (most recent call last):
+        ...
+        TypeError: unhashable type: 'sage.rings.padics.qadic_flint_CR.qAdicCappedRelativeElement'
 
     Eigenvalues must all be elements of the ring::
 
@@ -3628,23 +3634,14 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
         raise ValueError("eigenspaces must have a dimension of at least 1")
     if len(eigenvalues) != len(dimensions):
         raise ValueError("each eigenvalue must have a corresponding dimension and each dimension a corresponding eigenvalue")
-    # Merge equal eigenvalues after coercion into the base ring.
-    eigenvalues = [ring(eigenvalue) for eigenvalue in eigenvalues]
-    try:
-        grouped = defaultdict(int)
-        for eigenvalue, dimension in zip(eigenvalues, dimensions):
-            grouped[eigenvalue] += dimension
-        eigenvalue_dimensions = list(grouped.items())
-    except TypeError:  # e.g. Qq(9) has unhashable elements
-        eigenvalue_dimensions = []
-        for eigenvalue, dimension in zip(eigenvalues, dimensions):
-            for i, (old_eigenvalue, old_dimension) in enumerate(eigenvalue_dimensions):
-                if eigenvalue == old_eigenvalue:
-                    eigenvalue_dimensions[i] = (old_eigenvalue, old_dimension + dimension)
-                    break
-            else:
-                eigenvalue_dimensions.append((eigenvalue, dimension))
-    eigenvalue_dimensions.sort(key=lambda pair: pair[1])
+    # Merge equal eigenvalues after coercion into the base ring.  Grouping by
+    # hash is deliberate: grouping by equality instead would compare inexact
+    # elements (of p-adic rings, say), which is unreliable, so rings with
+    # unhashable elements raise a TypeError here.
+    grouped = defaultdict(int)
+    for eigenvalue, dimension in zip(eigenvalues, dimensions):
+        grouped[ring(eigenvalue)] += dimension
+    eigenvalue_dimensions = sorted(grouped.items(), key=lambda pair: pair[1])
     dimensions = [dimension for _, dimension in eigenvalue_dimensions]
     # Create the matrix of eigenvalues on the diagonal, each repeated according to its dimension.
     diag_matrix = diagonal_matrix(ring, [e for e, d in eigenvalue_dimensions for _ in range(d)])

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -3479,10 +3479,11 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
     Repeated eigenvalues describe a single eigenspace, so their dimensions
     are added before constructing the matrix::
 
-        sage: set_random_seed(42)
+        sage: s = randint(0, 2^32)
+        sage: set_random_seed(s)
         sage: B = random_matrix(QQ, 4, algorithm='diagonalizable',
         ....:                   eigenvalues=[0, 0, 1], dimensions=[1, 1, 2])
-        sage: set_random_seed(42)
+        sage: set_random_seed(s)
         sage: B_normalized = random_matrix(QQ, 4, algorithm='diagonalizable',
         ....:                              eigenvalues=[0, 1], dimensions=[2, 2])
         sage: B == B_normalized
@@ -3509,10 +3510,11 @@ def random_diagonalizable_matrix(parent, eigenvalues=None, dimensions=None):
 
         sage: K(0) == K(3)
         True
-        sage: set_random_seed(42)
+        sage: s = randint(0, 2^32)
+        sage: set_random_seed(s)
         sage: M = random_matrix(K, 4, algorithm='diagonalizable',
         ....:                   eigenvalues=[0, 3, 1], dimensions=[1, 2, 1])
-        sage: set_random_seed(42)
+        sage: set_random_seed(s)
         sage: M_normalized = random_matrix(K, 4, algorithm='diagonalizable',
         ....:                              eigenvalues=[0, 1], dimensions=[3, 1])
         sage: M == M_normalized


### PR DESCRIPTION
Fixes #37426.

#38578 reports the same seed-dependent failure and was closed as a duplicate of #37426.

## Relationship to #38579

Following the discussion on this PR, the earlier implementation has been replaced by an adapted port of the two substantive changes from #38579: the repeated-eigenvalue fix and the follow-up Sage-style refactor by Gareth Ma (@grhkm21). Gareth remains the author of both commits, and both original source commit references are retained in the Git history.

This is not a byte-for-byte cherry-pick because #39374 generalized `random_diagonalizable_matrix` to the parent base ring after #38579 was written. The conflict resolutions therefore:

- retain base-ring membership validation and ring-aware error wording;
- coerce generated and supplied eigenvalues into the parent base ring;
- compare repeated values after coercion and combine their dimensions.

Coercing before grouping is what actually fixes the bug: distinct integers can collide in the base ring (`0` and `3` in `GF(3)`), so grouping the raw inputs would not be enough.

## Changes

In addition to fixing repeated eigenvalues, the port includes the surrounding cleanup from #38579:

- the main example subtracts the eigenvalues that were actually supplied;
- default eigenvalue generation and dimension counting are simplified;
- dimension totals use `sum`;
- diagonal-matrix and protected-eigenvector construction are made more direct;
- the dimension lookup, protected-column search, loop bounds, and final multiplication are simplified;
- literal-block formatting and validation-message punctuation are normalized.

Deterministic regressions compare repeated and normalized inputs over `QQ`, verify the resulting eigenspace dimension and integral RREF, and check base-ring coercion with `0 == 3` in `GF(3)`.

As in the original refactor, exact matrices produced by a fixed random seed can change when dimension ties are ordered differently; the eigenvalue, eigenspace, diagonalizability, and base-ring contracts are preserved.

## Rings with unhashable elements

Eigenvalues are tallied with a `defaultdict`, so grouping is by hash. Following @orlitzky's review, the earlier equality-based fallback has been removed: for inexact elements (p-adics) `==` can group eigenvalues incorrectly, so the `TypeError` from hashing is left to propagate instead.

**This is a behavior change beyond duplicate eigenvalues, and reviewers should be aware of its scope.** `random_diagonalizable_matrix` now rejects base rings with unhashable elements outright, including the default path where no eigenvalues are supplied:

```
sage: K = Qq(9, names='a')
sage: random_matrix(K, 4, algorithm='diagonalizable')
Traceback (most recent call last):
...
TypeError: unhashable type: 'sage.rings.padics.qadic_flint_CR.qAdicCappedRelativeElement'
```

On `develop` that call succeeds, because the old default path counted duplicates with `list.count` (equality, never hashing). The regression is unavoidable given the mandate: the grouping has to happen after coercion to fix `GF(3)`, and a post-coercion grouping needs hashable elements. Both the supplied-eigenvalue and generated-eigenvalue cases are now covered by doctests, so the limitation is documented rather than latent. Happy to revisit if someone familiar with p-adics wants a precision-aware grouping.

## Tests

- `./sage -t --long src/sage/matrix/special.py` (610 tests)
- `./sage -t --random-seed=214483688537001353062577859282581597229 src/sage/matrix/special.py`
- `./sage -t --random-seed=219213017983787015809160823911288952745 src/sage/matrix/special.py`
- default constructions and duplicate-normalization comparisons across `QQ`, `ZZ`, `GF(3)`, `GF(4)`, and `Zmod(4)`
- edge cases created by grouping: full collapse to a single eigenvalue (yields the expected scalar matrix), equal dimensions after merging, and the `GF(3)` `0 == 3` collision
- seeded old/new protected-eigenvector construction comparisons
- targeted Ruff and pycodestyle checks (no new findings relative to `develop`)
- `git diff --check upstream/develop...HEAD`

All doctests passed in each run.
