### PR TITLE
Fixes #40356 add root_sum class and Maxima rootsof converter

### DIFF
--- a/src/sage/interfaces/maxima_lib.py
+++ b/src/sage/interfaces/maxima_lib.py
@@ -272,6 +272,8 @@ max_minus = EclObject("$MINUS")
 max_use_grobner = EclObject("$USE_GROBNER")
 max_to_poly_solve = EclObject("$TO_POLY_SOLVE")
 max_at = EclObject("%AT")
+max_lsum = EclObject("%LSUM")
+max_rootsof = EclObject("$ROOTSOF")
 
 
 def stdout_to_string(s):
@@ -1494,6 +1496,61 @@ def max_pochhammer_to_sage(expr):
     return gamma(x + y) / gamma(x)
 
 
+def max_lsum_to_sage(expr):
+    r"""
+    Special conversion rule for Maxima's ``%LSUM`` (list-sum) operator
+    when its list argument is a ``$ROOTSOF`` wrapper -- i.e. the RootSum
+    representation Maxima emits when ``integrate_use_rootsof:true`` is
+    set.
+
+    INPUT:
+
+    - ``expr`` -- ECL object; a Maxima expression of the form
+      ``((%LSUM SIMP) <body> <dummy> (($ROOTSOF) <poly> <dummy>))``
+
+    OUTPUT:
+
+    A Sage ``root_sum(body, dummy, poly)`` symbolic expression, where
+    ``root_sum`` is :class:`sage.symbolic.rootsum.Function_root_sum`.
+
+    Falls back to a generic translation when the inner list argument
+    is not a ``$ROOTSOF`` wrapper (e.g. an ordinary ``lsum`` over an
+    explicit list).  See :issue:`40356`.
+
+    EXAMPLES::
+
+        sage: from sage.interfaces.maxima_lib import maxima_lib, max_to_sr
+        sage: _ = maxima_lib.eval("integrate_use_rootsof:true")
+        sage: result = maxima_lib("integrate(1/(x^3+a*x+1), x)")
+        sage: _ = maxima_lib.eval("integrate_use_rootsof:false")
+        sage: max_to_sr(result.ecl()).operator().__class__.__name__
+        'Function_root_sum'
+    """
+    args = list(cdr(expr))
+    if len(args) == 3:
+        body_ecl, dummy_ecl, listexpr_ecl = args
+        if (listexpr_ecl.consp()
+                and caar(listexpr_ecl) == max_rootsof):
+            rootsof_args = list(cdr(listexpr_ecl))
+            if len(rootsof_args) == 2:
+                from sage.symbolic.rootsum import root_sum
+                body = max_to_sr(body_ecl)
+                dummy = max_to_sr(dummy_ecl)
+                poly = max_to_sr(rootsof_args[0])
+                return root_sum(body, dummy, poly)
+    # Fallback: generic lsum (e.g. lsum over an explicit list).
+    # Try to expand if the list is concrete, otherwise leave unevaluated
+    # as a symbolic sum.
+    if len(args) == 3:
+        body = max_to_sr(args[0])
+        dummy = max_to_sr(args[1])
+        listexpr = max_to_sr(args[2])
+        if isinstance(listexpr, list):
+            return sum(body.subs({dummy: v}) for v in listexpr)
+    # Last-resort: round-trip the whole expression through SR.
+    return SR(maxima(expr))
+
+
 # The dictionaries
 special_max_to_sage = {
     mrat: mrat_to_sage,
@@ -1503,7 +1560,8 @@ special_max_to_sage = {
     max_at: max_at_to_sage,
     mlist: mlist_to_sage,
     max_harmo: max_harmonic_to_sage,
-    max_pochhammer: max_pochhammer_to_sage
+    max_pochhammer: max_pochhammer_to_sage,
+    max_lsum: max_lsum_to_sage,
 }
 
 special_sage_to_max = {

--- a/src/sage/symbolic/rootsum.py
+++ b/src/sage/symbolic/rootsum.py
@@ -1,0 +1,129 @@
+r"""
+Sum over the roots of a polynomial
+
+This module implements :class:`Function_root_sum`, a symbolic function
+representing a sum
+
+.. MATH::
+
+    \sum_{r \,:\, p(r) = 0} f(r)
+
+over the roots of a polynomial ``p`` in a dummy variable ``r``.  This
+matches Maxima's ``lsum(f(r), r, rootsof(p, r))`` representation, which
+Maxima emits when ``integrate_use_rootsof:true`` is set, and SymPy's
+``RootSum(p, Lambda(r, f(r)))``.
+
+Concretely, the antiderivative
+
+.. MATH::
+
+    \int \frac{1}{x^3 + a x + 1} \, dx
+        = \sum_{r \,:\, r^3 + a r + 1 = 0} \frac{\log(x - r)}{3 r^2 + a}
+
+is represented in Sage as
+``root_sum(log(x - r)/(3*r^2 + a), r, r^3 + a*r + 1)``.
+
+See :issue:`40356` for the original feature request and the converter in
+:mod:`sage.interfaces.maxima_lib`.
+"""
+# ****************************************************************************
+#       Copyright (C) 2026
+#
+#  Distributed under the terms of the GNU General Public License (GPL)
+#  as published by the Free Software Foundation; either version 2 of
+#  the License, or (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
+
+from sage.symbolic.function import BuiltinFunction
+
+
+class Function_root_sum(BuiltinFunction):
+    r"""
+    Symbolic representation of `\sum_{r \,:\, p(r) = 0} f(r)`, the sum of
+    an expression ``f(r)`` over the roots of a polynomial ``p`` in a
+    dummy variable ``r``.
+
+    The three arguments are ``(body, dummy, poly)``, matching Maxima's
+    ``lsum(body, dummy, rootsof(poly, dummy))`` argument order:
+
+    - ``body`` -- the symbolic expression in the dummy variable
+    - ``dummy`` -- the symbolic variable representing a generic root
+    - ``poly`` -- the polynomial whose roots index the sum (expressed
+      in the dummy variable)
+
+    EXAMPLES::
+
+        sage: from sage.symbolic.rootsum import root_sum
+        sage: var('x a r')
+        (x, a, r)
+        sage: root_sum(log(x - r) / (a + 3*r^2), r, r^3 + a*r + 1)
+        root_sum(log(x - r)/(3*r^2 + a), r, r^3 + a*r + 1)
+
+    LaTeX renders the canonical math notation::
+
+        sage: latex(root_sum(log(x - r) / (3*r^2 + a), r, r^3 + a*r + 1))
+        \sum_{r \,:\, r^{3} + a r + 1 = 0} \frac{\log\left(x - r\right)}{3 \, r^{2} + a}
+
+    The expression is intentionally inert.  No automatic simplification or
+    evaluation is performed -- even when the polynomial has explicit
+    rational roots, the sum stays symbolic::
+
+        sage: root_sum(r^2, r, r^2 - 1)
+        root_sum(r^2, r, r^2 - 1)
+
+    Sage receives ``root_sum`` expressions from Maxima when
+    ``integrate_use_rootsof:true`` is active; see :issue:`40356`.
+
+    .. NOTE::
+
+        Bridges for SymPy's ``RootSum`` and FriCAS's ``RootSum``, as well
+        as ``_derivative_`` and ``_evalf_``, are intentionally not
+        implemented in this initial version and are tracked as follow-up
+        work.
+    """
+    def __init__(self):
+        r"""
+        EXAMPLES::
+
+            sage: from sage.symbolic.rootsum import root_sum
+            sage: loads(dumps(root_sum))
+            root_sum
+        """
+        BuiltinFunction.__init__(self, "root_sum", nargs=3)
+
+    def _eval_(self, body, dummy, poly):
+        r"""
+        Symbolic evaluation. Returns ``None`` to keep the expression
+        unevaluated.
+
+        TESTS::
+
+            sage: from sage.symbolic.rootsum import root_sum
+            sage: var('r')
+            r
+            sage: rs = root_sum(r^2, r, r^2 - 1)
+            sage: rs.operator() is root_sum
+            True
+        """
+        return None
+
+    def _print_latex_(self, body, dummy, poly):
+        r"""
+        Render as ``\sum_{r \,:\, p(r) = 0} body``.
+
+        EXAMPLES::
+
+            sage: from sage.symbolic.rootsum import root_sum
+            sage: var('a r')
+            (a, r)
+            sage: latex(root_sum(1/r, r, r^3 - a))
+            \sum_{r \,:\, r^{3} - a = 0} \frac{1}{r}
+        """
+        from sage.misc.latex import latex
+        return r"\sum_{%s \,:\, %s = 0} %s" % (latex(dummy),
+                                               latex(poly),
+                                               latex(body))
+
+
+root_sum = Function_root_sum()


### PR DESCRIPTION
Adds a `root_sum` symbolic class in `sage/symbolic/rootsum.py` and a `special_max_to_sage` entry that translates Maxima's `lsum` over `rootsof` (returned with `integrate_use_rootsof:true`) into a first-class Sage expression instead of dropping it.