### PR TITLE
make the tabloid basis action use the inverse permutation

### DIFF
--- a/src/sage/combinat/specht_module.py
+++ b/src/sage/combinat/specht_module.py
@@ -419,9 +419,9 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
     A *tabloid* is an :class:`OrderedSetPartition` whose underlying set
     is `\{1, \ldots, n\}`. The symmetric group acts by permuting the
     entries of the set. Hence, this is a representation of the symmetric
-    group defined over any field. This is a left representation, so an
-    entry `i` is sent to `g^{-1}(i)` in Sage's permutation multiplication
-    convention.
+    group defined over any field. This is a left representation, so the
+    permutation applied to the entries depends on the multiplication
+    convention of the defining symmetric group algebra.
 
     EXAMPLES::
 
@@ -609,12 +609,31 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
             [5, 1, 2, 3, 4]
             sage: TM._symmetric_group_action(osp, g)
             [{2, 5}, {1, 4}, {3}]
+
+            sage: from sage.combinat.permutation import Permutations
+            sage: Permutations.options.mult = 'r2l'
+            sage: TM._symmetric_group_action(osp, g)
+            [{3, 5}, {2, 4}, {1}]
+            sage: Permutations.options.mult = 'l2r'
         """
         P = self._indices
-        # Sage permutations multiply from left to right; using the inverse
-        # gives a left action on tabloids.
-        g = ~self._symgp(g)
+        g = self._left_action_permutation(g)
         return P.element_class(P, [[g(val) for val in row] for row in osp], check=False)
+
+    def _left_action_permutation(self, g):
+        r"""
+        Return the permutation applied to entries for the left action of ``g``.
+
+        The classical :class:`~sage.combinat.permutation.Permutations`
+        parent has a user-settable multiplication convention. When it is
+        set to ``'r2l'``, the direct action on entries is already a left
+        action; otherwise we use the inverse.
+        """
+        g = self._symgp(g)
+        options = getattr(self._semigroup, "options", None)
+        if options is not None and options.mult == 'r2l':
+            return g
+        return ~g
 
     def specht_module(self):
         r"""
@@ -686,6 +705,16 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
                 sage: d = SGA(Permutation([2,3,1,4,5]))
                 sage: c * (d * a) == (c*d) * a
                 True
+                sage: from sage.combinat.permutation import Permutations
+                sage: Permutations.options.mult = 'r2l'
+                sage: SGA = SymmetricGroupAlgebra(QQ, 5)
+                sage: SM = SGA.tabloid_module([2,2,1])
+                sage: a = SM([{2,1}, {3,4}, {5}])
+                sage: c = SGA(Permutation([2,3,4,1,5]))
+                sage: d = SGA(Permutation([2,3,1,4,5]))
+                sage: c * (d * a) == (c*d) * a
+                True
+                sage: Permutations.options.mult = 'l2r'
                 sage: G = SymmetricGroup(5)
                 sage: SG = G.algebra(QQ)
                 sage: SM = SG.tabloid_module([2,2,1])

--- a/src/sage/combinat/specht_module.py
+++ b/src/sage/combinat/specht_module.py
@@ -365,7 +365,7 @@ class SpechtModule(SymmetricGroupRepresentation, SubmoduleWithBasis):
                 sage: SGA = SymmetricGroupAlgebra(QQ, 4)
                 sage: SM = SGA.specht_module([3,1])
                 sage: SGA.an_element() * SM.an_element()
-                9*S[[1, 2, 3], [4]] + 17*S[[1, 2, 4], [3]] + 14*S[[1, 3, 4], [2]]
+                18*S[[1, 2, 3], [4]] + 16*S[[1, 2, 4], [3]] + 5*S[[1, 3, 4], [2]]
                 sage: 4 * SM.an_element()
                 12*S[[1, 2, 3], [4]] + 8*S[[1, 2, 4], [3]] + 8*S[[1, 3, 4], [2]]
 
@@ -379,6 +379,18 @@ class SpechtModule(SymmetricGroupRepresentation, SubmoduleWithBasis):
                 TypeError: unsupported operand parent(s) for *:
                  'Specht module of [3, 1] over Rational Field'
                  and 'Symmetric group algebra of order 4 over Rational Field'
