### PR TITLE
gh-40301: Fix submodule containment over polynomial rings

### DIFF
--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -1002,20 +1002,19 @@ class Module_free_ambient(Module):
                     return x.__copy__()
                 return x
             x = x.list()
-        if check and self.coordinate_ring().is_exact():
-            # Check entries are in the base ring
-            try:
-                R = self.base_ring()
-                for d in x:
-                    if d not in R:
-                        raise ArithmeticError
-            except ArithmeticError:
-                raise TypeError("element {!r} is not in free module".format(x))
         if check:
+            if self.coordinate_ring().is_exact():
+                # Check entries are in the base ring
+                try:
+                    R = self.base_ring()
+                    for d in x:
+                        if d not in R:
+                            raise ArithmeticError
+                except ArithmeticError:
+                    raise TypeError("element {!r} is not in free module".format(x))
             # Additional membership check (e.g., submodule membership).
-            # This must run even over inexact coordinate rings, because
-            # otherwise a submodule could silently accept vectors that are
-            # not in its span (see :issue:`40301`).
+            # Unsupported Gröbner-basis membership tests are skipped by
+            # ``_check_element_membership`` rather than raising.
             self._check_element_membership(x)
         return self.element_class(self, x, coerce, copy)
 

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -1011,7 +1011,11 @@ class Module_free_ambient(Module):
                         raise ArithmeticError
             except ArithmeticError:
                 raise TypeError("element {!r} is not in free module".format(x))
-            # Additional membership check (e.g., submodule membership)
+        if check:
+            # Additional membership check (e.g., submodule membership).
+            # This must run even over inexact coordinate rings, because
+            # otherwise a submodule could silently accept vectors that are
+            # not in its span (see :issue:`40301`).
             self._check_element_membership(x)
         return self.element_class(self, x, coerce, copy)
 
@@ -1667,7 +1671,8 @@ class Module_free_ambient(Module):
         if not other.gens():
             # other is the zero module
             return False
-        if self.ambient_module().is_submodule(other):
+        ambient = self.ambient_module()
+        if ambient is not self and ambient.is_submodule(other):
             return True
 
         raise NotImplementedError("could not determine containment")

--- a/src/sage/modules/free_module.py
+++ b/src/sage/modules/free_module.py
@@ -1013,8 +1013,7 @@ class Module_free_ambient(Module):
                 except ArithmeticError:
                     raise TypeError("element {!r} is not in free module".format(x))
             # Additional membership check (e.g., submodule membership).
-            # Unsupported Gröbner-basis membership tests are skipped by
-            # ``_check_element_membership`` rather than raising.
+            # Subclasses decide how to handle unavailable membership tests.
             self._check_element_membership(x)
         return self.element_class(self, x, coerce, copy)
 

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -279,11 +279,8 @@ class Submodule_free_ambient(Module_free_ambient):
 
         When no Gröbner-basis membership test is available, this low-level
         method raises :class:`NotImplementedError`. The higher-level check
-        :meth:`_check_element_membership` catches this and skips the test
-        (see :issue:`40301`), keeping ``in`` and element construction usable
-        at the cost of possible false positives. This includes inexact
-        coefficient rings, where numerical imprecision could otherwise
-        turn a true member into a spurious non-member::
+        :meth:`_check_element_membership` treats this as failed membership
+        unless membership is known for a trivial reason::
 
             sage: R.<x, y> = CC[]
             sage: F = FreeModule(R, 1)
@@ -298,7 +295,8 @@ class Submodule_free_ambient(Module_free_ambient):
             ...
             NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
 
-        It also includes exact rings that Singular does not support::
+        Exact rings that Singular does not support also raise
+        :class:`NotImplementedError` at this low-level boundary::
 
             sage: A.<t> = ZZ[]
             sage: B.<w> = A[]
@@ -466,12 +464,11 @@ class Submodule_free_ambient(Module_free_ambient):
         Check that ``x`` belongs to this submodule using Gröbner bases.
 
         This overrides the no-op in the base class to verify actual
-        submodule membership. When no Gröbner-basis membership test is
-        available for the base ring, the check is skipped rather than
-        raising. This preserves the historical permissive behavior for
-        rings beyond the implemented test, and in particular avoids false
-        negatives over inexact coefficient rings, where numerical
-        imprecision could turn a true member into a spurious non-member.
+        submodule membership. Membership known for a trivial reason (the
+        zero vector or one of the listed generators) is accepted directly.
+        Otherwise, when no Gröbner-basis membership test is available, the
+        check raises :class:`TypeError` so containment cannot report
+        ``True`` for membership that cannot be verified.
         See :issue:`40301`.
 
         EXAMPLES::
@@ -487,29 +484,53 @@ class Submodule_free_ambient(Module_free_ambient):
             TypeError: element (0, 1, 0, 0, 0, 0, 0, 0, 0, 0) is not in this submodule
 
         Over rings for which no Gröbner-basis membership test is available,
