### PR TITLE
Fix MathJax output for backslash strings

### DIFF
--- a/src/sage/misc/html.py
+++ b/src/sage/misc/html.py
@@ -297,6 +297,12 @@ class MathJax:
             sage: from sage.misc.html import MathJax
             sage: MathJax().eval(IntegerModRing(6))
             <html>\[\newcommand{\ZZ}{\Bold{Z}}\newcommand{\Bold}[1]{\mathbf{#1}}\ZZ/6\ZZ\]</html>
+            sage: MathJax().eval(['\\'], mode='display_left')
+            <html>\(\displaystyle \left[\verb|\|\right]\)</html>
+            sage: MathJax().eval(['{'], mode='display_left')
+            <html>\(\displaystyle \left[\texttt{\{}\right]\)</html>
+            sage: MathJax().eval(['a{b}c'], mode='display_left')
+            <html>\(\displaystyle \left[\verb|a|\texttt{\{}\verb|b|\texttt{\}}\verb|c|\right]\)</html>
         """
         # Get a regular LaTeX representation of x
         x = latex(x, combine_all=combine_all)
@@ -309,11 +315,17 @@ class MathJax:
             if i == 0:
                 continue    # Nothing to do with the head part
             n = 1
+            escaped = False
             for closing, c in enumerate(part):
-                if c == "{" and part[closing - 1] != "\\":
-                    n += 1
-                if c == "}" and part[closing - 1] != "\\":
-                    n -= 1
+                if c == "\\":
+                    escaped = not escaped
+                    continue
+                if not escaped:
+                    if c == "{":
+                        n += 1
+                    elif c == "}":
+                        n -= 1
+                escaped = False
                 if n == -1:
                     break
             # part should end in "}}", so omit the last two characters
@@ -340,7 +352,14 @@ class MathJax:
                 if nspaces > 0:
                     subparts.append(wrapper % (" " * nspaces))
                 nspaces = 1
-                subparts.append(wrapper % subpart)
+                # Unbalanced braces in \verb hide the closing math delimiter.
+                for piece in re.split(r"([{}])", subpart):
+                    if not piece:
+                        continue
+                    if piece in "{}":
+                        subparts.append(r"\texttt{\%s}" % piece)
+                    else:
+                        subparts.append(wrapper % piece)
             subparts.append(part[closing + 1:])
             parts[i] = "".join(subparts)
 

--- a/src/sage/misc/html.py
+++ b/src/sage/misc/html.py
@@ -292,7 +292,7 @@ class MathJax:
             sage: MathJax().eval(type(3), mode='inline')
             <html>\(\verb|&lt;class|\verb| |\verb|'sage.rings.integer.Integer'>|\)</html>
 
-        TESTS:
+        TESTS::
 
             sage: from sage.misc.html import MathJax
             sage: MathJax().eval(IntegerModRing(6))

--- a/src/sage/repl/rich_output/pretty_print.py
+++ b/src/sage/repl/rich_output/pretty_print.py
@@ -286,6 +286,21 @@ def pretty_print(*args, **kwds):
 
         sage: dm.preferences.text = None
 
+    Check that notebook-style LaTeX output through ``pretty_print`` handles
+    strings containing a single backslash (:issue:`42179`)::
+
+        sage: from sage.repl.rich_output.backend_doctest import BackendDoctest
+        sage: from sage.repl.rich_output.output_catalog import OutputHtml
+        sage: class HtmlBackend(BackendDoctest):
+        ....:     def supported_output(self):
+        ....:         return super().supported_output() | {OutputHtml}
+        sage: old_backend = dm.switch_backend(HtmlBackend())
+        sage: try:
+        ....:     pretty_print(['\\'])
+        ....: finally:
+        ....:     _ = dm.switch_backend(old_backend)
+        <html>\(\displaystyle \left[\verb|\|\right]\)</html>
+
     ::
 
         sage: plt = plot(sin)


### PR DESCRIPTION
Fixes #42179.

## Problem

In notebook rich output,

```python
pretty_print(["\\"])
```

produced malformed MathJax input instead of rendering a list containing one backslash. String elements containing literal braces exposed a related rendering problem.

## Root cause

Sage rewrites `\\text{\\texttt{...}}` string output into `\\verb` fragments for MathJax. The boundary scanner treated every brace immediately preceded by a backslash as escaped.

A literal backslash is represented with two consecutive backslashes before a closing brace. That brace is not escaped, but the old scanner skipped it, ran past the end of the `\\texttt` block, and consumed part of the surrounding `\\right]` suffix.

An unmatched literal brace inside `\\verb` can also prevent MathJax from finding the closing inline-math delimiter.

## Changes

- Track the parity of consecutive backslashes while locating the end of each `\\texttt` block. A brace is escaped only after an odd-length run.
- Emit literal braces as `\\texttt{\\{}` and `\\texttt{\\}}` outside `\\verb`, while keeping the remaining string content in `\\verb` and preserving typewriter styling.
- Add direct `MathJax.eval` regressions and an end-to-end notebook-style `pretty_print` regression.

## Validation

- 117 focused doctests pass in `src/sage/misc/html.py` and `src/sage/repl/rich_output/pretty_print.py`.
- Ruff passes with both normal and preview rules.
- Chromium with MathJax 3.2.2 renders one and two backslashes, opening and closing braces, and mixed text such as `a{b}c` correctly, with no MathJax error nodes or raw TeX left behind.