+
+                sage: c = SGA(Permutation([2,3,4,1]))
+                sage: d = SGA(Permutation([2,1,3,4]))
+                sage: v = SM.an_element()
+                sage: c * (d * v) == (c*d) * v
+                True
+                sage: from sage.combinat.diagram import Diagram
+                sage: D = Diagram([(0,0), (1,1), (1,2), (2,1)])
+                sage: SM_generic = SGA.specht_module(D)
+                sage: v = SM_generic.an_element()
+                sage: c * (d * v) == (c*d) * v
+                True
                 sage: groups.permutation.Dihedral(3).an_element() * SM.an_element()
                 Traceback (most recent call last):
                 ...
@@ -407,7 +419,9 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
     A *tabloid* is an :class:`OrderedSetPartition` whose underlying set
     is `\{1, \ldots, n\}`. The symmetric group acts by permuting the
     entries of the set. Hence, this is a representation of the symmetric
-    group defined over any field.
+    group defined over any field. This is a left representation, so an
+    entry `i` is sent to `g^{-1}(i)` in Sage's permutation multiplication
+    convention.
 
     EXAMPLES::
 
@@ -594,10 +608,12 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
             sage: g = SGA.group().an_element(); g
             [5, 1, 2, 3, 4]
             sage: TM._symmetric_group_action(osp, g)
-            [{3, 5}, {2, 4}, {1}]
+            [{2, 5}, {1, 4}, {3}]
         """
         P = self._indices
-        g = self._symgp(g)
+        # Sage permutations multiply from left to right; using the inverse
+        # gives a left action on tabloids.
+        g = ~self._symgp(g)
         return P.element_class(P, [[g(val) for val in row] for row in osp], check=False)
 
     def specht_module(self):
@@ -654,7 +670,7 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
                 sage: SGA = SymmetricGroupAlgebra(QQ, 5)
                 sage: SM = SGA.tabloid_module([2,2,1])
                 sage: SGA.an_element() * SM.an_element()
-                2*T[{1, 5}, {2, 3}, {4}] + 2*T[{1, 5}, {2, 4}, {3}] + 3*T[{1, 5}, {3, 4}, {2}]
+                2*T[{2, 3}, {4, 5}, {1}] + 2*T[{2, 3}, {1, 4}, {5}] + 3*T[{2, 3}, {1, 5}, {4}]
                  + 12*T[{1, 2}, {3, 4}, {5}] + 15*T[{1, 2}, {3, 5}, {4}] + 15*T[{1, 2}, {4, 5}, {3}]
                 sage: 4 * SM.an_element()
                 8*T[{1, 2}, {3, 4}, {5}] + 8*T[{1, 2}, {3, 5}, {4}] + 12*T[{1, 2}, {4, 5}, {3}]
@@ -664,6 +680,20 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
                 TypeError: unsupported operand parent(s) for *:
                  'Tabloid module of [2, 2, 1] over Rational Field'
                  and 'Symmetric group algebra of order 5 over Rational Field'
+
+                sage: a = SM([{2,1}, {3,4}, {5}])
+                sage: c = SGA(Permutation([2,3,4,1,5]))
+                sage: d = SGA(Permutation([2,3,1,4,5]))
+                sage: c * (d * a) == (c*d) * a
+                True
+                sage: G = SymmetricGroup(5)
+                sage: SG = G.algebra(QQ)
+                sage: SM = SG.tabloid_module([2,2,1])
+                sage: a = SM([{2,1}, {3,4}, {5}])
+                sage: c = G([2,3,4,1,5])
+                sage: d = G([2,3,1,4,5])
+                sage: c * (d * a) == (c*d) * a
+                True
             """
             # first check for the base action
             ret = super()._acted_upon_(x, self_on_left)
@@ -987,7 +1017,7 @@ class MaximalSpechtSubmodule(SymmetricGroupRepresentation, SubmoduleWithBasis):
         sage: u = U.an_element(); u
         2*U[0] + 2*U[1]
         sage: [p * u for p in list(SGA.basis())[:4]]
