### PR TITLE
Fix infinite polynomial coefficient coercion

### DIFF
--- a/src/sage/rings/polynomial/infinite_polynomial_element.py
+++ b/src/sage/rings/polynomial/infinite_polynomial_element.py
@@ -1487,6 +1487,8 @@ class InfinitePolynomial_sparse(InfinitePolynomial):
             sage: X.<x> = InfinitePolynomialRing(QQ, implementation='sparse')
             sage: x[10]._common_polynomial_ring(x[5])
             Multivariate Polynomial Ring in x_10, x_5, x_0 over Rational Field
+            sage: (x[10] + x[2])._common_polynomial_ring(x[5])
+            Multivariate Polynomial Ring in x_10, x_5, x_2, x_0 over Rational Field
         """
         VarList = set(self._p.parent().variable_names())
         VarList.update(x._p.parent().variable_names())
@@ -1894,10 +1896,20 @@ class InfinitePolynomial_sparse(InfinitePolynomial):
             sage: R.<a> = InfinitePolynomialRing(QQ, implementation="sparse")
             sage: P.<x> = LazyPowerSeriesRing(R)
             sage: f1 = P(lambda n: -a[n] if n else 1)
-            sage: diff(log(f1))[3]
+            sage: q = diff(log(f1))[3]; q
             -4*a_4 - 4*a_3*a_1 - 2*a_2^2 - 4*a_2*a_1^2 - a_1^4
-            sage: diff(log(f1))[3].coefficient(a[3]*a[1])
+            sage: q.coefficient(a[4])
             -4
+            sage: q.coefficient(a[3])
+            -4*a_1
+            sage: q.coefficient(a[3]*a[1])
+            -4
+            sage: q.coefficient({a[3]: 1, a[1]: 1})
+            -4
+            sage: q.monomial_coefficient(a[3]*a[1])
+            -4
+            sage: q.coefficient(a[5])
+            0
         """
         if isinstance(x, dict):
             if x:
@@ -1908,9 +1920,9 @@ class InfinitePolynomial_sparse(InfinitePolynomial):
 
             return self
 
-        try:
+        if self._p.parent() is x._p.parent():
             result = self._p.coefficient(x._p)
-        except TypeError:
+        else:
             R = self._common_polynomial_ring(x)
             result = R(self._p).coefficient(R(x._p))
 
@@ -2275,10 +2287,20 @@ class InfinitePolynomial_dense(InfinitePolynomial):
             sage: R.<a> = InfinitePolynomialRing(QQ)
             sage: P.<x> = LazyPowerSeriesRing(R)
             sage: f1 = P(lambda n: -a[n] if n else 1)
-            sage: diff(log(f1))[3]
+            sage: q = diff(log(f1))[3]; q
             -4*a_4 - 4*a_3*a_1 - 2*a_2^2 - 4*a_2*a_1^2 - a_1^4
-            sage: diff(log(f1))[3].coefficient(a[3]*a[1])
+            sage: q.coefficient(a[4])
             -4
+            sage: q.coefficient(a[3])
+            -4*a_1
+            sage: q.coefficient(a[3]*a[1])
+            -4
+            sage: q.coefficient({a[3]: 1, a[1]: 1})
+            -4
+            sage: q.monomial_coefficient(a[3]*a[1])
+            -4
+            sage: q.coefficient(a[5])
+            0
         """
         P = self.parent()
         if not self._p:

--- a/src/sage/rings/polynomial/infinite_polynomial_element.py
+++ b/src/sage/rings/polynomial/infinite_polynomial_element.py
@@ -1445,35 +1445,89 @@ class InfinitePolynomial_sparse(InfinitePolynomial):
             sage: a(x_1=M)                                                              # needs sage.modules
             [x_0 + 1       1]
             [      2     x_0]
+
+        TESTS:
+
+        Check that :issue:`40504` is fixed: the common ring must include all
+        variable names of every involved backend ring, not only those that
+        physically appear in the polynomials::
+
+            sage: X.<x> = InfinitePolynomialRing(QQ, implementation='sparse')
+            sage: p = x[1] + x[3]
+            sage: p(x_3=x[7])
+            x_7 + x_1
+            sage: p(x_3=x[7] + 1)
+            x_7 + x_1 + 1
+
+        Positional substitution still counts only the variables that actually
+        occur in ``self``::
+
+            sage: x[3](2)
+            2
+            sage: p(2, 3)
+            5
+            sage: p([2, 3])
+            5
+
+        A constant polynomial is unaffected by any call::
+
+            sage: c = X(5)
+            sage: c()
+            5
+            sage: c(2, 3)
+            5
+            sage: c(x_3=2)
+            5
+            sage: c(x_3=x[5])
+            5
         """
