### PR TITLE
Pytest: add support for "long" and "longlong" markings

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -169,9 +169,9 @@ jobs:
           ${{ matrix.editable && 'true' || 'rm -R ./src/sage_setup/' }}
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             # Ignore errors on Windows, for now
-            pytest --doctest-ignore-import-errors --doctest -rfEs -s src || true
+            pytest -n 4 --doctest-ignore-import-errors --doctest -rfEs -s src || true
           else
-            pytest -rfEs -s src
+            pytest -n 4 -rfEs -s src
             ./sage -t ${{
               matrix.tests == 'all' &&
               '--all-except="$SEPARATELY_TESTED_FLAKY_FILES"' ||
@@ -197,9 +197,9 @@ jobs:
           # The output also includes a long list of modules together with the number of tests in each module.
           # This can be ignored.
           if [[ "${{ matrix.os }}" == "windows" ]]; then
-            pytest -qq --doctest --collect-only || true
+            pytest -n 4 -qq --doctest --collect-only || true
           else
-            pytest -qq --doctest --collect-only
+            pytest -n 4 -qq --doctest --collect-only
           fi
 
       - name: Check for cyclic imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,14 @@ platforms = ['linux-64', 'linux-aarch64', 'osx-64', 'osx-arm64']
 norecursedirs = "local prefix venv build builddir pkgs .git src/doc src/bin src/sage/libs/giac tools subprojects"
 python_files = "*_test.py"
 # The "no:warnings" is to stop pytest from capturing warnings so that they are printed to the output of the doctest
-addopts = "--import-mode importlib -p no:warnings"
+addopts = "--import-mode importlib -p no:warnings --strict-markers"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 # https://docs.pytest.org/en/stable/reference/reference.html#confval-consider_namespace_packages
 consider_namespace_packages = true
+markers = [
+  "long: long-running tests",
+  "longlong: extremely long-running tests",
+]
 
 # External dependencies in the format proposed by https://peps.python.org/pep-0725
 [external]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ platforms = ['linux-64', 'linux-aarch64', 'osx-64', 'osx-arm64']
 [tool.pytest.ini_options]
 # sage.libs.giac is a stub to keep the old imports working; all
 # it does is try to import sagemath_giac.
-norecursedirs = "local prefix venv build builddir pkgs .git src/doc src/bin src/sage/libs/giac tools subprojects"
+norecursedirs = "local prefix venv build builddir pkgs .git .github src/doc src/bin src/sage/libs/giac tools subprojects"
 python_files = "*_test.py"
 # The "no:warnings" is to stop pytest from capturing warnings so that they are printed to the output of the doctest
 addopts = "--import-mode importlib -p no:warnings --strict-markers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ extra = [
   'sage_numerical_backends_coin',
   'symengine >= 0.6.1', # Only used in tests
 ]
+test = ["pytest-xdist"]
 #giac = ['sagemath_giac'] # Not yet available on PyPI (https://github.com/sagemath/sagemath-giac/issues/3)
 
 [project.readme]
@@ -248,7 +249,7 @@ docs = [
   "sphinx-inline-tabs",
 ]
 lint = ["flake8-rst-docstrings", "pycodestyle", "relint", "ruff"]
-test = ["coverage", "pytest", "pytest-xdist"]
+test = ["coverage", "pytest"]
 
 [tool.ruff]
 # https://docs.astral.sh/ruff/configuration

--- a/src/sage/doctest/__main__.py
+++ b/src/sage/doctest/__main__.py
@@ -200,7 +200,20 @@ def main():
     err = DC.run()
 
     exit_code_pytest = 0
-    pytest_options = []
+
+    # Never run "long long" tests via sage -t (or python -m
+    # sage.doctest) to avoid catching users by surprise with
+    # tests that run for several minutes.
+    pytest_markers = "not longlong"
+    if not args.long:
+        # Multiple "-m" flags cannot be combined,
+        #
+        #   https://github.com/pytest-dev/pytest/issues/7229
+        #
+        # so we construct one big compound statement instead.
+        pytest_markers += " and not long"
+    pytest_options = ["-m", pytest_markers]
+
     if args.verbose:
         pytest_options.append("-v")
 

--- a/src/sage/doctest/__main__.py
+++ b/src/sage/doctest/__main__.py
@@ -214,6 +214,14 @@ def main():
         pytest_markers += " and not long"
     pytest_options = ["-m", pytest_markers]
 
+    if args.warn_long > 0:
+        # Show all test durations...
+        pytest_options.append("--durations=0")
+
+        # But then limit the list to the ones that exceed the
+        # warn-long limit.
+        pytest_options.append(f"--durations-min={args.warn_long}")
+
     if args.verbose:
         pytest_options.append("-v")
 

--- a/src/sage/doctest/__main__.py
+++ b/src/sage/doctest/__main__.py
@@ -161,6 +161,7 @@ def _make_parser():
 
 
 def main():
+    from importlib.util import find_spec
     from sage.doctest.control import DocTestController
     from sage.env import SAGE_SRC
 
@@ -186,6 +187,13 @@ def main():
     if not args.filenames and not (args.all or args.new or args.installed) and args.all_except is None:
         print('either use --new, --all, --all-except=..., --installed, or some filenames')
         return 2
+
+    # The number of processes to use for pytest, if pytest-xdist is
+    # installed.  The doctest controller can change the value of
+    # args.threads, but we need to know the initial value because "0"
+    # has a special meaning for pytest that differs somewhat from
+    # that for the doctest runner.
+    pytest_nprocs = args.nthreads
 
     # Limit the number of threads to 2 to save system resources.
     # See Issue #23713, #23892, #30351
@@ -213,6 +221,21 @@ def main():
         # so we construct one big compound statement instead.
         pytest_markers += " and not long"
     pytest_options = ["-m", pytest_markers]
+
+    if pytest_nprocs != 1 and not find_spec("xdist"):
+        # The default is "1", so anything else is an explicit request
+        # that we should warn about if we are unable to comply.
+        from pytest import PytestWarning
+        from warnings import warn
+        warn("pytest-xdist not found, pytest will run sequentially",
+             PytestWarning)
+        pytest_nprocs = 1
+
+    # pytest-xdist is now guaranteed to be available in these cases
+    if pytest_nprocs == 0:
+        pytest_options += ["-n", "auto"]
+    elif pytest_nprocs > 1:
+        pytest_options += ["-n", f"{pytest_nprocs}"]
 
     if args.warn_long > 0:
         # Show all test durations...

--- a/src/sage/graphs/generators/generators_test.py
+++ b/src/sage/graphs/generators/generators_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.longlong
 def test_shortened_000_111_extended_binary_Golay_code_graph():
     r"""
     Test that Sage produces a graph equal to the one that we get

--- a/src/sage/graphs/tests/is_projective_planar_test.py
+++ b/src/sage/graphs/tests/is_projective_planar_test.py
@@ -1,10 +1,11 @@
 import pytest
 
 
+@pytest.mark.longlong
 def test_petersen_graph_is_projective_planar():
     r"""
     Ensure that the Petersen graph is projective planar without
-    using the cache.
+    using the cache. This can take several minutes.
     """
     from sage.graphs.generators.smallgraphs import PetersenGraph
     P = PetersenGraph()

--- a/src/sage/libs/gap/gap_test.py
+++ b/src/sage/libs/gap/gap_test.py
@@ -18,6 +18,7 @@ def test_libgap_can_read_and_write_files(tmpfile):
     assert SystemFile(tmpfile.name) == libgap(message)
 
 
+@pytest.mark.long
 def test_gc_loop_1():
     r"""
     Stress test for garbage collection in libgap.
@@ -33,6 +34,7 @@ def test_gc_loop_1():
     assert True
 
 
+@pytest.mark.long
 def test_gc_loop_2():
     r"""
     Stress test for garbage collection in libgap.
@@ -66,6 +68,7 @@ def test_gc_loop_2():
     assert result
 
 
+@pytest.mark.long
 def test_gc_loop_3():
     r"""
     Stress test for garbage collection in libgap.

--- a/src/sage/manifolds/differentiable/symplectic_form_test.py
+++ b/src/sage/manifolds/differentiable/symplectic_form_test.py
@@ -50,6 +50,7 @@ class TestGenericSymplecticForm:
         assert omega._poisson is None  # type: ignore reportPrivateUsage
 
 
+@pytest.mark.long
 class TestCoherenceOfFormulas:
     r"""
     Test correctness of the implementation, by checking that equivalent formulas give the correct result.

--- a/src/sage/rings/function_field/function_field_test.py
+++ b/src/sage/rings/function_field/function_field_test.py
@@ -82,6 +82,7 @@ pairs = [("J", None),
          ("S", 8)]
 
 
+@pytest.mark.long
 @pytest.mark.parametrize("ff,max_runs", pairs)
 def test_function_field_testsuite(ff, max_runs, request) -> None:
     r"""

--- a/src/sage/rings/padics/padic_lattice_element_test.py
+++ b/src/sage/rings/padics/padic_lattice_element_test.py
@@ -36,6 +36,7 @@ def R4():
 elements = ( "R1", "R2", "R3", "R4" )
 
 
+@pytest.mark.long
 @pytest.mark.parametrize("e", elements)
 def test_padic_lattice_element(e, request):
     r"""

--- a/src/sage/rings/valuation/mapped_valuation_test.py
+++ b/src/sage/rings/valuation/mapped_valuation_test.py
@@ -18,6 +18,7 @@ def w():
     return v.extensions(L)
 
 
+@pytest.mark.long
 @pytest.mark.parametrize("idx", [0,1])
 def test_finite_extension_from_limit_valuation_w(w, idx):
     r"""


### PR DESCRIPTION
Pytest is now invoked by `sage -t`, so it has become important to control when certain long-running tests get run. Here we add support for "long" and "longlong" tests, subsequently marking a few examples of these.

Tests marked "long" are run only with `sage -t --long`. Tests marked "longlong", on the other hand, are run only when pytest is invoked directly (i.e. not by `sage -t`). This should ensure that they are run on the CI, and can be run by hand, but not by mistake.

