### PR TITLE
make sure Singular only gets used in characteristic ≤ 29 bits

### DIFF
--- a/src/sage/libs/singular/ring.pyx
+++ b/src/sage/libs/singular/ring.pyx
@@ -195,9 +195,9 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
         //        block   1 : ordering dp
         //                  : names    a b
         //        block   2 : ordering C
-        sage: R = PolynomialRing(GF(1000000007), ("a", "b"), implementation="singular"); print(sing_print(R))
+        sage: R = PolynomialRing(GF(100000007), ("a", "b"), implementation="singular"); print(sing_print(R))
         polynomial ring, over a field, global ordering
-        // coefficients: ZZ/1000000007...
+        // coefficients: ZZ/100000007...
         // number of vars : 2
         //        block   1 : ordering dp
         //                  : names    a b
@@ -301,7 +301,7 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
         sage: PolynomialRing(GF((2^31+11)^2), ("a", "b"), implementation="singular")
         Traceback (most recent call last):
         ...
-        TypeError: characteristic must be <= 2147483647.
+        TypeError: characteristic must be < 2^29.
     """
     cdef long cexponent
     cdef GFInfo* _param
@@ -529,7 +529,7 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
 
         isprime = ch.is_prime()
 
-        if isprime and ch <= 2147483647 and isinstance(base_ring, FiniteField_generic):
+        if isprime and ch < 2**29 and isinstance(base_ring, FiniteField_generic):
             # don't use this branch for e.g. Zmod(5)
             characteristic = base_ring.characteristic()
 
@@ -559,8 +559,8 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
 
     elif isinstance(base_ring, FiniteField_generic):
         assert not base_ring.is_prime_field()  # would have been handled above
-        if base_ring.characteristic() > 2147483647:
-            raise TypeError("characteristic must be <= 2147483647.")
+        if base_ring.characteristic() >= 2**29:
+            raise TypeError("characteristic must be < 2^29.")
 
         # TODO: This is lazy, it should only call Singular stuff not PolynomialRing()
         k = PolynomialRing(base_ring.prime_subfield(),

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -5071,7 +5071,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: ((x+y)^2*(x+z)^3).gcd((x+y)^3*(y+z)^5)
             Traceback (most recent call last):
             ...
-            NotImplementedError: GCD of multivariate polynomials over prime fields with characteristic > 2^29 is not implemented.
+            NotImplementedError: GCD over rings not implemented.
             sage: R.<x,y,z> = Zmod(2^29+10)[]
             sage: ((x+y)^2*(x+z)^3).gcd((x+y)^3*(y+z)^5)
             Traceback (most recent call last):
@@ -5185,7 +5185,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: ((x+y)^2*(x+z)^3).lcm((x+y)^3*(y+z)^5)
             Traceback (most recent call last):
             ...
-            NotImplementedError: LCM of multivariate polynomials over prime fields with characteristic > 2^29 is not implemented.
+            TypeError: LCM over non-integral domains not available.
             sage: R.<x,y,z> = Zmod(2^29+10)[]
             sage: ((x+y)^2*(x+z)^3).lcm((x+y)^3*(y+z)^5)
             Traceback (most recent call last):

--- a/src/sage/rings/polynomial/polynomial_element.pyx
+++ b/src/sage/rings/polynomial/polynomial_element.pyx
@@ -4359,13 +4359,25 @@ cdef class Polynomial(CommutativePolynomial):
 
         This shows that the issue at :issue:`7711` is resolved::
 
-            sage: P.<x,z> = PolynomialRing(GF(2147483647))
+            sage: P.<x,z> = PolynomialRing(GF(2^29 - 3))
             sage: Q.<y> = PolynomialRing(P)
             sage: p = x + y + z
             sage: p.integral()
-            -1073741823*y^2 + (x + z)*y
+            -268435454*y^2 + (x + z)*y
 
-            sage: P.<x,z> = PolynomialRing(GF(next_prime(2147483647)))
+            sage: P.<x,z> = PolynomialRing(GF(2^29 + 11))
+            sage: Q.<y> = PolynomialRing(P)
+            sage: p = x + y + z
+            sage: p.integral()
+            268435462*y^2 + (x + z)*y
+
+            sage: P.<x,z> = PolynomialRing(GF(2^31 - 1))
+            sage: Q.<y> = PolynomialRing(P)
+            sage: p = x + y + z
+            sage: p.integral()
+            1073741824*y^2 + (x + z)*y
+
+            sage: P.<x,z> = PolynomialRing(GF(2^31 + 11))
             sage: Q.<y> = PolynomialRing(P)
             sage: p = x + y + z
             sage: p.integral()

--- a/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
@@ -420,6 +420,16 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
 
             sage: ~S(3)
             11
+
+        Check that :issue:`40809` is fixed::
+
+            sage: F.<i> = GF((2**31-1,2), modulus=[1,0,1])
+            sage: R.<x> = F[]
+            sage: f = x^2 + (1196423630*i + 1564527877)*x + 2041534867*i + 2147483645
+            sage: g = x^3 + x
+            sage: S.<y> = R.quotient_ring(g)
+            sage: ~S(f)
+            (2068022062*i + 1610612738)*y^2 + (774635916*i + 1219480766)*y + 2041534867*i + 2
         """
         P = self.parent()
         try:

