### PR TITLE
New "minimal" CI job

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -1,0 +1,154 @@
+name: Build & Test with all meson features disabled
+
+# TODO:
+#
+#   * -Dbrial=disabled
+#   * -Declib=disabled
+#   * -Dauto_features=disabled (when all others are working)
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+  workflow_dispatch:
+    # Allow to run manually
+
+concurrency:
+  # Cancel previous runs of this workflow for the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Conda minimal (${{ matrix.os }}, Python ${{ matrix.python }}, all)
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu']
+        python: ['3.14']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Merge CI fixes from sagemath/sage
+        run: |
+          .github/workflows/merge-fixes.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Cache conda packages
+        uses: actions/cache@v4
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ hashFiles('environment-3.12-linux.yml') }}
+
+      - name: Compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-meson-${{ matrix.python }}-minimal
+
+      - name: Setup Conda environment
+        uses: conda-incubator/setup-miniconda@v3
+        continue-on-error: true
+        id: conda1
+        with:
+          python-version: ${{ matrix.python }}
+          # Disabled for now due to
+          # https://github.com/conda-incubator/setup-miniconda/issues/379
+          # miniforge-version: latest
+          use-mamba: true
+          channels: conda-forge
+          channel-priority: true
+          activate-environment: sage-dev
+          environment-file: environment-${{ matrix.python }}-linux.yml
+
+      # Sometimes the conda setup fails due to network issues.
+      # This is a workaround to retry the setup step if it fails.
+      # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/129
+      - name: Setup Conda environment (2nd time)
+        uses: conda-incubator/setup-miniconda@v3
+        if: steps.conda1.outcome == 'failure'
+        with:
+          python-version: ${{ matrix.python }}
+          miniforge-version: latest
+          use-mamba: true
+          channels: conda-forge
+          channel-priority: true
+          activate-environment: sage-dev
+          environment-file: environment-${{ matrix.python }}-linux.yml
+
+
+      - name: Print Conda environment
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+
+      - name: Build
+        shell: bash -l {0}
+        run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export CC="ccache $CC"
+          export CXX="ccache $CXX"
+
+          meson setup --python.install-env=prefix --prefix="${HOME}/.local" --wrap-mode=nodownload -Dbuild-docs=false -Dbliss=disabled -Dcoxeter3=disabled -Dlibhomfly=disabled -Dmcqd=disabled -Dmeataxe=disabled -Drankwidth=disabled -Dsirocco=disabled -Dtdlib=disabled builddir
+          meson install -C builddir
+
+      - name: Check that all modules can be imported
+        shell: bash -l {0}
+        run: |
+          # We want pytest to ignore sage_setup and sage_docbuild when
+          # they are not installed (not able to be imported). We also
+          # kill src/build-docs.py because it is used to build the
+          # docs and thus imports sage_docbuild.
+          rm -R src/sage_setup src/sage_docbuild src/build-docs.py
+
+          # Increase the length of the lines in the "short summary"
+          export COLUMNS=120
+
+          # The following command checks that all modules can be imported.
+          # The output also includes a long list of modules together with
+          # the number of tests in each module (this can be ignored).
+          # We do this before the "Test" step because we delete two
+          # modules with flaky tests in that step, but we'd still like
+          # to make sure that pytest can import them.
+          pytest -n 4 -qq --doctest --collect-only
+
+      - name: Test
+        shell: bash -l {0}
+        run: |
+          pytest -n 4 -rfEs -s src
+
+          # These modules have flaky tests, and don't use any optional
+          # features in any case.
+          rm src/sage/libs/singular/function.pyx
+          rm src/sage/rings/polynomial/plural.pyx
+
+          # These are all sage-the-distro scripts, and at least one
+          # is so bit-rotted that it can't be imported.
+          rm -R src/bin
+
+          # Two failures (GH issue 39872) that should be fixed in
+          # the (as yet unreleased) cython-3.3. Not worth losing
+          # sleep over at the moment.
+          rm src/sage/misc/sageinspect.py
+
+          # Hides a spurious warning that breaks a doctest
+          export PYDEVD_DISABLE_FILE_VALIDATION=1
+
+          python3 -m sage.doctest -p4 --format github src
+
+      - name: Upload log
+        uses: actions/upload-artifact@v4.5.0
+        if: failure()
+        with:
+          name: ${{ runner.os }}-meson-${{ matrix.python }}-minimal-log
+          path: builddir/meson-logs/

