### PR TITLE
Fix wrong parameter for non-editible install in spkg-install.in

### DIFF
--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -75,7 +75,7 @@ else
     sdh_pip_install --no-build-isolation . --config-setting=build-dir="build/sage-distro" \
         --config-setting=setup-args="-DSAGE_LOCAL=$SAGE_LOCAL" \
         --config-setting=setup-args="-Dbuild-docs=$SAGE_BUILD_DOCS" \
-        --config-settings=setup-args="-Ddefer_feature_checks=true"
+        --config-setting=setup-args="-Ddefer_feature_checks=true"
 fi
 
 # Remove (potentially invalid) star import caches.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
```
#29 10723.5 [sagelib-10.10.beta1] [spkg-install] usage: python -m build [-h] [--version] [--quiet | --verbose] [--outdir PATH]
#29 10723.5 [sagelib-10.10.beta1] [spkg-install]                        [--sdist] [--wheel] [--metadata]
#29 10723.5 [sagelib-10.10.beta1] [spkg-install]                        [--config-setting KEY[=VALUE] | --config-json
#29 10723.5 [sagelib-10.10.beta1] [spkg-install]                        JSON_STRING] [--installer {pip,uv} | --no-isolation]
#29 10723.5 [sagelib-10.10.beta1] [spkg-install]                        [--dependency-constraints-txt PATH]
#29 10723.5 [sagelib-10.10.beta1] [spkg-install]                        [--skip-dependency-check]
#29 10723.5 [sagelib-10.10.beta1] [spkg-install]                        [srcdir]
#29 10723.5 [sagelib-10.10.beta1] [spkg-install] python -m build: error: unrecognized arguments: --config-settings=setup-args=-Ddefer_feature_checks=true
```


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


