### PR TITLE
Further bound `random_cone` in `matrix2.pyx`

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -18344,8 +18344,8 @@ cdef class Matrix(Matrix1):
         the underlying ring symbolic (the usual case is tested by
         the ``positive_operators_gens`` method)::
 
-            sage: K1 = random_cone(max_ambient_dim=5, max_rays=15)
-            sage: K2 = random_cone(max_ambient_dim=5, max_rays=15)
+            sage: K1 = random_cone(max_ambient_dim=4, max_rays=10)
+            sage: K2 = random_cone(max_ambient_dim=4, max_rays=10)
             sage: results = ( L.change_ring(SR).is_positive_operator_on(K1, K2)
             ....:             for L in K1.positive_operators_gens(K2) )
             sage: all(results)                  # long time
@@ -18492,9 +18492,18 @@ cdef class Matrix(Matrix1):
         Everything in ``K.cross_positive_operators_gens()`` should be
         cross-positive on ``K``, even if we make the underlying ring
         symbolic (the usual case is tested by the
-        ``cross_positive_operators_gens`` method)::
+        ``cross_positive_operators_gens`` method). We throw out
+        randomly-generated cones whose intermediate dual has too many
+        rays, since dualizing it can be prohibitively expensive::
 
-            sage: K = random_cone(max_ambient_dim=5, max_rays=15)
+            sage: _max_cp_dual_rays = 55
+            sage: for _ in range(50):
+            ....:     K = random_cone(max_ambient_dim=4, max_rays=10)
+            ....:     _cp_dual_n_rays = K._cross_positive_operators_dual().n_rays()
+            ....:     if _cp_dual_n_rays <= _max_cp_dual_rays:
+            ....:         break
+            ....: else:
+            ....:     raise RuntimeError("could not find a small enough test cone")
             sage: results = ( L.change_ring(SR).is_cross_positive_on(K)
             ....:             for L in K.cross_positive_operators_gens() )
             sage: all(results)                  # long time
@@ -18629,9 +18638,18 @@ cdef class Matrix(Matrix1):
 
         Everything in ``K.Z_operators_gens()`` should be a Z-operator on
         ``K``, , even if we make the underlying ring symbolic (the usual
-        case is tested by the ``Z_operators_gens`` method)::
+        case is tested by the ``Z_operators_gens`` method). We throw
+        out randomly-generated cones whose intermediate dual has too
+        many rays, since dualizing it can be prohibitively expensive::
 
-            sage: K = random_cone(max_ambient_dim=5, max_rays=15)                       # needs sage.geometry.polyhedron
+            sage: _max_cp_dual_rays = 55
+            sage: for _ in range(50):                                                   # needs sage.geometry.polyhedron
+            ....:     K = random_cone(max_ambient_dim=4, max_rays=10)
+            ....:     _cp_dual_n_rays = K._cross_positive_operators_dual().n_rays()
+            ....:     if _cp_dual_n_rays <= _max_cp_dual_rays:
+            ....:         break
+            ....: else:
+            ....:     raise RuntimeError("could not find a small enough test cone")
             sage: all(L.change_ring(SR).is_Z_operator_on(K)     # long time             # needs sage.geometry.polyhedron sage.symbolic
             ....:     for L in K.Z_operators_gens())
             True
@@ -18748,7 +18766,7 @@ cdef class Matrix(Matrix1):
         symbolic (the usual case is tested by the
         ``lyapunov_like_basis`` method)::
 
-            sage: K = random_cone(max_ambient_dim=5, max_rays=15)                       # needs sage.geometry.polyhedron
+            sage: K = random_cone(max_ambient_dim=4, max_rays=10)                       # needs sage.geometry.polyhedron
             sage: all(L.change_ring(SR).is_lyapunov_like_on(K)  # long time             # needs sage.geometry.polyhedron sage.symbolic
             ....:     for L in K.lyapunov_like_basis())
             True
@@ -18785,7 +18803,7 @@ cdef class Matrix(Matrix1):
         A matrix is Lyapunov-like on a cone if and only if both the
         matrix and its negation are cross-positive on the cone::
 
-            sage: K = random_cone(max_ambient_dim=5, max_rays=15)
+            sage: K = random_cone(max_ambient_dim=4, max_rays=10)
             sage: R = K.lattice().vector_space().base_ring()
             sage: L = random_matrix(R, K.lattice_dim())
             sage: actual = L.is_lyapunov_like_on(K)             # long time


### PR DESCRIPTION
This PR follows [#42163](https://github.com/sagemath/sage/pull/42163), which added `max_rays=15` to several `random_cone(...)` calls in `src/sage/matrix/matrix2.pyx` to avoid a PPL-driven hang. A different random seed has surfaced the same class of hang while the previous bound was still in effect, so this PR tightens the bound further.

## Reproducer

```
./sage -t --long --warn-long 30.0 \
    --random-seed=197597894149255922638363008828604884754 \
    src/sage/matrix/matrix2.pyx
```

Hangs at:

```python
sage: K = random_cone(max_ambient_dim=5, max_rays=15)              ## line 18497 ##
sage: results = ( L.change_ring(SR).is_cross_positive_on(K)
....:             for L in K.cross_positive_operators_gens() )    ## line 18498 ##
```

The cysignals traceback ends inside PPL:

```
libppl.so.14: Parma_Polyhedra_Library::subset_or_equal(Bit_Row, Bit_Row)
            : Polyhedron::conversion<Generator_System, Constraint_System>
            : Polyhedron::update_constraints
            : Polyhedron::minimize
            : Polyhedron::minimized_constraints
ppl/polyhedron.cpython-...so : (PPL Python binding)
```

## Root cause

It is **not a discrete bug in PPL**. The hang is in PPL 1.2's Chernikova-style double-description algorithm (`src/Polyhedron_conversion_templates.hh`). PPL's own `NEWS` calls this an "exponential time" computation and even names the official mitigation hook accordingly (`abandon_expensive_computations`).

For this seed the doctest builds:

| Object | Dim | Rays |
|---|---:|---:|
| `K` from `random_cone(max_ambient_dim=5, max_rays=15)` | 5 | 8 |
| `K.dual()` | 5 | 16 |
| `K.discrete_complementarity_set()` size | — | 64 |
| `cp_dual = K._cross_positive_operators_dual()` | **25** | **64** |
| `cp_dual.dual()` ← hangs here | — | — |

`cp_dual.dual()` ultimately calls `cp_dual._PPL_cone().minimized_constraints()` (via `facet_normals()` in `sage/geometry/cone.py:2303`), which is exactly the V→H conversion in the stack trace.

### Combinatorial blow-up, measured

Adding the 64 rays one at a time and timing `affine_dimension()`:

| #rays | #facets | wall time |
|---:|---:|---:|
| 50 | 39 | 0.002 s |
| 55 | 147 | 0.005 s |
| 57 | — | 2.69 s |
| 58 | — | **> 20 s (timeout)** |

Classic double-description explosion: the `|Q⁺| · |Q⁻|` adjacency loop in `conversion()` keeps growing the intermediate ray system, and the inner `subset_or_equal` adjacency test at `Polyhedron_conversion_templates.hh:820` is called billions of times. `subset_or_equal` itself is cheap; it just happens to be where the trace lands.


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


