### PR TITLE
Refactor the hash function of permgrp elements to make it behave correctly

### DIFF
--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -1526,6 +1526,17 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
             sage: hash(h) == hash(k)
             True
 
+        Distinct cycles are not identified::
+
+            sage: a = PermutationGroupElement('(1,2,3)')
+            sage: b = PermutationGroupElement('(1,3,2)')
+            sage: a != b
+            True
+            sage: len({a, b})
+            2
+            sage: Set([a]) != Set([b])
+            True
+
         Check that the hash looks reasonable::
 
             sage: len(set(map(hash, SymmetricGroup(5)))) == 120
@@ -1548,11 +1559,11 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
         """
         cdef size_t i
         from_gap = self._parent._domain_from_gap
-        moved = []
+        moved_pairs = []
         for i in range(self.n):
             if self.perm[i] != i:
-                moved.append((from_gap[i + 1], from_gap[self.perm[i] + 1]))
-        return hash(frozenset(moved))
+                moved_pairs.append((from_gap[i + 1], from_gap[self.perm[i] + 1]))
+        return hash(frozenset(moved_pairs))
 
     def tuple(self):
         r"""

--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -1559,10 +1559,9 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
         """
         cdef size_t i
         from_gap = self._parent._domain_from_gap
-        moved_pairs = []
-        for i in range(self.n):
-            if self.perm[i] != i:
-                moved_pairs.append((from_gap[i + 1], from_gap[self.perm[i] + 1]))
+        moved_pairs = [(from_gap[i + 1], from_gap[self.perm[i] + 1])
+                       for i in range(self.n)
+                       if self.perm[i] != i]
         return hash(frozenset(moved_pairs))
 
     def tuple(self):

--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -1534,7 +1534,7 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
             True
             sage: len({a, b})
             2
-            sage: Set([a]) != Set([b])
+            sage: set([a]) != set([b])
             True
 
         Check that the hash looks reasonable::
@@ -1553,7 +1553,7 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
             ....:                     for x in pete.vertices()]
             sage: subgroup_check = [PermutationGroup(pointstabilizers[i])
             ....:                   for i in range(len(pointstabilizers))]
-            sage: all(Set(subgroup_check[i]) == Set(pointstabilizers[i])
+            sage: all(set(subgroup_check[i]) == set(pointstabilizers[i])
             ....:     for i in range(10))
             True
         """

--- a/src/sage/groups/perm_gps/permgroup_element.pyx
+++ b/src/sage/groups/perm_gps/permgroup_element.pyx
@@ -1511,28 +1511,48 @@ cdef class PermutationGroupElement(MultiplicativeGroupElement):
         EXAMPLES::
 
             sage: G = SymmetricGroup(5)
-            sage: hash32 = -1203337681
-            sage: hash64 = -1527414595000039889
-            sage: hash(G([2,1,5,3,4])) in [hash32, hash64]
+            sage: g = G([2,1,5,3,4])
+            sage: hash(g) == hash(g)
+            True
+
+        The hash is compatible with equality of permutations from
+        different parents::
+
+            sage: from sage.groups.perm_gps.constructor import PermutationGroupElement
+            sage: h = PermutationGroupElement('(1,3,2)')
+            sage: k = PermutationGroupElement('(1,2,3)(4,5)')^2
+            sage: h == k
+            True
+            sage: hash(h) == hash(k)
             True
 
         Check that the hash looks reasonable::
 
-            sage: s = set()
-            sage: s.update(map(hash,SymmetricGroup(0)))
-            sage: s.update(map(hash,SymmetricGroup(1)))
-            sage: s.update(map(hash,SymmetricGroup(2)))
-            sage: s.update(map(hash,SymmetricGroup(3)))
-            sage: s.update(map(hash,SymmetricGroup(4)))
-            sage: s.update(map(hash,SymmetricGroup(5)))
-            sage: len(s) == 1 + 1 + 2 + 6 + 24 + 120
+            sage: len(set(map(hash, SymmetricGroup(5)))) == 120
+            True
+
+        TESTS:
+
+        Check that :issue:`40041` is fixed::
+
+            sage: # needs sage.graphs
+            sage: pete = graphs.PetersenGraph()
+            sage: autpete = pete.automorphism_group()
+            sage: pointstabilizers = [[g for g in autpete if g(x) == x]
+            ....:                     for x in pete.vertices()]
+            sage: subgroup_check = [PermutationGroup(pointstabilizers[i])
+            ....:                   for i in range(len(pointstabilizers))]
+            sage: all(Set(subgroup_check[i]) == Set(pointstabilizers[i])
+            ....:     for i in range(10))
             True
         """
         cdef size_t i
-        cdef long ans = self.n
+        from_gap = self._parent._domain_from_gap
+        moved = []
         for i in range(self.n):
-            ans = (ans ^ (self.perm[i])) * 1000003L
-        return ans
+            if self.perm[i] != i:
+                moved.append((from_gap[i + 1], from_gap[self.perm[i] + 1]))
+        return hash(frozenset(moved))
 
     def tuple(self):
         r"""


### PR DESCRIPTION
The old hash for `PermutationGroupElement` depended on the parent group's
internal permutation array length.  Sage equality for permutation group elements
is more mathematical than that: it can identify the same permutation even when
the two elements live in different parents, or when one parent has extra fixed
points.

That combination violated Python's core hash invariant:

```python
if a == b:
    assert hash(a) == hash(b)
```

The new hash is based on the permutation's moved-point action:

```python
frozenset((x, g(x)) for x in domain if g(x) != x)
```

This is a better mathematical representative of the permutation because fixed
points outside the support do not change the permutation as a map.

## The old behavior

Sage already treats these two elements as equal:

```python
from sage.groups.perm_gps.constructor import PermutationGroupElement

h = PermutationGroupElement('(1,3,2)')          # parent S_3
k = PermutationGroupElement('(1,2,3)(4,5)')^2  # parent S_5

h == k
```

The result is `True`, because both elements act as `(1,3,2)` and `4`, `5` are
only fixed points for `k`.

Before the fix, their hashes differed because the hash included the internal
array length:

```text
h:  [2, 3, 1]
k:  [2, 3, 1, 4, 5]
```

Fix #40041 
Those arrays are different representations of the same permutation action.
Hashing them differently is not compatible with `h == k`.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


