### PR TITLE
Fix conversion between polynomial quotient rings

### DIFF
--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -449,19 +449,48 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             sage: Q3.has_coerce_map_from(Q1)
             False
 
+        Such a conversion is not a coercion and need not define a ring
+        homomorphism::
+
+            sage: R.<x> = GF(7)[]
+            sage: S.<u> = R.quotient(x^4 + x^3)
+            sage: T.<v> = R.quotient(x^3 + x^2)
+            sage: S.has_coerce_map_from(T)
+            False
+            sage: S(v)
+            u
+            sage: S(v^3 + v^2)
+            0
+            sage: S(v)^3 + S(v)^2
+            u^3 + u^2
+
         String conversion takes into account both the generators of the quotient
         ring and its base ring::
 
             sage: Q3('x*ybar^2')
             -x
+
+        If direct conversion to the cover polynomial ring fails, conversion of
+        a quotient element falls back to its representative lift
+        (:issue:`42027`)::
+
+            sage: R.<x> = GF(7)[]
+            sage: S.<u> = R.quotient(x^2 + x)
+            sage: T.<v> = R.quotient(x)
+            sage: T.has_coerce_map_from(S)
+            True
+            sage: T(u)
+            0
         """
         if not isinstance(x, str):
             try:
-                return self.element_class(self, self.__ring(x), check=True)
+                polynomial = self.__ring(x)
             except (TypeError, ValueError):
                 xlift = getattr(x, 'lift', None)
                 if xlift is not None: # duck typing for quotient ring elements
                     return self.element_class(self, self.__ring(x.lift()), check=False)
+            else:
+                return self.element_class(self, polynomial, check=True)
         # The problem with the string representation is that it could in principle
         # mix elements of self with elements of self's cover ring. We therefore
         # resort to sage_eval.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Fix conversion between polynomial quotient rings when direct conversion of a
quotient element to the cover polynomial ring raises `ValueError`.

This fixes #42027.

## Root Cause

For polynomial quotient rings, explicit conversion first tries to convert the
input into the cover polynomial ring:

```python
self.__ring(x)
```

In the example from #42027:

```sage
sage: R.<x> = GF(7)[]
sage: S.<u> = R.quotient(x^2 + x)
sage: T.<v> = R.quotient(x)
sage: T(u)
```

the conversion internally tries:

```sage
sage: R(u)
```

which fails with:

```text
ValueError: could not complete rational reconstruction
```

The existing code only handled `TypeError`, so it never reached the fallback
that converts via the quotient element's representative lift.

## Fix

Separate cover-ring conversion from quotient element construction, and catch
both `TypeError` and `ValueError` from the cover-ring conversion step:

```python
try:
    polynomial = self.__ring(x)
except (TypeError, ValueError):
    xlift = getattr(x, 'lift', None)
    if xlift is not None:
        return self.element_class(self, self.__ring(x.lift()), check=False)
else:
    return self.element_class(self, polynomial, check=True)
```

This keeps the existing explicit-conversion behavior while allowing the
documented lift fallback to handle cases where direct cover-ring conversion
fails.

## Conversion vs Coercion

This change does not make arbitrary quotient-ring conversions into coercions.
Explicit conversion may still succeed by lifting a representative even when no
coercion exists:

```sage
sage: R.<x> = GF(7)[]
sage: S.<u> = R.quotient(x^4 + x^3)
sage: T.<v> = R.quotient(x^3 + x^2)
sage: S.has_coerce_map_from(T)
False
sage: S(v)
u
```

This conversion is not a ring homomorphism in general:

```sage
sage: S(v^3 + v^2)
0
sage: S(v)^3 + S(v)^2
u^3 + u^2
```

The added doctests document this distinction explicitly.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