--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -85,6 +85,15 @@ jobs:
           activate-environment: sage-dev
           environment-file: environment-${{ matrix.python }}-linux.yml
 
+      # Build without the packages whose support we are disabling, to
+      # be on the safe side. The -Dfoo=disabled option is an off switch
+      # for sage.features.foo, but it's possible that some parts of the
+      # code are bypassing the feature framework and e.g. attempting
+      # to detect an optional package with an import statement. We want
+      # those to fail as well.
+      - name: Remove optional packages from Conda environment
+        shell: bash -l {0}
+        run: conda remove bliss libhomfly rw sirocco
 
       - name: Print Conda environment
         shell: bash -l {0}

--- a/src/sage/algebras/hecke_algebras/cubic_hecke_algebra.py
+++ b/src/sage/algebras/hecke_algebras/cubic_hecke_algebra.py
@@ -545,6 +545,8 @@ class CubicHeckeElement(CombinatorialFreeModule.Element):
             sage: sup = mt3_1.support()
             sage: u, v, w, s = mt3_1.base_ring().gens()
             sage: LK3_1 = mt3_1*s**-3 # since the writhe of K3_1 is 3
+
+            sage: # needs libhomfly
             sage: f = MT.specialize_homfly()
             sage: g = sum(f(LK3_1.coefficient(b)) * b.regular_homfly_polynomial() for b in sup); g
             L^-2*M^2 - 2*L^-2 - L^-4

--- a/src/sage/algebras/hecke_algebras/cubic_hecke_base_ring.py
+++ b/src/sage/algebras/hecke_algebras/cubic_hecke_base_ring.py
@@ -1317,6 +1317,7 @@ class CubicHeckeRingOfDefinition(Localization):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: from sage.knots.knotinfo import KnotInfo
             sage: CHA2 = algebras.CubicHecke(2)
             sage: K5_1 = KnotInfo.K5_1.link()

--- a/src/sage/databases/cubic_hecke_db.py
+++ b/src/sage/databases/cubic_hecke_db.py
@@ -497,6 +497,7 @@ class MarkovTraceModuleBasis(Enum):
 
         EXAMPLES::
 
+            sage: # needs libhomfly
             sage: from sage.databases.cubic_hecke_db import MarkovTraceModuleBasis
             sage: MarkovTraceModuleBasis.U1.regular_homfly_polynomial()
             1

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -2860,13 +2860,12 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
         """
         tester = options['tester']
         max_samples = tester._max_samples
-        try:
+        from sage.features.libhomfly import Libhomfly
+        if Libhomfly().is_present():
             if max_samples:
                 tester.assertTrue(self.is_recoverable(unique=False, max_samples=max_samples))
             else:
                 tester.assertTrue(self.is_recoverable(unique=False))
-        except ImportError:
-            pass
 
     def inject(self, verbose=True):
         r"""

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -3349,6 +3349,12 @@ class Link(SageObject):
                 s += ' {} {}'.format(abs(cr) - 1, sign(cr))
         for i, cr in enumerate(ogc[1]):
             s += ' {} {}'.format(i, cr)
+
+        # Raise a more informative error if libhomfly is not available
+        # or was disabled.
+        from sage.features.libhomfly import Libhomfly
+        Libhomfly().require()
+
         from sage.libs.homfly import homfly_polynomial_dict
         dic = homfly_polynomial_dict(s)
         if normalization == 'lm':


### PR DESCRIPTION
Add a "minimal" CI job that...

* Builds with `meson setup` and `meson install` rather than `pip install`.
* Disables the documentation (`-Dbuild-docs=false`)
* Disables bliss, coxeter3, libhomfly, mcqd, meataxe, rankwidth, sirocco, and tdlib (`-Dfeature=disabled`)
* Leaves brial and eclib enabled for now due to failing tests (missing features and "needs" tags). When these are working, we can replace the list of individual options with `-Dauto_features=disabled`.

**Dependencies**
1. https://github.com/sagemath/sage/pull/42198
2. https://github.com/sagemath/sage/pull/42237 (positive review)
3. https://github.com/sagemath/sage/pull/42247

**Closes**
1. https://github.com/sagemath/sage/issues/42091