-        the check is skipped and no error is raised, even for elements that
-        are not in the submodule::
+        trivially known members are still accepted::
 
             sage: R.<x, y> = CC[]
             sage: F = FreeModule(R, 1)
             sage: G = F.submodule([F([0])])
-            sage: G._check_element_membership(F([1]).list())  # no error
+            sage: G._check_element_membership(F([0]).list())  # no error
+            sage: H = F.submodule([F([1])])
+            sage: H._check_element_membership(F([1]).list())  # no error
+
+        Other elements are rejected rather than accepted as possible false
+        positives, even over inexact rings::
+
+            sage: G._check_element_membership(F([1]).list())
+            Traceback (most recent call last):
+            ...
+            TypeError: element (1.00000000000000,) is not in this submodule
+            sage: F([1]) in G
+            False
+
+        The same conservative fallback is used for exact rings whose
+        Gröbner-basis membership test is unavailable::
+
             sage: A.<t> = ZZ[]
             sage: B.<w> = A[]
             sage: F = FreeModule(B, 2)
             sage: G = F.submodule([F.gen(0)])
-            sage: G._check_element_membership(F.gen(1).list())  # no error
+            sage: F.gen(0) in G
+            True
+            sage: F.gen(1) in G
+            False
+            sage: G._check_element_membership(F.gen(1).list())
+            Traceback (most recent call last):
+            ...
+            TypeError: element (0, 1) is not in this submodule
         """
+        x_tuple = tuple(x)
+        if all(not c for c in x_tuple):
+            return
+        if any(x_tuple == tuple(g) for g in self.gens()):
+            return
         try:
             contained = self._groebner_basis_contains(x)
         except NotImplementedError:
-            # No Gröbner-basis membership test is available over this ring.
-            # Keep the historical permissive fallback rather than rejecting
-            # elements whose membership we cannot decide with this method.
-            return
+            contained = False
         if not contained:
             raise TypeError(
-                "element {} is not in this submodule".format(tuple(x)))
+                "element {} is not in this submodule".format(x_tuple))
 
     def _repr_(self):
         """

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -318,12 +318,12 @@ class Submodule_free_ambient(Module_free_ambient):
         # inexact coefficient rings (e.g. ``CC[x, y]``).
         has_module_relations = (isinstance(ambient, QuotientModule_free_ambient)
                                 and bool(ambient.relations().gens()))
-        has_ring_relations = isinstance(R, QuotientRing_generic) and \
-            bool(R.defining_ideal().gens())
+        has_ring_relations = (isinstance(R, QuotientRing_generic)
+                              and bool(R.defining_ideal().gens()))
         if not self.gens() and not has_module_relations and not has_ring_relations:
             if isinstance(v, (list, tuple, Vector)):
-                return all(c == 0 for c in v)
-            return v == 0
+                return all(not c for c in v)
+            return not v
 
         def _singular_wrap(ring):
             """
@@ -368,8 +368,7 @@ class Submodule_free_ambient(Module_free_ambient):
             poly_ring = _singular_wrap(R)
             ideal_gens = []
 
-            def to_poly(c):
-                return poly_ring(c)
+            to_poly = poly_ring.__call__
         else:
             raise NotImplementedError(
                 "Gröbner basis membership test is not implemented for "

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -85,6 +85,22 @@ class Submodule_free_ambient(Module_free_ambient):
         [  y*z   x*z]
           To:   Ambient free module of rank 2 over the integral domain
         Multivariate Polynomial Ring in x, y, z over Rational Field
+
+    Containment is decided using Gröbner bases (see :issue:`40301`)::
+
+        sage: R.<x, y> = QQ[]
+        sage: F = FreeModule(R, 1)
+        sage: G = F.submodule([F([0])])
+        sage: F([1]) in G
+        False
+        sage: F([0]) in G
+        True
+        sage: F2 = FreeModule(R, 2)
+        sage: G2 = F2.submodule([F2.0])
+        sage: F2.0 in G2
+        True
+        sage: F2.1 in G2
+        False
     """
     def __init__(self, ambient, gens, check=True, already_echelonized=False):
         r"""
@@ -189,33 +205,117 @@ class Submodule_free_ambient(Module_free_ambient):
             True
             sage: s._groebner_basis_contains(M.2)
             False
+
+        Univariate polynomial rings that are not PIDs are supported by
+        wrapping into a libsingular multivariate ring with one variable
+        (see :issue:`40301`)::
+
+            sage: R.<x> = ZZ[]
+            sage: F = FreeModule(R, 2)
+            sage: G = F.submodule([F.0])
+            sage: G._groebner_basis_contains(F.0)
+            True
+            sage: G._groebner_basis_contains(F.1)
+            False
+
+        Over inexact rings, only the zero submodule is checked
+        (Singular cannot compute Gröbner bases over inexact coefficient
+        rings); other cases raise :class:`NotImplementedError`::
+
+            sage: R.<x, y> = CC[]
+            sage: F = FreeModule(R, 1)
+            sage: Z = F.submodule([F([0])])
+            sage: Z._groebner_basis_contains(F([0]))
+            True
+            sage: Z._groebner_basis_contains(F([1]))
+            False
+            sage: G = F.submodule([F([1])])
+            sage: G._groebner_basis_contains(F([1]))
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
         """
         from sage.libs.singular.function import singular_function
         from sage.libs.singular.option import opt_verb
         from sage.matrix.constructor import matrix