--- a/src/sage/rings/polynomial/polynomial_singular_interface.py
+++ b/src/sage/rings/polynomial/polynomial_singular_interface.py
@@ -45,6 +45,13 @@ from sage.rings.finite_rings.finite_field_base import FiniteField
 from sage.rings.integer_ring import ZZ
 from sage.rings.number_field.number_field_base import NumberField
 
+'''
+Singular supports characteristics up to 2^31-1 in principle,
+but many algorithms are broken unless the characteristic is
+actually <= 2^29-1. See the manual:
+https://www.singular.uni-kl.de/Manual/latest/sing_418.htm
+'''
+singular_max_char = 2**29 - 1
 
 def _do_singular_init_(singular, base_ring, char, _vars, order):
     r"""
@@ -100,7 +107,7 @@ def _do_singular_init_(singular, base_ring, char, _vars, order):
 
     if isinstance(base_ring, sage.rings.abc.IntegerModRing):
         char = base_ring.characteristic()
-        if isinstance(base_ring, FiniteField) and char <= 2147483647:
+        if isinstance(base_ring, FiniteField) and char <= singular_max_char:
             return make_ring(str(char)), None
         if char.is_power_of(2):
             return make_ring(f"(integer,2,{char.nbits()-1})"), None
@@ -145,7 +152,7 @@ def _do_singular_init_(singular, base_ring, char, _vars, order):
         if B.is_prime_field() or B is ZZ:
             return make_ring(f"({base_char},{gens})"), None
 
-        if isinstance(B, FiniteField) and B.characteristic() <= 2147483647:
+        if isinstance(B, FiniteField) and B.characteristic() <= singular_max_char:
             ext_gen = str(B.gen())
             _vars = '(' + ext_gen + ', ' + _vars[1:]
 
@@ -406,10 +413,10 @@ def can_convert_to_singular(R):
 
     Check for :issue:`33319`::
 
-        sage: R.<x,y> = GF((2^31-1)^3)[]
+        sage: R.<x,y> = GF((2^29-3)^3)[]
         sage: R._has_singular
         True
-        sage: R.<x,y> = GF((2^31+11)^2)[]
+        sage: R.<x,y> = GF((2^29+11)^2)[]
         sage: R._has_singular
         False
         sage: R.<x,y> = GF(10^20 - 11)[]
@@ -444,14 +451,14 @@ def can_convert_to_singular(R):
                                   sage.rings.abc.RealDoubleField, sage.rings.abc.ComplexDoubleField))):
         return True
     if isinstance(base_ring, FiniteField):
-        return base_ring.characteristic() <= 2147483647
+        return base_ring.characteristic() <= singular_max_char
     if isinstance(base_ring, NumberField):
         return base_ring.is_absolute()
     if (isinstance(base_ring, sage.rings.fraction_field.FractionField_generic)
         and isinstance(base_ring.base(), (PolynomialRing_general, MPolynomialRing_base))):
         B = base_ring.base_ring()
         return (B.is_prime_field() or B is ZZ
-                or (isinstance(B, FiniteField) and B.characteristic() <= 2147483647))
+                or (isinstance(B, FiniteField) and B.characteristic() <= singular_max_char))
     if isinstance(base_ring, RationalFunctionField):
         return base_ring.constant_field().is_prime_field()
     return False

--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -1558,6 +1558,27 @@ def isogenies_13_1728(E, minimal_models=True):
           363594277511/574456513088876544*a^11 + 7213386922793/2991961005671232*a^9
             + 2810970361185589/1329760446964992*a^7 - 281503836888046601/8975883017013696*a^5
             + 1287313166530075/848061509544*a^3 - 9768837984886039/6925835661276*a)]
+
+    TESTS:
+
+    Check that :issue:`42262` is fixed::
+
+        sage: F = GF((2**31-1, 2))
+        sage: E = EllipticCurve(F, [1,0])
+        sage: E.isogenies_prime_degree(13)
+        [Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...,
+         Isogeny of degree 13 from Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 2147483647^2 to ...]
     """
     if E.j_invariant() != 1728:
         raise ValueError("j-invariant must be 1728")


### PR DESCRIPTION
While Singular in principle supports characteristics greater than $$2^{29}$$, many algorithms aren't implemented in that case, which in turn causes some very strange bugs in Sage. As a workaround/fix, we make sure that Singular only gets used for characteristic $$<2^{29}$$. A more fine-grained distinction of when it is acceptable to use Singular would be desirable, but for the moment we need to take care of the problem in a way that doesn't cause weird failures at random times.

Resolves #34302, fixes #40809, fixes #42262.