### PR TITLE
src/sage/graphs/connectivity.pyx: tolerance for vertex connectivity

### DIFF
--- a/src/sage/graphs/connectivity.pyx
+++ b/src/sage/graphs/connectivity.pyx
@@ -2327,11 +2327,16 @@ def vertex_connectivity(G, value_only=True, sets=False, k=None, solver=None, ver
         except MIPSolverException:
             return True
 
+    # The objective function is a sum of booleans, but they get summed
+    # before conversion. This can lead to an objective value that is
+    # very close to, but not actually, an integer. So instead of
+    # querying the objective value directly, we (re)compute it from
+    # the optimal booleans, post-conversion, taking the integrality
+    # tolerance into consideration.
     p.set_objective(p.sum(in_set[1, v] for v in g))
-
-    val = p.solve(log=verbose)
-
+    p.solve(log=verbose)
     in_set = p.get_values(in_set, convert=bool, tolerance=integrality_tolerance)
+    val = sum(in_set[1, v] for v in g)
 
     if value_only:
         return sum(1 for v in g if in_set[1, v])


### PR DESCRIPTION
The `vertex_connectivity()` method is supposed to return an integer: the sum of some boolean variables in a solution to an MILP. The optimal value of that MILP is however real (a float/double), and can be non-integral by a small amount.

To avoid this issue, we ignore the optimal value that the backend returns, and simply compute it ourselves from the (post-conversion) boolean optimals that have already taken the `integrality_tolerance` into consideration.

cc: @kiwifb @strogdon 