### PR TITLE
exploit powersmoothness in EllipticCurveHom_fractional._eval()

### DIFF
--- a/src/sage/rings/generic.py
+++ b/src/sage/rings/generic.py
@@ -7,6 +7,7 @@ AUTHORS:
 """
 
 from sage.misc.misc_c import prod
+from sage.misc.cachefunc import cached_method
 
 
 class ProductTree:
@@ -202,7 +203,59 @@ class ProductTree:
             X = [X[i // 2] % V[i] for i in range(len(V))]
         return X
 
-    _crt_bases = None
+    @cached_method
+    def CRT_bases(self):
+        r"""
+        Return a tuple of tuples containing all CRT bases needed
+        to compute the :meth:`interpolation` from the roots of this
+        product tree to the root by following the tree structure.
+
+        In more detail, the return value is a three-fold nested
+        tuple ``msss`` such that:
+
+        - The tuple ``msss`` runs parallel to pairs of adjacent layers
+          of the tree, i.e., each of its entries corresponds to a layer
+          of "parents" and a layer of "children".
+
+        - Each tuple ``mss`` inside ``msss`` runs parallel to the parents
+          inside its associated pair of layers.
+
+        - Each tuple ``ms`` inside ``mss`` runs parallel to the children
+          of its associated parent.
+
+        ...and the following property holds: The entries of ``ms`` are
+        valid CRT coefficients for computing a CRT interpolation modulo
+        its associated children.
+
+        EXAMPLES::
+
+            sage: from sage.rings.generic import ProductTree
+            sage: tree = ProductTree([2,3,5,7])
+            sage: ms0, ms1 = tree.CRT_bases()
+            sage: tree.remainders(ms0[0][0])
+            [1, 0, 3, 3]
+            sage: tree.remainders(ms0[0][1])
+            [0, 1, 4, 4]
+            sage: tree.remainders(ms0[1][0])
+            [1, 0, 1, 0]
+            sage: tree.remainders(ms0[1][1])
+            [1, 0, 0, 1]
+            sage: tree.remainders(ms1[0][0] * ms0[0][0])
+            [1, 0, 0, 0]
+            sage: tree.remainders(ms1[0][0] * ms0[0][1])
+            [0, 1, 0, 0]
+            sage: tree.remainders(ms1[0][1] * ms0[1][0])
+            [0, 0, 1, 0]
+            sage: tree.remainders(ms1[0][1] * ms0[1][1])
+            [0, 0, 0, 1]
+        """
+        from sage.arith.misc import CRT_basis
+        # tuples all the way for immutability
+        bases = []
+        for V in self.layers[:-1]:
+            B = tuple(tuple(CRT_basis(V[i:i+2])) for i in range(0, len(V), 2))
+            bases.append(B)
+        return tuple(bases)
 
     def interpolation(self, xs):
         r"""
@@ -237,15 +290,10 @@ class ProductTree:
             sage: %timeit tree.interpolation(rs())  # not tested
             146 µs ± 479 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
         """
-        if self._crt_bases is None:
-            from sage.arith.misc import CRT_basis
-            self._crt_bases = []
-            for V in self.layers[:-1]:
-                B = tuple(CRT_basis(V[i:i+2]) for i in range(0, len(V), 2))
-                self._crt_bases.append(B)
+        bases = self.CRT_bases()
         if len(xs) != len(self.layers[0]):
             raise ValueError('number of given elements must equal the number of leaves')
-        for basis, layer in zip(self._crt_bases, self.layers[1:]):
+        for basis, layer in zip(bases, self.layers[1:]):
             xs = [sum(c*x for c, x in zip(cs, xs[2*i:2*i+2])) % mod
                   for i, (cs, mod) in enumerate(zip(basis, layer))]
         assert len(xs) == 1

--- a/src/sage/schemes/elliptic_curves/hom_fractional.py
+++ b/src/sage/schemes/elliptic_curves/hom_fractional.py
@@ -230,6 +230,22 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
             sage: phi._eval(Q)
             (z3^2 + 9*z3 : 10*z3^2 + 6*z3 + 10 : 1)
 
+        The complexity is generally determined by the size of the
+        prime *powers* in the denominator. For example, the following
+        works rather quickly::
+
+            sage: p = 419
+            sage: E = EllipticCurve(GF(p^2), [1,0])
+            sage: pi = E.frobenius_endomorphism()
+            sage: factor(p + 1)
+            2^2 * 3 * 5 * 7
+            sage: phi = (pi - 1) / (p + 1)
+            sage: Q = E(91, 129)
+            sage: phi(Q)
+            (91 : 290 : 1)
+
+        ALGORITHM: See [EPSV2023]_, p. 8, "Evaluating fractional isogenies".
+
         TESTS:
 
         Check for :issue:`41902`::
@@ -258,8 +274,27 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
         if not P:
             return self._codomain.base_extend(F).zero()
 
-        P = P.divide(self._d, extend=True)
-        Q = self._phi._eval(P).change_ring(F)
+        n = P.order()
+        t = self._d
+        u = t.prime_to_m_part(n)
+        if u == t:
+            Q = t.inverse_mod(n) * self._phi._eval(P)
+        else:
+            ls = t.prime_divisors()
+            qs = [l**t.valuation(l) for l in ls]
+            ms = [l**n.valuation(l) for l in ls]
+            ms[0] *= n.prime_to_m_part(t)
+            Ts = [P]
+            from sage.rings.generic import ProductTree
+            for bas in ProductTree(ms).CRT_bases()[::-1]:
+                Ts = [k * T for (vec, T) in zip(bas, Ts) for k in vec]
+            # now sum(Ts) == P and each T has the corresponding order m
+
+            Q = self._codomain.base_extend(F).zero()
+            for q, m, T in zip(qs, ms, Ts):
+                T = T.divide(q, extend=True)
+                k = (t // q).inverse_mod(m)
+                Q += k * self._phi._eval(T).change_ring(F)
 
         return self._codomain.base_extend(F)(*Q)
 


### PR DESCRIPTION
...which minimizes the size of the field extensions involved and is the asymptotically correct thing to do.

The example from the new doctest takes about 12 seconds before this patch, and less than half a second afterwards.