+        from sage.modules.quotient_module import QuotientModule_free_ambient
+        from sage.rings.polynomial.multi_polynomial_libsingular import \
+            MPolynomialRing_libsingular
+        from sage.rings.polynomial.multi_polynomial_ring_base import \
+            MPolynomialRing_base
+        from sage.rings.polynomial.polynomial_ring import PolynomialRing_generic
+        from sage.rings.polynomial.polynomial_ring_constructor import \
+            PolynomialRing
         from sage.rings.quotient_ring import QuotientRing_generic
         from sage.structure.element import Vector
 
         R = self.base_ring()
         n = self.degree()
+        ambient = self._ambient
 
-        # Determine the polynomial ring and ideal generators
+        # Short-circuit the zero submodule (no generators and no module
+        # relations) before any Gröbner basis machinery is invoked.  This
+        # also works over rings that Singular cannot handle, such as
+        # inexact coefficient rings (e.g. ``CC[x, y]``).
+        has_module_relations = (isinstance(ambient, QuotientModule_free_ambient)
+                                and bool(ambient.relations().gens()))
+        has_ring_relations = isinstance(R, QuotientRing_generic) and \
+            bool(R.defining_ideal().gens())
+        if not self.gens() and not has_module_relations and not has_ring_relations:
+            if isinstance(v, (list, tuple, Vector)):
+                return all(c == 0 for c in v)
+            return v == 0
+
+        def _singular_wrap(ring):
+            """
+            Return a libsingular multivariate polynomial ring equivalent
+            to ``ring`` if possible, else raise ``NotImplementedError``.
+            """
+            if isinstance(ring, MPolynomialRing_libsingular):
+                return ring
+            names = [str(v) for v in ring.variable_names()]
+            try:
+                wrapped = PolynomialRing(ring.base_ring(), names,
+                                         implementation='singular')
+            except (TypeError, ValueError, NotImplementedError) as exc:
+                raise NotImplementedError(
+                    "Gröbner basis membership test is not implemented "
+                    "for modules over {}: {}".format(ring, exc))
+            if not isinstance(wrapped, MPolynomialRing_libsingular):
+                raise NotImplementedError(
+                    "Gröbner basis membership test is not implemented "
+                    "for modules over {}".format(ring))
+            return wrapped
+
+        # Determine the polynomial ring ``poly_ring`` in which the Gröbner
+        # basis computation is performed, and a callable ``to_poly`` that
+        # maps elements of ``R`` into ``poly_ring``.  ``ideal_gens`` lists
+        # the defining ideal generators when ``R`` is a quotient ring.
         if isinstance(R, QuotientRing_generic):
-            poly_ring = R.cover_ring()
-            ideal_gens = R.defining_ideal().gens()
-            do_lift = True
-        else:
-            from sage.rings.polynomial.multi_polynomial_ring_base import \
-                MPolynomialRing_base
-            if isinstance(R, MPolynomialRing_base):
-                poly_ring = R
-                ideal_gens = []
-                do_lift = False
+            cover = R.cover_ring()
+            ideal_gens_raw = list(R.defining_ideal().gens())
+            if isinstance(cover, (MPolynomialRing_base, PolynomialRing_generic)):
+                poly_ring = _singular_wrap(cover)
+                ideal_gens = [poly_ring(f) for f in ideal_gens_raw]
+
+                def to_poly(c):
+                    return poly_ring(c.lift())
             else:
                 raise NotImplementedError(
                     "Gröbner basis membership test is not implemented for "
                     "modules over {}".format(R)
                 )
+        elif isinstance(R, (MPolynomialRing_base, PolynomialRing_generic)):
+            poly_ring = _singular_wrap(R)
+            ideal_gens = []
+
+            def to_poly(c):
+                return poly_ring(c)
+        else:
+            raise NotImplementedError(
+                "Gröbner basis membership test is not implemented for "
+                "modules over {}".format(R)
+            )
 
         # Suppress "_ is no standard basis" warning from Singular
         opt_verb['not_warn_sb'] = True
@@ -226,11 +326,15 @@ class Submodule_free_ambient(Module_free_ambient):
         # Lift generators of self to the polynomial ring
         gen_rows = []
         for g in self.gens():
