### PR TITLE
faster construction of interval graphs

### DIFF
--- a/src/sage/graphs/generators/intersection.py
+++ b/src/sage/graphs/generators/intersection.py
@@ -93,30 +93,23 @@ def IntervalGraph(intervals, points_ordered=False, immutable=False):
     n = len(intervals)
 
     if points_ordered:
-        def edges():
-            for i in range(n - 1):
-                li, ri = intervals[i]
-                for j in range(i + 1, n):
-                    lj, rj = intervals[j]
-                    if ri < lj or rj < li:
-                        continue
-                    yield (i, j)
-
+        I = sorted((i, u) for u, i in enumerate(intervals))
     else:
-        def edges():
-            for i in range(n - 1):
-                min_I = min(intervals[i])
-                max_I = max(intervals[i])
-                for j in range(i + 1, n):
-                    J = intervals[j]
-                    if max_I < min(J) or max(J) < min_I:
-                        continue
-                    yield (i, j)
+        I = sorted((sorted(i), u) for u, i in enumerate(intervals))
+
+    def edges():
+        for i in range(n - 1):
+            (_, ri), u = I[i]
+            for j in range(i + 1, n):
+                (lj, _), v = I[j]
+                if lj > ri:
+                    break
+                yield (u, v)
 
     g = Graph([range(n), edges()], format="vertices_and_edges",
               immutable=immutable)
 
-    rep = dict(zip(range(n), intervals))
+    rep = dict(enumerate(intervals))
     g.set_vertices(rep)
 
     return g


### PR DESCRIPTION
The original construction was in $O(n^2)$, where $n$ is the number of intervals. We change that to a straightforward $O(n\log{n} + m)$ time algorithm, where $m$ is the number of edges of the resulting interval graph. This is way faster.
The labeling of the vertices is unchanged.

Before
```py
sage: intervals = [(i, i + 5) for i in range(100)]
sage: %timeit g = graphs.IntervalGraph(intervals, True)
726 μs ± 6.79 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
sage: rev_intervals = intervals[::-1]
sage: %timeit h = graphs.IntervalGraph(rev_intervals,False)
2.24 ms ± 6.49 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
sage: g = graphs.IntervalGraph(intervals, True)
sage: h = graphs.IntervalGraph(rev_intervals,False)
sage: g.edges(sort=True) == h.edges(sort=True)
```

After
```py
sage: intervals = [(i, i + 5) for i in range(100)]
sage: %timeit g = graphs.IntervalGraph(intervals, True)
280 μs ± 3.53 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
sage: rev_intervals = intervals[::-1]
sage: %timeit h = graphs.IntervalGraph(rev_intervals,False)
301 μs ± 512 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
sage: g = graphs.IntervalGraph(intervals, True)
sage: h = graphs.IntervalGraph(rev_intervals,False)
sage: g.edges(sort=True) == h.edges(sort=True)
True
```



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


