### PR TITLE
Fix conversion of `SetPartition` to `DisjointSet`

### DIFF
--- a/src/sage/sets/disjoint_set.pyx
+++ b/src/sage/sets/disjoint_set.pyx
@@ -115,6 +115,17 @@ cpdef DisjointSet(arg):
         sage: DisjointSet(SP) == DisjointSet(5)
         True
 
+    The parts of the set partition are preserved (see :issue:`39714`)::
+
+        sage: s = SetPartition([[0, 1, 2, 3]])
+        sage: DisjointSet(s)
+        {{0, 1, 2, 3}}
+        sage: SetPartition(DisjointSet(s)) == s
+        True
+        sage: s = SetPartition([[1, 3], [2, 5], [4]])
+        sage: SetPartition(DisjointSet(s)) == s
+        True
+
     TESTS::
 
         sage: DisjointSet(0)
@@ -150,7 +161,16 @@ cpdef DisjointSet(arg):
             raise ValueError('arg must be a nonnegative integer (%s given)' % arg)
         return DisjointSet_of_integers(arg)
     elif isinstance(arg, SetPartition):
-        return DisjointSet(arg.base_set())
+        d = DisjointSet_of_hashables(arg.base_set())
+        for part in arg:
+            it = iter(part)
+            try:
+                first = next(it)
+            except StopIteration:
+                continue
+            for x in it:
+                d.union(first, x)
+        return d
     else:
         return DisjointSet_of_hashables(arg)
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
Fixes #39714.

## Root cause

The `SetPartition` branch added in #38693 was:

```python
elif isinstance(arg, SetPartition):
    return DisjointSet(arg.base_set())
```

This only seeded the disjoint set with the elements of the base set — it
never unioned the elements within each block. The pre-existing doctest
did not catch the bug because it round-tripped through a partition into
singletons (`SetPartition(DisjointSet(5))`), where unioning is a no-op
and the wrong behavior coincides with the right one.

## Fix

Seed the disjoint set with `arg.base_set()`, then for each block of the
partition union all of its elements together:

```python
elif isinstance(arg, SetPartition):
    d = DisjointSet_of_hashables(arg.base_set())
    for part in arg:
        it = iter(part)
        try:
            first = next(it)
        except StopIteration:
            continue
        for x in it:
            d.union(first, x)
    return d
```

This makes `SetPartition(DisjointSet(s)) == s` hold for every set
partition `s`, as the issue requests.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