-            if do_lift:
-                row = [c.lift() for c in g]
-            else:
-                row = list(g)
-            gen_rows.append(row)
+            gen_rows.append([to_poly(c) for c in g])
+
+        # If the ambient module is itself a quotient ``M / W``, then
+        # ``self`` is a subquotient and ``v`` is in ``self`` iff ``v`` is
+        # in the submodule of ``M`` spanned by the generators of ``self``
+        # together with the generators of ``W``.
+        if isinstance(ambient, QuotientModule_free_ambient):
+            for w in ambient.relations().gens():
+                gen_rows.append([to_poly(c) for c in w])
 
         # Add ideal relation generators: for each ideal generator f and
         # each standard basis vector e_j, add f * e_j as a row
@@ -241,7 +345,8 @@ class Submodule_free_ambient(Module_free_ambient):
                 gen_rows.append(row)
 
         if not gen_rows:
-            # Zero submodule: only zero vector is contained
+            # Should not happen here (handled by the early short-circuit
+            # above), but kept for safety.
             if isinstance(v, (list, tuple, Vector)):
                 return all(c == 0 for c in v)
             return v == 0
@@ -249,17 +354,17 @@ class Submodule_free_ambient(Module_free_ambient):
         # Build the matrix and compute Gröbner basis
         # Singular's std() for modules expects the matrix transposed
         # (columns = generators)
-        gen_matrix = matrix(poly_ring, gen_rows).transpose()
-        gb = std(gen_matrix, ring=poly_ring)
-
-        # Lift the target vector
-        if do_lift:
-            v_lifted = matrix(poly_ring, [[c.lift() for c in v]]).transpose()
-        else:
-            v_lifted = matrix(poly_ring, [list(v)]).transpose()
+        try:
+            gen_matrix = matrix(poly_ring, gen_rows).transpose()
+            gb = std(gen_matrix, ring=poly_ring)
+            v_lifted = matrix(poly_ring, [[to_poly(c) for c in v]]).transpose()
+            remainder = reduce_func(v_lifted, gb, ring=poly_ring)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise NotImplementedError(
+                "Gröbner basis membership test failed for modules over "
+                "{}: {}".format(R, exc))
 
         # Reduce v modulo the Gröbner basis; zero result means v is in the submodule
-        remainder = reduce_func(v_lifted, gb, ring=poly_ring)
         return matrix(remainder).is_zero()
 
     def _check_element_membership(self, x):
@@ -295,6 +400,38 @@ class Submodule_free_ambient(Module_free_ambient):
                     tuple(x)
                 )
             )
+
+    def __contains__(self, x):
+        r"""
+        Test whether ``x`` belongs to ``self``.
+
+        This bypasses the default
+        :meth:`sage.structure.parent.Parent.__contains__`, which after
+        converting ``x`` to an element of ``self`` requires an equality
+        comparison with the original ``x``.  When the ambient module of
+        ``self`` is a quotient module, there is in general no coercion
+        registered between ``self`` and the parent of ``x``, so the
+        equality test would spuriously fail.  Instead, we rely on the
+        element constructor (which calls
+        :meth:`_check_element_membership`) to determine membership.
+
+        EXAMPLES::
+
+            sage: S.<x,y,z> = PolynomialRing(QQ)
+            sage: M = S**2
+            sage: N = M.submodule([vector([x - y, z]), vector([y*z, x*z])])
+            sage: Q = M.quotient_module(N)
+            sage: NQ = Q.submodule([Q([1, x])])
+            sage: Q([1, x]) in NQ
+            True
+            sage: Q([0, 1]) in NQ
+            False
+        """
+        try:
+            self(x)
+        except (TypeError, ArithmeticError, ValueError):
+            return False
+        return True
 
     def _repr_(self):
         """

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -275,6 +275,24 @@ class Submodule_free_ambient(Module_free_ambient):
             Traceback (most recent call last):
             ...
             NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
+
+        Even queries that are mathematically true (such as ``v in <v>``)
+        cannot be decided over inexact coefficient rings, and correctly
+        raise :class:`NotImplementedError` instead of returning a
+        possibly wrong answer::
+
+            sage: R.<x, y> = CC[]
+            sage: F = FreeModule(R, 2)
+            sage: G = F.submodule([F([1, 0]), F([0, 1])])
+            sage: G._groebner_basis_contains(F([1, 0]))
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
+            sage: G2 = F.submodule([vector(R, [x, y])])
+            sage: G2._groebner_basis_contains(vector(R, [x, y]))
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
         """
         from sage.libs.singular.function import singular_function
         from sage.libs.singular.option import opt_verb

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -101,6 +101,24 @@ class Submodule_free_ambient(Module_free_ambient):
         True
         sage: F2.1 in G2
         False
