### PR TITLE
Fix corner facet labels to use cyclic order in Singmaster notation

### DIFF
--- a/src/sage/groups/perm_gps/cubegroup.py
+++ b/src/sage/groups/perm_gps/cubegroup.py
@@ -254,10 +254,10 @@ face_polys = {
     'flu': [[0,2],[1,2], [1,3], [0,3]],      # square labeled 17
     'fu': [[1,2],[2,2], [2,3], [1,3]],      # square labeled 18
     'fur': [[2,2],[3,2], [3,3], [2,3]],      # square labeled 19
-    'ruf': [[3,2],[4,2], [4,3], [3,3]],      # square labeled 25
+    'rfu': [[3,2],[4,2], [4,3], [3,3]],      # square labeled 25
     'ru': [[4,2],[5,2], [5,3], [4,3]],      # square labeled 26
     'rub': [[5,2],[6,2], [6,3], [5,3]],      # square labeled 27
-    'bur': [[6,2],[7,2], [7,3], [6,3]],      # square labeled 33
+    'bru': [[6,2],[7,2], [7,3], [6,3]],      # square labeled 33
     'bu': [[7,2],[8,2], [8,3], [7,3]],      # square labeled 34
     'bul': [[8,2],[9,2], [9,3], [8,3]],      # square labeled 35
 # down face
@@ -267,7 +267,7 @@ face_polys = {
     'dl': [[0,-2],[1,-2], [1,-1], [0,-1]],      # square labeled 44
     'd_center': [[1,-2],[2,-2], [2,-1], [1,-1]],        # center square
     'dr': [[2,-2],[3,-2], [3,-1], [2,-1]],      # square labeled 45
-    'dlb': [[0,-3],[1,-3], [1,-2], [0,-2]],      # square labeled 46
+    'dbl': [[0,-3],[1,-3], [1,-2], [0,-2]],      # square labeled 46
     'db': [[1,-3],[2,-3], [2,-2], [1,-2]],      # square labeled 47
     'drb': [[2,-3],[3,-3], [3,-2], [2,-2]],      # square labeled 48
 # up face
@@ -328,10 +328,10 @@ singmaster_indices = {
     43: "dfr",
     44: "dl",
     45: "dr",
-    46: "dlb",
+    46: "dbl",
     47: "db",
     48: "drb",
-    33: "bur",
+    33: "bru",
     34: "bu",
     35: "bul",
     36: "br",
@@ -339,7 +339,7 @@ singmaster_indices = {
     38: "bdr",
     39: "bd",
     40: "bld",
-    25: "ruf",
+    25: "rfu",
     26: "ru",
     27: "rub",
     28: "rf",
@@ -357,9 +357,37 @@ def index2singmaster(facet):
 
     EXAMPLES::
 
-        sage: from sage.groups.perm_gps.cubegroup import index2singmaster
+        sage: from sage.groups.perm_gps.cubegroup import index2singmaster, singmaster_indices
         sage: index2singmaster(41)
         'dlf'
+
+    TESTS:
+
+    Check that the corner labels use cyclic order (:issue:`39964`)::
+
+        sage: index2singmaster(25)
+        'rfu'
+        sage: index2singmaster(33)
+        'bru'
+        sage: index2singmaster(46)
+        'dbl'
+        sage: G = CubeGroup()
+        sage: [tuple(index2singmaster(f) for f in x)
+        ....:  for x in G.parse("R U R' U' R U R' U'").cycle_tuples()]
+        [('ulb', 'bul', 'lbu'),
+         ('ub', 'ur', 'fr'),
+         ('ubr', 'rub', 'bru'),
+         ('urf', 'rfu', 'fur'),
+         ('frd', 'rdf', 'dfr'),
+         ('ru', 'rf', 'bu')]
+        sage: corners = {}
+        sage: for label in singmaster_indices.values():
+        ....:     if len(label) == 3:
+        ....:         corners.setdefault(''.join(sorted(label)), []).append(label)
+        sage: all(sorted(c) == sorted([c[0], c[0][1:] + c[0][0],
+        ....:                            c[0][2] + c[0][:2]])
+        ....:     for c in corners.values())
+        True
     """
     return singmaster_indices[facet]
 


### PR DESCRIPTION
Fixes three incorrect corner labels in `CubeGroup`
`src/sage/groups/perm_gps/cubegroup.py`
that violated Singmaster's convention: corner labels must list facets in
**clockwise cyclic order**, so the three labels for the same physical corner
are cyclic rotations of one another.

| Facet | Old label | New label |
|-------|-----------|-----------|
| 25 (R-U-F corner, R face) | `ruf` | `rfu` |
| 33 (B-R-U corner, B face) | `bur` | `bru` |
| 46 (D-B-L corner, D face) | `dlb` | `dbl` |

Closes [#39964](https://github.com/sagemath/sage/issues/39964).

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


