### PR TITLE
fix the -> Family annotations

### DIFF
--- a/src/sage/algebras/clifford_algebra.py
+++ b/src/sage/algebras/clifford_algebra.py
@@ -36,7 +36,7 @@ from sage.rings.noncommutative_ideals import Ideal_nc
 from sage.modules.free_module import FreeModule, FreeModule_generic
 from sage.matrix.constructor import Matrix
 from sage.matrix.args import MatrixArgs
-from sage.sets.family import Family
+from sage.sets.family import Family, AbstractFamily
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.quadratic_forms.quadratic_form import QuadraticForm
 from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
@@ -801,7 +801,7 @@ class CliffordAlgebra(CombinatorialFreeModule):
         """
         return self._from_dict({FrozenBitset((i,)): self.base_ring().one()}, remove_zeros=False)
 
-    def algebra_generators(self) -> Family:
+    def algebra_generators(self) -> AbstractFamily:
         """
         Return the algebra generators of ``self``.
 

--- a/src/sage/algebras/jordan_algebra.py
+++ b/src/sage/algebras/jordan_algebra.py
@@ -24,7 +24,7 @@ from sage.misc.cachefunc import cached_method
 from sage.structure.element import Matrix
 from sage.modules.free_module import FreeModule
 from sage.matrix.constructor import matrix
-from sage.sets.family import Family
+from sage.sets.family import Family, AbstractFamily
 
 
 class JordanAlgebra(UniqueRepresentation, Parent):
@@ -326,7 +326,7 @@ class SpecialJordanAlgebra(JordanAlgebra):
         return self.element_class(self, self._A.an_element())
 
     @cached_method
-    def basis(self) -> Family:
+    def basis(self) -> AbstractFamily:
         """
         Return the basis of ``self``.
 
@@ -805,7 +805,7 @@ class JordanAlgebraSymmetricBilinear(JordanAlgebra):
         return self._generic_coerce_map(self.base_ring())
 
     @cached_method
-    def basis(self) -> Family:
+    def basis(self) -> AbstractFamily:
         """
         Return a basis of ``self``.
 
@@ -1350,7 +1350,7 @@ class ExceptionalJordanAlgebra(JordanAlgebra):
                     tester.assertEqual(val.imag_part(), zerO)
 
     @cached_method
-    def basis(self) -> Family:
+    def basis(self) -> AbstractFamily:
         r"""
         Return a basis of ``self``.
 

--- a/src/sage/algebras/lie_conformal_algebras/freely_generated_lie_conformal_algebra.py
+++ b/src/sage/algebras/lie_conformal_algebras/freely_generated_lie_conformal_algebra.py
@@ -22,7 +22,7 @@ from sage.algebras.lie_conformal_algebras.lie_conformal_algebra_with_basis impor
 from sage.categories.cartesian_product import cartesian_product
 from sage.rings.integer import Integer
 from sage.sets.disjoint_union_enumerated_sets import DisjointUnionEnumeratedSets
-from sage.sets.family import Family
+from sage.sets.family import Family, AbstractFamily
 from sage.sets.non_negative_integers import NonNegativeIntegers
 
 
@@ -89,7 +89,7 @@ class FreelyGeneratedLieConformalAlgebra(LieConformalAlgebraWithBasis):
             return tuple(F)
         return F
 
-    def central_elements(self) -> Family:
+    def central_elements(self) -> AbstractFamily:
         """
         The central generators of this Lie conformal algebra.
 