+
+    For a submodule of a *quotient* module there is in general no coercion
+    between the submodule and the quotient module, so the ``in`` operator
+    (which relies on such a coercion) is deliberately conservative and may
+    report ``False`` for a genuine member. Test membership by attempting
+    the conversion instead, which uses the Gröbner basis check directly::
+
+        sage: S.<x,y,z> = QQ[]
+        sage: M = S**2
+        sage: N = M.submodule([vector([x - y, z]), vector([y*z, x*z])])
+        sage: Q = M.quotient_module(N)
+        sage: NQ = Q.submodule([Q([1, x])])
+        sage: NQ(Q([1, x]))
+        (1, x)
+        sage: NQ(Q([0, 1]))
+        Traceback (most recent call last):
+        ...
+        TypeError: element (0, 1) is not in this submodule
     """
     def __init__(self, ambient, gens, check=True, already_echelonized=False):
         r"""
@@ -259,27 +277,41 @@ class Submodule_free_ambient(Module_free_ambient):
             sage: G._groebner_basis_contains(vector(R, [1, 0]))
             False
 
-        Over inexact rings, only the zero submodule is checked
-        (Singular cannot compute Gröbner bases over inexact coefficient
-        rings); other cases raise :class:`NotImplementedError`::
+        When no Gröbner-basis membership test is available, this low-level
+        method raises :class:`NotImplementedError`. The higher-level check
+        :meth:`_check_element_membership` catches this and skips the test
+        (see :issue:`40301`), keeping ``in`` and element construction usable
+        at the cost of possible false positives. This includes inexact
+        coefficient rings, where numerical imprecision could otherwise
+        turn a true member into a spurious non-member::
 
             sage: R.<x, y> = CC[]
             sage: F = FreeModule(R, 1)
             sage: Z = F.submodule([F([0])])
             sage: Z._groebner_basis_contains(F([0]))
-            True
-            sage: Z._groebner_basis_contains(F([1]))
-            False
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
             sage: G = F.submodule([F([1])])
             sage: G._groebner_basis_contains(F([1]))
             Traceback (most recent call last):
             ...
             NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
 
+        It also includes exact rings that Singular does not support::
+
+            sage: A.<t> = ZZ[]
+            sage: B.<w> = A[]
+            sage: F = FreeModule(B, 2)
+            sage: G = F.submodule([F.gen(0)])
+            sage: G._groebner_basis_contains(F.gen(1))
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
+
         Even queries that are mathematically true (such as ``v in <v>``)
-        cannot be decided over inexact coefficient rings, and correctly
-        raise :class:`NotImplementedError` instead of returning a
-        possibly wrong answer::
+        cannot be decided over inexact coefficient rings, so this
+        low-level method raises :class:`NotImplementedError`::
 
             sage: R.<x, y> = CC[]
             sage: F = FreeModule(R, 2)
@@ -312,10 +344,14 @@ class Submodule_free_ambient(Module_free_ambient):
         n = self.degree()
         ambient = self._ambient
 
+        if not R.is_exact():
+            raise NotImplementedError(
+                "Gröbner basis membership test is not implemented for "
+                "modules over {}".format(R))
+
         # Short-circuit the zero submodule (no generators and no module