-        # Replace any InfinitePolynomials by their underlying polynomials
-        if hasattr(self._p, 'variables'):
-            V = [str(x) for x in self._p.variables()]
-        else:
-            V = []
+        # A constant is unaffected by any substitution.
+        if hasattr(self._p, 'variables') and not self._p.variables():
+            return self
+
+        P = self.parent()
+
+        # Translate positional args into keyword args.  Positional
+        # substitution acts on the variables that actually occur in
+        # ``self``, taken in the parent ring's gens() order (i.e.
+        # descending ``varname_key``).  Both ``p(2, 3)`` and
+        # ``p([2, 3])`` are accepted.
+        if args:
+            if len(args) == 1 and isinstance(args[0], (list, tuple)):
+                values = list(args[0])
+            else:
+                values = list(args)
+            appearing = sorted((str(v) for v in self._p.variables()),
+                               key=P.varname_key, reverse=True)
+            if len(values) != len(appearing):
+                raise TypeError(
+                    "number of arguments does not match number of variables in parent")
+            for name, value in zip(appearing, values):
+                if name in kwargs:
+                    raise TypeError(f"got multiple values for variable {name!r}")
+                kwargs[name] = value
+
+        # Build a temporary ring whose generators contain every variable
+        # name the substitution might touch: those of ``self._p``'s parent,
+        # every keyword used, and the parent generators of each substituted
+        # ``InfinitePolynomial``.  Using ``variable_names()`` instead of
+        # ``variables()`` is essential -- omitting a variable that is
+        # present in some backend parent can silently trigger an illegal
+        # positional coercion between polynomial rings (see :issue:`40504`).
+        var_names = set(self._p.parent().variable_names())
         for kw, value in kwargs.items():
+            var_names.add(kw)
             if isinstance(value, InfinitePolynomial):
                 kwargs[kw] = value._p
-                V.append(kw)
-                if hasattr(value._p, 'variables'):
-                    V.extend([str(x) for x in value._p.variables()])
-        args = list(args)
-        for i, arg in enumerate(args):
-            if isinstance(arg, InfinitePolynomial):
-                args[i] = arg._p
-                if hasattr(arg._p, 'variables'):
-                    V.extend([str(x) for x in arg._p.variables()])
-        V = list(set(V))
-        V.sort(key=self.parent().varname_key, reverse=True)
-        if V:
-            from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-            R = PolynomialRing(self._p.base_ring(), V, order=self.parent()._order)
-        else:
-            return self
-        res = R(self._p)(*args, **kwargs)
+                var_names.update(value._p.parent().variable_names())
+        var_names = sorted(var_names, key=P.varname_key, reverse=True)
+
+        from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+        R = PolynomialRing(self._p.base_ring(), var_names, order=P._order)
+        res = R(self._p).subs(**kwargs)
         try:
             from sage.misc.sage_eval import sage_eval
-            return sage_eval(repr(res), self.parent().gens_dict())
+            return sage_eval(repr(res), P.gens_dict())
         except Exception:
             return res
 
@@ -1487,8 +1541,6 @@ class InfinitePolynomial_sparse(InfinitePolynomial):
             sage: X.<x> = InfinitePolynomialRing(QQ, implementation='sparse')
             sage: x[10]._common_polynomial_ring(x[5])
             Multivariate Polynomial Ring in x_10, x_5, x_0 over Rational Field
