### PR TITLE
Minor edit: Fixed missing ':' (colon) in the EXAMPLES string.

### DIFF
--- a/src/sage/rings/number_field/order_ideal.py
+++ b/src/sage/rings/number_field/order_ideal.py
@@ -464,7 +464,7 @@ class NumberFieldOrderIdeal_quadratic(NumberFieldOrderIdeal_generic):
 
             To find a generator, use :meth:`gens_reduced`.
 
-        EXAMPLES:
+        EXAMPLES::
 
             sage: K.<a> = QuadraticField(-163)
             sage: O = K.order(7*a)


### PR DESCRIPTION
One of the examples was being displayed wrong. This was caused by a missing colon in 'EXAMPLES:'. It is now correct and it does display correctly (tested locally ofc).

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [ x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