-        # relations) before any Gröbner basis machinery is invoked.  This
-        # also works over rings that Singular cannot handle, such as
-        # inexact coefficient rings (e.g. ``CC[x, y]``).
+        # relations) before any Gröbner basis machinery is invoked. This
+        # also avoids invoking Singular when no reduction is needed.
         has_module_relations = (isinstance(ambient, QuotientModule_free_ambient)
                                 and bool(ambient.relations().gens()))
         has_ring_relations = (isinstance(R, QuotientRing_generic)
@@ -348,7 +384,7 @@ class Submodule_free_ambient(Module_free_ambient):
 
         # Determine the polynomial ring ``poly_ring`` in which the Gröbner
         # basis computation is performed, and a callable ``to_poly`` that
-        # maps elements of ``R`` into ``poly_ring``.  ``ideal_gens`` lists
+        # maps elements of ``R`` into ``poly_ring``. ``ideal_gens`` lists
         # the defining ideal generators when ``R`` is a quotient ring.
         if isinstance(R, QuotientRing_generic):
             cover = R.cover_ring()
@@ -429,9 +465,14 @@ class Submodule_free_ambient(Module_free_ambient):
         r"""
         Check that ``x`` belongs to this submodule using Gröbner bases.
 
-        This overrides the no-op in the base class to verify actual submodule
-        membership. For rings where Gröbner basis computation is not
-        implemented, this falls back to no check.
+        This overrides the no-op in the base class to verify actual
+        submodule membership. When no Gröbner-basis membership test is
+        available for the base ring, the check is skipped rather than
+        raising. This preserves the historical permissive behavior for
+        rings beyond the implemented test, and in particular avoids false
+        negatives over inexact coefficient rings, where numerical
+        imprecision could turn a true member into a spurious non-member.
+        See :issue:`40301`.
 
         EXAMPLES::
 
@@ -444,52 +485,31 @@ class Submodule_free_ambient(Module_free_ambient):
             Traceback (most recent call last):
             ...
             TypeError: element (0, 1, 0, 0, 0, 0, 0, 0, 0, 0) is not in this submodule
+
+        Over rings for which no Gröbner-basis membership test is available,
+        the check is skipped and no error is raised, even for elements that
+        are not in the submodule::
+
+            sage: R.<x, y> = CC[]
+            sage: F = FreeModule(R, 1)
+            sage: G = F.submodule([F([0])])
+            sage: G._check_element_membership(F([1]).list())  # no error
+            sage: A.<t> = ZZ[]
+            sage: B.<w> = A[]
+            sage: F = FreeModule(B, 2)
+            sage: G = F.submodule([F.gen(0)])
+            sage: G._check_element_membership(F.gen(1).list())  # no error
         """
         try:
-            if not self._groebner_basis_contains(x):
-                raise ArithmeticError
+            contained = self._groebner_basis_contains(x)
         except NotImplementedError:
-            # For rings where we can't do the Gröbner basis check,
-            # fall back to no check (old behavior)
-            pass
-        except ArithmeticError:
+            # No Gröbner-basis membership test is available over this ring.
+            # Keep the historical permissive fallback rather than rejecting
+            # elements whose membership we cannot decide with this method.
+            return
+        if not contained:
             raise TypeError(
-                "element {} is not in this submodule".format(
-                    tuple(x)
-                )
-            )
-
-    def __contains__(self, x):
-        r"""
-        Test whether ``x`` belongs to ``self``.
-
-        This bypasses the default
-        :meth:`sage.structure.parent.Parent.__contains__`, which after
-        converting ``x`` to an element of ``self`` requires an equality
-        comparison with the original ``x``.  When the ambient module of
-        ``self`` is a quotient module, there is in general no coercion
-        registered between ``self`` and the parent of ``x``, so the
-        equality test would spuriously fail.  Instead, we rely on the
-        element constructor (which calls
-        :meth:`_check_element_membership`) to determine membership.
-
-        EXAMPLES::
-
-            sage: S.<x,y,z> = PolynomialRing(QQ)
-            sage: M = S**2
-            sage: N = M.submodule([vector([x - y, z]), vector([y*z, x*z])])
-            sage: Q = M.quotient_module(N)
-            sage: NQ = Q.submodule([Q([1, x])])
-            sage: Q([1, x]) in NQ
-            True
-            sage: Q([0, 1]) in NQ
-            False
-        """
-        try:
-            self(x)
-        except (TypeError, ArithmeticError, ValueError):
-            return False
-        return True
+                "element {} is not in this submodule".format(tuple(x)))
 
     def _repr_(self):
         """

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -218,6 +218,47 @@ class Submodule_free_ambient(Module_free_ambient):
             sage: G._groebner_basis_contains(F.1)
             False
 
+        Nonzero submodules over univariate polynomial rings that are
+        not PIDs (e.g. ``ZZ[x]``) are decided correctly, including the
+        distinction between the ``ZZ[x]``-span and the ``QQ(x)``-span::
+
+            sage: R.<x> = ZZ[]
+            sage: F = FreeModule(R, 2)
+            sage: G = F.submodule([vector(R, [x, 1]), vector(R, [1, x])])
+            sage: G._groebner_basis_contains(vector(R, [x, 1]))
+            True
+            sage: G._groebner_basis_contains((x + 2) * vector(R, [x, 1])
+            ....:                            + (x - 3) * vector(R, [1, x]))
+            True
+            sage: G._groebner_basis_contains(vector(R, [2*x, 2]))
+            True
+            sage: G._groebner_basis_contains(vector(R, [1, 0]))
+            False
+
+        Nonzero submodules over multivariate polynomial rings over
+        ``ZZ`` are also supported by Singular's module Gröbner-basis
+        machinery; integer-linear-combination membership is decided
+        correctly::
+
+            sage: R.<x, y> = ZZ[]
+            sage: F = FreeModule(R, 2)
+            sage: G = F.submodule([vector(R, [x, y]), vector(R, [y, x])])
+            sage: G._groebner_basis_contains(vector(R, [x, y]))
+            True
+            sage: G._groebner_basis_contains(vector(R, [2*x, 2*y]))
+            True
+            sage: G._groebner_basis_contains(vector(R, [x + y, x + y]))
+            True
+            sage: G._groebner_basis_contains((3*x + y) * vector(R, [x, y])
+            ....:                            + (x - 5) * vector(R, [y, x]))
+            True
+            sage: G._groebner_basis_contains(vector(R, [1, 1]))
+            False
+            sage: G._groebner_basis_contains(vector(R, [x, 0]))
+            False
+            sage: G._groebner_basis_contains(vector(R, [1, 0]))
+            False
+
         Over inexact rings, only the zero submodule is checked
         (Singular cannot compute Gröbner bases over inexact coefficient
         rings); other cases raise :class:`NotImplementedError`::

--- a/src/sage/modules/submodule.py
+++ b/src/sage/modules/submodule.py
@@ -102,6 +102,12 @@ class Submodule_free_ambient(Module_free_ambient):
         sage: F2.1 in G2
         False
 
+    Over base rings for which no Gröbner-basis membership test is
+    available (for instance inexact rings), nonzero submodules skip the
+    membership check and containment keeps the historical permissive
+    behavior, so it may report false positives; see
+    :meth:`_check_element_membership`.
+
     For a submodule of a *quotient* module there is in general no coercion
     between the submodule and the quotient module, so the ``in`` operator
     (which relies on such a coercion) is deliberately conservative and may
@@ -277,18 +283,24 @@ class Submodule_free_ambient(Module_free_ambient):
             sage: G._groebner_basis_contains(vector(R, [1, 0]))
             False
 
-        When no Gröbner-basis membership test is available, this low-level
-        method raises :class:`NotImplementedError`. The higher-level check
-        :meth:`_check_element_membership` treats this as failed membership
-        unless membership is known for a trivial reason::
+        The zero submodule needs no Gröbner basis machinery: membership
+        just means being the zero vector, which is decided exactly even
+        over an inexact coefficient ring::
 
             sage: R.<x, y> = CC[]
             sage: F = FreeModule(R, 1)
             sage: Z = F.submodule([F([0])])
             sage: Z._groebner_basis_contains(F([0]))
-            Traceback (most recent call last):
-            ...
-            NotImplementedError: Gröbner basis membership test is not implemented for modules over ...
+            True
+            sage: Z._groebner_basis_contains(F([1]))
+            False
+
+        For a nonzero submodule over an inexact ring, no reliable
+        Gröbner-basis membership test is available, so this low-level
+        method raises :class:`NotImplementedError`; the higher-level check
+        :meth:`_check_element_membership` then skips the membership test,
+        keeping the historical permissive behavior::
+
             sage: G = F.submodule([F([1])])
             sage: G._groebner_basis_contains(F([1]))
             Traceback (most recent call last):
@@ -342,14 +354,10 @@ class Submodule_free_ambient(Module_free_ambient):
         n = self.degree()
         ambient = self._ambient
 
-        if not R.is_exact():
-            raise NotImplementedError(
-                "Gröbner basis membership test is not implemented for "
-                "modules over {}".format(R))
-
         # Short-circuit the zero submodule (no generators and no module
-        # relations) before any Gröbner basis machinery is invoked. This
-        # also avoids invoking Singular when no reduction is needed.
+        # or ring relations) before any Gröbner basis machinery is
+        # invoked: membership then only asks whether ``v`` is zero, which
+        # is decided exactly even when ``R`` is inexact.
         has_module_relations = (isinstance(ambient, QuotientModule_free_ambient)
                                 and bool(ambient.relations().gens()))
         has_ring_relations = (isinstance(R, QuotientRing_generic)
@@ -358,6 +366,11 @@ class Submodule_free_ambient(Module_free_ambient):
             if isinstance(v, (list, tuple, Vector)):
                 return all(not c for c in v)
             return not v
+
+        if not R.is_exact():
+            raise NotImplementedError(
+                "Gröbner basis membership test is not implemented for "
+                "modules over {}".format(R))
 
         def _singular_wrap(ring):
             """