--- a/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
+++ b/src/sage/algebras/lie_conformal_algebras/lie_conformal_algebra_with_structure_coefs.py
@@ -25,7 +25,7 @@ from sage.algebras.lie_conformal_algebras.lie_conformal_algebra_element import (
 from sage.arith.misc import binomial
 from sage.categories.lie_conformal_algebras import LieConformalAlgebras
 from sage.sets.disjoint_union_enumerated_sets import DisjointUnionEnumeratedSets
-from sage.sets.family import Family
+from sage.sets.family import Family, AbstractFamily
 from sage.structure.indexed_generators import (
     IndexedGenerators,
     standardize_names_index_set,
@@ -291,7 +291,7 @@ class LieConformalAlgebraWithStructureCoefficients(
         self._parity = dict(zip(self.gens(),
                                 parity + (0,) * len(central_elements)))
 
-    def structure_coefficients(self) -> Family:
+    def structure_coefficients(self) -> AbstractFamily:
         """
         The structure coefficients of this Lie conformal algebra.
 

--- a/src/sage/algebras/quantum_matrix_coordinate_algebra.py
+++ b/src/sage/algebras/quantum_matrix_coordinate_algebra.py
@@ -18,7 +18,7 @@ AUTHORS:
 
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_attribute import lazy_attribute
-from sage.sets.family import Family
+from sage.sets.family import Family, AbstractFamily
 from sage.categories.algebras import Algebras
 from sage.categories.bialgebras import Bialgebras
 from sage.categories.hopf_algebras import HopfAlgebras
@@ -584,7 +584,7 @@ class QuantumMatrixCoordinateAlgebra(QuantumMatrixCoordinateAlgebra_abstract):
         return self._m
 
     @cached_method
-    def algebra_generators(self) -> Family:
+    def algebra_generators(self) -> AbstractFamily:
         """
         Return the algebra generators of ``self``.
 

--- a/src/sage/algebras/steenrod/steenrod_algebra.py
+++ b/src/sage/algebras/steenrod/steenrod_algebra.py
@@ -457,7 +457,7 @@ from sage.categories.tensor import tensor
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_attribute import lazy_attribute
-from sage.sets.family import Family
+from sage.sets.family import Family, AbstractFamily
 
 ######################################################
 # the main class
@@ -2635,7 +2635,7 @@ class SteenrodAlgebra_generic(CombinatorialFreeModule):
             return sum(self._profile)
         return sum(self._profile[0]) + len([a for a in self._profile[1] if a == 2])
 
-    def gens(self) -> Family:
+    def gens(self) -> AbstractFamily:
         r"""
         Family of generators for this algebra.
 

--- a/src/sage/monoids/indexed_free_monoid.py
+++ b/src/sage/monoids/indexed_free_monoid.py
@@ -29,7 +29,7 @@ from sage.categories.sets_cat import Sets
 from sage.rings.integer import Integer
 from sage.rings.infinity import infinity
 from sage.rings.integer_ring import ZZ
-from sage.sets.family import Family
+from sage.sets.family import Family, AbstractFamily
 
 
 class IndexedMonoidElement(MonoidElement):
@@ -845,7 +845,7 @@ class IndexedMonoid(Parent, IndexedGenerators, UniqueRepresentation):
         return infinity
 
     @cached_method
-    def monoid_generators(self) -> Family:
+    def monoid_generators(self) -> AbstractFamily:
         """
         Return the monoid generators of ``self``.
 

--- a/src/sage/rings/polynomial/integer_valued_polynomials.py
+++ b/src/sage/rings/polynomial/integer_valued_polynomials.py
@@ -25,7 +25,7 @@ from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.polynomial_ring import polygen
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.rational_field import QQ
-from sage.sets.family import Family
+from sage.sets.family import Family, AbstractFamily
 from sage.sets.non_negative_integers import NonNegativeIntegers
 from sage.structure.parent import Parent
 from sage.structure.unique_representation import UniqueRepresentation
@@ -262,7 +262,7 @@ class IntegerValuedPolynomialRing(UniqueRepresentation, Parent):
                 return self.algebra_generators()[0]
 
             @cached_method
-            def algebra_generators(self) -> Family:
+            def algebra_generators(self) -> AbstractFamily:
                 r"""
                 Return the generators of this algebra.
 


### PR DESCRIPTION
to use the class `AbstractFamily` instead, as  `Family` is just a function.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.

