### PR TITLE
Improve the portability of two doctests

### DIFF
--- a/src/sage/repl/configuration.py
+++ b/src/sage/repl/configuration.py
@@ -6,12 +6,13 @@ TESTS:
 We check that Sage stdin can be piped in even if stdout is a tty; In that case
 the IPython simple prompt is being used::
 
+    sage: # needs pexpect
     sage: cmd = 'print([sys.stdin.isatty(), sys.stdout.isatty()])'
-    sage: import pexpect                                                                # needs pexpect
-    sage: output = pexpect.run(                                                         # needs pexpect
-    ....:     'bash -c \'echo "{0}" | sage\''.format(cmd),
+    sage: import pexpect
+    sage: output = pexpect.run(
+    ....:     f'sh -c \'echo "{cmd}" | python3 -m sage.cli\''
     ....: ).decode('utf-8', 'surrogateescape')
-    sage: 'sage: [False, True]' in output                                               # needs pexpect
+    sage: 'sage: [False, True]' in output
     True
 """
 # ****************************************************************************

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -723,7 +723,7 @@ def get_test_shell():
 
         sage: from sage.tests import check_executable
         sage: cmd = 'from sage.repl.interpreter import get_test_shell; shell = get_test_shell()'
-        sage: (out, err, ret) = check_executable(["sage", "-c", cmd])
+        sage: (out, err, ret) = check_executable(["python3", "-m", "sage.cli", "-c", cmd])
         sage: out + err
         ''
     """


### PR DESCRIPTION
Use `python3 -m sage.cli` instead of `sage` to support pure-meson installs, and POSIX sh instead of bash when the latter is overkill.