@@ -464,11 +477,10 @@ class Submodule_free_ambient(Module_free_ambient):
         Check that ``x`` belongs to this submodule using Gröbner bases.
 
         This overrides the no-op in the base class to verify actual
-        submodule membership. Membership known for a trivial reason (the
-        zero vector or one of the listed generators) is accepted directly.
-        Otherwise, when no Gröbner-basis membership test is available, the
-        check raises :class:`TypeError` so containment cannot report
-        ``True`` for membership that cannot be verified.
+        submodule membership. When no Gröbner-basis membership test is
+        available for the base ring, the check is skipped, keeping the
+        historical permissive behavior: a possible false positive is
+        preferred over silently rejecting a genuine member.
         See :issue:`40301`.
 
         EXAMPLES::
@@ -483,54 +495,53 @@ class Submodule_free_ambient(Module_free_ambient):
             ...
             TypeError: element (0, 1, 0, 0, 0, 0, 0, 0, 0, 0) is not in this submodule
 
-        Over rings for which no Gröbner-basis membership test is available,
-        trivially known members are still accepted::
+        Membership in the zero submodule is decided exactly even over
+        inexact rings, since it only asks whether the element is zero::
 
             sage: R.<x, y> = CC[]
             sage: F = FreeModule(R, 1)
-            sage: G = F.submodule([F([0])])
-            sage: G._check_element_membership(F([0]).list())  # no error
-            sage: H = F.submodule([F([1])])
-            sage: H._check_element_membership(F([1]).list())  # no error
-
-        Other elements are rejected rather than accepted as possible false
-        positives, even over inexact rings::
-
-            sage: G._check_element_membership(F([1]).list())
+            sage: Z = F.submodule([F([0])])
+            sage: Z._check_element_membership(F([0]).list())  # no error
+            sage: Z._check_element_membership(F([1]).list())
             Traceback (most recent call last):
             ...
             TypeError: element (1.00000000000000,) is not in this submodule
