### PR TITLE
implement proper hash for gap integers and rationals

### DIFF
--- a/src/sage/libs/gap/element.pxd
+++ b/src/sage/libs/gap/element.pxd
@@ -8,6 +8,7 @@
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
+from sage.libs.gmp.types cimport mpz_t
 from sage.libs.gap.gap_includes cimport Obj, UInt
 from sage.structure.sage_object cimport SageObject
 from sage.structure.element cimport Element, ModuleElement, RingElement
@@ -59,7 +60,7 @@ cdef class GapElement(RingElement):
     cpdef GapElement deepcopy(self, bint mut)
 
 cdef class GapElement_Integer(GapElement):
-    pass
+    cdef inline int mpz_ro(self, mpz_t)
 
 cdef class GapElement_Rational(GapElement):
     pass

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -7,6 +7,7 @@ elements. For general information about GAP, you should read the
 """
 # ****************************************************************************
 #       Copyright (C) 2012 Volker Braun <vbraun.name@gmail.com>
+#                     2026 Vincent Delecroix <20100.delecroix@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -2203,6 +2204,33 @@ cdef class GapElement_Rational(GapElement):
         sage: type(r)
         <class 'sage.libs.gap.element.GapElement_Rational'>
     """
+    def __hash__(self):
+        r"""
+        TESTS::
+
+            sage: all(hash(libgap(x)) == hash(x) for x in [1/2, -1/3, 2^1024/3^352])
+            True
+        """
+        cdef int snum, sden
+        cdef mpz_t znum, zden
+        cdef Py_hash_t n, d
+        cdef GapElement_Integer num = libgap.NumeratorRat(self)
+        cdef GapElement_Integer den = libgap.DenominatorRat(self)
+
+        if num.is_C_int():
+            n = GAP_ValueInt(num.value)
+        else:
+            snum = num.mpz_ro(znum)
+            n = snum * mpz_pythonhash(znum)
+
+        if den.is_C_int():
+            d = GAP_ValueInt(den.value)
+        else:
+            sden = den.mpz_ro(zden)
+            d = sden * mpz_pythonhash(zden)
+
+        return n + (d - 1) * <Py_hash_t>(7461864723258187525)
+
     def _rational_(self):
         r"""
         EXAMPLES::

--- a/src/sage/libs/gap/element.pyx
+++ b/src/sage/libs/gap/element.pyx
@@ -23,7 +23,7 @@ from sage.libs.gap.libgap import libgap
 from sage.libs.gap.util cimport *
 from sage.libs.gap.util import GAPError, gap_sig_on, gap_sig_off
 from sage.libs.gmp.mpz cimport *
-from sage.libs.gmp.pylong cimport mpz_get_pylong, mpz_set_pylong
+from sage.libs.gmp.pylong cimport mpz_get_pylong, mpz_set_pylong, mpz_pythonhash
 from sage.cpython.string cimport str_to_bytes, char_to_str
 from sage.rings.integer cimport Integer
 from sage.rings.integer_ring import ZZ
@@ -1603,6 +1603,38 @@ cdef class GapElement_Integer(GapElement):
         sage: ZZ(i)
         123
     """
+    cdef inline int mpz_ro(self, mpz_t z):
+        cdef Int size
+        cdef int c_sign
+        cdef int c_size
+        cdef const UInt* x
+
+        # gap integers are stored as a mp_limb_t
+        size = GAP_SizeInt(self.value) # count limbs and extract sign
+        if size > 0:
+            c_sign = 1
+            c_size = size
+        else: # Must have size < 0, or else self.value == 0 and self.is_C_int() == True
+            c_sign = -1
+            c_size = -size
+        x = GAP_AddrInt(self.value) # pointer to limbs
+        mpz_roinit_n(z, <mp_limb_t *>x, c_size)
+        return c_sign
+
+    def __hash__(self):
+        r"""
+        TESTS::
+
+            sage: all(hash(libgap(i)) == hash(i) for i in range(-100, 100))
+            True
+            sage: all(hash(s * libgap(2)^i + j) == hash(s * 2^i + j) for s in [-1, 1] for i in range(1, 1024, 13) for j in [-1,0,1])
+            True
+        """
+        if self.is_C_int():
+            return GAP_ValueInt(self.value)
+        cdef mpz_t z
+        cdef c_sign = self.mpz_ro(z)
+        return c_sign * mpz_pythonhash(z)
 
     def is_C_int(self):
         r"""
@@ -1681,10 +1713,8 @@ cdef class GapElement_Integer(GapElement):
             10000
         """
         cdef const UInt* x
-        cdef Int size
-        cdef int c_sign
-        cdef int c_size
         cdef mpz_t output
+        cdef int c_sign
         if ring is None:
             ring = ZZ
         try:
@@ -1692,17 +1722,8 @@ cdef class GapElement_Integer(GapElement):
             if self.is_C_int():
                 return ring(GAP_ValueInt(self.value))
             else:
-                # gap integers are stored as a mp_limb_t
-                size = GAP_SizeInt(self.value) # count limbs and extract sign
-                if size > 0:
-                    c_sign = 1
-                    c_size = size
-                else: # Must have size < 0, or else self.value == 0 and self.is_C_int() == True
-                    c_sign = -1
-                    c_size = -size
-                x = GAP_AddrInt(self.value) # pointer to limbs
-                mpz_roinit_n(output, <mp_limb_t *>x, c_size)
-                return ring(c_sign*mpz_get_pylong(output))
+                c_sign = self.mpz_ro(output)
+                return ring(c_sign * mpz_get_pylong(output))
         finally:
             GAP_Leave()
 


### PR DESCRIPTION
Make libgap hash to coincide with sage on integers and rationals.

A step towards https://github.com/sagemath/sage/issues/30498