### PR TITLE
Fix memory leak converting matrices over number fields to PARI

### DIFF
--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -85,9 +85,26 @@ cdef class Matrix(Matrix0):
             [3.0 1.0]
             sage: b = pari(a); b                                                        # needs sage.libs.pari
             [1.000000000..., 2.000000000...; 3.000000000..., 1.000000000...]
+
+        Conversion of a matrix over a number field (:issue:`39615`)::
+
+            sage: # needs sage.rings.number_field
+            sage: x = polygen(ZZ)
+            sage: K.<a> = NumberField(x^2 - 2, embedding=AA(2).sqrt())
+            sage: pari(matrix(K, [[1, a], [a, 1]]))
+            [Mod(1, y^2 - 2), Mod(y, y^2 - 2); Mod(y, y^2 - 2), Mod(1, y^2 - 2)]
         """
         from sage.libs.pari import pari
-        return pari.matrix(self._nrows, self._ncols, self._list())
+        # Convert the entries to PARI before building the matrix.  This works
+        # around a memory leak (:issue:`39615`) in ``pari.matrix``: when the
+        # entries are converted lazily inside ``pari.matrix``, the resulting
+        # PARI matrix lives on the PARI stack while its (cloned) entries live
+        # on the PARI heap, and freeing the matrix does not reclaim those
+        # clones.  Passing already-converted entries forces the matrix onto
+        # the heap, so the clones are freed together with it.  (The leak is
+        # fixed in cypari2 > 2.2.4.)
+        return pari.matrix(self._nrows, self._ncols,
+                           [pari(x) for x in self._list()])
 
     def _gap_init_(self) -> str:
         """

--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -86,7 +86,7 @@ cdef class Matrix(Matrix0):
             sage: b = pari(a); b                                                        # needs sage.libs.pari
             [1.000000000..., 2.000000000...; 3.000000000..., 1.000000000...]
 
-        Conversion of a matrix over a number field (:issue:`39615`)::
+        Conversion of a matrix over a number field::
 
             sage: # needs sage.rings.number_field
             sage: x = polygen(ZZ)


### PR DESCRIPTION
Fixes #39615.

## Summary

Constructing many polyhedra over a number field leaks memory linearly and
without bound (≈ **6 MB per 1000 polyhedra**), even with explicit
`gc.collect()` calls. This PR fixes the underlying leak, which is in the
generic `Matrix.__pari__` conversion.

```python
sage: sqrt2_AA = AA(sqrt(2))
sage: K.<sqrt2> = NumberField(sqrt2_AA.minpoly(), embedding=sqrt2_AA)
sage: N = 100000
sage: for i in range(1, N):                      # leaked ~6 MB / 1000 iters
....:     a = i/N
....:     p = Polyhedron(vertices=[(1-a, 0), (1, 0),
....:                              (1+1/sqrt2, 1/sqrt2),
....:                              (1+1/sqrt2-a, 1/sqrt2)], base_ring=K)
```

## Root cause

The default backend for an exact field such as a number field is `'field'`,
which computes the H/V-representation with the double description method
(`sage/geometry/polyhedron/double_description_inhomogeneous.py`). That calls
`matrix.right_kernel()` over the number field, which routes through

```
matrix2.pyx:_right_kernel_matrix_over_number_field  ->  self.__pari__().matker()
matrix1.pyx:Matrix.__pari__                         ->  pari.matrix(nr, nc, entries)
```

The leak is **C-level**: `tracemalloc` shows the Python heap stays flat
(+0.04 MB) while RSS grows +39 MB over the same loop — which is why earlier
investigations that counted `gc` objects (see the issue thread) found nothing.

The bug is in cypari2's `pari.matrix`. It builds the matrix `A` on the PARI
**stack**, then sets each coefficient to a heap **clone** of the converted
entry (via `ref_target()` / `gcloneref`):

```cython
A = new_gen(zeromatcopy(m, n))            # A lives on the PARI stack
...
x = objtogen(entries[k])
set_gcoeff(A.g, i+1, j+1, x.ref_target()) # coefficient is a heap clone
A.cache((i, j), x)
```

A stack `Gen` is released through `remove_from_pari_stack`, which simply
rewinds the stack pointer and does **not** recursively unclone the coefficient
clones. So every freshly-converted entry clone is leaked. (A heap `Gen` would
instead be freed with `gunclone_deep`, which *does* recurse.)

This has been fixed upstream in cypari2
([commit `5273a890d`](https://github.com/sagemath/cypari2/commit/5273a890d),
which adds `A.fixGEN()` to pin the matrix to the heap), but the fix is **not in
any released version** (latest release is 2.2.4), so Sage cannot simply rely on
it yet.

## The fix

Work around the bug at the conversion boundary in the generic
`Matrix.__pari__`, by converting the entries to PARI **before** building the
matrix:

```python
return pari.matrix(self._nrows, self._ncols,
                   [pari(x) for x in self._list()])
```

This is semantically identical — `pari.matrix` performs exactly the same
`objtogen` conversion internally — but it places the entry `Gen`s on the PARI
stack *below* the matrix. The first `ref_target()` then calls
`move_gens_to_heap`, which drags the matrix onto the heap, so freeing it
reclaims all the coefficient clones via `gunclone_deep`. The fix benefits every
generic matrix → PARI conversion (kernel, `det`, `charpoly`, …), not just the
polyhedron path.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