-            sage: F([1]) in G
+            sage: F([1]) in Z
             False
 
-        The same conservative fallback is used for exact rings whose
-        Gröbner-basis membership test is unavailable::
+        For nonzero submodules over inexact rings, no reliable membership
+        test is available, so the check is skipped; in particular a
+        genuine member such as ``F([2])`` here is never rejected::
+
+            sage: H = F.submodule([F([1])])
+            sage: H._check_element_membership(F([2]).list())  # no error
+            sage: F([2]) in H
+            True
+
+        The same permissive fallback applies to exact rings whose
+        Gröbner-basis membership test is unavailable. Genuine members are
+        accepted, at the price of possible false positives::
 
             sage: A.<t> = ZZ[]
             sage: B.<w> = A[]
             sage: F = FreeModule(B, 2)
             sage: G = F.submodule([F.gen(0)])
-            sage: F.gen(0) in G
+            sage: w * F.gen(0) in G
             True
-            sage: F.gen(1) in G
-            False
-            sage: G._check_element_membership(F.gen(1).list())
-            Traceback (most recent call last):
-            ...
-            TypeError: element (0, 1) is not in this submodule
+            sage: F.gen(1) in G  # false positive: membership is not decidable here
+            True
         """
-        x_tuple = tuple(x)
-        if all(not c for c in x_tuple):
-            return
-        if any(x_tuple == tuple(g) for g in self.gens()):
-            return
         try:
             contained = self._groebner_basis_contains(x)
         except NotImplementedError:
-            contained = False
+            # No membership test is available for this ring: keep the
+            # historical permissive behavior rather than rejecting
+            # elements whose membership cannot be decided, which would
+            # silently exclude genuine members.
+            return
         if not contained:
             raise TypeError(
-                "element {} is not in this submodule".format(x_tuple))
+                "element {} is not in this submodule".format(tuple(x)))
 
     def _repr_(self):
         """


### PR DESCRIPTION
Issue: Containment test `vec in G` returned `True` for vectors not in `G` when the base ring was a multivariate polynomial ring, because the fallback element constructor in `Module_free_ambient` performed no actual submodule membership check.

This PR adds a Gröbner-basis membership check for the polynomial-ring cases where Sage/Singular can compute it, while preserving the historical permissive fallback when that test is unavailable.

Main changes:

1. `free_module.py`: in `Module_free_ambient._element_constructor_`, always call `_check_element_membership` when `check=True`. The coordinate-entry check remains restricted to exact coordinate rings, but subclasses now get a chance to validate additional membership constraints.

2. `free_module.py`: guard `is_submodule` against infinite recursion when `self.ambient_module() is self`, which occurs for quotient-module instances and caused stack overflows for subquotients.

3. `submodule.py`: rework `Submodule_free_ambient._groebner_basis_contains` so that:
   - zero submodules are short-circuited when there are no module or ring relations; this runs before the exactness guard, so membership in the zero submodule (the reported case) is decided exactly even over inexact rings without any numerical Gröbner computation,
   - univariate polynomial rings are wrapped into one-variable libsingular multivariate rings when possible,
   - quotient-ring relations and quotient-module ambient relations are included in the module membership computation,
   - unsupported Gröbner-basis computations raise `NotImplementedError` at the low-level helper boundary.

4. `submodule.py`: keep `Submodule_free_ambient.__contains__` on the default coercion/equality path. For submodules of quotient modules, `in` may therefore be conservative because there is no coercion between the quotient ambient and its submodule. In that case, use explicit conversion, such as `NQ(Q([1, x]))`, to run the membership check directly.

5. `submodule.py`: `_check_element_membership` catches `NotImplementedError` from unsupported Gröbner-basis membership tests and skips the check. This preserves the historical permissive behavior for rings beyond the implemented test, and in particular avoids false negatives over inexact coefficient rings where numerical imprecision could reject a genuine member.

Regression doctests cover the original exact multivariate polynomial-ring example, nonzero submodule containment, univariate non-PID polynomial rings, quotient/subquotient membership via conversion, and unavailable Gröbner-basis tests over both inexact and exact-but-Singular-unsupported rings.

Addresses #40301.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.

