### PR TITLE
Default to Accelerate BLAS on modern macOS

### DIFF
--- a/build/pkgs/openblas/spkg-configure.m4
+++ b/build/pkgs/openblas/spkg-configure.m4
@@ -18,6 +18,8 @@ SAGE_SPKG_CONFIGURE([openblas], [dnl CHECK
     PKG_CHECK_MODULES([OPENBLAS], [openblas >= ]SAGE_OPENBLAS_MIN_VERSION [openblas < ]SAGE_OPENBLAS_LT_VERSION, [dnl Have openblas.pc
       LIBS="$OPENBLAS_LIBS $LIBS"
       CFLAGS="$OPENBLAS_CFLAGS $CFLAGS"
+      OPENBLAS_VERSION=`$PKG_CONFIG --modversion openblas 2>/dev/null`
+      AS_IF([test x"$OPENBLAS_VERSION" = x], [OPENBLAS_VERSION=]SAGE_OPENBLAS_MIN_VERSION)
       PKG_CHECK_VAR([OPENBLASPCDIR], [openblas], [pcfiledir], [dnl
         sage_install_blas_pc=yes
         AC_CHECK_FUNC([cblas_dgemm], [dnl openblas works as cblas
@@ -57,7 +59,32 @@ SAGE_SPKG_CONFIGURE([openblas], [dnl CHECK
       ])
       AS_IF([test x$sage_spkg_install_openblas != xyes], [dnl
         AC_SUBST([SAGE_SYSTEM_FACADE_PC_FILES])
-        AC_SUBST([SAGE_OPENBLAS_PC_COMMAND], ["\$(LN) -sf \"$OPENBLASPCDIR/openblas.pc\" \"\$(@)\""])
+        AS_CASE([$host],
+          [*-*-darwin*], [dnl
+            dnl Homebrew OpenBLAS on macOS can publish OpenMP compile flags in
+            dnl openblas.pc.  BLAS consumers do not need these flags, and they
+            dnl break packages that use Apple clang but do not enable OpenMP.
+            SAGE_OPENBLAS_CFLAGS=
+            sage_openblas_deferred_xpreprocessor=no
+            for sage_openblas_cflag in $OPENBLAS_CFLAGS; do
+              AS_IF([test x$sage_openblas_deferred_xpreprocessor = xyes], [
+                sage_openblas_deferred_xpreprocessor=no
+                AS_IF([test x"$sage_openblas_cflag" = x-fopenmp], [continue])
+                AS_VAR_APPEND([SAGE_OPENBLAS_CFLAGS], [" -Xpreprocessor"])
+              ])
+              AS_CASE([$sage_openblas_cflag],
+                [-Xpreprocessor], [sage_openblas_deferred_xpreprocessor=yes],
+                [-Xpreprocessor=-fopenmp|-Wp,-fopenmp|-fopenmp|-fopenmp=*], [],
+                [AS_VAR_APPEND([SAGE_OPENBLAS_CFLAGS], [" $sage_openblas_cflag"])])
+            done
+            AS_IF([test x$sage_openblas_deferred_xpreprocessor = xyes],
+                  [AS_VAR_APPEND([SAGE_OPENBLAS_CFLAGS], [" -Xpreprocessor"])])
+            PKG_CHECK_VAR([OPENBLAS_PREFIX], [openblas], [prefix])
+            PKG_CHECK_VAR([OPENBLAS_LIBDIR], [openblas], [libdir])
+            PKG_CHECK_VAR([OPENBLAS_INCLUDEDIR], [openblas], [includedir])
+            AC_SUBST([SAGE_OPENBLAS_PC_COMMAND], ["(pc_name=\`basename \"\$(@)\" .pc\`; echo \"prefix=$OPENBLAS_PREFIX\"; echo \"libdir=$OPENBLAS_LIBDIR\"; echo \"includedir=$OPENBLAS_INCLUDEDIR\"; echo \"Name: \$pc_name\"; echo \"Description: OpenBLAS BLAS/LAPACK facade for SageMath\"; echo \"Version: $OPENBLAS_VERSION\"; echo \"Cflags: $SAGE_OPENBLAS_CFLAGS\"; echo \"Libs: $OPENBLAS_LIBS\") > \"\$(@)\""])
+          ],
+          [AC_SUBST([SAGE_OPENBLAS_PC_COMMAND], ["\$(LN) -sf \"$OPENBLASPCDIR/openblas.pc\" \"\$(@)\""])])
         m4_foreach([blaslibnam], [blas, cblas, lapack], [dnl
           AS_IF([test x$sage_install_]blaslibnam[_pc = xyes], [dnl
              AS_VAR_APPEND([SAGE_SYSTEM_FACADE_PC_FILES], [" \$(SAGE_PKGCONFIG)/]blaslibnam[.pc"])

--- a/configure.ac
+++ b/configure.ac
@@ -341,21 +341,51 @@ m4_pushdef([SAGE_BOOTSTRAP_URL],[See https://doc.sagemath.org/html/en/reference/
     ], [AC_MSG_ERROR([could not find bzlib.h - the header of libbz2 library. $SAGE_PREREQ_URL])
    ])
 
-# choose BLAS/LAPACK on Darwin
+# Choose BLAS/LAPACK on Darwin.  Accelerate is reliable enough on
+# macOS 13.3 and newer, and avoids Homebrew OpenBLAS OpenMP flags that
+# Apple clang cannot use directly.
 AC_ARG_WITH([darwin-accelerate],
-            [AS_HELP_STRING([--with-darwin-accelerate={no (default)},yes}],
-                            [use Darwin (macOS) Accelerate BLAS/LAPACK])],
+            [AS_HELP_STRING([--with-darwin-accelerate={auto (default),yes,no}],
+                            [use Darwin (macOS) Accelerate BLAS/LAPACK; auto enables it on macOS 13.3 or newer])],
             [SAGE_DARWIN_ACCELERATE="$withval"],
-            [SAGE_DARWIN_ACCELERATE="no"])
+            [SAGE_DARWIN_ACCELERATE="auto"])
 AC_SUBST([SAGE_DARWIN_ACCELERATE])
 
 SAGE_DARWIN_PKG_CONFIG_PATH=
 case $host in
     *-*-darwin*)
-   AS_IF([test x$SAGE_DARWIN_ACCELERATE = xyes],
-    [SAGE_DARWIN_PKG_CONFIG_PATH=`pwd`"/build/platform/darwin/accelerate/pkgconfig:"])
+      AS_CASE([$SAGE_DARWIN_ACCELERATE],
+        [yes|no], [],
+        [auto], [
+          sage_darwin_version=${host_os#darwin}
+          sage_darwin_major=${sage_darwin_version%%.*}
+          sage_darwin_minor=${sage_darwin_version#*.}
+          sage_darwin_minor=${sage_darwin_minor%%.*}
+          AS_IF([test x"$sage_darwin_minor" = x"$sage_darwin_version"],
+                [sage_darwin_minor=0])
+          case $sage_darwin_major,$sage_darwin_minor in
+            *[[!0-9]]*,*|*,*[[!0-9]]*)
+              SAGE_DARWIN_ACCELERATE=no
+              ;;
+            *)
+              AS_IF([test "$sage_darwin_major" -gt 22 \
+                     || { test "$sage_darwin_major" -eq 22 && test "$sage_darwin_minor" -ge 4; }],
+                    [SAGE_DARWIN_ACCELERATE=yes],
+                    [SAGE_DARWIN_ACCELERATE=no])
+              ;;
+          esac
+        ],
+        [AC_MSG_ERROR([--with-darwin-accelerate must be yes, no, or auto])])
+      AS_IF([test x$SAGE_DARWIN_ACCELERATE = xyes],
+        [SAGE_DARWIN_PKG_CONFIG_PATH=`pwd`"/build/platform/darwin/accelerate/pkgconfig:"])
     ;;
     *)
+      AS_CASE([$SAGE_DARWIN_ACCELERATE],
+        [yes], [AC_MSG_ERROR([--with-darwin-accelerate is only supported on Darwin/macOS])],
+        [auto], [SAGE_DARWIN_ACCELERATE=no],
+        [no], [],
+        [AC_MSG_ERROR([--with-darwin-accelerate must be yes, no, or auto])])
+      ;;
 esac
 
 # Check for zlib

--- a/src/doc/en/installation/source-distro.rst
+++ b/src/doc/en/installation/source-distro.rst
@@ -253,6 +253,10 @@ Sage, run ::
 command like this to your shell profile if you want the settings to
 persist between shell sessions.
 
+On macOS 13.3 or newer, the classical ``./configure && make`` build uses
+Apple's Accelerate BLAS/LAPACK by default. To force Sage to use OpenBLAS
+instead, configure with ``--with-darwin-accelerate=no``.
+
 If you wish to do Sage development, we recommend that you additionally
 install the following:
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Fixes #42096.

On macOS with many Homebrew packages installed, Sage can pick up Homebrew
OpenBLAS by default. Recent Homebrew OpenBLAS publishes OpenMP-related compiler
flags through `openblas.pc`, for example `-Xpreprocessor -fopenmp`. These flags
then flow through Sage's generated BLAS facade files into packages such as
FFLAS-FFPACK.

This causes a build failure with Apple clang. FFLAS-FFPACK receives the OpenBLAS
Cflags via `--with-blas-cflags`, and its libtool link step later turns the
Darwin-specific OpenMP spelling into a bare `-fopenmp`, which Apple clang rejects
with:

```text
clang++: error: unsupported option '-fopenmp'
```

The issue is avoided when configuring with `--with-darwin-accelerate`, because
Sage then uses Apple's Accelerate BLAS/LAPACK framework instead of Homebrew
OpenBLAS for the BLAS facade.

This PR changes the Darwin BLAS selection so that:

- `--with-darwin-accelerate` now defaults to `auto`;
- `auto` enables Accelerate on macOS 13.3 or newer, where Accelerate is suitable
  for this use;
- explicit `--with-darwin-accelerate=no` still forces the previous OpenBLAS path;
- on Darwin, Sage-generated OpenBLAS facade `.pc` files filter OpenMP compile
  flags out of OpenBLAS Cflags, so BLAS consumers do not inherit flags they did
  not ask for;
- the macOS source-build documentation mentions the new default and the opt-out
  flag.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