-            sage: (x[10] + x[2])._common_polynomial_ring(x[5])
-            Multivariate Polynomial Ring in x_10, x_5, x_2, x_0 over Rational Field
         """
         VarList = set(self._p.parent().variable_names())
         VarList.update(x._p.parent().variable_names())
@@ -1896,20 +1948,10 @@ class InfinitePolynomial_sparse(InfinitePolynomial):
             sage: R.<a> = InfinitePolynomialRing(QQ, implementation="sparse")
             sage: P.<x> = LazyPowerSeriesRing(R)
             sage: f1 = P(lambda n: -a[n] if n else 1)
-            sage: q = diff(log(f1))[3]; q
+            sage: diff(log(f1))[3]
             -4*a_4 - 4*a_3*a_1 - 2*a_2^2 - 4*a_2*a_1^2 - a_1^4
-            sage: q.coefficient(a[4])
+            sage: diff(log(f1))[3].coefficient(a[3]*a[1])
             -4
-            sage: q.coefficient(a[3])
-            -4*a_1
-            sage: q.coefficient(a[3]*a[1])
-            -4
-            sage: q.coefficient({a[3]: 1, a[1]: 1})
-            -4
-            sage: q.monomial_coefficient(a[3]*a[1])
-            -4
-            sage: q.coefficient(a[5])
-            0
         """
         if isinstance(x, dict):
             if x:
@@ -1920,9 +1962,9 @@ class InfinitePolynomial_sparse(InfinitePolynomial):
 
             return self
 
-        if self._p.parent() is x._p.parent():
+        try:
             result = self._p.coefficient(x._p)
-        else:
+        except TypeError:
             R = self._common_polynomial_ring(x)
             result = R(self._p).coefficient(R(x._p))
 
@@ -1959,19 +2001,72 @@ class InfinitePolynomial_dense(InfinitePolynomial):
 
             sage: a(x_1=x[100])
             x_100 + x_0
+
+        TESTS:
+
+        Positional substitution acts on the variables that actually
+        occur in ``self``::
+
+            sage: X.<x> = InfinitePolynomialRing(QQ)
+            sage: x[3](2)
+            2
+            sage: p = x[1] + x[3]
+            sage: p(2, 3)
+            5
+            sage: p([2, 3])
+            5
+
+        A constant polynomial is unaffected by any call::
+
+            sage: c = X(5)
+            sage: c()
+            5
+            sage: c(2, 3)
+            5
+            sage: c(x_3=2)
+            5
+            sage: c(x_3=x[5])
+            5
         """
-        # Replace any InfinitePolynomials by their underlying polynomials
+        # A constant is unaffected by any substitution.
+        if hasattr(self._p, 'variables') and not self._p.variables():
+            return self
+
+        P = self.parent()
+
+        # Translate positional args into keyword args.  Positional
+        # substitution acts on the variables that actually occur in
+        # ``self``, taken in the parent ring's gens() order (i.e.
+        # descending ``varname_key``).  Both ``p(2, 3)`` and
+        # ``p([2, 3])`` are accepted.
+        if args:
+            if len(args) == 1 and isinstance(args[0], (list, tuple)):
+                values = list(args[0])
+            else:
+                values = list(args)
+            appearing = sorted((str(v) for v in self._p.variables()),
+                               key=P.varname_key, reverse=True)
+            if len(values) != len(appearing):
+                raise TypeError(
+                    "number of arguments does not match number of variables in parent")
+            for name, value in zip(appearing, values):
+                if name in kwargs:
+                    raise TypeError(f"got multiple values for variable {name!r}")
+                kwargs[name] = value
+
+        # Replace any InfinitePolynomials by their underlying polynomials.
+        # Accessing each ``InfinitePolynomial`` may grow ``P._P``, the
+        # canonical backend ring shared by all dense elements.
         for kw, value in kwargs.items():
             if isinstance(value, InfinitePolynomial):
                 kwargs[kw] = value._p
-        args = list(args)
-        for i, arg in enumerate(args):
-            if isinstance(arg, InfinitePolynomial):
-                args[i] = arg._p
-        self._p = self.parent().polynomial_ring()(self._p)
-        res = self._p(*args, **kwargs)
+
+        # Pull ``self._p`` into the (possibly grown) canonical ring and
+        # substitute there.
+        self._p = P.polynomial_ring()(self._p)
+        res = self._p.subs(**kwargs)
         try:
-            return self.parent()(res)
+            return P(res)
         except ValueError:
             return res
 
@@ -2287,20 +2382,10 @@ class InfinitePolynomial_dense(InfinitePolynomial):
             sage: R.<a> = InfinitePolynomialRing(QQ)
             sage: P.<x> = LazyPowerSeriesRing(R)
             sage: f1 = P(lambda n: -a[n] if n else 1)
-            sage: q = diff(log(f1))[3]; q
+            sage: diff(log(f1))[3]
             -4*a_4 - 4*a_3*a_1 - 2*a_2^2 - 4*a_2*a_1^2 - a_1^4
-            sage: q.coefficient(a[4])
+            sage: diff(log(f1))[3].coefficient(a[3]*a[1])
             -4
-            sage: q.coefficient(a[3])
-            -4*a_1
-            sage: q.coefficient(a[3]*a[1])
-            -4
-            sage: q.coefficient({a[3]: 1, a[1]: 1})
-            -4
-            sage: q.monomial_coefficient(a[3]*a[1])
-            -4
-            sage: q.coefficient(a[5])
-            0
         """
         P = self.parent()
         if not self._p:


