### PR TITLE
Fix memory leak in repeated nonconstant polynomial substitutions in libsingular

### DIFF
--- a/src/sage/libs/singular/polynomial.pyx
+++ b/src/sage/libs/singular/polynomial.pyx
@@ -35,7 +35,6 @@ from sage.libs.singular.decl cimport omAlloc0, omStrDup, omFree
 from sage.libs.singular.decl cimport p_GetComp
 from sage.libs.singular.decl cimport pSubst
 from sage.libs.singular.decl cimport p_Normalize
-from sage.libs.singular.decl cimport ndCopyMap, maMapPoly
 
 from sage.libs.singular.singular cimport sa2si, si2sa, overflow_check
 
@@ -222,7 +221,9 @@ cdef int singular_polynomial_call(poly **ret, poly *p, ring *r, list args,
         id_Delete(&from_id, r)
         id_Delete(&res_id, r)
     else:
-        ret[0] = maMapPoly(p, r, to_id, r, ndCopyMap)
+        ret[0] = p_Copy(p, r)
+        for i from 0 <= i < l:
+            ret[0] = pSubst(ret[0], i + 1, to_id.m[i])
 
     # Unsure why we have to normalize here. See #16958
     p_Normalize(ret[0], r)

--- a/src/sage/libs/singular/singular.pyx
+++ b/src/sage/libs/singular/singular.pyx
@@ -1413,8 +1413,9 @@ cdef number *sa2si_NF(object elem, ring *_ring) noexcept:
     cdef number *n1
     cdef number *n2
     cdef number *a
-    cdef number *nlCoeff
     cdef number *naCoeff
+    cdef number *cfnum
+    cdef number *cfden
     cdef number *apow1
     cdef number *apow2
 
@@ -1426,29 +1427,12 @@ cdef number *sa2si_NF(object elem, ring *_ring) noexcept:
     a = _ring.cf.cfParameter(1, _ring.cf)
     apow1 = _ring.cf.cfInit(1, _ring.cf)
 
-    cdef char *_name
-
-    # the result of nlInit2gmp() is in a plain polynomial ring over QQ (not an extension ring!),
-    # so we have to get/create one:
-    #
-    # todo: reuse qqr/ get an existing Singular polynomial ring over Q.
-    _name = omStrDup("a")
-    cdef char **_ext_names
-    _ext_names = <char**>omAlloc0(sizeof(char*))
-    _ext_names[0] = omStrDup(_name)
-    qqr = rDefault( 0, 1, _ext_names)
-    rComplete(qqr,1)
-    qqr.ShortOut = 0
-
-    assert _ring.cf.type == n_algExt  # if false naSetMap will segmentation fault (should never happen)
-    cdef nMapFunc nMapFuncPtr = naSetMap(qqr.cf, _ring.cf)  # choose correct mapping function
-    if nMapFuncPtr is NULL:
-        raise RuntimeError("Failed to determine nMapFuncPtr")
-    cdef poly *_p
     for i from 0 <= i < len(elem):
-        nlCoeff = nlInit2gmp( mpq_numref((<Rational>elem[i]).value), mpq_denref((<Rational>elem[i]).value),  qqr.cf )
-        naCoeff = nMapFuncPtr(nlCoeff, qqr.cf, _ring.cf)
-        nlDelete(&nlCoeff, _ring.cf)
+        cfnum = _ring.cf.cfInitMPZ(mpq_numref((<Rational>elem[i]).value), _ring.cf)
+        cfden = _ring.cf.cfInitMPZ(mpq_denref((<Rational>elem[i]).value), _ring.cf)
+        naCoeff = _ring.cf.cfDiv(cfnum, cfden, _ring.cf)
+        _ring.cf.cfDelete(&cfnum, _ring.cf)
+        _ring.cf.cfDelete(&cfden, _ring.cf)
 
         # faster would be to assign the coefficient directly
         apow2 = _ring.cf.cfMult(naCoeff, apow1,_ring.cf)

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -3644,26 +3644,6 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             (c + d)*z^2
             sage: f.subs({z:x+1})
             c*x^2*y + d*x^2 + (2*c)*x*y + (2*d)*x + c*y + d
-
-        Check for a memory leak in repeated nonconstant substitutions
-        (:issue:`27261`)::
-
-            sage: import gc, os
-            sage: def rss():
-            ....:     _ = gc.collect()
-            ....:     with open('/proc/self/statm') as statm:
-            ....:         pages = int(statm.read().split()[1])
-            ....:     return pages * os.sysconf('SC_PAGE_SIZE')
-            sage: R = PolynomialRing(ZZ, 'x', 50)
-            sage: d = {str(g): g for g in R.gens()}
-            sage: p = sum(d.values())
-            sage: for _ in range(200):  # warm up caches
-            ....:     _ = p.subs(**d)
-            sage: before = rss()
-            sage: for _ in range(1500):
-            ....:     _ = p.subs(**d)
-            sage: rss() - before < 6 * 1024 * 1024
-            True
         """
         cdef int mi, i
         cdef bint change_ring = False   # indicates the need to change the parent ring

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -2054,6 +2054,76 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: S.<y> = PolynomialRing(k, 1)
             sage: f(y).parent()
             Multivariate Polynomial Ring in y over Finite Field in a of size 2^4
+
+        Check that substitution and evaluation do not leak (:issue:`27261`)::
+
+            sage: import gc
+            sage: import resource
+            sage: R = PolynomialRing(ZZ, 'x', 50)
+            sage: d = {str(g): g for g in R.gens()}
+            sage: p = sum(d.values())
+            sage: S.<x, y> = ZZ[]
+            sage: q = (x + y)**100
+            sage: def leak_27261():
+            ....:     before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            ....:     gc.collect()
+            ....:     for _ in range(50):
+            ....:         _ = p.subs(**d)
+            ....:     for _ in range(20):
+            ....:         _ = q(x + y, y)
+            ....:         _ = q(1, 2)
+            ....:     after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            ....:     return (after - before) * 1024   # ru_maxrss is in kilobytes
+
+            sage: zeros = 0
+            sage: for i in range(30):  # long time
+            ....:     n = leak_27261()
+            ....:     print("Leaked {} bytes".format(n))
+            ....:     if n == 0:
+            ....:         zeros += 1
+            ....:         if zeros >= 6:
+            ....:             break
+            ....:     else:
+            ....:         zeros = 0
+            Leaked...
+            Leaked 0 bytes
+            Leaked 0 bytes
+            Leaked 0 bytes
+            Leaked 0 bytes
+            Leaked 0 bytes
+
+        Check that evaluating and adding polynomials over number fields does
+        not leak (:issue:`32604`)::
+
+            sage: import gc
+            sage: import resource
+            sage: K.<a> = QuadraticField(-1)
+            sage: R.<x> = PolynomialRing(K, 1)
+            sage: def leak(N):
+            ....:     before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            ....:     gc.collect()
+            ....:     for _ in range(N):
+            ....:         _ = x(1)
+            ....:         _ = x + 1
+            ....:     after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            ....:     return (after - before) * 1024   # ru_maxrss is in kilobytes
+
+            sage: zeros = 0
+            sage: for i in range(30):  # long time
+            ....:     n = leak(10000)
+            ....:     print("Leaked {} bytes".format(n))
+            ....:     if n == 0:
+            ....:         zeros += 1
+            ....:         if zeros >= 6:
+            ....:             break
+            ....:     else:
+            ....:         zeros = 0
+            Leaked...
+            Leaked 0 bytes
+            Leaked 0 bytes
+            Leaked 0 bytes
+            Leaked 0 bytes
+            Leaked 0 bytes
         """
         cdef Element sage_res
 

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -3644,6 +3644,26 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             (c + d)*z^2
             sage: f.subs({z:x+1})
             c*x^2*y + d*x^2 + (2*c)*x*y + (2*d)*x + c*y + d
+
+        Check for a memory leak in repeated nonconstant substitutions
+        (:issue:`27261`)::
+
+            sage: import gc, os
+            sage: def rss():
+            ....:     _ = gc.collect()
+            ....:     with open('/proc/self/statm') as statm:
+            ....:         pages = int(statm.read().split()[1])
+            ....:     return pages * os.sysconf('SC_PAGE_SIZE')
+            sage: R = PolynomialRing(ZZ, 'x', 50)
+            sage: d = {str(g): g for g in R.gens()}
+            sage: p = sum(d.values())
+            sage: for _ in range(200):  # warm up caches
+            ....:     _ = p.subs(**d)
+            sage: before = rss()
+            sage: for _ in range(1500):
+            ....:     _ = p.subs(**d)
+            sage: rss() - before < 6 * 1024 * 1024
+            True
         """
         cdef int mi, i
         cdef bint change_ring = False   # indicates the need to change the parent ring
@@ -3735,7 +3755,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             res_id = fast_map_common_subexp(from_id, _ring, to_id, _ring)
             _p = res_id.m[0]
 
-            from_id.m[0] = NULL
+            p_Delete(&from_id.m[0], _ring)
             res_id.m[0] = NULL
 
             id_Delete(&from_id, _ring)


### PR DESCRIPTION
Close #27261 

Close #32604 

## Background

Two long-standing memleak tickets reported fast memory growth in multivariate
polynomial operations backed by libsingular.

Issue #27261 reported leaks in polynomial substitution and evaluation:

```python
R = PolynomialRing(ZZ, 'x', 50)
d = {str(g): g for g in R.gens()}
p = sum(d.values())
for _ in range(50):
    _ = p.subs(**d)
```

and:

```python
R.<x, y> = ZZ[]
p = (x + y)**100
_ = p(x + y, y)
```

Issue #32604 reported very fast leaks over number fields:

```python
R.<x> = PolynomialRing(QuadraticField(-1), 1)
while True:
    a = x(1)
```

and:

```python
R.<x> = PolynomialRing(QuadraticField(-1), 1)
while True:
    a = x + 1
```

## Root Cause

There were two independent leak paths.

### 1. Number-field coefficient conversion

`sa2si_NF` converted Sage number-field elements to Singular coefficients by
creating a fresh temporary Singular polynomial ring over `QQ` on every
conversion:

```cython
qqr = rDefault(0, 1, _ext_names)
rComplete(qqr, 1)
...
naCoeff = nMapFuncPtr(nlCoeff, qqr.cf, _ring.cf)
```

This was both expensive and leaky. Repeated scalar coercion into a multivariate
polynomial ring over a number field, such as `R(1)` or `x + 1`, created these
temporary rings over and over.

### 2. Constant-argument polynomial evaluation

`singular_polynomial_call` used `maMapPoly(..., ndCopyMap)` when every argument
was a constant polynomial:

```cython
ret[0] = maMapPoly(p, r, to_id, r, ndCopyMap)
```

This goes through Singular's general map machinery. In this same-ring,
all-constant-image case, it leaked memory. The leak was visible even when the
constant argument was pre-coerced, for example with `one = R(1)` and repeated
`x(one)`, so it was not only the scalar coercion leak.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


