### PR TITLE
Add reference to SageMath AppImage in installation documentation

### DIFF
--- a/src/doc/en/installation/index.rst
+++ b/src/doc/en/installation/index.rst
@@ -74,7 +74,7 @@ options below to find instructions for your operating system.
     version of SageMath is only available on a newer version of the
     distribution, consider upgrading your distribution.
 
-    Alternatively, an independent project provides a `SageMath AppImage <https://github.com/3-manifolds/sage_appimage>`.
+    Alternatively, the 3-manifolds project provides a `SageMath AppImage <https://github.com/3-manifolds/sage_appimage>`.
     It provides a self-contained binary distribution of SageMath that should be able to run on a wide variety of Linux
     systems. Beware that it is not packaged with Cython, so building certain sagemath programs or installing certain
     optional packages is not possible.

--- a/src/doc/en/installation/index.rst
+++ b/src/doc/en/installation/index.rst
@@ -12,6 +12,12 @@ If you are planning to do development on SageMath, please refer instead to the
 `Sage Developer's Guide <../developer/walkthrough.html>`_ for instructions on
 obtaining the source code and building SageMath.
 
+Local installation options
+==========================
+
+Depending on your operating system, various installation options are available. Select from the
+options below to find instructions for your operating system.
+
 .. tab:: Linux
 
   .. tab:: Conda
@@ -67,6 +73,11 @@ obtaining the source code and building SageMath.
     If you are on an older version of your distribution and a recent
     version of SageMath is only available on a newer version of the
     distribution, consider upgrading your distribution.
+
+    Alternatively, an independent project provides a `SageMath AppImage <https://github.com/3-manifolds/sage_appimage>`.
+    It provides a self-contained binary distribution of SageMath that should be able to run on a wide variety of Linux
+    systems. Beware that it is not packaged with Cython, so building certain sagemath programs or installing certain
+    optional packages is not possible.
 
 .. tab:: macOS 
 

--- a/src/doc/en/installation/index.rst
+++ b/src/doc/en/installation/index.rst
@@ -74,7 +74,7 @@ options below to find instructions for your operating system.
     version of SageMath is only available on a newer version of the
     distribution, consider upgrading your distribution.
 
-    Alternatively, the 3-manifolds project provides a `SageMath AppImage <https://github.com/3-manifolds/sage_appimage>`.
+    Alternatively, the 3-manifolds project provides a `SageMath AppImage <https://github.com/3-manifolds/sage_appimage>`_.
     It provides a self-contained binary distribution of SageMath that should be able to run on a wide variety of Linux
     systems. Beware that it is not packaged with Cython, so building certain sagemath programs or installing certain
     optional packages is not possible.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

3-manifolds has a consistent track record now of maintaining up-to-date AppImages of sagemath for linux. It provides a very good backup strategy for installing sage in cases where other options fail or are too bothersome. We add a link so that users can be informed of the option.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