### PR DESCRIPTION
Fixes #40504.

## Background

Issue #40504 reports an *illegal coercion between polynomial rings* in `InfinitePolynomial.coefficient`. The visible symptom was a silently wrong answer:

```python
sage: R.<a> = InfinitePolynomialRing(QQ, implementation="sparse")
sage: P.<x> = LazyPowerSeriesRing(R)
sage: f1 = P(lambda n: -a[n] if n else 1)
sage: diff(log(f1))[3]
-4*a_4 - 4*a_3*a_1 - 2*a_2^2 - 4*a_2*a_1^2 - a_1^4
sage: diff(log(f1))[3].coefficient(a[3]*a[1])
0                  # WRONG -- should be -4
```

The bug in `coefficient` itself was fixed by the larger refactor in #40533. However, the **same root cause** still affected `InfinitePolynomial_sparse.__call__` (substitution), and the dense `__call__` had several long-standing limitations that were inconsistent with the sparse implementation.

## Root cause

In the sparse implementation, different `InfinitePolynomial` elements may live in *different* finite backend polynomial rings:

```
diff(log(f1))[3]._p.parent() = Multivariate Polynomial Ring in a_4, a_3, a_2, a_1, a_0 over Rational Field
(a[3]*a[1])._p.parent()      = Multivariate Polynomial Ring in a_3, a_1, a_0       over Rational Field
```

To combine such elements, the code builds a temporary ring `R` and coerces both polynomials into it. The buggy code built `R` from the *variables that appear* in each polynomial (`.variables()`), not from the *generator names of each parent ring* (`.variable_names()`):

```python
VarList = [str(X) for X in self._p.variables()]            # a_4, a_3, a_2, a_1
VarList.extend([str(X) for X in monomial._p.variables()])  # a_3, a_1
R = PolynomialRing(self._p.base_ring(), VarList, ...)      # missing a_0!
res = R(self._p).coefficient(R(monomial._p))               # ← illegal coercion
```

`R` omits `a_0`, even though `a_0` is a generator of both source rings. When the name sets do not fully overlap, **libsingular silently falls back to a *positional* coercion**:

```
R_target = QQ[a_4, a_3, a_2, a_1]      # what the buggy code built
R_source = QQ[a_3, a_1, a_0]           # parent of monomial._p
R_target(a_3 * a_1)   # = a_4 * a_3    ← positional mapping, silently wrong
```

The subsequent `.coefficient(...)` then returned `0` because the wrong monomial was being queried.

## Fix

The fix is one structural principle: **build the temporary ring from `parent().variable_names()`, not from `.variables()`**, so the temporary ring is always a *name-superset* of every source ring. This guarantees libsingular uses by-name coercion and never falls back to position-based mapping.

This PR applies that principle to `__call__` in both the sparse and dense implementations, and simplifies the methods so the substitution flow reads top-to-bottom:

1. **Guard constants up front** — substitution into a constant is a vacuous operation; return `self` unchanged.
2. **Translate positional args into kwargs** — positional substitution acts on the variables that actually occur in `self`, taken in the parent ring's `gens()` order (descending `varname_key`). Both `p(2, 3)` and `p([2, 3])` are accepted.
3. **Collect every variable name** the substitution might touch: parent generators of `self._p`, every keyword used, and parent generators of each substituted `InfinitePolynomial`.
4. **Substitute** in the resulting (safe) ring with libsingular's `subs(**kwargs)`.