### PR TITLE
Fix doctests in graph_latex.py  which use dot2tex

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -23501,7 +23501,7 @@ class GenericGraph(GenericGraph_pyx):
             sage: print(G.latex_options().dot2tex_picture())    # optional - dot2tex graphviz, needs sage.plot
             \begin{tikzpicture}[>=latex,line join=bevel,]
             ...
-              \definecolor{strokecolor}{rgb}{0.25,0.5,1.0};
+              \definecolor{strokecolor}{rgb}{0.25,0.5,1.0}
               \draw [strokecolor,] (node_0) ... (node_1);
             ...
             \end{tikzpicture}

--- a/src/sage/graphs/graph_latex.py
+++ b/src/sage/graphs/graph_latex.py
@@ -1337,17 +1337,17 @@ class GraphLatex(SageObject):
             %%
             \begin{scope}
               \pgfsetstrokecolor{black}
-              \definecolor{strokecol}{rgb}{...};
+              \definecolor{strokecol}{rgb}{...}
               \pgfsetstrokecolor{strokecol}
-              \definecolor{fillcol}{rgb}{...};
+              \definecolor{fillcol}{rgb}{...}
               \pgfsetfillcolor{fillcol}
               \filldraw ... cycle;
             \end{scope}
             \begin{scope}
               \pgfsetstrokecolor{black}
-              \definecolor{strokecol}{rgb}{...};
+              \definecolor{strokecol}{rgb}{...}
               \pgfsetstrokecolor{strokecol}
-              \definecolor{fillcol}{rgb}{...};
+              \definecolor{fillcol}{rgb}{...}
               \pgfsetfillcolor{fillcol}
               \filldraw ... cycle;
             \end{scope}
@@ -1395,7 +1395,7 @@ class GraphLatex(SageObject):
             \node (node_...) at (...bp,...bp) [draw,draw=none] {$...$};
               \node (node_...) at (...bp,...bp) [draw,draw=none] {$...$};
               \draw [black,->] (node_...) ..controls (...bp,...bp) and (...bp,...bp)  .. (node_...);
-              \definecolor{strokecol}{rgb}{0.0,0.0,0.0};
+              \definecolor{strokecol}{rgb}{0.0,0.0,0.0}
               \pgfsetstrokecolor{strokecol}
               \draw (...bp,...bp) node {$\text{\texttt{my{\char`\_}label}}$};
             %


### PR DESCRIPTION
There are two doctests in `graphs/graph_latex.py` and one doctest in `graphs/generic_graph.py` which have superfluous semicolons at the end of a call to the LaTeX macro `\definecolor`.
This causes these doctests to fail.
The failures do not occur unless the options `dot2tex` and `graphviz` are available.
This PR fixes the doctests by simply removing the trailing semicolons.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


