### PR TITLE
Use RankWidth feature for Graph.rank_decoposition

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -9538,7 +9538,8 @@ class Graph(GenericGraph):
     from sage.graphs.weakly_chordal import is_long_hole_free, is_long_antihole_free, is_weakly_chordal
     from sage.graphs.asteroidal_triples import is_asteroidal_triple_free
     chromatic_polynomial = LazyImport('sage.graphs.chrompoly', 'chromatic_polynomial', at_startup=True)
-    rank_decomposition = LazyImport('sage.graphs.graph_decompositions.rankwidth', 'rank_decomposition', at_startup=True)
+    from sage.features.rankwidth import RankWidth
+    rank_decomposition = LazyImport('sage.graphs.graph_decompositions.rankwidth', 'rank_decomposition', at_startup=True, feature=RankWidth())
     from sage.graphs.graph_decompositions.tree_decomposition import treewidth
     from sage.graphs.graph_decompositions.vertex_separation import pathwidth
     from sage.graphs.graph_decompositions.tree_decomposition import treelength

--- a/src/sage/misc/lazy_import.pyx
+++ b/src/sage/misc/lazy_import.pyx
@@ -261,19 +261,18 @@ cdef class LazyImport():
             if finish_startup_called:
                 warn(f"Option ``at_startup=True`` for lazy import {self._name} not needed anymore")
 
-        feature = self._feature
         try:
             self._object = getattr(__import__(self._module, {}, {}, [self._name]), self._name)
         except ImportError as e:
-            if feature:
+            if self._feature:
                 # Avoid warnings from static type checkers by explicitly importing FeatureNotPresentError.
                 from sage.features import FeatureNotPresentError
-                raise FeatureNotPresentError(feature, reason=f'Importing {self._name} failed: {e}')
+                raise FeatureNotPresentError(self._feature, reason=f'Importing {self._name} failed: {e}')
             raise
 
-        if feature:
+        if self._feature:
             # for the case that the feature is hidden
-            feature.require()
+            self._feature.require()
 
         if self._deprecation is not None:
             from sage.misc.superseded import deprecation_cython as deprecation

--- a/src/sage/misc/lazy_import.pyx
+++ b/src/sage/misc/lazy_import.pyx
@@ -255,12 +255,6 @@ cdef class LazyImport():
         if self._object is not None:
             return self._object
 
-        if startup_guard and not self._at_startup:
-            warn(f"Resolving lazy import {self._name} during startup")
-        elif self._at_startup and not startup_guard:
-            if finish_startup_called:
-                warn(f"Option ``at_startup=True`` for lazy import {self._name} not needed anymore")
-
         try:
             self._object = getattr(__import__(self._module, {}, {}, [self._name]), self._name)
         except ImportError as e:
@@ -273,6 +267,21 @@ cdef class LazyImport():
         if self._feature:
             # for the case that the feature is hidden
             self._feature.require()
+
+        # Warn if the at_startup parameter looks incorrect. This
+        # method short-circuits (returns the cached response) only
+        # when self._object is not None. If the lazy import is backed
+        # by a missing feature, or if the import refers to a
+        # module/function that simply does not exist, an error will be
+        # raised above and self._object will remain None. The check
+        # below is not meant to be re-run (it will print spurious
+        # warnings times 2 through N with at_startup=True); to avoid
+        # that, we run it only after the import/feature test.
+        if startup_guard and not self._at_startup:
+            warn(f"Resolving lazy import {self._name} during startup")
+        elif self._at_startup and not startup_guard:
+            if finish_startup_called:
+                warn(f"Option ``at_startup=True`` for lazy import {self._name} not needed anymore")
 
         if self._deprecation is not None:
             from sage.misc.superseded import deprecation_cython as deprecation

--- a/src/sage/misc/rest_index_of_methods.py
+++ b/src/sage/misc/rest_index_of_methods.py
@@ -9,6 +9,7 @@ for use in doc-strings.
 
 import inspect
 
+from sage.features import FeatureNotPresentError
 from sage.misc.sageinspect import _extract_embedded_position
 from sage.misc.sageinspect import is_function_or_cython_function as _isfunction
 
@@ -279,7 +280,7 @@ def list_of_subfunctions(root, only_local_functions=True):
         # poke it to provoke a lazy import to resolve
         try:
             hasattr(f, 'xyz')
-        except ImportError:
+        except (ImportError, FeatureNotPresentError):
             return False
         return True
 


### PR DESCRIPTION
* Teach `gen_thematic_rest_table_index()` to ignore missing features
* Back `Graph.rank_decoposition` by the RankWidth feature
* Reorder the `at_startup` warning in `LazyImport` to avoid printing an error on the CI when RankWidth is disabled

My goal here is just to eliminate a warning on the CI, since I am hoping to add a "minimal" run soon. The ReST generation happens at startup, so `at_startup=True` is used to import `rank_decomposition` lazily. But when the import fails and we go to actually _use_ the method, the lazy import gets attempted again; now, `at_startup=True` raises a warning.

The minimal CI job is in progress on https://github.com/sagemath/sage/pull/42228, and tests these changes in the absence of RankWidth.