-        [2*U[0] + 2*U[1], 2*U[2] + 2*U[3], 2*U[0] + 2*U[1], U[0] + 2*U[2]]
+        [2*U[0] + 2*U[1], 2*U[2] + 2*U[3], 2*U[0] + 2*U[1], 2*U[2] + 2*U[3]]
         sage: sum(SGA.basis()) * u
         0
     """
@@ -1086,7 +1116,7 @@ class SimpleModule(SymmetricGroupRepresentation, QuotientModuleWithBasis):
         sage: v = D.an_element(); v
         2*D[[[1, 3, 5], [2], [4]]] + 2*D[[[1, 4, 5], [2], [3]]]
         sage: SGA.an_element() * v
-        2*D[[[1, 2, 4], [3], [5]]] + 2*D[[[1, 3, 5], [2], [4]]]
+        2*D[[[1, 2, 4], [3], [5]]] + 2*D[[[1, 2, 5], [3], [4]]] + 2*D[[[1, 3, 4], [2], [5]]] + D[[[1, 4, 5], [2], [3]]]
 
     We give an example on how to construct the decomposition matrix
     (the Specht modules are a complete set of irreducible projective

--- a/src/sage/combinat/specht_module.py
+++ b/src/sage/combinat/specht_module.py
@@ -28,6 +28,7 @@ from sage.categories.modules_with_basis import ModulesWithBasis
 from sage.combinat.diagram import Diagram
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.combinat.partition import _Partitions
+from sage.combinat.permutation import Permutations
 from sage.matrix.constructor import matrix
 from sage.misc.cachefunc import cached_method
 from sage.misc.latex import latex
@@ -610,30 +611,16 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
             sage: TM._symmetric_group_action(osp, g)
             [{2, 5}, {1, 4}, {3}]
 
-            sage: from sage.combinat.permutation import Permutations
             sage: Permutations.options.mult = 'r2l'
             sage: TM._symmetric_group_action(osp, g)
             [{3, 5}, {2, 4}, {1}]
             sage: Permutations.options.mult = 'l2r'
         """
         P = self._indices
-        g = self._left_action_permutation(g)
-        return P.element_class(P, [[g(val) for val in row] for row in osp], check=False)
-
-    def _left_action_permutation(self, g):
-        r"""
-        Return the permutation applied to entries for the left action of ``g``.
-
-        The classical :class:`~sage.combinat.permutation.Permutations`
-        parent has a user-settable multiplication convention. When it is
-        set to ``'r2l'``, the direct action on entries is already a left
-        action; otherwise we use the inverse.
-        """
         g = self._symgp(g)
-        options = getattr(self._semigroup, "options", None)
-        if options is not None and options.mult == 'r2l':
-            return g
-        return ~g
+        if not isinstance(self._semigroup, Permutations) or self._semigroup.options.mult != 'r2l':
+            g = ~g
+        return P.element_class(P, [[g(val) for val in row] for row in osp], check=False)
 
     def specht_module(self):
         r"""
@@ -705,13 +692,13 @@ class TabloidModule(SymmetricGroupRepresentation, CombinatorialFreeModule):
                 sage: d = SGA(Permutation([2,3,1,4,5]))
                 sage: c * (d * a) == (c*d) * a
                 True
-                sage: from sage.combinat.permutation import Permutations
                 sage: Permutations.options.mult = 'r2l'
                 sage: SGA = SymmetricGroupAlgebra(QQ, 5)
                 sage: SM = SGA.tabloid_module([2,2,1])
                 sage: a = SM([{2,1}, {3,4}, {5}])
-                sage: c = SGA(Permutation([2,3,4,1,5]))
-                sage: d = SGA(Permutation([2,3,1,4,5]))
+                sage: G = SGA.group()
+                sage: c = SGA(G([2,3,4,1,5]))
+                sage: d = SGA(G([2,3,1,4,5]))
                 sage: c * (d * a) == (c*d) * a
                 True
                 sage: Permutations.options.mult = 'l2r'

--- a/src/sage/modules/with_basis/representation.py
+++ b/src/sage/modules/with_basis/representation.py
@@ -910,7 +910,7 @@ class Representation_abstract:
             sage: v = CF[1].an_element(); v
             2*B[0] + 2*B[1]
             sage: x * v
-            B[1] + B[2]
+            B[0] + B[3]
 
         We reproduce the decomposition matrix for `S_5` over `\GF{2}`::
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
The tabloid module is intended to be a left representation of the symmetric
group algebra. However, its basis action applied a permutation `g` directly to
the entries of a tabloid. With Sage's permutation multiplication convention,
that direct action behaves like a right action. As a result, the module action
was not associative:

```sage
c * (d * a) != (c*d) * a
```

The proper fix is to make the tabloid basis action use the inverse permutation:

```python
g = ~self._symgp(g)
```

so each entry `i` is sent to `g^{-1}(i)`.

Fix #40487 


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


